### PR TITLE
Body: state the AnyBlob -> Value and DrainResult -> ByteStream mappings once

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -65,7 +65,6 @@
 "same_match_twice:src/runtime/server/server_body.rs" = 1
 "same_match_twice:src/runtime/shell/builtin/cat.rs" = 1
 "same_match_twice:src/runtime/webcore/Blob.rs" = 2
-"same_match_twice:src/runtime/webcore/Body.rs" = 2
 "unchecked_construction:src/runtime/api/js_bundle_completion_task.rs" = 1
 "unchecked_construction:src/runtime/cli/pack_command.rs" = 2
 "unchecked_construction:src/runtime/server/HTMLBundle.rs" = 2

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -656,6 +656,18 @@ impl ValueError {
     }
 }
 
+impl From<AnyBlob> for Value {
+    /// Each arm moves its payload as is: a `WTFStringImpl`'s `+1` travels with
+    /// the pointer and is released by `Value::drop`, so nothing is ref'd here.
+    fn from(blob: AnyBlob) -> Value {
+        match blob {
+            AnyBlob::Blob(b) => Value::Blob(b),
+            AnyBlob::InternalBlob(b) => Value::InternalBlob(b),
+            AnyBlob::WTFStringImpl(s) => Value::WTFStringImpl(s),
+        }
+    }
+}
+
 impl Value {
     /// Downcast a `JSValue` to the `Body.Value` it owns, if any.
     ///
@@ -722,11 +734,7 @@ impl Value {
         };
 
         if let Some(blob) = locked.to_any_blob() {
-            *self = match blob {
-                AnyBlob::Blob(b) => Value::Blob(b),
-                AnyBlob::InternalBlob(b) => Value::InternalBlob(b),
-                AnyBlob::WTFStringImpl(s) => Value::WTFStringImpl(s),
-            };
+            *self = Value::from(blob);
         }
     }
 
@@ -894,21 +902,7 @@ impl Value {
         reader.producer.set(locked.producer);
 
         reader.context.setup();
-
-        match drain_result {
-            DrainResult::EstimatedSize(estimated_size) => {
-                reader.context.high_water_mark = estimated_size as blob::SizeType;
-                reader
-                    .context
-                    .size_hint
-                    .set(estimated_size as blob::SizeType);
-            }
-            DrainResult::Owned { list, size_hint } => {
-                reader.context.buffer.set(list);
-                reader.context.size_hint.set(size_hint as blob::SizeType);
-            }
-            _ => {}
-        }
+        reader.context.apply_drain_result(drain_result);
 
         let context_ptr: *mut ByteStream = &raw mut reader.context;
         let stream_value = if text_mode {
@@ -1034,16 +1028,8 @@ impl Value {
                 webcore::readable_stream::Source::Blob(blob) => {
                     // SAFETY: `Source::Blob` holds a live *mut ByteBlobLoader for the
                     // lifetime of the ReadableStream JS wrapper.
-                    let result = if let Some(any_blob) = unsafe { (*blob).to_any_blob(global_this) }
-                    {
-                        match any_blob {
-                            AnyBlob::Blob(b) => Value::Blob(b),
-                            AnyBlob::InternalBlob(b) => Value::InternalBlob(b),
-                            AnyBlob::WTFStringImpl(s) => Value::WTFStringImpl(s),
-                        }
-                    } else {
-                        Value::Empty
-                    };
+                    let result = unsafe { (*blob).to_any_blob(global_this) }
+                        .map_or(Value::Empty, Value::from);
                     readable.force_detach(global_this);
                     return Ok(result);
                 }
@@ -1533,21 +1519,7 @@ impl Value {
         );
 
         reader.context.setup();
-
-        match drain_result {
-            DrainResult::EstimatedSize(estimated_size) => {
-                reader.context.high_water_mark = estimated_size as blob::SizeType;
-                reader
-                    .context
-                    .size_hint
-                    .set(estimated_size as blob::SizeType);
-            }
-            DrainResult::Owned { list, size_hint } => {
-                reader.context.buffer.set(list);
-                reader.context.size_hint.set(size_hint as blob::SizeType);
-            }
-            _ => {}
-        }
+        reader.context.apply_drain_result(drain_result);
 
         // reshaped for borrowck — re-borrow locked after the early *self = Null path above.
         let Value::Locked(locked) = self else {

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -5,9 +5,8 @@ use bun_jsc::strong::Optional as StrongOptional;
 use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsCell};
 use bun_sys::Error as SysError;
 
-use crate::webcore::SinkHandle;
 use crate::webcore::streams::{self, BufferAction, IntoArray};
-use crate::webcore::{blob, readable_stream};
+use crate::webcore::{DrainResult, SinkHandle, blob, readable_stream};
 
 bun_output::declare_scope!(ByteStream, visible);
 
@@ -120,6 +119,25 @@ impl ByteStream {
         // the old value owns nothing the new one
         // reuses, so dropping it is the intended reset.
         drop(core::mem::take(self));
+    }
+
+    /// Seeds the stream with what the producer's `on_start_streaming` handed
+    /// over: the bytes it had already buffered, or its estimate of the total.
+    /// Init-time like [`Self::setup`] (no JS wrapper yet, so `&mut self` is
+    /// sound). Callers drop the body to `Null` on `Empty` / `Aborted` instead
+    /// of realising a stream, so those arms have nothing to seed.
+    pub(crate) fn apply_drain_result(&mut self, drain_result: DrainResult) {
+        match drain_result {
+            DrainResult::EstimatedSize(estimated_size) => {
+                self.high_water_mark = estimated_size as blob::SizeType;
+                self.size_hint.set(estimated_size as blob::SizeType);
+            }
+            DrainResult::Owned { list, size_hint } => {
+                self.buffer.set(list);
+                self.size_hint.set(size_hint as blob::SizeType);
+            }
+            DrainResult::Empty | DrainResult::Aborted => {}
+        }
     }
 
     fn on_start(&self) -> streams::Start {

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,4 +1,4 @@
-import { file, spawn, version } from "bun";
+import { file, spawn, version, type Socket } from "bun";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, exampleSite } from "harness";
 import net from "net";
@@ -229,6 +229,18 @@ for (const { body, fn } of bodyTypes) {
             },
             content: /Example Domain/,
           },
+          // Blob-backed streams are not wrapped: the constructor takes the
+          // blob out of the stream and stores it as the body itself.
+          {
+            label: "Blob.stream()",
+            stream: () => new Blob(["bye\n"]).stream(),
+            content: "bye\n",
+          },
+          {
+            label: ".body of an unread in-memory body",
+            stream: () => new Response("bye\n").body as ReadableStream,
+            content: "bye\n",
+          },
         ];
         for (const { label, stream, content, skip } of streams) {
           const it = skip ? test.skip : test;
@@ -250,6 +262,30 @@ for (const { body, fn } of bodyTypes) {
           }).not.toThrow();
           expect(await fn(buffer).text()).toBe(string);
         }
