### PR TITLE
Bun.serve: map RouteMethod to Option<Method> in one place

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -85,7 +85,6 @@
 "same_match_twice:src/runtime/cli/update_interactive_command.rs" = 2
 "same_match_twice:src/runtime/ipc.rs" = 2
 "same_match_twice:src/runtime/server/RequestContext.rs" = 4
-"same_match_twice:src/runtime/server/server_body.rs" = 1
 "same_match_twice:src/runtime/shell/builtin/cat.rs" = 1
 "same_match_twice:src/runtime/webcore/Blob.rs" = 2
 "same_match_twice:src/runtime/webcore/Body.rs" = 2

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -174,6 +174,17 @@ pub enum RouteMethod {
     Specific(Method),
 }
 
+impl RouteMethod {
+    /// `None` for [`RouteMethod::Any`]: the method is not known until it is
+    /// read off the request.
+    pub(crate) fn specific(&self) -> Option<Method> {
+        match self {
+            RouteMethod::Any => None,
+            RouteMethod::Specific(method) => Some(*method),
+        }
+    }
+}
+
 impl Default for RouteDeclaration {
     fn default() -> Self {
         Self {

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1181,10 +1181,7 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             resp,
             Some(bun_ptr::BackRef::new(&should_deinit_context)),
             CreateJsRequest::No,
-            match &user_route.route.method {
-                server_config::RouteMethod::Any => None,
-                server_config::RouteMethod::Specific(m) => Some(*m),
-            },
+            user_route.route.method.specific(),
         ) else {
             return;
         };

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2971,10 +2971,7 @@ where
             resp,
             Some(bun_ptr::BackRef::new(&should_deinit_context)),
             CreateJsRequest::No,
-            match &user_route.route.method {
-                server_config::RouteMethod::Any => None,
-                server_config::RouteMethod::Specific(m) => Some(*m),
-            },
+            user_route.route.method.specific(),
         ) else {
             return;
         };


### PR DESCRIPTION
### Problem
- mordant `same_match_twice` on `src/runtime/server/server_body.rs:2974`: "this `match` on `server_config::RouteMethod` repeats an earlier one arm for arm. The mapping exists twice, and a change to one copy will miss the other".
- The other copy is `src/runtime/server/mod.rs:1184`. Both are the user-route dispatchers (HTTP/1 in `mod.rs`, the `Ctx`-generic one used for HTTP/3 in `server_body.rs`) turning the route's `RouteMethod` into the `Option<Method>` that `prepare_js_request_context` takes.

### Fix
- Adds `RouteMethod::specific(&self) -> Option<Method>` in `ServerConfig.rs` and calls it from both dispatchers. No behavior change: the one remaining match has the same two arms the two copies had.
- Removes the `same_match_twice:src/runtime/server/server_body.rs` entry from `mordant-baseline.toml`.
- The two other matches on `RouteMethod` in `mod.rs` (route registration at ~2351, the explicit-HEAD check at ~2474) map to different things and are left alone.
- No new tests: there is no behavior to assert that differs from main. Both arms are already exercised at both call sites by existing tests (`bun-serve-routes.test.ts` "preserves request method" hits an any-method route with PATCH and "route precedence for method-specific routes" hits per-method routes over HTTP/1; `serve-http3.test.ts` "routes: handler with :params" and "routes: per-method handler" do the same over HTTP/3). The guard against the duplication coming back is the removed baseline entry: the `mordant` job fails if a second copy of this match reappears.
- Verified:
  - `bun bd test test/js/bun/http/bun-serve-routes.test.ts`: 61 pass.
  - `bun bd test test/js/bun/http/serve-http3.test.ts -t routes`: 4 pass (covers the `server_body.rs` path).
  - `bun run rust:mordant` with this baseline: clean (`target/mordant/over-baseline.txt` not written). With the `src/` change stashed and only the baseline edit applied it reports the `server_body.rs` finding as over baseline, so the removed entry is this one.
  - `bun run rust:mordant:baseline` on this branch regenerates the file with this entry gone and nothing added. It also drops two entries unrelated to this change (`always_unwrapped_option` in `src/install/PackageInstall.rs`, `narrowed_two_ways` in `src/runtime/node/node_crypto_binding.rs`) that were fixed on main after the baseline was last regenerated; those are not included here, since stale entries are harmless.

### Background
- `RouteMethod` (`ServerConfig.rs`) is how a `routes: { "/x": { GET: ... } }` entry records its method: `Specific(Method)` for a per-method handler, `Any` for a handler that takes every method.
- `prepare_js_request_context` takes `Option<Method>`: `Some` when the route already pins the method, `None` to read it off the request.
- mordant is the dylint pack run by the `rust-lints` workflow; `mordant-baseline.toml` holds per-(lint, file) counts of pre-existing findings, and a PR fails the job only when it adds one. Removing a line makes the job enforce that the site stays fixed.
