### PR TITLE
server: write the AnyResponse pointer erasure and the deferred-body protect once

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -75,7 +75,6 @@
 "same_match_twice:src/runtime/cli/pack_command.rs" = 1
 "same_match_twice:src/runtime/cli/publish_command.rs" = 1
 "same_match_twice:src/runtime/cli/update_interactive_command.rs" = 2
-"same_match_twice:src/runtime/server/RequestContext.rs" = 4
 "same_match_twice:src/runtime/server/server_body.rs" = 1
 "same_match_twice:src/runtime/shell/builtin/cat.rs" = 1
 "same_match_twice:src/runtime/webcore/Blob.rs" = 2

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -50,17 +50,6 @@ impl AdditionalOnAbortCallback {
 // variant `create()` constructs and gate H3-specific code paths.
 pub type Req<const SSL_ENABLED: bool, const HTTP3: bool> = c_void;
 
-/// Extract the raw FFI pointer from an `AnyResponse` for C-ABI shims that
-/// take `*mut c_void` (e.g. `FetchHeaders::to_uws_response`, `CookieMap::write`).
-#[inline]
-fn any_response_as_ptr(r: uws::AnyResponse) -> *mut c_void {
-    match r {
-        uws::AnyResponse::SSL(p) => p.cast::<c_void>(),
-        uws::AnyResponse::TCP(p) => p.cast::<c_void>(),
-        uws::AnyResponse::H3(p) => p.cast::<c_void>(),
-    }
-}
-
 /// Back-reference to a stack-local "should this RequestContext defer its
 /// deinit until the JS callback returns" flag. The dispatching frame owns the
 /// `Cell<bool>`; `RequestContext` stores a `BackRef` to it (cleared before the
@@ -2025,17 +2014,10 @@ where
 
         stream.value.ensure_still_alive();
 
-        // `HTTPServerWritable::res` stores the type-erased uws response handle;
-        // `any_res()` reconstructs the variant from the const generics.
-        let raw_res: *mut c_void = match resp {
-            uws::AnyResponse::SSL(p) => p.cast::<c_void>(),
-            uws::AnyResponse::TCP(p) => p.cast::<c_void>(),
-            uws::AnyResponse::H3(p) => p.cast::<c_void>(),
-        };
-
         let response_stream_box = Box::new(ResponseStreamJSSink::<SSL_ENABLED, HTTP3> {
             sink: ResponseStream::<SSL_ENABLED, HTTP3> {
-                res: Some(raw_res),
+                // `any_res()` recovers the variant from the const generics.
+                res: Some(resp.as_ptr()),
                 buffer: Vec::<u8>::default(),
                 on_first_write: Some(Self::handle_first_stream_write_thunk),
                 ctx: Some(this.as_ctx_ptr().cast::<c_void>()),
@@ -2698,26 +2680,8 @@ where
                 }
                 return;
             } else {
-                // SAFETY: sole `&mut Response` for this cell in scope; the
-                // borrow ends before `render` reborrows the same pointer.
-                let body_value = unsafe { (*response).get_body_value() };
-                body_value.to_blob_if_possible();
-
-                match body_value {
-                    Body::Value::Blob(blob) => {
-                        if shim::blob_needs_to_read_file(blob) {
-                            response_value.protect();
-                            ctx.flags.set_response_protected(true);
-                        }
-                    }
-                    Body::Value::Locked(_) => {
-                        response_value.protect();
-                        ctx.flags.set_response_protected(true);
-                    }
-                    _ => {}
-                }
                 // SAFETY: `response` is the live, rooted cell pointer.
-                unsafe { ctx.render(response) };
+                unsafe { ctx.protect_for_body_and_render(response_value, response) };
             }
             return;
         }
@@ -2776,25 +2740,8 @@ where
                         }
                         return;
                     }
