### PR TITLE
install: name build_store's timing flag with an enum instead of a bool

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -15,7 +15,6 @@
 "tuple_wants_struct:src/css/values/color.rs" = 5
 
 [bun_install]
-"bare_bool_args:src/install/isolated_install.rs" = 1
 "defaulted_failure:src/install/npm.rs" = 1
 "interchangeable_aliases:src/install/lockfile/Tree.rs" = 1
 "same_match_twice:src/install/PackageManager/install_with_manager.rs" = 1

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -214,13 +214,20 @@ impl<'a, 'b> Wait<'a, 'b> {
     }
 }
 
+/// Whether `build_store` reports how long each of its two passes took.
+#[derive(Clone, Copy)]
+pub(crate) enum Timings {
+    Print,
+    Quiet,
+}
+
 pub(crate) fn build_store(
     manager: &PackageManager,
     lockfile: &Lockfile,
     install_root_dependencies: bool,
     workspace_filters: &[WorkspaceFilter],
     packages_to_install: Option<&[PackageID]>,
-    print_timings: bool,
+    timings: Timings,
 ) -> Result<Store, AllocError> {
     let mut timer = std::time::Instant::now();
     let pkgs = lockfile.packages.slice();
@@ -862,7 +869,7 @@ pub(crate) fn build_store(
         node_queue[queue_mark..].reverse();
     }
 
-    if print_timings {
+    if matches!(timings, Timings::Print) {
         let full_tree_end = timer.elapsed();
         timer = std::time::Instant::now();
         bun_core::pretty_errorln!(
@@ -1119,7 +1126,7 @@ pub(crate) fn build_store(
         }
     }
 
-    if print_timings {
+    if matches!(timings, Timings::Print) {
         let dedupe_end = timer.elapsed();
         bun_core::pretty_errorln!(
             "Created store [{}]",
@@ -1151,13 +1158,18 @@ pub(crate) fn install_isolated_packages(
     // while this reborrow is live (column slices below borrow through it).
     let lockfile: &mut Lockfile = unsafe { &mut *lockfile };
 
+    let timings = if manager.options.log_level.is_verbose() {
+        Timings::Print
+    } else {
+        Timings::Quiet
+    };
     let store: Store = build_store(
         &*manager,
         &*lockfile,
         install_root_dependencies,
         workspace_filters,
         packages_to_install,
-        manager.options.log_level.is_verbose(),
+        timings,
     )?;
 
     let global_store_path: Option<Vec<u8>> = if manager.options.enable.global_virtual_store() {

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -11,7 +11,7 @@ use bun_paths::SEP;
 use bun_sys::{self as sys, Dir, E, EntryKind, O};
 
 use crate::isolated_install::store::{EntryColumns as _, NodeColumns as _, entry as store_entry};
-use crate::isolated_install::{Store, build_store};
+use crate::isolated_install::{Store, Timings, build_store};
 use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile::tree::is_filtered_dependency_or_workspace;
 use crate::lockfile::{LoadResult, Lockfile, reachable, tree};
@@ -1475,7 +1475,14 @@ fn build_store_with(manager: &mut PackageManager, (local, remote): StoreFeatures
     );
     manager.options.local_package_features = local;
     manager.options.remote_package_features = remote;
-    let store = build_store(&*manager, &manager.lockfile, true, &[], None, false);
+    let store = build_store(
+        &*manager,
+        &manager.lockfile,
+        true,
+        &[],
+        None,
+        Timings::Quiet,
+    );
     (
         manager.options.local_package_features,
         manager.options.remote_package_features,

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -641,6 +641,28 @@ test.concurrent("isolated linker: removes unused store entries and their links",
   await expectProductionInstallIsNoop(dir);
 });
 
+test.concurrent("isolated linker: --verbose does not print the store build timings", async () => {
+  const dir = await setup(
+    { name: "foo", dependencies: { "no-deps": "1.0.0" }, devDependencies: { "one-dep": "1.0.0" } },
+    { linker: "isolated" },
+  );
+
+  // `--production` makes prune build the store twice (once with every
+  // dependency type, once with the production set); `bun install --verbose`
+  // prints a timing line per store build, prune must print none.
+  const { stdout, stderr, exitCode } = await prune(dir, "--production", "--verbose");
+  expect(out(stdout)).toMatchInlineSnapshot(`
+    "bun prune <version> (<revision>)
+
+    - no-deps@1.0.1
+    - one-dep@1.0.0
+    2 packages removed (checked 5)"
+  `);
+  expect(stderr).not.toContain("Resolved peers");
+  expect(stderr).not.toContain("Created store");
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("isolated linker: prune removes the peer-hash variants a peer bump left behind", async () => {
   const dir = await setupWithLinker("isolated", {
     name: "foo",

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2886,6 +2886,43 @@ test("invalid --linker value is echoed back in the error", async () => {
   expect(exitCode).toBe(1);
 });
 
+test("store build timings are printed by --verbose only", async () => {
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "store-timings",
+      dependencies: {
+        "no-deps": "1.0.0",
+      },
+    }),
+  );
+
+  async function install(...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install", ...args],
+      cwd: packageDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    return stderr;
+  }
+
+  const verbose = await install("--verbose");
+  expect(verbose).toMatch(/^Resolved peers \[\S+\]$/m);
+  expect(verbose).toMatch(/^Created store \[\S+\]$/m);
+
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  const quiet = await install();
+  expect(quiet).not.toContain("Resolved peers");
+  expect(quiet).not.toContain("Created store");
+});
+
 describe("hoist", () => {
   // `node_modules/.bun/node_modules` holds a symlink to every installed
   // package and sits on the upward resolution path of every store entry, so


### PR DESCRIPTION
### Problem
- `build_store` in `src/install/isolated_install.rs` takes two bools, `install_root_dependencies` and `print_timings`. Its call in `src/install/prune.rs` (`build_store_with`) reads `build_store(&*manager, &manager.lockfile, true, &[], None, false)`: nothing at the call site says which flag is which, and swapping them would still compile.
- mordant reports this as the `bare_bool_args` finding baselined for that file.

### Fix
- `print_timings: bool` becomes `timings: Timings`, a two-variant enum (`Timings::Print` / `Timings::Quiet`) declared next to `build_store`. `install_isolated_packages` passes `Print` when the log level is verbose (the condition it passed as a bool before); prune passes `Quiet` (was `false`).
- `install_root_dependencies` stays a bool. It is threaded as a bool through the hoisted installer, `Tree::Builder`, `Lockfile::hoist`/`filter` and `is_filtered_dependency_or_workspace` as well, so changing its type is a separate, wider refactor. With one bool left there is nothing to confuse it with, and the lint no longer applies to `build_store`.
- No behavior change: the timing lines are still printed only by a verbose isolated install, and prune's store builds stay silent. Neither was covered by a test before, so each call site gets one: `isolated-install.test.ts` ("store build timings are printed by --verbose only") checks the `Print`/`Quiet` choice in `install_isolated_packages`, and `bun-prune.test.ts` ("isolated linker: --verbose does not print the store build timings") checks prune's `Quiet`. They pin the existing behavior, so they pass before and after the refactor.
- `mordant-baseline.toml` loses the `bare_bool_args` entry for `src/install/isolated_install.rs`, the only entry this finding accounted for (`bun run rust:mordant:baseline` on this branch produces the same file).
- Verified:
  - `bun run rust:mordant` on the previous source with the baseline entry removed reports the `build_store` finding (`over-baseline.txt`: `bun_install 1`); with this change and the regenerated baseline it reports nothing across the workspace.
  - `bun bd test test/cli/install/bun-prune.test.ts test/cli/install/isolated-install.test.ts` (177 pass, 1 skip, including the two new tests)
  - `bun bd test test/cli/install/isolated-relink.test.ts test/cli/install/frozen-lockfile-pruned.test.ts` (107 pass, 1 skip)
  - The new install test also passes against a bun built before this change (`USE_SYSTEM_BUN=1`), as expected for a refactor. That older build has no `bun prune` yet, so the prune test was only run against this branch.

### Background
- `build_store` turns the lockfile into the isolated linker's store layout (`node_modules/.bun/...`) in two passes, resolving peers and then deduplicating entries. A verbose install prints how long each pass took. `bun prune` also builds the store (up to twice, with different feature sets) only to learn which store entry names are still wanted, and does not want those lines.
- mordant is the advisory lint pack run by the `rust-lints` workflow. `mordant-baseline.toml` records, per lint and file, how many findings predate the job; a run fails only on findings above those counts, so fixing a baselined finding means removing its entry.
