### PR TITLE
css: return RGBA from parse_hash_color instead of a tuple

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -14,7 +14,6 @@
 [bun_css]
 "arg_named_like_other_param:src/css/rules/mod.rs" = 1
 "bare_bool_args:src/css/selectors/builder.rs" = 1
-"tuple_wants_struct:src/css/css_parser.rs" = 1
 "tuple_wants_struct:src/css/values/color.rs" = 5
 
 [bun_install]

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5537,8 +5537,10 @@ impl<'a> CopyOnWriteStr<'a> {
 // ───────────────────────────── color ─────────────────────────────
 
 pub mod color {
-    /// The opaque alpha value of 1.0.
-    pub(crate) const OPAQUE: f32 = 1.0;
+    use crate::values::color::RGBA;
+
+    /// The alpha channel of a fully opaque color.
+    pub(crate) const OPAQUE: u8 = 255;
 
     #[derive(Debug, strum::IntoStaticStr)]
     pub enum ColorError {
@@ -5727,29 +5729,39 @@ pub mod color {
     }
 
     /// Parse a color hash, without the leading '#' character.
-    pub(crate) fn parse_hash_color(value: &[u8]) -> Option<(u8, u8, u8, f32)> {
+    pub(crate) fn parse_hash_color(value: &[u8]) -> Option<RGBA> {
         parse_hash_color_impl(value).ok()
     }
 
-    pub(crate) fn parse_hash_color_impl(value: &[u8]) -> Result<(u8, u8, u8, f32), ColorError> {
+    pub(crate) fn parse_hash_color_impl(value: &[u8]) -> Result<RGBA, ColorError> {
         let pair = |i: usize| {
             bun_core::fmt::hex_pair_value(value[i], value[i + 1]).ok_or(ColorError::Parse)
         };
         match value.len() {
-            8 => Ok((pair(0)?, pair(2)?, pair(4)?, pair(6)? as f32 / 255.0)),
-            6 => Ok((pair(0)?, pair(2)?, pair(4)?, OPAQUE)),
-            4 => Ok((
-                from_hex(value[0])? * 17,
-                from_hex(value[1])? * 17,
-                from_hex(value[2])? * 17,
-                (from_hex(value[3])? * 17) as f32 / 255.0,
-            )),
-            3 => Ok((
-                from_hex(value[0])? * 17,
-                from_hex(value[1])? * 17,
-                from_hex(value[2])? * 17,
-                OPAQUE,
-            )),
+            8 => Ok(RGBA {
+                red: pair(0)?,
+                green: pair(2)?,
+                blue: pair(4)?,
+                alpha: pair(6)?,
+            }),
+            6 => Ok(RGBA {
+                red: pair(0)?,
+                green: pair(2)?,
+                blue: pair(4)?,
+                alpha: OPAQUE,
+            }),
+            4 => Ok(RGBA {
+                red: from_hex(value[0])? * 17,
+                green: from_hex(value[1])? * 17,
+                blue: from_hex(value[2])? * 17,
+                alpha: from_hex(value[3])? * 17,
+            }),
+            3 => Ok(RGBA {
+                red: from_hex(value[0])? * 17,
+                green: from_hex(value[1])? * 17,
+                blue: from_hex(value[2])? * 17,
+                alpha: OPAQUE,
+            }),
             _ => Err(ColorError::Parse),
         }
     }

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -15,7 +15,7 @@ use crate::printer::Printer;
 
 use crate::values as css_values;
 use css_values::angle::Angle;
-use css_values::color::{ColorFallbackKind, CssColor, RGBA};
+use css_values::color::{ColorFallbackKind, CssColor};
 use css_values::ident::{
     CustomIdent, CustomIdentFns, DashedIdent, DashedIdentReference, Ident, IdentFns,
 };
@@ -650,16 +650,11 @@ impl TokenList {
                 }
                 Token::UnrestrictedHash(h) | Token::IdHash(h) => {
                     'brk: {
-                        let Some((r, g, b, a)) = css_parser::color::parse_hash_color(h) else {
+                        let Some(rgba) = css_parser::color::parse_hash_color(h) else {
                             tokens.push(TokenOrValue::Token(Token::UnrestrictedHash(*h)));
                             break 'brk;
                         };
-                        tokens.push(TokenOrValue::Color(CssColor::Rgba(RGBA::from_floats(
-                            r as f32 / 255.0,
-                            g as f32 / 255.0,
-                            b as f32 / 255.0,
-                            a,
-                        ))));
+                        tokens.push(TokenOrValue::Color(CssColor::Rgba(rgba)));
                     }
                     last_is_delim = false;
                     last_is_whitespace = false;

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -405,10 +405,10 @@ impl CssColor {
 
         match token {
             css::Token::UnrestrictedHash(v) | css::Token::IdHash(v) => {
-                let Some((r, g, b, a)) = css::color::parse_hash_color(v) else {
+                let Some(rgba) = css::color::parse_hash_color(v) else {
                     return Err(location.new_unexpected_token_error(token));
                 };
-                Ok(CssColor::Rgba(RGBA::new(r, g, b, a)))
+                Ok(CssColor::Rgba(rgba))
             }
             css::Token::Ident(value) => crate::match_ignore_ascii_case! { value, {
                 b"currentcolor" => Ok(CssColor::CurrentColor),


### PR DESCRIPTION
### Problem
- mordant's `tuple_wants_struct` flags `color::parse_hash_color` in `src/css/css_parser.rs:5730`: it returns `(u8, u8, u8, f32)`, and both callers (`CssColor::parse` in `src/css/values/color.rs:408`, `TokenList` hash tokens in `src/css/properties/custom.rs:653`) unpack it as `(r, g, b, a)`. The channel names live only at the call sites, and since the first three fields are all `u8`, a swapped pair still compiles.
- Both callers then immediately build an `RGBA` out of the tuple, so the function already had a named type for its result; `custom.rs` also converted each byte to a float and `RGBA::from_floats` converted it straight back.

### Fix
- `parse_hash_color` / `parse_hash_color_impl` build the `RGBA` (`red`/`green`/`blue`/`alpha`, all `u8`) themselves and return it; the callers wrap it in `CssColor::Rgba`. `OPAQUE` becomes the `u8` alpha `255` it was being converted to.
- No behavior change. The hex digits were already parsed as bytes; the only thing removed is the byte -> f32 -> byte round trip through `RGBA::new` / `RGBA::from_floats`, which is the identity for all 256 values (checked with f32 arithmetic), and `OPAQUE` (`1.0`) mapped to `255` the same way.
- The baseline entry `tuple_wants_struct:src/css/css_parser.rs` is removed from `mordant-baseline.toml`. The `[bun_css]` section was regenerated with `MORDANT_BASELINE_WRITE=1 cargo dylint --all -p bun_css --no-deps` (the per-crate form of `bun run rust:mordant:baseline`); that line is the only difference, the `values/color.rs = 5` entry is unchanged.
- No test is added. The change has no observable effect (the `RGBA` produced for every hash is byte for byte what it was), so there is no test that fails before it and passes after it; the check that does flip is the mordant run, which reports the `css_parser.rs` finding over the trimmed baseline without this change and is clean with it. The existing coverage below is what guards the refactor.
- Verified with `bun bd`:
  - `bun bd test test/js/bun/css/css.test.ts`: 1142 pass. This covers both callers with every hash length: 8-digit hashes inside custom properties (`--bar: ... #01010116` round-trips through `custom.rs`), `#0006` / `#ffffff80` / 3- and 6-digit hashes in regular properties through `color.rs`.
  - `bun bd test test/js/bun/css/color.test.ts` (`Bun.color`): 993 pass.
  - `bun bd test test/bundler/css/`: 169 pass.
  - `cargo check -p bun_css`, `cargo clippy -p bun_css --no-deps` and `cargo dylint --all -p bun_css --no-deps` (mordant) are clean; the latter writes no `target/mordant/over-baseline.txt`.

### Background
- `css_parser::color` is the port of the `cssparser` crate's color helpers; `parse_hash_color` parses the text after `#` (3, 4, 6 or 8 hex digits) into channels. `RGBA` (`src/css/values/color.rs`) is the crate's byte-per-channel color and is what `CssColor::Rgba` stores, which is why both callers were converting to it.
- `mordant-baseline.toml` is the ratchet for the mordant lint pack: it records the per-(lint, file) finding counts that predate the job so CI only fails on new findings. Fixing a site means removing (or decrementing) its entry; mordant's write mode rewrites one section per compiled crate, so regenerating with only `bun_css` compiled touches only that section.
