### PR TITLE
test: replace the dead REACT_COMPILER_FIXTURE_SNAPSHOT mode in react-compiler-fixtures.test.ts with a dump directory

### DIFF
--- a/test/bundler/transpiler/react-compiler-fixtures.test.ts
+++ b/test/bundler/transpiler/react-compiler-fixtures.test.ts
@@ -15,6 +15,17 @@
 // parse, so we retry with the failing files removed (their build error is
 // recorded and asserted on in that fixture's test case).
 //
+// The assertions below only look at slot counts, so to see what a compiler
+// change does to the actual output of the whole corpus, dump both build passes
+// before and after the change and diff the two trees:
+//
+//   REACT_COMPILER_FIXTURE_DUMP=/tmp/rc-before bun bd test test/bundler/transpiler/react-compiler-fixtures.test.ts
+//   REACT_COMPILER_FIXTURE_DUMP=/tmp/rc-after  bun bd test test/bundler/transpiler/react-compiler-fixtures.test.ts
+//   diff -ru /tmp/rc-before /tmp/rc-after
+//
+// Each fixture becomes `<dir>/{plain,minify}/<fixture>.js` holding its output,
+// or a `// build error` comment followed by the error when it failed to build.
+//
 // ## Pragma handling
 //
 // Upstream's snap harness parses `// @key value` directives from each fixture
@@ -26,10 +37,10 @@
 //   - relaxes the slot-count check when the effective `compilationMode` differs
 //     from Bun's hardcoded `infer` default (upstream's snap default is `all`).
 
-import { describe, test, expect, beforeAll } from "bun:test";
-import { readFileSync, existsSync } from "node:fs";
-import { join, basename } from "node:path";
-import { isDebug, isASAN } from "harness";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { isASAN, isDebug } from "harness";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
 
 const FIXTURE_ROOT = join(import.meta.dir, "react-compiler-fixtures");
 // `parse_fixture_pragmas` and the lint-mode validation passes are
@@ -37,7 +48,7 @@ const FIXTURE_ROOT = join(import.meta.dir, "react-compiler-fixtures");
 // builds without ASAN compile them out, so pragma-gated fixtures cannot be
 // validated there.
 const HAS_FIXTURE_PRAGMA_SUPPORT = isDebug || isASAN;
-const SNAPSHOT_BUN_OUTPUT = !!process.env.REACT_COMPILER_FIXTURE_SNAPSHOT;
+const DUMP_DIR = process.env.REACT_COMPILER_FIXTURE_DUMP;
 const FILTER = process.env.REACT_COMPILER_FIXTURE_FILTER;
 
 const INPUT_EXTS = [".js", ".jsx", ".ts", ".tsx", ".mjs"];
@@ -381,9 +392,21 @@ async function compileInto(into: Compiled, minify: false | { syntax: true }): Pr
   }
 }
 
