### PR TITLE
bun --print: exit 1 and run exit listeners when the result promise is still pending after the event loop stops

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -42,7 +42,6 @@
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
-"reimplemented_helper:src/runtime/hw_exports.rs" = 1
 "same_match_twice:src/runtime/api/bun/h2_frame_parser.rs" = 1
 "same_match_twice:src/runtime/cli/pack_command.rs" = 1
 "same_match_twice:src/runtime/cli/update_interactive_command.rs" = 2

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3993,8 +3993,8 @@ JSC::JSValue EvalGlobalObject::moduleLoaderEvaluate(JSGlobalObject* lexicalGloba
         //
         // Instead, when the module yielded, capture the async capability's
         // promise. Its resolution value is the module's final completion
-        // value; the --print loop in run_command.rs already unwraps promises
-        // via asAnyPromise + Bun__onResolveEntryPointResult.
+        // value; the --print path in run_command.rs unwraps a promise result
+        // once the event loop has drained.
         JSC::JSValue valueToStore = result;
         if (auto* moduleRecord = dynamicDowncast<JSC::AbstractModuleRecord>(moduleRecordValue)) {
             JSC::JSValue state = moduleRecord->internalField(JSC::AbstractModuleRecord::Field::State).get();
@@ -4127,10 +4127,6 @@ GlobalObject::PromiseFunctions GlobalObject::promiseHandlerID(Zig::FFIFunction h
         return GlobalObject::PromiseFunctions::Bun__HTMLRewriter__onHandlerResolve;
     } else if (handler == Bun__HTMLRewriter__onHandlerReject) {
         return GlobalObject::PromiseFunctions::Bun__HTMLRewriter__onHandlerReject;
-    } else if (handler == Bun__onResolveEntryPointResult) {
-        return GlobalObject::PromiseFunctions::Bun__onResolveEntryPointResult;
-    } else if (handler == Bun__onRejectEntryPointResult) {
-        return GlobalObject::PromiseFunctions::Bun__onRejectEntryPointResult;
     } else if (handler == Bun__NodeHTTPRequest__onResolve) {
         return GlobalObject::PromiseFunctions::Bun__NodeHTTPRequest__onResolve;
     } else if (handler == Bun__NodeHTTPRequest__onReject) {

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -413,8 +413,6 @@ public:
         Bun__TestScope__Describe2__bunTestCatch,
         Bun__HTMLRewriter__onHandlerResolve,
         Bun__HTMLRewriter__onHandlerReject,
-        Bun__onResolveEntryPointResult,
-        Bun__onRejectEntryPointResult,
         Bun__NodeHTTPRequest__onResolve,
         Bun__NodeHTTPRequest__onReject,
         Bun__FileStreamWrapper__onRejectRequestStream,
@@ -438,7 +436,7 @@ public:
         Bun__HTMLRewriter__onResolveInputStream,
         Bun__HTMLRewriter__onRejectInputStream,
     };
-    static constexpr size_t promiseFunctionsSize = 48;
+    static constexpr size_t promiseFunctionsSize = 46;
 
     static PromiseFunctions promiseHandlerID(SYSV_ABI EncodedJSValue (*handler)(JSC::JSGlobalObject* arg0, JSC::CallFrame* arg1));
 

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -816,10 +816,6 @@ CPP_DECL bool JSC__CustomGetterSetter__isSetterNull(JSC::CustomGetterSetter *arg
 
 #ifdef __cplusplus
 
-BUN_DECLARE_HOST_FUNCTION(Bun__onResolveEntryPointResult);
-BUN_DECLARE_HOST_FUNCTION(Bun__onRejectEntryPointResult);
-
-
 BUN_DECLARE_HOST_FUNCTION(Bun__FileStreamWrapper__onResolveRequestStream);
 BUN_DECLARE_HOST_FUNCTION(Bun__FileStreamWrapper__onRejectRequestStream);
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1495,37 +1495,36 @@ impl Run<'_> {
             }
 
             if ctx.runtime_options.eval.eval_and_print {
-                let to_print: JSValue = 'brk: {
-                    let result = vm
-                        .entry_point_result
-                        .value
-                        .get()
-                        .unwrap_or(JSValue::UNDEFINED);
-                    if let Some(promise) = result.as_any_promise() {
-                        match promise.status() {
-                            PromiseStatus::Pending => {
-                                // C-ABI shims are emitted by
-                                // `generate-host-exports.ts` into
-                                // `crate::generated_host_exports` under their
-                                // link name (`Bun__on…EntryPointResult`).
-                                result.then2(
-                                    vm.global(),
-                                    JSValue::UNDEFINED,
-                                    crate::generated_host_exports::Bun__onResolveEntryPointResult,
-                                    crate::generated_host_exports::Bun__onRejectEntryPointResult,
-                                );
+                let result = vm
+                    .entry_point_result
+                    .value
+                    .get()
+                    .unwrap_or(JSValue::UNDEFINED);
+                let to_print: JSValue = match result.as_any_promise() {
+                    Some(promise) => {
+                        // Drained with the result unsettled (only unref'd work
+                        // left): one more turn, then print whatever state it is
+                        // in. Not when an unhandled error stopped the loop: as in
+                        // `on_before_exit`, nothing of the script runs after that
+                        // (the turn would only race its timers against the next
+                        // internal wakeup). Exiting stays with the sequence
+                        // below; a reaction on the promise would bypass it.
+                        if promise.status() == PromiseStatus::Pending
+                            && vm.unhandled_error_counter == 0
+                        {
+                            vm.tick();
+                            vm.auto_tick_active();
+                            while vm.is_event_loop_alive() {
                                 vm.tick();
                                 vm.auto_tick_active();
-                                while vm.is_event_loop_alive() {
-                                    vm.tick();
-                                    vm.auto_tick_active();
-                                }
-                                break 'brk result;
                             }
-                            _ => break 'brk promise.result(vm.jsc_vm()),
+                        }
+                        match promise.status() {
+                            PromiseStatus::Pending => result,
+                            _ => promise.result(vm.jsc_vm()),
                         }
                     }
-                    result
+                    None => result,
                 };
                 // SAFETY: `vals[..1]` is the single stack `to_print`; null
                 // `ctype` routes to the VM's stdout/stderr default.

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -302,54 +302,6 @@ mod sql_hooks {
     };
 }
 
-// ─── entry-point promise reactions (used by `--print`) ───────────────────────
-
-// HOST_EXPORT(Bun__onResolveEntryPointResult)
-pub fn on_resolve_entry_point_result(
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
-) -> bun_jsc::JsResult<JSValue> {
-    let result = callframe.argument(0);
-    // SAFETY: `vals[..len]` is the single stack `result`; `ctype` is ignored by
-    // `message_with_type_and_level` (it always resolves the per-VM console via
-    // `vm_console(global)`), so null is fine.
-    unsafe {
-        bun_jsc::ConsoleObject::message_with_type_and_level(
-            core::ptr::null_mut(),
-            bun_jsc::ConsoleObject::MessageType::Log,
-            bun_jsc::ConsoleObject::MessageLevel::Log,
-            global,
-            &raw const result,
-            1,
-        );
-    }
-    // SAFETY: bun_vm() never null for a Bun-owned global.
-    bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code));
-}
-
-// HOST_EXPORT(Bun__onRejectEntryPointResult)
-pub fn on_reject_entry_point_result(
-    global: &JSGlobalObject,
-    callframe: &CallFrame,
-) -> bun_jsc::JsResult<JSValue> {
-    let result = callframe.argument(0);
-    // SAFETY: `vals[..len]` is the single stack `result`; `ctype` is ignored by
-    // `message_with_type_and_level` (it always resolves the per-VM console via
-    // `vm_console(global)`), so null is fine.
-    unsafe {
-        bun_jsc::ConsoleObject::message_with_type_and_level(
-            core::ptr::null_mut(),
-            bun_jsc::ConsoleObject::MessageType::Log,
-            bun_jsc::ConsoleObject::MessageLevel::Log,
-            global,
-            &raw const result,
-            1,
-        );
-    }
-    // SAFETY: bun_vm() never null for a Bun-owned global.
-    bun_core::Global::exit(u32::from(global.bun_vm().as_mut().exit_handler.exit_code));
-}
-
 // ─── bindgenv2 dispatch shims (`bindgen_*_dispatch*`) ────────────────────────
 //
 // These satisfy the `extern "C"` refs C++ emits from

--- a/test/cli/run/run-eval.test.ts
+++ b/test/cli/run/run-eval.test.ts
@@ -175,6 +175,98 @@ describe("--print for cjs/esm", () => {
   });
 });
 
+// `--print` looks at the result once the event loop is done. A result promise
+// that is still pending when the loop drained on its own gets one more turn of
+// the loop; one left pending because an unhandled error stopped the loop does
+// not (nothing of the script runs after such an error, as with `-e`). Either
+// way the process then leaves through the regular exit path ('exit' listeners,
+// exit code), not from inside a reaction on the promise.
+//
+// Every script below arms the timer that would settle the result and then
+// blocks in Bun.sleepSync, so the timer is overdue by the time the loop is
+// looked at: it fires for sure in the extra turn of the unref cases, and its
+// callback not having run in the error cases shows that nothing ran after the
+// error, whatever the timing.
+describe.concurrent("--print with a result promise still pending when the event loop is done", () => {
+  const exitListener = `process.on("exit", () => console.log("exit listener ran"));`;
+
+  async function print(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--print", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("fulfilled by an unref'd timer: prints the value, then runs 'exit' listeners", async () => {
+    const { stdout, stderr, exitCode } = await print(
+      `${exitListener}
+       new Promise(resolve => { setTimeout(() => resolve("settled late"), 1).unref(); Bun.sleepSync(10); })`,
+    );
+    expect(stderr).toBe("");
+    expect(stdout).toBe("settled late\nexit listener ran\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("rejected by an unref'd timer: reported as unhandled and exits 1, like a rejection during the loop", async () => {
+    const { stdout, stderr, exitCode } = await print(
+      `${exitListener}
+       new Promise((_, reject) => { setTimeout(() => reject("rejected late"), 1).unref(); Bun.sleepSync(10); })`,
+    );
+    expect(stderr).toContain("error: rejected late");
+    // What a rejected result is printed as is not this block's subject.
+    expect(stdout).toEndWith("exit listener ran\n");
+    expect(exitCode).toBe(1);
+  });
+
+  test.each(["resolve", "reject"])(
+    "unhandled rejection stopped the loop: the %s() timer does not run, exits 1 after 'exit' listeners",
+    async settle => {
+      const { stdout, stderr, exitCode } = await print(
+        `${exitListener}
+         Promise.reject(new Error("early rejection"));
+         new Promise((resolve, reject) => {
+           setTimeout(() => { console.log("timer ran"); ${settle}("late"); }, 1);
+           Bun.sleepSync(10);
+         })`,
+      );
+      expect(stderr).toContain("early rejection");
+      expect(stdout).toBe("Promise { <pending> }\nexit listener ran\n");
+      expect(exitCode).toBe(1);
+    },
+  );
+
+  test("uncaught exception from a timer stopped the loop: 'exit' listeners see code 1", async () => {
+    // The settling timer is armed by the throwing callback itself. Whether the
+    // turn of the loop that ran the throw still fires it differs by platform
+    // (libuv runs timers again after its poll), so what gets printed is not
+    // asserted, only that the process left through the exit listeners.
+    const { stdout, stderr, exitCode } = await print(
+      `process.on("exit", code => console.log("exit listener ran with", code));
+       new Promise(resolve => {
+         setTimeout(() => {
+           setTimeout(() => resolve("settled late"), 1);
+           Bun.sleepSync(10);
+           throw new Error("thrown in timer");
+         }, 1);
+       })`,
+    );
+    expect(stderr).toContain("thrown in timer");
+    expect(stdout).toEndWith("exit listener ran with 1\n");
+    expect(exitCode).toBe(1);
+  });
+
+  test("never settles: prints the promise and exits normally", async () => {
+    const { stdout, stderr, exitCode } = await print(`${exitListener} new Promise(() => {})`);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("Promise { <pending> }\nexit listener ran\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
 function group(run: (code: string) => SyncSubprocess<"pipe", "inherit">) {
   test("it works", async () => {
     const { stdout } = run('console.log("hello world")');


### PR DESCRIPTION
### Problem

- `bun --print` (`-p`) exits 0 after reporting an unhandled rejection when the result promise is settled by a timer that comes due shortly after. `bun -e` with the same script exits 1.
  ```
  bun --print 'Promise.reject(new Error("early")); new Promise(r => setTimeout(() => r(5), 30))'; echo $?
  # error: early ...   5   0
  ```
- Whether that happens depends on the timer: on the release build the same script with a 200ms timer prints `Promise { <pending> }` and exits 1, because an internal wakeup (the GC timer, about 100ms in) ends the wait first; with `BUN_GC_TIMER_DISABLE=1` a 500ms timer runs too and the exit code is 0 again. So after a fatal error, what `--print` prints, whether more of the script runs, and the exit code all depend on timing.
- On the same path `process.on("exit")` listeners never run (also after an uncaught exception thrown from a timer, which does exit 1), and a result promise that rejects late is printed like a value and exits 0 instead of being reported.
- Not limited to errors: a result settled by an unref'd timer that is already overdue when the loop drains (`new Promise(r => { setTimeout(() => r(1), 1).unref(); Bun.sleepSync(10) })`) takes the same path, so its exit listeners are skipped too, and under the ASAN lanes' settings (`BUN_DESTRUCT_VM_ON_EXIT=1` plus LSan) every script on this path aborts at exit with a leak report because the VM teardown is skipped as well (why #39128 had to run its test with `detect_leaks=0`).
- Cause: when the result was still pending after the main loop, `Run::start` (`src/runtime/cli/run_command.rs`) attached two native reactions to it (`then2` with `Bun__onResolveEntryPointResult` / `Bun__onRejectEntryPointResult`, `src/runtime/hw_exports.rs`) and ran one more turn of the loop, whether the loop had drained or an unhandled error had stopped it. Each reaction `console.log`s the settled value and calls `Global::exit(exit_handler.exit_code)` from inside the promise job, skipping everything `Run::start` does after printing: `on_before_exit()`, `handle_rejected_promises()`, `on_exit()` (the `exit` event), the `ANY_UNHANDLED` -> exit code 1 step and `global_exit()`. Attaching reactions also marks the promise handled, which is why its own late rejection was never reported. The Zig version had the same shape; not a port regression.

### Fix

- Remove the reactions (with their `PromiseFunctions` slots, header declarations and the mordant baseline entry that pointed at them). After the extra turn, `Run::start` reads the promise's status again and prints its result if it settled, or the promise itself if not, the handling the already-settled case always had; then it continues into the same exit sequence as every other `--print` / `-e` run. One print site instead of three.
- Take the extra turn only when the loop drained on its own (`unhandled_error_counter == 0`, the check `on_before_exit` uses since #34639 to skip `beforeExit` after a fatal error). After an unhandled error `--print` now prints `Promise { <pending> }` and exits 1 at once, whatever the timer, which is what `-e` does with the same script (the timer does not run there either) and what `node -p` prints for a pending promise. An error that is not fatal (an `unhandledRejection` listener, `--unhandled-rejections=warn`) does not touch the counter, so those runs still wait for the result as before (probed). Every other run loop (`Run::start`'s own, `on_before_exit`, workers, the REPL) ticks inside `while is_event_loop_alive()` and so already stops on the counter; this turn was the one that did not. #38524, which makes `auto_tick_active()` itself return early in that state, composes with this: after an error the turn is no longer taken, and in the drained case the counter is 0.
- Why this is right: the reactions existed only to print the value once it arrived, and the extra turn only to let that happen; keeping the second of those for the drained case and dropping the first means the exit code, the `exit` event, the report for a late rejection and the teardown all come from the one existing exit path instead of a second one that had to reproduce it and did not. What the drained case prints is unchanged; a result that rejects in the extra turn is now handled like one that rejects during the loop (reported on stderr, exit 1).
- Verified with `test/cli/run/run-eval.test.ts`, new block `--print with a result promise still pending when the event loop is done`: unref'd timer fulfilling / rejecting the result, unhandled rejection with a resolve / reject timer that must not run, uncaught exception from a timer, and a never-settling result as a guard. Five of the six fail on the release binary and on a debug build of main (value printed, no `exit listener ran` line; the error cases print `timer ran` / `late` and exit 0); all six pass with the change. 20 runs each way, plus the whole file and the block again under the ASAN lanes' environment (`BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1:abort_on_error=1`, `test/leaksan.supp`, exception-check validation).
- The tests do not depend on scheduling: each script arms the timer and then blocks in `Bun.sleepSync`, so by the time the loop is looked at the timer is overdue. In the unref cases it therefore fires in the extra turn on every platform (the turn drains due timers whether or not they are ref'd, through `us_loop_pump` on libuv); in the rejection cases the error is counted before any timer drain, so the callback not having run holds on every platform; in the uncaught case the settling timer is armed by the throwing callback, and because libuv runs timers again after its poll that turn may still fire it on Windows, so that test only asserts the error, the listener line and the code. The rejected-unref test does not assert what the rejected result is printed as (#36448's subject).
- Also green here: the rest of `run-eval.test.ts`, `globals.test.js`, `no-addons.test.ts`, `workerd/html-rewriter.test.js` and `cron/in-process-cron.test.ts` (users of the other `PromiseFunctions` slots, whose indices shift), and the dead-symbol source lints.
- Supersedes #39128 (dedupes the two functions this deletes; its tests pin the post-error value that no longer prints) and the `hw_exports.rs` half of #37173 (formatter throw while printing; one site left for it). #36448 (what a rejected result prints) applies unchanged to the late-settled case now. #38116 is why the rejection tests only check that the `exit` listener ran, not the code it received. #32622 rewrites `--print` to print from JS on exit, Node's model, and deletes the same reactions; this is the targeted subset of that.

### Background

- `--print` result: the C++ module loader stores the eval entry's completion value in `vm.entry_point_result` (`Bun__VM__setEntryPointEvalResult*`). After the main loop, `Run::start` prints it, unwrapping a promise to its result.
- Two ways the loop ends with the result pending: `VirtualMachine::is_event_loop_alive()` is false once `unhandled_error_counter` is non-zero (an error nothing handled was reported; this is how `bun run` exits 1 after one), and once nothing ref'd is left (an unref'd timer does not count). One turn of the loop is `tick()` (queued tasks, microtasks) plus `auto_tick_active()` (immediates, a poll that ends at the next timer or wakeup, then the timers that are due).
- Exit sequence at the end of `Run::start`: `on_before_exit()` emits `beforeExit` (skipped after a fatal error), `handle_rejected_promises()` reports rejections left by the last turn, `on_exit()` emits `exit`, `ANY_UNHANDLED` (set by the run command's unhandled-error handler) becomes exit code 1, `global_exit()` tears the VM down when asked to and exits with `exit_handler.exit_code`.
- `then2`: attaches two native functions as a promise's fulfil/reject reactions. `GlobalObject::thenable` caches one `JSFunction` per native function in a table indexed by the `PromiseFunctions` enum (`promiseFunctionsSize` is its length), which is why removing a pair of reactions touches `ZigGlobalObject.h/.cpp`. A promise with reactions attached counts as handled for unhandled-rejection tracking.
- `mordant-baseline.toml`: per-(lint, file) counts of pre-existing findings from the advisory `mordant` job; the removed line was the `reimplemented_helper` finding for the two identical reactions.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-eval.test.ts

<!-- robobun:evidence:end -->