### PR TITLE
jsc: dedupe the Msg to BuildMessage/ResolveMessage mapping in process_fetch_log and clear its mordant baseline entry

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -19,7 +19,6 @@
 
 [bun_jsc]
 "defaulted_failure:src/jsc/ConsoleObject.rs" = 4
-"same_match_twice:src/jsc/VirtualMachine.rs" = 1
 
 [bun_parsers]
 "parallel_vecs:src/parsers/xml.rs" = 1

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2963,6 +2963,15 @@ pub fn process_fetch_log(
     // we must convert to UTF-8 here.
     let referrer_utf8 = referrer.to_utf8();
 
+    let msg_to_js = |msg: bun_ast::Msg| -> JSValue {
+        take(match msg.metadata {
+            bun_ast::Metadata::Build => BuildMessage::create(global_this, msg),
+            bun_ast::Metadata::Resolve(_) => {
+                ResolveMessage::create(global_this, &msg, referrer_utf8.slice())
+            }
+        })
+    };
+
     match log.msgs.len() {
         0 => {
             let msg = if err == crate::CrateError::UnexpectedPendingResolution {
@@ -3000,14 +3009,7 @@ pub fn process_fetch_log(
             // Note: `Msg` is not `Copy`, so move it out — the caller deinits
             // the log immediately after, so consuming the vec is sound.
             let msg = log.msgs.swap_remove(0);
-            match msg.metadata {
-                bun_ast::Metadata::Build => take(BuildMessage::create(global_this, msg)),
-                bun_ast::Metadata::Resolve(_) => take(ResolveMessage::create(
-                    global_this,
-                    &msg,
-                    referrer_utf8.slice(),
-                )),
-            }
+            msg_to_js(msg)
         }
 
         _ => {
@@ -3020,14 +3022,7 @@ pub fn process_fetch_log(
             let mut errors_stack: [JSValue; 256] = [JSValue::default(); 256];
             let len = log.msgs.len().min(errors_stack.len());
             for (i, msg) in log.msgs.drain(..len).enumerate() {
-                errors_stack[i] = match msg.metadata {
-                    bun_ast::Metadata::Build => take(BuildMessage::create(global_this, msg)),
-                    bun_ast::Metadata::Resolve(_) => take(ResolveMessage::create(
-                        global_this,
-                        &msg,
-                        referrer_utf8.slice(),
-                    )),
-                };
+                errors_stack[i] = msg_to_js(msg);
             }
 
             take(global_this.create_aggregate_error(

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -140,6 +140,48 @@ test.concurrent(
   },
 );
 
+test("import whose transpile log holds a resolve error rejects with a ResolveMessage next to the BuildMessage", async () => {
+  // A macro import that cannot be resolved is logged by the resolver while the
+  // file is being transpiled, so process_fetch_log sees one Resolve-metadata
+  // message and one Build-metadata message and has to wrap each in the
+  // matching JS class.
+  using dir = tempDir("build-error-resolve-message", {
+    "needs-macro.ts": `
+      import { nope } from "./does-not-exist" with { type: "macro" };
+      export const value = nope();
+    `,
+  });
+
+  let error: any;
+  try {
+    await import(join(String(dir), "needs-macro.ts"));
+    expect.unreachable();
+  } catch (e) {
+    error = e;
+  }
+
+  expect(error).toBeInstanceOf(AggregateError);
+  expect(error.message).toMatch(/^2 errors building ".*needs-macro\.ts"$/);
+  expect(
+    error.errors.map((e: any) => ({
+      name: e.name,
+      message: e.message,
+      ...(e.name === "ResolveMessage" ? { specifier: e.specifier, importKind: e.importKind } : {}),
+    })),
+  ).toEqual([
+    {
+      name: "ResolveMessage",
+      message: 'Macro "./does-not-exist" not found',
+      specifier: "./does-not-exist",
+      importKind: "import-statement",
+    },
+    {
+      name: "BuildMessage",
+      message: '"MacroNotFound" error in macro',
+    },
+  ]);
+});
+
 test("BuildMessage finalize frees with the same allocator it was created with", async () => {
   // BuildMessage.create() clones the message with the passed allocator
   // but finalize() was freeing it with bun.default_allocator and never


### PR DESCRIPTION
### Problem
- mordant `same_match_twice` on `src/jsc/VirtualMachine.rs`: `process_fetch_log` matched on `bun_ast::Metadata` twice, arm for arm (the one-message arm and the loop in the many-messages arm), to pick `BuildMessage::create` vs `ResolveMessage::create`. A change to one copy would miss the other.
- The entry `"same_match_twice:src/jsc/VirtualMachine.rs" = 1` in `mordant-baseline.toml` was carrying it.

### Fix
- Move the mapping into one local `msg_to_js` closure in `process_fetch_log` and call it from both arms. Same inputs (the owned `Msg`, the global, the referrer), same `take(..)` unwrapping, same `JSValue` out, so this is a no behavior change refactor. The zero-messages arm still builds its synthesized `BuildMessage` directly.
- Drop the now-clean baseline entry.
- Add a test to `test/js/bun/resolve/build-error.test.ts` for the `Resolve` arm of this mapping, which nothing exercised through `process_fetch_log` before: importing a file whose macro import does not resolve rejects with an `AggregateError` holding a `ResolveMessage` (specifier, importKind) and a `BuildMessage`. It pins the mapping on both binaries; as a refactor there is no before/after difference for it to catch.
- Verified:
  - `bun bd test test/js/bun/resolve/build-error.test.ts test/js/bun/resolve/resolve-error.test.ts` pass (the existing tests cover the one-message `BuildMessage` path and the 256-entry `AggregateError` path through `process_fetch_log`; the new one covers the `ResolveMessage` path).
  - `bun bd test test/js/bun/plugin/plugins.test.ts test/js/bun/transpiler/transpiler-error-gc-uaf.test.ts` pass (`N errors building ...` via the async module path).
  - A fixture importing a file with a missing macro (`ResolveMessage` inside the `AggregateError`), a file with a syntax error (single `BuildMessage`), and a file with duplicate declarations (`AggregateError` of `BuildMessage`s) prints byte-identical output on this build and on the release binary (details below).
  - The ratchet is what fails before and passes after here, since no runtime test can tell the two versions apart: with this PR's `mordant-baseline.toml` and main's `VirtualMachine.rs`, `bun run rust:mordant` writes `bun_jsc 1` to `target/mordant/over-baseline.txt` (the `same_match_twice` warning at the many-messages loop; this is what fails the `rust-lints` job). With this PR's `VirtualMachine.rs` it writes nothing, and `bun run rust:mordant:baseline` regenerates the file without this entry.

### Background
- `process_fetch_log` runs when a module fails to transpile. It turns the parser's `Log` into the value the import promise rejects with: one message becomes a `BuildMessage` or `ResolveMessage` JS object (chosen by the message's `Metadata`, which is `Resolve` for messages logged by the resolver, e.g. a macro import that cannot be found), and two or more become an `AggregateError` of those objects.
- `take` is the existing local closure that turns the `JsResult<JSValue>` from `create` into the pending exception value on the error path; the new closure wraps the whole match in it, as both copies did per arm.
- `mordant-baseline.toml` is the ratchet for the mordant lint pack run by the `rust-lints` workflow: per (lint, file) counts of pre-existing findings. Removing an entry makes CI fail if the finding ever comes back.

<details>
<summary>Fixture used for the before/after comparison</summary>

```
needs-macro.ts:  import { nope } from "./does-not-exist" with { type: "macro" }; console.log(nope());
syntax-bad.js:   function bad( {
many.js:         const dup = 1; const dup = 2; const dup = 3;
```

Each was dynamically imported and the rejection printed as `{ctor, message, referrer, errors[]}`. Output on this build and on the release `bun` was identical:

```
{"spec":"./needs-macro.ts","ctor":"AggregateError","message":"2 errors building \"[dir]/needs-macro.ts\"","errors":[{"ctor":"ResolveMessage","message":"Macro \"./does-not-exist\" not found","referrer":"undefined"},{"ctor":"BuildMessage","message":"\"MacroNotFound\" error in macro"}]}
{"spec":"./syntax-bad.js","ctor":"BuildMessage","message":"Expected identifier but found end of file"}
{"spec":"./many.js","ctor":"AggregateError","message":"2 errors building \"[dir]/many.js\"","errors":[{"ctor":"BuildMessage","message":"\"dup\" has already been declared"},{"ctor":"BuildMessage","message":"\"dup\" has already been declared"}]}
```

(The `"undefined"` referrer string is pre-existing: `moduleLoaderFetch` passes that literal as the referrer. It is unchanged here and reported separately.)

Regenerating the baseline locally also dropped two entries unrelated to this change (`always_unwrapped_option:src/install/PackageInstall.rs`, already removed by #39130, and `narrowed_two_ways:src/runtime/node/node_crypto_binding.rs`, fixed by #37648). They are left in place here to keep this PR to its one site.

Rebase onto main (09cbfe6): two conflicts, both mechanical. `process_fetch_log` now returns the `JSValue` instead of writing it into an `ErrorableResolvedSource` out-param, so the one-message arm became `msg_to_js(msg)` as the arm's value. The `[bun_jsc]` section of the baseline had shrunk on main in the meantime, so the resolution is main's section minus this one entry. The ratchet was re-run on the rebased tree: main's `VirtualMachine.rs` with this baseline writes `bun_jsc 1` to `target/mordant/over-baseline.txt`, this branch writes nothing. The same tests and the fixture comparison were re-run on the rebased build with the same results.

Second rebase onto main (e6a1692): the source and baseline commit applied cleanly. The only conflict was in `test/js/bun/resolve/build-error.test.ts`, where #40568 added two tests at the same spot as the new test here; both sides are kept (main's tests first). The ratchet, the tests and the fixture comparison were re-run on this tree with the same results.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/build-error.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/resolve/build-error.test.ts:
(pass) BuildError is modifiable [37.11ms]
(pass) import with many build errors keeps AggregateError entries alive across GC [509.75ms]
(pass) unhandled import() of a file that mixes import with module.exports prints the parser's notes [272.08ms]
(pass) import() of a file that mixes import with module.exports rejects with the parser's error [400.40ms]
(pass) import whose transpile log holds a resolve error rejects with a ResolveMessage next to the BuildMessage [22.15ms]
(pass) BuildMessage finalize frees with the same allocator it was created with [1256.84ms]

 6 pass
 0 fail
 55 expect() calls
Ran 6 tests across 1 file. [4.36s]
__F:0:S:0

release without fix: 2 FAILED
bun test v1.4.1-canary.1 (adc354d99)

test/js/bun/resolve/build-error.test.ts:
(pass) BuildError is modifiable [0.57ms]
(pass) import with many build errors keeps AggregateError entries alive across GC [18.59ms]
131 |     });
132 | 
133 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
134 | 
135 |     expect(stdout).toBe("");
136 |     expect(stderr).toContain("error: Cannot use import statement with CommonJS-only features");
                         ^
error: expect(received).toContain(expected)

Expected to contain: "error: Cannot use import statement with CommonJS-only features"
Received: "SyntaxError: Unexpected token '{'. import call expects one or two arguments.\n\nBun v1.4.1-canary.1+adc354d99 (Linux x64)\n"

      at <anonymous> (/workspace/bun/test/js/bun/resolve/build-error.test.ts:136:20)
(fail) unhandled import() of a file that mixes import with module.exports prints the parser's notes [7.83ms]
108 | 
109 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
110 | 
111 |     if (exitCode !== 0) console.error(stderr);
112 |     con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/resolve/build-error.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/resolve/build-error.test.ts:
(pass) BuildError is modifiable [40.76ms]
(pass) import with many build errors keeps AggregateError entries alive across GC [515.74ms]
(pass) import() of a file that mixes import with module.exports rejects with the parser's error [335.38ms]
(pass) unhandled import() of a file that mixes import with module.exports prints the parser's notes [342.32ms]
(pass) import whose transpile log holds a resolve error rejects with a ResolveMessage next to the BuildMessage [22.47ms]
(pass) BuildMessage finalize frees with the same allocator it was created with [1303.31ms]

 6 pass
 0 fail
 55 expect() calls
Ran 6 tests across 1 file. [4.30s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 658ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_js
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
mordant-baseline.toml                   |  1 -
 src/jsc/VirtualMachine.rs               | 27 +++++++++------------
 test/js/bun/resolve/build-error.test.ts | 42 +++++++++++++++++++++++++++++++++
 3 files changed, 53 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 1 passed · 4 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
mordant-baseline.toml                        2      1      0
src/jsc/VirtualMachine.rs                    2      5      0
test/js/bun/resolve/build-error.test.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->