### PR TITLE
ResolveMessage: report the module being transpiled as the referrer of transpile-time resolve errors

### DIFF
--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -156,7 +156,6 @@ impl AsyncModule {
         promise: JSValue,
         result: Result<ResolvedSource, crate::CrateError>,
         specifier: &BunString,
-        referrer: &BunString,
         log: &mut bun_ast::Log,
     ) -> JsResult<()> {
         jsc::mark_binding();
@@ -168,7 +167,6 @@ impl AsyncModule {
             Err(e) => ErrorableResolvedSource::err(crate::virtual_machine::process_fetch_log(
                 global_this,
                 specifier,
-                referrer,
                 log,
                 e,
             )),
@@ -176,7 +174,7 @@ impl AsyncModule {
         bun_core::scoped_log!(AsyncModule, "fulfill: {}", specifier);
 
         jsc::from_js_host_call_generic(global_this, || {
-            Bun__onFulfillAsyncModule(global_this, promise, &mut errorable, specifier, referrer)
+            Bun__onFulfillAsyncModule(global_this, promise, &mut errorable, specifier)
         })
     }
 }
@@ -197,7 +195,6 @@ unsafe extern "C" {
         promise_value: JSValue,
         res: &mut ErrorableResolvedSource,
         specifier: &BunString,
-        referrer: &BunString,
     );
 }
 
@@ -649,13 +646,11 @@ impl AsyncModule {
         ));
         let result = this.resume_loading_module(&mut log);
         let spec = BunString::borrow_utf8(this.specifier());
