### PR TITLE
install: make PackageID and DependencyID newtypes and index the lockfile buffers by them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
  "bun_core",
  "bun_semver",
  "bun_wyhash",
+ "bytemuck",
  "const_format",
  "enum-map",
  "enumset",

--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -11,7 +11,6 @@
 
 [bun_install]
 "defaulted_failure:src/install/npm.rs" = 1
-"interchangeable_aliases:src/install/lockfile/Tree.rs" = 1
 
 [bun_js_parser]
 "same_match_twice:src/js_parser/p.rs" = 3

--- a/src/collections/id_slice.rs
+++ b/src/collections/id_slice.rs
@@ -139,7 +139,10 @@ impl<I, T: fmt::Debug> fmt::Debug for IdSlice<I, T> {
 
 /// A `Vec<T>` whose positions are `I`s; derefs to [`IdSlice`]. The `Vec`
 /// itself is reachable through [`raw`](IdVec::raw) / [`raw_mut`](IdVec::raw_mut)
-/// for the operations not forwarded here.
+/// for the operations not forwarded here. Anything not forwarded resolves to
+/// the *slice* through `Deref`; that matters for `as_ptr` / `as_mut_ptr`,
+/// whose slice versions only cover the initialized `len` elements, so code
+/// that fills reserved capacity must take the pointer from `raw_mut()`.
 #[repr(transparent)]
 pub struct IdVec<I, T> {
     raw: Vec<T>,

--- a/src/collections/id_slice.rs
+++ b/src/collections/id_slice.rs
@@ -1,0 +1,292 @@
+//! Slices and vectors whose positions are an id newtype rather than `usize`.
+//!
+//! [`IdSlice<I, T>`] is a `[T]` that is subscripted with an `I`, so a buffer
+//! indexed by one kind of id rejects the other kind at compile time. It derefs
+//! to the plain slice for everything that is not subscripting (`len`, `iter`,
+//! passing to a `&[T]` parameter, byte views). Subscripting does not fall
+//! through the deref: once a type has an `Index` impl of its own, `s[0]` and
+//! `s[a..b]` are type errors rather than slice indexing, so raw positions have
+//! to be spelled out with [`raw`](IdSlice::raw) / [`raw_mut`](IdSlice::raw_mut).
+//! The wrapper is `#[repr(transparent)]` over the slice, so converting between
+//! the two views is free. [`IdVec<I, T>`] is the owning counterpart.
+
+use core::fmt;
+use core::marker::PhantomData;
+use core::ops::{Deref, DerefMut, Index, IndexMut};
+
+/// An id newtype that addresses an [`IdSlice`].
+pub trait Idx: Copy {
+    fn from_index(index: usize) -> Self;
+    fn index(self) -> usize;
+}
+
+/// A `[T]` whose positions are `I`s. See the module docs.
+#[repr(transparent)]
+pub struct IdSlice<I, T> {
+    _id: PhantomData<fn(I) -> I>,
+    raw: [T],
+}
+
+impl<I: Idx, T> IdSlice<I, T> {
+    #[inline]
+    pub fn from_raw(raw: &[T]) -> &Self {
+        // SAFETY: `#[repr(transparent)]` over `[T]`, so the two pointee types
+        // have the same layout and the same (length) metadata.
+        unsafe { &*(core::ptr::from_ref::<[T]>(raw) as *const Self) }
+    }
+
+    #[inline]
+    pub fn from_raw_mut(raw: &mut [T]) -> &mut Self {
+        // SAFETY: as in `from_raw`; `&mut` exclusivity carries over unchanged.
+        unsafe { &mut *(core::ptr::from_mut::<[T]>(raw) as *mut Self) }
+    }
+
+    /// The `usize`-indexed view: sub-ranges, sorting helpers, byte casts.
+    /// Plain slice methods are reachable through `Deref` without this.
+    #[inline]
+    pub fn raw(&self) -> &[T] {
+        &self.raw
+    }
+
+    #[inline]
+    pub fn raw_mut(&mut self) -> &mut [T] {
+        &mut self.raw
+    }
+
+    #[inline]
+    pub fn get(&self, id: I) -> Option<&T> {
+        self.raw.get(id.index())
+    }
+
+    /// Is `id` a position in this slice?
+    #[inline]
+    pub fn has(&self, id: I) -> bool {
+        id.index() < self.raw.len()
+    }
+
+    /// The id of every position, in order.
+    #[inline]
+    pub fn ids(&self) -> impl DoubleEndedIterator<Item = I> + ExactSizeIterator + use<I, T> {
+        (0..self.raw.len()).map(I::from_index)
+    }
+
+    #[inline]
+    pub fn iter_enumerated(&self) -> impl DoubleEndedIterator<Item = (I, &T)> + ExactSizeIterator {
+        self.raw
+            .iter()
+            .enumerate()
+            .map(|(index, item)| (I::from_index(index), item))
+    }
+}
+
+impl<I, T> Deref for IdSlice<I, T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &[T] {
+        &self.raw
+    }
+}
+
+impl<I, T> DerefMut for IdSlice<I, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut [T] {
+        &mut self.raw
+    }
+}
+
+impl<I: Idx, T> Index<I> for IdSlice<I, T> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, id: I) -> &T {
+        &self.raw[id.index()]
+    }
+}
+
+impl<I: Idx, T> IndexMut<I> for IdSlice<I, T> {
+    #[inline]
+    fn index_mut(&mut self, id: I) -> &mut T {
+        &mut self.raw[id.index()]
+    }
+}
+
+impl<'a, I, T> IntoIterator for &'a IdSlice<I, T> {
+    type Item = &'a T;
+    type IntoIter = core::slice::Iter<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.raw.iter()
+    }
+}
+
+impl<'a, I, T> IntoIterator for &'a mut IdSlice<I, T> {
+    type Item = &'a mut T;
+    type IntoIter = core::slice::IterMut<'a, T>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.raw.iter_mut()
+    }
+}
+
+impl<I, T: fmt::Debug> fmt::Debug for IdSlice<I, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.raw, f)
+    }
+}
+
+/// A `Vec<T>` whose positions are `I`s; derefs to [`IdSlice`]. The `Vec`
+/// itself is reachable through [`raw`](IdVec::raw) / [`raw_mut`](IdVec::raw_mut)
+/// for the operations not forwarded here.
+#[repr(transparent)]
+pub struct IdVec<I, T> {
+    raw: Vec<T>,
+    _id: PhantomData<fn(I) -> I>,
+}
+
+impl<I: Idx, T> IdVec<I, T> {
+    #[inline]
+    pub const fn new() -> Self {
+        Self::from_raw(Vec::new())
+    }
+
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::from_raw(Vec::with_capacity(capacity))
+    }
+
+    #[inline]
+    pub const fn from_raw(raw: Vec<T>) -> Self {
+        Self {
+            raw,
+            _id: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn raw(&self) -> &Vec<T> {
+        &self.raw
+    }
+
+    #[inline]
+    pub fn raw_mut(&mut self) -> &mut Vec<T> {
+        &mut self.raw
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &IdSlice<I, T> {
+        IdSlice::from_raw(&self.raw)
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut IdSlice<I, T> {
+        IdSlice::from_raw_mut(&mut self.raw)
+    }
+
+    #[inline]
+    pub fn push(&mut self, value: T) {
+        self.raw.push(value);
+    }
+
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        self.raw.truncate(len);
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        self.raw.reserve(additional);
+    }
+
+    #[inline]
+    pub fn reserve_exact(&mut self, additional: usize) {
+        self.raw.reserve_exact(additional);
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.raw.capacity()
+    }
+
+    #[inline]
+    pub fn resize(&mut self, new_len: usize, value: T)
+    where
+        T: Clone,
+    {
+        self.raw.resize(new_len, value);
+    }
+
+    /// Moves every element of `other` onto the end, leaving it empty.
+    #[inline]
+    pub fn append(&mut self, other: &mut Vec<T>) {
+        self.raw.append(other);
+    }
+}
+
+impl<I: Idx, T> Default for IdVec<I, T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<I: Idx, T: Clone> Clone for IdVec<I, T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self::from_raw(self.raw.clone())
+    }
+}
+
+impl<I: Idx, T> From<Vec<T>> for IdVec<I, T> {
+    #[inline]
+    fn from(raw: Vec<T>) -> Self {
+        Self::from_raw(raw)
+    }
+}
+
+impl<I: Idx, T> Deref for IdVec<I, T> {
+    type Target = IdSlice<I, T>;
+
+    #[inline]
+    fn deref(&self) -> &IdSlice<I, T> {
+        self.as_slice()
+    }
+}
+
+impl<I: Idx, T> DerefMut for IdVec<I, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut IdSlice<I, T> {
+        self.as_mut_slice()
+    }
+}
+
+impl<I: Idx, T> Index<I> for IdVec<I, T> {
+    type Output = T;
+
+    #[inline]
+    fn index(&self, id: I) -> &T {
+        &self.raw[id.index()]
+    }
+}
+
+impl<I: Idx, T> IndexMut<I> for IdVec<I, T> {
+    #[inline]
+    fn index_mut(&mut self, id: I) -> &mut T {
+        &mut self.raw[id.index()]
+    }
+}
+
+impl<I: Idx, T> FromIterator<T> for IdVec<I, T> {
+    #[inline]
+    fn from_iter<Iter: IntoIterator<Item = T>>(iter: Iter) -> Self {
+        Self::from_raw(Vec::from_iter(iter))
+    }
+}
+
+impl<I, T: fmt::Debug> fmt::Debug for IdVec<I, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.raw, f)
+    }
+}

--- a/src/collections/id_slice.rs
+++ b/src/collections/id_slice.rs
@@ -293,3 +293,115 @@ impl<I, T: fmt::Debug> fmt::Debug for IdVec<I, T> {
         fmt::Debug::fmt(&self.raw, f)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    struct Id(u32);
+
+    impl Idx for Id {
+        fn from_index(index: usize) -> Self {
+            Self(index as u32)
+        }
+
+        fn index(self) -> usize {
+            self.0 as usize
+        }
+    }
+
+    #[test]
+    fn slice_view_reads_through_ids() {
+        let raw = [10u8, 20, 30];
+        let view = IdSlice::<Id, u8>::from_raw(&raw);
+        assert_eq!(view.len(), 3);
+        assert_eq!(view[Id(1)], 20);
+        assert_eq!(view.get(Id(2)), Some(&30));
+        assert_eq!(view.get(Id(3)), None);
+        assert!(view.has(Id(2)));
+        assert!(!view.has(Id(3)));
+        assert_eq!(view.ids().collect::<Vec<_>>(), [Id(0), Id(1), Id(2)]);
+        assert_eq!(view.ids().next_back(), Some(Id(2)));
+        assert_eq!(
+            view.iter_enumerated().collect::<Vec<_>>(),
+            [(Id(0), &10), (Id(1), &20), (Id(2), &30)]
+        );
+        assert_eq!(view.iter().copied().sum::<u8>(), 60);
+        assert_eq!(view.raw(), &raw);
+        assert_eq!(format!("{view:?}"), "[10, 20, 30]");
+    }
+
+    #[test]
+    fn slice_view_writes_through_to_the_slice() {
+        let mut raw = [1u32, 2, 3, 4];
+        let view = IdSlice::<Id, u32>::from_raw_mut(&mut raw);
+        view[Id(0)] = 10;
+        for item in view.iter_mut() {
+            *item += 1;
+        }
+        for item in &mut *view {
+            *item *= 2;
+        }
+        view.raw_mut()[2..].reverse();
+        assert_eq!(raw, [22, 6, 10, 8]);
+    }
+
+    #[test]
+    fn empty_slice_view() {
+        let view = IdSlice::<Id, u64>::from_raw(&[]);
+        assert!(view.is_empty());
+        assert_eq!(view.get(Id(0)), None);
+        assert!(!view.has(Id(0)));
+        assert_eq!(view.ids().len(), 0);
+        assert_eq!(view.iter_enumerated().len(), 0);
+
+        let mut empty: [u64; 0] = [];
+        assert!(IdSlice::<Id, u64>::from_raw_mut(&mut empty).is_empty());
+    }
+
+    #[test]
+    fn vec_is_addressed_like_its_slice() {
+        let mut names: IdVec<Id, &str> = IdVec::new();
+        names.push("a");
+        names.push("b");
+        names.append(&mut vec!["c", "d"]);
+        assert_eq!(names.len(), 4);
+        assert_eq!(names[Id(3)], "d");
+        names[Id(0)] = "z";
+        names.as_mut_slice()[Id(1)] = "y";
+        assert_eq!(names.as_slice().raw(), ["z", "y", "c", "d"]);
+        assert_eq!(
+            names.ids().collect::<Vec<_>>(),
+            [Id(0), Id(1), Id(2), Id(3)]
+        );
+        assert_eq!(names.get(Id(4)), None);
+
+        names.truncate(2);
+        assert_eq!(*names.raw(), ["z", "y"]);
+        names.raw_mut().insert(0, "x");
+        assert_eq!(
+            names.iter_enumerated().collect::<Vec<_>>(),
+            [(Id(0), &"x"), (Id(1), &"z"), (Id(2), &"y")]
+        );
+        assert_eq!(format!("{names:?}"), r#"["x", "z", "y"]"#);
+    }
+
+    #[test]
+    fn vec_constructors() {
+        let mut sized: IdVec<Id, u32> = IdVec::with_capacity(8);
+        assert!(sized.capacity() >= 8);
+        sized.resize(3, 7);
+        sized.reserve(1);
+        sized.reserve_exact(1);
+        assert_eq!(sized.as_slice().raw(), [7, 7, 7]);
+
+        let collected: IdVec<Id, u32> = (1..=3).collect();
+        assert_eq!(collected[Id(2)], 3);
+
+        let converted: IdVec<Id, u32> = vec![4, 5].into();
+        assert_eq!(converted.clone().raw(), converted.raw());
+        assert_eq!(IdVec::<Id, u32>::from_raw(Vec::new()).len(), 0);
+        assert!(IdVec::<Id, u32>::default().is_empty());
+    }
+}

--- a/src/collections/lib.rs
+++ b/src/collections/lib.rs
@@ -13,6 +13,7 @@
 #![warn(unused_must_use)]
 
 pub mod hive_array;
+pub mod id_slice;
 pub mod index_sort;
 pub mod multi_array_list;
 pub mod vec_ext;
@@ -35,6 +36,7 @@ pub use bounded_array::BoundedArray;
 pub use hive_array::{
     Fallback as HiveArrayFallback, HiveArray, HiveBox, HiveRef, HiveRefHandle, HiveSlot,
 };
+pub use id_slice::{IdSlice, IdVec, Idx};
 pub use linear_fifo::LinearFifo;
 pub use multi_array_list::MultiArrayList;
 #[doc(hidden)]

--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -1521,4 +1521,92 @@ mod tests {
         assert_eq!(list.items::<"a", u32>(), &[0, 1, 2, 3, 4]);
         assert_eq!(list.items::<"c", u64>(), &[0, 10, 20, 30, 40]);
     }
+
+    fn three_foos() -> MultiArrayList<Foo> {
+        let mut list = MultiArrayList::<Foo>::default();
+        for i in 0..3u32 {
+            list.push(Foo {
+                a: i,
+                b: i as u8,
+                c: i as u64 * 10,
+            })
+            .unwrap();
+        }
+        list
+    }
+
+    mod declared_columns {
+        use super::*;
+
+        crate::multi_array_columns! {
+            trait FooColumns for Foo {
+                a: u32,
+                c: u64,
+            }
+        }
+
+        #[test]
+        fn plain_slices() {
+            let mut list = three_foos();
+            assert_eq!(list.items_c(), &[0, 10, 20]);
+            list.items_a_mut()[1] = 5;
+            assert_eq!(list.slice().items_a(), &[0, 5, 2]);
+
+            let columns = list.split_mut();
+            for (a, c) in columns.a.iter().zip(columns.c.iter_mut()) {
+                *c += u64::from(*a);
+            }
+            assert_eq!(list.items_c(), &[0, 15, 22]);
+
+            let raw = list.split_raw();
+            assert_eq!(raw.a.len(), 3);
+            assert_eq!(raw.c.len(), 3);
+        }
+    }
+
+    mod declared_columns_indexed_by_id {
+        use super::*;
+
+        #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+        struct FooId(u32);
+
+        impl crate::Idx for FooId {
+            fn from_index(index: usize) -> Self {
+                Self(index as u32)
+            }
+
+            fn index(self) -> usize {
+                self.0 as usize
+            }
+        }
+
+        crate::multi_array_columns! {
+            trait FooColumns for Foo, indexed by FooId {
+                a: u32,
+                c: u64,
+            }
+        }
+
+        #[test]
+        fn id_slices() {
+            let mut list = three_foos();
+            let c: &crate::IdSlice<FooId, u64> = list.items_c();
+            assert_eq!(c[FooId(2)], 20);
+            assert_eq!(c.ids().collect::<Vec<_>>(), [FooId(0), FooId(1), FooId(2)]);
+            list.items_a_mut()[FooId(1)] = 5;
+            assert_eq!(list.get(1).a, 5);
+            assert_eq!(list.slice().items_a().raw(), &[0, 5, 2]);
+
+            let columns = list.split_mut();
+            for id in columns.a.ids() {
+                columns.c[id] += u64::from(columns.a[id]);
+            }
+            assert_eq!(list.items_c().raw(), &[0, 15, 22]);
+            assert_eq!(list.items::<"c", u64>(), &[0, 15, 22]);
+
+            let raw = list.split_raw();
+            assert_eq!(raw.a.len(), 3);
+            assert_eq!(raw.c.len(), 3);
+        }
+    }
 }

--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -72,6 +72,10 @@ use bun_alloc::AllocError;
 /// Each generated method calls `items::<"field", $ty>()`, so the field name
 /// and type are checked against `$T`'s reflected layout at compile time —
 /// a typo or type mismatch is a const-eval error, not UB.
+///
+/// `for Foo, indexed by FooId` (where `FooId: Idx`) makes the accessors return
+/// [`IdSlice<FooId, _>`](crate::IdSlice) instead of plain slices, so the
+/// columns can only be subscripted with the list's own id type.
 #[macro_export]
 macro_rules! multi_array_columns {
     // Non-generic form.
@@ -81,7 +85,16 @@ macro_rules! multi_array_columns {
         }
     ) => {
         $crate::multi_array_columns! {
-            @emit $vis $trait [] [] $elem { $( $field : $ty, )* }
+            @emit $vis $trait [] [] [] $elem { $( $field : $ty, )* }
+        }
+    };
+    (
+        $vis:vis trait $trait:ident for $elem:ty, indexed by $idx:ident {
+            $( $field:ident : $ty:ty ),* $(,)?
+        }
+    ) => {
+        $crate::multi_array_columns! {
+            @emit $vis $trait [] [] [$idx] $elem { $( $field : $ty, )* }
         }
     };
     // Lifetime-only generic form: `['a]` / `['a, 'b]`.
@@ -91,7 +104,16 @@ macro_rules! multi_array_columns {
         }
     ) => {
         $crate::multi_array_columns! {
-            @emit $vis $trait [$($lt),+] [$($lt),+] $elem { $( $field : $ty, )* }
+            @emit $vis $trait [$($lt),+] [$($lt),+] [] $elem { $( $field : $ty, )* }
+        }
+    };
+    (
+        $vis:vis trait $trait:ident [ $($lt:lifetime),+ ] for $elem:ty, indexed by $idx:ident {
+            $( $field:ident : $ty:ty ),* $(,)?
+        }
+    ) => {
+        $crate::multi_array_columns! {
+            @emit $vis $trait [$($lt),+] [$($lt),+] [$idx] $elem { $( $field : $ty, )* }
         }
     };
     // Single bounded type-parameter form: `[T: Bound + ...]`.
@@ -101,10 +123,19 @@ macro_rules! multi_array_columns {
         }
     ) => {
         $crate::multi_array_columns! {
-            @emit $vis $trait [$param: $($bound)+] [$param] $elem { $( $field : $ty, )* }
+            @emit $vis $trait [$param: $($bound)+] [$param] [] $elem { $( $field : $ty, )* }
         }
     };
-    (@emit $vis:vis $trait:ident [$($decl:tt)*] [$($use:tt)*] $elem:ty {
+    (
+        $vis:vis trait $trait:ident [ $param:ident : $($bound:tt)+ ] for $elem:ty, indexed by $idx:ident {
+            $( $field:ident : $ty:ty ),* $(,)?
+        }
+    ) => {
+        $crate::multi_array_columns! {
+            @emit $vis $trait [$param: $($bound)+] [$param] [$idx] $elem { $( $field : $ty, )* }
+        }
+    };
+    (@emit $vis:vis $trait:ident [$($decl:tt)*] [$($use:tt)*] $idx:tt $elem:ty {
         $( $field:ident : $ty:ty, )*
     }) => {
         $crate::__mal_paste! {
@@ -117,7 +148,7 @@ macro_rules! multi_array_columns {
             /// per-site `unsafe { &mut * }` pattern.
             #[allow(dead_code, non_snake_case)]
             $vis struct [<$trait Mut>] <'__mal, $($decl)*> {
-                $( pub $field: &'__mal mut [$ty], )*
+                $( pub $field: &'__mal mut $crate::__mal_column_ty!($idx $ty), )*
                 #[doc(hidden)]
                 pub __mal: ::core::marker::PhantomData<&'__mal mut $elem>,
             }
@@ -147,7 +178,7 @@ macro_rules! multi_array_columns {
 
             #[allow(dead_code, non_snake_case)]
             $vis trait $trait <$($decl)*> {
-                $( $crate::__mal_column_sig!($field : $ty); )*
+                $( $crate::__mal_column_sig!($idx $field : $ty); )*
                 /// Split-borrow every column at once.
                 fn split_mut(&mut self) -> [<$trait Mut>]<'_, $($use)*>;
                 /// Raw column pointers (root provenance, no `&mut` intermediate).
@@ -155,27 +186,60 @@ macro_rules! multi_array_columns {
             }
             #[allow(dead_code, non_snake_case)]
             impl <$($decl)*> $trait <$($use)*> for $crate::MultiArrayList<$elem> {
-                $( $crate::__mal_column_impl!($field : $ty); )*
-                $crate::__mal_split_mut_impl!([<$trait Mut>] [$($use)*] { $( $field : $ty, )* });
+                $( $crate::__mal_column_impl!($idx $field : $ty); )*
+                $crate::__mal_split_mut_impl!([<$trait Mut>] [$($use)*] $idx { $( $field : $ty, )* });
                 $crate::__mal_split_raw_impl!([<$trait Raw>] [$($use)*] { $( $field : $ty, )* });
             }
             #[allow(dead_code, non_snake_case)]
             impl <$($decl)*> $trait <$($use)*> for $crate::multi_array_list::Slice<$elem> {
-                $( $crate::__mal_column_impl!($field : $ty); )*
-                $crate::__mal_split_mut_impl!([<$trait Mut>] [$($use)*] { $( $field : $ty, )* });
+                $( $crate::__mal_column_impl!($idx $field : $ty); )*
+                $crate::__mal_split_mut_impl!([<$trait Mut>] [$($use)*] $idx { $( $field : $ty, )* });
                 $crate::__mal_split_raw_impl!([<$trait Raw>] [$($use)*] { $( $field : $ty, )* });
             }
         }
     };
 }
 
+/// The column type a `multi_array_columns!` accessor hands out: the plain
+/// slice, or the id-indexed one when the trait was declared `indexed by`.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __mal_column_ty {
+    ([] $ty:ty) => { [$ty] };
+    ([$idx:ident] $ty:ty) => { $crate::IdSlice<$idx, $ty> };
+}
+
+/// Wraps a freshly materialized `&[T]` / `&mut [T]` column in the declared
+/// column type (see `__mal_column_ty`).
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __mal_column_wrap {
+    ([] $column:expr) => {
+        $column
+    };
+    ([$idx:ident] $column:expr) => {
+        $crate::IdSlice::<$idx, _>::from_raw($column)
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __mal_column_wrap_mut {
+    ([] $column:expr) => {
+        $column
+    };
+    ([$idx:ident] $column:expr) => {
+        $crate::IdSlice::<$idx, _>::from_raw_mut($column)
+    };
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __mal_column_sig {
-    ($field:ident : $ty:ty) => {
+    ($idx:tt $field:ident : $ty:ty) => {
         $crate::__mal_paste! {
-            fn [<items_ $field>](&self) -> &[$ty];
-            fn [<items_ $field _mut>](&mut self) -> &mut [$ty];
+            fn [<items_ $field>](&self) -> &$crate::__mal_column_ty!($idx $ty);
+            fn [<items_ $field _mut>](&mut self) -> &mut $crate::__mal_column_ty!($idx $ty);
         }
     };
 }
@@ -183,7 +247,7 @@ macro_rules! __mal_column_sig {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __mal_split_mut_impl {
-    ($struct:ident [$($use:tt)*] { $( $field:ident : $ty:ty, )* }) => {
+    ($struct:ident [$($use:tt)*] $idx:tt { $( $field:ident : $ty:ty, )* }) => {
         #[inline]
         fn split_mut(&mut self) -> $struct<'_, $($use)*> {
             let __len = self.len();
@@ -194,10 +258,10 @@ macro_rules! __mal_split_mut_impl {
             // one `&mut [F]` per column simultaneously cannot alias.
             unsafe {
                 $struct {
-                    $( $field: ::core::slice::from_raw_parts_mut(
+                    $( $field: $crate::__mal_column_wrap_mut!($idx ::core::slice::from_raw_parts_mut(
                         self.items_raw::<{ ::core::stringify!($field) }, $ty>(),
                         __len,
-                    ), )*
+                    )), )*
                     __mal: ::core::marker::PhantomData,
                 }
             }
@@ -226,15 +290,17 @@ macro_rules! __mal_split_raw_impl {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __mal_column_impl {
-    ($field:ident : $ty:ty) => {
+    ($idx:tt $field:ident : $ty:ty) => {
         $crate::__mal_paste! {
             #[inline]
-            fn [<items_ $field>](&self) -> &[$ty] {
-                self.items::<{ ::core::stringify!($field) }, $ty>()
+            fn [<items_ $field>](&self) -> &$crate::__mal_column_ty!($idx $ty) {
+                $crate::__mal_column_wrap!($idx self.items::<{ ::core::stringify!($field) }, $ty>())
             }
             #[inline]
-            fn [<items_ $field _mut>](&mut self) -> &mut [$ty] {
-                self.items_mut::<{ ::core::stringify!($field) }, $ty>()
+            fn [<items_ $field _mut>](&mut self) -> &mut $crate::__mal_column_ty!($idx $ty) {
+                $crate::__mal_column_wrap_mut!(
+                    $idx self.items_mut::<{ ::core::stringify!($field) }, $ty>()
+                )
             }
         }
     };

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -312,7 +312,7 @@ fn find_native_binlink_target_tree(
             .dependencies
             .get(hoisted_deps)
             .iter()
-            .any(|&dep_id| resolutions[dep_id as usize] == target_pkg_id)
+            .any(|&dep_id| resolutions[dep_id.index()] == target_pkg_id)
     };
 
     for t in trees {
@@ -593,13 +593,13 @@ impl<'a> PackageInstaller<'a> {
         let mut deferred: Vec<DependencyID> = Vec::new();
 
         while let Some(dep_id) = tree.binaries.remove_or_null() {
-            debug_assert!((dep_id as usize) < lockfile.buffers.dependencies.as_slice().len());
-            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+            debug_assert!(dep_id.index() < lockfile.buffers.dependencies.as_slice().len());
+            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
             debug_assert!(package_id != invalid_package_id);
-            let bin = self.bins[package_id as usize];
+            let bin = self.bins[package_id.index()];
             debug_assert!(bin.tag != bin::Tag::None);
 
-            let alias = lockfile.buffers.dependencies.as_slice()[dep_id as usize]
+            let alias = lockfile.buffers.dependencies.as_slice()[dep_id.index()]
                 .name
                 .slice(string_buf);
             let package_name_ = strings::StringOrTinyString::init(alias);
@@ -614,7 +614,7 @@ impl<'a> PackageInstaller<'a> {
                     break 'native_binlink_optimization;
                 }
                 // Check for native binlink optimization
-                let name_hash = pkg_name_hashes[package_id as usize];
+                let name_hash = pkg_name_hashes[package_id.index()];
                 if let Some(optimizer) =
                     manager
                         .postinstall_optimizer
@@ -629,7 +629,7 @@ impl<'a> PackageInstaller<'a> {
                             let target_os = manager.options.os;
                             if let Some(replacement_pkg_id) =
                                 PostinstallOptimizer::get_native_binlink_replacement_package_id(
-                                    pkg_resolutions_lists[package_id as usize]
+                                    pkg_resolutions_lists[package_id.index()]
                                         .get(pkg_resolutions_buffer),
                                     pkg_metas,
                                     target_cpu,
@@ -666,7 +666,7 @@ impl<'a> PackageInstaller<'a> {
                                 }
 
                                 let replacement_name =
-                                    pkg_names[replacement_pkg_id as usize].slice(string_buf);
+                                    pkg_names[replacement_pkg_id.index()].slice(string_buf);
                                 target_package_name =
                                     strings::StringOrTinyString::init(replacement_name);
                                 can_retry_without_native_binlink_optimization = true;
@@ -920,8 +920,8 @@ impl<'a> PackageInstaller<'a> {
                 let resolutions = self.resolutions;
                 for context in core::mem::take(&mut self.trees[i].pending_installs) {
                     let package_id = self.lockfile().buffers.resolutions.as_slice()
-                        [context.dependency_id as usize];
-                    let name = self.names[package_id as usize];
+                        [context.dependency_id.index()];
+                    let name = self.names[package_id.index()];
                     self.node_modules.tree_id = context.tree_id;
                     self.node_modules.path = context.path;
                     self.current_tree_id = context.tree_id;
@@ -937,7 +937,7 @@ impl<'a> PackageInstaller<'a> {
                         package_id,
                         log_level,
                         name,
-                        &resolutions[package_id as usize],
+                        &resolutions[package_id.index()],
                     );
                 }
             }
@@ -1102,8 +1102,8 @@ impl<'a> PackageInstaller<'a> {
         data: &ExtractData,
         log_level: Options::LogLevel,
     ) {
-        let package_id = self.lockfile().buffers.resolutions.as_slice()[dependency_id as usize];
-        let name = self.names[package_id as usize];
+        let package_id = self.lockfile().buffers.resolutions.as_slice()[dependency_id.index()];
+        let name = self.names[package_id.index()];
 
         // const resolution = &this.resolutions[package_id];
         // const task_id = switch (resolution.tag) {
@@ -1120,8 +1120,8 @@ impl<'a> PackageInstaller<'a> {
         // the lockfile gets re-saved with the hash.
         if data.integrity.tag.is_supported() {
             let pkg_metas = self.lockfile_mut().packages.items_meta_mut();
-            if !pkg_metas[package_id as usize].integrity.tag.is_supported() {
-                pkg_metas[package_id as usize].integrity = data.integrity;
+            if !pkg_metas[package_id.index()].integrity.tag.is_supported() {
+                pkg_metas[package_id.index()].integrity = data.integrity;
                 self.manager_mut()
                     .options
                     .enable
@@ -1158,7 +1158,7 @@ impl<'a> PackageInstaller<'a> {
                     continue;
                 };
                 let callback_package_id =
-                    self.lockfile().buffers.resolutions.as_slice()[context.dependency_id as usize];
+                    self.lockfile().buffers.resolutions.as_slice()[context.dependency_id.index()];
                 self.node_modules.tree_id = context.tree_id;
                 // `DependencyInstallContext.path: Vec<u8>` — clone since `cb` is `&`.
                 self.node_modules.path.clone_from(&context.path);
@@ -1173,7 +1173,7 @@ impl<'a> PackageInstaller<'a> {
                     callback_package_id,
                     log_level,
                     name,
-                    &resolutions[callback_package_id as usize],
+                    &resolutions[callback_package_id.index()],
                 );
             }
             self.node_modules = prev_node_modules;
@@ -1201,10 +1201,10 @@ impl<'a> PackageInstaller<'a> {
     ) -> usize {
         debug_assert!(resolution_tag != resolution::Tag::Root);
         debug_assert!(resolution_tag != resolution::Tag::Workspace);
-        debug_assert!(package_id != 0);
+        debug_assert!(package_id != PackageID::ROOT);
         let mut count: usize = 0;
         let scripts = 'brk: {
-            let scripts = self.lockfile().packages.items_scripts()[package_id as usize];
+            let scripts = self.lockfile().packages.items_scripts()[package_id.index()];
             if scripts.filled {
                 break 'brk scripts;
             }
@@ -1287,7 +1287,7 @@ impl<'a> PackageInstaller<'a> {
             };
         }
 
-        let alias = self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize].name;
+        let alias = self.lockfile().buffers.dependencies.as_slice()[dependency_id.index()].name;
 
         // The alias is used as a path relative to `node_modules` for delete,
         // rename, and create operations. Refuse anything that could escape it.
@@ -1325,7 +1325,7 @@ impl<'a> PackageInstaller<'a> {
             unsafe { ZStr::from_raw_mut((*subpath_buf_ptr).as_mut_ptr(), alias_slice.len()) }
         };
 
-        let pkg_name_hash = self.pkg_name_hashes[package_id as usize];
+        let pkg_name_hash = self.pkg_name_hashes[package_id.index()];
 
         let mut resolution_buf = [0u8; 512];
         let mut resolution_spill = Vec::new();
@@ -1489,7 +1489,7 @@ impl<'a> PackageInstaller<'a> {
                             // override was written by the user and is trusted the same
                             // as a direct dependency of the root.
                             let dep = &self.lockfile().buffers.dependencies.as_slice()
-                                [dependency_id as usize];
+                                [dependency_id.index()];
                             !self.lockfile().overrides.contains_name(
                                 dep.name_hash,
                                 dep.name.slice(string_buf!()),
@@ -1914,15 +1914,15 @@ impl<'a> PackageInstaller<'a> {
 
             match install_result {
                 package_install::InstallResult::Success => {
-                    let is_duplicate = self.successfully_installed.is_set(package_id as usize);
+                    let is_duplicate = self.successfully_installed.is_set(package_id.index());
                     self.summary.success += (!is_duplicate) as u32;
-                    self.successfully_installed.set(package_id as usize);
+                    self.successfully_installed.set(package_id.index());
 
                     if log_level.show_progress() {
                         self.node.complete_one();
                     }
 
-                    if self.bins[package_id as usize].tag != bin::Tag::None {
+                    if self.bins[package_id.index()].tag != bin::Tag::None {
                         self.trees[self.current_tree_id as usize]
                             .binaries
                             .add(dependency_id)
@@ -1930,7 +1930,7 @@ impl<'a> PackageInstaller<'a> {
                     }
 
                     let dep =
-                        &self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize];
+                        &self.lockfile().buffers.dependencies.as_slice()[dependency_id.index()];
                     let dep_behavior = dep.behavior;
                     let truncated_dep_name_hash: TruncatedPackageNameHash =
                         dep.name_hash as TruncatedPackageNameHash;
@@ -1976,8 +1976,8 @@ impl<'a> PackageInstaller<'a> {
                                         version_buf: string_buf!(),
                                     },
                                     self.lockfile().packages.items_resolutions()
-                                        [package_id as usize]
-                                        .get(self.lockfile().buffers.resolutions.as_slice()),
+                                        [package_id.index()]
+                                    .get(self.lockfile().buffers.resolutions.as_slice()),
                                     self.lockfile().packages.items_meta(),
                                     self.manager().options.cpu,
                                     self.manager().options.os,
@@ -2034,7 +2034,7 @@ impl<'a> PackageInstaller<'a> {
                             // these will never be blocked
                         }
                         _ => {
-                            if !is_trusted && self.metas[package_id as usize].has_install_script() {
+                            if !is_trusted && self.metas[package_id.index()].has_install_script() {
                                 // Check if the package actually has scripts. `hasInstallScript` can be false positive if a package is published with
                                 // an auto binding.gyp rebuild script but binding.gyp is excluded from the published files.
                                 let mut folder_path =
@@ -2099,7 +2099,7 @@ impl<'a> PackageInstaller<'a> {
                         bun_core::pretty_errorln!(
                             "<r><red>error<r>: <b>{}<r> \"link:{}\" not found (try running 'bun link' in the intended package's folder)<r>",
                             cause.err.name(),
-                            bstr::BStr::new(self.names[package_id as usize].slice(string_buf!())),
+                            bstr::BStr::new(self.names[package_id.index()].slice(string_buf!())),
                         );
                         self.summary.fail += 1;
                     } else if resolution.tag == resolution::Tag::Folder
@@ -2134,7 +2134,7 @@ impl<'a> PackageInstaller<'a> {
                                             "EACCES",
                                             "Permission denied while installing <b>{}<r>",
                                             (bstr::BStr::new(
-                                                self.names[package_id as usize].slice(
+                                                self.names[package_id.index()].slice(
                                                     self.lockfile().buffers.string_bytes.as_slice(),
                                                 ),
                                             ),),
@@ -2152,7 +2152,7 @@ impl<'a> PackageInstaller<'a> {
                                             "EACCES",
                                             "Permission denied while installing <b>{}<r>",
                                             (bstr::BStr::new(
-                                                self.names[package_id as usize].slice(
+                                                self.names[package_id.index()].slice(
                                                     self.lockfile().buffers.string_bytes.as_slice(),
                                                 ),
                                             ),),
@@ -2194,7 +2194,7 @@ impl<'a> PackageInstaller<'a> {
                             "EACCES",
                             "Permission denied while installing <b>{}<r>",
                             (bstr::BStr::new(
-                                self.names[package_id as usize].slice(string_buf!()),
+                                self.names[package_id.index()].slice(string_buf!()),
                             ),),
                         );
 
@@ -2206,7 +2206,7 @@ impl<'a> PackageInstaller<'a> {
                             (
                                 bstr::BStr::new(cause.step.name()),
                                 bstr::BStr::new(
-                                    self.names[package_id as usize].slice(string_buf!()),
+                                    self.names[package_id.index()].slice(string_buf!()),
                                 ),
                             ),
                         );
@@ -2241,7 +2241,7 @@ impl<'a> PackageInstaller<'a> {
 
             self.summary.skipped += 1;
 
-            if self.bins[package_id as usize].tag != bin::Tag::None {
+            if self.bins[package_id.index()].tag != bin::Tag::None {
                 self.trees[self.current_tree_id as usize]
                     .binaries
                     .add(dependency_id)
@@ -2261,7 +2261,7 @@ impl<'a> PackageInstaller<'a> {
             // `defer { destination_dir.close(); }` + `defer increment_tree_install_count`.
             // No early returns after this point, so manual calls at end are equivalent.
 
-            let dep = &self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize];
+            let dep = &self.lockfile().buffers.dependencies.as_slice()[dependency_id.index()];
             let dep_behavior = dep.behavior;
             let truncated_dep_name_hash: TruncatedPackageNameHash =
                 dep.name_hash as TruncatedPackageNameHash;
@@ -2315,7 +2315,7 @@ impl<'a> PackageInstaller<'a> {
                                 },
                                 version_buf: string_buf!(),
                             },
-                            self.lockfile().packages.items_resolutions()[package_id as usize]
+                            self.lockfile().packages.items_resolutions()[package_id.index()]
                                 .get(self.lockfile().buffers.resolutions.as_slice()),
                             self.lockfile().packages.items_meta(),
                             self.manager().options.cpu,
@@ -2408,7 +2408,7 @@ impl<'a> PackageInstaller<'a> {
         resolution: &Resolution,
     ) -> bool {
         let mut scripts: PackageScripts =
-            self.lockfile().packages.items_scripts()[package_id as usize];
+            self.lockfile().packages.items_scripts()[package_id.index()];
         let log = self.manager().log_mut();
         let scripts_list = match scripts.get_list(
             log,
@@ -2503,9 +2503,9 @@ impl<'a> PackageInstaller<'a> {
     }
 
     pub(crate) fn install_package(&mut self, dep_id: DependencyID, log_level: Options::LogLevel) {
-        let package_id = self.lockfile().buffers.resolutions.as_slice()[dep_id as usize];
+        let package_id = self.lockfile().buffers.resolutions.as_slice()[dep_id.index()];
 
-        let name = self.names[package_id as usize];
+        let name = self.names[package_id.index()];
         // `self.resolutions` is `RawSlice<Resolution>` (Copy); copy out so the
         // `&Resolution` argument borrows the local, not `*self`, across the
         // `&mut self` call.
@@ -2518,7 +2518,7 @@ impl<'a> PackageInstaller<'a> {
             package_id,
             log_level,
             name,
-            &resolutions[package_id as usize],
+            &resolutions[package_id.index()],
         );
     }
 }

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1,6 +1,6 @@
 use core::sync::atomic::Ordering;
 
-use bun_collections::{ArrayHashMap, DynamicBitSet, StringHashMap};
+use bun_collections::{ArrayHashMap, DynamicBitSet, IdSlice, StringHashMap};
 use bun_core::fmt::PathSep;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
@@ -75,19 +75,17 @@ pub struct PackageInstaller<'a> {
     // `self.manager().options` so the shared borrow stays a child of the live
     // `&mut PackageManager` Unique tag rather than a sibling raw.
     // The following slice fields alias into `self.lockfile.packages` (BACKREF).
-    // Stored as `RawSlice<T>` (raw `*const [T]`, `usize` len) — the lockfile's
-    // `MultiArrayList<Package>` column buffers outlive this `PackageInstaller`
-    // and are only ever *grown*, never freed; `fix_cached_lockfile_package_slices`
-    // re-snapshots after a grow. `RawSlice` carries no lifetime, so the
-    // assignment sites do not need a `&'a → &'a` lifetime-detach round-trip.
-    // Every `resolutions` call site is a read (`&raw const self.resolutions[i]`),
-    // so it is also `RawSlice` here.
-    pub(crate) metas: bun_ptr::RawSlice<Package::Meta>,
-    pub(crate) names: bun_ptr::RawSlice<String>,
-    pub(crate) pkg_dependencies: bun_ptr::RawSlice<DependencySlice>,
-    pub(crate) pkg_name_hashes: bun_ptr::RawSlice<PackageNameHash>,
-    pub(crate) bins: bun_ptr::RawSlice<Bin>,
-    pub(crate) resolutions: bun_ptr::RawSlice<Resolution>,
+    // Stored as lifetime-less `BackRef`s to the id-indexed columns — the
+    // lockfile's `MultiArrayList<Package>` column buffers outlive this
+    // `PackageInstaller` and are only ever *grown*, never freed;
+    // `fix_cached_lockfile_package_slices` re-snapshots after a grow. Every
+    // `resolutions` call site is a read, so it is a shared `BackRef` too.
+    pub(crate) metas: bun_ptr::BackRef<IdSlice<PackageID, Package::Meta>>,
+    pub(crate) names: bun_ptr::BackRef<IdSlice<PackageID, String>>,
+    pub(crate) pkg_dependencies: bun_ptr::BackRef<IdSlice<PackageID, DependencySlice>>,
+    pub(crate) pkg_name_hashes: bun_ptr::BackRef<IdSlice<PackageID, PackageNameHash>>,
+    pub(crate) bins: bun_ptr::BackRef<IdSlice<PackageID, Bin>>,
+    pub(crate) resolutions: bun_ptr::BackRef<IdSlice<PackageID, Resolution>>,
     pub(crate) node: &'a mut ProgressNode,
     pub(crate) destination_dir_subpath_buf: PathBuffer,
     pub(crate) folder_path_buf: PathBuffer,
@@ -300,8 +298,8 @@ type TreeContextId = lockfile::tree::Id;
 fn find_native_binlink_target_tree(
     trees: &[Tree],
     hoisted_deps: &[DependencyID],
-    resolutions: &[PackageID],
-    deps: &[crate::Dependency],
+    resolutions: &IdSlice<DependencyID, PackageID>,
+    deps: &IdSlice<DependencyID, crate::Dependency>,
     string_buf: &[u8],
     start_tree: lockfile::tree::Id,
     alias: &[u8],
@@ -312,7 +310,7 @@ fn find_native_binlink_target_tree(
             .dependencies
             .get(hoisted_deps)
             .iter()
-            .any(|&dep_id| resolutions[dep_id.index()] == target_pkg_id)
+            .any(|&dep_id| resolutions[dep_id] == target_pkg_id)
     };
 
     for t in trees {
@@ -593,13 +591,13 @@ impl<'a> PackageInstaller<'a> {
         let mut deferred: Vec<DependencyID> = Vec::new();
 
         while let Some(dep_id) = tree.binaries.remove_or_null() {
-            debug_assert!(dep_id.index() < lockfile.buffers.dependencies.as_slice().len());
-            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
+            debug_assert!(lockfile.buffers.dependencies.has(dep_id));
+            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id];
             debug_assert!(package_id != invalid_package_id);
-            let bin = self.bins[package_id.index()];
+            let bin = self.bins[package_id];
             debug_assert!(bin.tag != bin::Tag::None);
 
-            let alias = lockfile.buffers.dependencies.as_slice()[dep_id.index()]
+            let alias = lockfile.buffers.dependencies.as_slice()[dep_id]
                 .name
                 .slice(string_buf);
             let package_name_ = strings::StringOrTinyString::init(alias);
@@ -614,7 +612,7 @@ impl<'a> PackageInstaller<'a> {
                     break 'native_binlink_optimization;
                 }
                 // Check for native binlink optimization
-                let name_hash = pkg_name_hashes[package_id.index()];
+                let name_hash = pkg_name_hashes[package_id];
                 if let Some(optimizer) =
                     manager
                         .postinstall_optimizer
@@ -629,8 +627,7 @@ impl<'a> PackageInstaller<'a> {
                             let target_os = manager.options.os;
                             if let Some(replacement_pkg_id) =
                                 PostinstallOptimizer::get_native_binlink_replacement_package_id(
-                                    pkg_resolutions_lists[package_id.index()]
-                                        .get(pkg_resolutions_buffer),
+                                    pkg_resolutions_lists[package_id].get(pkg_resolutions_buffer),
                                     pkg_metas,
                                     target_cpu,
                                     target_os,
@@ -666,7 +663,7 @@ impl<'a> PackageInstaller<'a> {
                                 }
 
                                 let replacement_name =
-                                    pkg_names[replacement_pkg_id.index()].slice(string_buf);
+                                    pkg_names[replacement_pkg_id].slice(string_buf);
                                 target_package_name =
                                     strings::StringOrTinyString::init(replacement_name);
                                 can_retry_without_native_binlink_optimization = true;
@@ -919,9 +916,9 @@ impl<'a> PackageInstaller<'a> {
                 // local, not `*self`, across the `&mut self` call.
                 let resolutions = self.resolutions;
                 for context in core::mem::take(&mut self.trees[i].pending_installs) {
-                    let package_id = self.lockfile().buffers.resolutions.as_slice()
-                        [context.dependency_id.index()];
-                    let name = self.names[package_id.index()];
+                    let package_id =
+                        self.lockfile().buffers.resolutions.as_slice()[context.dependency_id];
+                    let name = self.names[package_id];
                     self.node_modules.tree_id = context.tree_id;
                     self.node_modules.path = context.path;
                     self.current_tree_id = context.tree_id;
@@ -937,7 +934,7 @@ impl<'a> PackageInstaller<'a> {
                         package_id,
                         log_level,
                         name,
-                        &resolutions[package_id.index()],
+                        &resolutions[package_id],
                     );
                 }
             }
@@ -1068,21 +1065,20 @@ impl<'a> PackageInstaller<'a> {
 
     /// Call when you mutate the length of `lockfile.packages`
     pub(crate) fn fix_cached_lockfile_package_slices(&mut self) {
-        // These `RawSlice<T>` fields alias into `self.lockfile.packages`
-        // (BACKREF). `RawSlice::new` stores the raw `(ptr, len)` without a
-        // lifetime, so the borrow of `packages` ends at the end of each
-        // statement — no `&'a → &'a` detach round-trip needed.
-        // SAFETY (RawSlice invariant): `self.lockfile` is a BACKREF whose
+        // These column fields alias into `self.lockfile.packages` (BACKREF).
+        // `BackRef::new` stores the pointer without a lifetime, so the borrow
+        // of `packages` ends at the end of each statement.
+        // SAFETY (BackRef invariant): `self.lockfile` is a BACKREF whose
         // pointee outlives `'a`; the packages column buffers are not freed for
         // the lifetime of this `PackageInstaller` (only grow, which is why
         // this fn exists — to re-snapshot after growth).
         let packages = self.lockfile_mut().packages.slice();
-        self.metas = bun_ptr::RawSlice::new(packages.items_meta());
-        self.names = bun_ptr::RawSlice::new(packages.items_name());
-        self.pkg_name_hashes = bun_ptr::RawSlice::new(packages.items_name_hash());
-        self.bins = bun_ptr::RawSlice::new(packages.items_bin());
-        self.resolutions = bun_ptr::RawSlice::new(packages.items_resolution());
-        self.pkg_dependencies = bun_ptr::RawSlice::new(packages.items_dependencies());
+        self.metas = bun_ptr::BackRef::new(packages.items_meta());
+        self.names = bun_ptr::BackRef::new(packages.items_name());
+        self.pkg_name_hashes = bun_ptr::BackRef::new(packages.items_name_hash());
+        self.bins = bun_ptr::BackRef::new(packages.items_bin());
+        self.resolutions = bun_ptr::BackRef::new(packages.items_resolution());
+        self.pkg_dependencies = bun_ptr::BackRef::new(packages.items_dependencies());
 
         // fixes an assertion failure where a transitive dependency is a git dependency newly added to the lockfile after the list of dependencies has been resized
         // this assertion failure would also only happen after the lockfile has been written to disk and the summary is being printed.
@@ -1102,8 +1098,8 @@ impl<'a> PackageInstaller<'a> {
         data: &ExtractData,
         log_level: Options::LogLevel,
     ) {
-        let package_id = self.lockfile().buffers.resolutions.as_slice()[dependency_id.index()];
-        let name = self.names[package_id.index()];
+        let package_id = self.lockfile().buffers.resolutions.as_slice()[dependency_id];
+        let name = self.names[package_id];
 
         // const resolution = &this.resolutions[package_id];
         // const task_id = switch (resolution.tag) {
@@ -1120,8 +1116,8 @@ impl<'a> PackageInstaller<'a> {
         // the lockfile gets re-saved with the hash.
         if data.integrity.tag.is_supported() {
             let pkg_metas = self.lockfile_mut().packages.items_meta_mut();
-            if !pkg_metas[package_id.index()].integrity.tag.is_supported() {
-                pkg_metas[package_id.index()].integrity = data.integrity;
+            if !pkg_metas[package_id].integrity.tag.is_supported() {
+                pkg_metas[package_id].integrity = data.integrity;
                 self.manager_mut()
                     .options
                     .enable
@@ -1158,7 +1154,7 @@ impl<'a> PackageInstaller<'a> {
                     continue;
                 };
                 let callback_package_id =
-                    self.lockfile().buffers.resolutions.as_slice()[context.dependency_id.index()];
+                    self.lockfile().buffers.resolutions.as_slice()[context.dependency_id];
                 self.node_modules.tree_id = context.tree_id;
                 // `DependencyInstallContext.path: Vec<u8>` — clone since `cb` is `&`.
                 self.node_modules.path.clone_from(&context.path);
@@ -1173,7 +1169,7 @@ impl<'a> PackageInstaller<'a> {
                     callback_package_id,
                     log_level,
                     name,
-                    &resolutions[callback_package_id.index()],
+                    &resolutions[callback_package_id],
                 );
             }
             self.node_modules = prev_node_modules;
@@ -1204,7 +1200,7 @@ impl<'a> PackageInstaller<'a> {
         debug_assert!(package_id != PackageID::ROOT);
         let mut count: usize = 0;
         let scripts = 'brk: {
-            let scripts = self.lockfile().packages.items_scripts()[package_id.index()];
+            let scripts = self.lockfile().packages.items_scripts()[package_id];
             if scripts.filled {
                 break 'brk scripts;
             }
@@ -1287,7 +1283,7 @@ impl<'a> PackageInstaller<'a> {
             };
         }
 
-        let alias = self.lockfile().buffers.dependencies.as_slice()[dependency_id.index()].name;
+        let alias = self.lockfile().buffers.dependencies.as_slice()[dependency_id].name;
 
         // The alias is used as a path relative to `node_modules` for delete,
         // rename, and create operations. Refuse anything that could escape it.
@@ -1325,7 +1321,7 @@ impl<'a> PackageInstaller<'a> {
             unsafe { ZStr::from_raw_mut((*subpath_buf_ptr).as_mut_ptr(), alias_slice.len()) }
         };
 
-        let pkg_name_hash = self.pkg_name_hashes[package_id.index()];
+        let pkg_name_hash = self.pkg_name_hashes[package_id];
 
         let mut resolution_buf = [0u8; 512];
         let mut resolution_spill = Vec::new();
@@ -1488,8 +1484,8 @@ impl<'a> PackageInstaller<'a> {
                             // package.json, so a folder path that reached here via an
                             // override was written by the user and is trusted the same
                             // as a direct dependency of the root.
-                            let dep = &self.lockfile().buffers.dependencies.as_slice()
-                                [dependency_id.index()];
+                            let dep =
+                                &self.lockfile().buffers.dependencies.as_slice()[dependency_id];
                             !self.lockfile().overrides.contains_name(
                                 dep.name_hash,
                                 dep.name.slice(string_buf!()),
@@ -1922,15 +1918,14 @@ impl<'a> PackageInstaller<'a> {
                         self.node.complete_one();
                     }
 
-                    if self.bins[package_id.index()].tag != bin::Tag::None {
+                    if self.bins[package_id].tag != bin::Tag::None {
                         self.trees[self.current_tree_id as usize]
                             .binaries
                             .add(dependency_id)
                             .unwrap_or_oom();
                     }
 
-                    let dep =
-                        &self.lockfile().buffers.dependencies.as_slice()[dependency_id.index()];
+                    let dep = &self.lockfile().buffers.dependencies.as_slice()[dependency_id];
                     let dep_behavior = dep.behavior;
                     let truncated_dep_name_hash: TruncatedPackageNameHash =
                         dep.name_hash as TruncatedPackageNameHash;
@@ -1975,9 +1970,8 @@ impl<'a> PackageInstaller<'a> {
                                         },
                                         version_buf: string_buf!(),
                                     },
-                                    self.lockfile().packages.items_resolutions()
-                                        [package_id.index()]
-                                    .get(self.lockfile().buffers.resolutions.as_slice()),
+                                    self.lockfile().packages.items_resolutions()[package_id]
+                                        .get(self.lockfile().buffers.resolutions.as_slice()),
                                     self.lockfile().packages.items_meta(),
                                     self.manager().options.cpu,
                                     self.manager().options.os,
@@ -2034,7 +2028,7 @@ impl<'a> PackageInstaller<'a> {
                             // these will never be blocked
                         }
                         _ => {
-                            if !is_trusted && self.metas[package_id.index()].has_install_script() {
+                            if !is_trusted && self.metas[package_id].has_install_script() {
                                 // Check if the package actually has scripts. `hasInstallScript` can be false positive if a package is published with
                                 // an auto binding.gyp rebuild script but binding.gyp is excluded from the published files.
                                 let mut folder_path =
@@ -2099,7 +2093,7 @@ impl<'a> PackageInstaller<'a> {
                         bun_core::pretty_errorln!(
                             "<r><red>error<r>: <b>{}<r> \"link:{}\" not found (try running 'bun link' in the intended package's folder)<r>",
                             cause.err.name(),
-                            bstr::BStr::new(self.names[package_id.index()].slice(string_buf!())),
+                            bstr::BStr::new(self.names[package_id].slice(string_buf!())),
                         );
                         self.summary.fail += 1;
                     } else if resolution.tag == resolution::Tag::Folder
@@ -2133,11 +2127,9 @@ impl<'a> PackageInstaller<'a> {
                                         Output::err(
                                             "EACCES",
                                             "Permission denied while installing <b>{}<r>",
-                                            (bstr::BStr::new(
-                                                self.names[package_id.index()].slice(
-                                                    self.lockfile().buffers.string_bytes.as_slice(),
-                                                ),
-                                            ),),
+                                            (bstr::BStr::new(self.names[package_id].slice(
+                                                self.lockfile().buffers.string_bytes.as_slice(),
+                                            )),),
                                         );
                                         if cfg!(debug_assertions) {
                                             Output::err(err, "Failed to stat node_modules", ());
@@ -2151,11 +2143,9 @@ impl<'a> PackageInstaller<'a> {
                                         Output::err(
                                             "EACCES",
                                             "Permission denied while installing <b>{}<r>",
-                                            (bstr::BStr::new(
-                                                self.names[package_id.index()].slice(
-                                                    self.lockfile().buffers.string_bytes.as_slice(),
-                                                ),
-                                            ),),
+                                            (bstr::BStr::new(self.names[package_id].slice(
+                                                self.lockfile().buffers.string_bytes.as_slice(),
+                                            )),),
                                         );
                                         if cfg!(debug_assertions) {
                                             Output::err(err, "Failed to stat node_modules", ());
@@ -2193,9 +2183,7 @@ impl<'a> PackageInstaller<'a> {
                         Output::err(
                             "EACCES",
                             "Permission denied while installing <b>{}<r>",
-                            (bstr::BStr::new(
-                                self.names[package_id.index()].slice(string_buf!()),
-                            ),),
+                            (bstr::BStr::new(self.names[package_id].slice(string_buf!())),),
                         );
 
                         self.summary.fail += 1;
@@ -2205,9 +2193,7 @@ impl<'a> PackageInstaller<'a> {
                             "failed {} for package <b>{}<r>",
                             (
                                 bstr::BStr::new(cause.step.name()),
-                                bstr::BStr::new(
-                                    self.names[package_id.index()].slice(string_buf!()),
-                                ),
+                                bstr::BStr::new(self.names[package_id].slice(string_buf!())),
                             ),
                         );
                         #[cfg(bun_debug)]
@@ -2241,7 +2227,7 @@ impl<'a> PackageInstaller<'a> {
 
             self.summary.skipped += 1;
 
-            if self.bins[package_id.index()].tag != bin::Tag::None {
+            if self.bins[package_id].tag != bin::Tag::None {
                 self.trees[self.current_tree_id as usize]
                     .binaries
                     .add(dependency_id)
@@ -2261,7 +2247,7 @@ impl<'a> PackageInstaller<'a> {
             // `defer { destination_dir.close(); }` + `defer increment_tree_install_count`.
             // No early returns after this point, so manual calls at end are equivalent.
 
-            let dep = &self.lockfile().buffers.dependencies.as_slice()[dependency_id.index()];
+            let dep = &self.lockfile().buffers.dependencies.as_slice()[dependency_id];
             let dep_behavior = dep.behavior;
             let truncated_dep_name_hash: TruncatedPackageNameHash =
                 dep.name_hash as TruncatedPackageNameHash;
@@ -2315,7 +2301,7 @@ impl<'a> PackageInstaller<'a> {
                                 },
                                 version_buf: string_buf!(),
                             },
-                            self.lockfile().packages.items_resolutions()[package_id.index()]
+                            self.lockfile().packages.items_resolutions()[package_id]
                                 .get(self.lockfile().buffers.resolutions.as_slice()),
                             self.lockfile().packages.items_meta(),
                             self.manager().options.cpu,
@@ -2407,8 +2393,7 @@ impl<'a> PackageInstaller<'a> {
         optional: bool,
         resolution: &Resolution,
     ) -> bool {
-        let mut scripts: PackageScripts =
-            self.lockfile().packages.items_scripts()[package_id.index()];
+        let mut scripts: PackageScripts = self.lockfile().packages.items_scripts()[package_id];
         let log = self.manager().log_mut();
         let scripts_list = match scripts.get_list(
             log,
@@ -2503,9 +2488,9 @@ impl<'a> PackageInstaller<'a> {
     }
 
     pub(crate) fn install_package(&mut self, dep_id: DependencyID, log_level: Options::LogLevel) {
-        let package_id = self.lockfile().buffers.resolutions.as_slice()[dep_id.index()];
+        let package_id = self.lockfile().buffers.resolutions.as_slice()[dep_id];
 
-        let name = self.names[package_id.index()];
+        let name = self.names[package_id];
         // `self.resolutions` is `RawSlice<Resolution>` (Copy); copy out so the
         // `&Resolution` argument borrows the local, not `*self`, across the
         // `&mut self` call.
@@ -2518,7 +2503,7 @@ impl<'a> PackageInstaller<'a> {
             package_id,
             log_level,
             name,
-            &resolutions[package_id.index()],
+            &resolutions[package_id],
         );
     }
 }

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -911,9 +911,9 @@ impl<'a> PackageInstaller<'a> {
                 // Drain by move (`mem::take`) to transfer ownership without the
                 // O(pending_installs) extra `.clone()` allocations and to leave
                 // `pending_installs` empty as the spec's defer does.
-                // `self.resolutions` is `RawSlice<Resolution>` (Copy); copy
-                // it out so the `&Resolution` argument below borrows the
-                // local, not `*self`, across the `&mut self` call.
+                // `self.resolutions` is `Copy`; copy it out so the
+                // `&Resolution` argument below borrows the local, not
+                // `*self`, across the `&mut self` call.
                 let resolutions = self.resolutions;
                 for context in core::mem::take(&mut self.trees[i].pending_installs) {
                     let package_id =
@@ -1145,8 +1145,8 @@ impl<'a> PackageInstaller<'a> {
                 return;
             }
 
-            // `self.resolutions` is `RawSlice<Resolution>` (Copy); copy out
-            // so the `&Resolution` argument borrows the local, not `*self`.
+            // `self.resolutions` is `Copy`; copy it out so the `&Resolution`
+            // argument borrows the local, not `*self`.
             let resolutions = self.resolutions;
             for cb in callbacks.iter() {
                 let TaskCallbackContext::DependencyInstallContext(context) = cb else {
@@ -2491,9 +2491,8 @@ impl<'a> PackageInstaller<'a> {
         let package_id = self.lockfile().buffers.resolutions.as_slice()[dep_id];
 
         let name = self.names[package_id];
-        // `self.resolutions` is `RawSlice<Resolution>` (Copy); copy out so the
-        // `&Resolution` argument borrows the local, not `*self`, across the
-        // `&mut self` call.
+        // `self.resolutions` is `Copy`; copy it out so the `&Resolution`
+        // argument borrows the local, not `*self`, across the `&mut self` call.
         let resolutions = self.resolutions;
 
         const NEEDS_VERIFY: bool = true;

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -279,7 +279,7 @@ pub type PatchTaskQueue = UnboundedQueue<PatchTask /* , .next */>;
 pub type AsyncNetworkTaskQueue = UnboundedQueue<NetworkTask /* , .next */>;
 
 pub(crate) type SuccessFn = fn(&mut PackageManager, DependencyID, PackageID);
-pub(crate) type FailFn = fn(&mut PackageManager, &Dependency, PackageID, Error);
+pub(crate) type FailFn = fn(&mut PackageManager, &Dependency, DependencyID, Error);
 
 // Default to a maximum of 64 simultaneous HTTP requests for bun install if no proxy is specified
 // if a proxy IS specified, default to 64. We have different values because we might change this in the future.
@@ -2167,7 +2167,7 @@ pub fn init(
             crate::resolvers::folder_resolver::hash(normalized),
             FolderResolutionEntry {
                 abs_path: Box::<[u8]>::from(&*normalized),
-                resolution: FolderResolution::PackageId(0),
+                resolution: FolderResolution::PackageId(PackageID::ROOT),
             },
         )?;
         // normalized.deinit() → Drop (stack buffer)

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -9,7 +9,9 @@ use crate::bun_fs::FileSystem;
 use crate::bun_progress::{Node as ProgressNode, Progress};
 use crate::bun_schema::api as Api;
 use bun_collections::linear_fifo::{DynamicBuffer, StaticBuffer};
-use bun_collections::{ArrayHashMap, HashMap, HiveArrayFallback, LinearFifo, StringArrayHashMap};
+use bun_collections::{
+    ArrayHashMap, HashMap, HiveArrayFallback, IdVec, LinearFifo, StringArrayHashMap,
+};
 use bun_core::ZBox;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
@@ -382,7 +384,7 @@ pub struct PackageManager {
     pub lockfile: Box<Lockfile>, // OWNED
 
     pub options: Options,
-    pub(crate) preinstall_state: Vec<PreinstallState>,
+    pub(crate) preinstall_state: IdVec<PackageID, PreinstallState>,
     pub(crate) postinstall_optimizer: crate::postinstall_optimizer::List,
 
     pub(crate) global_link_dir: Option<bun_sys::Dir>,
@@ -2097,7 +2099,7 @@ pub fn init(
         wr!(total_scripts, 0);
         wr!(root_lifecycle_scripts, None);
         wr!(node_gyp_tempdir_name, Box::default());
-        wr!(preinstall_state, Vec::new());
+        wr!(preinstall_state, IdVec::new());
         wr!(postinstall_optimizer, Default::default());
         wr!(global_link_dir, None);
         wr!(global_dir, None);
@@ -2541,7 +2543,7 @@ fn init_with_runtime_once(
         wr!(total_scripts, 0);
         wr!(root_lifecycle_scripts, None);
         wr!(node_gyp_tempdir_name, Box::default());
-        wr!(preinstall_state, Vec::new());
+        wr!(preinstall_state, IdVec::new());
         wr!(postinstall_optimizer, Default::default());
         wr!(global_link_dir, None);
         wr!(global_dir, None);

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -531,9 +531,8 @@ fn edit_update_entries(
                         lockfile.get_workspace_package_id(workspace_name_hash);
                     let packages = lockfile.packages.slice();
                     let resolutions = packages.items_resolution();
-                    let deps = packages.items_dependencies()[workspace_package_id as usize];
-                    let resolution_ids =
-                        packages.items_resolutions()[workspace_package_id as usize];
+                    let deps = packages.items_dependencies()[workspace_package_id.index()];
+                    let resolution_ids = packages.items_resolutions()[workspace_package_id.index()];
                     let workspace_deps: &[Dependency] =
                         deps.get(lockfile.buffers.dependencies.as_slice());
                     let workspace_resolution_ids =
@@ -589,7 +588,7 @@ fn edit_update_entries(
                                         continue;
                                     }
 
-                                    let resolution = &resolutions[package_id as usize];
+                                    let resolution = &resolutions[package_id.index()];
                                     if resolution.tag != resolution::Tag::Npm {
                                         continue;
                                     }
@@ -901,7 +900,7 @@ fn resolve_catalog_literals(
             continue;
         }
 
-        let resolution = &package_resolutions[package_id as usize];
+        let resolution = &package_resolutions[package_id.index()];
         if resolution.tag != resolution::Tag::Npm {
             continue;
         }
@@ -1338,8 +1337,8 @@ pub(crate) fn edit(
             {
                 continue;
             }
-            if request.package_id as usize >= resolutions.len()
-                || resolutions[request.package_id as usize].tag == resolution::Tag::Uninitialized
+            if request.package_id.index() >= resolutions.len()
+                || resolutions[request.package_id.index()].tag == resolution::Tag::Uninitialized
             {
                 // The entry `bun update` is updating keeps its alias target whatever gets resolved.
                 let existing: Option<&[u8]> = (manager.subcommand == Subcommand::Update
@@ -1374,10 +1373,10 @@ pub(crate) fn edit(
 
                 continue;
             }
-            let new_literal: &[u8] = match resolutions[request.package_id as usize].tag {
+            let new_literal: &[u8] = match resolutions[request.package_id.index()].tag {
                 resolution::Tag::Npm => 'npm: {
                     let installed = request.version.literal.slice(request.version_buf());
-                    let resolved = resolutions[request.package_id as usize].npm().version;
+                    let resolved = resolutions[request.package_id.index()].npm().version;
                     let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
                     // `bun update <name>` keeps a dist-tag literal as written unless --latest, like the bare path.
                     if manager.subcommand == Subcommand::Update

--- a/src/install/PackageManager/PackageJSONEditor.rs
+++ b/src/install/PackageManager/PackageJSONEditor.rs
@@ -1,4 +1,4 @@
-use bun_collections::{StringArrayHashMap, VecExt};
+use bun_collections::{IdSlice, StringArrayHashMap, VecExt};
 use std::io::Write as _;
 
 use bun_ast as js_ast;
@@ -531,8 +531,8 @@ fn edit_update_entries(
                         lockfile.get_workspace_package_id(workspace_name_hash);
                     let packages = lockfile.packages.slice();
                     let resolutions = packages.items_resolution();
-                    let deps = packages.items_dependencies()[workspace_package_id.index()];
-                    let resolution_ids = packages.items_resolutions()[workspace_package_id.index()];
+                    let deps = packages.items_dependencies()[workspace_package_id];
+                    let resolution_ids = packages.items_resolutions()[workspace_package_id];
                     let workspace_deps: &[Dependency] =
                         deps.get(lockfile.buffers.dependencies.as_slice());
                     let workspace_resolution_ids =
@@ -588,7 +588,7 @@ fn edit_update_entries(
                                         continue;
                                     }
 
-                                    let resolution = &resolutions[package_id.index()];
+                                    let resolution = &resolutions[package_id];
                                     if resolution.tag != resolution::Tag::Npm {
                                         continue;
                                     }
@@ -900,7 +900,7 @@ fn resolve_catalog_literals(
             continue;
         }
 
-        let resolution = &package_resolutions[package_id.index()];
+        let resolution = &package_resolutions[package_id];
         if resolution.tag != resolution::Tag::Npm {
             continue;
         }
@@ -1310,7 +1310,7 @@ pub(crate) fn edit(
     let resolutions = if !options.before_install {
         manager.lockfile.packages.items_resolution()
     } else {
-        &[]
+        IdSlice::from_raw(&[])
     };
     for request in updates.iter_mut() {
         if let Some(e_string) = request.e_string {
@@ -1337,8 +1337,8 @@ pub(crate) fn edit(
             {
                 continue;
             }
-            if request.package_id.index() >= resolutions.len()
-                || resolutions[request.package_id.index()].tag == resolution::Tag::Uninitialized
+            if !resolutions.has(request.package_id)
+                || resolutions[request.package_id].tag == resolution::Tag::Uninitialized
             {
                 // The entry `bun update` is updating keeps its alias target whatever gets resolved.
                 let existing: Option<&[u8]> = (manager.subcommand == Subcommand::Update
@@ -1373,10 +1373,10 @@ pub(crate) fn edit(
 
                 continue;
             }
-            let new_literal: &[u8] = match resolutions[request.package_id.index()].tag {
+            let new_literal: &[u8] = match resolutions[request.package_id].tag {
                 resolution::Tag::Npm => 'npm: {
                     let installed = request.version.literal.slice(request.version_buf());
-                    let resolved = resolutions[request.package_id.index()].npm().version;
+                    let resolved = resolutions[request.package_id].npm().version;
                     let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
                     // `bun update <name>` keeps a dist-tag literal as written unless --latest, like the bare path.
                     if manager.subcommand == Subcommand::Update

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -922,7 +922,7 @@ pub fn path_for_resolution<'a>(
     match resolution.tag {
         ResolutionTag::Npm => {
             let npm = *resolution.npm();
-            let package_name_ = this.lockfile.packages.items_name()[package_id as usize];
+            let package_name_ = this.lockfile.packages.items_name()[package_id.index()];
             // borrowck — `path_for_cached_npm_path` reborrows `this`
             // mutably (for `get_cache_directory`), so the `&this.lockfile`
             // borrow can't be held across it. Copy the name out first.

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -922,7 +922,7 @@ pub fn path_for_resolution<'a>(
     match resolution.tag {
         ResolutionTag::Npm => {
             let npm = *resolution.npm();
-            let package_name_ = this.lockfile.packages.items_name()[package_id.index()];
+            let package_name_ = this.lockfile.packages.items_name()[package_id];
             // borrowck — `path_for_cached_npm_path` reborrows `this`
             // mutably (for `get_cache_directory`), so the `&this.lockfile`
             // borrow can't be held across it. Copy the name out first.

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -105,9 +105,11 @@ pub fn enqueue_dependency_list(
 
     // we have to be very careful with pointers here
     while i < end {
-        let dependency = this.lockfile.buffers.dependencies[i as usize].clone();
-        let resolution = this.lockfile.buffers.resolutions[i as usize];
-        if let Err(err) = enqueue_dependency_with_main(this, i, &dependency, resolution, false) {
+        let dep_id = DependencyID::new(i);
+        let dependency = this.lockfile.buffers.dependencies[dep_id.index()].clone();
+        let resolution = this.lockfile.buffers.resolutions[dep_id.index()];
+        if let Err(err) = enqueue_dependency_with_main(this, dep_id, &dependency, resolution, false)
+        {
             let path_sep = match dependency.version.tag {
                 dependency::version::Tag::Folder => bun_fmt::PathSep::Auto,
                 _ => bun_fmt::PathSep::Any,
@@ -169,10 +171,10 @@ pub fn enqueue_tarball_for_download(
         return Ok(());
     }
 
-    let is_required = this.lockfile.buffers.dependencies[dependency_id as usize]
+    let is_required = this.lockfile.buffers.dependencies[dependency_id.index()]
         .behavior
         .is_required();
-    let package = *this.lockfile.packages.get(package_id as usize);
+    let package = *this.lockfile.packages.get(package_id.index());
     if let Some(task) = run_tasks::generate_network_task_for_tarball(
         this,
         task_id,
@@ -225,7 +227,7 @@ pub fn enqueue_tarball_for_reading(
         return;
     }
 
-    let integrity = this.lockfile.packages.items_meta()[package_id as usize].integrity;
+    let integrity = this.lockfile.packages.items_meta()[package_id.index()].integrity;
 
     let task = enqueue_local_tarball(
         this,
@@ -301,7 +303,7 @@ pub fn enqueue_git_for_checkout(
             return;
         }
 
-        let dep = this.lockfile.buffers.dependencies[dependency_id as usize].clone();
+        let dep = this.lockfile.buffers.dependencies[dependency_id.index()].clone();
         let task = enqueue_git_clone(this, clone_id, alias, &repository, &dep, resolution, None);
         this.task_batch.push(ThreadPool::Batch::from(task));
     }
@@ -368,10 +370,10 @@ pub fn enqueue_package_for_download(
         return Ok(());
     }
 
-    let is_required = this.lockfile.buffers.dependencies[dependency_id as usize]
+    let is_required = this.lockfile.buffers.dependencies[dependency_id.index()]
         .behavior
         .is_required();
-    let package = *this.lockfile.packages.get(package_id as usize);
+    let package = *this.lockfile.packages.get(package_id.index());
 
     if let Some(task) = run_tasks::generate_network_task_for_tarball(
         this,
@@ -411,7 +413,7 @@ pub fn enqueue_dependency_to_root(
     version_buf: &[u8],
     behavior: Behavior,
 ) -> DependencyToEnqueue {
-    let dep_id = 'brk: {
+    let dep_index: usize = 'brk: {
         let str_buf = this.lockfile.buffers.string_bytes.as_slice();
         for (id, dep) in this.lockfile.buffers.dependencies.iter().enumerate() {
             if !strings::eql_long(dep.name.slice(str_buf), name, true) {
@@ -449,13 +451,14 @@ pub fn enqueue_dependency_to_root(
         lf.resolutions.push(invalid_package_id);
         debug_assert!(lf.dependencies.len() == lf.resolutions.len());
         break 'brk index;
-    } as DependencyID;
+    };
+    let dep_id = DependencyID::from_index(dep_index);
 
-    if this.lockfile.buffers.resolutions[dep_id as usize] == invalid_package_id {
+    if this.lockfile.buffers.resolutions[dep_id.index()] == invalid_package_id {
         // Copy to the stack: `enqueueDependencyWithMainAndSuccessFn` can call
         // `Lockfile.Package.fromNPM`, which grows `buffers.dependencies` and
         // would invalidate a pointer taken directly into it.
-        let dependency = this.lockfile.buffers.dependencies[dep_id as usize].clone();
+        let dependency = this.lockfile.buffers.dependencies[dep_id.index()].clone();
         if let Err(err) = enqueue_dependency_with_main_and_success_fn(
             this,
             dep_id,
@@ -470,7 +473,7 @@ pub fn enqueue_dependency_to_root(
         }
     }
 
-    let resolution_id = match this.lockfile.buffers.resolutions[dep_id as usize] {
+    let resolution_id = match this.lockfile.buffers.resolutions[dep_id.index()] {
         id if id == invalid_package_id => 'brk: {
             this.drain_dependency_list();
 
@@ -538,7 +541,7 @@ pub fn enqueue_dependency_to_root(
                 return DependencyToEnqueue::Failure(err);
             }
 
-            break 'brk this.lockfile.buffers.resolutions[dep_id as usize];
+            break 'brk this.lockfile.buffers.resolutions[dep_id.index()];
         }
         // we managed to synchronously resolve the dependency
         pkg_id => pkg_id,
@@ -549,7 +552,7 @@ pub fn enqueue_dependency_to_root(
     }
 
     DependencyToEnqueue::Resolution {
-        resolution: this.lockfile.packages.items_resolution()[resolution_id as usize],
+        resolution: this.lockfile.packages.items_resolution()[resolution_id.index()],
         package_id: resolution_id,
     }
 }
@@ -615,9 +618,9 @@ fn resolve_from_appended_task(
     id: DependencyID,
 ) -> Option<PackageID> {
     let &pkg_id = this.appended_task_packages.get(&task_id)?;
-    let pkg_name = this.lockfile.packages.items_name()[pkg_id as usize];
-    let pkg_res = this.lockfile.packages.items_resolution()[pkg_id as usize];
-    let v = &mut this.lockfile.buffers.dependencies[id as usize].version;
+    let pkg_name = this.lockfile.packages.items_name()[pkg_id.index()];
+    let pkg_res = this.lockfile.packages.items_resolution()[pkg_id.index()];
+    let v = &mut this.lockfile.buffers.dependencies[id.index()].version;
     // The buffer row can hold a different tag than the enqueue arm when the
     // dependency comes from `overrides`.
     match v.tag {
@@ -1230,8 +1233,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             }
 
             if let Some(repo_fd) = this.git_repositories.get(&clone_id).copied() {
-                let needs_ctx =
-                    this.lockfile.buffers.resolutions[id as usize] == invalid_package_id;
+                let needs_ctx = this.lockfile.buffers.resolutions[id.index()] == invalid_package_id;
 
                 // An already-resolved dependency (install-phase re-enqueue
                 // after the shared clone finished) is pinned: its install
@@ -1240,8 +1242,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 let pinned: Option<Vec<u8>> = if needs_ctx {
                     None
                 } else {
-                    let pkg_id = this.lockfile.buffers.resolutions[id as usize];
-                    let pkg_res = this.lockfile.packages.items_resolution()[pkg_id as usize];
+                    let pkg_id = this.lockfile.buffers.resolutions[id.index()];
+                    let pkg_res = this.lockfile.packages.items_resolution()[pkg_id.index()];
                     // SAFETY: tag checked — `value.git` is the active union arm.
                     (pkg_res.tag == ResolutionTag::Git)
                         .then(|| this.lockfile.str(&pkg_res.git().resolved).to_vec())
@@ -1351,7 +1353,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 );
             }
 
-            if this.lockfile.buffers.resolutions[id as usize] == invalid_package_id {
+            if this.lockfile.buffers.resolutions[id.index()] == invalid_package_id {
                 if let Some(pkg_id) = resolve_from_appended_task(this, task_id, id) {
                     success_fn(this, id, pkg_id);
                     return Ok(());
@@ -1557,7 +1559,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 );
             }
 
-            if this.lockfile.buffers.resolutions[id as usize] == invalid_package_id {
+            if this.lockfile.buffers.resolutions[id.index()] == invalid_package_id {
                 if let Some(pkg_id) = resolve_from_appended_task(this, task_id, id) {
                     success_fn(this, id, pkg_id);
                     return Ok(());
@@ -1862,7 +1864,7 @@ pub fn enqueue_git_checkout(
             },
             apply_patch_task: if let Some((h, patch_hash)) = patch {
                 let dep_name_hash =
-                    this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
+                    this.lockfile.buffers.dependencies[dependency_id.index()].name_hash;
                 let pkg_id = match this
                     .lockfile
                     .package_index
@@ -1911,7 +1913,7 @@ fn enqueue_local_tarball(
             break 'tarball_path (path, true);
         }
 
-        let workspace_res = this.lockfile.packages.items_resolution()[workspace_pkg_id as usize];
+        let workspace_res = this.lockfile.packages.items_resolution()[workspace_pkg_id.index()];
         if workspace_res.tag != ResolutionTag::Workspace {
             break 'tarball_path (path, true);
         }
@@ -2091,7 +2093,7 @@ fn get_or_put_resolved_package_with_find_result(
             this.kept_patched.push(id);
             success_fn(this, dependency_id, id);
             return Ok(Some(ResolvedPackageResult {
-                package: *this.lockfile.packages.get(id as usize),
+                package: *this.lockfile.packages.get(id.index()),
                 is_first_time: false,
                 task: None,
             }));
@@ -2131,7 +2133,7 @@ fn get_or_put_resolved_package_with_find_result(
     ) {
         success_fn(this, dependency_id, id);
         return Ok(Some(ResolvedPackageResult {
-            package: *this.lockfile.packages.get(id as usize),
+            package: *this.lockfile.packages.get(id.index()),
             is_first_time: false,
             task: None,
         }));
@@ -2287,18 +2289,18 @@ fn get_or_put_resolved_package(
             match index {
                 PackageIndexEntry::Id(existing_id) => {
                     let existing_id = *existing_id;
-                    if (existing_id as usize) < resolutions.len() {
-                        let existing_resolution = resolutions[existing_id as usize];
+                    if existing_id.index() < resolutions.len() {
+                        let existing_resolution = resolutions[existing_id.index()];
                         if resolution_satisfies_dependency(this, &existing_resolution, version) {
                             success_fn(this, dependency_id, existing_id);
                             return Ok(Some(ResolvedPackageResult {
                                 // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
-                                package: *this.lockfile.packages.get(existing_id as usize),
+                                package: *this.lockfile.packages.get(existing_id.index()),
                                 ..Default::default()
                             }));
                         }
 
-                        let res_tag = resolutions[existing_id as usize].tag;
+                        let res_tag = resolutions[existing_id.index()].tag;
                         let ver_tag = version.tag;
                         if (res_tag == ResolutionTag::Npm
                             && ver_tag == dependency::version::Tag::Npm)
@@ -2307,7 +2309,7 @@ fn get_or_put_resolved_package(
                             || (res_tag == ResolutionTag::Github
                                 && ver_tag == dependency::version::Tag::Github)
                         {
-                            let existing_package = this.lockfile.packages.get(existing_id as usize);
+                            let existing_package = this.lockfile.packages.get(existing_id.index());
                             this.log_mut().add_warning_fmt(
                                 None,
                                 bun_ast::Loc::EMPTY,
@@ -2325,7 +2327,7 @@ fn get_or_put_resolved_package(
                             success_fn(this, dependency_id, existing_id);
                             return Ok(Some(ResolvedPackageResult {
                                 // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
-                                package: *this.lockfile.packages.get(existing_id as usize),
+                                package: *this.lockfile.packages.get(existing_id.index()),
                                 ..Default::default()
                             }));
                         }
@@ -2333,21 +2335,21 @@ fn get_or_put_resolved_package(
                 }
                 PackageIndexEntry::Ids(list) => {
                     for &existing_id in list.iter() {
-                        if (existing_id as usize) < resolutions.len() {
-                            let existing_resolution = resolutions[existing_id as usize];
+                        if existing_id.index() < resolutions.len() {
+                            let existing_resolution = resolutions[existing_id.index()];
                             if resolution_satisfies_dependency(this, &existing_resolution, version)
                             {
                                 success_fn(this, dependency_id, existing_id);
                                 return Ok(Some(ResolvedPackageResult {
-                                    package: *this.lockfile.packages.get(existing_id as usize),
+                                    package: *this.lockfile.packages.get(existing_id.index()),
                                     ..Default::default()
                                 }));
                             }
                         }
                     }
 
-                    if (list[0] as usize) < resolutions.len() {
-                        let res_tag = resolutions[list[0] as usize].tag;
+                    if list[0].index() < resolutions.len() {
+                        let res_tag = resolutions[list[0].index()].tag;
                         let ver_tag = version.tag;
                         if (res_tag == ResolutionTag::Npm
                             && ver_tag == dependency::version::Tag::Npm)
@@ -2358,7 +2360,7 @@ fn get_or_put_resolved_package(
                         {
                             let existing_package_id = list[0];
                             let existing_package =
-                                this.lockfile.packages.get(existing_package_id as usize);
+                                this.lockfile.packages.get(existing_package_id.index());
                             this.log_mut().add_warning_fmt(
                                 None,
                                 bun_ast::Loc::EMPTY,
@@ -2376,7 +2378,7 @@ fn get_or_put_resolved_package(
                             success_fn(this, dependency_id, list[0]);
                             return Ok(Some(ResolvedPackageResult {
                                 // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
-                                package: *this.lockfile.packages.get(existing_package_id as usize),
+                                package: *this.lockfile.packages.get(existing_package_id.index()),
                                 ..Default::default()
                             }));
                         }
@@ -2386,9 +2388,9 @@ fn get_or_put_resolved_package(
         }
     }
 
-    if (resolution as usize) < this.lockfile.packages.len() {
+    if resolution.index() < this.lockfile.packages.len() {
         return Ok(Some(ResolvedPackageResult {
-            package: *this.lockfile.packages.get(resolution as usize),
+            package: *this.lockfile.packages.get(resolution.index()),
             ..Default::default()
         }));
     }
@@ -2421,7 +2423,7 @@ fn get_or_put_resolved_package(
                         // make sure verifyResolutions sees this resolution as a valid package id
                         success_fn(this, dependency_id, workspace_package_id);
                         return Ok(Some(ResolvedPackageResult {
-                            package: *this.lockfile.packages.get(workspace_package_id as usize),
+                            package: *this.lockfile.packages.get(workspace_package_id.index()),
                             is_first_time: false,
                             task: None,
                         }));
@@ -2581,7 +2583,7 @@ fn get_or_put_resolved_package(
                                     package: *this
                                         .lockfile
                                         .packages
-                                        .get(workspace_package_id as usize),
+                                        .get(workspace_package_id.index()),
                                     is_first_time: false,
                                     task: None,
                                 }));
@@ -2745,7 +2747,7 @@ fn get_or_put_resolved_package(
                     };
                     success_fn(this, dependency_id, workspace_package_id);
                     return Ok(Some(ResolvedPackageResult {
-                        package: *this.lockfile.packages.get(workspace_package_id as usize),
+                        package: *this.lockfile.packages.get(workspace_package_id.index()),
                         ..Default::default()
                     }));
                 }
@@ -2825,7 +2827,7 @@ fn resolved_folder_package(
     };
     success_fn(this, dependency_id, package_id);
     Ok(Some(ResolvedPackageResult {
-        package: *this.lockfile.packages.get(package_id as usize),
+        package: *this.lockfile.packages.get(package_id.index()),
         is_first_time,
         task: None,
     }))
@@ -2867,7 +2869,7 @@ fn locked_version_of_invoking_workspace_row<'a>(
         return None;
     }
     let own_rows = this.root_package_id.id?;
-    if !this.lockfile.packages.items_dependencies()[own_rows as usize].contains(dependency_id) {
+    if !this.lockfile.packages.items_dependencies()[own_rows.index()].contains(dependency_id) {
         return None;
     }
     let entry = this
@@ -2898,8 +2900,8 @@ fn locked_version_in_lockfile<'a>(
     candidates
         .iter()
         .copied()
-        .filter(|&id| id < lockfile.loaded_package_count)
-        .map(|id| &pkg_res[id as usize])
+        .filter(|&id| id.get() < lockfile.loaded_package_count)
+        .map(|id| &pkg_res[id.index()])
         .filter(|res| res.tag == ResolutionTag::Npm)
         .map(|res| res.npm().version)
         .find(|&locked| range.satisfies(locked, buf, buf))
@@ -2928,7 +2930,7 @@ fn patched_package_satisfying(
     let pkg_res = lockfile.packages.items_resolution();
     let buf = lockfile.buffers.string_bytes.as_slice();
     candidates.iter().copied().find(|&id| {
-        let res = &pkg_res[id as usize];
+        let res = &pkg_res[id.index()];
         res.tag == ResolutionTag::Npm
             && res.satisfies_dependency_version(version, buf, buf)
             && lockfile

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -106,8 +106,8 @@ pub fn enqueue_dependency_list(
     // we have to be very careful with pointers here
     while i < end {
         let dep_id = DependencyID::new(i);
-        let dependency = this.lockfile.buffers.dependencies[dep_id.index()].clone();
-        let resolution = this.lockfile.buffers.resolutions[dep_id.index()];
+        let dependency = this.lockfile.buffers.dependencies[dep_id].clone();
+        let resolution = this.lockfile.buffers.resolutions[dep_id];
         if let Err(err) = enqueue_dependency_with_main(this, dep_id, &dependency, resolution, false)
         {
             let path_sep = match dependency.version.tag {
@@ -171,10 +171,10 @@ pub fn enqueue_tarball_for_download(
         return Ok(());
     }
 
-    let is_required = this.lockfile.buffers.dependencies[dependency_id.index()]
+    let is_required = this.lockfile.buffers.dependencies[dependency_id]
         .behavior
         .is_required();
-    let package = *this.lockfile.packages.get(package_id.index());
+    let package = this.lockfile.package(package_id);
     if let Some(task) = run_tasks::generate_network_task_for_tarball(
         this,
         task_id,
@@ -227,7 +227,7 @@ pub fn enqueue_tarball_for_reading(
         return;
     }
 
-    let integrity = this.lockfile.packages.items_meta()[package_id.index()].integrity;
+    let integrity = this.lockfile.packages.items_meta()[package_id].integrity;
 
     let task = enqueue_local_tarball(
         this,
@@ -303,7 +303,7 @@ pub fn enqueue_git_for_checkout(
             return;
         }
 
-        let dep = this.lockfile.buffers.dependencies[dependency_id.index()].clone();
+        let dep = this.lockfile.buffers.dependencies[dependency_id].clone();
         let task = enqueue_git_clone(this, clone_id, alias, &repository, &dep, resolution, None);
         this.task_batch.push(ThreadPool::Batch::from(task));
     }
@@ -370,10 +370,10 @@ pub fn enqueue_package_for_download(
         return Ok(());
     }
 
-    let is_required = this.lockfile.buffers.dependencies[dependency_id.index()]
+    let is_required = this.lockfile.buffers.dependencies[dependency_id]
         .behavior
         .is_required();
-    let package = *this.lockfile.packages.get(package_id.index());
+    let package = this.lockfile.package(package_id);
 
     if let Some(task) = run_tasks::generate_network_task_for_tarball(
         this,
@@ -454,11 +454,11 @@ pub fn enqueue_dependency_to_root(
     };
     let dep_id = DependencyID::from_index(dep_index);
 
-    if this.lockfile.buffers.resolutions[dep_id.index()] == invalid_package_id {
+    if this.lockfile.buffers.resolutions[dep_id] == invalid_package_id {
         // Copy to the stack: `enqueueDependencyWithMainAndSuccessFn` can call
         // `Lockfile.Package.fromNPM`, which grows `buffers.dependencies` and
         // would invalidate a pointer taken directly into it.
-        let dependency = this.lockfile.buffers.dependencies[dep_id.index()].clone();
+        let dependency = this.lockfile.buffers.dependencies[dep_id].clone();
         if let Err(err) = enqueue_dependency_with_main_and_success_fn(
             this,
             dep_id,
@@ -473,7 +473,7 @@ pub fn enqueue_dependency_to_root(
         }
     }
 
-    let resolution_id = match this.lockfile.buffers.resolutions[dep_id.index()] {
+    let resolution_id = match this.lockfile.buffers.resolutions[dep_id] {
         id if id == invalid_package_id => 'brk: {
             this.drain_dependency_list();
 
@@ -541,7 +541,7 @@ pub fn enqueue_dependency_to_root(
                 return DependencyToEnqueue::Failure(err);
             }
 
-            break 'brk this.lockfile.buffers.resolutions[dep_id.index()];
+            break 'brk this.lockfile.buffers.resolutions[dep_id];
         }
         // we managed to synchronously resolve the dependency
         pkg_id => pkg_id,
@@ -552,7 +552,7 @@ pub fn enqueue_dependency_to_root(
     }
 
     DependencyToEnqueue::Resolution {
-        resolution: this.lockfile.packages.items_resolution()[resolution_id.index()],
+        resolution: this.lockfile.packages.items_resolution()[resolution_id],
         package_id: resolution_id,
     }
 }
@@ -618,9 +618,9 @@ fn resolve_from_appended_task(
     id: DependencyID,
 ) -> Option<PackageID> {
     let &pkg_id = this.appended_task_packages.get(&task_id)?;
-    let pkg_name = this.lockfile.packages.items_name()[pkg_id.index()];
-    let pkg_res = this.lockfile.packages.items_resolution()[pkg_id.index()];
-    let v = &mut this.lockfile.buffers.dependencies[id.index()].version;
+    let pkg_name = this.lockfile.packages.items_name()[pkg_id];
+    let pkg_res = this.lockfile.packages.items_resolution()[pkg_id];
+    let v = &mut this.lockfile.buffers.dependencies[id].version;
     // The buffer row can hold a different tag than the enqueue arm when the
     // dependency comes from `overrides`.
     match v.tag {
@@ -1233,7 +1233,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             }
 
             if let Some(repo_fd) = this.git_repositories.get(&clone_id).copied() {
-                let needs_ctx = this.lockfile.buffers.resolutions[id.index()] == invalid_package_id;
+                let needs_ctx = this.lockfile.buffers.resolutions[id] == invalid_package_id;
 
                 // An already-resolved dependency (install-phase re-enqueue
                 // after the shared clone finished) is pinned: its install
@@ -1242,8 +1242,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 let pinned: Option<Vec<u8>> = if needs_ctx {
                     None
                 } else {
-                    let pkg_id = this.lockfile.buffers.resolutions[id.index()];
-                    let pkg_res = this.lockfile.packages.items_resolution()[pkg_id.index()];
+                    let pkg_id = this.lockfile.buffers.resolutions[id];
+                    let pkg_res = this.lockfile.packages.items_resolution()[pkg_id];
                     // SAFETY: tag checked — `value.git` is the active union arm.
                     (pkg_res.tag == ResolutionTag::Git)
                         .then(|| this.lockfile.str(&pkg_res.git().resolved).to_vec())
@@ -1353,7 +1353,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 );
             }
 
-            if this.lockfile.buffers.resolutions[id.index()] == invalid_package_id {
+            if this.lockfile.buffers.resolutions[id] == invalid_package_id {
                 if let Some(pkg_id) = resolve_from_appended_task(this, task_id, id) {
                     success_fn(this, id, pkg_id);
                     return Ok(());
@@ -1559,7 +1559,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 );
             }
 
-            if this.lockfile.buffers.resolutions[id.index()] == invalid_package_id {
+            if this.lockfile.buffers.resolutions[id] == invalid_package_id {
                 if let Some(pkg_id) = resolve_from_appended_task(this, task_id, id) {
                     success_fn(this, id, pkg_id);
                     return Ok(());
@@ -1863,8 +1863,7 @@ pub fn enqueue_git_checkout(
                 }),
             },
             apply_patch_task: if let Some((h, patch_hash)) = patch {
-                let dep_name_hash =
-                    this.lockfile.buffers.dependencies[dependency_id.index()].name_hash;
+                let dep_name_hash = this.lockfile.buffers.dependencies[dependency_id].name_hash;
                 let pkg_id = match this
                     .lockfile
                     .package_index
@@ -1913,7 +1912,7 @@ fn enqueue_local_tarball(
             break 'tarball_path (path, true);
         }
 
-        let workspace_res = this.lockfile.packages.items_resolution()[workspace_pkg_id.index()];
+        let workspace_res = this.lockfile.packages.items_resolution()[workspace_pkg_id];
         if workspace_res.tag != ResolutionTag::Workspace {
             break 'tarball_path (path, true);
         }
@@ -2093,7 +2092,7 @@ fn get_or_put_resolved_package_with_find_result(
             this.kept_patched.push(id);
             success_fn(this, dependency_id, id);
             return Ok(Some(ResolvedPackageResult {
-                package: *this.lockfile.packages.get(id.index()),
+                package: this.lockfile.package(id),
                 is_first_time: false,
                 task: None,
             }));
@@ -2133,7 +2132,7 @@ fn get_or_put_resolved_package_with_find_result(
     ) {
         success_fn(this, dependency_id, id);
         return Ok(Some(ResolvedPackageResult {
-            package: *this.lockfile.packages.get(id.index()),
+            package: this.lockfile.package(id),
             is_first_time: false,
             task: None,
         }));
@@ -2289,18 +2288,18 @@ fn get_or_put_resolved_package(
             match index {
                 PackageIndexEntry::Id(existing_id) => {
                     let existing_id = *existing_id;
-                    if existing_id.index() < resolutions.len() {
-                        let existing_resolution = resolutions[existing_id.index()];
+                    if resolutions.has(existing_id) {
+                        let existing_resolution = resolutions[existing_id];
                         if resolution_satisfies_dependency(this, &existing_resolution, version) {
                             success_fn(this, dependency_id, existing_id);
                             return Ok(Some(ResolvedPackageResult {
                                 // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
-                                package: *this.lockfile.packages.get(existing_id.index()),
+                                package: this.lockfile.package(existing_id),
                                 ..Default::default()
                             }));
                         }
 
-                        let res_tag = resolutions[existing_id.index()].tag;
+                        let res_tag = resolutions[existing_id].tag;
                         let ver_tag = version.tag;
                         if (res_tag == ResolutionTag::Npm
                             && ver_tag == dependency::version::Tag::Npm)
@@ -2309,7 +2308,7 @@ fn get_or_put_resolved_package(
                             || (res_tag == ResolutionTag::Github
                                 && ver_tag == dependency::version::Tag::Github)
                         {
-                            let existing_package = this.lockfile.packages.get(existing_id.index());
+                            let existing_package = this.lockfile.package(existing_id);
                             this.log_mut().add_warning_fmt(
                                 None,
                                 bun_ast::Loc::EMPTY,
@@ -2327,7 +2326,7 @@ fn get_or_put_resolved_package(
                             success_fn(this, dependency_id, existing_id);
                             return Ok(Some(ResolvedPackageResult {
                                 // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
-                                package: *this.lockfile.packages.get(existing_id.index()),
+                                package: this.lockfile.package(existing_id),
                                 ..Default::default()
                             }));
                         }
@@ -2335,13 +2334,13 @@ fn get_or_put_resolved_package(
                 }
                 PackageIndexEntry::Ids(list) => {
                     for &existing_id in list.iter() {
-                        if existing_id.index() < resolutions.len() {
-                            let existing_resolution = resolutions[existing_id.index()];
+                        if resolutions.has(existing_id) {
+                            let existing_resolution = resolutions[existing_id];
                             if resolution_satisfies_dependency(this, &existing_resolution, version)
                             {
                                 success_fn(this, dependency_id, existing_id);
                                 return Ok(Some(ResolvedPackageResult {
-                                    package: *this.lockfile.packages.get(existing_id.index()),
+                                    package: this.lockfile.package(existing_id),
                                     ..Default::default()
                                 }));
                             }
@@ -2349,7 +2348,7 @@ fn get_or_put_resolved_package(
                     }
 
                     if list[0].index() < resolutions.len() {
-                        let res_tag = resolutions[list[0].index()].tag;
+                        let res_tag = resolutions[list[0]].tag;
                         let ver_tag = version.tag;
                         if (res_tag == ResolutionTag::Npm
                             && ver_tag == dependency::version::Tag::Npm)
@@ -2359,8 +2358,7 @@ fn get_or_put_resolved_package(
                                 && ver_tag == dependency::version::Tag::Github)
                         {
                             let existing_package_id = list[0];
-                            let existing_package =
-                                this.lockfile.packages.get(existing_package_id.index());
+                            let existing_package = this.lockfile.package(existing_package_id);
                             this.log_mut().add_warning_fmt(
                                 None,
                                 bun_ast::Loc::EMPTY,
@@ -2378,7 +2376,7 @@ fn get_or_put_resolved_package(
                             success_fn(this, dependency_id, list[0]);
                             return Ok(Some(ResolvedPackageResult {
                                 // we must fetch it from the packages array again, incase the package array mutates the value in the `successFn`
-                                package: *this.lockfile.packages.get(existing_package_id.index()),
+                                package: this.lockfile.package(existing_package_id),
                                 ..Default::default()
                             }));
                         }
@@ -2390,7 +2388,7 @@ fn get_or_put_resolved_package(
 
     if resolution.index() < this.lockfile.packages.len() {
         return Ok(Some(ResolvedPackageResult {
-            package: *this.lockfile.packages.get(resolution.index()),
+            package: this.lockfile.package(resolution),
             ..Default::default()
         }));
     }
@@ -2423,7 +2421,7 @@ fn get_or_put_resolved_package(
                         // make sure verifyResolutions sees this resolution as a valid package id
                         success_fn(this, dependency_id, workspace_package_id);
                         return Ok(Some(ResolvedPackageResult {
-                            package: *this.lockfile.packages.get(workspace_package_id.index()),
+                            package: this.lockfile.package(workspace_package_id),
                             is_first_time: false,
                             task: None,
                         }));
@@ -2580,10 +2578,7 @@ fn get_or_put_resolved_package(
                                 // make sure verifyResolutions sees this resolution as a valid package id
                                 success_fn(this, dependency_id, workspace_package_id);
                                 return Ok(Some(ResolvedPackageResult {
-                                    package: *this
-                                        .lockfile
-                                        .packages
-                                        .get(workspace_package_id.index()),
+                                    package: this.lockfile.package(workspace_package_id),
                                     is_first_time: false,
                                     task: None,
                                 }));
@@ -2747,7 +2742,7 @@ fn get_or_put_resolved_package(
                     };
                     success_fn(this, dependency_id, workspace_package_id);
                     return Ok(Some(ResolvedPackageResult {
-                        package: *this.lockfile.packages.get(workspace_package_id.index()),
+                        package: this.lockfile.package(workspace_package_id),
                         ..Default::default()
                     }));
                 }
@@ -2827,7 +2822,7 @@ fn resolved_folder_package(
     };
     success_fn(this, dependency_id, package_id);
     Ok(Some(ResolvedPackageResult {
-        package: *this.lockfile.packages.get(package_id.index()),
+        package: this.lockfile.package(package_id),
         is_first_time,
         task: None,
     }))
@@ -2869,7 +2864,7 @@ fn locked_version_of_invoking_workspace_row<'a>(
         return None;
     }
     let own_rows = this.root_package_id.id?;
-    if !this.lockfile.packages.items_dependencies()[own_rows.index()].contains(dependency_id) {
+    if !this.lockfile.packages.items_dependencies()[own_rows].contains(dependency_id) {
         return None;
     }
     let entry = this
@@ -2901,7 +2896,7 @@ fn locked_version_in_lockfile<'a>(
         .iter()
         .copied()
         .filter(|&id| id.get() < lockfile.loaded_package_count)
-        .map(|id| &pkg_res[id.index()])
+        .map(|id| &pkg_res[id])
         .filter(|res| res.tag == ResolutionTag::Npm)
         .map(|res| res.npm().version)
         .find(|&locked| range.satisfies(locked, buf, buf))
@@ -2930,7 +2925,7 @@ fn patched_package_satisfying(
     let pkg_res = lockfile.packages.items_resolution();
     let buf = lockfile.buffers.string_bytes.as_slice();
     candidates.iter().copied().find(|&id| {
-        let res = &pkg_res[id.index()];
+        let res = &pkg_res[id];
         res.tag == ResolutionTag::Npm
             && res.satisfies_dependency_version(version, buf, buf)
             && lockfile

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -48,14 +48,14 @@ impl PackageManager {
     pub(crate) fn set_preinstall_state(&mut self, package_id: PackageID, value: PreinstallState) {
         let count = self.lockfile.packages.len();
         self.ensure_preinstall_state_list_capacity(count);
-        self.preinstall_state[package_id as usize] = value;
+        self.preinstall_state[package_id.index()] = value;
     }
 
     pub(crate) fn get_preinstall_state(&self, package_id: PackageID) -> PreinstallState {
-        if (package_id as usize) >= self.preinstall_state.len() {
+        if package_id.index() >= self.preinstall_state.len() {
             return PreinstallState::Unknown;
         }
-        self.preinstall_state[package_id as usize]
+        self.preinstall_state[package_id.index()]
     }
 
     /// A separate `lockfile` parameter would always be `manager.lockfile` at every call
@@ -443,7 +443,8 @@ impl PackageManager {
         if self.options.do_.trust_dependencies_from_args() && self.lockfile.packages.len() > 0 {
             let root_id = self
                 .root_package_id
-                .get(&self.lockfile, self.workspace_name_hash) as usize;
+                .get(&self.lockfile, self.workspace_name_hash)
+                .index();
             let root_deps = self.lockfile.packages.items_dependencies()[root_id];
             let mut dep_id = root_deps.off;
             let end = dep_id.saturating_add(root_deps.len);
@@ -478,7 +479,7 @@ fn add_package_to_set(
     }
     let mut stack: Vec<PackageID> = vec![package_id];
     while let Some(current) = stack.pop() {
-        let dependencies_slice = lockfile.packages.items_dependencies()[current as usize];
+        let dependencies_slice = lockfile.packages.items_dependencies()[current.index()];
         let begin = dependencies_slice.off;
         let end = begin.saturating_add(dependencies_slice.len);
         let mut dep_id = begin;

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -23,7 +23,7 @@ use crate::lockfile_real::package::scripts::List as ScriptsList;
 use crate::package_manager_real::Command;
 use crate::resolution_real::Tag as ResolutionTag;
 use bun_install::lockfile::{Lockfile, Package};
-use bun_install::{PackageID, PackageManager, PreinstallState, invalid_package_id};
+use bun_install::{DependencyID, PackageID, PackageManager, PreinstallState, invalid_package_id};
 
 impl PackageManager {
     pub(crate) fn ensure_preinstall_state_list_capacity(&mut self, count: usize) {
@@ -48,14 +48,14 @@ impl PackageManager {
     pub(crate) fn set_preinstall_state(&mut self, package_id: PackageID, value: PreinstallState) {
         let count = self.lockfile.packages.len();
         self.ensure_preinstall_state_list_capacity(count);
-        self.preinstall_state[package_id.index()] = value;
+        self.preinstall_state[package_id] = value;
     }
 
     pub(crate) fn get_preinstall_state(&self, package_id: PackageID) -> PreinstallState {
-        if package_id.index() >= self.preinstall_state.len() {
-            return PreinstallState::Unknown;
-        }
-        self.preinstall_state[package_id.index()]
+        self.preinstall_state
+            .get(package_id)
+            .copied()
+            .unwrap_or(PreinstallState::Unknown)
     }
 
     /// A separate `lockfile` parameter would always be `manager.lockfile` at every call
@@ -443,16 +443,16 @@ impl PackageManager {
         if self.options.do_.trust_dependencies_from_args() && self.lockfile.packages.len() > 0 {
             let root_id = self
                 .root_package_id
-                .get(&self.lockfile, self.workspace_name_hash)
-                .index();
+                .get(&self.lockfile, self.workspace_name_hash);
             let root_deps = self.lockfile.packages.items_dependencies()[root_id];
             let mut dep_id = root_deps.off;
             let end = dep_id.saturating_add(root_deps.len);
             while dep_id < end {
-                let root_dep = &self.lockfile.buffers.dependencies[dep_id as usize];
+                let root_dep_id = DependencyID::new(dep_id);
+                let root_dep = &self.lockfile.buffers.dependencies[root_dep_id];
                 for request in self.update_requests.iter() {
                     if request.matches(root_dep, self.lockfile.buffers.string_bytes.as_slice()) {
-                        let package_id = self.lockfile.buffers.resolutions[dep_id as usize];
+                        let package_id = self.lockfile.buffers.resolutions[root_dep_id];
                         if package_id == invalid_package_id {
                             continue;
                         }
@@ -479,12 +479,12 @@ fn add_package_to_set(
     }
     let mut stack: Vec<PackageID> = vec![package_id];
     while let Some(current) = stack.pop() {
-        let dependencies_slice = lockfile.packages.items_dependencies()[current.index()];
+        let dependencies_slice = lockfile.packages.items_dependencies()[current];
         let begin = dependencies_slice.off;
         let end = begin.saturating_add(dependencies_slice.len);
         let mut dep_id = begin;
         while dep_id < end {
-            let dep_package_id = lockfile.buffers.resolutions[dep_id as usize];
+            let dep_package_id = lockfile.buffers.resolutions[DependencyID::new(dep_id)];
             if dep_package_id != invalid_package_id
                 && !handle_oom(set.get_or_put(dep_package_id)).found_existing
             {

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -9,7 +9,7 @@ use bun_semver::{SlicedString, String as SemverString};
 
 use crate::_folder_resolver::{self as folder_resolver, GlobalOrRelative};
 use crate::dependency;
-use crate::lockfile::{DependencyIDSlice, DependencySlice};
+use crate::lockfile::{DependencySlice, PackageIDSlice};
 use crate::npm;
 use crate::resolution::Tag as ResolutionTag;
 use crate::{DependencyID, PackageID, PackageNameHash, Resolution, invalid_package_id};
@@ -231,12 +231,12 @@ impl PackageManager {
                     self,
                 ) {
                     folder_resolver::FolderResolution::NewPackageId(id) => {
-                        let deps = self.lockfile.packages.items_dependencies()[id as usize];
+                        let deps = self.lockfile.packages.items_dependencies()[id.index()];
                         super::enqueue_dependency_list(self, deps);
                         return Some(id);
                     }
                     folder_resolver::FolderResolution::PackageId(id) => {
-                        let deps = self.lockfile.packages.items_dependencies()[id as usize];
+                        let deps = self.lockfile.packages.items_dependencies()[id.index()];
                         super::enqueue_dependency_list(self, deps);
                         return Some(id);
                     }
@@ -256,20 +256,18 @@ impl PackageManager {
 
     pub(crate) fn assign_resolution(&mut self, dependency_id: DependencyID, package_id: PackageID) {
         // reshaped for borrowck — capture lengths before mutable borrows.
-        debug_assert!(
-            (dependency_id as usize) < self.lockfile.buffers.resolutions.as_slice().len()
-        );
-        debug_assert!((package_id as usize) < self.lockfile.packages.len());
+        debug_assert!(dependency_id.index() < self.lockfile.buffers.resolutions.as_slice().len());
+        debug_assert!(package_id.index() < self.lockfile.packages.len());
         // debug_assert!(self.lockfile.buffers.resolutions.as_slice()[dependency_id as usize] == invalid_package_id);
         let buffers = &mut self.lockfile.buffers;
-        buffers.resolutions.as_mut_slice()[dependency_id as usize] = package_id;
+        buffers.resolutions.as_mut_slice()[dependency_id.index()] = package_id;
         let string_buf = buffers.string_bytes.as_slice();
-        let dep = &mut buffers.dependencies.as_mut_slice()[dependency_id as usize];
+        let dep = &mut buffers.dependencies.as_mut_slice()[dependency_id.index()];
         if dep.name.is_empty()
             || dep.name.slice(string_buf) == dep.version.literal.slice(string_buf)
         {
-            dep.name = self.lockfile.packages.items_name()[package_id as usize];
-            dep.name_hash = self.lockfile.packages.items_name_hash()[package_id as usize];
+            dep.name = self.lockfile.packages.items_name()[package_id.index()];
+            dep.name_hash = self.lockfile.packages.items_name_hash()[package_id.index()];
         }
     }
 
@@ -279,34 +277,32 @@ impl PackageManager {
         package_id: PackageID,
     ) {
         // reshaped for borrowck — capture lengths before mutable borrows.
+        debug_assert!(dependency_id.index() < self.lockfile.buffers.resolutions.as_slice().len());
+        debug_assert!(package_id.index() < self.lockfile.packages.len());
         debug_assert!(
-            (dependency_id as usize) < self.lockfile.buffers.resolutions.as_slice().len()
-        );
-        debug_assert!((package_id as usize) < self.lockfile.packages.len());
-        debug_assert!(
-            self.lockfile.buffers.resolutions.as_slice()[dependency_id as usize]
+            self.lockfile.buffers.resolutions.as_slice()[dependency_id.index()]
                 == invalid_package_id
         );
         let buffers = &mut self.lockfile.buffers;
-        buffers.resolutions.as_mut_slice()[dependency_id as usize] = package_id;
+        buffers.resolutions.as_mut_slice()[dependency_id.index()] = package_id;
         let string_buf = buffers.string_bytes.as_slice();
-        let dep = &mut buffers.dependencies.as_mut_slice()[dependency_id as usize];
+        let dep = &mut buffers.dependencies.as_mut_slice()[dependency_id.index()];
         if dep.name.is_empty()
             || dep.name.slice(string_buf) == dep.version.literal.slice(string_buf)
         {
-            dep.name = self.lockfile.packages.items_name()[package_id as usize];
-            dep.name_hash = self.lockfile.packages.items_name_hash()[package_id as usize];
+            dep.name = self.lockfile.packages.items_name()[package_id.index()];
+            dep.name_hash = self.lockfile.packages.items_name_hash()[package_id.index()];
         }
     }
 
     pub(crate) fn verify_resolutions(&mut self, log_level: LogLevel) {
         let lockfile = &self.lockfile;
-        let resolutions_lists: &[DependencyIDSlice] = lockfile.packages.items_resolutions();
+        let resolutions_lists: &[PackageIDSlice] = lockfile.packages.items_resolutions();
         let dependency_lists: &[DependencySlice] = lockfile.packages.items_dependencies();
         let pkg_resolutions = lockfile.packages.items_resolution();
         let dependencies_buffer = lockfile.buffers.dependencies.as_slice();
         let resolutions_buffer = lockfile.buffers.resolutions.as_slice();
-        let end: PackageID = lockfile.packages.len() as PackageID;
+        let end = lockfile.packages.len();
 
         let mut any_failed = false;
         let string_buf = lockfile.buffers.string_bytes.as_slice();
@@ -321,7 +317,7 @@ impl PackageManager {
             let dep_slice = dependency_list.get(dependencies_buffer);
             debug_assert_eq!(res_slice.len(), dep_slice.len());
             for (package_id, failed_dep) in res_slice.iter().copied().zip(dep_slice.iter()) {
-                if package_id < end {
+                if package_id.index() < end {
                     continue;
                 }
 

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -9,7 +9,6 @@ use bun_semver::{SlicedString, String as SemverString};
 
 use crate::_folder_resolver::{self as folder_resolver, GlobalOrRelative};
 use crate::dependency;
-use crate::lockfile::{DependencySlice, PackageIDSlice};
 use crate::npm;
 use crate::resolution::Tag as ResolutionTag;
 use crate::{DependencyID, PackageID, PackageNameHash, Resolution, invalid_package_id};
@@ -231,12 +230,12 @@ impl PackageManager {
                     self,
                 ) {
                     folder_resolver::FolderResolution::NewPackageId(id) => {
-                        let deps = self.lockfile.packages.items_dependencies()[id.index()];
+                        let deps = self.lockfile.packages.items_dependencies()[id];
                         super::enqueue_dependency_list(self, deps);
                         return Some(id);
                     }
                     folder_resolver::FolderResolution::PackageId(id) => {
-                        let deps = self.lockfile.packages.items_dependencies()[id.index()];
+                        let deps = self.lockfile.packages.items_dependencies()[id];
                         super::enqueue_dependency_list(self, deps);
                         return Some(id);
                     }
@@ -256,18 +255,18 @@ impl PackageManager {
 
     pub(crate) fn assign_resolution(&mut self, dependency_id: DependencyID, package_id: PackageID) {
         // reshaped for borrowck — capture lengths before mutable borrows.
-        debug_assert!(dependency_id.index() < self.lockfile.buffers.resolutions.as_slice().len());
+        debug_assert!(self.lockfile.buffers.resolutions.has(dependency_id));
         debug_assert!(package_id.index() < self.lockfile.packages.len());
         // debug_assert!(self.lockfile.buffers.resolutions.as_slice()[dependency_id as usize] == invalid_package_id);
         let buffers = &mut self.lockfile.buffers;
-        buffers.resolutions.as_mut_slice()[dependency_id.index()] = package_id;
+        buffers.resolutions.as_mut_slice()[dependency_id] = package_id;
         let string_buf = buffers.string_bytes.as_slice();
-        let dep = &mut buffers.dependencies.as_mut_slice()[dependency_id.index()];
+        let dep = &mut buffers.dependencies.as_mut_slice()[dependency_id];
         if dep.name.is_empty()
             || dep.name.slice(string_buf) == dep.version.literal.slice(string_buf)
         {
-            dep.name = self.lockfile.packages.items_name()[package_id.index()];
-            dep.name_hash = self.lockfile.packages.items_name_hash()[package_id.index()];
+            dep.name = self.lockfile.packages.items_name()[package_id];
+            dep.name_hash = self.lockfile.packages.items_name_hash()[package_id];
         }
     }
 
@@ -277,28 +276,27 @@ impl PackageManager {
         package_id: PackageID,
     ) {
         // reshaped for borrowck — capture lengths before mutable borrows.
-        debug_assert!(dependency_id.index() < self.lockfile.buffers.resolutions.as_slice().len());
+        debug_assert!(self.lockfile.buffers.resolutions.has(dependency_id));
         debug_assert!(package_id.index() < self.lockfile.packages.len());
         debug_assert!(
-            self.lockfile.buffers.resolutions.as_slice()[dependency_id.index()]
-                == invalid_package_id
+            self.lockfile.buffers.resolutions.as_slice()[dependency_id] == invalid_package_id
         );
         let buffers = &mut self.lockfile.buffers;
-        buffers.resolutions.as_mut_slice()[dependency_id.index()] = package_id;
+        buffers.resolutions.as_mut_slice()[dependency_id] = package_id;
         let string_buf = buffers.string_bytes.as_slice();
-        let dep = &mut buffers.dependencies.as_mut_slice()[dependency_id.index()];
+        let dep = &mut buffers.dependencies.as_mut_slice()[dependency_id];
         if dep.name.is_empty()
             || dep.name.slice(string_buf) == dep.version.literal.slice(string_buf)
         {
-            dep.name = self.lockfile.packages.items_name()[package_id.index()];
-            dep.name_hash = self.lockfile.packages.items_name_hash()[package_id.index()];
+            dep.name = self.lockfile.packages.items_name()[package_id];
+            dep.name_hash = self.lockfile.packages.items_name_hash()[package_id];
         }
     }
 
     pub(crate) fn verify_resolutions(&mut self, log_level: LogLevel) {
         let lockfile = &self.lockfile;
-        let resolutions_lists: &[PackageIDSlice] = lockfile.packages.items_resolutions();
-        let dependency_lists: &[DependencySlice] = lockfile.packages.items_dependencies();
+        let resolutions_lists = lockfile.packages.items_resolutions();
+        let dependency_lists = lockfile.packages.items_dependencies();
         let pkg_resolutions = lockfile.packages.items_resolution();
         let dependencies_buffer = lockfile.buffers.dependencies.as_slice();
         let resolutions_buffer = lockfile.buffers.resolutions.as_slice();
@@ -308,10 +306,9 @@ impl PackageManager {
         let string_buf = lockfile.buffers.string_bytes.as_slice();
 
         debug_assert_eq!(resolutions_lists.len(), dependency_lists.len());
-        for (parent_id, (resolution_list, dependency_list)) in resolutions_lists
-            .iter()
+        for ((parent_id, resolution_list), dependency_list) in resolutions_lists
+            .iter_enumerated()
             .zip(dependency_lists.iter())
-            .enumerate()
         {
             let res_slice = resolution_list.get(resolutions_buffer);
             let dep_slice = dependency_list.get(dependencies_buffer);

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -154,7 +154,7 @@ pub fn populate_manifest_cache(
             for _dep_id in 0..dependencies.len() {
                 let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
 
-                let pkg_id = resolutions[dep_id as usize];
+                let pkg_id = resolutions[dep_id.index()];
                 if pkg_id == invalid_package_id {
                     continue;
                 }
@@ -164,12 +164,12 @@ pub fn populate_manifest_cache(
                     continue;
                 }
 
-                let res = &pkg_resolutions[pkg_id as usize];
+                let res = &pkg_resolutions[pkg_id.index()];
                 if res.tag != ResolutionTag::Npm {
                     continue;
                 }
 
-                let pkg_name = pkg_names[pkg_id as usize];
+                let pkg_name = pkg_names[pkg_id.index()];
                 let pkg_name_slice = pkg_name.slice(string_buf);
                 // `options` is not mutated between here and the
                 // `start_manifest_task` call — read via the BACKREF `mgr_ref`.
@@ -213,9 +213,9 @@ pub fn populate_manifest_cache(
         }
         Packages::Ids(ids) => {
             for &root_pkg_id in ids {
-                let pkg_deps = pkg_dependencies[root_pkg_id as usize];
-                for dep_id in pkg_deps.begin()..pkg_deps.end() {
-                    let dep_id = dep_id as usize;
+                let pkg_deps = pkg_dependencies[root_pkg_id.index()];
+                for dep_id in pkg_deps.dependency_ids() {
+                    let dep_id = dep_id.index();
                     if dep_id >= dependencies.len() {
                         continue;
                     }
@@ -225,7 +225,7 @@ pub fn populate_manifest_cache(
                     }
                     let dep = &dependencies[dep_id];
 
-                    let resolution: &Resolution = &pkg_resolutions[pkg_id as usize];
+                    let resolution: &Resolution = &pkg_resolutions[pkg_id.index()];
                     if resolution.tag != ResolutionTag::Npm {
                         continue;
                     }
@@ -233,7 +233,7 @@ pub fn populate_manifest_cache(
                     // `options` read via BACKREF `mgr_ref` — see provenance-root
                     // note above.
                     let needs_extended_manifest = mgr_ref.options.minimum_release_age_ms.is_some();
-                    let package_name = pkg_names[pkg_id as usize].slice(string_buf);
+                    let package_name = pkg_names[pkg_id.index()].slice(string_buf);
                     // See disjoint-field note on the `.All` arm above.
                     let scope =
                         bun_ptr::BackRef::new(mgr_ref.options.scope_for_package_name(package_name));
@@ -269,10 +269,10 @@ pub fn populate_manifest_cache(
         }
         Packages::Exact(ids) => {
             for &pkg_id in ids {
-                if pkg_resolutions[pkg_id as usize].tag != ResolutionTag::Npm {
+                if pkg_resolutions[pkg_id.index()].tag != ResolutionTag::Npm {
                     continue;
                 }
-                let package_name = pkg_names[pkg_id as usize].slice(string_buf);
+                let package_name = pkg_names[pkg_id.index()].slice(string_buf);
                 let needs_extended_manifest = mgr_ref.options.minimum_release_age_ms.is_some();
                 let scope =
                     bun_ptr::BackRef::new(mgr_ref.options.scope_for_package_name(package_name));

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -154,7 +154,7 @@ pub fn populate_manifest_cache(
             for _dep_id in 0..dependencies.len() {
                 let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
 
-                let pkg_id = resolutions[dep_id.index()];
+                let pkg_id = resolutions[dep_id];
                 if pkg_id == invalid_package_id {
                     continue;
                 }
@@ -164,12 +164,12 @@ pub fn populate_manifest_cache(
                     continue;
                 }
 
-                let res = &pkg_resolutions[pkg_id.index()];
+                let res = &pkg_resolutions[pkg_id];
                 if res.tag != ResolutionTag::Npm {
                     continue;
                 }
 
-                let pkg_name = pkg_names[pkg_id.index()];
+                let pkg_name = pkg_names[pkg_id];
                 let pkg_name_slice = pkg_name.slice(string_buf);
                 // `options` is not mutated between here and the
                 // `start_manifest_task` call — read via the BACKREF `mgr_ref`.
@@ -213,10 +213,9 @@ pub fn populate_manifest_cache(
         }
         Packages::Ids(ids) => {
             for &root_pkg_id in ids {
-                let pkg_deps = pkg_dependencies[root_pkg_id.index()];
+                let pkg_deps = pkg_dependencies[root_pkg_id];
                 for dep_id in pkg_deps.dependency_ids() {
-                    let dep_id = dep_id.index();
-                    if dep_id >= dependencies.len() {
+                    if !dependencies.has(dep_id) {
                         continue;
                     }
                     let pkg_id = resolutions[dep_id];
@@ -225,7 +224,7 @@ pub fn populate_manifest_cache(
                     }
                     let dep = &dependencies[dep_id];
 
-                    let resolution: &Resolution = &pkg_resolutions[pkg_id.index()];
+                    let resolution: &Resolution = &pkg_resolutions[pkg_id];
                     if resolution.tag != ResolutionTag::Npm {
                         continue;
                     }
@@ -233,7 +232,7 @@ pub fn populate_manifest_cache(
                     // `options` read via BACKREF `mgr_ref` — see provenance-root
                     // note above.
                     let needs_extended_manifest = mgr_ref.options.minimum_release_age_ms.is_some();
-                    let package_name = pkg_names[pkg_id.index()].slice(string_buf);
+                    let package_name = pkg_names[pkg_id].slice(string_buf);
                     // See disjoint-field note on the `.All` arm above.
                     let scope =
                         bun_ptr::BackRef::new(mgr_ref.options.scope_for_package_name(package_name));
@@ -269,10 +268,10 @@ pub fn populate_manifest_cache(
         }
         Packages::Exact(ids) => {
             for &pkg_id in ids {
-                if pkg_resolutions[pkg_id.index()].tag != ResolutionTag::Npm {
+                if pkg_resolutions[pkg_id].tag != ResolutionTag::Npm {
                     continue;
                 }
-                let package_name = pkg_names[pkg_id.index()].slice(string_buf);
+                let package_name = pkg_names[pkg_id].slice(string_buf);
                 let needs_extended_manifest = mgr_ref.options.minimum_release_age_ms.is_some();
                 let scope =
                     bun_ptr::BackRef::new(mgr_ref.options.scope_for_package_name(package_name));

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -119,7 +119,7 @@ impl UpdateRequest {
         if self.package_id == INVALID_PACKAGE_ID {
             None
         } else {
-            Some(lockfile.packages.items_name()[self.package_id as usize].slice(self.version_buf()))
+            Some(lockfile.packages.items_name()[self.package_id.index()].slice(self.version_buf()))
         }
     }
 

--- a/src/install/PackageManager/UpdateRequest.rs
+++ b/src/install/PackageManager/UpdateRequest.rs
@@ -119,7 +119,7 @@ impl UpdateRequest {
         if self.package_id == INVALID_PACKAGE_ID {
             None
         } else {
-            Some(lockfile.packages.items_name()[self.package_id.index()].slice(self.version_buf()))
+            Some(lockfile.packages.items_name()[self.package_id].slice(self.version_buf()))
         }
     }
 

--- a/src/install/PackageManager/add_catalog.rs
+++ b/src/install/PackageManager/add_catalog.rs
@@ -688,7 +688,7 @@ fn settle_resolved_positional(
     quiet: bool,
 ) -> Decision {
     let name: &[u8] = request.get_resolved_name(lockfile);
-    let name_hash = lockfile.packages.items_name_hash()[request.package_id as usize];
+    let name_hash = lockfile.packages.items_name_hash()[request.package_id.index()];
     // SAFETY: same slot `edit` just wrote through; see the write in `edit_target`.
     let literal: &[u8] = unsafe { (*e_string).data }.slice();
 
@@ -1025,8 +1025,8 @@ pub(crate) fn edit_root_after_install(
         {
             if dep.version.tag != dependency::Tag::Catalog
                 || pkg_id == INVALID_PACKAGE_ID
-                || (pkg_id as usize) >= resolutions.len()
-                || resolutions[pkg_id as usize].tag != resolution::Tag::Npm
+                || pkg_id.index() >= resolutions.len()
+                || resolutions[pkg_id.index()].tag != resolution::Tag::Npm
             {
                 continue;
             }
@@ -1099,7 +1099,7 @@ pub(crate) fn edit_root_after_install(
                     &mut literal,
                     "{}{}",
                     if exact { "" } else { "^" },
-                    resolutions[pkg_id as usize].npm().version.fmt(buf)
+                    resolutions[pkg_id.index()].npm().version.fmt(buf)
                 )
                 .expect("infallible: in-memory write");
                 literal

--- a/src/install/PackageManager/add_catalog.rs
+++ b/src/install/PackageManager/add_catalog.rs
@@ -639,7 +639,7 @@ pub(crate) fn refuse_declared_positionals(manager: &PackageManager) {
         .filter(|request| !request.is_aliased)
     {
         let literal = request_literal(request);
-        for (pkg_id, list) in dependency_lists.iter().enumerate() {
+        for (pkg_id, list) in dependency_lists.iter_enumerated() {
             if !matches!(
                 resolutions[pkg_id].tag,
                 resolution::Tag::Root | resolution::Tag::Workspace
@@ -688,7 +688,7 @@ fn settle_resolved_positional(
     quiet: bool,
 ) -> Decision {
     let name: &[u8] = request.get_resolved_name(lockfile);
-    let name_hash = lockfile.packages.items_name_hash()[request.package_id.index()];
+    let name_hash = lockfile.packages.items_name_hash()[request.package_id];
     // SAFETY: same slot `edit` just wrote through; see the write in `edit_target`.
     let literal: &[u8] = unsafe { (*e_string).data }.slice();
 
@@ -1025,8 +1025,8 @@ pub(crate) fn edit_root_after_install(
         {
             if dep.version.tag != dependency::Tag::Catalog
                 || pkg_id == INVALID_PACKAGE_ID
-                || pkg_id.index() >= resolutions.len()
-                || resolutions[pkg_id.index()].tag != resolution::Tag::Npm
+                || !resolutions.has(pkg_id)
+                || resolutions[pkg_id].tag != resolution::Tag::Npm
             {
                 continue;
             }
@@ -1099,7 +1099,7 @@ pub(crate) fn edit_root_after_install(
                     &mut literal,
                     "{}{}",
                     if exact { "" } else { "^" },
-                    resolutions[pkg_id.index()].npm().version.fmt(buf)
+                    resolutions[pkg_id].npm().version.fmt(buf)
                 )
                 .expect("infallible: in-memory write");
                 literal

--- a/src/install/PackageManager/add_remove_with_filter.rs
+++ b/src/install/PackageManager/add_remove_with_filter.rs
@@ -515,7 +515,7 @@ impl PendingWrite {
             .filter(|pending| pending.received.contains(&request))
             .filter_map(|pending| {
                 let id = lockfile.get_workspace_package_id(pending.target.name_hash);
-                (pending.target.name_hash.is_none() || id != 0).then_some(id)
+                (pending.target.name_hash.is_none() || id != PackageID::ROOT).then_some(id)
             })
             .collect()
     }

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -381,7 +381,7 @@ pub fn install_with_manager(
                         )?;
                         lf.dependencies[off as usize + i] = cloned;
                         if mapping[i] != invalid_package_id {
-                            lf.resolutions[off as usize + i] = old_resolutions[mapping[i] as usize];
+                            lf.resolutions[off as usize + i] = old_resolutions[mapping[i].index()];
                         }
                     }
                     for (k, (dep, res)) in kept_pruned.into_iter().enumerate() {
@@ -502,7 +502,7 @@ pub fn install_with_manager(
                                     invalid_package_id;
                                 if let Err(err) = enqueue_dependency_with_main(
                                     manager,
-                                    dependency_i as u32,
+                                    DependencyID::from_index(dependency_i),
                                     &dependency,
                                     invalid_package_id,
                                     false,
@@ -523,12 +523,11 @@ pub fn install_with_manager(
                         catalog_overridden.dedup();
                         let dependencies_len = manager.lockfile.buffers.dependencies.len();
                         for _dep_id in 0..dependencies_len {
-                            let dep_id: DependencyID = u32::try_from(_dep_id).expect("int cast");
+                            let dep_id = DependencyID::try_from(_dep_id).expect("int cast");
                             if pinned_rows.is_set_allow_out_of_bound(_dep_id, false) {
                                 continue;
                             }
-                            let dep =
-                                manager.lockfile.buffers.dependencies[dep_id as usize].clone();
+                            let dep = manager.lockfile.buffers.dependencies[dep_id.index()].clone();
                             if dep.version.tag != DependencyVersionTag::Catalog
                                 && (catalog_overridden.is_empty()
                                     || catalog_overridden.binary_search(&dep.name_hash).is_err())
@@ -536,7 +535,7 @@ pub fn install_with_manager(
                                 continue;
                             }
 
-                            manager.lockfile.buffers.resolutions[dep_id as usize] =
+                            manager.lockfile.buffers.resolutions[dep_id.index()] =
                                 invalid_package_id;
                             if let Err(err) = enqueue_dependency_with_main(
                                 manager,
@@ -552,20 +551,19 @@ pub fn install_with_manager(
 
                     // Split this into two passes because the below may allocate memory or invalidate pointers
                     if manager.summary.add > 0 || manager.summary.update > 0 {
-                        let changes = mapping.len() as PackageID;
-                        let mut counter_i: PackageID = 0;
+                        let changes = mapping.len() as u32;
 
                         let _ = manager.get_cache_directory();
                         let _ = manager.get_temporary_directory();
 
-                        while counter_i < changes {
+                        for counter_i in 0..changes {
                             if mapping[counter_i as usize] == invalid_package_id {
-                                let dependency_i = counter_i + off;
+                                let dependency_i = DependencyID::new(counter_i + off);
                                 let dependency = manager.lockfile.buffers.dependencies
-                                    [dependency_i as usize]
-                                    .clone();
+                                    [dependency_i.index()]
+                                .clone();
                                 let resolution =
-                                    manager.lockfile.buffers.resolutions[dependency_i as usize];
+                                    manager.lockfile.buffers.resolutions[dependency_i.index()];
                                 if let Err(err) = enqueue_dependency_with_main(
                                     manager,
                                     dependency_i,
@@ -576,7 +574,6 @@ pub fn install_with_manager(
                                     add_dependency_error(manager, &dependency, err);
                                 }
                             }
-                            counter_i += 1;
                         }
                     }
 
@@ -1165,7 +1162,7 @@ fn print_install_summary(
             && (this.update_requests.is_empty() || this.subcommand == Subcommand::Update)
         {
             // Hot no-op path (install/fastify bench): kept inline.
-            let count = this.lockfile.packages.len() as PackageID;
+            let count = this.lockfile.packages.len() as u32;
             if count != install_summary.skipped {
                 bun_core::pretty!(
                     "Checked <green>{} install{}<r> across {} package{} <d>(no changes)<r> ",
@@ -1394,7 +1391,7 @@ pub(crate) fn get_workspace_filters(
         }
     };
     let filters = vec![WorkspaceFilter::from_ids(ids)];
-    let install_root_dependencies = WorkspaceFilter::is_selected(&filters, 0);
+    let install_root_dependencies = WorkspaceFilter::is_selected(&filters, PackageID::ROOT);
     Ok((filters, install_root_dependencies))
 }
 
@@ -1574,22 +1571,26 @@ fn enqueue_named_updates(
         }
         matched.set(request);
         if collect_latest_rows {
-            named.latest_rows.push(dependency_i as DependencyID);
+            named
+                .latest_rows
+                .push(DependencyID::from_index(dependency_i));
         }
         if package_id == invalid_package_id || dependency.behavior.is_bundled() {
             continue;
         }
         if dependency.behavior.is_peer() {
             if plannable_peers.is_set(dependency_i) {
-                peer_rows.push(dependency_i as DependencyID);
+                peer_rows.push(DependencyID::from_index(dependency_i));
             }
             continue;
         }
         manager.lockfile.buffers.resolutions[dependency_i] = invalid_package_id;
-        named.moved.push((dependency_i as DependencyID, package_id));
+        named
+            .moved
+            .push((DependencyID::from_index(dependency_i), package_id));
         if let Err(err) = enqueue_dependency_with_main(
             manager,
-            dependency_i as DependencyID,
+            DependencyID::from_index(dependency_i),
             &dependency,
             invalid_package_id,
             false,
@@ -1620,11 +1621,11 @@ fn index_of_named_update(
         return Some(i);
     }
     if package_id != invalid_package_id {
-        let name_hash = manager.lockfile.packages.items_name_hash()[package_id as usize];
+        let name_hash = manager.lockfile.packages.items_name_hash()[package_id.index()];
         if name_hash == dependency.name_hash {
             return None;
         }
-        let name = manager.lockfile.packages.items_name()[package_id as usize].slice(buf);
+        let name = manager.lockfile.packages.items_name()[package_id.index()].slice(buf);
         return manager.index_of_update_request(name_hash, name);
     }
     let realname = dependency.realname();
@@ -1734,9 +1735,9 @@ fn workspaces_reaching_request<'a>(
         let reached = reachable::packages_from(
             lockfile,
             all_resolutions,
-            &[importer as PackageID],
+            &[PackageID::from_index(importer)],
             false,
-            reachable::Options::all(0),
+            reachable::Options::all(PackageID::ROOT),
         );
         if (0..packages.len()).any(|pkg_id| owners.is_set(pkg_id) && reached.is_set(pkg_id)) {
             workspaces.push(name);
@@ -1768,7 +1769,8 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
         None => workspaces.set(
             manager
                 .root_package_id
-                .get(lockfile, manager.workspace_name_hash) as usize,
+                .get(lockfile, manager.workspace_name_hash)
+                .index(),
         ),
         Some(targets) => {
             let buf = lockfile.buffers.string_bytes.as_slice();
@@ -1823,7 +1825,7 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
             if entry_ptr.original_version.is_some() {
                 continue;
             }
-            let original_resolution: Resolution = resolutions[package_id as usize];
+            let original_resolution: Resolution = resolutions[package_id.index()];
             if original_resolution.tag != ResolutionTag::Npm {
                 continue;
             }
@@ -2009,11 +2011,11 @@ fn refresh_children_of_named(
         let pkg_res = lockfile.packages.items_resolution();
         latest_rows
             .iter()
-            .map(|&dep_id| resolutions[dep_id as usize])
+            .map(|&dep_id| resolutions[dep_id.index()])
             .filter(|&id| {
-                (id as usize) < pkg_res.len()
+                id.index() < pkg_res.len()
                     && !matches!(
-                        pkg_res[id as usize].tag,
+                        pkg_res[id.index()].tag,
                         ResolutionTag::Root | ResolutionTag::Workspace
                     )
             })

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -258,7 +258,7 @@ pub fn install_with_manager(
                         .scripts
                         .count(&lockfile.buffers.string_bytes, builder);
                     builder.allocate()?;
-                    lf.packages.items_scripts_mut()[0] = maybe_root
+                    lf.packages.items_scripts_mut()[PackageID::ROOT] = maybe_root
                         .scripts
                         .clone_into(&lockfile.buffers.string_bytes, builder);
                     builder.clamp();
@@ -276,9 +276,9 @@ pub fn install_with_manager(
                             Vec::new()
                         } else {
                             root.dependencies
-                                .get(&lf.dependencies[..])
+                                .get(lf.dependencies.as_slice())
                                 .iter()
-                                .zip(root.resolutions.get(&lf.resolutions[..]))
+                                .zip(root.resolutions.get(lf.resolutions.as_slice()))
                                 .filter(|(dep, _)| {
                                     dep.behavior.is_workspace()
                                         && summary.pruned_workspaces.contains(&dep.name_hash)
@@ -313,10 +313,10 @@ pub fn install_with_manager(
 
                     let off = lf.dependencies.len() as u32;
                     let len = (new_dependencies.len() + kept_pruned.len()) as u32;
-                    let old_resolutions_list = lf.packages.items_resolutions()[0];
-                    lf.packages.items_dependencies_mut()[0] =
+                    let old_resolutions_list = lf.packages.items_resolutions()[PackageID::ROOT];
+                    lf.packages.items_dependencies_mut()[PackageID::ROOT] =
                         lockfile::DependencySlice::new(off, len);
-                    lf.packages.items_resolutions_mut()[0] =
+                    lf.packages.items_resolutions_mut()[PackageID::ROOT] =
                         lockfile::PackageIDSlice::new(off, len);
                     builder.allocate()?;
 
@@ -364,10 +364,10 @@ pub fn install_with_manager(
                     // never form `&mut [T]` over uninitialized storage and never drop garbage.
                     debug_assert_eq!(lf.dependencies.len(), off as usize);
                     debug_assert_eq!(lf.resolutions.len(), off as usize);
-                    bun_core::vec::extend_from_fn(lf.dependencies, len as usize, |_| {
+                    bun_core::vec::extend_from_fn(lf.dependencies.raw_mut(), len as usize, |_| {
                         Dependency::default()
                     });
-                    bun_core::vec::extend_from_fn(lf.resolutions, len as usize, |_| {
+                    bun_core::vec::extend_from_fn(lf.resolutions.raw_mut(), len as usize, |_| {
                         invalid_package_id
                     });
                     debug_assert_eq!(lf.dependencies.len(), (off + len) as usize);
@@ -379,18 +379,19 @@ pub fn install_with_manager(
                             &lockfile.buffers.string_bytes,
                             builder,
                         )?;
-                        lf.dependencies[off as usize + i] = cloned;
+                        let dep_id = DependencyID::new(off + i as u32);
+                        lf.dependencies[dep_id] = cloned;
                         if mapping[i] != invalid_package_id {
-                            lf.resolutions[off as usize + i] = old_resolutions[mapping[i].index()];
+                            lf.resolutions[dep_id] = old_resolutions[mapping[i].index()];
                         }
                     }
                     for (k, (dep, res)) in kept_pruned.into_iter().enumerate() {
-                        let slot = off as usize + new_dependencies.len() + k;
+                        let slot = DependencyID::new(off + (new_dependencies.len() + k) as u32);
                         lf.dependencies[slot] = dep;
                         lf.resolutions[slot] = res;
                     }
 
-                    lf.packages.items_scripts_mut()[0] = maybe_root
+                    lf.packages.items_scripts_mut()[PackageID::ROOT] = maybe_root
                         .scripts
                         .clone_into(&lockfile.buffers.string_bytes, builder);
 
@@ -495,14 +496,13 @@ pub fn install_with_manager(
                             if pinned_rows.is_set_allow_out_of_bound(dependency_i, false) {
                                 continue;
                             }
-                            let dependency =
-                                manager.lockfile.buffers.dependencies[dependency_i].clone();
+                            let dep_id = DependencyID::from_index(dependency_i);
+                            let dependency = manager.lockfile.buffers.dependencies[dep_id].clone();
                             if all_name_hashes.binary_search(&dependency.name_hash).is_ok() {
-                                manager.lockfile.buffers.resolutions[dependency_i] =
-                                    invalid_package_id;
+                                manager.lockfile.buffers.resolutions[dep_id] = invalid_package_id;
                                 if let Err(err) = enqueue_dependency_with_main(
                                     manager,
-                                    DependencyID::from_index(dependency_i),
+                                    dep_id,
                                     &dependency,
                                     invalid_package_id,
                                     false,
@@ -527,7 +527,7 @@ pub fn install_with_manager(
                             if pinned_rows.is_set_allow_out_of_bound(_dep_id, false) {
                                 continue;
                             }
-                            let dep = manager.lockfile.buffers.dependencies[dep_id.index()].clone();
+                            let dep = manager.lockfile.buffers.dependencies[dep_id].clone();
                             if dep.version.tag != DependencyVersionTag::Catalog
                                 && (catalog_overridden.is_empty()
                                     || catalog_overridden.binary_search(&dep.name_hash).is_err())
@@ -535,8 +535,7 @@ pub fn install_with_manager(
                                 continue;
                             }
 
-                            manager.lockfile.buffers.resolutions[dep_id.index()] =
-                                invalid_package_id;
+                            manager.lockfile.buffers.resolutions[dep_id] = invalid_package_id;
                             if let Err(err) = enqueue_dependency_with_main(
                                 manager,
                                 dep_id,
@@ -559,11 +558,9 @@ pub fn install_with_manager(
                         for counter_i in 0..changes {
                             if mapping[counter_i as usize] == invalid_package_id {
                                 let dependency_i = DependencyID::new(counter_i + off);
-                                let dependency = manager.lockfile.buffers.dependencies
-                                    [dependency_i.index()]
-                                .clone();
-                                let resolution =
-                                    manager.lockfile.buffers.resolutions[dependency_i.index()];
+                                let dependency =
+                                    manager.lockfile.buffers.dependencies[dependency_i].clone();
+                                let resolution = manager.lockfile.buffers.resolutions[dependency_i];
                                 if let Err(err) = enqueue_dependency_with_main(
                                     manager,
                                     dependency_i,
@@ -682,7 +679,7 @@ pub fn install_with_manager(
     };
 
     if manager.lockfile.packages.len() > 0 {
-        root = *manager.lockfile.packages.get(0);
+        root = manager.lockfile.package(PackageID::ROOT);
     }
 
     if manager.lockfile.packages.len() > 0 {
@@ -735,7 +732,7 @@ pub fn install_with_manager(
         let packages = &lockfile.packages;
         let string_bytes = lockfile.buffers.string_bytes.as_slice();
         let lockfile_scripts = &mut lockfile.scripts;
-        for pkg_i in 0..packages.len() {
+        for pkg_i in packages.items_resolution().ids() {
             let resolution = packages.items_resolution()[pkg_i];
             if resolution.tag != ResolutionTag::Workspace {
                 continue;
@@ -1560,8 +1557,9 @@ fn enqueue_named_updates(
     let mut peer_rows: Vec<DependencyID> = Vec::new();
     let dependencies_len = manager.lockfile.buffers.dependencies.len();
     for dependency_i in 0..dependencies_len {
-        let dependency = manager.lockfile.buffers.dependencies[dependency_i].clone();
-        let package_id = manager.lockfile.buffers.resolutions[dependency_i];
+        let dep_id = DependencyID::from_index(dependency_i);
+        let dependency = manager.lockfile.buffers.dependencies[dep_id].clone();
+        let package_id = manager.lockfile.buffers.resolutions[dep_id];
         let Some(request) = index_of_named_update(manager, &dependency, package_id) else {
             continue;
         };
@@ -1571,30 +1569,22 @@ fn enqueue_named_updates(
         }
         matched.set(request);
         if collect_latest_rows {
-            named
-                .latest_rows
-                .push(DependencyID::from_index(dependency_i));
+            named.latest_rows.push(dep_id);
         }
         if package_id == invalid_package_id || dependency.behavior.is_bundled() {
             continue;
         }
         if dependency.behavior.is_peer() {
             if plannable_peers.is_set(dependency_i) {
-                peer_rows.push(DependencyID::from_index(dependency_i));
+                peer_rows.push(dep_id);
             }
             continue;
         }
-        manager.lockfile.buffers.resolutions[dependency_i] = invalid_package_id;
-        named
-            .moved
-            .push((DependencyID::from_index(dependency_i), package_id));
-        if let Err(err) = enqueue_dependency_with_main(
-            manager,
-            DependencyID::from_index(dependency_i),
-            &dependency,
-            invalid_package_id,
-            false,
-        ) {
+        manager.lockfile.buffers.resolutions[dep_id] = invalid_package_id;
+        named.moved.push((dep_id, package_id));
+        if let Err(err) =
+            enqueue_dependency_with_main(manager, dep_id, &dependency, invalid_package_id, false)
+        {
             add_dependency_error(manager, &dependency, err);
         }
     }
@@ -1621,11 +1611,11 @@ fn index_of_named_update(
         return Some(i);
     }
     if package_id != invalid_package_id {
-        let name_hash = manager.lockfile.packages.items_name_hash()[package_id.index()];
+        let name_hash = manager.lockfile.packages.items_name_hash()[package_id];
         if name_hash == dependency.name_hash {
             return None;
         }
-        let name = manager.lockfile.packages.items_name()[package_id.index()].slice(buf);
+        let name = manager.lockfile.packages.items_name()[package_id].slice(buf);
         return manager.index_of_update_request(name_hash, name);
     }
     let realname = dependency.realname();
@@ -1721,7 +1711,7 @@ fn workspaces_reaching_request<'a>(
     }
 
     let mut workspaces: Vec<&'a [u8]> = Vec::new();
-    for importer in 0..packages.len() {
+    for importer in package_resolutions.ids() {
         let tag = package_resolutions[importer].tag;
         if !matches!(tag, ResolutionTag::Root | ResolutionTag::Workspace) {
             continue;
@@ -1735,7 +1725,7 @@ fn workspaces_reaching_request<'a>(
         let reached = reachable::packages_from(
             lockfile,
             all_resolutions,
-            &[PackageID::from_index(importer)],
+            &[importer],
             false,
             reachable::Options::all(PackageID::ROOT),
         );
@@ -1776,20 +1766,21 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
             let buf = lockfile.buffers.string_bytes.as_slice();
             let names = packages.items_name();
             let name_hashes = packages.items_name_hash();
-            for (id, resolution) in resolutions.iter().enumerate() {
+            for (id, resolution) in resolutions.iter_enumerated() {
                 let is_root = resolution.tag == ResolutionTag::Root;
                 if (is_root || resolution.tag == ResolutionTag::Workspace)
                     && targets.iter().any(|target| {
                         target.matches(is_root, name_hashes[id], names[id].slice(buf))
                     })
                 {
-                    workspaces.set(id);
+                    workspaces.set(id.index());
                 }
             }
         }
     }
     let mut selected = workspaces.iterator::<true, true>();
     while let Some(workspace_package_id) = selected.next() {
+        let workspace_package_id = PackageID::from_index(workspace_package_id);
         let workspace_dep_list = packages.items_dependencies()[workspace_package_id];
         let workspace_res_list = packages.items_resolutions()[workspace_package_id];
         let workspace_deps = workspace_dep_list.get(&lockfile.buffers.dependencies);
@@ -1825,7 +1816,7 @@ fn record_updating_package_versions(manager: &mut PackageManager) {
             if entry_ptr.original_version.is_some() {
                 continue;
             }
-            let original_resolution: Resolution = resolutions[package_id.index()];
+            let original_resolution: Resolution = resolutions[package_id];
             if original_resolution.tag != ResolutionTag::Npm {
                 continue;
             }
@@ -2011,11 +2002,11 @@ fn refresh_children_of_named(
         let pkg_res = lockfile.packages.items_resolution();
         latest_rows
             .iter()
-            .map(|&dep_id| resolutions[dep_id.index()])
+            .map(|&dep_id| resolutions[dep_id])
             .filter(|&id| {
-                id.index() < pkg_res.len()
+                pkg_res.has(id)
                     && !matches!(
-                        pkg_res[id.index()].tag,
+                        pkg_res[id].tag,
                         ResolutionTag::Root | ResolutionTag::Workspace
                     )
             })

--- a/src/install/PackageManager/package_json_write_back.rs
+++ b/src/install/PackageManager/package_json_write_back.rs
@@ -246,7 +246,7 @@ fn target_package_ids(lockfile: &Lockfile, edited: &[EditedPackageJson]) -> Vec<
     let mut ids = vec![invalid_package_id; edited.len()];
     for (i, e) in edited.iter().enumerate() {
         if e.target.name_hash.is_none() {
-            ids[i] = 0;
+            ids[i] = PackageID::ROOT;
         }
     }
     let resolutions = lockfile.packages.items_resolution();
@@ -257,7 +257,7 @@ fn target_package_ids(lockfile: &Lockfile, edited: &[EditedPackageJson]) -> Vec<
         }
         for (i, e) in edited.iter().enumerate() {
             if ids[i] == invalid_package_id && e.target.name_hash == Some(name_hashes[pkg_id]) {
-                ids[i] = pkg_id as PackageID;
+                ids[i] = PackageID::from_index(pkg_id);
             }
         }
     }
@@ -289,7 +289,7 @@ fn sync_lockfile(manager: &mut PackageManager, edited: &[EditedPackageJson]) -> 
             continue;
         }
         let is_root = edited[*i].target.name_hash.is_none();
-        let row = manager.lockfile.packages.items_dependencies()[target_id as usize];
+        let row = manager.lockfile.packages.items_dependencies()[target_id.index()];
         let scratch_deps = pkg
             .dependencies
             .get(scratch.buffers.dependencies.as_slice());

--- a/src/install/PackageManager/package_json_write_back.rs
+++ b/src/install/PackageManager/package_json_write_back.rs
@@ -123,7 +123,7 @@ fn edit_update_targets(
         let name_hashes = lockfile.packages.items_name_hash();
         let names = lockfile.packages.items_name();
         let mut path_buf = path_buffer_pool::get();
-        for pkg_id in 0..resolutions.len() {
+        for pkg_id in resolutions.ids() {
             let res = resolutions[pkg_id];
             let (name_hash, rel): (Option<PackageNameHash>, &[u8]) = match res.tag {
                 ResolutionTag::Root => (None, b""),
@@ -251,13 +251,13 @@ fn target_package_ids(lockfile: &Lockfile, edited: &[EditedPackageJson]) -> Vec<
     }
     let resolutions = lockfile.packages.items_resolution();
     let name_hashes = lockfile.packages.items_name_hash();
-    for pkg_id in 0..resolutions.len() {
+    for pkg_id in resolutions.ids() {
         if resolutions[pkg_id].tag != ResolutionTag::Workspace {
             continue;
         }
         for (i, e) in edited.iter().enumerate() {
             if ids[i] == invalid_package_id && e.target.name_hash == Some(name_hashes[pkg_id]) {
-                ids[i] = PackageID::from_index(pkg_id);
+                ids[i] = pkg_id;
             }
         }
     }
@@ -289,7 +289,7 @@ fn sync_lockfile(manager: &mut PackageManager, edited: &[EditedPackageJson]) -> 
             continue;
         }
         let is_root = edited[*i].target.name_hash.is_none();
-        let row = manager.lockfile.packages.items_dependencies()[target_id.index()];
+        let row = manager.lockfile.packages.items_dependencies()[target_id];
         let scratch_deps = pkg
             .dependencies
             .get(scratch.buffers.dependencies.as_slice());

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -114,7 +114,7 @@ pub fn do_patch_commit(
     let workspace_package_id = manager
         .root_package_id
         .get(&lockfile, manager.workspace_name_hash);
-    let not_in_workspace_root = workspace_package_id != 0;
+    let not_in_workspace_root = workspace_package_id != PackageID::ROOT;
     // reshaped for borrowck — owned buffer kept separately so `argument` can borrow it
     let mut argument_owned: Option<Box<[u8]>> = None;
     let argument: &[u8] = if arg_kind == PatchArgKind::Path
@@ -226,11 +226,11 @@ pub fn do_patch_commit(
                     );
                     Global::crash();
                 }
-                Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(*id as usize),
+                Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(id.index()),
                 Some(PackageIndexEntry::Ids(ids)) => 'brk: {
                     let mut resolution_label = Vec::new();
                     for &id in ids.as_slice() {
-                        let pkg = *lockfile.packages.get(id as usize);
+                        let pkg = *lockfile.packages.get(id.index());
                         if print_resolution_label(
                             &mut resolution_label,
                             &pkg.resolution,
@@ -263,7 +263,7 @@ pub fn do_patch_commit(
             )
             .as_bytes()
             .to_vec();
-            break 'brk (changes_dir, *lockfile.packages.get(pkg_id as usize));
+            break 'brk (changes_dir, *lockfile.packages.get(pkg_id.index()));
         }
     };
 
@@ -711,7 +711,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     let workspace_package_id = manager
         .root_package_id
         .get(&manager.lockfile, workspace_name_hash);
-    let not_in_workspace_root = workspace_package_id != 0;
+    let not_in_workspace_root = workspace_package_id != PackageID::ROOT;
     // reshaped for borrowck — owned buffer kept so `argument` can borrow it.
     let argument_owned: Option<Box<[u8]>>;
     let argument: &[u8] = if arg_kind == PatchArgKind::Path
@@ -811,11 +811,11 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                         );
                         Global::crash();
                     }
-                    Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(*id as usize),
+                    Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(id.index()),
                     Some(PackageIndexEntry::Ids(ids)) => 'id: {
                         let mut resolution_label = Vec::new();
                         for &id in ids.as_slice() {
-                            let pkg = *lockfile.packages.get(id as usize);
+                            let pkg = *lockfile.packages.get(id.index());
                             if print_resolution_label(
                                 &mut resolution_label,
                                 &pkg.resolution,
@@ -888,7 +888,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                 );
 
                 let strbuf = manager.lockfile.buffers.string_bytes.as_slice();
-                let pkg = *manager.lockfile.packages.get(pkg_id as usize);
+                let pkg = *manager.lockfile.packages.get(pkg_id.index());
                 let pkg_name = pkg.name.slice(strbuf).to_vec();
 
                 let existing_patchfile_hash: Option<u64> = 'existing_patchfile_hash: {
@@ -1275,13 +1275,13 @@ fn pkg_info_for_name_and_version(
         if pkg_id == invalid_package_id {
             continue;
         }
-        let pkg = *lockfile.packages.get(pkg_id as usize);
+        let pkg = *lockfile.packages.get(pkg_id.index());
         if let Some(v) = version {
             if print_resolution_label(&mut resolution_label, &pkg.resolution, strbuf) == v {
-                pairs.push((dep_id as DependencyID, pkg_id));
+                pairs.push((DependencyID::from_index(dep_id), pkg_id));
             }
         } else {
-            pairs.push((dep_id as DependencyID, pkg_id));
+            pairs.push((DependencyID::from_index(dep_id), pkg_id));
         }
     }
 
@@ -1391,7 +1391,7 @@ fn pkg_info_for_name_and_version(
             continue;
         }
 
-        let pkg = *lockfile.packages.get(pkgid as usize);
+        let pkg = *lockfile.packages.get(pkgid.index());
 
         bun_core::pretty_error!(
             "  {}@<blue>{}<r>\n",
@@ -1419,10 +1419,10 @@ fn path_argument_relative_to_root_workspace_package(
     workspace_package_id: PackageID,
     argument: &[u8],
 ) -> Option<Box<[u8]>> {
-    if workspace_package_id == 0 {
+    if workspace_package_id == PackageID::ROOT {
         return None;
     }
-    let workspace_res = &lockfile.packages.items_resolution()[workspace_package_id as usize];
+    let workspace_res = &lockfile.packages.items_resolution()[workspace_package_id.index()];
     let workspace_str = *workspace_res.workspace();
     let rel_path: &[u8] = workspace_str.slice(lockfile.buffers.string_bytes.as_slice());
     Some(Box::<[u8]>::from(resolve_path::join::<platform::Posix>(&[

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -226,11 +226,11 @@ pub fn do_patch_commit(
                     );
                     Global::crash();
                 }
-                Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(id.index()),
+                Some(PackageIndexEntry::Id(id)) => lockfile.package(*id),
                 Some(PackageIndexEntry::Ids(ids)) => 'brk: {
                     let mut resolution_label = Vec::new();
                     for &id in ids.as_slice() {
-                        let pkg = *lockfile.packages.get(id.index());
+                        let pkg = lockfile.package(id);
                         if print_resolution_label(
                             &mut resolution_label,
                             &pkg.resolution,
@@ -263,7 +263,7 @@ pub fn do_patch_commit(
             )
             .as_bytes()
             .to_vec();
-            break 'brk (changes_dir, *lockfile.packages.get(pkg_id.index()));
+            break 'brk (changes_dir, lockfile.package(pkg_id));
         }
     };
 
@@ -811,11 +811,11 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                         );
                         Global::crash();
                     }
-                    Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(id.index()),
+                    Some(PackageIndexEntry::Id(id)) => lockfile.package(*id),
                     Some(PackageIndexEntry::Ids(ids)) => 'id: {
                         let mut resolution_label = Vec::new();
                         for &id in ids.as_slice() {
-                            let pkg = *lockfile.packages.get(id.index());
+                            let pkg = lockfile.package(id);
                             if print_resolution_label(
                                 &mut resolution_label,
                                 &pkg.resolution,
@@ -888,7 +888,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                 );
 
                 let strbuf = manager.lockfile.buffers.string_bytes.as_slice();
-                let pkg = *manager.lockfile.packages.get(pkg_id.index());
+                let pkg = manager.lockfile.package(pkg_id);
                 let pkg_name = pkg.name.slice(strbuf).to_vec();
 
                 let existing_patchfile_hash: Option<u64> = 'existing_patchfile_hash: {
@@ -1267,7 +1267,7 @@ fn pkg_info_for_name_and_version(
     let mut resolution_label = Vec::new();
     let dependencies = lockfile.buffers.dependencies.as_slice();
 
-    for (dep_id, dep) in dependencies.iter().enumerate() {
+    for (dep_id, dep) in dependencies.iter_enumerated() {
         if dep.name_hash != name_hash {
             continue;
         }
@@ -1275,13 +1275,13 @@ fn pkg_info_for_name_and_version(
         if pkg_id == invalid_package_id {
             continue;
         }
-        let pkg = *lockfile.packages.get(pkg_id.index());
+        let pkg = lockfile.package(pkg_id);
         if let Some(v) = version {
             if print_resolution_label(&mut resolution_label, &pkg.resolution, strbuf) == v {
-                pairs.push((DependencyID::from_index(dep_id), pkg_id));
+                pairs.push((dep_id, pkg_id));
             }
         } else {
-            pairs.push((DependencyID::from_index(dep_id), pkg_id));
+            pairs.push((dep_id, pkg_id));
         }
     }
 
@@ -1391,7 +1391,7 @@ fn pkg_info_for_name_and_version(
             continue;
         }
 
-        let pkg = *lockfile.packages.get(pkgid.index());
+        let pkg = lockfile.package(pkgid);
 
         bun_core::pretty_error!(
             "  {}@<blue>{}<r>\n",
@@ -1422,7 +1422,7 @@ fn path_argument_relative_to_root_workspace_package(
     if workspace_package_id == PackageID::ROOT {
         return None;
     }
-    let workspace_res = &lockfile.packages.items_resolution()[workspace_package_id.index()];
+    let workspace_res = &lockfile.packages.items_resolution()[workspace_package_id];
     let workspace_str = *workspace_res.workspace();
     let rel_path: &[u8] = workspace_str.slice(lockfile.buffers.string_bytes.as_slice());
     Some(Box::<[u8]>::from(resolve_path::join::<platform::Posix>(&[

--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -190,7 +190,7 @@ impl PackageManager {
                     let new_name = Repository::create_dependency_name_from_version_literal(
                         &repo,
                         self.lockfile.buffers.string_bytes.as_slice(),
-                        &self.lockfile.buffers.dependencies[dep_id as usize],
+                        &self.lockfile.buffers.dependencies[dep_id.index()],
                     );
                     // `defer manager.allocator.free(new_name)` — `new_name: Vec<u8>` drops at scope end.
 
@@ -332,7 +332,7 @@ impl PackageManager {
                     // `parse_count`/`allocate` don't touch `packages`.)
                     debug_assert!(*package_id != INVALID_PACKAGE_ID);
                     let mut scripts: Scripts =
-                        self.lockfile.packages.items_scripts()[*package_id as usize];
+                        self.lockfile.packages.items_scripts()[package_id.index()];
                     let mut builder = self.lockfile.string_builder();
                     Scripts::parse_count(&mut builder, json_root);
                     builder.allocate().expect("unreachable");
@@ -357,10 +357,10 @@ impl PackageManager {
                 // Clone the dependency row out of the buffer before
                 // re-borrowing `self` for enqueue.
                 let dependency = Clone::clone(
-                    &self.lockfile.buffers.dependencies.as_slice()[dependency_id as usize],
+                    &self.lockfile.buffers.dependencies.as_slice()[dependency_id.index()],
                 );
                 let resolution =
-                    self.lockfile.buffers.resolutions.as_slice()[dependency_id as usize];
+                    self.lockfile.buffers.resolutions.as_slice()[dependency_id.index()];
 
                 enqueue::enqueue_dependency_with_main(
                     self,
@@ -372,10 +372,10 @@ impl PackageManager {
             }
             TaskCallbackContext::RootDependency(dependency_id) => {
                 let dependency = Clone::clone(
-                    &self.lockfile.buffers.dependencies.as_slice()[dependency_id as usize],
+                    &self.lockfile.buffers.dependencies.as_slice()[dependency_id.index()],
                 );
                 let resolution =
-                    self.lockfile.buffers.resolutions.as_slice()[dependency_id as usize];
+                    self.lockfile.buffers.resolutions.as_slice()[dependency_id.index()];
 
                 enqueue::enqueue_dependency_with_main_and_success_fn(
                     self,
@@ -389,7 +389,7 @@ impl PackageManager {
                 )?;
                 if let Some(ptr) = any_root {
                     let new_resolution_id =
-                        self.lockfile.buffers.resolutions.as_slice()[dependency_id as usize];
+                        self.lockfile.buffers.resolutions.as_slice()[dependency_id.index()];
                     if new_resolution_id != resolution {
                         ptr.set(true);
                     }
@@ -405,10 +405,10 @@ impl PackageManager {
             // Clone the dependency row out of the buffer before re-borrowing
             // `self` for enqueue.
             let dependency = Clone::clone(
-                &self.lockfile.buffers.dependencies.as_slice()[peer_dependency_id as usize],
+                &self.lockfile.buffers.dependencies.as_slice()[peer_dependency_id.index()],
             );
             let resolution =
-                self.lockfile.buffers.resolutions.as_slice()[peer_dependency_id as usize];
+                self.lockfile.buffers.resolutions.as_slice()[peer_dependency_id.index()];
 
             enqueue::enqueue_dependency_with_main(
                 self,

--- a/src/install/PackageManager/processDependencyList.rs
+++ b/src/install/PackageManager/processDependencyList.rs
@@ -190,7 +190,7 @@ impl PackageManager {
                     let new_name = Repository::create_dependency_name_from_version_literal(
                         &repo,
                         self.lockfile.buffers.string_bytes.as_slice(),
-                        &self.lockfile.buffers.dependencies[dep_id.index()],
+                        &self.lockfile.buffers.dependencies[dep_id],
                     );
                     // `defer manager.allocator.free(new_name)` — `new_name: Vec<u8>` drops at scope end.
 
@@ -331,8 +331,7 @@ impl PackageManager {
                     // effect. (Hoisted above `string_builder()` for borrowck —
                     // `parse_count`/`allocate` don't touch `packages`.)
                     debug_assert!(*package_id != INVALID_PACKAGE_ID);
-                    let mut scripts: Scripts =
-                        self.lockfile.packages.items_scripts()[package_id.index()];
+                    let mut scripts: Scripts = self.lockfile.packages.items_scripts()[*package_id];
                     let mut builder = self.lockfile.string_builder();
                     Scripts::parse_count(&mut builder, json_root);
                     builder.allocate().expect("unreachable");
@@ -356,11 +355,9 @@ impl PackageManager {
             TaskCallbackContext::Dependency(dependency_id) => {
                 // Clone the dependency row out of the buffer before
                 // re-borrowing `self` for enqueue.
-                let dependency = Clone::clone(
-                    &self.lockfile.buffers.dependencies.as_slice()[dependency_id.index()],
-                );
-                let resolution =
-                    self.lockfile.buffers.resolutions.as_slice()[dependency_id.index()];
+                let dependency =
+                    Clone::clone(&self.lockfile.buffers.dependencies.as_slice()[dependency_id]);
+                let resolution = self.lockfile.buffers.resolutions.as_slice()[dependency_id];
 
                 enqueue::enqueue_dependency_with_main(
                     self,
@@ -371,11 +368,9 @@ impl PackageManager {
                 )?;
             }
             TaskCallbackContext::RootDependency(dependency_id) => {
-                let dependency = Clone::clone(
-                    &self.lockfile.buffers.dependencies.as_slice()[dependency_id.index()],
-                );
-                let resolution =
-                    self.lockfile.buffers.resolutions.as_slice()[dependency_id.index()];
+                let dependency =
+                    Clone::clone(&self.lockfile.buffers.dependencies.as_slice()[dependency_id]);
+                let resolution = self.lockfile.buffers.resolutions.as_slice()[dependency_id];
 
                 enqueue::enqueue_dependency_with_main_and_success_fn(
                     self,
@@ -389,7 +384,7 @@ impl PackageManager {
                 )?;
                 if let Some(ptr) = any_root {
                     let new_resolution_id =
-                        self.lockfile.buffers.resolutions.as_slice()[dependency_id.index()];
+                        self.lockfile.buffers.resolutions.as_slice()[dependency_id];
                     if new_resolution_id != resolution {
                         ptr.set(true);
                     }
@@ -404,11 +399,9 @@ impl PackageManager {
         while let Some(peer_dependency_id) = self.peer_dependencies.read_item() {
             // Clone the dependency row out of the buffer before re-borrowing
             // `self` for enqueue.
-            let dependency = Clone::clone(
-                &self.lockfile.buffers.dependencies.as_slice()[peer_dependency_id.index()],
-            );
-            let resolution =
-                self.lockfile.buffers.resolutions.as_slice()[peer_dependency_id.index()];
+            let dependency =
+                Clone::clone(&self.lockfile.buffers.dependencies.as_slice()[peer_dependency_id]);
+            let resolution = self.lockfile.buffers.resolutions.as_slice()[peer_dependency_id];
 
             enqueue::enqueue_dependency_with_main(
                 self,

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -222,7 +222,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             installer.current_tree_id = ctx.tree_id;
                             let pkg_id = apply.pkg_id;
                             let resolution =
-                                &manager.lockfile.packages.items_resolution()[pkg_id as usize];
+                                &manager.lockfile.packages.items_resolution()[pkg_id.index()];
 
                             installer.install_package_with_name_and_resolution::<false, false>(
                                 ctx.dependency_id,
@@ -277,7 +277,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let entry_id = task.entry_id;
                     let node_id = installer.store.entries.items_node_id()[entry_id.get() as usize];
                     let dep_id = installer.store.nodes.items_dep_id()[node_id.get() as usize];
-                    let dep = &installer.lockfile().buffers.dependencies[dep_id as usize];
+                    let dep = &installer.lockfile().buffers.dependencies[dep_id.index()];
                     let optional = dep.behavior.contains(Behavior::OPTIONAL);
                     // SAFETY: `list` is the per-entry scripts slot owned by
                     // `store.entries.items_scripts()[entry_id]`; this Task is
@@ -725,8 +725,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                 &task.url_buf,
                             );
                         } else {
-                            let package_id = manager.lockfile.buffers.resolutions
-                                [extract.dependency_id as usize];
+                            let package_id =
+                                manager.lockfile.buffers.resolutions[extract.dependency_id.index()];
                             C::on_package_download_error_pkg(
                                 extract_ctx,
                                 package_id,
@@ -814,8 +814,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                 &task.url_buf,
                             );
                         } else {
-                            let package_id = manager.lockfile.buffers.resolutions
-                                [extract.dependency_id as usize];
+                            let package_id =
+                                manager.lockfile.buffers.resolutions[extract.dependency_id.index()];
                             C::on_package_download_error_pkg(
                                 extract_ctx,
                                 package_id,
@@ -1058,7 +1058,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     }
                 };
                 let dependency_id = tarball.dependency_id;
-                let mut package_id = manager.lockfile.buffers.resolutions[dependency_id as usize];
+                let mut package_id = manager.lockfile.buffers.resolutions[dependency_id.index()];
                 // SAFETY: `tarball` borrows `task.request` which is reborrowed
                 // `&mut` below; the backing `StringOrTinyString` lives in the
                 // pooled `Task` for the whole iteration and is not mutated.
@@ -1188,8 +1188,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                 bun_install::TaskCallbackContext::Dependency(id)
                                 | bun_install::TaskCallbackContext::RootDependency(id) => {
                                     let version = &mut manager.lockfile.buffers.dependencies
-                                        [id as usize]
-                                        .version;
+                                        [id.index()]
+                                    .version;
                                     match version.tag {
                                         bun_install::DependencyVersionTag::Git => {
                                             version.git_mut().package_name = pkg.name;
@@ -1222,7 +1222,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     manager.task_queue.get_mut(&Task::Id::for_manifest(
                         manager
                             .lockfile
-                            .str(&manager.lockfile.packages.items_name()[package_id as usize]),
+                            .str(&manager.lockfile.packages.items_name()[package_id.index()]),
                     ))
                 {
                     // Peer dependencies do not initiate any downloads of their own, thus need to be resolved here instead
@@ -1274,11 +1274,11 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                     bun_install::TaskCallbackContext::Dependency(id) => *id,
                                     _ => continue,
                                 };
-                                let pkg_id = manager.lockfile.buffers.resolutions[dep_id as usize];
+                                let pkg_id = manager.lockfile.buffers.resolutions[dep_id.index()];
                                 if pkg_id == INVALID_PACKAGE_ID {
                                     continue;
                                 }
-                                let res = &pkg_resolutions[pkg_id as usize];
+                                let res = &pkg_resolutions[pkg_id.index()];
                                 if res.tag != bun_install::ResolutionTag::Git {
                                     continue;
                                 }
@@ -1350,14 +1350,14 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         // so the `&manager.lockfile` borrow doesn't extend across
                         // the `&mut manager` calls below.
                         let (dep_name_handle, is_required) = {
-                            let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
+                            let dep = &manager.lockfile.buffers.dependencies[dep_id.index()];
                             (dep.name, dep.behavior.is_required())
                         };
-                        let pkg_id = manager.lockfile.buffers.resolutions[dep_id as usize];
+                        let pkg_id = manager.lockfile.buffers.resolutions[dep_id.index()];
                         if pkg_id == INVALID_PACKAGE_ID {
                             continue;
                         }
-                        let res = manager.lockfile.packages.items_resolution()[pkg_id as usize];
+                        let res = manager.lockfile.packages.items_resolution()[pkg_id.index()];
                         if res.tag != bun_install::ResolutionTag::Git {
                             continue;
                         }
@@ -1516,7 +1516,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                     // SAFETY: this branch is only reached for
                                     // git dependencies — `version.tag == Git`.
                                     let repo = unsafe {
-                                        &mut *manager.lockfile.buffers.dependencies[id as usize]
+                                        &mut *manager.lockfile.buffers.dependencies[id.index()]
                                             .version
                                             .value
                                             .git
@@ -1623,13 +1623,11 @@ pub fn flush_patch_task_queue(this: &mut PackageManager) {
 
 fn do_flush_dependency_queue(this: &mut PackageManager) {
     while let Some(dependencies_list) = this.lockfile.scratch.dependency_list_queue.read_item() {
-        let mut i: u32 = dependencies_list.off;
-        let end = dependencies_list.off + dependencies_list.len;
-        while i < end {
-            let dependency = this.lockfile.buffers.dependencies[i as usize].clone();
-            let resolution = this.lockfile.buffers.resolutions[i as usize];
-            let _ = enqueue::enqueue_dependency_with_main(this, i, &dependency, resolution, false);
-            i += 1;
+        for dep_id in dependencies_list.dependency_ids() {
+            let dependency = this.lockfile.buffers.dependencies[dep_id.index()].clone();
+            let resolution = this.lockfile.buffers.resolutions[dep_id.index()];
+            let _ =
+                enqueue::enqueue_dependency_with_main(this, dep_id, &dependency, resolution, false);
         }
     }
 

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -221,8 +221,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             installer.node_modules.path = path;
                             installer.current_tree_id = ctx.tree_id;
                             let pkg_id = apply.pkg_id;
-                            let resolution =
-                                &manager.lockfile.packages.items_resolution()[pkg_id.index()];
+                            let resolution = &manager.lockfile.packages.items_resolution()[pkg_id];
 
                             installer.install_package_with_name_and_resolution::<false, false>(
                                 ctx.dependency_id,
@@ -277,7 +276,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let entry_id = task.entry_id;
                     let node_id = installer.store.entries.items_node_id()[entry_id.get() as usize];
                     let dep_id = installer.store.nodes.items_dep_id()[node_id.get() as usize];
-                    let dep = &installer.lockfile().buffers.dependencies[dep_id.index()];
+                    let dep = &installer.lockfile().buffers.dependencies[dep_id];
                     let optional = dep.behavior.contains(Behavior::OPTIONAL);
                     // SAFETY: `list` is the per-entry scripts slot owned by
                     // `store.entries.items_scripts()[entry_id]`; this Task is
@@ -726,7 +725,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             );
                         } else {
                             let package_id =
-                                manager.lockfile.buffers.resolutions[extract.dependency_id.index()];
+                                manager.lockfile.buffers.resolutions[extract.dependency_id];
                             C::on_package_download_error_pkg(
                                 extract_ctx,
                                 package_id,
@@ -815,7 +814,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             );
                         } else {
                             let package_id =
-                                manager.lockfile.buffers.resolutions[extract.dependency_id.index()];
+                                manager.lockfile.buffers.resolutions[extract.dependency_id];
                             C::on_package_download_error_pkg(
                                 extract_ctx,
                                 package_id,
@@ -1058,7 +1057,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     }
                 };
                 let dependency_id = tarball.dependency_id;
-                let mut package_id = manager.lockfile.buffers.resolutions[dependency_id.index()];
+                let mut package_id = manager.lockfile.buffers.resolutions[dependency_id];
                 // SAFETY: `tarball` borrows `task.request` which is reborrowed
                 // `&mut` below; the backing `StringOrTinyString` lives in the
                 // pooled `Task` for the whole iteration and is not mutated.
@@ -1187,9 +1186,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             match dep {
                                 bun_install::TaskCallbackContext::Dependency(id)
                                 | bun_install::TaskCallbackContext::RootDependency(id) => {
-                                    let version = &mut manager.lockfile.buffers.dependencies
-                                        [id.index()]
-                                    .version;
+                                    let version =
+                                        &mut manager.lockfile.buffers.dependencies[id].version;
                                     match version.tag {
                                         bun_install::DependencyVersionTag::Git => {
                                             version.git_mut().package_name = pkg.name;
@@ -1222,7 +1220,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     manager.task_queue.get_mut(&Task::Id::for_manifest(
                         manager
                             .lockfile
-                            .str(&manager.lockfile.packages.items_name()[package_id.index()]),
+                            .str(&manager.lockfile.packages.items_name()[package_id]),
                     ))
                 {
                     // Peer dependencies do not initiate any downloads of their own, thus need to be resolved here instead
@@ -1274,11 +1272,11 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                     bun_install::TaskCallbackContext::Dependency(id) => *id,
                                     _ => continue,
                                 };
-                                let pkg_id = manager.lockfile.buffers.resolutions[dep_id.index()];
+                                let pkg_id = manager.lockfile.buffers.resolutions[dep_id];
                                 if pkg_id == INVALID_PACKAGE_ID {
                                     continue;
                                 }
-                                let res = &pkg_resolutions[pkg_id.index()];
+                                let res = &pkg_resolutions[pkg_id];
                                 if res.tag != bun_install::ResolutionTag::Git {
                                     continue;
                                 }
@@ -1350,14 +1348,14 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         // so the `&manager.lockfile` borrow doesn't extend across
                         // the `&mut manager` calls below.
                         let (dep_name_handle, is_required) = {
-                            let dep = &manager.lockfile.buffers.dependencies[dep_id.index()];
+                            let dep = &manager.lockfile.buffers.dependencies[dep_id];
                             (dep.name, dep.behavior.is_required())
                         };
-                        let pkg_id = manager.lockfile.buffers.resolutions[dep_id.index()];
+                        let pkg_id = manager.lockfile.buffers.resolutions[dep_id];
                         if pkg_id == INVALID_PACKAGE_ID {
                             continue;
                         }
-                        let res = manager.lockfile.packages.items_resolution()[pkg_id.index()];
+                        let res = manager.lockfile.packages.items_resolution()[pkg_id];
                         if res.tag != bun_install::ResolutionTag::Git {
                             continue;
                         }
@@ -1516,7 +1514,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                     // SAFETY: this branch is only reached for
                                     // git dependencies — `version.tag == Git`.
                                     let repo = unsafe {
-                                        &mut *manager.lockfile.buffers.dependencies[id.index()]
+                                        &mut *manager.lockfile.buffers.dependencies[id]
                                             .version
                                             .value
                                             .git
@@ -1624,8 +1622,8 @@ pub fn flush_patch_task_queue(this: &mut PackageManager) {
 fn do_flush_dependency_queue(this: &mut PackageManager) {
     while let Some(dependencies_list) = this.lockfile.scratch.dependency_list_queue.read_item() {
         for dep_id in dependencies_list.dependency_ids() {
-            let dependency = this.lockfile.buffers.dependencies[dep_id.index()].clone();
-            let resolution = this.lockfile.buffers.resolutions[dep_id.index()];
+            let dependency = this.lockfile.buffers.dependencies[dep_id].clone();
+            let resolution = this.lockfile.buffers.resolutions[dep_id];
             let _ =
                 enqueue::enqueue_dependency_with_main(this, dep_id, &dependency, resolution, false);
         }

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -162,23 +162,22 @@ impl<'a> ScannerFinder<'a> {
         let pkg_resolutions = pkgs.items_resolution();
         let string_buf = self.manager.lockfile.buffers.string_bytes.as_slice();
 
-        let root_pkg_id: PackageID = 0;
-        let root_deps = pkg_dependencies[root_pkg_id as usize];
+        let root_pkg_id = PackageID::ROOT;
+        let root_deps = pkg_dependencies[root_pkg_id.index()];
 
-        for _dep_id in root_deps.begin()..root_deps.end() {
-            let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
-            let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id as usize];
+        for dep_id in root_deps.dependency_ids() {
+            let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id.index()];
 
             if dep_pkg_id == invalid_package_id {
                 continue;
             }
 
-            let dep_res = &pkg_resolutions[dep_pkg_id as usize];
+            let dep_res = &pkg_resolutions[dep_pkg_id.index()];
             if dep_res.tag != bun_install::resolution::Tag::Npm {
                 continue;
             }
 
-            let dep_name = self.manager.lockfile.buffers.dependencies[dep_id as usize].name;
+            let dep_name = self.manager.lockfile.buffers.dependencies[dep_id.index()].name;
             if dep_name.slice(string_buf) == self.scanner_name {
                 return Some(dep_pkg_id);
             }
@@ -199,9 +198,8 @@ impl<'a> ScannerFinder<'a> {
             }
 
             let deps = pkg_deps[pkg_idx];
-            for _dep_id in deps.begin()..deps.end() {
-                let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
-                let dep = &self.manager.lockfile.buffers.dependencies[dep_id as usize];
+            for dep_id in deps.dependency_ids() {
+                let dep = &self.manager.lockfile.buffers.dependencies[dep_id.index()];
 
                 if dep.name.slice(string_buf) == self.scanner_name {
                     return Err(crate::Error::SecurityScannerInWorkspace);
@@ -328,7 +326,7 @@ pub fn print_security_advisories(manager: &PackageManager, results: &SecuritySca
                     if idx > 0 {
                         bun_core::pretty!(" › ");
                     }
-                    let ancestor_name = pkg_names[*ancestor_id as usize].slice(string_buf);
+                    let ancestor_name = pkg_names[ancestor_id.index()].slice(string_buf);
                     bun_core::pretty!("{}", BStr::new(ancestor_name));
                 }
                 bun_core::pretty!(" › <red>{}<r>\n", BStr::new(&advisory.package));
@@ -474,13 +472,12 @@ impl<'a> PackageCollector<'a> {
         let pkg_dependencies = pkgs.items_dependencies();
         let pkg_resolutions = pkgs.items_resolution();
 
-        let root_pkg_id: PackageID = 0;
-        let root_deps = pkg_dependencies[root_pkg_id as usize];
+        let root_pkg_id = PackageID::ROOT;
+        let root_deps = pkg_dependencies[root_pkg_id.index()];
 
         // collect all npm deps from the root package
-        for _dep_id in root_deps.begin()..root_deps.end() {
-            let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
-            let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id as usize];
+        for dep_id in root_deps.dependency_ids() {
+            let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id.index()];
 
             if dep_pkg_id == invalid_package_id {
                 continue;
@@ -505,14 +502,13 @@ impl<'a> PackageCollector<'a> {
         // and collect npm deps from workspace packages
         for pkg_idx in 0..pkgs.len() {
             let pkg_id: PackageID = PackageID::try_from(pkg_idx).expect("int cast");
-            if pkg_resolutions[pkg_id as usize].tag != bun_install::resolution::Tag::Workspace {
+            if pkg_resolutions[pkg_id.index()].tag != bun_install::resolution::Tag::Workspace {
                 continue;
             }
 
-            let workspace_deps = pkg_dependencies[pkg_id as usize];
-            for _dep_id in workspace_deps.begin()..workspace_deps.end() {
-                let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
-                let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id as usize];
+            let workspace_deps = pkg_dependencies[pkg_id.index()];
+            for dep_id in workspace_deps.dependency_ids() {
+                let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id.index()];
 
                 if dep_pkg_id == invalid_package_id {
                     continue;
@@ -556,18 +552,16 @@ impl<'a> PackageCollector<'a> {
 
                 'update_dep_id: for _pkg_id in 0..pkgs.len() {
                     let pkg_id: PackageID = PackageID::try_from(_pkg_id).expect("int cast");
-                    let pkg_res = &pkg_resolutions[pkg_id as usize];
+                    let pkg_res = &pkg_resolutions[pkg_id.index()];
                     if pkg_res.tag != bun_install::resolution::Tag::Root
                         && pkg_res.tag != bun_install::resolution::Tag::Workspace
                     {
                         continue;
                     }
 
-                    let pkg_deps = pkg_dependencies[pkg_id as usize];
-                    for _dep_id in pkg_deps.begin()..pkg_deps.end() {
-                        let dep_id: DependencyID =
-                            DependencyID::try_from(_dep_id).expect("int cast");
-                        let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id as usize];
+                    let pkg_deps = pkg_dependencies[pkg_id.index()];
+                    for dep_id in pkg_deps.dependency_ids() {
+                        let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id.index()];
                         if dep_pkg_id == invalid_package_id {
                             continue;
                         }
@@ -619,17 +613,16 @@ impl<'a> PackageCollector<'a> {
 
         let mut wanted = bun_collections::DynamicBitSet::init_empty(pkgs.len())?;
         for &seed in seeds {
-            if (seed as usize) < pkgs.len() {
-                wanted.set(seed as usize);
+            if seed.index() < pkgs.len() {
+                wanted.set(seed.index());
             }
         }
 
         for (parent_idx, deps) in pkg_dependencies.iter().enumerate() {
             let parent: PackageID = PackageID::try_from(parent_idx).expect("int cast");
-            for _dep_id in deps.begin()..deps.end() {
-                let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
-                let target = resolutions[dep_id as usize];
-                if target == invalid_package_id || !wanted.is_set(target as usize) {
+            for dep_id in deps.dependency_ids() {
+                let target = resolutions[dep_id.index()];
+                if target == invalid_package_id || !wanted.is_set(target.index()) {
                     continue;
                 }
                 if self.dedupe.get_or_put(target)?.found_existing {
@@ -659,7 +652,7 @@ impl<'a> PackageCollector<'a> {
             let pkg_id = item.pkg_id;
             let _ = item.dep_id; // Could be useful in the future for dependency-specific processing
 
-            if pkg_resolutions[pkg_id as usize].tag == bun_install::resolution::Tag::Npm {
+            if pkg_resolutions[pkg_id.index()].tag == bun_install::resolution::Tag::Npm {
                 let pkg_path_copy: Box<[PackageID]> = item.pkg_path.clone().into_boxed_slice();
                 let dep_path_copy: Box<[DependencyID]> = item.dep_path.clone().into_boxed_slice();
 
@@ -672,11 +665,9 @@ impl<'a> PackageCollector<'a> {
                 )?;
             }
 
-            let pkg_deps = pkg_dependencies[pkg_id as usize];
-            for _next_dep_id in pkg_deps.begin()..pkg_deps.end() {
-                let next_dep_id: DependencyID =
-                    DependencyID::try_from(_next_dep_id).expect("int cast");
-                let next_pkg_id = self.manager.lockfile.buffers.resolutions[next_dep_id as usize];
+            let pkg_deps = pkg_dependencies[pkg_id.index()];
+            for next_dep_id in pkg_deps.dependency_ids() {
+                let next_pkg_id = self.manager.lockfile.buffers.resolutions[next_dep_id.index()];
 
                 if next_pkg_id == invalid_package_id {
                     continue;
@@ -740,8 +731,8 @@ impl<'a> JSONBuilder<'a> {
                 invalid_dependency_id
             };
 
-            let pkg_name = pkg_names[pkg_id as usize];
-            let pkg_res = &pkg_resolutions[pkg_id as usize];
+            let pkg_name = pkg_names[pkg_id.index()];
+            let pkg_res = &pkg_resolutions[pkg_id.index()];
 
             if !first {
                 json_buf.extend_from_slice(b",\n");
@@ -762,7 +753,7 @@ impl<'a> JSONBuilder<'a> {
                 )?;
             } else {
                 let dep_version =
-                    &self.manager.lockfile.buffers.dependencies[dep_id as usize].version;
+                    &self.manager.lockfile.buffers.dependencies[dep_id.index()].version;
                 write!(
                     &mut json_buf,
                     "  {{\n    \"name\": {},\n    \"version\": \"{}\",\n    \"requestedRange\": {},\n    \"tarball\": {}\n  }}",

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -163,21 +163,21 @@ impl<'a> ScannerFinder<'a> {
         let string_buf = self.manager.lockfile.buffers.string_bytes.as_slice();
 
         let root_pkg_id = PackageID::ROOT;
-        let root_deps = pkg_dependencies[root_pkg_id.index()];
+        let root_deps = pkg_dependencies[root_pkg_id];
 
         for dep_id in root_deps.dependency_ids() {
-            let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id.index()];
+            let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id];
 
             if dep_pkg_id == invalid_package_id {
                 continue;
             }
 
-            let dep_res = &pkg_resolutions[dep_pkg_id.index()];
+            let dep_res = &pkg_resolutions[dep_pkg_id];
             if dep_res.tag != bun_install::resolution::Tag::Npm {
                 continue;
             }
 
-            let dep_name = self.manager.lockfile.buffers.dependencies[dep_id.index()].name;
+            let dep_name = self.manager.lockfile.buffers.dependencies[dep_id].name;
             if dep_name.slice(string_buf) == self.scanner_name {
                 return Some(dep_pkg_id);
             }
@@ -192,14 +192,14 @@ impl<'a> ScannerFinder<'a> {
         let pkg_res = pkgs.items_resolution();
         let string_buf = self.manager.lockfile.buffers.string_bytes.as_slice();
 
-        for pkg_idx in 0..pkgs.len() {
+        for pkg_idx in pkg_res.ids() {
             if pkg_res[pkg_idx].tag != bun_install::resolution::Tag::Workspace {
                 continue;
             }
 
             let deps = pkg_deps[pkg_idx];
             for dep_id in deps.dependency_ids() {
-                let dep = &self.manager.lockfile.buffers.dependencies[dep_id.index()];
+                let dep = &self.manager.lockfile.buffers.dependencies[dep_id];
 
                 if dep.name.slice(string_buf) == self.scanner_name {
                     return Err(crate::Error::SecurityScannerInWorkspace);
@@ -326,7 +326,7 @@ pub fn print_security_advisories(manager: &PackageManager, results: &SecuritySca
                     if idx > 0 {
                         bun_core::pretty!(" › ");
                     }
-                    let ancestor_name = pkg_names[ancestor_id.index()].slice(string_buf);
+                    let ancestor_name = pkg_names[*ancestor_id].slice(string_buf);
                     bun_core::pretty!("{}", BStr::new(ancestor_name));
                 }
                 bun_core::pretty!(" › <red>{}<r>\n", BStr::new(&advisory.package));
@@ -473,11 +473,11 @@ impl<'a> PackageCollector<'a> {
         let pkg_resolutions = pkgs.items_resolution();
 
         let root_pkg_id = PackageID::ROOT;
-        let root_deps = pkg_dependencies[root_pkg_id.index()];
+        let root_deps = pkg_dependencies[root_pkg_id];
 
         // collect all npm deps from the root package
         for dep_id in root_deps.dependency_ids() {
-            let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id.index()];
+            let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id];
 
             if dep_pkg_id == invalid_package_id {
                 continue;
@@ -502,13 +502,13 @@ impl<'a> PackageCollector<'a> {
         // and collect npm deps from workspace packages
         for pkg_idx in 0..pkgs.len() {
             let pkg_id: PackageID = PackageID::try_from(pkg_idx).expect("int cast");
-            if pkg_resolutions[pkg_id.index()].tag != bun_install::resolution::Tag::Workspace {
+            if pkg_resolutions[pkg_id].tag != bun_install::resolution::Tag::Workspace {
                 continue;
             }
 
-            let workspace_deps = pkg_dependencies[pkg_id.index()];
+            let workspace_deps = pkg_dependencies[pkg_id];
             for dep_id in workspace_deps.dependency_ids() {
-                let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id.index()];
+                let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id];
 
                 if dep_pkg_id == invalid_package_id {
                     continue;
@@ -552,16 +552,16 @@ impl<'a> PackageCollector<'a> {
 
                 'update_dep_id: for _pkg_id in 0..pkgs.len() {
                     let pkg_id: PackageID = PackageID::try_from(_pkg_id).expect("int cast");
-                    let pkg_res = &pkg_resolutions[pkg_id.index()];
+                    let pkg_res = &pkg_resolutions[pkg_id];
                     if pkg_res.tag != bun_install::resolution::Tag::Root
                         && pkg_res.tag != bun_install::resolution::Tag::Workspace
                     {
                         continue;
                     }
 
-                    let pkg_deps = pkg_dependencies[pkg_id.index()];
+                    let pkg_deps = pkg_dependencies[pkg_id];
                     for dep_id in pkg_deps.dependency_ids() {
-                        let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id.index()];
+                        let dep_pkg_id = self.manager.lockfile.buffers.resolutions[dep_id];
                         if dep_pkg_id == invalid_package_id {
                             continue;
                         }
@@ -621,7 +621,7 @@ impl<'a> PackageCollector<'a> {
         for (parent_idx, deps) in pkg_dependencies.iter().enumerate() {
             let parent: PackageID = PackageID::try_from(parent_idx).expect("int cast");
             for dep_id in deps.dependency_ids() {
-                let target = resolutions[dep_id.index()];
+                let target = resolutions[dep_id];
                 if target == invalid_package_id || !wanted.is_set(target.index()) {
                     continue;
                 }
@@ -652,7 +652,7 @@ impl<'a> PackageCollector<'a> {
             let pkg_id = item.pkg_id;
             let _ = item.dep_id; // Could be useful in the future for dependency-specific processing
 
-            if pkg_resolutions[pkg_id.index()].tag == bun_install::resolution::Tag::Npm {
+            if pkg_resolutions[pkg_id].tag == bun_install::resolution::Tag::Npm {
                 let pkg_path_copy: Box<[PackageID]> = item.pkg_path.clone().into_boxed_slice();
                 let dep_path_copy: Box<[DependencyID]> = item.dep_path.clone().into_boxed_slice();
 
@@ -665,9 +665,9 @@ impl<'a> PackageCollector<'a> {
                 )?;
             }
 
-            let pkg_deps = pkg_dependencies[pkg_id.index()];
+            let pkg_deps = pkg_dependencies[pkg_id];
             for next_dep_id in pkg_deps.dependency_ids() {
-                let next_pkg_id = self.manager.lockfile.buffers.resolutions[next_dep_id.index()];
+                let next_pkg_id = self.manager.lockfile.buffers.resolutions[next_dep_id];
 
                 if next_pkg_id == invalid_package_id {
                     continue;
@@ -731,8 +731,8 @@ impl<'a> JSONBuilder<'a> {
                 invalid_dependency_id
             };
 
-            let pkg_name = pkg_names[pkg_id.index()];
-            let pkg_res = &pkg_resolutions[pkg_id.index()];
+            let pkg_name = pkg_names[pkg_id];
+            let pkg_res = &pkg_resolutions[pkg_id];
 
             if !first {
                 json_buf.extend_from_slice(b",\n");
@@ -752,8 +752,7 @@ impl<'a> JSONBuilder<'a> {
                     bun_core::fmt::format_json_string_utf8(npm.url.slice(string_buf), json_opts),
                 )?;
             } else {
-                let dep_version =
-                    &self.manager.lockfile.buffers.dependencies[dep_id.index()].version;
+                let dep_version = &self.manager.lockfile.buffers.dependencies[dep_id].version;
                 write!(
                     &mut json_buf,
                     "  {{\n    \"name\": {},\n    \"version\": \"{}\",\n    \"requestedRange\": {},\n    \"tarball\": {}\n  }}",

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -266,17 +266,17 @@ fn update_package_json_and_install_with_manager_with_updates(
             selected
                 .iter()
                 .map(|&id| super::UpdateTargetWorkspace {
-                    is_root: resolutions[id as usize].tag == crate::resolution::Tag::Root,
-                    name_hash: name_hashes[id as usize],
-                    name: Box::from(names[id as usize].slice(sbuf)),
+                    is_root: resolutions[id.index()].tag == crate::resolution::Tag::Root,
+                    name_hash: name_hashes[id.index()],
+                    name: Box::from(names[id.index()].slice(sbuf)),
                 })
                 .collect(),
         );
         if !filter_patterns.is_empty() {
             manager.filtered_link_targets = Some(workspace_selection::LinkTargets::from_importers(
                 selected.iter().map(|&id| {
-                    (resolutions[id as usize].tag != crate::resolution::Tag::Root)
-                        .then(|| name_hashes[id as usize])
+                    (resolutions[id.index()].tag != crate::resolution::Tag::Root)
+                        .then(|| name_hashes[id.index()])
                 }),
             ));
         }

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -266,17 +266,16 @@ fn update_package_json_and_install_with_manager_with_updates(
             selected
                 .iter()
                 .map(|&id| super::UpdateTargetWorkspace {
-                    is_root: resolutions[id.index()].tag == crate::resolution::Tag::Root,
-                    name_hash: name_hashes[id.index()],
-                    name: Box::from(names[id.index()].slice(sbuf)),
+                    is_root: resolutions[id].tag == crate::resolution::Tag::Root,
+                    name_hash: name_hashes[id],
+                    name: Box::from(names[id].slice(sbuf)),
                 })
                 .collect(),
         );
         if !filter_patterns.is_empty() {
             manager.filtered_link_targets = Some(workspace_selection::LinkTargets::from_importers(
                 selected.iter().map(|&id| {
-                    (resolutions[id.index()].tag != crate::resolution::Tag::Root)
-                        .then(|| name_hashes[id.index()])
+                    (resolutions[id].tag != crate::resolution::Tag::Root).then(|| name_hashes[id])
                 }),
             ));
         }

--- a/src/install/PackageManager/workspace_selection.rs
+++ b/src/install/PackageManager/workspace_selection.rs
@@ -338,7 +338,7 @@ impl WorkspaceGraph {
                 if dep.behavior == Behavior::WORKSPACE {
                     continue;
                 }
-                let Some(&to) = candidate_of.get(dep_pkg as usize) else {
+                let Some(&to) = candidate_of.get(dep_pkg.index()) else {
                     continue;
                 };
                 if to == u32::MAX || to == from {
@@ -397,7 +397,7 @@ pub fn select_lockfile_workspaces(
         .iter()
         .enumerate()
         .filter(|(_, res)| matches!(res.tag, ResolutionTag::Root | ResolutionTag::Workspace))
-        .map(|(pkg_id, _)| pkg_id as PackageID)
+        .map(|(pkg_id, _)| PackageID::from_index(pkg_id))
         .collect();
 
     if patterns.is_empty() {
@@ -416,7 +416,7 @@ pub fn select_lockfile_workspaces(
     let dirs: Vec<Box<[u8]>> = ids
         .iter()
         .map(|&pkg_id| {
-            let res = &pkg_resolutions[pkg_id as usize];
+            let res = &pkg_resolutions[pkg_id.index()];
             let rel: &[u8] = match res.tag {
                 ResolutionTag::Workspace => res.workspace().slice(string_buf),
                 _ => b".",
@@ -434,9 +434,9 @@ pub fn select_lockfile_workspaces(
         .iter()
         .zip(&dirs)
         .map(|(&pkg_id, dir)| Candidate {
-            name: pkg_names[pkg_id as usize].slice(string_buf),
+            name: pkg_names[pkg_id.index()].slice(string_buf),
             abs_posix_dir: dir,
-            is_root: pkg_resolutions[pkg_id as usize].tag == ResolutionTag::Root,
+            is_root: pkg_resolutions[pkg_id.index()].tag == ResolutionTag::Root,
         })
         .collect();
 
@@ -444,7 +444,7 @@ pub fn select_lockfile_workspaces(
         let hashes: Vec<Option<PackageNameHash>> = candidates
             .iter()
             .zip(&ids)
-            .map(|(c, &pkg_id)| (!c.is_root).then(|| name_hashes[pkg_id as usize]))
+            .map(|(c, &pkg_id)| (!c.is_root).then(|| name_hashes[pkg_id.index()]))
             .collect();
         WorkspaceGraph::from_lockfile(lockfile, &hashes)
     });
@@ -527,7 +527,7 @@ impl LinkTargets {
                 }
                 _ => false,
             })
-            .map(|i| i as PackageID)
+            .map(PackageID::from_index)
             .collect()
     }
 }

--- a/src/install/PackageManager/workspace_selection.rs
+++ b/src/install/PackageManager/workspace_selection.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use bstr::BStr;
-use bun_collections::{DynamicBitSet, HashMap, index_sort};
+use bun_collections::{DynamicBitSet, HashMap, IdVec, index_sort};
 use bun_core::{Global, Output, UnwrapOrOom as _, strings};
 use bun_paths::path_buffer_pool;
 use bun_paths::resolve_path::{join_abs_string_buf, platform};
@@ -314,7 +314,7 @@ impl WorkspaceGraph {
         let resolutions = lockfile.buffers.resolutions.as_slice();
         let dependencies = lockfile.buffers.dependencies.as_slice();
 
-        let candidate_of: Vec<u32> = pkg_resolutions
+        let candidate_of: IdVec<PackageID, u32> = pkg_resolutions
             .iter()
             .zip(name_hashes)
             .map(|(res, name_hash)| match res.tag {
@@ -328,7 +328,7 @@ impl WorkspaceGraph {
             dependencies: vec![Vec::new(); n],
             dependents: vec![Vec::new(); n],
         };
-        for (pkg_id, &from) in candidate_of.iter().enumerate() {
+        for (pkg_id, &from) in candidate_of.iter_enumerated() {
             if from == u32::MAX {
                 continue;
             }
@@ -338,7 +338,7 @@ impl WorkspaceGraph {
                 if dep.behavior == Behavior::WORKSPACE {
                     continue;
                 }
-                let Some(&to) = candidate_of.get(dep_pkg.index()) else {
+                let Some(&to) = candidate_of.get(dep_pkg) else {
                     continue;
                 };
                 if to == u32::MAX || to == from {
@@ -416,7 +416,7 @@ pub fn select_lockfile_workspaces(
     let dirs: Vec<Box<[u8]>> = ids
         .iter()
         .map(|&pkg_id| {
-            let res = &pkg_resolutions[pkg_id.index()];
+            let res = &pkg_resolutions[pkg_id];
             let rel: &[u8] = match res.tag {
                 ResolutionTag::Workspace => res.workspace().slice(string_buf),
                 _ => b".",
@@ -434,9 +434,9 @@ pub fn select_lockfile_workspaces(
         .iter()
         .zip(&dirs)
         .map(|(&pkg_id, dir)| Candidate {
-            name: pkg_names[pkg_id.index()].slice(string_buf),
+            name: pkg_names[pkg_id].slice(string_buf),
             abs_posix_dir: dir,
-            is_root: pkg_resolutions[pkg_id.index()].tag == ResolutionTag::Root,
+            is_root: pkg_resolutions[pkg_id].tag == ResolutionTag::Root,
         })
         .collect();
 
@@ -444,7 +444,7 @@ pub fn select_lockfile_workspaces(
         let hashes: Vec<Option<PackageNameHash>> = candidates
             .iter()
             .zip(&ids)
-            .map(|(c, &pkg_id)| (!c.is_root).then(|| name_hashes[pkg_id.index()]))
+            .map(|(c, &pkg_id)| (!c.is_root).then(|| name_hashes[pkg_id]))
             .collect();
         WorkspaceGraph::from_lockfile(lockfile, &hashes)
     });
@@ -519,7 +519,7 @@ impl LinkTargets {
     pub(crate) fn package_ids(&self, lockfile: &Lockfile) -> Vec<PackageID> {
         let tags = lockfile.packages.items_resolution();
         let name_hashes = lockfile.packages.items_name_hash();
-        (0..tags.len())
+        tags.ids()
             .filter(|&i| match tags[i].tag {
                 ResolutionTag::Root => self.importers.binary_search(&None).is_ok(),
                 ResolutionTag::Workspace => {
@@ -527,7 +527,6 @@ impl LinkTargets {
                 }
                 _ => false,
             })
-            .map(PackageID::from_index)
             .collect()
     }
 }

--- a/src/install/audit_fix.rs
+++ b/src/install/audit_fix.rs
@@ -315,7 +315,7 @@ pub fn print_unaudited(groups: &[UnauditedRegistry]) {
 
 fn importer_file(lockfile: &Lockfile, parent: PackageID) -> Option<Box<[u8]>> {
     let buf = lockfile.buffers.string_bytes.as_slice();
-    let parent_res = &lockfile.packages.items_resolution()[parent as usize];
+    let parent_res = &lockfile.packages.items_resolution()[parent.index()];
     match parent_res.tag {
         ResolutionTag::Root => Some(Box::from(&b"package.json"[..])),
         ResolutionTag::Workspace => {
@@ -340,8 +340,8 @@ fn dependent_label(lockfile: &Lockfile, parent: PackageID) -> Box<[u8]> {
         return file;
     }
     let buf = lockfile.buffers.string_bytes.as_slice();
-    let name = lockfile.packages.items_name()[parent as usize].slice(buf);
-    let res = &lockfile.packages.items_resolution()[parent as usize];
+    let name = lockfile.packages.items_name()[parent.index()].slice(buf);
+    let res = &lockfile.packages.items_resolution()[parent.index()];
     if res.tag != ResolutionTag::Npm {
         return Box::from(name);
     }
@@ -440,7 +440,7 @@ fn pin_for(
     }
     let buf = lockfile.buffers.string_bytes.as_slice();
     let res = lockfile.packages.items_resolution();
-    let parent_res = &res[parent as usize];
+    let parent_res = &res[parent.index()];
     if !matches!(
         parent_res.tag,
         ResolutionTag::Root | ResolutionTag::Workspace
@@ -451,7 +451,7 @@ fn pin_for(
     if !is_alias
         && lockfile
             .overrides
-            .get(lockfile, dep_id as DependencyID, dep.name_hash)
+            .get(lockfile, DependencyID::from_index(dep_id), dep.name_hash)
             .is_some()
     {
         return None;
@@ -469,7 +469,7 @@ fn pin_for(
                 return None;
             }
             Some(PackageJsonEdit {
-                owner: 0,
+                owner: PackageID::ROOT,
                 file: Box::from(&b"package.json"[..]),
                 catalog: Some(Box::from(catalog_name)),
                 key,
@@ -535,7 +535,7 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
             }
             instance_of[pkg_id] = instances.len() as u32;
             instances.push(Instance {
-                pkg_id: pkg_id as PackageID,
+                pkg_id: PackageID::from_index(pkg_id),
                 name: Box::from(names[pkg_id].slice(buf)),
                 name_hash: name_hashes[pkg_id],
                 from: fmt_version(current, buf),
@@ -550,7 +550,7 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
             for (pkg_id, slice) in dep_slices.iter().enumerate() {
                 let end = (slice.end() as usize).min(deps.len());
                 for slot in &mut parent_of[(slice.begin() as usize).min(end)..end] {
-                    *slot = pkg_id as PackageID;
+                    *slot = PackageID::from_index(pkg_id);
                 }
             }
 
@@ -558,7 +558,7 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
                 if target == invalid_package_id {
                     continue;
                 }
-                let Some(&instance) = instance_of.get(target as usize) else {
+                let Some(&instance) = instance_of.get(target.index()) else {
                     continue;
                 };
                 if instance == u32::MAX || deps[dep_id].behavior.is_optional_peer() {
@@ -572,11 +572,11 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
                     pin = pin_for(lockfile, dep_id, dep, parent, false);
                 }
                 instances[instance as usize].edges.push(Edge {
-                    dep_id: dep_id as DependencyID,
+                    dep_id: DependencyID::from_index(dep_id),
                     parent,
                     range: crate::dedupe::effective_npm_range(
                         lockfile,
-                        dep_id as DependencyID,
+                        DependencyID::from_index(dep_id),
                         dep,
                     ),
                     literal: Box::from(dep.version.literal.slice(buf)),
@@ -1251,7 +1251,11 @@ fn live_edge(
     edge: PlannedEdge,
 ) -> Option<(DependencyID, Semver::String)> {
     let deps = lockfile.buffers.dependencies.as_slice();
-    let target = *lockfile.buffers.resolutions.get(edge.dep_id as usize)? as usize;
+    let target = lockfile
+        .buffers
+        .resolutions
+        .get(edge.dep_id.index())?
+        .index();
     let res = lockfile.packages.items_resolution().get(target)?;
     if res.tag != ResolutionTag::Npm
         || lockfile.packages.items_name_hash()[target] != pin.name_hash
@@ -1264,19 +1268,19 @@ fn live_edge(
     let Some(&slice) = lockfile
         .packages
         .items_dependencies()
-        .get(edge.parent as usize)
+        .get(edge.parent.index())
     else {
         return Some((edge.dep_id, pkg_name));
     };
     if slice.contains(edge.dep_id) {
         return Some((edge.dep_id, pkg_name));
     }
-    let planned = &deps[edge.dep_id as usize];
+    let planned = &deps[edge.dep_id.index()];
     let live = slice
         .get(deps)
         .iter()
         .position(|dep| dep.name_hash == planned.name_hash && dep.behavior == planned.behavior)?;
-    Some((slice.off + live as DependencyID, pkg_name))
+    Some((DependencyID::new(slice.off + live as u32), pkg_name))
 }
 
 /// Re-resolves the edge `dep_id` (which must currently resolve to an npm package) to exactly `to_version`.
@@ -1285,8 +1289,8 @@ pub(crate) fn enqueue_pinned(
     dep_id: DependencyID,
     to_version: Semver::Version,
 ) -> crate::Result<()> {
-    let target = manager.lockfile.buffers.resolutions[dep_id as usize];
-    let pkg_name = manager.lockfile.packages.items_name()[target as usize];
+    let target = manager.lockfile.buffers.resolutions[dep_id.index()];
+    let pkg_name = manager.lockfile.packages.items_name()[target.index()];
     enqueue_pinned_as(manager, dep_id, pkg_name, to_version)
 }
 
@@ -1296,7 +1300,7 @@ fn enqueue_pinned_as(
     pkg_name: Semver::String,
     to_version: Semver::Version,
 ) -> crate::Result<()> {
-    let row = manager.lockfile.buffers.dependencies[dep_id as usize].clone();
+    let row = manager.lockfile.buffers.dependencies[dep_id.index()].clone();
     let pinned = Dependency {
         name: row.name,
         name_hash: row.name_hash,
@@ -1313,6 +1317,6 @@ fn enqueue_pinned_as(
             },
         },
     };
-    manager.lockfile.buffers.resolutions[dep_id as usize] = invalid_package_id;
+    manager.lockfile.buffers.resolutions[dep_id.index()] = invalid_package_id;
     enqueue_dependency_with_main(manager, dep_id, &pinned, invalid_package_id, false)
 }

--- a/src/install/audit_fix.rs
+++ b/src/install/audit_fix.rs
@@ -3,7 +3,7 @@ use core::mem::ManuallyDrop;
 use std::io::Write as _;
 
 use bstr::BStr;
-use bun_collections::{DynamicBitSet, HashMap, index_sort};
+use bun_collections::{DynamicBitSet, HashMap, IdVec, index_sort};
 use bun_core::{Global, Output, UnwrapOrOom as _, pretty, prettyln, strings};
 use bun_semver::query::Group;
 use bun_semver::{self as Semver, SlicedString};
@@ -315,7 +315,7 @@ pub fn print_unaudited(groups: &[UnauditedRegistry]) {
 
 fn importer_file(lockfile: &Lockfile, parent: PackageID) -> Option<Box<[u8]>> {
     let buf = lockfile.buffers.string_bytes.as_slice();
-    let parent_res = &lockfile.packages.items_resolution()[parent.index()];
+    let parent_res = &lockfile.packages.items_resolution()[parent];
     match parent_res.tag {
         ResolutionTag::Root => Some(Box::from(&b"package.json"[..])),
         ResolutionTag::Workspace => {
@@ -340,8 +340,8 @@ fn dependent_label(lockfile: &Lockfile, parent: PackageID) -> Box<[u8]> {
         return file;
     }
     let buf = lockfile.buffers.string_bytes.as_slice();
-    let name = lockfile.packages.items_name()[parent.index()].slice(buf);
-    let res = &lockfile.packages.items_resolution()[parent.index()];
+    let name = lockfile.packages.items_name()[parent].slice(buf);
+    let res = &lockfile.packages.items_resolution()[parent];
     if res.tag != ResolutionTag::Npm {
         return Box::from(name);
     }
@@ -430,7 +430,7 @@ fn print_manifest_unavailable(manager: &PackageManager, items: &[ManifestUnavail
 
 fn pin_for(
     lockfile: &Lockfile,
-    dep_id: usize,
+    dep_id: DependencyID,
     dep: &Dependency,
     parent: PackageID,
     latest: bool,
@@ -440,7 +440,7 @@ fn pin_for(
     }
     let buf = lockfile.buffers.string_bytes.as_slice();
     let res = lockfile.packages.items_resolution();
-    let parent_res = &res[parent.index()];
+    let parent_res = &res[parent];
     if !matches!(
         parent_res.tag,
         ResolutionTag::Root | ResolutionTag::Workspace
@@ -451,7 +451,7 @@ fn pin_for(
     if !is_alias
         && lockfile
             .overrides
-            .get(lockfile, DependencyID::from_index(dep_id), dep.name_hash)
+            .get(lockfile, dep_id, dep.name_hash)
             .is_some()
     {
         return None;
@@ -512,8 +512,8 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
         let deps = lockfile.buffers.dependencies.as_slice();
         let resolutions = lockfile.buffers.resolutions.as_slice();
 
-        let mut instance_of: Vec<u32> = vec![u32::MAX; res.len()];
-        for pkg_id in 0..res.len() {
+        let mut instance_of: IdVec<PackageID, u32> = vec![u32::MAX; res.len()].into();
+        for pkg_id in res.ids() {
             if res[pkg_id].tag != ResolutionTag::Npm {
                 continue;
             }
@@ -535,7 +535,7 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
             }
             instance_of[pkg_id] = instances.len() as u32;
             instances.push(Instance {
-                pkg_id: PackageID::from_index(pkg_id),
+                pkg_id,
                 name: Box::from(names[pkg_id].slice(buf)),
                 name_hash: name_hashes[pkg_id],
                 from: fmt_version(current, buf),
@@ -546,19 +546,20 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
         }
 
         if !instances.is_empty() {
-            let mut parent_of: Vec<PackageID> = vec![invalid_package_id; deps.len()];
-            for (pkg_id, slice) in dep_slices.iter().enumerate() {
+            let mut parent_of: IdVec<DependencyID, PackageID> =
+                vec![invalid_package_id; deps.len()].into();
+            for (pkg_id, slice) in dep_slices.iter_enumerated() {
                 let end = (slice.end() as usize).min(deps.len());
-                for slot in &mut parent_of[(slice.begin() as usize).min(end)..end] {
-                    *slot = PackageID::from_index(pkg_id);
+                for slot in &mut parent_of.raw_mut()[(slice.begin() as usize).min(end)..end] {
+                    *slot = pkg_id;
                 }
             }
 
-            for (dep_id, &target) in resolutions.iter().enumerate() {
+            for (dep_id, &target) in resolutions.iter_enumerated() {
                 if target == invalid_package_id {
                     continue;
                 }
-                let Some(&instance) = instance_of.get(target.index()) else {
+                let Some(&instance) = instance_of.get(target) else {
                     continue;
                 };
                 if instance == u32::MAX || deps[dep_id].behavior.is_optional_peer() {
@@ -572,13 +573,9 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
                     pin = pin_for(lockfile, dep_id, dep, parent, false);
                 }
                 instances[instance as usize].edges.push(Edge {
-                    dep_id: DependencyID::from_index(dep_id),
+                    dep_id,
                     parent,
-                    range: crate::dedupe::effective_npm_range(
-                        lockfile,
-                        DependencyID::from_index(dep_id),
-                        dep,
-                    ),
+                    range: crate::dedupe::effective_npm_range(lockfile, dep_id, dep),
                     literal: Box::from(dep.version.literal.slice(buf)),
                     dependent: dependent_label(lockfile, parent),
                     bundled: dep.behavior.is_bundled(),
@@ -1139,7 +1136,7 @@ impl FixPlan {
             .collect();
 
         let mut still_vulnerable: Vec<StillVulnerable> = Vec::new();
-        for pkg_id in 0..res.len() {
+        for pkg_id in res.ids() {
             if res[pkg_id].tag != ResolutionTag::Npm {
                 continue;
             }
@@ -1251,11 +1248,7 @@ fn live_edge(
     edge: PlannedEdge,
 ) -> Option<(DependencyID, Semver::String)> {
     let deps = lockfile.buffers.dependencies.as_slice();
-    let target = lockfile
-        .buffers
-        .resolutions
-        .get(edge.dep_id.index())?
-        .index();
+    let target = *lockfile.buffers.resolutions.get(edge.dep_id)?;
     let res = lockfile.packages.items_resolution().get(target)?;
     if res.tag != ResolutionTag::Npm
         || lockfile.packages.items_name_hash()[target] != pin.name_hash
@@ -1265,17 +1258,13 @@ fn live_edge(
         return None;
     }
     let pkg_name = lockfile.packages.items_name()[target];
-    let Some(&slice) = lockfile
-        .packages
-        .items_dependencies()
-        .get(edge.parent.index())
-    else {
+    let Some(&slice) = lockfile.packages.items_dependencies().get(edge.parent) else {
         return Some((edge.dep_id, pkg_name));
     };
     if slice.contains(edge.dep_id) {
         return Some((edge.dep_id, pkg_name));
     }
-    let planned = &deps[edge.dep_id.index()];
+    let planned = &deps[edge.dep_id];
     let live = slice
         .get(deps)
         .iter()
@@ -1289,8 +1278,8 @@ pub(crate) fn enqueue_pinned(
     dep_id: DependencyID,
     to_version: Semver::Version,
 ) -> crate::Result<()> {
-    let target = manager.lockfile.buffers.resolutions[dep_id.index()];
-    let pkg_name = manager.lockfile.packages.items_name()[target.index()];
+    let target = manager.lockfile.buffers.resolutions[dep_id];
+    let pkg_name = manager.lockfile.packages.items_name()[target];
     enqueue_pinned_as(manager, dep_id, pkg_name, to_version)
 }
 
@@ -1300,7 +1289,7 @@ fn enqueue_pinned_as(
     pkg_name: Semver::String,
     to_version: Semver::Version,
 ) -> crate::Result<()> {
-    let row = manager.lockfile.buffers.dependencies[dep_id.index()].clone();
+    let row = manager.lockfile.buffers.dependencies[dep_id].clone();
     let pinned = Dependency {
         name: row.name,
         name_hash: row.name_hash,
@@ -1317,6 +1306,6 @@ fn enqueue_pinned_as(
             },
         },
     };
-    manager.lockfile.buffers.resolutions[dep_id.index()] = invalid_package_id;
+    manager.lockfile.buffers.resolutions[dep_id] = invalid_package_id;
     enqueue_dependency_with_main(manager, dep_id, &pinned, invalid_package_id, false)
 }

--- a/src/install/audit_fix/package_json_edits.rs
+++ b/src/install/audit_fix/package_json_edits.rs
@@ -98,7 +98,7 @@ pub(super) fn apply(manager: &mut PackageManager, plan: &super::FixPlan) -> crat
 }
 
 fn target_for(manager: &PackageManager, owner: PackageID) -> Option<WorkspaceTarget> {
-    if owner == 0 {
+    if owner == PackageID::ROOT {
         return Some(WorkspaceTarget {
             name: Box::default(),
             name_hash: None,
@@ -106,7 +106,7 @@ fn target_for(manager: &PackageManager, owner: PackageID) -> Option<WorkspaceTar
         });
     }
     let lockfile = &manager.lockfile;
-    let res = lockfile.packages.items_resolution()[owner as usize];
+    let res = lockfile.packages.items_resolution()[owner.index()];
     match res.tag {
         ResolutionTag::Root => Some(WorkspaceTarget {
             name: Box::default(),
@@ -118,8 +118,8 @@ fn target_for(manager: &PackageManager, owner: PackageID) -> Option<WorkspaceTar
             let top_level = strings::without_trailing_slash(FileSystem::instance().top_level_dir());
             let mut path_buf = path_buffer_pool::get();
             Some(WorkspaceTarget {
-                name: Box::from(lockfile.packages.items_name()[owner as usize].slice(buf)),
-                name_hash: Some(lockfile.packages.items_name_hash()[owner as usize]),
+                name: Box::from(lockfile.packages.items_name()[owner.index()].slice(buf)),
+                name_hash: Some(lockfile.packages.items_name_hash()[owner.index()]),
                 package_json_path: join_abs_string_buf::<platform::Auto>(
                     top_level,
                     &mut path_buf.0,

--- a/src/install/audit_fix/package_json_edits.rs
+++ b/src/install/audit_fix/package_json_edits.rs
@@ -106,7 +106,7 @@ fn target_for(manager: &PackageManager, owner: PackageID) -> Option<WorkspaceTar
         });
     }
     let lockfile = &manager.lockfile;
-    let res = lockfile.packages.items_resolution()[owner.index()];
+    let res = lockfile.packages.items_resolution()[owner];
     match res.tag {
         ResolutionTag::Root => Some(WorkspaceTarget {
             name: Box::default(),
@@ -118,8 +118,8 @@ fn target_for(manager: &PackageManager, owner: PackageID) -> Option<WorkspaceTar
             let top_level = strings::without_trailing_slash(FileSystem::instance().top_level_dir());
             let mut path_buf = path_buffer_pool::get();
             Some(WorkspaceTarget {
-                name: Box::from(lockfile.packages.items_name()[owner.index()].slice(buf)),
-                name_hash: Some(lockfile.packages.items_name_hash()[owner.index()]),
+                name: Box::from(lockfile.packages.items_name()[owner].slice(buf)),
+                name_hash: Some(lockfile.packages.items_name_hash()[owner]),
                 package_json_path: join_abs_string_buf::<platform::Auto>(
                     top_level,
                     &mut path_buf.0,

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -137,7 +137,7 @@ impl hooks::AutoInstaller for PackageManager {
     }
 
     fn lockfile_package_dependencies(&self, id: PackageID) -> hooks::DependencySlice {
-        let s = self.lockfile.packages.get(id as usize).dependencies;
+        let s = self.lockfile.packages.get(id.index()).dependencies;
         // `lockfile::DependencySlice` and `hooks::DependencySlice` are both
         // `ExternalSlice<Dependency>` (same `Dependency` after MOVE_DOWN), so
         // this is a no-op; spelled via `new` for nominal-type clarity.
@@ -145,12 +145,12 @@ impl hooks::AutoInstaller for PackageManager {
     }
 
     fn lockfile_package_resolutions(&self, id: PackageID) -> hooks::ResolutionSlice {
-        let s = self.lockfile.packages.get(id as usize).resolutions;
+        let s = self.lockfile.packages.get(id.index()).resolutions;
         hooks::ResolutionSlice::new(s.off, s.len)
     }
 
     fn lockfile_package_resolution(&self, id: PackageID) -> hooks::Resolution {
-        resolution_to_hooks(&self.lockfile.packages.get(id as usize).resolution)
+        resolution_to_hooks(&self.lockfile.packages.get(id.index()).resolution)
     }
 
     fn lockfile_dependencies_buf(&self) -> &[hooks::Dependency] {

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -22,6 +22,7 @@
 
 use core::mem::{align_of, size_of};
 
+use bun_collections::IdSlice;
 use bun_install_types::resolver_hooks as hooks;
 use bun_semver::{SlicedString, String as SemverString};
 
@@ -137,7 +138,7 @@ impl hooks::AutoInstaller for PackageManager {
     }
 
     fn lockfile_package_dependencies(&self, id: PackageID) -> hooks::DependencySlice {
-        let s = self.lockfile.packages.get(id.index()).dependencies;
+        let s = self.lockfile.package(id).dependencies;
         // `lockfile::DependencySlice` and `hooks::DependencySlice` are both
         // `ExternalSlice<Dependency>` (same `Dependency` after MOVE_DOWN), so
         // this is a no-op; spelled via `new` for nominal-type clarity.
@@ -145,20 +146,20 @@ impl hooks::AutoInstaller for PackageManager {
     }
 
     fn lockfile_package_resolutions(&self, id: PackageID) -> hooks::ResolutionSlice {
-        let s = self.lockfile.packages.get(id.index()).resolutions;
+        let s = self.lockfile.package(id).resolutions;
         hooks::ResolutionSlice::new(s.off, s.len)
     }
 
     fn lockfile_package_resolution(&self, id: PackageID) -> hooks::Resolution {
-        resolution_to_hooks(&self.lockfile.packages.get(id.index()).resolution)
+        resolution_to_hooks(&self.lockfile.package(id).resolution)
     }
 
-    fn lockfile_dependencies_buf(&self) -> &[hooks::Dependency] {
+    fn lockfile_dependencies_buf(&self) -> &IdSlice<DependencyID, hooks::Dependency> {
         // `dependency::Dependency` IS `hooks::Dependency` (re-export).
         self.lockfile.buffers.dependencies.as_slice()
     }
 
-    fn lockfile_resolutions_buf(&self) -> &[PackageID] {
+    fn lockfile_resolutions_buf(&self) -> &IdSlice<DependencyID, PackageID> {
         self.lockfile.buffers.resolutions.as_slice()
     }
 
@@ -241,8 +242,10 @@ impl hooks::AutoInstaller for PackageManager {
         // Default-fill the tail now and `truncate` back
         // to `dep_start` on the error path so a failed `clone_in` leaves both
         // buffer lengths consistent.
-        let mut dependencies: &mut [dependency::Dependency] =
-            bun_core::vec::grow_default(dependencies_list, total_dependencies_count as usize);
+        let mut dependencies: &mut [dependency::Dependency] = bun_core::vec::grow_default(
+            dependencies_list.raw_mut(),
+            total_dependencies_count as usize,
+        );
 
         for (_, dep) in package_json.dependency_iter() {
             if !dep.behavior.is_enabled(features) {

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -715,8 +715,8 @@ impl PriorityQueueContext {
         // `BackRef<Vec>` (header) on every compare instead of caching a slice.
         let deps = self.dependencies.as_slice();
         let buf = self.string_buf.as_slice();
-        let a_name = deps[a as usize].name.slice(buf);
-        let b_name = deps[b as usize].name.slice(buf);
+        let a_name = deps[a.index()].name.slice(buf);
+        let b_name = deps[b.index()].name.slice(buf);
         strings::order(a_name, b_name)
     }
 }

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -712,7 +712,8 @@ impl PriorityQueueContext {
         // for the entire install (the `PackageInstaller` that owns this queue
         // also borrows the same `Lockfile`). The Vecs may be reallocated by
         // `fix_cached_lockfile_package_slices`, which is why we re-deref the
-        // `BackRef<Vec>` (header) on every compare instead of caching a slice.
+        // `BackRef` (the vector header) on every compare instead of caching a
+        // slice.
         let deps = self.dependencies.as_slice();
         let buf = self.string_buf.as_slice();
         let a_name = deps[a].name.slice(buf);

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -3,7 +3,7 @@ use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use crate::Error;
 use bun_alloc::AllocError;
-use bun_collections::{StringHashMap, VecExt};
+use bun_collections::{IdVec, StringHashMap, VecExt};
 use bun_core::ZStr;
 #[cfg(windows)]
 use bun_core::w;
@@ -701,7 +701,7 @@ impl<'a> NamesIterator<'a> {
 // `TreeContext.binaries` field to carry an unsatisfiable `'static` (the
 // installer outlives no concrete lifetime for its own self-borrowed buffers).
 pub struct PriorityQueueContext {
-    pub(crate) dependencies: bun_ptr::BackRef<Vec<Dependency>>,
+    pub(crate) dependencies: bun_ptr::BackRef<IdVec<DependencyID, Dependency>>,
     pub(crate) string_buf: bun_ptr::BackRef<Vec<u8>>,
 }
 
@@ -715,8 +715,8 @@ impl PriorityQueueContext {
         // `BackRef<Vec>` (header) on every compare instead of caching a slice.
         let deps = self.dependencies.as_slice();
         let buf = self.string_buf.as_slice();
-        let a_name = deps[a.index()].name.slice(buf);
-        let b_name = deps[b.index()].name.slice(buf);
+        let a_name = deps[a].name.slice(buf);
+        let b_name = deps[b].name.slice(buf);
         strings::order(a_name, b_name)
     }
 }

--- a/src/install/dedupe.rs
+++ b/src/install/dedupe.rs
@@ -159,13 +159,13 @@ impl<'a> Pass<'a> {
                 if target == invalid_package_id {
                     continue;
                 }
-                let Some(&g) = group_of.get(target as usize) else {
+                let Some(&g) = group_of.get(target.index()) else {
                     continue;
                 };
                 if g == u32::MAX {
                     continue;
                 }
-                self.edges[g as usize].push((dep_id as DependencyID, direct));
+                self.edges[g as usize].push((DependencyID::from_index(dep_id), direct));
                 self.voted.set(pkg_id);
             }
         }
@@ -177,7 +177,7 @@ impl<'a> Pass<'a> {
             }
             self.candidates.clear();
             self.candidates
-                .extend(group.iter().copied().filter(|&id| live.is_set(id as usize)));
+                .extend(group.iter().copied().filter(|&id| live.is_set(id.index())));
             let n = self.candidates.len();
             if n < 2 {
                 continue;
@@ -198,8 +198,8 @@ impl<'a> Pass<'a> {
             self.required.unmanaged.set_all(false);
 
             for (e, &(dep_id, _)) in edges.iter().enumerate() {
-                let dep = &deps[dep_id as usize];
-                let target = cur[dep_id as usize];
+                let dep = &deps[dep_id.index()];
+                let target = cur[dep_id.index()];
                 let cur_c = self
                     .candidates
                     .iter()
@@ -208,7 +208,7 @@ impl<'a> Pass<'a> {
                 self.cur_c[e] = cur_c;
                 let row = e * n;
 
-                let range = if pinned.is_set(target as usize) || dep.behavior.is_bundled() {
+                let range = if pinned.is_set(target.index()) || dep.behavior.is_bundled() {
                     None
                 } else {
                     effective_npm_range(lockfile, dep_id, dep)
@@ -223,7 +223,7 @@ impl<'a> Pass<'a> {
                         let query = &range.npm().version;
                         for c in 0..n {
                             let id = self.candidates[c];
-                            if query.satisfies(pkg_res[id as usize].npm().version, buf, buf) {
+                            if query.satisfies(pkg_res[id.index()].npm().version, buf, buf) {
                                 self.sat.set(row + c);
                             }
                         }
@@ -265,7 +265,7 @@ impl<'a> Pass<'a> {
                     continue;
                 }
                 if let Some(p) = self.placement(e) {
-                    next[dep_id as usize] = self.candidates[p];
+                    next[dep_id.index()] = self.candidates[p];
                 }
             }
             self.edges[g] = edges;
@@ -299,8 +299,8 @@ pub(crate) fn label(lockfile: &Lockfile, id: PackageID) -> Vec<u8> {
     let _ = write!(
         label,
         "{}@{}",
-        BStr::new(lockfile.packages.items_name()[id as usize].slice(buf)),
-        lockfile.packages.items_resolution()[id as usize]
+        BStr::new(lockfile.packages.items_name()[id.index()].slice(buf)),
+        lockfile.packages.items_resolution()[id.index()]
             .npm()
             .version
             .fmt(buf)
@@ -312,7 +312,7 @@ fn order_by_name_then_version(lockfile: &Lockfile, a: PackageID, b: PackageID) -
     let buf = lockfile.buffers.string_bytes.as_slice();
     let names = lockfile.packages.items_name();
     let pkg_res = lockfile.packages.items_resolution();
-    let (a, b) = (a as usize, b as usize);
+    let (a, b) = (a.index(), b.index());
     strings::order(names[a].slice(buf), names[b].slice(buf)).then_with(|| {
         pkg_res[a]
             .npm()
@@ -322,7 +322,9 @@ fn order_by_name_then_version(lockfile: &Lockfile, a: PackageID, b: PackageID) -
 }
 
 fn sort_by_name_then_version(lockfile: &Lockfile, ids: &mut [PackageID]) {
-    index_sort::sort_indices(ids, &mut |a, b| order_by_name_then_version(lockfile, a, b));
+    index_sort::sort_indices(bytemuck::cast_slice_mut(ids), &mut |a, b| {
+        order_by_name_then_version(lockfile, PackageID::new(a), PackageID::new(b))
+    });
 }
 
 // (name, removed version, surviving version(s) its dependents now resolve to)
@@ -354,7 +356,10 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
         for id in 0..pkg_res.len() {
             if pkg_res[id].tag == ResolutionTag::Npm
                 && lockfile.patched_dependencies.contains(
-                    &bun_semver::string::Builder::string_hash(&label(lockfile, id as PackageID)),
+                    &bun_semver::string::Builder::string_hash(&label(
+                        lockfile,
+                        PackageID::from_index(id),
+                    )),
                 )
             {
                 pinned.set(id);
@@ -369,12 +374,12 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
         let mut candidates: Vec<PackageID> = ids
             .iter()
             .copied()
-            .filter(|&id| pkg_res[id as usize].tag == ResolutionTag::Npm)
+            .filter(|&id| pkg_res[id.index()].tag == ResolutionTag::Npm)
             .collect();
         if candidates.len() < 2 {
             continue;
         }
-        index_sort::sort_indices(&mut candidates, &mut |a, b| {
+        index_sort::sort_indices(bytemuck::cast_slice_mut(&mut candidates), &mut |a, b| {
             pkg_res[b as usize]
                 .npm()
                 .version
@@ -382,7 +387,7 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
                 .then(a.cmp(&b))
         });
         for &id in &candidates {
-            group_of[id as usize] = groups.len() as u32;
+            group_of[id.index()] = groups.len() as u32;
         }
         max_candidates = max_candidates.max(candidates.len());
         groups.push(candidates);
@@ -398,7 +403,7 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
     // Re-pointing keeps an edge inside its group, so the initial per-group edge counts bound every pass.
     let mut edge_counts: Vec<u32> = vec![0; groups.len()];
     for &target in lockfile.buffers.resolutions.iter() {
-        if let Some(&g) = group_of.get(target as usize)
+        if let Some(&g) = group_of.get(target.index())
             && g != u32::MAX
         {
             edge_counts[g as usize] += 1;
@@ -409,7 +414,7 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
     let initial = reachable(lockfile, &lockfile.buffers.resolutions);
     let patched: Vec<PackageID> = (0..pkg_res.len())
         .filter(|&p| pinned.is_set(p) && initial.is_set(p))
-        .map(|p| p as PackageID)
+        .map(PackageID::from_index)
         .collect();
     let mut kept: Vec<(PackageID, Vec<PackageID>)> = Vec::new();
 
@@ -439,14 +444,14 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
         let orphaned: Vec<PackageID> = patched
             .iter()
             .copied()
-            .filter(|&p| !live.is_set(p as usize))
+            .filter(|&p| !live.is_set(p.index()))
             .collect();
         if orphaned.is_empty() {
             break (cur, live);
         }
         let before = kept.len();
         for &v in groups.iter().flatten() {
-            let i = v as usize;
+            let i = v.index();
             if !initial.is_set(i) || live.is_set(i) || pinned.is_set(i) {
                 continue;
             }
@@ -455,12 +460,12 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
                 &lockfile.buffers.resolutions,
                 core::slice::from_ref(&v),
                 true,
-                crate::lockfile::reachable::Options::all(0),
+                crate::lockfile::reachable::Options::all(PackageID::ROOT),
             );
             let needed: Vec<PackageID> = orphaned
                 .iter()
                 .copied()
-                .filter(|&p| leads.is_set(p as usize))
+                .filter(|&p| leads.is_set(p.index()))
                 .collect();
             if !needed.is_empty() {
                 pinned.set(i);
@@ -500,7 +505,7 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
         .iter()
         .flatten()
         .copied()
-        .filter(|&id| initial.is_set(id as usize) && !live.is_set(id as usize))
+        .filter(|&id| initial.is_set(id.index()) && !live.is_set(id.index()))
         .collect();
     if removed.is_empty() {
         return Report {
@@ -513,7 +518,7 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
     sort_by_name_then_version(lockfile, &mut removed);
     let mut slot: Vec<u32> = vec![u32::MAX; pkg_res.len()];
     for (i, &id) in removed.iter().enumerate() {
-        slot[id as usize] = i as u32;
+        slot[id.index()] = i as u32;
     }
     let mut targets: Vec<Vec<PackageID>> = vec![Vec::new(); removed.len()];
     let original = lockfile.buffers.resolutions.as_slice();
@@ -522,7 +527,7 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
             continue;
         }
         for dep_id in slice.begin() as usize..slice.end() as usize {
-            let Some(&s) = slot.get(original[dep_id] as usize) else {
+            let Some(&s) = slot.get(original[dep_id].index()) else {
                 continue;
             };
             if s == u32::MAX {
@@ -541,23 +546,23 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
         .zip(&targets)
         .map(|(&id, moved_to)| {
             let mut from: Vec<u8> = Vec::new();
-            let _ = write!(from, "{}", pkg_res[id as usize].npm().version.fmt(buf));
+            let _ = write!(from, "{}", pkg_res[id.index()].npm().version.fmt(buf));
             let mut survivors: Vec<PackageID> = moved_to.clone();
             index_sort::sort_vec_by(&mut survivors, |&a, &b| {
-                pkg_res[a as usize]
+                pkg_res[a.index()]
                     .npm()
                     .version
-                    .order(pkg_res[b as usize].npm().version, buf, buf)
+                    .order(pkg_res[b.index()].npm().version, buf, buf)
             });
             let mut to: Vec<u8> = Vec::new();
             for &c in &survivors {
                 if !to.is_empty() {
                     to.extend_from_slice(b", ");
                 }
-                let _ = write!(to, "{}", pkg_res[c as usize].npm().version.fmt(buf));
+                let _ = write!(to, "{}", pkg_res[c.index()].npm().version.fmt(buf));
             }
             (
-                Box::from(names[id as usize].slice(buf)),
+                Box::from(names[id.index()].slice(buf)),
                 from.into_boxed_slice(),
                 to.into_boxed_slice(),
             )
@@ -610,7 +615,7 @@ fn reachable(lockfile: &Lockfile, resolutions: &[PackageID]) -> DynamicBitSet {
     crate::lockfile::reachable::packages(
         lockfile,
         resolutions,
-        crate::lockfile::reachable::Options::all(0),
+        crate::lockfile::reachable::Options::all(PackageID::ROOT),
     )
 }
 

--- a/src/install/dedupe.rs
+++ b/src/install/dedupe.rs
@@ -3,7 +3,7 @@ use std::io::Write as _;
 
 use bstr::BStr;
 use bun_collections::bit_set::Range;
-use bun_collections::{DynamicBitSet, index_sort};
+use bun_collections::{DynamicBitSet, IdSlice, IdVec, index_sort};
 use bun_core::{Global, Output, UnwrapOrOom as _, strings};
 
 use crate::lockfile::package::PackageColumns as _;
@@ -18,7 +18,7 @@ use crate::{
 struct Pass<'a> {
     lockfile: &'a Lockfile,
     groups: &'a [Vec<PackageID>],
-    group_of: &'a [u32],
+    group_of: &'a IdSlice<PackageID, u32>,
     pinned: &'a DynamicBitSet,
     edges: Vec<Vec<(DependencyID, bool)>>,
     candidates: Vec<PackageID>,
@@ -40,7 +40,7 @@ impl<'a> Pass<'a> {
     fn new(
         lockfile: &'a Lockfile,
         groups: &'a [Vec<PackageID>],
-        group_of: &'a [u32],
+        group_of: &'a IdSlice<PackageID, u32>,
         pinned: &'a DynamicBitSet,
         max_candidates: usize,
         max_edges: usize,
@@ -132,7 +132,11 @@ impl<'a> Pass<'a> {
     }
 
     // Keeps the fewest versions that satisfy every group edge owned by `voters` and re-points only edges whose version is dropped; `voted` records who voted.
-    fn vote(&mut self, cur: &[PackageID], live: &DynamicBitSet) -> Vec<PackageID> {
+    fn vote(
+        &mut self,
+        cur: &IdSlice<DependencyID, PackageID>,
+        live: &DynamicBitSet,
+    ) -> IdVec<DependencyID, PackageID> {
         let lockfile = self.lockfile;
         let groups = self.groups;
         let group_of = self.group_of;
@@ -146,31 +150,31 @@ impl<'a> Pass<'a> {
             edges.clear();
         }
         self.voted.unmanaged.set_all(false);
-        for (pkg_id, slice) in dep_slices.iter().enumerate() {
-            if !self.voters.is_set(pkg_id) {
+        for (pkg_id, slice) in dep_slices.iter_enumerated() {
+            if !self.voters.is_set(pkg_id.index()) {
                 continue;
             }
             let direct = matches!(
                 pkg_res[pkg_id].tag,
                 ResolutionTag::Root | ResolutionTag::Workspace
             );
-            for dep_id in slice.begin() as usize..slice.end() as usize {
+            for dep_id in slice.dependency_ids() {
                 let target = cur[dep_id];
                 if target == invalid_package_id {
                     continue;
                 }
-                let Some(&g) = group_of.get(target.index()) else {
+                let Some(&g) = group_of.get(target) else {
                     continue;
                 };
                 if g == u32::MAX {
                     continue;
                 }
-                self.edges[g as usize].push((DependencyID::from_index(dep_id), direct));
-                self.voted.set(pkg_id);
+                self.edges[g as usize].push((dep_id, direct));
+                self.voted.set(pkg_id.index());
             }
         }
 
-        let mut next: Vec<PackageID> = cur.to_vec();
+        let mut next: IdVec<DependencyID, PackageID> = cur.to_vec().into();
         for (g, group) in groups.iter().enumerate() {
             if self.edges[g].is_empty() {
                 continue;
@@ -198,8 +202,8 @@ impl<'a> Pass<'a> {
             self.required.unmanaged.set_all(false);
 
             for (e, &(dep_id, _)) in edges.iter().enumerate() {
-                let dep = &deps[dep_id.index()];
-                let target = cur[dep_id.index()];
+                let dep = &deps[dep_id];
+                let target = cur[dep_id];
                 let cur_c = self
                     .candidates
                     .iter()
@@ -223,7 +227,7 @@ impl<'a> Pass<'a> {
                         let query = &range.npm().version;
                         for c in 0..n {
                             let id = self.candidates[c];
-                            if query.satisfies(pkg_res[id.index()].npm().version, buf, buf) {
+                            if query.satisfies(pkg_res[id].npm().version, buf, buf) {
                                 self.sat.set(row + c);
                             }
                         }
@@ -265,7 +269,7 @@ impl<'a> Pass<'a> {
                     continue;
                 }
                 if let Some(p) = self.placement(e) {
-                    next[dep_id.index()] = self.candidates[p];
+                    next[dep_id] = self.candidates[p];
                 }
             }
             self.edges[g] = edges;
@@ -274,9 +278,13 @@ impl<'a> Pass<'a> {
     }
 
     // Packages the pass itself removes must not vote (pnpm/pnpm#9213): shrink voters until the outcome agrees.
-    fn settle(&mut self, cur: &[PackageID], live: &DynamicBitSet) -> Vec<PackageID> {
+    fn settle(
+        &mut self,
+        cur: &IdSlice<DependencyID, PackageID>,
+        live: &DynamicBitSet,
+    ) -> IdVec<DependencyID, PackageID> {
         live.copy_into(&mut self.voters);
-        let mut best: Option<Vec<PackageID>> = None;
+        let mut best: Option<IdVec<DependencyID, PackageID>> = None;
         loop {
             let next = self.vote(cur, live);
             let after = reachable(self.lockfile, &next);
@@ -299,8 +307,8 @@ pub(crate) fn label(lockfile: &Lockfile, id: PackageID) -> Vec<u8> {
     let _ = write!(
         label,
         "{}@{}",
-        BStr::new(lockfile.packages.items_name()[id.index()].slice(buf)),
-        lockfile.packages.items_resolution()[id.index()]
+        BStr::new(lockfile.packages.items_name()[id].slice(buf)),
+        lockfile.packages.items_resolution()[id]
             .npm()
             .version
             .fmt(buf)
@@ -312,7 +320,6 @@ fn order_by_name_then_version(lockfile: &Lockfile, a: PackageID, b: PackageID) -
     let buf = lockfile.buffers.string_bytes.as_slice();
     let names = lockfile.packages.items_name();
     let pkg_res = lockfile.packages.items_resolution();
-    let (a, b) = (a.index(), b.index());
     strings::order(names[a].slice(buf), names[b].slice(buf)).then_with(|| {
         pkg_res[a]
             .npm()
@@ -348,21 +355,18 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
     let has_patches = lockfile.patched_dependencies.count() > 0;
 
     let mut groups: Vec<Vec<PackageID>> = Vec::new();
-    let mut group_of: Vec<u32> = vec![u32::MAX; pkg_res.len()];
+    let mut group_of: IdVec<PackageID, u32> = vec![u32::MAX; pkg_res.len()].into();
     let mut pinned = DynamicBitSet::init_empty(pkg_res.len()).unwrap_or_oom();
     let mut max_candidates = 0;
 
     if has_patches {
-        for id in 0..pkg_res.len() {
+        for id in pkg_res.ids() {
             if pkg_res[id].tag == ResolutionTag::Npm
                 && lockfile.patched_dependencies.contains(
-                    &bun_semver::string::Builder::string_hash(&label(
-                        lockfile,
-                        PackageID::from_index(id),
-                    )),
+                    &bun_semver::string::Builder::string_hash(&label(lockfile, id)),
                 )
             {
-                pinned.set(id);
+                pinned.set(id.index());
             }
         }
     }
@@ -374,20 +378,20 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
         let mut candidates: Vec<PackageID> = ids
             .iter()
             .copied()
-            .filter(|&id| pkg_res[id.index()].tag == ResolutionTag::Npm)
+            .filter(|&id| pkg_res[id].tag == ResolutionTag::Npm)
             .collect();
         if candidates.len() < 2 {
             continue;
         }
         index_sort::sort_indices(bytemuck::cast_slice_mut(&mut candidates), &mut |a, b| {
-            pkg_res[b as usize]
+            pkg_res[PackageID::new(b)]
                 .npm()
                 .version
-                .order(pkg_res[a as usize].npm().version, buf, buf)
+                .order(pkg_res[PackageID::new(a)].npm().version, buf, buf)
                 .then(a.cmp(&b))
         });
         for &id in &candidates {
-            group_of[id.index()] = groups.len() as u32;
+            group_of[id] = groups.len() as u32;
         }
         max_candidates = max_candidates.max(candidates.len());
         groups.push(candidates);
@@ -403,7 +407,7 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
     // Re-pointing keeps an edge inside its group, so the initial per-group edge counts bound every pass.
     let mut edge_counts: Vec<u32> = vec![0; groups.len()];
     for &target in lockfile.buffers.resolutions.iter() {
-        if let Some(&g) = group_of.get(target.index())
+        if let Some(&g) = group_of.get(target)
             && g != u32::MAX
         {
             edge_counts[g as usize] += 1;
@@ -421,7 +425,7 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
     // Walked over the original resolutions: pinning every removed version that led to the orphan keeps those paths intact on the re-run.
     let (cur, live) = loop {
         let mut live = initial.clone().unwrap_or_oom();
-        let mut cur: Vec<PackageID> = lockfile.buffers.resolutions.clone();
+        let mut cur = lockfile.buffers.resolutions.clone();
         {
             let mut pass = Pass::new(
                 lockfile,
@@ -516,18 +520,18 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
     }
 
     sort_by_name_then_version(lockfile, &mut removed);
-    let mut slot: Vec<u32> = vec![u32::MAX; pkg_res.len()];
+    let mut slot: IdVec<PackageID, u32> = vec![u32::MAX; pkg_res.len()].into();
     for (i, &id) in removed.iter().enumerate() {
-        slot[id.index()] = i as u32;
+        slot[id] = i as u32;
     }
     let mut targets: Vec<Vec<PackageID>> = vec![Vec::new(); removed.len()];
     let original = lockfile.buffers.resolutions.as_slice();
-    for (owner, slice) in lockfile.packages.items_dependencies().iter().enumerate() {
-        if !live.is_set(owner) {
+    for (owner, slice) in lockfile.packages.items_dependencies().iter_enumerated() {
+        if !live.is_set(owner.index()) {
             continue;
         }
-        for dep_id in slice.begin() as usize..slice.end() as usize {
-            let Some(&s) = slot.get(original[dep_id].index()) else {
+        for dep_id in slice.dependency_ids() {
+            let Some(&s) = slot.get(original[dep_id]) else {
                 continue;
             };
             if s == u32::MAX {
@@ -546,23 +550,23 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
         .zip(&targets)
         .map(|(&id, moved_to)| {
             let mut from: Vec<u8> = Vec::new();
-            let _ = write!(from, "{}", pkg_res[id.index()].npm().version.fmt(buf));
+            let _ = write!(from, "{}", pkg_res[id].npm().version.fmt(buf));
             let mut survivors: Vec<PackageID> = moved_to.clone();
             index_sort::sort_vec_by(&mut survivors, |&a, &b| {
-                pkg_res[a.index()]
+                pkg_res[a]
                     .npm()
                     .version
-                    .order(pkg_res[b.index()].npm().version, buf, buf)
+                    .order(pkg_res[b].npm().version, buf, buf)
             });
             let mut to: Vec<u8> = Vec::new();
             for &c in &survivors {
                 if !to.is_empty() {
                     to.extend_from_slice(b", ");
                 }
-                let _ = write!(to, "{}", pkg_res[c.index()].npm().version.fmt(buf));
+                let _ = write!(to, "{}", pkg_res[c].npm().version.fmt(buf));
             }
             (
-                Box::from(names[id.index()].slice(buf)),
+                Box::from(names[id].slice(buf)),
                 from.into_boxed_slice(),
                 to.into_boxed_slice(),
             )
@@ -611,7 +615,7 @@ pub(crate) fn effective_version(
 }
 
 // Optional-peer edges are followed too: with an in-sync package.json `clean` runs with `keep_optional_peer_targets`.
-fn reachable(lockfile: &Lockfile, resolutions: &[PackageID]) -> DynamicBitSet {
+fn reachable(lockfile: &Lockfile, resolutions: &IdSlice<DependencyID, PackageID>) -> DynamicBitSet {
     crate::lockfile::reachable::packages(
         lockfile,
         resolutions,

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -339,13 +339,13 @@ pub(crate) fn install_hoisted_packages(
             // so we want to make sure they're not accessible to the rest of this function
             // to make mistakes harder
             //
-            // BACKREF — the `PackageInstaller` slice fields are
-            // `bun_ptr::RawSlice<T>` (raw `*const [T]`, no lifetime), so
-            // wrapping each column with `RawSlice::new` stores the (ptr, len)
-            // without keeping a borrow live — no `&'a → &'a` detach
-            // round-trip needed. Derive through `lockfile_ptr` so the
-            // provenance root matches `installer.lockfile`/`installer.manager`.
-            // RawSlice invariant: `lockfile_ref` derived from `mgr_ptr`;
+            // BACKREF — the `PackageInstaller` column fields are
+            // `bun_ptr::BackRef<IdSlice<..>>` (no lifetime), so wrapping each
+            // column with `BackRef::new` stores the pointer without keeping a
+            // borrow live — no `&'a → &'a` detach round-trip needed. Derive
+            // through `lockfile_ptr` so the provenance root matches
+            // `installer.lockfile`/`installer.manager`.
+            // BackRef invariant: `lockfile_ref` derived from `mgr_ptr`;
             // the packages column buffers are not freed for the lifetime of
             // `installer` (only grow, which is why
             // `fix_cached_lockfile_package_slices` re-snapshots). Read-only

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -2,7 +2,7 @@ use crate::lockfile::package::PackageColumns as _;
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 
-use bun_collections::{DynamicBitSet as Bitset, DynamicBitSetList, StringHashMap};
+use bun_collections::{DynamicBitSet as Bitset, DynamicBitSetList, IdVec, StringHashMap};
 use bun_core::strings;
 use bun_core::{Global, Output};
 use bun_paths::SEP;
@@ -241,7 +241,7 @@ pub(crate) fn install_hoisted_packages(
             *mut crate::lockfile::Lockfile,
             bun_ptr::BackRef<Vec<tree::Tree>>,
             bun_ptr::BackRef<Vec<DependencyID>>,
-            bun_ptr::BackRef<Vec<crate::Dependency>>,
+            bun_ptr::BackRef<IdVec<DependencyID, crate::Dependency>>,
             bun_ptr::BackRef<Vec<u8>>,
         ) = unsafe {
             let lockfile_ptr: *mut crate::lockfile::Lockfile = &raw mut *(*mgr_ptr).lockfile;
@@ -351,12 +351,12 @@ pub(crate) fn install_hoisted_packages(
             // `fix_cached_lockfile_package_slices` re-snapshots). Read-only
             // projection via the safe `BackRef::Deref`.
             let parts = lockfile_ref.packages.slice();
-            let metas = bun_ptr::RawSlice::new(parts.items_meta());
-            let bins = bun_ptr::RawSlice::new(parts.items_bin());
-            let names = bun_ptr::RawSlice::new(parts.items_name());
-            let pkg_name_hashes = bun_ptr::RawSlice::new(parts.items_name_hash());
-            let resolutions = bun_ptr::RawSlice::new(parts.items_resolution());
-            let pkg_dependencies = bun_ptr::RawSlice::new(parts.items_dependencies());
+            let metas = bun_ptr::BackRef::new(parts.items_meta());
+            let bins = bun_ptr::BackRef::new(parts.items_bin());
+            let names = bun_ptr::BackRef::new(parts.items_name());
+            let pkg_name_hashes = bun_ptr::BackRef::new(parts.items_name_hash());
+            let resolutions = bun_ptr::BackRef::new(parts.items_resolution());
+            let pkg_dependencies = bun_ptr::BackRef::new(parts.items_dependencies());
 
             // Hoist the by-value reads out of the struct literal so they
             // finish before the long-lived `&mut *mgr_ptr` borrow for

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -235,8 +235,8 @@ pub(crate) fn build_store(
     let pkg_resolutions = pkgs.items_resolution();
     let pkg_names = pkgs.items_name();
 
-    let resolutions = &lockfile.buffers.resolutions[..];
-    let dependencies = &lockfile.buffers.dependencies[..];
+    let resolutions = lockfile.buffers.resolutions.as_slice();
+    let dependencies = lockfile.buffers.dependencies.as_slice();
     let string_buf = &lockfile.buffers.string_bytes[..];
 
     let mut nodes: store::node::List = store::node::List::default();
@@ -304,9 +304,9 @@ pub(crate) fn build_store(
             DynamicBitSetList::init_empty(lockfile.packages.len(), peer_name_count as usize)?;
         for pkg_idx in 0..lockfile.packages.len() {
             let pkg_id = PackageID::try_from(pkg_idx).expect("int cast");
-            let deps = pkg_dependency_slices[pkg_id.index()];
+            let deps = pkg_dependency_slices[pkg_id];
             for dep_id in deps.dependency_ids() {
-                let dep = &dependencies[dep_id.index()];
+                let dep = &dependencies[dep_id];
                 let Some(bit) = peer_name_idx.get_index(&dep.name_hash) else {
                     continue;
                 };
@@ -333,12 +333,12 @@ pub(crate) fn build_store(
             changed = false;
             for pkg_idx in 0..lockfile.packages.len() {
                 let pkg_id = PackageID::try_from(pkg_idx).expect("int cast");
-                let deps = pkg_dependency_slices[pkg_id.index()];
+                let deps = pkg_dependency_slices[pkg_id];
 
                 scratch.copy_into(&own_peers.at(pkg_id.index()));
 
                 for dep_id in deps.dependency_ids() {
-                    let dep = &dependencies[dep_id.index()];
+                    let dep = &dependencies[dep_id];
                     if dep.behavior.is_peer() {
                         if let Some(bit) = peer_name_idx.get_index(&dep.name_hash) {
                             for &child in &peer_targets[bit] {
@@ -346,7 +346,7 @@ pub(crate) fn build_store(
                             }
                         }
                     } else {
-                        let res_pkg = resolutions[dep_id.index()];
+                        let res_pkg = resolutions[dep_id];
                         if res_pkg != invalid_package_id {
                             scratch.set_union(&leaking_peers.at(res_pkg.index()));
                         }
@@ -369,11 +369,11 @@ pub(crate) fn build_store(
     let mut early_dedupe: HashMap<EarlyDedupeKey, store::node::Id> = HashMap::default();
 
     let mut root_declares_workspace = DynamicBitSet::init_empty(lockfile.packages.len())?;
-    for dep_idx in pkg_dependency_slices[0].dependency_ids() {
-        if !dependencies[dep_idx.index()].behavior.is_workspace() {
+    for dep_idx in pkg_dependency_slices[PackageID::ROOT].dependency_ids() {
+        if !dependencies[dep_idx].behavior.is_workspace() {
             continue;
         }
-        let res = resolutions[dep_idx.index()];
+        let res = resolutions[dep_idx];
         if res == invalid_package_id {
             continue;
         }
@@ -435,8 +435,8 @@ pub(crate) fn build_store(
                         break 'check_cycle;
                     }
 
-                    let curr_dep = &dependencies[dep_id.index()];
-                    let entry_dep = &dependencies[entry.dep_id.index()];
+                    let curr_dep = &dependencies[dep_id];
+                    let entry_dep = &dependencies[entry.dep_id];
 
                     // ensure the dependency name is the same before skipping the cycle. if they aren't
                     // we lose dependency name information for the symlinks
@@ -455,7 +455,7 @@ pub(crate) fn build_store(
 
         let node_id: store::node::Id =
             store::node::Id::from(u32::try_from(nodes.len()).expect("int cast"));
-        let pkg_deps = pkg_dependency_slices[entry.pkg_id.index()];
+        let pkg_deps = pkg_dependency_slices[entry.pkg_id];
 
         // for skipping dependnecies of workspace packages and the root package. the dependencies
         // of these packages should only be pulled in once, but we might need to create more than
@@ -464,7 +464,7 @@ pub(crate) fn build_store(
             entry.pkg_id == PackageID::ROOT && entry.dep_id != invalid_dependency_id;
 
         if entry.dep_id != invalid_dependency_id {
-            let entry_dep = &dependencies[entry.dep_id.index()];
+            let entry_dep = &dependencies[entry.dep_id];
 
             // A `workspace:` protocol reference does not own the workspace's
             // dependencies when root also declares that workspace; the
@@ -489,55 +489,53 @@ pub(crate) fn build_store(
                     ..
                 } = nodes_slice.split_mut();
 
-                let ctx_hash: u64 =
-                    if entry_dep.version.tag == VersionTag::Workspace || peer_name_count == 0 {
-                        0
-                    } else {
-                        'ctx: {
-                            let leaks = leaking_peers.at(entry.pkg_id.index());
-                            if leaks.count() == 0 {
-                                break 'ctx 0;
-                            }
-
-                            let peer_names = peer_name_idx.keys();
-                            let mut hasher = Wyhash11::init(0);
-                            let mut it = leaks.iterator::<true, true>();
-                            while let Some(bit) = it.next() {
-                                let peer_name_hash = peer_names[bit];
-                                let resolved: PackageID = 'resolved: {
-                                    let mut curr_id = entry.parent_id;
-                                    while curr_id != store::node::Id::INVALID {
-                                        for ids in &node_dependencies[curr_id.get() as usize] {
-                                            if dependencies[ids.dep_id.index()].name_hash
-                                                == peer_name_hash
-                                            {
-                                                break 'resolved ids.pkg_id;
-                                            }
-                                        }
-                                        for ids in &node_peers[curr_id.get() as usize].list {
-                                            if !ids.auto_installed
-                                                && dependencies[ids.dep_id.index()].name_hash
-                                                    == peer_name_hash
-                                            {
-                                                break 'resolved ids.pkg_id;
-                                            }
-                                        }
-                                        curr_id = node_parent_ids[curr_id.get() as usize];
-                                    }
-                                    break 'resolved invalid_package_id;
-                                };
-                                // Auto-install fallback is declarer-specific; let the
-                                // second pass handle this position rather than risk an
-                                // unsound key.
-                                if resolved == invalid_package_id {
-                                    break 'dont_dedupe;
-                                }
-                                hasher.update(bun_core::bytes_of(&peer_name_hash));
-                                hasher.update(bun_core::bytes_of(&resolved));
-                            }
-                            break 'ctx hasher.final_();
+                let ctx_hash: u64 = if entry_dep.version.tag == VersionTag::Workspace
+                    || peer_name_count == 0
+                {
+                    0
+                } else {
+                    'ctx: {
+                        let leaks = leaking_peers.at(entry.pkg_id.index());
+                        if leaks.count() == 0 {
+                            break 'ctx 0;
                         }
-                    };
+
+                        let peer_names = peer_name_idx.keys();
+                        let mut hasher = Wyhash11::init(0);
+                        let mut it = leaks.iterator::<true, true>();
+                        while let Some(bit) = it.next() {
+                            let peer_name_hash = peer_names[bit];
+                            let resolved: PackageID = 'resolved: {
+                                let mut curr_id = entry.parent_id;
+                                while curr_id != store::node::Id::INVALID {
+                                    for ids in &node_dependencies[curr_id.get() as usize] {
+                                        if dependencies[ids.dep_id].name_hash == peer_name_hash {
+                                            break 'resolved ids.pkg_id;
+                                        }
+                                    }
+                                    for ids in &node_peers[curr_id.get() as usize].list {
+                                        if !ids.auto_installed
+                                            && dependencies[ids.dep_id].name_hash == peer_name_hash
+                                        {
+                                            break 'resolved ids.pkg_id;
+                                        }
+                                    }
+                                    curr_id = node_parent_ids[curr_id.get() as usize];
+                                }
+                                break 'resolved invalid_package_id;
+                            };
+                            // Auto-install fallback is declarer-specific; let the
+                            // second pass handle this position rather than risk an
+                            // unsound key.
+                            if resolved == invalid_package_id {
+                                break 'dont_dedupe;
+                            }
+                            hasher.update(bun_core::bytes_of(&peer_name_hash));
+                            hasher.update(bun_core::bytes_of(&resolved));
+                        }
+                        break 'ctx hasher.final_();
+                    }
+                };
 
                 let dedupe_entry = early_dedupe.get_or_put(EarlyDedupeKey {
                     pkg_id: entry.pkg_id,
@@ -550,7 +548,7 @@ pub(crate) fn build_store(
                     if dedupe_dep_id == invalid_dependency_id {
                         break 'dont_dedupe;
                     }
-                    let dedupe_dep = &dependencies[dedupe_dep_id.index()];
+                    let dedupe_dep = &dependencies[dedupe_dep_id];
 
                     if dedupe_dep.name_hash != entry_dep.name_hash {
                         break 'dont_dedupe;
@@ -583,11 +581,11 @@ pub(crate) fn build_store(
                     let dedupe_peers: Vec<_> =
                         node_peers[dedupe_node_id.get() as usize].list.clone();
                     for peer in dedupe_peers {
-                        let peer_name_hash = dependencies[peer.dep_id.index()].name_hash;
+                        let peer_name_hash = dependencies[peer.dep_id].name_hash;
                         let mut curr_id = entry.parent_id;
                         'walk: while curr_id != store::node::Id::INVALID {
                             for ids in &node_dependencies[curr_id.get() as usize] {
-                                if dependencies[ids.dep_id.index()].name_hash == peer_name_hash {
+                                if dependencies[ids.dep_id].name_hash == peer_name_hash {
                                     break 'walk;
                                 }
                             }
@@ -666,7 +664,7 @@ pub(crate) fn build_store(
                 if node_id == store::node::Id::ROOT {
                     // TODO: print an error when scanner is actually a dependency of a workspace (we should not support this)
                     for &dep_id in &dep_ids_sort_buf {
-                        let pkg_id = resolutions[dep_id.index()];
+                        let pkg_id = resolutions[dep_id];
                         if pkg_id == invalid_package_id {
                             continue;
                         }
@@ -701,8 +699,8 @@ pub(crate) fn build_store(
                     continue;
                 }
 
-                let pkg_id = resolutions[dep_id.index()];
-                let dep = &dependencies[dep_id.index()];
+                let pkg_id = resolutions[dep_id];
+                let dep = &dependencies[dep_id];
 
                 // TODO: handle duplicate dependencies. should be similar logic
                 // like we have for dev dependencies in `hoistDependency`
@@ -732,7 +730,7 @@ pub(crate) fn build_store(
                 // the package id for the chosen peer marked as a transitive peer. Nodes
                 // are deduplicated only if their package id and their transitive peer package
                 // ids are equal.
-                let peer_dep = &dependencies[peer_dep_id.index()];
+                let peer_dep = &dependencies[peer_dep_id];
 
                 // TODO: double check this
                 // Start with the current package. A package
@@ -742,13 +740,13 @@ pub(crate) fn build_store(
                 visited_parent_node_ids.clear();
                 while curr_id != store::node::Id::INVALID {
                     for ids in &node_dependencies[curr_id.get() as usize] {
-                        let dep = &dependencies[ids.dep_id.index()];
+                        let dep = &dependencies[ids.dep_id];
 
                         if dep.name_hash != peer_dep.name_hash {
                             continue;
                         }
 
-                        let res = &pkg_resolutions[ids.pkg_id.index()];
+                        let res = &pkg_resolutions[ids.pkg_id];
 
                         if peer_dep.version.tag != VersionTag::Npm || res.tag != ResolutionTag::Npm
                         {
@@ -771,7 +769,7 @@ pub(crate) fn build_store(
 
                     let curr_peers = &node_peers[curr_id.get() as usize];
                     for ids in &curr_peers.list {
-                        let transitive_peer_dep = &dependencies[ids.dep_id.index()];
+                        let transitive_peer_dep = &dependencies[ids.dep_id];
 
                         if transitive_peer_dep.name_hash != peer_dep.name_hash {
                             continue;
@@ -793,7 +791,7 @@ pub(crate) fn build_store(
                         // version. Only mark all parents if resolution is
                         // different from this transitive peer.
 
-                        let best_version = resolutions[peer_dep_id.index()];
+                        let best_version = resolutions[peer_dep_id];
 
                         if best_version == invalid_package_id {
                             break 'resolved_pkg_id (invalid_package_id, true);
@@ -821,7 +819,7 @@ pub(crate) fn build_store(
                 }
 
                 // choose the current best version
-                break 'resolved_pkg_id (resolutions[peer_dep_id.index()], true);
+                break 'resolved_pkg_id (resolutions[peer_dep_id], true);
             };
 
             if resolved_pkg_id == invalid_package_id {
@@ -914,8 +912,8 @@ pub(crate) fn build_store(
                     }
                 }
                 if info.dep_id != invalid_dependency_id && curr_dep_id != invalid_dependency_id {
-                    let curr_dep = &dependencies[curr_dep_id.index()];
-                    let existing_dep = &dependencies[info.dep_id.index()];
+                    let curr_dep = &dependencies[curr_dep_id];
+                    let existing_dep = &dependencies[info.dep_id];
 
                     if existing_dep.version.tag == VersionTag::Workspace
                         && curr_dep.version.tag == VersionTag::Workspace
@@ -946,7 +944,7 @@ pub(crate) fn build_store(
                     let parents = &mut entry_parents[info.entry_id.get() as usize];
 
                     if curr_dep_id != invalid_dependency_id
-                        && dependencies[curr_dep_id.index()].behavior.is_workspace()
+                        && dependencies[curr_dep_id].behavior.is_workspace()
                     {
                         parents.push(entry.entry_parent_id);
                         continue 'next_entry;
@@ -977,9 +975,9 @@ pub(crate) fn build_store(
             }
             let mut hasher = Wyhash11::init(0);
             for peer_ids in peers.slice() {
-                let pkg_name = pkg_names[peer_ids.pkg_id.index()];
+                let pkg_name = pkg_names[peer_ids.pkg_id];
                 hasher.update(pkg_name.slice(string_buf));
-                let pkg_res = &pkg_resolutions[peer_ids.pkg_id.index()];
+                let pkg_res = &pkg_resolutions[peer_ids.pkg_id];
                 res_fmt_buf.clear();
                 write!(
                     &mut res_fmt_buf,
@@ -996,7 +994,7 @@ pub(crate) fn build_store(
 
         let new_entry_is_root = new_entry_dep_id == invalid_dependency_id;
         let new_entry_is_workspace = !new_entry_is_root
-            && dependencies[new_entry_dep_id.index()].version.tag == VersionTag::Workspace;
+            && dependencies[new_entry_dep_id].version.tag == VersionTag::Workspace;
 
         let new_entry_dependencies: store::entry::Dependencies =
             if dedupe_entry.found_existing && new_entry_is_workspace {
@@ -1018,9 +1016,7 @@ pub(crate) fn build_store(
                 break 'hoisted false;
             }
 
-            let dep_name = dependencies[new_entry_dep_id.index()]
-                .name
-                .slice(string_buf);
+            let dep_name = dependencies[new_entry_dep_id].name.slice(string_buf);
 
             let Some(hoist_pattern) = &manager.options.hoist_pattern else {
                 let hoist_entry = hidden_hoisted.get_or_put(dep_name)?;
@@ -1053,9 +1049,7 @@ pub(crate) fn build_store(
         if let Some(entry_parent_id) = entry.entry_parent_id.try_get() {
             'skip_adding_dependency: {
                 if new_entry_dep_id != invalid_dependency_id
-                    && dependencies[new_entry_dep_id.index()]
-                        .behavior
-                        .is_workspace()
+                    && dependencies[new_entry_dep_id].behavior.is_workspace()
                 {
                     // skip implicit workspace dependencies on the root.
                     break 'skip_adding_dependency;
@@ -1078,15 +1072,11 @@ pub(crate) fn build_store(
                 if new_entry_dep_id != invalid_dependency_id {
                     if entry.entry_parent_id == store::entry::Id::ROOT {
                         // make sure direct dependencies are not replaced
-                        let dep_name = dependencies[new_entry_dep_id.index()]
-                            .name
-                            .slice(string_buf);
+                        let dep_name = dependencies[new_entry_dep_id].name.slice(string_buf);
                         public_hoisted.put(dep_name, ())?;
                     } else {
                         // transitive dependencies (also direct dependencies of workspaces!)
-                        let dep_name = dependencies[new_entry_dep_id.index()]
-                            .name
-                            .slice(string_buf);
+                        let dep_name = dependencies[new_entry_dep_id].name.slice(string_buf);
                         if let Some(public_hoist_pattern) = &manager.options.public_hoist_pattern {
                             if public_hoist_pattern.is_match(dep_name) {
                                 let hoist_entry = public_hoisted.get_or_put(dep_name)?;
@@ -1186,7 +1176,7 @@ pub(crate) fn install_isolated_packages(
             let pkg_metas = pkgs.items_meta();
 
             let string_buf = &lockfile.buffers.string_bytes[..];
-            let dependencies = &lockfile.buffers.dependencies[..];
+            let dependencies = lockfile.buffers.dependencies.as_slice();
 
             // Packages newly trusted via `bun add --trust` (not yet written to the
             // lockfile) will have their lifecycle scripts run this install; treat
@@ -1227,7 +1217,7 @@ pub(crate) fn install_isolated_packages(
                         let node_id = entry_node_ids[entry_idx];
                         let pkg_id = node_pkg_ids[node_id.get() as usize];
                         let dep_id = node_dep_ids[node_id.get() as usize];
-                        let pkg_res = &pkg_resolutions[pkg_id.index()];
+                        let pkg_res = &pkg_resolutions[pkg_id];
 
                         let eligible = match pkg_res.tag {
                             ResolutionTag::Npm
@@ -1246,7 +1236,7 @@ pub(crate) fn install_isolated_packages(
                                     let name_version: &[u8] = match write!(
                                         &mut cursor,
                                         "{}@{}",
-                                        BStr::new(pkg_names[pkg_id.index()].slice(string_buf)),
+                                        BStr::new(pkg_names[pkg_id].slice(string_buf)),
                                         pkg_res.fmt(string_buf, bun_fmt::PathSep::Posix),
                                     ) {
                                         Ok(()) => {
@@ -1281,13 +1271,13 @@ pub(crate) fn install_isolated_packages(
                                 // scripts" case in exchange for not needing a
                                 // lockfile-format change.
                                 let dep_name = if dep_id != invalid_dependency_id {
-                                    dependencies[dep_id.index()].name.slice(string_buf)
+                                    dependencies[dep_id].name.slice(string_buf)
                                 } else {
-                                    pkg_names[pkg_id.index()].slice(string_buf)
+                                    pkg_names[pkg_id].slice(string_buf)
                                 };
                                 if lockfile.has_trusted_dependency(
                                     dep_name,
-                                    pkg_names[pkg_id.index()].slice(string_buf),
+                                    pkg_names[pkg_id].slice(string_buf),
                                     pkg_res,
                                 ) || trusted_from_update.contains(&pkg_id)
                                 {
@@ -1327,7 +1317,7 @@ pub(crate) fn install_isolated_packages(
                         // first project's bytes.
                         stack[top_idx]
                             .hasher
-                            .update(bun_core::bytes_of(&pkg_metas[pkg_id.index()].integrity));
+                            .update(bun_core::bytes_of(&pkg_metas[pkg_id].integrity));
                     }
 
                     if states[entry_idx] == State::Ineligible {
@@ -1340,7 +1330,7 @@ pub(crate) fn install_isolated_packages(
                     while (stack[top_idx].next_dep as usize) < deps.len() {
                         let dep = &deps[stack[top_idx].next_dep as usize];
                         let dep_entry_idx = dep.entry_id.get() as usize;
-                        let dep_name_hash = dependencies[dep.dep_id.index()].name_hash;
+                        let dep_name_hash = dependencies[dep.dep_id].name_hash;
                         match states[dep_entry_idx] {
                             State::Done => {
                                 stack[top_idx]
@@ -1513,9 +1503,8 @@ pub(crate) fn install_isolated_packages(
                                     }
                                     sub.update(bun_core::bytes_of(
                                         &pkg_metas[node_pkg_ids
-                                            [entry_node_ids[m as usize].get() as usize]
-                                            .index()]
-                                        .integrity,
+                                            [entry_node_ids[m as usize].get() as usize]]
+                                            .integrity,
                                     ));
                                     let mut poisoned = false;
                                     for dep in entry_dependencies[m as usize].slice() {
@@ -1524,8 +1513,7 @@ pub(crate) fn install_isolated_packages(
                                             poisoned = true;
                                             break;
                                         }
-                                        let dep_name_hash =
-                                            dependencies[dep.dep_id.index()].name_hash;
+                                        let dep_name_hash = dependencies[dep.dep_id].name_hash;
                                         sub.update(bun_core::bytes_of(&dep_name_hash));
                                         sub.update(bun_core::bytes_of(&dh));
                                     }
@@ -1569,9 +1557,8 @@ pub(crate) fn install_isolated_packages(
                                     }
                                     sub.update(bun_core::bytes_of(
                                         &pkg_metas[node_pkg_ids
-                                            [entry_node_ids[m as usize].get() as usize]
-                                            .index()]
-                                        .integrity,
+                                            [entry_node_ids[m as usize].get() as usize]]
+                                            .integrity,
                                     ));
                                     member_sub.push(sub.final_());
                                     for dep in entry_dependencies[m as usize].slice() {
@@ -1590,7 +1577,7 @@ pub(crate) fn install_isolated_packages(
                                         // different aliases must hash differently.
                                         let mut ext = Wyhash::init(0);
                                         ext.update(bun_core::bytes_of(
-                                            &dependencies[dep.dep_id.index()].name_hash,
+                                            &dependencies[dep.dep_id].name_hash,
                                         ));
                                         ext.update(bun_core::bytes_of(&entry_hashes[di]));
                                         scc_ext.put(ext.final_(), ())?;
@@ -2112,9 +2099,9 @@ pub(crate) fn install_isolated_packages(
             let pkg_id = node_pkg_ids[node_id.get() as usize];
             let dep_id = node_dep_ids[node_id.get() as usize];
 
-            let pkg_name = pkg_names[pkg_id.index()];
-            let pkg_name_hash = pkg_name_hashes[pkg_id.index()];
-            let pkg_res: Resolution = pkg_resolutions[pkg_id.index()];
+            let pkg_name = pkg_names[pkg_id];
+            let pkg_name_hash = pkg_name_hashes[pkg_id];
+            let pkg_res: Resolution = pkg_resolutions[pkg_id];
 
             // Validate the package name and every dependency alias as
             // `node_modules/<name>` components before any filesystem work.
@@ -2126,7 +2113,7 @@ pub(crate) fn install_isolated_packages(
                     unsafe_folder_name = Some(name);
                 } else {
                     for dep in entry_dependencies[entry_id.get() as usize].slice() {
-                        let dep_name = lockfile_ro.buffers.dependencies[dep.dep_id.index()]
+                        let dep_name = lockfile_ro.buffers.dependencies[dep.dep_id]
                             .name
                             .slice(string_buf);
                         if !crate::package_installer::alias_is_safe_install_target(dep_name) {
@@ -2400,7 +2387,7 @@ pub(crate) fn install_isolated_packages(
 
                     let ctx = install::TaskCallbackContext::IsolatedPackageInstallContext(entry_id);
 
-                    let dep = &lockfile_ro.buffers.dependencies[dep_id.index()];
+                    let dep = &lockfile_ro.buffers.dependencies[dep_id];
 
                     match pkg_res_tag {
                         ResolutionTag::Npm => {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -248,7 +248,7 @@ pub(crate) fn build_store(
     node_queue.push(QueuedNode {
         parent_id: store::node::Id::INVALID,
         dep_id: invalid_dependency_id,
-        pkg_id: 0,
+        pkg_id: PackageID::ROOT,
     });
 
     let mut dep_ids_sort_buf: Vec<DependencyID> = Vec::new();
@@ -303,16 +303,15 @@ pub(crate) fn build_store(
         let provides: DynamicBitSetList =
             DynamicBitSetList::init_empty(lockfile.packages.len(), peer_name_count as usize)?;
         for pkg_idx in 0..lockfile.packages.len() {
-            let pkg_id: PackageID = u32::try_from(pkg_idx).expect("int cast");
-            let deps = pkg_dependency_slices[pkg_id as usize];
-            for _dep_id in deps.begin()..deps.end() {
-                let dep_id: DependencyID = _dep_id;
-                let dep = &dependencies[dep_id as usize];
+            let pkg_id = PackageID::try_from(pkg_idx).expect("int cast");
+            let deps = pkg_dependency_slices[pkg_id.index()];
+            for dep_id in deps.dependency_ids() {
+                let dep = &dependencies[dep_id.index()];
                 let Some(bit) = peer_name_idx.get_index(&dep.name_hash) else {
                     continue;
                 };
                 if dep.behavior.is_peer() {
-                    own_peers.set(pkg_id as usize, bit);
+                    own_peers.set(pkg_id.index(), bit);
                 } else if !is_filtered_dependency_or_workspace(
                     dep_id,
                     pkg_id,
@@ -322,7 +321,7 @@ pub(crate) fn build_store(
                     lockfile,
                     resolutions,
                 ) {
-                    provides.set(pkg_id as usize, bit);
+                    provides.set(pkg_id.index(), bit);
                 }
             }
         }
@@ -333,30 +332,29 @@ pub(crate) fn build_store(
         while changed {
             changed = false;
             for pkg_idx in 0..lockfile.packages.len() {
-                let pkg_id: PackageID = u32::try_from(pkg_idx).expect("int cast");
-                let deps = pkg_dependency_slices[pkg_id as usize];
+                let pkg_id = PackageID::try_from(pkg_idx).expect("int cast");
+                let deps = pkg_dependency_slices[pkg_id.index()];
 
-                scratch.copy_into(&own_peers.at(pkg_id as usize));
+                scratch.copy_into(&own_peers.at(pkg_id.index()));
 
-                for _dep_id in deps.begin()..deps.end() {
-                    let dep_id: DependencyID = _dep_id;
-                    let dep = &dependencies[dep_id as usize];
+                for dep_id in deps.dependency_ids() {
+                    let dep = &dependencies[dep_id.index()];
                     if dep.behavior.is_peer() {
                         if let Some(bit) = peer_name_idx.get_index(&dep.name_hash) {
                             for &child in &peer_targets[bit] {
-                                scratch.set_union(&leaking_peers.at(child as usize));
+                                scratch.set_union(&leaking_peers.at(child.index()));
                             }
                         }
                     } else {
-                        let res_pkg = resolutions[dep_id as usize];
+                        let res_pkg = resolutions[dep_id.index()];
                         if res_pkg != invalid_package_id {
-                            scratch.set_union(&leaking_peers.at(res_pkg as usize));
+                            scratch.set_union(&leaking_peers.at(res_pkg.index()));
                         }
                     }
                 }
-                scratch.set_exclude(&provides.at(pkg_id as usize));
+                scratch.set_exclude(&provides.at(pkg_id.index()));
 
-                let mut dst = leaking_peers.at(pkg_id as usize);
+                let mut dst = leaking_peers.at(pkg_id.index());
                 if !scratch.eql(&dst) {
                     dst.copy_into(&scratch);
                     changed = true;
@@ -371,12 +369,11 @@ pub(crate) fn build_store(
     let mut early_dedupe: HashMap<EarlyDedupeKey, store::node::Id> = HashMap::default();
 
     let mut root_declares_workspace = DynamicBitSet::init_empty(lockfile.packages.len())?;
-    for _dep_idx in pkg_dependency_slices[0].begin()..pkg_dependency_slices[0].end() {
-        let dep_idx: DependencyID = _dep_idx;
-        if !dependencies[dep_idx as usize].behavior.is_workspace() {
+    for dep_idx in pkg_dependency_slices[0].dependency_ids() {
+        if !dependencies[dep_idx.index()].behavior.is_workspace() {
             continue;
         }
-        let res = resolutions[dep_idx as usize];
+        let res = resolutions[dep_idx.index()];
         if res == invalid_package_id {
             continue;
         }
@@ -385,7 +382,7 @@ pub(crate) fn build_store(
         // so a `workspace:` reference must keep its dependencies.
         if is_filtered_dependency_or_workspace(
             dep_idx,
-            0,
+            PackageID::ROOT,
             workspace_filters,
             install_root_dependencies,
             manager,
@@ -399,7 +396,7 @@ pub(crate) fn build_store(
                 continue;
             }
         }
-        root_declares_workspace.set(res as usize);
+        root_declares_workspace.set(res.index());
     }
 
     let mut peer_dep_ids: Vec<DependencyID> = Vec::new();
@@ -438,8 +435,8 @@ pub(crate) fn build_store(
                         break 'check_cycle;
                     }
 
-                    let curr_dep = &dependencies[dep_id as usize];
-                    let entry_dep = &dependencies[entry.dep_id as usize];
+                    let curr_dep = &dependencies[dep_id.index()];
+                    let entry_dep = &dependencies[entry.dep_id.index()];
 
                     // ensure the dependency name is the same before skipping the cycle. if they aren't
                     // we lose dependency name information for the symlinks
@@ -458,15 +455,16 @@ pub(crate) fn build_store(
 
         let node_id: store::node::Id =
             store::node::Id::from(u32::try_from(nodes.len()).expect("int cast"));
-        let pkg_deps = pkg_dependency_slices[entry.pkg_id as usize];
+        let pkg_deps = pkg_dependency_slices[entry.pkg_id.index()];
 
         // for skipping dependnecies of workspace packages and the root package. the dependencies
         // of these packages should only be pulled in once, but we might need to create more than
         // one entry if there's multiple dependencies on the workspace or root package.
-        let mut skip_dependencies = entry.pkg_id == 0 && entry.dep_id != invalid_dependency_id;
+        let mut skip_dependencies =
+            entry.pkg_id == PackageID::ROOT && entry.dep_id != invalid_dependency_id;
 
         if entry.dep_id != invalid_dependency_id {
-            let entry_dep = &dependencies[entry.dep_id as usize];
+            let entry_dep = &dependencies[entry.dep_id.index()];
 
             // A `workspace:` protocol reference does not own the workspace's
             // dependencies when root also declares that workspace; the
@@ -474,7 +472,7 @@ pub(crate) fn build_store(
             // protocol reference is the only one and must keep them.)
             if entry_dep.version.tag == VersionTag::Workspace
                 && !entry_dep.behavior.is_workspace()
-                && root_declares_workspace.is_set(entry.pkg_id as usize)
+                && root_declares_workspace.is_set(entry.pkg_id.index())
             {
                 skip_dependencies = true;
             }
@@ -496,7 +494,7 @@ pub(crate) fn build_store(
                         0
                     } else {
                         'ctx: {
-                            let leaks = leaking_peers.at(entry.pkg_id as usize);
+                            let leaks = leaking_peers.at(entry.pkg_id.index());
                             if leaks.count() == 0 {
                                 break 'ctx 0;
                             }
@@ -510,7 +508,7 @@ pub(crate) fn build_store(
                                     let mut curr_id = entry.parent_id;
                                     while curr_id != store::node::Id::INVALID {
                                         for ids in &node_dependencies[curr_id.get() as usize] {
-                                            if dependencies[ids.dep_id as usize].name_hash
+                                            if dependencies[ids.dep_id.index()].name_hash
                                                 == peer_name_hash
                                             {
                                                 break 'resolved ids.pkg_id;
@@ -518,7 +516,7 @@ pub(crate) fn build_store(
                                         }
                                         for ids in &node_peers[curr_id.get() as usize].list {
                                             if !ids.auto_installed
-                                                && dependencies[ids.dep_id as usize].name_hash
+                                                && dependencies[ids.dep_id.index()].name_hash
                                                     == peer_name_hash
                                             {
                                                 break 'resolved ids.pkg_id;
@@ -552,7 +550,7 @@ pub(crate) fn build_store(
                     if dedupe_dep_id == invalid_dependency_id {
                         break 'dont_dedupe;
                     }
-                    let dedupe_dep = &dependencies[dedupe_dep_id as usize];
+                    let dedupe_dep = &dependencies[dedupe_dep_id.index()];
 
                     if dedupe_dep.name_hash != entry_dep.name_hash {
                         break 'dont_dedupe;
@@ -585,11 +583,11 @@ pub(crate) fn build_store(
                     let dedupe_peers: Vec<_> =
                         node_peers[dedupe_node_id.get() as usize].list.clone();
                     for peer in dedupe_peers {
-                        let peer_name_hash = dependencies[peer.dep_id as usize].name_hash;
+                        let peer_name_hash = dependencies[peer.dep_id.index()].name_hash;
                         let mut curr_id = entry.parent_id;
                         'walk: while curr_id != store::node::Id::INVALID {
                             for ids in &node_dependencies[curr_id.get() as usize] {
-                                if dependencies[ids.dep_id as usize].name_hash == peer_name_hash {
+                                if dependencies[ids.dep_id.index()].name_hash == peer_name_hash {
                                     break 'walk;
                                 }
                             }
@@ -644,11 +642,7 @@ pub(crate) fn build_store(
         let queue_mark = node_queue.len();
 
         dep_ids_sort_buf.clear();
-        dep_ids_sort_buf.reserve(pkg_deps.len as usize);
-        for _dep_id in pkg_deps.begin()..pkg_deps.end() {
-            let dep_id: DependencyID = _dep_id;
-            dep_ids_sort_buf.push(dep_id);
-        }
+        dep_ids_sort_buf.extend(pkg_deps.dependency_ids());
 
         // TODO: make this sort in an order that allows peers to be resolved last
         // and devDependency handling to match `hoistDependency`
@@ -672,7 +666,7 @@ pub(crate) fn build_store(
                 if node_id == store::node::Id::ROOT {
                     // TODO: print an error when scanner is actually a dependency of a workspace (we should not support this)
                     for &dep_id in &dep_ids_sort_buf {
-                        let pkg_id = resolutions[dep_id as usize];
+                        let pkg_id = resolutions[dep_id.index()];
                         if pkg_id == invalid_package_id {
                             continue;
                         }
@@ -707,8 +701,8 @@ pub(crate) fn build_store(
                     continue;
                 }
 
-                let pkg_id = resolutions[dep_id as usize];
-                let dep = &dependencies[dep_id as usize];
+                let pkg_id = resolutions[dep_id.index()];
+                let dep = &dependencies[dep_id.index()];
 
                 // TODO: handle duplicate dependencies. should be similar logic
                 // like we have for dev dependencies in `hoistDependency`
@@ -738,7 +732,7 @@ pub(crate) fn build_store(
                 // the package id for the chosen peer marked as a transitive peer. Nodes
                 // are deduplicated only if their package id and their transitive peer package
                 // ids are equal.
-                let peer_dep = &dependencies[peer_dep_id as usize];
+                let peer_dep = &dependencies[peer_dep_id.index()];
 
                 // TODO: double check this
                 // Start with the current package. A package
@@ -748,13 +742,13 @@ pub(crate) fn build_store(
                 visited_parent_node_ids.clear();
                 while curr_id != store::node::Id::INVALID {
                     for ids in &node_dependencies[curr_id.get() as usize] {
-                        let dep = &dependencies[ids.dep_id as usize];
+                        let dep = &dependencies[ids.dep_id.index()];
 
                         if dep.name_hash != peer_dep.name_hash {
                             continue;
                         }
 
-                        let res = &pkg_resolutions[ids.pkg_id as usize];
+                        let res = &pkg_resolutions[ids.pkg_id.index()];
 
                         if peer_dep.version.tag != VersionTag::Npm || res.tag != ResolutionTag::Npm
                         {
@@ -777,7 +771,7 @@ pub(crate) fn build_store(
 
                     let curr_peers = &node_peers[curr_id.get() as usize];
                     for ids in &curr_peers.list {
-                        let transitive_peer_dep = &dependencies[ids.dep_id as usize];
+                        let transitive_peer_dep = &dependencies[ids.dep_id.index()];
 
                         if transitive_peer_dep.name_hash != peer_dep.name_hash {
                             continue;
@@ -799,7 +793,7 @@ pub(crate) fn build_store(
                         // version. Only mark all parents if resolution is
                         // different from this transitive peer.
 
-                        let best_version = resolutions[peer_dep_id as usize];
+                        let best_version = resolutions[peer_dep_id.index()];
 
                         if best_version == invalid_package_id {
                             break 'resolved_pkg_id (invalid_package_id, true);
@@ -827,7 +821,7 @@ pub(crate) fn build_store(
                 }
 
                 // choose the current best version
-                break 'resolved_pkg_id (resolutions[peer_dep_id as usize], true);
+                break 'resolved_pkg_id (resolutions[peer_dep_id.index()], true);
             };
 
             if resolved_pkg_id == invalid_package_id {
@@ -920,8 +914,8 @@ pub(crate) fn build_store(
                     }
                 }
                 if info.dep_id != invalid_dependency_id && curr_dep_id != invalid_dependency_id {
-                    let curr_dep = &dependencies[curr_dep_id as usize];
-                    let existing_dep = &dependencies[info.dep_id as usize];
+                    let curr_dep = &dependencies[curr_dep_id.index()];
+                    let existing_dep = &dependencies[info.dep_id.index()];
 
                     if existing_dep.version.tag == VersionTag::Workspace
                         && curr_dep.version.tag == VersionTag::Workspace
@@ -952,7 +946,7 @@ pub(crate) fn build_store(
                     let parents = &mut entry_parents[info.entry_id.get() as usize];
 
                     if curr_dep_id != invalid_dependency_id
-                        && dependencies[curr_dep_id as usize].behavior.is_workspace()
+                        && dependencies[curr_dep_id.index()].behavior.is_workspace()
                     {
                         parents.push(entry.entry_parent_id);
                         continue 'next_entry;
@@ -983,9 +977,9 @@ pub(crate) fn build_store(
             }
             let mut hasher = Wyhash11::init(0);
             for peer_ids in peers.slice() {
-                let pkg_name = pkg_names[peer_ids.pkg_id as usize];
+                let pkg_name = pkg_names[peer_ids.pkg_id.index()];
                 hasher.update(pkg_name.slice(string_buf));
-                let pkg_res = &pkg_resolutions[peer_ids.pkg_id as usize];
+                let pkg_res = &pkg_resolutions[peer_ids.pkg_id.index()];
                 res_fmt_buf.clear();
                 write!(
                     &mut res_fmt_buf,
@@ -1002,7 +996,7 @@ pub(crate) fn build_store(
 
         let new_entry_is_root = new_entry_dep_id == invalid_dependency_id;
         let new_entry_is_workspace = !new_entry_is_root
-            && dependencies[new_entry_dep_id as usize].version.tag == VersionTag::Workspace;
+            && dependencies[new_entry_dep_id.index()].version.tag == VersionTag::Workspace;
 
         let new_entry_dependencies: store::entry::Dependencies =
             if dedupe_entry.found_existing && new_entry_is_workspace {
@@ -1024,7 +1018,7 @@ pub(crate) fn build_store(
                 break 'hoisted false;
             }
 
-            let dep_name = dependencies[new_entry_dep_id as usize]
+            let dep_name = dependencies[new_entry_dep_id.index()]
                 .name
                 .slice(string_buf);
 
@@ -1059,7 +1053,7 @@ pub(crate) fn build_store(
         if let Some(entry_parent_id) = entry.entry_parent_id.try_get() {
             'skip_adding_dependency: {
                 if new_entry_dep_id != invalid_dependency_id
-                    && dependencies[new_entry_dep_id as usize]
+                    && dependencies[new_entry_dep_id.index()]
                         .behavior
                         .is_workspace()
                 {
@@ -1084,13 +1078,13 @@ pub(crate) fn build_store(
                 if new_entry_dep_id != invalid_dependency_id {
                     if entry.entry_parent_id == store::entry::Id::ROOT {
                         // make sure direct dependencies are not replaced
-                        let dep_name = dependencies[new_entry_dep_id as usize]
+                        let dep_name = dependencies[new_entry_dep_id.index()]
                             .name
                             .slice(string_buf);
                         public_hoisted.put(dep_name, ())?;
                     } else {
                         // transitive dependencies (also direct dependencies of workspaces!)
-                        let dep_name = dependencies[new_entry_dep_id as usize]
+                        let dep_name = dependencies[new_entry_dep_id.index()]
                             .name
                             .slice(string_buf);
                         if let Some(public_hoist_pattern) = &manager.options.public_hoist_pattern {
@@ -1233,7 +1227,7 @@ pub(crate) fn install_isolated_packages(
                         let node_id = entry_node_ids[entry_idx];
                         let pkg_id = node_pkg_ids[node_id.get() as usize];
                         let dep_id = node_dep_ids[node_id.get() as usize];
-                        let pkg_res = &pkg_resolutions[pkg_id as usize];
+                        let pkg_res = &pkg_resolutions[pkg_id.index()];
 
                         let eligible = match pkg_res.tag {
                             ResolutionTag::Npm
@@ -1252,7 +1246,7 @@ pub(crate) fn install_isolated_packages(
                                     let name_version: &[u8] = match write!(
                                         &mut cursor,
                                         "{}@{}",
-                                        BStr::new(pkg_names[pkg_id as usize].slice(string_buf)),
+                                        BStr::new(pkg_names[pkg_id.index()].slice(string_buf)),
                                         pkg_res.fmt(string_buf, bun_fmt::PathSep::Posix),
                                     ) {
                                         Ok(()) => {
@@ -1287,13 +1281,13 @@ pub(crate) fn install_isolated_packages(
                                 // scripts" case in exchange for not needing a
                                 // lockfile-format change.
                                 let dep_name = if dep_id != invalid_dependency_id {
-                                    dependencies[dep_id as usize].name.slice(string_buf)
+                                    dependencies[dep_id.index()].name.slice(string_buf)
                                 } else {
-                                    pkg_names[pkg_id as usize].slice(string_buf)
+                                    pkg_names[pkg_id.index()].slice(string_buf)
                                 };
                                 if lockfile.has_trusted_dependency(
                                     dep_name,
-                                    pkg_names[pkg_id as usize].slice(string_buf),
+                                    pkg_names[pkg_id.index()].slice(string_buf),
                                     pkg_res,
                                 ) || trusted_from_update.contains(&pkg_id)
                                 {
@@ -1333,7 +1327,7 @@ pub(crate) fn install_isolated_packages(
                         // first project's bytes.
                         stack[top_idx]
                             .hasher
-                            .update(bun_core::bytes_of(&pkg_metas[pkg_id as usize].integrity));
+                            .update(bun_core::bytes_of(&pkg_metas[pkg_id.index()].integrity));
                     }
 
                     if states[entry_idx] == State::Ineligible {
@@ -1346,7 +1340,7 @@ pub(crate) fn install_isolated_packages(
                     while (stack[top_idx].next_dep as usize) < deps.len() {
                         let dep = &deps[stack[top_idx].next_dep as usize];
                         let dep_entry_idx = dep.entry_id.get() as usize;
-                        let dep_name_hash = dependencies[dep.dep_id as usize].name_hash;
+                        let dep_name_hash = dependencies[dep.dep_id.index()].name_hash;
                         match states[dep_entry_idx] {
                             State::Done => {
                                 stack[top_idx]
@@ -1520,8 +1514,8 @@ pub(crate) fn install_isolated_packages(
                                     sub.update(bun_core::bytes_of(
                                         &pkg_metas[node_pkg_ids
                                             [entry_node_ids[m as usize].get() as usize]
-                                            as usize]
-                                            .integrity,
+                                            .index()]
+                                        .integrity,
                                     ));
                                     let mut poisoned = false;
                                     for dep in entry_dependencies[m as usize].slice() {
@@ -1531,7 +1525,7 @@ pub(crate) fn install_isolated_packages(
                                             break;
                                         }
                                         let dep_name_hash =
-                                            dependencies[dep.dep_id as usize].name_hash;
+                                            dependencies[dep.dep_id.index()].name_hash;
                                         sub.update(bun_core::bytes_of(&dep_name_hash));
                                         sub.update(bun_core::bytes_of(&dh));
                                     }
@@ -1576,8 +1570,8 @@ pub(crate) fn install_isolated_packages(
                                     sub.update(bun_core::bytes_of(
                                         &pkg_metas[node_pkg_ids
                                             [entry_node_ids[m as usize].get() as usize]
-                                            as usize]
-                                            .integrity,
+                                            .index()]
+                                        .integrity,
                                     ));
                                     member_sub.push(sub.final_());
                                     for dep in entry_dependencies[m as usize].slice() {
@@ -1596,7 +1590,7 @@ pub(crate) fn install_isolated_packages(
                                         // different aliases must hash differently.
                                         let mut ext = Wyhash::init(0);
                                         ext.update(bun_core::bytes_of(
-                                            &dependencies[dep.dep_id as usize].name_hash,
+                                            &dependencies[dep.dep_id.index()].name_hash,
                                         ));
                                         ext.update(bun_core::bytes_of(&entry_hashes[di]));
                                         scc_ext.put(ext.final_(), ())?;
@@ -2118,9 +2112,9 @@ pub(crate) fn install_isolated_packages(
             let pkg_id = node_pkg_ids[node_id.get() as usize];
             let dep_id = node_dep_ids[node_id.get() as usize];
 
-            let pkg_name = pkg_names[pkg_id as usize];
-            let pkg_name_hash = pkg_name_hashes[pkg_id as usize];
-            let pkg_res: Resolution = pkg_resolutions[pkg_id as usize];
+            let pkg_name = pkg_names[pkg_id.index()];
+            let pkg_name_hash = pkg_name_hashes[pkg_id.index()];
+            let pkg_res: Resolution = pkg_resolutions[pkg_id.index()];
 
             // Validate the package name and every dependency alias as
             // `node_modules/<name>` components before any filesystem work.
@@ -2132,7 +2126,7 @@ pub(crate) fn install_isolated_packages(
                     unsafe_folder_name = Some(name);
                 } else {
                     for dep in entry_dependencies[entry_id.get() as usize].slice() {
-                        let dep_name = lockfile_ro.buffers.dependencies[dep.dep_id as usize]
+                        let dep_name = lockfile_ro.buffers.dependencies[dep.dep_id.index()]
                             .name
                             .slice(string_buf);
                         if !crate::package_installer::alias_is_safe_install_target(dep_name) {
@@ -2406,7 +2400,7 @@ pub(crate) fn install_isolated_packages(
 
                     let ctx = install::TaskCallbackContext::IsolatedPackageInstallContext(entry_id);
 
-                    let dep = &lockfile_ro.buffers.dependencies[dep_id as usize];
+                    let dep = &lockfile_ro.buffers.dependencies[dep_id.index()];
 
                     match pkg_res_tag {
                         ResolutionTag::Npm => {

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -205,9 +205,9 @@ impl<'a> Installer<'a> {
 
                 let node_id = entry_node_ids[entry_id.get() as usize];
                 let pkg_id = node_pkg_ids[node_id.get() as usize];
-                let pkg_name = pkg_names[pkg_id as usize];
-                let pkg_name_hash = pkg_name_hashes[pkg_id as usize];
-                let pkg_res = &pkg_resolutions[pkg_id as usize];
+                let pkg_name = pkg_names[pkg_id.index()];
+                let pkg_name_hash = pkg_name_hashes[pkg_id.index()];
+                let pkg_res = &pkg_resolutions[pkg_id.index()];
 
                 let patch_info =
                     bun_core::handle_oom(self.package_patch_info(pkg_name, pkg_name_hash, pkg_res));
@@ -331,8 +331,8 @@ impl<'a> Installer<'a> {
         let node_id = entry_node_ids[entry_id.get() as usize];
         let pkg_id = node_pkg_ids[node_id.get() as usize];
 
-        let pkg_name = pkg_names[pkg_id as usize];
-        let pkg_res = pkg_resolutions[pkg_id as usize];
+        let pkg_name = pkg_names[pkg_id.index()];
+        let pkg_res = pkg_resolutions[pkg_id.index()];
 
         match err {
             TaskError::LinkPackage(link_err) => {
@@ -539,7 +539,7 @@ impl<'a> Installer<'a> {
                 break 'state (StoreNodeId::ROOT, CompleteState::Skipped);
             }
 
-            let dep = &self.lockfile().buffers.dependencies[dep_id as usize];
+            let dep = &self.lockfile().buffers.dependencies[dep_id.index()];
 
             if dep.behavior.is_workspace() {
                 break 'state (node_id, CompleteState::Skipped);
@@ -562,9 +562,9 @@ impl<'a> Installer<'a> {
 
         let pkg_id = nodes.items_pkg_id()[node_id.get() as usize];
 
-        let is_duplicate = self.installed.is_set(pkg_id as usize);
+        let is_duplicate = self.installed.is_set(pkg_id.index());
         self.summary.success += (!is_duplicate) as u32;
-        self.installed.set(pkg_id as usize);
+        self.installed.set(pkg_id.index());
     }
 
     /// Main thread only: `completed` just reached `Step::Done`; re-check every entry waiting on it.
@@ -902,9 +902,9 @@ impl Task {
         let pkg_id = node_pkg_ids[node_id.get() as usize];
         let dep_id = node_dep_ids[node_id.get() as usize];
 
-        let pkg_name = pkg_names[pkg_id as usize];
-        let pkg_name_hash = pkg_name_hashes[pkg_id as usize];
-        let pkg_res = pkg_resolutions[pkg_id as usize];
+        let pkg_name = pkg_names[pkg_id.index()];
+        let pkg_name_hash = pkg_name_hashes[pkg_id.index()];
+        let pkg_res = pkg_resolutions[pkg_id.index()];
 
         let mut step =
             Step::from_u32(entry_steps[self.entry_id.get() as usize].load(Ordering::Acquire));
@@ -1609,7 +1609,7 @@ impl Task {
 
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
 
-                    let dep = &lockfile.buffers.dependencies[dep_id as usize];
+                    let dep = &lockfile.buffers.dependencies[dep_id.index()];
                     let truncated_dep_name_hash: TruncatedPackageNameHash =
                         dep.name_hash as TruncatedPackageNameHash;
 
@@ -1640,7 +1640,7 @@ impl Task {
                             break 'enqueue_lifecycle_scripts;
                         }
                         let mut pkg_scripts: package::scripts::Scripts =
-                            pkg_script_lists[pkg_id as usize];
+                            pkg_script_lists[pkg_id.index()];
                         let manager = manager_ref.get();
                         if is_trusted
                             && manager
@@ -1655,7 +1655,7 @@ impl Task {
                                         },
                                         version_buf: lockfile.buffers.string_bytes.as_slice(),
                                     },
-                                    pkg_resolutions_lists[pkg_id as usize]
+                                    pkg_resolutions_lists[pkg_id.index()]
                                         .get(lockfile.buffers.resolutions.as_slice()),
                                     pkg_metas,
                                     manager.options.cpu,
@@ -1760,7 +1760,7 @@ impl Task {
                         continue;
                     }
 
-                    let bin = pkg_bins[pkg_id as usize];
+                    let bin = pkg_bins[pkg_id.index()];
                     if bin.tag == bin::Tag::None {
                         match installer.commit_global_store_entry(self.entry_id) {
                             sys::Result::Ok(()) => {}
@@ -1775,7 +1775,7 @@ impl Task {
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
                     let dependencies = lockfile.buffers.dependencies.as_slice();
 
-                    let dep_name = dependencies[dep_id as usize].name.slice(string_buf);
+                    let dep_name = dependencies[dep_id.index()].name.slice(string_buf);
 
                     let mut abs_target_buf = paths::path_buffer_pool::get();
                     let mut abs_dest_buf = paths::path_buffer_pool::get();
@@ -1815,7 +1815,7 @@ impl Task {
                             entry_node_ids[replacement_entry_id.get() as usize];
                         let replacement_pkg_id = node_pkg_ids[replacement_node_id.get() as usize];
                         target_package_name = strings::StringOrTinyString::init(
-                            lockfile.str(&pkg_names[replacement_pkg_id as usize]),
+                            lockfile.str(&pkg_names[replacement_pkg_id.index()]),
                         );
                     }
 
@@ -2133,7 +2133,7 @@ impl<'a> Installer<'a> {
 
         let node_id = self.store.entries.items_node_id()[entry_id.get() as usize];
         let pkg_id = self.store.nodes.items_pkg_id()[node_id.get() as usize];
-        let pkg_name = self.lockfile().packages.items_name()[pkg_id as usize];
+        let pkg_name = self.lockfile().packages.items_name()[pkg_id.index()];
 
         let mut hidden_hoisted_node_modules = AutoPath::init();
 
@@ -2201,7 +2201,7 @@ impl<'a> Installer<'a> {
         if !postinstall_optimizer.is_native_binlink_enabled() {
             return None;
         }
-        let name_hash = name_hashes[pkg_id as usize];
+        let name_hash = name_hashes[pkg_id.index()];
 
         if let Some(optimizer) = postinstall_optimizer.get(&postinstall_optimizer::PkgInfo {
             name_hash,
@@ -2214,7 +2214,7 @@ impl<'a> Installer<'a> {
                     let target_os = manager.options.os;
                     if let Some(replacement_pkg_id) =
                         postinstall_optimizer::PostinstallOptimizer::get_native_binlink_replacement_package_id(
-                            pkg_resolutions_lists[pkg_id as usize].get(pkg_resolutions_buffer),
+                            pkg_resolutions_lists[pkg_id.index()].get(pkg_resolutions_buffer),
                             pkg_metas,
                             target_cpu,
                             target_os,
@@ -2255,7 +2255,7 @@ impl<'a> Installer<'a> {
         let node_id = self.store.entries.items_node_id()[entry_id.get() as usize];
         let pkg_id = self.store.nodes.items_pkg_id()[node_id.get() as usize];
         let dep_id = self.store.nodes.items_dep_id()[node_id.get() as usize];
-        let pkg_res = &pkg_resolutions[pkg_id as usize];
+        let pkg_res = &pkg_resolutions[pkg_id.index()];
 
         let entry_node_modules_name =
             self.entry_store_node_modules_package_name(dep_id, pkg_id, pkg_res, pkg_names);
@@ -2267,7 +2267,7 @@ impl<'a> Installer<'a> {
 
         let mut changed = false;
         for dep in self.store.entries.items_dependencies()[entry_id.get() as usize].slice() {
-            let dep_name = dependencies[dep.dep_id as usize].name.slice(string_buf);
+            let dep_name = dependencies[dep.dep_id.index()].name.slice(string_buf);
 
             dest.set_length(base_len);
             let _ = dest.append(dep_name); // OOM/capacity: fire-and-forget
@@ -2343,11 +2343,11 @@ impl<'a> Installer<'a> {
             let node_id = entry_node_ids[dep.entry_id.get() as usize];
             let dep_id = node_dep_ids[node_id.get() as usize];
             let pkg_id = node_pkg_ids[node_id.get() as usize];
-            let bin = pkg_bins[pkg_id as usize];
+            let bin = pkg_bins[pkg_id.index()];
             if bin.tag == bin::Tag::None {
                 continue;
             }
-            let alias = lockfile.buffers.dependencies[dep_id as usize].name;
+            let alias = lockfile.buffers.dependencies[dep_id.index()].name;
 
             let mut target_node_modules_path: Option<DefaultAbsPath> = None;
             let package_name = strings::StringOrTinyString::init(alias.slice(string_buf));
@@ -2375,7 +2375,7 @@ impl<'a> Installer<'a> {
                 let replacement_pkg_id = node_pkg_ids[replacement_node_id.get() as usize];
                 let pkg_names = pkgs.items_name();
                 target_package_name = strings::StringOrTinyString::init(
-                    self.lockfile().str(&pkg_names[replacement_pkg_id as usize]),
+                    self.lockfile().str(&pkg_names[replacement_pkg_id.index()]),
                 );
             }
 
@@ -2657,7 +2657,7 @@ impl<'a> Installer<'a> {
 
         let node_id = entry_node_ids[entry_id.get() as usize];
         let pkg_id = node_pkg_ids[node_id.get() as usize];
-        let pkg_res = pkg_resolutions[pkg_id as usize];
+        let pkg_res = pkg_resolutions[pkg_id.index()];
 
         match pkg_res.tag {
             ResolutionTag::Root => {
@@ -2707,7 +2707,7 @@ impl<'a> Installer<'a> {
             let string_buf = self.lockfile().buffers.string_bytes.as_slice();
             let node_id = self.store.entries.items_node_id()[entry_id.get() as usize];
             let pkg_id = self.store.nodes.items_pkg_id()[node_id.get() as usize];
-            let pkg_name = self.lockfile().packages.items_name()[pkg_id as usize];
+            let pkg_name = self.lockfile().packages.items_name()[pkg_id.index()];
             self.append_global_store_entry_path(buf, entry_id, which);
             buf.append(b"node_modules");
             buf.append(pkg_name.slice(string_buf));
@@ -2735,12 +2735,12 @@ impl<'a> Installer<'a> {
         // let peers = node_peers[node_id.get() as usize];
         let pkg_id = node_pkg_ids[node_id.get() as usize];
         let dep_id = node_dep_ids[node_id.get() as usize];
-        let pkg_res = pkg_resolutions[pkg_id as usize];
+        let pkg_res = pkg_resolutions[pkg_id.index()];
 
         match pkg_res.tag {
             ResolutionTag::Root => {
                 if dep_id != invalid_dependency_id {
-                    let pkg_name = pkg_names[pkg_id as usize];
+                    let pkg_name = pkg_names[pkg_id.index()];
                     buf.append(NODE_MODULES_BUN.as_bytes());
                     buf.append_fmt(format_args!(
                         "{}",
@@ -2779,7 +2779,7 @@ impl<'a> Installer<'a> {
                 buf.append(pkg_res.symlink().slice(string_buf));
             }
             _ => {
-                let pkg_name = pkg_names[pkg_id as usize];
+                let pkg_name = pkg_names[pkg_id.index()];
                 buf.append(NODE_MODULES_BUN.as_bytes());
                 buf.append_fmt(format_args!(
                     "{}",
@@ -2809,18 +2809,18 @@ impl<'a> Installer<'a> {
         match pkg_res.tag {
             ResolutionTag::Root => {
                 if dep_id != invalid_dependency_id {
-                    if pkg_names[pkg_id as usize].is_empty() {
+                    if pkg_names[pkg_id.index()].is_empty() {
                         return Some(paths::basename(
                             bun_fs::FileSystem::instance().top_level_dir(),
                         ));
                     }
-                    return Some(pkg_names[pkg_id as usize].slice(string_buf));
+                    return Some(pkg_names[pkg_id.index()].slice(string_buf));
                 }
                 None
             }
             ResolutionTag::Workspace => None,
             ResolutionTag::Symlink => None,
-            _ => Some(pkg_names[pkg_id as usize].slice(string_buf)),
+            _ => Some(pkg_names[pkg_id.index()].slice(string_buf)),
         }
     }
 }

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -2,7 +2,7 @@ use core::sync::atomic::{AtomicU8, Ordering};
 use std::io::Write as _;
 
 use bun_ast::Log;
-use bun_collections::{ArrayHashMap, DynamicBitSet, StringHashMap};
+use bun_collections::{ArrayHashMap, DynamicBitSet, IdSlice, StringHashMap};
 use bun_core::{Environment, Global, Output};
 use bun_core::{ZStr, strings};
 use bun_paths::{self as paths, AbsPath, AutoAbsPath, AutoRelPath};
@@ -205,9 +205,9 @@ impl<'a> Installer<'a> {
 
                 let node_id = entry_node_ids[entry_id.get() as usize];
                 let pkg_id = node_pkg_ids[node_id.get() as usize];
-                let pkg_name = pkg_names[pkg_id.index()];
-                let pkg_name_hash = pkg_name_hashes[pkg_id.index()];
-                let pkg_res = &pkg_resolutions[pkg_id.index()];
+                let pkg_name = pkg_names[pkg_id];
+                let pkg_name_hash = pkg_name_hashes[pkg_id];
+                let pkg_res = &pkg_resolutions[pkg_id];
 
                 let patch_info =
                     bun_core::handle_oom(self.package_patch_info(pkg_name, pkg_name_hash, pkg_res));
@@ -331,8 +331,8 @@ impl<'a> Installer<'a> {
         let node_id = entry_node_ids[entry_id.get() as usize];
         let pkg_id = node_pkg_ids[node_id.get() as usize];
 
-        let pkg_name = pkg_names[pkg_id.index()];
-        let pkg_res = pkg_resolutions[pkg_id.index()];
+        let pkg_name = pkg_names[pkg_id];
+        let pkg_res = pkg_resolutions[pkg_id];
 
         match err {
             TaskError::LinkPackage(link_err) => {
@@ -539,7 +539,7 @@ impl<'a> Installer<'a> {
                 break 'state (StoreNodeId::ROOT, CompleteState::Skipped);
             }
 
-            let dep = &self.lockfile().buffers.dependencies[dep_id.index()];
+            let dep = &self.lockfile().buffers.dependencies[dep_id];
 
             if dep.behavior.is_workspace() {
                 break 'state (node_id, CompleteState::Skipped);
@@ -884,7 +884,7 @@ impl Task {
         let pkg_name_hashes = pkgs.items_name_hash();
         let pkg_resolutions = pkgs.items_resolution();
         let pkg_resolutions_lists = pkgs.items_resolutions();
-        let pkg_metas: &[package::Meta] = pkgs.items_meta();
+        let pkg_metas = pkgs.items_meta();
         let pkg_bins = pkgs.items_bin();
         let pkg_script_lists = pkgs.items_scripts();
 
@@ -902,9 +902,9 @@ impl Task {
         let pkg_id = node_pkg_ids[node_id.get() as usize];
         let dep_id = node_dep_ids[node_id.get() as usize];
 
-        let pkg_name = pkg_names[pkg_id.index()];
-        let pkg_name_hash = pkg_name_hashes[pkg_id.index()];
-        let pkg_res = pkg_resolutions[pkg_id.index()];
+        let pkg_name = pkg_names[pkg_id];
+        let pkg_name_hash = pkg_name_hashes[pkg_id];
+        let pkg_res = pkg_resolutions[pkg_id];
 
         let mut step =
             Step::from_u32(entry_steps[self.entry_id.get() as usize].load(Ordering::Acquire));
@@ -1609,7 +1609,7 @@ impl Task {
 
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
 
-                    let dep = &lockfile.buffers.dependencies[dep_id.index()];
+                    let dep = &lockfile.buffers.dependencies[dep_id];
                     let truncated_dep_name_hash: TruncatedPackageNameHash =
                         dep.name_hash as TruncatedPackageNameHash;
 
@@ -1639,8 +1639,7 @@ impl Task {
                         {
                             break 'enqueue_lifecycle_scripts;
                         }
-                        let mut pkg_scripts: package::scripts::Scripts =
-                            pkg_script_lists[pkg_id.index()];
+                        let mut pkg_scripts: package::scripts::Scripts = pkg_script_lists[pkg_id];
                         let manager = manager_ref.get();
                         if is_trusted
                             && manager
@@ -1655,7 +1654,7 @@ impl Task {
                                         },
                                         version_buf: lockfile.buffers.string_bytes.as_slice(),
                                     },
-                                    pkg_resolutions_lists[pkg_id.index()]
+                                    pkg_resolutions_lists[pkg_id]
                                         .get(lockfile.buffers.resolutions.as_slice()),
                                     pkg_metas,
                                     manager.options.cpu,
@@ -1760,7 +1759,7 @@ impl Task {
                         continue;
                     }
 
-                    let bin = pkg_bins[pkg_id.index()];
+                    let bin = pkg_bins[pkg_id];
                     if bin.tag == bin::Tag::None {
                         match installer.commit_global_store_entry(self.entry_id) {
                             sys::Result::Ok(()) => {}
@@ -1775,7 +1774,7 @@ impl Task {
                     let string_buf = lockfile.buffers.string_bytes.as_slice();
                     let dependencies = lockfile.buffers.dependencies.as_slice();
 
-                    let dep_name = dependencies[dep_id.index()].name.slice(string_buf);
+                    let dep_name = dependencies[dep_id].name.slice(string_buf);
 
                     let mut abs_target_buf = paths::path_buffer_pool::get();
                     let mut abs_dest_buf = paths::path_buffer_pool::get();
@@ -1815,7 +1814,7 @@ impl Task {
                             entry_node_ids[replacement_entry_id.get() as usize];
                         let replacement_pkg_id = node_pkg_ids[replacement_node_id.get() as usize];
                         target_package_name = strings::StringOrTinyString::init(
-                            lockfile.str(&pkg_names[replacement_pkg_id.index()]),
+                            lockfile.str(&pkg_names[replacement_pkg_id]),
                         );
                     }
 
@@ -2133,7 +2132,7 @@ impl<'a> Installer<'a> {
 
         let node_id = self.store.entries.items_node_id()[entry_id.get() as usize];
         let pkg_id = self.store.nodes.items_pkg_id()[node_id.get() as usize];
-        let pkg_name = self.lockfile().packages.items_name()[pkg_id.index()];
+        let pkg_name = self.lockfile().packages.items_name()[pkg_id];
 
         let mut hidden_hoisted_node_modules = AutoPath::init();
 
@@ -2191,17 +2190,17 @@ impl<'a> Installer<'a> {
         &self,
         entry_node_ids: &[StoreNodeId],
         node_pkg_ids: &[PackageID],
-        name_hashes: &[PackageNameHash],
-        pkg_resolutions_lists: &[PackageIDSlice],
-        pkg_resolutions_buffer: &[PackageID],
-        pkg_metas: &[package::Meta],
+        name_hashes: &IdSlice<PackageID, PackageNameHash>,
+        pkg_resolutions_lists: &IdSlice<PackageID, PackageIDSlice>,
+        pkg_resolutions_buffer: &IdSlice<DependencyID, PackageID>,
+        pkg_metas: &IdSlice<PackageID, package::Meta>,
         pkg_id: PackageID,
     ) -> Option<StoreEntryId> {
         let postinstall_optimizer = &self.manager().postinstall_optimizer;
         if !postinstall_optimizer.is_native_binlink_enabled() {
             return None;
         }
-        let name_hash = name_hashes[pkg_id.index()];
+        let name_hash = name_hashes[pkg_id];
 
         if let Some(optimizer) = postinstall_optimizer.get(&postinstall_optimizer::PkgInfo {
             name_hash,
@@ -2214,7 +2213,7 @@ impl<'a> Installer<'a> {
                     let target_os = manager.options.os;
                     if let Some(replacement_pkg_id) =
                         postinstall_optimizer::PostinstallOptimizer::get_native_binlink_replacement_package_id(
-                            pkg_resolutions_lists[pkg_id.index()].get(pkg_resolutions_buffer),
+                            pkg_resolutions_lists[pkg_id].get(pkg_resolutions_buffer),
                             pkg_metas,
                             target_cpu,
                             target_os,
@@ -2255,7 +2254,7 @@ impl<'a> Installer<'a> {
         let node_id = self.store.entries.items_node_id()[entry_id.get() as usize];
         let pkg_id = self.store.nodes.items_pkg_id()[node_id.get() as usize];
         let dep_id = self.store.nodes.items_dep_id()[node_id.get() as usize];
-        let pkg_res = &pkg_resolutions[pkg_id.index()];
+        let pkg_res = &pkg_resolutions[pkg_id];
 
         let entry_node_modules_name =
             self.entry_store_node_modules_package_name(dep_id, pkg_id, pkg_res, pkg_names);
@@ -2267,7 +2266,7 @@ impl<'a> Installer<'a> {
 
         let mut changed = false;
         for dep in self.store.entries.items_dependencies()[entry_id.get() as usize].slice() {
-            let dep_name = dependencies[dep.dep_id.index()].name.slice(string_buf);
+            let dep_name = dependencies[dep.dep_id].name.slice(string_buf);
 
             dest.set_length(base_len);
             let _ = dest.append(dep_name); // OOM/capacity: fire-and-forget
@@ -2343,11 +2342,11 @@ impl<'a> Installer<'a> {
             let node_id = entry_node_ids[dep.entry_id.get() as usize];
             let dep_id = node_dep_ids[node_id.get() as usize];
             let pkg_id = node_pkg_ids[node_id.get() as usize];
-            let bin = pkg_bins[pkg_id.index()];
+            let bin = pkg_bins[pkg_id];
             if bin.tag == bin::Tag::None {
                 continue;
             }
-            let alias = lockfile.buffers.dependencies[dep_id.index()].name;
+            let alias = lockfile.buffers.dependencies[dep_id].name;
 
             let mut target_node_modules_path: Option<DefaultAbsPath> = None;
             let package_name = strings::StringOrTinyString::init(alias.slice(string_buf));
@@ -2375,7 +2374,7 @@ impl<'a> Installer<'a> {
                 let replacement_pkg_id = node_pkg_ids[replacement_node_id.get() as usize];
                 let pkg_names = pkgs.items_name();
                 target_package_name = strings::StringOrTinyString::init(
-                    self.lockfile().str(&pkg_names[replacement_pkg_id.index()]),
+                    self.lockfile().str(&pkg_names[replacement_pkg_id]),
                 );
             }
 
@@ -2657,7 +2656,7 @@ impl<'a> Installer<'a> {
 
         let node_id = entry_node_ids[entry_id.get() as usize];
         let pkg_id = node_pkg_ids[node_id.get() as usize];
-        let pkg_res = pkg_resolutions[pkg_id.index()];
+        let pkg_res = pkg_resolutions[pkg_id];
 
         match pkg_res.tag {
             ResolutionTag::Root => {
@@ -2707,7 +2706,7 @@ impl<'a> Installer<'a> {
             let string_buf = self.lockfile().buffers.string_bytes.as_slice();
             let node_id = self.store.entries.items_node_id()[entry_id.get() as usize];
             let pkg_id = self.store.nodes.items_pkg_id()[node_id.get() as usize];
-            let pkg_name = self.lockfile().packages.items_name()[pkg_id.index()];
+            let pkg_name = self.lockfile().packages.items_name()[pkg_id];
             self.append_global_store_entry_path(buf, entry_id, which);
             buf.append(b"node_modules");
             buf.append(pkg_name.slice(string_buf));
@@ -2735,12 +2734,12 @@ impl<'a> Installer<'a> {
         // let peers = node_peers[node_id.get() as usize];
         let pkg_id = node_pkg_ids[node_id.get() as usize];
         let dep_id = node_dep_ids[node_id.get() as usize];
-        let pkg_res = pkg_resolutions[pkg_id.index()];
+        let pkg_res = pkg_resolutions[pkg_id];
 
         match pkg_res.tag {
             ResolutionTag::Root => {
                 if dep_id != invalid_dependency_id {
-                    let pkg_name = pkg_names[pkg_id.index()];
+                    let pkg_name = pkg_names[pkg_id];
                     buf.append(NODE_MODULES_BUN.as_bytes());
                     buf.append_fmt(format_args!(
                         "{}",
@@ -2779,7 +2778,7 @@ impl<'a> Installer<'a> {
                 buf.append(pkg_res.symlink().slice(string_buf));
             }
             _ => {
-                let pkg_name = pkg_names[pkg_id.index()];
+                let pkg_name = pkg_names[pkg_id];
                 buf.append(NODE_MODULES_BUN.as_bytes());
                 buf.append_fmt(format_args!(
                     "{}",
@@ -2802,25 +2801,25 @@ impl<'a> Installer<'a> {
         dep_id: DependencyID,
         pkg_id: PackageID,
         pkg_res: &Resolution,
-        pkg_names: &'b [SemverString],
+        pkg_names: &'b IdSlice<PackageID, SemverString>,
     ) -> Option<&'b [u8]> {
         let string_buf = self.lockfile().buffers.string_bytes.as_slice();
 
         match pkg_res.tag {
             ResolutionTag::Root => {
                 if dep_id != invalid_dependency_id {
-                    if pkg_names[pkg_id.index()].is_empty() {
+                    if pkg_names[pkg_id].is_empty() {
                         return Some(paths::basename(
                             bun_fs::FileSystem::instance().top_level_dir(),
                         ));
                     }
-                    return Some(pkg_names[pkg_id.index()].slice(string_buf));
+                    return Some(pkg_names[pkg_id].slice(string_buf));
                 }
                 None
             }
             ResolutionTag::Workspace => None,
             ResolutionTag::Symlink => None,
-            _ => Some(pkg_names[pkg_id.index()].slice(string_buf)),
+            _ => Some(pkg_names[pkg_id].slice(string_buf)),
         }
     }
 }

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -432,8 +432,8 @@ pub mod entry {
                 f,
                 "{}",
                 fmt_store_key(
-                    pkgs.items_name()[pkg_id as usize],
-                    &pkgs.items_resolution()[pkg_id as usize],
+                    pkgs.items_name()[pkg_id.index()],
+                    &pkgs.items_resolution()[pkg_id.index()],
                     self.lockfile.buffers.string_bytes.as_slice(),
                 )
             )?;
@@ -538,16 +538,16 @@ pub mod entry {
             }
 
             let dependencies = self.dependencies;
-            let l_dep = &dependencies[l_item.dep_id as usize];
-            let r_dep = &dependencies[r_item.dep_id as usize];
+            let l_dep = &dependencies[l_item.dep_id.index()];
+            let r_dep = &dependencies[r_item.dep_id.index()];
 
             l_dep.name_hash == r_dep.name_hash
         }
 
         fn order(&self, l: DependenciesItem, r: DependenciesItem) -> Ordering {
             let dependencies = self.dependencies;
-            let l_dep = &dependencies[l.dep_id as usize];
-            let r_dep = &dependencies[r.dep_id as usize];
+            let l_dep = &dependencies[l.dep_id.index()];
+            let r_dep = &dependencies[r.dep_id.index()];
 
             if l.entry_id == r.entry_id && l_dep.name_hash == r_dep.name_hash {
                 return Ordering::Equal;
@@ -621,7 +621,7 @@ pub mod node {
         fn default() -> Self {
             Self {
                 dep_id: INVALID_DEPENDENCY_ID,
-                pkg_id: 0,
+                pkg_id: PackageID::ROOT,
                 parent_id: Id::INVALID,
                 dependencies: Vec::new(),
                 peers: Peers::EMPTY,
@@ -657,8 +657,8 @@ pub mod node {
 
             let string_buf = self.string_buf;
             let pkg_names = self.pkg_names;
-            let l_pkg_name = pkg_names[l_pkg_id as usize];
-            let r_pkg_name = pkg_names[r_pkg_id as usize];
+            let l_pkg_name = pkg_names[l_pkg_id.index()];
+            let r_pkg_name = pkg_names[r_pkg_id.index()];
 
             l_pkg_name.order(r_pkg_name, string_buf, string_buf)
         }

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 use bstr::BStr;
 
 use bun_alloc::AllocError;
-use bun_collections::{ArrayHashMap, MultiArrayList};
+use bun_collections::{ArrayHashMap, IdSlice, MultiArrayList};
 use bun_semver::String as SemverString;
 
 use crate::lockfile::{Lockfile, package};
@@ -432,8 +432,8 @@ pub mod entry {
                 f,
                 "{}",
                 fmt_store_key(
-                    pkgs.items_name()[pkg_id.index()],
-                    &pkgs.items_resolution()[pkg_id.index()],
+                    pkgs.items_name()[pkg_id],
+                    &pkgs.items_resolution()[pkg_id],
                     self.lockfile.buffers.string_bytes.as_slice(),
                 )
             )?;
@@ -528,7 +528,7 @@ pub mod entry {
 
     pub(crate) struct DependenciesOrderedArraySetCtx<'a> {
         pub string_buf: &'a [u8],
-        pub dependencies: &'a [Dependency],
+        pub dependencies: &'a IdSlice<DependencyID, Dependency>,
     }
 
     impl<'a> OrderedArraySetCtx<DependenciesItem> for DependenciesOrderedArraySetCtx<'a> {
@@ -538,16 +538,16 @@ pub mod entry {
             }
 
             let dependencies = self.dependencies;
-            let l_dep = &dependencies[l_item.dep_id.index()];
-            let r_dep = &dependencies[r_item.dep_id.index()];
+            let l_dep = &dependencies[l_item.dep_id];
+            let r_dep = &dependencies[r_item.dep_id];
 
             l_dep.name_hash == r_dep.name_hash
         }
 
         fn order(&self, l: DependenciesItem, r: DependenciesItem) -> Ordering {
             let dependencies = self.dependencies;
-            let l_dep = &dependencies[l.dep_id.index()];
-            let r_dep = &dependencies[r.dep_id.index()];
+            let l_dep = &dependencies[l.dep_id];
+            let r_dep = &dependencies[r.dep_id];
 
             if l.entry_id == r.entry_id && l_dep.name_hash == r_dep.name_hash {
                 return Ordering::Equal;
@@ -639,7 +639,7 @@ pub mod node {
 
     pub(crate) struct TransitivePeerOrderedArraySetCtx<'a> {
         pub(crate) string_buf: &'a [u8],
-        pub(crate) pkg_names: &'a [SemverString],
+        pub(crate) pkg_names: &'a IdSlice<PackageID, SemverString>,
     }
 
     impl<'a> OrderedArraySetCtx<TransitivePeer> for TransitivePeerOrderedArraySetCtx<'a> {
@@ -657,8 +657,8 @@ pub mod node {
 
             let string_buf = self.string_buf;
             let pkg_names = self.pkg_names;
-            let l_pkg_name = pkg_names[l_pkg_id.index()];
-            let r_pkg_name = pkg_names[r_pkg_id.index()];
+            let l_pkg_name = pkg_names[l_pkg_id];
+            let r_pkg_name = pkg_names[r_pkg_id];
 
             l_pkg_name.order(r_pkg_name, string_buf, string_buf)
         }

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -991,7 +991,7 @@ pub(crate) fn initialize_mini_store() {
     });
 }
 
-// MOVE_DOWN: identity/sentinel scalar aliases live in `bun_install_types::resolver_hooks`
+// MOVE_DOWN: the id types and their sentinels live in `bun_install_types::resolver_hooks`
 // (single canonical definition shared with `bun_resolver`). Re-exported here so existing
 // `bun_install::PackageID` / `INVALID_PACKAGE_ID` / etc. paths continue to resolve.
 pub use bun_install_types::{

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -1082,7 +1082,7 @@ pub struct ExtractData {
 /// borrowed `*const [u8]` raw slice with `Copy` semantics, which broke
 /// ownership: callers push into this buffer; the raw-ptr version cannot grow
 /// and aliases caller memory with no lifetime. Own the buffer.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct DependencyInstallContext {
     pub(crate) tree_id: lockfile::tree::Id,
     pub(crate) path: Vec<u8>,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -201,7 +201,7 @@ pub struct Lockfile {
     /// session-appended").
     ///
     /// Runtime-only — never serialised.
-    pub(crate) loaded_package_count: PackageID,
+    pub(crate) loaded_package_count: u32,
 
     /// `bit[id] == true` ⇔ package `id` was appended for a dependency whose
     /// version range was an exact `=X.Y.Z` (i.e. the user — root or workspace
@@ -228,8 +228,8 @@ impl<'a> DepSorter<'a> {
         let deps_buf = self.lockfile.buffers.dependencies.as_slice();
         let string_buf = self.lockfile.buffers.string_bytes.as_slice();
 
-        let l_dep = &deps_buf[l as usize];
-        let r_dep = &deps_buf[r as usize];
+        let l_dep = &deps_buf[l.index()];
+        let r_dep = &deps_buf[r.index()];
 
         match l_dep.behavior.cmp(r_dep.behavior) {
             Ordering::Less => true,
@@ -724,7 +724,7 @@ impl Lockfile {
             return true;
         }
 
-        let dep = &self.buffers.dependencies[dep_id as usize];
+        let dep = &self.buffers.dependencies[dep_id.index()];
 
         dep.behavior.is_bundled() || !dep.behavior.is_enabled(features)
     }
@@ -755,7 +755,7 @@ impl Lockfile {
         let root_id = manager
             .root_package_id
             .get(self, manager.workspace_name_hash);
-        self.packages.items_dependencies()[root_id as usize].contains(id)
+        self.packages.items_dependencies()[root_id.index()].contains(id)
     }
 
     /// Is `id` a direct dependency of one of the `targets` workspaces?
@@ -769,10 +769,10 @@ impl Lockfile {
             return false;
         }
         let is_root =
-            self.packages.items_resolution()[pkg_id as usize].tag == crate::resolution::Tag::Root;
-        let hash = self.packages.items_name_hash()[pkg_id as usize];
+            self.packages.items_resolution()[pkg_id.index()].tag == crate::resolution::Tag::Root;
+        let hash = self.packages.items_name_hash()[pkg_id.index()];
         let name =
-            self.packages.items_name()[pkg_id as usize].slice(self.buffers.string_bytes.as_slice());
+            self.packages.items_name()[pkg_id.index()].slice(self.buffers.string_bytes.as_slice());
         targets.iter().any(|t| t.matches(is_root, hash, name))
     }
 
@@ -806,7 +806,7 @@ impl Lockfile {
     /// TODO(dylan-conway) fix!
     pub(crate) fn is_workspace_tree_id(&self, id: tree::Id) -> bool {
         id == 0
-            || self.buffers.dependencies[self.buffers.trees[id as usize].dependency_id as usize]
+            || self.buffers.dependencies[self.buffers.trees[id as usize].dependency_id.index()]
                 .behavior
                 .is_workspace()
     }
@@ -819,9 +819,9 @@ impl Lockfile {
             return false;
         }
         let dependency_id = self.buffers.trees[id as usize].dependency_id;
-        let package_id = self.buffers.resolutions[dependency_id as usize];
+        let package_id = self.buffers.resolutions[dependency_id.index()];
         package_id != invalid_package_id
-            && self.packages.slice().items_resolution()[package_id as usize].tag
+            && self.packages.slice().items_resolution()[package_id.index()].tag
                 == ResolutionTag::Folder
     }
 
@@ -841,9 +841,9 @@ impl Lockfile {
             }
 
             // should not hit this, default to root just in case
-            0
+            PackageID::ROOT
         } else {
-            0
+            PackageID::ROOT
         }
     }
 
@@ -873,15 +873,15 @@ impl Lockfile {
                 None => &cwd_workspace,
             };
             for &workspace_package_id in workspace_ids {
-                let dep_list = slice.items_dependencies()[workspace_package_id as usize];
-                let res_list = slice.items_resolutions()[workspace_package_id as usize];
+                let dep_list = slice.items_dependencies()[workspace_package_id.index()];
+                let res_list = slice.items_resolutions()[workspace_package_id.index()];
                 let workspace_deps: &[Dependency] =
                     dep_list.get(self.buffers.dependencies.as_slice());
                 let resolved_ids: &[PackageID] = res_list.get(self.buffers.resolutions.as_slice());
                 debug_assert_eq!(resolved_ids.len(), workspace_deps.len());
                 for (&package_id, dep) in resolved_ids.iter().zip(workspace_deps.iter()) {
                     if update.matches(dep, string_buf) {
-                        if package_id as usize > self.packages.len() {
+                        if package_id.index() > self.packages.len() {
                             continue;
                         }
                         update.version_buf = string_buf_ptr;
@@ -1221,24 +1221,24 @@ impl<'a> Cloner<'a> {
     pub(crate) fn flush(&mut self) -> Result<(), BunError> {
         let max_package_id = self.old.packages.len();
         while let Some(to_clone) = self.clone_queue.pop() {
-            let mapping = self.mapping[to_clone.old_resolution as usize];
-            if (mapping as usize) < max_package_id {
-                self.lockfile.buffers.resolutions[to_clone.resolve_id as usize] = mapping;
+            let mapping = self.mapping[to_clone.old_resolution.index()];
+            if mapping.index() < max_package_id {
+                self.lockfile.buffers.resolutions[to_clone.resolve_id.index()] = mapping;
                 continue;
             }
 
-            let old_package = *self.old.packages.get(to_clone.old_resolution as usize);
+            let old_package = *self.old.packages.get(to_clone.old_resolution.index());
 
             // `Package::clone` reads/writes through `cloner` exclusively.
             let new_id = old_package.clone(self)?;
-            self.lockfile.buffers.resolutions[to_clone.resolve_id as usize] = new_id;
+            self.lockfile.buffers.resolutions[to_clone.resolve_id.index()] = new_id;
         }
 
         // bun.lock.rs binds these before hoisting; the hoist below has to see the same bindings.
         for pending in self.optional_peers.drain(..) {
-            let mapping = self.mapping[pending.old_resolution as usize];
-            if (mapping as usize) < max_package_id {
-                self.lockfile.buffers.resolutions[pending.resolve_id as usize] = mapping;
+            let mapping = self.mapping[pending.old_resolution.index()];
+            if mapping.index() < max_package_id {
+                self.lockfile.buffers.resolutions[pending.resolve_id.index()] = mapping;
             }
         }
 
@@ -1354,7 +1354,9 @@ impl Lockfile {
 #[derive(Clone, Copy)]
 pub struct PendingResolution {
     pub(crate) old_resolution: PackageID,
-    pub(crate) resolve_id: PackageID,
+    /// Slot in the new lockfile's `buffers.resolutions` to fill in once
+    /// `old_resolution` has been cloned.
+    pub(crate) resolve_id: DependencyID,
 }
 
 pub(crate) type PendingResolutions = Vec<PendingResolution>;
@@ -1995,14 +1997,14 @@ impl Lockfile {
     /// migration) before any manifest-driven `append_package`.
     #[inline]
     pub(crate) fn mark_loaded_packages(&mut self) {
-        self.loaded_package_count = self.packages.len() as PackageID;
+        self.loaded_package_count = self.packages.len() as u32;
     }
 
     /// Record that package `id` was appended via an exact-version dependency
     /// (`=X.Y.Z`). See the `exact_pinned` field doc.
     #[inline]
     pub(crate) fn mark_exact_pin(&mut self, id: PackageID) {
-        let i = id as usize;
+        let i = id.index();
         if self.exact_pinned.bit_length() <= i {
             bun_core::handle_oom(self.exact_pinned.resize(i + 1, false));
         }
@@ -2047,7 +2049,7 @@ impl Lockfile {
         let loaded_watermark = self.loaded_package_count;
         let exact_pinned = &self.exact_pinned;
         let try_satisfies_dedupe = |id: PackageID| -> bool {
-            let existing = &resolutions[id as usize];
+            let existing = &resolutions[id.index()];
             if existing.tag != ResolutionTag::Npm {
                 return false;
             }
@@ -2073,7 +2075,8 @@ impl Lockfile {
             // flake: a wide range (`*`, `>=X`) collapsing onto a sibling's
             // *range-resolved* lower major depending on whose manifest landed
             // first ("text lockfile is hoisted").
-            if id >= loaded_watermark && !exact_pinned.is_set_allow_out_of_bound(id as usize, false)
+            if id.get() >= loaded_watermark
+                && !exact_pinned.is_set_allow_out_of_bound(id.index(), false)
             {
                 if let Some(floor) = resolved_npm_floor {
                     if existing_ver.order(floor, buf, buf) == Ordering::Less
@@ -2088,9 +2091,9 @@ impl Lockfile {
 
         match entry {
             PackageIndexEntry::Id(id) => {
-                debug_assert!((*id as usize) < resolutions.len());
+                debug_assert!(id.index() < resolutions.len());
 
-                if resolutions[*id as usize].eql(resolution, buf, buf) {
+                if resolutions[id.index()].eql(resolution, buf, buf) {
                     return Some(*id);
                 }
 
@@ -2100,9 +2103,9 @@ impl Lockfile {
             }
             PackageIndexEntry::Ids(ids) => {
                 for &id in ids.iter() {
-                    debug_assert!((id as usize) < resolutions.len());
+                    debug_assert!(id.index() < resolutions.len());
 
-                    if resolutions[id as usize].eql(resolution, buf, buf) {
+                    if resolutions[id.index()].eql(resolution, buf, buf) {
                         return Some(id);
                     }
 
@@ -2143,7 +2146,7 @@ impl Lockfile {
                 let existing_id = *existing_id;
                 if pkg
                     .resolution
-                    .eql(&resolutions[existing_id as usize], buf, buf)
+                    .eql(&resolutions[existing_id.index()], buf, buf)
                 {
                     pkg.meta.id = existing_id;
                     return Ok(existing_id);
@@ -2157,7 +2160,7 @@ impl Lockfile {
 
                 let pair = if pkg
                     .resolution
-                    .order(&resolutions[existing_id as usize], buf, buf)
+                    .order(&resolutions[existing_id.index()], buf, buf)
                     == Ordering::Greater
                 {
                     [new_id, existing_id]
@@ -2175,7 +2178,7 @@ impl Lockfile {
                 for &existing_id in existing_ids.iter() {
                     if pkg
                         .resolution
-                        .eql(&resolutions[existing_id as usize], buf, buf)
+                        .eql(&resolutions[existing_id.index()], buf, buf)
                     {
                         pkg.meta.id = existing_id;
                         return Ok(existing_id);
@@ -2192,7 +2195,7 @@ impl Lockfile {
                     let existing_id = existing_ids[i];
                     if pkg
                         .resolution
-                        .order(&resolutions[existing_id as usize], buf, buf)
+                        .order(&resolutions[existing_id.index()], buf, buf)
                         == Ordering::Greater
                     {
                         existing_ids.insert(i, new_id);
@@ -2223,8 +2226,8 @@ impl Lockfile {
                     let resolutions = self.packages.items_resolution();
                     let buf = self.buffers.string_bytes.as_slice();
 
-                    let pair = if resolutions[id as usize].order(
-                        &resolutions[existing_id as usize],
+                    let pair = if resolutions[id.index()].order(
+                        &resolutions[existing_id.index()],
                         buf,
                         buf,
                     ) == Ordering::Greater
@@ -2244,8 +2247,8 @@ impl Lockfile {
 
                     for i in 0..existing_ids.len() {
                         let existing_id = existing_ids[i];
-                        if resolutions[id as usize].order(
-                            &resolutions[existing_id as usize],
+                        if resolutions[id.index()].order(
+                            &resolutions[existing_id.index()],
                             buf,
                             buf,
                         ) == Ordering::Greater
@@ -2266,7 +2269,7 @@ impl Lockfile {
     }
 
     pub(crate) fn append_package(&mut self, package_: &Package) -> Result<Package, AllocError> {
-        let id: PackageID = self.packages.len() as PackageID;
+        let id: PackageID = PackageID::from_index(self.packages.len());
         self.append_package_with_id(package_, id)
     }
 
@@ -2583,7 +2586,7 @@ pub mod package_index {
         /// the caller writes the real `Entry::Id(..)` / `Entry::Ids(..)`.
         #[inline]
         fn default() -> Self {
-            Entry::Id(0)
+            Entry::Id(PackageID::default())
         }
     }
 }
@@ -2653,15 +2656,15 @@ impl<'a> EqlSorter<'a> {
         let r_path = r.tree_path.slice();
         strings::order(l_path, r_path)
             .then_with(|| {
-                let l_name = self.pkg_names[l.pkg_id as usize];
-                let r_name = self.pkg_names[r.pkg_id as usize];
+                let l_name = self.pkg_names[l.pkg_id.index()];
+                let r_name = self.pkg_names[r.pkg_id.index()];
                 l_name.order(r_name, self.string_buf, self.string_buf)
             })
             // npm: aliases allow same-named packages in one tree node, so the
             // resolution is needed for a total order.
             .then_with(|| {
-                let l_res = &self.pkg_resolutions[l.pkg_id as usize];
-                let r_res = &self.pkg_resolutions[r.pkg_id as usize];
+                let l_res = &self.pkg_resolutions[l.pkg_id.index()];
+                let r_res = &self.pkg_resolutions[r.pkg_id.index()];
                 l_res.order(r_res, self.string_buf, self.string_buf)
             })
     }
@@ -2711,7 +2714,7 @@ impl Lockfile {
                 if l_dep_id == invalid_dependency_id {
                     continue;
                 }
-                let l_pkg_id = l.buffers.resolutions[l_dep_id as usize];
+                let l_pkg_id = l.buffers.resolutions[l_dep_id.index()];
                 if l_pkg_id == invalid_package_id {
                     continue;
                 }
@@ -2739,11 +2742,11 @@ impl Lockfile {
                 if r_dep_id == invalid_dependency_id {
                     continue;
                 }
-                let r_pkg_id = r.buffers.resolutions[r_dep_id as usize];
+                let r_pkg_id = r.buffers.resolutions[r_dep_id.index()];
                 if r_pkg_id == invalid_package_id {
                     continue;
                 }
-                if r_pkg_id as usize >= r_loaded_package_count {
+                if r_pkg_id.index() >= r_loaded_package_count {
                     return Ok(false);
                 }
                 sort_buf.push(PathToId {
@@ -2794,8 +2797,8 @@ impl Lockfile {
 
         debug_assert_eq!(l_buf.len(), r_buf.len());
         for (l_ids, r_ids) in l_buf.iter().zip(r_buf.iter()) {
-            let l_pkg_id = l_ids.pkg_id as usize;
-            let r_pkg_id = r_ids.pkg_id as usize;
+            let l_pkg_id = l_ids.pkg_id.index();
+            let r_pkg_id = r_ids.pkg_id.index();
             if l_pkg_name_hashes[l_pkg_id] != r_pkg_name_hashes[r_pkg_id] {
                 return Ok(false);
             }
@@ -2863,7 +2866,8 @@ impl Lockfile {
         let names: &[SemverString] = &self.packages.items_name()[..packages_len];
         let resolutions: &[Resolution] = &self.packages.items_resolution()[..packages_len];
         let bytes = self.buffers.string_bytes.as_slice();
-        let mut alphabetized_names: Vec<PackageID> = vec![0; packages_len.saturating_sub(1)];
+        let mut alphabetized_names: Vec<PackageID> =
+            vec![PackageID::default(); packages_len.saturating_sub(1)];
 
         const HASH_PREFIX: &[u8] =
             b"\n-- BEGIN SHA512/256(`${alphabetize(name)}@${order(version)}`) --\n";
@@ -2874,7 +2878,7 @@ impl Lockfile {
 
             while i + 16 < packages_len {
                 for j in 0..16usize {
-                    alphabetized_names[(i + j) - 1] = (i + j) as PackageID;
+                    alphabetized_names[(i + j) - 1] = PackageID::from_index(i + j);
                     // posix path separators because we only use posix in the lockfile
                     string_builder.fmt_count(format_args!(
                         "{}@{}\n",
@@ -2886,7 +2890,7 @@ impl Lockfile {
             }
 
             while i < packages_len {
-                alphabetized_names[i - 1] = i as PackageID;
+                alphabetized_names[i - 1] = PackageID::from_index(i);
                 // posix path separators because we only use posix in the lockfile
                 string_builder.fmt_count(format_args!(
                     "{}@{}\n",
@@ -2934,8 +2938,8 @@ impl Lockfile {
         for &i in alphabetized_names.iter() {
             let _ = string_builder.fmt(format_args!(
                 "{}@{}\n",
-                bstr::BStr::new(names[i as usize].slice(bytes)),
-                resolutions[i as usize].fmt(bytes, PathSep::Any)
+                bstr::BStr::new(names[i.index()].slice(bytes)),
+                resolutions[i.index()].fmt(bytes, PathSep::Any)
             ));
         }
 
@@ -3006,8 +3010,8 @@ impl Lockfile {
                     PackageIndexEntry::Id(id) => {
                         let resolutions = self.packages.items_resolution();
 
-                        debug_assert!((*id as usize) < resolutions.len());
-                        if satisfies(&resolutions[*id as usize]) {
+                        debug_assert!(id.index() < resolutions.len());
+                        if satisfies(&resolutions[id.index()]) {
                             return Some(*id);
                         }
                     }
@@ -3015,8 +3019,8 @@ impl Lockfile {
                         let resolutions = self.packages.items_resolution();
 
                         for &id in ids.iter() {
-                            debug_assert!((id as usize) < resolutions.len());
-                            if satisfies(&resolutions[id as usize]) {
+                            debug_assert!(id.index() < resolutions.len());
+                            if satisfies(&resolutions[id.index()]) {
                                 return Some(id);
                             }
                         }
@@ -3204,16 +3208,16 @@ impl Lockfile {
             {
                 continue;
             }
-            for dep_id in dependencies.begin()..dependencies.end() {
-                let dep = &self.buffers.dependencies[dep_id as usize];
+            for dep_id in dependencies.dependency_ids() {
+                let dep = &self.buffers.dependencies[dep_id.index()];
                 if dep.name.slice(buf) != alias {
                     continue;
                 }
-                let package_id = self.buffers.resolutions[dep_id as usize];
-                if package_id == invalid_package_id || package_id as usize >= resolutions.len() {
+                let package_id = self.buffers.resolutions[dep_id.index()];
+                if package_id == invalid_package_id || package_id.index() >= resolutions.len() {
                     continue;
                 }
-                if resolutions[package_id as usize].eql(resolution, buf, buf) {
+                if resolutions[package_id.index()].eql(resolution, buf, buf) {
                     return true;
                 }
             }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1401,8 +1401,8 @@ impl Lockfile {
         );
         let mut pkgs = self.packages.slice();
 
-        // `split_mut()` yields disjoint `&mut [_]` per column from one
-        // `&mut Slice` borrow.
+        // `split_mut()` yields a disjoint `&mut IdSlice<PackageID, _>` per
+        // column from one `&mut Slice` borrow.
         let self::package::PackageColumnsMut {
             name: pkg_names,
             name_hash: pkg_name_hashes,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -8,7 +8,7 @@ use crate::Error as BunError;
 use bun_alloc::AllocError;
 use bun_collections::{
     ArrayHashMap, ArrayIdentityContext, ArrayIdentityContextU64, DynamicBitSet,
-    HashMap as BunHashMap, IdentityContext, LinearFifo, linear_fifo::DynamicBuffer,
+    HashMap as BunHashMap, IdSlice, IdVec, IdentityContext, LinearFifo, linear_fifo::DynamicBuffer,
 };
 use bun_core::fmt::PathSep;
 use bun_core::{Global, Output};
@@ -106,7 +106,6 @@ pub type DependencySlice = ExternalSlice<Dependency>;
 pub(crate) type DependencyIDSlice = ExternalSlice<DependencyID>;
 
 pub(crate) type PackageIDList = Vec<PackageID>;
-pub(crate) type DependencyList = Vec<Dependency>;
 pub(crate) type DependencyIDList = Vec<DependencyID>;
 
 pub(crate) type StringBuffer = Vec<u8>;
@@ -228,8 +227,8 @@ impl<'a> DepSorter<'a> {
         let deps_buf = self.lockfile.buffers.dependencies.as_slice();
         let string_buf = self.lockfile.buffers.string_bytes.as_slice();
 
-        let l_dep = &deps_buf[l.index()];
-        let r_dep = &deps_buf[r.index()];
+        let l_dep = &deps_buf[l];
+        let r_dep = &deps_buf[r];
 
         match l_dep.behavior.cmp(r_dep.behavior) {
             Ordering::Less => true,
@@ -484,9 +483,14 @@ impl<'a> LoadResult<'a> {
 // ────────────────────────────────────────────────────────────────────────────
 
 impl Lockfile {
+    /// Package `id`, gathered out of the column store by value.
+    pub fn package(&self, id: PackageID) -> Package {
+        *self.packages.get(id.index())
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.packages.len() == 0
-            || (self.packages.len() == 1 && self.packages.get(0).resolutions.len == 0)
+            || (self.packages.len() == 1 && self.package(PackageID::ROOT).resolutions.len == 0)
     }
 
     pub fn load_from_cwd<'a, const ATTEMPT_LOADING_FROM_OTHER_LOCKFILE: bool>(
@@ -724,7 +728,7 @@ impl Lockfile {
             return true;
         }
 
-        let dep = &self.buffers.dependencies[dep_id.index()];
+        let dep = &self.buffers.dependencies[dep_id];
 
         dep.behavior.is_bundled() || !dep.behavior.is_enabled(features)
     }
@@ -742,7 +746,7 @@ impl Lockfile {
 
     /// Is this a direct dependency of the workspace root package.json?
     pub(crate) fn is_workspace_root_dependency(&self, id: DependencyID) -> bool {
-        self.packages.items_dependencies()[0].contains(id)
+        self.packages.items_dependencies()[PackageID::ROOT].contains(id)
     }
 
     /// Is this a direct dependency of the workspace the install is taking place in?
@@ -755,7 +759,7 @@ impl Lockfile {
         let root_id = manager
             .root_package_id
             .get(self, manager.workspace_name_hash);
-        self.packages.items_dependencies()[root_id.index()].contains(id)
+        self.packages.items_dependencies()[root_id].contains(id)
     }
 
     /// Is `id` a direct dependency of one of the `targets` workspaces?
@@ -768,11 +772,9 @@ impl Lockfile {
         if pkg_id == invalid_package_id {
             return false;
         }
-        let is_root =
-            self.packages.items_resolution()[pkg_id.index()].tag == crate::resolution::Tag::Root;
-        let hash = self.packages.items_name_hash()[pkg_id.index()];
-        let name =
-            self.packages.items_name()[pkg_id.index()].slice(self.buffers.string_bytes.as_slice());
+        let is_root = self.packages.items_resolution()[pkg_id].tag == crate::resolution::Tag::Root;
+        let hash = self.packages.items_name_hash()[pkg_id];
+        let name = self.packages.items_name()[pkg_id].slice(self.buffers.string_bytes.as_slice());
         targets.iter().any(|t| t.matches(is_root, hash, name))
     }
 
@@ -806,7 +808,7 @@ impl Lockfile {
     /// TODO(dylan-conway) fix!
     pub(crate) fn is_workspace_tree_id(&self, id: tree::Id) -> bool {
         id == 0
-            || self.buffers.dependencies[self.buffers.trees[id as usize].dependency_id.index()]
+            || self.buffers.dependencies[self.buffers.trees[id as usize].dependency_id]
                 .behavior
                 .is_workspace()
     }
@@ -819,10 +821,9 @@ impl Lockfile {
             return false;
         }
         let dependency_id = self.buffers.trees[id as usize].dependency_id;
-        let package_id = self.buffers.resolutions[dependency_id.index()];
+        let package_id = self.buffers.resolutions[dependency_id];
         package_id != invalid_package_id
-            && self.packages.slice().items_resolution()[package_id.index()].tag
-                == ResolutionTag::Folder
+            && self.packages.slice().items_resolution()[package_id].tag == ResolutionTag::Folder
     }
 
     /// Returns the package id of the workspace the install is taking place in.
@@ -873,8 +874,8 @@ impl Lockfile {
                 None => &cwd_workspace,
             };
             for &workspace_package_id in workspace_ids {
-                let dep_list = slice.items_dependencies()[workspace_package_id.index()];
-                let res_list = slice.items_resolutions()[workspace_package_id.index()];
+                let dep_list = slice.items_dependencies()[workspace_package_id];
+                let res_list = slice.items_resolutions()[workspace_package_id];
                 let workspace_deps: &[Dependency] =
                     dep_list.get(self.buffers.dependencies.as_slice());
                 let resolved_ids: &[PackageID] = res_list.get(self.buffers.resolutions.as_slice());
@@ -967,7 +968,8 @@ impl Lockfile {
         // Step 1. Recreate the lockfile with only the packages that are still alive
         let root = old.root_package().ok_or(crate::Error::NoPackage)?;
 
-        let mut package_id_mapping = vec![invalid_package_id; old.packages.len()];
+        let mut package_id_mapping: IdVec<PackageID, PackageID> =
+            vec![invalid_package_id; old.packages.len()].into();
         let clone_queue_ = PendingResolutions::new();
         // A frozen install never saves, so dropping peer-held targets could only fail its check.
         let keep_optional_peer_targets =
@@ -1210,10 +1212,11 @@ pub struct Cloner<'a> {
     pub(crate) keep_optional_peer_targets: bool,
     pub lockfile: &'a mut Lockfile,
     pub(crate) old: &'a mut Lockfile,
-    pub(crate) mapping: &'a mut [PackageID],
+    /// Old package id -> new package id (`invalid_package_id` until cloned).
+    pub(crate) mapping: &'a mut IdSlice<PackageID, PackageID>,
     pub(crate) trees_count: u32,
     pub(crate) log: &'a mut bun_ast::Log,
-    pub(crate) old_preinstall_state: Vec<Install::PreinstallState>,
+    pub(crate) old_preinstall_state: IdVec<PackageID, Install::PreinstallState>,
     pub(crate) manager: &'a mut PackageManager,
 }
 
@@ -1221,24 +1224,24 @@ impl<'a> Cloner<'a> {
     pub(crate) fn flush(&mut self) -> Result<(), BunError> {
         let max_package_id = self.old.packages.len();
         while let Some(to_clone) = self.clone_queue.pop() {
-            let mapping = self.mapping[to_clone.old_resolution.index()];
+            let mapping = self.mapping[to_clone.old_resolution];
             if mapping.index() < max_package_id {
-                self.lockfile.buffers.resolutions[to_clone.resolve_id.index()] = mapping;
+                self.lockfile.buffers.resolutions[to_clone.resolve_id] = mapping;
                 continue;
             }
 
-            let old_package = *self.old.packages.get(to_clone.old_resolution.index());
+            let old_package = self.old.package(to_clone.old_resolution);
 
             // `Package::clone` reads/writes through `cloner` exclusively.
             let new_id = old_package.clone(self)?;
-            self.lockfile.buffers.resolutions[to_clone.resolve_id.index()] = new_id;
+            self.lockfile.buffers.resolutions[to_clone.resolve_id] = new_id;
         }
 
         // bun.lock.rs binds these before hoisting; the hoist below has to see the same bindings.
         for pending in self.optional_peers.drain(..) {
-            let mapping = self.mapping[pending.old_resolution.index()];
+            let mapping = self.mapping[pending.old_resolution];
             if mapping.index() < max_package_id {
-                self.lockfile.buffers.resolutions[pending.resolve_id.index()] = mapping;
+                self.lockfile.buffers.resolutions[pending.resolve_id] = mapping;
             }
         }
 
@@ -1397,7 +1400,6 @@ impl Lockfile {
             core::ptr::NonNull::new(manager_ptr).expect("derived from &mut, non-null"),
         );
         let mut pkgs = self.packages.slice();
-        let len = pkgs.len();
 
         // `split_mut()` yields disjoint `&mut [_]` per column from one
         // `&mut Slice` borrow.
@@ -1411,10 +1413,13 @@ impl Lockfile {
         } = pkgs.split_mut();
         // One loop serves both modes: bind `pkg_metas` as an empty slice
         // when the const generic is false.
-        let pkg_metas: &mut [self::package::meta::Meta] =
-            if UPDATE_OS_CPU { meta } else { &mut [] };
+        let pkg_metas: &mut IdSlice<PackageID, self::package::meta::Meta> = if UPDATE_OS_CPU {
+            meta
+        } else {
+            IdSlice::from_raw_mut(&mut [])
+        };
 
-        for i in 0..len {
+        for i in pkg_names.ids() {
             let pkg_name = pkg_names[i];
             let pkg_name_hash = pkg_name_hashes[i];
             let pkg_res = pkg_resolutions[i];
@@ -1731,7 +1736,7 @@ impl Lockfile {
         debug_assert!(self.format == FormatVersion::current());
         let mut i: usize = 0;
         while i < self.packages.len() {
-            let package: Package = *self.packages.get(i);
+            let package = self.package(PackageID::from_index(i));
             debug_assert!(self.str(&package.name).len() == package.name.len());
             debug_assert!(
                 SemverStringBuilder::string_hash(self.str(&package.name)) == package.name_hash
@@ -1924,7 +1929,7 @@ impl Lockfile {
             return None;
         }
 
-        Some(*self.packages.get(0))
+        Some(self.package(PackageID::ROOT))
     }
 
     #[inline]
@@ -2020,7 +2025,7 @@ impl Lockfile {
         resolution: &Resolution,
     ) -> Option<PackageID> {
         let entry = self.package_index.get(&name_hash)?;
-        let resolutions: &[Resolution] = self.packages.items_resolution();
+        let resolutions = self.packages.items_resolution();
         // Borrow the `npm` arm's `Semver::Group` (not `Copy` — owns a linked
         // list head). `version` is held by-value for the whole fn body so the
         // borrow is sound.
@@ -2049,7 +2054,7 @@ impl Lockfile {
         let loaded_watermark = self.loaded_package_count;
         let exact_pinned = &self.exact_pinned;
         let try_satisfies_dedupe = |id: PackageID| -> bool {
-            let existing = &resolutions[id.index()];
+            let existing = &resolutions[id];
             if existing.tag != ResolutionTag::Npm {
                 return false;
             }
@@ -2091,9 +2096,9 @@ impl Lockfile {
 
         match entry {
             PackageIndexEntry::Id(id) => {
-                debug_assert!(id.index() < resolutions.len());
+                debug_assert!(resolutions.has(*id));
 
-                if resolutions[id.index()].eql(resolution, buf, buf) {
+                if resolutions[*id].eql(resolution, buf, buf) {
                     return Some(*id);
                 }
 
@@ -2103,9 +2108,9 @@ impl Lockfile {
             }
             PackageIndexEntry::Ids(ids) => {
                 for &id in ids.iter() {
-                    debug_assert!(id.index() < resolutions.len());
+                    debug_assert!(resolutions.has(id));
 
-                    if resolutions[id.index()].eql(resolution, buf, buf) {
+                    if resolutions[id].eql(resolution, buf, buf) {
                         return Some(id);
                     }
 
@@ -2144,10 +2149,7 @@ impl Lockfile {
         match entry.value_ptr {
             PackageIndexEntry::Id(existing_id) => {
                 let existing_id = *existing_id;
-                if pkg
-                    .resolution
-                    .eql(&resolutions[existing_id.index()], buf, buf)
-                {
+                if pkg.resolution.eql(&resolutions[existing_id], buf, buf) {
                     pkg.meta.id = existing_id;
                     return Ok(existing_id);
                 }
@@ -2158,9 +2160,7 @@ impl Lockfile {
 
                 resolutions = self.packages.items_resolution();
 
-                let pair = if pkg
-                    .resolution
-                    .order(&resolutions[existing_id.index()], buf, buf)
+                let pair = if pkg.resolution.order(&resolutions[existing_id], buf, buf)
                     == Ordering::Greater
                 {
                     [new_id, existing_id]
@@ -2176,10 +2176,7 @@ impl Lockfile {
             }
             PackageIndexEntry::Ids(existing_ids) => {
                 for &existing_id in existing_ids.iter() {
-                    if pkg
-                        .resolution
-                        .eql(&resolutions[existing_id.index()], buf, buf)
-                    {
+                    if pkg.resolution.eql(&resolutions[existing_id], buf, buf) {
                         pkg.meta.id = existing_id;
                         return Ok(existing_id);
                     }
@@ -2193,9 +2190,7 @@ impl Lockfile {
 
                 for i in 0..existing_ids.len() {
                     let existing_id = existing_ids[i];
-                    if pkg
-                        .resolution
-                        .order(&resolutions[existing_id.index()], buf, buf)
+                    if pkg.resolution.order(&resolutions[existing_id], buf, buf)
                         == Ordering::Greater
                     {
                         existing_ids.insert(i, new_id);
@@ -2226,11 +2221,8 @@ impl Lockfile {
                     let resolutions = self.packages.items_resolution();
                     let buf = self.buffers.string_bytes.as_slice();
 
-                    let pair = if resolutions[id.index()].order(
-                        &resolutions[existing_id.index()],
-                        buf,
-                        buf,
-                    ) == Ordering::Greater
+                    let pair = if resolutions[id].order(&resolutions[existing_id], buf, buf)
+                        == Ordering::Greater
                     {
                         [id, existing_id]
                     } else {
@@ -2247,11 +2239,8 @@ impl Lockfile {
 
                     for i in 0..existing_ids.len() {
                         let existing_id = existing_ids[i];
-                        if resolutions[id.index()].order(
-                            &resolutions[existing_id.index()],
-                            buf,
-                            buf,
-                        ) == Ordering::Greater
+                        if resolutions[id].order(&resolutions[existing_id], buf, buf)
+                            == Ordering::Greater
                         {
                             existing_ids.insert(i, id);
                             return Ok(());
@@ -2387,8 +2376,8 @@ impl Default for Scratch {
 /// / `overrides` / … without raw-pointer reborrow gymnastics.
 pub(crate) struct LockfileFields<'a> {
     pub(crate) packages: &'a mut PackageList,
-    pub(crate) dependencies: &'a mut DependencyList,
-    pub(crate) resolutions: &'a mut PackageIDList,
+    pub(crate) dependencies: &'a mut IdVec<DependencyID, Dependency>,
+    pub(crate) resolutions: &'a mut IdVec<DependencyID, PackageID>,
     pub(crate) overrides: &'a mut OverrideMap,
     pub(crate) catalogs: &'a mut CatalogMap,
     pub(crate) workspace_paths: &'a mut NameHashMap,
@@ -2637,8 +2626,8 @@ impl FormatVersion {
 
 struct EqlSorter<'a> {
     pub string_buf: &'a [u8],
-    pub pkg_names: &'a [SemverString],
-    pub pkg_resolutions: &'a [Resolution],
+    pub pkg_names: &'a IdSlice<PackageID, SemverString>,
+    pub pkg_resolutions: &'a IdSlice<PackageID, Resolution>,
 }
 
 /// Basically placement id
@@ -2656,15 +2645,15 @@ impl<'a> EqlSorter<'a> {
         let r_path = r.tree_path.slice();
         strings::order(l_path, r_path)
             .then_with(|| {
-                let l_name = self.pkg_names[l.pkg_id.index()];
-                let r_name = self.pkg_names[r.pkg_id.index()];
+                let l_name = self.pkg_names[l.pkg_id];
+                let r_name = self.pkg_names[r.pkg_id];
                 l_name.order(r_name, self.string_buf, self.string_buf)
             })
             // npm: aliases allow same-named packages in one tree node, so the
             // resolution is needed for a total order.
             .then_with(|| {
-                let l_res = &self.pkg_resolutions[l.pkg_id.index()];
-                let r_res = &self.pkg_resolutions[r.pkg_id.index()];
+                let l_res = &self.pkg_resolutions[l.pkg_id];
+                let r_res = &self.pkg_resolutions[r.pkg_id];
                 l_res.order(r_res, self.string_buf, self.string_buf)
             })
     }
@@ -2714,7 +2703,7 @@ impl Lockfile {
                 if l_dep_id == invalid_dependency_id {
                     continue;
                 }
-                let l_pkg_id = l.buffers.resolutions[l_dep_id.index()];
+                let l_pkg_id = l.buffers.resolutions[l_dep_id];
                 if l_pkg_id == invalid_package_id {
                     continue;
                 }
@@ -2742,7 +2731,7 @@ impl Lockfile {
                 if r_dep_id == invalid_dependency_id {
                     continue;
                 }
-                let r_pkg_id = r.buffers.resolutions[r_dep_id.index()];
+                let r_pkg_id = r.buffers.resolutions[r_dep_id];
                 if r_pkg_id == invalid_package_id {
                     continue;
                 }
@@ -2797,8 +2786,8 @@ impl Lockfile {
 
         debug_assert_eq!(l_buf.len(), r_buf.len());
         for (l_ids, r_ids) in l_buf.iter().zip(r_buf.iter()) {
-            let l_pkg_id = l_ids.pkg_id.index();
-            let r_pkg_id = r_ids.pkg_id.index();
+            let l_pkg_id = l_ids.pkg_id;
+            let r_pkg_id = r_ids.pkg_id;
             if l_pkg_name_hashes[l_pkg_id] != r_pkg_name_hashes[r_pkg_id] {
                 return Ok(false);
             }
@@ -2863,8 +2852,11 @@ impl Lockfile {
         }
 
         let mut string_builder = bun_core::StringBuilder::default();
-        let names: &[SemverString] = &self.packages.items_name()[..packages_len];
-        let resolutions: &[Resolution] = &self.packages.items_resolution()[..packages_len];
+        let names =
+            IdSlice::<PackageID, _>::from_raw(&self.packages.items_name().raw()[..packages_len]);
+        let resolutions = IdSlice::<PackageID, _>::from_raw(
+            &self.packages.items_resolution().raw()[..packages_len],
+        );
         let bytes = self.buffers.string_bytes.as_slice();
         let mut alphabetized_names: Vec<PackageID> =
             vec![invalid_package_id; packages_len.saturating_sub(1)];
@@ -2878,24 +2870,26 @@ impl Lockfile {
 
             while i + 16 < packages_len {
                 for j in 0..16usize {
-                    alphabetized_names[(i + j) - 1] = PackageID::from_index(i + j);
+                    let id = PackageID::from_index(i + j);
+                    alphabetized_names[(i + j) - 1] = id;
                     // posix path separators because we only use posix in the lockfile
                     string_builder.fmt_count(format_args!(
                         "{}@{}\n",
-                        bstr::BStr::new(names[i + j].slice(bytes)),
-                        resolutions[i + j].fmt(bytes, PathSep::Posix)
+                        bstr::BStr::new(names[id].slice(bytes)),
+                        resolutions[id].fmt(bytes, PathSep::Posix)
                     ));
                 }
                 i += 16;
             }
 
             while i < packages_len {
-                alphabetized_names[i - 1] = PackageID::from_index(i);
+                let id = PackageID::from_index(i);
+                alphabetized_names[i - 1] = id;
                 // posix path separators because we only use posix in the lockfile
                 string_builder.fmt_count(format_args!(
                     "{}@{}\n",
-                    bstr::BStr::new(names[i].slice(bytes)),
-                    resolutions[i].fmt(bytes, PathSep::Posix)
+                    bstr::BStr::new(names[id].slice(bytes)),
+                    resolutions[id].fmt(bytes, PathSep::Posix)
                 ));
                 i += 1;
             }
@@ -2925,9 +2919,9 @@ impl Lockfile {
 
         {
             let alphabetizer = package::Alphabetizer::<u64> {
-                names: names.into(),
-                buf: bytes.into(),
-                resolutions: resolutions.into(),
+                names,
+                buf: bytes,
+                resolutions,
             };
             alphabetized_names.sort_unstable_by(|a, b| alphabetizer.order(*a, *b));
         }
@@ -2938,8 +2932,8 @@ impl Lockfile {
         for &i in alphabetized_names.iter() {
             let _ = string_builder.fmt(format_args!(
                 "{}@{}\n",
-                bstr::BStr::new(names[i.index()].slice(bytes)),
-                resolutions[i.index()].fmt(bytes, PathSep::Any)
+                bstr::BStr::new(names[i].slice(bytes)),
+                resolutions[i].fmt(bytes, PathSep::Any)
             ));
         }
 
@@ -3010,8 +3004,8 @@ impl Lockfile {
                     PackageIndexEntry::Id(id) => {
                         let resolutions = self.packages.items_resolution();
 
-                        debug_assert!(id.index() < resolutions.len());
-                        if satisfies(&resolutions[id.index()]) {
+                        debug_assert!(resolutions.has(*id));
+                        if satisfies(&resolutions[*id]) {
                             return Some(*id);
                         }
                     }
@@ -3019,8 +3013,8 @@ impl Lockfile {
                         let resolutions = self.packages.items_resolution();
 
                         for &id in ids.iter() {
-                            debug_assert!(id.index() < resolutions.len());
-                            if satisfies(&resolutions[id.index()]) {
+                            debug_assert!(resolutions.has(id));
+                            if satisfies(&resolutions[id]) {
                                 return Some(id);
                             }
                         }
@@ -3209,15 +3203,15 @@ impl Lockfile {
                 continue;
             }
             for dep_id in dependencies.dependency_ids() {
-                let dep = &self.buffers.dependencies[dep_id.index()];
+                let dep = &self.buffers.dependencies[dep_id];
                 if dep.name.slice(buf) != alias {
                     continue;
                 }
-                let package_id = self.buffers.resolutions[dep_id.index()];
-                if package_id == invalid_package_id || package_id.index() >= resolutions.len() {
+                let package_id = self.buffers.resolutions[dep_id];
+                if package_id == invalid_package_id || !resolutions.has(package_id) {
                     continue;
                 }
-                if resolutions[package_id.index()].eql(resolution, buf, buf) {
+                if resolutions[package_id].eql(resolution, buf, buf) {
                     return true;
                 }
             }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -2586,7 +2586,7 @@ pub mod package_index {
         /// the caller writes the real `Entry::Id(..)` / `Entry::Ids(..)`.
         #[inline]
         fn default() -> Self {
-            Entry::Id(PackageID::default())
+            Entry::Id(invalid_package_id)
         }
     }
 }
@@ -2867,7 +2867,7 @@ impl Lockfile {
         let resolutions: &[Resolution] = &self.packages.items_resolution()[..packages_len];
         let bytes = self.buffers.string_bytes.as_slice();
         let mut alphabetized_names: Vec<PackageID> =
-            vec![PackageID::default(); packages_len.saturating_sub(1)];
+            vec![invalid_package_id; packages_len.saturating_sub(1)];
 
         const HASH_PREFIX: &[u8] =
             b"\n-- BEGIN SHA512/256(`${alphabetize(name)}@${order(version)}`) --\n";

--- a/src/install/lockfile/Buffers.rs
+++ b/src/install/lockfile/Buffers.rs
@@ -13,7 +13,10 @@ use super::{
 };
 use crate::lockfile_real as lockfile;
 use crate::package_manager_real::package_manager_options::Options as PackageManagerOptions;
-use crate::{Aligner, DependencyID, PackageID, PackageManager, dependency, invalid_package_id};
+use crate::{
+    Aligner, DependencyID, PackageID, PackageManager, dependency, invalid_dependency_id,
+    invalid_package_id,
+};
 
 #[derive(Default)]
 pub struct Buffers {
@@ -369,8 +372,8 @@ impl Buffers {
         package_id: PackageID,
     ) -> crate::Result<DependencyID> {
         match package_id {
-            0 => return Ok(tree::ROOT_DEP_ID),
-            id if id == invalid_package_id => return Ok(invalid_package_id),
+            PackageID::ROOT => return Ok(tree::ROOT_DEP_ID),
+            id if id == invalid_package_id => return Ok(invalid_dependency_id),
             _ => {
                 // `dependency_visited` is captured once outside the loop
                 // instead of re-matched per iteration (borrowck).
@@ -383,7 +386,7 @@ impl Buffers {
                             }
                             visited.set(dep_id);
                         }
-                        return Ok(dep_id as DependencyID);
+                        return Ok(DependencyID::from_index(dep_id));
                     }
                 }
             }
@@ -472,14 +475,15 @@ pub(crate) fn load(
     }
     debug_assert!(external_dependency_list.len() == this.dependencies.len());
 
-    // Legacy tree structure stores package IDs instead of dependency IDs
+    // Legacy tree structure stores package IDs instead of dependency IDs, so the
+    // `dependency_id` slots just loaded actually hold package ids.
     if !this.trees.is_empty() && this.trees[0].dependency_id != tree::ROOT_DEP_ID {
         let mut visited = Bitset::init_empty(this.dependencies.len())?;
         // Iterate by index so
         // `legacy_package_to_dependency_id` can borrow `&self` while we hold
         // `&mut this.trees[i]`.
         for i in 0..this.trees.len() {
-            let package_id = this.trees[i].dependency_id;
+            let package_id = PackageID::new(this.trees[i].dependency_id.get());
             this.trees[i].dependency_id =
                 this.legacy_package_to_dependency_id(Some(&mut visited), package_id)?;
         }
@@ -491,7 +495,7 @@ pub(crate) fn load(
             false,
         );
         for i in 0..this.hoisted_dependencies.len() {
-            let pid = this.hoisted_dependencies[i];
+            let pid = PackageID::new(this.hoisted_dependencies[i].get());
             this.hoisted_dependencies[i] =
                 this.legacy_package_to_dependency_id(Some(&mut visited), pid)?;
         }

--- a/src/install/lockfile/Buffers.rs
+++ b/src/install/lockfile/Buffers.rs
@@ -1,6 +1,7 @@
 use core::mem::size_of;
 
 use bun_collections::DynamicBitSet as Bitset;
+use bun_collections::IdVec;
 #[cfg(debug_assertions)]
 use bun_core::strings;
 
@@ -8,14 +9,14 @@ use bun_core::strings;
 // rejected by rustc (E0432: "no `super` in the root" — rust-lang/rust#48067), so the
 // parent-module alias is spelled via its crate path instead.
 use super::{
-    DependencyIDList, DependencyList, ExternalStringBuffer, Lockfile, PackageIDList, Stream,
-    StringBuffer, Tree, assert_no_uninitialized_padding, tree,
+    DependencyIDList, ExternalStringBuffer, Lockfile, Stream, StringBuffer, Tree,
+    assert_no_uninitialized_padding, tree,
 };
 use crate::lockfile_real as lockfile;
 use crate::package_manager_real::package_manager_options::Options as PackageManagerOptions;
 use crate::{
-    Aligner, DependencyID, PackageID, PackageManager, dependency, invalid_dependency_id,
-    invalid_package_id,
+    Aligner, Dependency, DependencyID, PackageID, PackageManager, dependency,
+    invalid_dependency_id, invalid_package_id,
 };
 
 #[derive(Default)]
@@ -23,10 +24,11 @@ pub struct Buffers {
     pub(crate) trees: tree::List,
     pub hoisted_dependencies: DependencyIDList,
     /// This is the underlying buffer used for the `resolutions` external slices inside of `Package`
-    /// Should be the same length as `dependencies`
-    pub resolutions: PackageIDList,
+    /// Should be the same length as `dependencies`: `resolutions[dep_id]` is the package
+    /// `dependencies[dep_id]` resolved to.
+    pub resolutions: IdVec<DependencyID, PackageID>,
     /// This is the underlying buffer used for the `dependencies` external slices inside of `Package`
-    pub dependencies: DependencyList,
+    pub dependencies: IdVec<DependencyID, Dependency>,
     /// This is the underlying buffer used for any `Semver.ExternalString` instance in the lockfile
     pub extern_strings: ExternalStringBuffer,
     /// This is where all non-inlinable `Semver.String`s are stored.
@@ -408,7 +410,7 @@ pub(crate) fn load(
 
     macro_rules! load_generic_field {
         ($field:ident, $name:literal, $elem:ty) => {{
-            this.$field = read_array::<$elem>(stream)?;
+            this.$field = read_array::<$elem>(stream)?.into();
             if let Some(pm) = pm_.as_deref() {
                 if pm.options.log_level.is_verbose() {
                     bun_core::pretty_errorln!("Loaded {} {}", this.$field.len(), $name);
@@ -458,7 +460,7 @@ pub(crate) fn load(
     let external_dependency_list = external_dependency_list_.as_slice();
     // Dependencies are serialized separately.
     // This is unfortunate. However, not using pointers for Semver Range's make the code a lot more complex.
-    this.dependencies = DependencyList::with_capacity(external_dependency_list.len());
+    this.dependencies = IdVec::with_capacity(external_dependency_list.len());
     let string_buf = this.string_bytes.as_slice();
     let mut extern_context = dependency::Context {
         log,

--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -174,7 +174,7 @@ impl OverrideMap {
         name_hash: PackageNameHash,
     ) -> Option<&'s ScopedOverride> {
         let buf = lockfile.buffers.string_bytes.as_slice();
-        let declared = &lockfile.buffers.dependencies[dependency_id as usize].version;
+        let declared = &lockfile.buffers.dependencies[dependency_id.index()].version;
         let mut owner: Option<Option<(PackageNameHash, Option<SemverVersion>)>> = None;
         let mut best: Option<(&'s ScopedOverride, u8)> = None;
 
@@ -249,7 +249,7 @@ impl OverrideMap {
         if owner_id == invalid_package_id {
             return None;
         }
-        let owner_id = owner_id as usize;
+        let owner_id = owner_id.index();
         let owner_name_hash = lockfile.packages.items_name_hash()[owner_id];
         let resolution = &lockfile.packages.items_resolution()[owner_id];
         let owner_version = match resolution.tag {
@@ -272,17 +272,17 @@ impl OverrideMap {
                 if end > index.by_dep.len() {
                     index.by_dep.resize(end, invalid_package_id);
                 }
-                index.by_dep[begin..end].fill(pkg_id as PackageID);
+                index.by_dep[begin..end].fill(PackageID::from_index(pkg_id));
             }
             index.packages_indexed = dep_slices.len();
         }
         let owner = index
             .by_dep
-            .get(dependency_id as usize)
+            .get(dependency_id.index())
             .copied()
             .unwrap_or(invalid_package_id);
         debug_assert!(
-            owner == invalid_package_id || dep_slices[owner as usize].contains(dependency_id)
+            owner == invalid_package_id || dep_slices[owner.index()].contains(dependency_id)
         );
         owner
     }

--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -6,7 +6,7 @@ use crate::Error;
 use crate::package_manager::workspace_package_json_cache::{GetJSONOptions, GetResult};
 use crate::resolution::Tag as ResolutionTag;
 use crate::{PackageID, invalid_package_id};
-use bun_collections::{ArrayHashMap, index_sort};
+use bun_collections::{ArrayHashMap, IdSlice, IdVec, index_sort};
 use bun_install::dependency::{
     self, Behavior, Dependency, DependencyExt as _, NpmAliasRegistry, Tag as VersionTag,
     VersionExt as _,
@@ -71,7 +71,7 @@ fn cmp_range_text(l: &ScopedOverride, r: &ScopedOverride, buf: &[u8]) -> Orderin
 /// dependency id -> owning package id, filled lazily because packages are only ever appended while a map is live.
 #[derive(Default)]
 struct OwnerIndex {
-    by_dep: Vec<PackageID>,
+    by_dep: IdVec<DependencyID, PackageID>,
     packages_indexed: usize,
 }
 
@@ -131,7 +131,7 @@ fn is_comment_key(key: &[u8]) -> bool {
 struct ParseContext<'a, 'b> {
     field: Field,
     pm: &'a mut PackageManager,
-    lockfile_dependencies: &'a [Dependency],
+    lockfile_dependencies: &'a IdSlice<DependencyID, Dependency>,
     root_package: &'a Package,
     log: &'a mut bun_ast::Log,
     source: &'a bun_ast::Source,
@@ -174,7 +174,7 @@ impl OverrideMap {
         name_hash: PackageNameHash,
     ) -> Option<&'s ScopedOverride> {
         let buf = lockfile.buffers.string_bytes.as_slice();
-        let declared = &lockfile.buffers.dependencies[dependency_id.index()].version;
+        let declared = &lockfile.buffers.dependencies[dependency_id].version;
         let mut owner: Option<Option<(PackageNameHash, Option<SemverVersion>)>> = None;
         let mut best: Option<(&'s ScopedOverride, u8)> = None;
 
@@ -249,7 +249,6 @@ impl OverrideMap {
         if owner_id == invalid_package_id {
             return None;
         }
-        let owner_id = owner_id.index();
         let owner_name_hash = lockfile.packages.items_name_hash()[owner_id];
         let resolution = &lockfile.packages.items_resolution()[owner_id];
         let owner_version = match resolution.tag {
@@ -266,24 +265,22 @@ impl OverrideMap {
         let mut index = self.owner_index.borrow_mut();
         let index = &mut *index;
         if index.packages_indexed < dep_slices.len() {
-            for (pkg_id, slice) in dep_slices.iter().enumerate().skip(index.packages_indexed) {
+            for (pkg_id, slice) in dep_slices.iter_enumerated().skip(index.packages_indexed) {
                 let end = (slice.end() as usize).min(dependencies_len);
                 let begin = (slice.begin() as usize).min(end);
                 if end > index.by_dep.len() {
                     index.by_dep.resize(end, invalid_package_id);
                 }
-                index.by_dep[begin..end].fill(PackageID::from_index(pkg_id));
+                index.by_dep.raw_mut()[begin..end].fill(pkg_id);
             }
             index.packages_indexed = dep_slices.len();
         }
         let owner = index
             .by_dep
-            .get(dependency_id.index())
+            .get(dependency_id)
             .copied()
             .unwrap_or(invalid_package_id);
-        debug_assert!(
-            owner == invalid_package_id || dep_slices[owner.index()].contains(dependency_id)
-        );
+        debug_assert!(owner == invalid_package_id || dep_slices[owner].contains(dependency_id));
         owner
     }
 
@@ -651,7 +648,7 @@ impl OverrideMap {
     pub(crate) fn parse_append(
         &mut self,
         pm: &mut PackageManager,
-        lockfile_dependencies: &[Dependency],
+        lockfile_dependencies: &IdSlice<DependencyID, Dependency>,
         root_package: &Package,
         log: &mut bun_ast::Log,
         json_source: &bun_ast::Source,

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -227,7 +227,7 @@ pub trait ResolverContext {
     }
     fn dep_id(&self) -> install::DependencyID {
         debug_assert!(false, "ResolverContext::dep_id called on non-git resolver");
-        0
+        install::DependencyID::default()
     }
     fn new_name(&self) -> &[u8] {
         b""
@@ -440,9 +440,9 @@ impl<SemverIntType: VersionInt> Alphabetizer<SemverIntType> {
             self.buf.slice(),
             self.resolutions.slice(),
         );
-        names[lhs as usize]
-            .order(names[rhs as usize], buf, buf)
-            .then_with(|| resolutions[lhs as usize].order(&resolutions[rhs as usize], buf, buf))
+        names[lhs.index()]
+            .order(names[rhs.index()], buf, buf)
+            .then_with(|| resolutions[lhs.index()].order(&resolutions[rhs.index()], buf, buf))
     }
 }
 
@@ -517,7 +517,7 @@ impl Package<u64> {
 
         let prev_len = new.buffers.dependencies.len() as u32;
         let end = prev_len + (old_dependencies.len() as u32);
-        let max_package_id = old.packages.len() as PackageID;
+        let old_packages_len = old.packages.len();
 
         // Grow both buffers by `old_dependencies.len()`, default-filling the
         // new tail. The zip-loops further below overwrite each slot with the
@@ -543,7 +543,7 @@ impl Package<u64> {
         // precomputed tail offset directly.
         let new_extern_strings_start = new.buffers.extern_strings.len() - new_extern_string_count;
 
-        let id = new.packages.len() as PackageID;
+        let id = PackageID::from_index(new.packages.len());
 
         // `appendPackageWithID` borrows `&mut Lockfile` whole, so build the
         // `Package` value and clone the dependency strings *first* (only needs
@@ -585,14 +585,14 @@ impl Package<u64> {
         // `self.meta.id` is range-checked at load time (bun.lockb.rs), but
         // defend here as well since an error returned from `clean_with_logger`
         // is not recoverable — it aborts the install instead of re-resolving.
-        if self.meta.id as usize >= package_id_mapping.len() {
+        if self.meta.id.index() >= package_id_mapping.len() {
             return Err(crate::Error::InvalidLockfile);
         }
-        package_id_mapping[self.meta.id as usize] = new_package.meta.id;
+        package_id_mapping[self.meta.id.index()] = new_package.meta.id;
 
         if cloner.manager.preinstall_state.len() > 0 {
-            cloner.manager.preinstall_state[new_package.meta.id as usize] =
-                cloner.old_preinstall_state[self.meta.id as usize];
+            cloner.manager.preinstall_state[new_package.meta.id.index()] =
+                cloner.old_preinstall_state[self.meta.id.index()];
         }
 
         cloner.trees_count += (old_resolutions.len() > 0) as u32;
@@ -606,14 +606,16 @@ impl Package<u64> {
             .zip(resolutions.iter_mut())
             .enumerate()
         {
-            if *old_resolution >= max_package_id {
+            if old_resolution.index() >= old_packages_len {
                 *resolution = invalid_package_id;
                 continue;
             }
 
             let pending = PendingResolution {
                 old_resolution: *old_resolution,
-                resolve_id: new_package.resolutions.off + PackageID::try_from(i).expect("int cast"),
+                resolve_id: install::DependencyID::new(
+                    new_package.resolutions.off + u32::try_from(i).expect("int cast"),
+                ),
             };
 
             // Peer slots must not keep their target alive; bound in `Cloner::flush`.
@@ -623,8 +625,8 @@ impl Package<u64> {
                 continue;
             }
 
-            let mapped = package_id_mapping[*old_resolution as usize];
-            if mapped < max_package_id {
+            let mapped = package_id_mapping[old_resolution.index()];
+            if mapped.index() < old_packages_len {
                 *resolution = mapped;
             } else {
                 cloner.clone_queue.push(pending);
@@ -1399,7 +1401,7 @@ impl Diff {
                         from_dep.name_hash,
                     )
                 {
-                    if (from_resolutions[i] as usize) < from_lockfile.packages.len() {
+                    if from_resolutions[i].index() < from_lockfile.packages.len() {
                         missing_workspaces.push(from_resolutions[i]);
                     }
                     if pm.options.enable.frozen_lockfile()
@@ -1512,7 +1514,7 @@ impl Diff {
                             .into();
                         survivors.push((workspace_pkg.name, workspace_pkg.dependencies));
 
-                        let from_pkg = from_lockfile.packages.get(from_resolutions[i] as usize);
+                        let from_pkg = from_lockfile.packages.get(from_resolutions[i].index());
                         let diff = Self::generate_inner(
                             pm,
                             log,
@@ -1545,7 +1547,7 @@ impl Diff {
                     };
 
                     if update_mapping {
-                        mapping[cur_to_i] = i as PackageID;
+                        mapping[cur_to_i] = PackageID::from_index(i);
                         continue;
                     }
                     if workspace_hooks_only {
@@ -1567,9 +1569,9 @@ impl Diff {
             if !is_explicit_update_target {
                 if let Some(mapping) = id_mapping.as_deref_mut() {
                     let from_res_id = from_resolutions[i];
-                    if (from_res_id as usize) < from_lockfile.packages.len() {
+                    if from_res_id.index() < from_lockfile.packages.len() {
                         let from_pkg_resolution =
-                            from_lockfile.packages.items_resolution()[from_res_id as usize];
+                            from_lockfile.packages.items_resolution()[from_res_id.index()];
                         let to_dep = &to_deps!()[cur_to_i];
                         if to_dep.version.tag == dependency::version::Tag::Npm
                             && from_pkg_resolution.tag == ResolutionTag::Npm
@@ -1579,7 +1581,7 @@ impl Diff {
                                 from_lockfile.buffers.string_bytes.as_slice(),
                             )
                         {
-                            mapping[cur_to_i] = i as PackageID;
+                            mapping[cur_to_i] = PackageID::from_index(i);
                             // Still counted as an update so `had_any_diffs`
                             // triggers the rebuild path; we just preserved
                             // the resolved package.
@@ -2208,7 +2210,7 @@ impl Package<u64> {
                 resolver.set_new_name(Repository::create_dependency_name_from_version_literal(
                     &repo,
                     string_builder.string_bytes.as_slice(),
-                    &lockfile.buffers.dependencies[resolver.dep_id() as usize],
+                    &lockfile.buffers.dependencies[resolver.dep_id().index()],
                 ));
 
                 string_builder.count(resolver.new_name());

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -227,7 +227,7 @@ pub trait ResolverContext {
     }
     fn dep_id(&self) -> install::DependencyID {
         debug_assert!(false, "ResolverContext::dep_id called on non-git resolver");
-        install::DependencyID::default()
+        install::INVALID_DEPENDENCY_ID
     }
     fn new_name(&self) -> &[u8] {
         b""

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1,7 +1,7 @@
 use bun_collections::VecExt;
 use core::mem;
 
-use bun_collections::{ArrayHashMap, ArrayIdentityContext, MultiArrayList, StringSet};
+use bun_collections::{ArrayHashMap, ArrayIdentityContext, IdSlice, MultiArrayList, StringSet};
 use bun_core::strings;
 use bun_core::{Global, Output};
 use bun_paths::{self as path, AutoAbsPath, MAX_PATH_BYTES, PathBuffer, resolve_path};
@@ -395,7 +395,7 @@ impl PackageField {
 }
 
 bun_collections::multi_array_columns! {
-    pub trait PackageColumns [SemverIntType: VersionInt] for Package<SemverIntType> {
+    pub trait PackageColumns [SemverIntType: VersionInt] for Package<SemverIntType>, indexed by PackageID {
         name: String,
         name_hash: PackageNameHash,
         resolution: ResolutionType<SemverIntType>,
@@ -424,25 +424,20 @@ impl<SemverIntType: VersionInt> Default for Package<SemverIntType> {
 
 pub use bun_install_types::DependencyGroup;
 
-// Borrows into lockfile.packages SoA columns + string_bytes; `RawSlice`
-// carries the outlives-holder invariant (the lockfile outlives every sort
-// pass that constructs an Alphabetizer).
-pub(crate) struct Alphabetizer<SemverIntType: VersionInt> {
-    pub names: bun_ptr::RawSlice<String>,
-    pub buf: bun_ptr::RawSlice<u8>,
-    pub resolutions: bun_ptr::RawSlice<Resolution<SemverIntType>>,
+/// Orders package ids by name, then by resolution. Borrows the lockfile's
+/// `name` and `resolution` columns plus its string bytes.
+pub(crate) struct Alphabetizer<'a, SemverIntType: VersionInt> {
+    pub names: &'a IdSlice<PackageID, String>,
+    pub buf: &'a [u8],
+    pub resolutions: &'a IdSlice<PackageID, Resolution<SemverIntType>>,
 }
 
-impl<SemverIntType: VersionInt> Alphabetizer<SemverIntType> {
+impl<SemverIntType: VersionInt> Alphabetizer<'_, SemverIntType> {
     pub(crate) fn order(&self, lhs: PackageID, rhs: PackageID) -> core::cmp::Ordering {
-        let (names, buf, resolutions) = (
-            self.names.slice(),
-            self.buf.slice(),
-            self.resolutions.slice(),
-        );
-        names[lhs.index()]
-            .order(names[rhs.index()], buf, buf)
-            .then_with(|| resolutions[lhs.index()].order(&resolutions[rhs.index()], buf, buf))
+        let (names, buf, resolutions) = (self.names, self.buf, self.resolutions);
+        names[lhs]
+            .order(names[rhs], buf, buf)
+            .then_with(|| resolutions[lhs].order(&resolutions[rhs], buf, buf))
     }
 }
 
@@ -524,13 +519,15 @@ impl Package<u64> {
         // real cloned value; pre-filling avoids ever forming `&mut T` over
         // uninitialized storage (the old `set_len`-then-assign dropped uninit).
         bun_core::vec::extend_from_fn(
-            &mut new.buffers.dependencies,
+            new.buffers.dependencies.raw_mut(),
             old_dependencies.len(),
             |_| Dependency::default(),
         );
-        bun_core::vec::extend_from_fn(&mut new.buffers.resolutions, old_dependencies.len(), |_| {
-            invalid_package_id
-        });
+        bun_core::vec::extend_from_fn(
+            new.buffers.resolutions.raw_mut(),
+            old_dependencies.len(),
+            |_| invalid_package_id,
+        );
         debug_assert_eq!(new.buffers.dependencies.len(), end as usize);
         debug_assert_eq!(new.buffers.resolutions.len(), end as usize);
 
@@ -571,7 +568,7 @@ impl Package<u64> {
 
         {
             let dependencies: &mut [Dependency] =
-                &mut new.buffers.dependencies[prev_len as usize..end as usize];
+                &mut new.buffers.dependencies.raw_mut()[prev_len as usize..end as usize];
             debug_assert_eq!(old_dependencies.len(), dependencies.len());
             for (old_dep, new_dep) in old_dependencies.iter().zip(dependencies.iter_mut()) {
                 *new_dep = old_dep.clone_in(cloner.manager, old_string_buf, &mut *builder)?;
@@ -585,20 +582,20 @@ impl Package<u64> {
         // `self.meta.id` is range-checked at load time (bun.lockb.rs), but
         // defend here as well since an error returned from `clean_with_logger`
         // is not recoverable — it aborts the install instead of re-resolving.
-        if self.meta.id.index() >= package_id_mapping.len() {
+        if !package_id_mapping.has(self.meta.id) {
             return Err(crate::Error::InvalidLockfile);
         }
-        package_id_mapping[self.meta.id.index()] = new_package.meta.id;
+        package_id_mapping[self.meta.id] = new_package.meta.id;
 
         if cloner.manager.preinstall_state.len() > 0 {
-            cloner.manager.preinstall_state[new_package.meta.id.index()] =
-                cloner.old_preinstall_state[self.meta.id.index()];
+            cloner.manager.preinstall_state[new_package.meta.id] =
+                cloner.old_preinstall_state[self.meta.id];
         }
 
         cloner.trees_count += (old_resolutions.len() > 0) as u32;
 
         let resolutions: &mut [PackageID] =
-            &mut new.buffers.resolutions[prev_len as usize..end as usize];
+            &mut new.buffers.resolutions.raw_mut()[prev_len as usize..end as usize];
         debug_assert_eq!(old_resolutions.len(), resolutions.len());
         debug_assert_eq!(old_dependencies.len(), resolutions.len());
         for (i, (old_resolution, resolution)) in old_resolutions
@@ -625,7 +622,7 @@ impl Package<u64> {
                 continue;
             }
 
-            let mapped = package_id_mapping[old_resolution.index()];
+            let mapped = package_id_mapping[*old_resolution];
             if mapped.index() < old_packages_len {
                 *resolution = mapped;
             } else {
@@ -735,12 +732,12 @@ impl Package<u64> {
 
             let dep_start = dependencies_list.len();
             bun_core::vec::extend_from_fn(
-                dependencies_list,
+                dependencies_list.raw_mut(),
                 total_dependencies_count as usize,
                 |_| Dependency::default(),
             );
             debug_assert_eq!(dependencies_list.len(), total_len);
-            let dependencies = &mut dependencies_list[dep_start..total_len];
+            let dependencies = &mut dependencies_list.raw_mut()[dep_start..total_len];
 
             total_dependencies_count = 0;
             for group in dependency_groups {
@@ -869,7 +866,7 @@ impl Package<u64> {
 
             debug_assert_eq!(resolutions_list.len(), dep_start);
             bun_core::vec::extend_from_fn(
-                resolutions_list,
+                resolutions_list.raw_mut(),
                 package.dependencies.len as usize,
                 |_| invalid_package_id,
             );
@@ -1514,7 +1511,7 @@ impl Diff {
                             .into();
                         survivors.push((workspace_pkg.name, workspace_pkg.dependencies));
 
-                        let from_pkg = from_lockfile.packages.get(from_resolutions[i].index());
+                        let from_pkg = from_lockfile.package(from_resolutions[i]);
                         let diff = Self::generate_inner(
                             pm,
                             log,
@@ -1571,7 +1568,7 @@ impl Diff {
                     let from_res_id = from_resolutions[i];
                     if from_res_id.index() < from_lockfile.packages.len() {
                         let from_pkg_resolution =
-                            from_lockfile.packages.items_resolution()[from_res_id.index()];
+                            from_lockfile.packages.items_resolution()[from_res_id];
                         let to_dep = &to_deps!()[cur_to_i];
                         if to_dep.version.tag == dependency::version::Tag::Npm
                             && from_pkg_resolution.tag == ResolutionTag::Npm
@@ -2210,7 +2207,7 @@ impl Package<u64> {
                 resolver.set_new_name(Repository::create_dependency_name_from_version_literal(
                     &repo,
                     string_builder.string_bytes.as_slice(),
-                    &lockfile.buffers.dependencies[resolver.dep_id().index()],
+                    &lockfile.buffers.dependencies[resolver.dep_id()],
                 ));
 
                 string_builder.count(resolver.new_name());

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -7,7 +7,7 @@ use bun_core::ZStr;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
 
 use crate::lockfile::package::PackageColumns as _;
-use crate::lockfile::{DepSorter, DependencyIDList, DependencyIDSlice, Lockfile};
+use crate::lockfile::{DepSorter, DependencyIDList, DependencyIDSlice, Lockfile, PackageIDSlice};
 use crate::package_manager::{PackageManager, WorkspaceFilter};
 use crate::{
     Dependency, DependencyID, PackageID, PackageNameHash, Resolution, invalid_dependency_id,
@@ -52,14 +52,15 @@ impl Default for Tree {
 pub type Id = u32;
 
 const EXTERNAL_SIZE: usize = core::mem::size_of::<Id>()
-    + core::mem::size_of::<PackageID>()
+    + core::mem::size_of::<DependencyID>()
     + core::mem::size_of::<Id>()
     + core::mem::size_of::<DependencyIDSlice>();
 
 pub(crate) type External = [u8; EXTERNAL_SIZE];
 pub type List = Vec<Tree>;
 
-pub(crate) const ROOT_DEP_ID: DependencyID = invalid_package_id - 1;
+/// The root tree node has no dependency of its own; this sentinel marks it.
+pub(crate) const ROOT_DEP_ID: DependencyID = DependencyID::new(invalid_dependency_id.get() - 1);
 pub(crate) const INVALID_ID: Id = Id::MAX;
 
 impl Tree {
@@ -92,13 +93,13 @@ impl Tree {
         if dep_id == invalid_dependency_id {
             return b"";
         }
-        deps[dep_id as usize].name.slice(buf)
+        deps[dep_id.index()].name.slice(buf)
     }
 
     pub(crate) fn to_external(self) -> External {
         let mut out: External = [0u8; EXTERNAL_SIZE];
         out[0..4].copy_from_slice(&self.id.to_ne_bytes());
-        out[4..8].copy_from_slice(&self.dependency_id.to_ne_bytes());
+        out[4..8].copy_from_slice(&self.dependency_id.get().to_ne_bytes());
         out[8..12].copy_from_slice(&self.parent.to_ne_bytes());
         out[12..16].copy_from_slice(&self.dependencies.off.to_ne_bytes());
         out[16..20].copy_from_slice(&self.dependencies.len.to_ne_bytes());
@@ -113,9 +114,9 @@ impl Tree {
     pub(crate) fn to_tree(out: External) -> Tree {
         Tree {
             id: u32::from_ne_bytes(out[0..4].try_into().expect("infallible: size matches")),
-            dependency_id: u32::from_ne_bytes(
+            dependency_id: DependencyID::new(u32::from_ne_bytes(
                 out[4..8].try_into().expect("infallible: size matches"),
-            ),
+            )),
             parent: u32::from_ne_bytes(out[8..12].try_into().expect("infallible: size matches")),
             dependencies: DependencyIDSlice::new(
                 u32::from_ne_bytes(out[12..16].try_into().expect("infallible: size matches")),
@@ -427,7 +428,7 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
     pub(crate) list: MultiArrayList<BuilderEntry>,
     pub(crate) resolutions: &'a mut [PackageID],
     pub(crate) dependencies: &'a [Dependency],
-    pub(crate) resolution_lists: &'a [DependencyIDSlice],
+    pub(crate) resolution_lists: &'a [PackageIDSlice],
     pub(crate) queue: TreeFiller,
     pub(crate) log: &'a mut bun_ast::Log,
     /// Stored as `ParentRef` (raw
@@ -516,7 +517,7 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
             // Avoid the `try_from` panic-format path on this per-tree hot loop.
             let off: u32 = dep_ids.len() as u32;
             for &dep_id in child.iter() {
-                let pkg_id = self.resolutions[dep_id as usize];
+                let pkg_id = self.resolutions[dep_id.index()];
                 if pkg_id == invalid_package_id {
                     // optional peers that never resolved
                     continue;
@@ -555,9 +556,9 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     lockfile: &Lockfile,
     resolutions: &[PackageID],
 ) -> bool {
-    let pkg_id = resolutions[dep_id as usize];
-    if (pkg_id as usize) >= lockfile.packages.len() {
-        let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
+    let pkg_id = resolutions[dep_id.index()];
+    if pkg_id.index() >= lockfile.packages.len() {
+        let dep = &lockfile.buffers.dependencies.as_slice()[dep_id.index()];
         if dep.behavior.is_optional_peer() {
             return false;
         }
@@ -569,13 +570,13 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     let pkg_metas = pkgs.items_meta();
     let pkg_resolutions = pkgs.items_resolution();
 
-    let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
-    let parent_res = &pkg_resolutions[parent_pkg_id as usize];
+    let dep = &lockfile.buffers.dependencies.as_slice()[dep_id.index()];
+    let parent_res = &pkg_resolutions[parent_pkg_id.index()];
 
-    if pkg_metas[pkg_id as usize].is_disabled(manager.options.cpu, manager.options.os) {
+    if pkg_metas[pkg_id.index()].is_disabled(manager.options.cpu, manager.options.os) {
         if manager.options.log_level.is_verbose() {
-            let meta = &pkg_metas[pkg_id as usize];
-            let name = lockfile.str(&pkg_names[pkg_id as usize]);
+            let meta = &pkg_metas[pkg_id.index()];
+            let name = lockfile.str(&pkg_names[pkg_id.index()]);
             if !meta.os.is_match(manager.options.os) && !meta.arch.is_match(manager.options.cpu) {
                 bun_core::pretty_errorln!(
                     "<d>Skip installing<r> <b>{}<r> <d>- cpu & os mismatch<r>",
@@ -611,7 +612,7 @@ pub(crate) fn is_filtered_dependency_or_workspace(
         return true;
     }
 
-    if parent_pkg_id != 0 {
+    if parent_pkg_id != PackageID::ROOT {
         return false;
     }
 
@@ -638,10 +639,10 @@ impl Tree {
         builder: &mut Builder<'_, METHOD>,
     ) -> Result<(), SubtreeError> {
         let parent_pkg_id = match dependency_id {
-            ROOT_DEP_ID => 0,
-            id => builder.resolutions[id as usize],
+            ROOT_DEP_ID => PackageID::ROOT,
+            id => builder.resolutions[id.index()],
         };
-        let resolution_list = builder.resolution_lists[parent_pkg_id as usize];
+        let resolution_list = builder.resolution_lists[parent_pkg_id.index()];
 
         if resolution_list.len == 0 {
             return Ok(());
@@ -672,13 +673,7 @@ impl Tree {
         let dependencies: &[Dependency] = builder.dependencies;
 
         builder.sort_buf.clear();
-        builder.sort_buf.reserve(resolution_list.len as usize);
-
-        for dep_id in resolution_list.begin()..resolution_list.end() {
-            // `resolution_list` bounds are u32
-            // (`ExternalSlice<u32>`); the range value is already u32-ranged.
-            builder.sort_buf.push(dep_id);
-        }
+        builder.sort_buf.extend(resolution_list.dependency_ids());
 
         {
             let sorter = DepSorter { lockfile };
@@ -698,7 +693,7 @@ impl Tree {
         let sort_buf_len = builder.sort_buf.len();
         'dep: for sort_idx in 0..sort_buf_len {
             let dep_id = builder.sort_buf[sort_idx];
-            let pkg_id = builder.resolutions[dep_id as usize];
+            let pkg_id = builder.resolutions[dep_id.index()];
 
             // filter out disabled dependencies
             if METHOD == BuilderMethod::Filter {
@@ -721,7 +716,7 @@ impl Tree {
                 }
 
                 if let Some(packages_to_install) = builder.packages_to_install {
-                    if parent_pkg_id == 0 {
+                    if parent_pkg_id == PackageID::ROOT {
                         let mut found = false;
                         for &package_to_install in packages_to_install {
                             if pkg_id == package_to_install {
@@ -737,7 +732,7 @@ impl Tree {
                 }
             }
 
-            let dependency = &dependencies[dep_id as usize];
+            let dependency = &dependencies[dep_id.index()];
 
             // An empty alias has no `node_modules/<name>` folder to escape, so
             // don't treat it as unsafe — match the lockfile parser and isolated
@@ -783,15 +778,15 @@ impl Tree {
                     continue 'dep;
                 }
 
-                if pkg_resolutions[pkg_id as usize].tag == crate::resolution::Tag::Folder {
+                if pkg_resolutions[pkg_id.index()].tag == crate::resolution::Tag::Folder {
                     // Folder packages never hoist, so a cycle between them would nest forever.
                     let mut tree_id = next_id;
                     while tree_id != INVALID_ID {
                         let tree: Tree = builder.list.items_tree()[tree_id as usize];
                         let ancestor_dep_id = tree.dependency_id;
-                        if (ancestor_dep_id as usize) < dependencies.len()
-                            && builder.resolutions[ancestor_dep_id as usize] == pkg_id
-                            && dependencies[ancestor_dep_id as usize].name_hash
+                        if ancestor_dep_id.index() < dependencies.len()
+                            && builder.resolutions[ancestor_dep_id.index()] == pkg_id
+                            && dependencies[ancestor_dep_id.index()].name_hash
                                 == dependency.name_hash
                         {
                             continue 'dep;
@@ -820,7 +815,7 @@ impl Tree {
                 HoistDependencyResult::Resolve(res_id) => {
                     debug_assert!(pkg_id == invalid_package_id);
                     debug_assert!(res_id != invalid_package_id);
-                    builder.resolutions[dep_id as usize] = res_id;
+                    builder.resolutions[dep_id.index()] = res_id;
                     debug_assert!(
                         !builder
                             .pending_optional_peers
@@ -836,10 +831,10 @@ impl Tree {
                             // the dependency should be either unresolved or the same dependency as above
                             debug_assert!(
                                 unresolved_dep_id == dep_id
-                                    || builder.resolutions[unresolved_dep_id as usize]
+                                    || builder.resolutions[unresolved_dep_id.index()]
                                         == invalid_package_id
                             );
-                            builder.resolutions[unresolved_dep_id as usize] = res_id;
+                            builder.resolutions[unresolved_dep_id.index()] = res_id;
                         }
                         // peers drops here
                     }
@@ -847,7 +842,7 @@ impl Tree {
                 HoistDependencyResult::ResolveReplace(replace) => {
                     debug_assert!(pkg_id != invalid_package_id);
                     builder.late_bound_optional_peer = true;
-                    builder.resolutions[replace.dep_id as usize] = pkg_id;
+                    builder.resolutions[replace.dep_id.index()] = pkg_id;
                     if let Some(entry) = builder
                         .pending_optional_peers
                         .fetch_swap_remove(&dependency.name_hash)
@@ -857,10 +852,10 @@ impl Tree {
                             // the dependency should be either unresolved or the same dependency as above
                             debug_assert!(
                                 unresolved_dep_id == replace.dep_id
-                                    || builder.resolutions[unresolved_dep_id as usize]
+                                    || builder.resolutions[unresolved_dep_id.index()]
                                         == invalid_package_id
                             );
-                            builder.resolutions[unresolved_dep_id as usize] = pkg_id;
+                            builder.resolutions[unresolved_dep_id.index()] = pkg_id;
                         }
                     }
                     {
@@ -873,7 +868,7 @@ impl Tree {
                         }
                     }
                     if pkg_id != invalid_package_id
-                        && builder.resolution_lists[pkg_id as usize].len > 0
+                        && builder.resolution_lists[pkg_id.index()].len > 0
                     {
                         builder.queue.write_item(FillItem {
                             tree_id: replace.id,
@@ -884,7 +879,7 @@ impl Tree {
                 }
                 HoistDependencyResult::Rebind(res_id) => {
                     debug_assert!(dependency.behavior.is_optional_peer());
-                    builder.resolutions[dep_id as usize] = res_id;
+                    builder.resolutions[dep_id.index()] = res_id;
                 }
                 HoistDependencyResult::ResolveLater => {
                     // `dep_id` is an unresolved optional peer. while hoisting it deduplicated
@@ -909,7 +904,7 @@ impl Tree {
                             .len += 1;
                     }
                     if pkg_id != invalid_package_id
-                        && builder.resolution_lists[pkg_id as usize].len > 0
+                        && builder.resolution_lists[pkg_id.index()].len > 0
                     {
                         builder.queue.write_item(FillItem {
                             tree_id: dest.id,
@@ -948,12 +943,12 @@ impl Tree {
         hoist_root_id: Id,
         package_id: PackageID,
         input_dep_id: DependencyID,
-        input_dep_range: DependencyIDSlice,
+        input_dep_range: PackageIDSlice,
         builder: &mut Builder<'_, METHOD>,
     ) -> HoistDependencyResult {
         // Copy the slice ref out of `builder` so subsequent `&mut builder` does not conflict.
         let deps: &[Dependency] = builder.dependencies;
-        let dependency: &Dependency = &deps[input_dep_id as usize];
+        let dependency: &Dependency = &deps[input_dep_id.index()];
 
         // Tree is Copy — snapshot the fields we need so we don't hold a borrow of builder.list.
         let this: Tree = builder.list.items_tree()[self_id as usize];
@@ -966,12 +961,12 @@ impl Tree {
         for &dep_id in this_deps {
             // SAFETY: `dep_id` was produced by the same lockfile that produced `deps`,
             // so it is always in bounds.
-            let dep = unsafe { deps.get_unchecked(dep_id as usize) };
+            let dep = unsafe { deps.get_unchecked(dep_id.index()) };
             if dep.name_hash != target_name_hash {
                 continue;
             }
 
-            let res_id = builder.resolutions[dep_id as usize];
+            let res_id = builder.resolutions[dep_id.index()];
 
             if res_id == invalid_package_id && package_id == invalid_package_id {
                 debug_assert!(dep.behavior.is_optional_peer());
@@ -1026,7 +1021,7 @@ impl Tree {
                     .resolve_range(builder.buf(), dependency);
                 if peer_range.tag == crate::dependency::VersionTag::Npm {
                     let resolution: Resolution =
-                        builder.lockfile().packages.items_resolution()[res_id as usize];
+                        builder.lockfile().packages.items_resolution()[res_id.index()];
                     let version = &peer_range.npm().version;
                     if resolution.tag == crate::resolution::Tag::Npm
                         && version.satisfies(resolution.npm().version, builder.buf(), builder.buf())

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -1,7 +1,7 @@
 use core::marker::ConstParamTy;
 
 use bun_alloc::AllocError;
-use bun_collections::{ArrayHashMap, DynamicBitSet, MultiArrayList};
+use bun_collections::{ArrayHashMap, DynamicBitSet, IdSlice, MultiArrayList};
 use bun_core::Output;
 use bun_core::ZStr;
 use bun_paths::{MAX_PATH_BYTES, PathBuffer, SEP};
@@ -88,12 +88,16 @@ pub(crate) fn depth_buf_uninit() -> DepthBuf {
 }
 
 impl Tree {
-    pub(crate) fn folder_name<'b>(&self, deps: &'b [Dependency], buf: &'b [u8]) -> &'b [u8] {
+    pub(crate) fn folder_name<'b>(
+        &self,
+        deps: &'b IdSlice<DependencyID, Dependency>,
+        buf: &'b [u8],
+    ) -> &'b [u8] {
         let dep_id = self.dependency_id;
         if dep_id == invalid_dependency_id {
             return b"";
         }
-        deps[dep_id.index()].name.slice(buf)
+        deps[dep_id].name.slice(buf)
     }
 
     pub(crate) fn to_external(self) -> External {
@@ -184,7 +188,7 @@ pub struct Iterator<'a, const PATH_STYLE: IteratorPathStyle> {
 
     trees: &'a [Tree],
     hoisted_dependencies: &'a [DependencyID],
-    dependencies: &'a [Dependency],
+    dependencies: &'a IdSlice<DependencyID, Dependency>,
     string_bytes: &'a [u8],
 
     pub(crate) depth_stack: DepthBuf,
@@ -224,7 +228,7 @@ impl<'a, const PATH_STYLE: IteratorPathStyle> Iterator<'a, PATH_STYLE> {
     pub(crate) fn from_slices(
         trees: &'a [Tree],
         hoisted_dependencies: &'a [DependencyID],
-        dependencies: &'a [Dependency],
+        dependencies: &'a IdSlice<DependencyID, Dependency>,
         string_bytes: &'a [u8],
     ) -> Self {
         let mut iter = Self {
@@ -309,7 +313,7 @@ pub(crate) fn folder_name_is_safe(name: &[u8]) -> bool {
 // `crate::lockfile_real` can use this without a shared `Lockfile` type.
 pub(crate) fn relative_path_and_depth<'b, const PATH_STYLE: IteratorPathStyle>(
     trees: &[Tree],
-    dependencies: &[Dependency],
+    dependencies: &IdSlice<DependencyID, Dependency>,
     string_buf: &[u8],
     tree_id: Id,
     path_buf: &'b mut PathBuffer,
@@ -426,9 +430,9 @@ pub struct Builder<'a, const METHOD: BuilderMethod> {
     // whose allocations are persistent, not arena-scoped. Global mimalloc is
     // correct here; no `&'bump Bump` threading needed.
     pub(crate) list: MultiArrayList<BuilderEntry>,
-    pub(crate) resolutions: &'a mut [PackageID],
-    pub(crate) dependencies: &'a [Dependency],
-    pub(crate) resolution_lists: &'a [PackageIDSlice],
+    pub(crate) resolutions: &'a mut IdSlice<DependencyID, PackageID>,
+    pub(crate) dependencies: &'a IdSlice<DependencyID, Dependency>,
+    pub(crate) resolution_lists: &'a IdSlice<PackageID, PackageIDSlice>,
     pub(crate) queue: TreeFiller,
     pub(crate) log: &'a mut bun_ast::Log,
     /// Stored as `ParentRef` (raw
@@ -517,7 +521,7 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
             // Avoid the `try_from` panic-format path on this per-tree hot loop.
             let off: u32 = dep_ids.len() as u32;
             for &dep_id in child.iter() {
-                let pkg_id = self.resolutions[dep_id.index()];
+                let pkg_id = self.resolutions[dep_id];
                 if pkg_id == invalid_package_id {
                     // optional peers that never resolved
                     continue;
@@ -554,11 +558,11 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     install_root_dependencies: bool,
     manager: &PackageManager,
     lockfile: &Lockfile,
-    resolutions: &[PackageID],
+    resolutions: &IdSlice<DependencyID, PackageID>,
 ) -> bool {
-    let pkg_id = resolutions[dep_id.index()];
+    let pkg_id = resolutions[dep_id];
     if pkg_id.index() >= lockfile.packages.len() {
-        let dep = &lockfile.buffers.dependencies.as_slice()[dep_id.index()];
+        let dep = &lockfile.buffers.dependencies.as_slice()[dep_id];
         if dep.behavior.is_optional_peer() {
             return false;
         }
@@ -570,13 +574,13 @@ pub(crate) fn is_filtered_dependency_or_workspace(
     let pkg_metas = pkgs.items_meta();
     let pkg_resolutions = pkgs.items_resolution();
 
-    let dep = &lockfile.buffers.dependencies.as_slice()[dep_id.index()];
-    let parent_res = &pkg_resolutions[parent_pkg_id.index()];
+    let dep = &lockfile.buffers.dependencies.as_slice()[dep_id];
+    let parent_res = &pkg_resolutions[parent_pkg_id];
 
-    if pkg_metas[pkg_id.index()].is_disabled(manager.options.cpu, manager.options.os) {
+    if pkg_metas[pkg_id].is_disabled(manager.options.cpu, manager.options.os) {
         if manager.options.log_level.is_verbose() {
-            let meta = &pkg_metas[pkg_id.index()];
-            let name = lockfile.str(&pkg_names[pkg_id.index()]);
+            let meta = &pkg_metas[pkg_id];
+            let name = lockfile.str(&pkg_names[pkg_id]);
             if !meta.os.is_match(manager.options.os) && !meta.arch.is_match(manager.options.cpu) {
                 bun_core::pretty_errorln!(
                     "<d>Skip installing<r> <b>{}<r> <d>- cpu & os mismatch<r>",
@@ -640,9 +644,9 @@ impl Tree {
     ) -> Result<(), SubtreeError> {
         let parent_pkg_id = match dependency_id {
             ROOT_DEP_ID => PackageID::ROOT,
-            id => builder.resolutions[id.index()],
+            id => builder.resolutions[id],
         };
-        let resolution_list = builder.resolution_lists[parent_pkg_id.index()];
+        let resolution_list = builder.resolution_lists[parent_pkg_id];
 
         if resolution_list.len == 0 {
             return Ok(());
@@ -670,7 +674,7 @@ impl Tree {
         let pkg_resolutions = pkgs.items_resolution();
         // reshaped for borrowck — copy the `&'a [Dependency]` out of
         // `builder` so `&dependencies[i]` does not keep `builder` borrowed.
-        let dependencies: &[Dependency] = builder.dependencies;
+        let dependencies = builder.dependencies;
 
         builder.sort_buf.clear();
         builder.sort_buf.extend(resolution_list.dependency_ids());
@@ -693,7 +697,7 @@ impl Tree {
         let sort_buf_len = builder.sort_buf.len();
         'dep: for sort_idx in 0..sort_buf_len {
             let dep_id = builder.sort_buf[sort_idx];
-            let pkg_id = builder.resolutions[dep_id.index()];
+            let pkg_id = builder.resolutions[dep_id];
 
             // filter out disabled dependencies
             if METHOD == BuilderMethod::Filter {
@@ -732,7 +736,7 @@ impl Tree {
                 }
             }
 
-            let dependency = &dependencies[dep_id.index()];
+            let dependency = &dependencies[dep_id];
 
             // An empty alias has no `node_modules/<name>` folder to escape, so
             // don't treat it as unsafe — match the lockfile parser and isolated
@@ -778,16 +782,15 @@ impl Tree {
                     continue 'dep;
                 }
 
-                if pkg_resolutions[pkg_id.index()].tag == crate::resolution::Tag::Folder {
+                if pkg_resolutions[pkg_id].tag == crate::resolution::Tag::Folder {
                     // Folder packages never hoist, so a cycle between them would nest forever.
                     let mut tree_id = next_id;
                     while tree_id != INVALID_ID {
                         let tree: Tree = builder.list.items_tree()[tree_id as usize];
                         let ancestor_dep_id = tree.dependency_id;
-                        if ancestor_dep_id.index() < dependencies.len()
-                            && builder.resolutions[ancestor_dep_id.index()] == pkg_id
-                            && dependencies[ancestor_dep_id.index()].name_hash
-                                == dependency.name_hash
+                        if dependencies.has(ancestor_dep_id)
+                            && builder.resolutions[ancestor_dep_id] == pkg_id
+                            && dependencies[ancestor_dep_id].name_hash == dependency.name_hash
                         {
                             continue 'dep;
                         }
@@ -815,7 +818,7 @@ impl Tree {
                 HoistDependencyResult::Resolve(res_id) => {
                     debug_assert!(pkg_id == invalid_package_id);
                     debug_assert!(res_id != invalid_package_id);
-                    builder.resolutions[dep_id.index()] = res_id;
+                    builder.resolutions[dep_id] = res_id;
                     debug_assert!(
                         !builder
                             .pending_optional_peers
@@ -831,10 +834,9 @@ impl Tree {
                             // the dependency should be either unresolved or the same dependency as above
                             debug_assert!(
                                 unresolved_dep_id == dep_id
-                                    || builder.resolutions[unresolved_dep_id.index()]
-                                        == invalid_package_id
+                                    || builder.resolutions[unresolved_dep_id] == invalid_package_id
                             );
-                            builder.resolutions[unresolved_dep_id.index()] = res_id;
+                            builder.resolutions[unresolved_dep_id] = res_id;
                         }
                         // peers drops here
                     }
@@ -842,7 +844,7 @@ impl Tree {
                 HoistDependencyResult::ResolveReplace(replace) => {
                     debug_assert!(pkg_id != invalid_package_id);
                     builder.late_bound_optional_peer = true;
-                    builder.resolutions[replace.dep_id.index()] = pkg_id;
+                    builder.resolutions[replace.dep_id] = pkg_id;
                     if let Some(entry) = builder
                         .pending_optional_peers
                         .fetch_swap_remove(&dependency.name_hash)
@@ -852,10 +854,9 @@ impl Tree {
                             // the dependency should be either unresolved or the same dependency as above
                             debug_assert!(
                                 unresolved_dep_id == replace.dep_id
-                                    || builder.resolutions[unresolved_dep_id.index()]
-                                        == invalid_package_id
+                                    || builder.resolutions[unresolved_dep_id] == invalid_package_id
                             );
-                            builder.resolutions[unresolved_dep_id.index()] = pkg_id;
+                            builder.resolutions[unresolved_dep_id] = pkg_id;
                         }
                     }
                     {
@@ -867,9 +868,7 @@ impl Tree {
                             }
                         }
                     }
-                    if pkg_id != invalid_package_id
-                        && builder.resolution_lists[pkg_id.index()].len > 0
-                    {
+                    if pkg_id != invalid_package_id && builder.resolution_lists[pkg_id].len > 0 {
                         builder.queue.write_item(FillItem {
                             tree_id: replace.id,
                             dependency_id: dep_id,
@@ -879,7 +878,7 @@ impl Tree {
                 }
                 HoistDependencyResult::Rebind(res_id) => {
                     debug_assert!(dependency.behavior.is_optional_peer());
-                    builder.resolutions[dep_id.index()] = res_id;
+                    builder.resolutions[dep_id] = res_id;
                 }
                 HoistDependencyResult::ResolveLater => {
                     // `dep_id` is an unresolved optional peer. while hoisting it deduplicated
@@ -903,9 +902,7 @@ impl Tree {
                             .dependencies
                             .len += 1;
                     }
-                    if pkg_id != invalid_package_id
-                        && builder.resolution_lists[pkg_id.index()].len > 0
-                    {
+                    if pkg_id != invalid_package_id && builder.resolution_lists[pkg_id].len > 0 {
                         builder.queue.write_item(FillItem {
                             tree_id: dest.id,
                             dependency_id: dep_id,
@@ -947,8 +944,8 @@ impl Tree {
         builder: &mut Builder<'_, METHOD>,
     ) -> HoistDependencyResult {
         // Copy the slice ref out of `builder` so subsequent `&mut builder` does not conflict.
-        let deps: &[Dependency] = builder.dependencies;
-        let dependency: &Dependency = &deps[input_dep_id.index()];
+        let deps = builder.dependencies;
+        let dependency: &Dependency = &deps[input_dep_id];
 
         // Tree is Copy — snapshot the fields we need so we don't hold a borrow of builder.list.
         let this: Tree = builder.list.items_tree()[self_id as usize];
@@ -966,7 +963,7 @@ impl Tree {
                 continue;
             }
 
-            let res_id = builder.resolutions[dep_id.index()];
+            let res_id = builder.resolutions[dep_id];
 
             if res_id == invalid_package_id && package_id == invalid_package_id {
                 debug_assert!(dep.behavior.is_optional_peer());
@@ -1021,7 +1018,7 @@ impl Tree {
                     .resolve_range(builder.buf(), dependency);
                 if peer_range.tag == crate::dependency::VersionTag::Npm {
                     let resolution: Resolution =
-                        builder.lockfile().packages.items_resolution()[res_id.index()];
+                        builder.lockfile().packages.items_resolution()[res_id];
                     let version = &peer_range.npm().version;
                     if resolution.tag == crate::resolution::Tag::Npm
                         && version.satisfies(resolution.npm().version, builder.buf(), builder.buf())

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -548,7 +548,7 @@ impl<'a, const METHOD: BuilderMethod> Builder<'a, METHOD> {
 // is_filtered_dependency_or_workspace
 // ──────────────────────────────────────────────────────────────────────────
 
-// `Builder` holds a live `&mut [PackageID]` over the resolutions buffer (see
+// `Builder` holds a live `&mut` view of the resolutions buffer (see
 // `Builder.lockfile` safety contract), so callers must thread `resolutions`
 // explicitly to avoid an aliasing read through the shared `&Lockfile`.
 pub(crate) fn is_filtered_dependency_or_workspace(

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -155,8 +155,8 @@ struct TreeDepsSortCtx<'a> {
 
 impl<'a> TreeDepsSortCtx<'a> {
     fn is_less_than(&self, lhs: DependencyID, rhs: DependencyID) -> bool {
-        let l = &self.deps_buf[lhs as usize];
-        let r = &self.deps_buf[rhs as usize];
+        let l = &self.deps_buf[lhs.index()];
+        let r = &self.deps_buf[rhs.index()];
         strings::cmp_strings_asc(
             (),
             l.name.slice(self.string_buf),
@@ -244,11 +244,11 @@ impl Stringifier {
 
         while let Some(node) = iter.next(None) {
             for &dep_id in node.dependencies {
-                let pkg_id = resolution_buf[dep_id as usize];
+                let pkg_id = resolution_buf[dep_id.index()];
                 if pkg_id == invalid_package_id {
                     continue;
                 }
-                let i = pkg_id as usize;
+                let i = pkg_id.index();
                 let res = &pkg_resolutions[i];
                 match res.tag {
                     ResolutionTag::Npm => {
@@ -343,7 +343,7 @@ impl Stringifier {
         if load_result.loaded_from_binary_lockfile() || load_result.migrated_from_pnpm() {
             while let Some(node) = pkgs_iter.next(None) {
                 for &dep_id in node.dependencies {
-                    let dep = &deps_buf[dep_id as usize];
+                    let dep = &deps_buf[dep_id.index()];
 
                     // clobber, there isn't data
                     let mut key: Vec<u8> = Vec::new();
@@ -384,7 +384,7 @@ impl Stringifier {
                 Self::write_workspace_deps(
                     writer,
                     indent,
-                    0,
+                    PackageID::ROOT,
                     String::default(),
                     pkg_names,
                     pkg_name_hashes,
@@ -403,8 +403,8 @@ impl Stringifier {
                 let mut workspace_sort_buf: Vec<PackageID> = Vec::new();
 
                 for _pkg_id in 0..pkgs.len() {
-                    let pkg_id: PackageID = u32::try_from(_pkg_id).expect("int cast");
-                    let res = &pkg_resolutions[pkg_id as usize];
+                    let pkg_id = PackageID::try_from(_pkg_id).expect("int cast");
+                    let res = &pkg_resolutions[pkg_id.index()];
                     if res.tag != ResolutionTag::Workspace {
                         continue;
                     }
@@ -413,13 +413,13 @@ impl Stringifier {
 
                 // local Sorter struct → closure
                 workspace_sort_buf.sort_by(|&l, &r| {
-                    let l_res = &pkg_resolutions[l as usize];
-                    let r_res = &pkg_resolutions[r as usize];
+                    let l_res = &pkg_resolutions[l.index()];
+                    let r_res = &pkg_resolutions[r.index()];
                     l_res.workspace().order(*r_res.workspace(), buf, buf)
                 });
 
                 for &workspace_pkg_id in &workspace_sort_buf {
-                    let res = &pkg_resolutions[workspace_pkg_id as usize];
+                    let res = &pkg_resolutions[workspace_pkg_id.index()];
                     writer.write_all(b"\n")?;
                     Self::write_indent(writer, *indent)?;
                     Self::write_workspace_deps(
@@ -439,7 +439,7 @@ impl Stringifier {
                         &lockfile.workspace_versions,
                         &mut optional_peers_buf,
                         &pkg_map,
-                        pkg_names[workspace_pkg_id as usize].slice(buf),
+                        pkg_names[workspace_pkg_id.index()].slice(buf),
                         &mut path_buf,
                     )?;
                 }
@@ -471,15 +471,15 @@ impl Stringifier {
                 ));
 
                 for &dep_id in node.dependencies {
-                    let pkg_id = resolution_buf[dep_id as usize];
+                    let pkg_id = resolution_buf[dep_id.index()];
                     if pkg_id == invalid_package_id {
                         continue;
                     }
 
-                    let pkg_name = pkg_names[pkg_id as usize];
-                    let pkg_name_hash = pkg_name_hashes[pkg_id as usize];
-                    let res = &pkg_resolutions[pkg_id as usize];
-                    let dep = &deps_buf[dep_id as usize];
+                    let pkg_name = pkg_names[pkg_id.index()];
+                    let pkg_name_hash = pkg_name_hashes[pkg_id.index()];
+                    let res = &pkg_resolutions[pkg_id.index()];
+                    let dep = &deps_buf[dep_id.index()];
 
                     if lockfile.patched_dependencies.count() > 0 {
                         use std::io::Write;
@@ -688,12 +688,12 @@ impl Stringifier {
                 }
 
                 for &dep_id in &tree_deps_sort_buf {
-                    let pkg_id = resolution_buf[dep_id as usize];
+                    let pkg_id = resolution_buf[dep_id.index()];
                     if pkg_id == invalid_package_id {
                         continue;
                     }
 
-                    let res = &pkg_resolutions[pkg_id as usize];
+                    let res = &pkg_resolutions[pkg_id.index()];
                     match res.tag {
                         ResolutionTag::Root
                         | ResolutionTag::Npm
@@ -734,7 +734,7 @@ impl Stringifier {
                         writer.write_byte(b'/')?;
                     }
 
-                    let dep = &deps_buf[dep_id as usize];
+                    let dep = &deps_buf[dep_id.index()];
                     let dep_name = dep.name.slice(buf);
 
                     pkg_key_buf.clear();
@@ -756,16 +756,13 @@ impl Stringifier {
                         ),
                     )?;
 
-                    let pkg_name = pkg_names[pkg_id as usize];
-                    let pkg_meta = &pkg_metas[pkg_id as usize];
-                    let pkg_bin = &pkg_bins[pkg_id as usize];
-                    let pkg_deps_list = pkg_dep_lists[pkg_id as usize];
+                    let pkg_name = pkg_names[pkg_id.index()];
+                    let pkg_meta = &pkg_metas[pkg_id.index()];
+                    let pkg_bin = &pkg_bins[pkg_id.index()];
+                    let pkg_deps_list = pkg_dep_lists[pkg_id.index()];
 
                     pkg_deps_sort_buf.clear();
-                    pkg_deps_sort_buf.reserve(pkg_deps_list.len as usize);
-                    for pkg_dep_id in pkg_deps_list.begin()..pkg_deps_list.end() {
-                        pkg_deps_sort_buf.push(pkg_dep_id);
-                    }
+                    pkg_deps_sort_buf.extend(pkg_deps_list.dependency_ids());
 
                     // there might be duplicate names due to dependency behaviors,
                     // but we print behaviors in different groups so it won't affect
@@ -1089,7 +1086,7 @@ impl Stringifier {
         for &(group_name, group_behavior) in WORKSPACE_DEPENDENCY_GROUPS.iter() {
             let mut first = true;
             for &dep_id in pkg_dep_ids {
-                let dep = &deps_buf[dep_id as usize];
+                let dep = &deps_buf[dep_id.index()];
                 if !dep.behavior.intersects(group_behavior) {
                     continue;
                 }
@@ -1264,7 +1261,7 @@ impl Stringifier {
 
         // always print the workspace key even if it doesn't have dependencies because we
         // need a way to detect new/deleted workspaces
-        if pkg_id == 0 {
+        if pkg_id == PackageID::ROOT {
             writer.write_all(b"\"\": {")?;
             let root_name = pkg_names[0].slice(buf);
             if !root_name.is_empty() {
@@ -1291,19 +1288,19 @@ impl Stringifier {
                 writer,
                 "\"name\": {}",
                 bun_core::fmt::format_json_string_utf8(
-                    pkg_names[pkg_id as usize].slice(buf),
+                    pkg_names[pkg_id.index()].slice(buf),
                     Default::default()
                 ),
             )?;
 
-            if let Some(version) = workspace_versions.get(&pkg_name_hashes[pkg_id as usize]) {
+            if let Some(version) = workspace_versions.get(&pkg_name_hashes[pkg_id.index()]) {
                 writer.write_all(b",\n")?;
                 Self::write_indent(writer, *indent)?;
                 write!(writer, "\"version\": \"{}\"", version.fmt(buf))?;
             }
 
-            if pkg_bins[pkg_id as usize].tag != BinTag::None {
-                let bin = &pkg_bins[pkg_id as usize];
+            if pkg_bins[pkg_id.index()].tag != BinTag::None {
+                let bin = &pkg_bins[pkg_id.index()];
                 writer.write_all(b",\n")?;
                 Self::write_indent(writer, *indent)?;
                 if bin.tag == BinTag::Dir {
@@ -1325,7 +1322,7 @@ impl Stringifier {
 
         for &(group_name, group_behavior) in WORKSPACE_DEPENDENCY_GROUPS.iter() {
             let mut first = true;
-            for dep in pkg_deps[pkg_id as usize].get(deps_buf) {
+            for dep in pkg_deps[pkg_id.index()].get(deps_buf) {
                 if !dep.behavior.intersects(group_behavior) {
                     continue;
                 }
@@ -2403,10 +2400,10 @@ pub(crate) fn parse_into_binary_lockfile(
         root_pkg.dependencies = DependencySlice::new(off, len);
         root_pkg.resolutions = PackageIDSlice::new(off, len);
 
-        root_pkg.meta.id = 0;
+        root_pkg.meta.id = PackageID::ROOT;
         let root_name_hash = root_pkg.name_hash;
         lockfile.packages.append(root_pkg)?;
-        lockfile.get_or_put_id(0, root_name_hash)?;
+        lockfile.get_or_put_id(PackageID::ROOT, root_name_hash)?;
     }
 
     let mut pkg_map: PkgMap<PackageID> = PkgMap::init();
@@ -2718,9 +2715,9 @@ pub(crate) fn parse_into_binary_lockfile(
                     for _workspace_pkg_id in
                         workspace_pkgs_off..workspace_pkgs_off + workspace_pkgs_len
                     {
-                        let workspace_pkg_id: PackageID = _workspace_pkg_id;
+                        let workspace_pkg_id = PackageID::new(_workspace_pkg_id);
                         if res.eql(
-                            &pkg_resolutions[workspace_pkg_id as usize],
+                            &pkg_resolutions[workspace_pkg_id.index()],
                             lockfile.buffers.string_bytes.as_slice(),
                             lockfile.buffers.string_bytes.as_slice(),
                         ) {
@@ -2728,7 +2725,7 @@ pub(crate) fn parse_into_binary_lockfile(
                             {
                                 debug_assert!(!strings::eql_long(
                                     pkg_path,
-                                    pkg_names[workspace_pkg_id as usize]
+                                    pkg_names[workspace_pkg_id.index()]
                                         .slice(lockfile.buffers.string_bytes.as_slice()),
                                     true,
                                 ));
@@ -3084,9 +3081,8 @@ pub(crate) fn parse_into_binary_lockfile(
 
         {
             // first the root dependencies are resolved
-            for _dep_id in pkg_deps[0].begin()..pkg_deps[0].end() {
-                let dep_id: DependencyID = _dep_id;
-                let dep = &mut dependencies[dep_id as usize];
+            for dep_id in pkg_deps[0].dependency_ids() {
+                let dep = &mut dependencies[dep_id.index()];
 
                 let peer_res_id = resolve_peer_dep_version_based(
                     dep,
@@ -3118,7 +3114,7 @@ pub(crate) fn parse_into_binary_lockfile(
                         .get_or_put(dep.name.slice(string_buf))?
                         .found_existing
                 {
-                    resolutions[dep_id as usize] = res_id;
+                    resolutions[dep_id.index()] = res_id;
                     continue;
                 }
 
@@ -3138,15 +3134,14 @@ pub(crate) fn parse_into_binary_lockfile(
         if lockfile_version != Version::V0 {
             // then workspace dependencies are resolved
             for _pkg_id in workspace_pkgs_off..workspace_pkgs_off + workspace_pkgs_len {
-                let pkg_id: PackageID = _pkg_id;
-                let workspace_name = pkg_names[pkg_id as usize].slice(string_buf);
+                let pkg_id = PackageID::new(_pkg_id);
+                let workspace_name = pkg_names[pkg_id.index()].slice(string_buf);
 
                 seen_deps.clear_retaining_capacity();
 
-                let deps = pkg_deps[pkg_id as usize];
-                for _dep_id in deps.begin()..deps.end() {
-                    let dep_id: DependencyID = _dep_id;
-                    let dep = &mut dependencies[dep_id as usize];
+                let deps = pkg_deps[pkg_id.index()];
+                for dep_id in deps.dependency_ids() {
+                    let dep = &mut dependencies[dep_id.index()];
                     let dep_name = dep.name.slice(string_buf);
 
                     let workspace_node_modules = {
@@ -3199,7 +3194,7 @@ pub(crate) fn parse_into_binary_lockfile(
                     };
 
                     if seen_deps.get_or_put(dep_name)?.found_existing {
-                        resolutions[dep_id as usize] = res_id;
+                        resolutions[dep_id.index()] = res_id;
                         continue;
                     }
 
@@ -3223,7 +3218,7 @@ pub(crate) fn parse_into_binary_lockfile(
                 return Err(ParseError::InvalidPackagesObject);
             };
 
-            let res = &pkg_resolutions[pkg_id as usize];
+            let res = &pkg_resolutions[pkg_id.index()];
 
             if res.tag == ResolutionTag::Workspace {
                 // we've already resolved the workspace dependencies above
@@ -3231,10 +3226,9 @@ pub(crate) fn parse_into_binary_lockfile(
             }
 
             // find resolutions. iterate up to root through the pkg path.
-            let deps = pkg_deps[pkg_id as usize];
-            'deps: for _dep_id in deps.begin()..deps.end() {
-                let dep_id: DependencyID = _dep_id;
-                let dep = &mut dependencies[dep_id as usize];
+            let deps = pkg_deps[pkg_id.index()];
+            'deps: for dep_id in deps.dependency_ids() {
+                let dep = &mut dependencies[dep_id.index()];
 
                 // A stripped `catalog:` edge (`CatalogMap::strip_reference`) stays unresolved, as in a fresh install.
                 if dep.version.tag == DependencyVersionTag::Uninitialized {
@@ -3409,8 +3403,8 @@ pub(crate) fn resolve_peer_dep_version_based(
 
     let candidates = package_index.get(&name_hash)?.as_slice();
     for &id in candidates {
-        if (id as usize) < pkg_resolutions.len()
-            && pkg_resolutions[id as usize]
+        if id.index() < pkg_resolutions.len()
+            && pkg_resolutions[id.index()]
                 .satisfies_dependency_version(range, string_buf, string_buf)
         {
             return Some(id);
@@ -3418,8 +3412,8 @@ pub(crate) fn resolve_peer_dep_version_based(
     }
 
     let &first = candidates.first()?;
-    if (first as usize) < pkg_resolutions.len() {
-        let res_tag = pkg_resolutions[first as usize].tag;
+    if first.index() < pkg_resolutions.len() {
+        let res_tag = pkg_resolutions[first.index()].tag;
         let ver_tag = range.tag;
         if (res_tag == ResolutionTag::Npm && ver_tag == DependencyVersionTag::Npm)
             || (res_tag == ResolutionTag::Git && ver_tag == DependencyVersionTag::Git)
@@ -3445,10 +3439,10 @@ fn map_dep_to_pkg(
     text_lockfile_version: Version,
     pkg_resolutions: &[Resolution],
 ) {
-    resolutions[dep_id as usize] = pkg_id;
+    resolutions[dep_id.index()] = pkg_id;
 
     if text_lockfile_version != Version::V0 {
-        let res = &pkg_resolutions[pkg_id as usize];
+        let res = &pkg_resolutions[pkg_id.index()];
         if res.tag == ResolutionTag::Workspace {
             // Whole-struct assign so `DependencyVersion::Drop` frees any prior
             // npm chain. SAFETY: `res.tag == Workspace` checked above.

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -4,7 +4,7 @@ use core::fmt::Write as _;
 
 use crate::bun_json as JSON;
 use bun_ast::{Expr, expr::Data as ExprData};
-use bun_collections::{HashContext, HashMap, StringHashMap};
+use bun_collections::{HashContext, HashMap, IdSlice, StringHashMap};
 use bun_core::strings;
 use bun_core::{self};
 use bun_paths::PathBuffer;
@@ -150,13 +150,13 @@ impl Version {
 /// only string compare
 struct TreeDepsSortCtx<'a> {
     string_buf: &'a [u8],
-    deps_buf: &'a [Dependency],
+    deps_buf: &'a IdSlice<DependencyID, Dependency>,
 }
 
 impl<'a> TreeDepsSortCtx<'a> {
     fn is_less_than(&self, lhs: DependencyID, rhs: DependencyID) -> bool {
-        let l = &self.deps_buf[lhs.index()];
-        let r = &self.deps_buf[rhs.index()];
+        let l = &self.deps_buf[lhs];
+        let r = &self.deps_buf[rhs];
         strings::cmp_strings_asc(
             (),
             l.name.slice(self.string_buf),
@@ -232,8 +232,8 @@ impl Stringifier {
         let deps_buf = lockfile.buffers.dependencies.as_slice();
         let resolution_buf = lockfile.buffers.resolutions.as_slice();
         let pkgs = lockfile.packages.slice();
-        let pkg_resolutions: &[Resolution] = pkgs.items_resolution();
-        let pkg_metas: &[Meta] = pkgs.items_meta();
+        let pkg_resolutions = pkgs.items_resolution();
+        let pkg_metas = pkgs.items_meta();
 
         let mut iter = tree::Iterator::<'_, { tree::IteratorPathStyle::PkgPath }>::from_slices(
             lockfile.buffers.trees.as_slice(),
@@ -244,15 +244,14 @@ impl Stringifier {
 
         while let Some(node) = iter.next(None) {
             for &dep_id in node.dependencies {
-                let pkg_id = resolution_buf[dep_id.index()];
+                let pkg_id = resolution_buf[dep_id];
                 if pkg_id == invalid_package_id {
                     continue;
                 }
-                let i = pkg_id.index();
-                let res = &pkg_resolutions[i];
+                let res = &pkg_resolutions[pkg_id];
                 match res.tag {
                     ResolutionTag::Npm => {
-                        if pkg_metas[i].integrity.tag.is_supported() {
+                        if pkg_metas[pkg_id].integrity.tag.is_supported() {
                             continue;
                         }
                         // No supported integrity: only v2-clean if the tarball
@@ -302,11 +301,11 @@ impl Stringifier {
         let deps_buf = lockfile.buffers.dependencies.as_slice();
         let resolution_buf = lockfile.buffers.resolutions.as_slice();
         let pkgs = lockfile.packages.slice();
-        let pkg_dep_lists: &[DependencySlice] = pkgs.items_dependencies();
-        let pkg_resolutions: &[Resolution] = pkgs.items_resolution();
-        let pkg_names: &[String] = pkgs.items_name();
-        let pkg_name_hashes: &[PackageNameHash] = pkgs.items_name_hash();
-        let pkg_metas: &[Meta] = pkgs.items_meta();
+        let pkg_dep_lists = pkgs.items_dependencies();
+        let pkg_resolutions = pkgs.items_resolution();
+        let pkg_names = pkgs.items_name();
+        let pkg_name_hashes = pkgs.items_name_hash();
+        let pkg_metas = pkgs.items_meta();
         let pkg_bins = pkgs.items_bin();
 
         let mut temp_buf: Vec<u8> = Vec::new();
@@ -343,7 +342,7 @@ impl Stringifier {
         if load_result.loaded_from_binary_lockfile() || load_result.migrated_from_pnpm() {
             while let Some(node) = pkgs_iter.next(None) {
                 for &dep_id in node.dependencies {
-                    let dep = &deps_buf[dep_id.index()];
+                    let dep = &deps_buf[dep_id];
 
                     // clobber, there isn't data
                     let mut key: Vec<u8> = Vec::new();
@@ -404,7 +403,7 @@ impl Stringifier {
 
                 for _pkg_id in 0..pkgs.len() {
                     let pkg_id = PackageID::try_from(_pkg_id).expect("int cast");
-                    let res = &pkg_resolutions[pkg_id.index()];
+                    let res = &pkg_resolutions[pkg_id];
                     if res.tag != ResolutionTag::Workspace {
                         continue;
                     }
@@ -413,13 +412,13 @@ impl Stringifier {
 
                 // local Sorter struct → closure
                 workspace_sort_buf.sort_by(|&l, &r| {
-                    let l_res = &pkg_resolutions[l.index()];
-                    let r_res = &pkg_resolutions[r.index()];
+                    let l_res = &pkg_resolutions[l];
+                    let r_res = &pkg_resolutions[r];
                     l_res.workspace().order(*r_res.workspace(), buf, buf)
                 });
 
                 for &workspace_pkg_id in &workspace_sort_buf {
-                    let res = &pkg_resolutions[workspace_pkg_id.index()];
+                    let res = &pkg_resolutions[workspace_pkg_id];
                     writer.write_all(b"\n")?;
                     Self::write_indent(writer, *indent)?;
                     Self::write_workspace_deps(
@@ -439,7 +438,7 @@ impl Stringifier {
                         &lockfile.workspace_versions,
                         &mut optional_peers_buf,
                         &pkg_map,
-                        pkg_names[workspace_pkg_id.index()].slice(buf),
+                        pkg_names[workspace_pkg_id].slice(buf),
                         &mut path_buf,
                     )?;
                 }
@@ -471,15 +470,15 @@ impl Stringifier {
                 ));
 
                 for &dep_id in node.dependencies {
-                    let pkg_id = resolution_buf[dep_id.index()];
+                    let pkg_id = resolution_buf[dep_id];
                     if pkg_id == invalid_package_id {
                         continue;
                     }
 
-                    let pkg_name = pkg_names[pkg_id.index()];
-                    let pkg_name_hash = pkg_name_hashes[pkg_id.index()];
-                    let res = &pkg_resolutions[pkg_id.index()];
-                    let dep = &deps_buf[dep_id.index()];
+                    let pkg_name = pkg_names[pkg_id];
+                    let pkg_name_hash = pkg_name_hashes[pkg_id];
+                    let res = &pkg_resolutions[pkg_id];
+                    let dep = &deps_buf[dep_id];
 
                     if lockfile.patched_dependencies.count() > 0 {
                         use std::io::Write;
@@ -688,12 +687,12 @@ impl Stringifier {
                 }
 
                 for &dep_id in &tree_deps_sort_buf {
-                    let pkg_id = resolution_buf[dep_id.index()];
+                    let pkg_id = resolution_buf[dep_id];
                     if pkg_id == invalid_package_id {
                         continue;
                     }
 
-                    let res = &pkg_resolutions[pkg_id.index()];
+                    let res = &pkg_resolutions[pkg_id];
                     match res.tag {
                         ResolutionTag::Root
                         | ResolutionTag::Npm
@@ -734,7 +733,7 @@ impl Stringifier {
                         writer.write_byte(b'/')?;
                     }
 
-                    let dep = &deps_buf[dep_id.index()];
+                    let dep = &deps_buf[dep_id];
                     let dep_name = dep.name.slice(buf);
 
                     pkg_key_buf.clear();
@@ -756,10 +755,10 @@ impl Stringifier {
                         ),
                     )?;
 
-                    let pkg_name = pkg_names[pkg_id.index()];
-                    let pkg_meta = &pkg_metas[pkg_id.index()];
-                    let pkg_bin = &pkg_bins[pkg_id.index()];
-                    let pkg_deps_list = pkg_dep_lists[pkg_id.index()];
+                    let pkg_name = pkg_names[pkg_id];
+                    let pkg_meta = &pkg_metas[pkg_id];
+                    let pkg_bin = &pkg_bins[pkg_id];
+                    let pkg_deps_list = pkg_dep_lists[pkg_id];
 
                     pkg_deps_sort_buf.clear();
                     pkg_deps_sort_buf.extend(pkg_deps_list.dependency_ids());
@@ -1065,7 +1064,7 @@ impl Stringifier {
     fn write_package_info_object(
         writer: &mut Writer,
         dep_behavior: Behavior,
-        deps_buf: &[Dependency],
+        deps_buf: &IdSlice<DependencyID, Dependency>,
         pkg_dep_ids: &[DependencyID],
         meta: &Meta,
         bin: &Bin,
@@ -1086,7 +1085,7 @@ impl Stringifier {
         for &(group_name, group_behavior) in WORKSPACE_DEPENDENCY_GROUPS.iter() {
             let mut first = true;
             for &dep_id in pkg_dep_ids {
-                let dep = &deps_buf[dep_id.index()];
+                let dep = &deps_buf[dep_id];
                 if !dep.behavior.intersects(group_behavior) {
                     continue;
                 }
@@ -1239,13 +1238,13 @@ impl Stringifier {
         indent: &mut u32,
         pkg_id: PackageID,
         res: String,
-        pkg_names: &[String],
-        pkg_name_hashes: &[PackageNameHash],
-        pkg_bins: &[Bin],
-        pkg_deps: &[DependencySlice],
+        pkg_names: &IdSlice<PackageID, String>,
+        pkg_name_hashes: &IdSlice<PackageID, PackageNameHash>,
+        pkg_bins: &IdSlice<PackageID, Bin>,
+        pkg_deps: &IdSlice<PackageID, DependencySlice>,
         buf: &[u8],
         extern_strings: &[ExternalString],
-        deps_buf: &[Dependency],
+        deps_buf: &IdSlice<DependencyID, Dependency>,
         workspace_versions: &VersionHashMap,
         optional_peers_buf: &mut Vec<String>,
         pkg_map: &PkgMap<()>,
@@ -1263,7 +1262,7 @@ impl Stringifier {
         // need a way to detect new/deleted workspaces
         if pkg_id == PackageID::ROOT {
             writer.write_all(b"\"\": {")?;
-            let root_name = pkg_names[0].slice(buf);
+            let root_name = pkg_names[PackageID::ROOT].slice(buf);
             if !root_name.is_empty() {
                 writer.write_byte(b'\n')?;
                 Self::inc_indent(writer, indent)?;
@@ -1288,19 +1287,19 @@ impl Stringifier {
                 writer,
                 "\"name\": {}",
                 bun_core::fmt::format_json_string_utf8(
-                    pkg_names[pkg_id.index()].slice(buf),
+                    pkg_names[pkg_id].slice(buf),
                     Default::default()
                 ),
             )?;
 
-            if let Some(version) = workspace_versions.get(&pkg_name_hashes[pkg_id.index()]) {
+            if let Some(version) = workspace_versions.get(&pkg_name_hashes[pkg_id]) {
                 writer.write_all(b",\n")?;
                 Self::write_indent(writer, *indent)?;
                 write!(writer, "\"version\": \"{}\"", version.fmt(buf))?;
             }
 
-            if pkg_bins[pkg_id.index()].tag != BinTag::None {
-                let bin = &pkg_bins[pkg_id.index()];
+            if pkg_bins[pkg_id].tag != BinTag::None {
+                let bin = &pkg_bins[pkg_id];
                 writer.write_all(b",\n")?;
                 Self::write_indent(writer, *indent)?;
                 if bin.tag == BinTag::Dir {
@@ -1322,7 +1321,7 @@ impl Stringifier {
 
         for &(group_name, group_behavior) in WORKSPACE_DEPENDENCY_GROUPS.iter() {
             let mut first = true;
-            for dep in pkg_deps[pkg_id.index()].get(deps_buf) {
+            for dep in pkg_deps[pkg_id].get(deps_buf) {
                 if !dep.behavior.intersects(group_behavior) {
                     continue;
                 }
@@ -2717,7 +2716,7 @@ pub(crate) fn parse_into_binary_lockfile(
                     {
                         let workspace_pkg_id = PackageID::new(_workspace_pkg_id);
                         if res.eql(
-                            &pkg_resolutions[workspace_pkg_id.index()],
+                            &pkg_resolutions[workspace_pkg_id],
                             lockfile.buffers.string_bytes.as_slice(),
                             lockfile.buffers.string_bytes.as_slice(),
                         ) {
@@ -2725,7 +2724,7 @@ pub(crate) fn parse_into_binary_lockfile(
                             {
                                 debug_assert!(!strings::eql_long(
                                     pkg_path,
-                                    pkg_names[workspace_pkg_id.index()]
+                                    pkg_names[workspace_pkg_id]
                                         .slice(lockfile.buffers.string_bytes.as_slice()),
                                     true,
                                 ));
@@ -3055,14 +3054,14 @@ pub(crate) fn parse_into_binary_lockfile(
         // The two `[0]` writes are done first via
         // sequential `&mut` accessors so the loops can take all column views
         // immutably without overlapping exclusive borrows or `unsafe`.
-        lockfile.packages.items_resolution_mut()[0] =
+        lockfile.packages.items_resolution_mut()[PackageID::ROOT] =
             Resolution::init(crate::resolution::TaggedValue::Root);
-        lockfile.packages.items_meta_mut()[0].origin = Origin::Local;
+        lockfile.packages.items_meta_mut()[PackageID::ROOT].origin = Origin::Local;
 
         let pkgs = lockfile.packages.slice();
         let pkg_deps = pkgs.items_dependencies();
         let pkg_names = pkgs.items_name();
-        let pkg_resolutions: &[Resolution] = pkgs.items_resolution();
+        let pkg_resolutions = pkgs.items_resolution();
 
         // Populated by `append_package_dedupe` while the packages object was
         // parsed above; used to bind peer edges by version rather than by
@@ -3076,13 +3075,13 @@ pub(crate) fn parse_into_binary_lockfile(
         // `string_bytes` view.
         let buffers = &mut lockfile.buffers;
         let string_buf: &[u8] = buffers.string_bytes.as_slice();
-        let dependencies: &mut [Dependency] = buffers.dependencies.as_mut_slice();
-        let resolutions: &mut [PackageID] = buffers.resolutions.as_mut_slice();
+        let dependencies = buffers.dependencies.as_mut_slice();
+        let resolutions = buffers.resolutions.as_mut_slice();
 
         {
             // first the root dependencies are resolved
-            for dep_id in pkg_deps[0].dependency_ids() {
-                let dep = &mut dependencies[dep_id.index()];
+            for dep_id in pkg_deps[PackageID::ROOT].dependency_ids() {
+                let dep = &mut dependencies[dep_id];
 
                 let peer_res_id = resolve_peer_dep_version_based(
                     dep,
@@ -3114,7 +3113,7 @@ pub(crate) fn parse_into_binary_lockfile(
                         .get_or_put(dep.name.slice(string_buf))?
                         .found_existing
                 {
-                    resolutions[dep_id.index()] = res_id;
+                    resolutions[dep_id] = res_id;
                     continue;
                 }
 
@@ -3135,13 +3134,13 @@ pub(crate) fn parse_into_binary_lockfile(
             // then workspace dependencies are resolved
             for _pkg_id in workspace_pkgs_off..workspace_pkgs_off + workspace_pkgs_len {
                 let pkg_id = PackageID::new(_pkg_id);
-                let workspace_name = pkg_names[pkg_id.index()].slice(string_buf);
+                let workspace_name = pkg_names[pkg_id].slice(string_buf);
 
                 seen_deps.clear_retaining_capacity();
 
-                let deps = pkg_deps[pkg_id.index()];
+                let deps = pkg_deps[pkg_id];
                 for dep_id in deps.dependency_ids() {
-                    let dep = &mut dependencies[dep_id.index()];
+                    let dep = &mut dependencies[dep_id];
                     let dep_name = dep.name.slice(string_buf);
 
                     let workspace_node_modules = {
@@ -3194,7 +3193,7 @@ pub(crate) fn parse_into_binary_lockfile(
                     };
 
                     if seen_deps.get_or_put(dep_name)?.found_existing {
-                        resolutions[dep_id.index()] = res_id;
+                        resolutions[dep_id] = res_id;
                         continue;
                     }
 
@@ -3218,7 +3217,7 @@ pub(crate) fn parse_into_binary_lockfile(
                 return Err(ParseError::InvalidPackagesObject);
             };
 
-            let res = &pkg_resolutions[pkg_id.index()];
+            let res = &pkg_resolutions[pkg_id];
 
             if res.tag == ResolutionTag::Workspace {
                 // we've already resolved the workspace dependencies above
@@ -3226,9 +3225,9 @@ pub(crate) fn parse_into_binary_lockfile(
             }
 
             // find resolutions. iterate up to root through the pkg path.
-            let deps = pkg_deps[pkg_id.index()];
+            let deps = pkg_deps[pkg_id];
             'deps: for dep_id in deps.dependency_ids() {
-                let dep = &mut dependencies[dep_id.index()];
+                let dep = &mut dependencies[dep_id];
 
                 // A stripped `catalog:` edge (`CatalogMap::strip_reference`) stays unresolved, as in a fresh install.
                 if dep.version.tag == DependencyVersionTag::Uninitialized {
@@ -3359,7 +3358,7 @@ pub(crate) fn resolve_peer_dep_version_based(
     catalogs: &CatalogMap,
     package_index: &PackageIndexMap,
     overrides: &OverrideMap,
-    pkg_resolutions: &[Resolution],
+    pkg_resolutions: &IdSlice<PackageID, Resolution>,
     string_buf: &[u8],
 ) -> Option<PackageID> {
     let range = deferred_peer_range(dep, catalogs, string_buf)?;
@@ -3403,17 +3402,16 @@ pub(crate) fn resolve_peer_dep_version_based(
 
     let candidates = package_index.get(&name_hash)?.as_slice();
     for &id in candidates {
-        if id.index() < pkg_resolutions.len()
-            && pkg_resolutions[id.index()]
-                .satisfies_dependency_version(range, string_buf, string_buf)
+        if pkg_resolutions.has(id)
+            && pkg_resolutions[id].satisfies_dependency_version(range, string_buf, string_buf)
         {
             return Some(id);
         }
     }
 
     let &first = candidates.first()?;
-    if first.index() < pkg_resolutions.len() {
-        let res_tag = pkg_resolutions[first.index()].tag;
+    if pkg_resolutions.has(first) {
+        let res_tag = pkg_resolutions[first].tag;
         let ver_tag = range.tag;
         if (res_tag == ResolutionTag::Npm && ver_tag == DependencyVersionTag::Npm)
             || (res_tag == ResolutionTag::Git && ver_tag == DependencyVersionTag::Git)
@@ -3435,14 +3433,14 @@ fn map_dep_to_pkg(
     dep: &mut Dependency,
     dep_id: DependencyID,
     pkg_id: PackageID,
-    resolutions: &mut [PackageID],
+    resolutions: &mut IdSlice<DependencyID, PackageID>,
     text_lockfile_version: Version,
-    pkg_resolutions: &[Resolution],
+    pkg_resolutions: &IdSlice<PackageID, Resolution>,
 ) {
-    resolutions[dep_id.index()] = pkg_id;
+    resolutions[dep_id] = pkg_id;
 
     if text_lockfile_version != Version::V0 {
-        let res = &pkg_resolutions[pkg_id.index()];
+        let res = &pkg_resolutions[pkg_id];
         if res.tag == ResolutionTag::Workspace {
             // Whole-struct assign so `DependencyVersion::Drop` frees any prior
             // npm chain. SAFETY: `res.tag == Workspace` checked above.
@@ -3704,7 +3702,7 @@ fn parse_append_dependencies<const CHECK_FOR_BUNDLED: bool, const IS_ROOT: bool>
         let bytes = lockfile.buffers.string_bytes.as_slice();
         // `slice::sort_by` is pattern-defeating quicksort; `Dependency::cmp` is the
         // total-order form of `isLessThan` (behavior group, then name ASC).
-        lockfile.buffers.dependencies[off..].sort_by(|a, b| Dependency::cmp(bytes, a, b));
+        lockfile.buffers.dependencies.raw_mut()[off..].sort_by(|a, b| Dependency::cmp(bytes, a, b));
     }
 
     optional_peers_buf.clear();

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -444,7 +444,7 @@ pub(crate) fn load(
     {
         let len = lockfile.packages.len();
         for meta in lockfile.packages.items_meta() {
-            if meta.id as usize >= len {
+            if meta.id.index() >= len {
                 return Err(crate::Error::InvalidLockfile);
             }
         }
@@ -824,7 +824,7 @@ pub(crate) fn load(
         for id in 0..len {
             let name_hash = lockfile.packages.items_name_hash()[id];
             let resolution = lockfile.packages.items_resolution()[id];
-            lockfile.get_or_put_id(id as PackageID, name_hash)?;
+            lockfile.get_or_put_id(PackageID::from_index(id), name_hash)?;
 
             if matches!(resolution.tag, ResolutionTag::Git | ResolutionTag::Github) {
                 let resolved = lockfile.str(&resolution.repository().resolved);
@@ -857,7 +857,7 @@ pub(crate) fn load(
         let len = lockfile.packages.len();
         for id in 0..len {
             let name_hash = lockfile.packages.items_name_hash()[id];
-            lockfile.get_or_put_id(id as PackageID, name_hash)?;
+            lockfile.get_or_put_id(PackageID::from_index(id), name_hash)?;
         }
     }
 

--- a/src/install/lockfile/bun.lockb.rs
+++ b/src/install/lockfile/bun.lockb.rs
@@ -821,10 +821,10 @@ pub(crate) fn load(
     // sound and avoids the overlapping borrow.
     if !has_workspace_name_hashes {
         let len = lockfile.packages.len();
-        for id in 0..len {
+        for id in (0..len).map(PackageID::from_index) {
             let name_hash = lockfile.packages.items_name_hash()[id];
             let resolution = lockfile.packages.items_resolution()[id];
-            lockfile.get_or_put_id(PackageID::from_index(id), name_hash)?;
+            lockfile.get_or_put_id(id, name_hash)?;
 
             if matches!(resolution.tag, ResolutionTag::Git | ResolutionTag::Github) {
                 let resolved = lockfile.str(&resolution.repository().resolved);
@@ -855,9 +855,9 @@ pub(crate) fn load(
         }
     } else {
         let len = lockfile.packages.len();
-        for id in 0..len {
+        for id in (0..len).map(PackageID::from_index) {
             let name_hash = lockfile.packages.items_name_hash()[id];
-            lockfile.get_or_put_id(PackageID::from_index(id), name_hash)?;
+            lockfile.get_or_put_id(id, name_hash)?;
         }
     }
 

--- a/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
+++ b/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
@@ -206,7 +206,7 @@ where
                 package_index::Entry::Id(id) => *id,
                 package_index::Entry::Ids(ids) => ids.as_slice()[0],
             };
-            let name = this.packages.items_name()[first_id as usize].slice(sb);
+            let name = this.packages.items_name()[first_id.index()].slice(sb);
             w.object_field(name)?;
             match entry {
                 package_index::Entry::Id(id) => w.write(*id)?,
@@ -272,8 +272,8 @@ where
 
                 for tree_dep_id in tree.dependencies.get(hoisted_deps) {
                     let tree_dep_id = *tree_dep_id;
-                    let dep = &dependencies[tree_dep_id as usize];
-                    let package_id = resolutions[tree_dep_id as usize];
+                    let dep = &dependencies[tree_dep_id.index()];
+                    let package_id = resolutions[tree_dep_id.index()];
 
                     w.object_field(dep.name.slice(sb))?;
                     {
@@ -308,7 +308,13 @@ where
         for dep_id in 0..dependencies.len() {
             let dep = &dependencies[dep_id];
             let res = resolutions[dep_id];
-            json_stringify_dependency(this, w, u32::try_from(dep_id).expect("int cast"), dep, res)?;
+            json_stringify_dependency(
+                this,
+                w,
+                DependencyID::try_from(dep_id).expect("int cast"),
+                dep,
+                res,
+            )?;
         }
 
         let _ = w.end_array();
@@ -591,6 +597,19 @@ macro_rules! json_scalar_uint {
     )+};
 }
 json_scalar_uint!(u8, u16, u32, u64, usize);
+
+impl JsonScalar for PackageID {
+    #[inline]
+    fn write_json(&self, out: &mut Vec<u8>, opts: WriteStreamOptions) {
+        self.get().write_json(out, opts);
+    }
+}
+impl JsonScalar for DependencyID {
+    #[inline]
+    fn write_json(&self, out: &mut Vec<u8>, opts: WriteStreamOptions) {
+        self.get().write_json(out, opts);
+    }
+}
 
 impl JsonScalar for &[u8] {
     fn write_json(&self, out: &mut Vec<u8>, _: WriteStreamOptions) {

--- a/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
+++ b/src/install/lockfile/lockfile_json_stringify_for_debugging.rs
@@ -13,7 +13,7 @@ use crate::{Dependency, DependencyID, Npm, Origin, PackageID, invalid_package_id
 
 use super::package::scripts::Scripts as PackageScripts;
 use super::tree::{DepthBuf, IteratorPathStyle, MAX_DEPTH};
-use super::{FormatVersion, Lockfile, Package, package_index, tree};
+use super::{FormatVersion, Lockfile, package_index, tree};
 
 // Since this output is debug-only and an error mid-stream already yields malformed JSON,
 // the matching `end_*` call is emitted at the natural end of each scope and its error
@@ -206,7 +206,7 @@ where
                 package_index::Entry::Id(id) => *id,
                 package_index::Entry::Ids(ids) => ids.as_slice()[0],
             };
-            let name = this.packages.items_name()[first_id.index()].slice(sb);
+            let name = this.packages.items_name()[first_id].slice(sb);
             w.object_field(name)?;
             match entry {
                 package_index::Entry::Id(id) => w.write(*id)?,
@@ -272,8 +272,8 @@ where
 
                 for tree_dep_id in tree.dependencies.get(hoisted_deps) {
                     let tree_dep_id = *tree_dep_id;
-                    let dep = &dependencies[tree_dep_id.index()];
-                    let package_id = resolutions[tree_dep_id.index()];
+                    let dep = &dependencies[tree_dep_id];
+                    let package_id = resolutions[tree_dep_id];
 
                     w.object_field(dep.name.slice(sb))?;
                     {
@@ -305,16 +305,8 @@ where
         let dependencies = this.buffers.dependencies.as_slice();
         let resolutions = this.buffers.resolutions.as_slice();
 
-        for dep_id in 0..dependencies.len() {
-            let dep = &dependencies[dep_id];
-            let res = resolutions[dep_id];
-            json_stringify_dependency(
-                this,
-                w,
-                DependencyID::try_from(dep_id).expect("int cast"),
-                dep,
-                res,
-            )?;
+        for (dep_id, dep) in dependencies.iter_enumerated() {
+            json_stringify_dependency(this, w, dep_id, dep, resolutions[dep_id])?;
         }
 
         let _ = w.end_array();
@@ -324,8 +316,8 @@ where
         w.object_field(b"packages")?;
         w.begin_array()?;
 
-        for i in 0..this.packages.len() {
-            let pkg: Package = *this.packages.get(i);
+        for i in (0..this.packages.len()).map(PackageID::from_index) {
+            let pkg = this.package(i);
             w.begin_object()?;
 
             w.object_field(b"id")?;

--- a/src/install/lockfile/printer/Yarn.rs
+++ b/src/install/lockfile/printer/Yarn.rs
@@ -69,17 +69,18 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
     let mut all_requested_versions_buf: Vec<dependency::Version> =
         Vec::with_capacity(resolutions_buffer.len());
 
-    let package_count = names.len() as PackageID;
-    let mut alphabetized_names: Vec<PackageID> = vec![0; (package_count - 1) as usize];
+    let package_count = names.len();
+    let mut alphabetized_names: Vec<PackageID> = vec![PackageID::default(); package_count - 1];
 
     let string_buf: &[u8] = this.lockfile.buffers.string_bytes.as_slice();
 
     // First, we need to build a map of all requested versions
     // This is so we can print requested versions
     {
-        let mut i: PackageID = 1;
-        while i < package_count {
-            alphabetized_names[(i - 1) as usize] = i;
+        // Package 0 is the root, which yarn.lock does not list.
+        for index in 1..package_count {
+            let i = PackageID::from_index(index);
+            alphabetized_names[index - 1] = i;
 
             let mut resolutions = resolutions_buffer;
             let mut dependencies = dependencies_buffer;
@@ -108,8 +109,6 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
                 });
             }
             requested_versions.insert(i, (requested_version_start, j));
-
-            i += 1;
         }
     }
 
@@ -124,10 +123,10 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
 
     // When printing, we start at 1
     for &i in alphabetized_names.iter() {
-        let name: &[u8] = names[i as usize].slice(string_buf);
-        let resolution = &resolved[i as usize];
-        let meta = &metas[i as usize];
-        let dependencies: &[Dependency] = dependency_lists[i as usize].get(dependencies_buffer);
+        let name: &[u8] = names[i.index()].slice(string_buf);
+        let resolution = &resolved[i.index()];
+        let meta = &metas[i.index()];
+        let dependencies: &[Dependency] = dependency_lists[i.index()].get(dependencies_buffer);
         let version_formatter = resolution.fmt(string_buf, bun_core::fmt::PathSep::Posix);
 
         // This prints:

--- a/src/install/lockfile/printer/Yarn.rs
+++ b/src/install/lockfile/printer/Yarn.rs
@@ -7,10 +7,10 @@ use bun_semver::String as SemverString;
 
 use crate::lockfile_real::package::Alphabetizer;
 use bun_install::Dependency;
-use bun_install::PackageID;
 use bun_install::Resolution;
 use bun_install::dependency::{self, Behavior, VersionExt as _};
 use bun_install::lockfile::package;
+use bun_install::{INVALID_PACKAGE_ID, PackageID};
 // `lockfile.packages.slice()` returns
 // `bun_collections::multi_array_list::Slice<Package<_>>`; the `items_<field>()`
 // column accessors are an extension trait (hand-expanded per Package.rs).
@@ -70,7 +70,7 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
         Vec::with_capacity(resolutions_buffer.len());
 
     let package_count = names.len();
-    let mut alphabetized_names: Vec<PackageID> = vec![PackageID::default(); package_count - 1];
+    let mut alphabetized_names: Vec<PackageID> = vec![INVALID_PACKAGE_ID; package_count - 1];
 
     let string_buf: &[u8] = this.lockfile.buffers.string_bytes.as_slice();
 

--- a/src/install/lockfile/printer/Yarn.rs
+++ b/src/install/lockfile/printer/Yarn.rs
@@ -3,13 +3,10 @@ use core::cmp::Ordering;
 
 use bun_collections::HashMap;
 use bun_core::strings;
-use bun_semver::String as SemverString;
 
 use crate::lockfile_real::package::Alphabetizer;
 use bun_install::Dependency;
-use bun_install::Resolution;
 use bun_install::dependency::{self, Behavior, VersionExt as _};
-use bun_install::lockfile::package;
 use bun_install::{INVALID_PACKAGE_ID, PackageID};
 // `lockfile.packages.slice()` returns
 // `bun_collections::multi_array_list::Slice<Package<_>>`; the `items_<field>()`
@@ -50,15 +47,15 @@ pub(crate) fn print(
 
 fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), crate::Error> {
     let slice = this.lockfile.packages.slice();
-    let names: &[SemverString] = slice.items_name();
-    let resolved: &[Resolution] = slice.items_resolution();
-    let metas: &[package::Meta] = slice.items_meta();
+    let names = slice.items_name();
+    let resolved = slice.items_resolution();
+    let metas = slice.items_meta();
     if names.is_empty() {
         return Ok(());
     }
     let dependency_lists = slice.items_dependencies();
-    let resolutions_buffer: &[PackageID] = this.lockfile.buffers.resolutions.as_slice();
-    let dependencies_buffer: &[Dependency] = this.lockfile.buffers.dependencies.as_slice();
+    let resolutions_buffer = this.lockfile.buffers.resolutions.as_slice();
+    let dependencies_buffer = this.lockfile.buffers.dependencies.as_slice();
 
     // Store (start, len) into `all_requested_versions_buf` instead of
     // overlapping &mut [Version] slices.
@@ -82,8 +79,8 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
             let i = PackageID::from_index(index);
             alphabetized_names[index - 1] = i;
 
-            let mut resolutions = resolutions_buffer;
-            let mut dependencies = dependencies_buffer;
+            let mut resolutions = resolutions_buffer.raw();
+            let mut dependencies = dependencies_buffer.raw();
 
             let mut j: usize = 0;
             let requested_version_start = all_requested_versions_buf.len();
@@ -114,19 +111,19 @@ fn packages(this: &mut Printer, writer: &mut impl bun_io::Write) -> Result<(), c
 
     {
         let alphabetizer = Alphabetizer::<u64> {
-            names: names.into(),
-            buf: string_buf.into(),
-            resolutions: resolved.into(),
+            names,
+            buf: string_buf,
+            resolutions: resolved,
         };
         alphabetized_names.sort_unstable_by(|&a, &b| alphabetizer.order(a, b));
     }
 
     // When printing, we start at 1
     for &i in alphabetized_names.iter() {
-        let name: &[u8] = names[i.index()].slice(string_buf);
-        let resolution = &resolved[i.index()];
-        let meta = &metas[i.index()];
-        let dependencies: &[Dependency] = dependency_lists[i.index()].get(dependencies_buffer);
+        let name: &[u8] = names[i].slice(string_buf);
+        let resolution = &resolved[i];
+        let meta = &metas[i];
+        let dependencies: &[Dependency] = dependency_lists[i].get(dependencies_buffer);
         let version_formatter = resolution.fmt(string_buf, bun_core::fmt::PathSep::Posix);
 
         // This prints:

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -7,8 +7,8 @@ use crate::package_manager_real::TrackInstalledBin;
 use bun_core::fmt::PathSep;
 use bun_install::lockfile::{Printer, package::Meta as PackageMeta};
 use bun_install::{
-    self as install, Bin, Dependency, DependencyID, INVALID_PACKAGE_ID, PackageID, PackageManager,
-    PackageNameHash, Resolution, Subcommand, bin, resolution,
+    self as install, Bin, Dependency, DependencyID, INVALID_DEPENDENCY_ID, PackageID,
+    PackageManager, PackageNameHash, Resolution, Subcommand, bin, resolution,
 };
 use bun_sys::Fd;
 
@@ -36,7 +36,7 @@ where
     let packages_slice = lockfile.packages.slice();
     let resolutions = lockfile.buffers.resolutions.as_slice();
     let dependencies = lockfile.buffers.dependencies.as_slice();
-    let workspace_res = &packages_slice.items_resolution()[workspace_package_id as usize];
+    let workspace_res = &packages_slice.items_resolution()[workspace_package_id.index()];
     let names = packages_slice.items_name();
     let pkg_metas = packages_slice.items_meta();
     debug_assert!(
@@ -58,11 +58,7 @@ where
 
     // find the updated packages
     for &owner in update_owners {
-        for _dep_id in
-            resolutions_list[owner as usize].begin()..resolutions_list[owner as usize].end()
-        {
-            let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
-
+        for dep_id in resolutions_list[owner.index()].dependency_ids() {
             match should_print_package_install(
                 this,
                 manager,
@@ -80,7 +76,7 @@ where
                 | ShouldPrintPackageInstallResult::Return => {}
                 ShouldPrintPackageInstallResult::Update(update_info) => {
                     if update_dedupe
-                        .get_or_put(dependencies[dep_id as usize].name_hash)?
+                        .get_or_put(dependencies[dep_id.index()].name_hash)?
                         .found_existing
                     {
                         continue;
@@ -92,7 +88,7 @@ where
                         if !printed_section_header {
                             printed_section_header = true;
                             let workspace_name =
-                                names[workspace_package_id as usize].slice(string_buf);
+                                names[workspace_package_id.index()].slice(string_buf);
                             bun_core::write_pretty!(
                                 writer,
                                 ENABLE_ANSI_COLORS,
@@ -132,11 +128,7 @@ where
         }
     }
 
-    for _dep_id in resolutions_list[workspace_package_id as usize].begin()
-        ..resolutions_list[workspace_package_id as usize].end()
-    {
-        let dep_id: DependencyID = DependencyID::try_from(_dep_id).expect("int cast");
-
+    for dep_id in resolutions_list[workspace_package_id.index()].dependency_ids() {
         match should_print_package_install(
             this,
             manager,
@@ -152,8 +144,8 @@ where
             }
         }
 
-        let dep = &dependencies[dep_id as usize];
-        let package_id = resolutions[dep_id as usize];
+        let dep = &dependencies[dep_id.index()];
+        let package_id = resolutions[dep_id.index()];
 
         if dep_dedupe.get_or_put(dep.name_hash)?.found_existing {
             continue;
@@ -164,7 +156,7 @@ where
         if PRINT_SECTION_HEADER {
             if !printed_section_header {
                 printed_section_header = true;
-                let workspace_name = names[workspace_package_id as usize].slice(string_buf);
+                let workspace_name = names[workspace_package_id.index()].slice(string_buf);
                 bun_core::write_pretty!(
                     writer,
                     ENABLE_ANSI_COLORS,
@@ -208,10 +200,10 @@ fn should_print_package_install(
 ) -> ShouldPrintPackageInstallResult {
     let dependencies = this.lockfile.buffers.dependencies.as_slice();
     let resolutions = this.lockfile.buffers.resolutions.as_slice();
-    let dependency = &dependencies[dep_id as usize];
-    let package_id = resolutions[dep_id as usize];
+    let dependency = &dependencies[dep_id.index()];
+    let package_id = resolutions[dep_id.index()];
 
-    if dependency.behavior.is_workspace() || (package_id as usize) >= this.lockfile.packages.len() {
+    if dependency.behavior.is_workspace() || package_id.index() >= this.lockfile.packages.len() {
         return ShouldPrintPackageInstallResult::No;
     }
 
@@ -225,7 +217,7 @@ fn should_print_package_install(
             if !is_update
                 && update.matches(dependency, this.lockfile.buffers.string_bytes.as_slice())
             {
-                if *update_dependency_id == INVALID_PACKAGE_ID {
+                if *update_dependency_id == INVALID_DEPENDENCY_ID {
                     *update_dependency_id = dep_id;
                 }
 
@@ -235,7 +227,7 @@ fn should_print_package_install(
     }
 
     // `bun update` reports a row that moved onto a package that was already on disk, so its update check runs before the installed check.
-    let is_installed = installed.is_set(package_id as usize);
+    let is_installed = installed.is_set(package_id.index());
     if !is_installed && manager.subcommand != Subcommand::Update {
         return ShouldPrintPackageInstallResult::No;
     }
@@ -246,14 +238,14 @@ fn should_print_package_install(
     if this.lockfile.is_resolved_dependency_disabled(
         dep_id,
         this.options.local_package_features,
-        &pkg_metas[package_id as usize],
+        &pkg_metas[package_id.index()],
         this.options.cpu,
         this.options.os,
     ) {
         return ShouldPrintPackageInstallResult::No;
     }
 
-    let resolution = this.lockfile.packages.items_resolution()[package_id as usize];
+    let resolution = this.lockfile.packages.items_resolution()[package_id.index()];
     if resolution.tag == resolution::Tag::Npm {
         let npm_version = resolution.npm().version;
         let name = dependency
@@ -293,9 +285,9 @@ where
 {
     let string_buf = this.lockfile.buffers.string_bytes.as_slice();
     let packages_slice = this.lockfile.packages.slice();
-    let package_id = update_info.package_id as usize;
+    let package_id = update_info.package_id.index();
     let dependency =
-        &this.lockfile.buffers.dependencies.as_slice()[update_info.dependency_id as usize];
+        &this.lockfile.buffers.dependencies.as_slice()[update_info.dependency_id.index()];
     let dep_name = dependency.name.slice(string_buf);
     let later = later_version_text(
         manager,
@@ -402,11 +394,11 @@ where
     let pkg_resolutions = packages_slice.items_resolution();
     let mut workspace_targets = Bitset::init_empty(pkg_resolutions.len())?;
     for &owner in update_owners {
-        for &package_id in packages_slice.items_resolutions()[owner as usize]
+        for &package_id in packages_slice.items_resolutions()[owner.index()]
             .get(lockfile.buffers.resolutions.as_slice())
         {
-            if (package_id as usize) < pkg_resolutions.len() {
-                workspace_targets.set(package_id as usize);
+            if package_id.index() < pkg_resolutions.len() {
+                workspace_targets.set(package_id.index());
             }
         }
     }
@@ -465,10 +457,10 @@ where
 {
     let string_buf = this.lockfile.buffers.string_bytes.as_slice();
     let packages_slice = this.lockfile.packages.slice();
-    let resolution: Resolution = packages_slice.items_resolution()[package_id as usize];
+    let resolution: Resolution = packages_slice.items_resolution()[package_id.index()];
     let name = dependency.name.slice(string_buf);
 
-    let package_name = packages_slice.items_name()[package_id as usize].slice(string_buf);
+    let package_name = packages_slice.items_name()[package_id.index()].slice(string_buf);
     if let Some(later_version_fmt) =
         manager.format_later_version_in_cache(package_name, dependency.name_hash, &resolution)
     {
@@ -583,32 +575,30 @@ where
     if dependencies_buffer.is_empty() {
         return Ok(());
     }
-    let mut id_map: Vec<DependencyID> = vec![INVALID_PACKAGE_ID; this.updates.len()];
+    let mut id_map: Vec<DependencyID> = vec![INVALID_DEPENDENCY_ID; this.updates.len()];
 
-    let end = resolved.len() as PackageID;
+    let end = resolved.len();
 
     let mut had_printed_new_install = false;
     if let Some(installed) = this.successfully_installed.as_ref() {
         if log_level.is_verbose() {
             let mut workspaces_to_print: Vec<DependencyID> = Vec::new();
 
-            for dep_id in resolutions_list[0].begin()..resolutions_list[0].end() {
-                let dep = &dependencies_buffer[dep_id as usize];
+            for dep_id in resolutions_list[0].dependency_ids() {
+                let dep = &dependencies_buffer[dep_id.index()];
                 if dep.behavior.is_workspace() {
-                    workspaces_to_print.push(DependencyID::try_from(dep_id).expect("int cast"));
+                    workspaces_to_print.push(dep_id);
                 }
             }
 
             let mut found_workspace_to_print = false;
             for &workspace_dep_id in &workspaces_to_print {
-                let workspace_package_id = resolutions_buffer[workspace_dep_id as usize];
-                for dep_id in resolutions_list[workspace_package_id as usize].begin()
-                    ..resolutions_list[workspace_package_id as usize].end()
-                {
+                let workspace_package_id = resolutions_buffer[workspace_dep_id.index()];
+                for dep_id in resolutions_list[workspace_package_id.index()].dependency_ids() {
                     match should_print_package_install(
                         this,
                         manager,
-                        DependencyID::try_from(dep_id).expect("int cast"),
+                        dep_id,
                         installed,
                         Some(&mut id_map),
                         pkg_metas,
@@ -624,15 +614,15 @@ where
                 this,
                 manager,
                 writer,
-                0,
+                PackageID::ROOT,
                 installed,
                 &mut had_printed_new_install,
                 None,
-                &[0],
+                &[PackageID::ROOT],
             )?;
 
             for &workspace_dep_id in &workspaces_to_print {
-                let workspace_package_id = resolutions_buffer[workspace_dep_id as usize];
+                let workspace_package_id = resolutions_buffer[workspace_dep_id.index()];
                 print_installed_workspace_section::<W, ENABLE_ANSI_COLORS, true>(
                     this,
                     manager,
@@ -646,12 +636,12 @@ where
             }
         } else {
             // just print installed packages for the current workspace
-            let mut workspace_package_id: PackageID = 0;
+            let mut workspace_package_id = PackageID::ROOT;
             if let Some(workspace_name_hash) = manager.workspace_name_hash {
-                for dep_id in resolutions_list[0].begin()..resolutions_list[0].end() {
-                    let dep = &dependencies_buffer[dep_id as usize];
+                for dep_id in resolutions_list[0].dependency_ids() {
+                    let dep = &dependencies_buffer[dep_id.index()];
                     if dep.behavior.is_workspace() && dep.name_hash == workspace_name_hash {
-                        workspace_package_id = resolutions_buffer[dep_id as usize];
+                        workspace_package_id = resolutions_buffer[dep_id.index()];
                         break;
                     }
                 }
@@ -663,20 +653,21 @@ where
                 if let Some(targets) = manager.update_target_workspaces.as_deref() {
                     let names = slice.items_name();
                     let name_hashes = slice.items_name_hash();
-                    let members = (resolutions_list[0].begin()..resolutions_list[0].end())
+                    let members = resolutions_list[0]
+                        .dependency_ids()
                         .filter(|&dep_id| {
-                            dependencies_buffer[dep_id as usize].behavior.is_workspace()
+                            dependencies_buffer[dep_id.index()].behavior.is_workspace()
                         })
-                        .map(|dep_id| resolutions_buffer[dep_id as usize]);
-                    update_owners = core::iter::once(0)
+                        .map(|dep_id| resolutions_buffer[dep_id.index()]);
+                    update_owners = core::iter::once(PackageID::ROOT)
                         .chain(members)
                         .filter(|&importer| {
-                            importer < end
+                            importer.index() < end
                                 && targets.iter().any(|target| {
                                     target.matches(
-                                        importer == 0,
-                                        name_hashes[importer as usize],
-                                        names[importer as usize].slice(string_buf),
+                                        importer == PackageID::ROOT,
+                                        name_hashes[importer.index()],
+                                        names[importer.index()].slice(string_buf),
                                     )
                                 })
                         })
@@ -703,7 +694,7 @@ where
             .zip(resolutions_buffer)
             .enumerate()
         {
-            if package_id >= end {
+            if package_id.index() >= end {
                 continue;
             }
             if dependency.behavior.is_peer() {
@@ -718,8 +709,8 @@ where
                         return Ok(());
                     }
                     if !is_update && update.matches(dependency, string_buf) {
-                        if *dependency_id == INVALID_PACKAGE_ID {
-                            *dependency_id = dep_id as DependencyID;
+                        if *dependency_id == INVALID_DEPENDENCY_ID {
+                            *dependency_id = DependencyID::from_index(dep_id);
                         }
 
                         continue 'outer;
@@ -732,7 +723,7 @@ where
                 ENABLE_ANSI_COLORS,
                 " <r><b>{s}<r><d>@<b>{f}<r>\n",
                 bstr::BStr::new(package_name),
-                resolved[package_id as usize].fmt(string_buf, PathSep::Auto),
+                resolved[package_id.index()].fmt(string_buf, PathSep::Auto),
             )?;
         }
     }
@@ -747,17 +738,17 @@ where
 
     let mut printed_installed_update_request = false;
     for &dependency_id in &id_map {
-        if dependency_id == INVALID_PACKAGE_ID {
+        if dependency_id == INVALID_DEPENDENCY_ID {
             continue;
         }
         if cfg!(debug_assertions) {
             had_printed_new_install = true;
         }
 
-        let dependency = &dependencies_buffer[dependency_id as usize];
-        let package_id = resolutions_buffer[dependency_id as usize];
-        let bin = bins[package_id as usize];
-        let resolution = &resolved[package_id as usize];
+        let dependency = &dependencies_buffer[dependency_id.index()];
+        let package_id = resolutions_buffer[dependency_id.index()];
+        let bin = bins[package_id.index()];
+        let resolution = &resolved[package_id.index()];
 
         match bin.tag {
             bin::Tag::None | bin::Tag::Dir => {

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -1,4 +1,4 @@
-use bun_collections::{DynamicBitSet, HashMap};
+use bun_collections::{DynamicBitSet, HashMap, IdSlice};
 use bun_io::Write;
 use bun_semver as semver;
 
@@ -7,8 +7,8 @@ use crate::package_manager_real::TrackInstalledBin;
 use bun_core::fmt::PathSep;
 use bun_install::lockfile::{Printer, package::Meta as PackageMeta};
 use bun_install::{
-    self as install, Bin, Dependency, DependencyID, INVALID_DEPENDENCY_ID, PackageID,
-    PackageManager, PackageNameHash, Resolution, Subcommand, bin, resolution,
+    self as install, Dependency, DependencyID, INVALID_DEPENDENCY_ID, PackageID, PackageManager,
+    PackageNameHash, Resolution, Subcommand, bin, resolution,
 };
 use bun_sys::Fd;
 
@@ -36,7 +36,7 @@ where
     let packages_slice = lockfile.packages.slice();
     let resolutions = lockfile.buffers.resolutions.as_slice();
     let dependencies = lockfile.buffers.dependencies.as_slice();
-    let workspace_res = &packages_slice.items_resolution()[workspace_package_id.index()];
+    let workspace_res = &packages_slice.items_resolution()[workspace_package_id];
     let names = packages_slice.items_name();
     let pkg_metas = packages_slice.items_meta();
     debug_assert!(
@@ -58,7 +58,7 @@ where
 
     // find the updated packages
     for &owner in update_owners {
-        for dep_id in resolutions_list[owner.index()].dependency_ids() {
+        for dep_id in resolutions_list[owner].dependency_ids() {
             match should_print_package_install(
                 this,
                 manager,
@@ -76,7 +76,7 @@ where
                 | ShouldPrintPackageInstallResult::Return => {}
                 ShouldPrintPackageInstallResult::Update(update_info) => {
                     if update_dedupe
-                        .get_or_put(dependencies[dep_id.index()].name_hash)?
+                        .get_or_put(dependencies[dep_id].name_hash)?
                         .found_existing
                     {
                         continue;
@@ -87,8 +87,7 @@ where
                     if PRINT_SECTION_HEADER {
                         if !printed_section_header {
                             printed_section_header = true;
-                            let workspace_name =
-                                names[workspace_package_id.index()].slice(string_buf);
+                            let workspace_name = names[workspace_package_id].slice(string_buf);
                             bun_core::write_pretty!(
                                 writer,
                                 ENABLE_ANSI_COLORS,
@@ -128,7 +127,7 @@ where
         }
     }
 
-    for dep_id in resolutions_list[workspace_package_id.index()].dependency_ids() {
+    for dep_id in resolutions_list[workspace_package_id].dependency_ids() {
         match should_print_package_install(
             this,
             manager,
@@ -144,8 +143,8 @@ where
             }
         }
 
-        let dep = &dependencies[dep_id.index()];
-        let package_id = resolutions[dep_id.index()];
+        let dep = &dependencies[dep_id];
+        let package_id = resolutions[dep_id];
 
         if dep_dedupe.get_or_put(dep.name_hash)?.found_existing {
             continue;
@@ -156,7 +155,7 @@ where
         if PRINT_SECTION_HEADER {
             if !printed_section_header {
                 printed_section_header = true;
-                let workspace_name = names[workspace_package_id.index()].slice(string_buf);
+                let workspace_name = names[workspace_package_id].slice(string_buf);
                 bun_core::write_pretty!(
                     writer,
                     ENABLE_ANSI_COLORS,
@@ -196,12 +195,12 @@ fn should_print_package_install(
     dep_id: DependencyID,
     installed: &Bitset,
     id_map: Option<&mut [DependencyID]>,
-    pkg_metas: &[PackageMeta],
+    pkg_metas: &IdSlice<PackageID, PackageMeta>,
 ) -> ShouldPrintPackageInstallResult {
     let dependencies = this.lockfile.buffers.dependencies.as_slice();
     let resolutions = this.lockfile.buffers.resolutions.as_slice();
-    let dependency = &dependencies[dep_id.index()];
-    let package_id = resolutions[dep_id.index()];
+    let dependency = &dependencies[dep_id];
+    let package_id = resolutions[dep_id];
 
     if dependency.behavior.is_workspace() || package_id.index() >= this.lockfile.packages.len() {
         return ShouldPrintPackageInstallResult::No;
@@ -238,14 +237,14 @@ fn should_print_package_install(
     if this.lockfile.is_resolved_dependency_disabled(
         dep_id,
         this.options.local_package_features,
-        &pkg_metas[package_id.index()],
+        &pkg_metas[package_id],
         this.options.cpu,
         this.options.os,
     ) {
         return ShouldPrintPackageInstallResult::No;
     }
 
-    let resolution = this.lockfile.packages.items_resolution()[package_id.index()];
+    let resolution = this.lockfile.packages.items_resolution()[package_id];
     if resolution.tag == resolution::Tag::Npm {
         let npm_version = resolution.npm().version;
         let name = dependency
@@ -285,9 +284,8 @@ where
 {
     let string_buf = this.lockfile.buffers.string_bytes.as_slice();
     let packages_slice = this.lockfile.packages.slice();
-    let package_id = update_info.package_id.index();
-    let dependency =
-        &this.lockfile.buffers.dependencies.as_slice()[update_info.dependency_id.index()];
+    let package_id = update_info.package_id;
+    let dependency = &this.lockfile.buffers.dependencies.as_slice()[update_info.dependency_id];
     let dep_name = dependency.name.slice(string_buf);
     let later = later_version_text(
         manager,
@@ -394,10 +392,10 @@ where
     let pkg_resolutions = packages_slice.items_resolution();
     let mut workspace_targets = Bitset::init_empty(pkg_resolutions.len())?;
     for &owner in update_owners {
-        for &package_id in packages_slice.items_resolutions()[owner.index()]
-            .get(lockfile.buffers.resolutions.as_slice())
+        for &package_id in
+            packages_slice.items_resolutions()[owner].get(lockfile.buffers.resolutions.as_slice())
         {
-            if package_id.index() < pkg_resolutions.len() {
+            if pkg_resolutions.has(package_id) {
                 workspace_targets.set(package_id.index());
             }
         }
@@ -405,8 +403,9 @@ where
 
     let mut printed = false;
     let mut installed_ids = installed.iterator::<true, true>();
-    while let Some(package_id) = installed_ids.next() {
-        if package_id >= pkg_resolutions.len() || workspace_targets.is_set(package_id) {
+    while let Some(package_index) = installed_ids.next() {
+        let package_id = PackageID::from_index(package_index);
+        if !pkg_resolutions.has(package_id) || workspace_targets.is_set(package_index) {
             continue;
         }
         let resolution = &pkg_resolutions[package_id];
@@ -457,10 +456,10 @@ where
 {
     let string_buf = this.lockfile.buffers.string_bytes.as_slice();
     let packages_slice = this.lockfile.packages.slice();
-    let resolution: Resolution = packages_slice.items_resolution()[package_id.index()];
+    let resolution: Resolution = packages_slice.items_resolution()[package_id];
     let name = dependency.name.slice(string_buf);
 
-    let package_name = packages_slice.items_name()[package_id.index()].slice(string_buf);
+    let package_name = packages_slice.items_name()[package_id].slice(string_buf);
     if let Some(later_version_fmt) =
         manager.format_later_version_in_cache(package_name, dependency.name_hash, &resolution)
     {
@@ -562,16 +561,16 @@ where
     writer.write_str("\n")?;
     // `allocator` param dropped — global mimalloc.
     let slice = this.lockfile.packages.slice();
-    let bins: &[Bin] = slice.items_bin();
-    let resolved: &[Resolution] = slice.items_resolution();
+    let bins = slice.items_bin();
+    let resolved = slice.items_resolution();
     if resolved.is_empty() {
         return Ok(());
     }
     let string_buf = this.lockfile.buffers.string_bytes.as_slice();
     let resolutions_list = slice.items_resolutions();
     let pkg_metas = slice.items_meta();
-    let resolutions_buffer: &[PackageID] = this.lockfile.buffers.resolutions.as_slice();
-    let dependencies_buffer: &[Dependency] = this.lockfile.buffers.dependencies.as_slice();
+    let resolutions_buffer = this.lockfile.buffers.resolutions.as_slice();
+    let dependencies_buffer = this.lockfile.buffers.dependencies.as_slice();
     if dependencies_buffer.is_empty() {
         return Ok(());
     }
@@ -584,8 +583,8 @@ where
         if log_level.is_verbose() {
             let mut workspaces_to_print: Vec<DependencyID> = Vec::new();
 
-            for dep_id in resolutions_list[0].dependency_ids() {
-                let dep = &dependencies_buffer[dep_id.index()];
+            for dep_id in resolutions_list[PackageID::ROOT].dependency_ids() {
+                let dep = &dependencies_buffer[dep_id];
                 if dep.behavior.is_workspace() {
                     workspaces_to_print.push(dep_id);
                 }
@@ -593,8 +592,8 @@ where
 
             let mut found_workspace_to_print = false;
             for &workspace_dep_id in &workspaces_to_print {
-                let workspace_package_id = resolutions_buffer[workspace_dep_id.index()];
-                for dep_id in resolutions_list[workspace_package_id.index()].dependency_ids() {
+                let workspace_package_id = resolutions_buffer[workspace_dep_id];
+                for dep_id in resolutions_list[workspace_package_id].dependency_ids() {
                     match should_print_package_install(
                         this,
                         manager,
@@ -622,7 +621,7 @@ where
             )?;
 
             for &workspace_dep_id in &workspaces_to_print {
-                let workspace_package_id = resolutions_buffer[workspace_dep_id.index()];
+                let workspace_package_id = resolutions_buffer[workspace_dep_id];
                 print_installed_workspace_section::<W, ENABLE_ANSI_COLORS, true>(
                     this,
                     manager,
@@ -638,10 +637,10 @@ where
             // just print installed packages for the current workspace
             let mut workspace_package_id = PackageID::ROOT;
             if let Some(workspace_name_hash) = manager.workspace_name_hash {
-                for dep_id in resolutions_list[0].dependency_ids() {
-                    let dep = &dependencies_buffer[dep_id.index()];
+                for dep_id in resolutions_list[PackageID::ROOT].dependency_ids() {
+                    let dep = &dependencies_buffer[dep_id];
                     if dep.behavior.is_workspace() && dep.name_hash == workspace_name_hash {
-                        workspace_package_id = resolutions_buffer[dep_id.index()];
+                        workspace_package_id = resolutions_buffer[dep_id];
                         break;
                     }
                 }
@@ -653,12 +652,10 @@ where
                 if let Some(targets) = manager.update_target_workspaces.as_deref() {
                     let names = slice.items_name();
                     let name_hashes = slice.items_name_hash();
-                    let members = resolutions_list[0]
+                    let members = resolutions_list[PackageID::ROOT]
                         .dependency_ids()
-                        .filter(|&dep_id| {
-                            dependencies_buffer[dep_id.index()].behavior.is_workspace()
-                        })
-                        .map(|dep_id| resolutions_buffer[dep_id.index()]);
+                        .filter(|&dep_id| dependencies_buffer[dep_id].behavior.is_workspace())
+                        .map(|dep_id| resolutions_buffer[dep_id]);
                     update_owners = core::iter::once(PackageID::ROOT)
                         .chain(members)
                         .filter(|&importer| {
@@ -666,8 +663,8 @@ where
                                 && targets.iter().any(|target| {
                                     target.matches(
                                         importer == PackageID::ROOT,
-                                        name_hashes[importer.index()],
-                                        names[importer.index()].slice(string_buf),
+                                        name_hashes[importer],
+                                        names[importer].slice(string_buf),
                                     )
                                 })
                         })
@@ -723,7 +720,7 @@ where
                 ENABLE_ANSI_COLORS,
                 " <r><b>{s}<r><d>@<b>{f}<r>\n",
                 bstr::BStr::new(package_name),
-                resolved[package_id.index()].fmt(string_buf, PathSep::Auto),
+                resolved[package_id].fmt(string_buf, PathSep::Auto),
             )?;
         }
     }
@@ -745,10 +742,10 @@ where
             had_printed_new_install = true;
         }
 
-        let dependency = &dependencies_buffer[dependency_id.index()];
-        let package_id = resolutions_buffer[dependency_id.index()];
-        let bin = bins[package_id.index()];
-        let resolution = &resolved[package_id.index()];
+        let dependency = &dependencies_buffer[dependency_id];
+        let package_id = resolutions_buffer[dependency_id];
+        let bin = bins[package_id];
+        let resolution = &resolved[package_id];
 
         match bin.tag {
             bin::Tag::None | bin::Tag::Dir => {

--- a/src/install/lockfile/pruned_workspaces.rs
+++ b/src/install/lockfile/pruned_workspaces.rs
@@ -55,7 +55,7 @@ pub(crate) fn exit_if_survivor_depends_on_missing(
         missing
             .iter()
             .copied()
-            .find(|&id| name_hashes[id as usize] == dep.name_hash)
+            .find(|&id| name_hashes[id.index()] == dep.name_hash)
     };
 
     let mut found = false;
@@ -70,7 +70,7 @@ pub(crate) fn exit_if_survivor_depends_on_missing(
         if silent {
             continue;
         }
-        let target = target as usize;
+        let target = target.index();
         debug_assert_eq!(pkg_res[target].tag, ResolutionTag::Workspace);
         bun_core::pretty_errorln!(
             "<r><red>error<r><d>:<r> the root package depends on workspace <b>\"{}\"<r> ({}), which is listed in bun.lock but not on disk",
@@ -88,7 +88,7 @@ pub(crate) fn exit_if_survivor_depends_on_missing(
             if silent {
                 continue;
             }
-            let target = target as usize;
+            let target = target.index();
             debug_assert_eq!(pkg_res[target].tag, ResolutionTag::Workspace);
             bun_core::pretty_errorln!(
                 "<r><red>error<r><d>:<r> workspace <b>\"{}\"<r> depends on workspace <b>\"{}\"<r> ({}), which is listed in bun.lock but not on disk",

--- a/src/install/lockfile/pruned_workspaces.rs
+++ b/src/install/lockfile/pruned_workspaces.rs
@@ -55,7 +55,7 @@ pub(crate) fn exit_if_survivor_depends_on_missing(
         missing
             .iter()
             .copied()
-            .find(|&id| name_hashes[id.index()] == dep.name_hash)
+            .find(|&id| name_hashes[id] == dep.name_hash)
     };
 
     let mut found = false;
@@ -70,7 +70,6 @@ pub(crate) fn exit_if_survivor_depends_on_missing(
         if silent {
             continue;
         }
-        let target = target.index();
         debug_assert_eq!(pkg_res[target].tag, ResolutionTag::Workspace);
         bun_core::pretty_errorln!(
             "<r><red>error<r><d>:<r> the root package depends on workspace <b>\"{}\"<r> ({}), which is listed in bun.lock but not on disk",
@@ -88,7 +87,6 @@ pub(crate) fn exit_if_survivor_depends_on_missing(
             if silent {
                 continue;
             }
-            let target = target.index();
             debug_assert_eq!(pkg_res[target].tag, ResolutionTag::Workspace);
             bun_core::pretty_errorln!(
                 "<r><red>error<r><d>:<r> workspace <b>\"{}\"<r> depends on workspace <b>\"{}\"<r> ({}), which is listed in bun.lock but not on disk",
@@ -196,7 +194,7 @@ fn catalog_entry_is_referenced(
     let dep_slices = pkgs.items_dependencies();
     let deps = lockfile.buffers.dependencies.as_slice();
 
-    (0..pkgs.len()).any(|pkg_id| match pkg_res[pkg_id].tag {
+    pkg_res.ids().any(|pkg_id| match pkg_res[pkg_id].tag {
         ResolutionTag::Root => dep_slices[pkg_id].get(deps).iter().any(&hits),
         ResolutionTag::Workspace => {
             dep_slices[pkg_id].get(deps).iter().any(&hits)

--- a/src/install/lockfile/reachable.rs
+++ b/src/install/lockfile/reachable.rs
@@ -35,7 +35,7 @@ impl Options {
     pub(crate) fn install(manager: &PackageManager) -> Options {
         let features = manager.options.local_package_features;
         Options {
-            root: 0,
+            root: PackageID::ROOT,
             dev: features.dev_dependencies,
             optional: features.optional_dependencies,
             peer: features.peer_dependencies,
@@ -79,7 +79,7 @@ pub fn packages_from(
 
 // Out-of-range ids (invalid_package_id) are treated as already seen.
 fn mark(seen: &mut DynamicBitSet, id: PackageID) -> bool {
-    let index = id as usize;
+    let index = id.index();
     if seen.is_set_allow_out_of_bound(index, true) {
         return false;
     }
@@ -105,7 +105,7 @@ pub fn dev_packages_from(
     }
     let mut worklist: Vec<PackageID> = Vec::new();
     while let Some(importer) = importers.pop() {
-        let slice = walk.dep_slices[importer as usize];
+        let slice = walk.dep_slices[importer.index()];
         for dep_id in slice.begin() as usize..slice.end() as usize {
             let behavior = walk.deps[dep_id].behavior;
             let target = walk.resolutions[dep_id];
@@ -181,21 +181,21 @@ impl<'a> Walk<'a> {
     }
 
     fn admit(&self, target: PackageID, seen: &mut DynamicBitSet, worklist: &mut Vec<PackageID>) {
-        if seen.is_set_allow_out_of_bound(target as usize, true) {
+        if seen.is_set_allow_out_of_bound(target.index(), true) {
             return;
         }
         if let Some((cpu, os)) = self.options.platform
-            && self.metas[target as usize].is_disabled(cpu, os)
+            && self.metas[target.index()].is_disabled(cpu, os)
         {
             return;
         }
-        seen.set(target as usize);
+        seen.set(target.index());
         worklist.push(target);
     }
 
     fn drain(&self, seen: &mut DynamicBitSet, worklist: &mut Vec<PackageID>) {
         while let Some(parent) = worklist.pop() {
-            let slice = self.dep_slices[parent as usize];
+            let slice = self.dep_slices[parent.index()];
             for dep_id in slice.begin() as usize..slice.end() as usize {
                 if !(self.follow_all || self.follows(self.deps[dep_id].behavior)) {
                     continue;

--- a/src/install/lockfile/reachable.rs
+++ b/src/install/lockfile/reachable.rs
@@ -3,8 +3,8 @@ use crate::lockfile::DependencySlice;
 use crate::lockfile::package::{Meta, PackageColumns as _};
 use crate::lockfile_real::Lockfile;
 use crate::npm::{Architecture, OperatingSystem};
-use crate::{PackageID, PackageManager};
-use bun_collections::DynamicBitSet;
+use crate::{DependencyID, PackageID, PackageManager};
+use bun_collections::{DynamicBitSet, IdSlice};
 use bun_core::UnwrapOrOom;
 
 #[derive(Clone, Copy)]
@@ -47,7 +47,11 @@ impl Options {
 }
 
 // `resolutions` is passed separately so callers can walk a candidate resolution buffer (dedupe).
-pub fn packages(lockfile: &Lockfile, resolutions: &[PackageID], options: Options) -> DynamicBitSet {
+pub fn packages(
+    lockfile: &Lockfile,
+    resolutions: &IdSlice<DependencyID, PackageID>,
+    options: Options,
+) -> DynamicBitSet {
     packages_from(
         lockfile,
         resolutions,
@@ -60,7 +64,7 @@ pub fn packages(lockfile: &Lockfile, resolutions: &[PackageID], options: Options
 // `options.root` is ignored; `follow_workspace_edges: false` keeps a root's workspace edges out of the walk (`--filter`).
 pub fn packages_from(
     lockfile: &Lockfile,
-    resolutions: &[PackageID],
+    resolutions: &IdSlice<DependencyID, PackageID>,
     roots: &[PackageID],
     follow_workspace_edges: bool,
     options: Options,
@@ -90,7 +94,7 @@ fn mark(seen: &mut DynamicBitSet, id: PackageID) -> bool {
 // What the devDependencies of `roots` (and of the workspaces they own) pull in — `bun pm licenses --dev`.
 pub fn dev_packages_from(
     lockfile: &Lockfile,
-    resolutions: &[PackageID],
+    resolutions: &IdSlice<DependencyID, PackageID>,
     roots: &[PackageID],
     follow_workspace_edges: bool,
     options: Options,
@@ -105,8 +109,8 @@ pub fn dev_packages_from(
     }
     let mut worklist: Vec<PackageID> = Vec::new();
     while let Some(importer) = importers.pop() {
-        let slice = walk.dep_slices[importer.index()];
-        for dep_id in slice.begin() as usize..slice.end() as usize {
+        let slice = walk.dep_slices[importer];
+        for dep_id in slice.dependency_ids() {
             let behavior = walk.deps[dep_id].behavior;
             let target = walk.resolutions[dep_id];
             if behavior.is_workspace() {
@@ -125,10 +129,10 @@ pub fn dev_packages_from(
 }
 
 struct Walk<'a> {
-    dep_slices: &'a [DependencySlice],
-    metas: &'a [Meta],
-    deps: &'a [Dependency],
-    resolutions: &'a [PackageID],
+    dep_slices: &'a IdSlice<PackageID, DependencySlice>,
+    metas: &'a IdSlice<PackageID, Meta>,
+    deps: &'a IdSlice<DependencyID, Dependency>,
+    resolutions: &'a IdSlice<DependencyID, PackageID>,
     follow_workspace_edges: bool,
     follow_all: bool,
     options: Options,
@@ -137,7 +141,7 @@ struct Walk<'a> {
 impl<'a> Walk<'a> {
     fn new(
         lockfile: &'a Lockfile,
-        resolutions: &'a [PackageID],
+        resolutions: &'a IdSlice<DependencyID, PackageID>,
         follow_workspace_edges: bool,
         options: Options,
     ) -> Walk<'a> {
@@ -185,7 +189,7 @@ impl<'a> Walk<'a> {
             return;
         }
         if let Some((cpu, os)) = self.options.platform
-            && self.metas[target.index()].is_disabled(cpu, os)
+            && self.metas[target].is_disabled(cpu, os)
         {
             return;
         }
@@ -195,8 +199,8 @@ impl<'a> Walk<'a> {
 
     fn drain(&self, seen: &mut DynamicBitSet, worklist: &mut Vec<PackageID>) {
         while let Some(parent) = worklist.pop() {
-            let slice = self.dep_slices[parent.index()];
-            for dep_id in slice.begin() as usize..slice.end() as usize {
+            let slice = self.dep_slices[parent];
+            for dep_id in slice.dependency_ids() {
                 if !(self.follow_all || self.follows(self.deps[dep_id].behavior)) {
                     continue;
                 }

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -7,7 +7,7 @@ use bun_semver::query::token::Wildcard;
 use bun_semver::{self as Semver, SlicedString};
 use bun_sys::{self, Fd, File, O};
 
-use crate::install::{self as Install, PackageManager, Subcommand};
+use crate::install::{self as Install, PackageID, PackageManager, Subcommand};
 use crate::lockfile::{
     Format as LockfileFormat, LoadResult, LoadResultErr, LoadResultOk, LoadStep, Lockfile, Migrated,
 };
@@ -423,7 +423,7 @@ fn migrate_npm_lockfile<'a>(
 /// packages (`Package::from_npm`); folder, tarball, git, and workspace packages
 /// install unconditionally, so a migrated lockfile must not constrain them.
 pub(crate) fn clear_non_registry_platform_constraints(lockfile: &mut Lockfile) {
-    for i in 0..lockfile.packages.len() {
+    for i in (0..lockfile.packages.len()).map(PackageID::from_index) {
         match lockfile.packages.items_resolution()[i].tag {
             resolution::Tag::Root | resolution::Tag::Npm => {}
             _ => {

--- a/src/install/migration/npm_lock.rs
+++ b/src/install/migration/npm_lock.rs
@@ -153,7 +153,7 @@ pub(super) fn migrate_packages(
     migrator.build_index()?;
 
     let root_id = migrator.build_package(0, false, DepTag::Npm)?;
-    debug_assert_eq!(root_id, 0);
+    debug_assert_eq!(root_id, PackageID::ROOT);
 
     let mut cursor = 0;
     while cursor < migrator.queue.len() {
@@ -416,10 +416,10 @@ impl<'a> Migrator<'a> {
                 );
                 // A bundled copy carries no `resolved`/`integrity`; a registry copy of the same version does.
                 if res.tag == resolution::Tag::Npm && meta.integrity.tag.is_supported() {
-                    let existing_meta = &mut self.this.packages.items_meta_mut()[existing as usize];
+                    let existing_meta = &mut self.this.packages.items_meta_mut()[existing.index()];
                     if !existing_meta.integrity.tag.is_supported() {
                         existing_meta.integrity = meta.integrity;
-                        self.this.packages.items_resolution_mut()[existing as usize] = res;
+                        self.this.packages.items_resolution_mut()[existing.index()] = res;
                     }
                 }
                 self.entry_package_ids[j as usize] = existing;
@@ -428,7 +428,7 @@ impl<'a> Migrator<'a> {
             }
         }
 
-        let id = self.this.packages.len() as PackageID;
+        let id = PackageID::from_index(self.this.packages.len());
         meta.id = id;
         let bin_value = Self::parse_bin(self.this, pkg, name)?;
 
@@ -675,7 +675,7 @@ impl<'a> Migrator<'a> {
         let start = self.this.buffers.dependencies.len();
         debug_assert_eq!(start, self.this.buffers.resolutions.len());
 
-        let res_tag = self.this.packages.items_resolution()[id as usize].tag;
+        let res_tag = self.this.packages.items_resolution()[id.index()].tag;
         let is_local = matches!(res_tag, resolution::Tag::Root | resolution::Tag::Workspace);
         let bundle = if is_local {
             Bundle::None
@@ -818,8 +818,8 @@ impl<'a> Migrator<'a> {
                 ExternalSlice::new(start as u32, len as u32),
             )
         };
-        self.this.packages.items_dependencies_mut()[id as usize] = deps_slice;
-        self.this.packages.items_resolutions_mut()[id as usize] = res_slice;
+        self.this.packages.items_dependencies_mut()[id.index()] = deps_slice;
+        self.this.packages.items_resolutions_mut()[id.index()] = res_slice;
         Ok(())
     }
 
@@ -916,7 +916,7 @@ impl<'a> Migrator<'a> {
         }
         let id = self.entry_package_ids[t as usize];
         if id != INVALID_PACKAGE_ID {
-            return self.this.packages.items_resolution()[id as usize].tag
+            return self.this.packages.items_resolution()[id.index()].tag
                 == resolution::Tag::Folder;
         }
         let pkg = entry_object(entry);

--- a/src/install/migration/npm_lock.rs
+++ b/src/install/migration/npm_lock.rs
@@ -27,7 +27,7 @@ use crate::npm as Npm;
 use crate::repository::{Repository, RepositoryExt as _, is_safe_resolved_tag};
 use crate::resolution::{self, Resolution, TaggedValue as ResTagged};
 use crate::versioned_url::VersionedURLType;
-use crate::{ExternalStringList, INVALID_PACKAGE_ID, PackageID, PackageManager};
+use crate::{DependencyID, ExternalStringList, INVALID_PACKAGE_ID, PackageID, PackageManager};
 
 macro_rules! debug {
     ($($args:tt)*) => { bun_output::scoped_log!(super::migrate, $($args)*) };
@@ -416,10 +416,10 @@ impl<'a> Migrator<'a> {
                 );
                 // A bundled copy carries no `resolved`/`integrity`; a registry copy of the same version does.
                 if res.tag == resolution::Tag::Npm && meta.integrity.tag.is_supported() {
-                    let existing_meta = &mut self.this.packages.items_meta_mut()[existing.index()];
+                    let existing_meta = &mut self.this.packages.items_meta_mut()[existing];
                     if !existing_meta.integrity.tag.is_supported() {
                         existing_meta.integrity = meta.integrity;
-                        self.this.packages.items_resolution_mut()[existing.index()] = res;
+                        self.this.packages.items_resolution_mut()[existing] = res;
                     }
                 }
                 self.entry_package_ids[j as usize] = existing;
@@ -675,7 +675,7 @@ impl<'a> Migrator<'a> {
         let start = self.this.buffers.dependencies.len();
         debug_assert_eq!(start, self.this.buffers.resolutions.len());
 
-        let res_tag = self.this.packages.items_resolution()[id.index()].tag;
+        let res_tag = self.this.packages.items_resolution()[id].tag;
         let is_local = matches!(res_tag, resolution::Tag::Root | resolution::Tag::Workspace);
         let bundle = if is_local {
             Bundle::None
@@ -753,10 +753,10 @@ impl<'a> Migrator<'a> {
                 let duplicate_of = if (is_peer_group && skip_peer_dups)
                     || (is_optional_group && replace_optional_dups)
                 {
-                    self.this.buffers.dependencies[start..]
+                    self.this.buffers.dependencies.raw()[start..]
                         .iter()
                         .position(|d| d.name_hash == name_hash)
-                        .map(|k| start + k)
+                        .map(|k| DependencyID::from_index(start + k))
                 } else {
                     None
                 };
@@ -818,8 +818,8 @@ impl<'a> Migrator<'a> {
                 ExternalSlice::new(start as u32, len as u32),
             )
         };
-        self.this.packages.items_dependencies_mut()[id.index()] = deps_slice;
-        self.this.packages.items_resolutions_mut()[id.index()] = res_slice;
+        self.this.packages.items_dependencies_mut()[id] = deps_slice;
+        self.this.packages.items_resolutions_mut()[id] = res_slice;
         Ok(())
     }
 
@@ -916,8 +916,7 @@ impl<'a> Migrator<'a> {
         }
         let id = self.entry_package_ids[t as usize];
         if id != INVALID_PACKAGE_ID {
-            return self.this.packages.items_resolution()[id.index()].tag
-                == resolution::Tag::Folder;
+            return self.this.packages.items_resolution()[id].tag == resolution::Tag::Folder;
         }
         let pkg = entry_object(entry);
         if pkg.get(b"resolved").is_some()
@@ -1054,7 +1053,7 @@ pub(super) fn apply_root_overrides(
 
     let empty = WorkspaceMap::init();
     let names = workspace_map.unwrap_or(&empty);
-    let root_package = *this.packages.get(0);
+    let root_package = this.package(PackageID::ROOT);
     let (mut builder, lf) = this.string_builder_split();
     lf.overrides
         .parse_count(manager, log, &source, names, json, &mut builder);

--- a/src/install/padding_checker.rs
+++ b/src/install/padding_checker.rs
@@ -136,6 +136,8 @@ pub mod layout_asserts {
     // ── leaf POD shared by both formats ──────────────────────────────────
     pin!(bun_semver::String, size = 8, align = 1); // [8]u8
     pin!(bun_semver::ExternalString, size = 16, align = 8); // String + u64
+    pin!(crate::PackageID, size = 4, align = 4); // u32 (`resolutions` buffer, `Meta.id`)
+    pin!(crate::DependencyID, size = 4, align = 4); // u32 (`hoisted_dependencies` buffer, `Tree`)
     pin!(crate::ExternalSlice<u8>, size = 8, align = 4); // u32 off + u32 len
     pin!(crate::ExternalStringMap, size = 16, align = 4);
     pin!(crate::integrity::Integrity, size = 65, align = 1); // u8 tag + [64]u8

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -276,7 +276,7 @@ impl PatchTask {
             let pkg_id = state.pkg_id;
             let dep_id = state.dependency_id;
 
-            let pkg: Package = *manager.lockfile.packages.get(pkg_id as usize);
+            let pkg: Package = *manager.lockfile.packages.get(pkg_id.index());
             // `Package` is not `Copy`; capture the scalar fields we need
             // after `determine_preinstall_state` consumes it.
             let pkg_meta_id = pkg.meta.id;
@@ -316,7 +316,7 @@ impl PatchTask {
                     // tarball; see the TODO below), which then read garbage
                     // version bytes into the task id, not UB.
                     let pkg_npm_version = unsafe {
-                        manager.lockfile.packages.items_resolution()[pkg_id as usize]
+                        manager.lockfile.packages.items_resolution()[pkg_id.index()]
                             .value
                             .npm
                             .version
@@ -325,10 +325,10 @@ impl PatchTask {
                         TaskId::for_npm_package(manager.lockfile.str(&pkg_name), pkg_npm_version);
                     debug_assert!(!manager.network_dedupe_map.contains_key(&task_id));
 
-                    let is_required = manager.lockfile.buffers.dependencies[dep_id as usize]
+                    let is_required = manager.lockfile.buffers.dependencies[dep_id.index()]
                         .behavior
                         .is_required();
-                    let pkg_again: Package = *manager.lockfile.packages.get(pkg_id as usize);
+                    let pkg_again: Package = *manager.lockfile.packages.get(pkg_id.index());
                     let network_task: *mut crate::NetworkTask =
                         package_manager::generate_network_task_for_tarball(
                             manager,
@@ -444,7 +444,7 @@ impl PatchTask {
             // off-thread.
             let manager = self.manager.get();
             let resolution: &Resolution =
-                &manager.lockfile.packages.items_resolution()[patch.pkg_id as usize];
+                &manager.lockfile.packages.items_resolution()[patch.pkg_id.index()];
             let mut label = Vec::<u8>::new();
             use std::io::Write as _;
             write!(
@@ -752,7 +752,7 @@ impl PatchTask {
         patch_hash: u64,
         name_and_version_hash: u64,
     ) -> Box<PatchTask> {
-        let pkg_name = pkg_manager.lockfile.packages.items_name()[pkg_id as usize];
+        let pkg_name = pkg_manager.lockfile.packages.items_name()[pkg_id.index()];
 
         // Borrowck — `compute_cache_dir_and_subpath` borrows `&mut PackageManager`
         // while `pkg_name.slice(..)` and `resolution` borrow `pkg_manager.lockfile` immutably.
@@ -763,7 +763,7 @@ impl PatchTask {
         // `Resolution` is `Copy`; copy out so the lockfile borrow ends
         // before `compute_cache_dir_and_subpath` reborrows `pkg_manager` mutably.
         let resolution_clone: Resolution =
-            pkg_manager.lockfile.packages.items_resolution()[pkg_id as usize];
+            pkg_manager.lockfile.packages.items_resolution()[pkg_id.index()];
 
         let mut folder_path_buf = PathBuffer::uninit();
         let stuff = package_manager::compute_cache_dir_and_subpath(

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -276,7 +276,7 @@ impl PatchTask {
             let pkg_id = state.pkg_id;
             let dep_id = state.dependency_id;
 
-            let pkg: Package = *manager.lockfile.packages.get(pkg_id.index());
+            let pkg: Package = manager.lockfile.package(pkg_id);
             // `Package` is not `Copy`; capture the scalar fields we need
             // after `determine_preinstall_state` consumes it.
             let pkg_meta_id = pkg.meta.id;
@@ -316,7 +316,7 @@ impl PatchTask {
                     // tarball; see the TODO below), which then read garbage
                     // version bytes into the task id, not UB.
                     let pkg_npm_version = unsafe {
-                        manager.lockfile.packages.items_resolution()[pkg_id.index()]
+                        manager.lockfile.packages.items_resolution()[pkg_id]
                             .value
                             .npm
                             .version
@@ -325,10 +325,10 @@ impl PatchTask {
                         TaskId::for_npm_package(manager.lockfile.str(&pkg_name), pkg_npm_version);
                     debug_assert!(!manager.network_dedupe_map.contains_key(&task_id));
 
-                    let is_required = manager.lockfile.buffers.dependencies[dep_id.index()]
+                    let is_required = manager.lockfile.buffers.dependencies[dep_id]
                         .behavior
                         .is_required();
-                    let pkg_again: Package = *manager.lockfile.packages.get(pkg_id.index());
+                    let pkg_again: Package = manager.lockfile.package(pkg_id);
                     let network_task: *mut crate::NetworkTask =
                         package_manager::generate_network_task_for_tarball(
                             manager,
@@ -444,7 +444,7 @@ impl PatchTask {
             // off-thread.
             let manager = self.manager.get();
             let resolution: &Resolution =
-                &manager.lockfile.packages.items_resolution()[patch.pkg_id.index()];
+                &manager.lockfile.packages.items_resolution()[patch.pkg_id];
             let mut label = Vec::<u8>::new();
             use std::io::Write as _;
             write!(
@@ -752,7 +752,7 @@ impl PatchTask {
         patch_hash: u64,
         name_and_version_hash: u64,
     ) -> Box<PatchTask> {
-        let pkg_name = pkg_manager.lockfile.packages.items_name()[pkg_id.index()];
+        let pkg_name = pkg_manager.lockfile.packages.items_name()[pkg_id];
 
         // Borrowck — `compute_cache_dir_and_subpath` borrows `&mut PackageManager`
         // while `pkg_name.slice(..)` and `resolution` borrow `pkg_manager.lockfile` immutably.
@@ -762,8 +762,7 @@ impl PatchTask {
             .to_vec();
         // `Resolution` is `Copy`; copy out so the lockfile borrow ends
         // before `compute_cache_dir_and_subpath` reborrows `pkg_manager` mutably.
-        let resolution_clone: Resolution =
-            pkg_manager.lockfile.packages.items_resolution()[pkg_id.index()];
+        let resolution_clone: Resolution = pkg_manager.lockfile.packages.items_resolution()[pkg_id];
 
         let mut folder_path_buf = PathBuffer::uninit();
         let stuff = package_manager::compute_cache_dir_and_subpath(

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -847,16 +847,19 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
             root_pkg.dependencies = ExternalSlice::new(off, len);
             root_pkg.resolutions = ExternalSlice::new(off, len);
 
-            root_pkg.meta.id = 0;
+            root_pkg.meta.id = PackageID::ROOT;
             root_pkg.resolution = Resolution::init_root();
             let root_name_hash = root_pkg.name_hash;
             lockfile.packages.append(root_pkg)?;
-            lockfile.get_or_put_id(0, root_name_hash)?;
+            lockfile.get_or_put_id(PackageID::ROOT, root_name_hash)?;
         }
 
         let mut pkg_map: StringArrayHashMap<PackageID> = StringArrayHashMap::new();
 
-        pkg_map.put(crate::bun_fs::FileSystem::instance().top_level_dir(), 0)?;
+        pkg_map.put(
+            crate::bun_fs::FileSystem::instance().top_level_dir(),
+            PackageID::ROOT,
+        )?;
 
         let workspace_pkgs_off = lockfile.packages.len();
 
@@ -957,17 +960,17 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
         // add packages for symlink dependencies. pnpm-lock does not add an entry
         // for these dependencies in packages/snapshots
         for _pkg_id in 0..workspace_pkgs_end {
-            let pkg_id: PackageID = u32::try_from(_pkg_id).expect("int cast");
+            let pkg_id = PackageID::try_from(_pkg_id).expect("int cast");
 
             // Own the bytes — the `'next_dep` loop body mutates
             // `lockfile.buffers.string_bytes` (via `sbuf!`) and takes
             // `&mut *lockfile` (`append_package_dedupe`), so a borrow that
             // spans the loop would conflict.
             let workspace_path_buf: Vec<u8>;
-            let workspace_path: &[u8] = if pkg_id == 0 {
+            let workspace_path: &[u8] = if pkg_id == PackageID::ROOT {
                 b"."
             } else {
-                let workspace_res = lockfile.packages.items_resolution()[pkg_id as usize];
+                let workspace_res = lockfile.packages.items_resolution()[pkg_id.index()];
                 let ws = *workspace_res.workspace();
                 workspace_path_buf = ws.slice(string_bytes!(lockfile)).to_vec();
                 &workspace_path_buf
@@ -977,11 +980,9 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 return Err(invalid_pnpm_lockfile());
             };
 
-            let deps = lockfile.packages.items_dependencies()[pkg_id as usize];
-            'next_dep: for _dep_id in deps.begin()..deps.end() {
-                let dep_id: DependencyID = _dep_id;
-
-                let dep = lockfile.buffers.dependencies[dep_id as usize].clone();
+            let deps = lockfile.packages.items_dependencies()[pkg_id.index()];
+            'next_dep: for dep_id in deps.dependency_ids() {
+                let dep = lockfile.buffers.dependencies[dep_id.index()].clone();
 
                 if dep.behavior.is_workspace() {
                     continue;
@@ -1244,7 +1245,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                     if let Some(workspace_pkg_id) = pkg_map
                         .get(path_buf.slice())
                         .copied()
-                        .filter(|id| (*id as usize) < workspace_pkgs_end)
+                        .filter(|id| id.index() < workspace_pkgs_end)
                     {
                         pkg_map.put(key_str, workspace_pkg_id)?;
                         continue;
@@ -1424,9 +1425,8 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
 
         // resolve root dependencies first
         let root_deps = lockfile.packages.items_dependencies()[0];
-        for _dep_id in root_deps.begin()..root_deps.end() {
-            let dep_id: DependencyID = _dep_id;
-            let dep = lockfile.buffers.dependencies[dep_id as usize].clone();
+        for dep_id in root_deps.dependency_ids() {
+            let dep = lockfile.buffers.dependencies[dep_id.index()].clone();
             let string_buf = string_bytes!(lockfile);
 
             // implicit workspace dependencies
@@ -1436,14 +1436,14 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 let mut path_buf = bun_paths::AutoAbsPath::init_top_level_dir();
                 let _ = path_buf.join(&[workspace_path]); // path-buffer overflow unreachable for bounded inputs
                 if let Some(workspace_pkg_id) = pkg_map.get(path_buf.slice()) {
-                    lockfile.buffers.resolutions[dep_id as usize] = *workspace_pkg_id;
+                    lockfile.buffers.resolutions[dep_id.index()] = *workspace_pkg_id;
                     continue;
                 }
             }
 
             let dep_name = dep.name.slice(string_buf);
             if let Some(peer_pkg_id) = resolve_peer_like_bun_lock(lockfile, &dep) {
-                lockfile.buffers.resolutions[dep_id as usize] = peer_pkg_id;
+                lockfile.buffers.resolutions[dep_id.index()] = peer_pkg_id;
                 continue;
             }
             let Some(mut version_maybe_alias) = importer_versions.get(dep_name).map(|v| &**v)
@@ -1472,7 +1472,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 let mut path_buf = bun_paths::AutoAbsPath::init_top_level_dir();
                 let _ = path_buf.join(&[maybe_symlink_or_folder_or_workspace_path]); // path-buffer overflow unreachable for bounded inputs
                 if let Some(pkg_id) = pkg_map.get(path_buf.slice()) {
-                    lockfile.buffers.resolutions[dep_id as usize] = *pkg_id;
+                    lockfile.buffers.resolutions[dep_id.index()] = *pkg_id;
                     continue;
                 }
             }
@@ -1488,14 +1488,14 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 ));
             };
 
-            lockfile.buffers.resolutions[dep_id as usize] = *pkg_id;
+            lockfile.buffers.resolutions[dep_id.index()] = *pkg_id;
         }
     }
 
     for _pkg_id in workspace_pkgs_off..workspace_pkgs_end {
-        let pkg_id: PackageID = u32::try_from(_pkg_id).expect("int cast");
+        let pkg_id = PackageID::try_from(_pkg_id).expect("int cast");
 
-        let workspace_res = lockfile.packages.items_resolution()[pkg_id as usize];
+        let workspace_res = lockfile.packages.items_resolution()[pkg_id.index()];
         let ws = *workspace_res.workspace();
         let workspace_path = ws.slice(string_bytes!(lockfile));
 
@@ -1503,14 +1503,13 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
             return Err(invalid_pnpm_lockfile());
         };
 
-        let deps = lockfile.packages.items_dependencies()[pkg_id as usize];
-        for _dep_id in deps.begin()..deps.end() {
-            let dep_id: DependencyID = _dep_id;
-            let dep = lockfile.buffers.dependencies[dep_id as usize].clone();
+        let deps = lockfile.packages.items_dependencies()[pkg_id.index()];
+        for dep_id in deps.dependency_ids() {
+            let dep = lockfile.buffers.dependencies[dep_id.index()].clone();
             let string_buf = string_bytes!(lockfile);
             let dep_name = dep.name.slice(string_buf);
             if let Some(peer_pkg_id) = resolve_peer_like_bun_lock(lockfile, &dep) {
-                lockfile.buffers.resolutions[dep_id as usize] = peer_pkg_id;
+                lockfile.buffers.resolutions[dep_id.index()] = peer_pkg_id;
                 continue;
             }
             let Some(mut version_maybe_alias) = importer_versions.get(dep_name).map(|v| &**v)
@@ -1540,7 +1539,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 let mut path_buf = bun_paths::AutoAbsPath::init_top_level_dir();
                 let _ = path_buf.join(&[workspace_path, maybe_symlink_or_folder_or_workspace_path]); // path-buffer overflow unreachable for bounded inputs
                 if let Some(link_pkg_id) = pkg_map.get(path_buf.slice()) {
-                    lockfile.buffers.resolutions[dep_id as usize] = *link_pkg_id;
+                    lockfile.buffers.resolutions[dep_id.index()] = *link_pkg_id;
                     continue;
                 }
             }
@@ -1556,21 +1555,20 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 ));
             };
 
-            lockfile.buffers.resolutions[dep_id as usize] = *res_pkg_id;
+            lockfile.buffers.resolutions[dep_id.index()] = *res_pkg_id;
         }
     }
 
     for _pkg_id in workspace_pkgs_end..lockfile.packages.len() {
-        let pkg_id: PackageID = u32::try_from(_pkg_id).expect("int cast");
+        let pkg_id = PackageID::try_from(_pkg_id).expect("int cast");
 
-        let deps = lockfile.packages.items_dependencies()[pkg_id as usize];
-        for _dep_id in deps.begin()..deps.end() {
-            let dep_id: DependencyID = _dep_id;
-            let dep = lockfile.buffers.dependencies[dep_id as usize].clone();
+        let deps = lockfile.packages.items_dependencies()[pkg_id.index()];
+        for dep_id in deps.dependency_ids() {
+            let dep = lockfile.buffers.dependencies[dep_id.index()].clone();
             let string_buf = string_bytes!(lockfile);
             let dep_name = dep.name.slice(string_buf);
             if let Some(peer_pkg_id) = resolve_peer_like_bun_lock(lockfile, &dep) {
-                lockfile.buffers.resolutions[dep_id as usize] = peer_pkg_id;
+                lockfile.buffers.resolutions[dep_id.index()] = peer_pkg_id;
                 continue;
             }
             let mut version_maybe_alias = dep.version.literal.slice(string_buf);
@@ -1593,7 +1591,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                         let mut path_buf = bun_paths::AutoAbsPath::init_top_level_dir();
                         let _ = path_buf.join(&[maybe_symlink_or_folder_or_workspace_path]); // path-buffer overflow unreachable for bounded inputs
                         if let Some(link_pkg_id) = pkg_map.get(path_buf.slice()) {
-                            lockfile.buffers.resolutions[dep_id as usize] = *link_pkg_id;
+                            lockfile.buffers.resolutions[dep_id.index()] = *link_pkg_id;
                             continue;
                         }
                     }
@@ -1604,7 +1602,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
             }
 
             let Some(res_pkg_id) = pkg_map.get(&res_buf) else {
-                let pkg_name = lockfile.packages.items_name()[pkg_id as usize].slice(string_buf);
+                let pkg_name = lockfile.packages.items_name()[pkg_id.index()].slice(string_buf);
                 return Err(missing_package_entry(
                     log,
                     &res_buf,
@@ -1613,7 +1611,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 ));
             };
 
-            lockfile.buffers.resolutions[dep_id as usize] = *res_pkg_id;
+            lockfile.buffers.resolutions[dep_id.index()] = *res_pkg_id;
         }
     }
 
@@ -1925,7 +1923,7 @@ fn parse_append_package_dependencies(
         let bytes = lockfile.buffers.string_bytes.as_slice();
         for (i, dep) in lockfile.buffers.dependencies[off..end].iter().enumerate() {
             if let Some(reference) = references_by_name.get(dep.name.slice(bytes)) {
-                let dep_id = u32::try_from(off + i).expect("int cast");
+                let dep_id = DependencyID::try_from(off + i).expect("int cast");
                 snapshot_dep_paths.put(dep_id, reference.clone())?;
             }
         }
@@ -1945,14 +1943,14 @@ fn bind_peers_from_variant(
     snapshot_obj: &Expr,
     snapshot_dep_paths: &mut SnapshotDepPaths,
 ) -> Result<bool, AllocError> {
-    let deps = lockfile.packages.items_dependencies()[pkg_id as usize];
+    let deps = lockfile.packages.items_dependencies()[pkg_id.index()];
     let groups = [
         snapshot_obj.get(b"dependencies"),
         snapshot_obj.get(b"optionalDependencies"),
     ];
     let mut all_bound = true;
-    for dep_id in deps.begin()..deps.end() {
-        let dep = &lockfile.buffers.dependencies[dep_id as usize];
+    for dep_id in deps.dependency_ids() {
+        let dep = &lockfile.buffers.dependencies[dep_id.index()];
         if !dep.behavior.is_peer() || snapshot_dep_paths.contains(&dep_id) {
             continue;
         }

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -970,7 +970,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
             let workspace_path: &[u8] = if pkg_id == PackageID::ROOT {
                 b"."
             } else {
-                let workspace_res = lockfile.packages.items_resolution()[pkg_id.index()];
+                let workspace_res = lockfile.packages.items_resolution()[pkg_id];
                 let ws = *workspace_res.workspace();
                 workspace_path_buf = ws.slice(string_bytes!(lockfile)).to_vec();
                 &workspace_path_buf
@@ -980,9 +980,9 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 return Err(invalid_pnpm_lockfile());
             };
 
-            let deps = lockfile.packages.items_dependencies()[pkg_id.index()];
+            let deps = lockfile.packages.items_dependencies()[pkg_id];
             'next_dep: for dep_id in deps.dependency_ids() {
-                let dep = lockfile.buffers.dependencies[dep_id.index()].clone();
+                let dep = lockfile.buffers.dependencies[dep_id].clone();
 
                 if dep.behavior.is_workspace() {
                     continue;
@@ -1424,9 +1424,9 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
         };
 
         // resolve root dependencies first
-        let root_deps = lockfile.packages.items_dependencies()[0];
+        let root_deps = lockfile.packages.items_dependencies()[PackageID::ROOT];
         for dep_id in root_deps.dependency_ids() {
-            let dep = lockfile.buffers.dependencies[dep_id.index()].clone();
+            let dep = lockfile.buffers.dependencies[dep_id].clone();
             let string_buf = string_bytes!(lockfile);
 
             // implicit workspace dependencies
@@ -1436,14 +1436,14 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 let mut path_buf = bun_paths::AutoAbsPath::init_top_level_dir();
                 let _ = path_buf.join(&[workspace_path]); // path-buffer overflow unreachable for bounded inputs
                 if let Some(workspace_pkg_id) = pkg_map.get(path_buf.slice()) {
-                    lockfile.buffers.resolutions[dep_id.index()] = *workspace_pkg_id;
+                    lockfile.buffers.resolutions[dep_id] = *workspace_pkg_id;
                     continue;
                 }
             }
 
             let dep_name = dep.name.slice(string_buf);
             if let Some(peer_pkg_id) = resolve_peer_like_bun_lock(lockfile, &dep) {
-                lockfile.buffers.resolutions[dep_id.index()] = peer_pkg_id;
+                lockfile.buffers.resolutions[dep_id] = peer_pkg_id;
                 continue;
             }
             let Some(mut version_maybe_alias) = importer_versions.get(dep_name).map(|v| &**v)
@@ -1472,7 +1472,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 let mut path_buf = bun_paths::AutoAbsPath::init_top_level_dir();
                 let _ = path_buf.join(&[maybe_symlink_or_folder_or_workspace_path]); // path-buffer overflow unreachable for bounded inputs
                 if let Some(pkg_id) = pkg_map.get(path_buf.slice()) {
-                    lockfile.buffers.resolutions[dep_id.index()] = *pkg_id;
+                    lockfile.buffers.resolutions[dep_id] = *pkg_id;
                     continue;
                 }
             }
@@ -1488,14 +1488,14 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 ));
             };
 
-            lockfile.buffers.resolutions[dep_id.index()] = *pkg_id;
+            lockfile.buffers.resolutions[dep_id] = *pkg_id;
         }
     }
 
     for _pkg_id in workspace_pkgs_off..workspace_pkgs_end {
         let pkg_id = PackageID::try_from(_pkg_id).expect("int cast");
 
-        let workspace_res = lockfile.packages.items_resolution()[pkg_id.index()];
+        let workspace_res = lockfile.packages.items_resolution()[pkg_id];
         let ws = *workspace_res.workspace();
         let workspace_path = ws.slice(string_bytes!(lockfile));
 
@@ -1503,13 +1503,13 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
             return Err(invalid_pnpm_lockfile());
         };
 
-        let deps = lockfile.packages.items_dependencies()[pkg_id.index()];
+        let deps = lockfile.packages.items_dependencies()[pkg_id];
         for dep_id in deps.dependency_ids() {
-            let dep = lockfile.buffers.dependencies[dep_id.index()].clone();
+            let dep = lockfile.buffers.dependencies[dep_id].clone();
             let string_buf = string_bytes!(lockfile);
             let dep_name = dep.name.slice(string_buf);
             if let Some(peer_pkg_id) = resolve_peer_like_bun_lock(lockfile, &dep) {
-                lockfile.buffers.resolutions[dep_id.index()] = peer_pkg_id;
+                lockfile.buffers.resolutions[dep_id] = peer_pkg_id;
                 continue;
             }
             let Some(mut version_maybe_alias) = importer_versions.get(dep_name).map(|v| &**v)
@@ -1539,7 +1539,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 let mut path_buf = bun_paths::AutoAbsPath::init_top_level_dir();
                 let _ = path_buf.join(&[workspace_path, maybe_symlink_or_folder_or_workspace_path]); // path-buffer overflow unreachable for bounded inputs
                 if let Some(link_pkg_id) = pkg_map.get(path_buf.slice()) {
-                    lockfile.buffers.resolutions[dep_id.index()] = *link_pkg_id;
+                    lockfile.buffers.resolutions[dep_id] = *link_pkg_id;
                     continue;
                 }
             }
@@ -1555,20 +1555,20 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 ));
             };
 
-            lockfile.buffers.resolutions[dep_id.index()] = *res_pkg_id;
+            lockfile.buffers.resolutions[dep_id] = *res_pkg_id;
         }
     }
 
     for _pkg_id in workspace_pkgs_end..lockfile.packages.len() {
         let pkg_id = PackageID::try_from(_pkg_id).expect("int cast");
 
-        let deps = lockfile.packages.items_dependencies()[pkg_id.index()];
+        let deps = lockfile.packages.items_dependencies()[pkg_id];
         for dep_id in deps.dependency_ids() {
-            let dep = lockfile.buffers.dependencies[dep_id.index()].clone();
+            let dep = lockfile.buffers.dependencies[dep_id].clone();
             let string_buf = string_bytes!(lockfile);
             let dep_name = dep.name.slice(string_buf);
             if let Some(peer_pkg_id) = resolve_peer_like_bun_lock(lockfile, &dep) {
-                lockfile.buffers.resolutions[dep_id.index()] = peer_pkg_id;
+                lockfile.buffers.resolutions[dep_id] = peer_pkg_id;
                 continue;
             }
             let mut version_maybe_alias = dep.version.literal.slice(string_buf);
@@ -1591,7 +1591,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                         let mut path_buf = bun_paths::AutoAbsPath::init_top_level_dir();
                         let _ = path_buf.join(&[maybe_symlink_or_folder_or_workspace_path]); // path-buffer overflow unreachable for bounded inputs
                         if let Some(link_pkg_id) = pkg_map.get(path_buf.slice()) {
-                            lockfile.buffers.resolutions[dep_id.index()] = *link_pkg_id;
+                            lockfile.buffers.resolutions[dep_id] = *link_pkg_id;
                             continue;
                         }
                     }
@@ -1602,7 +1602,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
             }
 
             let Some(res_pkg_id) = pkg_map.get(&res_buf) else {
-                let pkg_name = lockfile.packages.items_name()[pkg_id.index()].slice(string_buf);
+                let pkg_name = lockfile.packages.items_name()[pkg_id].slice(string_buf);
                 return Err(missing_package_entry(
                     log,
                     &res_buf,
@@ -1611,7 +1611,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
                 ));
             };
 
-            lockfile.buffers.resolutions[dep_id.index()] = *res_pkg_id;
+            lockfile.buffers.resolutions[dep_id] = *res_pkg_id;
         }
     }
 
@@ -1921,7 +1921,10 @@ fn parse_append_package_dependencies(
 
     if references_by_name.count() > 0 {
         let bytes = lockfile.buffers.string_bytes.as_slice();
-        for (i, dep) in lockfile.buffers.dependencies[off..end].iter().enumerate() {
+        for (i, dep) in lockfile.buffers.dependencies.raw()[off..end]
+            .iter()
+            .enumerate()
+        {
             if let Some(reference) = references_by_name.get(dep.name.slice(bytes)) {
                 let dep_id = DependencyID::try_from(off + i).expect("int cast");
                 snapshot_dep_paths.put(dep_id, reference.clone())?;
@@ -1943,14 +1946,14 @@ fn bind_peers_from_variant(
     snapshot_obj: &Expr,
     snapshot_dep_paths: &mut SnapshotDepPaths,
 ) -> Result<bool, AllocError> {
-    let deps = lockfile.packages.items_dependencies()[pkg_id.index()];
+    let deps = lockfile.packages.items_dependencies()[pkg_id];
     let groups = [
         snapshot_obj.get(b"dependencies"),
         snapshot_obj.get(b"optionalDependencies"),
     ];
     let mut all_bound = true;
     for dep_id in deps.dependency_ids() {
-        let dep = &lockfile.buffers.dependencies[dep_id.index()];
+        let dep = &lockfile.buffers.dependencies[dep_id];
         if !dep.behavior.is_peer() || snapshot_dep_paths.contains(&dep_id) {
             continue;
         }
@@ -2292,7 +2295,7 @@ fn parse_append_importer_dependencies(
 fn sort_appended_dependencies(lockfile: &mut Lockfile, off: usize) {
     let buffers = &mut lockfile.buffers;
     let bytes = buffers.string_bytes.as_slice();
-    let mut appended = buffers.dependencies.split_off(off);
+    let mut appended = buffers.dependencies.raw_mut().split_off(off);
     index_sort::sort_vec_by(&mut appended, |a, b| Dependency::cmp(bytes, a, b));
     buffers.dependencies.append(&mut appended);
 }

--- a/src/install/postinstall_optimizer.rs
+++ b/src/install/postinstall_optimizer.rs
@@ -98,10 +98,10 @@ impl PostinstallOptimizer {
         // Loop through the list of optional dependencies with platform-specific constraints
         // Find a matching target-specific dependency.
         for &resolution in resolutions {
-            if (resolution as usize) >= metas.len() {
+            if resolution.index() >= metas.len() {
                 continue;
             }
-            let meta: &Meta = &metas[resolution as usize];
+            let meta: &Meta = &metas[resolution.index()];
             if meta.arch == npm::Architecture::ALL || meta.os == npm::OperatingSystem::ALL {
                 continue;
             }

--- a/src/install/postinstall_optimizer.rs
+++ b/src/install/postinstall_optimizer.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use bun_collections::{ArrayHashMap, ArrayIdentityContextU64};
+use bun_collections::{ArrayHashMap, ArrayIdentityContextU64, IdSlice};
 // `Expr` here is the T2 `bun_ast::Expr` (re-exported via
 // `crate::bun_json`), not the T4 `bun_ast::Expr`. The sole caller
 // (`lockfile::Package::parse_with_json`) holds a JSON-parsed `bun_json::Expr`,
@@ -91,17 +91,17 @@ impl PostinstallOptimizer {
 
     pub(crate) fn get_native_binlink_replacement_package_id(
         resolutions: &[PackageID],
-        metas: &[Meta],
+        metas: &IdSlice<PackageID, Meta>,
         target_cpu: npm::Architecture,
         target_os: npm::OperatingSystem,
     ) -> Option<PackageID> {
         // Loop through the list of optional dependencies with platform-specific constraints
         // Find a matching target-specific dependency.
         for &resolution in resolutions {
-            if resolution.index() >= metas.len() {
+            if !metas.has(resolution) {
                 continue;
             }
-            let meta: &Meta = &metas[resolution.index()];
+            let meta: &Meta = &metas[resolution];
             if meta.arch == npm::Architecture::ALL || meta.os == npm::OperatingSystem::ALL {
                 continue;
             }
@@ -168,7 +168,7 @@ impl List {
         &self,
         pkg_info: &PkgInfo<'_>,
         resolutions: &[PackageID],
-        metas: &[Meta],
+        metas: &IdSlice<PackageID, Meta>,
         target_cpu: npm::Architecture,
         target_os: npm::OperatingSystem,
     ) -> bool {

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -565,8 +565,8 @@ fn select_importers(manager: &PackageManager, original_cwd: &[u8]) -> Option<Sel
 
     let mut selected = handle_oom(DynamicBitSet::init_empty(pkg_res.len()));
     for id in ids {
-        if (id as usize) < pkg_res.len() {
-            selected.set(id as usize);
+        if id.index() < pkg_res.len() {
+            selected.set(id.index());
         }
     }
 
@@ -581,15 +581,15 @@ fn select_importers(manager: &PackageManager, original_cwd: &[u8]) -> Option<Sel
             continue;
         }
         visited.set(importer);
-        worklist.push(importer as PackageID);
+        worklist.push(PackageID::from_index(importer));
         while let Some(pkg_id) = worklist.pop() {
-            let slice = dep_slices[pkg_id as usize];
+            let slice = dep_slices[pkg_id.index()];
             for dep_id in slice.begin() as usize..slice.end() as usize {
                 let target = resolutions[dep_id];
-                let valid = target != invalid_package_id && (target as usize) < pkg_res.len();
+                let valid = target != invalid_package_id && target.index() < pkg_res.len();
                 if valid
-                    && is_importer(target as usize)
-                    && is_pruned_workspace(manager, target as usize)
+                    && is_importer(target.index())
+                    && is_pruned_workspace(manager, target.index())
                 {
                     continue;
                 }
@@ -597,11 +597,11 @@ fn select_importers(manager: &PackageManager, original_cwd: &[u8]) -> Option<Sel
                 if !valid {
                     continue;
                 }
-                if visited.is_set(target as usize) {
+                if visited.is_set(target.index()) {
                     continue;
                 }
-                visited.set(target as usize);
-                if !is_importer(target as usize) {
+                visited.set(target.index());
+                if !is_importer(target.index()) {
                     worklist.push(target);
                 }
             }
@@ -679,8 +679,8 @@ impl<'a> HoistedTree<'a> {
             scratch.clear();
             scratch.extend(folder.dependencies.iter().map(|&dep_id| {
                 (
-                    deps[dep_id as usize].name.slice(buf),
-                    resolutions[dep_id as usize],
+                    deps[dep_id.index()].name.slice(buf),
+                    resolutions[dep_id.index()],
                 )
             }));
             index_sort::sort_vec_unstable_by(&mut scratch, |a, b| a.cmp(b));
@@ -809,7 +809,7 @@ impl<'a> HoistedTree<'a> {
             .lockfile
             .packages
             .items_resolution()
-            .get(pkg_id as usize)
+            .get(pkg_id.index())
         else {
             return Installed::Mismatch;
         };
@@ -834,7 +834,7 @@ impl<'a> HoistedTree<'a> {
         let Some(package) = descend(&folder, alias) else {
             return Installed::Mismatch;
         };
-        let expected_name = self.lockfile.packages.items_name()[pkg_id as usize].slice(buf);
+        let expected_name = self.lockfile.packages.items_name()[pkg_id.index()].slice(buf);
         let matches = match res.tag {
             ResolutionTag::Npm => {
                 installed_package_json(&package).is_some_and(|(name, version)| {
@@ -929,16 +929,25 @@ fn plan_hoisted(
         if folder_path.is_empty() {
             continue;
         }
-        let importer = tree_importer.get(tree_idx).copied().unwrap_or(0);
-        if selection.is_some_and(|sel| importer != 0 && !sel.selected.is_set(importer as usize)) {
+        let importer = tree_importer
+            .get(tree_idx)
+            .copied()
+            .unwrap_or(PackageID::ROOT);
+        if selection.is_some_and(|sel| {
+            importer != PackageID::ROOT && !sel.selected.is_set(importer.index())
+        }) {
             continue;
         }
-        let protected: &[Box<[u8]>] = if importer == 0 { root_protected } else { &[] };
+        let protected: &[Box<[u8]>] = if importer == PackageID::ROOT {
+            root_protected
+        } else {
+            &[]
+        };
         let tree_id = tree_idx as tree::Id;
         let owner = tree_owner(lockfile, tree_idx);
-        if owner != invalid_package_id && (owner as usize) < pkg_res.len() {
-            visited.set(owner as usize);
-            let tag = pkg_res[owner as usize].tag;
+        if owner != invalid_package_id && owner.index() < pkg_res.len() {
+            visited.set(owner.index());
+            let tag = pkg_res[owner.index()].tag;
             if tag != ResolutionTag::Root
                 && tag != ResolutionTag::Workspace
                 && has_bundled_deps(lockfile, owner)
@@ -954,13 +963,13 @@ fn plan_hoisted(
         };
 
         for &(alias, pkg_id) in expected {
-            if (pkg_id as usize) >= pkg_res.len()
+            if pkg_id.index() >= pkg_res.len()
                 || nested_trees.binary_search(&(tree_id, alias)).is_ok()
             {
                 continue;
             }
             let extracted = matches!(
-                pkg_res[pkg_id as usize].tag,
+                pkg_res[pkg_id.index()].tag,
                 ResolutionTag::Npm
                     | ResolutionTag::LocalTarball
                     | ResolutionTag::RemoteTarball
@@ -1012,7 +1021,8 @@ fn plan_hoisted(
         }
     }
     for pkg_id in 0..pkg_res.len() {
-        let Some(folder_path) = workspace_node_modules(lockfile, pkg_id as PackageID) else {
+        let Some(folder_path) = workspace_node_modules(lockfile, PackageID::from_index(pkg_id))
+        else {
             continue;
         };
         if visited.is_set(pkg_id)
@@ -1042,8 +1052,8 @@ fn plan_hoisted(
 
 fn tree_owner(lockfile: &Lockfile, tree_idx: usize) -> PackageID {
     match lockfile.buffers.trees.as_slice()[tree_idx].dependency_id {
-        tree::ROOT_DEP_ID => 0,
-        dep_id => lockfile.buffers.resolutions.as_slice()[dep_id as usize],
+        tree::ROOT_DEP_ID => PackageID::ROOT,
+        dep_id => lockfile.buffers.resolutions.as_slice()[dep_id.index()],
     }
 }
 
@@ -1054,16 +1064,16 @@ fn tree_importers(lockfile: &Lockfile) -> Vec<PackageID> {
     for tree_idx in 0..trees.len() {
         let owner = tree_owner(lockfile, tree_idx);
         let importer = if tree_idx == 0 {
-            0
-        } else if (owner as usize) < pkg_res.len()
-            && pkg_res[owner as usize].tag == ResolutionTag::Workspace
+            PackageID::ROOT
+        } else if owner.index() < pkg_res.len()
+            && pkg_res[owner.index()].tag == ResolutionTag::Workspace
         {
             owner
         } else {
             importers
                 .get(trees[tree_idx].parent as usize)
                 .copied()
-                .unwrap_or(0)
+                .unwrap_or(PackageID::ROOT)
         };
         importers.push(importer);
     }
@@ -1071,11 +1081,11 @@ fn tree_importers(lockfile: &Lockfile) -> Vec<PackageID> {
 }
 
 fn has_bundled_deps(lockfile: &Lockfile, pkg_id: PackageID) -> bool {
-    if pkg_id as usize >= lockfile.packages.len() {
+    if pkg_id.index() >= lockfile.packages.len() {
         return false;
     }
     let deps = lockfile.buffers.dependencies.as_slice();
-    let slice = lockfile.packages.items_dependencies()[pkg_id as usize];
+    let slice = lockfile.packages.items_dependencies()[pkg_id.index()];
     (slice.begin() as usize..slice.end() as usize).any(|i| deps[i].behavior.is_bundled())
 }
 
@@ -1182,14 +1192,14 @@ pub(crate) fn remove_collapsed_copies(manager: &PackageManager, before: &Lockfil
     let buf = after.buffers.string_bytes.as_slice();
     let pkg_names = after.packages.items_name();
     for pkg_id in 0..after.packages.len() {
-        let Some(folder_path) = workspace_node_modules(after, pkg_id as PackageID) else {
+        let Some(folder_path) = workspace_node_modules(after, PackageID::from_index(pkg_id)) else {
             continue;
         };
         if is_pruned_workspace(manager, pkg_id)
             || selected_after
                 .as_ref()
-                .is_some_and(|sel| sel.binary_search(&(pkg_id as PackageID)).is_err())
-            || has_bundled_deps(after, pkg_id as PackageID)
+                .is_some_and(|sel| sel.binary_search(&PackageID::from_index(pkg_id)).is_err())
+            || has_bundled_deps(after, PackageID::from_index(pkg_id))
         {
             continue;
         }
@@ -1275,7 +1285,7 @@ fn open_tree_folder(lockfile: &Lockfile, tree_id: tree::Id) -> Option<Dir> {
 }
 
 fn workspace_node_modules(lockfile: &Lockfile, pkg_id: PackageID) -> Option<Box<[u8]>> {
-    let res = lockfile.packages.items_resolution().get(pkg_id as usize)?;
+    let res = lockfile.packages.items_resolution().get(pkg_id.index())?;
     if res.tag != ResolutionTag::Workspace {
         return None;
     }
@@ -1425,7 +1435,7 @@ fn importer_roots(manager: &PackageManager, keep: &dyn Fn(usize) -> bool) -> Vec
                 && !is_pruned_workspace(manager, id)
                 && keep(id)
         })
-        .map(|id| id as PackageID)
+        .map(PackageID::from_index)
         .collect()
 }
 
@@ -1501,7 +1511,7 @@ fn push_store_entry_names(
     names.reserve(store.entries.len());
     let mut name: Vec<u8> = Vec::new();
     for (entry_idx, node_id) in store.entries.items_node_id().iter().enumerate() {
-        let pkg_id = node_pkg_ids[node_id.get() as usize] as usize;
+        let pkg_id = node_pkg_ids[node_id.get() as usize].index();
         if pkg_res[pkg_id].tag == ResolutionTag::Workspace || !wanted.is_set(pkg_id) {
             continue;
         }
@@ -1544,9 +1554,9 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
     let buf = lockfile.buffers.string_bytes.as_slice();
     let deps = lockfile.buffers.dependencies.as_slice();
     let resolutions = lockfile.buffers.resolutions.as_slice();
-    let slice = lockfile.packages.items_dependencies()[pkg_id as usize];
+    let slice = lockfile.packages.items_dependencies()[pkg_id.index()];
     let mut direct: Vec<Box<[u8]>> = Vec::new();
-    for dep_id in slice.begin()..slice.end() {
+    for dep_id in slice.dependency_ids() {
         if is_filtered_dependency_or_workspace(
             dep_id,
             pkg_id,
@@ -1558,11 +1568,11 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
         ) {
             continue;
         }
-        let target = resolutions[dep_id as usize];
-        if target == invalid_package_id || (target as usize) >= lockfile.packages.len() {
+        let target = resolutions[dep_id.index()];
+        if target == invalid_package_id || target.index() >= lockfile.packages.len() {
             continue;
         }
-        direct.push(deps[dep_id as usize].name.slice(buf).into());
+        direct.push(deps[dep_id.index()].name.slice(buf).into());
     }
     sort_names(&mut direct);
     direct.dedup();
@@ -1631,7 +1641,7 @@ fn plan_isolated(
         let Ok(dir) = Dir::open(&folder_path) else {
             continue;
         };
-        let direct = direct_aliases(manager, pkg_id as PackageID);
+        let direct = direct_aliases(manager, PackageID::from_index(pkg_id));
         let folder_idx = scan_folder(
             dir,
             &folder_path,

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -407,7 +407,7 @@ fn print_apply_hint() {
     Output::flush();
 }
 
-fn is_pruned_workspace(manager: &PackageManager, pkg_id: usize) -> bool {
+fn is_pruned_workspace(manager: &PackageManager, pkg_id: PackageID) -> bool {
     let pruned = &manager.summary.pruned_workspaces;
     !pruned.is_empty() && pruned.contains(&manager.lockfile.packages.items_name_hash()[pkg_id])
 }
@@ -418,8 +418,7 @@ fn collect_workspace_names(manager: &PackageManager) -> Vec<Box<[u8]>> {
     let names = lockfile.packages.items_name();
     let pkg_res = lockfile.packages.items_resolution();
     let mut out: Vec<Box<[u8]>> = pkg_res
-        .iter()
-        .enumerate()
+        .iter_enumerated()
         .filter(|(pkg_id, res)| {
             res.tag == ResolutionTag::Workspace && !is_pruned_workspace(manager, *pkg_id)
         })
@@ -556,7 +555,7 @@ fn select_importers(manager: &PackageManager, original_cwd: &[u8]) -> Option<Sel
     let resolutions = lockfile.buffers.resolutions.as_slice();
     let pkg_res = lockfile.packages.items_resolution();
     let dep_slices = lockfile.packages.items_dependencies();
-    let is_importer = |pkg_id: usize| {
+    let is_importer = |pkg_id: PackageID| {
         matches!(
             pkg_res[pkg_id].tag,
             ResolutionTag::Root | ResolutionTag::Workspace
@@ -565,7 +564,7 @@ fn select_importers(manager: &PackageManager, original_cwd: &[u8]) -> Option<Sel
 
     let mut selected = handle_oom(DynamicBitSet::init_empty(pkg_res.len()));
     for id in ids {
-        if id.index() < pkg_res.len() {
+        if pkg_res.has(id) {
             selected.set(id.index());
         }
     }
@@ -573,24 +572,21 @@ fn select_importers(manager: &PackageManager, original_cwd: &[u8]) -> Option<Sel
     let mut visited = handle_oom(DynamicBitSet::init_empty(pkg_res.len()));
     let mut protected_aliases: Vec<Box<[u8]>> = Vec::new();
     let mut worklist: Vec<PackageID> = Vec::new();
-    for importer in 0..pkg_res.len() {
-        if selected.is_set(importer)
+    for importer in pkg_res.ids() {
+        if selected.is_set(importer.index())
             || !is_importer(importer)
             || is_pruned_workspace(manager, importer)
         {
             continue;
         }
-        visited.set(importer);
-        worklist.push(PackageID::from_index(importer));
+        visited.set(importer.index());
+        worklist.push(importer);
         while let Some(pkg_id) = worklist.pop() {
-            let slice = dep_slices[pkg_id.index()];
-            for dep_id in slice.begin() as usize..slice.end() as usize {
+            let slice = dep_slices[pkg_id];
+            for dep_id in slice.dependency_ids() {
                 let target = resolutions[dep_id];
-                let valid = target != invalid_package_id && target.index() < pkg_res.len();
-                if valid
-                    && is_importer(target.index())
-                    && is_pruned_workspace(manager, target.index())
-                {
+                let valid = pkg_res.has(target);
+                if valid && is_importer(target) && is_pruned_workspace(manager, target) {
                     continue;
                 }
                 protected_aliases.push(deps[dep_id].name.slice(buf).into());
@@ -601,7 +597,7 @@ fn select_importers(manager: &PackageManager, original_cwd: &[u8]) -> Option<Sel
                     continue;
                 }
                 visited.set(target.index());
-                if !is_importer(target.index()) {
+                if !is_importer(target) {
                     worklist.push(target);
                 }
             }
@@ -677,12 +673,12 @@ impl<'a> HoistedTree<'a> {
             paths.extend_from_slice(folder.relative_path.as_bytes());
 
             scratch.clear();
-            scratch.extend(folder.dependencies.iter().map(|&dep_id| {
-                (
-                    deps[dep_id.index()].name.slice(buf),
-                    resolutions[dep_id.index()],
-                )
-            }));
+            scratch.extend(
+                folder
+                    .dependencies
+                    .iter()
+                    .map(|&dep_id| (deps[dep_id].name.slice(buf), resolutions[dep_id])),
+            );
             index_sort::sort_vec_unstable_by(&mut scratch, |a, b| a.cmp(b));
             let start = expected.len();
             for &item in &scratch {
@@ -805,12 +801,7 @@ impl<'a> HoistedTree<'a> {
 
     fn installed(&self, tree_id: tree::Id, alias: &[u8], pkg_id: PackageID) -> Installed {
         let buf = self.lockfile.buffers.string_bytes.as_slice();
-        let Some(res) = self
-            .lockfile
-            .packages
-            .items_resolution()
-            .get(pkg_id.index())
-        else {
+        let Some(res) = self.lockfile.packages.items_resolution().get(pkg_id) else {
             return Installed::Mismatch;
         };
         let Some(folder) = open_tree_folder(self.lockfile, tree_id) else {
@@ -834,7 +825,7 @@ impl<'a> HoistedTree<'a> {
         let Some(package) = descend(&folder, alias) else {
             return Installed::Mismatch;
         };
-        let expected_name = self.lockfile.packages.items_name()[pkg_id.index()].slice(buf);
+        let expected_name = self.lockfile.packages.items_name()[pkg_id].slice(buf);
         let matches = match res.tag {
             ResolutionTag::Npm => {
                 installed_package_json(&package).is_some_and(|(name, version)| {
@@ -945,9 +936,9 @@ fn plan_hoisted(
         };
         let tree_id = tree_idx as tree::Id;
         let owner = tree_owner(lockfile, tree_idx);
-        if owner != invalid_package_id && owner.index() < pkg_res.len() {
+        if owner != invalid_package_id && pkg_res.has(owner) {
             visited.set(owner.index());
-            let tag = pkg_res[owner.index()].tag;
+            let tag = pkg_res[owner].tag;
             if tag != ResolutionTag::Root
                 && tag != ResolutionTag::Workspace
                 && has_bundled_deps(lockfile, owner)
@@ -963,13 +954,11 @@ fn plan_hoisted(
         };
 
         for &(alias, pkg_id) in expected {
-            if pkg_id.index() >= pkg_res.len()
-                || nested_trees.binary_search(&(tree_id, alias)).is_ok()
-            {
+            if !pkg_res.has(pkg_id) || nested_trees.binary_search(&(tree_id, alias)).is_ok() {
                 continue;
             }
             let extracted = matches!(
-                pkg_res[pkg_id.index()].tag,
+                pkg_res[pkg_id].tag,
                 ResolutionTag::Npm
                     | ResolutionTag::LocalTarball
                     | ResolutionTag::RemoteTarball
@@ -1020,13 +1009,12 @@ fn plan_hoisted(
             scan_folder(dir, b"node_modules", false, &keep_workspaces, plan);
         }
     }
-    for pkg_id in 0..pkg_res.len() {
-        let Some(folder_path) = workspace_node_modules(lockfile, PackageID::from_index(pkg_id))
-        else {
+    for pkg_id in pkg_res.ids() {
+        let Some(folder_path) = workspace_node_modules(lockfile, pkg_id) else {
             continue;
         };
-        if visited.is_set(pkg_id)
-            || selection.is_some_and(|sel| !sel.selected.is_set(pkg_id))
+        if visited.is_set(pkg_id.index())
+            || selection.is_some_and(|sel| !sel.selected.is_set(pkg_id.index()))
             || is_pruned_workspace(&*manager, pkg_id)
         {
             continue;
@@ -1053,7 +1041,7 @@ fn plan_hoisted(
 fn tree_owner(lockfile: &Lockfile, tree_idx: usize) -> PackageID {
     match lockfile.buffers.trees.as_slice()[tree_idx].dependency_id {
         tree::ROOT_DEP_ID => PackageID::ROOT,
-        dep_id => lockfile.buffers.resolutions.as_slice()[dep_id.index()],
+        dep_id => lockfile.buffers.resolutions.as_slice()[dep_id],
     }
 }
 
@@ -1065,9 +1053,7 @@ fn tree_importers(lockfile: &Lockfile) -> Vec<PackageID> {
         let owner = tree_owner(lockfile, tree_idx);
         let importer = if tree_idx == 0 {
             PackageID::ROOT
-        } else if owner.index() < pkg_res.len()
-            && pkg_res[owner.index()].tag == ResolutionTag::Workspace
-        {
+        } else if pkg_res.has(owner) && pkg_res[owner].tag == ResolutionTag::Workspace {
             owner
         } else {
             importers
@@ -1081,12 +1067,13 @@ fn tree_importers(lockfile: &Lockfile) -> Vec<PackageID> {
 }
 
 fn has_bundled_deps(lockfile: &Lockfile, pkg_id: PackageID) -> bool {
-    if pkg_id.index() >= lockfile.packages.len() {
-        return false;
-    }
     let deps = lockfile.buffers.dependencies.as_slice();
-    let slice = lockfile.packages.items_dependencies()[pkg_id.index()];
-    (slice.begin() as usize..slice.end() as usize).any(|i| deps[i].behavior.is_bundled())
+    let Some(slice) = lockfile.packages.items_dependencies().get(pkg_id) else {
+        return false;
+    };
+    slice
+        .dependency_ids()
+        .any(|i| deps[i].behavior.is_bundled())
 }
 
 // Hoisted post-install pass for dedupe / audit fix / update (install_with_manager.rs).
@@ -1191,15 +1178,15 @@ pub(crate) fn remove_collapsed_copies(manager: &PackageManager, before: &Lockfil
     let selected_after: Option<Vec<PackageID>> = targets.map(|targets| targets.package_ids(after));
     let buf = after.buffers.string_bytes.as_slice();
     let pkg_names = after.packages.items_name();
-    for pkg_id in 0..after.packages.len() {
-        let Some(folder_path) = workspace_node_modules(after, PackageID::from_index(pkg_id)) else {
+    for pkg_id in pkg_names.ids() {
+        let Some(folder_path) = workspace_node_modules(after, pkg_id) else {
             continue;
         };
         if is_pruned_workspace(manager, pkg_id)
             || selected_after
                 .as_ref()
-                .is_some_and(|sel| sel.binary_search(&PackageID::from_index(pkg_id)).is_err())
-            || has_bundled_deps(after, PackageID::from_index(pkg_id))
+                .is_some_and(|sel| sel.binary_search(&pkg_id).is_err())
+            || has_bundled_deps(after, pkg_id)
         {
             continue;
         }
@@ -1285,7 +1272,7 @@ fn open_tree_folder(lockfile: &Lockfile, tree_id: tree::Id) -> Option<Dir> {
 }
 
 fn workspace_node_modules(lockfile: &Lockfile, pkg_id: PackageID) -> Option<Box<[u8]>> {
-    let res = lockfile.packages.items_resolution().get(pkg_id.index())?;
+    let res = lockfile.packages.items_resolution().get(pkg_id)?;
     if res.tag != ResolutionTag::Workspace {
         return None;
     }
@@ -1427,15 +1414,15 @@ fn scan_folder(
     folder_idx
 }
 
-fn importer_roots(manager: &PackageManager, keep: &dyn Fn(usize) -> bool) -> Vec<PackageID> {
+fn importer_roots(manager: &PackageManager, keep: &dyn Fn(PackageID) -> bool) -> Vec<PackageID> {
     let pkg_res = manager.lockfile.packages.items_resolution();
-    (0..pkg_res.len())
+    pkg_res
+        .ids()
         .filter(|&id| {
-            (id == 0 || pkg_res[id].tag == ResolutionTag::Workspace)
+            (id == PackageID::ROOT || pkg_res[id].tag == ResolutionTag::Workspace)
                 && !is_pruned_workspace(manager, id)
                 && keep(id)
         })
-        .map(PackageID::from_index)
         .collect()
 }
 
@@ -1450,7 +1437,7 @@ fn wanted_packages(manager: &PackageManager, selection: Option<&Selection>) -> D
         reachable::packages_from(lockfile, resolutions, &roots, false, options)
     };
     if let Some(sel) = selection {
-        let unselected = importer_roots(manager, &|id| !sel.selected.is_set(id));
+        let unselected = importer_roots(manager, &|id| !sel.selected.is_set(id.index()));
         if !unselected.is_empty() {
             let full = reachable::Options {
                 dev: true,
@@ -1511,8 +1498,8 @@ fn push_store_entry_names(
     names.reserve(store.entries.len());
     let mut name: Vec<u8> = Vec::new();
     for (entry_idx, node_id) in store.entries.items_node_id().iter().enumerate() {
-        let pkg_id = node_pkg_ids[node_id.get() as usize].index();
-        if pkg_res[pkg_id].tag == ResolutionTag::Workspace || !wanted.is_set(pkg_id) {
+        let pkg_id = node_pkg_ids[node_id.get() as usize];
+        if pkg_res[pkg_id].tag == ResolutionTag::Workspace || !wanted.is_set(pkg_id.index()) {
             continue;
         }
         name.clear();
@@ -1554,7 +1541,7 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
     let buf = lockfile.buffers.string_bytes.as_slice();
     let deps = lockfile.buffers.dependencies.as_slice();
     let resolutions = lockfile.buffers.resolutions.as_slice();
-    let slice = lockfile.packages.items_dependencies()[pkg_id.index()];
+    let slice = lockfile.packages.items_dependencies()[pkg_id];
     let mut direct: Vec<Box<[u8]>> = Vec::new();
     for dep_id in slice.dependency_ids() {
         if is_filtered_dependency_or_workspace(
@@ -1568,11 +1555,11 @@ fn direct_aliases(manager: &PackageManager, pkg_id: PackageID) -> Vec<Box<[u8]>>
         ) {
             continue;
         }
-        let target = resolutions[dep_id.index()];
+        let target = resolutions[dep_id];
         if target == invalid_package_id || target.index() >= lockfile.packages.len() {
             continue;
         }
-        direct.push(deps[dep_id.index()].name.slice(buf).into());
+        direct.push(deps[dep_id].name.slice(buf).into());
     }
     sort_names(&mut direct);
     direct.dedup();
@@ -1619,10 +1606,10 @@ fn plan_isolated(
     let lockfile: &Lockfile = &manager.lockfile;
     let buf = lockfile.buffers.string_bytes.as_slice();
     let pkg_res = lockfile.packages.items_resolution();
-    for pkg_id in 0..lockfile.packages.len() {
+    for pkg_id in pkg_res.ids() {
         let res = &pkg_res[pkg_id];
         let folder_path: Box<[u8]> = match res.tag {
-            ResolutionTag::Root if pkg_id == 0 => b"node_modules".as_slice().into(),
+            ResolutionTag::Root if pkg_id == PackageID::ROOT => b"node_modules".as_slice().into(),
             ResolutionTag::Workspace => {
                 let path = strings::without_trailing_slash(res.workspace().slice(buf));
                 if path.is_empty() {
@@ -1632,7 +1619,7 @@ fn plan_isolated(
             }
             _ => continue,
         };
-        if selection.is_some_and(|sel| !sel.selected.is_set(pkg_id)) {
+        if selection.is_some_and(|sel| !sel.selected.is_set(pkg_id.index())) {
             continue;
         }
         if is_pruned_workspace(manager, pkg_id) {
@@ -1641,7 +1628,7 @@ fn plan_isolated(
         let Ok(dir) = Dir::open(&folder_path) else {
             continue;
         };
-        let direct = direct_aliases(manager, PackageID::from_index(pkg_id));
+        let direct = direct_aliases(manager, pkg_id);
         let folder_idx = scan_folder(
             dir,
             &folder_path,

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -363,8 +363,8 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
             .get_package_id(package.name_hash, Some(version), &package.resolution)
     {
         package.meta.id = existing_id;
-        manager.lockfile.packages.set(existing_id as usize, package);
-        return Ok(*manager.lockfile.packages.get(existing_id as usize));
+        manager.lockfile.packages.set(existing_id.index(), package);
+        return Ok(*manager.lockfile.packages.get(existing_id.index()));
     }
 
     Ok(manager.lockfile.append_package(&package)?)

--- a/src/install/resolvers/folder_resolver.rs
+++ b/src/install/resolvers/folder_resolver.rs
@@ -364,7 +364,7 @@ fn read_package_json_from_disk<R: FolderResolverImpl>(
     {
         package.meta.id = existing_id;
         manager.lockfile.packages.set(existing_id.index(), package);
-        return Ok(*manager.lockfile.packages.get(existing_id.index()));
+        return Ok(manager.lockfile.package(existing_id));
     }
 
     Ok(manager.lockfile.append_package(&package)?)

--- a/src/install/update_scope.rs
+++ b/src/install/update_scope.rs
@@ -103,7 +103,7 @@ impl UpdateScope<'_> {
                         names[id].slice(buf),
                     )
             })
-            .map(|id| id as PackageID)
+            .map(PackageID::from_index)
             .collect();
         // The root's `workspaces` listing is not a dependency edge; a `workspace:` dependency between members is.
         reachable::packages_from(
@@ -111,7 +111,7 @@ impl UpdateScope<'_> {
             lockfile.buffers.resolutions.as_slice(),
             &roots,
             false,
-            reachable::Options::all(0),
+            reachable::Options::all(PackageID::ROOT),
         )
     }
 
@@ -390,9 +390,9 @@ pub fn expand_positionals(manager: &mut PackageManager, original_cwd: &[u8], gro
             .ids
             .into_iter()
             .map(|id| UpdateTargetWorkspace {
-                is_root: resolutions[id as usize].tag == ResolutionTag::Root,
-                name_hash: name_hashes[id as usize],
-                name: Box::from(names[id as usize].slice(buf)),
+                is_root: resolutions[id.index()].tag == ResolutionTag::Root,
+                name_hash: name_hashes[id.index()],
+                name: Box::from(names[id.index()].slice(buf)),
             })
             .collect()
     });
@@ -439,7 +439,7 @@ pub fn expand_positionals(manager: &mut PackageManager, original_cwd: &[u8], gro
                 let target = resolutions[i];
                 if target == invalid_package_id
                     || matches!(
-                        pkg_res[target as usize].tag,
+                        pkg_res[target.index()].tag,
                         ResolutionTag::Root | ResolutionTag::Workspace
                     )
                 {
@@ -450,7 +450,7 @@ pub fn expand_positionals(manager: &mut PackageManager, original_cwd: &[u8], gro
                 if owner_is_ws && !selects(groups, dep.behavior) {
                     continue;
                 }
-                let real = pkg_names[target as usize].slice(buf);
+                let real = pkg_names[target.index()].slice(buf);
                 let alias = dep.name.slice(buf);
                 let mut positive_hit = patterns.iter().all(|p| p.negated);
                 let mut excluded = false;
@@ -470,7 +470,7 @@ pub fn expand_positionals(manager: &mut PackageManager, original_cwd: &[u8], gro
                 if positive_hit
                     && !excluded
                     && decided
-                        .insert(pkg_name_hashes[target as usize], ())
+                        .insert(pkg_name_hashes[target.index()], ())
                         .is_none()
                 {
                     // The named path matches `npm:` aliases through the real name, so the real name reaches both spellings.

--- a/src/install/update_scope.rs
+++ b/src/install/update_scope.rs
@@ -93,7 +93,8 @@ impl UpdateScope<'_> {
         let name_hashes = lockfile.packages.items_name_hash();
         let names = lockfile.packages.items_name();
         let buf = lockfile.buffers.string_bytes.as_slice();
-        let roots: Vec<PackageID> = (0..pkg_res.len())
+        let roots: Vec<PackageID> = pkg_res
+            .ids()
             .filter(|&id| {
                 let tag = pkg_res[id].tag;
                 matches!(tag, ResolutionTag::Root | ResolutionTag::Workspace)
@@ -103,7 +104,6 @@ impl UpdateScope<'_> {
                         names[id].slice(buf),
                     )
             })
-            .map(PackageID::from_index)
             .collect();
         // The root's `workspaces` listing is not a dependency edge; a `workspace:` dependency between members is.
         reachable::packages_from(
@@ -130,7 +130,7 @@ impl UpdateScope<'_> {
         }
     }
 
-    fn contains_package(&self, lockfile: &Lockfile, id: usize) -> bool {
+    fn contains_package(&self, lockfile: &Lockfile, id: PackageID) -> bool {
         let tag = lockfile.packages.items_resolution()[id].tag;
         match tag {
             ResolutionTag::Root | ResolutionTag::Workspace => self.contains_workspace(
@@ -140,7 +140,10 @@ impl UpdateScope<'_> {
             ),
             // Packages appended after the walk (ids past its end) were resolved for an in-scope row.
             _ => {
-                self.whole_workspace || self.reachable(lockfile).is_set_allow_out_of_bound(id, true)
+                self.whole_workspace
+                    || self
+                        .reachable(lockfile)
+                        .is_set_allow_out_of_bound(id.index(), true)
             }
         }
     }
@@ -150,10 +153,10 @@ impl UpdateScope<'_> {
         match lockfile
             .packages
             .items_dependencies()
-            .iter()
-            .position(|slice| slice.contains(dep_id))
+            .iter_enumerated()
+            .find(|(_, slice)| slice.contains(dep_id))
         {
-            Some(owner) => self.contains_package(lockfile, owner),
+            Some((owner, _)) => self.contains_package(lockfile, owner),
             None => true,
         }
     }
@@ -162,7 +165,7 @@ impl UpdateScope<'_> {
     pub fn walkable_rows(&self, lockfile: &Lockfile) -> DynamicBitSet {
         let mut walk =
             DynamicBitSet::init_empty(lockfile.buffers.dependencies.len()).unwrap_or_oom();
-        for (id, slice) in lockfile.packages.items_dependencies().iter().enumerate() {
+        for (id, slice) in lockfile.packages.items_dependencies().iter_enumerated() {
             if slice.len == 0 {
                 continue;
             }
@@ -390,9 +393,9 @@ pub fn expand_positionals(manager: &mut PackageManager, original_cwd: &[u8], gro
             .ids
             .into_iter()
             .map(|id| UpdateTargetWorkspace {
-                is_root: resolutions[id.index()].tag == ResolutionTag::Root,
-                name_hash: name_hashes[id.index()],
-                name: Box::from(names[id.index()].slice(buf)),
+                is_root: resolutions[id].tag == ResolutionTag::Root,
+                name_hash: name_hashes[id],
+                name: Box::from(names[id].slice(buf)),
             })
             .collect()
     });
@@ -421,7 +424,7 @@ pub fn expand_positionals(manager: &mut PackageManager, original_cwd: &[u8], gro
             decided.insert(StringBuilder::string_hash(name_of_plain_arg(arg)), ());
         }
 
-        for (owner, slice) in lockfile.packages.items_dependencies().iter().enumerate() {
+        for (owner, slice) in lockfile.packages.items_dependencies().iter_enumerated() {
             if slice.len == 0 {
                 continue;
             }
@@ -432,14 +435,14 @@ pub fn expand_positionals(manager: &mut PackageManager, original_cwd: &[u8], gro
             if !owner_is_ws && !include_transitive {
                 continue;
             }
-            for i in slice.begin() as usize..slice.end() as usize {
-                if !walk.is_set(i) {
+            for i in slice.dependency_ids() {
+                if !walk.is_set(i.index()) {
                     continue;
                 }
                 let target = resolutions[i];
                 if target == invalid_package_id
                     || matches!(
-                        pkg_res[target.index()].tag,
+                        pkg_res[target].tag,
                         ResolutionTag::Root | ResolutionTag::Workspace
                     )
                 {
@@ -450,7 +453,7 @@ pub fn expand_positionals(manager: &mut PackageManager, original_cwd: &[u8], gro
                 if owner_is_ws && !selects(groups, dep.behavior) {
                     continue;
                 }
-                let real = pkg_names[target.index()].slice(buf);
+                let real = pkg_names[target].slice(buf);
                 let alias = dep.name.slice(buf);
                 let mut positive_hit = patterns.iter().all(|p| p.negated);
                 let mut excluded = false;
@@ -469,9 +472,7 @@ pub fn expand_positionals(manager: &mut PackageManager, original_cwd: &[u8], gro
                 }
                 if positive_hit
                     && !excluded
-                    && decided
-                        .insert(pkg_name_hashes[target.index()], ())
-                        .is_none()
+                    && decided.insert(pkg_name_hashes[target], ()).is_none()
                 {
                     // The named path matches `npm:` aliases through the real name, so the real name reaches both spellings.
                     names.push(Box::from(real));

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -55,7 +55,7 @@ impl DirectDependencies {
                     .map(|(dep, &resolved)| (dep.name_hash, dep.behavior, resolved)),
             );
             out.owners.push((
-                owner as PackageID,
+                PackageID::from_index(owner),
                 start as u32,
                 (out.rows.len() - start) as u32,
             ));
@@ -82,7 +82,7 @@ impl DirectDependencies {
 
         let mut pairs: Vec<(PackageID, PackageID)> = Vec::new();
         for &(owner, start, len) in &self.owners {
-            let owner = owner as usize;
+            let owner = owner.index();
             if owner >= packages_len {
                 continue;
             }
@@ -124,10 +124,10 @@ impl DirectDependencies {
                 };
                 let old = rows[index].2;
                 if old == new
-                    || (old as usize) >= packages_len
-                    || (new as usize) >= packages_len
-                    || pkg_res[new as usize].tag != ResolutionTag::Npm
-                    || name_hashes[old as usize] != name_hashes[new as usize]
+                    || old.index() >= packages_len
+                    || new.index() >= packages_len
+                    || pkg_res[new.index()].tag != ResolutionTag::Npm
+                    || name_hashes[old.index()] != name_hashes[new.index()]
                 {
                     continue;
                 }
@@ -146,13 +146,13 @@ fn rows_between(manager: &mut PackageManager, pairs: Vec<(PackageID, PackageID)>
             let lockfile: &Lockfile = &manager.lockfile;
             let buf = lockfile.buffers.string_bytes.as_slice();
             let pkg_res = lockfile.packages.items_resolution();
-            if pkg_res[old as usize].tag != ResolutionTag::Npm {
+            if pkg_res[old.index()].tag != ResolutionTag::Npm {
                 continue;
             }
             (
-                Box::<[u8]>::from(lockfile.packages.items_name()[old as usize].slice(buf)),
-                text(pkg_res[old as usize].npm().version.fmt(buf)),
-                text(pkg_res[new as usize].npm().version.fmt(buf)),
+                Box::<[u8]>::from(lockfile.packages.items_name()[old.index()].slice(buf)),
+                text(pkg_res[old.index()].npm().version.fmt(buf)),
+                text(pkg_res[new.index()].npm().version.fmt(buf)),
             )
         };
         let later = later_in_cache(manager, new);
@@ -171,9 +171,9 @@ fn later_in_cache(manager: &mut PackageManager, pkg_id: PackageID) -> Box<[u8]> 
         let lockfile: &Lockfile = &manager.lockfile;
         let buf = lockfile.buffers.string_bytes.as_slice();
         (
-            Box::<[u8]>::from(lockfile.packages.items_name()[pkg_id as usize].slice(buf)),
-            lockfile.packages.items_name_hash()[pkg_id as usize],
-            lockfile.packages.items_resolution()[pkg_id as usize],
+            Box::<[u8]>::from(lockfile.packages.items_name()[pkg_id.index()].slice(buf)),
+            lockfile.packages.items_name_hash()[pkg_id.index()],
+            lockfile.packages.items_resolution()[pkg_id.index()],
         )
     };
     match manager.format_later_version_in_cache(&name, name_hash, &resolution) {
@@ -193,13 +193,13 @@ fn named_pairs(
     let resolutions = lockfile.buffers.resolutions.as_slice();
     moved
         .iter()
-        .map(|&(dep_id, from)| (from, resolutions[dep_id as usize]))
+        .map(|&(dep_id, from)| (from, resolutions[dep_id.index()]))
         .filter(|&(from, to)| {
             from != to
-                && (from as usize) < packages_len
-                && (to as usize) < packages_len
-                && pkg_res[to as usize].tag == ResolutionTag::Npm
-                && name_hashes[from as usize] == name_hashes[to as usize]
+                && from.index() < packages_len
+                && to.index() < packages_len
+                && pkg_res[to.index()].tag == ResolutionTag::Npm
+                && name_hashes[from.index()] == name_hashes[to.index()]
         })
         .collect()
 }
@@ -211,7 +211,7 @@ fn redirect(lockfile: &mut Lockfile, pairs: Vec<(PackageID, PackageID)>) {
     }
     let mut new_of: Vec<PackageID> = vec![invalid_package_id; lockfile.packages.len()];
     for (old, new) in pairs {
-        let slot = &mut new_of[old as usize];
+        let slot = &mut new_of[old.index()];
         if *slot == invalid_package_id {
             *slot = new;
         }
@@ -224,7 +224,7 @@ fn redirect(lockfile: &mut Lockfile, pairs: Vec<(PackageID, PackageID)>) {
         let deps = lockfile.buffers.dependencies.as_slice();
         let mut moved = Vec::new();
         for (j, &target) in lockfile.buffers.resolutions.iter().enumerate() {
-            let Some(&new) = new_of.get(target as usize) else {
+            let Some(&new) = new_of.get(target.index()) else {
                 continue;
             };
             if new == invalid_package_id {
@@ -234,13 +234,15 @@ fn redirect(lockfile: &mut Lockfile, pairs: Vec<(PackageID, PackageID)>) {
             if dep.behavior.is_bundled() {
                 continue;
             }
-            let Some(range) = dedupe::effective_npm_range(lockfile, j as DependencyID, dep) else {
+            let Some(range) =
+                dedupe::effective_npm_range(lockfile, DependencyID::from_index(j), dep)
+            else {
                 continue;
             };
             if range
                 .npm()
                 .version
-                .satisfies(pkg_res[new as usize].npm().version, buf, buf)
+                .satisfies(pkg_res[new.index()].npm().version, buf, buf)
             {
                 moved.push((j, new));
             }
@@ -318,7 +320,7 @@ impl TransitiveUpdate {
         let _ = manager.get_cache_directory();
         let _ = manager.get_temporary_directory();
         for pin in &self.pins {
-            if manager.lockfile.buffers.resolutions[pin.dep_id as usize] != pin.from {
+            if manager.lockfile.buffers.resolutions[pin.dep_id.index()] != pin.from {
                 continue;
             }
             match pin.to {
@@ -326,7 +328,7 @@ impl TransitiveUpdate {
                 None => reresolve(manager, pin.dep_id)?,
             }
             if let Some(pinned) = pinned.as_deref_mut() {
-                pinned.set(pin.dep_id as usize);
+                pinned.set(pin.dep_id.index());
             }
             manager.summary.update += 1;
         }
@@ -411,8 +413,8 @@ pub(crate) fn refresh_children_of(
         let lockfile = &*manager.lockfile;
         let mut edges = DynamicBitSet::init_empty(lockfile.buffers.dependencies.len())?;
         for &owner in package_ids {
-            if (owner as usize) < lockfile.packages.len() {
-                set_rows_of(&mut edges, lockfile, owner as usize);
+            if owner.index() < lockfile.packages.len() {
+                set_rows_of(&mut edges, lockfile, owner.index());
             }
         }
         edges
@@ -430,9 +432,9 @@ pub(crate) fn refresh_children_of(
 
 /// Only the synchronous resolve sees the cleared peer bit (the manifest callback re-reads the buffer row), so callers fetch the manifest first.
 fn reresolve(manager: &mut PackageManager, dep_id: DependencyID) -> crate::Result<()> {
-    let mut dep = manager.lockfile.buffers.dependencies[dep_id as usize].clone();
+    let mut dep = manager.lockfile.buffers.dependencies[dep_id.index()].clone();
     dep.behavior = dep.behavior.with(Behavior::PEER, false);
-    manager.lockfile.buffers.resolutions[dep_id as usize] = invalid_package_id;
+    manager.lockfile.buffers.resolutions[dep_id.index()] = invalid_package_id;
     enqueue_dependency_with_main(manager, dep_id, &dep, invalid_package_id, false)
 }
 
@@ -445,14 +447,14 @@ pub(crate) fn enqueue_peer_rows(
     if !rows.is_empty() {
         let mut targets: Vec<PackageID> = rows
             .iter()
-            .map(|&row| manager.lockfile.buffers.resolutions[row as usize])
+            .map(|&row| manager.lockfile.buffers.resolutions[row.index()])
             .collect();
         targets.sort_unstable();
         targets.dedup();
         populate_manifest_cache::populate_manifest_cache(manager, Packages::Exact(&targets))?;
         print_log(manager)?;
         for &row in rows {
-            moved.push((row, manager.lockfile.buffers.resolutions[row as usize]));
+            moved.push((row, manager.lockfile.buffers.resolutions[row.index()]));
             reresolve(manager, row)?;
         }
     }
@@ -479,11 +481,11 @@ pub(crate) fn redirect_moved_edges(lockfile: &mut Lockfile, moved: &[(Dependency
         let resolutions = lockfile.buffers.resolutions.as_slice();
         moved
             .iter()
-            .map(|&(dep_id, from)| (from, resolutions[dep_id as usize]))
+            .map(|&(dep_id, from)| (from, resolutions[dep_id.index()]))
             .filter(|&(from, to)| {
                 to != from
-                    && (to as usize) < pkg_res.len()
-                    && pkg_res[to as usize].tag == ResolutionTag::Npm
+                    && to.index() < pkg_res.len()
+                    && pkg_res[to.index()].tag == ResolutionTag::Npm
             })
             .collect()
     };
@@ -508,19 +510,19 @@ pub(crate) fn moved_targets_after_clean(
 
     let mut targets: Vec<PackageID> = Vec::new();
     for &(dep_id, _) in moved {
-        let Some(&old_id) = old_resolutions.get(dep_id as usize) else {
+        let Some(&old_id) = old_resolutions.get(dep_id.index()) else {
             continue;
         };
-        if (old_id as usize) >= old_res.len() {
+        if old_id.index() >= old_res.len() {
             continue;
         }
-        let Some(entry) = cleaned.package_index.get(&old_name_hashes[old_id as usize]) else {
+        let Some(entry) = cleaned.package_index.get(&old_name_hashes[old_id.index()]) else {
             continue;
         };
         if let Some(&id) = entry
             .as_slice()
             .iter()
-            .find(|&&c| new_res[c as usize].eql(&old_res[old_id as usize], new_buf, old_buf))
+            .find(|&&c| new_res[c.index()].eql(&old_res[old_id.index()], new_buf, old_buf))
         {
             targets.push(id);
         }
@@ -558,11 +560,11 @@ pub(crate) fn register_moved(
     let names = lockfile.packages.items_name();
     let res = lockfile.packages.items_resolution();
     for &pkg_id in moved {
-        if (pkg_id as usize) >= res.len() || res[pkg_id as usize].tag != ResolutionTag::Npm {
+        if pkg_id.index() >= res.len() || res[pkg_id.index()].tag != ResolutionTag::Npm {
             continue;
         }
-        let current = res[pkg_id as usize].npm().version;
-        let entry = updating.get_or_put(names[pkg_id as usize].slice(buf))?;
+        let current = res[pkg_id.index()].npm().version;
+        let entry = updating.get_or_put(names[pkg_id.index()].slice(buf))?;
         if entry.found_existing {
             let info = &*entry.value_ptr;
             let keep = !info.original_version_literal.is_empty()
@@ -662,9 +664,9 @@ fn kept_patched_rows(manager: &mut PackageManager) -> Vec<Row> {
         let lockfile: &Lockfile = &manager.lockfile;
         let buf = lockfile.buffers.string_bytes.as_slice();
         rows.push(Row {
-            name: Box::from(lockfile.packages.items_name()[id as usize].slice(buf)),
+            name: Box::from(lockfile.packages.items_name()[id.index()].slice(buf)),
             from: text(
-                lockfile.packages.items_resolution()[id as usize]
+                lockfile.packages.items_resolution()[id.index()]
                     .npm()
                     .version
                     .fmt(buf),
@@ -760,14 +762,14 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) {
             .map_or(&[], PackageIndexEntry::as_slice);
         if installed
             .iter()
-            .any(|&id| pkg_res[id as usize].tag != ResolutionTag::Npm)
+            .any(|&id| pkg_res[id.index()].tag != ResolutionTag::Npm)
         {
             continue;
         }
         let mut now: Vec<u8> = Vec::new();
         let mut still_applies = false;
         for &id in installed {
-            let current = text(pkg_res[id as usize].npm().version.fmt(buf));
+            let current = text(pkg_res[id.index()].npm().version.fmt(buf));
             if &*current == version {
                 still_applies = true;
                 break;
@@ -805,7 +807,7 @@ fn newest_allowed(manager: &mut PackageManager, pkg_id: PackageID) -> Option<Box
     let excludes = manager.options.minimum_release_age_excludes;
     let lockfile: &Lockfile = &manager.lockfile;
     let buf = lockfile.buffers.string_bytes.as_slice();
-    let pkg = pkg_id as usize;
+    let pkg = pkg_id.index();
     let res = lockfile.packages.items_resolution();
     if pkg >= res.len() || res[pkg].tag != ResolutionTag::Npm {
         return None;
@@ -833,7 +835,9 @@ fn newest_allowed(manager: &mut PackageManager, pkg_id: PackageID) -> Option<Box
         if target != pkg_id || dep.behavior.is_bundled() {
             continue;
         }
-        let Some(range) = dedupe::effective_npm_range(lockfile, dep_id as DependencyID, dep) else {
+        let Some(range) =
+            dedupe::effective_npm_range(lockfile, DependencyID::from_index(dep_id), dep)
+        else {
             continue;
         };
         let Some(found) = manifest
@@ -978,8 +982,8 @@ pub(crate) fn plannable_peer_rows(
 
     let mut providers = DynamicBitSet::init_empty(packages_len).unwrap_or_oom();
     for &(_, behavior, resolved) in &direct.rows {
-        if !behavior.is_peer() && (resolved as usize) < packages_len {
-            providers.set(resolved as usize);
+        if !behavior.is_peer() && resolved.index() < packages_len {
+            providers.set(resolved.index());
         }
     }
     for owner in 0..packages_len {
@@ -988,8 +992,8 @@ pub(crate) fn plannable_peer_rows(
             .iter()
             .zip(res_slices[owner].get(resolutions));
         for (dep, &resolved) in owned {
-            if !dep.behavior.is_peer() && (resolved as usize) < packages_len {
-                providers.set(resolved as usize);
+            if !dep.behavior.is_peer() && resolved.index() < packages_len {
+                providers.set(resolved.index());
             }
         }
     }
@@ -1010,8 +1014,8 @@ pub(crate) fn plannable_peer_rows(
         for (i, (dep, &resolved)) in owned.enumerate() {
             if dep.behavior.is_peer()
                 && !dep.behavior.is_optional_peer()
-                && (resolved as usize) < packages_len
-                && !providers.is_set(resolved as usize)
+                && resolved.index() < packages_len
+                && !providers.is_set(resolved.index())
             {
                 rows.set(first + i);
             }
@@ -1046,7 +1050,7 @@ fn plan_edges(
             let Some(&target) = resolutions.get(dep_id) else {
                 break;
             };
-            let Some(&slot) = instance_of.get(target as usize) else {
+            let Some(&slot) = instance_of.get(target.index()) else {
                 continue;
             };
             let dep = &deps[dep_id];
@@ -1063,7 +1067,7 @@ fn plan_edges(
             let instance = if slot != u32::MAX {
                 slot
             } else {
-                let pkg_id = target as usize;
+                let pkg_id = target.index();
                 if res[pkg_id].tag != ResolutionTag::Npm {
                     instance_of[pkg_id] = SKIP;
                     continue;
@@ -1084,7 +1088,7 @@ fn plan_edges(
                 });
                 instance_of[pkg_id]
             };
-            let dep_id = dep_id as DependencyID;
+            let dep_id = DependencyID::from_index(dep_id);
             let inst = &mut instances[instance as usize];
             let literal = (no_overrides
                 && match dep.version.tag {
@@ -1109,7 +1113,7 @@ fn plan_edges(
                 DependencyVersionTag::DistTag => version.dist_tag().name,
                 _ => continue,
             };
-            if !names.eql(pkg_names[inst.pkg_id as usize], buf, buf) {
+            if !names.eql(pkg_names[inst.pkg_id.index()], buf, buf) {
                 continue;
             }
             inst.wants.push(Want {
@@ -1146,7 +1150,7 @@ fn plan_edges(
         if inst.held {
             continue;
         }
-        let name = pkg_names[inst.pkg_id as usize].slice(buf);
+        let name = pkg_names[inst.pkg_id.index()].slice(buf);
         let mut expired = false;
         let scope = manager.options.scope_for_package_name(name);
         let Some(manifest) = manager.manifests.by_name_allow_expired(

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -3,7 +3,7 @@ use std::io::Write as _;
 
 use bstr::BStr;
 use bun_collections::bit_set::Range as BitRange;
-use bun_collections::{DynamicBitSet, index_sort};
+use bun_collections::{DynamicBitSet, IdVec, index_sort};
 use bun_core::{Output, UnwrapOrOom as _, pretty, prettyln, strings};
 use bun_semver as Semver;
 
@@ -39,7 +39,7 @@ impl DirectDependencies {
         let resolutions = lockfile.buffers.resolutions.as_slice();
 
         let mut out = DirectDependencies::default();
-        for owner in 0..pkg_res.len() {
+        for owner in pkg_res.ids() {
             if !matches!(
                 pkg_res[owner].tag,
                 ResolutionTag::Root | ResolutionTag::Workspace
@@ -54,11 +54,8 @@ impl DirectDependencies {
                     .zip(res_slices[owner].get(resolutions))
                     .map(|(dep, &resolved)| (dep.name_hash, dep.behavior, resolved)),
             );
-            out.owners.push((
-                PackageID::from_index(owner),
-                start as u32,
-                (out.rows.len() - start) as u32,
-            ));
+            out.owners
+                .push((owner, start as u32, (out.rows.len() - start) as u32));
         }
         out
     }
@@ -82,8 +79,7 @@ impl DirectDependencies {
 
         let mut pairs: Vec<(PackageID, PackageID)> = Vec::new();
         for &(owner, start, len) in &self.owners {
-            let owner = owner.index();
-            if owner >= packages_len {
+            if owner.index() >= packages_len {
                 continue;
             }
             let rows = &self.rows[start as usize..(start + len) as usize];
@@ -126,8 +122,8 @@ impl DirectDependencies {
                 if old == new
                     || old.index() >= packages_len
                     || new.index() >= packages_len
-                    || pkg_res[new.index()].tag != ResolutionTag::Npm
-                    || name_hashes[old.index()] != name_hashes[new.index()]
+                    || pkg_res[new].tag != ResolutionTag::Npm
+                    || name_hashes[old] != name_hashes[new]
                 {
                     continue;
                 }
@@ -146,13 +142,13 @@ fn rows_between(manager: &mut PackageManager, pairs: Vec<(PackageID, PackageID)>
             let lockfile: &Lockfile = &manager.lockfile;
             let buf = lockfile.buffers.string_bytes.as_slice();
             let pkg_res = lockfile.packages.items_resolution();
-            if pkg_res[old.index()].tag != ResolutionTag::Npm {
+            if pkg_res[old].tag != ResolutionTag::Npm {
                 continue;
             }
             (
-                Box::<[u8]>::from(lockfile.packages.items_name()[old.index()].slice(buf)),
-                text(pkg_res[old.index()].npm().version.fmt(buf)),
-                text(pkg_res[new.index()].npm().version.fmt(buf)),
+                Box::<[u8]>::from(lockfile.packages.items_name()[old].slice(buf)),
+                text(pkg_res[old].npm().version.fmt(buf)),
+                text(pkg_res[new].npm().version.fmt(buf)),
             )
         };
         let later = later_in_cache(manager, new);
@@ -171,9 +167,9 @@ fn later_in_cache(manager: &mut PackageManager, pkg_id: PackageID) -> Box<[u8]> 
         let lockfile: &Lockfile = &manager.lockfile;
         let buf = lockfile.buffers.string_bytes.as_slice();
         (
-            Box::<[u8]>::from(lockfile.packages.items_name()[pkg_id.index()].slice(buf)),
-            lockfile.packages.items_name_hash()[pkg_id.index()],
-            lockfile.packages.items_resolution()[pkg_id.index()],
+            Box::<[u8]>::from(lockfile.packages.items_name()[pkg_id].slice(buf)),
+            lockfile.packages.items_name_hash()[pkg_id],
+            lockfile.packages.items_resolution()[pkg_id],
         )
     };
     match manager.format_later_version_in_cache(&name, name_hash, &resolution) {
@@ -193,13 +189,13 @@ fn named_pairs(
     let resolutions = lockfile.buffers.resolutions.as_slice();
     moved
         .iter()
-        .map(|&(dep_id, from)| (from, resolutions[dep_id.index()]))
+        .map(|&(dep_id, from)| (from, resolutions[dep_id]))
         .filter(|&(from, to)| {
             from != to
                 && from.index() < packages_len
                 && to.index() < packages_len
-                && pkg_res[to.index()].tag == ResolutionTag::Npm
-                && name_hashes[from.index()] == name_hashes[to.index()]
+                && pkg_res[to].tag == ResolutionTag::Npm
+                && name_hashes[from] == name_hashes[to]
         })
         .collect()
 }
@@ -209,22 +205,23 @@ fn redirect(lockfile: &mut Lockfile, pairs: Vec<(PackageID, PackageID)>) {
     if pairs.is_empty() {
         return;
     }
-    let mut new_of: Vec<PackageID> = vec![invalid_package_id; lockfile.packages.len()];
+    let mut new_of: IdVec<PackageID, PackageID> =
+        vec![invalid_package_id; lockfile.packages.len()].into();
     for (old, new) in pairs {
-        let slot = &mut new_of[old.index()];
+        let slot = &mut new_of[old];
         if *slot == invalid_package_id {
             *slot = new;
         }
     }
 
-    let moved: Vec<(usize, PackageID)> = {
+    let moved: Vec<(DependencyID, PackageID)> = {
         let lockfile: &Lockfile = lockfile;
         let buf = lockfile.buffers.string_bytes.as_slice();
         let pkg_res = lockfile.packages.items_resolution();
         let deps = lockfile.buffers.dependencies.as_slice();
         let mut moved = Vec::new();
-        for (j, &target) in lockfile.buffers.resolutions.iter().enumerate() {
-            let Some(&new) = new_of.get(target.index()) else {
+        for (j, &target) in lockfile.buffers.resolutions.iter_enumerated() {
+            let Some(&new) = new_of.get(target) else {
                 continue;
             };
             if new == invalid_package_id {
@@ -234,15 +231,13 @@ fn redirect(lockfile: &mut Lockfile, pairs: Vec<(PackageID, PackageID)>) {
             if dep.behavior.is_bundled() {
                 continue;
             }
-            let Some(range) =
-                dedupe::effective_npm_range(lockfile, DependencyID::from_index(j), dep)
-            else {
+            let Some(range) = dedupe::effective_npm_range(lockfile, j, dep) else {
                 continue;
             };
             if range
                 .npm()
                 .version
-                .satisfies(pkg_res[new.index()].npm().version, buf, buf)
+                .satisfies(pkg_res[new].npm().version, buf, buf)
             {
                 moved.push((j, new));
             }
@@ -280,9 +275,10 @@ impl TransitiveUpdate {
             let scope = UpdateScope::of(&*manager);
             let owners = (!scope.is_whole_workspace()).then(|| scope.reachable(lockfile));
             let mut edges = DynamicBitSet::init_empty(lockfile.buffers.dependencies.len())?;
-            for owner in 0..lockfile.packages.len() {
-                if owners.is_none_or(|reachable| reachable.is_set_allow_out_of_bound(owner, false))
-                {
+            for owner in lockfile.packages.items_resolution().ids() {
+                if owners.is_none_or(|reachable| {
+                    reachable.is_set_allow_out_of_bound(owner.index(), false)
+                }) {
                     set_rows_of(&mut edges, lockfile, owner);
                 }
             }
@@ -320,7 +316,7 @@ impl TransitiveUpdate {
         let _ = manager.get_cache_directory();
         let _ = manager.get_temporary_directory();
         for pin in &self.pins {
-            if manager.lockfile.buffers.resolutions[pin.dep_id.index()] != pin.from {
+            if manager.lockfile.buffers.resolutions[pin.dep_id] != pin.from {
                 continue;
             }
             match pin.to {
@@ -414,7 +410,7 @@ pub(crate) fn refresh_children_of(
         let mut edges = DynamicBitSet::init_empty(lockfile.buffers.dependencies.len())?;
         for &owner in package_ids {
             if owner.index() < lockfile.packages.len() {
-                set_rows_of(&mut edges, lockfile, owner.index());
+                set_rows_of(&mut edges, lockfile, owner);
             }
         }
         edges
@@ -432,9 +428,9 @@ pub(crate) fn refresh_children_of(
 
 /// Only the synchronous resolve sees the cleared peer bit (the manifest callback re-reads the buffer row), so callers fetch the manifest first.
 fn reresolve(manager: &mut PackageManager, dep_id: DependencyID) -> crate::Result<()> {
-    let mut dep = manager.lockfile.buffers.dependencies[dep_id.index()].clone();
+    let mut dep = manager.lockfile.buffers.dependencies[dep_id].clone();
     dep.behavior = dep.behavior.with(Behavior::PEER, false);
-    manager.lockfile.buffers.resolutions[dep_id.index()] = invalid_package_id;
+    manager.lockfile.buffers.resolutions[dep_id] = invalid_package_id;
     enqueue_dependency_with_main(manager, dep_id, &dep, invalid_package_id, false)
 }
 
@@ -447,14 +443,14 @@ pub(crate) fn enqueue_peer_rows(
     if !rows.is_empty() {
         let mut targets: Vec<PackageID> = rows
             .iter()
-            .map(|&row| manager.lockfile.buffers.resolutions[row.index()])
+            .map(|&row| manager.lockfile.buffers.resolutions[row])
             .collect();
         targets.sort_unstable();
         targets.dedup();
         populate_manifest_cache::populate_manifest_cache(manager, Packages::Exact(&targets))?;
         print_log(manager)?;
         for &row in rows {
-            moved.push((row, manager.lockfile.buffers.resolutions[row.index()]));
+            moved.push((row, manager.lockfile.buffers.resolutions[row]));
             reresolve(manager, row)?;
         }
     }
@@ -481,11 +477,9 @@ pub(crate) fn redirect_moved_edges(lockfile: &mut Lockfile, moved: &[(Dependency
         let resolutions = lockfile.buffers.resolutions.as_slice();
         moved
             .iter()
-            .map(|&(dep_id, from)| (from, resolutions[dep_id.index()]))
+            .map(|&(dep_id, from)| (from, resolutions[dep_id]))
             .filter(|&(from, to)| {
-                to != from
-                    && to.index() < pkg_res.len()
-                    && pkg_res[to.index()].tag == ResolutionTag::Npm
+                to != from && pkg_res.has(to) && pkg_res[to].tag == ResolutionTag::Npm
             })
             .collect()
     };
@@ -510,19 +504,19 @@ pub(crate) fn moved_targets_after_clean(
 
     let mut targets: Vec<PackageID> = Vec::new();
     for &(dep_id, _) in moved {
-        let Some(&old_id) = old_resolutions.get(dep_id.index()) else {
+        let Some(&old_id) = old_resolutions.get(dep_id) else {
             continue;
         };
-        if old_id.index() >= old_res.len() {
+        if !old_res.has(old_id) {
             continue;
         }
-        let Some(entry) = cleaned.package_index.get(&old_name_hashes[old_id.index()]) else {
+        let Some(entry) = cleaned.package_index.get(&old_name_hashes[old_id]) else {
             continue;
         };
         if let Some(&id) = entry
             .as_slice()
             .iter()
-            .find(|&&c| new_res[c.index()].eql(&old_res[old_id.index()], new_buf, old_buf))
+            .find(|&&c| new_res[c].eql(&old_res[old_id], new_buf, old_buf))
         {
             targets.push(id);
         }
@@ -560,11 +554,11 @@ pub(crate) fn register_moved(
     let names = lockfile.packages.items_name();
     let res = lockfile.packages.items_resolution();
     for &pkg_id in moved {
-        if pkg_id.index() >= res.len() || res[pkg_id.index()].tag != ResolutionTag::Npm {
+        if !res.has(pkg_id) || res[pkg_id].tag != ResolutionTag::Npm {
             continue;
         }
-        let current = res[pkg_id.index()].npm().version;
-        let entry = updating.get_or_put(names[pkg_id.index()].slice(buf))?;
+        let current = res[pkg_id].npm().version;
+        let entry = updating.get_or_put(names[pkg_id].slice(buf))?;
         if entry.found_existing {
             let info = &*entry.value_ptr;
             let keep = !info.original_version_literal.is_empty()
@@ -664,9 +658,9 @@ fn kept_patched_rows(manager: &mut PackageManager) -> Vec<Row> {
         let lockfile: &Lockfile = &manager.lockfile;
         let buf = lockfile.buffers.string_bytes.as_slice();
         rows.push(Row {
-            name: Box::from(lockfile.packages.items_name()[id.index()].slice(buf)),
+            name: Box::from(lockfile.packages.items_name()[id].slice(buf)),
             from: text(
-                lockfile.packages.items_resolution()[id.index()]
+                lockfile.packages.items_resolution()[id]
                     .npm()
                     .version
                     .fmt(buf),
@@ -762,14 +756,14 @@ pub(crate) fn warn_orphaned_patches(manager: &mut PackageManager) {
             .map_or(&[], PackageIndexEntry::as_slice);
         if installed
             .iter()
-            .any(|&id| pkg_res[id.index()].tag != ResolutionTag::Npm)
+            .any(|&id| pkg_res[id].tag != ResolutionTag::Npm)
         {
             continue;
         }
         let mut now: Vec<u8> = Vec::new();
         let mut still_applies = false;
         for &id in installed {
-            let current = text(pkg_res[id.index()].npm().version.fmt(buf));
+            let current = text(pkg_res[id].npm().version.fmt(buf));
             if &*current == version {
                 still_applies = true;
                 break;
@@ -807,18 +801,17 @@ fn newest_allowed(manager: &mut PackageManager, pkg_id: PackageID) -> Option<Box
     let excludes = manager.options.minimum_release_age_excludes;
     let lockfile: &Lockfile = &manager.lockfile;
     let buf = lockfile.buffers.string_bytes.as_slice();
-    let pkg = pkg_id.index();
     let res = lockfile.packages.items_resolution();
-    if pkg >= res.len() || res[pkg].tag != ResolutionTag::Npm {
+    if !res.has(pkg_id) || res[pkg_id].tag != ResolutionTag::Npm {
         return None;
     }
-    let current = res[pkg].npm().version;
-    let name = lockfile.packages.items_name()[pkg].slice(buf);
+    let current = res[pkg_id].npm().version;
+    let name = lockfile.packages.items_name()[pkg_id].slice(buf);
     let manifest: &PackageManifest = manager.manifests.by_name_hash_allow_expired(
         cache_ctx,
         manager.options.scope_for_package_name(name),
         name,
-        lockfile.packages.items_name_hash()[pkg],
+        lockfile.packages.items_name_hash()[pkg_id],
         Some(&mut false),
         ManifestLoad::LoadFromMemoryFallbackToDisk,
         min_age.is_some(),
@@ -949,7 +942,7 @@ struct Instance {
 }
 
 /// Workspace-owned rows belong to the differ; rows it orphaned by re-parsing a workspace belong to nobody.
-fn set_rows_of(edges: &mut DynamicBitSet, lockfile: &Lockfile, owner: usize) {
+fn set_rows_of(edges: &mut DynamicBitSet, lockfile: &Lockfile, owner: PackageID) {
     let slice = lockfile.packages.items_dependencies()[owner];
     if slice.len == 0
         || matches!(
@@ -986,7 +979,7 @@ pub(crate) fn plannable_peer_rows(
             providers.set(resolved.index());
         }
     }
-    for owner in 0..packages_len {
+    for owner in dep_slices.ids() {
         let owned = dep_slices[owner]
             .get(deps)
             .iter()
@@ -999,7 +992,7 @@ pub(crate) fn plannable_peer_rows(
     }
 
     let mut rows = DynamicBitSet::init_empty(deps.len()).unwrap_or_oom();
-    for owner in 0..packages_len {
+    for owner in dep_slices.ids() {
         if matches!(
             pkg_res[owner].tag,
             ResolutionTag::Root | ResolutionTag::Workspace
@@ -1037,7 +1030,7 @@ fn plan_edges(
         let res = lockfile.packages.items_resolution();
         let has_patches = lockfile.patched_dependencies.count() > 0;
         const SKIP: u32 = u32::MAX - 1;
-        let mut instance_of: Vec<u32> = vec![u32::MAX; res.len()];
+        let mut instance_of: IdVec<PackageID, u32> = vec![u32::MAX; res.len()].into();
 
         let no_overrides = lockfile.overrides.is_empty();
         let buf = lockfile.buffers.string_bytes.as_slice();
@@ -1046,11 +1039,12 @@ fn plan_edges(
         let resolutions = lockfile.buffers.resolutions.as_slice();
         let mut plannable_peers: Option<DynamicBitSet> = None;
         let mut set_edges = edges.iterator::<true, true>();
-        while let Some(dep_id) = set_edges.next() {
+        while let Some(dep_index) = set_edges.next() {
+            let dep_id = DependencyID::from_index(dep_index);
             let Some(&target) = resolutions.get(dep_id) else {
                 break;
             };
-            let Some(&slot) = instance_of.get(target.index()) else {
+            let Some(&slot) = instance_of.get(target) else {
                 continue;
             };
             let dep = &deps[dep_id];
@@ -1060,16 +1054,15 @@ fn plan_edges(
             if dep.behavior.is_peer()
                 && !plannable_peers
                     .get_or_insert_with(|| plannable_peer_rows(lockfile, direct))
-                    .is_set(dep_id)
+                    .is_set(dep_index)
             {
                 continue;
             }
             let instance = if slot != u32::MAX {
                 slot
             } else {
-                let pkg_id = target.index();
-                if res[pkg_id].tag != ResolutionTag::Npm {
-                    instance_of[pkg_id] = SKIP;
+                if res[target].tag != ResolutionTag::Npm {
+                    instance_of[target] = SKIP;
                     continue;
                 }
                 let held = has_patches
@@ -1079,16 +1072,15 @@ fn plan_edges(
                 if held {
                     kept.push(target);
                 }
-                instance_of[pkg_id] = instances.len() as u32;
+                instance_of[target] = instances.len() as u32;
                 instances.push(Instance {
                     pkg_id: target,
-                    current: res[pkg_id].npm().version,
+                    current: res[target].npm().version,
                     wants: Vec::new(),
                     held,
                 });
-                instance_of[pkg_id]
+                instance_of[target]
             };
-            let dep_id = DependencyID::from_index(dep_id);
             let inst = &mut instances[instance as usize];
             let literal = (no_overrides
                 && match dep.version.tag {
@@ -1113,7 +1105,7 @@ fn plan_edges(
                 DependencyVersionTag::DistTag => version.dist_tag().name,
                 _ => continue,
             };
-            if !names.eql(pkg_names[inst.pkg_id.index()], buf, buf) {
+            if !names.eql(pkg_names[inst.pkg_id], buf, buf) {
                 continue;
             }
             inst.wants.push(Want {
@@ -1150,7 +1142,7 @@ fn plan_edges(
         if inst.held {
             continue;
         }
-        let name = pkg_names[inst.pkg_id.index()].slice(buf);
+        let name = pkg_names[inst.pkg_id].slice(buf);
         let mut expired = false;
         let scope = manager.options.scope_for_package_name(name);
         let Some(manifest) = manager.manifests.by_name_allow_expired(

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -775,7 +775,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             dependencies: Default::default(),
             resolutions: Default::default(),
             meta: PackageMeta {
-                id: 0,
+                id: PackageID::ROOT,
                 origin: Origin::Local,
                 arch: npm::Architecture::ALL,
                 os: npm::OperatingSystem::ALL,
@@ -802,13 +802,14 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         bun_core::ffi::slice_mut(resolutions_base_ptr, num_deps as usize)
     };
 
-    let mut yarn_entry_to_package_id: Vec<PackageID> = vec![0; yarn_lock.entries.len()];
+    let mut yarn_entry_to_package_id: Vec<PackageID> =
+        vec![PackageID::default(); yarn_lock.entries.len()];
 
     let mut package_versions: StringHashMap<VersionInfo> = StringHashMap::new();
 
     let mut scoped_packages: StringHashMap<Vec<VersionInfo>> = StringHashMap::new();
 
-    let mut next_package_id: PackageID = 1; // 0 is root
+    let mut next_package_id: u32 = 1; // 0 is root
 
     for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
         let mut is_npm_alias = false;
@@ -862,7 +863,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 }
 
                 if !found_new {
-                    let package_id = next_package_id;
+                    let package_id = PackageID::new(next_package_id);
                     next_package_id += 1;
                     list.push(VersionInfo {
                         yarn_idx,
@@ -884,7 +885,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 yarn_entry_to_package_id[yarn_idx] = existing.package_id;
             }
         } else {
-            let package_id = next_package_id;
+            let package_id = PackageID::new(next_package_id);
             next_package_id += 1;
             yarn_entry_to_package_id[yarn_idx] = package_id;
             package_versions.put(
@@ -931,13 +932,13 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             };
         let package_id = yarn_entry_to_package_id[yarn_idx];
 
-        if (package_id as usize) < package_id_to_yarn_idx.len()
-            && package_id_to_yarn_idx[package_id as usize] != usize::MAX
+        if package_id.index() < package_id_to_yarn_idx.len()
+            && package_id_to_yarn_idx[package_id.index()] != usize::MAX
         {
             continue;
         }
 
-        package_id_to_yarn_idx[package_id as usize] = yarn_idx;
+        package_id_to_yarn_idx[package_id.index()] = yarn_idx;
 
         let name_to_use: &[u8] = 'blk: {
             if entry.commit.is_some() && entry.git_repo_name.is_some() {
@@ -1182,7 +1183,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
     this.packages.items_dependencies_mut()[0] =
         lockfile::DependencySlice::new(0, actual_root_dep_count);
     this.packages.items_resolutions_mut()[0] =
-        lockfile::DependencyIDSlice::new(0, actual_root_dep_count);
+        lockfile::PackageIDSlice::new(0, actual_root_dep_count);
 
     dependencies_buf = &mut dependencies_buf[actual_root_dep_count as usize..];
     resolutions_buf = &mut resolutions_buf[actual_root_dep_count as usize..];
@@ -1266,18 +1267,16 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         // dependencies_start/dependencies_buf.as_ptr() are within the same allocation
         let deps_len = (dependencies_buf.as_mut_ptr() as usize) - (dependencies_start as usize);
         let deps_off = (dependencies_start as usize) - (dependencies_base_ptr as usize);
-        this.packages.items_dependencies_mut()[package_id as usize] =
-            lockfile::DependencySlice::new(
-                u32::try_from(deps_off / core::mem::size_of::<Dependency>()).expect("int cast"),
-                u32::try_from(deps_len / core::mem::size_of::<Dependency>()).expect("int cast"),
-            );
+        this.packages.items_dependencies_mut()[package_id.index()] = lockfile::DependencySlice::new(
+            u32::try_from(deps_off / core::mem::size_of::<Dependency>()).expect("int cast"),
+            u32::try_from(deps_len / core::mem::size_of::<Dependency>()).expect("int cast"),
+        );
         let res_off = (resolutions_start as usize) - (resolutions_base_ptr as usize);
         let res_len = (resolutions_buf.as_mut_ptr() as usize) - (resolutions_start as usize);
-        this.packages.items_resolutions_mut()[package_id as usize] =
-            lockfile::DependencyIDSlice::new(
-                u32::try_from(res_off / core::mem::size_of::<PackageID>()).expect("int cast"),
-                u32::try_from(res_len / core::mem::size_of::<PackageID>()).expect("int cast"),
-            );
+        this.packages.items_resolutions_mut()[package_id.index()] = lockfile::PackageIDSlice::new(
+            u32::try_from(res_off / core::mem::size_of::<PackageID>()).expect("int cast"),
+            u32::try_from(res_len / core::mem::size_of::<PackageID>()).expect("int cast"),
+        );
     }
 
     let final_deps_len = ((dependencies_buf.as_mut_ptr() as usize)
@@ -1350,7 +1349,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
 
                         if found {
                             let dep_package_id = yarn_entry_to_package_id[idx];
-                            package_dependents[dep_package_id as usize].push(parent_package_id);
+                            package_dependents[dep_package_id.index()].push(parent_package_id);
                             break;
                         }
                     }
@@ -1373,7 +1372,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             for spec in entry.specs.iter() {
                 if *spec == dep_spec.as_slice() {
                     let dep_package_id = yarn_entry_to_package_id[idx];
-                    package_dependents[dep_package_id as usize].push(0); // 0 is root package
+                    package_dependents[dep_package_id.index()].push(PackageID::ROOT);
                     break;
                 }
             }
@@ -1439,8 +1438,8 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
 
     for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
         let package_id = yarn_entry_to_package_id[yarn_idx];
-        if package_names[package_id as usize].is_empty() {
-            package_names[package_id as usize] = Entry::get_name_from_spec(entry.specs[0]);
+        if package_names[package_id.index()].is_empty() {
+            package_names[package_id.index()] = Entry::get_name_from_spec(entry.specs[0]);
         }
     }
 
@@ -1452,7 +1451,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         if package_id == install::INVALID_PACKAGE_ID {
             continue;
         }
-        let base_name = package_names[package_id as usize];
+        let base_name = package_names[package_id.index()];
 
         for dep_entry in yarn_lock.entries.iter() {
             if let Some(deps) = &dep_entry.dependencies {
@@ -1471,7 +1470,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         if package_id == install::INVALID_PACKAGE_ID {
             continue;
         }
-        let base_name = package_names[package_id as usize];
+        let base_name = package_names[package_id.index()];
 
         if root_packages.get(base_name).is_none() {
             root_packages.put(base_name, package_id)?;
@@ -1487,7 +1486,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         if package_id == install::INVALID_PACKAGE_ID {
             continue;
         }
-        let base_name = package_names[package_id as usize];
+        let base_name = package_names[package_id.index()];
 
         if let Some(root_pkg_id) = root_packages.get(base_name).copied() {
             if root_pkg_id == package_id {
@@ -1508,7 +1507,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 for (dep_name_key, _) in deps.iter() {
                     if dep_name_key.as_ref() == base_name {
                         if dep_package_id != package_id {
-                            let parent_name = package_names[dep_package_id as usize];
+                            let parent_name = package_names[dep_package_id.index()];
 
                             let mut potential_name = Vec::new();
                             write!(
@@ -1542,7 +1541,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         }
 
         if scoped_name.is_none() {
-            let pkg_resolution = this.packages.get(package_id as usize).resolution;
+            let pkg_resolution = this.packages.get(package_id.index()).resolution;
             let version_str: Vec<u8> = match pkg_resolution.tag {
                 ResolutionTag::Npm => 'brk: {
                     let mut version_buf = [0u8; 64];
@@ -1670,7 +1669,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         root_deps_off,
         u32::try_from(root_dependencies.len()).expect("int cast"),
     );
-    this.packages.items_resolutions_mut()[0] = lockfile::DependencyIDSlice::new(
+    this.packages.items_resolutions_mut()[0] = lockfile::PackageIDSlice::new(
         root_resolutions_off,
         u32::try_from(root_dependencies.len()).expect("int cast"),
     );
@@ -1894,11 +1893,11 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             }
         }
 
-        this.packages.items_dependencies_mut()[package_id as usize] =
+        this.packages.items_dependencies_mut()[package_id.index()] =
             lockfile::DependencySlice::new(deps_off, dep_count);
 
-        this.packages.items_resolutions_mut()[package_id as usize] =
-            lockfile::DependencyIDSlice::new(resolutions_off, dep_count);
+        this.packages.items_resolutions_mut()[package_id.index()] =
+            lockfile::PackageIDSlice::new(resolutions_off, dep_count);
     }
 
     // `Lockfile::resolve` returns `Result<(), tree::SubtreeError>`; surface as

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use std::io::Write as _;
 
 use crate::Error;
-use bun_collections::{HashMap, StringHashMap};
+use bun_collections::{HashMap, IdVec, StringHashMap};
 use bun_install::bin::Bin;
 use bun_install::dependency::{self, Dependency, DependencyExt as _};
 use bun_install::install::{self, DependencyID, PackageID, PackageManager};
@@ -899,7 +899,8 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         }
     }
 
-    let mut package_id_to_yarn_idx: Vec<usize> = vec![usize::MAX; next_package_id as usize];
+    let mut package_id_to_yarn_idx: IdVec<PackageID, usize> =
+        vec![usize::MAX; next_package_id as usize].into();
 
     let created_packages: StringHashMap<bool> = StringHashMap::new();
     let _ = &created_packages; // never populated
@@ -932,13 +933,13 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             };
         let package_id = yarn_entry_to_package_id[yarn_idx];
 
-        if package_id.index() < package_id_to_yarn_idx.len()
-            && package_id_to_yarn_idx[package_id.index()] != usize::MAX
+        if package_id_to_yarn_idx.has(package_id)
+            && package_id_to_yarn_idx[package_id] != usize::MAX
         {
             continue;
         }
 
-        package_id_to_yarn_idx[package_id.index()] = yarn_idx;
+        package_id_to_yarn_idx[package_id] = yarn_idx;
 
         let name_to_use: &[u8] = 'blk: {
             if entry.commit.is_some() && entry.git_repo_name.is_some() {
@@ -1180,9 +1181,9 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         }
     }
 
-    this.packages.items_dependencies_mut()[0] =
+    this.packages.items_dependencies_mut()[PackageID::ROOT] =
         lockfile::DependencySlice::new(0, actual_root_dep_count);
-    this.packages.items_resolutions_mut()[0] =
+    this.packages.items_resolutions_mut()[PackageID::ROOT] =
         lockfile::PackageIDSlice::new(0, actual_root_dep_count);
 
     dependencies_buf = &mut dependencies_buf[actual_root_dep_count as usize..];
@@ -1267,13 +1268,13 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         // dependencies_start/dependencies_buf.as_ptr() are within the same allocation
         let deps_len = (dependencies_buf.as_mut_ptr() as usize) - (dependencies_start as usize);
         let deps_off = (dependencies_start as usize) - (dependencies_base_ptr as usize);
-        this.packages.items_dependencies_mut()[package_id.index()] = lockfile::DependencySlice::new(
+        this.packages.items_dependencies_mut()[package_id] = lockfile::DependencySlice::new(
             u32::try_from(deps_off / core::mem::size_of::<Dependency>()).expect("int cast"),
             u32::try_from(deps_len / core::mem::size_of::<Dependency>()).expect("int cast"),
         );
         let res_off = (resolutions_start as usize) - (resolutions_base_ptr as usize);
         let res_len = (resolutions_buf.as_mut_ptr() as usize) - (resolutions_start as usize);
-        this.packages.items_resolutions_mut()[package_id.index()] = lockfile::PackageIDSlice::new(
+        this.packages.items_resolutions_mut()[package_id] = lockfile::PackageIDSlice::new(
             u32::try_from(res_off / core::mem::size_of::<PackageID>()).expect("int cast"),
             u32::try_from(res_len / core::mem::size_of::<PackageID>()).expect("int cast"),
         );
@@ -1284,8 +1285,8 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         / core::mem::size_of::<Dependency>();
     unsafe {
         // SAFETY: all elements in 0..final_deps_len initialized above; capacity >= num_deps
-        this.buffers.dependencies.set_len(final_deps_len);
-        this.buffers.resolutions.set_len(final_deps_len);
+        this.buffers.dependencies.raw_mut().set_len(final_deps_len);
+        this.buffers.resolutions.raw_mut().set_len(final_deps_len);
     }
 
     this.buffers.hoisted_dependencies.reserve(
@@ -1300,7 +1301,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         dependencies: lockfile::DependencyIDSlice::new(0, 0),
     });
 
-    let mut package_dependents: Vec<Vec<PackageID>> =
+    let mut package_dependents: IdVec<PackageID, Vec<PackageID>> =
         (0..next_package_id).map(|_| Vec::new()).collect();
 
     for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
@@ -1349,7 +1350,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
 
                         if found {
                             let dep_package_id = yarn_entry_to_package_id[idx];
-                            package_dependents[dep_package_id.index()].push(parent_package_id);
+                            package_dependents[dep_package_id].push(parent_package_id);
                             break;
                         }
                     }
@@ -1372,7 +1373,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             for spec in entry.specs.iter() {
                 if *spec == dep_spec.as_slice() {
                     let dep_package_id = yarn_entry_to_package_id[idx];
-                    package_dependents[dep_package_id.index()].push(PackageID::ROOT);
+                    package_dependents[dep_package_id].push(PackageID::ROOT);
                     break;
                 }
             }
@@ -1434,12 +1435,13 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         }
     }
 
-    let mut package_names: Vec<&[u8]> = vec![b"".as_slice(); next_package_id as usize];
+    let mut package_names: IdVec<PackageID, &[u8]> =
+        vec![b"".as_slice(); next_package_id as usize].into();
 
     for (yarn_idx, entry) in yarn_lock.entries.iter().enumerate() {
         let package_id = yarn_entry_to_package_id[yarn_idx];
-        if package_names[package_id.index()].is_empty() {
-            package_names[package_id.index()] = Entry::get_name_from_spec(entry.specs[0]);
+        if package_names[package_id].is_empty() {
+            package_names[package_id] = Entry::get_name_from_spec(entry.specs[0]);
         }
     }
 
@@ -1451,7 +1453,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         if package_id == install::INVALID_PACKAGE_ID {
             continue;
         }
-        let base_name = package_names[package_id.index()];
+        let base_name = package_names[package_id];
 
         for dep_entry in yarn_lock.entries.iter() {
             if let Some(deps) = &dep_entry.dependencies {
@@ -1470,7 +1472,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         if package_id == install::INVALID_PACKAGE_ID {
             continue;
         }
-        let base_name = package_names[package_id.index()];
+        let base_name = package_names[package_id];
 
         if root_packages.get(base_name).is_none() {
             root_packages.put(base_name, package_id)?;
@@ -1486,7 +1488,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         if package_id == install::INVALID_PACKAGE_ID {
             continue;
         }
-        let base_name = package_names[package_id.index()];
+        let base_name = package_names[package_id];
 
         if let Some(root_pkg_id) = root_packages.get(base_name).copied() {
             if root_pkg_id == package_id {
@@ -1507,7 +1509,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                 for (dep_name_key, _) in deps.iter() {
                     if dep_name_key.as_ref() == base_name {
                         if dep_package_id != package_id {
-                            let parent_name = package_names[dep_package_id.index()];
+                            let parent_name = package_names[dep_package_id];
 
                             let mut potential_name = Vec::new();
                             write!(
@@ -1541,7 +1543,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         }
 
         if scoped_name.is_none() {
-            let pkg_resolution = this.packages.get(package_id.index()).resolution;
+            let pkg_resolution = this.package(package_id).resolution;
             let version_str: Vec<u8> = match pkg_resolution.tag {
                 ResolutionTag::Npm => 'brk: {
                     let mut version_buf = [0u8; 64];
@@ -1665,11 +1667,11 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         }
     }
 
-    this.packages.items_dependencies_mut()[0] = lockfile::DependencySlice::new(
+    this.packages.items_dependencies_mut()[PackageID::ROOT] = lockfile::DependencySlice::new(
         root_deps_off,
         u32::try_from(root_dependencies.len()).expect("int cast"),
     );
-    this.packages.items_resolutions_mut()[0] = lockfile::PackageIDSlice::new(
+    this.packages.items_resolutions_mut()[PackageID::ROOT] = lockfile::PackageIDSlice::new(
         root_resolutions_off,
         u32::try_from(root_dependencies.len()).expect("int cast"),
     );
@@ -1893,10 +1895,10 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
             }
         }
 
-        this.packages.items_dependencies_mut()[package_id.index()] =
+        this.packages.items_dependencies_mut()[package_id] =
             lockfile::DependencySlice::new(deps_off, dep_count);
 
-        this.packages.items_resolutions_mut()[package_id.index()] =
+        this.packages.items_resolutions_mut()[package_id] =
             lockfile::PackageIDSlice::new(resolutions_off, dep_count);
     }
 
@@ -1969,7 +1971,7 @@ fn parse_root_overrides(
         )?;
     }
 
-    let root_package = *this.packages.get(0);
+    let root_package = this.package(PackageID::ROOT);
     let (mut string_builder, lf) = this.string_builder_split();
     lf.overrides.parse_count(
         manager,

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -803,7 +803,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
     };
 
     let mut yarn_entry_to_package_id: Vec<PackageID> =
-        vec![PackageID::default(); yarn_lock.entries.len()];
+        vec![install::INVALID_PACKAGE_ID; yarn_lock.entries.len()];
 
     let mut package_versions: StringHashMap<VersionInfo> = StringHashMap::new();
 

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -790,9 +790,11 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
     }
 
     // SAFETY: capacity reserved above to num_deps; we write past `len` through
-    // raw pointers into the reserved capacity and set `len` at the end.
-    let dependencies_base_ptr = this.buffers.dependencies.as_mut_ptr();
-    let resolutions_base_ptr = this.buffers.resolutions.as_mut_ptr();
+    // raw pointers into the reserved capacity and set `len` at the end. The
+    // pointers come from the `Vec`s themselves (`raw_mut()`), so they are valid
+    // for the whole capacity; the slice-derived ones would only cover `len`.
+    let dependencies_base_ptr = this.buffers.dependencies.raw_mut().as_mut_ptr();
+    let resolutions_base_ptr = this.buffers.resolutions.raw_mut().as_mut_ptr();
     let mut dependencies_buf: &mut [Dependency] = unsafe {
         // SAFETY: capacity >= num_deps reserved above
         bun_core::ffi::slice_mut(dependencies_base_ptr, num_deps as usize)

--- a/src/install_types/Cargo.toml
+++ b/src/install_types/Cargo.toml
@@ -10,6 +10,7 @@ path = "lib.rs"
 workspace = true
 
 [dependencies]
+bytemuck = "1"
 strum.workspace = true
 bstr.workspace = true
 scopeguard.workspace = true

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -25,12 +25,117 @@ use bun_semver::{
 
 // ─── Identity / sentinel ──────────────────────────────────────────────────
 
-pub type PackageID = u32;
-pub type DependencyID = u32;
+/// Index into the lockfile's package list (`Lockfile.packages`).
+///
+/// Distinct from [`DependencyID`] so that the two kinds of index cannot be
+/// mixed up: `resolutions[dep_id]` is a `PackageID`, and the package columns
+/// are indexed by `PackageID`. Both are serialized into `bun.lockb` as the
+/// bare `u32` (`#[repr(transparent)]`).
+///
+/// `Default` is id 0 (the root package), matching the zero-initialised `u32`
+/// it replaced; "no package" is [`PackageID::INVALID`].
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct PackageID(u32);
+
+/// Index into the lockfile's dependency buffer (`Lockfile.buffers.dependencies`).
+/// The same index into `Lockfile.buffers.resolutions` gives the [`PackageID`]
+/// the dependency resolved to.
+///
+/// `Default` is id 0, matching the zero-initialised `u32` it replaced; "no
+/// dependency" is [`DependencyID::INVALID`].
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct DependencyID(u32);
+
+macro_rules! impl_id {
+    ($name:ident) => {
+        impl $name {
+            pub const INVALID: Self = Self(u32::MAX);
+
+            #[inline]
+            pub const fn new(id: u32) -> Self {
+                Self(id)
+            }
+
+            /// Truncating, like the `as u32` casts at the sites that build an
+            /// id from a buffer position. Use `try_from` for a checked build.
+            #[inline]
+            pub const fn from_index(index: usize) -> Self {
+                Self(index as u32)
+            }
+
+            #[inline]
+            pub const fn get(self) -> u32 {
+                self.0
+            }
+
+            #[inline]
+            pub const fn index(self) -> usize {
+                self.0 as usize
+            }
+        }
+
+        // SAFETY: `#[repr(transparent)]` over `u32`.
+        unsafe impl bytemuck::Zeroable for $name {}
+        // SAFETY: `#[repr(transparent)]` over `u32` (Pod).
+        unsafe impl bytemuck::Pod for $name {}
+
+        impl TryFrom<usize> for $name {
+            type Error = core::num::TryFromIntError;
+
+            #[inline]
+            fn try_from(index: usize) -> Result<Self, Self::Error> {
+                u32::try_from(index).map(Self)
+            }
+        }
+
+        // Ids are already well distributed, so maps keyed by them use the
+        // identity context like the `u32` keys did.
+        impl bun_collections::array_hash_map::ArrayHashContext<$name>
+            for bun_collections::ArrayIdentityContext
+        {
+            #[inline]
+            fn hash(&self, key: &$name) -> u32 {
+                key.0
+            }
+
+            #[inline]
+            fn eql(&self, a: &$name, b: &$name, _b_index: usize) -> bool {
+                a == b
+            }
+        }
+
+        // Formats as the bare number, exactly like the `u32` this replaced, so
+        // log lines and debug dumps are unchanged.
+        impl core::fmt::Debug for $name {
+            #[inline]
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                core::fmt::Debug::fmt(&self.0, f)
+            }
+        }
+
+        impl core::fmt::Display for $name {
+            #[inline]
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                core::fmt::Display::fmt(&self.0, f)
+            }
+        }
+    };
+}
+
+impl_id!(PackageID);
+impl_id!(DependencyID);
+
+impl PackageID {
+    /// The root package (the project being installed) is always package 0.
+    pub const ROOT: Self = Self(0);
+}
+
 pub type PackageNameHash = u64;
 pub type TruncatedPackageNameHash = u32;
-pub const INVALID_PACKAGE_ID: PackageID = PackageID::MAX;
-pub const INVALID_DEPENDENCY_ID: DependencyID = DependencyID::MAX;
+pub const INVALID_PACKAGE_ID: PackageID = PackageID::INVALID;
+pub const INVALID_DEPENDENCY_ID: DependencyID = DependencyID::INVALID;
 
 // ─── ExternalSlice ────────────────────────────────────────────────────────
 // An `(off, len)` index pair into a
@@ -103,11 +208,6 @@ impl<T> ExternalSlice<T> {
     }
 
     #[inline]
-    pub fn contains(self, id: u32) -> bool {
-        id >= self.off && (id as u64) < self.len as u64 + self.off as u64
-    }
-
-    #[inline]
     pub fn get(self, in_: &[T]) -> &[T] {
         // Compute the sum in usize so
         // the release-mode clamp applies instead of a debug u32-overflow panic.
@@ -159,6 +259,32 @@ pub type ExternalPackageNameHashList = ExternalSlice<PackageNameHash>;
 pub type VersionSlice = ExternalSlice<SemverVersion>;
 pub type DependencySlice = ExternalSlice<Dependency>;
 pub type ResolutionSlice = ExternalSlice<PackageID>;
+
+// A package's `dependencies` and `resolutions` slices cover the same positions
+// of the parallel `buffers.dependencies` / `buffers.resolutions` buffers, so
+// the positions either slice covers are `DependencyID`s.
+macro_rules! impl_dependency_id_range {
+    ($($slice:ty),* $(,)?) => {$(
+        impl $slice {
+            /// The ids of the dependencies this slice covers, in buffer order.
+            #[inline]
+            pub fn dependency_ids(
+                self,
+            ) -> impl DoubleEndedIterator<Item = DependencyID> + ExactSizeIterator {
+                (self.begin()..self.end()).map(DependencyID::new)
+            }
+
+            /// Is `id` one of the dependencies this slice covers?
+            #[inline]
+            pub fn contains(self, id: DependencyID) -> bool {
+                let id = id.get();
+                id >= self.off && (id as u64) < self.len as u64 + self.off as u64
+            }
+        }
+    )*};
+}
+
+impl_dependency_id_range!(DependencySlice, ResolutionSlice);
 
 // ─── Dependency / Behavior ────────────────────────────────────────────────
 
@@ -1288,7 +1414,7 @@ impl Features {
 
 #[derive(Default, Clone, Copy)]
 pub struct TaskCallbackContext {
-    pub root_request_id: u32,
+    pub root_request_id: PackageID,
 }
 
 /// Opaque

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -30,22 +30,16 @@ use bun_semver::{
 /// Distinct from [`DependencyID`] so that the two kinds of index cannot be
 /// mixed up: `resolutions[dep_id]` is a `PackageID`, and the package columns
 /// are indexed by `PackageID`. Both are serialized into `bun.lockb` as the
-/// bare `u32` (`#[repr(transparent)]`).
-///
-/// `Default` is id 0 (the root package), matching the zero-initialised `u32`
-/// it replaced; "no package" is [`PackageID::INVALID`].
+/// bare `u32` (`#[repr(transparent)]`). `Default` is [`PackageID::INVALID`].
 #[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PackageID(u32);
 
 /// Index into the lockfile's dependency buffer (`Lockfile.buffers.dependencies`).
 /// The same index into `Lockfile.buffers.resolutions` gives the [`PackageID`]
-/// the dependency resolved to.
-///
-/// `Default` is id 0, matching the zero-initialised `u32` it replaced; "no
-/// dependency" is [`DependencyID::INVALID`].
+/// the dependency resolved to. `Default` is [`DependencyID::INVALID`].
 #[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DependencyID(u32);
 
 macro_rules! impl_id {
@@ -73,6 +67,15 @@ macro_rules! impl_id {
             #[inline]
             pub const fn index(self) -> usize {
                 self.0 as usize
+            }
+        }
+
+        /// The sentinel, so a slot that was never assigned fails loudly when
+        /// used as an index instead of silently naming entry 0.
+        impl Default for $name {
+            #[inline]
+            fn default() -> Self {
+                Self::INVALID
             }
         }
 
@@ -1412,7 +1415,7 @@ impl Features {
     };
 }
 
-#[derive(Default, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct TaskCallbackContext {
     pub root_request_id: PackageID,
 }

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -17,6 +17,7 @@ use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use core::ptr::NonNull;
 
+use bun_collections::IdSlice;
 use bun_core::strings;
 use bun_semver::version::VersionInt;
 use bun_semver::{
@@ -90,6 +91,18 @@ macro_rules! impl_id {
             #[inline]
             fn try_from(index: usize) -> Result<Self, Self::Error> {
                 u32::try_from(index).map(Self)
+            }
+        }
+
+        impl bun_collections::Idx for $name {
+            #[inline]
+            fn from_index(index: usize) -> Self {
+                Self(index as u32)
+            }
+
+            #[inline]
+            fn index(self) -> usize {
+                self.0 as usize
             }
         }
 
@@ -1572,8 +1585,8 @@ pub trait AutoInstaller {
     fn lockfile_package_dependencies(&self, id: PackageID) -> DependencySlice;
     fn lockfile_package_resolutions(&self, id: PackageID) -> ResolutionSlice;
     fn lockfile_package_resolution(&self, id: PackageID) -> Resolution;
-    fn lockfile_dependencies_buf(&self) -> &[Dependency];
-    fn lockfile_resolutions_buf(&self) -> &[PackageID];
+    fn lockfile_dependencies_buf(&self) -> &IdSlice<DependencyID, Dependency>;
+    fn lockfile_resolutions_buf(&self) -> &IdSlice<DependencyID, PackageID>;
     fn lockfile_string_bytes(&self) -> &[u8];
     fn lockfile_resolve(&self, name: &[u8], version: &DependencyVersion) -> Option<PackageID>;
     fn lockfile_legacy_package_to_dependency_id(

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -501,7 +501,7 @@ impl Queue {
         // reshaped for borrowck — compaction loop → retain_mut.
         self.map.retain_mut(|module| {
             for pending in module.parse_result.pending_imports.iter() {
-                if resolution_ids.slice()[pending.root_dependency_id as usize] != package_id {
+                if resolution_ids.slice()[pending.root_dependency_id.index()] != package_id {
                     continue;
                 }
                 let import_record_id = pending.import_record_id;
@@ -549,10 +549,10 @@ impl Queue {
                 for tag_i in 0..tags_len {
                     let root_id = pending_imports[tag_i].root_dependency_id;
                     let resolution_ids = pm.lockfile.buffers.resolutions.as_slice();
-                    if root_id as usize >= resolution_ids.len() {
+                    if root_id.index() >= resolution_ids.len() {
                         continue;
                     }
-                    let package_id = resolution_ids[root_id as usize];
+                    let package_id = resolution_ids[root_id.index()];
 
                     match pending_imports[tag_i].tag {
                         bun_resolver::PendingResolutionTag::Resolve => {
@@ -579,7 +579,7 @@ impl Queue {
                         continue;
                     }
 
-                    let package = pm.lockfile.packages.get(package_id as usize);
+                    let package = pm.lockfile.packages.get(package_id.index());
                     debug_assert!(package.resolution.tag != install::resolution::Tag::Root);
 
                     let mut name_and_version_hash: Option<u64> = None;

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -486,9 +486,9 @@ impl Queue {
         // S017: per-thread VM singleton (safe accessor) instead of
         // `container_of`-derived `*mut` reborrow. `resolution_ids` borrows the
         // lockfile (separate heap allocation, never reallocated on the
-        // download-error path); detach via `RawSlice` so the closure can fetch
+        // download-error path); detach via `BackRef` so the closure can fetch
         // a fresh `&mut VirtualMachine` without borrowck tying it to this read.
-        let resolution_ids = bun_ptr::RawSlice::new(
+        let resolution_ids = bun_ptr::BackRef::new(
             VirtualMachine::get()
                 .as_mut()
                 .package_manager()
@@ -501,7 +501,7 @@ impl Queue {
         // reshaped for borrowck — compaction loop → retain_mut.
         self.map.retain_mut(|module| {
             for pending in module.parse_result.pending_imports.iter() {
-                if resolution_ids.slice()[pending.root_dependency_id.index()] != package_id {
+                if resolution_ids[pending.root_dependency_id] != package_id {
                     continue;
                 }
                 let import_record_id = pending.import_record_id;
@@ -549,10 +549,9 @@ impl Queue {
                 for tag_i in 0..tags_len {
                     let root_id = pending_imports[tag_i].root_dependency_id;
                     let resolution_ids = pm.lockfile.buffers.resolutions.as_slice();
-                    if root_id.index() >= resolution_ids.len() {
+                    let Some(&package_id) = resolution_ids.get(root_id) else {
                         continue;
-                    }
-                    let package_id = resolution_ids[root_id.index()];
+                    };
 
                     match pending_imports[tag_i].tag {
                         bun_resolver::PendingResolutionTag::Resolve => {
@@ -579,7 +578,7 @@ impl Queue {
                         continue;
                     }
 
-                    let package = pm.lockfile.packages.get(package_id.index());
+                    let package = pm.lockfile.package(package_id);
                     debug_assert!(package.resolution.tag != install::resolution::Tag::Root);
 
                     let mut name_and_version_hash: Option<u64> = None;

--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -815,7 +815,7 @@ impl PackageJSON {
                                         pm.lockfile_resolve(&package_json.name, &dependency_version)
                                     {
                                         package_json.package_manager_package_id = resolved;
-                                        if resolved > 0 {
+                                        if resolved != PackageID::ROOT {
                                             break 'update_dependencies;
                                         }
                                     }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3117,7 +3117,9 @@ impl<'a> Resolver<'a> {
                                                 dependency_id,
                                                 resolved_package_id,
                                                 &resolution,
-                                                Install::TaskCallbackContext { root_request_id: 0 },
+                                                Install::TaskCallbackContext {
+                                                    root_request_id: Install::PackageID::ROOT,
+                                                },
                                                 None,
                                             )
                                         {
@@ -3588,7 +3590,9 @@ impl<'a> Resolver<'a> {
             }
         }
 
-        if input_package_id == Install::INVALID_PACKAGE_ID || input_package_id == 0 {
+        if input_package_id == Install::INVALID_PACKAGE_ID
+            || input_package_id == Install::PackageID::ROOT
+        {
             // All packages are enqueued to the root
             // because we download all the npm package dependencies
             match pm!().enqueue_dependency_to_root(esm.name, &version, version_buf, behavior) {

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -429,7 +429,7 @@ impl Default for PendingResolution {
         Self {
             esm: Default::default(),
             dependency: Default::default(),
-            root_dependency_id: Install::INVALID_PACKAGE_ID,
+            root_dependency_id: Install::INVALID_DEPENDENCY_ID,
             import_record_id: u32::MAX,
             string_buf: Vec::new(),
             tag: PendingResolutionTag::Download,

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -324,11 +324,11 @@ fn build_dependency_tree(
         let res_slice = pkg_resolutions[pkg_idx].get(resolutions);
 
         for (_, &resolved_pkg_id) in dep_slice.iter().zip(res_slice.iter()) {
-            if (resolved_pkg_id as usize) >= pkg_names.len() {
+            if resolved_pkg_id.index() >= pkg_names.len() {
                 continue;
             }
 
-            let resolved_name = pkg_names[resolved_pkg_id as usize].slice(buf);
+            let resolved_name = pkg_names[resolved_pkg_id.index()].slice(buf);
 
             // `StringHashMap::get_or_put` always boxes the key on miss.
             let result = dependency_tree.get_or_put(resolved_name)?;
@@ -475,7 +475,7 @@ fn collect_packages_for_audit(
     let mut ver_scratch: Vec<u8> = Vec::new();
 
     for (idx, (name, res)) in pkg_names.iter().zip(pkg_resolutions.iter()).enumerate() {
-        if idx as u32 == root_id {
+        if idx == root_id.index() {
             continue;
         }
         if res.tag != ResolutionTag::Npm {
@@ -852,7 +852,7 @@ fn find_dependency_paths(
     let pkg_resolutions = packages.items_resolution();
     let pkg_deps = packages.items_dependencies();
 
-    let root_deps = pkg_deps[root_id as usize];
+    let root_deps = pkg_deps[root_id.index()];
     let dep_slice = root_deps.get(dependencies);
 
     for dependency in dep_slice {

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -313,7 +313,7 @@ fn build_dependency_tree(
     let dependencies = pm.lockfile.buffers.dependencies.as_slice();
     let resolutions = pm.lockfile.buffers.resolutions.as_slice();
 
-    for pkg_idx in 0..pkg_names.len() {
+    for pkg_idx in pkg_names.ids() {
         let package_name = pkg_names[pkg_idx].slice(buf);
 
         if pkg_resolution[pkg_idx].tag != ResolutionTag::Npm {
@@ -324,11 +324,11 @@ fn build_dependency_tree(
         let res_slice = pkg_resolutions[pkg_idx].get(resolutions);
 
         for (_, &resolved_pkg_id) in dep_slice.iter().zip(res_slice.iter()) {
-            if resolved_pkg_id.index() >= pkg_names.len() {
+            if !pkg_names.has(resolved_pkg_id) {
                 continue;
             }
 
-            let resolved_name = pkg_names[resolved_pkg_id.index()].slice(buf);
+            let resolved_name = pkg_names[resolved_pkg_id].slice(buf);
 
             // `StringHashMap::get_or_put` always boxes the key on miss.
             let result = dependency_tree.get_or_put(resolved_name)?;
@@ -474,8 +474,8 @@ fn collect_packages_for_audit(
         HashMap::with_capacity(pkg_names.len());
     let mut ver_scratch: Vec<u8> = Vec::new();
 
-    for (idx, (name, res)) in pkg_names.iter().zip(pkg_resolutions.iter()).enumerate() {
-        if idx == root_id.index() {
+    for ((idx, name), res) in pkg_names.iter_enumerated().zip(pkg_resolutions.iter()) {
+        if idx == root_id {
             continue;
         }
         if res.tag != ResolutionTag::Npm {
@@ -484,7 +484,7 @@ fn collect_packages_for_audit(
 
         if wanted_packages
             .as_ref()
-            .is_some_and(|wanted| !wanted.is_set(idx))
+            .is_some_and(|wanted| !wanted.is_set(idx.index()))
         {
             continue;
         }
@@ -852,7 +852,7 @@ fn find_dependency_paths(
     let pkg_resolutions = packages.items_resolution();
     let pkg_deps = packages.items_dependencies();
 
-    let root_deps = pkg_deps[root_id.index()];
+    let root_deps = pkg_deps[root_id];
     let dep_slice = root_deps.get(dependencies);
 
     for dependency in dep_slice {

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -221,7 +221,7 @@ impl OutdatedCommand {
 
         for item in outdated_items {
             if item.is_catalog {
-                let dep = &dependencies[item.dep_id as usize];
+                let dep = &dependencies[item.dep_id.index()];
                 let name_hash = hash(dep.name.slice(string_buf));
                 let catalog = *dep.version.catalog();
                 let catalog_name = catalog.slice(string_buf);
@@ -251,7 +251,7 @@ impl OutdatedCommand {
                 continue;
             }
 
-            let dep = &dependencies[item.dep_id as usize];
+            let dep = &dependencies[item.dep_id.index()];
             let name_hash = hash(dep.name.slice(string_buf));
             let catalog = *dep.version.catalog();
             let catalog_name = catalog.slice(string_buf);
@@ -283,7 +283,7 @@ impl OutdatedCommand {
                 if i > 0 {
                     workspace_names.extend_from_slice(b", ");
                 }
-                let workspace_name = pkg_names[workspace_id as usize].slice(string_buf);
+                let workspace_name = pkg_names[workspace_id.index()].slice(string_buf);
                 workspace_names.extend_from_slice(workspace_name);
             }
             workspace_names.push(b')');
@@ -358,15 +358,14 @@ impl OutdatedCommand {
         let mut outdated_ids: Vec<OutdatedInfo> = Vec::new();
 
         for &workspace_pkg_id in workspace_pkg_ids {
-            let pkg_deps =
-                manager.lockfile.packages.items_dependencies()[workspace_pkg_id as usize];
-            for dep_id in pkg_deps.begin()..pkg_deps.end() {
-                let package_id = manager.lockfile.buffers.resolutions[dep_id as usize];
+            let pkg_deps = manager.lockfile.packages.items_dependencies()[workspace_pkg_id.index()];
+            for dep_id in pkg_deps.dependency_ids() {
+                let package_id = manager.lockfile.buffers.resolutions[dep_id.index()];
                 if package_id == bun_install::INVALID_PACKAGE_ID {
                     continue;
                 }
                 let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
-                let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
+                let dep = &manager.lockfile.buffers.dependencies[dep_id.index()];
                 let Some(resolved_version) = manager.lockfile.resolve_catalog_dependency(dep)
                 else {
                     continue;
@@ -376,7 +375,7 @@ impl OutdatedCommand {
                 {
                     continue;
                 }
-                let resolution = manager.lockfile.packages.items_resolution()[package_id as usize];
+                let resolution = manager.lockfile.packages.items_resolution()[package_id.index()];
                 if resolution.tag != resolution::Tag::Npm {
                     continue;
                 }
@@ -408,7 +407,7 @@ impl OutdatedCommand {
                 }
 
                 let package_name =
-                    manager.lockfile.packages.items_name()[package_id as usize].slice(string_buf);
+                    manager.lockfile.packages.items_name()[package_id.index()].slice(string_buf);
                 let scope = manager.options.scope_for_package_name(package_name).clone();
                 let mut expired = false;
                 let Some(manifest) = manager.manifests.by_name_allow_expired(
@@ -507,8 +506,8 @@ impl OutdatedCommand {
                 version_buf.clear();
 
                 let workspace_name = manager.lockfile.packages.items_name()
-                    [workspace_pkg_id as usize]
-                    .slice(string_buf);
+                    [workspace_pkg_id.index()]
+                .slice(string_buf);
                 if workspace_name.len() > max_workspace {
                     max_workspace = workspace_name.len();
                 }
@@ -599,14 +598,14 @@ impl OutdatedCommand {
                 let dep_id = item.dep_id;
 
                 let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
-                let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
+                let dep = &manager.lockfile.buffers.dependencies[dep_id.index()];
                 if !dep.behavior.includes(group_behavior) {
                     continue;
                 }
 
                 let package_name =
-                    manager.lockfile.packages.items_name()[package_id as usize].slice(string_buf);
-                let resolution = manager.lockfile.packages.items_resolution()[package_id as usize];
+                    manager.lockfile.packages.items_name()[package_id.index()].slice(string_buf);
+                let resolution = manager.lockfile.packages.items_resolution()[package_id.index()];
 
                 let scope = manager.options.scope_for_package_name(package_name).clone();
                 let mut expired = false;
@@ -757,7 +756,7 @@ impl OutdatedCommand {
                     let workspace_name: &[u8] = if let Some(names) = &item.grouped_workspace_names {
                         names
                     } else {
-                        manager.lockfile.packages.items_name()[item.workspace_pkg_id as usize]
+                        manager.lockfile.packages.items_name()[item.workspace_pkg_id.index()]
                             .slice(string_buf)
                     };
                     bun_core::pretty!("{}", BStr::new(workspace_name));

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -221,7 +221,7 @@ impl OutdatedCommand {
 
         for item in outdated_items {
             if item.is_catalog {
-                let dep = &dependencies[item.dep_id.index()];
+                let dep = &dependencies[item.dep_id];
                 let name_hash = hash(dep.name.slice(string_buf));
                 let catalog = *dep.version.catalog();
                 let catalog_name = catalog.slice(string_buf);
@@ -251,7 +251,7 @@ impl OutdatedCommand {
                 continue;
             }
 
-            let dep = &dependencies[item.dep_id.index()];
+            let dep = &dependencies[item.dep_id];
             let name_hash = hash(dep.name.slice(string_buf));
             let catalog = *dep.version.catalog();
             let catalog_name = catalog.slice(string_buf);
@@ -283,7 +283,7 @@ impl OutdatedCommand {
                 if i > 0 {
                     workspace_names.extend_from_slice(b", ");
                 }
-                let workspace_name = pkg_names[workspace_id.index()].slice(string_buf);
+                let workspace_name = pkg_names[workspace_id].slice(string_buf);
                 workspace_names.extend_from_slice(workspace_name);
             }
             workspace_names.push(b')');
@@ -358,14 +358,14 @@ impl OutdatedCommand {
         let mut outdated_ids: Vec<OutdatedInfo> = Vec::new();
 
         for &workspace_pkg_id in workspace_pkg_ids {
-            let pkg_deps = manager.lockfile.packages.items_dependencies()[workspace_pkg_id.index()];
+            let pkg_deps = manager.lockfile.packages.items_dependencies()[workspace_pkg_id];
             for dep_id in pkg_deps.dependency_ids() {
-                let package_id = manager.lockfile.buffers.resolutions[dep_id.index()];
+                let package_id = manager.lockfile.buffers.resolutions[dep_id];
                 if package_id == bun_install::INVALID_PACKAGE_ID {
                     continue;
                 }
                 let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
-                let dep = &manager.lockfile.buffers.dependencies[dep_id.index()];
+                let dep = &manager.lockfile.buffers.dependencies[dep_id];
                 let Some(resolved_version) = manager.lockfile.resolve_catalog_dependency(dep)
                 else {
                     continue;
@@ -375,7 +375,7 @@ impl OutdatedCommand {
                 {
                     continue;
                 }
-                let resolution = manager.lockfile.packages.items_resolution()[package_id.index()];
+                let resolution = manager.lockfile.packages.items_resolution()[package_id];
                 if resolution.tag != resolution::Tag::Npm {
                     continue;
                 }
@@ -407,7 +407,7 @@ impl OutdatedCommand {
                 }
 
                 let package_name =
-                    manager.lockfile.packages.items_name()[package_id.index()].slice(string_buf);
+                    manager.lockfile.packages.items_name()[package_id].slice(string_buf);
                 let scope = manager.options.scope_for_package_name(package_name).clone();
                 let mut expired = false;
                 let Some(manifest) = manager.manifests.by_name_allow_expired(
@@ -505,9 +505,8 @@ impl OutdatedCommand {
                 }
                 version_buf.clear();
 
-                let workspace_name = manager.lockfile.packages.items_name()
-                    [workspace_pkg_id.index()]
-                .slice(string_buf);
+                let workspace_name =
+                    manager.lockfile.packages.items_name()[workspace_pkg_id].slice(string_buf);
                 if workspace_name.len() > max_workspace {
                     max_workspace = workspace_name.len();
                 }
@@ -598,14 +597,14 @@ impl OutdatedCommand {
                 let dep_id = item.dep_id;
 
                 let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
-                let dep = &manager.lockfile.buffers.dependencies[dep_id.index()];
+                let dep = &manager.lockfile.buffers.dependencies[dep_id];
                 if !dep.behavior.includes(group_behavior) {
                     continue;
                 }
 
                 let package_name =
-                    manager.lockfile.packages.items_name()[package_id.index()].slice(string_buf);
-                let resolution = manager.lockfile.packages.items_resolution()[package_id.index()];
+                    manager.lockfile.packages.items_name()[package_id].slice(string_buf);
+                let resolution = manager.lockfile.packages.items_resolution()[package_id];
 
                 let scope = manager.options.scope_for_package_name(package_name).clone();
                 let mut expired = false;
@@ -756,7 +755,7 @@ impl OutdatedCommand {
                     let workspace_name: &[u8] = if let Some(names) = &item.grouped_workspace_names {
                         names
                     } else {
-                        manager.lockfile.packages.items_name()[item.workspace_pkg_id.index()]
+                        manager.lockfile.packages.items_name()[item.workspace_pkg_id]
                             .slice(string_buf)
                     };
                     bun_core::pretty!("{}", BStr::new(workspace_name));

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -622,10 +622,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 ));
                 let string_bytes = lockfile.buffers.string_bytes.as_slice();
                 let mut sorted_dependencies: Vec<DependencyID> =
-                    Vec::with_capacity(root_deps.len as usize);
-                for i in 0..root_deps.len {
-                    sorted_dependencies.push(DependencyID::new(root_deps.off + i));
-                }
+                    root_deps.dependency_ids().collect();
                 let by_name = ByName {
                     dependencies,
                     buf: string_bytes,

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -44,10 +44,10 @@ struct ByName<'a> {
 
 impl<'a> ByName<'a> {
     fn cmp(&self, lhs: DependencyID, rhs: DependencyID) -> Ordering {
-        self.dependencies[lhs as usize]
+        self.dependencies[lhs.index()]
             .name
             .slice(self.buf)
-            .cmp(self.dependencies[rhs as usize].name.slice(self.buf))
+            .cmp(self.dependencies[rhs.index()].name.slice(self.buf))
     }
 }
 
@@ -624,7 +624,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 let mut sorted_dependencies: Vec<DependencyID> =
                     Vec::with_capacity(root_deps.len as usize);
                 for i in 0..root_deps.len {
-                    sorted_dependencies.push((root_deps.off + i) as DependencyID);
+                    sorted_dependencies.push(DependencyID::new(root_deps.off + i));
                 }
                 let by_name = ByName {
                     dependencies,
@@ -636,31 +636,28 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
 
                 if trusted_only {
                     sorted_dependencies.retain(|&dep_id| {
-                        let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
-                        if package_id as usize >= lockfile.packages.len() {
+                        let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
+                        if package_id.index() >= lockfile.packages.len() {
                             return false;
                         }
-                        let alias = dependencies[dep_id as usize].name.slice(string_bytes);
-                        let pkg_name = pkg_names[package_id as usize].slice(string_bytes);
+                        let alias = dependencies[dep_id.index()].name.slice(string_bytes);
+                        let pkg_name = pkg_names[package_id.index()].slice(string_bytes);
                         lockfile.has_trusted_dependency(
                             alias,
                             pkg_name,
-                            &resolutions[package_id as usize],
+                            &resolutions[package_id.index()],
                         )
                     });
                 }
 
                 for (index, &dependency_id) in sorted_dependencies.iter().enumerate() {
-                    let package_id =
-                        lockfile.buffers.resolutions.as_slice()[dependency_id as usize];
-                    if package_id as usize >= lockfile.packages.len() {
+                    let package_id = lockfile.buffers.resolutions.as_slice()[dependency_id.index()];
+                    if package_id.index() >= lockfile.packages.len() {
                         continue;
                     }
-                    let name = dependencies[dependency_id as usize]
-                        .name
-                        .slice(string_bytes);
+                    let name = dependencies[dependency_id.index()].name.slice(string_bytes);
                     let resolution =
-                        resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto);
+                        resolutions[package_id.index()].fmt(string_bytes, PathSep::Auto);
 
                     if index < sorted_dependencies.len() - 1 {
                         bun_core::prettyln!(
@@ -814,7 +811,7 @@ fn print_node_modules_folder_structure(
                 &mut resolution_buf,
                 format_args!(
                     "{}",
-                    resolutions[id as usize].fmt(string_bytes, PathSep::Auto)
+                    resolutions[id.index()].fmt(string_bytes, PathSep::Auto)
                 ),
             );
             if let Some(j) = strings::index_of(path, b"node_modules") {
@@ -857,9 +854,7 @@ fn print_node_modules_folder_structure(
 
     let sorted_len = sorted_dependencies.len();
     for (index, &dependency_id) in sorted_dependencies.iter().enumerate() {
-        let package_name = dependencies[dependency_id as usize]
-            .name
-            .slice(string_bytes);
+        let package_name = dependencies[dependency_id.index()].name.slice(string_bytes);
         let mut possible_path: Vec<u8> = Vec::new();
         write!(
             &mut possible_path,
@@ -875,9 +870,9 @@ fn print_node_modules_folder_structure(
             more_packages[depth] = false;
         }
 
-        let package_id = lockfile.buffers.resolutions[dependency_id as usize];
+        let package_id = lockfile.buffers.resolutions[dependency_id.index()];
 
-        if package_id as usize >= lockfile.packages.len() {
+        if package_id.index() >= lockfile.packages.len() {
             // in case we are loading from a binary lockfile with invalid package ids
             continue;
         }
@@ -940,7 +935,7 @@ fn print_node_modules_folder_structure(
             &mut resolution_buf,
             format_args!(
                 "{}",
-                resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto)
+                resolutions[package_id.index()].fmt(string_bytes, PathSep::Auto)
             ),
         );
         bun_core::prettyln!(
@@ -980,17 +975,17 @@ fn print_trusted_dependencies_flat(
     let mut trusted: Vec<DependencyID> = Vec::new();
 
     let mut visit = |dep_id: DependencyID| {
-        let package_id = resolutions_buf[dep_id as usize];
-        if package_id as usize >= pkg_count {
+        let package_id = resolutions_buf[dep_id.index()];
+        if package_id.index() >= pkg_count {
             return;
         }
-        if seen.is_set(package_id as usize) {
+        if seen.is_set(package_id.index()) {
             return;
         }
-        let alias = dependencies[dep_id as usize].name.slice(string_bytes);
-        let pkg_name = pkg_names[package_id as usize].slice(string_bytes);
-        if lockfile.has_trusted_dependency(alias, pkg_name, &resolutions[package_id as usize]) {
-            seen.set(package_id as usize);
+        let alias = dependencies[dep_id.index()].name.slice(string_bytes);
+        let pkg_name = pkg_names[package_id.index()].slice(string_bytes);
+        if lockfile.has_trusted_dependency(alias, pkg_name, &resolutions[package_id.index()]) {
+            seen.set(package_id.index());
             trusted.push(dep_id);
         }
     };
@@ -1010,9 +1005,9 @@ fn print_trusted_dependencies_flat(
     trusted.sort_unstable_by(|a, b| by_name.cmp(*a, *b));
 
     for (index, &dep_id) in trusted.iter().enumerate() {
-        let package_id = resolutions_buf[dep_id as usize];
-        let name = dependencies[dep_id as usize].name.slice(string_bytes);
-        let resolution = resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto);
+        let package_id = resolutions_buf[dep_id.index()];
+        let name = dependencies[dep_id.index()].name.slice(string_bytes);
+        let resolution = resolutions[package_id.index()].fmt(string_bytes, PathSep::Auto);
         if index + 1 < trusted.len() {
             bun_core::prettyln!(
                 "<d>├──<r> {}<r><d>@{}<r>\n",

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -1,7 +1,7 @@
 use core::cmp::Ordering;
 use std::io::Write as _;
 
-use bun_collections::DynamicBitSet;
+use bun_collections::{DynamicBitSet, IdSlice};
 use bun_core::fmt::PathSep;
 use bun_core::strings;
 use bun_core::{Global, Output, env_var, fmt as bun_fmt};
@@ -38,16 +38,16 @@ pub(crate) struct NodeModulesFolder {
 
 // Transient sort-comparator context; lifetime is fn-local.
 struct ByName<'a> {
-    dependencies: &'a [Dependency],
+    dependencies: &'a IdSlice<DependencyID, Dependency>,
     buf: &'a [u8],
 }
 
 impl<'a> ByName<'a> {
     fn cmp(&self, lhs: DependencyID, rhs: DependencyID) -> Ordering {
-        self.dependencies[lhs.index()]
+        self.dependencies[lhs]
             .name
             .slice(self.buf)
-            .cmp(self.dependencies[rhs.index()].name.slice(self.buf))
+            .cmp(self.dependencies[rhs].name.slice(self.buf))
     }
 }
 
@@ -613,7 +613,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 let slice = lockfile.packages.slice();
                 let resolutions = slice.items_resolution();
                 let pkg_names = slice.items_name();
-                let root_deps = slice.items_dependencies()[0];
+                let root_deps = slice.items_dependencies()[PackageID::ROOT];
 
                 Output::println(format_args!(
                     "{} node_modules ({})",
@@ -633,28 +633,23 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
 
                 if trusted_only {
                     sorted_dependencies.retain(|&dep_id| {
-                        let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
+                        let package_id = lockfile.buffers.resolutions.as_slice()[dep_id];
                         if package_id.index() >= lockfile.packages.len() {
                             return false;
                         }
-                        let alias = dependencies[dep_id.index()].name.slice(string_bytes);
-                        let pkg_name = pkg_names[package_id.index()].slice(string_bytes);
-                        lockfile.has_trusted_dependency(
-                            alias,
-                            pkg_name,
-                            &resolutions[package_id.index()],
-                        )
+                        let alias = dependencies[dep_id].name.slice(string_bytes);
+                        let pkg_name = pkg_names[package_id].slice(string_bytes);
+                        lockfile.has_trusted_dependency(alias, pkg_name, &resolutions[package_id])
                     });
                 }
 
                 for (index, &dependency_id) in sorted_dependencies.iter().enumerate() {
-                    let package_id = lockfile.buffers.resolutions.as_slice()[dependency_id.index()];
+                    let package_id = lockfile.buffers.resolutions.as_slice()[dependency_id];
                     if package_id.index() >= lockfile.packages.len() {
                         continue;
                     }
-                    let name = dependencies[dependency_id.index()].name.slice(string_bytes);
-                    let resolution =
-                        resolutions[package_id.index()].fmt(string_bytes, PathSep::Auto);
+                    let name = dependencies[dependency_id].name.slice(string_bytes);
+                    let resolution = resolutions[package_id].fmt(string_bytes, PathSep::Auto);
 
                     if index < sorted_dependencies.len() - 1 {
                         bun_core::prettyln!(
@@ -806,10 +801,7 @@ fn print_node_modules_folder_structure(
             }
             let directory_version = buf_print(
                 &mut resolution_buf,
-                format_args!(
-                    "{}",
-                    resolutions[id.index()].fmt(string_bytes, PathSep::Auto)
-                ),
+                format_args!("{}", resolutions[id].fmt(string_bytes, PathSep::Auto)),
             );
             if let Some(j) = strings::index_of(path, b"node_modules") {
                 bun_core::prettyln!(
@@ -851,7 +843,7 @@ fn print_node_modules_folder_structure(
 
     let sorted_len = sorted_dependencies.len();
     for (index, &dependency_id) in sorted_dependencies.iter().enumerate() {
-        let package_name = dependencies[dependency_id.index()].name.slice(string_bytes);
+        let package_name = dependencies[dependency_id].name.slice(string_bytes);
         let mut possible_path: Vec<u8> = Vec::new();
         write!(
             &mut possible_path,
@@ -867,7 +859,7 @@ fn print_node_modules_folder_structure(
             more_packages[depth] = false;
         }
 
-        let package_id = lockfile.buffers.resolutions[dependency_id.index()];
+        let package_id = lockfile.buffers.resolutions[dependency_id];
 
         if package_id.index() >= lockfile.packages.len() {
             // in case we are loading from a binary lockfile with invalid package ids
@@ -932,7 +924,7 @@ fn print_node_modules_folder_structure(
             &mut resolution_buf,
             format_args!(
                 "{}",
-                resolutions[package_id.index()].fmt(string_bytes, PathSep::Auto)
+                resolutions[package_id].fmt(string_bytes, PathSep::Auto)
             ),
         );
         bun_core::prettyln!(
@@ -972,16 +964,16 @@ fn print_trusted_dependencies_flat(
     let mut trusted: Vec<DependencyID> = Vec::new();
 
     let mut visit = |dep_id: DependencyID| {
-        let package_id = resolutions_buf[dep_id.index()];
+        let package_id = resolutions_buf[dep_id];
         if package_id.index() >= pkg_count {
             return;
         }
         if seen.is_set(package_id.index()) {
             return;
         }
-        let alias = dependencies[dep_id.index()].name.slice(string_bytes);
-        let pkg_name = pkg_names[package_id.index()].slice(string_bytes);
-        if lockfile.has_trusted_dependency(alias, pkg_name, &resolutions[package_id.index()]) {
+        let alias = dependencies[dep_id].name.slice(string_bytes);
+        let pkg_name = pkg_names[package_id].slice(string_bytes);
+        if lockfile.has_trusted_dependency(alias, pkg_name, &resolutions[package_id]) {
             seen.set(package_id.index());
             trusted.push(dep_id);
         }
@@ -1002,9 +994,9 @@ fn print_trusted_dependencies_flat(
     trusted.sort_unstable_by(|a, b| by_name.cmp(*a, *b));
 
     for (index, &dep_id) in trusted.iter().enumerate() {
-        let package_id = resolutions_buf[dep_id.index()];
-        let name = dependencies[dep_id.index()].name.slice(string_bytes);
-        let resolution = resolutions[package_id.index()].fmt(string_bytes, PathSep::Auto);
+        let package_id = resolutions_buf[dep_id];
+        let name = dependencies[dep_id].name.slice(string_bytes);
+        let resolution = resolutions[package_id].fmt(string_bytes, PathSep::Auto);
         if index + 1 < trusted.len() {
             bun_core::prettyln!(
                 "<d>├──<r> {}<r><d>@{}<r>\n",

--- a/src/runtime/cli/pm_licenses_command.rs
+++ b/src/runtime/cli/pm_licenses_command.rs
@@ -155,7 +155,7 @@ impl PmLicensesCommand {
         };
 
         let options = reachable::Options {
-            root: 0,
+            root: PackageID::ROOT,
             dev: features.dev_dependencies,
             optional: features.optional_dependencies,
             peer: features.peer_dependencies,
@@ -358,17 +358,17 @@ fn tree_locations(lockfile: &Lockfile) -> Vec<Option<Box<[u8]>>> {
     let mut it = tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(lockfile);
     while let Some(folder) = it.next(None) {
         for &dep_id in folder.dependencies {
-            let pkg_id = resolutions[dep_id as usize];
-            if (pkg_id as usize) >= len || out[pkg_id as usize].is_some() {
+            let pkg_id = resolutions[dep_id.index()];
+            if pkg_id.index() >= len || out[pkg_id.index()].is_some() {
                 continue;
             }
             let relative_path = folder.relative_path.as_bytes();
-            let alias = dependencies[dep_id as usize].name.slice(buf);
+            let alias = dependencies[dep_id.index()].name.slice(buf);
             let mut location: Vec<u8> = Vec::with_capacity(relative_path.len() + 1 + alias.len());
             location.extend_from_slice(relative_path);
             location.push(bun_paths::SEP);
             location.extend_from_slice(alias);
-            out[pkg_id as usize] = Some(location.into_boxed_slice());
+            out[pkg_id.index()] = Some(location.into_boxed_slice());
         }
     }
 

--- a/src/runtime/cli/pm_licenses_command.rs
+++ b/src/runtime/cli/pm_licenses_command.rs
@@ -4,7 +4,7 @@ use std::io::Write as _;
 
 use bstr::BStr;
 use bun_ast::{Expr, Log, Source};
-use bun_collections::{DynamicBitSet, StringHashMap, index_sort};
+use bun_collections::{DynamicBitSet, IdVec, StringHashMap, index_sort};
 use bun_core::fmt::PathSep;
 use bun_core::{FileKind, Global, Output, strings};
 use bun_install::isolated_install::store::entry::fmt_store_key;
@@ -203,8 +203,8 @@ impl PmLicensesCommand {
         let mut missing: usize = 0;
         let mut checked: usize = 0;
 
-        for pkg_id in 0..packages.len() {
-            if !wanted.is_set(pkg_id) {
+        for pkg_id in pkg_resolution.ids() {
+            if !wanted.is_set(pkg_id.index()) {
                 continue;
             }
             let resolution = &pkg_resolution[pkg_id];
@@ -281,7 +281,9 @@ impl PmLicensesCommand {
                 homepage: info.homepage,
                 author: info.author,
                 description: info.description,
-                dev_only: production.as_ref().is_some_and(|prod| !prod.is_set(pkg_id)),
+                dev_only: production
+                    .as_ref()
+                    .is_some_and(|prod| !prod.is_set(pkg_id.index())),
             });
         }
 
@@ -348,9 +350,8 @@ fn printable(s: &[u8]) -> Cow<'_, [u8]> {
     }
 }
 
-fn tree_locations(lockfile: &Lockfile) -> Vec<Option<Box<[u8]>>> {
-    let len = lockfile.packages.len();
-    let mut out: Vec<Option<Box<[u8]>>> = vec![None; len];
+fn tree_locations(lockfile: &Lockfile) -> IdVec<PackageID, Option<Box<[u8]>>> {
+    let mut out: IdVec<PackageID, Option<Box<[u8]>>> = vec![None; lockfile.packages.len()].into();
     let dependencies = lockfile.buffers.dependencies.as_slice();
     let resolutions = lockfile.buffers.resolutions.as_slice();
     let buf = lockfile.buffers.string_bytes.as_slice();
@@ -358,17 +359,17 @@ fn tree_locations(lockfile: &Lockfile) -> Vec<Option<Box<[u8]>>> {
     let mut it = tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(lockfile);
     while let Some(folder) = it.next(None) {
         for &dep_id in folder.dependencies {
-            let pkg_id = resolutions[dep_id.index()];
-            if pkg_id.index() >= len || out[pkg_id.index()].is_some() {
+            let pkg_id = resolutions[dep_id];
+            if !out.has(pkg_id) || out[pkg_id].is_some() {
                 continue;
             }
             let relative_path = folder.relative_path.as_bytes();
-            let alias = dependencies[dep_id.index()].name.slice(buf);
+            let alias = dependencies[dep_id].name.slice(buf);
             let mut location: Vec<u8> = Vec::with_capacity(relative_path.len() + 1 + alias.len());
             location.extend_from_slice(relative_path);
             location.push(bun_paths::SEP);
             location.extend_from_slice(alias);
-            out[pkg_id.index()] = Some(location.into_boxed_slice());
+            out[pkg_id] = Some(location.into_boxed_slice());
         }
     }
 

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -88,15 +88,15 @@ impl UntrustedCommand {
         // loop through dependencies and get trusted and untrusted deps with lifecycle scripts
         for (i, dep) in lockfile.buffers.dependencies.as_slice().iter().enumerate() {
             let dep_id: DependencyID = DependencyID::try_from(i).expect("int cast");
-            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
             if package_id == install::INVALID_PACKAGE_ID {
                 continue;
             }
 
             // called alias because a dependency name is not always the package name
             let alias = dep.name.slice(buf);
-            let pkg_name = packages.items_name()[package_id as usize].slice(buf);
-            let resolution = &resolutions[package_id as usize];
+            let pkg_name = packages.items_name()[package_id.index()].slice(buf);
+            let resolution = &resolutions[package_id.index()];
             if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
                 untrusted_dep_ids.put(dep_id, ())?;
             }
@@ -128,16 +128,16 @@ impl UntrustedCommand {
                 if !untrusted_dep_ids.contains(&dep_id) {
                     continue;
                 }
-                let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
+                let dep = &lockfile.buffers.dependencies.as_slice()[dep_id.index()];
                 let alias = dep.name.slice(buf);
-                let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+                let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
 
-                if package_id as usize >= packages.len() {
+                if package_id.index() >= packages.len() {
                     continue;
                 }
 
-                let resolution = &resolutions[package_id as usize];
-                let mut package_scripts = scripts[package_id as usize];
+                let resolution = &resolutions[package_id.index()];
+                let mut package_scripts = scripts[package_id.index()];
 
                 let folder_saved = node_modules_path.len();
                 let _ = node_modules_path.append(alias);
@@ -177,8 +177,8 @@ impl UntrustedCommand {
         while let Some(entry) = iter.next() {
             let dep_id = *entry.key_ptr;
             let scripts_list = &*entry.value_ptr;
-            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
-            let resolution = &lockfile.packages.items_resolution()[package_id as usize];
+            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
+            let resolution = &lockfile.packages.items_resolution()[package_id.index()];
 
             scripts_list.print_scripts(resolution, buf, PrintFormat::Untrusted);
             bun_core::pretty!("\n");
@@ -310,14 +310,14 @@ impl TrustCommand {
             .zip(lockfile.buffers.resolutions.as_slice())
             .enumerate()
         {
-            let dep_id: u32 = u32::try_from(i).expect("int cast");
+            let dep_id = DependencyID::try_from(i).expect("int cast");
             if package_id == install::INVALID_PACKAGE_ID {
                 continue;
             }
 
             let alias = dep.name.slice(buf);
-            let pkg_name = packages.items_name()[package_id as usize].slice(buf);
-            let resolution = &resolutions[package_id as usize];
+            let pkg_name = packages.items_name()[package_id.index()].slice(buf);
+            let resolution = &resolutions[package_id.index()];
             if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
                 untrusted_dep_ids.put(dep_id, ())?;
             }
@@ -361,16 +361,16 @@ impl TrustCommand {
                 if !untrusted_dep_ids.contains(&dep_id) {
                     continue;
                 }
-                let dep = &lockfile.buffers.dependencies.as_slice()[dep_id as usize];
+                let dep = &lockfile.buffers.dependencies.as_slice()[dep_id.index()];
                 let alias = dep.name.slice(buf);
-                let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+                let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
 
-                if package_id as usize >= packages.len() {
+                if package_id.index() >= packages.len() {
                     continue;
                 }
 
-                let resolution = &resolutions[package_id as usize];
-                let mut package_scripts = scripts[package_id as usize];
+                let resolution = &resolutions[package_id.index()];
+                let mut package_scripts = scripts[package_id.index()];
 
                 let folder_saved = node_modules_path.len();
                 let _ = node_modules_path.append(alias);
@@ -401,7 +401,7 @@ impl TrustCommand {
                             if strings::eql_long(package_name_from_cli, alias, true)
                                 && !lockfile.has_trusted_dependency(
                                     alias,
-                                    packages.items_name()[package_id as usize].slice(buf),
+                                    packages.items_name()[package_id.index()].slice(buf),
                                     resolution,
                                 )
                             {
@@ -595,7 +595,7 @@ impl TrustCommand {
         let buf = lockfile.buffers.string_bytes.as_slice();
         for entry in scripts_at_depth.values().iter().rev() {
             for info in entry.iter() {
-                let resolution = &lockfile.packages.items_resolution()[info.package_id as usize];
+                let resolution = &lockfile.packages.items_resolution()[info.package_id.index()];
                 if info.skip {
                     info.scripts_list
                         .print_scripts(resolution, buf, PrintFormat::Untrusted);

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -8,7 +8,7 @@ use bun_core::{Global, Output, Progress};
 use bun_install::lockfile::{
     LoadResult, Lockfile,
     package::PackageColumns as _,
-    package::scripts::{List as ScriptsList, PrintFormat, Scripts},
+    package::scripts::{List as ScriptsList, PrintFormat},
     tree,
 };
 use bun_install::package_manager_real::{
@@ -16,7 +16,7 @@ use bun_install::package_manager_real::{
 };
 use bun_install::{
     self as install, DEFAULT_TRUSTED_DEPENDENCIES_LIST, DependencyID, LifecycleScriptSubprocess,
-    PackageID, PackageManager, Resolution,
+    PackageID, PackageManager,
 };
 use bun_paths::AutoAbsPath;
 
@@ -79,8 +79,8 @@ impl UntrustedCommand {
         let lockfile: &Lockfile = &pm.lockfile;
 
         let packages = lockfile.packages.slice();
-        let scripts: &[Scripts] = packages.items_scripts();
-        let resolutions: &[Resolution] = packages.items_resolution();
+        let scripts = packages.items_scripts();
+        let resolutions = packages.items_resolution();
         let buf = lockfile.buffers.string_bytes.as_slice();
 
         let mut untrusted_dep_ids: DepIdSet = DepIdSet::new();
@@ -88,15 +88,15 @@ impl UntrustedCommand {
         // loop through dependencies and get trusted and untrusted deps with lifecycle scripts
         for (i, dep) in lockfile.buffers.dependencies.as_slice().iter().enumerate() {
             let dep_id: DependencyID = DependencyID::try_from(i).expect("int cast");
-            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
+            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id];
             if package_id == install::INVALID_PACKAGE_ID {
                 continue;
             }
 
             // called alias because a dependency name is not always the package name
             let alias = dep.name.slice(buf);
-            let pkg_name = packages.items_name()[package_id.index()].slice(buf);
-            let resolution = &resolutions[package_id.index()];
+            let pkg_name = packages.items_name()[package_id].slice(buf);
+            let resolution = &resolutions[package_id];
             if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
                 untrusted_dep_ids.put(dep_id, ())?;
             }
@@ -128,16 +128,16 @@ impl UntrustedCommand {
                 if !untrusted_dep_ids.contains(&dep_id) {
                     continue;
                 }
-                let dep = &lockfile.buffers.dependencies.as_slice()[dep_id.index()];
+                let dep = &lockfile.buffers.dependencies.as_slice()[dep_id];
                 let alias = dep.name.slice(buf);
-                let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
+                let package_id = lockfile.buffers.resolutions.as_slice()[dep_id];
 
                 if package_id.index() >= packages.len() {
                     continue;
                 }
 
-                let resolution = &resolutions[package_id.index()];
-                let mut package_scripts = scripts[package_id.index()];
+                let resolution = &resolutions[package_id];
+                let mut package_scripts = scripts[package_id];
 
                 let folder_saved = node_modules_path.len();
                 let _ = node_modules_path.append(alias);
@@ -177,8 +177,8 @@ impl UntrustedCommand {
         while let Some(entry) = iter.next() {
             let dep_id = *entry.key_ptr;
             let scripts_list = &*entry.value_ptr;
-            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
-            let resolution = &lockfile.packages.items_resolution()[package_id.index()];
+            let package_id = lockfile.buffers.resolutions.as_slice()[dep_id];
+            let resolution = &lockfile.packages.items_resolution()[package_id];
 
             scripts_list.print_scripts(resolution, buf, PrintFormat::Untrusted);
             bun_core::pretty!("\n");
@@ -293,8 +293,8 @@ impl TrustCommand {
 
         let buf = lockfile.buffers.string_bytes.as_slice();
         let packages = lockfile.packages.slice();
-        let resolutions: &[Resolution] = packages.items_resolution();
-        let scripts: &[Scripts] = packages.items_scripts();
+        let resolutions = packages.items_resolution();
+        let scripts = packages.items_scripts();
 
         let mut untrusted_dep_ids: DepIdSet = DepIdSet::new();
 
@@ -316,8 +316,8 @@ impl TrustCommand {
             }
 
             let alias = dep.name.slice(buf);
-            let pkg_name = packages.items_name()[package_id.index()].slice(buf);
-            let resolution = &resolutions[package_id.index()];
+            let pkg_name = packages.items_name()[package_id].slice(buf);
+            let resolution = &resolutions[package_id];
             if !lockfile.has_trusted_dependency(alias, pkg_name, resolution) {
                 untrusted_dep_ids.put(dep_id, ())?;
             }
@@ -361,16 +361,16 @@ impl TrustCommand {
                 if !untrusted_dep_ids.contains(&dep_id) {
                     continue;
                 }
-                let dep = &lockfile.buffers.dependencies.as_slice()[dep_id.index()];
+                let dep = &lockfile.buffers.dependencies.as_slice()[dep_id];
                 let alias = dep.name.slice(buf);
-                let package_id = lockfile.buffers.resolutions.as_slice()[dep_id.index()];
+                let package_id = lockfile.buffers.resolutions.as_slice()[dep_id];
 
                 if package_id.index() >= packages.len() {
                     continue;
                 }
 
-                let resolution = &resolutions[package_id.index()];
-                let mut package_scripts = scripts[package_id.index()];
+                let resolution = &resolutions[package_id];
+                let mut package_scripts = scripts[package_id];
 
                 let folder_saved = node_modules_path.len();
                 let _ = node_modules_path.append(alias);
@@ -401,7 +401,7 @@ impl TrustCommand {
                             if strings::eql_long(package_name_from_cli, alias, true)
                                 && !lockfile.has_trusted_dependency(
                                     alias,
-                                    packages.items_name()[package_id.index()].slice(buf),
+                                    packages.items_name()[package_id].slice(buf),
                                     resolution,
                                 )
                             {
@@ -595,7 +595,7 @@ impl TrustCommand {
         let buf = lockfile.buffers.string_bytes.as_slice();
         for entry in scripts_at_depth.values().iter().rev() {
             for info in entry.iter() {
-                let resolution = &lockfile.packages.items_resolution()[info.package_id.index()];
+                let resolution = &lockfile.packages.items_resolution()[info.package_id];
                 if info.skip {
                     info.scripts_list
                         .print_scripts(resolution, buf, PrintFormat::Untrusted);

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -695,7 +695,7 @@ impl UpdateInteractiveCommand {
             // Get the workspace path for this package
             let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
             let workspace_resolution =
-                manager.lockfile.packages.items_resolution()[pkg.workspace_pkg_id as usize];
+                manager.lockfile.packages.items_resolution()[pkg.workspace_pkg_id.index()];
             let workspace_path: &[u8] = if workspace_resolution.tag == resolution::Tag::Workspace {
                 workspace_resolution.workspace().slice(string_buf)
             } else {
@@ -845,16 +845,15 @@ impl UpdateInteractiveCommand {
         let mut version_buf: String = String::new();
 
         for &workspace_pkg_id in workspace_pkg_ids {
-            let pkg_deps =
-                manager.lockfile.packages.items_dependencies()[workspace_pkg_id as usize];
-            for dep_id in pkg_deps.begin()..pkg_deps.end() {
-                let package_id = manager.lockfile.buffers.resolutions[dep_id as usize];
+            let pkg_deps = manager.lockfile.packages.items_dependencies()[workspace_pkg_id.index()];
+            for dep_id in pkg_deps.dependency_ids() {
+                let package_id = manager.lockfile.buffers.resolutions[dep_id.index()];
                 if package_id == INVALID_PACKAGE_ID {
                     continue;
                 }
                 checked += 1;
                 let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
-                let dep = &manager.lockfile.buffers.dependencies[dep_id as usize];
+                let dep = &manager.lockfile.buffers.dependencies[dep_id.index()];
                 if !selects(groups, dep.behavior) {
                     continue;
                 }
@@ -867,14 +866,14 @@ impl UpdateInteractiveCommand {
                 {
                     continue;
                 }
-                let resolution = manager.lockfile.packages.items_resolution()[package_id as usize];
+                let resolution = manager.lockfile.packages.items_resolution()[package_id.index()];
                 if resolution.tag != resolution::Tag::Npm {
                     continue;
                 }
 
                 let name_slice = dep.name.slice(string_buf);
                 let package_name =
-                    manager.lockfile.packages.items_name()[package_id as usize].slice(string_buf);
+                    manager.lockfile.packages.items_name()[package_id.index()].slice(string_buf);
 
                 let scope = manager.options.scope_for_package_name(package_name).clone();
                 // Snapshot for `OutdatedPackage.uses_default_registry` (see
@@ -969,10 +968,10 @@ impl UpdateInteractiveCommand {
 
                 // Get workspace name but only show if it's actually a workspace
                 let workspace_resolution =
-                    manager.lockfile.packages.items_resolution()[workspace_pkg_id as usize];
+                    manager.lockfile.packages.items_resolution()[workspace_pkg_id.index()];
                 let workspace_name: &[u8] =
                     if workspace_resolution.tag == resolution::Tag::Workspace {
-                        manager.lockfile.packages.items_name()[workspace_pkg_id as usize]
+                        manager.lockfile.packages.items_name()[workspace_pkg_id.index()]
                             .slice(string_buf)
                     } else {
                         b""

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -695,7 +695,7 @@ impl UpdateInteractiveCommand {
             // Get the workspace path for this package
             let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
             let workspace_resolution =
-                manager.lockfile.packages.items_resolution()[pkg.workspace_pkg_id.index()];
+                manager.lockfile.packages.items_resolution()[pkg.workspace_pkg_id];
             let workspace_path: &[u8] = if workspace_resolution.tag == resolution::Tag::Workspace {
                 workspace_resolution.workspace().slice(string_buf)
             } else {
@@ -845,15 +845,15 @@ impl UpdateInteractiveCommand {
         let mut version_buf: String = String::new();
 
         for &workspace_pkg_id in workspace_pkg_ids {
-            let pkg_deps = manager.lockfile.packages.items_dependencies()[workspace_pkg_id.index()];
+            let pkg_deps = manager.lockfile.packages.items_dependencies()[workspace_pkg_id];
             for dep_id in pkg_deps.dependency_ids() {
-                let package_id = manager.lockfile.buffers.resolutions[dep_id.index()];
+                let package_id = manager.lockfile.buffers.resolutions[dep_id];
                 if package_id == INVALID_PACKAGE_ID {
                     continue;
                 }
                 checked += 1;
                 let string_buf = manager.lockfile.buffers.string_bytes.as_slice();
-                let dep = &manager.lockfile.buffers.dependencies[dep_id.index()];
+                let dep = &manager.lockfile.buffers.dependencies[dep_id];
                 if !selects(groups, dep.behavior) {
                     continue;
                 }
@@ -866,14 +866,14 @@ impl UpdateInteractiveCommand {
                 {
                     continue;
                 }
-                let resolution = manager.lockfile.packages.items_resolution()[package_id.index()];
+                let resolution = manager.lockfile.packages.items_resolution()[package_id];
                 if resolution.tag != resolution::Tag::Npm {
                     continue;
                 }
 
                 let name_slice = dep.name.slice(string_buf);
                 let package_name =
-                    manager.lockfile.packages.items_name()[package_id.index()].slice(string_buf);
+                    manager.lockfile.packages.items_name()[package_id].slice(string_buf);
 
                 let scope = manager.options.scope_for_package_name(package_name).clone();
                 // Snapshot for `OutdatedPackage.uses_default_registry` (see
@@ -968,11 +968,10 @@ impl UpdateInteractiveCommand {
 
                 // Get workspace name but only show if it's actually a workspace
                 let workspace_resolution =
-                    manager.lockfile.packages.items_resolution()[workspace_pkg_id.index()];
+                    manager.lockfile.packages.items_resolution()[workspace_pkg_id];
                 let workspace_name: &[u8] =
                     if workspace_resolution.tag == resolution::Tag::Workspace {
-                        manager.lockfile.packages.items_name()[workspace_pkg_id.index()]
-                            .slice(string_buf)
+                        manager.lockfile.packages.items_name()[workspace_pkg_id].slice(string_buf)
                     } else {
                         b""
                     };

--- a/src/runtime/cli/why_command.rs
+++ b/src/runtime/cli/why_command.rs
@@ -396,7 +396,7 @@ impl WhyCommand {
 
             for (dep_idx, dependency) in dependencies.iter().enumerate() {
                 let target_id = resolutions[dep_idx];
-                if target_id as usize >= packages.len() {
+                if target_id.index() >= packages.len() {
                     continue;
                 }
 
@@ -473,7 +473,7 @@ impl WhyCommand {
         }
 
         for target_version in &target_versions {
-            let target_name = pkg_names[target_version.pkg_id as usize].slice(string_bytes);
+            let target_name = pkg_names[target_version.pkg_id.index()].slice(string_bytes);
             bun_core::prettyln!(
                 "<b>{}@{}<r>",
                 BStr::new(target_name),

--- a/src/runtime/cli/why_command.rs
+++ b/src/runtime/cli/why_command.rs
@@ -384,7 +384,7 @@ impl WhyCommand {
         let _pkg_resolutions = packages.items_resolutions();
         let pkg_resolution = packages.items_resolution();
 
-        for pkg_idx in 0..packages.len() {
+        for pkg_idx in pkg_names.ids() {
             let pkg_name = pkg_names[pkg_idx].slice(string_bytes);
 
             if pkg_name.is_empty() {
@@ -436,7 +436,7 @@ impl WhyCommand {
                     version: dep_pkg_version,
                     spec,
                     dep_type,
-                    pkg_id: PackageID::try_from(pkg_idx).expect("int cast"),
+                    pkg_id: pkg_idx,
                     workspace,
                 });
             }
@@ -460,7 +460,7 @@ impl WhyCommand {
 
             target_versions.push(VersionInfo {
                 version,
-                pkg_id: PackageID::try_from(pkg_idx).expect("int cast"),
+                pkg_id: pkg_idx,
             });
         }
 
@@ -473,7 +473,7 @@ impl WhyCommand {
         }
 
         for target_version in &target_versions {
-            let target_name = pkg_names[target_version.pkg_id.index()].slice(string_bytes);
+            let target_name = pkg_names[target_version.pkg_id].slice(string_bytes);
             bun_core::prettyln!(
                 "<b>{}@{}<r>",
                 BStr::new(target_name),

--- a/test/internal/source-lints/install-id-indexing.test.ts
+++ b/test/internal/source-lints/install-id-indexing.test.ts
@@ -1,0 +1,101 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+
+// The lockfile is a set of parallel buffers addressed by two kinds of id:
+// the package columns (`Lockfile.packages`) by `PackageID`, and
+// `buffers.dependencies` / `buffers.resolutions` by `DependencyID`. Both ids
+// are newtypes, and the buffers they address are `IdSlice` / `IdVec`, so a
+// subscript takes the id itself and the compiler rejects the other kind. The
+// escape hatch is `id.index()`, which turns an id back into a plain `usize`;
+// it exists for bitsets and `packages.len()` checks. Writing
+// `buffer[id.index()]` (or `buffer.get(id.index())`) instead of `buffer[id]`
+// throws the type check away again, so this lint keeps those subscripts out
+// of the install crate and the `bun pm` commands.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+function read(rel: string): Promise<string> {
+  return file(path.join(root, rel)).text();
+}
+
+test("PackageID and DependencyID are newtypes, not integer aliases", async () => {
+  const hooks = await read("src/install_types/resolver_hooks.rs");
+  expect(hooks).toMatch(/^pub struct PackageID\(u32\);/m);
+  expect(hooks).toMatch(/^pub struct DependencyID\(u32\);/m);
+  expect(hooks).not.toMatch(/^pub type (?:PackageID|DependencyID)\b/m);
+});
+
+test("the package columns and the dependency buffers are indexed by id", async () => {
+  const packageColumns = await read("src/install/lockfile/Package.rs");
+  expect(packageColumns).toMatch(/trait PackageColumns\b[^{]*\bindexed by PackageID\s*\{/);
+
+  const buffers = await read("src/install/lockfile/Buffers.rs");
+  expect(buffers).toMatch(/^\s*pub dependencies: IdVec<DependencyID, Dependency>,/m);
+  expect(buffers).toMatch(/^\s*pub resolutions: IdVec<DependencyID, PackageID>,/m);
+});
+
+// `x[id.index()]` (the id expression may itself contain a subscript, as in
+// `x[ids[i].index()]`), except ranges (`raw[a.index()..b.index()]` is how a
+// raw sub-range is spelled on purpose), and `x.get(id.index())`.
+const SUBSCRIPT = /\[((?:[^[\]\n]|\[[^[\]\n]*\])*)\.index\(\)\s*\]/g;
+const GET = /\.get(?:_mut)?\(\s*[^()\n]*\.index\(\)\s*\)/g;
+
+// Documented exceptions, each the one place a `usize` is genuinely the index:
+const ALLOW: Record<string, number> = {
+  // `Lockfile::package` is the row accessor over `MultiArrayList::get(usize)`;
+  // everything else goes through it.
+  "src/install/lockfile.rs": 1,
+  // `Diff::generate`'s mapping holds positions within the old root package's
+  // dependency list, read back into that sub-slice.
+  "src/install/PackageManager/install_with_manager.rs": 1,
+};
+
+const scanRoots = ["src/install", "src/install_types", "src/runtime/cli"];
+
+const sources: string[] = [];
+for (const dir of scanRoots) {
+  for (const rel of new Bun.Glob("**/*.rs").scanSync({ cwd: path.join(root, dir) })) {
+    const abs = path.join(root, dir, rel);
+    const source = path.relative(root, abs).replaceAll(path.sep, "/");
+    // Count each file once under its canonical path (`src/cli` is a symlink
+    // into `src/runtime/cli`).
+    if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+    sources.push(source);
+  }
+}
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+for (const source of sources.sort()) {
+  // Only the pm commands in `src/runtime/cli` touch the lockfile.
+  const content = await read(source);
+  if (source.startsWith("src/runtime/cli/") && !content.includes("bun_install")) continue;
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  const hits: { index: number; text: string }[] = [];
+  for (const m of stripped.matchAll(SUBSCRIPT)) {
+    if (!m[1].includes("..")) hits.push({ index: m.index, text: m[0] });
+  }
+  for (const m of stripped.matchAll(GET)) hits.push({ index: m.index, text: m[0] });
+  for (const { index, text } of hits) {
+    counts[source] = (counts[source] ?? 0) + 1;
+    if (counts[source] > (ALLOW[source] ?? 0)) {
+      const line = stripped.slice(0, index).split("\n").length;
+      offenders.push(`${source}:${line}: \`${text.replace(/\s+/g, " ")}\` subscripts with a usize; index with the id`);
+    }
+  }
+}
+
+test("scans the install crate", () => {
+  expect(sources.filter(s => s.startsWith("src/install/")).length).toBeGreaterThan(50);
+});
+
+test("id-indexed buffers are subscripted with the id, not id.index()", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  const actual = Object.fromEntries(Object.keys(ALLOW).map(source => [source, counts[source] ?? 0]));
+  expect(actual).toEqual(ALLOW);
+});


### PR DESCRIPTION
### Problem
- `PackageID` and `DependencyID` were both `type X = u32;` aliases (`src/install_types/resolver_hooks.rs`), so a package id used where a dependency id belongs compiled silently. mordant's `interchangeable_aliases` flagged one such site, `ROOT_DEP_ID: DependencyID = invalid_package_id - 1` in `src/install/lockfile/Tree.rs`.
- Making the two ids distinct types turned up more of the same, none of which the lint could see. All of them hold the same numeric value as before, so none is a behavior bug, but each is a place where the declared type lied:
  - `PackageManager::FailFn` took a `PackageID`; its only implementation (`fail_root_resolution`) and every caller pass a dependency id.
  - `lockfile::PendingResolution::resolve_id` was a `PackageID`; it indexes `buffers.resolutions`, i.e. it is a dependency id.
  - `tree::Builder::resolution_lists` and `Tree::hoist_dependency`'s range parameter were typed as `DependencyIDSlice` but are fed `Package.resolutions` (`PackageIDSlice`); `verify_resolutions` annotated the same column the same way; `yarn.rs` built `Package.resolutions` as `DependencyIDSlice::new(..)` in four places; `Tree::EXTERNAL_SIZE` sized the `dependency_id` slot with `size_of::<PackageID>()`.
  - `INVALID_PACKAGE_ID` served as the dependency-id sentinel in `printer/tree_printer.rs` (4 sites) and in the resolver's `PendingResolution::default()`.
  - `hooks::TaskCallbackContext::root_request_id` was a bare `u32` while the `bun_install` side is a `PackageID`.
  - `Lockfile::loaded_package_count` and a few local counters were typed as `PackageID` but are counts.
  - `Buffers::load`'s legacy-lockfile path reads package ids out of `DependencyID` slots; that reinterpretation is now explicit.
- With the ids typed, the buffers they index were still plain slices: about 600 `column[id.index()]` subscripts accepted any `usize`, so the types guarded parameters and fields but not the indexing itself (review feedback on the first version of this PR).

### Fix
Commits, in order (plus three small follow-ups from review: stale comments, the yarn capacity pointers described under typed indexing, and unit tests for `IdSlice` / `IdVec` and the `indexed by` column traits in `bun_collections`, which the `cargo miri test` job runs, so the `from_raw` casts and the wrapped `split_mut` columns are interpreted under Tree Borrows in CI rather than only compiled):
- `PackageID` and `DependencyID` become `#[repr(transparent)]` newtypes over `u32` with `new`, `from_index` (truncating, like the `as` casts it replaces), `TryFrom<usize>` (for the existing checked sites), `get`, `index`, `INVALID`, and `PackageID::ROOT`. `Debug`/`Display` print the bare number, so log lines, `bun pm ls`-style output and the debug lockfile JSON are unchanged. They are `bytemuck::Pod` so the `bun.lockb` buffers and `index_sort` keep working on them, and `ArrayIdentityContext` is implemented for them so the identity-hashed maps keyed by ids keep their context. `INVALID_PACKAGE_ID` / `invalid_package_id` etc. keep their names. `DependencySlice` and `ResolutionSlice` (the two slices whose positions are dependency ids) gain `dependency_ids()` and a typed `contains(DependencyID)`; the untyped `ExternalSlice::contains(u32)` had no other callers and is removed. The mislabeled declarations above get the type their values actually have; on-disk layout is unaffected (`padding_checker.rs` pins both types at 4 bytes next to the other serialized leaf types).
- `mordant-baseline.toml` loses the `interchangeable_aliases:src/install/lockfile/Tree.rs` entry; the lint only looks at integer aliases, so the newtypes make that site (and any future one) impossible to write. `bun run rust:mordant` on this branch reports nothing over the baseline.
- `Default` for both ids is `INVALID`, like `NewId` in the isolated installer and `bun_ast::Index`, instead of the derived 0 (which is the root package). The only consumers of `Default` are the `get_or_put` fills in the bun.lock / pnpm parsers, which every path overwrites or abandons on error; the scratch buffers that used to be zero-filled now say `invalid_package_id` explicitly, and the two structs that derived `Default` only to hold an id did not use it (derives dropped).
- Typed indexing: `bun_collections::IdSlice<I, T>` / `IdVec<I, T>` are a slice and a vector subscripted with an id type `I: Idx` (implemented by both ids). They deref to `[T]` for everything that is not subscripting, so `len`/`iter`/`&[T]` parameters/byte casts need no changes, but because the wrapper has its own `Index` impl, `s[0]`, `s[some_usize]` and `s[a..b]` are compile errors; raw positions go through `raw()` / `raw_mut()` (24 sites: sub-ranges being filled, sorted or walked, the `Vec` being handed to the capacity-growing helpers, and the yarn migration's capacity fill, which takes its base pointers from the `Vec`s because the slice's `as_mut_ptr` reached through `Deref` would only cover `len`; that last point is also called out in `IdVec`'s docs). `multi_array_columns!` accepts `for Package<_>, indexed by PackageID`, so every `items_*()` accessor (and `split_mut`) hands out `IdSlice<PackageID, _>`; `buffers.dependencies` / `buffers.resolutions` are `IdVec<DependencyID, _>`; the resolver hooks, `tree::Builder`, `reachable::Walk`, the dedupe pass, the printers, `PackageInstaller`'s column back-references (now `BackRef<IdSlice<..>>` instead of `RawSlice`), and the per-package / per-dependency scratch vectors (`preinstall_state`, the clone mapping, dedupe's `group_of`, audit's `parent_of`, ...) follow. `x[id.index()]` no longer occurs anywhere in `src/install` or the `bun pm` commands; loops that counted `0..len` and converted use `ids()` / `iter_enumerated()`; `Lockfile::package(id)` gathers a row (the one remaining `packages.get(id.index())`); the `.index()` calls left feed bitsets and `packages.len()` bounds checks. `has(id)` replaces the `id.index() < col.len()` checks against typed slices.
- `test/internal/source-lints/install-id-indexing.test.ts` keeps this in place: it checks that the two ids are newtypes, that the package columns and the dependency buffers are declared id-indexed, and that no `buffer[id.index()]` / `buffer.get(id.index())` subscript is left in the install crate or the pm commands (the two exceptions above are allow-listed with exact counts). It fails on main's sources and passes here.
- One deliberate pun is unchanged: the `id_mapping` slice passed to `Diff::generate` stores positions within the old root package's dependency list in a `[PackageID]`, and `install_with_manager` reads it back with `.index()` into a sub-slice. It is internally consistent and a separate cleanup.
- Verified:
  - `cargo check --workspace`; clippy on `bun_collections`, `bun_install_types`, `bun_resolver`, `bun_install`, `bun_jsc`, `bun_runtime`, `bun_ast`, `bun_bundler` (the other `multi_array_columns!` users); `cargo fmt --all`; `bun run rust:mordant`; `cargo test -p bun_collections` and `bun run rust:miri -p bun_collections` (42 tests, 7 of them new).
  - Debug build, then `bun bd test` on about 2,450 tests: the lockfile suites (`bun-lockb`, `bun-lock`, `migrate-bun-lockb-v2`, `lockfile-version-2`, `lockfile-only`), `test/cli/install/migration/`, `bun-install`, `bun-pm`, `bun-pm-why`, `bun-pm-licenses`, `bun-audit`, `bun-dedupe`, `bun-prune`, `bun-add`, `bun-update-transitive`, `bun-workspaces`, `hoist`, `isolated-install`, `catalogs`, `overrides`, `nested-overrides`, `frozen-lockfile-pruned`, `bun-add-filter`, `bun-install-security-provider`, `bun-install-registry`, `bun-update`, `bun-patch`, `bun-install-patch`, `bun-remove`, `bun-link`, and `test/cli/update_interactive_*`. The failures are the same set before and after every step of this PR and are unrelated to it: tests needing network access (git/bitbucket/gitlab clones, remote tarballs), two migration tests that sit at the 5 s limit on an unoptimized build when run in a batch and pass alone (4.6 s / 2.6 s, same as before this change), and one `bun-link` expectation that does not account for the `#[cfg(bun_debug)]` failure trace debug builds print (file untouched here). Details in the block below.

### Background
- The lockfile is a set of flat, parallel buffers. `Lockfile.packages` is a struct-of-arrays of packages (`MultiArrayList`, one column per field), indexed by `PackageID`; package 0 is always the root project. `buffers.dependencies` holds every declared dependency edge, indexed by `DependencyID`, and `buffers.resolutions` is parallel to it: `resolutions[dep_id]` is the `PackageID` the edge resolved to (or `INVALID_PACKAGE_ID`). Each package stores a `DependencySlice` / `PackageIDSlice` pair of `(offset, len)` ranges into those two buffers, which is why the positions covered by either slice are dependency ids, and why a package's own sub-slice of either buffer is position-indexed rather than id-indexed (those stay plain slices).
- `bun.lockb` serializes `buffers.resolutions` and `buffers.hoisted_dependencies` as raw `u32` arrays, and `Tree` (one per `node_modules` folder) as 20 raw bytes including a `DependencyID`; `repr(transparent)` keeps those byte-for-byte identical. Very old lockfiles stored package ids in the tree's dependency-id slots, which is the legacy conversion in `Buffers::load`.
- `ROOT_DEP_ID` is a sentinel dependency id given to the root `node_modules` tree node, which has no dependency edge of its own; `Tree::process_subtree` maps it to package 0. Its value (`u32::MAX - 1`) is unchanged; it is now derived from the dependency-id sentinel rather than the package-id one.
- Why `IdSlice` can deref to `[T]` and still reject `s[0]`: indexing stops at the first type in the auto-deref chain that implements `Index` at all and then requires the subscript to match one of that type's impls; it does not keep dereferencing to find an impl for a different index type. So `IdSlice` gets the whole slice API through `Deref` while subscripting is only possible with its id. `multi_array_columns!` is the macro that generates the `items_<field>()` column accessors from a struct's fields; the new `indexed by` clause wraps each accessor's result in `IdSlice::from_raw`, which is a pointer cast made sound by `#[repr(transparent)]`.
- mordant is the dylint lint pack CI runs as a ratchet against `mordant-baseline.toml`; `interchangeable_aliases` reports a value declared under one integer alias flowing into a slot declared under another.

<details>
<summary>Local test runs (unoptimized debug build)</summary>

```
test/cli/install/bun-install.test.ts (14 of 714 in that batch; same 14 fail with USE_SYSTEM_BUN=1 and with the
first version of this branch):
  should support --registry CLI flag
  should handle bitbucket git dependencies > install/add bitbucket:..., bitbucket.org:..., bitbucket.com:..., git@bitbucket.org:...  (8)
  should handle gitlab git dependencies > install/add gitlab:..., gitlab.com:...  (4)
  should treat non-GitHub http(s) URLs as tarballs (https://some.url/path?stuff)
test/cli/install/migration/complex-workspace.test.ts:
  "the install succeeds" and its dependents: `"git clone" for "install-test" failed` (same with USE_SYSTEM_BUN=1)
test/cli/install/migration/yarn-lock-migration.test.ts > yarn-cli-repo, pnpm-migration-complete.test.ts:
  5 s timeouts when run as part of a 13-file batch; 4.6 s and 2.6 s when run alone (4.9 s / 2.8 s before the typed
  slices), so no measurable cost from the wrappers even at opt-level 0
test/cli/install/bun-link.test.ts > should link dependency without crashing:
  stdout contains the failure trace that Failure::boxed captures under cfg(bun_debug); the test expects the release
  output. PackageInstall.rs is not touched by this PR.
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 71 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/install-id-indexing.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/26] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/26] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /work
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (a13e861e9)

test/internal/source-lints/install-id-indexing.test.ts:
20 |   return file(path.join(root, rel)).text();
21 | }
22 | 
23 | test("PackageID and DependencyID are newtypes, not integer aliases", async () => {
24 |   const hooks = await read("src/install_types/resolver_hooks.rs");
25 |   expect(hooks).toMatch(/^pub struct PackageID\(u32\);/m);
                     ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /^pub struct PackageID\(u32\);/m
Received: "//! Shared install↔resolver type surface.\n//!\n//! MOVE_DOWN from `bun_install` so `bun_resolver` can spell these types\n//! without an upward dep edge (resolver→install would cycle through\n//! install→resolver). The behaviourful `PackageManager` itself stays in\n//! `bun_install`; the resolver talks to it through the [`AutoInstaller`]\n//! trait below, which `bun_install::PackageManager` implements\n//! (`bun_install::auto_installer`).\n//!\n//! Every value type here is the SINGLE canonical definition — `bun_install`\n//! re-exports them (`pub use bun_install_types::…`); there is exactly one\n//! nominal type per name.\n\nuse core::cmp::Order
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/install-id-indexing.test.ts
bun test v1.4.0 (88a639883)

test/internal/source-lints/install-id-indexing.test.ts:
(pass) PackageID and DependencyID are newtypes, not integer aliases [11.92ms]
(pass) the package columns and the dependency buffers are indexed by id [19.90ms]
(pass) scans the install crate [10.77ms]
(pass) id-indexed buffers are subscripted with the id, not id.index() [1.75ms]
(pass) allowlisted files still carry exactly their documented count [6.53ms]

 5 pass
 0 fail
 9 expect() calls
Ran 5 tests across 1 file. [3.57s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 829ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/24] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/24] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser (32 fields)
Found 9 cl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
Cargo.lock                                         |   1 +
 mordant-baseline.toml                              |   1 -
 src/collections/id_slice.rs                        | 407 +++++++++++++++++++++
 src/collections/lib.rs                             |   2 +
 src/collections/multi_array_list.rs                | 196 ++++++++--
 src/install/PackageInstaller.rs                    | 170 ++++-----
 src/install/PackageManager.rs                      |  14 +-
 src/install/PackageManager/PackageJSONEditor.rs    |  21 +-
 .../PackageManager/PackageManagerDirectories.rs    |   2 +-
 .../PackageManager/PackageManagerEnqueue.rs        | 111 +++---
 .../PackageManager/PackageManagerLifecycle.rs      |  23 +-
 .../PackageManager/PackageManagerResolution.rs     |  49 ++-
 .../PackageManager/PopulateManifestCache.rs        |  21 +-
 src/install/PackageManager/UpdateRequest.rs        |   2 +-
 src/install/PackageManager/add_catalog.rs          |  10 +-
 .../PackageManager/add_remove_with_filter.rs       |   2 +-
 src/install/PackageManager/install_with_manager.rs | 115 +++---
 .../PackageManager/package_json_write_back.rs      |  10 +-
 src/install/PackageManager/patchPackage.rs         |  30 +-
 .../PackageManager/processDependencyList.rs        |  31 +-
 src/install/PackageManager/runTasks.rs             |  46 ++-
 src/install/PackageManager/security_scanner.rs     |  78 ++--
 .../PackageManager/updatePackageJSONAndInstall.rs  |   9 +-
 src/install/PackageManager/workspace_selection.rs  |  21 +-
 src/install/audit_fix.rs                           |  65 ++--
 src/install/audit_fix/package_json_edits.rs        |   8 +-
 src/install/auto_installer.rs                      |  17 +-
 src/install/bin.rs                                 |  11 +-
 src/install/dedupe.rs                              | 115 +++---
 src/install/hoisted_install.rs                     |  30 +-
 src/install/isolated_install.rs                    | 241 ++++++------
 src/install/isolated_install/Insta
... (truncated)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
Cargo.lock                                                   0      0      0
mordant-baseline.toml                                        2      2      0
src/collections/id_slice.rs                                  4      8      0
src/collections/lib.rs                                       1      3      0
src/collections/multi_array_list.rs                          6      7      0
src/install/PackageInstaller.rs                              0      0      0
src/install/PackageManager.rs                                2      2      0
src/install/PackageManager/PackageJSONEditor.rs              0      0      0
src/install/PackageManager/PackageManagerDirectories.rs      0      0      0
src/install/PackageManager/PackageManagerEnqueue.rs          2      5      0
src/install/PackageManager/PackageManagerLifecycle.rs        0      0      0
src/install/PackageManager/PackageManagerResolution.rs       2      4      0
src/install/PackageManager/PopulateManifestCache.rs          0      0      0
src/install/PackageManager/UpdateRequest.rs                  0      0      0
src/install/PackageManager/add_catalog.rs                    0      0      0
src/install/PackageManager/add_remove_with_filter.rs         0      0      0
(+ 55 more files)
```

</details>

<!-- robobun:evidence:end -->