### PR TITLE
HTMLRewriter: store each on() registration as one struct instead of two parallel vecs

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -70,7 +70,6 @@
 "field_valid_only_when:src/runtime/cli/filter_run.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
 "narrowed_two_ways:src/runtime/node/node_crypto_binding.rs" = 1
-"parallel_vecs:src/runtime/api/html_rewriter.rs" = 1
 "parallel_vecs:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
 "reimplemented_helper:src/runtime/ffi/abi_type.rs" = 1

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -200,19 +200,21 @@ macro_rules! lol_content_ops {
 
 // ───────────────────────────── LOLHTMLContext ─────────────────────────────
 
+/// One `on(selector, handlers)` registration.
+pub(crate) struct ElementHandlerEntry {
+    pub(crate) selector: lol_html::Selector,
+    // The `Box` is load-bearing (here and in `document_handlers`): the lol-html
+    // handler closures produced by `build_settings` capture raw pointers into
+    // the box interiors; unboxing would dangle them on `Vec` realloc.
+    pub(crate) handler: Box<ElementHandler>,
+}
+
 /// Selector + handler registry shared between an [`HTMLRewriter`] and every
 /// rewriter it spawns — `transform()` can run more than once, so
 /// [`build_settings`] re-derives fresh handler closures from it each time.
 #[derive(Default)]
 pub struct LOLHTMLContext {
-    /// Paired with `element_handlers` by index: each `on()` pushes one entry
-    /// into both.
-    pub(crate) selectors: Vec<lol_html::Selector>,
-    // The `Box` is load-bearing: the lol-html handler closures produced by
-    // `build_settings` capture raw pointers into the box interiors; unboxing
-    // would dangle them on `Vec` realloc.
-    #[expect(clippy::vec_box)]
-    pub(crate) element_handlers: Vec<Box<ElementHandler>>,
+    pub(crate) element_handlers: Vec<ElementHandlerEntry>,
     #[expect(clippy::vec_box)]
     pub(crate) document_handlers: Vec<Box<DocumentHandler>>,
 }
@@ -255,7 +257,7 @@ fn build_settings(
     Vec<lol_html::DocumentContentHandlers<'static>>,
 ) {
     let mut element_content_handlers = Vec::with_capacity(ctx.element_handlers.len());
-    for (selector, handler) in ctx.selectors.iter().zip(ctx.element_handlers.iter_mut()) {
+    for ElementHandlerEntry { selector, handler } in &mut ctx.element_handlers {
         let has_element = handler.on_element_callback.is_some();
         let has_comment = handler.on_comment_callback.is_some();
         let has_text = handler.on_text_callback.is_some();
@@ -372,12 +374,10 @@ impl HTMLRewriter {
         };
 
         let handler = Box::new(ElementHandler::init(global, listener)?);
-
-        // Invariant: `selectors[i]` pairs with `element_handlers[i]`; the two
-        // parallel vecs are zipped into lol-html `Settings` at transform time.
-        let mut ctx = self.context.borrow_mut();
-        ctx.selectors.push(selector);
-        ctx.element_handlers.push(handler);
+        self.context
+            .borrow_mut()
+            .element_handlers
+            .push(ElementHandlerEntry { selector, handler });
         Ok(call_frame.this())
     }
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2332,6 +2332,62 @@ it.each([
   await expect(res.text()).rejects.toThrow("Body already used");
 });
 
+// `on()` stores one (selector, handlers) record per call; `transform()` turns
+// the records collected so far into a fresh lol-html rewriter each time.
+describe("on() registrations", () => {
+  it("each selector runs the handlers it was registered with, also after a rejected on()", () => {
+    const rw = new HTMLRewriter();
+    const count = 24;
+    for (let i = 0; i < count; i++) {
+      if (i === count / 2) {
+        // Neither of these may leave a half-registered record behind, or the
+        // registrations after them would pair up with the wrong handlers.
+        expect(() => rw.on("p[", { element() {} })).toThrow();
+        expect(() => rw.on(`p[data-i="${i}"]`, { element: "not a function" })).toThrow("element must be a function");
+      }
+      if (i % 2 === 0) {
+        rw.on(`p[data-i="${i}"]`, { element: el => el.setInnerContent(`element ${i}`) });
+      } else {
+        rw.on(`p[data-i="${i}"]`, {
+          text(chunk) {
+            if (chunk.text) chunk.replace(`text ${i}`);
+          },
+        });
+      }
+    }
+
+    const indices = Array.from({ length: count }, (_, i) => count - 1 - i);
+    const input = indices.map(i => `<p data-i="${i}">x</p>`).join("");
+    const expected = indices.map(i => `<p data-i="${i}">${i % 2 === 0 ? "element" : "text"} ${i}</p>`).join("");
+    expect(rw.transform(input)).toBe(expected);
+    expect(rw.transform(input)).toBe(expected);
+  });
+
+  it("on() from inside a handler applies to the next transform, not the running one", () => {
+    const rw = new HTMLRewriter();
+    let grown = false;
+    rw.on("div", {
+      element(el) {
+        el.setInnerContent("div");
+        if (!grown) {
+          grown = true;
+          // Many more records than were registered before this transform
+          // started, so the registry has to grow while lol-html is still
+          // calling the handlers registered above and below.
+          for (let i = 0; i < 64; i++) {
+            rw.on("span", { element: span => span.setAttribute("n", String(i)) });
+          }
+        }
+      },
+    });
+    rw.on("span", { element: el => el.setInnerContent("span") });
+
+    const input = "<div>1</div><span>2</span><div>3</div><span>4</span>";
+    expect(rw.transform(input)).toBe("<div>div</div><span>span</span><div>div</div><span>span</span>");
+    expect(rw.transform(input)).toBe('<div>div</div><span n="63">span</span><div>div</div><span n="63">span</span>');
+  });
+});
+
 // lol-html reports an absent attribute with a NULL pointer and a
 // present-but-empty one with an empty string; they are not the same thing.
 describe("getAttribute distinguishes empty from absent", () => {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2342,7 +2342,7 @@ describe("on() registrations", () => {
       if (i === count / 2) {
         // Neither of these may leave a half-registered record behind, or the
         // registrations after them would pair up with the wrong handlers.
-        expect(() => rw.on("p[", { element() {} })).toThrow();
+        expect(() => rw.on("p[", { element() {} })).toThrow(expect.objectContaining({ name: "HTMLRewriterError" }));
         expect(() => rw.on(`p[data-i="${i}"]`, { element: "not a function" })).toThrow("element must be a function");
       }
       if (i % 2 === 0) {


### PR DESCRIPTION
### Problem
- `LOLHTMLContext` in `src/runtime/api/html_rewriter.rs` keeps two vecs, `selectors` and `element_handlers`, that describe one thing: entry `i` of each is the selector and the handler object from the same `rewriter.on(selector, handlers)` call.
- The pairing is only held up by convention: `on_()` pushes to both, `build_settings()` zips them back together, and a doc comment plus an invariant comment explain it. The mordant `parallel_vecs` lint flags this (the one baselined finding for this file).

### Fix
- Add `ElementHandlerEntry { selector, handler: Box<ElementHandler> }` and store `element_handlers: Vec<ElementHandlerEntry>`. One vec, one push in `on_()`, and `build_settings()` destructures each entry instead of zipping.
- No behavior change: the same values are pushed in the same order, the handler is still boxed (the lol-html closures built in `build_settings()` hold raw pointers into the box, so it must not move when the vec reallocates), and the body of the `build_settings()` loop is unchanged. The `#[expect(clippy::vec_box)]` comes off `element_handlers` because it is no longer a `Vec<Box<_>>`; `document_handlers` keeps its own.
- Remove the `parallel_vecs:src/runtime/api/html_rewriter.rs` line from `mordant-baseline.toml`.
- Tests, in `test/js/workerd/html-rewriter.test.js` (`on() registrations`), pin down the two things this storage has to get right. They pass before and after this change, since it is a refactor:
  - Many selectors registered on one rewriter, with two rejected `on()` calls in the middle, each still run the handlers they were registered with, on two transforms of the same rewriter.
  - `on()` called from inside a handler, often enough to reallocate the registry while lol-html is still calling the handlers registered before the transform started: the running transform is unaffected and the next one picks the additions up. With the `Box` removed from `ElementHandlerEntry` this test fails under ASAN with a heap-use-after-free (report in the details below), so the boxing is now covered rather than only commented.
- Verified:
  - `bun bd test` on `test/js/workerd/html-rewriter.test.js` (165 tests, including the new ones), `html-rewriter-end-error.test.ts`, `html-rewriter-leak.test.ts`, `test/js/web/html/html-rewriter-doctype.test.ts` and the HTMLRewriter regression tests: all pass.
  - `cargo clippy -p bun_runtime --no-deps`: clean.
  - `cargo dylint --all -p bun_runtime` with this baseline: nothing over the baseline. The same command with the baseline line removed but the source change stashed reports exactly the one `parallel_vecs` finding for this file, so the removed line is the one this change fixes.
  - Regenerating the baseline with `MORDANT_BASELINE_WRITE=1` also drops two entries this PR does not touch (`always_unwrapped_option:src/install/PackageInstall.rs`, `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs`); those findings were already fixed on main by other changes and are left for a separate cleanup.

### Background
- `HTMLRewriter.on(selector, handlers)` parses the CSS selector with lol-html and wraps the JS handler object in an `ElementHandler` (the protected `element`/`comments`/`text` callbacks). Nothing is handed to lol-html at that point; registrations are collected in `LOLHTMLContext`, which is shared by the rewriter and every transform it starts, because `transform()` can run more than once.
- `build_settings()` runs at transform time and turns each registration into a `(selector, ElementContentHandlers)` pair for lol-html. Its closures capture a `NonNull<ElementHandler>` pointing into the heap allocation owned by the `Box`, which is why the handler has to stay boxed even though clippy would normally suggest otherwise. An `on()` call after a transform has started (for example from inside a handler) pushes onto the same vec, which is what makes the reallocation case reachable from JS.
- `mordant-baseline.toml` is the ratchet for the mordant lint pack run by the Rust lints workflow: it records the accepted number of findings per (lint, file), and CI reports anything above those counts. Removing the line here means a reintroduction of the pattern in this file would be reported.

<details>
<summary>ASAN report from the new test with the Box removed from ElementHandlerEntry</summary>

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 8
    #3 <ElementHandler as HandlerLike>::global            src/runtime/api/html_rewriter.rs
    #4 handler_callback::<ElementHandler, Element, ...>   src/runtime/api/html_rewriter.rs
    #5 ElementHandler::on_element                         src/runtime/api/html_rewriter.rs
    #6 build_settings::{closure#0}                        src/runtime/api/html_rewriter.rs
    #8 lol_html ContentHandlersDispatcher::handle_start_tag
freed by thread T0 here:
    #13 RawVec<ElementHandlerEntry>::grow_one
    #15 Vec<ElementHandlerEntry>::push
    #16 HTMLRewriter::on_                                 src/runtime/api/html_rewriter.rs
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/workerd/html-rewriter.test.js

<!-- robobun:evidence:end -->