-        let referrer = BunString::borrow_utf8(this.referrer());
         Self::fulfill(
             global_this,
             this.promise.get().unwrap(),
             result,
             &spec,
-            &referrer,
             &mut log,
         )
     }

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -316,7 +316,6 @@ impl RuntimeTranspilerStore {
         global_object: &JSGlobalObject,
         input_specifier: String,
         path: &Fs::Path<'_>,
-        referrer: String,
         loader: Loader,
         package_json: Option<&PackageJSON>,
     ) -> *mut c_void {
@@ -355,7 +354,6 @@ impl RuntimeTranspilerStore {
                 non_threadsafe_input_specifier: input_specifier,
                 path: owned_path,
                 global_this: BackRef::new(global_object),
-                non_threadsafe_referrer: referrer,
                 vm,
                 ticket: None,
                 log: bun_ast::Log::init(),
@@ -404,7 +402,6 @@ pub struct TranspilerJob {
     // Box'd buffer allocated in `transpile()` and freed in `reset_for_pool()`.
     pub path: bun_paths::fs::Path<'static>,
     pub(crate) non_threadsafe_input_specifier: bun_core::String,
-    pub(crate) non_threadsafe_referrer: bun_core::String,
     pub(crate) loader: Loader,
     pub(crate) promise: StrongOptional,
     // Note: struct is stored in a HiveArray and crosses to a worker thread;
@@ -477,7 +474,7 @@ impl TranspilerJob {
     /// `run_from_js_thread`.
     ///
     /// Note: `HiveArrayFallback::put` runs `drop_in_place` on the slot (see
-    /// hive_array.rs note), so the Drop-carrying fields — `bun_core::String` ×2,
+    /// hive_array.rs note), so the Drop-carrying fields — `bun_core::String`,
     /// `ResolvedSource`, `Log`, `StrongOptional` — are torn down
     /// *there*, not here. This function handles only the teardown that field
     /// drop glue does **not** cover: the leaked `path.text` Box and
@@ -523,7 +520,6 @@ impl TranspilerJob {
         // vtable; resolve it via the `get_vm_ctx` hook (registered by `bun_runtime::init`).
         self.poll_ref.unref(get_vm_ctx(AllocatorType::Js));
 
-        let referrer = core::mem::take(&mut self.non_threadsafe_referrer);
         let mut log = core::mem::replace(&mut self.log, bun_ast::Log::init());
         let (specifier, result) = match self.parse_error {
             Some(e) => (String::clone_utf8(self.path.text), Err(e)),
@@ -547,14 +543,7 @@ impl TranspilerJob {
                 .put(std::ptr::from_mut::<TranspilerJob>(self))
         };
 
-        AsyncModule::fulfill(
-            &global_this,
-            promise,
-            result,
-            &specifier,
-            &referrer,
-            &mut log,
-        )
+        AsyncModule::fulfill(&global_this, promise, result, &specifier, &mut log)
     }
 
     fn schedule(&mut self) {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2900,7 +2900,6 @@ impl VirtualMachine {
 pub fn process_fetch_log(
     global_this: &JSGlobalObject,
     specifier: &bun_core::String,
-    referrer: &bun_core::String,
     log: &mut bun_ast::Log,
     err: crate::CrateError,
 ) -> JSValue {
@@ -2912,7 +2911,7 @@ pub fn process_fetch_log(
 
     // `ResolveMessage::create` takes raw `&[u8]` and stores them verbatim, so
     // we must convert to UTF-8 here.
-    let referrer_utf8 = referrer.to_utf8();
+    let referrer_utf8 = specifier.to_utf8();
 
     match log.msgs.len() {
         0 => {

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -460,8 +460,7 @@ extern "C" void Bun__onFulfillAsyncModule(
     Zig::GlobalObject* globalObject,
     JSC::EncodedJSValue encodedPromiseValue,
     ErrorableResolvedSource* res,
-    const BunString* specifier,
-    const BunString* referrer)
+    const BunString* specifier)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4336,7 +4336,6 @@ pub unsafe extern "C" fn Bun__transpileFile(
                     global,
                     specifier.clone(),
                     &lr.path,
-                    referrer.clone(),
                     concurrent_loader,
                     lr.package_json,
                 )
@@ -4460,7 +4459,7 @@ pub unsafe extern "C" fn Bun__transpileFile(
             promise.cast::<c_void>()
         }
         Err(err) => {
-            if let Some(value) = transpile_error_value(global, specifier, referrer, &mut log, err) {
+            if let Some(value) = transpile_error_value(global, specifier, &mut log, err) {
                 *ret = ErrorableResolvedSource::err(value);
             }
             ptr::null_mut()
@@ -4473,7 +4472,6 @@ pub unsafe extern "C" fn Bun__transpileFile(
 fn transpile_error_value(
     global: &JSGlobalObject,
     specifier: &bun_core::String,
-    referrer: &bun_core::String,
     log: &mut bun_ast::Log,
     err: crate::Error,
 ) -> Option<JSValue> {
@@ -4491,7 +4489,6 @@ fn transpile_error_value(
         err => Some(bun_jsc::virtual_machine::process_fetch_log(
             global,
             specifier,
-            referrer,
             log,
             to_jsc_fetch_error(&err),
         )),
@@ -4599,9 +4596,7 @@ pub extern "C" fn Bun__transpileVirtualModule(
             true
         }
         Err(err) => {
-            if let Some(value) =
-                transpile_error_value(global, specifier_str, referrer_str, &mut log, err)
-            {
+            if let Some(value) = transpile_error_value(global, specifier_str, &mut log, err) {
                 *ret = ErrorableResolvedSource::err(value);
             }
             true

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -170,6 +170,106 @@ describe("ResolveMessage", () => {
   });
 });
 
+// A resolve error logged while a module is being transpiled belongs to the
+// module being transpiled, so that module is the ResolveMessage's referrer. It
+// used to be whatever the module loader passed as the fetch's referrer: the
+// literal string "undefined" for import(), and the requiring file for require().
+//
+// Two things log resolve errors at transpile time: a macro import that does not
+// resolve (always accompanied by a second, build-level message, so the load
+// rejects with an AggregateError), and a static import of an unknown node:
+// builtin in a module transpiled on the JS thread, such as a require()d one
+// (a single message, so the load rejects with the ResolveMessage itself).
+describe.concurrent("ResolveMessage.referrer for resolve errors raised during transpile", () => {
+  const macroSource = `import { nope } from "./does-not-exist" with { type: "macro" };\nexport const x = nope();\n`;
+  const nodeBuiltinSource = `import "node:this_builtin_does_not_exist";\nexport const x = 1;\n`;
+
+  function makeDir() {
+    return tempDir("resolve-error-transpile-referrer", {
+      "import-me.ts": macroSource,
+      "require-me.ts": macroSource,
+      "require-me-node-builtin.ts": nodeBuiltinSource,
+      "fixture.ts": `
+        Bun.plugin({
+          name: "virtual modules with an unresolvable macro import",
+          setup(build) {
+            for (const name of ["virt:import-me", "virt:require-me"]) {
+              build.module(name, () => ({ contents: ${JSON.stringify(macroSource)}, loader: "ts" }));
+            }
+          },
+        });
+
+        function resolveMessages(error) {
+          return (error.errors ?? [error])
+            .filter(e => e.name === "ResolveMessage")
+            .map(e => ({ specifier: e.specifier, referrer: e.referrer, file: e.position?.file }));
+        }
+
+        const out = {
+          importMe: Bun.resolveSync("./import-me.ts", import.meta.dir),
+          requireMe: Bun.resolveSync("./require-me.ts", import.meta.dir),
+          requireMeNodeBuiltin: Bun.resolveSync("./require-me-node-builtin.ts", import.meta.dir),
+        };
+        const loads = {
+          import: () => import("./import-me.ts"),
+          require: () => require("./require-me.ts"),
+          importVirtual: () => import("virt:import-me"),
+          requireVirtual: () => require("virt:require-me"),
+          requireNodeBuiltin: () => require("./require-me-node-builtin.ts"),
+        };
+        for (const [name, load] of Object.entries(loads)) {
+          try {
+            await load();
+            out[name] = "loaded";
+          } catch (error) {
+            out[name] = resolveMessages(error);
+          }
+        }
+        console.log(JSON.stringify(out));
+      `,
+    });
+  }
+
+  async function run(dir: string, env: Record<string, string | undefined>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      env,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { importMe, requireMe, requireMeNodeBuiltin, ...results } = JSON.parse(stdout);
+    expect(results).toEqual({
+      import: [{ specifier: "./does-not-exist", referrer: importMe, file: importMe }],
+      require: [{ specifier: "./does-not-exist", referrer: requireMe, file: requireMe }],
+      importVirtual: [{ specifier: "./does-not-exist", referrer: "virt:import-me", file: "virt:import-me" }],
+      requireVirtual: [{ specifier: "./does-not-exist", referrer: "virt:require-me", file: "virt:require-me" }],
+      requireNodeBuiltin: [
+        {
+          specifier: "node:this_builtin_does_not_exist",
+          referrer: requireMeNodeBuiltin,
+          file: requireMeNodeBuiltin,
+        },
+      ],
+    });
+    expect(exitCode).toBe(0);
+  }
+
+  it("import(), require() and plugin virtual modules", async () => {
+    using dir = makeDir();
+    await run(String(dir), bunEnv);
+  });
+
+  // import() normally transpiles on the concurrent transpiler; this covers the
+  // same-thread transpile path import() takes when that is disabled.
+  it("with the concurrent transpiler disabled", async () => {
+    using dir = makeDir();
+    await run(String(dir), { ...bunEnv, BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1" });
+  });
+});
+
 // These tests reproduce panics where the module resolver wrote past fixed-size
 // PathBuffers when given very long import specifiers. The bug triggers when
 // `import_path < PATH_MAX` but `baseUrl + import_path > PATH_MAX` (otherwise a


### PR DESCRIPTION
### Problem
- When a module fails to transpile because of a resolve error logged during the transpile, the `ResolveMessage` the load rejects with has the wrong `.referrer`:
  - `import()` (and static imports): `.referrer` is the 9-character string `"undefined"`.
  - `require()`: `.referrer` is the requiring file, not the file that contains the failing import.
  - Same for plugin virtual modules (`build.module()` / `onLoad` source) on both paths.
- Two things log resolve errors at transpile time: a macro import that does not resolve (`src/js_parser_jsc/Macro.rs:139`; always paired with a second, build-level message, so the load rejects with an `AggregateError` holding the `ResolveMessage`), and a static import of an unknown `node:` builtin in a module linked on the JS thread, for example a `require()`d one (`src/bundler/linker.rs:449` to `when_module_not_found`; a single message, so the load rejects with the `ResolveMessage` itself).
- Cause: `process_fetch_log` (`src/jsc/VirtualMachine.rs:2862`) copied the referrer argument of the fetch into every `ResolveMessage` it created. That argument is the placeholder `String("undefined"_s)` that `GlobalObject::moduleLoaderFetch` passes (`src/jsc/bindings/ZigGlobalObject.cpp:3862`, JSC's fetch hook has no referrer) or, for `require()`, the requiring module's filename (`src/jsc/bindings/JSCommonJSModule.cpp:1316`). Neither is the module whose import failed.
- Everywhere else `.referrer` is the module containing the failing import: the resolve hook stores its `source` argument (`src/runtime/jsc_hooks.rs:5504`), and `test/js/bun/resolve/resolve-test.js` asserts `referrer === import.meta.path`.

### Fix
- `process_fetch_log` uses the `specifier` it already receives as the referrer of the `ResolveMessage`s it creates. Correct because the log it converts is the log of transpiling `specifier`, so every resolve error in it was raised for an import inside `specifier`: `.referrer` becomes the value the resolve hook would have stored had the same import failed at load time, and it equals `.position.file` on the same message.
- Message text is unchanged: `.referrer` only feeds `.message` / `.requireStack` for `Cannot find module/package` texts, and neither transpile-time producer uses that shape.
- Deletions (that was the last reader of the referrer carried by the concurrent transpiler, so the rest of that chain is removed here): the `referrer` parameter of `process_fetch_log` and of `transpile_error_value` (`jsc_hooks.rs`); the `referrer.clone()` argument in `Bun__transpileFile`; `RuntimeTranspilerStore::transpile`'s `referrer` parameter and `TranspilerJob.non_threadsafe_referrer`; `AsyncModule::fulfill`'s `referrer` parameter; the `referrer` parameter of `Bun__onFulfillAsyncModule` (`ModuleLoader.cpp`; its body never read it) and the matching local in `AsyncModule::on_done`. The referrer still flowing into `TranspileArgs` stays: the `.wasm` entry-point check and the auto-install error objects in `AsyncModule` read it.
- The `"undefined"` placeholder in `moduleLoaderFetch` is left alone for the same reason; it no longer reaches a user-visible property from this path.
- Test: `test/js/bun/resolve/resolve-error.test.ts`, `describe("ResolveMessage.referrer for resolve errors raised during transpile")`. One fixture loads five distinct modules (`import()` and `require()` of a file with an unresolvable macro import, `import()` and `require()` of a `build.module()` virtual module with the same source, and `require()` of a file with `import "node:this_builtin_does_not_exist"`) and asserts `referrer` equals the loaded module's key and its `position.file`. A second case runs it with `BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER=1`. Between them the cases reach `process_fetch_log` from `AsyncModule::fulfill` (concurrent transpiler, the default for `import()`), `transpile_file` (`require()`, and `import()` with the flag) and `transpile_virtual_module`, and exercise both its one-message and many-messages arms. The remaining caller, `AsyncModule::on_done` (auto-install), gets the same one-argument change.
- Verified:
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/resolve-error.test.ts -t "raised during transpile"`: both cases fail on the 1.4.0 release binary, each reporting the five wrong referrers described above (output below).
  - `bun bd test test/js/bun/resolve/resolve-error.test.ts test/js/bun/resolve/concurrent-dynamic-import.test.ts test/js/bun/resolve/build-error.test.ts test/js/bun/transpiler/transpiler-error-gc-uaf.test.ts`: 29 pass (ASAN build; covers the changed `Bun__onFulfillAsyncModule` signature and the `OwnedString` deref on both the success and error paths of the concurrent transpiler).
  - `bun bd test test/js/bun/plugin/plugins.test.ts test/bundler/transpiler/macro-test.test.ts test/regression/issue/{03830,22656,26360}.test.ts`: pass.
  - `BUN_DEBUG_AsyncModule=1` on the fixture confirms `import()` goes through `AsyncModule::fulfill` by default and through `transpile_file` with the flag set.
- Rebased onto main after #40238 (`bun_core::String` owns its WTF ref) and the module-loader cleanups that followed #39177. Every file of the diff conflicted. The resolution keeps main's shape and drops only the referrer: `process_fetch_log` keeps main's `&bun_core::String` parameters and `JSValue` return, `fulfill` keeps main's `Result<ResolvedSource, CrateError>` signature, the string handling of the first version (`OwnedString` in `fulfill`, the `ModuleLoader.rs` shim) is gone because main already replaced it, and the new `transpile_error_value` helper loses its `referrer` parameter in place of the two former `process_fetch_log` call sites in `jsc_hooks.rs`. The behavior change is still the one `referrer_utf8` line.

### Background
- `ResolveMessage` is the error object Bun throws when a module specifier cannot be resolved. `.specifier` is the string that failed to resolve and `.referrer` is the module it was being resolved for (the file containing the import).
- Most resolve errors are raised at load time: the module loader asks Bun's resolve hook to resolve each import of a module, and on failure the hook creates a `ResolveMessage` with that module as the referrer. Some imports are resolved earlier, while the module's source is being transpiled: macros (`with { type: "macro" }`) are resolved and run by the transpiler, and modules transpiled on the JS thread also run the runtime linker over their static imports, which reports unknown `node:` builtins itself. Those failures land in the transpile `Log`, and `process_fetch_log` turns a failed transpile's `Log` into the value the load rejects with: one message becomes a `BuildMessage` or `ResolveMessage`, several become an `AggregateError` of them.
- The fetch referrer: Bun's fetch entry points take a referrer argument. The ESM one (`moduleLoaderFetch`) is called by JSC's module loader, which does not supply one, so Bun passes the literal string `"undefined"`; the CommonJS one passes the module calling `require()`. It is threaded into `TranspileArgs` for the transpile itself and, until this change, was also copied along with each concurrent transpile job purely so `process_fetch_log` could read it at the end.
- Concurrent transpiler: once the entry point has loaded, `import()`ed files are transpiled on a thread pool (`RuntimeTranspilerStore`) and the result or failure log is delivered back to the JS thread through `AsyncModule::fulfill` and `Bun__onFulfillAsyncModule`; `require()` and plugin-provided source always transpile on the JS thread. `BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER=1` forces everything onto the JS thread, which is how the test reaches the second path for `import()`.

<details>
<summary>Release binary (1.4.0) output of the new test before the fix</summary>

```
    "import": [
      {
        "file": "/tmp/resolve-error-transpile-referrer_JZ5DNi/import-me.ts",
-       "referrer": "/tmp/resolve-error-transpile-referrer_JZ5DNi/import-me.ts",
+       "referrer": "undefined",
      },
    ],
    "importVirtual": [
      {
        "file": "virt:import-me",
-       "referrer": "virt:import-me",
+       "referrer": "undefined",
      },
    ],
    "require": [
      {
        "file": "/tmp/resolve-error-transpile-referrer_JZ5DNi/require-me.ts",
-       "referrer": "/tmp/resolve-error-transpile-referrer_JZ5DNi/require-me.ts",
+       "referrer": "/tmp/resolve-error-transpile-referrer_JZ5DNi/fixture.ts",
      },
    ],
    "requireNodeBuiltin": [
      {
        "file": "/tmp/resolve-error-transpile-referrer_JZ5DNi/require-me-node-builtin.ts",
-       "referrer": "/tmp/resolve-error-transpile-referrer_JZ5DNi/require-me-node-builtin.ts",
+       "referrer": "/tmp/resolve-error-transpile-referrer_JZ5DNi/fixture.ts",
      },
    ],
    "requireVirtual": [
      {
        "file": "virt:require-me",
-       "referrer": "virt:require-me",
+       "referrer": "/tmp/resolve-error-transpile-referrer_JZ5DNi/fixture.ts",
      },
    ],
```

Minimal standalone reproduction:

```
needs-macro.ts:
  import { nope } from "./does-not-exist" with { type: "macro" };
  console.log(nope());
main.js:
  try { await import("./needs-macro.ts"); }
  catch (e) { console.log(e.errors[0].constructor.name, JSON.stringify(e.errors[0].referrer)); }
```

`bun main.js` printed `ResolveMessage "undefined"`; with this change it prints the absolute path of `needs-macro.ts`.

Noticed while testing, not changed here (reported separately): reloading a module that failed with two or more transpile errors rejects with an `AggregateError` that has no `.errors` (the test therefore loads a distinct module per case), and the unknown `node:` builtin message differs between the linker (`Could not resolve ... "bun install"`) and the resolve hook (`No such built-in module`).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/resolve/resolve-error.test.ts

<!-- robobun:evidence:end -->
