### PR TITLE
cli: load a package.json and name a lockfile load step from one place

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -80,9 +80,7 @@
 "same_match_twice:src/runtime/api/csrf_jsc.rs" = 1
 "same_match_twice:src/runtime/bake/dev_server/mod.rs" = 1
 "same_match_twice:src/runtime/bake/production.rs" = 2
-"same_match_twice:src/runtime/cli/pack_command.rs" = 1
 "same_match_twice:src/runtime/cli/publish_command.rs" = 1
-"same_match_twice:src/runtime/cli/update_interactive_command.rs" = 2
 "same_match_twice:src/runtime/ipc.rs" = 2
 "same_match_twice:src/runtime/server/RequestContext.rs" = 4
 "same_match_twice:src/runtime/server/server_body.rs" = 1

--- a/src/install/PackageManager/WorkspacePackageJSONCache.rs
+++ b/src/install/PackageManager/WorkspacePackageJSONCache.rs
@@ -114,13 +114,35 @@ pub enum GetResult<'a> {
     ParseErr(Error),
 }
 
+/// The step of [`WorkspacePackageJSONCache::get_with_path`] that failed.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum GetStep {
+    Read,
+    Parse,
+}
+
+impl GetStep {
+    /// The word for the step in a "failed to ... package.json" message.
+    pub fn verb(self) -> &'static str {
+        match self {
+            GetStep::Read => "read",
+            GetStep::Parse => "parse",
+        }
+    }
+}
+
 impl<'a> GetResult<'a> {
-    pub(crate) fn unwrap(self) -> Result<&'a mut MapEntry, Error> {
+    /// The entry, or the step that failed and its error.
+    pub fn entry(self) -> Result<&'a mut MapEntry, (GetStep, Error)> {
         match self {
             GetResult::Entry(entry) => Ok(entry),
-            GetResult::ReadErr(err) => Err(err),
-            GetResult::ParseErr(err) => Err(err),
+            GetResult::ReadErr(err) => Err((GetStep::Read, err)),
+            GetResult::ParseErr(err) => Err((GetStep::Parse, err)),
         }
+    }
+
+    pub(crate) fn unwrap(self) -> Result<&'a mut MapEntry, Error> {
+        self.entry().map_err(|(_, err)| err)
     }
 }
 

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -324,7 +324,8 @@ pub enum LoadStep {
 }
 
 impl LoadStep {
-    pub(crate) fn verb(self) -> &'static str {
+    /// The word for the step in a "failed to ... lockfile" message.
+    pub fn verb(self) -> &'static str {
         match self {
             LoadStep::OpenFile => "open",
             LoadStep::ReadFile => "read",

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -7,8 +7,8 @@ use bun_core::strings;
 use bun_core::{Global, Output};
 use bun_glob as glob;
 use bun_install::dependency::{self, Behavior};
+use bun_install::lockfile::LoadResult;
 use bun_install::lockfile::package::PackageColumns as _;
-use bun_install::lockfile::{LoadResult, LoadStep};
 use bun_install::package_manager::{
     LogLevel, ManifestLoad, Subcommand, WorkspaceFilter, populate_manifest_cache,
 };
@@ -118,24 +118,10 @@ impl OutdatedCommand {
                 if not_silent
                     && !bun_install::migration::reported_unsupported_lockfile_version(&cause)
                 {
-                    match cause.step {
-                        LoadStep::OpenFile => Output::err_generic(
-                            "failed to open lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::ParseFile => Output::err_generic(
-                            "failed to parse lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::ReadFile => Output::err_generic(
-                            "failed to read lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::Migrating => Output::err_generic(
-                            "failed to migrate lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                    }
+                    Output::err_generic(
+                        "failed to {s} lockfile: {s}",
+                        (cause.step.verb(), cause.value.name()),
+                    );
                     if ctx.log_ref().has_errors() {
                         // SAFETY: `log_ptr` aliases `manager.log` which is the
                         // `*logger.Log` borrowed from `Command::Context`; no

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1889,6 +1889,43 @@ fn opt_pack_gzip_level(m: &PackageManager) -> Option<&[u8]> {
 // `Some` only when FOR_PUBLISH == true.
 pub(crate) type PackReturn<'a, const FOR_PUBLISH: bool> = Option<Publish::Context<'a, true>>;
 
+/// The package.json being packed, through the manager's cache; a package.json
+/// that cannot be read or parsed ends the command.
+///
+/// `workspace_package_json_cache` and `log` are disjoint fields on
+/// `PackageManager`; route through raw-pointer field projections so the two
+/// `&mut` borrows don't conflict.
+fn package_json_entry<'a>(
+    manager_ptr: *mut PackageManager,
+    abs_package_json_path: &ZStr,
+) -> &'a mut WorkspacePackageJSONCache::MapEntry {
+    let result = pm_workspace_cache(manager_ptr).get_with_path(
+        pm_log(manager_ptr),
+        abs_package_json_path.as_bytes(),
+        WorkspacePackageJSONCache::GetJSONOptions {
+            guess_indentation: true,
+            ..Default::default()
+        },
+    );
+    match result.entry() {
+        Ok(entry) => entry,
+        Err((step, err)) => {
+            Output::err(
+                err,
+                "failed to {} package.json: {}",
+                (
+                    step.verb(),
+                    bstr::BStr::new(abs_package_json_path.as_bytes()),
+                ),
+            );
+            if step == WorkspacePackageJSONCache::GetStep::Parse {
+                let _ = pm_log(manager_ptr).print(std::ptr::from_mut(Output::error_writer()));
+            }
+            Global::crash();
+        }
+    }
+}
+
 pub(crate) fn pack<const FOR_PUBLISH: bool>(
     ctx: &mut Context<'_>,
     abs_package_json_path: &ZStr,
@@ -1899,36 +1936,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     let manager_ptr: *mut PackageManager = &raw mut *ctx.manager;
     let log_level = ctx.manager.options.log_level;
     let bump = pack_bump();
-    // Note: `workspace_package_json_cache` and `log` are disjoint fields on
-    // `PackageManager`; route through raw-pointer field projections so the
-    // two `&mut` borrows don't conflict.
-    let mut json = match pm_workspace_cache(manager_ptr).get_with_path(
-        pm_log(manager_ptr),
-        abs_package_json_path.as_bytes(),
-        WorkspacePackageJSONCache::GetJSONOptions {
-            guess_indentation: true,
-            ..Default::default()
-        },
-    ) {
-        WorkspacePackageJSONCache::GetResult::ReadErr(err) => {
-            Output::err(
-                err,
-                "failed to read package.json: {}",
-                format_args!("{}", bstr::BStr::new(abs_package_json_path.as_bytes())),
-            );
-            Global::crash();
-        }
-        WorkspacePackageJSONCache::GetResult::ParseErr(err) => {
-            Output::err(
-                err,
-                "failed to parse package.json: {}",
-                format_args!("{}", bstr::BStr::new(abs_package_json_path.as_bytes())),
-            );
-            let _ = pm_log(manager_ptr).print(std::ptr::from_mut(Output::error_writer()));
-            Global::crash();
-        }
-        WorkspacePackageJSONCache::GetResult::Entry(entry) => entry,
-    };
+    let mut json = package_json_entry(manager_ptr, abs_package_json_path);
 
     if FOR_PUBLISH {
         if let Some(config) = json.root.get(b"publishConfig") {
@@ -2153,34 +2161,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         let cache_key: &[u8] = abs_package_json_path.as_bytes();
         let _ = pm_workspace_cache(manager_ptr).map.remove(cache_key);
 
-        // Re-read package.json from disk
-        json = match pm_workspace_cache(manager_ptr).get_with_path(
-            pm_log(manager_ptr),
-            abs_package_json_path.as_bytes(),
-            WorkspacePackageJSONCache::GetJSONOptions {
-                guess_indentation: true,
-                ..Default::default()
-            },
-        ) {
-            WorkspacePackageJSONCache::GetResult::ReadErr(err) => {
-                Output::err(
-                    err,
-                    "failed to read package.json: {}",
-                    format_args!("{}", bstr::BStr::new(abs_package_json_path.as_bytes())),
-                );
-                Global::crash();
-            }
-            WorkspacePackageJSONCache::GetResult::ParseErr(err) => {
-                Output::err(
-                    err,
-                    "failed to parse package.json: {}",
-                    format_args!("{}", bstr::BStr::new(abs_package_json_path.as_bytes())),
-                );
-                let _ = pm_log(manager_ptr).print(std::ptr::from_mut(Output::error_writer()));
-                Global::crash();
-            }
-            WorkspacePackageJSONCache::GetResult::Entry(entry) => entry,
-        };
+        json = package_json_entry(manager_ptr, abs_package_json_path);
 
         // Re-validate private flag after scripts may have modified it.
         if FOR_PUBLISH {

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -6,7 +6,7 @@ use bun_core::fmt::PathSep;
 use bun_core::strings;
 use bun_core::{Global, Output, env_var, fmt as bun_fmt};
 use bun_install::dependency::Dependency;
-use bun_install::lockfile::{LoadResult, LoadStep, Lockfile, package::PackageColumns as _, tree};
+use bun_install::lockfile::{LoadResult, Lockfile, package::PackageColumns as _, tree};
 use bun_install::npm as Npm;
 use bun_install::package_manager_real::{
     CommandLineArguments, Subcommand, fetch_cache_directory_path, get_cache_directory,
@@ -51,15 +51,6 @@ impl<'a> ByName<'a> {
     }
 }
 
-fn load_step_verb(step: LoadStep) -> &'static str {
-    match step {
-        LoadStep::OpenFile => "open",
-        LoadStep::ReadFile => "read",
-        LoadStep::ParseFile => "parse",
-        LoadStep::Migrating => "migrate",
-    }
-}
-
 pub(crate) struct PackageManagerCommand;
 
 impl PackageManagerCommand {
@@ -93,7 +84,7 @@ impl PackageManagerCommand {
                 if not_silent && !migration::reported_unsupported_lockfile_version(err) {
                     Output::err_generic(
                         "failed to {s} lockfile: {s}",
-                        (load_step_verb(err.step), err.value.name()),
+                        (err.step.verb(), err.value.name()),
                     );
                 }
                 Global::exit(1);

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -9,8 +9,8 @@ use bun_alloc::Arena as Bump;
 use bun_collections::{StringHashMap, index_sort};
 use bun_core::{Global, Output};
 use bun_install::dependency::{self, Behavior};
+use bun_install::lockfile::LoadResult;
 use bun_install::lockfile::package::PackageColumns as _;
-use bun_install::lockfile::{LoadResult, LoadStep};
 use bun_install::package_manager::options::Do;
 use bun_install::package_manager::{
     LogLevel, ManifestLoad, Subcommand, WorkspaceFilter, populate_manifest_cache,
@@ -19,8 +19,8 @@ use bun_install::package_manager::{
 use bun_install::package_manager_real::command_line_arguments::UpdateGroups;
 use bun_install::update_scope::selects;
 use bun_install::{
-    CommandLineArguments, GetJsonOptions, GetJsonResult, INVALID_PACKAGE_ID, PackageID,
-    PackageManager, WorkspacePackageJsonCacheEntry, resolution,
+    CommandLineArguments, GetJsonOptions, INVALID_PACKAGE_ID, PackageID, PackageManager,
+    WorkspacePackageJsonCacheEntry, resolution,
 };
 use bun_install_types::DependencyGroup;
 use bun_js_printer::{self as js_printer, BufferPrinter, BufferWriter, PrintJsonOptions};
@@ -181,6 +181,36 @@ impl UpdateInteractiveCommand {
         }
     }
 
+    /// A workspace's package.json through the manager's cache. One that cannot
+    /// be read or parsed is reported and returns `None`, so the caller skips
+    /// that workspace and carries on with the others.
+    fn load_package_json<'m>(
+        manager: &'m mut PackageManager,
+        package_json_path: &[u8],
+    ) -> Option<&'m mut WorkspacePackageJsonCacheEntry> {
+        // `log_mut()` returns a borrow decoupled from `&self`, so it can
+        // overlap the `workspace_package_json_cache` field borrow.
+        let log = manager.log_mut();
+        let result = manager.workspace_package_json_cache.get_with_path(
+            log,
+            package_json_path,
+            GetJsonOptions {
+                guess_indentation: true,
+                ..Default::default()
+            },
+        );
+        match result.entry() {
+            Ok(entry) => Some(entry),
+            Err((step, err)) => {
+                Output::err_generic(
+                    "Failed to {s} package.json at {s}: {s}",
+                    (step.verb(), BStr::new(package_json_path), err.name()),
+                );
+                None
+            }
+        }
+    }
+
     // Helper to update a catalog entry at a specific path in the package.json AST
     // No `*PackageManager` parameter: there is no per-manager allocator,
     // and dropping it avoids overlapping `&mut PackageManager` with the live
@@ -334,36 +364,9 @@ impl UpdateInteractiveCommand {
             let package_json_path =
                 Self::build_package_json_path(root_dir, workspace_path, &mut path_buf);
 
-            // Load and parse the package.json
-            // Reshaped for borrowck — `log_mut()` returns a borrow
-            // decoupled from `&self`, so it can overlap the disjoint
-            // `workspace_package_json_cache` field borrow below.
-            let log = manager.log_mut();
-            let package_json: &mut WorkspacePackageJsonCacheEntry =
-                match manager.workspace_package_json_cache.get_with_path(
-                    log,
-                    package_json_path,
-                    GetJsonOptions {
-                        guess_indentation: true,
-                        ..Default::default()
-                    },
-                ) {
-                    GetJsonResult::ParseErr(err) => {
-                        Output::err_generic(
-                            "Failed to parse package.json at {s}: {s}",
-                            (BStr::new(package_json_path), err.name()),
-                        );
-                        continue;
-                    }
-                    GetJsonResult::ReadErr(err) => {
-                        Output::err_generic(
-                            "Failed to read package.json at {s}: {s}",
-                            (BStr::new(package_json_path), err.name()),
-                        );
-                        continue;
-                    }
-                    GetJsonResult::Entry(entry) => entry,
-                };
+            let Some(package_json) = Self::load_package_json(manager, package_json_path) else {
+                continue;
+            };
 
             let mut modified = false;
 
@@ -464,33 +467,9 @@ impl UpdateInteractiveCommand {
             let package_json_path =
                 Self::build_package_json_path(root_dir, workspace_path, &mut path_buf);
 
-            // Load and parse the package.json properly
-            let log = manager.log_mut();
-            let package_json: &mut WorkspacePackageJsonCacheEntry =
-                match manager.workspace_package_json_cache.get_with_path(
-                    log,
-                    package_json_path,
-                    GetJsonOptions {
-                        guess_indentation: true,
-                        ..Default::default()
-                    },
-                ) {
-                    GetJsonResult::ParseErr(err) => {
-                        Output::err_generic(
-                            "Failed to parse package.json at {s}: {s}",
-                            (BStr::new(package_json_path), err.name()),
-                        );
-                        continue;
-                    }
-                    GetJsonResult::ReadErr(err) => {
-                        Output::err_generic(
-                            "Failed to read package.json at {s}: {s}",
-                            (BStr::new(package_json_path), err.name()),
-                        );
-                        continue;
-                    }
-                    GetJsonResult::Entry(entry) => entry,
-                };
+            let Some(package_json) = Self::load_package_json(manager, package_json_path) else {
+                continue;
+            };
 
             edit_catalog_definitions(
                 &mut updates_for_workspace[..],
@@ -527,24 +506,10 @@ impl UpdateInteractiveCommand {
                 if not_silent
                     && !bun_install::migration::reported_unsupported_lockfile_version(&cause)
                 {
-                    match cause.step {
-                        LoadStep::OpenFile => Output::err_generic(
-                            "failed to open lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::ParseFile => Output::err_generic(
-                            "failed to parse lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::ReadFile => Output::err_generic(
-                            "failed to read lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::Migrating => Output::err_generic(
-                            "failed to migrate lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                    }
+                    Output::err_generic(
+                        "failed to {s} lockfile: {s}",
+                        (cause.step.verb(), cause.value.name()),
+                    );
                     // SAFETY: `ctx.log` is set by `Command::create_context_data`
                     // for every subcommand and is non-null for the command's
                     // lifetime.

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1267,6 +1267,61 @@ describe.concurrent("hand-edited bun.lock that lists workspaces but has no packa
   });
 });
 
+// The commands that only read the lockfile name the step that failed and stop, without touching the registry.
+describe.concurrent("a bun.lock that does not parse", () => {
+  const projectFiles = {
+    "package.json": JSON.stringify({ name: "unparsable-lockfile", dependencies: { "no-deps": "1.0.0" } }),
+    "bun.lock": "this is not a lockfile\n",
+  };
+
+  async function run(prefix: string, ...args: string[]) {
+    using dir = tempDir(prefix, projectFiles);
+    await using proc = spawn({
+      cmd: [bunExe(), ...args],
+      cwd: String(dir),
+      env,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { out: normalizeBunSnapshot(out, String(dir)), err: normalizeBunSnapshot(err, String(dir)), exitCode };
+  }
+
+  it("bun outdated", async () => {
+    const { out, err, exitCode } = await run("unparsable-lockfile-outdated", "outdated");
+    expect(err).toMatchInlineSnapshot(`
+      "1 | this is not a lockfile
+          ^
+      error: Unexpected this
+          at bun.lock:1:1
+      error: failed to parse lockfile: ParserError"
+    `);
+    expect(out).toMatchInlineSnapshot(`"bun outdated <version> (<revision>)"`);
+    expect(exitCode).toBe(1);
+  });
+
+  it("bun update --interactive", async () => {
+    const { out, err, exitCode } = await run("unparsable-lockfile-update-interactive", "update", "--interactive");
+    expect(err).toMatchInlineSnapshot(`
+      "1 | this is not a lockfile
+          ^
+      error: Unexpected this
+          at bun.lock:1:1
+      error: failed to parse lockfile: ParserError"
+    `);
+    expect(out).toMatchInlineSnapshot(`"bun update --interactive <version> (<revision>)"`);
+    expect(exitCode).toBe(1);
+  });
+
+  it("bun pm ls", async () => {
+    const { out, err, exitCode } = await run("unparsable-lockfile-pm-ls", "pm", "ls");
+    expect(err).toMatchInlineSnapshot(`"error: failed to parse lockfile: ParserError"`);
+    expect(out).toMatchInlineSnapshot(`""`);
+    expect(exitCode).toBe(1);
+  });
+});
+
 const makeInstallRunner = (cwd: string) => async (args: string[]) => {
   await using proc = spawn({
     cmd: [bunExe(), ...args],

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -837,6 +837,50 @@ test("lifecycle script modifying version updates tarball filename (#17195)", asy
   ]);
 });
 
+describe.concurrent("package.json that cannot be loaded", () => {
+  test("unparsable package.json", async () => {
+    using dir = tempDir("pack-unparsable-package-json", {
+      "package.json": `{ "name": "pack-unparsable", "version": "1.0.0",`,
+    });
+
+    const { err } = await packExpectError(String(dir), bunEnv);
+    // the parser's own diagnostic is printed along with the error
+    expect(err).toMatch(/at .*package\.json:1:\d+/);
+    expect(err).toMatch(/^ParserError: failed to parse package\.json: .*package\.json$/m);
+  });
+
+  test("prepack script removes package.json before it is re-read", async () => {
+    using dir = tempDir("pack-prepack-removes-package-json", {
+      "package.json": JSON.stringify({
+        name: "pack-prepack-removes",
+        version: "1.0.0",
+        scripts: { prepack: `${bunExe()} remove.js` },
+      }),
+      "remove.js": `require("fs").unlinkSync("package.json");`,
+    });
+
+    const { err } = await packExpectError(String(dir), bunEnv);
+    expect(err).toMatch(/^ENOENT: failed to read package\.json: .*package\.json$/m);
+    expect(await exists(join(String(dir), "pack-prepack-removes-1.0.0.tgz"))).toBeFalse();
+  });
+
+  test("prepack script leaves package.json unparsable before it is re-read", async () => {
+    using dir = tempDir("pack-prepack-breaks-package-json", {
+      "package.json": JSON.stringify({
+        name: "pack-prepack-breaks",
+        version: "1.0.0",
+        scripts: { prepack: `${bunExe()} break.js` },
+      }),
+      "break.js": `require("fs").writeFileSync("package.json", "{ broken\\n");`,
+    });
+
+    const { err } = await packExpectError(String(dir), bunEnv);
+    expect(err).toMatch(/at .*package\.json:1:\d+/);
+    expect(err).toMatch(/^ParserError: failed to parse package\.json: .*package\.json$/m);
+    expect(await exists(join(String(dir), "pack-prepack-breaks-1.0.0.tgz"))).toBeFalse();
+  });
+});
+
 describe("bundledDependnecies", () => {
   for (const bundledDependencies of ["bundledDependencies", "bundleDependencies"]) {
     test(`basic (${bundledDependencies})`, async () => {

--- a/test/cli/install/bun-update-transitive.test.ts
+++ b/test/cli/install/bun-update-transitive.test.ts
@@ -2465,3 +2465,17 @@ test.concurrent("`bun update -i --latest` honours an entry toggled back to its i
   await frozen(dir);
   expect(exitCode).toBe(0);
 });
+
+// A member whose package.json no longer parses is reported and skipped; the other members are still written.
+test.concurrent(
+  "`bun update -i -r` reports a member whose package.json cannot be parsed and still updates the rest",
+  async () => {
+    const { dir } = await staleMembers("~1.0.0", "~1.0.0");
+    await write(join(dir, "packages/pkg2/package.json"), "{ broken\n");
+    const { stderr, exitCode } = await runInteractive(dir, "a\r", "-r");
+    expect(stderr).toMatch(/^error: Failed to parse package\.json at .*pkg2[\\/]package\.json: ParserError$/m);
+    expect(await packageJsonOf(dir, "packages/pkg1")).toStrictEqual(member("pkg1", { "no-deps": "~1.0.1" }));
+    expect(await packageJsonText(dir, "packages/pkg2")).toBe("{ broken\n");
+    expect(exitCode).toBe(1);
+  },
+);


### PR DESCRIPTION
### Problem
- mordant `same_match_twice` reports three findings in the CLI crate, recorded in `mordant-baseline.toml` as `pack_command.rs = 1` and `update_interactive_command.rs = 2`:
  - `pack_command.rs:2157` repeats `:1905`: the `match` on `GetJsonResult` that loads the package.json being packed is written out once for the initial read and again for the re-read after lifecycle scripts.
  - `update_interactive_command.rs:470` repeats `:343`: the `match` on `GetJsonResult` that loads a workspace's package.json is written out once in the dependency-update loop and again in the catalog-update loop.
  - `update_interactive_command.rs:530` repeats `outdated_command.rs:121`: a `match` on `LoadStep` spelling out the "failed to open/read/parse/migrate lockfile" table, which #38841 already turned into `LoadStep::verb()` inside `bun_install` (it was `pub(crate)`, so the CLI crate could not use it).
- `exit_for_root_package_json` from #38841 does not fit these sites: pack crashes with `failed to <verb> package.json: <path>` and prints the log only on a parse failure, update --interactive reports `Failed to <verb> package.json at <path>: <name>` and skips the workspace, while that helper prints `failed to <verb> '<path>'` and exits 1. What all of them share is the `ReadErr` -> "read" / `ParseErr` -> "parse" mapping, so that is the part this PR puts next to the enum.

### Fix
- `WorkspacePackageJSONCache.rs`: `GetResult::entry()` returns the entry or `(GetStep, Error)`, where `GetStep::verb()` is "read" or "parse". The existing `unwrap()` is implemented on top of it, so the variant mapping exists once.
- `pack_command.rs`: one `package_json_entry()` does the lookup and the crash; both sites call it. The log is still printed only on a parse failure, before `Global::crash()`, as before.
- `update_interactive_command.rs`: one `load_package_json()` does the lookup and reports a failure, returning `None` so both loops `continue` as before.
- `lockfile.rs`: `LoadStep::verb()` becomes `pub`. `update_interactive_command.rs` and `outdated_command.rs` print `failed to {verb} lockfile: {name}` through it, and `package_manager_command.rs` drops its private copy of the same table.
- No user-visible change: every message template, the order of message vs. log output, and every exit path are the same; only the verb is now supplied by the enum instead of by the arm. Checked by running the same commands with the released bun and this build and diffing stderr/stdout/exit code: `bun pm pack` on an unparsable package.json, on a `prepack` script that deletes package.json (read error on the re-read), and on one that writes invalid JSON (parse error on the re-read); `bun outdated` and `bun update --interactive` on an unparsable `bun.lock`. All identical.
- None of these messages had a test before, so the folded sites now have one each, pinning what the helpers must keep printing: `bun-pack.test.ts` ("package.json that cannot be loaded": the three `bun pm pack` cases above), `bun-lock.test.ts` ("a bun.lock that does not parse": `bun outdated`, `bun update --interactive` and `bun pm ls`, as inline snapshots), and `bun-update-transitive.test.ts` (`bun update -i -r` on a workspace whose second member's package.json does not parse: that member is reported and skipped, the first member is still updated). They pass on this build and, being a refactor, also on the released bun, except `bun pm ls`, whose wording changed on main in #38333 after the released build.
- `mordant-baseline.toml`: the `pack_command.rs` and `update_interactive_command.rs` `same_match_twice` lines are removed. With those lines removed, `bun run rust:mordant` on the unmodified sources reports exactly the three findings above (`bun_runtime 3` in `over-baseline.txt`); with this change it reports nothing. Regenerating the baseline with `bun run rust:mordant:baseline` adds no new entries.
- The `install_with_manager.rs` entry for the same lint is the subject of #39154; its helper could use `GetResult::entry()` once either lands, but this PR leaves that file alone.
- Tests run on the debug build: `test/cli/install/bun-pack.test.ts` (79 pass), `test/cli/update_interactive_install.test.ts`, `test/cli/update_interactive_formatting.test.ts`, `test/cli/update_interactive_snapshots.test.ts`, `test/regression/issue/update-interactive-formatting.test.ts`, `test/cli/install/bun-pm.test.ts` (53 pass together), `test/cli/install/migration/pnpm-lock-v9.test.ts` (81 pass), the `bun-install.test.ts` invalid package.json snapshot, and `bun-publish.test.ts` (the publish flow goes through the same `pack()` helper; the two "should run in order" cases time out here at 5s because each lifecycle script starts a debug build, which takes ~0.8s, and the timeout kills the shared registry for the tests after them; the other 17 pass when run without those two). `cargo clippy -p bun_install -p bun_runtime` is clean.

### Background
- `WorkspacePackageJSONCache::get_with_path` reads and parses a package.json once per process and hands back a cached `MapEntry` (AST, source, indentation). It returns `GetResult`, a three-way enum (`Entry`, `ReadErr`, `ParseErr`); parse diagnostics go into the package manager's `Log`, which is why the parse paths print the log next to the one-line error.
- `LoadStep` is the lockfile loader's counterpart: `LoadResult::Err(cause)` carries `cause.step` (open / read / parse / migrate) and `cause.value`; `verb()` is the word the error message uses for the step.
- `same_match_twice` compares whole `match` expressions on one enum across a crate (scrutinee, patterns and arm bodies), so a repeated copy only goes away when one function owns the `match` and the other sites call it; two copies that both forward to a helper still count.
- `mordant-baseline.toml` holds the per-(lint, file) counts that predate the mordant CI job; the job fails only on counts above the baseline, so a line can be deleted once the file is clean for that lint.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lock.test.ts test/cli/install/bun-pack.test.ts

<!-- robobun:evidence:end -->