### PR TITLE
install: read the root package.json through one helper in install_with_manager

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -25,7 +25,6 @@
 "defaulted_failure:src/install/npm.rs" = 1
 "index_of_other_kind:src/install/isolated_install.rs" = 1
 "interchangeable_aliases:src/install/lockfile/Tree.rs" = 1
-"same_match_twice:src/install/PackageManager/install_with_manager.rs" = 1
 
 [bun_js_parser]
 "bare_bool_args:src/js_parser/visit/mod.rs" = 1

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1847,8 +1847,6 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
     }
 }
 
-/// A copy of the root package.json source. A read or parse failure exits the
-/// process; `Err` only means printing the log failed first.
 fn root_package_json_source(
     manager: &mut PackageManager,
     root_package_json_path: &ZStr,

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1,5 +1,6 @@
 use core::sync::atomic::Ordering;
 
+use bun_ast::Source;
 use bun_collections::DynamicBitSet;
 use bun_core::UnwrapOrOom as _;
 use bun_core::time::nano_timestamp;
@@ -160,36 +161,7 @@ pub fn install_with_manager(
                 let mut lockfile = Lockfile::default();
                 let mut maybe_root = lockfile::Package::default();
 
-                // SAFETY: `manager.log` is a non-null backref to the CLI log set at init().
-                let root_package_json_entry =
-                    match manager.workspace_package_json_cache.get_with_path(
-                        manager.log_mut(),
-                        root_package_json_path.as_bytes(),
-                        Default::default(),
-                    ) {
-                        WorkspacePackageJsonCacheResult::Entry(entry) => entry,
-                        WorkspacePackageJsonCacheResult::ReadErr(err) => {
-                            return Err(exit_for_root_package_json(
-                                manager,
-                                err,
-                                "read",
-                                root_package_json_path,
-                            ));
-                        }
-                        WorkspacePackageJsonCacheResult::ParseErr(err) => {
-                            return Err(exit_for_root_package_json(
-                                manager,
-                                err,
-                                "parse",
-                                root_package_json_path,
-                            ));
-                        }
-                    };
-
-                // `Source` is not `Copy`, so
-                // clone it (cheap — `Source` is a few `Box<[u8]>` handles) so the
-                // `&mut *mgr` reborrow below doesn't conflict with the cache borrow.
-                let source_copy = root_package_json_entry.source.clone();
+                let source_copy = root_package_json_source(manager, root_package_json_path)?;
 
                 let mut resolver: () = ();
                 // `parse` needs `manager`, `manager.log` and a fresh
@@ -1875,20 +1847,26 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
     }
 }
 
