### PR TITLE
Bun.build: keep publicPath for standalone HTML compile builds

### DIFF
--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1209,13 +1209,11 @@ pub mod js_bundler {
                         this.define.insert(key, value)?;
                     }
 
-                    // The executable loads its modules and assets (e.g. yoga.wasm)
-                    // out of the embedded virtual filesystem, so that root
-                    // replaces any publicPath the caller passed.
                     let base_public_path = StandaloneModuleGraph::target_base_public_path(
                         compile.compile_target.os,
                         b"root/",
                     );
+                    // Replaces any publicPath: executable assets live in the virtual filesystem.
                     this.public_path.reset();
                     this.public_path.append(base_public_path)?;
 

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1209,10 +1209,14 @@ pub mod js_bundler {
                         this.define.insert(key, value)?;
                     }
 
+                    // The executable loads its modules and assets (e.g. yoga.wasm)
+                    // out of the embedded virtual filesystem, so that root
+                    // replaces any publicPath the caller passed.
                     let base_public_path = StandaloneModuleGraph::target_base_public_path(
                         compile.compile_target.os,
                         b"root/",
                     );
+                    this.public_path.reset();
                     this.public_path.append(base_public_path)?;
 
                     // When using --compile, only `external` sourcemaps work, as we do not

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1004,44 +1004,15 @@ impl CompletionStruct for JSBundleCompletionTask {
 
         transpiler.options.output_format = config.format;
         transpiler.options.bytecode = config.bytecode;
-
-        let compile_to_standalone_html = 'brk: {
-            if config.compile.is_none() || config.target != bun_ast::Target::Browser {
-                break 'brk false;
-            }
-            // Only activate standalone HTML when all entrypoints are HTML files
-            for ep in config.entry_points.keys() {
-                if !ep.ends_with(b".html") {
-                    break 'brk false;
-                }
-            }
-            config.entry_points.count() > 0
+        transpiler.options.compile_mode = if config.compile.is_some() {
+            options::CompileMode::Executable
+        } else {
+            options::CompileMode::None
         };
-        // When compiling to standalone HTML, don't use the bun executable compile path
-        if compile_to_standalone_html {
-            config.compile = None;
-        }
 
-        match &config.compile {
-            Some(compile_opts) => {
-                transpiler.options.compile_mode = options::CompileMode::Executable;
-                // Executables load emitted asset paths (e.g. yoga.wasm) out of
-                // the embedded virtual filesystem. Standalone HTML is fetched by
-                // a browser, so it keeps the caller's publicPath like the CLI does.
-                transpiler.options.public_path = Box::from(target_base_public_path(
-                    compile_opts.compile_target.os,
-                    b"root/",
-                ));
-            }
-            None => {
-                transpiler.options.compile_mode = if compile_to_standalone_html {
-                    options::CompileMode::StandaloneHtml
-                } else {
-                    options::CompileMode::None
-                };
-                transpiler.options.public_path = Box::from(config.public_path.list.as_slice());
-            }
-        }
+        // Executable builds already had their public_path replaced with the
+        // virtual filesystem root in `Config::from_js`.
+        transpiler.options.public_path = Box::from(config.public_path.list.as_slice());
 
         transpiler.options.output_dir = Box::from(config.outdir.list.as_slice());
         transpiler.options.root_dir = Box::from(config.rootdir.list.as_slice());
@@ -1066,6 +1037,23 @@ impl CompletionStruct for JSBundleCompletionTask {
         transpiler.options.ignore_dce_annotations = config.ignore_dce_annotations;
         transpiler.options.tree_shaking_override = config.tree_shaking;
         transpiler.options.css_chunking = config.css_chunking;
+        let compile_to_standalone_html = 'brk: {
+            if config.compile.is_none() || config.target != bun_ast::Target::Browser {
+                break 'brk false;
+            }
+            // Only activate standalone HTML when all entrypoints are HTML files
+            for ep in config.entry_points.keys() {
+                if !ep.ends_with(b".html") {
+                    break 'brk false;
+                }
+            }
+            config.entry_points.count() > 0
+        };
+        // When compiling to standalone HTML, don't use the bun executable compile path
+        if compile_to_standalone_html {
+            transpiler.options.compile_mode = options::CompileMode::StandaloneHtml;
+            config.compile = None;
+        }
         // `BundleOptions.{banner,footer}` are `Cow<'static, [u8]>`; clone into
         // Owned so the static bound holds without tying `&mut self` to `'a`.
         transpiler.options.banner = std::borrow::Cow::Owned(config.banner.list.clone());

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1004,20 +1004,43 @@ impl CompletionStruct for JSBundleCompletionTask {
 
         transpiler.options.output_format = config.format;
         transpiler.options.bytecode = config.bytecode;
-        transpiler.options.compile_mode = if config.compile.is_some() {
-            options::CompileMode::Executable
-        } else {
-            options::CompileMode::None
-        };
 
-        // For compile mode, set the public_path to the target-specific base path
-        // This ensures embedded resources like yoga.wasm are correctly found
-        if let Some(compile_opts) = &config.compile {
-            let base_public_path =
-                target_base_public_path(compile_opts.compile_target.os, b"root/");
-            transpiler.options.public_path = Box::from(base_public_path);
-        } else {
-            transpiler.options.public_path = Box::from(config.public_path.list.as_slice());
+        let compile_to_standalone_html = 'brk: {
+            if config.compile.is_none() || config.target != bun_ast::Target::Browser {
+                break 'brk false;
+            }
+            // Only activate standalone HTML when all entrypoints are HTML files
+            for ep in config.entry_points.keys() {
+                if !ep.ends_with(b".html") {
+                    break 'brk false;
+                }
+            }
+            config.entry_points.count() > 0
+        };
+        // When compiling to standalone HTML, don't use the bun executable compile path
+        if compile_to_standalone_html {
+            config.compile = None;
+        }
+
+        match &config.compile {
+            Some(compile_opts) => {
+                transpiler.options.compile_mode = options::CompileMode::Executable;
+                // Executables load emitted asset paths (e.g. yoga.wasm) out of
+                // the embedded virtual filesystem. Standalone HTML is fetched by
+                // a browser, so it keeps the caller's publicPath like the CLI does.
+                transpiler.options.public_path = Box::from(target_base_public_path(
+                    compile_opts.compile_target.os,
+                    b"root/",
+                ));
+            }
+            None => {
+                transpiler.options.compile_mode = if compile_to_standalone_html {
+                    options::CompileMode::StandaloneHtml
+                } else {
+                    options::CompileMode::None
+                };
+                transpiler.options.public_path = Box::from(config.public_path.list.as_slice());
+            }
         }
 
         transpiler.options.output_dir = Box::from(config.outdir.list.as_slice());
@@ -1043,23 +1066,6 @@ impl CompletionStruct for JSBundleCompletionTask {
         transpiler.options.ignore_dce_annotations = config.ignore_dce_annotations;
         transpiler.options.tree_shaking_override = config.tree_shaking;
         transpiler.options.css_chunking = config.css_chunking;
-        let compile_to_standalone_html = 'brk: {
-            if config.compile.is_none() || config.target != bun_ast::Target::Browser {
-                break 'brk false;
-            }
-            // Only activate standalone HTML when all entrypoints are HTML files
-            for ep in config.entry_points.keys() {
-                if !ep.ends_with(b".html") {
-                    break 'brk false;
-                }
-            }
-            config.entry_points.count() > 0
-        };
-        // When compiling to standalone HTML, don't use the bun executable compile path
-        if compile_to_standalone_html {
-            transpiler.options.compile_mode = options::CompileMode::StandaloneHtml;
-            config.compile = None;
-        }
         // `BundleOptions.{banner,footer}` are `Cow<'static, [u8]>`; clone into
         // Owned so the static bound holds without tying `&mut self` to `'a`.
         transpiler.options.banner = std::borrow::Cow::Owned(config.banner.list.clone());

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1009,11 +1009,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         } else {
             options::CompileMode::None
         };
-
-        // Executable builds already had their public_path replaced with the
-        // virtual filesystem root in `Config::from_js`.
         transpiler.options.public_path = Box::from(config.public_path.list.as_slice());
-
         transpiler.options.output_dir = Box::from(config.outdir.list.as_slice());
         transpiler.options.root_dir = Box::from(config.rootdir.list.as_slice());
         transpiler.options.minify_syntax = config.minify.syntax;

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import { basename } from "node:path";
 
@@ -393,6 +393,46 @@ body { color: blue; }`,
     expect(result.success).toBe(true);
   });
 
+  // Writing the executable copies the whole bun binary, which can exceed the
+  // default timeout under debug + ASAN.
+  const EXECUTABLE_TIMEOUT = 60_000;
+
+  test(
+    "executable fallback replaces publicPath with the virtual filesystem root",
+    async () => {
+      using dir = tempDir("compile-browser-no-html-public-path", {
+        "app.js": `
+          import asset from "./data.bin" with { type: "file" };
+          import { readFileSync } from "node:fs";
+          console.log(JSON.stringify({ asset, content: readFileSync(asset, "utf8") }));
+        `,
+        "data.bin": "embedded",
+      });
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/app.js`],
+        compile: { outfile: `${dir}/app` },
+        target: "browser",
+        publicPath: "https://cdn.example.com/assets/",
+      });
+      expect(result.success).toBe(true);
+
+      await using proc = Bun.spawn({
+        cmd: [`${dir}/app${isWindows ? ".exe" : ""}`],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const { asset, content } = JSON.parse(stdout);
+      expect(asset).toStartWith(isWindows ? "B:/~BUN/root/" : "/$bunfs/root/");
+      expect(content).toBe("embedded");
+      expect(exitCode).toBe(0);
+    },
+    EXECUTABLE_TIMEOUT,
+  );
+
   test("CLI --compile --target=browser with non-HTML falls back to normal compile", async () => {
     using dir = tempDir("compile-browser-cli-no-html", {
       "app.js": `console.log("test");`,
@@ -638,8 +678,8 @@ console.log(greet("world"));`,
       expect(mapFile).toMatch(/\.js\.map$/);
 
       // The inline <script> must reference the .map artifact relative to the
-      // HTML document, like the CLI does, not the virtual filesystem root that
-      // executable builds use ("/$bunfs/root/" or "B:/~BUN/root/").
+      // HTML document, not the virtual filesystem root executable builds use
+      // ("/$bunfs/root/" or "B:/~BUN/root/").
       const html = await htmlOutput!.text();
       expect(html).toContain(`//# sourceMappingURL=./${mapFile}\n</script>`);
 

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { existsSync } from "node:fs";
+import { basename } from "node:path";
 
 describe("compile --target=browser", () => {
   test("inlines JS and CSS into HTML", async () => {
@@ -633,12 +634,66 @@ console.log(greet("world"));`,
       expect(htmlOutput).toBeDefined();
       expect(mapOutput).toBeDefined();
 
+      const mapFile = basename(mapOutput!.path);
+      expect(mapFile).toMatch(/\.js\.map$/);
+
+      // The inline <script> must reference the .map artifact relative to the
+      // HTML document, like the CLI does, not the virtual filesystem root that
+      // executable builds use ("/$bunfs/root/" or "B:/~BUN/root/").
       const html = await htmlOutput!.text();
-      expect(html).toContain("//# sourceMappingURL=");
+      expect(html).toContain(`//# sourceMappingURL=./${mapFile}\n</script>`);
 
       const map = JSON.parse(await mapOutput!.text());
       expect(map.version).toBe(3);
       expect(map.sourcesContent.join("\n")).toContain("function greet(name: string): string {");
+    });
+
+    test("Bun.build() with sourcemap: 'linked' prefixes the sourceMappingURL with publicPath", async () => {
+      using dir = tempDir("compile-browser-sourcemap-api-public-path", fixture);
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/index.html`],
+        compile: true,
+        target: "browser",
+        sourcemap: "linked",
+        publicPath: "https://cdn.example.com/assets/",
+      });
+
+      expect(result.success).toBe(true);
+      const htmlOutput = result.outputs.find(o => o.loader === "html");
+      const mapOutput = result.outputs.find(o => o.kind === "sourcemap");
+      expect(htmlOutput).toBeDefined();
+      expect(mapOutput).toBeDefined();
+
+      const mapFile = basename(mapOutput!.path);
+      const html = await htmlOutput!.text();
+      expect(html).toContain(`//# sourceMappingURL=https://cdn.example.com/assets/${mapFile}\n</script>`);
+    });
+
+    test("Bun.build() with sourcemap: 'linked' and outdir links the .map written next to the HTML", async () => {
+      using dir = tempDir("compile-browser-sourcemap-api-outdir", fixture);
+      const outdir = `${dir}/dist`;
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/index.html`],
+        compile: true,
+        target: "browser",
+        sourcemap: "linked",
+        outdir,
+      });
+
+      expect(result.success).toBe(true);
+      const files = Array.from(new Bun.Glob("**/*").scanSync({ cwd: outdir })).sort();
+      expect(files).toHaveLength(2);
+      expect(files).toContain("index.html");
+      const mapFile = files.find(f => f.endsWith(".js.map"))!;
+      expect(mapFile).toBeDefined();
+
+      const html = await Bun.file(`${outdir}/index.html`).text();
+      expect(html).toContain(`//# sourceMappingURL=./${mapFile}\n</script>`);
+
+      const map = await Bun.file(`${outdir}/${mapFile}`).json();
+      expect(map.version).toBe(3);
     });
 
     test("Bun.build() with sourcemap: 'inline' keeps a single HTML output", async () => {


### PR DESCRIPTION
### Problem
- `Bun.build({ entrypoints: ["index.html"], compile: true, target: "browser", sourcemap: "linked" })` inlines the script into the HTML with `//# sourceMappingURL=/$bunfs/root/chunk-xxxxxxxx.js.map` (`B:/~BUN/root/...` when targeting Windows), a URL no browser can fetch. The `.map` artifact itself is emitted next to the HTML.
- Passing `publicPath` to the same build is ignored: the comment still says `/$bunfs/root/...`.
- Cause: the public path for a compile build was decided in two places that disagree. `Config::from_js` (`src/runtime/api/JSBundler.rs`) decides whether the build is standalone HTML and only applies the virtual filesystem root to executables, but `configure_bundler` (`src/runtime/api/js_bundle_completion_task.rs`) then threw that away and applied the root again to anything with `compile` set, standalone HTML included. The linked sourcemap comment is built from that public path.
- The `from_js` copy also had a latent bug of its own: it appended the root to the caller's `publicPath` instead of replacing it (`"https://cdn/" + "/$bunfs/root/"`). Nothing observed this because `configure_bundler` overwrote the value.

### Fix
- `Config::from_js` becomes the only place that sets the public path for compile builds: it resets `public_path` before writing the virtual root, so executables get exactly the root whatever `publicPath` the caller passed, and standalone HTML is left with the caller's `publicPath` (or none).
- `configure_bundler` copies `config.public_path` unchanged instead of re-deciding. The standalone HTML detection it already does for `compile_mode` is untouched.
- Correct because the virtual root only means something to a compiled executable, which loads its modules and assets out of the embedded filesystem. Standalone HTML is loaded by a browser, so its public path should do what it does for any browser build: prefix emitted URLs, or leave them relative to the document. Executables see no change: their public path was already the root, now it is set once instead of twice.
- Tests in `test/bundler/standalone.test.ts`:
  - the existing `sourcemap: "linked"` API test now asserts the comment is `./<map artifact>`; two new tests cover `publicPath` (comment becomes `https://cdn.example.com/assets/<map>`) and `outdir` (comment names the `.map` written next to `index.html`). These three fail on the current build with `/$bunfs/root/` in the comment and pass with this change.
  - a new guard test builds an executable through `Bun.build` with `publicPath` set and runs it: the file-loader asset path must start with the virtual root and be readable. With `configure_bundler` no longer overriding, this is what protects the executable path; checked that it fails (asset path `https://cdn.example.com/assets//$bunfs/root/data-xxxxxxxx.bin`, ENOENT) if the `reset()` is dropped.
- Other runs, all green with this change: `compile-asset-bunfs.test.ts`, `bun-build-compile.test.ts`, `bun-build-compile-sourcemap.test.ts` (includes a test asserting `/$bunfs/root/` paths still appear in executables built through `Bun.build`), `bun-build-compile-wasm.test.ts`, `bundler_html_server.test.ts`, `bundler_compile.test.ts -t HelloWorldWithProcessVersionsBunAPI`, `test/js/bun/http/bun-serve-html.test.ts` (the other producer of this config, which never sets `compile`).
- Out of scope: the CLI keeps its own copy of this logic in `build_command.rs`. Its linked sourcemap comment for standalone HTML is already relative, but it forces `target=bun` and injects the compile-target defines before making the standalone decision, so `bun build --compile --target=browser index.html` accepts `bun:` imports and inlines `process.platform` into the document. That is a CLI behavior change and is tracked separately.

### Background
- `compile: true` normally produces a single executable. Its bundled modules and assets are embedded and addressed at runtime through a virtual filesystem rooted at `/$bunfs/root/` (`B:/~BUN/root/` for Windows targets). The bundler sets `public_path` to that root for executable builds so every emitted path (split chunks, file-loader assets such as `.wasm`) resolves inside the embedded filesystem.
- Standalone HTML is the other flavor of `compile`: when the target is `browser` and every entrypoint is an `.html` file, the bundler instead inlines the JS and CSS chunks into the HTML document (`CompileMode::StandaloneHtml`). The HTML is served to a browser, not run by bun, so the virtual root has no meaning for it.
- `public_path` is the bundler's URL prefix for emitted references (`publicPath` in `Bun.build`, `--public-path` on the CLI). With `sourcemap: "linked"` the inlined script's `sourceMappingURL` is either `public_path + <map path>` or, when `public_path` is empty, a path relative to the HTML document.
- `Config` is the parsed `Bun.build` options object. `Config::from_js` fills it on the JS thread; `configure_bundler` later copies it into the bundler's options on the bundle thread. `Bun.serve` HTML routes build the same `Config` directly and never set `compile`, so they only ever took the copy-through path.

<details>
<summary>Earlier revision of this PR</summary>

The first push kept both decision sites and instead reordered `configure_bundler` so that its standalone HTML detection ran before its public path override. Review pointed out that the `from_js` site already made the decision and that the override in `configure_bundler` was what masked the append bug there, so the PR now removes the second site instead of reordering it, and adds the executable guard test.
</details>
