### PR TITLE
node/types: replace the StringOrBuffer parser bool flags with enums

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -59,7 +59,6 @@
 "bare_bool_args:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "bare_bool_args:src/runtime/cli/run_command.rs" = 1
 "bare_bool_args:src/runtime/dns_jsc/dns.rs" = 1
-"bare_bool_args:src/runtime/node/types.rs" = 4
 "defaulted_failure:src/runtime/ffi/ffi_body.rs" = 1
 "defaulted_failure:src/runtime/server/RequestContext.rs" = 1
 "defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4

--- a/src/jsc/node_path.rs
+++ b/src/jsc/node_path.rs
@@ -46,7 +46,7 @@ pub struct ThreadSafe<T: Unprotect>(T);
 
 impl<T: Unprotect> ThreadSafe<T> {
     /// Wrap an **already-protected** `T`. Use when the protect was taken
-    /// elsewhere (e.g. inside `from_js_maybe_async(.., is_async=true)`).
+    /// elsewhere (e.g. inside `from_js_maybe_async(.., Flavor::Async, ..)`).
     #[inline]
     pub fn adopt(value: T) -> Self {
         Self(value)

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2726,12 +2726,11 @@ pub mod JSZstd {
 
         let level = get_level(global_this, options_val)?;
 
-        let allow_string_object = true;
         if let Some(buffer) = node::StringOrBuffer::from_js_maybe_async(
             global_this,
             buffer_value,
-            true,
-            allow_string_object,
+            node::Flavor::Async,
+            node::StringObjects::Allow,
         )? {
             return Ok((buffer, options_val, level));
         }
@@ -2807,7 +2806,7 @@ pub mod JSZstd {
 
     /// `Bun.zstdCompress` / `Bun.zstdDecompress` off the JS thread.
     pub(crate) struct ZstdJob {
-        /// Created with `is_async=true` (JS-backed buffer protected); the
+        /// Created with `Flavor::Async` (JS-backed buffer protected); the
         /// [`bun_jsc::ThreadSafe`] releases that with the job.
         pub buffer: bun_jsc::ThreadSafe<node::StringOrBuffer>,
         pub is_compress: bool,

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -5,7 +5,7 @@ use bun_options_types::TargetExt as _;
 use std::io::Write as _;
 
 use crate::Error;
-use crate::node::{Encoding, StringOrBuffer};
+use crate::node::{Encoding, Flavor, StringObjects, StringOrBuffer};
 use bun_alloc::{Arena, ArenaVec}; // bumpalo::Bump / bumpalo::collections::Vec re-exports
 use bun_ast::Expr;
 use bun_ast::Loader;
@@ -1392,13 +1392,12 @@ impl JSTranspiler {
             ));
         };
 
-        let allow_string_object = true;
         let Some(code) = StringOrBuffer::from_js_with_encoding_maybe_async(
             global,
             code_arg,
             Encoding::Utf8,
-            true,
-            allow_string_object,
+            Flavor::Async,
+            StringObjects::Allow,
         )?
         else {
             return Err(global.throw_invalid_argument_type(
@@ -1415,7 +1414,7 @@ impl JSTranspiler {
             code = StringOrBuffer::EncodedSlice(bun_core::ZigStringSlice::init_owned(bytes));
         }
         // `errdefer code.deinitAndUnprotect()` — `from_js_with_encoding_maybe_async`
-        // (is_async=true) already protected; adopt into a `ThreadSafe` so any
+        // (`Flavor::Async`) already protected; adopt into a `ThreadSafe` so any
         // early-return drop unprotects. `TransformTask::create` takes the guard.
         let code = bun_jsc::ThreadSafe::adopt(code);
 

--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -6,7 +6,7 @@ use bun_jsc::{
     JsThread,
 };
 
-use crate::node::StringOrBuffer;
+use crate::node::{Flavor, StringObjects, StringOrBuffer};
 
 use crate::crypto::evp::{self, Algorithm};
 
@@ -68,7 +68,7 @@ impl PBKDF2 {
     pub(crate) fn from_js(
         global_this: &JSGlobalObject,
         call_frame: &CallFrame,
-        is_async: bool,
+        flavor: Flavor,
     ) -> JsResult<PBKDF2> {
         let [arg0, arg1, arg2, arg3, arg4, arg5] = call_frame.arguments_as_array::<6>();
 
@@ -181,17 +181,16 @@ impl PBKDF2 {
         };
         // Non-async path: `StringOrBuffer` fields drop with `out` on early return — no explicit call needed.
         let mut guard = scopeguard::guard(&mut out, |out| {
-            if global_this.has_exception() && is_async {
+            if global_this.has_exception() && flavor == Flavor::Async {
                 bun_jsc::Unprotect::unprotect(out);
             }
         });
 
-        let allow_string_object = true;
         guard.salt = match StringOrBuffer::from_js_maybe_async(
             global_this,
             arg1,
-            is_async,
-            allow_string_object,
+            flavor,
+            StringObjects::Allow,
         )? {
             Some(v) => v,
             None => {
@@ -210,8 +209,8 @@ impl PBKDF2 {
         guard.password = match StringOrBuffer::from_js_maybe_async(
             global_this,
             arg0,
-            is_async,
-            allow_string_object,
+            flavor,
+            StringObjects::Allow,
         )? {
             Some(v) => v,
             None => {
@@ -227,13 +226,13 @@ impl PBKDF2 {
             return Err(global_this.throw_invalid_arguments(format_args!("password is too long")));
         }
 
-        if !is_async {
+        if flavor == Flavor::Sync {
             if let StringOrBuffer::Buffer(buffer) = &mut guard.salt {
                 buffer.buffer = ArrayBuffer::from_typed_array(global_this, buffer.buffer.value);
             }
         }
 
-        if is_async {
+        if flavor == Flavor::Async {
             if !arg5.is_function() {
                 return Err(global_this.throw_invalid_argument_type_value(
                     b"callback",
@@ -260,7 +259,7 @@ impl bun_jsc::Unprotect for PBKDF2 {
 
 /// `crypto.pbkdf2` off the JS thread.
 pub(crate) struct Pbkdf2Job {
-    /// `from_js(.., is_async=true)` protected the input buffers; the
+    /// `from_js(.., Flavor::Async)` protected the input buffers; the
     /// [`bun_jsc::ThreadSafe`] releases that with the job.
     pub pbkdf2: bun_jsc::ThreadSafe<PBKDF2>,
     pub output: Vec<u8>,
@@ -316,7 +315,7 @@ pub(crate) fn create_job(global_this: &JSGlobalObject, data: PBKDF2) -> JSValue 
     Job::<Pbkdf2Job>::schedule(
         &cx,
         Pbkdf2Job {
-            // `from_js(.., is_async=true)` already protected — adopt, don't re-protect.
+            // `from_js(.., Flavor::Async)` already protected — adopt, don't re-protect.
             pbkdf2: bun_jsc::ThreadSafe::adopt(data),
             output: Vec::new(),
             err: false,

--- a/src/runtime/node.rs
+++ b/src/runtime/node.rs
@@ -16,8 +16,9 @@ pub mod assert {
 #[path = "node/types.rs"]
 pub mod types;
 pub use types::{
-    BlobOrStringOrBuffer, Dirent, Encoding, FileSystemFlags, PathLike, PathOrBlob,
-    PathOrFileDescriptor, StringOrBuffer, Valid, VectorArrayBuffer, mode_from_js,
+    BlobOrStringOrBuffer, Dirent, Encoding, FileBlobs, FileSystemFlags, Flavor, PathLike,
+    PathOrBlob, PathOrFileDescriptor, StringObjects, StringOrBuffer, Valid, VectorArrayBuffer,
+    mode_from_js,
 };
 
 pub use bun_jsc::MarkedArrayBuffer as Buffer;

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -10,7 +10,7 @@ use bun_jsc::{
     JsThread, Protected, Strong,
 };
 
-use crate::node::StringOrBuffer;
+use crate::node::{Flavor, StringObjects, StringOrBuffer};
 
 // `&JSGlobalObject` is ABI-identical to a non-null pointer; remaining params
 // are by-value `JSValue`, so no caller-side preconditions remain.
@@ -735,7 +735,8 @@ pub mod random {
 pub(crate) struct Scrypt {
     // Plain `StringOrBuffer` — NOT `ThreadSafe<_>`. The struct serves both
     // `scryptSync` (no protect taken) and async `scrypt` (protect taken in
-    // `from_js_maybe_async(.., true)`, adopted into a `ThreadSafe` by the job).
+    // `from_js_maybe_async(.., Flavor::Async, ..)`, adopted into a `ThreadSafe`
+    // by the job).
     password: StringOrBuffer,
     salt: StringOrBuffer,
     n: u32,
@@ -768,6 +769,11 @@ mod _impl {
             ] = call_frame.arguments_as_array::<5>();
             let mut maybe_options_value: Option<JSValue> = Some(options_arg);
             let mut callback = callback_arg;
+            let flavor = if IS_ASYNC {
+                Flavor::Async
+            } else {
+                Flavor::Sync
+            };
 
             if IS_ASYNC {
                 if callback.is_undefined() {
@@ -776,8 +782,12 @@ mod _impl {
                 }
             }
 
-            let Some(password) =
-                StringOrBuffer::from_js_maybe_async(global, password_value, IS_ASYNC, true)?
+            let Some(password) = StringOrBuffer::from_js_maybe_async(
+                global,
+                password_value,
+                flavor,
+                StringObjects::Allow,
+            )?
             else {
                 return Err(global.throw_invalid_argument_type_value(
                     b"password",
@@ -795,8 +805,12 @@ mod _impl {
                 }
             });
 
-            let Some(salt) =
-                StringOrBuffer::from_js_maybe_async(global, salt_value, IS_ASYNC, true)?
+            let Some(salt) = StringOrBuffer::from_js_maybe_async(
+                global,
+                salt_value,
+                flavor,
+                StringObjects::Allow,
+            )?
             else {
                 return Err(global.throw_invalid_argument_type_value(
                     b"salt",
@@ -1028,8 +1042,8 @@ mod _impl {
     }
 
     impl bun_jsc::Unprotect for Scrypt {
-        /// Release the `protect()` taken by `from_js_maybe_async(.., true)` on the
-        /// async path (via the job's `ThreadSafe`). The sync path never calls this.
+        /// Release the `protect()` taken by `from_js_maybe_async(.., Flavor::Async, ..)`
+        /// on the async path (via the job's `ThreadSafe`). The sync path never calls this.
         #[inline]
         fn unprotect(&mut self) {
             bun_jsc::Unprotect::unprotect(&mut self.password);
@@ -1109,14 +1123,14 @@ mod _impl {
 
     #[bun_jsc::host_fn]
     fn pbkdf2(global_this: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
-        let data = PBKDF2::from_js(global_this, call_frame, true)?;
+        let data = PBKDF2::from_js(global_this, call_frame, Flavor::Async)?;
 
         Ok(pbkdf2::create_job(global_this, data))
     }
 
     #[bun_jsc::host_fn]
     fn pbkdf2_sync(global_this: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
-        let data = PBKDF2::from_js(global_this, call_frame, false)?;
+        let data = PBKDF2::from_js(global_this, call_frame, Flavor::Sync)?;
         // `PBKDF2`'s `StringOrBuffer` fields release on `Drop`, so the local
         // just goes out of scope.
         let mut data = data;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -154,11 +154,13 @@ use super::stat::Stats;
 use super::time_like::TimeLike;
 use super::types::{
     ArgumentsSlice, Dirent, Encoding, FdArgExt as _, FileSystemFlags, FileSystemFlagsKind,
-    NameTooLong, PathLike, PathLikeExt as _, PathOrFdExt as _, StringOrBuffer, VectorArrayBuffer,
+    NameTooLong, PathLike, PathLikeExt as _, PathOrFdExt as _, StringObjects, StringOrBuffer,
+    VectorArrayBuffer,
 };
 // Re-exported publicly: `crate::node::fs::PathOrFileDescriptor` is the
-// canonical path used by `cli/build_command.rs` et al.
-pub use super::types::PathOrFileDescriptor;
+// canonical path used by `cli/build_command.rs` et al., and `node_fs::Flavor`
+// by every caller that runs an operation directly (`read_file(.., Flavor::Sync)`).
+pub use super::types::{Flavor, PathOrFileDescriptor};
 
 /// Local alias for the many `node::foo` call sites below, routing to `super::*`.
 mod node {
@@ -472,15 +474,6 @@ pub(crate) const DEFAULT_PERMISSION: Mode = 0;
 // `signal.pending_activity_ref()` / `signal.aborted()` resolve directly to the
 // `&AbortSignal` inherent methods — the former `AbortSignalRefExt` shim with
 // per-call `unsafe { self.as_ref() }` is gone. `unref()` is handled by `Drop`.
-
-/// All async FS functions are run in a thread pool, but some implementations may
-/// decide to do something slightly different. For example, reading a file has
-/// an extra stack buffer in the async case.
-#[derive(Copy, Clone, PartialEq, Eq, core::marker::ConstParamTy)]
-pub enum Flavor {
-    Sync,
-    Async,
-}
 
 // ──────────────────────────────────────────────────────────────────────────
 // Async task type aliases
@@ -4213,11 +4206,14 @@ pub mod args {
                     }
                 }
             }
+            let flavor = if arguments.will_be_async {
+                Flavor::Async
+            } else {
+                Flavor::Sync
+            };
             // String objects not allowed (typeof new String("hi") === "object")
             // https://github.com/nodejs/node/blob/6f946c95b9da75c70e868637de8161bc8d048379/lib/internal/fs/utils.js#L916
-            let allow_string_object = false;
-            let is_async = arguments.will_be_async;
-            let data = StringOrBuffer::from_js_with_encoding_maybe_async(ctx, data_value, encoding, is_async, allow_string_object)?
+            let data = StringOrBuffer::from_js_with_encoding_maybe_async(ctx, data_value, encoding, flavor, StringObjects::Reject)?
                 .ok_or_else(|| validators::throw_err_invalid_arg_type_with_message(ctx, format_args!("The \"data\" argument must be of type string or an instance of Buffer, TypedArray, or DataView")))?;
             let abort_signal = scopeguard::ScopeGuard::into_inner(abort_signal);
             Ok(WriteFile {

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -59,6 +59,42 @@ pub use bun_sys::PlatformIoVec;
 
 // ──────────────────────────────────────────────────────────────────────────
 
+/// Whether a call is serviced on the JS thread before it returns (`Sync`) or
+/// handed to the thread pool (`Async`). A few FS operations take a different
+/// path per flavor (`read_file`'s scratch buffer, recursive `readdir`), and
+/// the arguments parsed for an async call must outlive it off the JS thread:
+/// strings are copied or re-referenced thread-safely, buffers are pinned and
+/// `protect()`ed until the owner calls [`bun_jsc::Unprotect::unprotect`].
+#[derive(Copy, Clone, PartialEq, Eq, core::marker::ConstParamTy)]
+pub enum Flavor {
+    Sync,
+    Async,
+}
+
+/// Whether a `String` wrapper object (`new String("..")`) counts as a string
+/// when parsing a string-or-buffer argument. Node's `fs.writeFile` family
+/// rejects wrapper objects; everything else unwraps them.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum StringObjects {
+    Allow,
+    /// Only primitive strings match; a wrapper object parses as "not a string
+    /// or buffer", so the caller throws its own type error.
+    Reject,
+}
+
+/// What [`BlobOrStringOrBuffer`] parsing does with a file-backed `Blob`
+/// (`Bun.file(..)`). Nothing here reads the file: an allowed one is returned
+/// as [`BlobOrStringOrBuffer::Blob`] like an in-memory blob, and its `slice()`
+/// is empty.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum FileBlobs {
+    Allow,
+    /// Throws "File blob cannot be used here".
+    Reject,
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+
 pub enum BlobOrStringOrBuffer {
     Blob(Box<Blob>),
     StringOrBuffer(StringOrBuffer),
@@ -92,11 +128,12 @@ impl BlobOrStringOrBuffer {
     pub(crate) fn from_js_maybe_file_maybe_async(
         global: &JSGlobalObject,
         value: JSValue,
-        allow_file: bool,
-        is_async: bool,
+        file_blobs: FileBlobs,
+        flavor: Flavor,
     ) -> JsResult<Option<BlobOrStringOrBuffer>> {
         // Check StringOrBuffer first because it's more common and cheaper.
-        let str = match StringOrBuffer::from_js_maybe_async(global, value, is_async, true)? {
+        let str = StringOrBuffer::from_js_maybe_async(global, value, flavor, StringObjects::Allow)?;
+        let str = match str {
             Some(s) => s,
             None => {
                 // `as_class_ref` is the safe shared-borrow downcast (centralised
@@ -106,12 +143,12 @@ impl BlobOrStringOrBuffer {
                 let Some(blob) = value.as_class_ref::<Blob>() else {
                     return Ok(None);
                 };
-                if allow_file && blob.needs_to_read_file() {
+                if file_blobs == FileBlobs::Reject && blob.needs_to_read_file() {
                     return Err(global
                         .throw_invalid_arguments(format_args!("File blob cannot be used here")));
                 }
 
-                if is_async {
+                if flavor == Flavor::Async {
                     // For async/cross-thread usage, copy the blob data to an owned slice
                     // rather than referencing the store which isn't thread-safe
                     let blob_data = blob.shared_view();
@@ -132,23 +169,23 @@ impl BlobOrStringOrBuffer {
     pub(crate) fn from_js_maybe_file(
         global: &JSGlobalObject,
         value: JSValue,
-        allow_file: bool,
+        file_blobs: FileBlobs,
     ) -> JsResult<Option<BlobOrStringOrBuffer>> {
-        Self::from_js_maybe_file_maybe_async(global, value, allow_file, false)
+        Self::from_js_maybe_file_maybe_async(global, value, file_blobs, Flavor::Sync)
     }
 
     pub fn from_js(
         global: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<Option<BlobOrStringOrBuffer>> {
-        Self::from_js_maybe_file(global, value, true)
+        Self::from_js_maybe_file(global, value, FileBlobs::Reject)
     }
 
     pub(crate) fn from_js_async(
         global: &JSGlobalObject,
         value: JSValue,
     ) -> JsResult<Option<BlobOrStringOrBuffer>> {
-        Self::from_js_maybe_file_maybe_async(global, value, true, true)
+        Self::from_js_maybe_file_maybe_async(global, value, FileBlobs::Reject, Flavor::Async)
     }
 
     /// Like [`from_js_with_encoding_value_allow_request_response`] but takes an
@@ -220,12 +257,11 @@ impl BlobOrStringOrBuffer {
             _ => {}
         }
 
-        let allow_string_object = true;
         match StringOrBuffer::from_js_with_encoding_value_allow_string_object(
             global,
             value,
             encoding_value,
-            allow_string_object,
+            StringObjects::Allow,
         )? {
             Some(s) => Ok(Some(Self::StringOrBuffer(s))),
             None => Ok(None),
@@ -294,8 +330,8 @@ impl bun_jsc::Unprotect for BlobOrStringOrBuffer {
 impl bun_jsc::Unprotect for StringOrBuffer {
     /// JS-side half of cleanup — undo the
     /// `protect()` taken by [`StringOrBuffer::to_thread_safe`] /
-    /// `from_js_maybe_async(.., is_async=true)`. Owned slices are released by
-    /// `Drop`.
+    /// `from_js_maybe_async(.., Flavor::Async, ..)`. Owned slices are released
+    /// by `Drop`.
     #[inline]
     fn unprotect(&mut self) {
         if let Self::Buffer(buffer) = self {
@@ -385,17 +421,17 @@ impl StringOrBuffer {
         out: &mut StringOrBuffer,
         global: &JSGlobalObject,
         value: JSValue,
-        is_async: bool,
-        allow_string_object: bool,
+        flavor: Flavor,
+        string_objects: StringObjects,
     ) -> JsResult<bool> {
         use jsc::JSType;
         match value.js_type() {
             str_type @ (JSType::String | JSType::StringObject | JSType::DerivedStringObject) => {
-                if !allow_string_object && str_type != JSType::String {
+                if string_objects == StringObjects::Reject && str_type != JSType::String {
                     return Ok(false);
                 }
                 let mut str = bun_core::String::from_js(value, global)?;
-                if is_async {
+                if flavor == Flavor::Async {
                     let mut possible_clone = str;
                     let mut sliced = possible_clone.to_thread_safe_slice();
                     sliced.report_extra_memory(global.vm());
@@ -437,14 +473,14 @@ impl StringOrBuffer {
             | JSType::BigInt64Array
             | JSType::BigUint64Array
             | JSType::DataView => {
-                let buffer = if is_async {
+                let buffer = if flavor == Flavor::Async {
                     Buffer::from_js_pinned(global, value)
                         .unwrap_or_else(|| Buffer::from_array_buffer(global, value))
                 } else {
                     Buffer::from_array_buffer(global, value)
                 };
 
-                if is_async {
+                if flavor == Flavor::Async {
                     buffer.buffer.value.protect();
                 }
 
@@ -459,11 +495,11 @@ impl StringOrBuffer {
     pub(crate) fn from_js_maybe_async(
         global: &JSGlobalObject,
         value: JSValue,
-        is_async: bool,
-        allow_string_object: bool,
+        flavor: Flavor,
+        string_objects: StringObjects,
     ) -> JsResult<Option<StringOrBuffer>> {
         let mut out = Self::EMPTY;
-        if Self::from_js_maybe_async_into(&mut out, global, value, is_async, allow_string_object)? {
+        if Self::from_js_maybe_async_into(&mut out, global, value, flavor, string_objects)? {
             Ok(Some(out))
         } else {
             Ok(None)
@@ -472,7 +508,7 @@ impl StringOrBuffer {
 
     #[inline]
     pub fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<StringOrBuffer>> {
-        Self::from_js_maybe_async(global, value, false, true)
+        Self::from_js_maybe_async(global, value, Flavor::Sync, StringObjects::Allow)
     }
 
     #[inline]
@@ -481,7 +517,13 @@ impl StringOrBuffer {
         value: JSValue,
         encoding: Encoding,
     ) -> JsResult<Option<StringOrBuffer>> {
-        Self::from_js_with_encoding_maybe_async(global, value, encoding, false, true)
+        Self::from_js_with_encoding_maybe_async(
+            global,
+            value,
+            encoding,
+            Flavor::Sync,
+            StringObjects::Allow,
+        )
     }
 
     /// Out-param convenience wrapper — see [`from_js_with_encoding_maybe_async_into`].
@@ -492,7 +534,14 @@ impl StringOrBuffer {
         value: JSValue,
         encoding: Encoding,
     ) -> JsResult<bool> {
-        Self::from_js_with_encoding_maybe_async_into(out, global, value, encoding, false, true)
+        Self::from_js_with_encoding_maybe_async_into(
+            out,
+            global,
+            value,
+            encoding,
+            Flavor::Sync,
+            StringObjects::Allow,
+        )
     }
 
     /// Out-param core of [`from_js_with_encoding_maybe_async`]. Writes into
@@ -504,17 +553,17 @@ impl StringOrBuffer {
         global: &JSGlobalObject,
         value: JSValue,
         encoding: Encoding,
-        is_async: bool,
-        allow_string_object: bool,
+        flavor: Flavor,
+        string_objects: StringObjects,
     ) -> JsResult<bool> {
         if value.is_cell() && value.js_type().is_array_buffer_like() {
-            let buffer = if is_async {
+            let buffer = if flavor == Flavor::Async {
                 Buffer::from_js_pinned(global, value)
                     .unwrap_or_else(|| Buffer::from_array_buffer(global, value))
             } else {
                 Buffer::from_array_buffer(global, value)
             };
-            if is_async {
+            if flavor == Flavor::Async {
                 buffer.buffer.value.protect();
             }
             *out = Self::Buffer(buffer);
@@ -522,25 +571,13 @@ impl StringOrBuffer {
         }
 
         if encoding == Encoding::Utf8 {
-            return Self::from_js_maybe_async_into(
-                out,
-                global,
-                value,
-                is_async,
-                allow_string_object,
-            );
+            return Self::from_js_maybe_async_into(out, global, value, flavor, string_objects);
         }
 
         if value.is_string() {
             let str = bun_core::OwnedString::new(bun_core::String::from_js(value, global)?);
             if str.is_empty() {
-                return Self::from_js_maybe_async_into(
-                    out,
-                    global,
-                    value,
-                    is_async,
-                    allow_string_object,
-                );
+                return Self::from_js_maybe_async_into(out, global, value, flavor, string_objects);
             }
 
             use crate::webcore::encoding::BunStringEncode as _;
@@ -559,8 +596,8 @@ impl StringOrBuffer {
         global: &JSGlobalObject,
         value: JSValue,
         encoding: Encoding,
-        is_async: bool,
-        allow_string_object: bool,
+        flavor: Flavor,
+        string_objects: StringObjects,
     ) -> JsResult<Option<StringOrBuffer>> {
         let mut out = Self::EMPTY;
         if Self::from_js_with_encoding_maybe_async_into(
@@ -568,8 +605,8 @@ impl StringOrBuffer {
             global,
             value,
             encoding,
-            is_async,
-            allow_string_object,
+            flavor,
+            string_objects,
         )? {
             Ok(Some(out))
         } else {
@@ -581,7 +618,7 @@ impl StringOrBuffer {
         global: &JSGlobalObject,
         value: JSValue,
         encoding_value: JSValue,
-        allow_string_object: bool,
+        string_objects: StringObjects,
     ) -> JsResult<Option<StringOrBuffer>> {
         let encoding: Encoding = 'brk: {
             if !encoding_value.is_cell() {
@@ -589,13 +626,12 @@ impl StringOrBuffer {
             }
             break 'brk Encoding::from_js(encoding_value, global)?.unwrap_or(Encoding::Utf8);
         };
-        let is_async = false;
         Self::from_js_with_encoding_maybe_async(
             global,
             value,
             encoding,
-            is_async,
-            allow_string_object,
+            Flavor::Sync,
+            string_objects,
         )
     }
 }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -24,7 +24,7 @@ use bun_jsc::SysErrorJsc;
 // struct directly so `VirtualMachine::get()` resolves as an associated fn.
 use super::upgraded_duplex::{Handlers as UpgradedDuplexHandlers, UpgradedDuplex};
 use crate::crypto::boringssl_jsc::err_to_js as boringssl_err_to_js;
-use crate::node::{BlobOrStringOrBuffer, StringOrBuffer};
+use crate::node::{BlobOrStringOrBuffer, StringObjects, StringOrBuffer};
 use crate::socket::{SSLConfig, SSLConfigFromJs};
 use bun_boringssl_sys as boringssl_sys;
 use bun_cares_sys::c_ares_draft as c_ares;
@@ -2594,7 +2594,6 @@ impl<const SSL: bool> NewSocket<SSL> {
             return self.write_or_end::<IS_END>(global, &mut values, true);
         }
 
-        let allow_string_object = true;
         let buffer: StringOrBuffer = if data_value.is_undefined() {
             StringOrBuffer::EMPTY
         } else {
@@ -2603,7 +2602,7 @@ impl<const SSL: bool> NewSocket<SSL> {
                 // allocator dropped (global mimalloc)
                 data_value,
                 encoding_value,
-                allow_string_object,
+                StringObjects::Allow,
             ) {
                 Ok(Some(b)) => b,
                 Ok(None) => {

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -1,4 +1,4 @@
-use crate::node::BlobOrStringOrBuffer as JSArgument;
+use crate::node::{BlobOrStringOrBuffer as JSArgument, FileBlobs};
 use bun_collections::VecExt as _;
 use bun_core::OwnedString;
 use bun_jsc::{
@@ -70,10 +70,10 @@ fn from_js(global: &JSGlobalObject, value: JSValue) -> JsResult<Option<JSArgumen
     if value.is_number() {
         // Allow numbers to be passed as strings.
         let str = value.to_js_string(global)?;
-        return JSArgument::from_js_maybe_file(global, str.to_js(), true);
+        return JSArgument::from_js_maybe_file(global, str.to_js(), FileBlobs::Reject);
     }
 
-    JSArgument::from_js_maybe_file(global, value, false)
+    JSArgument::from_js_maybe_file(global, value, FileBlobs::Allow)
 }
 
 /// Shim around `protocol::valkey_error_to_js` that:

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -218,6 +218,25 @@ describe("bundler files option", () => {
     expect(output).toContain("hello from blob");
   });
 
+  test("in-memory file with a file-backed Blob is rejected", () => {
+    // Only in-memory blobs are accepted as content; a Bun.file() blob would
+    // have to be read from disk and is rejected like every other
+    // string-or-blob argument, instead of being treated as empty content.
+    // Like the other invalid options, this throws from Bun.build() itself.
+    using dir = tempDir("bundler-files-bun-file", {
+      "entry.js": `console.log("from disk");`,
+    });
+
+    expect(() =>
+      Bun.build({
+        entrypoints: ["/entry.js"],
+        files: {
+          "/entry.js": Bun.file(`${dir}/entry.js`),
+        },
+      }),
+    ).toThrow("File blob cannot be used here");
+  });
+
   test("in-memory file with Uint8Array content", async () => {
     const encoder = new TextEncoder();
     const result = await Bun.build({

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2740,6 +2740,29 @@ describe("writeFileSync", () => {
   });
 });
 
+describe("writeFile/appendFile data argument", () => {
+  it("rejects a String wrapper object on the sync and callback paths, like node", () => {
+    // Node only accepts primitive strings here (`new String("x")` is an
+    // object), unlike most other string-or-buffer arguments, which unwrap it.
+    // The callback forms validate before scheduling anything, so they throw
+    // synchronously too. (fs.promises.* is different: there node accepts any
+    // iterable, which a String object is.)
+    using dir = tempDir("fs-data-string-object", {});
+    const file = (name: string) => join(String(dir), name);
+    const data = new String("data") as any;
+
+    expect(() => writeFileSync(file("write-sync.txt"), data)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(() => fs.appendFileSync(file("append-sync.txt"), data)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(() => fs.writeFile(file("write-cb.txt"), data, () => {})).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(() => fs.appendFile(file("append-cb.txt"), data, () => {})).toThrowWithCode(
+      TypeError,
+      "ERR_INVALID_ARG_TYPE",
+    );
+
+    expect(readdirSync(String(dir))).toEqual([]);
+  });
+});
+
 function triggerDOMJIT(target: fs.Stats, fn: (..._: any[]) => any, result: any) {
   for (let i = 0; i < 9999; i++) {
     if (fn.apply(target) !== result) {


### PR DESCRIPTION
### Problem
- mordant's `bare_bool_args` reports four functions in `src/runtime/node/types.rs` (the `bare_bool_args:src/runtime/node/types.rs = 4` baseline entry): `BlobOrStringOrBuffer::from_js_maybe_file_maybe_async(.., allow_file, is_async)`, `StringOrBuffer::from_js_maybe_async(.., is_async, allow_string_object)`, `from_js_with_encoding_maybe_async_into(..)` and `from_js_with_encoding_maybe_async(..)` (same two bools). Each has a caller passing bare literals, e.g. `from_js_maybe_file_maybe_async(global, value, true, true)` and `from_js_maybe_async(global, value, false, true)`, where nothing says which flag is which.
- The callers outside the file are not much clearer: `BunObject.rs` and `JSTranspiler.rs` pass `true, allow_string_object`, `PBKDF2::from_js(.., true)` / `(.., false)` forward a bare bool, Scrypt passes `IS_ASYNC, true`.
- `allow_file` is also named backwards: `allow_file == true` is what makes a file-backed `Blob` throw "File blob cannot be used here" (`types.rs:109` on main). Only the Redis client passes `false`.

### Fix
- Each flag becomes a two-variant enum, and the four functions (plus their forwarders `from_js_maybe_file` and `from_js_with_encoding_value_allow_string_object`) take the enums instead of bools:
  - `is_async` -> `Flavor::{Sync, Async}`. This is `node_fs.rs`'s existing enum for the same fact (is this call serviced inline or on the thread pool). It moves to `types.rs` so the argument parsers can use it; `node_fs.rs` re-exports it, so the `node_fs::Flavor` / `node::fs::Flavor` callers are untouched.
  - `allow_string_object` -> `StringObjects::{Allow, Reject}`.
  - `allow_file` -> `FileBlobs::{Allow, Reject}`, named for what the flag does: `from_js` / `from_js_async` pass `Reject` (was `true`), the Redis client passes `Allow` (was `false`).
- Call sites now read `from_js_maybe_async(global, value, Flavor::Async, StringObjects::Allow)`, and the bodies compare against a variant where they tested the bool. Every call maps its old literal to the equivalent variant, so there is no behavior change. `PBKDF2::from_js` takes `Flavor` itself, since its `is_async` only existed to be forwarded; Scrypt (const-generic `IS_ASYNC`) and `WriteFile::from_js` (`arguments.will_be_async`) convert their bool once.
- Comments describing the old parameters (`is_async=true`) are updated, including the `ThreadSafe::adopt` doc in `src/jsc/node_path.rs`.
- `mordant-baseline.toml`: the `bare_bool_args:src/runtime/node/types.rs` entry is removed. Checked with mordant on `bun_runtime` (`cargo dylint --all -p bun_runtime`) with the entry removed: the unfixed tree reports the four functions above as over the baseline, this tree reports nothing, and `MORDANT_BASELINE_WRITE=1` regenerates the `[bun_runtime]` section without the entry and without any new one. The regeneration also wanted to drop two entries this PR has nothing to do with, `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs` (its `as usize` cast was removed by #37648, after the baseline was last regenerated) and `always_unwrapped_option:src/install/PackageInstall.rs`, so the file is edited by hand here and those are left for the next full regeneration.
- Tests: the value each call site passes is the only thing this change can get wrong, so the two flag values that had no coverage get a test each; the rest were already pinned (`bun-cryptohasher.test.ts` has `Bun.file()` rejected and in-memory Blob / `new String` inputs accepted by the static hashers, `test-fs-write-file-sync.js` has `writeFileSync(new String(..))` rejected, `bundler_files.test.ts` has Blob content accepted).
  - `test/bundler/bundler_files.test.ts`: `Bun.build({ files })` rejects a `Bun.file()` blob with "File blob cannot be used here" (`FileBlobs::Reject` on the `from_js_async` site).
  - `test/js/node/fs/fs.test.ts`: `writeFileSync`, `appendFileSync`, callback `writeFile` and `appendFile` reject a String wrapper with `ERR_INVALID_ARG_TYPE` and create nothing (`StringObjects::Reject` on the one site that uses it, on both its sync and its thread-pool flavor; Node behaves the same for all four).
  - Both pass on main as well: they pin behavior this refactor preserves, there is no input that distinguishes the old code from the new.
- Verified with `bun bd`:
  - `bun bd test test/js/node/fs/fs.test.ts`: 511 pass (512 with the new case); `bun bd test test/bundler/bundler_files.test.ts`: 24 pass.
  - `test/js/node/test/parallel/test-fs-write-file-sync.js`, `test-fs-write-file.js`, `test-fs-write-file-buffer.js`, `test-fs-write-file-typedarrays.js`, `test-fs-append-file.js`, `test-fs-append-file-sync.js`, `test-fs-promises-write-optional-params.js`, `test-fs-write-optional-params.js`, `test-fs-write.js`: all pass.
  - `bun bd test test/js/node/crypto/pbkdf2.test.ts test/js/node/crypto/scrypt.test.ts test/js/bun/util/bun-cryptohasher.test.ts test/js/bun/util/zstd.test.ts test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts`: 535 pass (pbkdf2/scrypt sync and async, `FileBlobs::Reject` via `CryptoHasher`, the async zstd and `Transpiler.transform` paths).
  - A script exercising each changed path once (file blob and `new String` inputs to `CryptoHasher`, `writeFileSync` / `fs.promises.writeFile`, async zstd, async `Transpiler.transform`, pbkdf2/scrypt sync and async, `net.Socket#write` with an encoding, and Redis `set` with number / string / Buffer / Blob / `Bun.file()` arguments against a local server) prints identical output on this build and on the released binary. The valkey test files need the docker `redis_unified` service and are skipped locally.

### Background
- `StringOrBuffer` / `BlobOrStringOrBuffer` (`src/runtime/node/types.rs`) parse the "string or Buffer (or Blob)" arguments of `node:fs`, `node:crypto`, `Bun.Transpiler`, the zlib/zstd functions, sockets and the Redis client. Parsing for a call that runs on the thread pool has to produce a value that survives leaving the JS thread: strings are copied or re-referenced thread-safely, JS buffers are pinned and `protect()`ed until the job's owner calls `unprotect()`. That is what `is_async` selected and what `Flavor::Async` selects now.
- `allow_string_object` exists because Node's `fs.writeFile` family rejects `new String("..")` wrapper objects while every other caller unwraps them.
- `mordant-baseline.toml` is the ratchet for the lint pack run by `bun run rust:mordant`: it records the per-(lint, file) finding counts that predate the job, so CI only fails on a new finding. `bare_bool_args` fires on a crate-private function with two or more `bool` parameters when some call passes bare `true`/`false` for at least two of them; fixing a site means deleting (or decrementing) its entry.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->