### PR TITLE
node:http2: pass SendDataOptions to send_data instead of three bools

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -18,7 +18,6 @@
 "tuple_wants_struct:src/css/values/color.rs" = 5
 
 [bun_install]
-"always_unwrapped_option:src/install/PackageInstall.rs" = 1
 "arg_named_like_other_param:src/install/PackageManager/PackageJSONEditor.rs" = 3
 "arg_named_like_other_param:src/install/resolution.rs" = 1
 "bare_bool_args:src/install/isolated_install.rs" = 1
@@ -55,7 +54,6 @@
 "arg_named_like_other_param:src/runtime/cli/pack_command.rs" = 1
 "arg_named_like_other_param:src/runtime/node/path.rs" = 2
 "bare_bool_args:src/runtime/api.rs" = 2
-"bare_bool_args:src/runtime/api/bun/h2_frame_parser.rs" = 1
 "bare_bool_args:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "bare_bool_args:src/runtime/cli/run_command.rs" = 1
 "bare_bool_args:src/runtime/dns_jsc/dns.rs" = 1
@@ -69,7 +67,6 @@
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/cli/filter_run.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
-"narrowed_two_ways:src/runtime/node/node_crypto_binding.rs" = 1
 "parallel_vecs:src/runtime/api/html_rewriter.rs" = 1
 "parallel_vecs:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1135,18 +1135,10 @@ enum BatchSegment {
 /// Flags for one `H2FrameParser::send_data` call.
 #[derive(Clone, Copy)]
 struct SendDataOptions {
-    /// End the stream after the payload: END_STREAM on the last DATA frame, or, while the
-    /// stream is waiting for trailers, an onWantTrailers dispatch instead.
     close: bool,
-    /// Skip the HALF_CLOSED_LOCAL onStreamEnd dispatch: the synchronous caller (writeStream)
-    /// hands the settled state to JS via its return value instead of re-entering the VM
-    /// mid-host-call.
+    /// Report a HALF_CLOSED_LOCAL transition through the return value instead of onStreamEnd.
     suppress_half_closed_local_dispatch: bool,
-    /// When the payload is handed to the socket without being queued (no flow-control /
-    /// socket backpressure), do not invoke the write callback here; report it as deferred so
-    /// the JS caller completes it asynchronously and a node Writable's `_write` callback never
-    /// settles synchronously inside `write()`. A queued payload keeps its callback with the
-    /// engine either way: it runs once the queued frames are flushed.
+    /// Hand an unqueued payload's write callback back to the caller instead of invoking it here.
     defer_write_callback: bool,
 }
 
@@ -7482,10 +7474,8 @@ impl H2FrameParser {
         ))
     }
 
-    /// Returns `(settled_state, callback_deferred)`: the state code the close tail settled on
-    /// (5 = HALF_CLOSED_LOCAL, 7 = CLOSED, 0 = no close-tail transition ran), and whether
-    /// `callback` was left for the caller to complete (see
-    /// `SendDataOptions::defer_write_callback`).
+    /// Returns `(settled_state, callback_deferred)`: the state the close tail settled on (5 =
+    /// HALF_CLOSED_LOCAL, 7 = CLOSED, 0 = none) and whether `callback` was left to the caller.
     fn send_data(
         &self,
         stream: &mut Stream,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1132,6 +1132,23 @@ enum BatchSegment {
     Ext { ptr: *const u8, len: u32 },
 }
 
+/// Flags for one `H2FrameParser::send_data` call.
+struct SendDataOptions {
+    /// End the stream after the payload: END_STREAM on the last DATA frame, or, while the
+    /// stream is waiting for trailers, an onWantTrailers dispatch instead.
+    close: bool,
+    /// Skip the HALF_CLOSED_LOCAL onStreamEnd dispatch: the synchronous caller (writeStream)
+    /// hands the settled state to JS via its return value instead of re-entering the VM
+    /// mid-host-call.
+    suppress_half_closed_local_dispatch: bool,
+    /// When the payload is handed to the socket without being queued (no flow-control /
+    /// socket backpressure), do not invoke the write callback here; report it as deferred so
+    /// the JS caller completes it asynchronously and a node Writable's `_write` callback never
+    /// settles synchronously inside `write()`. A queued payload keeps its callback with the
+    /// engine either way: it runs once the queued frames are flushed.
+    defer_write_callback: bool,
+}
+
 struct DispatchGuard<'a>(&'a Cell<u32>);
 
 impl Drop for DispatchGuard<'_> {
@@ -7464,29 +7481,22 @@ impl H2FrameParser {
         ))
     }
 