-/// Returns only when printing the log itself fails; otherwise exits.
-fn exit_for_root_package_json(
-    manager: &PackageManager,
-    err: crate::Error,
-    verb: &str,
+/// The root package.json, cloned out of the cache so callers can reborrow
+/// `manager` while parsing it. A read or parse failure exits the process;
+/// this returns `Err` only when printing the log itself fails.
+fn root_package_json_source(
+    manager: &mut PackageManager,
     root_package_json_path: &ZStr,
-) -> crate::Error {
+) -> crate::Result<Source> {
+    let (verb, err) = match manager.workspace_package_json_cache.get_with_path(
+        manager.log_mut(),
+        root_package_json_path.as_bytes(),
+        Default::default(),
+    ) {
+        WorkspacePackageJsonCacheResult::Entry(entry) => return Ok(entry.source.clone()),
+        WorkspacePackageJsonCacheResult::ReadErr(err) => ("read", err),
+        WorkspacePackageJsonCacheResult::ParseErr(err) => ("parse", err),
+    };
     if manager.log_mut().errors > 0 {
-        if let Err(print_err) = manager
+        manager
             .log_mut()
-            .print(std::ptr::from_mut(Output::error_writer()))
-        {
-            return print_err.into();
-        }
+            .print(std::ptr::from_mut(Output::error_writer()))?;
     }
     Output::err(
         err,
@@ -1935,32 +1913,7 @@ fn create_new_lockfile_and_enqueue(
         Global::crash();
     }
 
-    // SAFETY: `manager.log` is a non-null backref to the CLI log set at init().
-    let root_package_json_entry = match manager.workspace_package_json_cache.get_with_path(
-        manager.log_mut(),
-        root_package_json_path.as_bytes(),
-        Default::default(),
-    ) {
-        WorkspacePackageJsonCacheResult::Entry(entry) => entry,
-        WorkspacePackageJsonCacheResult::ReadErr(err) => {
-            return Err(exit_for_root_package_json(
-                manager,
-                err,
-                "read",
-                root_package_json_path,
-            ));
-        }
-        WorkspacePackageJsonCacheResult::ParseErr(err) => {
-            return Err(exit_for_root_package_json(
-                manager,
-                err,
-                "parse",
-                root_package_json_path,
-            ));
-        }
-    };
-
-    let source_copy = root_package_json_entry.source.clone();
+    let source_copy = root_package_json_source(manager, root_package_json_path)?;
 
     let mut resolver: () = ();
     {

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -1847,9 +1847,8 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
     }
 }
 
-/// The root package.json, cloned out of the cache so callers can reborrow
-/// `manager` while parsing it. A read or parse failure exits the process;
-/// this returns `Err` only when printing the log itself fails.
+/// A copy of the root package.json source. A read or parse failure exits the
+/// process; `Err` only means printing the log failed first.
 fn root_package_json_source(
     manager: &mut PackageManager,
     root_package_json_path: &ZStr,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -4985,7 +4985,12 @@ describe.concurrent("bun-install", () => {
           stdout: "pipe",
           stderr: "pipe",
         });
-        expect(await first.exited).toBe(0);
+        const [firstStdout, firstStderr, firstExitCode] = await Promise.all([
+          first.stdout.text(),
+          first.stderr.text(),
+          first.exited,
+        ]);
+        expect(firstExitCode, `bun install --lockfile-only failed: ${firstStdout}${firstStderr}`).toBe(0);
         expect(await exists(join(String(dir), "bun.lock"))).toBe(true);
       }
       await breakPackageJson(join(String(dir), "package.json"));

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -4966,6 +4966,74 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  // The root package.json is read on two paths: against a bun.lock that already lists
+  // dependencies, and when the lockfile has to be created. Both report it the same way.
+  describe.concurrent("root package.json that cannot be read or parsed", () => {
+    async function installWithBrokenRootPackageJson(
+      withLockfile: boolean,
+      breakPackageJson: (packageJsonPath: string) => Promise<void>,
+    ) {
+      using dir = tempDir("broken-root-package-json", {
+        "package.json": JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { dep: "file:./dep" } }),
+        "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+      });
+      if (withLockfile) {
+        await using first = spawn({
+          cmd: [bunExe(), "install", "--lockfile-only"],
+          cwd: String(dir),
+          env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        expect(await first.exited).toBe(0);
+        expect(await exists(join(String(dir), "bun.lock"))).toBe(true);
+      }
+      await breakPackageJson(join(String(dir), "package.json"));
+
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toStartWith("bun install v1.");
+      return { stderr: normalizeBunSnapshot(stderr, String(dir)), exitCode };
+    }
+
+    const unparseable = (packageJsonPath: string) => writeFile(packageJsonPath, "foo");
+    const unreadable = async (packageJsonPath: string) => {
+      await rm(packageJsonPath);
+      await mkdir(packageJsonPath);
+    };
+
+    for (const [lockfile, withLockfile] of [
+      ["with a bun.lock", true],
+      ["without a bun.lock", false],
+    ] as const) {
+      it(`prints the parse error and the path ${lockfile}`, async () => {
+        const { stderr, exitCode } = await installWithBrokenRootPackageJson(withLockfile, unparseable);
+        expect(stderr).toBe(
+          [
+            "1 | foo",
+            "    ^",
+            "error: Unexpected foo",
+            "    at <dir>/package.json:1:1",
+            "ParserError: failed to parse '<dir>/package.json'",
+          ].join("\n"),
+        );
+        expect(exitCode).toBe(1);
+      });
+
+      it(`prints the read error and the path ${lockfile}`, async () => {
+        const { stderr, exitCode } = await installWithBrokenRootPackageJson(withLockfile, unreadable);
+        expect(stderr).toBe("EISDIR: failed to read '<dir>/package.json'");
+        expect(exitCode).toBe(1);
+      });
+    }
+  });
+
   test.serial("should report error on invalid format for dependencies", async () => {
     await withContext(defaultOpts, async ctx => {
       await writeFile(


### PR DESCRIPTION
### Problem
- mordant `same_match_twice` in `src/install/PackageManager/install_with_manager.rs` (the one `[bun_install]` entry for that lint in `mordant-baseline.toml`): "this `match` on `workspace_package_json_cache::GetResult` repeats an earlier one arm for arm".
- The two copies were the root package.json lookup in the differ branch of `install_with_manager` (around line 165) and in `create_new_lockfile_and_enqueue` (around line 1939). #38841 folded what the error arms did into `exit_for_root_package_json`, but both sites still spelled out the lookup plus the `Entry` / `ReadErr` -> `"read"` / `ParseErr` -> `"parse"` mapping, and both then only did `entry.source.clone()`.

### Fix
- One helper, `root_package_json_source(manager, root_package_json_path) -> crate::Result<Source>`, does the cache lookup, maps the error variant to its verb, and absorbs the body of `exit_for_root_package_json` (which had no other callers). Both sites become `let source_copy = root_package_json_source(manager, root_package_json_path)?;`.
- No behavior change: the same `get_with_path` call with the same options, the same clone of `source`, the same log print before `failed to read/parse '<path>'`, the same exit code, and the same `Err` return in the one case where printing the log fails (`?` on `print` instead of the explicit `if let Err`). Returning the cloned `Source` rather than the cache entry is what lets the helper be a plain function: the callers reborrow `manager` mutably right after, and the entry borrow would otherwise have to stay alive across the error arms.
- `mordant-baseline.toml`: dropped the `same_match_twice` line for this file.
- Tests (`test/cli/install/bun-install.test.ts`, "root package.json that cannot be read or parsed"): the read failure (package.json replaced by a directory) and the parse failure, each once against a bun.lock that already lists a dependency and once without a lockfile. Only the fresh-install parse case had a test before. A temporarily instrumented build confirmed the bun.lock cases go through the differ and the others through `create_new_lockfile_and_enqueue`. Since the change is a refactor, these pass before and after it; they pin the output the helper now owns for both callers and both verbs. Verified on the debug build here and, for the `EISDIR` and path expectations, against the current canary on Windows.
- Other verification:
  - `bun bd test` on `bun-workspaces`, `bad-workspace`, `frozen-lockfile-missing-workspace`, `frozen-lockfile-pruned`, `lockfile-only`: 207 pass.
  - Full `bun-install.test.ts`: everything passes except the bitbucket/gitlab/remote tarball/`--registry` cases that need network and fail identically here with `USE_SYSTEM_BUN=1`.
  - `cargo dylint --all -p bun_install --no-deps` (mordant at the pinned rev, baseline line removed): clean, no `target/mordant/over-baseline.txt`. The same command on the unmodified file reports exactly this finding at line 1939, and removing a different `[bun_install]` baseline line makes it report that one, so the run is exercising the baseline.

### Background
- `WorkspacePackageJSONCache::get_with_path` reads and parses a package.json once and caches it; it returns `GetResult`, a three-way enum (`Entry(&mut MapEntry)`, `ReadErr`, `ParseErr`), and any parse diagnostics go into the package manager's `Log`. The install code prints that log before the final `failed to parse` line so the user sees where in the file the error is.
- `bun install` reaches this lookup on one of two paths: the differ, when an existing bun.lock already has dependencies and package.json is re-read to diff against it, or `create_new_lockfile_and_enqueue`, when there is no usable lockfile yet.
- `mordant-baseline.toml` records the per-(lint, file) finding counts that predate the mordant CI job; the job only fails on findings above those counts, so an entry can be deleted once the file is clean for that lint.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->