### PR TITLE
test runner: drop the allow_in_preload flag from GetActiveCfg

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -63,7 +63,6 @@
 "defaulted_failure:src/runtime/ffi/ffi_body.rs" = 1
 "defaulted_failure:src/runtime/server/RequestContext.rs" = 1
 "defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4
-"derived_field:src/runtime/test_runner/bun_test.rs" = 1
 "error_collapsed_to_bool:src/runtime/api/bun/Terminal.rs" = 1
 "error_collapsed_to_bool:src/runtime/api/bun/h2_frame_parser.rs" = 32
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -5,7 +5,7 @@ use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsResult};
 use bun_core::String as BunString;
 
 use crate::test_runner::bun_test::{self, BaseScopeCfg, BunTest, DescribeScope};
-use crate::test_runner::bun_test::js_fns::{Signature, GetActiveCfg};
+use crate::test_runner::bun_test::js_fns::Signature;
 use crate::test_runner::jest;
 
 // `group_log` wraps `test_runner::debug::group` (a begin/end/log tracer) as an RAII guard
@@ -166,13 +166,7 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
     let this: &ScopeFunctions = unsafe { &*this_ptr.cast_const() };
     let line_no = jest::capture_test_line_number(frame, global);
 
-    let buntest_strong = bun_test::js_fns::clone_active_strong(
-        global,
-        &GetActiveCfg {
-            signature: Signature::ScopeFunctions(this),
-            allow_in_preload: false,
-        },
-    )?;
+    let buntest_strong = bun_test::js_fns::clone_active_strong(global, Signature::ScopeFunctions(this))?;
     let bun_test_ptr = buntest_strong.get();
 
     let callback_mode: CallbackMode = match this.cfg.self_mode {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -76,43 +76,38 @@ pub mod js_fns {
         }
     }
 
-    pub(crate) struct GetActiveCfg<'a> {
-        pub(crate) signature: Signature<'a>,
-        pub(crate) allow_in_preload: bool,
-    }
-
-    fn get_active_test_root<'a>(
+    /// Only requires the runner: hooks are legal in preload scripts (they attach
+    /// to the root), so the preload check lives in `clone_active_strong`.
+    fn get_test_root(
         global_this: &JSGlobalObject,
-        cfg: &GetActiveCfg<'a>,
+        signature: Signature<'_>,
     ) -> JsResult<&'static mut BunTestRoot> {
         // `Jest.runner` is a process-global that outlives every caller, so the
         // unbounded `&'static mut` is the honest model here.
         let Some(runner) = Jest::runner() else {
             return Err(global_this.throw(format_args!(
                 "Cannot use {} outside of the test runner. Run \"bun test\" to run tests.",
-                cfg.signature
+                signature
             )));
         };
