### PR TITLE
bake: name both flags at every insert_stale_extra call

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -18,7 +18,6 @@
 "tuple_wants_struct:src/css/values/color.rs" = 5
 
 [bun_install]
-"always_unwrapped_option:src/install/PackageInstall.rs" = 1
 "arg_named_like_other_param:src/install/PackageManager/PackageJSONEditor.rs" = 3
 "arg_named_like_other_param:src/install/resolution.rs" = 1
 "bare_bool_args:src/install/isolated_install.rs" = 1
@@ -56,7 +55,6 @@
 "arg_named_like_other_param:src/runtime/node/path.rs" = 2
 "bare_bool_args:src/runtime/api.rs" = 2
 "bare_bool_args:src/runtime/api/bun/h2_frame_parser.rs" = 1
-"bare_bool_args:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "bare_bool_args:src/runtime/cli/run_command.rs" = 1
 "bare_bool_args:src/runtime/dns_jsc/dns.rs" = 1
 "bare_bool_args:src/runtime/node/types.rs" = 4
@@ -69,7 +67,6 @@
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/cli/filter_run.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
-"narrowed_two_ways:src/runtime/node/node_crypto_binding.rs" = 1
 "parallel_vecs:src/runtime/api/html_rewriter.rs" = 1
 "parallel_vecs:src/runtime/bake/dev_server/incremental_graph.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -908,7 +908,9 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         // `debug_assert!` does not evaluate its argument in release. Hoist
         // the side-effecting `insert_stale`
         // out so the refresh runtime is registered at index 0 in all builds.
-        let idx = dev.client_graph.insert_stale(&rfr.import_source, false)?;
+        let idx = dev
+            .client_graph
+            .insert_stale(&rfr.import_source, bake::Graph::Client)?;
         debug_assert!(idx == incremental_graph::FileIndex::<{ bake::Side::Client }>::init(0));
     }
 
