### PR TITLE
sql: replace the datetime text parser's two bool parameters with enums

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -101,7 +101,6 @@
 "bare_bool_args:src/shell_parser/parse.rs" = 1
 
 [bun_sql_jsc]
-"bare_bool_args:src/sql_jsc/shared/datetime_text.rs" = 1
 "same_match_twice:src/sql_jsc/mysql/protocol/ResultSet.rs" = 1
 
 [bun_sys]

--- a/src/sql_jsc/shared/datetime_text.rs
+++ b/src/sql_jsc/shared/datetime_text.rs
@@ -24,10 +24,25 @@ pub struct DateTimeText {
     pub(crate) microsecond: u32,
 }
 
+/// Whether the 10-byte date-only form (`YYYY-MM-DD`) parses, or only the full
+/// date-and-time shape does.
+#[derive(Clone, Copy)]
+enum TimePart {
+    Optional,
+    Required,
+}
+
+/// Which bytes may separate the date from the time.
+#[derive(Clone, Copy)]
+enum Separator {
+    Space,
+    SpaceOrT,
+}
+
 /// MySQL DATE/DATETIME/TIMESTAMP text. Accepts the 10-byte date-only form
 /// (`YYYY-MM-DD`) and either `' '` or `'T'` as the date/time separator.
 pub(crate) fn parse_mysql(text: &[u8]) -> Option<DateTimeText> {
-    parse(text, true, true)
+    parse(text, TimePart::Optional, Separator::SpaceOrT)
 }
 
 /// Postgres `timestamp` (WITHOUT TIME ZONE) text. Requires the full
@@ -35,10 +50,10 @@ pub(crate) fn parse_mysql(text: &[u8]) -> Option<DateTimeText> {
 /// separator, `infinity`, BC dates, 5+ digit years) returns `None` so the
 /// caller can fall back to `Date.parse`.
 pub(crate) fn parse_postgres_timestamp(text: &[u8]) -> Option<DateTimeText> {
-    parse(text, false, false)
+    parse(text, TimePart::Required, Separator::Space)
 }
 
-fn parse(text: &[u8], allow_date_only: bool, allow_t_separator: bool) -> Option<DateTimeText> {
+fn parse(text: &[u8], time_part: TimePart, separator: Separator) -> Option<DateTimeText> {
     fn parse_u(bytes: &[u8]) -> Option<u32> {
         if bytes.is_empty() {
             return None;
@@ -63,10 +78,16 @@ fn parse(text: &[u8], allow_date_only: bool, allow_t_separator: bool) -> Option<
         ..Default::default()
     };
     if text.len() == 10 {
-        return if allow_date_only { Some(result) } else { None };
+        return match time_part {
+            TimePart::Optional => Some(result),
+            TimePart::Required => None,
+        };
     }
 
-    let separator_ok = text[10] == b' ' || (allow_t_separator && text[10] == b'T');
+    let separator_ok = match separator {
+        Separator::Space => text[10] == b' ',
+        Separator::SpaceOrT => text[10] == b' ' || text[10] == b'T',
+    };
     if text.len() < 19 || !separator_ok || text[13] != b':' || text[16] != b':' {
         return None;
     }


### PR DESCRIPTION
### Problem
- `parse` in `src/sql_jsc/shared/datetime_text.rs` took `allow_date_only: bool, allow_t_separator: bool`, and both callers passed bare literals: `parse(text, true, true)` in `parse_mysql`, `parse(text, false, false)` in `parse_postgres_timestamp`. At the call site nothing says which literal is which flag.
- This is the one `bare_bool_args` finding recorded for this file in `mordant-baseline.toml`.

### Fix
- Each flag becomes a two-variant enum: `TimePart::{Optional, Required}` (is the 10-byte `YYYY-MM-DD` form accepted) and `Separator::{Space, SpaceOrT}` (which byte may sit between the date and the time). MySQL passes `Optional, SpaceOrT`; Postgres passes `Required, Space`, matching the previous `true, true` / `false, false`.
- The two checks inside `parse` match on the enums; the accepted inputs are unchanged. No behavior change.
- Removes the `bare_bool_args:src/sql_jsc/shared/datetime_text.rs` entry from `mordant-baseline.toml`. This is what `bun run rust:mordant:baseline` now writes for the `[bun_sql_jsc]` section.
- Verified:
  - `cargo dylint --all -p bun_sql_jsc` with the baseline entry removed: no findings with this change; with the old `parse` restored it reports exactly this finding over the baseline (`over-baseline.txt` contains `bun_sql_jsc 1`).
  - `bun bd test test/js/sql/sql-postgres-datetime-roundtrip.test.ts test/js/sql/sql-mysql-datetime-roundtrip.test.ts test/js/sql/postgres-datestyle.test.ts test/js/sql/postgres-infinity-date.test.ts` against local Postgres and MariaDB servers: all pass. Both round-trip files exercise the text protocol (`.simple()`), which is the path that goes through this parser.
  - An ad hoc script over both drivers on the text protocol: MySQL `DATE` (date-only form) and `DATETIME(6)` with fractional seconds, and a Postgres `timestamp` with fractional seconds, all decode to the same instants as the binary protocol.
  - `cargo clippy -p bun_sql_jsc --no-deps` is clean.
- No new test: the change is type-level in a private function and accepts exactly the inputs it did before, so there is no input on which a test could distinguish the old code from the new. Both settings of each flag are already covered by existing tests on the text protocol: `sql-mysql-datetime-roundtrip.test.ts` and the `date` test in `sql-mysql.test.ts` (`TimePart::Optional`, `Separator::SpaceOrT` with the space form), `sql-postgres-datetime-roundtrip.test.ts` (`TimePart::Required`, `Separator::Space`).

### Background
- `datetime_text.rs` is the parser both SQL drivers use for the wall-clock `YYYY-MM-DD HH:MM:SS[.ffffff]` strings their text protocols return. MySQL additionally returns bare dates for `DATE` columns and the parser tolerates `T` as the separator; Postgres `timestamp` text is always the full shape, and anything else must return `None` so the caller falls back to `Date.parse`.
- mordant is the advisory Rust lint pack CI runs; `mordant-baseline.toml` records the pre-existing findings per (lint, file) so only new ones are reported. Fixing a recorded finding lets its entry be deleted.

<details>
<summary>Regenerating the whole baseline also drops two unrelated entries</summary>

A full `bun run rust:mordant:baseline` run on top of this branch additionally removes `always_unwrapped_option:src/install/PackageInstall.rs` and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs`. Those findings were fixed on main after the baseline was recorded (#37648 for the crypto one; #38271 / #38841 touched `PackageInstall.rs`). They are left out of this PR to keep it to the one site; happy to include them or send them separately.
</details>
