### PR TITLE
shell(cat): map Step to a Yield in one place

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -63,7 +63,6 @@
 "same_match_twice:src/runtime/cli/update_interactive_command.rs" = 2
 "same_match_twice:src/runtime/server/RequestContext.rs" = 4
 "same_match_twice:src/runtime/server/server_body.rs" = 1
-"same_match_twice:src/runtime/shell/builtin/cat.rs" = 1
 "same_match_twice:src/runtime/webcore/Blob.rs" = 2
 "same_match_twice:src/runtime/webcore/Body.rs" = 2
 "unchecked_construction:src/runtime/api/js_bundle_completion_task.rs" = 1

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -46,6 +46,16 @@ pub(crate) enum Step {
     Next,
 }
 
+impl Step {
+    fn run(self, interp: &Interpreter, cmd: NodeId) -> Yield {
+        match self {
+            Step::Suspend => Yield::suspended(),
+            Step::Done(code) => Builtin::done(interp, cmd, code),
+            Step::Next => Cat::next(interp, cmd),
+        }
+    }
+}
+
 impl Cat {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
         let mut opts = Opts::default();
@@ -300,11 +310,7 @@ impl Cat {
             CatState::WaitingWriteErr => Step::Done(1),
             _ => panic!("Invalid state"),
         };
-        match step {
-            Step::Suspend => Yield::suspended(),
-            Step::Done(code) => Builtin::done(interp, cmd, code),
-            Step::Next => Self::next(interp, cmd),
-        }
+        step.run(interp, cmd)
     }
 
     pub(crate) fn on_io_reader_chunk(
@@ -394,11 +400,7 @@ impl Cat {
                 fd.writer.cancel_chunks(wchild);
             }
         }