+function dumpInto(dir: string, results: Compiled): void {
+  for (const [name, result] of results) {
+    const path = join(dir, name + ".js");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, "output" in result ? result.output : `// build error\n${result.error}\n`);
+  }
+}
+
 async function compileAll(): Promise<void> {
   await compileInto(compiled, false);
   await compileInto(compiledMinify, { syntax: true });
+  if (DUMP_DIR) {
+    dumpInto(join(DUMP_DIR, "plain"), compiled);
+    dumpInto(join(DUMP_DIR, "minify"), compiledMinify);
+  }
 }
 
 describe("react-compiler upstream fixtures", () => {
@@ -424,10 +447,6 @@ describe("react-compiler upstream fixtures", () => {
       if (result == null) throw new Error(`no Bun.build result recorded for fixture "${name}"`);
       const output = "output" in result ? result.output : "";
       const buildError = "error" in result ? result.error : null;
-
-      if (SNAPSHOT_BUN_OUTPUT) {
-        expect({ buildError, output }).toMatchSnapshot();
-      }
 
       if (isErrorFixture || isBailFixture) {
         // Upstream expects a compile error / bailout. Bun may surface this as a


### PR DESCRIPTION
### Problem
- `test/bundler/transpiler/react-compiler-fixtures.test.ts` carries a debugging mode, `REACT_COMPILER_FIXTURE_SNAPSHOT=1`, meant to record every upstream fixture's output with `toMatchSnapshot()` so a compiler change can be diffed across the whole corpus (the assertions themselves only compare `_c(N)` slot counts).
- It has never worked: the `toMatchSnapshot()` call sits inside the per-fixture `compile` case, which is registered with `test.concurrent` (`react-compiler-fixtures.test.ts:401`), and bun:test refuses snapshot matchers inside concurrent tests (`SnapshotInConcurrentGroup`, `src/runtime/test_runner/expect.rs`). With the env var set all 1646 `compile` cases fail with `error: Snapshot matchers are not supported in concurrent tests` and the `.snap` is a 55 byte header. Both halves shipped together in the initial commit of the file.
- Even repaired, that shape is a poor tool: it records only the first of the file's two build passes (`compiled`, not `compiledMinify`), and it writes a 1.9 MB untracked `__snapshots__/react-compiler-fixtures.test.ts.snap` into the tree.

### Fix
- Remove the snapshot mode and replace it with `REACT_COMPILER_FIXTURE_DUMP=<dir>`: after the two build passes, `compileAll()` writes every fixture's output to `<dir>/plain/<fixture>.js` and `<dir>/minify/<fixture>.js` (a `// build error` comment plus the error text for fixtures that failed to build). Two dumps are compared with `diff -r`; the header comment documents the three commands.
- This is the same idiom as the other hand-run knobs in the suite (`WPT_STREAMS_RECORD` in `test/js/third_party/wpt-streams/wpt-streams.test.ts`, `REACT_COMPILER_FIXTURE_FILTER` in this file): an env var read at module level, plain `node:fs` writes, nothing registered with bun:test. It does not depend on how bun:test schedules the cases, which is what broke the old mode, so the `compile` cases stay `test.concurrent` and the normal run is unchanged.
- Like those knobs it has no test of its own; it is only ever exercised by hand. Verified locally on a debug build:
  - `bun bd test test/bundler/transpiler/react-compiler-fixtures.test.ts`: 3293 pass, 320 skip, 0 fail, same as main.
  - `REACT_COMPILER_FIXTURE_DUMP=/tmp/rc-a ...` and `=/tmp/rc-b ...`: 1646 files under each of `plain/` and `minify/` (162 of them build errors, nested fixture directories created), `diff -r /tmp/rc-a /tmp/rc-b` is empty, and `plain/` vs `minify/` differ in 1462 files, so both passes are captured and a baseline is reproducible.
  - `REACT_COMPILER_FIXTURE_FILTER=while-break REACT_COMPILER_FIXTURE_DUMP=...`: dumps just the two matching fixtures.
  - On main, `REACT_COMPILER_FIXTURE_SNAPSHOT=1 bun bd test ... -u` reports 1646 fail.
- Test-only change; nothing under `src/` is touched. The import lines are reordered by `bun run prettier`.

### Background
- The file builds the whole fixture corpus twice in `beforeAll` (`compileAll`), once plain and once with `minify: { syntax: true }`, into two `Map<fixture, { output } | { error }>`; the per-fixture cases only read those maps. The dump is a third consumer of the same maps, so it sees exactly what the assertions see.
- bun:test derives a snapshot's name from the test currently executing. Inside a concurrent group several tests are in flight at once, so there is no single current test and `toMatchSnapshot()` throws rather than guess. That is why the old mode could not work from a `test.concurrent` case.

<details>
<summary>Earlier version of this PR</summary>

The first push kept the `toMatchSnapshot()` mode and made it work by registering the `compile` cases with `test.serial` while the env var was set, plus a case that re-ran the file in a child process to keep the mode alive. Review of that version pointed out the problems listed under Problem (one build pass recorded, untracked `.snap` in the tree, a second-binary test with its own timeout to guard a hand-run knob), and that a dump hook is both smaller and more useful, so the branch was reworked into the current shape.

</details>

<details>
<summary>Failure on main with the old env var set</summary>

```
$ REACT_COMPILER_FIXTURE_SNAPSHOT=1 bun bd test test/bundler/transpiler/react-compiler-fixtures.test.ts -u
...
429 |         expect({ buildError, output }).toMatchSnapshot();
                                             ^
error: Snapshot matchers are not supported in concurrent tests
...
 1647 pass
 320 skip
 1646 fail
$ wc -c test/bundler/transpiler/__snapshots__/react-compiler-fixtures.test.ts.snap
55
```

</details>
