### PR TITLE
text formats: name the input flags passed to with_text_format_source

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -41,7 +41,6 @@
 "reimplemented_helper:src/react_compiler/reactive_scopes/propagate_early_returns.rs" = 1
 
 [bun_runtime]
-"bare_bool_args:src/runtime/api.rs" = 2
 "bare_bool_args:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "bare_bool_args:src/runtime/dns_jsc/dns.rs" = 1
 "bare_bool_args:src/runtime/node/types.rs" = 4

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -218,19 +218,45 @@ fn with_text_format_source<R>(
     global: &bun_jsc::JSGlobalObject,
     frame: &bun_jsc::CallFrame,
     path: &'static [u8],
-    accept_blob_or_buffer: bool,
-    reject_nullish: bool,
+    blob_or_buffer_input: BlobOrBufferInput,
+    nullish_input: NullishInput,
     f: impl FnOnce(&bun_alloc::Arena, &mut bun_ast::Log, &bun_ast::Source) -> bun_jsc::JsResult<R>,
 ) -> bun_jsc::JsResult<R> {
     with_text_format_source_encoded(
         global,
         frame,
         path,
-        accept_blob_or_buffer,
-        reject_nullish,
-        false,
+        blob_or_buffer_input,
+        nullish_input,
+        StringInput::Utf8,
         |arena, log, source, _| f(arena, log, source),
     )
+}
+
+/// What `parse` does with a `Blob`, `ArrayBuffer`, typed array or `DataView`.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BlobOrBufferInput {
+    /// Parses its bytes.
+    Bytes,
+    /// Stringifies it like any other argument, as `JSON.parse` would.
+    ToString,
+}
+
+/// What `parse` does with an `undefined` or `null` argument.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum NullishInput {
+    Throw,
+    /// Parses the text `"undefined"` / `"null"`.
+    ToString,
+}
+
+/// What `parse` hands the closure for a string argument.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StringInput {
+    /// The string re-encoded as UTF-8 ([`SourceEncoding::Utf8Text`]).
+    Utf8,
+    /// The string's own storage, Latin-1 or UTF-16, as is.
+    AsIs,
 }
 
 /// How the bytes handed to the closure of
@@ -241,10 +267,10 @@ enum SourceEncoding {
     Bytes,
     /// A JS string, re-encoded as UTF-8.
     Utf8Text,
-    /// A Latin-1 JS string, borrowed as is (only when `string_passthrough`).
+    /// A Latin-1 JS string, borrowed as is (only under [`StringInput::AsIs`]).
     Latin1Text,
     /// A UTF-16 JS string, borrowed as is: the bytes are its code units
-    /// (only when `string_passthrough`).
+    /// (only under [`StringInput::AsIs`]).
     Utf16Text,
 }
 
