### PR TITLE
react_compiler: name the nesting passed to get_context_reassignment

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -43,7 +43,6 @@
 "parallel_vecs:src/parsers/xml.rs" = 1
 
 [bun_react_compiler]
-"bare_bool_args:src/react_compiler/validation/validate_locals_not_reassigned_after_render.rs" = 1
 "reimplemented_helper:src/react_compiler/reactive_scopes/propagate_early_returns.rs" = 1
 
 [bun_runtime]

--- a/src/react_compiler/validation/validate_locals_not_reassigned_after_render.rs
+++ b/src/react_compiler/validation/validate_locals_not_reassigned_after_render.rs
@@ -34,8 +34,7 @@ pub(crate) fn validate_locals_not_reassigned_after_render(
         &env.functions,
         env,
         &mut context_variables,
-        false,
-        false,
+        Nesting::Outer,
         &mut diagnostics,
     );
 
@@ -79,6 +78,20 @@ fn format_variable_name(place: &Place, identifiers: &[Identifier]) -> String {
     }
 }
 
+/// Which function `get_context_reassignment` is walking: the outer function
+/// being validated, whose context variables it records, or a function
+/// expression nested in it, whose stores to those variables are the
+/// reassignments being looked for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Nesting {
+    Outer,
+    /// `is_async` is set if this function expression, or any function
+    /// expression enclosing it, is async.
+    FunctionExpression {
+        is_async: bool,
+    },
+}
+
 /// Recursively checks whether a function (or its dependencies) reassigns a
 /// context variable. Returns the reassigned place if found, or None.
 ///
@@ -90,10 +103,14 @@ fn get_context_reassignment(
     functions: &[HirFunction],
     env: &Environment,
     context_variables: &mut HashSet<IdentifierId>,
-    is_function_expression: bool,
-    is_async: bool,
+    nesting: Nesting,
     diagnostics: &mut Vec<CompilerDiagnostic>,
 ) -> Option<Place> {
+    let (is_function_expression, is_async) = match nesting {
+        Nesting::Outer => (false, false),
+        Nesting::FunctionExpression { is_async } => (true, is_async),
+    };
+
     // Maps identifiers to the place that they reassign
     let mut reassigning_functions: IdMap<IdentifierId, Place> = IdMap::new();
 
@@ -115,8 +132,9 @@ fn get_context_reassignment(
                         functions,
                         env,
                         context_variables,
-                        true,
-                        inner_is_async,
+                        Nesting::FunctionExpression {
+                            is_async: inner_is_async,
+                        },
                         diagnostics,
                     );
 

--- a/src/react_compiler/validation/validate_locals_not_reassigned_after_render.rs
+++ b/src/react_compiler/validation/validate_locals_not_reassigned_after_render.rs
@@ -78,16 +78,11 @@ fn format_variable_name(place: &Place, identifiers: &[Identifier]) -> String {
     }
 }
 
-/// Which function `get_context_reassignment` is walking: the outer function
-/// being validated, whose context variables it records, or a function
-/// expression nested in it, whose stores to those variables are the
-/// reassignments being looked for.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Nesting {
     Outer,
-    /// `is_async` is set if this function expression, or any function
-    /// expression enclosing it, is async.
     FunctionExpression {
+        /// Also set when a function expression enclosing this one is async.
         is_async: bool,
     },
 }

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { isASAN, isDebug, tempDir } from "harness";
 import { itBundled } from "../expectBundled";
 
 // The React Compiler emits `import { c as _c } from "react/compiler-runtime"` and
@@ -1063,4 +1065,102 @@ describe("bundler", () => {
       expect(out).toMatch(/__MEMO_CACHE_SENTINEL\)\s*\{[^}]*globalFn\(\)/);
     },
   });