-        match step {
-            Step::Suspend => Yield::suspended(),
-            Step::Done(code) => Builtin::done(interp, cmd, code),
-            Step::Next => Self::next(interp, cmd),
-        }
+        step.run(interp, cmd)
     }
 }
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -560,17 +560,16 @@ describe("bunshell", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
+    // On Windows the message carries the absolute path (shell_openat only
+    // re-tags the error with the argument as written on POSIX).
+    const missingFileError = expect.stringMatching(/^cat: (.*[\\/])?missing\.txt: No such file or directory\n$/);
     expect(JSON.parse(stdout)).toEqual({
       "captured": { stdout: "hi\n", stderr: "", exitCode: 0 },
       "stdout to fd": { stdout: "", stderr: "", exitCode: 0 },
-      "missing file, stderr captured": {
-        stdout: "",
-        stderr: "cat: missing.txt: No such file or directory\n",
-        exitCode: 1,
-      },
+      "missing file, stderr captured": { stdout: "", stderr: missingFileError, exitCode: 1 },
       "missing file, stderr to fd": { stdout: "", stderr: "", exitCode: 1 },
       "out.txt": "hi\n",
-      "err.txt": "cat: missing.txt: No such file or directory\n",
+      "err.txt": missingFileError,
     });
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -528,6 +528,53 @@ describe("bunshell", () => {
     expect(stdout.toString()).toEqual("LMAO\n");
   });
 
+  // The builtin cat is only on by default on Windows; the flag turns it on
+  // everywhere. Captured output finishes the command from the reader side,
+  // output on a real fd also goes through the writer completions, and the
+  // missing-file case with stderr on a fd finishes from the writer side alone.
+  test("builtin cat finishes from its reader and writer completions", async () => {
+    using dir = tempDir("builtin-cat", {});
+    const script = /* ts */ `
+      import { $ } from "bun";
+      $.nothrow();
+      const results = {};
+      for (const [name, run] of Object.entries({
+        "captured": () => $\`echo hi | cat\`,
+        "stdout to fd": () => $\`echo hi | cat > out.txt\`,
+        "missing file, stderr captured": () => $\`cat missing.txt\`,
+        "missing file, stderr to fd": () => $\`cat missing.txt 2> err.txt\`,
+      })) {
+        const r = await run().quiet();
+        results[name] = { stdout: r.stdout.toString(), stderr: r.stderr.toString(), exitCode: r.exitCode };
+      }
+      results["out.txt"] = await Bun.file("out.txt").text();
+      results["err.txt"] = await Bun.file("err.txt").text();
+      console.log(JSON.stringify(results));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      "captured": { stdout: "hi\n", stderr: "", exitCode: 0 },
+      "stdout to fd": { stdout: "", stderr: "", exitCode: 0 },
+      "missing file, stderr captured": {
+        stdout: "",
+        stderr: "cat: missing.txt: No such file or directory\n",
+        exitCode: 1,
+      },
+      "missing file, stderr to fd": { stdout: "", stderr: "", exitCode: 1 },
+      "out.txt": "hi\n",
+      "err.txt": "cat: missing.txt: No such file or directory\n",
+    });
+    expect(exitCode).toBe(0);
+  });
+
   describe("operators no spaces", async () => {
     TestBuilder.command`echo LMAO|cat`.stdout("LMAO\n").runAsTest("pipeline");
     TestBuilder.command`echo foo&&echo hi`.stdout("foo\nhi\n").runAsTest("&&");


### PR DESCRIPTION
### Problem
- `Cat::on_io_writer_chunk` and `Cat::on_io_reader_done` (src/runtime/shell/builtin/cat.rs:303 and :397 before this change) both end with the same three-arm `match` turning a `Step` into a `Yield`. A change to one copy would miss the other.
- This is the `same_match_twice:src/runtime/shell/builtin/cat.rs` entry in `mordant-baseline.toml`.

### Fix
- Add `Step::run(self, interp, cmd) -> Yield` holding the one mapping; both callbacks now end with `step.run(interp, cmd)`.
- No behavior change: the arms are the ones that were there (`Suspend` -> `Yield::suspended()`, `Done(code)` -> `Builtin::done`, `Next` -> `Cat::next`), only the location moved. `Step` is private to cat.rs, so nothing else is affected.
- Remove the now-fixed entry from `mordant-baseline.toml`.
- Add a test to test/js/bun/shell/bunshell.test.ts ("builtin cat finishes from its reader and writer completions") that runs the builtin with captured output, with stdout on a file, and on a missing file with stderr captured and on a file. Instrumenting `Step::run` locally showed these go through `on_io_reader_done` -> `Done(0)`, `on_io_writer_chunk` -> `Suspend` then `on_io_reader_done` -> `Done(0)`, and `on_io_writer_chunk` -> `Done(1)`. It is a characterization test for the refactor: it passes before and after this change (`USE_SYSTEM_BUN=1` and `bun bd`), it does not fail without it.
- The missing-file assertions accept the message with or without a directory prefix: on Windows the file branch of `shell_openat` leaves the resolved absolute path in the error, so the builtin prints `cat: C:\...\missing.txt: ...` where POSIX prints `cat: missing.txt: ...` (seen on both Windows lanes of the first run of this test). That inconsistency is pre-existing and filed separately rather than fixed here.
- Verified:
  - `bun bd test test/js/bun/shell/bunshell.test.ts`: 424 pass, 0 fail. Note that on POSIX the builtin is only used when `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS` is set (`Kind::DISABLED_ON_POSIX`), so on Linux only the new test and the flagged case in yield.test.ts run cat.rs; the rest of the shell suite exercises it on the Windows lanes, where the builtin is always on.
  - `bun bd test` on file-io, yield, shell-write-fault, shell-pipe-read-fault, exec, assignments-in-pipeline, bunshell-instance: all pass.
  - `bun run rust:mordant` with this diff: no findings, `target/mordant/over-baseline.txt` not written. As a control, the same command with cat.rs reverted and the baseline entry still removed reports the cat.rs:397 finding as 1 over baseline in bun_runtime.
- The `Next` arm is not reachable from the new test on POSIX: reading a regular file through the builtin currently fails there (epoll rejects regular files), which is what #35337 fixes. #35337 and #37743 also edit the tail of these two callbacks, so whichever of those and this lands later needs a one-line rebase in cat.rs.

### Background
- The cat builtin is a small state machine driven by IOReader/IOWriter callbacks. Each callback mutates `CatState` under a `&mut` borrow and produces a `Step` (suspend, finish with an exit code, or move to the next file), then acts on it after the borrow is released; `Step::run` is that second half.
- mordant is the advisory Rust lint pack run by `bun run rust:mordant`; `mordant-baseline.toml` holds per-(lint, file) counts of pre-existing findings, and a fixed finding's entry is deleted so the ratchet tightens.

<details>
<summary>Local leak.test.ts note</summary>

`bun bd test test/js/bun/shell/leak.test.ts` in this (debug + ASAN) environment times out the 500-iteration `memleak_*` cases at their 100s limit, including ones that never run cat (`memleak_change_cwd`, `memleak_redirect_file`, `memleak_ls`, `memleak_Blob_*`); the 100-iteration cases and the 1000-iteration `fdleak_*` cases pass. The timeouts are machine speed, not this change (and on Linux those tests run the system cat anyway, see above).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->