### PR TITLE
js_parser: type RequireString.unwrapped_id as an optional index

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -23,7 +23,6 @@
 [bun_js_parser]
 "bare_bool_args:src/js_parser/visit/mod.rs" = 1
 "same_match_twice:src/js_parser/p.rs" = 3
-"sentinel_integer:src/js_parser/parse/parse_entry.rs" = 1
 
 [bun_js_printer]
 "parallel_vecs:src/js_printer/lib.rs" = 1

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2391,17 +2391,25 @@ pub struct If {
     pub no: ExprNodeIndex,
 }
 
+pub enum UnwrappedRequireMarker {}
+/// Index into the parser's `imports_to_convert_from_require`.
+pub type UnwrappedRequireIndex = bun_core::GenericIndex<u32, UnwrappedRequireMarker>;
+pub type UnwrappedRequireIndexOptional =
+    bun_core::GenericIndexOptional<u32, UnwrappedRequireMarker>;
+
 #[derive(Clone, Copy)]
 pub struct RequireString {
     pub import_record_index: u32,
 
-    pub unwrapped_id: u32,
+    /// Set when `unwrap_commonjs_to_esm` turned this `require()` into an
+    /// import; `NONE` for a `require()` that stays a `require()`.
+    pub unwrapped_id: UnwrappedRequireIndexOptional,
 }
 impl Default for RequireString {
     fn default() -> Self {
         Self {
             import_record_index: 0,
-            unwrapped_id: u32::MAX,
+            unwrapped_id: UnwrappedRequireIndexOptional::NONE,
         }
     }
 }

--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2401,8 +2401,7 @@ pub type UnwrappedRequireIndexOptional =
 pub struct RequireString {
     pub import_record_index: u32,
 
-    /// Set when `unwrap_commonjs_to_esm` turned this `require()` into an
-    /// import; `NONE` for a `require()` that stays a `require()`.
+    /// Set when `unwrap_commonjs_to_esm` turned this `require()` into an import.
     pub unwrapped_id: UnwrappedRequireIndexOptional,
 }
 impl Default for RequireString {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1200,13 +1200,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         );
                     }
 