@@ -252,9 +278,9 @@ fn with_text_format_source_encoded<R>(
     global: &bun_jsc::JSGlobalObject,
     frame: &bun_jsc::CallFrame,
     path: &'static [u8],
-    accept_blob_or_buffer: bool,
-    reject_nullish: bool,
-    string_passthrough: bool,
+    blob_or_buffer_input: BlobOrBufferInput,
+    nullish_input: NullishInput,
+    string_input: StringInput,
     f: impl FnOnce(
         &bun_alloc::Arena,
         &mut bun_ast::Log,
@@ -286,7 +312,7 @@ fn with_text_format_source_encoded<R>(
     let _ast_scope = ast_memory_allocator.enter();
 
     let input_value = frame.argument(0);
-    if reject_nullish && input_value.is_empty_or_undefined_or_null() {
+    if nullish_input == NullishInput::Throw && input_value.is_empty_or_undefined_or_null() {
         return Err(global.throw_invalid_arguments(format_args!("Expected a string to parse")));
     }
 
@@ -299,7 +325,7 @@ fn with_text_format_source_encoded<R>(
     let _latin1_hold: bun_core::OwnedString;
     let mut encoding = SourceEncoding::Utf8Text;
     let bytes: &[u8] = 'bytes: {
-        if accept_blob_or_buffer && !input_value.is_string() {
+        if blob_or_buffer_input == BlobOrBufferInput::Bytes && !input_value.is_string() {
             if let Some(v) = BlobOrStringOrBuffer::from_js(global, input_value)? {
                 _blob_hold = v;
                 encoding = SourceEncoding::Bytes;
@@ -307,7 +333,7 @@ fn with_text_format_source_encoded<R>(
             }
         }
         let mut s = input_value.to_bun_string(global)?;
-        if string_passthrough {
+        if string_input == StringInput::AsIs {
             _latin1_hold = bun_core::OwnedString::new(s);
             if _latin1_hold.is_8bit() {
                 encoding = SourceEncoding::Latin1Text;

--- a/src/runtime/api/JSON5Object.rs
+++ b/src/runtime/api/JSON5Object.rs
@@ -49,8 +49,8 @@ pub(crate) fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         global,
         frame,
         b"input.json5",
-        true,
-        true,
+        super::BlobOrBufferInput::Bytes,
+        super::NullishInput::Throw,
         |bump, log, source| {
             let root = match json5::JSON5Parser::parse(source, log, bump) {
                 Ok(r) => r,

--- a/src/runtime/api/JSONCObject.rs
+++ b/src/runtime/api/JSONCObject.rs
@@ -14,8 +14,8 @@ pub(crate) fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         global,
         frame,
         b"input.jsonc",
-        false,
-        true,
+        super::BlobOrBufferInput::ToString,
+        super::NullishInput::Throw,
         |_arena, log, source| {
             // parse_jsonc maps empty input to {}; the public API rejects it like JSON.parse.
             if source.contents.is_empty() {

--- a/src/runtime/api/TOMLObject.rs
+++ b/src/runtime/api/TOMLObject.rs
@@ -22,8 +22,8 @@ pub(crate) fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         global,
         frame,
         b"input.toml",
-        true,
-        true,
+        super::BlobOrBufferInput::Bytes,
+        super::NullishInput::Throw,
         |arena, log, source| {
             let root = match TOML::parse(source, log, arena, false) {
                 Ok(v) => v,

--- a/src/runtime/api/XMLObject.rs
+++ b/src/runtime/api/XMLObject.rs
@@ -52,9 +52,9 @@ pub(crate) fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         global,
         frame,
         b"input.xml",
-        true,
-        true,
-        true,
+        super::BlobOrBufferInput::Bytes,
+        super::NullishInput::Throw,
+        super::StringInput::AsIs,
         |arena, log, source, source_encoding| {
             let encoding = match source_encoding {
                 super::SourceEncoding::Bytes => xml::InputEncoding::Bytes,

--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -1026,13 +1026,13 @@ fn is_inf_suffix(str: &BunString, i: usize) -> bool {
 
 #[bun_jsc::host_fn]
 pub(crate) fn parse(global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
-    // reject_nullish=false preserves YAML's coerce-undefined-to-"undefined" behavior.
+    // `NullishInput::ToString` preserves YAML's coerce-undefined-to-"undefined" behavior.
     super::with_text_format_source(
         global,
         call_frame,
         b"input.yaml",
-        true,
-        false,
+        super::BlobOrBufferInput::Bytes,
+        super::NullishInput::ToString,
         |arena, log, source| {
             // `ParserCtx::to_js` materializes each `E::Array`/`E::Object`
             // once by pointer identity, so a cyclic graph is fine here.

--- a/test/js/bun/jsonc/jsonc.test.ts
+++ b/test/js/bun/jsonc/jsonc.test.ts
@@ -140,6 +140,22 @@ test("Bun.JSONC.parse throws a SyntaxError on invalid input", () => {
   }
 });
 
+test("Bun.JSONC.parse throws on undefined and null input", () => {
+  expect(() => Bun.JSONC.parse(undefined as any)).toThrow("Expected a string to parse");
+  expect(() => (Bun.JSONC.parse as any)()).toThrow("Expected a string to parse");
+  expect(() => Bun.JSONC.parse(null as any)).toThrow("Expected a string to parse");
+});
+
+test("Bun.JSONC.parse stringifies non-string input like JSON.parse does", () => {
+  expect(Bun.JSONC.parse(42 as any)).toBe(42);
+  expect(Bun.JSONC.parse({ toString: () => "[1, 2,] // ok" } as any)).toEqual([1, 2]);
+  // A Buffer stringifies to its text; a Blob stringifies to "[object Blob]"
+  // rather than being read as bytes (unlike Bun.TOML.parse and friends).
+  expect(Bun.JSONC.parse(Buffer.from('{"a": 1, /* c */}') as any)).toEqual({ a: 1 });
+  expect(() => Bun.JSONC.parse(new Blob(['{"a": 1}']) as any)).toThrow(SyntaxError);
+  expect(() => JSON.parse(new Blob(['{"a": 1}']) as any)).toThrow(SyntaxError);
+});
+
 test("Bun.JSONC.parse SyntaxError names the actual error, not a preceding warning", () => {
   let thrown: unknown;
   try {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -317,6 +317,15 @@ development:
         });
       });
 
+      test("stringifies any other input instead of throwing, undefined and null included", () => {
+        // Unlike TOML/JSONC/JSON5/XML, YAML.parse(undefined) parses the text "undefined".
+        expect(YAML.parse(undefined as any)).toBe("undefined");
+        expect((YAML.parse as any)()).toBe("undefined");
+        expect(YAML.parse(null as any)).toBe(null);
+        expect(YAML.parse(42 as any)).toBe(42);
+        expect(YAML.parse({ toString: () => "a: 1" } as any)).toEqual({ a: 1 });
+      });
+
       test("complex nested structure from various input types", () => {
         const complexYaml = `
 version: "1.0"


### PR DESCRIPTION
### Problem
- `with_text_format_source` (`src/runtime/api.rs`) takes two positional bools, `accept_blob_or_buffer` and `reject_nullish`, and all four callers (`Bun.TOML.parse`, `Bun.JSONC.parse`, `Bun.JSON5.parse`, `Bun.YAML.parse`) pass bare literals for both. At `with_text_format_source(.., b"input.toml", true, true, ..)` nothing says which flag is which, and swapping them compiles.
- `with_text_format_source_encoded` adds a third bool, `string_passthrough`, and `Bun.XML.parse` calls it with `true, true, true`.
- These are the two `bare_bool_args` findings mordant has baselined for `src/runtime/api.rs`.

### Fix
- Each flag becomes a two-variant enum in `api.rs`, and every call site spells out what it sets:
  - `BlobOrBufferInput::{Bytes, ToString}` replaces `accept_blob_or_buffer` (JSONC is the one `ToString` caller).
  - `NullishInput::{Throw, ToString}` replaces `reject_nullish` (YAML is the one `ToString` caller).
  - `StringInput::{Utf8, AsIs}` replaces `string_passthrough` (XML is the one `AsIs` caller; the `with_text_format_source` wrapper passes `Utf8`).
- Enums rather than an options struct because the two helpers differ only in the string flag: the wrapper's closure is not told the encoding, so it must force `StringInput::Utf8` itself, and a separate parameter keeps that from being settable through the wrapper.
- The three `if` tests in the helper body compare against the enum instead of reading the bool; the values every caller passes are unchanged, so there is no behavior change.
- The `"bare_bool_args:src/runtime/api.rs" = 2` line is removed from `mordant-baseline.toml`.
- Tests, for the two call sites whose flag values differ from the rest and had no coverage:
  - `yaml.test.ts`: `YAML.parse` stringifies `undefined`, `null` and a missing argument instead of throwing (`NullishInput::ToString`).
  - `jsonc.test.ts`: `JSONC.parse` throws on nullish input, and stringifies everything else (a `Blob` included) rather than reading bytes (`BlobOrBufferInput::ToString`).
  - The other variants were already covered: nullish and `Buffer`/`Blob` tests in `toml.test.ts`, `json5.test.ts`, `xml.test.ts`; the `xml.test.ts` encodings block for `StringInput::AsIs`; Latin-1 range strings in `toml.test.ts` for the wrapper's `Utf8`.
  - This is a refactor, so the new tests pass before and after it; they guard against a call site picking the wrong variant later. What enforces the refactor itself is the removed baseline line: the `mordant` CI job fails if `bare_bool_args` fires in `api.rs` again.
- Verified:
  - `bun bd test` on `test/js/bun/{toml,jsonc,json5,yaml,xml}/*.test.ts`, `test/js/bun/resolve/toml/toml-parse.test.ts`, `test/js/bun/resolve/jsonc.test.ts` and the YAML regression tests: 4718 pass. Three stringify/leak-loop tests hit the 5s timeout under the local debug+ASAN build; two of them time out identically on an unmodified build and the third passes when run alone, and all three pass on main's CI (build 98374).
  - A script calling every format's `parse` with a string, `Buffer`, `Blob`, `undefined`, `null`, no argument, a number and a `toString` object, plus XML with Latin-1 and UTF-16 strings and declared-encoding buffers (46 cases, covering both values of all three flags), produces byte-identical output before and after (see below).
  - `rustfmt --check` on the touched files.
  - `bun run rust:mordant` with this baseline: nothing over the baseline, locally and in the `mordant` job on this PR. As a check that the local run was live, deleting the `types.rs` `bare_bool_args` line as well makes it report exactly those 4 findings and still nothing for `api.rs`.
  - `bun run rust:mordant:baseline` reproduces the committed file (the only other lines it dropped at the time have since been removed on main by their own PRs).

### Background
- `Bun.TOML.parse`, `Bun.JSONC.parse`, `Bun.JSON5.parse`, `Bun.YAML.parse` and `Bun.XML.parse` share one scaffold, `with_text_format_source`: it takes argument 0 of the call, turns it into bytes, and hands the bytes to a per-format closure that runs the parser and converts the result to JS. Outside the closure, the formats differ only in how argument 0 is treated, which is what these flags select.
- `BlobOrBufferInput`: whether a `Blob`, `ArrayBuffer`, typed array or `DataView` argument is parsed as bytes. JSONC mirrors `JSON.parse` and instead runs every non-string argument through JS `ToString` (so a `Buffer` still parses via `Buffer.prototype.toString`, while a `Blob` becomes `"[object Blob]"` and fails to parse).
- `NullishInput`: whether `undefined`/`null` (including a missing argument) throws `Expected a string to parse`. YAML instead stringifies them, so `Bun.YAML.parse()` returns the string `"undefined"` and `Bun.YAML.parse(null)` returns `null`.
- `StringInput`: whether a JS string is re-encoded to UTF-8 before parsing or handed over as its own Latin-1 bytes or UTF-16 code units along with a `SourceEncoding` tag. Only XML wants the latter, because a string is already-decoded text whose `encoding="..."` declaration must not be applied to it.
- mordant is the dylint pack run by `bun run rust:mordant` (pinned in `Cargo.toml`); `mordant-baseline.toml` records the pre-existing findings per lint and file, so fixing a site means deleting its line.

<details>
<summary>Before/after probe</summary>

Output of the probe script below is byte-identical on main (88a6398836) and with this change:

```
TOML string                                  ok  {"a":1}
TOML Buffer                                  ok  {"a":1}
TOML Blob                                    ok  {"a":1}
TOML undefined                               throws TypeError: Expected a string to parse
TOML null                                    throws TypeError: Expected a string to parse
TOML no args                                 throws TypeError: Expected a string to parse
TOML number                                  throws SyntaxError: TOML Parse error: Expected '=' after a key but found end of file
TOML toString object                         ok  {"a":1}
JSONC string                                 ok  {"a":1}
JSONC Buffer                                 ok  {"a":1}
JSONC Blob                                   throws SyntaxError: JSONC Parse error: Unexpected object
JSONC undefined                              throws TypeError: Expected a string to parse
JSONC null                                   throws TypeError: Expected a string to parse
JSONC no args                                throws TypeError: Expected a string to parse
JSONC number                                 ok  1
JSONC toString object                        ok  {"a":1}
JSON5 string                                 ok  {"a":1}
JSON5 Buffer                                 ok  {"a":1}
JSON5 Blob                                   ok  {"a":1}
JSON5 undefined                              throws TypeError: Expected a string to parse
JSON5 null                                   throws TypeError: Expected a string to parse
JSON5 no args                                throws TypeError: Expected a string to parse
JSON5 number                                 ok  1
JSON5 toString object                        ok  {"a":1}
YAML string                                  ok  {"a":1}
YAML Buffer                                  ok  {"a":1}
YAML Blob                                    ok  {"a":1}
YAML undefined                               ok  "undefined"
YAML null                                    ok  null
YAML no args                                 ok  "undefined"
YAML number                                  ok  1
YAML toString object                         ok  {"a":1}
XML string                                   ok  {"a":"1"}
XML Buffer                                   ok  {"a":"1"}
XML Blob                                     ok  {"a":"1"}
XML undefined                                throws TypeError: Expected a string to parse
XML null                                     throws TypeError: Expected a string to parse
XML no args                                  throws TypeError: Expected a string to parse
XML number                                   throws SyntaxError: XML Parse error: Expected the root element but found '1'
XML toString object                          ok  {"a":"1"}
XML latin1 string                            ok  {"d":{"@a":"café","#text":"naïve"}}
XML utf16 string                             ok  {"d":"🎉 é"}
XML latin1 string needing wider encoding     ok  {"d":"🎉"}
XML latin1 buffer                            ok  {"d":"é"}
XML utf8 buffer declared latin1 mismatch     throws SyntaxError: XML Parse error: Document is not UTF-16 but declares encoding 'UTF-16'
XML non-compact string                       ok  {"name":"a","attributes":{"x":"1"},"children":["t"]}
```

Probe script:

```js
// Exercises every input-handling flag of the Bun.{TOML,JSONC,JSON5,YAML,XML}.parse scaffold.
const out = {};
function probe(name, fn) {
  try {
    out[name] = { ok: fn() };
  } catch (e) {
    out[name] = { err: `${e.constructor.name}: ${e.message}` };
  }
}

const formats = {
  TOML: { text: 'a = 1', buf: Buffer.from('a = 1') },
  JSONC: { text: '{"a": 1 /* c */}', buf: Buffer.from('{"a": 1}') },
  JSON5: { text: "{a: 1}", buf: Buffer.from("{a: 1}") },
  YAML: { text: "a: 1", buf: Buffer.from("a: 1") },
  XML: { text: "<a>1</a>", buf: Buffer.from("<a>1</a>") },
};

for (const [fmt, { text, buf }] of Object.entries(formats)) {
  const api = Bun[fmt];
  probe(`${fmt} string`, () => api.parse(text));
  probe(`${fmt} Buffer`, () => api.parse(buf));
  probe(`${fmt} Blob`, () => api.parse(new Blob([buf])));
  probe(`${fmt} undefined`, () => api.parse(undefined));
  probe(`${fmt} null`, () => api.parse(null));
  probe(`${fmt} no args`, () => api.parse());
  probe(`${fmt} number`, () => api.parse(1));
  probe(`${fmt} toString object`, () => api.parse({ toString: () => text }));
}

// XML only: a JS string's own encoding declaration is ignored (string passthrough),
// while the same bytes in a Buffer are decoded per the declaration.
probe("XML latin1 string", () => Bun.XML.parse(`<?xml version="1.0" encoding="ISO-8859-1"?><d a="caf\xe9">na\xefve</d>`));
probe("XML utf16 string", () => Bun.XML.parse(`<?xml version="1.0" encoding="UTF-16"?><d>\u{1F389} \u00e9</d>`));
probe("XML latin1 string needing wider encoding", () => Bun.XML.parse(`<d>&#x1F389;</d>`));
probe("XML latin1 buffer", () =>
  Bun.XML.parse(Buffer.from(`<?xml version="1.0" encoding="ISO-8859-1"?><d>\xe9</d>`, "latin1")),
);
probe("XML utf8 buffer declared latin1 mismatch", () =>
  Bun.XML.parse(Buffer.from(`<?xml version="1.0" encoding="UTF-16"?><a/>`)),
);
probe("XML non-compact string", () => Bun.XML.parse("<a x='1'>t</a>", { compact: false }));

console.log(JSON.stringify(out, null, 1));
```

</details>