+});
+
+// validate_locals_not_reassigned_after_render (src/react_compiler/validation)
+// records the locals a component's closures capture while walking the
+// component body, and reports a nested function that assigns to one of them,
+// with a different diagnostic when that function, or one it is nested in, is
+// async. `error` is the headline of the diagnostic, or null when the component
+// compiles.
+//
+// In a normal build a reported component is silently left uncompiled, and the
+// aliasing validator independently reports the same components, so the
+// diagnostic text is the only place this validator's decision is observable.
+// That needs the fixture pragma support, which turns compiler diagnostics into
+// build errors and is compiled out of release builds (see
+// react-compiler-fixtures.test.ts).
+const localReassignmentCases = {
+  InComponentBody: {
+    error: null,
+    source: /* jsx */ `
+      export function Comp({ items }) {
+        let count = 0;
+        count = items.length;
+        const onClick = () => console.log(count);
+        return <button onClick={onClick}>{count}</button>;
+      }
+    `,
+  },
+  InSyncCallback: {
+    error: "React Compiler: Error: Cannot reassign variable after render completes",
+    source: /* jsx */ `
+      import { useEffect } from "react";
+      export function Comp({ items }) {
+        let count = 0;
+        useEffect(() => {
+          count = items.length;
+        });
+        return <div>{count}</div>;
+      }
+    `,
+  },
+  InAsyncCallback: {
+    error: "React Compiler: Error: Cannot reassign variable in async function",
+    source: /* jsx */ `
+      export function Comp({ load }) {
+        let data = null;
+        const onClick = async () => {
+          data = await load();
+        };
+        return <button onClick={onClick}>{data}</button>;
+      }
+    `,
+  },
+  InSyncCallbackInsideAsyncCallback: {
+    error: "React Compiler: Error: Cannot reassign variable in async function",
+    source: /* jsx */ `
+      export function Comp({ load }) {
+        let data = null;
+        const onClick = async () => {
+          const store = value => {
+            data = value;
+          };
+          store(await load());
+        };
+        return <button onClick={onClick}>{data}</button>;
+      }
+    `,
+  },
+};
+
+test.skipIf(!isDebug && !isASAN)("react-compiler reports which kind of function reassigned a local", async () => {
+  using dir = tempDir(
+    "react-compiler-reassign",
+    Object.fromEntries(Object.entries(localReassignmentCases).map(([name, { source }]) => [`${name}.jsx`, source])),
+  );
+
+  const results: Record<string, { error: string | null; memoized: boolean }> = {};
+  for (const name of Object.keys(localReassignmentCases)) {
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), `${name}.jsx`)],
+      target: "browser",
+      external: ["*"],
+      reactCompiler: true,
+      // @ts-expect-error test-only option, not in bun-types
+      reactCompilerParseTestPragmas: true,
+      throw: false,
+    });
+    const errors = result.logs.filter(log => log.level === "error");
+    results[name] = {
+      error: errors.length === 0 ? null : errors.map(log => String(log.message).split(".")[0]).join("\n"),
+      memoized: result.success && /\b_c\(\d+\)/.test(await result.outputs[0].text()),
+    };
+  }
+
+  expect(results).toEqual(
+    Object.fromEntries(
+      Object.entries(localReassignmentCases).map(([name, { error }]) => [name, { error, memoized: error === null }]),
+    ),
+  );
 });

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import { isASAN, isDebug, tempDir } from "harness";
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
-import { isASAN, isDebug, tempDir } from "harness";
 import { itBundled } from "../expectBundled";
 
 // The React Compiler emits `import { c as _c } from "react/compiler-runtime"` and


### PR DESCRIPTION
### Problem
- `get_context_reassignment` in `src/react_compiler/validation/validate_locals_not_reassigned_after_render.rs` takes two adjacent bools, `is_function_expression` and `is_async`, and its top-level call passes `false, false`. Nothing at that call site says which flag is which.
- This is the one `bare_bool_args` finding recorded for the file in `mordant-baseline.toml`.

