### PR TITLE
css: add the missing comma before the alpha when downleveling rgb() with an unresolved alpha

### DIFF
--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -908,6 +908,7 @@ impl UnresolvedColor {
                     css_parser::to_css::integer(conv(*g), dest)?;
                     dest.delim(b',', false)?;
                     css_parser::to_css::integer(conv(*b), dest)?;
+                    dest.delim(b',', false)?;
                     alpha.to_css(dest, is_custom_property)?;
                     dest.write_char(b')')?;
                     return Ok(());

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7811,6 +7811,135 @@ describe("css tests", () => {
       );
     });
 
+    // rgb()/hsl() whose alpha is only known at runtime (var(), calc(var()), ...)
+    // are downleveled to the legacy comma syntax for targets without
+    // space-separated color notation. Every component, including the alpha,
+    // has to be comma separated there or the declaration is invalid.
+    describe("unresolved alpha downleveled to rgba()/hsla()", () => {
+      const legacyOnly = { chrome: 60 << 16 };
+      const modern = { chrome: 90 << 16 };
+
+      prefix_test(
+        ".foo { color: rgb(12 34 56 / var(--alpha)); }",
+        indoc`
+          .foo {
+            color: rgba(12, 34, 56, var(--alpha));
+          }
+        `,
+        legacyOnly,
+      );
+      prefix_test(
+        ".foo { color: rgb(12 34 56 / var(--alpha, 50%)); }",
+        indoc`
+          .foo {
+            color: rgba(12, 34, 56, var(--alpha, 50%));
+          }
+        `,
+        legacyOnly,
+      );
+      prefix_test(
+        ".foo { color: rgb(12 34 56 / calc(var(--alpha) * 2)); }",
+        indoc`
+          .foo {
+            color: rgba(12, 34, 56, calc(var(--alpha) * 2));
+          }
+        `,
+        legacyOnly,
+      );
+      prefix_test(
+        ".foo { color: rgb(5% 50% 100% / var(--alpha)); }",
+        indoc`
+          .foo {
+            color: rgba(13, 128, 255, var(--alpha));
+          }
+        `,
+        legacyOnly,
+      );
+      prefix_test(
+        ".foo { --x: rgb(12 34 56 / var(--alpha)); }",
+        indoc`
+          .foo {
+            --x: rgba(12, 34, 56, var(--alpha));
+          }
+        `,
+        legacyOnly,
+      );
+      prefix_test(
+        ".foo { box-shadow: 0 0 4px rgb(12 34 56 / var(--alpha)); }",
+        indoc`
+          .foo {
+            box-shadow: 0 0 4px rgba(12, 34, 56, var(--alpha));
+          }
+        `,
+        legacyOnly,
+      );
+      prefix_test(
+        ".foo { color: rgb(from light-dark(yellow, red) r g b / var(--alpha)); }",
+        indoc`
+          .foo {
+            color: var(--buncss-light, rgba(255, 255, 0, var(--alpha))) var(--buncss-dark, rgba(255, 0, 0, var(--alpha)));
+          }
+        `,
+        legacyOnly,
+      );
+      prefix_test(
+        ".foo { color: light-dark(rgb(12 34 56 / var(--alpha)), hsl(200 30% 40% / var(--alpha))); }",
+        indoc`
+          .foo {
+            color: var(--buncss-light, rgba(12, 34, 56, var(--alpha))) var(--buncss-dark, hsla(200, 30%, 40%, var(--alpha)));
+          }
+        `,
+        legacyOnly,
+      );
+      prefix_test(
+        ".foo { color: hsl(200 30% 40% / var(--alpha)); }",
+        indoc`
+          .foo {
+            color: hsla(200, 30%, 40%, var(--alpha));
+          }
+        `,
+        legacyOnly,
+      );
+      prefix_test(
+        ".foo { --x: hsl(200 30% 40% / var(--alpha)); }",
+        indoc`
+          .foo {
+            --x: hsla(200, 30%, 40%, var(--alpha));
+          }
+        `,
+        legacyOnly,
+      );
+
+      // Targets that support the modern syntax keep it as written.
+      prefix_test(
+        ".foo { color: rgb(12 34 56 / var(--alpha)); }",
+        indoc`
+          .foo {
+            color: rgb(12 34 56 / var(--alpha));
+          }
+        `,
+        modern,
+      );
+      prefix_test(
+        ".foo { --x: rgb(12 34 56 / var(--alpha)); }",
+        indoc`
+          .foo {
+            --x: rgb(12 34 56 / var(--alpha));
+          }
+        `,
+        modern,
+      );
+      prefix_test(
+        ".foo { color: hsl(200 30% 40% / var(--alpha)); }",
+        indoc`
+          .foo {
+            color: hsl(200 30% 40% / var(--alpha));
+          }
+        `,
+        modern,
+      );
+    });
+
     // Deeply nested @keyframes with invalid percentages
     describe("nested keyframes", () => {
       cssTest(


### PR DESCRIPTION
### Problem
- When the CSS targets lack space-separated color notation, `rgb(12 34 56 / var(--alpha))` is printed as `rgba(12, 34, 56var(--alpha))`: there is no comma between the blue channel and the alpha, so the declaration is invalid and browsers drop it.
- Same for every place such a value can appear (`color:`, `box-shadow:`, custom properties, relative colors, inside the `light-dark()` downlevel); `hsl()` is printed correctly as `hsla(200, 30%, 40%, var(--alpha))`.
- Cause: `UnresolvedColor::to_css` in `src/css/properties/custom.rs:905-913` writes `r`, `,`, `g`, `,`, `b` and then the alpha token list directly. The `HSL` arm right below it (line 937) writes the `,` before the alpha; the `RGB` arm never did (the Zig version had the same omission, so this is not a regression of the Rust port).
- In a release build this branch is reached through the `bun:internal-for-testing` CSS hooks; the bundler's own browser defaults (chrome 87, edge 88, firefox 78, safari 14) all support the modern syntax, and older targets can currently only be set through the `BUN_DEBUG_CSS_TARGET_*` overrides of debug builds.

### Fix
- Add the `dest.delim(b',', false)` between the blue channel and the alpha, identical to the `HSL` arm and to the `rgba()` fallback for resolved colors in `src/css/values/color.rs:465-470`.
- The legacy `rgba()` syntax is comma separated for all four arguments, and the alpha token list prints nothing of its own in front of the value, so the printer has to write that comma. With this change bun's output for the repro (pretty and minified) is byte-identical to lightningcss 1.30.2 with the same `chrome: 60` target.
- Test: new `unresolved alpha downleveled to rgba()/hsla()` block in `test/js/bun/css/css.test.ts`. 8 cases cover the rgb paths that were wrong (`color`, `var()` with fallback, `calc()` alpha, percentage channels, a custom property, `box-shadow`, relative color from `light-dark()`, `rgb()` nested in `light-dark()`); the hsl and modern-target cases pin the output that was already right. The 8 rgb cases fail on bun 1.4.0 and pass with this change.
- `bun bd test test/js/bun/css/css.test.ts`: 1155 pass, 0 fail.
- `bun bd build --target=browser` with `BUN_DEBUG_CSS_TARGET_chrome="60 << 16"` now prints `rgba(12, 34, 56, var(--alpha))` (and `rgba(12,34,56,var(--alpha))` with `--minify`); the default targets still print `rgb(12 34 56 / var(--alpha))` unchanged.

### Background
- `UnresolvedColor` (`src/css/properties/custom.rs`) is what the parser produces for an `rgb()`/`hsl()` whose channels are known at build time but whose alpha is a token list it cannot evaluate (`var()`, `calc(var())`, ...). It exists so that such a color can still be rewritten between the modern slash syntax and the legacy comma syntax; a fully opaque token list could not be, since a variable may expand to any number of tokens.
- `Printer::delim(b',', false)` writes the delimiter followed by a space, or just the delimiter when minifying; it is how every comma separated list in the CSS printer is emitted.
- `Targets::should_compile_same(Feature::SpaceSeparatedColorNotation)` is true when at least one target browser predates `rgb(r g b / a)` (chrome 65, firefox 52, safari 12.1, edge 79), which selects the legacy `rgba()`/`hsla()` output.