+      });
+    });
+    // Two places move a blob out of a blob-backed stream and into the body:
+    // the constructor (above), and the readers, when the body getter has
+    // already turned an in-memory body into a stream that nothing has read.
+    // Either way the body ends up holding the blob again, type included.
+    describe("blob-backed stream bodies", () => {
+      test("the constructor keeps the type of the Blob behind the stream", async () => {
+        const blob = await fn(new Blob(["bye"], { type: "text/x-bun" }).stream()).blob();
+        expect([blob.type, await blob.text()]).toEqual(["text/x-bun", "bye"]);
+      });
+
+      test("blob() after the body getter returns the original Blob's type and bytes", async () => {
+        const subject = fn(new Blob(["bye"], { type: "text/x-bun" }));
+        expect(subject.body).toBeInstanceOf(ReadableStream);
+        const blob = await subject.blob();
+        expect([blob.type, await blob.text(), subject.bodyUsed]).toEqual(["text/x-bun", "bye", true]);
+      });
+
+      test("text() after the body getter returns a string body's bytes", async () => {
+        const subject = fn("bye");
+        expect(subject.body).toBeInstanceOf(ReadableStream);
+        expect(await subject.text()).toBe("bye");
+        expect(subject.bodyUsed).toBe(true);
       });
     });
     for (const { string, buffer } of utf8) {
@@ -1260,4 +1296,35 @@ describe("constructing a body from an unusable ReadableStream", () => {
     expect(() => new Response(rs)).toThrow(TypeError);
     expect(() => new Request("http://example.com/", { method: "POST", body: rs, duplex: "half" })).toThrow(TypeError);
   });
+});
+
+// Until the body arrives, a fetch() Response's size (the number Bun.inspect
+// prints) is the upstream Content-Length. The body getter creates the stream
+// from that size alone when no bytes have been received yet, and the size has
+// to be carried over onto the stream, which reports it from then on.
+test("a fetch() Response still reports the Content-Length after .body created the stream", async () => {
+  const payload = "0123456789";
+  const { promise: upstream, resolve: gotUpstream } = Promise.withResolvers<Socket>();
+  using listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(socket) {
+        socket.write(`HTTP/1.1 200 OK\r\nContent-Length: ${payload.length}\r\nConnection: close\r\n\r\n`);
+        gotUpstream(socket);
+      },
+      data() {},
+    },
+  });
+
+  const response = await fetch(`http://127.0.0.1:${listener.port}/`);
+  expect(Bun.inspect(response)).toStartWith(`Response (${payload.length} bytes)`);
+
+  // The upstream socket has not written any of the body yet, so this stream
+  // starts out empty and only knows the size.
+  const stream = response.body!;
+  expect(Bun.inspect(response)).toStartWith(`Response (${payload.length} bytes)`);
+
+  (await upstream).end(payload);
+  expect(await stream.text()).toBe(payload);
 });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -673,6 +673,35 @@ describe("HTMLRewriter", () => {
       });
     });
 
