### PR TITLE
ci: keep comment-cop working when GITHUB_TOKEN's GraphQL quota is exhausted

### DIFF
--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -103,77 +103,18 @@ jobs:
             }
 
             const keyFor = g => `${g.path}:${crypto.createHash('sha256').update(g.text).digest('hex').slice(0, 12)}`;
-            const presentKeys = new Set(groups.map(keyFor));
-            const MARKER = /<!-- comment-cop:([^>\s]+) -->/;
 
-            // Dedup goes through REST on purpose: GITHUB_TOKEN's GraphQL quota is
-            // shared by every workflow run in the repo and is routinely exhausted,
-            // the REST quota is a separate pool, and a scan that cannot dedup
-            // would re-post every comment already on the PR.
+            // Keys already flagged on this PR, read from its review comments. REST
+            // only: GITHUB_TOKEN's GraphQL quota is shared by every workflow run in
+            // the repo and is routinely exhausted; the REST quota is separate, and
+            // posting below needs it anyway.
             const reviewComments = await github.paginate(github.rest.pulls.listReviewComments, {
               owner, repo, pull_number, per_page: 100,
             });
             const seenKeys = new Set();
             for (const c of reviewComments) {
-              const m = MARKER.exec(c.body || '');
+              const m = /<!-- comment-cop:([^>\s]+) -->/.exec(c.body || '');
               if (m) seenKeys.add(m[1]);
-            }
-            const staleKeys = new Set([...seenKeys].filter(k => !presentKeys.has(k)));
-
-            // Ids of the unresolved threads for staleKeys. Thread ids and resolved
-            // state only exist in GraphQL, so this lookup is best effort: when it
-            // fails, nothing gets resolved and the scan below still runs.
-            async function staleThreadIds() {
-              const q = `
-                query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
-                  repository(owner: $owner, name: $repo) {
-                    pullRequest(number: $pr) {
-                      reviewThreads(first: 100, after: $after) {
-                        pageInfo { hasNextPage endCursor }
-                        nodes { id isResolved comments(first: 1) { nodes { body } } }
-                      }
-                    }
-                  }
-                }`;
-              const ids = [];
-              let after = null;
-              for (;;) {
-                const res = await github.graphql(q, { owner, repo, pr: pull_number, after });
-                const page = res.repository.pullRequest.reviewThreads;
-                for (const t of page.nodes) {
-                  if (t.isResolved) continue;
-                  const m = MARKER.exec(t.comments.nodes[0]?.body || '');
-                  if (m && staleKeys.has(m[1])) ids.push(t.id);
-                }
-                if (!page.pageInfo.hasNextPage) break;
-                after = page.pageInfo.endCursor;
-              }
-              return ids;
-            }
-
-            let toResolve = [];
-            if (staleKeys.size > 0) {
-              try {
-                toResolve = await staleThreadIds();
-              } catch (e) {
-                core.warning(`Listing review threads failed, not resolving up to ${staleKeys.size} stale comment-cop thread(s): ${e.message}`);
-              }
-            }
-
-            // Auto-resolve threads whose flagged block is gone from the current diff.
-            if (toResolve.length > 0) {
-              const mut = `
-                mutation($id: ID!) {
-                  resolveReviewThread(input: { threadId: $id }) { thread { id } }
-                }`;
-              for (const id of toResolve) {
-                try {
-                  await github.graphql(mut, { id });
-                } catch (e) {
-                  core.warning(`resolveReviewThread failed for ${id}: ${e.message}`);
-                }
-              }
-              core.info(`Resolved ${toResolve.length} stale comment-cop thread(s).`);
             }
 
             // Post new line comments for groups not already flagged.

--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -104,10 +104,26 @@ jobs:
 
             const keyFor = g => `${g.path}:${crypto.createHash('sha256').update(g.text).digest('hex').slice(0, 12)}`;
             const presentKeys = new Set(groups.map(keyFor));
+            const MARKER = /<!-- comment-cop:([^>\s]+) -->/;
 
