### PR TITLE
Blob: drop is_bun_file, a duplicate of needs_to_read_file

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -36,7 +36,6 @@
 [bun_jsc]
 "bare_bool_args:src/jsc/ZigStackFrame.rs" = 1
 "defaulted_failure:src/jsc/ConsoleObject.rs" = 4
-"reimplemented_helper:src/jsc/webcore_types.rs" = 1
 "same_match_twice:src/jsc/VirtualMachine.rs" = 1
 
 [bun_parsers]

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -415,20 +415,15 @@ impl Blob {
         }
     }
 
-    /// `Blob.isBunFile()` — backed by a filesystem `Store::File`.
-    #[inline]
-    pub fn is_bun_file(&self) -> bool {
-        matches!(self.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::File(_)))
-    }
-
     /// `Blob.isS3()` — backed by an S3 `Store::S3`.
     #[inline]
     pub fn is_s3(&self) -> bool {
         matches!(self.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::S3(_)))
     }
 
-    /// `Blob.needsToReadFile()` — true when bytes must be fetched off-disk
-    /// before any in-memory consumer can see them (i.e. `Store::File`).
+    /// `Blob.needsToReadFile()` — backed by a filesystem `Store::File` (a
+    /// `Bun.file()`), so the bytes must be fetched off-disk before any
+    /// in-memory consumer can see them.
     #[inline]
     pub fn needs_to_read_file(&self) -> bool {
         matches!(self.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::File(_)))

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -40,11 +40,11 @@ fn boring_engine(global: &JSGlobalObject) -> *mut boring_ssl::ENGINE {
         .cast::<boring_ssl::ENGINE>()
 }
 
