### PR TITLE
css: return named component structs from the color helpers instead of tuples

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -15,7 +15,6 @@
 "arg_named_like_other_param:src/css/rules/mod.rs" = 1
 "bare_bool_args:src/css/selectors/builder.rs" = 1
 "tuple_wants_struct:src/css/css_parser.rs" = 1
-"tuple_wants_struct:src/css/values/color.rs" = 5
 
 [bun_install]
 "always_unwrapped_option:src/install/PackageInstall.rs" = 1

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -979,13 +979,14 @@ impl UnresolvedColor {
         depth: usize,
     ) -> Result<UnresolvedColor> {
         use css_values::color::{
-            ComponentParser, HSL, SRGB, parse_hsl_hwb_components, parse_rgb_components,
+            ComponentParser, HSL, RgbComponents, SRGB, parse_hsl_hwb_components,
+            parse_rgb_components,
         };
         let mut parser = ComponentParser::new(false);
         crate::match_ignore_ascii_case! { f, {
             b"rgb" => return input.parse_nested_block(|input2| {
                 parser.parse_relative::<SRGB, UnresolvedColor, _>(input2, |i, p| {
-                    let (r, g, b, is_legacy) = parse_rgb_components(i, p)?;
+                    let RgbComponents { r, g, b, is_legacy } = parse_rgb_components(i, p)?;
                     if is_legacy {
                         return Err(i.new_custom_error(ParserError::invalid_value));
                     }

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1174,10 +1174,20 @@ pub(crate) fn parse_color_function(
     }}
 }
 
+/// The channels of an `rgb()` / `rgba()` call, up to but not including the
+/// alpha: 0..=255 in the legacy comma syntax, otherwise 0..=1 (NaN for `none`).
+pub(crate) struct RgbComponents {
+    pub(crate) r: f32,
+    pub(crate) g: f32,
+    pub(crate) b: f32,
+    /// `rgb(0, 0, 0, 0.5)`: the alpha that follows is comma-separated too.
+    pub(crate) is_legacy: bool,
+}
+
 pub(crate) fn parse_rgb_components(
     input: &mut css::Parser,
     parser: &mut ComponentParser,
-) -> CssResult<(f32, f32, f32, bool)> {
+) -> CssResult<RgbComponents> {
     let red = parser.parse_number_or_percentage(input)?;
 
     let is_legacy_syntax = parser.from.is_none()
@@ -1228,7 +1238,12 @@ pub(crate) fn parse_rgb_components(
     if is_legacy_syntax && (g.is_nan() || b.is_nan()) {
         return Err(input.new_custom_error(css::ParserError::invalid_value));
     }
-    Ok((r, g, b, is_legacy_syntax))
+    Ok(RgbComponents {
+        r,
+        g,
+        b,
+        is_legacy: is_legacy_syntax,
+    })
 }
 
 fn map_gamut<T>(color: T) -> T
@@ -1423,7 +1438,7 @@ fn parse_rgb(input: &mut css::Parser, parser: &mut ComponentParser) -> CssResult
     // https://drafts.csswg.org/css-color-4/#rgb-functions
     input.parse_nested_block(|i| {
         parser.parse_relative::<SRGB, CssColor, _>(i, |i, p| {
-            let (r, g, b, is_legacy) = parse_rgb_components(i, p)?;
+            let RgbComponents { r, g, b, is_legacy } = parse_rgb_components(i, p)?;
             let alpha = if is_legacy {
                 parse_legacy_alpha(i, p)?
             } else {
@@ -2520,7 +2535,14 @@ impl HueInterpolationMethod {
     }
 }
 
-fn rectangular_to_polar(l: f32, a: f32, b: f32) -> (f32, f32, f32) {
+/// The channels of a polar lab-form space (`LCH`, `OKLCH`), without alpha.
+struct LchComponents {
+    l: f32,
+    c: f32,
+    h: f32,
+}
+
+fn rectangular_to_polar(l: f32, a: f32, b: f32) -> LchComponents {
     // https://github.com/w3c/csswg-drafts/blob/fba005e2ce9bcac55b49e4aa19b87208b3a0631e/css-color-4/conversions.js#L375
 
     let mut h = b.atan2(a) * 180.0 / core::f32::consts::PI;
@@ -2531,7 +2553,7 @@ fn rectangular_to_polar(l: f32, a: f32, b: f32) -> (f32, f32, f32) {
     let c = (a.powi(2) + b.powi(2)).sqrt();
 
     h = h.rem_euclid(360.0);
-    (l, c, h)
+    LchComponents { l, c, h }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -2651,59 +2673,43 @@ pub(crate) fn write_predefined(
 
 use bun_core::powf as bun_powf;
 
-fn gam_srgb(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
+fn gam_srgb_component(c: f32) -> f32 {
     // https://github.com/w3c/csswg-drafts/blob/fba005e2ce9bcac55b49e4aa19b87208b3a0631e/css-color-4/conversions.js#L31
-    // convert an array of linear-light sRGB values in the range 0.0-1.0
+    // convert a linear-light sRGB channel in the range 0.0-1.0
     // to gamma corrected form
     // https://en.wikipedia.org/wiki/SRGB
     // Extended transfer function:
     // For negative values, linear portion extends on reflection
     // of axis, then uses reflected pow below that
 
-    fn gam_srgb_component(c: f32) -> f32 {
-        let abs = c.abs();
-        if abs > 0.0031308 {
-            let sign: f32 = if c < 0.0 { -1.0 } else { 1.0 };
-            let x: f32 = bun_powf(abs, 1.0 / 2.4);
-            let y: f32 = 1.055 * x;
-            let z: f32 = y - 0.055;
-            return sign * z;
-        }
-
-        12.92 * c
+    let abs = c.abs();
+    if abs > 0.0031308 {
+        let sign: f32 = if c < 0.0 { -1.0 } else { 1.0 };
+        let x: f32 = bun_powf(abs, 1.0 / 2.4);
+        let y: f32 = 1.055 * x;
+        let z: f32 = y - 0.055;
+        return sign * z;
     }
 
-    (
-        gam_srgb_component(r),
-        gam_srgb_component(g),
-        gam_srgb_component(b),
-    )
+    12.92 * c
 }
 
-fn lin_srgb(r: f32, g: f32, b: f32) -> (f32, f32, f32) {
+fn lin_srgb_component(c: f32) -> f32 {
     // https://github.com/w3c/csswg-drafts/blob/fba005e2ce9bcac55b49e4aa19b87208b3a0631e/css-color-4/conversions.js#L11
-    // convert sRGB values where in-gamut values are in the range [0 - 1]
+    // convert an sRGB channel where in-gamut values are in the range [0 - 1]
     // to linear light (un-companded) form.
     // https://en.wikipedia.org/wiki/SRGB
     // Extended transfer function:
     // for negative values, linear portion is extended on reflection of axis,
     // then reflected power function is used.
 
-    fn lin_srgb_component(c: f32) -> f32 {
-        let abs = c.abs();
-        if abs < 0.04045 {
-            return c / 12.92;
-        }
-
-        let sign: f32 = if c < 0.0 { -1.0 } else { 1.0 };
-        sign * bun_powf((abs + 0.055) / 1.055, 2.4)
+    let abs = c.abs();
+    if abs < 0.04045 {
+        return c / 12.92;
     }
 
-    (
-        lin_srgb_component(r),
-        lin_srgb_component(g),
-        lin_srgb_component(b),
-    )
+    let sign: f32 = if c < 0.0 { -1.0 } else { 1.0 };
+    sign * bun_powf((abs + 0.055) / 1.055, 2.4)
 }
 
 /// PERF: SIMD?
@@ -2714,12 +2720,19 @@ fn multiply_matrix(m: &[f32; 9], x: f32, y: f32, z: f32) -> (f32, f32, f32) {
     (a, b, c)
 }
 
-fn polar_to_rectangular(l: f32, c: f32, h: f32) -> (f32, f32, f32) {
+/// The channels of a rectangular lab-form space (`LAB`, `OKLAB`), without alpha.
+struct LabComponents {
+    l: f32,
+    a: f32,
+    b: f32,
+}
+
+fn polar_to_rectangular(l: f32, c: f32, h: f32) -> LabComponents {
     // https://github.com/w3c/csswg-drafts/blob/fba005e2ce9bcac55b49e4aa19b87208b3a0631e/css-color-4/conversions.js#L385
 
     let a = c * (h * core::f32::consts::PI / 180.0).cos();
     let b = c * (h * core::f32::consts::PI / 180.0).sin();
-    (l, a, b)
+    LabComponents { l, a, b }
 }
 
 const D50: [f32; 3] = [
@@ -2760,7 +2773,7 @@ impl From<HWB> for RGBA {
 impl From<LAB> for LCH {
     fn from(lab_: LAB) -> LCH {
         let lab = lab_.resolve_missing();
-        let (l, c, h) = rectangular_to_polar(lab.l, lab.a, lab.b);
+        let LchComponents { l, c, h } = rectangular_to_polar(lab.l, lab.a, lab.b);
         LCH {
             l,
             c,
@@ -2818,11 +2831,10 @@ impl From<LAB> for XYZd50 {
 impl From<SRGB> for SRGBLinear {
     fn from(rgb: SRGB) -> SRGBLinear {
         let srgb = rgb.resolve_missing();
-        let (r, g, b) = lin_srgb(srgb.r, srgb.g, srgb.b);
         SRGBLinear {
-            r,
-            g,
-            b,
+            r: lin_srgb_component(srgb.r),
+            g: lin_srgb_component(srgb.g),
+            b: lin_srgb_component(srgb.b),
             alpha: srgb.alpha,
         }
     }
@@ -2944,11 +2956,10 @@ impl From<SRGBLinear> for PredefinedColor {
 impl From<SRGBLinear> for SRGB {
     fn from(rgb_: SRGBLinear) -> SRGB {
         let rgb = rgb_.resolve_missing();
-        let (r, g, b) = gam_srgb(rgb.r, rgb.g, rgb.b);
         SRGB {
-            r,
-            g,
-            b,
+            r: gam_srgb_component(rgb.r),
+            g: gam_srgb_component(rgb.g),
+            b: gam_srgb_component(rgb.b),
             alpha: rgb.alpha,
         }
     }
@@ -3006,8 +3017,12 @@ impl From<P3> for XYZd65 {
         ];
 
         let p3 = p3_.resolve_missing();
-        let (r, g, b) = lin_srgb(p3.r, p3.g, p3.b);
-        let (x, y, z) = multiply_matrix(&MATRIX, r, g, b);
+        let (x, y, z) = multiply_matrix(
+            &MATRIX,
+            lin_srgb_component(p3.r),
+            lin_srgb_component(p3.g),
+            lin_srgb_component(p3.b),
+        );
         XYZd65 {
             x,
             y,
@@ -3482,12 +3497,12 @@ impl From<XYZd65> for P3 {
         ];
 
         let xyz = xyz_.resolve_missing();
-        let (r1, g1, b1) = multiply_matrix(&MATRIX, xyz.x, xyz.y, xyz.z);
-        let (r, g, b) = gam_srgb(r1, g1, b1); // same as sRGB
+        let (r, g, b) = multiply_matrix(&MATRIX, xyz.x, xyz.y, xyz.z);
+        // display-p3 uses the sRGB transfer curve.
         P3 {
-            r,
-            g,
-            b,
+            r: gam_srgb_component(r),
+            g: gam_srgb_component(g),
+            b: gam_srgb_component(b),
             alpha: xyz.alpha,
         }
     }
@@ -3497,7 +3512,7 @@ impl From<XYZd65> for P3 {
 impl From<LCH> for LAB {
     fn from(lch_: LCH) -> LAB {
         let lch = lch_.resolve_missing();
-        let (l, a, b) = polar_to_rectangular(lch.l, lch.c, lch.h);
+        let LabComponents { l, a, b } = polar_to_rectangular(lch.l, lch.c, lch.h);
         LAB {
             l,
             a,
@@ -3511,7 +3526,7 @@ impl From<LCH> for LAB {
 impl From<OKLAB> for OKLCH {
     fn from(labb: OKLAB) -> OKLCH {
         let lab = labb.resolve_missing();
-        let (l, c, h) = rectangular_to_polar(lab.l, lab.a, lab.b);
+        let LchComponents { l, c, h } = rectangular_to_polar(lab.l, lab.a, lab.b);
         OKLCH {
             l,
             c,
@@ -3569,7 +3584,7 @@ impl From<OKLAB> for XYZd65 {
 impl From<OKLCH> for OKLAB {
     fn from(lch_: OKLCH) -> OKLAB {
         let lch = lch_.resolve_missing();
-        let (l, a, b) = polar_to_rectangular(lch.l, lch.c, lch.h);
+        let LabComponents { l, a, b } = polar_to_rectangular(lch.l, lch.c, lch.h);
         OKLAB {
             l,
             a,

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -649,3 +649,118 @@ describe("color-mix() percentage range", () => {
     expect(color(input, "css")).toBe(expected);
   });
 });
+
+describe("rgb() channel order and legacy syntax", () => {
+  // Distinct channel values, so any two channels ending up in each other's
+  // place shows in the output. The legacy comma syntax gives the channels on a
+  // 0-255 scale and takes its alpha after another comma; the modern syntax
+  // takes its alpha after a slash and is the only one that allows `none`.
+  test.each([
+    ["rgb(12 34 56)", "#0c2238"],
+    ["rgb(12, 34, 56)", "#0c2238"],
+    ["rgb(4.7% 13.3% 22%)", "#0c2238"],
+    ["rgb(4.7%, 13.3%, 22%)", "#0c2238"],
+    ["rgb(12 13.3% 56)", "#0c2238"],
+    ["rgb(12 34 56 / 0.5)", "#0c223880"],
+    ["rgb(12, 34, 56, 0.5)", "#0c223880"],
+    ["rgba(12, 34, 56, 0.5)", "#0c223880"],
+    ["rgb(12 none 56)", "#0c0038"],
+    ["rgb(none 34 56)", "#002238"],
+  ])("%s is %s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  test.each([
+    "rgb(12, 34, 56 / 0.5)",
+    "rgb(12 34 56, 0.5)",
+    "rgb(12, 13.3%, 56)",
+    "rgb(12, none, 56)",
+    "rgb(none, 34, 56)",
+  ])("%s mixes the two syntaxes and is rejected", input => {
+    expect(color(input, "css")).toBeNull();
+  });
+});
+
+describe("conversions between color spaces", () => {
+  // Each case converts a color whose channels all differ, so a channel landing
+  // in another channel's place shows up in the output. Mixing a color with
+  // itself is how a color is converted into a space Bun.color has no output
+  // format for: color-mix() converts both operands into the interpolation
+  // space and prints the result in it.
+  const same = (space: string, value: string) => color(`color-mix(in ${space}, ${value}, ${value})`, "css") as string;
+  const channels = (css: string) =>
+    css
+      .slice(css.indexOf("(") + 1)
+      .match(/-?\d*\.?\d+(?:e[+-]?\d+)?/g)!
+      .map(Number);
+  const expectChannels = (css: string, expected: number[], digits: number) => {
+    const actual = channels(css);
+    expect(actual).toHaveLength(expected.length);
+    for (let i = 0; i < expected.length; i++) {
+      expect(actual[i]).toBeCloseTo(expected[i], digits);
+    }
+  };
+
+  // Transcendental functions differ in the last f32 digit between platforms,
+  // so the polar conversions are compared numerically.
+  test.each([
+    ["lch(50% 30 0)", [50, 30, 0]],
+    ["lch(50% 30 90)", [50, 0, 30]],
+    ["lch(50% 30 180)", [50, -30, 0]],
+    ["lch(50% 30 270)", [50, 0, -30]],
+  ])("%s has the lab channels %p", (input, expected) => {
+    expectChannels(color(input, "lab") as string, expected as number[], 4);
+  });
+
+  test.each([
+    ["oklch(60% 0.1 0)", "oklab(60% 0.1 0)"],
+    ["oklch(60% 0.1 90)", "oklab(60% 0 0.1)"],
+  ])("%s is the same color as %s", (polar, rectangular) => {
+    expectChannels(color(polar, "lab") as string, channels(color(rectangular, "lab") as string), 3);
+  });
+
+  test.each([
+    ["lch", "lab(50% 30 40)", [50, 50, 53.1301]],
+    ["lch", "lab(50% 0 30)", [50, 30, 90]],
+    ["lch", "lab(50% -30 0)", [50, 30, 180]],
+    ["lch", "lab(50% 0 -30)", [50, 30, 270]],
+    ["oklch", "oklab(60% 0.03 0.04)", [60, 0.05, 53.1301]],
+  ])("converted to %s, %s has the channels %p", (space, input, expected) => {
+    const out = same(space as string, input as string);
+    expect(out).toStartWith(`${space}(`);
+    expectChannels(out, expected as number[], 3);
+  });
+
+  // https://www.w3.org/TR/css-color-4/#color-conversion-code
+  const linear = (v: number) => (v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4);
+
+  test("srgb to srgb-linear applies the transfer function to each channel", () => {
+    const out = same("srgb-linear", "#ff8005");
+    expect(out).toStartWith("color(srgb-linear ");
+    expectChannels(out, [1, linear(128 / 255), linear(5 / 255)], 5);
+  });
+
+  test("srgb-linear to srgb applies the inverse to each channel", () => {
+    // 1 -> 255, 0.2 -> 1.055 * 0.2^(1/2.4) - 0.055 = 0.4845 -> 124, and 0.001
+    // is on the linear segment: 12.92 * 0.001 -> 3.
+    expect(same("srgb", "color(srgb-linear 1 0.2 0.001)")).toBe("#ff7c03");
+  });
+
+  test("display-p3 to xyz linearizes each channel before the matrix", () => {
+    // XYZ of the display-p3 primaries, i.e. the columns of the matrix in
+    // https://www.w3.org/TR/css-color-4/#color-conversion-code. The matrix is
+    // linear, so a color is the sum of its linearized channels times these.
+    const red = [0.486571, 0.228975, 0];
+    const green = [0.265668, 0.691739, 0.045113];
+    const blue = [0.198217, 0.079287, 1.043944];
+    const g = linear(0.5);
+    const b = linear(0.002);
+    const out = same("xyz", "color(display-p3 1 0.5 0.002)");
+    expect(out).toStartWith("color(xyz ");
+    expectChannels(
+      out,
+      [0, 1, 2].map(i => red[i] + g * green[i] + b * blue[i]),
+      4,
+    );
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -125,6 +125,12 @@ describe("css tests", () => {
     // Same trimming applies inside function arguments.
     minify_test(":root{--a:f(x y z)}", ":root{--a:f(x y z)}");
     minify_test(":root{--a:f( x y z )}", ":root{--a:f(x y z)}");
+
+    // An rgb() whose alpha is only known at runtime is parsed into its channels
+    // and printed back from them, in order; the legacy comma form is not a color
+    // here and is left as written.
+    minify_test(":root{--a: rgb(4.7% 13.3% 22% / var(--alpha))}", ":root{--a:rgb(12 34 56/var(--alpha))}");
+    minify_test(":root{--a: rgb(12, 34, 56, var(--alpha))}", ":root{--a:rgb(12,34,56,var(--alpha))}");
   });
 
   describe("pseudo-class edge case", () => {


### PR DESCRIPTION
### Problem
- mordant's `tuple_wants_struct` records five findings for `src/css/values/color.rs` (`mordant-baseline.toml`, `[bun_css]`): `parse_rgb_components` returned `(f32, f32, f32, bool)`, and `rectangular_to_polar`, `polar_to_rectangular`, `lin_srgb` and `gam_srgb` returned `(f32, f32, f32)`.
- Every caller unpacked them positionally under the same names (`(r, g, b, is_legacy)` in `parse_rgb` and in `UnresolvedColor::parse` in `properties/custom.rs`; `(l, c, h)`, `(l, a, b)` and `(r, g, b)` in the `From` impls that build `LCH`/`OKLCH`, `LAB`/`OKLAB`, `SRGBLinear`/`SRGB`/`P3`). The members share a type, so a transposed pair at either end compiles; the names lived at every call site but not in the type.

### Fix
- `parse_rgb_components` returns `RgbComponents { r, g, b, is_legacy }` (`pub(crate)`, it is used from `custom.rs`); the struct's doc also records what the tuple could not, that the channels are 0..=255 in the legacy comma syntax and 0..=1 otherwise.
- `rectangular_to_polar` returns `LchComponents { l, c, h }` and `polar_to_rectangular` returns `LabComponents { l, a, b }`; the four `From` impls destructure them by field name.
- `lin_srgb` / `gam_srgb` were the per-channel transfer function mapped over a triple, so instead of a third struct the wrappers are removed and the callers apply `lin_srgb_component` / `gam_srgb_component` to each channel at the point where the destination field is named (`r: lin_srgb_component(srgb.r)`, ...). That removes the positional coupling on both the argument and the result side.
- `parse_hsl_hwb_components` has the same tuple shape but is not flagged: its two callers bind the middle members as `(h, a, b)` and `(h, s, l)` because the function is shared by `hsl()` and `hwb()`, so a struct for it would need positional field names. Left as is.
- No behavior change: same arithmetic on the same values in the same order.
- Tests (`test/js/bun/css/color.test.ts`, `test/js/bun/css/css.test.ts`): a case per refactored site, each with channels that all differ, so a channel in another channel's place shows in the output: `rgb()` in both syntaxes plus the alpha/`none` rules that `is_legacy` decides, `lch()`/`oklch()` to lab and `lab()`/`oklab()` to their polar form (via `color-mix()` of a color with itself, which is how a value is converted into a space `Bun.color` cannot print), sRGB to and from linear against the css-color-4 transfer function, display-p3 to xyz against the spec matrix columns, and an unresolved `rgb(... / var(--alpha))` for the `custom.rs` caller. The polar cases compare numerically, as the existing lab cases in that file do, since the last f32 digit of atan2/powf varies by platform. Being a refactor, they necessarily pass both before and after this change (there is no output that differs); what they pin is the roles. The before/after check that does flip is the baseline entry: with this `mordant-baseline.toml` and main's `color.rs`, mordant reports the five findings as over the baseline (reproduced locally by regenerating against the unmodified file, which puts the `= 5` line back); with this branch it reports nothing, and the mordant CI job on this PR is green. Checked by building once with every refactored site deliberately transposed (r/g in `RgbComponents` plus an inverted `is_legacy`, c/h in `LchComponents`, a/b in `LabComponents`, g/b in each of the four transfer-function call sites): 27 of the 31 new cases fail, the 4 that do not are the ones documenting which legacy forms are rejected, and the existing `border` test in `css.test.ts` (`lab(40% 56.6 39)` -> `color(display-p3 .643308 .192455 .167712)`) catches the one site without a new case, XYZ to P3.
- Also verified: `bun bd test test/js/bun/css/color.test.ts` (1022 pass), `test/js/bun/css/css.test.ts` (1144 pass, 67 skip), `test/bundler/css/wpt/` (159 pass); a differential run of 1935 generated colors (legacy/modern/relative `rgb()`, `lab()`/`lch()`/`oklab()`/`oklch()` grids, every `color()` space, `color-mix()` in every interpolation space) through `Bun.color` in 8 output formats plus the same values minified as a stylesheet for old, mid and current targets, 25,093 output lines byte-identical between this build and the unmodified bun on this machine.
- `cargo dylint` (mordant) in baseline-write mode for `bun_css`, the only crate touched: the regenerated `[bun_css]` section differs from main only by the removed `tuple_wants_struct:src/css/values/color.rs = 5` line, so the new structs do not introduce a finding of their own; a ratchet-mode run on the branch reports nothing. The workspace-wide regeneration would also drop unrelated entries that are already stale on main; those are left alone here. `cargo clippy -p bun_css --no-deps` and `cargo fmt` are clean.

### Background
- `parse_rgb_components` parses the channels of `rgb()` / `rgba()` and reports whether the legacy comma syntax was used, because that decides how the caller parses the alpha (after a comma rather than a `/`) and what scale the channels are on. `rectangular_to_polar` / `polar_to_rectangular` convert between the lab-form spaces (`LAB`, `OKLAB`: lightness plus two rectangular axes) and their lch-form counterparts (`LCH`, `OKLCH`: lightness, chroma, hue); `lin_srgb` / `gam_srgb` are the sRGB transfer curve, which display-p3 shares, applied channel by channel.
- `mordant-baseline.toml` is the ratchet for the mordant lint pack: it records the per-(lint, file) finding counts that predate the CI job, so CI only fails on new findings. Clearing a file's findings means deleting its entry.
