### PR TITLE
shell(which): render the output once so captured and streamed stdout print the same not-found line

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -180,12 +180,12 @@ shell_builtins! {
         Cd       => (cd::Cd,            "cd",       b""),
         Echo     => (echo::Echo,        "echo",     b""),
         Export   => (export::Export,    "export",   b""),
+        Which    => (which::Which,      "which",    b""),
     }
     boxed: {
         Cat      => (cat::Cat,          "cat",      b"usage: cat [-belnstuv] [file ...]\n"),
         Mv       => (mv::Mv,            "mv",       b"usage: mv [-f | -i | -n] [-hv] source target\n       mv [-f | -i | -n] [-v] source ... directory\n"),
         Rm       => (rm::Rm,            "rm",       b"usage: rm [-f | -i] [-dIPRrvWx] file ...\n       unlink [--] file\n"),
-        Which    => (which::Which,      "which",    b""),
         Ls       => (ls::Ls,            "ls",       b"usage: ls [-@ABCFGHILOPRSTUWabcdefghiklmnopqrstuvwxy1%,] [--color=when] [-D format] [file ...]\n"),
         Mkdir    => (mkdir::Mkdir,      "mkdir",    b"usage: mkdir [-pv] [-m mode] directory_name ...\n"),
         Touch    => (touch::Touch,      "touch",    b"usage: touch [-A [-][[hh]mm]SS] [-achm] [-r file] [-t [[CC]YY]MMDDhhmm[.SS]]\n       [-d YYYY-MM-DDThh:mm:SS[.frac][tz]] file ...\n"),

--- a/src/runtime/shell/builtin/which.rs
+++ b/src/runtime/shell/builtin/which.rs
@@ -4,7 +4,8 @@
 //! is not found, exit code becomes 1, but continues execution until all args
 //! are processed.
 
-use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
+use crate::shell::ExitCode;
+use crate::shell::builtin::{Builtin, BuiltinState, IoKind};
 use crate::shell::env_str::EnvStr;
 use crate::shell::interpreter::{Interpreter, NodeId};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
@@ -12,164 +13,46 @@ use crate::shell::yield_::Yield;
 
 #[derive(Default)]
 pub struct Which {
-    pub(crate) state: State,
-}
-
-#[derive(Default)]
-pub enum State {
-    #[default]
-    Idle,
-    /// Called with no args: queued a single "\n" and waiting for the write.
-    OneArg,
-    MultiArgs {
-        arg_idx: usize,
-        had_not_found: bool,
-        waiting_write: bool,
-    },
+    exit_code: ExitCode,
 }
 
 impl Which {
     pub(crate) fn start(interp: &Interpreter, cmd: NodeId) -> Yield {
-        let argc = Builtin::of(interp, cmd).args_slice().len();
+        let (out, exit_code) = Self::render(interp, cmd);
+        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+            Self::state_mut(interp, cmd).exit_code = exit_code;
+            let child = ChildPtr::new(cmd, WriterTag::Builtin);
+            return Builtin::of_mut(interp, cmd)
+                .stdout
+                .enqueue(child, &out, safeguard);
+        }
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &out);
+        Builtin::done(interp, cmd, exit_code)
+    }
+
+    fn render(interp: &Interpreter, cmd: NodeId) -> (Vec<u8>, ExitCode) {
+        let bltn = Builtin::of(interp, cmd);
+        let argc = bltn.args_slice().len();
         if argc == 0 {
-            if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-                Self::state_mut(interp, cmd).state = State::OneArg;
-                let child = ChildPtr::new(cmd, WriterTag::Builtin);
-                return Builtin::of_mut(interp, cmd)
-                    .stdout
-                    .enqueue(child, b"\n", safeguard);
-            }
-            let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, b"\n");
-            return Builtin::done(interp, cmd, 1);
+            return (b"\n".to_vec(), 1);
         }
 