-                    // SAFETY: sole `&mut Response` for this cell in scope; the
-                    // borrow ends before `render` reborrows the same pointer.
-                    let body_value = unsafe { (*response).get_body_value() };
-                    body_value.to_blob_if_possible();
-                    match body_value {
-                        Body::Value::Blob(blob) => {
-                            if shim::blob_needs_to_read_file(blob) {
-                                fulfilled_value.protect();
-                                ctx.flags.set_response_protected(true);
-                            }
-                        }
-                        Body::Value::Locked(_) => {
-                            fulfilled_value.protect();
-                            ctx.flags.set_response_protected(true);
-                        }
-                        _ => {}
-                    }
                     // SAFETY: `response` is the live, rooted cell pointer.
-                    unsafe { ctx.render(response) };
+                    unsafe { ctx.protect_for_body_and_render(fulfilled_value, response) };
                     return;
                 }
                 jsc::PromiseResult::Rejected(err) => {
@@ -3660,26 +3607,8 @@ where
                             }
                             self.response_jsvalue.set(result);
                             self.flags.set_response_protected(false);
-                            // SAFETY: sole `&mut Response` borrow for this
-                            // cell; it ends before `render` reborrows the
-                            // same pointer.
-                            let body_value = unsafe { (*response).get_body_value() };
-                            body_value.to_blob_if_possible();
-                            match body_value {
-                                Body::Value::Blob(blob) => {
-                                    if shim::blob_needs_to_read_file(blob) {
-                                        result.protect();
-                                        self.flags.set_response_protected(true);
-                                    }
-                                }
-                                Body::Value::Locked(_) => {
-                                    result.protect();
-                                    self.flags.set_response_protected(true);
-                                }
-                                _ => {}
-                            }
                             // SAFETY: as above.
-                            unsafe { self.render(response) };
+                            unsafe { self.protect_for_body_and_render(result, response) };
                             return;
                         }
                     }
@@ -3744,25 +3673,8 @@ where
                 fulfilled_value.ensure_still_alive();
                 ctx.flags.set_response_protected(false);
 
-                // SAFETY: sole `&mut Response` for this cell in scope; the
-                // borrow ends before `render` reborrows the same pointer.
-                let body_value = unsafe { (*response).get_body_value() };
-                body_value.to_blob_if_possible();
-                match body_value {
-                    Body::Value::Blob(blob) => {
-                        if shim::blob_needs_to_read_file(blob) {
-                            fulfilled_value.protect();
-                            ctx.flags.set_response_protected(true);
-                        }
-                    }
-                    Body::Value::Locked(_) => {
-                        fulfilled_value.protect();
-                        ctx.flags.set_response_protected(true);
-                    }
-                    _ => {}
-                }
                 // SAFETY: `response` is the live, rooted cell pointer.
-                unsafe { ctx.render(response) };
+                unsafe { ctx.protect_for_body_and_render(fulfilled_value, response) };
                 return;
             }
             jsc::PromiseResult::Rejected(err) => {
@@ -3843,7 +3755,7 @@ where
             let r = cookies.write(
                 global_this,
                 Self::RESP_KIND,
-                any_response_as_ptr(self.resp.get().expect("infallible: resp bound")),
+                self.resp.get().expect("infallible: resp bound").as_ptr(),
             );
             // `cookies` drops here, releasing the ref taken in `set_cookies`.
             if r.is_err() {
@@ -3956,7 +3868,7 @@ where
             headers.fast_remove(jsc::HTTPHeaderName::Upgrade);
         }
         if let Some(resp) = self.resp.get() {
-            headers.to_uws_response(Self::RESP_KIND, any_response_as_ptr(resp));
+            headers.to_uws_response(Self::RESP_KIND, resp.as_ptr());
         }
     }
 
@@ -4030,6 +3942,32 @@ where
         }
 
         self.do_render();