-        let bun_test_root = &mut runner.bun_test_root;
-        let vm = global_this.bun_vm();
-        if vm.is_in_preload && !cfg.allow_in_preload {
-            return Err(global_this.throw(format_args!(
-                "Cannot use {} during preload.",
-                cfg.signature
-            )));
-        }
-        Ok(bun_test_root)
+        Ok(&mut runner.bun_test_root)
     }
 
     pub(crate) fn clone_active_strong(
         global_this: &JSGlobalObject,
-        cfg: &GetActiveCfg<'_>,
+        signature: Signature<'_>,
     ) -> JsResult<BunTestPtr> {
-        let bun_test_root = get_active_test_root(global_this, cfg)?;
+        let bun_test_root = get_test_root(global_this, signature)?;
+        if global_this.bun_vm().is_in_preload {
+            return Err(global_this.throw(format_args!(
+                "Cannot use {} during preload.",
+                signature
+            )));
+        }
         let Some(bun_test) = bun_test_root.clone_active_file() else {
             return Err(global_this.throw(format_args!(
                 "Cannot use {} outside of a test file.",
-                cfg.signature
+                signature
             )));
         };
         Ok(bun_test)
@@ -186,10 +181,7 @@ pub mod js_fns {
                 false
             };
 
-            let bun_test_root = get_active_test_root(
-                global_this,
-                &GetActiveCfg { signature: Signature::Str(sig_bytes), allow_in_preload: true },
-            )?;
+            let bun_test_root = get_test_root(global_this, Signature::Str(sig_bytes))?;
 
             let cfg = ExecutionEntryCfg {
                 has_done_parameter,

--- a/test/js/bun/test/bun_test.test.ts
+++ b/test/js/bun/test/bun_test.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 
 test("describe/test", async () => {
   const result = await Bun.spawn({
@@ -265,6 +265,79 @@ test("multi-file", async () => {
     preload: afterEach
     preload: after last file"
   `);
+});
+
+test.concurrent("hooks may be registered during preload, test/describe may not", async () => {
+  using dir = tempDir("bun-test-preload-scope", {
+    "preload.ts": `
+      import { test, describe, beforeAll } from "bun:test";
+      beforeAll(() => console.log("preload beforeAll ran"));
+      for (const [name, fn] of [
+        ["test", () => test("in preload", () => {})],
+        ["describe", () => describe("in preload", () => {})],
+      ] as const) {
+        try {
+          fn();
+          console.log(name + ": did not throw");
+        } catch (e) {
+          console.log(name + ": " + (e as Error).message);
+        }
+      }
+    `,
+    "a.test.ts": `
+      import { test } from "bun:test";
+      test("a", () => console.log("a ran"));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--preload", "./preload.ts", "./a.test.ts"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+    "bun test <version> (<revision>)
+    test: Cannot use test during preload.
+    describe: Cannot use describe during preload.
+    preload beforeAll ran
+    a ran"
+  `);
+  expect(stderr).toContain("1 pass");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("test/describe and hooks throw outside of the test runner", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        import { test, describe, beforeAll } from "bun:test";
+        for (const fn of [() => test("x", () => {}), () => describe("x", () => {}), () => beforeAll(() => {})]) {
+          try {
+            fn();
+            console.log("did not throw");
+          } catch (e) {
+            console.log(e.message);
+          }
+        }
+      `,
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toMatchInlineSnapshot(`
+    "Cannot use test outside of the test runner. Run "bun test" to run tests.
+    Cannot use describe outside of the test runner. Run "bun test" to run tests.
+    Cannot use beforeAll() outside of the test runner. Run "bun test" to run tests.
+    "
+  `);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 test("--only flag with multiple files", async () => {


### PR DESCRIPTION
### Problem
- mordant `derived_field` on `GetActiveCfg` (`src/runtime/test_runner/bun_test.rs:79`): `allow_in_preload` has the same value for a given `signature` at both places the struct is built.
- The two constructions are the only two callers of the lookup: the hook entry point (`generic_hook_impl`) always passes `true`, the `test`/`describe` entry point (`ScopeFunctions::call_as_function`) always passes `false`. The Zig original had the same two callers with the same two constants, so the flag only ever encoded "which caller am I".
- It is not a property of `Signature`, though: `Signature` is the enum used to name the caller in error messages (`Signature::Str` is any static name, it happens to be used only by hooks today), so a `Signature::allow_in_preload()` method would be an arbitrary rule hung on a display type.

### Fix
- Delete `GetActiveCfg` and the flag. `get_test_root` (was `get_active_test_root`) only does the runner lookup and takes the `Signature` for its error message; `clone_active_strong`, the `test`/`describe` path, does the preload check inline before looking up the active file. The hook path calls `get_test_root` directly, as it already handles preload itself (`get_active_file_unless_in_preload`, a few lines down).
- No behavior change: the three throws (`outside of the test runner`, `during preload`, `outside of a test file`) are raised in the same order with the same messages on both paths.
- `mordant-baseline.toml`: dropped the `derived_field` entry for `bun_test.rs`. A full `bun run rust:mordant:baseline` additionally drops two entries unrelated to this change that went stale when #38271 and #37648 landed (`always_unwrapped_option` in `PackageInstall.rs`, `narrowed_two_ways` in `node_crypto_binding.rs`); left out of this PR on purpose.
- Verified:
  - `test/js/bun/test/bun_test.test.ts`: two new tests pin the `during preload` and `outside of the test runner` messages for `test`/`describe`/`beforeAll`, plus `beforeAll` working from a preload. They pass on the release build too, as expected for a refactor.
  - `bun bd test` on `test/js/bun/test/{bun_test,test-test,preload-test,expect-extend-preload,jest-hooks,describe,jest-each,nested-describes,test-only,concurrent}` and `test/cli/test/bun-test.test.ts`: 0 failures.
  - `cargo dylint --all -p bun_runtime` with the baseline line removed: reports exactly this `derived_field` finding on the old source, nothing on the new source.

### Background
- `bun test --preload <file>` runs the preload script before any test file is loaded. At that point there is no active test file, so `test()`/`describe()` have nothing to attach to and throw; hooks are allowed and attach to `BunTestRoot.hook_scope`, becoming global hooks for every file.
- `Signature` (`js_fns::Signature`) is how the test runner names the calling function in those error messages: either a `ScopeFunctions` object, which prints as the chain the user called (`test`, `test.skip`, `describe.only`, ...), or a static string such as `beforeAll()`.
- mordant is the lint pack run by `bun run rust:mordant`; `mordant-baseline.toml` records pre-existing findings per (lint, file) so CI fails only on new ones, and an entry is removed once its site is fixed.