-    /// Returns `(settled_state, callback_deferred)`.
-    ///
-    /// `settled_state` is the state code the close tail settled on (5 = HALF_CLOSED_LOCAL,
-    /// 7 = CLOSED, 0 = no close-tail transition ran). With
-    /// `suppress_half_closed_local_dispatch` the HALF_CLOSED_LOCAL onStreamEnd dispatch
-    /// is skipped — the synchronous caller (writeStream) hands the state to JS via its
-    /// return value instead of re-entering the VM mid-host-call.
-    ///
-    /// With `defer_write_callback`, when the payload is handed to the socket without being
-    /// queued (no flow-control / socket backpressure) the write callback is NOT invoked here:
-    /// `callback_deferred` is true and the JS caller completes it asynchronously instead, so a
-    /// node Writable's `_write` callback never settles synchronously inside `write()`. When the
-    /// payload is queued, the engine still owns the callback and invokes it once the queued
-    /// frames are flushed (backpressure cleared), exactly as before.
+    /// Returns `(settled_state, callback_deferred)`: the state code the close tail settled on
+    /// (5 = HALF_CLOSED_LOCAL, 7 = CLOSED, 0 = no close-tail transition ran), and whether
+    /// `callback` was left for the caller to complete (see
+    /// `SendDataOptions::defer_write_callback`).
     fn send_data(
         &self,
         stream: &mut Stream,
         payload: &[u8],
-        close: bool,
         callback: JSValue,
-        suppress_half_closed_local_dispatch: bool,
-        defer_write_callback: bool,
+        options: SendDataOptions,
     ) -> (u8, bool) {
+        let SendDataOptions {
+            close,
+            suppress_half_closed_local_dispatch,
+            defer_write_callback,
+        } = options;
         bun_output::scoped_log!(
             H2FrameParser,
             "HTTP_FRAME_DATA {} sendData({}, {}, {})",
@@ -7748,7 +7758,16 @@ impl H2FrameParser {
         let stream = unsafe { &mut *stream };
 
         stream.wait_for_trailers = false;
-        let _ = this.send_data(stream, b"", true, JSValue::UNDEFINED, false, false);
+        let _ = this.send_data(
+            stream,
+            b"",
+            JSValue::UNDEFINED,
+            SendDataOptions {
+                close: true,
+                suppress_half_closed_local_dispatch: false,
+                defer_write_callback: false,
+            },
+        );
         Ok(JSValue::UNDEFINED)
     }
 
@@ -8280,10 +8299,12 @@ impl H2FrameParser {
         let (settled_state, callback_deferred) = this.send_data(
             &mut stream,
             &payload,
-            close,
             callback_arg,
-            true,
-            defer_callback_arg.to_boolean(),
+            SendDataOptions {
+                close,
+                suppress_half_closed_local_dispatch: true,
+                defer_write_callback: defer_callback_arg.to_boolean(),
+            },
         );
 
         // 5 = HALF_CLOSED_LOCAL: the JS caller runs markWritableDone itself instead of

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1133,6 +1133,7 @@ enum BatchSegment {
 }
 
 /// Flags for one `H2FrameParser::send_data` call.
+#[derive(Clone, Copy)]
 struct SendDataOptions {
     /// End the stream after the payload: END_STREAM on the last DATA frame, or, while the
     /// stream is waiting for trailers, an onWantTrailers dispatch instead.

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4720,6 +4720,82 @@ it("end(chunk) on a HALF_CLOSED_REMOTE stream still emits 'finish'", async () =>
   }
 });
 
+it("write() completes its callback on a later turn, not inside write()", async () => {
+  // _write hands the chunk to the native session with the write callback deferred, so the
+  // chunk is still counted in writableLength when write() returns and the Writable settles it
+  // later, like node, where a write only completes once the session has flushed it. Were the
+  // callback invoked inside the native call, writableLength would already be 0 here.
+  const server = http2.createServer();
+  try {
+    const lengths = Promise.withResolvers();
+    server.on("stream", async stream => {
+      try {
+        stream.respond({ ":status": 200 });
+        const chunk = Buffer.from("hello");
+        const written = new Promise((resolve, reject) => stream.write(chunk, err => (err ? reject(err) : resolve())));
+        const afterWrite = stream.writableLength;
+        await written;
+        lengths.resolve({ afterWrite, afterCallback: stream.writableLength });
+        stream.end();
+      } catch (err) {
+        lengths.reject(err);
+      }
+    });
+    const port = await new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
+    const client = http2.connect(`http://127.0.0.1:${port}`);
+    client.on("error", lengths.reject);
+    const req = client.request({ ":path": "/" });
+    req.on("error", lengths.reject);
+    const body = new Promise(resolve => {
+      const chunks = [];
+      req.on("data", chunk => chunks.push(chunk));
+      req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    });
+    req.end();
+    expect(await lengths.promise).toEqual({ afterWrite: 5, afterCallback: 0 });
+    expect(await body).toBe("hello");
+    client.close();
+  } finally {
+    server.close();
+  }
+});
+
+it("sendTrailers({}) ends the stream without a trailer block", async () => {
+  // An empty trailer object ends the stream with an empty END_STREAM DATA frame rather than a
+  // HEADERS frame: the peer sees the body end and no 'trailers' event, and the stream closes
+  // cleanly on both sides.
+  const server = http2.createServer();
+  try {
+    const serverClose = Promise.withResolvers();
+    server.on("stream", stream => {
+      stream.on("error", serverClose.reject);
+      stream.on("wantTrailers", () => stream.sendTrailers({}));
+      stream.on("close", () => serverClose.resolve(stream.rstCode));
+      stream.respond({ ":status": 200 }, { waitForTrailers: true });
+      stream.end("OK");
+    });
+    const port = await new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
+    const client = http2.connect(`http://127.0.0.1:${port}`);
+    client.on("error", serverClose.reject);
+    const req = client.request({ ":path": "/" });
+    req.on("error", serverClose.reject);
+    const trailerEvents = [];
+    req.on("trailers", headers => trailerEvents.push(headers));
+    const body = new Promise(resolve => {
+      const chunks = [];
+      req.on("data", chunk => chunks.push(chunk));
+      req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    });
+    req.end();
+    expect(await body).toBe("OK");
+    expect(await serverClose.promise).toBe(0);
+    expect(trailerEvents).toEqual([]);
+    client.close();
+  } finally {
+    server.close();
+  }
+});
+
 it("client connects over a user Duplex that already has a 'data' listener", async () => {
   // A 'data' listener attached before connect() puts the stream in flowing mode, so the
   // peer's first frames can arrive before the connect callback has run. The preface must

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4726,6 +4726,7 @@ it("write() completes its callback on a later turn, not inside write()", async (
   // later, like node, where a write only completes once the session has flushed it. Were the
   // callback invoked inside the native call, writableLength would already be 0 here.
   const server = http2.createServer();
+  let client;
   try {
     const lengths = Promise.withResolvers();
     server.on("stream", async stream => {
@@ -4742,20 +4743,19 @@ it("write() completes its callback on a later turn, not inside write()", async (
       }
     });
     const port = await new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
-    const client = http2.connect(`http://127.0.0.1:${port}`);
+    client = http2.connect(`http://127.0.0.1:${port}`);
     client.on("error", lengths.reject);
     const req = client.request({ ":path": "/" });
-    req.on("error", lengths.reject);
-    const body = new Promise(resolve => {
+    const body = new Promise((resolve, reject) => {
       const chunks = [];
+      req.on("error", reject);
       req.on("data", chunk => chunks.push(chunk));
       req.on("end", () => resolve(Buffer.concat(chunks).toString()));
     });
     req.end();
-    expect(await lengths.promise).toEqual({ afterWrite: 5, afterCallback: 0 });
-    expect(await body).toBe("hello");
-    client.close();
+    expect(await Promise.all([lengths.promise, body])).toEqual([{ afterWrite: 5, afterCallback: 0 }, "hello"]);
   } finally {
+    client?.close();
     server.close();
   }
 });
@@ -4765,6 +4765,7 @@ it("sendTrailers({}) ends the stream without a trailer block", async () => {
   // HEADERS frame: the peer sees the body end and no 'trailers' event, and the stream closes
   // cleanly on both sides.
   const server = http2.createServer();
+  let client;
   try {
     const serverClose = Promise.withResolvers();
     server.on("stream", stream => {
@@ -4775,23 +4776,22 @@ it("sendTrailers({}) ends the stream without a trailer block", async () => {
       stream.end("OK");
     });
     const port = await new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
-    const client = http2.connect(`http://127.0.0.1:${port}`);
+    client = http2.connect(`http://127.0.0.1:${port}`);
     client.on("error", serverClose.reject);
     const req = client.request({ ":path": "/" });
-    req.on("error", serverClose.reject);
     const trailerEvents = [];
     req.on("trailers", headers => trailerEvents.push(headers));
-    const body = new Promise(resolve => {
+    const body = new Promise((resolve, reject) => {
       const chunks = [];
+      req.on("error", reject);
       req.on("data", chunk => chunks.push(chunk));
       req.on("end", () => resolve(Buffer.concat(chunks).toString()));
     });
     req.end();
-    expect(await body).toBe("OK");
-    expect(await serverClose.promise).toBe(0);
+    expect(await Promise.all([body, serverClose.promise])).toEqual(["OK", 0]);
     expect(trailerEvents).toEqual([]);
-    client.close();
   } finally {
+    client?.close();
     server.close();
   }
 });


### PR DESCRIPTION
### Problem
- mordant's `bare_bool_args` flags `H2FrameParser::send_data` in `src/runtime/api/bun/h2_frame_parser.rs`: it takes `close: bool`, `suppress_half_closed_local_dispatch: bool` and `defer_write_callback: bool`, and `no_trailers` calls it as `send_data(stream, b"", true, JSValue::UNDEFINED, false, false)`, where nothing says which flag is which (the other caller, `write_stream`, passes a bare `true` for the middle one).
- The three flags are independent: `close` is data (it flows on into `queue_frame`'s `end_stream` and the END_STREAM flag), while the other two select how the result is reported to the caller, so they do not collapse into one enum.

### Fix
- The three flags move into a `SendDataOptions` struct (`Copy`, it is three bools), which both callers build as a struct literal, so each call names what it sets. `send_data` destructures it on entry and the body is unchanged; `payload` and `callback` stay positional. `send_data`'s doc comment shrinks to the meaning of its return tuple; the two reporting modes were already explained at the `write_stream` call site and on `WRITE_FLUSHED_WITHOUT_CALLBACK`, so the fields just name them.
- No behavior change: both calls pass the same values as before, in named form.
- Two tests in `test/js/node/http2/node-http2.test.js` pin the flags the two callers set, which is the mistake this change is meant to make impossible (neither path had coverage in this file; they pass before and after, as a refactor's tests should): `write()` leaves its chunk in `writableLength` until the deferred write callback runs (`write_stream`'s `defer_write_callback`), and `sendTrailers({})` ends the stream with END_STREAM and no trailer block (`no_trailers`'s `close`). Inverting `close` in `no_trailers` makes the second test time out waiting for 'end'; inverting `defer_write_callback` in `write_stream` makes the first one see `writableLength` already 0 when `write()` returns.
- The `bare_bool_args:src/runtime/api/bun/h2_frame_parser.rs` entry is removed from `mordant-baseline.toml`: the file was regenerated with `bun run rust:mordant:baseline` at the pinned mordant revision. The regeneration also drops two entries whose findings were already fixed on main after the baseline was recorded, `always_unwrapped_option:src/install/PackageInstall.rs` (gone since #38271 / #38841 touched that file) and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs` (gone since #37648). Happy to trim the file back to just the h2 line if you would rather keep this PR to one entry.
- Verified with `bun bd`:
  - `bun bd test test/js/node/http2/node-http2.test.js`: the two new tests pass (and also pass on the unmodified binary, as expected); the full file before they were added: 349 pass, 6 skip. The 8 failures are the `describe.concurrent` block "DATA payload survives its ArrayBuffer being detached/resized" hitting its 5s per-test timeout in this debug+ASAN container; the same 9 tests pass when the block is run on its own (each takes 2.4s to 3.9s alone).
  - `bun bd test test/js/node/http2/h2-conformance.test.ts`: 67 pass.
  - 27 `test/js/node/test/parallel/test-http2-*.js` scripts covering trailers, `noTrailers`, write callbacks, empty and zero-length writes, backpressure and flow control, each run with the debug binary: all exit 0.
  - `cargo clippy -p bun_runtime --no-deps`: clean (the first push failed CI's `needless_pass_by_value` until the struct derived `Copy`).
  - `bun run rust:mordant` against the regenerated baseline: with the old `send_data` it reports exactly one finding over the baseline, this `bare_bool_args` at `h2_frame_parser.rs:7481` (`target/mordant/over-baseline.txt` contains `bun_runtime 1`); with this change it reports nothing and that file is not written.

### Background
- `H2FrameParser` is the native side of `node:http2`. `send_data` writes one stream's DATA payload, splitting it into frames and either handing the frames to the socket or queueing them when flow control or socket backpressure blocks the write.
- `write_stream` is the host function behind a stream's `_write`; it returns the stream state it settled on to JS instead of having the engine dispatch `onStreamEnd` back into JS in the middle of the call, and it can ask for the write callback to be left to JS (`defer_write_callback`) so a Writable's callback never completes synchronously inside `write()`. `no_trailers` sends the empty END_STREAM frame once JS decides not to send trailers, and wants the normal dispatch.
- `mordant-baseline.toml` is the ratchet for the mordant lint pack: it records per-(lint, file) counts of the findings that predate the job, so CI fails only on new findings. Clearing a site means deleting or decrementing its entry.