-        if Builtin::of(interp, cmd).stdout.needs_io().is_none() {
-            // Synchronous path: resolve every arg, write straight to the
-            // captured buffer, then finish.
-            let search = SearchEnv::load(interp, cmd);
-            let mut had_not_found = false;
-            for i in 0..argc {
-                let arg = Self::arg(interp, cmd, i);
-                match search.resolve(&arg) {
-                    Some(resolved) => {
-                        let buf = Builtin::fmt_error_arena(
-                            interp,
-                            cmd,
-                            None,
-                            format_args!("{}\n", bstr::BStr::new(&resolved)),
-                        )
-                        .to_vec();
-                        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-                    }
-                    None => {
-                        had_not_found = true;
-                        let buf = Builtin::fmt_error_arena(
-                            interp,
-                            cmd,
-                            Some(Kind::Which),
-                            format_args!("{} not found\n", bstr::BStr::new(&arg)),
-                        )
-                        .to_vec();
-                        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-                    }
+        let search = SearchEnv::load(interp, cmd);
+        let mut out = Vec::new();
+        let mut exit_code = 0;
+        for i in 0..argc {
+            let arg = bltn.arg_bytes(i);
+            match search.resolve(arg) {
+                Some(resolved) => out.extend_from_slice(&resolved),
+                None => {
+                    exit_code = 1;
+                    out.extend_from_slice(arg);
+                    out.extend_from_slice(b" not found");
                 }
             }
-            return Builtin::done(interp, cmd, if had_not_found { 1 } else { 0 });
+            out.push(b'\n');
         }
-
-        Self::state_mut(interp, cmd).state = State::MultiArgs {
-            arg_idx: 0,
-            had_not_found: false,
-            waiting_write: false,
-        };
-        Self::next(interp, cmd)
-    }
-
-    fn next(interp: &Interpreter, cmd: NodeId) -> Yield {
-        let argc = Builtin::of(interp, cmd).args_slice().len();
-        let (arg_idx, had_not_found) = match &Self::state_mut(interp, cmd).state {
-            State::MultiArgs {
-                arg_idx,
-                had_not_found,
-                ..
-            } => (*arg_idx, *had_not_found),
-            _ => unreachable!(),
-        };
-        if arg_idx >= argc {
-            return Builtin::done(interp, cmd, if had_not_found { 1 } else { 0 });
-        }
-
-        let arg = Self::arg(interp, cmd, arg_idx);
-        let resolved = SearchEnv::load(interp, cmd).resolve(&arg);
-
-        let child = ChildPtr::new(cmd, WriterTag::Builtin);
-        match resolved {
-            None => {
-                if let State::MultiArgs {
-                    had_not_found,
-                    waiting_write,
-                    ..
-                } = &mut Self::state_mut(interp, cmd).state
-                {
-                    *had_not_found = true;
-                    *waiting_write = true;
-                }
-                if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-                    return Builtin::of_mut(interp, cmd).stdout.enqueue_fmt(
-                        child,
-                        None,
-                        format_args!("{} not found\n", bstr::BStr::new(&arg)),
-                        safeguard,
-                    );
-                }
-                let buf = Builtin::fmt_error_arena(
-                    interp,
-                    cmd,
-                    None,
-                    format_args!("{} not found\n", bstr::BStr::new(&arg)),
-                )
-                .to_vec();
-                let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-                Self::arg_complete(interp, cmd)
-            }
-            Some(resolved) => {
-                if let State::MultiArgs { waiting_write, .. } =
-                    &mut Self::state_mut(interp, cmd).state
-                {
-                    *waiting_write = true;
-                }
-                if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-                    return Builtin::of_mut(interp, cmd).stdout.enqueue_fmt(
-                        child,
-                        None,
-                        format_args!("{}\n", bstr::BStr::new(&resolved)),
-                        safeguard,
-                    );
-                }
-                let buf = Builtin::fmt_error_arena(
-                    interp,
-                    cmd,
-                    None,
-                    format_args!("{}\n", bstr::BStr::new(&resolved)),
-                )
-                .to_vec();
-                let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-                Self::arg_complete(interp, cmd)
-            }
-        }
-    }
-
-    fn arg_complete(interp: &Interpreter, cmd: NodeId) -> Yield {
-        if let State::MultiArgs {
-            arg_idx,
-            waiting_write,
-            ..
-        } = &mut Self::state_mut(interp, cmd).state
-        {
-            *arg_idx += 1;
-            *waiting_write = false;
-        }
-        Self::next(interp, cmd)
+        (out, exit_code)
     }
 
     pub(crate) fn on_io_writer_chunk(
@@ -179,19 +62,10 @@ impl Which {
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
         if let Some(err) = e {
-            return Builtin::done(interp, cmd, err.errno as crate::shell::ExitCode);
+            return Builtin::done(interp, cmd, err.errno as ExitCode);
         }
-        match Self::state_mut(interp, cmd).state {
-            State::OneArg => Builtin::done(interp, cmd, 1),
-            State::MultiArgs { .. } => Self::arg_complete(interp, cmd),
-            _ => Builtin::done(interp, cmd, 0),
-        }
-    }
-
-    // ── helpers ────────────────────────────────────────────────────────────
-
-    fn arg(interp: &Interpreter, cmd: NodeId, idx: usize) -> Vec<u8> {
-        Builtin::of(interp, cmd).arg_bytes(idx).to_vec()
+        let exit_code = Self::state_mut(interp, cmd).exit_code;
+        Builtin::done(interp, cmd, exit_code)
     }
 }
 

