### PR TITLE
bun:ffi: fail cc() with the real error when its header directory cannot be created

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -31,7 +31,6 @@
 "defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4
 "error_collapsed_to_bool:src/runtime/api/bun/Terminal.rs" = 1
 "error_collapsed_to_bool:src/runtime/api/bun/h2_frame_parser.rs" = 32
-"error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
 "reimplemented_helper:src/runtime/hw_exports.rs" = 1

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -613,6 +613,21 @@ impl CompileC {
         &mut self,
         global_this: &JSGlobalObject,
     ) -> crate::Result<NonNull<TCC::State>> {
+        // Without the bundled headers even `#include <stddef.h>` fails, so
+        // failing to stage them is the compile error; reporting it here gives
+        // the cause instead of TinyCC's later "include file not found".
+        let compiler_rt = match CompilerRT::dirs() {
+            Ok(dirs) => dirs,
+            Err(err) => {
+                global_this.throw(format_args!(
+                    "cc() could not write its bundled C headers to the temporary directory \"{}\": {}. Set $BUN_TMPDIR to a writable directory.",
+                    BStr::new(Fs::RealFS::tmpdir_path()),
+                    err,
+                ));
+                return Err(crate::Error::JSError);
+            }
+        };
+
         let tcc_options_owned: ZBox;
         let compile_options: &ZStr = if !self.flags.is_empty() {
             &self.flags
@@ -647,14 +662,8 @@ impl CompileC {
         // we hold the only reference for the rest of this function.
         let state: &mut TCC::State = unsafe { &mut *state_ptr.as_ptr() };
 
-        if let Some(compiler_rt_dir) = CompilerRT::dir() {
-            if state.add_sys_include_path(compiler_rt_dir).is_err() {
-                bun_output::scoped_log!(TCC, "TinyCC failed to add sysinclude path");
-            }
-        }
-
-        if let Some(node_dir) = CompilerRT::node_dir() {
-            if state.add_sys_include_path(node_dir).is_err() {
+        for include_dir in [&compiler_rt.dir, &compiler_rt.node_dir] {
+            if state.add_sys_include_path(include_dir).is_err() {
                 bun_output::scoped_log!(TCC, "TinyCC failed to add sysinclude path");
             }
         }
@@ -2259,10 +2268,18 @@ use super::abi_type::ABIType;
 
 struct CompilerRT;
 
+/// Where the headers `cc()` bundles were staged for this process.
+struct CompilerRtDirs {
+    /// `CompilerRtSources::SOURCES`
+    dir: ZBox,
+    /// `CompilerRtSources::NODE_HEADERS`
+    node_dir: ZBox,
+}
+
 // Process-lifetime singleton — PORTING.md §Forbidden: use OnceLock, never
-// `static mut` + leak.
-static COMPILER_RT_DIR: OnceLock<bun_core::ZBox> = OnceLock::new();
-static COMPILER_RT_NODE_DIR: OnceLock<bun_core::ZBox> = OnceLock::new();
+// `static mut` + leak. A failure is kept too: staging is attempted once per
+// process and every `cc()` call reports the same error.
+static COMPILER_RT_DIRS: OnceLock<bun_sys::Maybe<CompilerRtDirs>> = OnceLock::new();
 
 struct CompilerRtSources;
 impl CompilerRtSources {
@@ -2290,54 +2307,55 @@ impl CompilerRtSources {
     ];
 }
 
-static CREATE_COMPILER_RT_DIR_ONCE: Once = Once::new();
-
 impl CompilerRT {
-    fn create_compiler_rt_dir() {
-        // `bun_resolver::fs::FileSystem` (the inline canonical surface) doesn't
-        // yet expose an inherent `tmpdir()`; reuse the crate-local
-        // `FileSystemTmpdirExt` shim already in service for `jsc_hooks`.
-        use crate::cli::upgrade_command::FileSystemTmpdirExt as _;
-        let Ok(tmpdir) = Fs::FileSystem::instance().tmpdir() else {
-            return;
-        };
+    /// The staged headers, or the error that stopped them from being staged.
+    fn dirs() -> Result<&'static CompilerRtDirs, &'static bun_sys::Error> {
+        COMPILER_RT_DIRS
+            .get_or_init(Self::create_compiler_rt_dir)
+            .as_ref()
+    }
+
+    fn create_compiler_rt_dir() -> bun_sys::Maybe<CompilerRtDirs> {
+        let tmpdir = bun_sys::Dir::open(Fs::RealFS::tmpdir_path())?;
 
         // Prefer the reusable per-user directory; if it cannot be safely
         // populated, fall back to a freshly created, randomly named one.
         #[cfg(unix)]
         if let Some(bun_cc) = Self::open_owned_compiler_rt_dir(&tmpdir)
-            && Self::populate_compiler_rt_dir(&bun_cc)
+            && let Ok(dirs) = Self::populate_compiler_rt_dir(&bun_cc)
         {
-            return;
+            return Ok(dirs);
         }
-        for _ in 0..8 {
-            let Some(name) = Self::fresh_compiler_rt_dir_name() else {
-                return;
-            };
+        let bun_cc = Self::create_fresh_compiler_rt_dir(&tmpdir)?;
+        Self::populate_compiler_rt_dir(&bun_cc)
+    }
+
+    /// Create and open a private directory with a random name under `tmpdir`,
+    /// drawing another name when the first ones are taken.
+    fn create_fresh_compiler_rt_dir(tmpdir: &bun_sys::Dir) -> bun_sys::Maybe<bun_sys::Dir> {
+        let dir_flags = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NOFOLLOW;
+        let mut attempts_left = 8;
+        loop {
+            let name = Self::fresh_compiler_rt_dir_name();
+            attempts_left -= 1;
             match bun_sys::mkdirat(tmpdir.fd(), name.as_zstr(), 0o700) {
-                Ok(()) => {}
-                Err(err) if err.get_errno() == bun_sys::E::EEXIST => continue,
-                Err(_) => return,
+                Ok(()) => return tmpdir.open_at_with(name.as_bytes(), dir_flags),
+                Err(err) if err.get_errno() == bun_sys::E::EEXIST && attempts_left > 0 => {}
+                Err(err) => return Err(err),
             }
-            let dir_flags = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NOFOLLOW;
-            let Ok(dir) = tmpdir.open_at_with(name.as_bytes(), dir_flags) else {
-                return;
-            };
-            let _ = Self::populate_compiler_rt_dir(&dir);
-            return;
         }
     }
 
     /// Random name for a freshly created header directory. The Windows shape
     /// keeps the leading characters and the extension random, so a generated
     /// short (8.3) alias of the directory is random as well.
-    fn fresh_compiler_rt_dir_name() -> Option<ZBox> {
+    fn fresh_compiler_rt_dir_name() -> ZBox {
         #[cfg(unix)]
         {
             let mut name_buf = PathBuffer::uninit();
             let name = Fs::FileSystem::tmpname(b"bun-cc", &mut name_buf.0, bun_core::fast_random())
-                .ok()?;
-            Some(ZBox::from_bytes(name.as_bytes()))
+                .expect("unreachable");
+            ZBox::from_bytes(name.as_bytes())
         }
         #[cfg(windows)]
         {
@@ -2348,51 +2366,40 @@ impl CompilerRT {
                 bun_fmt::truncated_hash32(bun_core::fast_random()),
                 bun_fmt::truncated_hash32(bun_core::fast_random()),
             )
-            .ok()?;
-            Some(ZBox::from_vec(name))
+            .expect("unreachable");
+            ZBox::from_vec(name)
         }
     }
 
-    /// Stage every header into `bun_cc` and publish its path; returns false
-    /// (leaving nothing published) if any entry could not be written -- e.g.
-    /// a pre-planted symlinked entry refused by the no-follow write.
-    fn populate_compiler_rt_dir(bun_cc: &bun_sys::Dir) -> bool {
+    /// Stage every header into `bun_cc`. Fails on the first entry that could
+    /// not be written -- e.g. a pre-planted symlinked entry refused by the
+    /// no-follow write.
+    fn populate_compiler_rt_dir(bun_cc: &bun_sys::Dir) -> bun_sys::Maybe<CompilerRtDirs> {
         for (name, source) in CompilerRtSources::SOURCES {
-            if !Self::write_compiler_rt_file(bun_cc, name.as_bytes(), source) {
-                return false;
-            }
+            Self::write_compiler_rt_file(bun_cc, name.as_bytes(), source)?;
         }
-        let Ok(node_dir) = bun_cc.make_open_path(b"node", bun_sys::OpenDirOptions::default())
-        else {
-            return false;
-        };
+        let node = bun_cc.make_open_path(b"node", bun_sys::OpenDirOptions::default())?;
         for (name, source) in CompilerRtSources::NODE_HEADERS {
-            if !Self::write_compiler_rt_file(&node_dir, name.as_bytes(), source) {
-                return false;
-            }
+            Self::write_compiler_rt_file(&node, name.as_bytes(), source)?;
         }
 
         let mut path_buf = PathBuffer::uninit();
-        let Ok(path) = bun_sys::get_fd_path(bun_cc.fd(), &mut path_buf) else {
-            return false;
-        };
         // `ZBox::from_bytes` panics on OOM.
-        let path = ZBox::from_bytes(&*path);
-        let Ok(node_path) = bun_sys::get_fd_path(node_dir.fd(), &mut path_buf) else {
-            return false;
-        };
-        let node_path = ZBox::from_bytes(&*node_path);
-        let _ = COMPILER_RT_DIR.set(path);
-        let _ = COMPILER_RT_NODE_DIR.set(node_path);
-        true
+        let dir = ZBox::from_bytes(bun_cc.get_fd_path(&mut path_buf)?);
+        let node_dir = ZBox::from_bytes(node.get_fd_path(&mut path_buf)?);
+        Ok(CompilerRtDirs { dir, node_dir })
     }
 
     /// Write one staged header without following a pre-planted symlinked
     /// entry inside the header directory.
-    fn write_compiler_rt_file(dir: &bun_sys::Dir, name: &[u8], source: &[u8]) -> bool {
+    fn write_compiler_rt_file(
+        dir: &bun_sys::Dir,
+        name: &[u8],
+        source: &[u8],
+    ) -> bun_sys::Maybe<()> {
         #[cfg(unix)]
         {
-            let Ok(file) = dir.open_file(
+            dir.open_file(
                 name,
                 bun_sys::O::WRONLY
                     | bun_sys::O::CREAT
@@ -2400,15 +2407,13 @@ impl CompilerRT {
                     | bun_sys::O::CLOEXEC
                     | bun_sys::O::NOFOLLOW,
                 0o644,
-            ) else {
-                return false;
-            };
-            file.write_all(source).is_ok()
+            )?
+            .write_all(source)
         }
         #[cfg(windows)]
         {
             let name_z = ZBox::from_bytes(name);
-            bun_sys::File::write_file(dir.fd(), name_z.as_zstr(), source).is_ok()
+            bun_sys::File::write_file(dir.fd(), name_z.as_zstr(), source)
         }
     }
 
@@ -2440,22 +2445,6 @@ impl CompilerRT {
             return None;
         }
         Some(dir)
-    }
-
-    pub(crate) fn dir() -> Option<&'static ZStr> {
-        CREATE_COMPILER_RT_DIR_ONCE.call_once(Self::create_compiler_rt_dir);
-        COMPILER_RT_DIR
-            .get()
-            .map(|b| b.as_zstr())
-            .filter(|d| !d.is_empty())
-    }
-
-    pub(crate) fn node_dir() -> Option<&'static ZStr> {
-        CREATE_COMPILER_RT_DIR_ONCE.call_once(Self::create_compiler_rt_dir);
-        COMPILER_RT_NODE_DIR
-            .get()
-            .map(|b| b.as_zstr())
-            .filter(|d| !d.is_empty())
     }
 
     #[inline(never)]

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -613,9 +613,6 @@ impl CompileC {
         &mut self,
         global_this: &JSGlobalObject,
     ) -> crate::Result<NonNull<TCC::State>> {
-        // Without the bundled headers even `#include <stddef.h>` fails, so
-        // failing to stage them is the compile error; reporting it here gives
-        // the cause instead of TinyCC's later "include file not found".
         let compiler_rt = match CompilerRT::dirs() {
             Ok(dirs) => dirs,
             Err(err) => {
@@ -2277,8 +2274,7 @@ struct CompilerRtDirs {
 }
 
 // Process-lifetime singleton — PORTING.md §Forbidden: use OnceLock, never
-// `static mut` + leak. A failure is kept too: staging is attempted once per
-// process and every `cc()` call reports the same error.
+// `static mut` + leak.
 static COMPILER_RT_DIRS: OnceLock<bun_sys::Maybe<CompilerRtDirs>> = OnceLock::new();
 
 struct CompilerRtSources;
@@ -2308,7 +2304,6 @@ impl CompilerRtSources {
 }
 
 impl CompilerRT {
-    /// The staged headers, or the error that stopped them from being staged.
     fn dirs() -> Result<&'static CompilerRtDirs, &'static bun_sys::Error> {
         COMPILER_RT_DIRS
             .get_or_init(Self::create_compiler_rt_dir)
@@ -2330,8 +2325,6 @@ impl CompilerRT {
         Self::populate_compiler_rt_dir(&bun_cc)
     }
 
-    /// Create and open a private directory with a random name under `tmpdir`,
-    /// drawing another name when the first ones are taken.
     fn create_fresh_compiler_rt_dir(tmpdir: &bun_sys::Dir) -> bun_sys::Maybe<bun_sys::Dir> {
         let dir_flags = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NOFOLLOW;
         let mut attempts_left = 8;
@@ -2371,9 +2364,7 @@ impl CompilerRT {
         }
     }
 
-    /// Stage every header into `bun_cc`. Fails on the first entry that could
-    /// not be written -- e.g. a pre-planted symlinked entry refused by the
-    /// no-follow write.
+    /// Stage every header into `bun_cc`.
     fn populate_compiler_rt_dir(bun_cc: &bun_sys::Dir) -> bun_sys::Maybe<CompilerRtDirs> {
         for (name, source) in CompilerRtSources::SOURCES {
             Self::write_compiler_rt_file(bun_cc, name.as_bytes(), source)?;

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -620,8 +620,8 @@ impl CompileC {
             Ok(dirs) => dirs,
             Err(err) => {
                 global_this.throw(format_args!(
-                    "cc() could not write its bundled C headers to the temporary directory \"{}\": {}. Set $BUN_TMPDIR to a writable directory.",
-                    BStr::new(Fs::RealFS::tmpdir_path()),
+                    "cc() could not write its bundled C headers to the temporary directory {}: {}. Set $BUN_TMPDIR to a writable directory.",
+                    bun_fmt::quote(Fs::RealFS::tmpdir_path()),
                     err,
                 ));
                 return Err(crate::Error::JSError);

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1307,3 +1307,41 @@ describe.concurrent("disabling cc()", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// Fails before TinyCC is created, so unlike the tests above this also runs under ASAN.
+describe("compiler runtime header directory that cannot be created", () => {
+  it("cc() throws the error that stopped the headers from being staged", async () => {
+    using dir = tempDir("bun-ffi-cc-rt-dir-missing-tmpdir", {
+      "add.c": /* c */ `
+        #include <stdbool.h>
+        int add(int a, int b) {
+          return a + b + (int)true - 1;
+        }
+      `,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        cc({ source: "add.c", symbols: { add: { args: ["int", "int"], returns: "int" } } });
+      `,
+    });
+    const missingTmpdir = path.join(String(dir), "missing");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: { ...bunEnv, BUN_TMPDIR: missingTmpdir },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Previously the failure to create the directory was ignored and TinyCC
+    // went on to report "include file 'stdbool.h' not found" for add.c.
+    expect(stderr).toContain(
+      `cc() could not write its bundled C headers to the temporary directory "${missingTmpdir}": ENOENT`,
+    );
+    expect(stderr).toContain("Set $BUN_TMPDIR to a writable directory.");
+    expect(stderr).not.toContain("include file");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
Fixes the `error_collapsed_to_bool` finding mordant reports for `src/runtime/ffi/ffi_body.rs`.

### Problem
- On its first use in a process, `cc()` writes the headers it bundles (`stddef.h`, `stdarg.h`, `stdbool.h`, ..., and the N-API headers) into a directory under the temp dir (`CompilerRT::create_compiler_rt_dir`, `src/runtime/ffi/ffi_body.rs`).
- Every failure in there was swallowed: `populate_compiler_rt_dir` collapsed its `bun_sys::Error` into `false`, and the fallback path discarded that with `let _ =`. `cc()` then compiled without the headers.
- What the user got was TinyCC's error for the first include, with nothing pointing at the temp dir. bun 1.4.0 with `BUN_TMPDIR=/does/not/exist` and a source containing `#include <stdbool.h>`:
  ```
  1 errors while compiling add.c
  add.c:2: error: include file 'stdbool.h' not found
  ```
- Nearly every C source hits this: on glibc, `stdio.h`, `stdlib.h` and `string.h` all include `stddef.h`.

### Fix
- `populate_compiler_rt_dir`, `write_compiler_rt_file` and `create_compiler_rt_dir` return `bun_sys::Maybe`; the random-name retry loop moved into `create_fresh_compiler_rt_dir`, which returns the `mkdir`/`open` error that stopped it.
- The `Once` plus two `OnceLock<ZBox>` statics became one `OnceLock<bun_sys::Maybe<CompilerRtDirs>>`: the single staging attempt's outcome, paths or error, is what `CompilerRT::dirs()` hands out.
- `CompileC::compile` is the call site that decides: a staging error fails `cc()` before the TinyCC state is created, naming the cause and the directory:
  ```
  cc() could not write its bundled C headers to the temporary directory "/does/not/exist": ENOENT: /does/not/exist: No such file or directory (open()). Set $BUN_TMPDIR to a writable directory.
  ```
- Behavior change to be aware of: a source that includes none of the bundled headers used to still compile with an unusable temp dir; it now fails with the same error. A compiler that is missing its own headers failing up front seemed better than one that works for some sources and gives a misleading error for the rest. The fallback from the shared `bun-cc-<uid>` directory to a fresh private one is unchanged; only the last resort's error is reported.
- The temp dir is still `RealFS::tmpdir_path()` (`BUN_TMPDIR`, then `TMPDIR`/`TMP`/`TEMP`), now opened with `bun_sys::Dir::open` directly instead of the `FileSystemTmpdirExt` shim, whose `crate::Error` conversion drops the path.
- `mordant-baseline.toml`: the `error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs` entry is removed; that is the only difference from main's file. Regenerating with `bun run rust:mordant:baseline` adds nothing for this change, and `bun run rust:mordant` on the branch reports nothing over the baseline.
- Verified:
  - `test/js/bun/ffi/cc.test.ts`, new test `compiler runtime header directory that cannot be created`: fails on the current release with the `include file 'stdbool.h' not found` output above, passes with `bun bd test`. It fails before TinyCC is involved, so it also runs under ASAN, unlike the other `cc()` tests.
  - The four existing `BUN_TMPDIR` staging tests (shared dir reuse, planted symlink, world-writable dir, fixed-name dir) pass against the debug build with their ASAN skip removed locally, so the fallback logic behaves as before.
  - `bun run rust:check-all x86_64-pc-windows-msvc aarch64-apple-darwin` passes (the `cfg(windows)` arms are not compiled on Linux).

### Background
- `cc()` compiles C with a TinyCC embedded in the bun binary. A normally installed TinyCC ships the freestanding headers (`stddef.h`, `stdarg.h`, ...) in its own include directory; bun instead embeds them and writes them to a temp directory on first use, which `compile()` adds as a system include path. `CompilerRT` in `ffi_body.rs` is that staging code. The `dlopen()` FFI path does not use it.
- `bun_sys::Maybe<T>` is `Result<T, bun_sys::Error>`. `bun_sys::Error` carries errno, syscall and path; its `Display` is the `ENOENT: /path: No such file or directory (open())` form in the message above.
- mordant is the lint pack behind `bun run rust:mordant`. `mordant-baseline.toml` holds the accepted finding count per (lint, file); CI only fails when a count goes up, and fixing a finding means regenerating the file so its entry disappears.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/ffi/cc.test.ts

<!-- robobun:evidence:end -->
