### PR TITLE
Drop the dead clone flag from Log::add_formatted_msg

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -1,6 +1,5 @@
 [bun_ast]
 "arg_named_like_other_param:src/ast/lib.rs" = 1
-"bare_bool_args:src/ast/lib.rs" = 1
 
 [bun_bundler]
 "arg_named_like_other_param:src/bundler/linker.rs" = 1

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -1534,7 +1534,6 @@ impl Log {
             },
             text,
             Box::default(),
-            true,
             false,
         )
     }
@@ -1613,23 +1612,21 @@ impl Log {
         r: Range,
         text: Cow<'static, [u8]>,
         notes: Box<[Data]>,
-        clone: bool,
-        redact: bool,
+        redact_sensitive_information: bool,
     ) {
         match kind {
             Kind::Err => self.errors += 1,
             Kind::Warn => self.warnings += 1,
             _ => {}
         }
-        let mut data = self.tracked_range_data(source, r, text);
-        if clone {
-            data = data.clone_line_text(self.clone_line_text);
-        }
+        let data = self
+            .tracked_range_data(source, r, text)
+            .clone_line_text(self.clone_line_text);
         self.add_msg(Msg {
             kind,
             data,
             notes,
-            redact_sensitive_information: redact,
+            redact_sensitive_information,
             ..Default::default()
         })
     }
@@ -1743,7 +1740,7 @@ impl Log {
         args: fmt::Arguments<'_>,
     ) {
         let text = alloc_print(args);
-        self.add_formatted_msg(Kind::Err, source, r, text, Box::default(), true, false)
+        self.add_formatted_msg(Kind::Err, source, r, text, Box::default(), false)
     }
 
     #[inline]
@@ -1755,7 +1752,7 @@ impl Log {
         args: fmt::Arguments<'_>,
     ) {
         let text = alloc_print(args);
-        self.add_formatted_msg(Kind::Err, source, r, text, notes, true, false)
+        self.add_formatted_msg(Kind::Err, source, r, text, notes, false)
     }
 
     #[inline]
@@ -1775,7 +1772,6 @@ impl Log {
             },
             text,
             Box::default(),
-            true,
             false,
         )
     }
@@ -1793,7 +1789,6 @@ impl Log {
             },
             text,
             Box::default(),
-            true,
             opts.redact_sensitive_information,
         )
     }
@@ -1857,7 +1852,6 @@ impl Log {
             },
             text,
             Box::default(),
-            true,
             false,
         )
     }
@@ -1921,7 +1915,7 @@ impl Log {
             return;
         }
         let text = alloc_print(args);
-        self.add_formatted_msg(Kind::Warn, source, r, text, Box::default(), true, false)
+        self.add_formatted_msg(Kind::Warn, source, r, text, Box::default(), false)
     }
 
     #[cold]
@@ -1959,7 +1953,7 @@ impl Log {
         args: fmt::Arguments<'_>,
     ) {
         let text = alloc_print(args);
-        self.add_formatted_msg(Kind::Warn, source, r, text, notes, true, false)
+        self.add_formatted_msg(Kind::Warn, source, r, text, notes, false)
     }
 
     #[cold]


### PR DESCRIPTION
### Problem
- mordant's `bare_bool_args` flags `Log::add_formatted_msg` (src/ast/lib.rs:1609): it takes `clone: bool` and `redact: bool`, and 7 of its 8 callers pass a bare `true, false`. This is the `bare_bool_args:src/ast/lib.rs` entry in mordant-baseline.toml.
- `clone` has never varied. Every caller has passed `true` since the helper was introduced (7e57e529bf, carried over unchanged by the Rust port), so the `if clone` branch is unconditional and the flag is dead.

### Fix
- Remove the `clone` parameter. `add_formatted_msg` now always runs `clone_line_text(self.clone_line_text)`, which is what every caller already got; the 8 call sites lose their `true` argument and nothing else.
- Rename the remaining parameter from `redact` to `redact_sensitive_information`, the `Msg` field it fills.
- No behavior change: the only removed branch was always taken. Nothing observable moves, so there is no new test that could tell before from after; what the helper now hard-codes (file name and line text copied out of the source, the redact flag reaching the message, counters per kind) is exercised by the suites below.
- The lint only considers functions with two or more bool parameters, so with one bool left the finding goes away by itself; the baseline entry is deleted instead of introducing an enum for a flag that was never switched.
- Verification:
  - `cargo dylint --all -p bun_ast` against the trimmed baseline: clean with this change. With the original src/ast/lib.rs it reports the finding at lib.rs:1609 (`bun_ast 1` in over-baseline.txt), so the deleted entry was this function.
  - `bun run rust:mordant` over the whole workspace from a clean target: no warnings, no target/mordant/over-baseline.txt.
  - `bun run rust:mordant:baseline` regenerates the file with this line removed. It also drops two entries this PR does not touch, which went stale on their own after the counts were recorded in 39fb3c103e: `always_unwrapped_option:src/install/PackageInstall.rs` (the `walker: Option` removed by #38271) and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs` (#37648). 3542216ceb only renamed keys, so it kept both. They are left in place here to keep this PR to the one finding; a stale entry is harmless to the ratchet.
  - `bun bd test test/js/bun/transpiler/parse-error-column.test.ts test/js/bun/transpiler/transpiler-error-gc-uaf.test.ts test/cli/install/redacted-config-logs.test.ts`: 24 pass (parser errors with line text, `Log.to_js`, and the one caller that passes a non-literal redact flag).
  - `bun bd test test/bundler/bundler_edgecase.test.ts`: 134 pass (bundler errors and warnings, the path with `Log.clone_line_text` set).
  - `bun bd test test/bundler/bundler_allow_unresolved.test.ts`: 16 pass.
  - `bun bd test test/bundler/bun-build-api.test.ts`: 52 pass. "Bun.build can be called thousands of times in one process" hit its 180s timeout under the debug/ASAN build in the container used here; every build in it succeeds, so it never emits a diagnostic and does not reach this function.

### Background
- `Log` (src/ast/lib.rs) collects parser, resolver and bundler diagnostics as `Msg` values. The `add_*_fmt` wrappers format their message and call `add_formatted_msg`, a shared out-of-line tail that bumps the error or warning counter, builds the `Data` (message text plus source location) and pushes the `Msg`.
- `Data::clone_line_text(should)` returns a deep copy of the `Data`, so the message no longer borrows anything from the `Source` (the bundler frees its arena-allocated sources before diagnostics are printed). `should` comes from the per-log `Log.clone_line_text` setting, which the bundler turns on; in the Rust port both arms deep-copy, because `Location`'s `Clone` already duplicates the file name and line text. The removed `clone` parameter was a second, per-call switch over whether that step runs at all, and nothing ever turned it off.
- mordant is the Rust lint pack behind `bun run rust:mordant`. mordant-baseline.toml records the pre-existing finding count per (lint, file) so CI only fails on new findings; fixing a finding means deleting its entry.