--- a/test/js/bun/shell/commands/which.test.ts
+++ b/test/js/bun/shell/commands/which.test.ts
@@ -1,5 +1,5 @@
 import { $ } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { chmodSync } from "node:fs";
 import { join } from "node:path";
@@ -37,7 +37,7 @@ test.concurrent("which searches $PATH for bare names and the shell cwd for ./ na
   const { pathDir, cwdDir, expected } = searchDirs(String(dir));
 
   // Without .quiet() the builtin writes to the process's stdout (the pipe
-  // below), which is the one-argument-per-write path in the builtin.
+  // below) through an IOWriter instead of appending to a captured buffer.
   const fixture = /* ts */ `
     import { $ } from "bun";
     const { exitCode } = await $\`which tool ./tool\`.env({ PATH: ${JSON.stringify(pathDir)} }).cwd(${JSON.stringify(cwdDir)}).nothrow();
@@ -61,8 +61,7 @@ test.skipIf(isWindows)("which with an absolute path at the platform path length 
     const max = process.platform === "linux" ? 4096 : 1024;
     const bin = "/" + Buffer.alloc(max - 1, "a").toString();
     const { exitCode, stdout } = await $\`which \${bin}\`.quiet().nothrow();
-    const out = stdout.toString().replace(/^which: /, "");
-    console.log(JSON.stringify({ exitCode, notFound: out === bin + " not found\\n" }));
+    console.log(JSON.stringify({ exitCode, notFound: stdout.toString() === bin + " not found\\n" }));
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", fixture],
@@ -83,4 +82,74 @@ test("which rlly long", async () => {
 test("which PATH rlly long", async () => {
   const longstr = "a".repeat(100000);
   expect(async () => await $`PATH=${longstr} slkdfjlsdkfj`.throws(true)).toThrow();
+});
+
+describe("which prints the same line for an unresolvable arg however stdout is collected", () => {
+  const BUN = bunExe();
+  const bogus = "bun_shell_which_test_bogus_command";
+  const expected = `${Bun.which(BUN)}\n${bogus} not found\n`;
+
+  test.concurrent(".quiet() (captured buffer)", async () => {
+    const { stdout, exitCode } = await $`which ${BUN} ${bogus}`.env(bunEnv).quiet().nothrow();
+    expect(stdout.toString()).toBe(expected);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent(".text()", async () => {
+    expect(await $`which ${BUN} ${bogus}`.env(bunEnv).nothrow().text()).toBe(expected);
+  });
+
+  test.concurrent("command substitution", async () => {
+    const { stdout, exitCode } = await $`echo "$(which ${BUN} ${bogus})"`.env(bunEnv).quiet().nothrow();
+    expect(stdout.toString()).toBe(expected);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("redirect into a Buffer", async () => {
+    const buf = Buffer.alloc(expected.length + 64);
+    const { exitCode } = await $`which ${BUN} ${bogus} > ${buf}`.env(bunEnv).quiet().nothrow();
+    expect(buf.subarray(0, buf.indexOf(0)).toString()).toBe(expected);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("redirect into a file (written through an IOWriter)", async () => {
+    using dir = tempDir("shell-which-redirect", {});
+    const { exitCode } = await $`which ${BUN} ${bogus} > out.txt`.env(bunEnv).cwd(String(dir)).quiet().nothrow();
+    expect(await Bun.file(join(String(dir), "out.txt")).text()).toBe(expected);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("only unresolvable args", async () => {
+    const { stdout, exitCode } = await $`which ${bogus} ${bogus}2`.env(bunEnv).quiet().nothrow();
+    expect(stdout.toString()).toBe(`${bogus} not found\n${bogus}2 not found\n`);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("no args", async () => {
+    const { stdout, exitCode } = await $`which`.env(bunEnv).quiet().nothrow();
+    expect(stdout.toString()).toBe("\n");
+    expect(exitCode).toBe(1);
+  });
+});
+
+describe("which echoes an arg that is not valid UTF-8 byte for byte", () => {
+  // 0xff never occurs in UTF-8, so a lossy conversion would turn it into
+  // U+FFFD (ef bf bd). The arg reaches `which` through command substitution
+  // because a JS string cannot carry the raw byte.
+  const arg = Buffer.from([0x6e, 0xff, 0x6d]);
+  const expected = Buffer.concat([arg, Buffer.from(" not found\n")]).toString("hex");
+
+  test.concurrent("captured buffer", async () => {
+    using dir = tempDir("shell-which-bytes-captured", { "arg.bin": arg });
+    const { stdout, exitCode } = await $`which $(cat arg.bin)`.env(bunEnv).cwd(String(dir)).quiet().nothrow();
+    expect(stdout.toString("hex")).toBe(expected);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("redirect into a file (written through an IOWriter)", async () => {
+    using dir = tempDir("shell-which-bytes-redirect", { "arg.bin": arg });
+    const { exitCode } = await $`which $(cat arg.bin) > out.bin`.env(bunEnv).cwd(String(dir)).quiet().nothrow();
+    expect(Buffer.from(await Bun.file(join(String(dir), "out.bin")).bytes()).toString("hex")).toBe(expected);
+    expect(exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
### Problem
- The shell's `which` builtin prints two different lines for an arg it cannot resolve, depending on how stdout is collected:
  - `.quiet()`, `.text()`, `$(which ...)`, `which ... > ${buf}`: `which: nope not found`
  - a tty, `| cmd`, `> file`: `nope not found`
- Cause: `src/runtime/shell/builtin/which.rs` had two implementations of its output. When stdout is a captured buffer, `start` resolved every arg in a loop and formatted the line with `fmt_error_arena(.., Some(Kind::Which), ..)`, which adds the prefix. When stdout is an fd, a per-arg state machine (`State::MultiArgs`, `next`, `arg_complete`) formatted the line with `enqueue_fmt(.., None, ..)`. The two had disagreed since the builtin was added; `which.test.ts` on main papers over it by stripping an optional `which: ` with a regex.
- Found by reading the code (while #39131 touched the same file); there is no user report.

### Fix
- `which` now renders its whole output once. `Which::render` builds one buffer with a line per arg (the resolved path, or `<arg> not found`) and the exit code; `start` either enqueues that buffer on the IOWriter or appends it to the captured buffer. This is the shape `pwd`, `basename` and `dirname` already use, and with one formatting site the two output modes cannot drift again. The only state left is the exit code to report when the write completes, so `Which` moves from the `boxed:` to the `inline:` row of the builtin table in `Builtin.rs`.
- Deleted: `State::{Idle, OneArg, MultiArgs}`, `next`, `arg_complete`, the `arg` helper and both formatter call sites. `SearchEnv` from #39131 is unchanged and is now loaded once per command in both modes (the fd mode used to reload it per arg). which.rs goes from 227 lines to 101.
- The unprefixed line is the one kept: it is what `bunshell.test.ts` "which" has asserted since the builtin was added, it is zsh's wording for its builtin `which`, and in this codebase the `"<builtin>: "` prefix (`Kind::as_str`) is the convention for stderr diagnostics, while this line is regular stdout output.
- Unchanged on purpose: the no-arg case still prints a lone newline and exits 1, the exit code is still 1 if any arg was not found, and a failed write still reports `err.errno` as the exit code exactly as before (the write-error exit convention is #32278's subject).
- Second visible change: lines are assembled from the raw bytes of the path or arg. Before, both modes went through `bstr::BStr`'s `Display`, which replaces invalid UTF-8 with U+FFFD; the other builtins write their stdout byte for byte and so did this one before the Rust port.
- Verified with `test/js/bun/shell/commands/which.test.ts`: a describe block asserts the same line for every buffer-backed mode (`.quiet()`, `.text()`, command substitution, `> ${Buffer}`) and for a file redirect (IOWriter mode), plus the all-not-found and no-arg cases; a second block feeds a `0xff` byte in through `$(cat arg.bin)` and compares hex output in both modes, which pins the raw-bytes change (the unfixed build produces `ef bf bd` in both modes). The long-path test no longer strips an optional prefix, and the comment in #39131's streamed-stdout test is updated since there is no longer a one-write-per-arg path. 8 of 14 cases fail on the unfixed build; all 14 pass with the fix.
- Also green against the debug build: `bunshell.test.ts` (423 pass), `pipeline_stack.test.ts`, `exec.test.ts`, the rest of `test/js/bun/shell/commands/`, and `test/internal/source-lints/`.

### Background
- Shell builtins have two ways to write. When stdout is an fd (tty, pipe, file redirect), `needs_io()` returns a safeguard and the builtin enqueues bytes on an `IOWriter`, which copies them and later calls the builtin's `on_io_writer_chunk`; when stdout is a captured buffer (`.quiet()`, command substitution, a `> ${buf}` redirect), the builtin appends synchronously with `write_no_io` and finishes on the spot. Small builtins build their output first and then pick one of the two writes; until now `which` instead had a separate implementation per write.
- `Builtin::fmt_error_arena(.., Option<Kind>, ..)` and `BuiltinIO::enqueue_fmt(.., Option<Kind>, ..)` prepend `"<builtin name>: "` when given a `Kind`; builtins use that for their error messages on stderr.
- The `shell_builtins!` table in `Builtin.rs` stores `inline:` builtins' state directly in the per-command enum and `boxed:` ones behind a `Box`, to keep the common node small; `Which` is now two bytes of state.

<details>
<summary>Repro on 1.4.0</summary>

```ts
import { $ } from "bun";
const quiet = await $`which ls nope_zz`.nothrow().quiet();
console.log(JSON.stringify(quiet.stdout.toString()));
// "/usr/bin/ls\nwhich: nope_zz not found\n"
const piped = await $`which ls nope_zz | cat`.nothrow().quiet();
console.log(JSON.stringify(piped.stdout.toString()));
// "/usr/bin/ls\nnope_zz not found\n"
```

</details>

<details>
<summary>Earlier version of this PR</summary>

The first revision kept both output paths and only routed them through a shared line-building helper (changing `Some(Kind::Which)` to the unprefixed form). Self-review pointed out that the two paths are themselves the mechanism of the bug and that the one-buffer shape used by the neighbouring builtins is both smaller and removes the drift structurally, and #39131 landed on main in the meantime, so the branch was rebased and the src side replaced with the rewrite described above. The tests from that revision are kept and extended with the byte-level cases.

</details>