-/// Local helper replacing `input == .blob && input.blob.isBunFile()`.
+/// The synchronous hashers only accept in-memory input, not a `Bun.file()`.
 #[inline]
 fn is_bun_file_blob(input: &BlobOrStringOrBuffer) -> bool {
     match input {
-        BlobOrStringOrBuffer::Blob(b) => b.is_bun_file(),
+        BlobOrStringOrBuffer::Blob(b) => b.needs_to_read_file(),
         _ => false,
     }
 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -136,12 +136,8 @@ pub use bun_jsc::generated::JSBlob as js;
 
 // ──────────────────────────────────────────────────────────────────────────
 
-// is_s3: defined once above (near is_bun_file); duplicate removed to fix E0034.
-
 // is_all_ascii: canonical impl lives later in this file (pub). Duplicate
 // private helper removed here to fix E0592.
-
-// needs_to_read_file: defined once above; duplicate removed to fix E0034.
 
 // ──────────────────────────────────────────────────────────────────────────
 // BlobExt — `bun_runtime`-tier behaviour layered on the `bun_jsc` data type.
@@ -153,9 +149,9 @@ pub use bun_jsc::generated::JSBlob as js;
 #[allow(non_snake_case, clippy::too_many_arguments)]
 pub trait BlobExt {
     fn get_form_data_encoding(&self) -> Option<Box<bun_core::form_data::AsyncFormData>>;
-    // `has_content_type_from_user`/`content_type_or_mime_type`/`is_bun_file`/
-    // `is_s3`/`needs_to_read_file`/`get_file_name`: data-only predicates,
-    // hoisted to inherent `impl Blob` in `bun_jsc::webcore_types` (LAYERING).
+    // `has_content_type_from_user`/`content_type_or_mime_type`/`is_s3`/
+    // `needs_to_read_file`/`get_file_name`: data-only predicates, hoisted to
+    // inherent `impl Blob` in `bun_jsc::webcore_types` (LAYERING).
     fn do_read_from_s3<F: read_file::ReadFileToJs>(
         &self,
         global: &JSGlobalObject,

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -606,7 +606,7 @@ mod _jsc_host_fns {
         match body {
             BodyValue::Used | BodyValue::Empty | BodyValue::Null => JSValue::UNDEFINED,
             BodyValue::Blob(blob) => {
-                if blob.is_bun_file() {
+                if blob.needs_to_read_file() {
                     return JSValue::UNDEFINED;
                 }
                 let result =


### PR DESCRIPTION
### Problem
- mordant's `reimplemented_helper` finding baselined for `src/jsc/webcore_types.rs`: `Blob::is_bun_file` and `Blob::needs_to_read_file` had the same signature and the same body (the store is `Some` and its data is `Store::File`), so a change to one would have silently missed the other.
- The duplication is inherited, not a porting mistake: `Blob.zig` already had `isBunFile` and `needsToReadFile` with the same body, and neither side has changed since the port (#30412). Nothing relies on them differing.

### Fix
- Delete `is_bun_file` and keep `needs_to_read_file`, which is what the ~40 other call sites (and the `blob_needs_to_read_file` hook that `bun_sql_jsc` goes through) already use.
- Point the two `is_bun_file` callers at it: `Response.rs` (`getCompleteWebRequestOrResponseBodyValueAsArrayBuffer` returns `undefined` for a file-backed body) and `CryptoHasher.rs` (the synchronous hashers reject `Bun.file()` input). Same predicate, so no behavior change.
- Remove the `reimplemented_helper:src/jsc/webcore_types.rs` entry from `mordant-baseline.toml`, and the two stale comments in `webcore/Blob.rs` that named the deleted method. The entry is removed by hand rather than by regenerating the file: a full `bun run rust:mordant:baseline` on Linux also drops two unrelated entries (`always_unwrapped_option` in `PackageInstall.rs`, `narrowed_two_ways` in `node_crypto_binding.rs`) that this PR has no business touching.
- No new test: there is no observable behavior to pin (the two predicates were byte-for-byte the same), so no test can distinguish before from after. The `Bun.file()` rejection at the `CryptoHasher` call site is already covered by `bun-cryptohasher.test.ts` ("Bun.file in CryptoHasher is not supported yet"), and the mordant run below is the check for the finding itself. Same shape as #39124, #39116 and #39135 from this batch.
- Verified:
  - `bun run rust:mordant` (full workspace) on this branch: clean, no `target/mordant/over-baseline.txt`. With main's `webcore_types.rs` restored on top of the trimmed baseline it reports `reimplemented_helper ... over the mordant baseline (0 recorded for src/jsc/webcore_types.rs)` and `1 finding(s) over the baseline in bun_jsc`, so the entry was this site and the lint no longer fires.
  - The `mordant` workflow also runs on this PR since the baseline changed; with the entry removed it fails if the finding is still reported.
  - `bun bd test test/js/bun/util/bun-cryptohasher.test.ts` (covers the `CryptoHasher` call site: `Bun.file()` input still throws): 402 pass.
  - `bun bd test` on `test/js/web/fetch/{blob,blob-write,body,blob-file-name-ownership,response}.test.ts`, `test/js/web/structured-clone-blob-file.test.ts` and `test/js/bun/io/bun-write.test.js` (`--timeout 60000`, since several of these spawn a debug+ASAN child and exceed the 5s default): everything passes except `blob.test.ts` "Bun.file(path).slice(start, end) streams only the slice", which fails identically on a clean checkout of main (88a6398836) and is being handled separately; it is a `FileReader` streaming bug unrelated to this predicate.
- Two open PRs add `is_bun_file()` calls in `Blob.rs` (#32434, #33659); whichever lands after this one needs those calls renamed to `needs_to_read_file()`. That is a compile error, not a silent change.

### Background
- `Blob` (`src/jsc/webcore_types.rs`) is a view (offset + size) onto a refcounted `Store`, whose `data` is one of `Bytes` (in memory), `File` (a path or fd; what `Bun.file()` creates) or `S3`. `needs_to_read_file()` asks whether the blob is `File`-backed, i.e. whether its bytes have to be read off disk before anything in memory can look at them; synchronous consumers use it to bail out.
- mordant is the advisory Rust lint pack the `rust-lints` workflow runs (`bun run rust:mordant`). `mordant-baseline.toml` holds the per-(lint, file) counts of findings that predate the job, so CI only fails when a count goes up; once a baselined finding is fixed its entry is deleted.