### Fix
- Replaces the two parameters with one enum, `Nesting`: `Outer` for the component or hook being validated, `FunctionExpression { is_async }` for a function expression nested in it. The two call sites now read `Nesting::Outer` and `Nesting::FunctionExpression { is_async: inner_is_async }`.
- One enum rather than one per flag because `is_async` is only ever set for a function expression (the top-level call always passed `false`), so `Outer` carrying an async flag would be a state the code never reaches.
- The body of the function is unchanged: the first statement unpacks the enum into the same two locals the body already used (`Outer` maps to the old `false, false`, `FunctionExpression { is_async }` to the old `true, is_async`). This file is a port of the upstream React Compiler crate (see `src/react_compiler/DESIGN.md`), so keeping the body identical keeps future upstream diffs applying cleanly; upstream still has the two bools.
- `mordant-baseline.toml` loses this file's `bare_bool_args` line, which is what `bun run rust:mordant:baseline` produces on this branch.
- Adds one test to `test/bundler/transpiler/react-compiler.test.ts` pinning which diagnostic the validator emits for each state the enum can be in: a reassignment in the component body compiles, one in a sync callback gets the after-render diagnostic, one in an async callback gets the async diagnostic, and so does one in a sync function nested inside an async callback. The last case is the only one that depends on `is_async` being carried into the nested walk, and the upstream fixture suite has no equivalent (it also only checks that error fixtures are not memoized, not which validator rejected them). Since this PR changes no behavior, there is no test that fails before it and passes after it: this one passes on both sides by design and is there so the no-behavior-change claim is checked rather than asserted, while the mordant job is the before/after check for the change itself. Swapping either match arm's mapping makes it fail (`Outer => (true, false)` flips all three error cases to the aliasing validator's diagnostic; dropping `is_async` from the `FunctionExpression` arm flips the nested case).
- The test needs `reactCompilerParseTestPragmas`, the fixture-harness option that turns compiler diagnostics into build errors, because in a normal build a rejected component is silently left uncompiled and the aliasing validator independently rejects the same components. That support is compiled out of release builds, so the test is gated on `isDebug || isASAN` like the fixture suite.
- No behavior change. Verified by:
  - `bun bd test test/bundler/transpiler/react-compiler.test.ts test/bundler/transpiler/react-compiler-fixtures.test.ts`: 3330 pass, 320 skip (pre-existing flow/pragma skips), 0 fail. Nine of the error fixtures go through this validator, including both async-callback ones.
  - Compiling all 1806 upstream fixture inputs with `Bun.build({ reactCompiler: true })`, plain and with `minify.syntax`, and dumping every output (3173) and every diagnostic (589) with and without this commit: the two dumps are byte-identical.
  - `cargo dylint --all -p bun_react_compiler` (what `bun run rust:mordant` runs, scoped to this crate) reports nothing with the baseline line removed. As a control, the same run with the baseline line removed but the source change stashed reports exactly the line 86 finding.
  - `cargo check -p bun_react_compiler` and `cargo clippy -p bun_react_compiler --no-deps` are clean.

### Background
- `validate_locals_not_reassigned_after_render` is a React Compiler validation pass. It walks the instructions of the component or hook, recording its context variables (locals captured by closures) as it meets them and recursing into each function expression it meets. A store inside a nested function to a variable recorded so far is a reassignment after render and is reported. `get_context_reassignment` is the walker used for both levels, and the parameter this PR changes is what tells it which level it is on: the outer level records variables, the nested level reports stores to them.
- `is_async` is accumulated down the recursion (`is_async || inner_function.is_async`): a reassignment inside an async function, or inside anything nested in one, is reported immediately as a separate diagnostic instead of being propagated to the caller.
- `mordant-baseline.toml` is the ratchet for the repo's Rust lint pack (`bun run rust:mordant`): per-file counts of findings that predate the lint job, so CI only fails on new findings. Removing a line lowers the ceiling for that file.