-            // Fetch existing comment-cop review threads (for dedup + auto-resolve).
-            const threads = [];
-            {
+            // Dedup goes through REST on purpose: GITHUB_TOKEN's GraphQL quota is
+            // shared by every workflow run in the repo and is routinely exhausted,
+            // the REST quota is a separate pool, and a scan that cannot dedup
+            // would re-post every comment already on the PR.
+            const reviewComments = await github.paginate(github.rest.pulls.listReviewComments, {
+              owner, repo, pull_number, per_page: 100,
+            });
+            const seenKeys = new Set();
+            for (const c of reviewComments) {
+              const m = MARKER.exec(c.body || '');
+              if (m) seenKeys.add(m[1]);
+            }
+            const staleKeys = new Set([...seenKeys].filter(k => !presentKeys.has(k)));
+
+            // Ids of the unresolved threads for staleKeys. Thread ids and resolved
+            // state only exist in GraphQL, so this lookup is best effort: when it
+            // fails, nothing gets resolved and the scan below still runs.
+            async function staleThreadIds() {
               const q = `
                 query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
                   repository(owner: $owner, name: $repo) {
@@ -119,25 +135,29 @@ jobs:
                     }
                   }
                 }`;
+              const ids = [];
               let after = null;
               for (;;) {
                 const res = await github.graphql(q, { owner, repo, pr: pull_number, after });
                 const page = res.repository.pullRequest.reviewThreads;
-                for (const t of page.nodes) threads.push(t);
+                for (const t of page.nodes) {
+                  if (t.isResolved) continue;
+                  const m = MARKER.exec(t.comments.nodes[0]?.body || '');
+                  if (m && staleKeys.has(m[1])) ids.push(t.id);
+                }
                 if (!page.pageInfo.hasNextPage) break;
                 after = page.pageInfo.endCursor;
               }
+              return ids;
             }
 
-            const seenKeys = new Set();
-            const toResolve = [];
-            for (const t of threads) {
-              const body = t.comments.nodes[0]?.body || '';
-              const m = /<!-- comment-cop:([^>\s]+) -->/.exec(body);
-              if (!m) continue;
-              const key = m[1];
-              seenKeys.add(key);
-              if (!t.isResolved && !presentKeys.has(key)) toResolve.push(t.id);
+            let toResolve = [];
+            if (staleKeys.size > 0) {
+              try {
+                toResolve = await staleThreadIds();
+              } catch (e) {
+                core.warning(`Listing review threads failed, not resolving up to ${staleKeys.size} stale comment-cop thread(s): ${e.message}`);
+              }
             }
 
             // Auto-resolve threads whose flagged block is gone from the current diff.

--- a/.github/workflows/source-lints.yml
+++ b/.github/workflows/source-lints.yml
@@ -24,6 +24,7 @@ on:
       - "test/_util/**"
       - "test/internal/source-lints/**"
       - ".github/workflows/source-lints.yml"
+      - ".github/workflows/comment-cop.yml"
       - ".github/actions/setup-bun/**"
   pull_request:
     paths:
@@ -39,6 +40,7 @@ on:
       - "test/_util/**"
       - "test/internal/source-lints/**"
       - ".github/workflows/source-lints.yml"
+      - ".github/workflows/comment-cop.yml"
       - ".github/actions/setup-bun/**"
   merge_group:
 

--- a/test/internal/source-lints/comment-cop.test.ts
+++ b/test/internal/source-lints/comment-cop.test.ts
@@ -1,14 +1,12 @@
 /**
  * The script embedded in .github/workflows/comment-cop.yml, run the way
- * actions/github-script runs it (as an async function body with `github`,
- * `context`, `core` and `require` in scope) against a fake `github` that
- * records writes instead of sending them.
+ * actions/github-script runs it (an async function body with `require`,
+ * `github`, `context` and `core` in scope) against a fake `github` that
+ * records the comments the script posts instead of sending them.
  *
- * The scenarios pin the workflow's dependence on the two GitHub API quotas:
  * GITHUB_TOKEN's GraphQL quota is shared by every workflow run in the repo and
- * is routinely exhausted, so scanning, dedup and posting have to work with
- * GraphQL unavailable, and only the auto-resolve of stale threads (thread ids
- * and resolved state exist only in GraphQL) may depend on it, as a warning.
+ * is routinely exhausted, so the fake fails every GraphQL request the way
+ * GitHub does then; the step has to dedup and post using REST alone.
  */
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
@@ -34,9 +32,10 @@ const PATH = "src/runtime/example.rs";
 
 /** Same key the workflow derives for a comment group: path plus a hash of the comment text. */
 const keyFor = (text: string) => `${PATH}:${createHash("sha256").update(text).digest("hex").slice(0, 12)}`;
-const markerComment = (key: string) => `<!-- comment-cop:${key} -->\nplease delete this comment\n`;
+/** What one of the workflow's own comments looks like when read back from the PR. */
+const botComment = (key: string) => `<!-- comment-cop:${key} -->\nplease delete this comment\n`;
 
-// Two three-line comment groups added at lines 2-4 and 6-8 of the new file.
+// Two three-line comment groups, added at lines 2-4 and 6-8 of the new file.
 const firstGroup = ["// first group, line one", "// first group, line two", "// first group, line three"];
 const secondGroup = ["// second group, line one", "// second group, line two", "// second group, line three"];
 const patch = [
@@ -50,9 +49,8 @@ const patch = [
 ].join("\n");
 const FIRST = keyFor(firstGroup.join("\n"));
 const SECOND = keyFor(secondGroup.join("\n"));
-/** Flagged on an earlier push, and the comment it flagged is no longer in the diff. */
-const STALE_UNRESOLVED = `${PATH}:000000000001`;
-const STALE_RESOLVED = `${PATH}:000000000002`;
+/** Flagged on an earlier push; the comment it flagged is no longer in the diff. */
+const STALE = `${PATH}:000000000001`;
 
 const expectedPost = (key: string, start: number, end: number) => ({
   owner: "oven-sh",
@@ -67,74 +65,34 @@ const expectedPost = (key: string, start: number, end: number) => ({
   body: expect.stringContaining(`<!-- comment-cop:${key} -->`),
 });
 
-const rateLimitError = () =>
-  Object.assign(
-    new Error(
-      "Request failed due to following response errors:\n - API rate limit already exceeded for site ID installation.",
-    ),
-    { name: "GraphqlResponseError", errors: [{ type: "RATE_LIMIT", code: "graphql_rate_limit" }] },
-  );
-
-type Thread = { id: string; isResolved: boolean; comments: { nodes: { body: string }[] } };
-const thread = (id: string, body: string | null, isResolved = false): Thread => ({
-  id,
-  isResolved,
-  comments: { nodes: body === null ? [] : [{ body }] },
-});
-
-interface Scenario {
-  /** Bodies of the review comments already on the PR, as `pulls.listReviewComments` returns them. */
-  reviewComments: string[];
-  /** Pages served for the reviewThreads query; omitted means every GraphQL request fails on the rate limit. */
-  threadPages?: Thread[][];
-}
-
-async function scan({ reviewComments, threadPages }: Scenario) {
-  const posted: unknown[] = [];
-  const resolved: string[] = [];
+/** Bodies of the review comments already on the PR, as `pulls.listReviewComments` returns them. */
+async function scan(reviewComments: string[]) {
+  const posted: { body: string }[] = [];
   const graphqlRequests: string[] = [];
-  const restPaginated: string[] = [];
   const warnings: string[] = [];
-  const info: string[] = [];
 
-  const endpoint = <T>(name: string, rows: () => T[]) =>
-    Object.assign(async () => ({ data: rows() }), { endpointName: name });
   const github = {
     rest: {
       pulls: {
-        listFiles: endpoint("pulls.listFiles", () => [{ filename: PATH, status: "modified", patch }]),
-        listReviewComments: endpoint("pulls.listReviewComments", () =>
-          reviewComments.map((body, i) => ({ id: i + 1, body, user: { login: "github-actions[bot]" } })),
-        ),
-        createReviewComment: async (params: unknown) => {
+        listFiles: async () => ({ data: [{ filename: PATH, status: "modified", patch }] }),
+        listReviewComments: async () => ({
+          data: reviewComments.map((body, i) => ({ id: i + 1, body, user: { login: "github-actions[bot]" } })),
+        }),
+        createReviewComment: async (params: { body: string }) => {
           posted.push(params);
           return { data: {} };
         },
       },
     },
-    paginate: async (fn: { endpointName: string; (): Promise<{ data: unknown[] }> }) => {
-      restPaginated.push(fn.endpointName);
-      return (await fn()).data;
-    },
-    graphql: async (query: string, variables: { id?: string; after?: string | null }) => {
-      const isMutation = /^\s*mutation\b/.test(query);
-      graphqlRequests.push(isMutation ? "mutation" : "query");
-      if (threadPages === undefined) throw rateLimitError();
-      if (isMutation) {
-        resolved.push(variables.id!);
-        return { resolveReviewThread: { thread: { id: variables.id } } };
-      }
-      const pageIndex = variables.after == null ? 0 : Number(variables.after);
-      return {
-        repository: {
-          pullRequest: {
-            reviewThreads: {
-              pageInfo: { hasNextPage: pageIndex + 1 < threadPages.length, endCursor: String(pageIndex + 1) },
-              nodes: threadPages[pageIndex],
-            },
-          },
-        },
-      };
+    paginate: async (endpoint: () => Promise<{ data: unknown[] }>) => (await endpoint()).data,
+    graphql: async (query: string) => {
+      graphqlRequests.push(query);
+      throw Object.assign(
+        new Error(
+          "Request failed due to following response errors:\n - API rate limit already exceeded for site ID installation.",
+        ),
+        { name: "GraphqlResponseError", errors: [{ type: "RATE_LIMIT", code: "graphql_rate_limit" }] },
+      );
     },
   };
   const context = {
@@ -142,90 +100,35 @@ async function scan({ reviewComments, threadPages }: Scenario) {
     payload: { pull_request: { number: 4242, head: { sha: HEAD_SHA }, base: { ref: "main" } } },
   };
   const core = {
-    info: (message: string) => info.push(message),
+    info: () => {},
     warning: (message: string) => warnings.push(message),
   };
 
   await runScan(require, github, context, core);
-  return { posted, resolved, graphqlRequests, restPaginated, warnings, info };
+  return { posted, graphqlRequests, warnings };
 }
 
 describe("comment-cop with the GraphQL quota exhausted", () => {
-  test("still posts the new groups and dedups the already flagged one", async () => {
-    const result = await scan({
-      reviewComments: [
-        markerComment(FIRST),
-        "nit: rename this (a human review comment)",
-        markerComment(STALE_UNRESOLVED),
-      ],
-    });
-    expect(result).toEqual({
+  test("posts the groups that are not flagged yet and skips the one that is", async () => {
+    expect(await scan([botComment(FIRST), "nit: rename this (a human review comment)", botComment(STALE)])).toEqual({
       posted: [expectedPost(SECOND, 6, 8)],
-      resolved: [],
-      // The stale key makes it try the thread lookup once; the failure is a warning, not a failed check.
-      graphqlRequests: ["query"],
-      restPaginated: ["pulls.listFiles", "pulls.listReviewComments"],
-      warnings: [expect.stringContaining("API rate limit already exceeded")],
-      info: ["Posted 1 review comment(s)."],
-    });
-  });
-
-  test("does not touch GraphQL when no flagged block has gone stale", async () => {
-    const result = await scan({ reviewComments: [markerComment(FIRST), "looks good"] });
-    expect(result).toEqual({
-      posted: [expectedPost(SECOND, 6, 8)],
-      resolved: [],
       graphqlRequests: [],
-      restPaginated: ["pulls.listFiles", "pulls.listReviewComments"],
       warnings: [],
-      info: ["Posted 1 review comment(s)."],
     });
   });
 
-  test("a second run after posting finds its own comments through REST and posts nothing", async () => {
-    const firstRun = await scan({ reviewComments: [] });
-    expect(firstRun.posted).toEqual([expectedPost(FIRST, 2, 4), expectedPost(SECOND, 6, 8)]);
+  test("a second run recognizes the comments the first run posted and posts nothing", async () => {
+    const firstRun = await scan([]);
+    expect(firstRun).toEqual({
+      posted: [expectedPost(FIRST, 2, 4), expectedPost(SECOND, 6, 8)],
+      graphqlRequests: [],
+      warnings: [],
+    });
 
-    const secondRun = await scan({ reviewComments: firstRun.posted.map(params => (params as { body: string }).body) });
-    expect(secondRun).toEqual({
+    expect(await scan(firstRun.posted.map(comment => comment.body))).toEqual({
       posted: [],
-      resolved: [],
       graphqlRequests: [],
-      restPaginated: ["pulls.listFiles", "pulls.listReviewComments"],
       warnings: [],
-      info: ["No new comment groups to flag (2 present, all already flagged)."],
-    });
-  });
-});
-
-describe("comment-cop with GraphQL available", () => {
-  test("resolves only the unresolved threads whose flagged block left the diff", async () => {
-    const result = await scan({
-      reviewComments: [
-        markerComment(FIRST),
-        markerComment(STALE_UNRESOLVED),
-        markerComment(STALE_RESOLVED),
-        "nit: rename this (a human review comment)",
-      ],
-      threadPages: [
-        [
-          thread("THREAD_FIRST", markerComment(FIRST)),
-          thread("THREAD_STALE_UNRESOLVED", markerComment(STALE_UNRESOLVED)),
-        ],
-        [
-          thread("THREAD_STALE_RESOLVED", markerComment(STALE_RESOLVED), true),
-          thread("THREAD_HUMAN", "nit: rename this (a human review comment)"),
-          thread("THREAD_EMPTY", null),
-        ],
-      ],
-    });
-    expect(result).toEqual({
-      posted: [expectedPost(SECOND, 6, 8)],
-      resolved: ["THREAD_STALE_UNRESOLVED"],
-      graphqlRequests: ["query", "query", "mutation"],
-      restPaginated: ["pulls.listFiles", "pulls.listReviewComments"],
-      warnings: [],
-      info: ["Resolved 1 stale comment-cop thread(s).", "Posted 1 review comment(s)."],
     });
   });
 });

--- a/test/internal/source-lints/comment-cop.test.ts
+++ b/test/internal/source-lints/comment-cop.test.ts
@@ -1,0 +1,231 @@
+/**
+ * The script embedded in .github/workflows/comment-cop.yml, run the way
+ * actions/github-script runs it (as an async function body with `github`,
+ * `context`, `core` and `require` in scope) against a fake `github` that
+ * records writes instead of sending them.
+ *
+ * The scenarios pin the workflow's dependence on the two GitHub API quotas:
+ * GITHUB_TOKEN's GraphQL quota is shared by every workflow run in the repo and
+ * is routinely exhausted, so scanning, dedup and posting have to work with
+ * GraphQL unavailable, and only the auto-resolve of stale threads (thread ids
+ * and resolved state exist only in GraphQL) may depend on it, as a warning.
+ */
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..", "..", "..");
+
+const workflow = Bun.YAML.parse(readFileSync(join(repoRoot, ".github", "workflows", "comment-cop.yml"), "utf8")) as {
+  jobs: { "comment-cop": { steps: { with?: { script?: string } }[] } };
+};
+const scanScript = workflow.jobs["comment-cop"].steps.find(step => step.with?.script)!.with!.script!;
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
+  ...args: string[]
+) => (...args: unknown[]) => Promise<unknown>;
+const runScan = new AsyncFunction("require", "github", "context", "core", scanScript);
+const require = createRequire(import.meta.url);
+
+const HEAD_SHA = "0123456789abcdef0123456789abcdef01234567";
+const PATH = "src/runtime/example.rs";
+
+/** Same key the workflow derives for a comment group: path plus a hash of the comment text. */
+const keyFor = (text: string) => `${PATH}:${createHash("sha256").update(text).digest("hex").slice(0, 12)}`;
+const markerComment = (key: string) => `<!-- comment-cop:${key} -->\nplease delete this comment\n`;
+
+// Two three-line comment groups added at lines 2-4 and 6-8 of the new file.
+const firstGroup = ["// first group, line one", "// first group, line two", "// first group, line three"];
+const secondGroup = ["// second group, line one", "// second group, line two", "// second group, line three"];
+const patch = [
+  "@@ -1,2 +1,9 @@",
+  " use bun_core::Output;",
+  ...firstGroup.map(line => `+${line}`),
+  "+fn first() {}",
+  ...secondGroup.map(line => `+${line}`),
+  "+fn second() {}",
+  " fn existing() {}",
+].join("\n");
+const FIRST = keyFor(firstGroup.join("\n"));
+const SECOND = keyFor(secondGroup.join("\n"));
+/** Flagged on an earlier push, and the comment it flagged is no longer in the diff. */
+const STALE_UNRESOLVED = `${PATH}:000000000001`;
+const STALE_RESOLVED = `${PATH}:000000000002`;
+
+const expectedPost = (key: string, start: number, end: number) => ({
+  owner: "oven-sh",
+  repo: "bun",
+  pull_number: 4242,
+  commit_id: HEAD_SHA,
+  path: PATH,
+  start_line: start,
+  start_side: "RIGHT",
+  line: end,
+  side: "RIGHT",
+  body: expect.stringContaining(`<!-- comment-cop:${key} -->`),
+});
+
+const rateLimitError = () =>
+  Object.assign(
+    new Error(
+      "Request failed due to following response errors:\n - API rate limit already exceeded for site ID installation.",
+    ),
+    { name: "GraphqlResponseError", errors: [{ type: "RATE_LIMIT", code: "graphql_rate_limit" }] },
+  );
+
+type Thread = { id: string; isResolved: boolean; comments: { nodes: { body: string }[] } };
+const thread = (id: string, body: string | null, isResolved = false): Thread => ({
+  id,
+  isResolved,
+  comments: { nodes: body === null ? [] : [{ body }] },
+});
+
+interface Scenario {
+  /** Bodies of the review comments already on the PR, as `pulls.listReviewComments` returns them. */
+  reviewComments: string[];
+  /** Pages served for the reviewThreads query; omitted means every GraphQL request fails on the rate limit. */
+  threadPages?: Thread[][];
+}
+
+async function scan({ reviewComments, threadPages }: Scenario) {
+  const posted: unknown[] = [];
+  const resolved: string[] = [];
+  const graphqlRequests: string[] = [];
+  const restPaginated: string[] = [];
+  const warnings: string[] = [];
+  const info: string[] = [];
+
+  const endpoint = <T>(name: string, rows: () => T[]) =>
+    Object.assign(async () => ({ data: rows() }), { endpointName: name });
+  const github = {
+    rest: {
+      pulls: {
+        listFiles: endpoint("pulls.listFiles", () => [{ filename: PATH, status: "modified", patch }]),
+        listReviewComments: endpoint("pulls.listReviewComments", () =>
+          reviewComments.map((body, i) => ({ id: i + 1, body, user: { login: "github-actions[bot]" } })),
+        ),
+        createReviewComment: async (params: unknown) => {
+          posted.push(params);
+          return { data: {} };
+        },
+      },
+    },
+    paginate: async (fn: { endpointName: string; (): Promise<{ data: unknown[] }> }) => {
+      restPaginated.push(fn.endpointName);
+      return (await fn()).data;
+    },
+    graphql: async (query: string, variables: { id?: string; after?: string | null }) => {
+      const isMutation = /^\s*mutation\b/.test(query);
+      graphqlRequests.push(isMutation ? "mutation" : "query");
+      if (threadPages === undefined) throw rateLimitError();
+      if (isMutation) {
+        resolved.push(variables.id!);
+        return { resolveReviewThread: { thread: { id: variables.id } } };
+      }
+      const pageIndex = variables.after == null ? 0 : Number(variables.after);
+      return {
+        repository: {
+          pullRequest: {
+            reviewThreads: {
+              pageInfo: { hasNextPage: pageIndex + 1 < threadPages.length, endCursor: String(pageIndex + 1) },
+              nodes: threadPages[pageIndex],
+            },
+          },
+        },
+      };
+    },
+  };
+  const context = {
+    repo: { owner: "oven-sh", repo: "bun" },
+    payload: { pull_request: { number: 4242, head: { sha: HEAD_SHA }, base: { ref: "main" } } },
+  };
+  const core = {
+    info: (message: string) => info.push(message),
+    warning: (message: string) => warnings.push(message),
+  };
+
+  await runScan(require, github, context, core);
+  return { posted, resolved, graphqlRequests, restPaginated, warnings, info };
+}
+
+describe("comment-cop with the GraphQL quota exhausted", () => {
+  test("still posts the new groups and dedups the already flagged one", async () => {
+    const result = await scan({
+      reviewComments: [
+        markerComment(FIRST),
+        "nit: rename this (a human review comment)",
+        markerComment(STALE_UNRESOLVED),
+      ],
+    });
+    expect(result).toEqual({
+      posted: [expectedPost(SECOND, 6, 8)],
+      resolved: [],
+      // The stale key makes it try the thread lookup once; the failure is a warning, not a failed check.
+      graphqlRequests: ["query"],
+      restPaginated: ["pulls.listFiles", "pulls.listReviewComments"],
+      warnings: [expect.stringContaining("API rate limit already exceeded")],
+      info: ["Posted 1 review comment(s)."],
+    });
+  });
+
+  test("does not touch GraphQL when no flagged block has gone stale", async () => {
+    const result = await scan({ reviewComments: [markerComment(FIRST), "looks good"] });
+    expect(result).toEqual({
+      posted: [expectedPost(SECOND, 6, 8)],
+      resolved: [],
+      graphqlRequests: [],
+      restPaginated: ["pulls.listFiles", "pulls.listReviewComments"],
+      warnings: [],
+      info: ["Posted 1 review comment(s)."],
+    });
+  });
+
+  test("a second run after posting finds its own comments through REST and posts nothing", async () => {
+    const firstRun = await scan({ reviewComments: [] });
+    expect(firstRun.posted).toEqual([expectedPost(FIRST, 2, 4), expectedPost(SECOND, 6, 8)]);
+
+    const secondRun = await scan({ reviewComments: firstRun.posted.map(params => (params as { body: string }).body) });
+    expect(secondRun).toEqual({
+      posted: [],
+      resolved: [],
+      graphqlRequests: [],
+      restPaginated: ["pulls.listFiles", "pulls.listReviewComments"],
+      warnings: [],
+      info: ["No new comment groups to flag (2 present, all already flagged)."],
+    });
+  });
+});
+
+describe("comment-cop with GraphQL available", () => {
+  test("resolves only the unresolved threads whose flagged block left the diff", async () => {
+    const result = await scan({
+      reviewComments: [
+        markerComment(FIRST),
+        markerComment(STALE_UNRESOLVED),
+        markerComment(STALE_RESOLVED),
+        "nit: rename this (a human review comment)",
+      ],
+      threadPages: [
+        [
+          thread("THREAD_FIRST", markerComment(FIRST)),
+          thread("THREAD_STALE_UNRESOLVED", markerComment(STALE_UNRESOLVED)),
+        ],
+        [
+          thread("THREAD_STALE_RESOLVED", markerComment(STALE_RESOLVED), true),
+          thread("THREAD_HUMAN", "nit: rename this (a human review comment)"),
+          thread("THREAD_EMPTY", null),
+        ],
+      ],
+    });
+    expect(result).toEqual({
+      posted: [expectedPost(SECOND, 6, 8)],
+      resolved: ["THREAD_STALE_UNRESOLVED"],
+      graphqlRequests: ["query", "query", "mutation"],
+      restPaginated: ["pulls.listFiles", "pulls.listReviewComments"],
+      warnings: [],
+      info: ["Resolved 1 stale comment-cop thread(s).", "Posted 1 review comment(s)."],
+    });
+  });
+});


### PR DESCRIPTION
### Problem

- The `Comment Cop` check is red on every claude-labeled PR whenever the repo's GraphQL quota is used up. The step dies before it scans anything:
  ```
  GraphqlResponseError: Request failed due to following response errors:
   - API rate limit already exceeded for site ID installation.
  ##[error]Unhandled error: GraphqlResponseError: ...
  ```
  with `x-ratelimit-resource: graphql`, `x-ratelimit-limit: 10000`, `x-ratelimit-remaining: 0` (run [31898901053](https://github.com/oven-sh/bun/actions/runs/31898901053) on #39139). All 33 comment-cop failures on Aug 15 are this error (197 runs succeeded, 171 were skipped); they hit unrelated PRs at the same time because the quota is shared by every workflow run in the repo, and they come back whenever PR volume is high.
- Cause, `.github/workflows/comment-cop.yml:124` on main: the step reads the PR's existing review threads with `github.graphql()`, outside any `try`, and dedup and posting both sit behind that call. The REST call just before it (`pulls.listFiles`) had succeeded in each failing run, so the step had the diff; it only lacked the dedup data, which it was reading from the exhausted quota.
- The same thread data also fed an auto-resolve of stale threads. That part does not work: under the Actions `GITHUB_TOKEN` every `resolveReviewThread` mutation fails with `Resource not accessible by integration`, after which the step still logs `Resolved N stale comment-cop thread(s).` Two successful runs from today: [31900717034](https://github.com/oven-sh/bun/actions/runs/31900717034) (20 attempted, 20 failed, "Resolved 20") and [31900354924](https://github.com/oven-sh/bun/actions/runs/31900354924) (4 attempted, 4 failed, "Resolved 4"). #36959 documents the same thing and is the PR that moves resolution to a token that can do it. So the GraphQL query was paying for one thing REST can provide and one thing that does not happen.

### Fix

- Dedup reads the PR's review comments with `pulls.listReviewComments` (REST) and collects the `<!-- comment-cop:KEY -->` markers from them. Every comment the step posts starts with that marker, so the review comments carry the same keys the thread roots did; REST is the quota the step already needs for `listFiles` and `createReviewComment`, and it was available in every failing run.
- The GraphQL query and the resolve loop are removed, so the step makes no GraphQL request at all; the failure in the Problem section cannot happen, rather than being caught. Nothing observable is lost: the mutations the loop issued all fail today, and the only other thing it did was log `Resolved N stale comment-cop thread(s).` after they had failed. Resolving stale threads stays with #36959, which will also need to move its thread lookup into its token step, since this PR removes the `GITHUB_TOKEN` lookup it currently reuses (noted there).
- What the step posts is unchanged: the script on main and the REST dedup were dry-run (real reads, writes recorded) against 9 PRs carrying existing comment-cop threads (#35988, #36956, #36713, #35635, #33632, #35596, #39139, #30609, #36959) and chose the same comments to post on every one of them; the canned scenarios below show the same thing with GraphQL working and with it exhausted.
- Test: `test/internal/source-lints/comment-cop.test.ts` extracts the script from the workflow and runs it the way `actions/github-script` does, against a fake `github` whose GraphQL requests all fail with the rate limit error above. It checks that groups not yet flagged are posted with the right line ranges, that a group already flagged (and a stale marker) are left alone, that a second run recognizes the comments the first run posted and posts nothing, and that no GraphQL request is made. Both tests fail against the workflow on main (the script throws the error above) and pass with this change. `source-lints.yml` now also triggers on changes to `comment-cop.yml`, so the test runs whenever the script is edited; it is excluded from the Buildkite shards like the rest of that directory.
- Also ran: `bun bd test test/internal/source-lints/comment-cop.test.ts`, `bun test test/internal/source-lints/` (whole directory green), prettier on the three files. The comment-cop run on this PR itself still executes the script from main (`pull_request_target`), so the `Source lints` job is the one that exercises the change here.
- Does not overlap with #37948 (which groups are flagged) or #38127 (where the file list comes from); both touch other parts of the script. #36959 rewrites the block this PR deletes and will need a rebase either way.

### Background

- Comment Cop (`.github/workflows/comment-cop.yml`): on each push to a claude-labeled PR it reads the PR diff, finds multi-line comments added under `src/`, and posts one review comment per comment block. Each bot comment starts with `<!-- comment-cop:KEY -->`, KEY being the file path plus a hash of the block's text; a block whose KEY is already on the PR is not posted again. The check is advisory (not required for merge).
- GitHub API quotas: REST and GraphQL requests count against separate hourly quotas (`x-ratelimit-resource` is `core` for REST and `graphql` for GraphQL). For the `GITHUB_TOKEN` Actions hands out, each quota is per repository, so every workflow run in oven-sh/bun draws on the same two pools, and GraphQL-heavy automation (the `gh pr` / `gh issue` / `gh search` commands used by other workflows go through GraphQL) empties the GraphQL pool for everything else when PR volume is high.
- Review threads vs review comments: a review thread is GraphQL's grouping of a line comment with its replies, and is the only place a thread's id (what `resolveReviewThread` takes) and its resolved flag exist. `GET /repos/{owner}/{repo}/pulls/{n}/comments` returns every review comment on the PR, including each thread's root comment, so the markers are reachable from REST; only resolving needs GraphQL, and under `GITHUB_TOKEN` GitHub refuses that mutation regardless of the `pull-requests: write` permission.

<details>
<summary>Script on main vs this branch against a fake github (the fake's resolve mutation fails the way GITHUB_TOKEN's does)</summary>

```
main   | quota ok, stale threads present                        | exit 0                                   | posts ["src/foo.ts:5-6"] | resolve attempts ["T_STALE_OPEN"] | graphql ["query","query","mutation"] | warnings 1
main   | graphql quota exhausted, stale threads present         | step fails (unhandled rate limit error)  | posts [] | resolve attempts [] | graphql ["query"] | warnings 0
main   | graphql quota exhausted, nothing stale                 | step fails (unhandled rate limit error)  | posts [] | resolve attempts [] | graphql ["query"] | warnings 0
main   | graphql quota exhausted, PR has no review comments yet | step fails (unhandled rate limit error)  | posts [] | resolve attempts [] | graphql ["query"] | warnings 0
fixed  | quota ok, stale threads present                        | exit 0                                   | posts ["src/foo.ts:5-6"] | resolve attempts [] | graphql [] | warnings 0
fixed  | graphql quota exhausted, stale threads present         | exit 0                                   | posts ["src/foo.ts:5-6"] | resolve attempts [] | graphql [] | warnings 0
fixed  | graphql quota exhausted, nothing stale                 | exit 0                                   | posts ["src/foo.ts:5-6"] | resolve attempts [] | graphql [] | warnings 0
fixed  | graphql quota exhausted, PR has no review comments yet | exit 0                                   | posts ["src/foo.ts:2-3","src/foo.ts:5-6"] | resolve attempts [] | graphql [] | warnings 0
```

</details>

<details>
<summary>Dry-run against live PRs: comments the script on main would post vs the REST dedup (real reads through a user token, writes recorded)</summary>

```
PR #35988: same posts (0 vs 0)        245 threads on the PR are stale; main attempts to resolve them, this branch does not
PR #36956: same posts (0 vs 0)
PR #36713: same posts (1832 vs 1832)  the stale cached file list that #38127 fixes; identical on both
PR #35635: same posts (0 vs 0)
PR #33632: same posts (0 vs 0)
PR #35596: same posts (0 vs 0)
PR #39139: same posts (1 vs 1)        the comment the failing run above did not get to post
PR #30609: same posts (0 vs 0)
PR #36959: same posts (0 vs 0)
```

</details>

<details>
<summary>Headers from the failing run</summary>

```
errors: [ { type: 'RATE_LIMIT', code: 'graphql_rate_limit',
            message: 'API rate limit already exceeded for site ID installation.' } ]
variables: { owner: 'oven-sh', repo: 'bun', pr: 39139, after: null }
'x-ratelimit-limit': '10000'
'x-ratelimit-remaining': '0'
'x-ratelimit-resource': 'graphql'
'x-ratelimit-used': '10000'
```

</details>