+                    let unwrapped_id = E::UnwrappedRequireIndex::init(
+                        u32::try_from(self.imports_to_convert_from_require.len() - 1)
+                            .expect("int cast"),
+                    )
+                    .to_optional();
                     return self.new_expr(
                         E::RequireString {
                             import_record_index,
-                            unwrapped_id: u32::try_from(
-                                self.imports_to_convert_from_require.len() - 1,
-                            )
-                            .expect("int cast"),
+                            unwrapped_id,
                         },
                         arg.loc,
                     );

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1470,22 +1470,17 @@ impl<'a> Parser<'a> {
                                     let right = bin.right;
 
                                     if bin.op == js_ast::op::Code::BinAssign
-                                        && matches!(right.data, js_ast::ExprData::ERequireString(_))
+                                        && let js_ast::ExprData::ERequireString(req) = right.data
+                                        && let Some(unwrapped_id) = req.unwrapped_id.get()
                                         && matches!(&left.data, js_ast::ExprData::EDot(d)
                                             if d.name == b"exports"
                                                 && matches!(&d.target.data, js_ast::ExprData::EIdentifier(id)
                                                     if id.ref_.eql(p.module_ref)))
                                     {
-                                        let req = match &right.data {
-                                            js_ast::ExprData::ERequireString(r) => r,
-                                            _ => unreachable!(),
-                                        };
                                         p.export_star_import_records.push(req.import_record_index);
-                                        let namespace_ref =
-                                            p.imports_to_convert_from_require.as_slice()
-                                                [req.unwrapped_id as usize]
-                                                .namespace
-                                                .ref_;
+                                        let deferred = &p.imports_to_convert_from_require
+                                            [unwrapped_id.get_usize()];
+                                        let namespace_ref = deferred.namespace.ref_;
 
                                         let stmt_loc = stmt.loc;
                                         part.stmts = {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -358,11 +358,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             let ref_ = id.r#ref;
                             if let Some(value) = decl.value {
                                 if let ExprData::ERequireString(req) = value.data {
-                                    if req.unwrapped_id != u32::MAX {
-                                        self.imports_to_convert_from_require
-                                            [req.unwrapped_id as usize]
-                                            .namespace
-                                            .ref_ = ref_;
+                                    if let Some(unwrapped_id) = req.unwrapped_id.get() {
+                                        let deferred = &mut self.imports_to_convert_from_require
+                                            [unwrapped_id.get_usize()];
+                                        deferred.namespace.ref_ = ref_;
                                         self.import_items_for_namespace
                                             .insert(ref_, ImportItemForNamespaceMap::default());
                                         continue 'outer;

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3315,7 +3315,7 @@ pub(crate) mod __gated_printer {
                 ExprData::ERequireString(e) => {
                     self.print_require_or_import_expr(
                         e.import_record_index,
-                        e.unwrapped_id != u32::MAX,
+                        e.unwrapped_id.is_some(),
                         &[],
                         Expr::EMPTY,
                         level,

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -284,6 +284,42 @@ describe("bundler", () => {
       stdout: "react\nreact\nreact\nreact\nundefined\nreact\nreact\nreact\nreact\nreact\nreact\n1 react\nreact\nreact",
     },
   });
+  // A require() of an unwrapped package that initializes a destructuring
+  // declaration is kept as a require expression that remembers it was
+  // unwrapped, and prints as the namespace object. One inside try/catch is
+  // never unwrapped and prints as an ordinary require.
+  itBundled("cjs2esm/UnwrappedModuleRequireDestructuredAndInTry", {
+    files: {
+      "/entry.js": /* js */ `
+        const { react: named } = require("react");
+        console.log(named);
+
+        let inTry = "missing";
+        try {
+          inTry = require("react").react;
+        } catch {}
+        console.log(inTry);
+      `,
+      "/node_modules/react/index.js": /* js */ `
+        exports.react = "react";
+      `,
+      "/node_modules/react/package.json": /* json */ `
+        {
+          "name": "react",
+          "version": "2.0.0",
+          "main": "index.js"
+        }
+      `,
+    },
+    onAfterBundle: api => {
+      const code = api.readFile("out.js");
+      expect(code).toMatch(/\{ react: named \} = \(?exports_react\)?;/);
+      expect(code).toContain("__toCommonJS(exports_react)).react");
+    },
+    run: {
+      stdout: "react\nreact",
+    },
+  });
   itBundled("cjs2esm/ReactSpecificUnwrapping", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### Problem
- `E::RequireString.unwrapped_id` (`src/ast/e.rs`) is a `u32` whose value `u32::MAX` means "this `require()` was not converted into an import". The printer (`src/js_printer/lib.rs:3318`) and the decl visitor (`src/js_parser/visit/mod.rs:361`) compare against the sentinel before using it; the export-star rewrite in `Parser::_parse` (`src/js_parser/parse/parse_entry.rs:1485`) indexes `imports_to_convert_from_require` with it directly. This is the `sentinel_integer` entry for `parse_entry.rs` in `mordant-baseline.toml`.
- The sentinel cannot reach that index today, for two independent reasons:
  - The block is guarded by `p.unwrap_all_requires`. With that set, every string `require()` outside a try/catch takes the unwrap branch of `transpose_require` (`src/js_parser/p.rs:1142`), which fills in a real index. The places that leave the field at `MAX` are the non-unwrap branch of `transpose_require` (only reachable inside a try/catch body, so its statement is not a part-level `SExpr`) and the two synthesized `const ... = require(...)` decls for jest globals and the React refresh runtime (`S::Local`, not `SExpr`). None of them can be the right-hand side of the `module.exports = require(...)` expression statement the block matches.
  - The guard also requires `import_records.len() == 1` together with `imports_to_convert_from_require.len() == 1`. Every `require()` adds its own import record (`add_import_record_by_range_and_path` does not deduplicate), and only unwrapped requires add to `imports_to_convert_from_require`, so a file containing a non-unwrapped `require()` plus the unwrapped one the guard needs has at least two import records and never enters the block.
- So this is a type change, not a behavior change: the field's readers now have to spell out what happens when there is no index.

### Fix
- `unwrapped_id` becomes `UnwrappedRequireIndexOptional`, a `bun_core::GenericIndexOptional<u32, _>`, the existing 4-byte optional-index type (`MAX` is `NONE`, the only accessor returns `Option`). It has to stay 4 bytes: `expr.rs` asserts `size_of::<E::RequireString>() <= 8` because the payload is stored inline in `ExprData`. The workspace has no `nonmax` crate, so this reuses the in-tree type rather than adding a dependency.
- No memory or runtime cost relative to the sentinel: the type is `#[repr(transparent)]` over the same `u32` with the same `u32::MAX` none value (the marker is `PhantomData`), so field, `RequireString`, `ExprData` and `Expr` sizes and bit patterns are unchanged; `is_some()` and `get_usize()` are the same `!= MAX` compare and cast as before, inlined. The only additions are two `debug_assert!`s (`init` rejects `MAX`, `get` rejects the none value), which compile out in release.
- The writer in `transpose_require` builds the index with `UnwrappedRequireIndex::init(..).to_optional()`; the `..Default::default()` constructors in the parser and linker keep getting `NONE`.
- The printer uses `is_some()`, the decl visitor uses `if let Some(..)`, and the `_parse` rewrite takes the index as part of its match condition, so a non-unwrapped require falls through and leaves the statement alone instead of indexing with the sentinel.
- The `sentinel_integer:src/js_parser/parse/parse_entry.rs` baseline entry is removed. Regenerating the baseline with `bun run rust:mordant:baseline` on this branch drops exactly this line relative to regenerating it on main; `bun run rust:mordant` on this branch reports nothing over the updated baseline.
- Test: `cjs2esm/UnwrappedModuleRequireDestructuredAndInTry` in `test/bundler/bundler_cjs2esm.test.ts` pins the two shapes the printer reader distinguishes, neither of which had coverage: a destructuring declaration initialized by a `require()` of an unwrapped package keeps the `RequireString` (index set) and prints as the namespace object, and a `require()` inside try/catch (no index) prints as an ordinary require. It passes before and after this change, as any test of a representation change must; inverting the printer's `is_some()` makes it fail on the first assertion, so it does exercise the reader. The `_parse` site is covered by the existing `ReactSpecificUnwrapping`, the decl visitor by `UnwrappedModuleRequireAssigned`.
- Other verification:
  - Existing suites: `bundler_cjs2esm.test.ts` (27 pass), `bundler_cjs.test.ts` (28), `bundler_edgecase.test.ts` (134), `esbuild/dce.test.ts` (78), `esbuild/packagejson.test.ts` (84), `transpiler/transpiler.test.js` (188), `test/cli/test/bun-test.test.ts` (89, covers the injected `require("bun:test")` decl). 0 failures.
  - `bun build` output of `node_modules/react` fixtures exercising all three readers (unwrapped `const x = require()`, destructured `const { a } = require()`, `require()` inside try/catch, `module.exports = require()`) is byte-identical between the released `bun` 1.4.0 and this build.
  - `cargo fmt --check` and `cargo clippy` on `bun_ast`, `bun_js_parser`, `bun_js_printer` are clean.
- Found while writing the test, not changed here: destructuring a `require()` of an unwrapped package whose module assigns `module.exports` (so it stays CommonJS-wrapped) prints that module's wrapper-local `exports` ref at the call site and reads `undefined`. Same output on 1.4.0 and on this branch; it is tracked separately, and the new test uses an `exports.x = ...` module so it pins the correct behavior.

### Background
- `unwrap_commonjs_to_esm`: when bundling, a CommonJS file from a package in `unwrap_commonjs_packages` (react, react-dom, ...) has each `require("x")` converted into an `import * as ns from "x"`. `transpose_require` records each conversion in the parser's `imports_to_convert_from_require` list and the import statements are emitted from that list at the end of the parse.
- In most positions the converted `require()` is replaced by an identifier for `ns` right away. When it is the initializer of a declaration (`const foo = require("x")`) it is instead left as an `E::RequireString` whose `unwrapped_id` points at the list entry, so that the decl visitor can rename the namespace to `foo` and drop the declaration (for a destructuring binding the `RequireString` survives to the printer, which then prints the namespace object). A `require()` that was not converted is also an `E::RequireString`, with no list entry; that is the case the sentinel encoded and the `Option` now encodes.
- `GenericIndexOptional<I, M>` (`src/bun_core/util.rs`) is the repo's optional index: same size as `I`, `I::MAX` reserved as `NONE`, `.get()` returns `Option<GenericIndex<I, M>>`. `M` is a marker type that keeps indices into different containers from mixing.
