### PR TITLE
bake: fail bun build --app on route scan errors, report aliased and unsupported route files instead of panicking

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -576,8 +576,8 @@ pub mod bv2_impl {
         /// `EntryPointMap`.
         /// Lives in the bundler (lower tier) so both `bun_runtime::bake::production`
         /// and `BundleV2::generate_from_bake_production_cli` share ONE nominal type
-        /// (PORTING.md §Layering). Router-integration methods (`InsertionHandler`)
-        /// are added by `bun_runtime::bake` via a local trait impl.
+        /// (PORTING.md §Layering). Router integration (`InsertionHandler`) lives in
+        /// `bun_runtime::bake::production::RouteScan`, which fills this map.
         pub mod production {
             use super::Side;
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -576,8 +576,7 @@ pub mod bv2_impl {
         /// `EntryPointMap`.
         /// Lives in the bundler (lower tier) so both `bun_runtime::bake::production`
         /// and `BundleV2::generate_from_bake_production_cli` share ONE nominal type
-        /// (PORTING.md §Layering). Router integration (`InsertionHandler`) lives in
-        /// `bun_runtime::bake::production::RouteScan`, which fills this map.
+        /// (PORTING.md §Layering).
         pub mod production {
             use super::Side;
 

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1167,12 +1167,10 @@ impl FrameworkRouter {
                 }
             };
             if let Some(aliased_route) = aliased_route {
-                // A route enters the maps only right before its page is stored
-                // below, and files are never removed, so the page is still there.
                 *out_colliding_file_id = self
                     .route_ptr(aliased_route)
                     .file_page
-                    .expect("aliased route has a page");
+                    .expect("routes in the url maps have a page");
                 return Err(InsertError::RouteCollision);
             }
         }
@@ -1665,14 +1663,14 @@ impl FrameworkRouter {
                         }
 
                         if param_count > MatchedParams::MAX_COUNT {
-                            log.write(format_args!(
-                                "Pattern cannot have more than {} params",
-                                MatchedParams::MAX_COUNT
-                            ));
-                            // The handlers print the log against `full_rel_path`
-                            // (`TinyLog::print`), so underline all of it.
-                            log.cursor_at = 0;
-                            log.cursor_len = u32::try_from(full_rel_path.len()).expect("int cast");
+                            log.fail(
+                                format_args!(
+                                    "Pattern cannot have more than {} params",
+                                    MatchedParams::MAX_COUNT
+                                ),
+                                0,
+                                full_rel_path.len(),
+                            );
                             ctx.on_router_syntax_error(full_rel_path, log)?;
                             arena_state.reset_retain_with_limit(8 * 1024 * 1024);
                             continue 'outer;

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1682,13 +1682,14 @@ impl FrameworkRouter {
                             ParsedPatternKind::Page => FileKind::Page,
                             ParsedPatternKind::Layout => FileKind::Layout,
                             ParsedPatternKind::Extra => {
+                                let file_name = paths::basename(full_rel_path);
                                 log.fail(
                                     format_args!(
                                         "Bun Bake currently does not support \"{}\" files",
-                                        bstr::BStr::new(paths::stem(base))
+                                        bstr::BStr::new(paths::stem(full_rel_path))
                                     ),
-                                    full_rel_path.len() - base.len(),
-                                    base.len(),
+                                    full_rel_path.len() - file_name.len(),
+                                    file_name.len(),
                                 );
                                 ctx.on_router_syntax_error(full_rel_path, log)?;
                                 arena_state.reset_retain_with_limit(8 * 1024 * 1024);

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1131,18 +1131,17 @@ impl FrameworkRouter {
 
         let file_id = ctx.get_file_id_for_router(file_path, new_route_index, file_kind)?;
 
-        let new_route = self.route_ptr_mut(new_route_index);
-        if let Some(existing) = *new_route.file_ptr(file_kind) {
+        if let Some(existing) = *self.route_ptr_mut(new_route_index).file_ptr(file_kind) {
             if existing == file_id {
                 return Ok(()); // exact match already exists. Hot-reloading code hits this
             }
             *out_colliding_file_id = existing;
             return Err(InsertError::RouteCollision);
         }
-        *new_route.file_ptr(file_kind) = Some(file_id);
 
         if file_kind == FileKind::Page {
-            match pattern {
+            // A different route can still serve the same URLs (see `dynamic_routes`).
+            let aliased_route = match pattern {
                 InsertPattern::Static(p) => {
                     let key: &[u8] = if p.route_path().is_empty() {
                         b"/"
@@ -1151,19 +1150,34 @@ impl FrameworkRouter {
                     };
                     let gop = self.static_routes.get_or_put(key)?;
                     if gop.found_existing {
-                        panic!("TODO: propagate aliased route error");
+                        Some(*gop.value_ptr)
+                    } else {
+                        *gop.value_ptr = new_route_index;
+                        None
                     }
-                    *gop.value_ptr = new_route_index;
                 }
                 InsertPattern::Dynamic(p) => {
                     let gop = self.dynamic_routes.get_or_put(p)?;
                     if gop.found_existing {
-                        panic!("TODO: propagate aliased route error");
+                        Some(*gop.value_ptr)
+                    } else {
+                        *gop.value_ptr = new_route_index;
+                        None
                     }
-                    *gop.value_ptr = new_route_index;
                 }
+            };
+            if let Some(aliased_route) = aliased_route {
+                // A route enters the maps only right before its page is stored
+                // below, and files are never removed, so the page is still there.
+                *out_colliding_file_id = self
+                    .route_ptr(aliased_route)
+                    .file_page
+                    .expect("aliased route has a page");
+                return Err(InsertError::RouteCollision);
             }
         }
+
+        *self.route_ptr_mut(new_route_index).file_ptr(file_kind) = Some(file_id);
         Ok(())
     }
 }
@@ -1650,8 +1664,15 @@ impl FrameworkRouter {
                             }
                         }
 
-                        if param_count > 64 {
-                            log.write(format_args!("Pattern cannot have more than 64 param"));
+                        if param_count > MatchedParams::MAX_COUNT {
+                            log.write(format_args!(
+                                "Pattern cannot have more than {} params",
+                                MatchedParams::MAX_COUNT
+                            ));
+                            // The handlers print the log against `full_rel_path`
+                            // (`TinyLog::print`), so underline all of it.
+                            log.cursor_at = 0;
+                            log.cursor_len = u32::try_from(full_rel_path.len()).expect("int cast");
                             ctx.on_router_syntax_error(full_rel_path, log)?;
                             arena_state.reset_retain_with_limit(8 * 1024 * 1024);
                             continue 'outer;
@@ -1745,13 +1766,21 @@ impl FrameworkRouter {
 pub struct JSFrameworkRouter {
     pub(crate) files: Vec<bun_core::String>,
     pub(crate) router: FrameworkRouter,
-    pub(crate) stored_parse_errors: Vec<StoredParseError>,
+    pub(crate) stored_scan_errors: Vec<StoredScanError>,
 }
 
-pub(crate) struct StoredParseError {
-    /// Owned by global allocator
-    pub rel_path: Box<[u8]>,
-    pub log: TinyLog,
+/// Collected while scanning and thrown together once the scan is done.
+pub(crate) enum StoredScanError {
+    InvalidRoute {
+        rel_path: Box<[u8]>,
+        log: TinyLog,
+    },
+    Collision {
+        rel_path: Box<[u8]>,
+        /// Indexes `JSFrameworkRouter.files`.
+        other: OpaqueFileId,
+        file_kind: FileKind,
+    },
 }
 
 impl JSFrameworkRouter {
@@ -1827,34 +1856,57 @@ impl JSFrameworkRouter {
         let mut jsfr = Box::new(JSFrameworkRouter {
             router: FrameworkRouter::init_empty(&abs_root, types)?,
             files: Vec::new(),
-            stored_parse_errors: Vec::new(),
+            stored_scan_errors: Vec::new(),
         });
 
         let resolver = &mut global.bun_vm().as_mut().transpiler.resolver;
-        // The handler only touches `files`/`stored_parse_errors`, so split-borrow
+        // The handler only touches `files`/`stored_scan_errors`, so split-borrow
         // those two fields into a dedicated context (see `JSFrameworkRouterScanCtx`).
         {
             let JSFrameworkRouter {
                 router,
                 files,
-                stored_parse_errors,
+                stored_scan_errors,
             } = &mut *jsfr;
             let mut ctx = JSFrameworkRouterScanCtx {
                 files,
-                stored_parse_errors,
+                stored_scan_errors,
             };
             router.scan(TypeIndex::init(0), resolver, &mut ctx)?;
         }
 
-        if !jsfr.stored_parse_errors.is_empty() {
-            let arr =
-                JSValue::create_array_from_iter(global, jsfr.stored_parse_errors.iter(), |item| {
-                    Ok(global.create_error_instance(format_args!(
-                        "Invalid route {}: {}",
-                        bun_core::fmt::quote(&item.rel_path),
-                        bstr::BStr::new(item.log.msg.const_slice()),
-                    )))
-                })?;
+        if !jsfr.stored_scan_errors.is_empty() {
+            let JSFrameworkRouter {
+                router,
+                files,
+                stored_scan_errors,
+            } = &*jsfr;
+            let arr = JSValue::create_array_from_iter(global, stored_scan_errors.iter(), |item| {
+                Ok(match item {
+                    StoredScanError::InvalidRoute { rel_path, log } => global
+                        .create_error_instance(format_args!(
+                            "Invalid route {}: {}",
+                            bun_core::fmt::quote(rel_path),
+                            bstr::BStr::new(log.msg.const_slice()),
+                        )),
+                    StoredScanError::Collision {
+                        rel_path,
+                        other,
+                        file_kind,
+                    } => {
+                        let other_abs_path = files[other.get() as usize].to_utf8();
+                        global.create_error_instance(format_args!(
+                            "Multiple {} matching the same route pattern is ambiguous: {} and {}",
+                            file_kind.collision_noun(),
+                            bun_core::fmt::quote(rel_path),
+                            bun_core::fmt::quote(paths::resolve_path::relative(
+                                &router.root,
+                                other_abs_path.slice(),
+                            )),
+                        ))
+                    }
+                })
+            })?;
             return Err(global.throw_value(global.create_aggregate_error_with_array(
                 bun_core::String::static_str("Errors scanning routes"),
                 arr,
@@ -1974,7 +2026,7 @@ impl JSFrameworkRouter {
 
     pub fn finalize(self: Box<Self>) {
         drop(self);
-        // files, router, stored_parse_errors freed by Drop.
+        // files, router, stored_scan_errors freed by Drop.
     }
 
     pub(crate) fn parse_route_pattern(
@@ -2061,12 +2113,12 @@ fn parse_route_pattern(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<J
 use bun_core::fmt::VecWriter as ByteFmtWriter;
 
 // `scan` needs `&mut jsfr.router` and the insertion handler simultaneously.
-// The handler only touches `files` / `stored_parse_errors`, so we split-borrow
+// The handler only touches `files` / `stored_scan_errors`, so we split-borrow
 // those two fields into a dedicated context struct instead of implementing the
 // trait on `JSFrameworkRouter` itself.
 struct JSFrameworkRouterScanCtx<'a> {
     files: &'a mut Vec<bun_core::String>,
-    stored_parse_errors: &'a mut Vec<StoredParseError>,
+    stored_scan_errors: &'a mut Vec<StoredScanError>,
 }
 
 impl InsertionHandler for JSFrameworkRouterScanCtx<'_> {
@@ -2083,9 +2135,8 @@ impl InsertionHandler for JSFrameworkRouterScanCtx<'_> {
     }
 
     fn on_router_syntax_error(&mut self, rel_path: &[u8], log: TinyLog) -> Result<(), AllocError> {
-        let rel_path_dupe: Box<[u8]> = rel_path.into();
-        self.stored_parse_errors.push(StoredParseError {
-            rel_path: rel_path_dupe,
+        self.stored_scan_errors.push(StoredScanError::InvalidRoute {
+            rel_path: rel_path.into(),
             log,
         });
         Ok(())
@@ -2093,10 +2144,15 @@ impl InsertionHandler for JSFrameworkRouterScanCtx<'_> {
 
     fn on_router_collision_error(
         &mut self,
-        _rel_path: &[u8],
-        _other_id: OpaqueFileId,
-        _file_kind: FileKind,
+        rel_path: &[u8],
+        other_id: OpaqueFileId,
+        file_kind: FileKind,
     ) -> Result<(), AllocError> {
-        panic!("TODO: onRouterCollisionError for JSFrameworkRouter")
+        self.stored_scan_errors.push(StoredScanError::Collision {
+            rel_path: rel_path.into(),
+            other: other_id,
+            file_kind,
+        });
+        Ok(())
     }
 }

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1682,7 +1682,17 @@ impl FrameworkRouter {
                             ParsedPatternKind::Page => FileKind::Page,
                             ParsedPatternKind::Layout => FileKind::Layout,
                             ParsedPatternKind::Extra => {
-                                panic!("TODO: associate extra files with route")
+                                log.fail(
+                                    format_args!(
+                                        "Bun Bake currently does not support \"{}\" files",
+                                        bstr::BStr::new(paths::stem(base))
+                                    ),
+                                    full_rel_path.len() - base.len(),
+                                    base.len(),
+                                );
+                                ctx.on_router_syntax_error(full_rel_path, log)?;
+                                arena_state.reset_retain_with_limit(8 * 1024 * 1024);
+                                continue 'outer;
                             }
                         };
 
@@ -1771,7 +1781,7 @@ pub struct JSFrameworkRouter {
 pub(crate) enum StoredScanError {
     InvalidRoute {
         rel_path: Box<[u8]>,
-        log: TinyLog,
+        message: Box<[u8]>,
     },
     Collision {
         rel_path: Box<[u8]>,
@@ -1881,11 +1891,11 @@ impl JSFrameworkRouter {
             } = &*jsfr;
             let arr = JSValue::create_array_from_iter(global, stored_scan_errors.iter(), |item| {
                 Ok(match item {
-                    StoredScanError::InvalidRoute { rel_path, log } => global
+                    StoredScanError::InvalidRoute { rel_path, message } => global
                         .create_error_instance(format_args!(
                             "Invalid route {}: {}",
                             bun_core::fmt::quote(rel_path),
-                            bstr::BStr::new(log.msg.const_slice()),
+                            bstr::BStr::new(message),
                         )),
                     StoredScanError::Collision {
                         rel_path,
@@ -2135,7 +2145,7 @@ impl InsertionHandler for JSFrameworkRouterScanCtx<'_> {
     fn on_router_syntax_error(&mut self, rel_path: &[u8], log: TinyLog) -> Result<(), AllocError> {
         self.stored_scan_errors.push(StoredScanError::InvalidRoute {
             rel_path: rel_path.into(),
-            log,
+            message: log.msg.const_slice().into(),
         });
         Ok(())
     }

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -1376,11 +1376,8 @@ extern "C" fn BakeProdResolve(
 pub use bun_bundler::bake_types::production::EntryPointMap;
 use bun_bundler::bake_types::production::{EntryPointHashMap, InputFile};
 
-/// Route scan callbacks for the production build: every route file becomes a
-/// server entry point. The scan keeps going after reporting an invalid or
-/// colliding route file, so the errors are counted here and `build_with_vm`
-/// fails the build once every route file has been reported. (The dev server
-/// only logs these, since it keeps serving the routes that did resolve.)
+/// Route scan callbacks for `bun build --app`: route files become server entry
+/// points, and reported errors are counted so the build fails after the scan.
 struct RouteScan<'a> {
     entry_points: &'a mut EntryPointMap,
     error_count: usize,

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -585,10 +585,18 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     }
 
     let mut router = FrameworkRouter::init_empty(cwd, router_types.into_boxed_slice())?;
+    let mut route_scan = RouteScan {
+        entry_points: &mut entry_points,
+        error_count: 0,
+    };
     router.scan_all(
         &mut server_transpiler.resolver,
-        framework_router::InsertionContext::wrap(&mut entry_points),
+        framework_router::InsertionContext::wrap(&mut route_scan),
     )?;
+    if route_scan.error_count > 0 {
+        // Every offending route file has already been reported by `RouteScan`.
+        Global::crash();
+    }
 
     // `bake_body::Framework` is the runtime-side superset; the bundler reads only
     // `built_in_modules` / `server_components` / `react_fast_refresh` /
@@ -1368,26 +1376,37 @@ extern "C" fn BakeProdResolve(
 pub use bun_bundler::bake_types::production::EntryPointMap;
 use bun_bundler::bake_types::production::{EntryPointHashMap, InputFile};
 
-impl framework_router::InsertionHandler for EntryPointMap {
+/// Route scan callbacks for the production build: every route file becomes a
+/// server entry point. The scan keeps going after reporting an invalid or
+/// colliding route file, so the errors are counted here and `build_with_vm`
+/// fails the build once every route file has been reported. (The dev server
+/// only logs these, since it keeps serving the routes that did resolve.)
+struct RouteScan<'a> {
+    entry_points: &'a mut EntryPointMap,
+    error_count: usize,
+}
+
+impl framework_router::InsertionHandler for RouteScan<'_> {
     fn get_file_id_for_router(
         &mut self,
         abs_path: &[u8],
         _: framework_router::RouteIndex,
         _: framework_router::FileKind,
     ) -> Result<OpaqueFileId, bun_alloc::AllocError> {
-        self.get_or_put_entry_point(abs_path, bake::Side::Server)
+        self.entry_points
+            .get_or_put_entry_point(abs_path, bake::Side::Server)
             .map(|id| OpaqueFileId::init(id.get()))
             .map_err(|_| bun_alloc::AllocError)
     }
 
     fn on_router_syntax_error(
         &mut self,
-        _rel_path: &[u8],
-        _fail: framework_router::TinyLog,
+        rel_path: &[u8],
+        fail: framework_router::TinyLog,
     ) -> Result<(), bun_alloc::AllocError> {
-        // EntryPointMap does not handle this, so a malformed route pattern
-        // during a production build must crash loudly rather than be swallowed.
-        bun_core::todo_panic!("onRouterSyntaxError for EntryPointMap")
+        fail.print(rel_path);
+        self.error_count += 1;
+        Ok(())
     }
 
     fn on_router_collision_error(
@@ -1404,11 +1423,12 @@ impl framework_router::InsertionHandler for EntryPointMap {
         bun_core::pretty_errorln!(
             "  - <blue>{}<r>",
             BStr::new(resolve_path::relative(
-                &self.root,
-                self.files.keys()[other_id.get() as usize].abs_path()
+                &self.entry_points.root,
+                self.entry_points.files.keys()[other_id.get() as usize].abs_path()
             ))
         );
         Output::flush();
+        self.error_count += 1;
         Ok(())
     }
 }

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -1376,8 +1376,7 @@ extern "C" fn BakeProdResolve(
 pub use bun_bundler::bake_types::production::EntryPointMap;
 use bun_bundler::bake_types::production::{EntryPointHashMap, InputFile};
 
-/// Route scan callbacks for `bun build --app`: route files become server entry
-/// points, and reported errors are counted so the build fails after the scan.
+/// Route scan callbacks for `bun build --app`; counts the reported errors so the build can fail.
 struct RouteScan<'a> {
     entry_points: &'a mut EntryPointMap,
     error_count: usize,

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -353,20 +353,6 @@ export default function Docs() {
     expect(exitCode).toBe(1);
   });
 
-  test("two pages resolving to the same route are reported", async () => {
-    const dir = await tempDirWithBakeDeps("bake-production-route-collision", {
-      "src/index.tsx": `export default { app: { framework: "react" } };`,
-      "pages/about.tsx": `export default function About() { return <p>about</p>; }`,
-      "pages/about/index.tsx": `export default function About() { return <p>about</p>; }`,
-    });
-
-    const { stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx --outdir ./dist`
-      .cwd(dir)
-      .env(bunEnv)
-      .throws(false);
-    expect(stderr.toString()).toContain("Multiple pages matching the same route pattern is ambiguous");
-  });
-
   test("handles build with no pages directory without crashing", async () => {
     const dir = await tempDirWithBakeDeps("bake-production-no-pages", {
       "app.ts": `export default { app: { framework: "react" } };`,
@@ -698,22 +684,48 @@ export default function IndexPage() {
       expect(existsSync(path.join(dir, "dist"))).toBe(false);
     });
 
+    test("two dynamic routes with the same shape fail the build", async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-route-alias", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "pages/blog/[id].tsx": `export default function Post() { return <p>post</p>; }`,
+        "pages/blog/[slug].tsx": `export default function Post() { return <p>post</p>; }`,
+      });
+
+      const { exitCode, stderr } = await build(dir);
+      expect(stderr).toContain("Multiple pages matching the same route pattern is ambiguous");
+      expect(stderr).toContain("  - pages/blog/[id].tsx");
+      expect(stderr).toContain("  - pages/blog/[slug].tsx");
+      expect(exitCode).toBe(1);
+      expect(existsSync(path.join(dir, "dist"))).toBe(false);
+    });
+
     test("every route error is reported before the build fails", async () => {
+      const tooManyParams = "pages/" + Array.from({ length: 65 }, (_, i) => `[p${i}]`).join("/") + ".tsx";
       const dir = await tempDirWithBakeDeps("bake-production-route-errors", {
         "src/index.tsx": `export default { app: { framework: "react" } };`,
         "pages/about.tsx": `export default function About() { return <p>about</p>; }`,
         "pages/about/index.tsx": `export default function About() { return <p>about</p>; }`,
         "pages/_layout.tsx": `export default function Layout({ children }) { return <main>{children}</main>; }`,
         "pages/_layout.jsx": `export default function Layout({ children }) { return <main>{children}</main>; }`,
+        "pages/[id].tsx": `export default function Item() { return <p>item</p>; }`,
+        "pages/[name].tsx": `export default function Item() { return <p>item</p>; }`,
         "pages/blog-[slug].tsx": `export default function Post() { return <p>post</p>; }`,
+        [tooManyParams]: `export default function Deep() { return <p>deep</p>; }`,
       });
 
       const { exitCode, stderr } = await build(dir);
-      expect(stderr).toContain("Multiple pages matching the same route pattern is ambiguous");
       expect(stderr).toContain("Multiple layout matching the same route pattern is ambiguous");
       expect(stderr).toContain("  - pages/_layout.tsx");
       expect(stderr).toContain("  - pages/_layout.jsx");
+      expect(stderr).toContain("Multiple pages matching the same route pattern is ambiguous");
+      expect(stderr).toContain("  - pages/about.tsx");
+      expect(stderr).toContain("  - pages/about/index.tsx");
+      expect(stderr).toContain("  - pages/[id].tsx");
+      expect(stderr).toContain("  - pages/[name].tsx");
       expect(stderr).toContain('"pages/blog-[slug].tsx" is not a valid route');
+      expect(stderr).toContain("Parameters must take up the entire file name");
+      expect(stderr).toContain(`"${tooManyParams}" is not a valid route`);
+      expect(stderr).toContain("Pattern cannot have more than 64 params");
       expect(exitCode).toBe(1);
       expect(existsSync(path.join(dir, "dist"))).toBe(false);
     });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -725,6 +725,27 @@ export default function IndexPage() {
       expect(existsSync(path.join(String(dir), "dist"))).toBe(false);
     });
 
+    test("an app router file bake does not support fails the build", async () => {
+      using dir = tempDir("bake-production-app-router-extra-file", {
+        "src/index.tsx": `export default {
+          app: {
+            framework: {
+              fileSystemRouterTypes: [{ root: "app", style: "nextjs-app-ui", serverEntryPoint: "./server.ts" }],
+            },
+          },
+        };`,
+        "server.ts": `export default {};`,
+        "app/page.tsx": `export default function Page() { return "page"; }`,
+        "app/loading.tsx": `export default function Loading() { return "loading"; }`,
+      });
+
+      const { exitCode, stderr } = await build(String(dir));
+      expect(stderr).toContain('"app/loading.tsx" is not a valid route');
+      expect(stderr).toContain('Bun Bake currently does not support "loading" files');
+      expect(exitCode).toBe(1);
+      expect(existsSync(path.join(String(dir), "dist"))).toBe(false);
+    });
+
     test("every route error is reported before the build fails", async () => {
       const tooManyParams = "pages/" + Array.from({ length: 65 }, (_, i) => `[p${i}]`).join("/") + ".tsx";
       const dir = await tempDirWithBakeDeps("bake-production-route-errors", {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -697,6 +697,32 @@ export default function IndexPage() {
       expect(stderr).toContain("  - pages/blog/[slug].tsx");
       expect(exitCode).toBe(1);
       expect(existsSync(path.join(dir, "dist"))).toBe(false);
+    });
+
+    test("two router types claiming the same static route fail the build", async () => {
+      // Router types share one URL space, so this needs a framework with two of them.
+      using dir = tempDir("bake-production-route-alias-across-types", {
+        "src/index.tsx": `export default {
+          app: {
+            framework: {
+              fileSystemRouterTypes: [
+                { root: "pages", style: "nextjs-pages", serverEntryPoint: "./server.ts" },
+                { root: "docs", style: "nextjs-pages", serverEntryPoint: "./server.ts" },
+              ],
+            },
+          },
+        };`,
+        "server.ts": `export default {};`,
+        "pages/about.tsx": `export default function About() { return "about"; }`,
+        "docs/about.tsx": `export default function About() { return "about"; }`,
+      });
+
+      const { exitCode, stderr } = await build(String(dir));
+      expect(stderr).toContain("Multiple pages matching the same route pattern is ambiguous");
+      expect(stderr).toContain("  - pages/about.tsx");
+      expect(stderr).toContain("  - docs/about.tsx");
+      expect(exitCode).toBe(1);
+      expect(existsSync(path.join(String(dir), "dist"))).toBe(false);
     });
 
     test("every route error is reported before the build fails", async () => {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -659,4 +659,63 @@ export default function IndexPage() {
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
   });
+
+  describe.concurrent("route scan errors", () => {
+    async function build(dir: string) {
+      const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx --outdir ./dist`
+        .cwd(dir)
+        .env(bunEnv)
+        .throws(false);
+      return { exitCode, stderr: normalizePath(stderr.toString()) };
+    }
+
+    test("two files resolving to the same route fail the build", async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-route-collision", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "pages/about.tsx": `export default function About() { return <p>about</p>; }`,
+        "pages/about/index.tsx": `export default function About() { return <p>about</p>; }`,
+      });
+
+      const { exitCode, stderr } = await build(dir);
+      expect(stderr).toContain("Multiple pages matching the same route pattern is ambiguous");
+      expect(stderr).toContain("  - pages/about.tsx");
+      expect(stderr).toContain("  - pages/about/index.tsx");
+      expect(exitCode).toBe(1);
+      expect(existsSync(path.join(dir, "dist"))).toBe(false);
+    });
+
+    test("a file that is not a valid route fails the build", async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-route-syntax-error", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "pages/index.tsx": `export default function Index() { return <p>index</p>; }`,
+        "pages/blog-[slug].tsx": `export default function Post() { return <p>post</p>; }`,
+      });
+
+      const { exitCode, stderr } = await build(dir);
+      expect(stderr).toContain('"pages/blog-[slug].tsx" is not a valid route');
+      expect(stderr).toContain("Parameters must take up the entire file name");
+      expect(exitCode).toBe(1);
+      expect(existsSync(path.join(dir, "dist"))).toBe(false);
+    });
+
+    test("every route error is reported before the build fails", async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-route-errors", {
+        "src/index.tsx": `export default { app: { framework: "react" } };`,
+        "pages/about.tsx": `export default function About() { return <p>about</p>; }`,
+        "pages/about/index.tsx": `export default function About() { return <p>about</p>; }`,
+        "pages/_layout.tsx": `export default function Layout({ children }) { return <main>{children}</main>; }`,
+        "pages/_layout.jsx": `export default function Layout({ children }) { return <main>{children}</main>; }`,
+        "pages/blog-[slug].tsx": `export default function Post() { return <p>post</p>; }`,
+      });
+
+      const { exitCode, stderr } = await build(dir);
+      expect(stderr).toContain("Multiple pages matching the same route pattern is ambiguous");
+      expect(stderr).toContain("Multiple layout matching the same route pattern is ambiguous");
+      expect(stderr).toContain("  - pages/_layout.tsx");
+      expect(stderr).toContain("  - pages/_layout.jsx");
+      expect(stderr).toContain('"pages/blog-[slug].tsx" is not a valid route');
+      expect(exitCode).toBe(1);
+      expect(existsSync(path.join(dir, "dist"))).toBe(false);
+    });
+  });
 });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -646,7 +646,7 @@ export default function IndexPage() {
     expect(htmlContent).not.toContain('<script type="module"');
   });
 
-  describe.concurrent("route scan errors", () => {
+  describe("route scan errors", () => {
     async function build(dir: string) {
       const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx --outdir ./dist`
         .cwd(dir)

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -740,8 +740,12 @@ export default function IndexPage() {
       });
 
       const { exitCode, stderr } = await build(String(dir));
-      expect(stderr).toContain('"app/loading.tsx" is not a valid route');
-      expect(stderr).toContain('Bun Bake currently does not support "loading" files');
+      // The file name is underlined (the indentation matches `error: "app/`).
+      expect(stderr).toContain(
+        'error: "app/loading.tsx" is not a valid route\n' +
+          "            ----------\n" +
+          '            Bun Bake currently does not support "loading" files\n',
+      );
       expect(exitCode).toBe(1);
       expect(existsSync(path.join(String(dir), "dist"))).toBe(false);
     });
@@ -771,8 +775,12 @@ export default function IndexPage() {
       expect(stderr).toContain("  - pages/[name].tsx");
       expect(stderr).toContain('"pages/blog-[slug].tsx" is not a valid route');
       expect(stderr).toContain("Parameters must take up the entire file name");
-      expect(stderr).toContain(`"${tooManyParams}" is not a valid route`);
-      expect(stderr).toContain("Pattern cannot have more than 64 params");
+      // The whole path is underlined (the indentation matches `error: "`).
+      expect(stderr).toContain(
+        `error: "${tooManyParams}" is not a valid route\n` +
+          `        ${Buffer.alloc(tooManyParams.length - 1, "-").toString()}\n` +
+          "        Pattern cannot have more than 64 params\n",
+      );
       expect(exitCode).toBe(1);
       expect(existsSync(path.join(dir, "dist"))).toBe(false);
     });

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -191,6 +191,19 @@ describe("scan errors", () => {
     ]);
   });
 
+  test("app router files that are not pages or layouts", () => {
+    expect(
+      scanErrors("nextjs-app-ui", {
+        "page.tsx": "1",
+        "loading.tsx": "1",
+        "docs/not-found.tsx": "1",
+      }),
+    ).toEqual([
+      'Invalid route "docs/not-found.tsx": Bun Bake currently does not support "not-found" files',
+      'Invalid route "loading.tsx": Bun Bake currently does not support "loading" files',
+    ]);
+  });
+
   test("invalid routes and collisions are reported together", () => {
     const params = Array.from({ length: 65 }, (_, i) => `[p${i}]`).join("/");
     expect(

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -197,9 +197,13 @@ describe("scan errors", () => {
         "page.tsx": "1",
         "loading.tsx": "1",
         "docs/not-found.tsx": "1",
+        // A plain error.tsx on Windows. On POSIX this is a file whose name starts with ".\",
+        // which the scan normalizes away, so the report must be derived from the normalized path.
+        ".\\error.tsx": "1",
       }),
     ).toEqual([
       'Invalid route "docs/not-found.tsx": Bun Bake currently does not support "not-found" files',
+      'Invalid route "error.tsx": Bun Bake currently does not support "error" files',
       'Invalid route "loading.tsx": Bun Bake currently does not support "loading" files',
     ]);
   });

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -179,7 +179,8 @@ describe("scan errors", () => {
     ).toEqual(['Multiple pages matching the same route pattern is ambiguous: "blog/[id].tsx" and "blog/[slug].tsx"']);
   });
 
-  test("a route group aliasing a static route", () => {
+  // A route group adds no URL segment, so both files land on the same route.
+  test("a route group next to the plain route", () => {
     expect(
       scanErrors("nextjs-app-ui", {
         "docs/page.tsx": "1",

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -133,3 +133,76 @@ test("discovers from filesystem paths", () => {
     ],
   });
 });
+
+describe("scan errors", () => {
+  // Everything found while scanning is thrown at once. A collision names the file being
+  // inserted first, which depends on scan order, so the two names are sorted here.
+  function scanErrors(style: string, files: Record<string, string>): string[] {
+    using dir = tempDir("fsr-scan-errors", files);
+    let thrown: unknown;
+    try {
+      new FrameworkRouter({ root: String(dir), style });
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(AggregateError);
+    expect((thrown as AggregateError).message).toBe("Errors scanning routes");
+    return (thrown as AggregateError).errors
+      .map((e: Error) =>
+        e.message
+          .replaceAll("\\", "/")
+          .replace(/: "(.*)" and "(.*)"$/, (_, a, b) => `: "${[a, b].sort().join('" and "')}"`),
+      )
+      .sort();
+  }
+
+  test("two files on the same route", () => {
+    expect(
+      scanErrors("nextjs-pages", {
+        "about.tsx": "1",
+        "about/index.tsx": "1",
+        "_layout.tsx": "1",
+        "_layout.js": "1",
+      }),
+    ).toEqual([
+      'Multiple layout matching the same route pattern is ambiguous: "_layout.js" and "_layout.tsx"',
+      'Multiple pages matching the same route pattern is ambiguous: "about.tsx" and "about/index.tsx"',
+    ]);
+  });
+
+  test("two dynamic routes with the same shape", () => {
+    expect(
+      scanErrors("nextjs-pages", {
+        "blog/[id].tsx": "1",
+        "blog/[slug].tsx": "1",
+      }),
+    ).toEqual(['Multiple pages matching the same route pattern is ambiguous: "blog/[id].tsx" and "blog/[slug].tsx"']);
+  });
+
+  test("a route group aliasing a static route", () => {
+    expect(
+      scanErrors("nextjs-app-ui", {
+        "docs/page.tsx": "1",
+        "(marketing)/docs/page.tsx": "1",
+      }),
+    ).toEqual([
+      'Multiple pages matching the same route pattern is ambiguous: "(marketing)/docs/page.tsx" and "docs/page.tsx"',
+    ]);
+  });
+
+  test("invalid routes and collisions are reported together", () => {
+    const params = Array.from({ length: 65 }, (_, i) => `[p${i}]`).join("/");
+    expect(
+      scanErrors("nextjs-pages", {
+        "blog-[slug].tsx": "1",
+        [`${params}.tsx`]: "1",
+        "[id].tsx": "1",
+        "[name].tsx": "1",
+      }),
+    ).toEqual([
+      `Invalid route "${params}.tsx": Pattern cannot have more than 64 params`,
+      'Invalid route "blog-[slug].tsx": Parameters must take up the entire file name',
+      'Multiple pages matching the same route pattern is ambiguous: "[id].tsx" and "[name].tsx"',
+    ]);
+  });
+});


### PR DESCRIPTION
### Problem
`bun build --app` (bake's static build; enabled on canary and debug builds, `feature_flags::bake()`) does not fail when the route scan finds a problem, and two of the problems the scan can find crash the process instead of being reported. All reproduced on the 1.4.0 canary build and on a debug build of main; there is no user report for the exit code, this came out of reading the scan code (the two panics below are also reachable from the dev server).

- Two files on the same route (`pages/about.tsx` + `pages/about/index.tsx`): prints `error: Multiple pages matching the same route pattern is ambiguous` with both files, then goes on to `Rendering routes`, writes `dist/about/index.html` from whichever file was inserted first, and exits 0. A CI build with an ambiguous route passes.
- A file whose name is not a valid route (`pages/blog-[slug].tsx`): `panic: TODO: onRouterSyntaxError for EntryPointMap`.
- Two routes that serve the same URLs (`pages/blog/[id].tsx` + `pages/blog/[slug].tsx`, or the same path under two router types): `panic: TODO: propagate aliased route error` from `FrameworkRouter::insert`, in the build and in the dev server.
- An app router file bake has no support for (`app/loading.tsx`; likewise `error`, `not-found`, `default`, `template` with `style: "nextjs-app-ui"`): `panic: TODO: associate extra files with route` from `scan_inner`, build and dev server.
- Cause of the first two: the production build's `InsertionHandler` (`impl InsertionHandler for EntryPointMap`, `src/runtime/bake/production.rs`) printed collisions and returned, and its syntax error callback was a `todo_panic!`; nothing recorded that the scan had failed, so `build_with_vm` bundled and prerendered anyway. The other two never reached a handler.

### Fix
- `production.rs`: the scan runs through a `RouteScan` context (`&mut EntryPointMap` plus an error count) implementing `InsertionHandler`. It registers route files as entry points as before, prints collisions exactly as before, prints invalid routes with `TinyLog::print` (the dev server's existing output for them), and counts both. After `scan_all`, `build_with_vm` exits 1 through `Global::crash()`, the exit the other user errors in that function use, if anything was counted. Nothing is bundled and no `dist/` is created.
- `FrameworkRouter::insert`: when the static or dynamic URL map already holds the pattern, return `InsertError::RouteCollision` with the existing route's page as the colliding file instead of panicking, so `scan_inner` reports it through `on_router_collision_error` like a tree collision. The dynamic arm is what `[id]`/`[slug]` hits; the static arm is only reachable across router types, since within one type a static alias walks to the same tree node and is caught there. The new file is stored on its route only after both checks pass, so a rejected file leaves an empty route node, which is a normal state (directory nodes have no files either). The `expect` on the existing route's page holds because a route enters the maps only in this function, immediately followed by storing its page, and nothing removes files from routes.
- `scan_inner`: `ParsedPatternKind::Extra` is reported through `on_router_syntax_error` as `Bun Bake currently does not support "loading" files` (underlining the file name), the way the parser already rejects named slots and intercepted routes. The name and span come from the normalized `full_rel_path`, which is what the parser classified and what the span indexes; the raw directory entry is not always a suffix of it (on POSIX a name containing `\` or a `.` segment normalizes shorter). The `>64 params` diagnostic was handed to the handlers without a cursor (`TinyLog::empty()` leaves it at `u32::MAX`), which `TinyLog::print` slices with, so with the first bullet alone that case would have traded one panic for another; it now goes through `TinyLog::fail` with the whole path as the span. That hunk is the same change as section 2 of #31697 (which additionally clamps the cursor in `print` and fixes the caret offset of parse errors); whichever lands second has a trivial conflict there, and this PR needs it so the syntax path it wires up cannot panic.
- The `FrameworkFileSystemRouter` test binding collects collisions next to invalid routes (`StoredScanError`, keeping the message bytes rather than the 4.6KB `TinyLog`, which `large_enum_variant` rejects) instead of panicking, so the router-level cases below can exist.
- Why counting instead of aborting on the first error: `scan_inner` reports and keeps walking, and the handler's only error channel is `AllocError`; counting is what lets one build list every offending file. It is the same shape the test binding already used for invalid routes (collect, then throw `Errors scanning routes`). The dev server's handlers are unchanged: it logs and keeps serving, which is right for a running server and wrong for a build whose output is about to be published.
- Reach today: the tree collision, invalid name and `[id]`/`[slug]` arms are hit by the built-in react framework. The cross-type static arm and the `Extra` arm need a custom framework (several router types, or the app router style), and a custom framework's production build currently dies later anyway (`Runtime file not found`, #32142, fixed by the open #32143), so until that lands those two arms matter for the dev server and the test binding; the production tests for them pass because the build stops at the scan.
- Not in this PR, filed separately: a failed chunk write (`Failed to write ... to output directory`) also exits 0, and a function passed as `style` is accepted by `Style::from_js` and then panics. Neither is part of the route scan.
- Verified:
  - `test/bake/dev/production.test.ts`, new `route scan errors` describe: page collision, invalid name, `[id]`/`[slug]` alias, a framework with two router types both defining `about.tsx` (static arm), an app router project with `loading.tsx`, and a project with a page collision, a layout collision, an alias, an invalid name and a 65-param file at once; each asserts the messages, exit 1 and no `dist/`, and the `loading.tsx` and 65-param cases assert the rendered underline, which pins the two spans the scan computes itself. All six fail on the unfixed build (exit 0, or the panics above) and pass on `bun bd`; the rest of the file passes on `bun bd`. The message-only collision test #39138 added to this file is removed, since the first case here asserts a superset of it.
  - `test/bake/framework-router.test.ts`, new `scan errors` describe: tree collision (page and layout), dynamic alias, a route group next to the plain route, app router `loading.tsx`/`not-found.tsx` plus a `.\error.tsx` entry (a plain file on Windows, a name the scan normalizes on POSIX), and invalid routes (including the param cap) reported together with a collision. On the unfixed build the file dies in the binding's collision panic; on `bun bd` all 40 tests pass.
  - `test/bake/dev/ssg-pages-router.test.ts` (dev server routing, hot reload) passes on `bun bd`; a dev server started on the `[id]`/`[slug]` project now logs the collision and starts instead of panicking.
  - `cargo clippy -p bun_runtime` and `cargo fmt --check` are clean.
- Textual overlap with #38233 (the lines after the `scan_all` call), #31697 (the param-cap lines, and both append to `framework-router.test.ts`) and #32143 (both append to `production.test.ts`).

### Background
- bake's production build (`src/runtime/bake/production.rs`) walks each framework router's directory (`pages/` for the built-in react framework) with `FrameworkRouter::scan_all`, bundles the files it found, and prerenders every route into `dist/`. The dev server walks the same way but then serves.
- `InsertionHandler` (`FrameworkRouter.rs`) is the callback interface the scan hands files to: `get_file_id_for_router` registers a file, `on_router_collision_error` reports a file whose route already has a page (or layout) from another file, `on_router_syntax_error` reports a file the scan cannot turn into a route. The scan continues after either error callback. The dev server, the production build, and the `FrameworkFileSystemRouter` binding used by `framework-router.test.ts` each implement it.
- `FrameworkRouter` keeps routes in a tree keyed by path segments, where `[id]` and `[slug]` are different nodes and each router type has its own root, and additionally in two URL maps shared by all types (`static_routes` by path, `dynamic_routes` by the pattern's effective URL, which ignores param names). The tree catches two files on one route; the maps catch two routes serving the same URLs, and also do the matching.
- `ParsedPatternKind::Extra` is what the app router parser returns for the Next.js convention files other than `page` and `layout`; the router has nowhere to attach them yet.
- `EntryPointMap` is the production build's list of files to bundle; the `OpaqueFileId`s given to the router index it, which is how the collision message names the other file.
- `TinyLog` is the fixed-size message plus cursor span the route pattern parser fills in via `fail`; `TinyLog::print` renders it as the `"..." is not a valid route` diagnostic with the span underlined.

<details>
<summary>Earlier revisions</summary>

The first revision only added `RouteScan` (collision exit code and the syntax error panic). Review pointed out that aliased routes still panicked in the same scan and that the param-cap diagnostic would have panicked inside `TinyLog::print`; the second revision added the `insert`, param-cap and test binding changes. A further pass found the `Extra` panic in the same loop and the `large_enum_variant` failure; the third revision added those, and a last pass moved the `Extra` report onto the normalized path and added the underline assertions.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/production.test.ts

<!-- robobun:evidence:end -->