+    // Same as above, but the rewriter has already produced output (the `<a>`)
+    // by the time the handler suspends. Nothing is consuming the body yet, so
+    // those bytes sit in the rewriter's own buffer; the stream that `.body` or
+    // `.clone()` creates afterwards has to be seeded with them, or the output
+    // would start at `<p>`. Both consumers are attached before the handler
+    // resumes.
+    describe("output produced before the rewrite suspended reaches a stream created later", () => {
+      const expected = "<a>first</a><p>new</p>";
+      const suspending = () =>
+        new HTMLRewriter()
+          .on("p", {
+            async element(element) {
+              await setImmediatePromise();
+              element.setInnerContent("new");
+            },
+          })
+          .transform(new Response("<a>first</a><p>old</p>"));
+
+      it(".body", async () => {
+        expect(await suspending().body.text()).toBe(expected);
+      });
+
+      it(".clone() seeds both branches", async () => {
+        const res = suspending();
+        const clone = res.clone();
+        expect(await Promise.all([res.text(), clone.text()])).toEqual([expected, expected]);
+      });
+    });
+
     it("transform(ArrayBuffer) throws the ArrayBuffer wording", () => {
       expect(() =>
         new HTMLRewriter()


### PR DESCRIPTION
### Problem
- `bun run rust:mordant` reports two `same_match_twice` findings in `src/runtime/webcore/Body.rs`, currently carried in `mordant-baseline.toml` as `"same_match_twice:src/runtime/webcore/Body.rs" = 2`:
  - `Body.rs:1039` (`Value::from_js`, body init from a blob-backed `ReadableStream`) repeats the `AnyBlob -> Value` match at `Body.rs:725` (`Value::to_blob_if_possible`) arm for arm.
  - `Body.rs:1537` (`Value::tee`) repeats the `DrainResult` match at `Body.rs:898` (`Value::locked_to_native_stream`) arm for arm: both seed a freshly created `ByteStream` from the producer's `DrainResult`.
- Both are real mappings written out twice, not shared plumbing: a new `AnyBlob` variant or a new field to seed from a `DrainResult` would have to be added in two places.

### Fix
- `impl From<AnyBlob> for Value` (Body.rs): the three arm moves, stated once. `to_blob_if_possible` becomes `*self = Value::from(blob)`, and `from_js` becomes `.map_or(Value::Empty, Value::from)`.
- `ByteStream::apply_drain_result(DrainResult)` (ByteStream.rs): the `EstimatedSize` / `Owned` arms, stated once. It lives on `ByteStream` rather than on `DrainResult` because it writes `ByteStream`'s init-time fields (`high_water_mark`, `size_hint`, `buffer`), next to `setup()`, which has the same "runs before the JS wrapper exists" contract. The `Empty | Aborted` arm is spelled out instead of `_`; both callers already return before reaching it.
- No behavior change: each call site does exactly the moves and field writes it did before, in the same order (the `Value::Empty` that `map_or` builds eagerly is a payload-free variant whose `Drop` is a no-op).
- `mordant-baseline.toml` regenerated with `bun run rust:mordant:baseline` on top of current main: the only difference is the removed `same_match_twice:src/runtime/webcore/Body.rs` entry, so CI now fails if either match comes back.
- Tests pin what the two moved mappings do, through the four call sites. They are coverage of behavior this PR keeps, not regression tests: they pass on main as well, since a refactor with no behavior change has no failing-before state.
  - `test/js/web/fetch/body.test.ts`, for `Request` and `Response`: a body constructed from `Blob.stream()` or from another body's `.body` reads back its content (`from_js`); a typed Blob's stream is adopted with its type, and `blob()` / `text()` after the body getter has materialized a stream return the original Blob's type and bytes (`to_blob_if_possible`); a fetch() Response whose body has not arrived still reports its Content-Length once `.body` has created the stream (`locked_to_native_stream`, `EstimatedSize` arm, observable through `Bun.inspect`, which is the one reader of that size).
  - `test/js/workerd/html-rewriter.test.js`: output a rewriter produced before a handler suspended reaches a stream created afterwards, via `.body` (`locked_to_native_stream`) and via both branches of `.clone()` (`tee`); both are the `Owned` arm, which is what hands the buffered `<a>first</a>` over.
  - Checked by mutation: removing the `Owned` arm's `buffer` hand-off fails both rewriter tests, removing the `EstimatedSize` arm's `size_hint` fails the Content-Length test (`Response (0 KB)`).
- Verified:
  - `cargo dylint --all -p bun_runtime` with the Body.rs baseline line removed: 2 findings over baseline before this change (at 1039 and 1537, output below), none after.
  - `bun run rust:mordant:baseline` on the fixed tree (rebased onto main at b1e6c59026) produces exactly the committed `mordant-baseline.toml`.
  - `bun bd test test/js/web/fetch/body.test.ts` (459 pass) and `test/js/workerd/html-rewriter.test.js` (165 pass) with the change.
  - `bun bd test` on `test/js/web/fetch/{body-clone,body-stream,body-mixin-errors,response,blob,fetch,fetch.stream}.test.ts`, `test/js/web/request/{request,request-clone-leak}.test.ts`, `test/js/workerd/html-rewriter*.test.*`, `test/js/bun/http/{serve-body-leak,async-iterator-stream,bun-serve-body-json-async}.test.ts`: same results as an unmodified build of the same base commit, A/B on the same machine (the shared failures are this container's environment and load timeouts; `blob.test.ts` "slice streams only the slice" is red on main independent of this PR and tracked separately).
  - `cargo clippy -p bun_runtime --no-deps` and `cargo fmt --all -- --check` clean.

### Background
- `Body.Value` is the enum behind a `Request`/`Response` body: it holds the bytes directly (`Blob`, `InternalBlob`, `WTFStringImpl`), or is `Locked` while a producer (the HTTP client, a server request, an HTMLRewriter) is still delivering them.
- `AnyBlob` (`webcore::blob::Any`) is the producer-side "some bytes" enum with the same three payload shapes; `Value` adopts one whenever a stream turns out to be fully materialized already. A `WTFStringImpl` is an intrusively refcounted pointer, so the conversion is a plain move of the `+1` the source held.
- `DrainResult` is what a `Locked` body's producer returns from `on_start_streaming` when the body is first turned into a JS `ReadableStream`: `Owned` carries whatever it had buffered so far plus a size hint, `EstimatedSize` carries only the expected total, and `Empty` / `Aborted` mean there is nothing to stream (the callers replace the body with `Null` in that case, before any `ByteStream` exists).
- `ByteStream` is the native source behind that `ReadableStream`. `high_water_mark` picks the chunk size the stream starts with (`on_start`), `size_hint` is the size the still-streaming body reports through `Value::size()` (read by `Bun.inspect`, which prints it as `Response (N bytes)`), and `buffer` is the data the producer had already received.
- mordant's `same_match_twice` reports the later copy of a repeated `match`; `mordant-baseline.toml` records per-(lint, file) counts of accepted findings so CI only fails on new ones. Deleting an entry means CI now fails on the first reappearance.

<details>
<summary>mordant output before the change (baseline line for Body.rs removed)</summary>

```
warning: this `match` on `webcore::blob::Any` repeats an earlier one arm for arm. The mapping exists twice, and a change to one copy will miss the other
    --> src/runtime/webcore/Body.rs:1039:25
note: the other copy
    --> src/runtime/webcore/Body.rs:725:21
    = help: move the mapping into a method on `webcore::blob::Any` and call it from both places

warning: this `match` on `webcore::DrainResult` repeats an earlier one arm for arm. The mapping exists twice, and a change to one copy will miss the other
    --> src/runtime/webcore/Body.rs:1537:9
note: the other copy
    --> src/runtime/webcore/Body.rs:898:9
    = help: move the mapping into a method on `webcore::DrainResult` and call it from both places

warning: mordant: 2 finding(s) over the baseline in bun_runtime
```

After the change the same command finishes with no warnings and no `target/mordant/over-baseline.txt`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/body.test.ts test/js/workerd/html-rewriter.test.js

<!-- robobun:evidence:end -->