+    }
+
+    /// [`Self::render`] for the Response a handler just returned, whose JS
+    /// wrapper `response_value` is already stored in `response_jsvalue`. A
+    /// file or streaming body is still being sent after this frame returns,
+    /// so for those the wrapper is protected first; in-memory bodies leave it
+    /// unprotected (see `response_jsvalue`).
+    ///
+    /// # Safety
+    /// Same contract as [`Self::render`].
+    unsafe fn protect_for_body_and_render(&self, response_value: JSValue, response: *mut Response) {
+        // SAFETY: caller contract: `response` is live. This is the only borrow
+        // of its body, and it ends before `render` reborrows the cell.
+        let body_value = unsafe { (*response).get_body_value() };
+        body_value.to_blob_if_possible();
+        let sent_after_return = match body_value {
+            Body::Value::Blob(blob) => shim::blob_needs_to_read_file(blob),
+            Body::Value::Locked(_) => true,
+            _ => false,
+        };
+        if sent_after_return {
+            response_value.protect();
+            self.flags.set_response_protected(true);
+        }
+        // SAFETY: caller contract.
+        unsafe { self.render(response) };
     }
 
     pub(crate) fn on_buffered_body_chunk(this: *mut Self, chunk: &[u8], last: bool) {

--- a/src/uws_sys/Response.rs
+++ b/src/uws_sys/Response.rs
@@ -747,6 +747,19 @@ impl AnyResponse {
         }
     }
 
+    /// The handle with its variant erased, for the C++ shims that take the
+    /// response as `void*` next to a `ResponseKind`, and for stores that keep
+    /// the kind elsewhere (`HTTPServerWritable::res` recovers the variant from
+    /// its const generics).
+    #[inline]
+    pub fn as_ptr(self) -> *mut c_void {
+        match self {
+            AnyResponse::SSL(ptr) => ptr.cast::<c_void>(),
+            AnyResponse::TCP(ptr) => ptr.cast::<c_void>(),
+            AnyResponse::H3(ptr) => ptr.cast::<c_void>(),
+        }
+    }
+
     pub fn get_remote_socket_info(self) -> Option<SocketAddress> {
         any_dispatch!(self, |r| r.get_remote_socket_info())
     }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -1060,6 +1060,55 @@ describe("streaming", () => {
   });
 });
 
