### PR TITLE
terminal: throw when a termios flag assignment fails and clear its mordant baseline entry

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -64,7 +64,6 @@
 "defaulted_failure:src/runtime/server/RequestContext.rs" = 1
 "defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4
 "derived_field:src/runtime/test_runner/bun_test.rs" = 1
-"error_collapsed_to_bool:src/runtime/api/bun/Terminal.rs" = 1
 "error_collapsed_to_bool:src/runtime/api/bun/h2_frame_parser.rs" = 32
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/cli/filter_run.rs" = 1

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8296,7 +8296,7 @@ declare module "bun" {
      * Terminal input flags (c_iflag from termios).
      * Controls input processing behavior like ICRNL, IXON, etc.
      * Returns 0 if the terminal is closed.
-     * Setting returns true on success, false on failure.
+     * Setting is a no-op on a closed terminal and throws if the PTY rejects the new flags.
      */
     inputFlags: number;
 
@@ -8304,7 +8304,7 @@ declare module "bun" {
      * Terminal output flags (c_oflag from termios).
      * Controls output processing behavior like OPOST, ONLCR, etc.
      * Returns 0 if the terminal is closed.
-     * Setting returns true on success, false on failure.
+     * Setting is a no-op on a closed terminal and throws if the PTY rejects the new flags.
      */
     outputFlags: number;
 
@@ -8312,7 +8312,7 @@ declare module "bun" {
      * Terminal local flags (c_lflag from termios).
      * Controls local processing like ICANON, ECHO, ISIG, etc.
      * Returns 0 if the terminal is closed.
-     * Setting returns true on success, false on failure.
+     * Setting is a no-op on a closed terminal and throws if the PTY rejects the new flags.
      */
     localFlags: number;
 
@@ -8320,7 +8320,7 @@ declare module "bun" {
      * Terminal control flags (c_cflag from termios).
      * Controls hardware characteristics like CSIZE, PARENB, etc.
      * Returns 0 if the terminal is closed.
-     * Setting returns true on success, false on failure.
+     * Setting is a no-op on a closed terminal and throws if the PTY rejects the new flags.
      */
     controlFlags: number;
   }

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1364,7 +1364,7 @@ impl Terminal {
             if self.flags.get().contains(Flags::CLOSED) || self.master_fd.get() == Fd::INVALID {
                 return JSValue::js_number(0.0);
             }
-            let Some(termios_data) = get_termios(self.master_fd.get()) else {
+            let Ok(termios_data) = get_termios(self.master_fd.get()) else {
                 return JSValue::js_number(0.0);
             };
             let raw: u64 = match FIELD {
@@ -1389,13 +1389,14 @@ impl Terminal {
         }
         #[cfg(unix)]
         {
-            if self.flags.get().contains(Flags::CLOSED) || self.master_fd.get() == Fd::INVALID {
+            let num = value.coerce_f64(global_object)?;
+            // Checked after coercion: a valueOf() may have closed the terminal.
+            let master_fd = self.master_fd.get();
+            if self.flags.get().contains(Flags::CLOSED) || master_fd == Fd::INVALID {
                 return Ok(());
             }
-            let num = value.coerce_f64(global_object)?;
-            let Some(mut termios_data) = get_termios(self.master_fd.get()) else {
-                return Ok(());
-            };
+            let mut termios_data =
+                get_termios(master_fd).map_err(|err| err.throw(global_object))?;
             let max_val: f64 = libc::tcflag_t::MAX as f64;
             // Match Zig's `@max(0, @min(num, max_val))`: apply min first so NaN
             // resolves to max_val (f64::min returns the non-NaN operand), not 0.
@@ -1407,8 +1408,7 @@ impl Terminal {
                 TermiosField::Lflag => termios_data.c_lflag = bits,
                 TermiosField::Cflag => termios_data.c_cflag = bits,
             }
-            let _ = set_termios(self.master_fd.get(), &termios_data);
-            Ok(())
+            set_termios(master_fd, &termios_data).map_err(|err| err.throw(global_object))
         }
     }
 
@@ -1675,14 +1675,14 @@ type Termios = sys::posix::Termios;
 
 /// Get terminal attributes using tcgetattr
 #[cfg(unix)]
-fn get_termios(fd: Fd) -> Option<Termios> {
-    sys::posix::tcgetattr(fd.native()).ok()
+fn get_termios(fd: Fd) -> sys::Result<Termios> {
+    sys::posix::tcgetattr(fd.native())
 }
 
 /// Set terminal attributes using tcsetattr (TCSANOW = immediate)
 #[cfg(unix)]
-fn set_termios(fd: Fd, termios_p: &Termios) -> bool {
-    sys::posix::tcsetattr(fd.native(), sys::posix::TCSA::Now, termios_p).is_ok()
+fn set_termios(fd: Fd, termios_p: &Termios) -> sys::Result<()> {
+    sys::posix::tcsetattr(fd.native(), sys::posix::TCSA::Now, termios_p)
 }
 
 impl Terminal {

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -489,22 +489,23 @@ describe("Bun.Terminal", () => {
 
     test.skipIf(isWindows)("setting flags throws when the terminal's fd is not a PTY", async () => {
       // No libc rejects a termios update on a healthy PTY portably, so swap
-      // the PTY master fd out for /dev/null (ENOTTY) behind the terminal's
-      // back. openpty() hands out the lowest free fd, so the master lands on
-      // the fd number the probe just freed.
+      // the PTY master fd out for a regular file behind the terminal's back.
+      // openpty() hands out the lowest free fd, so the master lands on the fd
+      // number the probe just freed. A regular file fails termios ioctls with
+      // ENOTTY on every POSIX kernel; /dev/null would be ENODEV on macOS.
       const script = `
         const fs = require("node:fs");
         // The first terminal may open unrelated fds on the side (openpty is
         // loaded lazily); construct one up front so the probe below sees a
         // settled fd table.
         new Bun.Terminal({}).close();
-        const probe = fs.openSync("/dev/null", "r");
+        const probe = fs.openSync(process.execPath, "r");
         fs.closeSync(probe);
 
         const terminal = new Bun.Terminal({});
         const flags = terminal.localFlags;
         fs.closeSync(probe);
-        const replacement = fs.openSync("/dev/null", "r");
+        const replacement = fs.openSync(process.execPath, "r");
 
         let thrown = null;
         try {

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isGlibc, isLinux, isWindows, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -474,16 +474,109 @@ describe("Bun.Terminal", () => {
       expect(terminal.inputFlags).toBe(0);
     });
 
+    test.skipIf(isWindows)("setting flags on a terminal closed while coercing the value is a no-op", () => {
+      const terminal = new Bun.Terminal({});
+
+      terminal.localFlags = {
+        valueOf() {
+          terminal.close();
+          return 0;
+        },
+      } as any;
+
+      expect(terminal.closed).toBe(true);
+    });
+
+    test.skipIf(!isGlibc)("setting flags the PTY refuses to apply throws", async () => {
+      // Linux forces CREAD on for PTYs. glibc's tcsetattr reads the attributes
+      // back and fails with EINVAL when the requested change did not take;
+      // libcs that only issue the ioctl report success, hence the gate.
+      const CREAD = 0x80;
+      await using terminal = new Bun.Terminal({});
+      const original = terminal.controlFlags;
+      expect(original & CREAD).toBe(CREAD);
+
+      let caught: any;
+      try {
+        terminal.controlFlags = original & ~CREAD;
+      } catch (e) {
+        caught = e;
+      }
+
+      expect({ code: caught?.code, syscall: caught?.syscall, controlFlags: terminal.controlFlags }).toEqual({
+        code: "EINVAL",
+        syscall: "ioctl",
+        controlFlags: original,
+      });
+    });
+
+    test.skipIf(isWindows)("setting flags throws when the terminal's fd is not a PTY", async () => {
+      // Portable version of the above: swap the PTY master fd out for
+      // /dev/null (ENOTTY) behind the terminal's back. openpty() hands out
+      // the lowest free fd, so the master lands on the fd number the probe
+      // just freed.
+      const script = `
+        const fs = require("node:fs");
+        // The first terminal may open unrelated fds on the side (openpty is
+        // loaded lazily); construct one up front so the probe below sees a
+        // settled fd table.
+        new Bun.Terminal({}).close();
+        const probe = fs.openSync("/dev/null", "r");
+        fs.closeSync(probe);
+
+        const terminal = new Bun.Terminal({});
+        const flags = terminal.localFlags;
+        fs.closeSync(probe);
+        const replacement = fs.openSync("/dev/null", "r");
+
+        let thrown = null;
+        try {
+          terminal.localFlags = flags;
+        } catch (e) {
+          thrown = { code: e.code, syscall: e.syscall };
+        }
+        console.log(JSON.stringify({
+          swapped: replacement === probe,
+          hadFlagsBeforeSwap: flags !== 0,
+          flagsAfterSwap: terminal.localFlags,
+          closed: terminal.closed,
+          thrown,
+        }));
+        terminal.close();
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        swapped: true,
+        hadFlagsBeforeSwap: true,
+        flagsAfterSwap: 0,
+        closed: false,
+        thrown: { code: "ENOTTY", syscall: "ioctl" },
+      });
+      expect(exitCode).toBe(0);
+    });
+
     test.skipIf(isWindows)("NaN clamps to tcflag_t max, same as Infinity", async () => {
       // Assigning NaN must clamp to the same value as Infinity (tcflag_t::MAX),
       // matching the reference `@max(0, @min(num, max))` semantics. The kernel
       // may mask some bits per field, so compare NaN against Infinity rather
-      // than a hard-coded constant.
+      // than a hard-coded constant. Both assignments start from the original
+      // flags: re-requesting the already-masked bits asks the PTY for a change
+      // it refuses, which glibc's tcsetattr reports as EINVAL.
       await using terminal = new Bun.Terminal({ cols: 80, rows: 24 });
 
       for (const prop of ["inputFlags", "outputFlags", "localFlags", "controlFlags"] as const) {
+        const original = terminal[prop];
         terminal[prop] = Infinity;
         const fromInfinity = terminal[prop];
+        terminal[prop] = original;
         terminal[prop] = NaN;
         const fromNaN = terminal[prop];
         expect({ prop, fromNaN }).toEqual({ prop, fromNaN: fromInfinity });

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isGlibc, isLinux, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -487,34 +487,11 @@ describe("Bun.Terminal", () => {
       expect(terminal.closed).toBe(true);
     });
 
-    test.skipIf(!isGlibc)("setting flags the PTY refuses to apply throws", async () => {
-      // Linux forces CREAD on for PTYs. glibc's tcsetattr reads the attributes
-      // back and fails with EINVAL when the requested change did not take;
-      // libcs that only issue the ioctl report success, hence the gate.
-      const CREAD = 0x80;
-      await using terminal = new Bun.Terminal({});
-      const original = terminal.controlFlags;
-      expect(original & CREAD).toBe(CREAD);
-
-      let caught: any;
-      try {
-        terminal.controlFlags = original & ~CREAD;
-      } catch (e) {
-        caught = e;
-      }
-
-      expect({ code: caught?.code, syscall: caught?.syscall, controlFlags: terminal.controlFlags }).toEqual({
-        code: "EINVAL",
-        syscall: "ioctl",
-        controlFlags: original,
-      });
-    });
-
     test.skipIf(isWindows)("setting flags throws when the terminal's fd is not a PTY", async () => {
-      // Portable version of the above: swap the PTY master fd out for
-      // /dev/null (ENOTTY) behind the terminal's back. openpty() hands out
-      // the lowest free fd, so the master lands on the fd number the probe
-      // just freed.
+      // No libc rejects a termios update on a healthy PTY portably, so swap
+      // the PTY master fd out for /dev/null (ENOTTY) behind the terminal's
+      // back. openpty() hands out the lowest free fd, so the master lands on
+      // the fd number the probe just freed.
       const script = `
         const fs = require("node:fs");
         // The first terminal may open unrelated fds on the side (openpty is
@@ -568,8 +545,9 @@ describe("Bun.Terminal", () => {
       // matching the reference `@max(0, @min(num, max))` semantics. The kernel
       // may mask some bits per field, so compare NaN against Infinity rather
       // than a hard-coded constant. Both assignments start from the original
-      // flags: re-requesting the already-masked bits asks the PTY for a change
-      // it refuses, which glibc's tcsetattr reports as EINVAL.
+      // flags: re-requesting only the already-masked c_cflag bits is a
+      // tcsetattr that changes nothing, which Debian's and Ubuntu's patched
+      // glibc reports as EINVAL (upstream glibc and other libcs return 0).
       await using terminal = new Bun.Terminal({ cols: 80, rows: 24 });
 
       for (const prop of ["inputFlags", "outputFlags", "localFlags", "controlFlags"] as const) {


### PR DESCRIPTION
### Problem
- `bun run rust:mordant` reports one `error_collapsed_to_bool` in `src/runtime/api/bun/Terminal.rs`: `set_termios` turns the `bun_sys::Error` from `tcsetattr` into `false`, and `set_termios_flag` (the shared body of the `inputFlags` / `outputFlags` / `localFlags` / `controlFlags` setters, line 1410 on main) ignores it. The `tcgetattr` side had the same shape: `get_termios` mapped its error to `None` and the setter returned early.
- So an assignment the PTY did not apply returned as if it had. Two ways to get there:
  - The master fd no longer refers to a tty (ENOTTY / EBADF).
  - On Debian and Ubuntu, whose glibc carries a patch that reads the attributes back after TCSETS: a `controlFlags` request whose only changes are bits the pty driver forces (CREAD, CS8, no PARENB) fails with EINVAL. Upstream glibc's `tcsetattr` is a single ioctl, so this part is distribution specific; bun's Linux glibc CI lanes are all Debian/Ubuntu.
- `resize()` and `setRawMode()` on the same object already throw when their ioctl fails, and `write()` throws the `SystemError`; node-pty's `resize` throws on a failed TIOCSWINSZ as well. A setter has no other channel: JSC ignores the return value of a `CustomAccessor` setter (`JSObject::putInlineSlow`), and the `bun_jsc` setter thunk maps `Ok(false)` and `Ok(true)` to the same thing, so the "returns false on failure" wording in the bun-types JSDoc never described anything observable.

### Fix
- `get_termios` / `set_termios` return `bun_sys::Result`; the setter throws the error as a `SystemError` (`code`, `syscall: "ioctl"`, `errno`, same conversion `write()` uses) when either call fails. The getter still reads 0 on failure, and assigning on a closed terminal is still a no-op (both pinned by existing tests).
- The closed check in the setter now runs after the value coercion, so a `valueOf()` that closes the terminal takes the no-op path instead of reaching the new throw with an invalid fd. Before this change that window was covered by the error being swallowed.
- bun-types JSDoc for the four properties says what setting does now. `mordant-baseline.toml`: the `error_collapsed_to_bool` entry for Terminal.rs is deleted by hand. A full `bun run rust:mordant:baseline` regeneration also dropped `always_unwrapped_option:src/install/PackageInstall.rs` (already removed in #39130) and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs`, which are unrelated, so they are left in place here. The `reimplemented_helper` entry for Terminal.rs is a different site (`get_optional_value`, line 243) and stays.
- Tests, `test/js/bun/terminal/terminal.test.ts`, "termios flags" block:
  - `setting flags throws when the terminal's fd is not a PTY` (any POSIX): a child process swaps the master fd for a regular file behind the terminal's back; the getter reads 0 and the assignment throws ENOTTY. No libc rejects a termios update on a healthy PTY portably, so this is the deterministic way to reach the throw. (A regular file rather than `/dev/null`: termios ioctls on `/dev/null` are ENODEV on macOS, which the first darwin run showed; the throw itself behaved the same there.)
  - `setting flags on a terminal closed while coercing the value is a no-op`: pins the check order above.
  - `NaN clamps to tcflag_t max` now restores the original flags between the Infinity and NaN assignments: on the Debian/Ubuntu lanes, assigning the same partly-masked `controlFlags` value twice is exactly the EINVAL case above, and starting both assignments from the same state is also what makes the comparison meaningful.
- Verification:
  - The ENOTTY test fails on the current release (`USE_SYSTEM_BUN=1`, assignment silently returns) and passes with `bun bd`; `bun bd test test/js/bun/terminal/ test/js/node/tty.test.ts`: all pass.
  - `bun run rust:mordant` with this baseline: without the `src/` change it reports the Terminal.rs:1410 finding (`bun_runtime 1` in `target/mordant/over-baseline.txt`); with it, nothing over the baseline. The `mordant` and `cargo clippy` GitHub checks passed on the first push as well.

### Background
- termios is the POSIX terminal attribute struct; its four flag words (`c_iflag`, `c_oflag`, `c_lflag`, `c_cflag`) are what `Bun.Terminal` exposes as the four properties. A setter does `tcgetattr` on the PTY master, replaces one word, and writes the struct back with `tcsetattr(TCSANOW)`; `bun_sys::posix::tcgetattr` / `tcsetattr` return `Result<_, bun_sys::Error>` tagged as the `ioctl` syscall.
- The Linux pty driver always keeps `CS8 | CREAD` set and parity off regardless of what is written, and the kernel reports success. Debian's glibc packaging (inherited by Ubuntu) patches `tcsetattr` to read the attributes back and return EINVAL when the requested `c_cflag` change had no effect; upstream glibc (`sysdeps/unix/sysv/linux/tcsetattr.c` is one `ioctl(TCSETS)`), musl, bionic and macOS return the kernel's success. That is why there is no direct PTY-based test for the EINVAL case and the test uses a regular file's fd instead (every POSIX kernel answers termios ioctls on a regular file with ENOTTY).
- `SysErrorJsc::throw` converts a `bun_sys::Error` into the JS `SystemError` (`code` such as `"ENOTTY"`, `syscall`, `errno`) and throws it; it is the same conversion Terminal's `write()` and most `node:fs` paths use.
- `mordant-baseline.toml` is a ratchet: it records the accepted finding count per (lint, file), and CI fails only on findings above the recorded count. Once a finding is fixed its entry has to go, otherwise it would hide a new finding of the same lint in that file.

<details>
<summary>Earlier revision of this PR</summary>

The first push also had a `test.skipIf(!isGlibc)` test asserting that clearing CREAD throws EINVAL, attributing the readback to glibc itself. Review pointed out the readback is Debian's patch, not upstream glibc, so the `isGlibc` gate would fail the test on Fedora, Arch, Amazon Linux and similar; confirmed against upstream `tcsetattr.c` and dropped in 2a8bc0d. The ENOTTY test carries the behavior on every libc; 49b6448 switched its stand-in fd from `/dev/null` to a regular file after the darwin lane reported ENODEV for `/dev/null`.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/terminal/terminal.test.ts

<!-- robobun:evidence:end -->