### PR TITLE
dns: replace the packed CacheConfig with a pending_slot: Option<u8> field

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -58,7 +58,6 @@
 "bare_bool_args:src/runtime/api/bun/h2_frame_parser.rs" = 1
 "bare_bool_args:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "bare_bool_args:src/runtime/cli/run_command.rs" = 1
-"bare_bool_args:src/runtime/dns_jsc/dns.rs" = 1
 "bare_bool_args:src/runtime/node/types.rs" = 4
 "defaulted_failure:src/runtime/ffi/ffi_body.rs" = 1
 "defaulted_failure:src/runtime/server/RequestContext.rs" = 1

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -154,7 +154,6 @@ mod lib_c {
             cache,
             get_addr_info_request::Backend::CAres,
             Some(this.as_ctx_ptr()),
-            &query,
             global_this,
             PendingCacheField::PendingHostCacheNative,
         );
@@ -243,7 +242,6 @@ pub(crate) mod lib_uv_backend {
             cache,
             get_addr_info_request::Backend::Libc(get_addr_info_request::LibcBackend::uv_uninit()),
             Some(this.as_ctx_ptr()),
-            &query,
             global_this,
             PendingCacheField::PendingHostCacheNative,
         );
@@ -287,9 +285,9 @@ pub(crate) mod lib_uv_backend {
                 // completion would have taken so the pending-cache slot is released
                 // and the promise is rejected with a DNSException.
                 if let Some(resolver) = (*request).resolver_for_caching {
-                    if (*request).cache.pending_cache() {
+                    if let Some(pos) = (*request).pending_slot {
                         (*resolver).drain_pending_host_native(
-                            (*request).cache.pos_in_pending(),
+                            pos,
                             (*request).head.global_this(),
                             rc.int(),
                             &GetAddrInfoResultAny::Addrinfo(ptr::null_mut()),
@@ -331,39 +329,6 @@ fn normalize_dns_name<'a>(name: &'a [u8], backend: &mut GetAddrInfoBackend) -> &
     }
 
     name
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// CacheConfig — packed struct(u16) shared by all request types
-// ──────────────────────────────────────────────────────────────────────────
-
-#[repr(transparent)]
-#[derive(Copy, Clone, Default)]
-pub struct CacheConfig(u16);
-
-impl CacheConfig {
-    #[inline]
-    pub(crate) const fn pending_cache(self) -> bool {
-        self.0 & 0x0001 != 0
-    }
-    #[inline]
-    pub(crate) const fn pos_in_pending(self) -> u8 {
-        ((self.0 >> 2) & 0x1F) as u8
-    }
-    #[inline]
-    pub(crate) const fn new(
-        pending_cache: bool,
-        entry_cache: bool,
-        pos_in_pending: u8,
-        name_len: u16,
-    ) -> Self {
-        Self(
-            (pending_cache as u16)
-                | ((entry_cache as u16) << 1)
-                | (((pos_in_pending as u16) & 0x1F) << 2)
-                | ((name_len & 0x1FF) << 7),
-        )
-    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -431,7 +396,9 @@ impl<T: CAresRecordType> Drop for OwnedReply<T> {
 pub(crate) struct ResolveInfoRequest<T: CAresRecordType> {
     // TODO: should be Option<&'a Resolver> (struct gets <'a>); raw ptr until reconciled with intrusive RC
     pub resolver_for_caching: Option<*mut Resolver>,
-    pub cache: CacheConfig,
+    /// Slot this request owns in the resolver's pending cache, which same-name
+    /// lookups chain onto until completion drains it; `None` when the cache was full.
+    pub pending_slot: Option<u8>,
     pub head: CAresLookup<T>,
     pub tail: *mut CAresLookup<T>, // INTRUSIVE — points at `head` or last appended node
 }
@@ -480,7 +447,7 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
         poll_ref.ref_(js_event_loop_ctx());
         let request = bun_core::heap::into_raw(Box::new(Self {
             resolver_for_caching: resolver,
-            cache: CacheConfig::default(),
+            pending_slot: None,
             head: CAresLookup {
                 // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
                 resolver: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
@@ -505,7 +472,7 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
                     .pending_cache_for::<T>(cache_field)
                     .index_of(new)
                     .unwrap();
-                (*request).cache = CacheConfig::new(true, false, pos as u8, name.len() as u16);
+                (*request).pending_slot = Some(pos as u8);
                 (*new).lookup = request;
             }
         }
@@ -522,13 +489,8 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching {
                 scopeguard::defer! { (*resolver).request_completed() };
-                if (*this).cache.pending_cache() {
-                    (*resolver).drain_pending_cares::<T>(
-                        (*this).cache.pos_in_pending(),
-                        err_,
-                        timeout,
-                        result,
-                    );
+                if let Some(pos) = (*this).pending_slot {
+                    (*resolver).drain_pending_cares::<T>(pos, err_, timeout, result);
                     return;
                 }
             }
@@ -568,7 +530,8 @@ impl<T: CAresRecordType> c_ares::ResolveHandler for ResolveInfoRequest<T> {
 pub(crate) struct GetHostByAddrInfoRequest {
     // TODO: should be Option<&'a Resolver>; raw ptr for now
     pub resolver_for_caching: Option<*mut Resolver>,
-    pub cache: CacheConfig,
+    /// See [`ResolveInfoRequest::pending_slot`].
+    pub pending_slot: Option<u8>,
     pub head: CAresReverse,
     pub tail: *mut CAresReverse, // INTRUSIVE
 }
@@ -618,7 +581,7 @@ impl GetHostByAddrInfoRequest {
         poll_ref.ref_(js_event_loop_ctx());
         let request = bun_core::heap::into_raw(Box::new(Self {
             resolver_for_caching: resolver,
-            cache: CacheConfig::default(),
+            pending_slot: None,
             head: CAresReverse {
                 // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
                 resolver: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
@@ -642,7 +605,7 @@ impl GetHostByAddrInfoRequest {
                     .get()
                     .index_of(new)
                     .unwrap();
-                (*request).cache = CacheConfig::new(true, false, pos as u8, name.len() as u16);
+                (*request).pending_slot = Some(pos as u8);
                 (*new).lookup = request;
             }
         }
@@ -658,13 +621,8 @@ impl GetHostByAddrInfoRequest {
         // SAFETY: this is the heap-allocated request c-ares calls back with
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching {
-                if (*this).cache.pending_cache() {
-                    (*resolver).drain_pending_addr_cares(
-                        (*this).cache.pos_in_pending(),
-                        err_,
-                        timeout,
-                        result,
-                    );
+                if let Some(pos) = (*this).pending_slot {
+                    (*resolver).drain_pending_addr_cares(pos, err_, timeout, result);
                     return;
                 }
             }
@@ -818,7 +776,8 @@ impl Drop for CAresNameInfo {
 pub(crate) struct GetNameInfoRequest {
     // TODO: should be Option<&'a Resolver>; raw ptr for now
     pub resolver_for_caching: Option<*mut Resolver>,
-    pub cache: CacheConfig,
+    /// See [`ResolveInfoRequest::pending_slot`].
+    pub pending_slot: Option<u8>,
     pub head: CAresNameInfo,
     pub tail: *mut CAresNameInfo, // INTRUSIVE
 }
@@ -865,10 +824,9 @@ impl GetNameInfoRequest {
     ) -> *mut Self {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
-        let name_len = name.len();
         let request = bun_core::heap::into_raw(Box::new(Self {
             resolver_for_caching: resolver,
-            cache: CacheConfig::default(),
+            pending_slot: None,
             head: CAresNameInfo {
                 global_this: bun_ptr::BackRef::new(global_this),
                 promise: JSPromiseStrong::init(global_this),
@@ -890,7 +848,7 @@ impl GetNameInfoRequest {
                     .get()
                     .index_of(new)
                     .unwrap();
-                (*request).cache = CacheConfig::new(true, false, pos as u8, name_len as u16);
+                (*request).pending_slot = Some(pos as u8);
                 (*new).lookup = request;
             }
         }
@@ -909,13 +867,8 @@ impl GetNameInfoRequest {
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching {
                 scopeguard::defer! { (*resolver).request_completed() };
-                if (*this).cache.pending_cache() {
-                    (*resolver).drain_pending_name_info_cares(
-                        (*this).cache.pos_in_pending(),
-                        err_,
-                        timeout,
-                        result,
-                    );
+                if let Some(pos) = (*this).pending_slot {
+                    (*resolver).drain_pending_name_info_cares(pos, err_, timeout, result);
                     return;
                 }
             }
@@ -957,7 +910,8 @@ pub struct GetAddrInfoRequest {
     pub(crate) backend: get_addr_info_request::Backend,
     // TODO: should be Option<&'a Resolver>; raw ptr for now
     pub(crate) resolver_for_caching: Option<*mut Resolver>,
-    pub(crate) cache: CacheConfig,
+    /// See [`ResolveInfoRequest::pending_slot`].
+    pub(crate) pending_slot: Option<u8>,
     pub(crate) head: DNSLookup,
     pub(crate) tail: *mut DNSLookup, // INTRUSIVE
 }
@@ -989,11 +943,11 @@ pub mod get_addr_info_request {
             // waiters, none of which anything else will touch again.
             unsafe {
                 if let Some(resolver) = (*req).resolver_for_caching {
-                    if (*req).cache.pending_cache() {
-                        drop((*resolver).get_key_host(
-                            (*req).cache.pos_in_pending(),
-                            PendingCacheField::PendingHostCacheNative,
-                        ));
+                    if let Some(pos) = (*req).pending_slot {
+                        drop(
+                            (*resolver)
+                                .get_key_host(pos, PendingCacheField::PendingHostCacheNative),
+                        );
                     }
                 }
                 let mut pending = (*req).head.next;
@@ -1189,7 +1143,6 @@ impl GetAddrInfoRequest {
         cache: CacheHit,
         backend: get_addr_info_request::Backend,
         resolver: Option<*mut Resolver>,
-        query: &GetAddrInfo,
         global_this: &JSGlobalObject,
         cache_field: PendingCacheField,
     ) -> *mut Self {
@@ -1199,7 +1152,7 @@ impl GetAddrInfoRequest {
         let request = bun_core::heap::into_raw(Box::new(Self {
             backend,
             resolver_for_caching: resolver,
-            cache: CacheConfig::default(),
+            pending_slot: None,
             head: DNSLookup {
                 // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
                 resolver: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
@@ -1221,8 +1174,7 @@ impl GetAddrInfoRequest {
                     .pending_host_cache(cache_field)
                     .index_of(new)
                     .unwrap();
-                (*request).cache =
-                    CacheConfig::new(true, false, pos as u8, query.name.len() as u16);
+                (*request).pending_slot = Some(pos as u8);
                 (*new).lookup = request;
             }
         }
@@ -1283,9 +1235,9 @@ impl GetAddrInfoRequest {
             };
 
             if let Some(resolver) = (*this).resolver_for_caching {
-                if (*this).cache.pending_cache() {
+                if let Some(pos) = (*this).pending_slot {
                     (*resolver).drain_pending_host_native(
-                        (*this).cache.pos_in_pending(),
+                        pos,
                         (*this).head.global_this(),
                         status,
                         &any,
@@ -1331,9 +1283,9 @@ impl GetAddrInfoRequest {
                     // at the end of whichever callee receives `any`.
                     let any = GetAddrInfoResultAny::List(result);
                     if let Some(resolver) = (*this).resolver_for_caching {
-                        if (*this).cache.pending_cache() {
+                        if let Some(pos) = (*this).pending_slot {
                             (*resolver).drain_pending_host_native(
-                                (*this).cache.pos_in_pending(),
+                                pos,
                                 (*this).head.global_this(),
                                 0,
                                 &any,
@@ -1351,9 +1303,9 @@ impl GetAddrInfoRequest {
                     err,
                 )) => {
                     if let Some(resolver) = (*this).resolver_for_caching {
-                        if (*this).cache.pending_cache() {
+                        if let Some(pos) = (*this).pending_slot {
                             (*resolver).drain_pending_host_native(
-                                (*this).cache.pos_in_pending(),
+                                pos,
                                 (*this).head.global_this(),
                                 err,
                                 &GetAddrInfoResultAny::Addrinfo(ptr::null_mut()),
@@ -1388,13 +1340,8 @@ impl GetAddrInfoRequest {
         // `resolver` (if set) is the live intrusive-RC ctx stored at init time.
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching {
-                if (*this).cache.pending_cache() {
-                    (*resolver).drain_pending_host_cares(
-                        (*this).cache.pos_in_pending(),
-                        err_,
-                        timeout,
-                        result,
-                    );
+                if let Some(pos) = (*this).pending_slot {
+                    (*resolver).drain_pending_host_cares(pos, err_, timeout, result);
                     return;
                 }
             }
@@ -1434,9 +1381,9 @@ impl GetAddrInfoRequest {
             };
 
             if let Some(resolver) = (*this).resolver_for_caching {
-                if (*this).cache.pending_cache() {
+                if let Some(pos) = (*this).pending_slot {
                     (*resolver).drain_pending_host_native(
-                        (*this).cache.pos_in_pending(),
+                        pos,
                         (*this).head.global_this(),
                         retcode,
                         &result_any,
@@ -5495,7 +5442,6 @@ impl Resolver {
             cache,
             get_addr_info_request::Backend::CAres,
             Some(self.as_ctx_ptr()),
-            query,
             global_this,
             PendingCacheField::PendingHostCacheCares,
         );

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -725,7 +725,6 @@ pub(crate) fn lookup(
         cache,
         get_addr_info_request::Backend::DnsSd(get_addr_info_request::BackendDnsSd::new(protocol)),
         Some(this.as_ctx_ptr()),
-        query,
         global_this,
         PendingCacheField::PendingHostCacheNative,
     );
@@ -742,8 +741,7 @@ pub(crate) fn lookup(
     ) else {
         // SAFETY: request is exclusively owned; dns_sd never accepted it.
         unsafe {
-            if (*request).cache.pending_cache() {
-                let pos = (*request).cache.pos_in_pending();
+            if let Some(pos) = (*request).pending_slot {
                 this.pending_host_cache_native.with_mut(|c| {
                     let slot = c.ptr_at(pos as usize);
                     // SAFETY: `pos` was alloc'd; no other token outstanding.

--- a/src/runtime/dns_jsc/mod.rs
+++ b/src/runtime/dns_jsc/mod.rs
@@ -30,7 +30,7 @@ pub mod options_jsc; // GetAddrInfo.Options ↔ JSValue
 #[cfg(target_os = "macos")]
 pub(crate) use dns_body::dns_sd;
 pub use dns_body::{
-    CacheConfig, CacheHit, GetAddrInfoRequest, GlobalData, InternalDNSRequest, Order, PendingCache,
+    CacheHit, GetAddrInfoRequest, GlobalData, InternalDNSRequest, Order, PendingCache,
     PendingCacheField, RecordType, Resolver, internal,
 };
 pub use dns_body::{

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -873,3 +873,122 @@ describe("dns.lookupService with a numeric-string port", () => {
     );
   });
 });
+
+// A resolver keeps a 32-slot pending cache per query kind. The first in-flight
+// query for a name owns a slot; identical queries issued while it is in flight
+// are chained onto it and settled together when it completes, so the server
+// sees one query per distinct name. Queries issued while all 32 slots are taken
+// get no slot and settle on their own. The fake server below records every
+// query it receives and answers an A query for "a<n>.pending.test" with
+// 10.0.0.<n>, so a promise settled from the wrong slot shows up as the wrong
+// address.
+describe("pending cache", () => {
+  function encodeName(name) {
+    return Buffer.concat([
+      ...name.split(".").map(label => Buffer.concat([Buffer.from([label.length]), Buffer.from(label)])),
+      Buffer.from([0]),
+    ]);
+  }
+
+  async function startFakeServer() {
+    const socket = dgram.createSocket("udp4");
+    const queries = [];
+    socket.on("message", (query, rinfo) => {
+      const labels = [];
+      let off = 12;
+      while (query[off] !== 0) {
+        labels.push(query.toString("latin1", off + 1, off + 1 + query[off]));
+        off += query[off] + 1;
+      }
+      const qtype = query.readUInt16BE(off + 1);
+      const question = query.subarray(12, off + 5);
+      const qname = labels.join(".");
+      queries.push(`${qtype === 1 ? "A" : qtype === 12 ? "PTR" : qtype} ${qname}`);
+
+      const rdata =
+        qtype === 1 ? Buffer.from([10, 0, 0, Number(/\d+/.exec(labels[0])[0])]) : encodeName("ptr.pending.test");
+      const header = Buffer.from([query[0], query[1], 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]);
+      const answer = Buffer.from([0xc0, 0x0c, 0, qtype, 0, 1, 0, 0, 0, 60, rdata.length >> 8, rdata.length & 0xff]);
+      socket.send(Buffer.concat([header, question, answer, rdata]), rinfo.port, rinfo.address);
+    });
+    socket.bind(0, "127.0.0.1");
+    await once(socket, "listening");
+    const resolver = new dns_promises.Resolver({ timeout: 1000, tries: 1 });
+    resolver.setServers(["127.0.0.1:" + socket.address().port]);
+    return { socket, queries, resolver, port: socket.address().port };
+  }
+
+  test.concurrent("concurrent resolve4() of the same names share one query per name", async () => {
+    const { socket, queries, resolver } = await startFakeServer();
+    try {
+      const names = Array.from({ length: 3 }, (_, i) => `a${i}.pending.test`);
+      const results = await Promise.all(
+        names.flatMap(name =>
+          Array.from({ length: 4 }, () => resolver.resolve4(name).then(addresses => [name, addresses])),
+        ),
+      );
+      expect(results).toEqual(names.flatMap((name, i) => Array(4).fill([name, ["10.0.0." + i]])));
+      expect(queries.sort()).toEqual(names.map(name => "A " + name));
+    } finally {
+      socket.close();
+    }
+  });
+
+  test.concurrent("more distinct resolve4() than pending-cache slots all settle with their own answers", async () => {
+    const { socket, queries, resolver } = await startFakeServer();
+    try {
+      const names = Array.from({ length: 40 }, (_, i) => `a${i}.pending.test`);
+      const results = await Promise.all(names.map(name => resolver.resolve4(name)));
+      expect(results).toEqual(names.map((_, i) => ["10.0.0." + i]));
+      expect(queries.sort()).toEqual(names.map(name => "A " + name).sort());
+    } finally {
+      socket.close();
+    }
+  });
+
+  test.concurrent("concurrent reverse() of the same address share one PTR query", async () => {
+    const { socket, queries, resolver } = await startFakeServer();
+    try {
+      const results = await Promise.all(Array.from({ length: 4 }, () => resolver.reverse("192.0.2.7")));
+      expect(results).toEqual(Array(4).fill(["ptr.pending.test"]));
+      expect(queries).toEqual(["PTR 7.2.0.192.in-addr.arpa"]);
+    } finally {
+      socket.close();
+    }
+  });
+
+  // Bun.dns.lookup with the c-ares backend goes through the default resolver,
+  // so point that resolver at the fake server in a child process. The trailing
+  // dot keeps c-ares from also trying the host's search domains.
+  test.concurrent("concurrent c-ares lookup() of the same name share one query", async () => {
+    const { socket, queries, port } = await startFakeServer();
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `require("node:dns").setServers(["127.0.0.1:" + process.argv[1]]);
+           const lookups = Array.from({ length: 4 }, () => Bun.dns.lookup("a5.pending.test.", { backend: "c-ares", family: 4 }));
+           Promise.all(lookups).then(results => console.log(JSON.stringify(results.map(r => r.map(({ address, family }) => ({ address, family }))))));`,
+          String(port),
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(Array(4).fill([{ address: "10.0.0.5", family: 4 }]));
+      expect(exitCode).toBe(0);
+      expect(queries).toEqual(["A a5.pending.test"]);
+    } finally {
+      socket.close();
+    }
+  });
+
+  // dns.lookup() uses the OS resolver, which answers "localhost" from the hosts
+  // file, so this stays offline while still coalescing onto one slot.
+  test.concurrent("concurrent lookup() of the same name all settle", async () => {
+    const results = await Promise.all(Array.from({ length: 8 }, () => dns_promises.lookup("localhost", { family: 4 })));
+    expect(results).toEqual(Array(8).fill({ address: "127.0.0.1", family: 4 }));
+  });
+});


### PR DESCRIPTION
### Problem
- `CacheConfig::new(pending_cache, entry_cache, pos_in_pending, name_len)` in `src/runtime/dns_jsc/dns.rs` is called from four places, all as `CacheConfig::new(true, false, pos as u8, name.len() as u16)`; at the call site nothing says which bool is which (the `bare_bool_args` entry for this file in `mordant-baseline.toml`).
- Two of the four fields are dead: `entry_cache` and `name_len` are packed into the `u16` and never read anywhere (they were reserved for a result cache that was never built; in the Zig original their only reader was commented out). `pending_cache` is `true` in every constructor call and `false` only via `Default`.
- So the struct carries exactly one piece of information: whether this request owns a pending-cache slot, and if so which one. Giving the two bools enums would keep a constructor that nobody calls with anything but one combination.

### Fix
- Delete `CacheConfig`. Each of the four request structs (`ResolveInfoRequest<T>`, `GetHostByAddrInfoRequest`, `GetNameInfoRequest`, `GetAddrInfoRequest`) now has `pending_slot: Option<u8>`: `None` at construction, `Some(pos)` when the lookup was entered into the pending cache.
- The eleven completion sites that did `if cache.pending_cache() { drain(cache.pos_in_pending(), ..) }` now do `if let Some(pos) = pending_slot { drain(pos, ..) }`, so the index cannot be read without first establishing that a slot exists.
- `GetAddrInfoRequest::init` loses its `query` parameter; its only use was supplying the unread `name_len`.
- No behavior change: `pos` was already masked to 5 bits against a 32-slot `HiveArray`, so the stored value is identical, and the `Default` state maps to `None`.
- Remove the now-cleared `"bare_bool_args:src/runtime/dns_jsc/dns.rs" = 1` baseline entry.
- Tests: a `pending cache` block at the end of `test/js/node/dns/node-dns.test.js` runs a fake nameserver on `127.0.0.1` that records every query and answers `a<n>.pending.test` with `10.0.0.<n>`. It checks that 4 concurrent `resolve4()` per name produce one query per name and that every caller gets its own name's address, that 40 distinct names (more than the 32 slots) each get their own address, that 4 concurrent `reverse()` share one PTR query, that 4 concurrent c-ares `Bun.dns.lookup()` in a child process share one query, and that concurrent system-backend lookups of `localhost` all settle. Draining the wrong slot (tried by storing `pos + 1`) fails them on the spot; as a refactor, the unmodified binary passes them too.
- Verified: `bun bd test test/js/bun/dns/ test/js/node/dns/` and the three dns regression tests pass except for the lookups that need outside DNS, which fail identically with the unmodified release binary in this sandbox (`ESERVFAIL`). `test/js/node/dns/dns-resolver-concurrent-timeout.test.ts` also runs offline and covers 32 held slots plus 8 overflow requests.
- `cargo check -p bun_runtime` for `aarch64-apple-darwin` (the `dns_sd.rs` and libc paths) and `x86_64-pc-windows-msvc` (the libuv path) is clean, as is `cargo clippy -p bun_runtime`.
- `bun run rust:mordant` with the baseline entry removed reports nothing; with the entry removed but `dns.rs` reverted it reports the one `bare_bool_args` finding, so the entry is what this change clears.

### Background
- The resolver keeps one 32-slot `HiveArray` per query kind (the `pending_*_cache_*` fields on `Resolver`). The first in-flight lookup for a name takes a slot and owns the request; later lookups for the same name while it is in flight are appended to that request's intrusive list instead of issuing another query. When the owning request completes, `Resolver::drain_pending_*` takes the slot's index, frees it, and settles every promise in the list. A lookup that arrives when all 32 slots are taken gets no slot and settles only itself on completion; `pending_slot` is what tells the two cases apart.
- `mordant-baseline.toml` records, per lint and file, how many pre-existing findings CI tolerates. Fixing a finding lets its entry be removed; a regeneration (`bun run rust:mordant:baseline`) on this branch drops this entry.

<details>
<summary>Baseline regeneration note</summary>

A full `bun run rust:mordant:baseline` on this branch also drops two entries unrelated to this change, `always_unwrapped_option:src/install/PackageInstall.rs` and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs` (the latter was fixed by #37648). They are already stale on main and are left in place here to keep this PR to its one finding.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->