+// A handler's Response reaches the server four ways: returned from fetch(),
+// returned from fetch() through an already-settled promise, returned from
+// error(), and returned from error() through a promise. A Bun.file() or
+// ReadableStream body is still being sent after the handler has returned, and
+// all four paths have to keep the Response alive for it; each must deliver
+// such a body whole.
+describe("file and stream bodies arrive whole from every handler path", () => {
+  const expected = Buffer.alloc(16 * 1024, "p").toString();
+  const chunk = Buffer.alloc(4 * 1024, "p").toString();
+  const boom = (): never => {
+    throw new Error("boom");
+  };
+  type Handlers = { fetch: () => Response | Promise<Response>; error?: () => Response | Promise<Response> };
+  const paths: [label: string, status: number, handlers: (make: () => Response) => Handlers][] = [
+    ["returned from fetch()", 201, make => ({ fetch: make })],
+    ["returned from fetch() through a settled promise", 201, make => ({ fetch: async () => make() })],
+    ["returned from error()", 597, make => ({ fetch: boom, error: make })],
+    ["returned from error() through a settled promise", 597, make => ({ fetch: boom, error: async () => make() })],
+  ];
+  const bodies: [kind: string, body: (dir: string) => Blob | ReadableStream][] = [
+    ["Bun.file()", dir => file(join(dir, "payload.txt"))],
+    [
+      "ReadableStream",
+      () => {
+        let remaining = 4;
+        return new ReadableStream({
+          pull(controller) {
+            controller.enqueue(chunk);
+            if (--remaining === 0) controller.close();
+          },
+        });
+      },
+    ],
+  ];
+
+  describe.each(bodies)("%s body", (_kind, body) => {
+    it.each(paths)("%s", async (_label, status, handlers) => {
+      using dir = tempDir("serve-deferred-body", { "payload.txt": expected });
+      using server = serve({
+        port: 0,
+        development: false,
+        ...handlers(() => new Response(body(String(dir)), { status })),
+      });
+      const response = await fetch(server.url);
+      expect({ status: response.status, body: await response.text() }).toEqual({ status, body: expected });
+    });
+  });
+});
+
 it("should work for a hello world", async () => {
   await runTest(
     {


### PR DESCRIPTION
### Problem
- `bun run rust:mordant` records four `same_match_twice` findings for `src/runtime/server/RequestContext.rs` ("this `match` on `bun_uws_sys::AnyResponse` repeats an earlier one arm for arm. The mapping exists twice, and a change to one copy will miss the other").
- Finding 1 is the `AnyResponse -> *mut c_void` match: a file-local `any_response_as_ptr` (line 56 before this change) plus an inline copy in `do_render_stream` (line 2030).
- Findings 2 to 4 are on `webcore::body::Value`, not `AnyResponse`: the "protect the Response JSValue when the body is a file or a stream" match is written out in `on_response` (line 2706, the copy the other three are reported against), in `on_response`'s settled-promise arm (2783), in the sync `error()` path (3668) and in `process_on_error_promise` (3751). Every copy sits between the same `to_blob_if_possible()` and `render()` calls.

### Fix
- `AnyResponse::as_ptr()` (`src/uws_sys/Response.rs`) holds the pointer erasure, next to the enum's other dispatch helpers. `any_response_as_ptr` is deleted; its two callers (`CookieMap::write`, `FetchHeaders::to_uws_response`) and `do_render_stream` call the method.
- `RequestContext::protect_for_body_and_render()` holds the `Body::Value` match together with the `to_blob_if_possible()` and `render()` calls that surrounded all four copies, and the four sites call it. The predicate (`Blob` backed by a file, or `Locked`), the value protected (the one just stored in `response_jsvalue`) and the flag set are the same as before at each site, so there is no behavior change.
- `mordant-baseline.toml`: the `same_match_twice` line for `RequestContext.rs` is dropped. Regenerating with `bun run rust:mordant:baseline` on this branch produces the same file (the two stale entries the regeneration also used to drop have since been removed on main by the sibling cleanups, so after rebasing this is the only baseline change).
- Verified:
  - mordant (pinned rev) with the baseline line removed: on main it reports exactly the four findings above; with this change (also after rebasing onto the other baseline cleanups) it reports nothing and `target/mordant/over-baseline.txt` is not written.
  - `test/js/bun/http/serve.test.ts` gains 8 cases that send a `Bun.file()` body and a `ReadableStream` body through each of the four handler paths (returned from `fetch()`, returned from `fetch()` through a settled promise, returned from `error()`, returned from `error()` through a settled promise) and check the body arrives whole. With temporary logging each case was confirmed to reach its intended call site and to take the protecting branch of the helper.
  - `serve.test.ts`, `serve-error-handler-stream.test.ts`, `serve-response-gc-backpressure-abort.test.ts`, `bun-serve-cookies.test.ts`, `bun-serve-headers.test.ts`, `bun-serve-file.test.ts`, `serve-http3.test.ts`, `bun-server.test.ts` and the other streaming suites pass with the debug build; the only failures are the IPv6 / root-port / `localhost` resolution tests that fail identically on this machine with the released binary.
  - `cargo clippy -p bun_uws_sys -p bun_runtime --no-deps` is clean.

### Background
- `mordant-baseline.toml` is a ratchet for the mordant lint pack CI runs over the Rust workspace: per (lint, file) counts of pre-existing findings. CI only fails on findings above the recorded count, so fixing a file's findings lets its line be deleted.
- `same_match_twice` flags a `match` over one of our enums whose arms are identical to an earlier `match` anywhere in the crate, and attributes the finding to the later copy. That is why findings 2 to 4 show up at the three later copies and the `on_response` copy does not.
- `AnyResponse` is a `Copy` enum over the three concrete uWS response handles (TCP, TLS, HTTP/3). `RequestContext` is generic over `SSL`/`HTTP3` but stores an `AnyResponse` and dispatches at runtime; some C++ shims instead take the handle as `void*` next to a `ResponseKind` tag, and `HTTPServerWritable::res` stores it as `void*` and rebuilds the variant from its own const generics. `as_ptr()` is that erasure.
- `response_jsvalue` is the JS `Response` a handler returned. In-memory bodies are written before the handler frame unwinds, so the value is deliberately left unprotected (the hot path); a file body is read and a stream body is pumped later, so for those the value is `protect()`ed against GC and `response_protected` records that there is an `unprotect()` to do on teardown.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve.test.ts

<!-- robobun:evidence:end -->