### PR TITLE
js_parser: pass visit_decl its flags as a VisitDeclOpts struct

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -20,7 +20,6 @@
 "same_match_twice:src/install/PackageManager/install_with_manager.rs" = 1
 
 [bun_js_parser]
-"bare_bool_args:src/js_parser/visit/mod.rs" = 1
 "same_match_twice:src/js_parser/p.rs" = 3
 "sentinel_integer:src/js_parser/parse/parse_entry.rs" = 1
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -685,6 +685,13 @@ pub struct VisitArgsOpts<'a> {
 }
 
 #[derive(Clone, Copy)]
+pub struct VisitDeclOpts {
+    pub(crate) was_anonymous_named_expr: bool,
+    pub(crate) could_be_const_value: bool,
+    pub(crate) could_be_macro: bool,
+}
+
+#[derive(Clone, Copy)]
 pub struct TransposeState {
     pub(crate) is_await_target: bool,
     pub(crate) is_then_catch_target: bool,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -11,7 +11,7 @@ use crate::p::{LowerUsingDeclarationsContext, P};
 use crate::parser::{
     ExprIn, FnOnlyDataVisit, FnOrArrowDataVisit, ImportItemForNamespaceMap, PrependTempRefsOpts,
     Ref, RelocateVarsMode, ScopeOrder, StmtsKind, StrictModeFeature, StringVoidMap, VisitArgsOpts,
-    is_eval_or_arguments,
+    VisitDeclOpts, is_eval_or_arguments,
 };
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast as js_ast;
@@ -390,12 +390,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let is_after = self.vis_scope().is_after_const_local_prefix;
                 self.visit_decl(
                     decl,
-                    was_anonymous_named_expr,
-                    was_const && !is_after,
-                    if Self::ALLOW_MACROS {
-                        prev_macro_call_count != self.macro_call_count
-                    } else {
-                        false
+                    VisitDeclOpts {
+                        was_anonymous_named_expr,
+                        could_be_const_value: was_const && !is_after,
+                        could_be_macro: if Self::ALLOW_MACROS {
+                            prev_macro_call_count != self.macro_call_count
+                        } else {
+                            false
+                        },
                     },
                 );
             } else if IS_POSSIBLY_DECL_TO_REMOVE {
@@ -414,7 +416,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         let replacer = _ptr.get();
                         if !self.replace_decl_and_possibly_remove(decl, replacer) {
                             let is_after = self.vis_scope().is_after_const_local_prefix;
-                            self.visit_decl(decl, false, was_const && !is_after, false);
+                            self.visit_decl(
+                                decl,
+                                VisitDeclOpts {
+                                    was_anonymous_named_expr: false,
+                                    could_be_const_value: was_const && !is_after,
+                                    could_be_macro: false,
+                                },
+                            );
                         } else {
                             continue 'outer;
                         }
@@ -514,13 +523,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    pub(crate) fn visit_decl(
-        &mut self,
-        decl: &mut G::Decl,
-        was_anonymous_named_expr: bool,
-        could_be_const_value: bool,
-        could_be_macro: bool,
-    ) {
+    pub(crate) fn visit_decl(&mut self, decl: &mut G::Decl, opts: VisitDeclOpts) {
+        let VisitDeclOpts {
+            was_anonymous_named_expr,
+            could_be_const_value,
+            could_be_macro,
+        } = opts;
         // Optionally preserve the name
         match decl.binding.data {
             BData::BIdentifier(id) => {


### PR DESCRIPTION
### Problem
- `visit_decl` in `src/js_parser/visit/mod.rs` took three adjacent `bool` parameters (`was_anonymous_named_expr`, `could_be_const_value`, `could_be_macro`), and the second of its two callers passed them positionally: `visit_decl(decl, false, was_const && !is_after, false)`. Nothing at that call says which flag is which.
- This is the one `bare_bool_args` finding recorded for this file in `mordant-baseline.toml`.
- The shape has already bitten once: the Zig version of this call site passed `was_const and !is_after` in the `was_anonymous_named_expr` slot (`src/js_parser/visit/visit.zig` before d4514457e8); the Rust port put it in the right slot. Two open PRs (#34089, #35548) each add a fourth positional bool to the same call.

### Fix
- Adds `VisitDeclOpts` to `src/js_parser/parser.rs`, next to `VisitArgsOpts`, with one documented field per former parameter. Same shape as the existing `VisitArgsOpts` / `ParenExprOpts` option structs; an options struct rather than three enums because `was_anonymous_named_expr` is handed straight on to `maybe_keep_expr_symbol_name` as a `bool`, and `dylint.toml` already treats several-bool structs as this repo's option-bag style.
- `visit_decl` now takes `opts: VisitDeclOpts` and destructures it on entry; the rest of its body is unchanged. Both callers build the struct with every field named, using the same expressions as before, in the same order.
- Removes the `"bare_bool_args:src/js_parser/visit/mod.rs" = 1` line from `mordant-baseline.toml`. Running the baseline writer scoped to `bun_js_parser` (`MORDANT_BASELINE_WRITE=1 cargo dylint --all -p bun_js_parser`) rewrites the file byte for byte identical to what is committed.
- No behavior change is intended. Verified with a debug build:
  - `bun bd test test/bundler/transpiler/`: 3870 pass, 0 fail. The only red was `jsx-production.test.ts`, whose 32 concurrent parent+child debug-build spawns exceed the 5s per-test timeout on an 8 core box; all 32 pass with `--timeout 120000`.
  - `bun bd test test/bundler/bundler_minify.test.ts test/bundler/esbuild/dce.test.ts test/regression/issue/26360.test.ts test/regression/issue/22656.test.ts` (keepNames, const inlining, macros): 128 pass, 0 fail.
  - `bun bd test test/bundler/bundler_edgecase.test.ts`: 134 pass, 0 fail.
  - `cargo dylint --all -p bun_js_parser -- --keep-going` with the baseline line removed: on the previous code it reports the finding quoted below as over the baseline; on this branch it reports nothing and `target/mordant/over-baseline.txt` is not written.
- No test is added: a signature refactor has no observable behavior to pin, so there is nothing a new test could fail on before this change. The existing suites above are the coverage; the lint run is what distinguishes before from after.

### Background
- `visit_decls` visits every `decl` of a `let`/`const`/`var` statement. For each one it visits the initializer and then calls `visit_decl`, which does the bookkeeping that depends on facts only the caller observed: whether the initializer was an anonymous function or class before visiting (so the binding's name can be attached to it via `maybe_keep_expr_symbol_name`), whether this is a `const` still inside the scope's leading run of `const`s (so the value may be recorded in `const_values` for inlining), and whether visiting the initializer ran a macro (so the macro result may be recorded or destructured into `const_values`). The three fields of `VisitDeclOpts` are those three facts.
- The second caller runs on the `exports.replace` / `exports.eliminate` path of `Bun.Transpiler` for a declaration with no initializer. Its replace/delete branches are inverted today (`eliminate` on `export let x;` hits an `unwrap` on `None`); that is pre-existing and already addressed by #33378, so it is left alone here.
- `mordant-baseline.toml` is a ratchet: it records the per (lint, file) counts of findings that predate the lint job, and the job fails only on findings above those counts. Fixing a finding means deleting its line so it cannot come back.

<details>
<summary>Lint output on the previous code with the baseline line removed</summary>

```
warning: `visit_decl` takes bools `was_anonymous_named_expr`, `could_be_const_value` and `could_be_macro`, and 1 of its 2 calls passes bare `true`/`false` for at least two of them. At `visit_decl(.., false, .., false)` nothing says which is which
   --> src/js_parser/visit/mod.rs:517:19
    |
517 |     pub(crate) fn visit_decl(
    |                   ^^^^^^^^^^
    |
note: one of those calls
   --> src/js_parser/visit/mod.rs:417:29
    |
417 | ...                   self.visit_decl(decl, false, was_const && !is_after, false);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = help: give `was_anonymous_named_expr`, `could_be_const_value` and `could_be_macro` a two-variant enum each, or an options struct, so every call names what it sets
    = note: `bare_bool_args` over the mordant baseline (0 recorded for src/js_parser/visit/mod.rs)

warning: mordant: 1 finding(s) over the baseline in bun_js_parser
```

On this branch the same command finishes with no warnings.
</details>
