### PR TITLE
jsc: name the line:column flag at source_url_formatter call sites

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -36,7 +36,6 @@
 "parallel_vecs:src/js_printer/lib.rs" = 1
 
 [bun_jsc]
-"bare_bool_args:src/jsc/ZigStackFrame.rs" = 1
 "defaulted_failure:src/jsc/ConsoleObject.rs" = 4
 "narrowed_two_ways:src/jsc/RuntimeTranspilerCache.rs" = 1
 "reimplemented_helper:src/jsc/webcore_types.rs" = 1

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5361,6 +5361,7 @@ impl VirtualMachine {
         trace: &crate::ZigStackTrace,
         allow_ansi_colors: bool,
     ) -> crate::CrateResult<()> {
+        use crate::zig_stack_frame::LineColumn;
         let stack = trace.frames();
         if stack.is_empty() {
             return Ok(());
@@ -5406,12 +5407,12 @@ impl VirtualMachine {
                 pretty_write!(
                     "<r>      <d>at <r>{}<d> (<r>{}<d>)<r>\n",
                     frame.name_formatter(allow_ansi_colors),
-                    frame.source_url_formatter(dir, origin, false, allow_ansi_colors)
+                    frame.source_url_formatter(dir, origin, LineColumn::Include, allow_ansi_colors)
                 )?;
             } else if !frame.position.is_invalid() {
                 pretty_write!(
                     "<r>      <d>at <r>{}\n",
-                    frame.source_url_formatter(dir, origin, false, allow_ansi_colors)
+                    frame.source_url_formatter(dir, origin, LineColumn::Include, allow_ansi_colors)
                 )?;
             } else if has_name {
                 pretty_write!(
@@ -5421,7 +5422,7 @@ impl VirtualMachine {
             } else {
                 pretty_write!(
                     "<r>      <d>at <r>{}<d>\n",
-                    frame.source_url_formatter(dir, origin, false, allow_ansi_colors)
+                    frame.source_url_formatter(dir, origin, LineColumn::Include, allow_ansi_colors)
                 )?;
             }
         }
@@ -6588,6 +6589,7 @@ impl VirtualMachine {
     #[cold]
     #[inline(never)]
     pub(crate) fn print_github_annotation(exception: &ZigException) {
+        use crate::zig_stack_frame::LineColumn;
         let name = &exception.name;
         let message = &exception.message;
         let frames = exception.stack.frames();
@@ -6677,7 +6679,7 @@ impl VirtualMachine {
                     let _ = write!(
                         loc_str,
                         "{}",
-                        frame.source_url_formatter(file, origin, false, false)
+                        frame.source_url_formatter(file, origin, LineColumn::Include, false)
                     );
                     (name_str, loc_str)
                 };

--- a/src/jsc/ZigStackFrame.rs
+++ b/src/jsc/ZigStackFrame.rs
@@ -52,7 +52,7 @@ impl ZigStackFrame {
             write!(
                 &mut file,
                 "{}",
-                self.source_url_formatter(root_path, origin, true, false)
+                self.source_url_formatter(root_path, origin, LineColumn::Exclude, false)
             )
             .expect("Vec<u8> write is infallible");
         }
@@ -88,12 +88,12 @@ impl ZigStackFrame {
         &self,
         root_path: &'a [u8],
         origin: Option<&'a ZigURL<'a>>,
-        exclude_line_column: bool,
+        line_column: LineColumn,
         enable_color: bool,
     ) -> SourceURLFormatter<'a> {
         SourceURLFormatter {
             source_url: self.source_url,
-            exclude_line_column,
+            line_column,
             origin,
             root_path,
             position: self.position,
@@ -103,12 +103,19 @@ impl ZigStackFrame {
     }
 }
 
+/// Whether [`SourceURLFormatter`] appends the frame's `:line:column` to the source URL.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub(crate) enum LineColumn {
+    Include,
+    Exclude,
+}
+
 pub struct SourceURLFormatter<'a> {
     pub(crate) source_url: BunString,
     pub(crate) position: ZigStackFramePosition,
     pub(crate) enable_color: bool,
     pub(crate) origin: Option<&'a ZigURL<'a>>,
-    pub(crate) exclude_line_column: bool,
+    pub(crate) line_column: LineColumn,
     pub(crate) remapped: bool,
     pub(crate) root_path: &'a [u8],
 }
@@ -164,7 +171,7 @@ impl<'a> fmt::Display for SourceURLFormatter<'a> {
             }
         }
 
-        if !self.exclude_line_column
+        if self.line_column == LineColumn::Include
             && !source_slice.is_empty()
             && (self.position.line.is_valid() || self.position.column.is_valid())
         {
@@ -179,7 +186,7 @@ impl<'a> fmt::Display for SourceURLFormatter<'a> {
             f.write_str(Output::pretty_fmt!("<r>", true))?;
         }
 
-        if !self.exclude_line_column {
+        if self.line_column == LineColumn::Include {
             if self.position.line.is_valid() && self.position.column.is_valid() {
                 if self.enable_color {
                     write!(


### PR DESCRIPTION
### Problem
- `ZigStackFrame::source_url_formatter` (`src/jsc/ZigStackFrame.rs`) takes two bools, `exclude_line_column` and `enable_color`. Two callers pass literals for both: `source_url_formatter(root_path, origin, true, false)` in `snapshot()` and `(file, origin, false, false)` in `print_github_annotation`. Nothing at those calls says which flag is which, and the swapped call compiles.
- This is the `"bare_bool_args:src/jsc/ZigStackFrame.rs"` entry in `mordant-baseline.toml`.

### Fix
- `exclude_line_column: bool` becomes `line_column: LineColumn`, a two-variant enum (`Include` / `Exclude`) next to `SourceURLFormatter`, so every call names it. The two `Display` conditions that read the flag are the only other code change.
- `enable_color` stays a bool: the `print_stack_trace` callers forward a runtime `allow_ansi_colors`, and `name_formatter` on the same lines takes the same bool. With one bool left in the signature there is nothing to confuse it with, which is also what makes the lint quiet. Same shape as `ErrorDisplayLevel::formatter(name, enable_colors: bool, colon: Colon)` in `ConsoleObject.rs`.
- The baseline line is removed. With the line removed, `cargo dylint --all -- -p bun_jsc` on main's source reports exactly this finding (`bun_jsc 1` in `target/mordant/over-baseline.txt`); on this branch it reports nothing. Regenerating in write mode scoped to `bun_jsc` and the crates it pulls in reproduces the file byte for byte apart from this line and one unrelated entry that is already stale on main (`always_unwrapped_option:src/install/PackageInstall.rs`), which this PR leaves alone.
- No new test: there is no behavior to pin that the existing tests below do not already pin, and a test cannot tell the enum from the bool. The guard against this site regressing is the baseline removal itself: with no count recorded for this file, the mordant job reports any `bare_bool_args` finding in it from now on.
- No output change:
  - `bun bd test test/js/bun/http/serve.test.ts -t "dev error page"` (the `Exclude` caller: the page's `frames[].file` must not carry `:line:col`), `test/cli/test/bun-test.test.ts -t "Github Actions"` (the annotation caller), `test/js/bun/util/reportError.test.ts`, `error-name-preservation.test.ts`, `test/regression/issue/{23649,11793,12782}.test.ts`: pass.
  - An uncaught error printed by this build and by the release `bun` gives byte-identical frame lines with `NO_COLOR`, with `FORCE_COLOR=1` (the dimmed cwd prefix path) and as a `GITHUB_ACTIONS` annotation.
  - `test/js/bun/util/inspect-error.test.js` has two snapshot failures under a debug build that reproduce identically on an unmodified checkout (a debug-only `at require (51:24)` frame its filter does not strip); tracked separately.

### Background
- `SourceURLFormatter` is the `Display` type behind every `at name (file:line:col)` stack frame line Bun prints: terminal error output, the `::error` annotation under GitHub Actions, and the `Bun.serve` development error page. The error page stores the position separately and wants only the file, which is the one `Exclude` use.
- mordant is the Rust lint pack behind the advisory `mordant` job in `rust-lints.yml`. `mordant-baseline.toml` records, per lint and file, how many findings predate the job; the job fails only on findings above the recorded count, so fixing one means deleting its line so the count cannot creep back.