@@ -951,8 +953,8 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
             // SAFETY: `server_graph` is disjoint from `framework`.
             let server_file = unsafe { &mut (*dev_ptr).server_graph }.insert_stale_extra(
                 &fsr.entry_server,
-                false,
-                true,
+                bake::Graph::Server,
+                incremental_graph::RouteKind::Route,
             )?;
 
             types.push(framework_router::Type {
@@ -974,7 +976,8 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
                 client_file: if let Some(client) = &fsr.entry_client {
                     Some(to_opaque_file_id::<{ bake::Side::Client }>(
                         // SAFETY: `client_graph` is disjoint from `framework`.
-                        unsafe { &mut (*dev_ptr).client_graph }.insert_stale(client, false)?,
+                        unsafe { &mut (*dev_ptr).client_graph }
+                            .insert_stale(client, bake::Graph::Client)?,
                     ))
                 } else {
                     None
@@ -5000,12 +5003,10 @@ impl DevServer {
         let _g = self.graph_safety_lock.guard();
 
         let owner: serialized_failure::OwnerPacked = if graph == bake::Graph::Client {
-            let idx = self.client_graph.insert_stale(abs_path, false)?;
+            let idx = self.client_graph.insert_stale(abs_path, graph)?;
             serialized_failure::OwnerPacked::new(bake::Side::Client, idx.get())
         } else {
-            let idx = self
-                .server_graph
-                .insert_stale(abs_path, graph == bake::Graph::Ssr)?;
+            let idx = self.server_graph.insert_stale(abs_path, graph)?;
             serialized_failure::OwnerPacked::new(bake::Side::Server, idx.get())
         };
         let current_bundle = self
@@ -5224,9 +5225,11 @@ impl DevServer {
                     // R-2: shared deref — only `bundle.path` is read; mutation of
                     // `dev_server_id` goes through the `Cell` `index_location` above.
                     let html_ref = unsafe { &*html };
-                    let incremental_graph_index =
-                        self.client_graph
-                            .insert_stale_extra(&html_ref.bundle.path, false, true)?;
+                    let incremental_graph_index = self.client_graph.insert_stale_extra(
+                        &html_ref.bundle.path,
+                        bake::Graph::Client,
+                        incremental_graph::RouteKind::Route,
+                    )?;
                     let file = &mut self.client_graph.bundled_files.values_mut()
                         [incremental_graph_index.get() as usize];
                     file.html_route_bundle_index = Some(bundle_index);
@@ -5847,7 +5850,11 @@ impl DevServer {
     ) -> crate::Result<OpaqueFileId> {
         let index = self
             .server_graph
-            .insert_stale_extra(abs_path, false, true)
+            .insert_stale_extra(
+                abs_path,
+                bake::Graph::Server,
+                incremental_graph::RouteKind::Route,
+            )
             .map_err(crate::Error::from)?;
         self.route_lookup.put(
             index,

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -198,6 +198,17 @@ enum FreeCssMode {
     IgnoreCss,
 }
 
+/// Whether the file `insert_stale_extra` adds is a route. On the server this
+/// sets `File::is_route`, which makes `trace_dependencies` look the file up in
+/// `DevServer::route_lookup`, so callers passing `Route` must register it
+/// there. The client graph ignores it; HTML routes are found through
+/// `File::html_route_bundle_index`.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub(crate) enum RouteKind {
+    NotRoute,
+    Route,
+}
+
 #[derive(Copy, Clone)]
 pub enum InsertFailureKey<'a> {
     AbsPath(&'a [u8]),
@@ -1277,23 +1288,30 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
     pub(crate) fn insert_stale(
         &mut self,
         abs_path: &[u8],
-        is_ssr_graph: bool,
+        graph: bake::Graph,
     ) -> Result<FileIndex<SIDE>, bun_alloc::AllocError> {
-        self.insert_stale_extra(abs_path, is_ssr_graph, false)
+        self.insert_stale_extra(abs_path, graph, RouteKind::NotRoute)
     }
 
     /// `IncrementalGraph(side).insertStaleExtra` (spec :1300).
+    ///
+    /// `graph` is `Client` on the client graph; on the server graph it picks
+    /// which of the two server graphs (`Server` = RSC, `Ssr`) the file is in.
     pub(crate) fn insert_stale_extra(
         &mut self,
         abs_path: &[u8],
-        is_ssr_graph: bool,
-        is_route: bool,
+        graph: bake::Graph,
+        route: RouteKind,
     ) -> Result<FileIndex<SIDE>, bun_alloc::AllocError> {
+        debug_assert!(match SIDE {
+            Side::Client => graph == bake::Graph::Client,
+            Side::Server => graph != bake::Graph::Client,
+        });
         let gop = self.bundled_files.get_or_put(abs_path)?;
         let idx = gop.index;
         let found_existing = gop.found_existing;
         if found_existing {
-            if matches!(SIDE, Side::Server) && is_route {
+            if matches!(SIDE, Side::Server) && route == RouteKind::Route {
                 gop.value_ptr.is_route = true;
             }
         } else {
@@ -1322,13 +1340,14 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                 }
             }
             Side::Server => {
+                let is_ssr_graph = graph == bake::Graph::Ssr;
                 if !found_existing {
                     self.bundled_files.values_mut()[idx] = File {
                         kind: FileKind::Unknown,
                         failed: false,
                         is_rsc: !is_ssr_graph,
                         is_ssr: is_ssr_graph,
-                        is_route,
+                        is_route: route == RouteKind::Route,
                         is_client_component_boundary: false,
                         ..Default::default()
                     };

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -207,11 +207,7 @@ enum FreeCssMode {
     IgnoreCss,
 }
 
-/// Whether the file `insert_stale_extra` adds is a route. On the server this
-/// sets `File::is_route`, which makes `trace_dependencies` look the file up in
-/// `DevServer::route_lookup`, so callers passing `Route` must register it
-/// there. The client graph ignores it; HTML routes are found through
-/// `File::html_route_bundle_index`.
+/// `Route` on the server must also be registered in `DevServer::route_lookup`.
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) enum RouteKind {
     NotRoute,
@@ -1300,9 +1296,6 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
     }
 
     /// `IncrementalGraph(side).insertStaleExtra` (spec :1300).
-    ///
-    /// `graph` is `Client` on the client graph; on the server graph it picks
-    /// which of the two server graphs (`Server` = RSC, `Ssr`) the file is in.
     pub(crate) fn insert_stale_extra(
         &mut self,
         abs_path: &[u8],


### PR DESCRIPTION
### Problem
- `IncrementalGraph::insert_stale_extra` (src/runtime/bake/dev_server/incremental_graph.rs:1286) takes two bools, `is_ssr_graph` and `is_route`, and three of its four calls pass them as bare literals: `insert_stale_extra(path, false, true)` at DevServer.rs:952, :5229 and :5850. Nothing at those sites says which flag is which, and the swapped call compiles.
- mordant reports it as `bare_bool_args` (the `bare_bool_args:src/runtime/bake/dev_server/incremental_graph.rs` entry in `mordant-baseline.toml`).

### Fix
- The graph flag becomes a `bake::Graph`. Every caller already holds one: the client graph passes `Graph::Client`, the server graph passes `Graph::Server` (the RSC graph) or `Graph::Ssr`, and `get_log_for_resolution_failures` passes its `graph` straight through instead of `graph == bake::Graph::Ssr`. Inside, the server arm derives `is_ssr_graph` from it, so the body is otherwise unchanged. A `debug_assert!` checks the graph passed matches the side of the graph it is inserted into, since a three-variant enum could otherwise be handed to the wrong side.
- The route flag becomes a two-variant `incremental_graph::RouteKind { NotRoute, Route }` (same shape as `BakeRouteKind` in src/bundler/OutputFile.rs). Its one-line doc records the contract the bool left implicit: a `Route` inserted on the server must also be registered in `DevServer::route_lookup`, because `trace_dependencies` panics on a route it cannot find there. Both server callers already do this right after the insert.
- `insert_stale` stays a forwarder and now passes `RouteKind::NotRoute`; its four callers take the `bake::Graph` change.
- No behavior change: every call passes the same values as before. That includes the client HTML route at DevServer.rs:5229, which still passes `Route` even though the client graph ignores the flag (it always has; HTML routes are found through `html_route_bundle_index`). Dropping it there would have been a judgment call outside this change.
- `mordant-baseline.toml` is regenerated with `bun run rust:mordant:baseline`; against current main the only difference is this finding's entry. (The first revision also dropped two entries for findings fixed on main after #38846 recorded the counts; main has since removed those itself, and merging main in folded that away.)
- No new test under test/: nothing observable changed, so a JS-level test would pass with and without this diff. The regression guard is the removed baseline entry itself: with it gone, the `mordant` job fails on any future call that passes bare bools here again (the control run below is that failure, produced on purpose).
- Verified:
  - `bun bd test` on test/bake/dev/{html,esm,bundle,incremental-graph-edge-deletion,react-response,react-spa,ssg-pages-router,server-sourcemap}.test.ts: 80 pass, 0 fail. These cover every changed call site (framework router setup and `get_file_id_for_router`, react refresh, HTML route bundles, resolution failures on both graphs, and the route hot-reload path that relies on `is_route`).
  - After merging main (which brought in #39151's changes to the same file), html, bundle and incremental-graph-edge-deletion re-run on the debug build: 32 pass, 0 fail.
  - `bun run rust:mordant` on this branch: no warnings, no `target/mordant/over-baseline.txt`.
  - Control: the same run with the two source files reverted (baseline entry still removed) reports exactly the finding above, `bun_runtime 1` over baseline.
  - `cargo clippy -p bun_runtime --no-deps`: clean.

### Background
- The dev server keeps two `IncrementalGraph`s, one per `bake::Side` (client and server). The server graph holds files for two bundler graphs at once: `Graph::Server`, the RSC graph where routes and server components live, and `Graph::Ssr`, the copies of client components bundled for rendering on the server. A server `File` records which of the two it belongs to in `is_rsc` / `is_ssr`; a file can be in both.
- "Stale" insertion registers a path in the graph without bundled content so it can be traced and queued for bundling; routes, framework entry points and files that failed to resolve all enter this way.
- `route_lookup` maps a server file index to the framework route it belongs to. `trace_dependencies` uses `File::is_route` to decide whether to consult it when a change propagates to that file, which is why the `Route` flag carries a registration obligation.
- mordant is the advisory lint pack run by the `rust-lints` workflow; `mordant-baseline.toml` holds per-(lint, file) counts of pre-existing findings, and a PR fails the job only if it adds one. Removing a fixed finding's entry keeps it from coming back.
