### PR TITLE
bundler: read destructured require() of an unwrapped package from its import namespace

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2401,7 +2401,7 @@ pub type UnwrappedRequireIndexOptional =
 pub struct RequireString {
     pub import_record_index: u32,
 
-    /// Set when `unwrap_commonjs_to_esm` turned this `require()` into an import.
+    /// Set when unwrapping `const x = require()` into an import; consumed by `visit_decls`.
     pub unwrapped_id: UnwrappedRequireIndexOptional,
 }
 impl Default for RequireString {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2309,25 +2309,16 @@ impl<'a> LinkerContext<'a> {
     pub(crate) fn require_or_import_meta_for_source(
         &mut self,
         source_index: crate::IndexInt,
-        was_unwrapped_require: bool,
     ) -> js_printer::RequireOrImportMeta {
         let flags = self.graph.meta.items_flags()[source_index as usize];
         js_printer::RequireOrImportMeta {
-            exports_ref: if flags.wrap == WrapKind::Esm
-                || (was_unwrapped_require
-                    && self.graph.ast.items_flags()[source_index as usize]
-                        .contains(AstFlags::FORCE_CJS_TO_ESM))
-            {
+            exports_ref: if flags.wrap == WrapKind::Esm {
                 self.graph.ast.items_exports_ref()[source_index as usize]
             } else {
                 Ref::NONE
             },
             is_wrapper_async: flags.is_async_or_has_async_dependency,
             wrapper_ref: self.graph.ast.items_wrapper_ref()[source_index as usize],
-
-            was_unwrapped_require: was_unwrapped_require
-                && self.graph.ast.items_flags()[source_index as usize]
-                    .contains(AstFlags::FORCE_CJS_TO_ESM),
         }
     }
 
@@ -2562,12 +2553,8 @@ impl<'a> LinkerContext<'a> {
 /// can call back into `LinkerContext::require_or_import_meta_for_source`.
 impl<'a> js_printer::RequireOrImportMetaSource for LinkerContext<'a> {
     #[inline]
-    fn require_or_import_meta_for_source(
-        &mut self,
-        id: u32,
-        was_unwrapped_require: bool,
-    ) -> js_printer::RequireOrImportMeta {
-        LinkerContext::require_or_import_meta_for_source(self, id, was_unwrapped_require)
+    fn require_or_import_meta_for_source(&mut self, id: u32) -> js_printer::RequireOrImportMeta {
+        LinkerContext::require_or_import_meta_for_source(self, id)
     }
 }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1011,8 +1011,7 @@ pub struct ExprIn {
     /// tests.
     pub(crate) assign_target: js_ast::AssignTarget,
 
-    /// Currently this is only used when unwrapping a call to `require()`
-    /// with `__toESM()`.
+    /// Identifier-binding initializer; only used to unwrap `const x = require()` into an import.
     pub(crate) is_immediately_assigned_to_decl: bool,
 
     pub(crate) property_access_for_method_call_maybe_should_replace_with_undefined: bool,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -320,7 +320,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.visit_expr_in_out(
                     &mut val,
                     ExprIn {
-                        is_immediately_assigned_to_decl: true,
+                        // Only the identifier unwrap below consumes the marker this requests.
+                        is_immediately_assigned_to_decl: matches!(
+                            decl.binding.data,
+                            BData::BIdentifier(_)
+                        ),
                         ..Default::default()
                     },
                 );

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1194,11 +1194,7 @@ pub struct Options<'a> {
 }
 
 impl<'a> Options<'a> {
-    pub(crate) fn require_or_import_meta_for_source(
-        &self,
-        id: u32,
-        was_unwrapped_require: bool,
-    ) -> RequireOrImportMeta {
+    pub(crate) fn require_or_import_meta_for_source(&self, id: u32) -> RequireOrImportMeta {
         if self
             .require_or_import_meta_for_source_callback
             .ctx
@@ -1206,8 +1202,7 @@ impl<'a> Options<'a> {
         {
             return RequireOrImportMeta::default();
         }
-        self.require_or_import_meta_for_source_callback
-            .call(id, was_unwrapped_require)
+        self.require_or_import_meta_for_source_callback.call(id)
     }
 }
 
@@ -1281,7 +1276,6 @@ pub struct RequireOrImportMeta {
     pub wrapper_ref: Ref,
     pub exports_ref: Ref,
     pub is_wrapper_async: bool,
-    pub was_unwrapped_require: bool,
 }
 
 // Clone/Copy: bitwise OK — `ctx` is a non-owning opaque backref the caller
@@ -1289,12 +1283,12 @@ pub struct RequireOrImportMeta {
 #[derive(Clone, Copy)]
 pub struct RequireOrImportMetaCallback {
     pub(crate) ctx: Option<NonNull<()>>,
-    pub(crate) callback: fn(*mut (), u32, bool) -> RequireOrImportMeta,
+    pub(crate) callback: fn(*mut (), u32) -> RequireOrImportMeta,
 }
 
 impl Default for RequireOrImportMetaCallback {
     fn default() -> Self {
-        fn noop(_: *mut (), _: u32, _: bool) -> RequireOrImportMeta {
+        fn noop(_: *mut (), _: u32) -> RequireOrImportMeta {
             RequireOrImportMeta::default()
         }
         Self {
@@ -1307,28 +1301,20 @@ impl Default for RequireOrImportMetaCallback {
 /// PORTING.md §Dispatch — manual vtable. The erased thunk is monomorphized
 /// over `T: RequireOrImportMetaSource`, so `callback` stays a captureless `fn`.
 pub trait RequireOrImportMetaSource {
-    fn require_or_import_meta_for_source(
-        &mut self,
-        id: u32,
-        was_unwrapped_require: bool,
-    ) -> RequireOrImportMeta;
+    fn require_or_import_meta_for_source(&mut self, id: u32) -> RequireOrImportMeta;
 }
 
 impl RequireOrImportMetaCallback {
-    pub(crate) fn call(&self, id: u32, was_unwrapped_require: bool) -> RequireOrImportMeta {
-        (self.callback)(self.ctx.unwrap().as_ptr(), id, was_unwrapped_require)
+    pub(crate) fn call(&self, id: u32) -> RequireOrImportMeta {
+        (self.callback)(self.ctx.unwrap().as_ptr(), id)
     }
 
     pub fn init<T: RequireOrImportMetaSource>(ctx: &mut T) -> Self {
-        fn thunk<T: RequireOrImportMetaSource>(
-            p: *mut (),
-            id: u32,
-            was_unwrapped_require: bool,
-        ) -> RequireOrImportMeta {
+        fn thunk<T: RequireOrImportMetaSource>(p: *mut (), id: u32) -> RequireOrImportMeta {
             // SAFETY: `p` was constructed from `&mut T` in `init` below; caller guarantees
             // `ctx` outlives this `RequireOrImportMetaCallback`, so the cast-back
             // deref is valid and exclusive.
-            unsafe { (*p.cast::<T>()).require_or_import_meta_for_source(id, was_unwrapped_require) }
+            unsafe { (*p.cast::<T>()).require_or_import_meta_for_source(id) }
         }
         Self {
             // Type-erased to `*mut ()` and cast back to `*mut T` inside the thunk before dereference.
@@ -1822,7 +1808,6 @@ pub(crate) mod __gated_printer {
                 match statement {
                     None => self.print_require_or_import_expr(
                         import.import_record_index,
-                        false,
                         &[],
                         Expr::EMPTY,
                         Level::Lowest,
@@ -1843,7 +1828,6 @@ pub(crate) mod __gated_printer {
                         self.print_equals();
                         self.print_require_or_import_expr(
                             import.import_record_index,
-                            false,
                             &[],
                             Expr::EMPTY,
                             Level::Lowest,
@@ -1893,7 +1877,6 @@ pub(crate) mod __gated_printer {
                     match statement {
                         None => self.print_require_or_import_expr(
                             import.import_record_index,
-                            false,
                             &[],
                             Expr::EMPTY,
                             Level::Lowest,
@@ -2455,7 +2438,6 @@ pub(crate) mod __gated_printer {
         pub(crate) fn print_require_or_import_expr(
             &mut self,
             import_record_index: u32,
-            was_unwrapped_require: bool,
             leading_interior_comments: &[G::Comment],
             import_options: Expr,
             level_: Level,
@@ -2504,10 +2486,9 @@ pub(crate) mod __gated_printer {
             }
 
             if record.source_index.is_valid() {
-                let mut meta = self.options.require_or_import_meta_for_source(
-                    record.source_index.get(),
-                    was_unwrapped_require,
-                );
+                let mut meta = self
+                    .options
+                    .require_or_import_meta_for_source(record.source_index.get());
 
                 // Don't need the namespace object if the result is unused anyway
                 if flags.contains(ExprFlag::ExprResultIsUnused) {
@@ -2534,7 +2515,6 @@ pub(crate) mod __gated_printer {
                 // Internal "require()" or "import()"
                 let has_side_effects = meta.wrapper_ref.is_valid()
                     || meta.exports_ref.is_valid()
-                    || meta.was_unwrapped_require
                     || self.options.input_files_for_dev_server.is_some();
                 if record.kind == ImportKind::Dynamic {
                     self.print_space_before_identifier();
@@ -2568,7 +2548,7 @@ pub(crate) mod __gated_printer {
                     let path = &input_files[record.source_index.get() as usize].path;
                     self.print_string_literal_utf8(path.pretty, false);
                     self.print(b")");
-                } else if !meta.was_unwrapped_require {
+                } else {
                     // Call the wrapper
                     if meta.wrapper_ref.is_valid() {
                         self.print_space_before_identifier();
@@ -2595,10 +2575,6 @@ pub(crate) mod __gated_printer {
                         if wrap_with_to_cjs {
                             self.print(b")");
                         }
-                    }
-                } else {
-                    if !meta.exports_ref.is_empty() {
-                        self.print_symbol(meta.exports_ref);
                     }
                 }
 
@@ -3313,9 +3289,10 @@ pub(crate) mod __gated_printer {
                     }
                 }
                 ExprData::ERequireString(e) => {
+                    // An unwrapped require() is consumed by the parser's visit_decls, never printed.
+                    debug_assert!(e.unwrapped_id.is_none());
                     self.print_require_or_import_expr(
                         e.import_record_index,
-                        e.unwrapped_id.is_some(),
                         &[],
                         Expr::EMPTY,
                         level,
@@ -3383,7 +3360,6 @@ pub(crate) mod __gated_printer {
                     } else {
                         self.print_require_or_import_expr(
                             e.import_record_index,
-                            false,
                             &[], // e.leading_interior_comments,
                             e.options,
                             level,

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -284,15 +284,70 @@ describe("bundler", () => {
       stdout: "react\nreact\nreact\nreact\nundefined\nreact\nreact\nreact\nreact\nreact\nreact\n1 react\nreact\nreact",
     },
   });
-  // A require() of an unwrapped package that initializes a destructuring
-  // declaration is kept as a require expression that remembers it was
-  // unwrapped, and prints as the namespace object. One inside try/catch is
+  // The required packages assign module.exports, so they stay wrapped in __commonJS.
+  // A destructuring declaration has to read from the import the require() became,
+  // not from the wrapped module's own `exports` binding.
+  itBundled("cjs2esm/UnwrappedModuleRequireDestructured", {
+    files: {
+      "/entry.js": /* js */ `
+        const { react } = require("react");
+        console.log(react);
+
+        let { react: renamed, missing = "fallback" } = require("react");
+        console.log(renamed, missing);
+
+        var { react: { length } } = require("react");
+        console.log(length);
+
+        const before = require("react"),
+          { react: between } = require("react"),
+          after = require("react");
+        console.log(before.react, between, after.react);
+
+        function inFunction() {
+          const { react } = require("react");
+          return react;
+        }
+        console.log(inFunction());
+
+        const [first, second] = require("scheduler");
+        console.log(first, second);
+      `,
+      ...fakeReactNodeModules,
+      "/node_modules/scheduler/index.js": /* js */ `
+        module.exports = ["first", "second"];
+      `,
+      "/node_modules/scheduler/package.json": /* json */ `
+        {
+          "name": "scheduler",
+          "version": "1.0.0",
+          "main": "index.js"
+        }
+      `,
+    },
+    onAfterBundle: api => {
+      const code = api.readFile("out.js");
+      expect(code).toContain("var require_react = __commonJS(");
+      expect(code).toContain("var require_scheduler = __commonJS(");
+      expect(code).toMatch(/\{ react: between \} = \w+;/);
+      expect(code).toMatch(/\[first, second\] = \w+;/);
+    },
+    run: {
+      stdout: "react\nreact fallback\n5\nreact react react\nreact\nfirst second",
+    },
+  });
+  // Against a package that does convert to ESM, a destructuring declaration
+  // reads from the generated namespace object. A require() inside try/catch is
   // never unwrapped and prints as an ordinary require.
   itBundled("cjs2esm/UnwrappedModuleRequireDestructuredAndInTry", {
     files: {
       "/entry.js": /* js */ `
-        const { react: named } = require("react");
-        console.log(named);
+        const { react: named, version = "none" } = require("react");
+        console.log(named, version);
+
+        const whole = require("react"),
+          { react: again } = require("react");
+        console.log(whole.react, again);
 
         let inTry = "missing";
         try {
@@ -313,11 +368,12 @@ describe("bundler", () => {
     },
     onAfterBundle: api => {
       const code = api.readFile("out.js");
-      expect(code).toMatch(/\{ react: named \} = \(?exports_react\)?;/);
+      expect(code).toMatch(/\{ react: named, version = "none" \} = \(?exports_react\)?;/);
+      expect(code).toMatch(/\{ react: again \} = \(?exports_react\)?;/);
       expect(code).toContain("__toCommonJS(exports_react)).react");
     },
     run: {
-      stdout: "react\nreact",
+      stdout: "react none\nreact react\nreact",
     },
   });
   itBundled("cjs2esm/ReactSpecificUnwrapping", {


### PR DESCRIPTION
### Problem
- `bun build` (ESM output, the default) of an entry that destructures a `require()` of a package in the CommonJS unwrap list reads `undefined` for every property when that package's module stays CommonJS (it assigns `module.exports`):
  ```js
  const { react } = require("react"); // node_modules/react/index.js: module.exports = { react: "react" }
  ```
  bundles to
  ```js
  var react = __toESM(require_react(), 1);
  var { react: react2 } = (__toESM(exports, 1));   // `exports` is the wrapper's parameter, unbound here
  ```
  Array destructuring throws `TypeError: {} is not iterable` instead. Same output on 1.4.0 and on main.
- This is the shape of a real `react` install: `react/index.js` is a `module.exports = require("./cjs/...")` redirect that stays wrapped, so `const { useState } = require("react")` in a bundled entry gives `useState === undefined` (verified with a copy of that layout).
- Cause: `transpose_require` (`src/js_parser/p.rs:1193`) returns an `E::RequireString` marker instead of the namespace identifier whenever the `require()` is a declaration initializer. `visit_decls` (`src/js_parser/visit/mod.rs:361`) only consumes the marker for an identifier binding; for a destructuring binding it survived to the printer. The printer's path for a surviving marker (`print_require_or_import_expr` with `was_unwrapped_require`, via `LinkerContext::require_or_import_meta_for_source`) printed the target's `exports_ref` whenever the target has `FORCE_CJS_TO_ESM`. That flag is set at parse time for every file in an unwrapped package (`src/js_parser/p.rs:8449`) whether or not the file converted, and for a file that did not convert `exports_ref` is the `__commonJS` callback's `exports` parameter.

### Fix
- `visit_decls` sets `is_immediately_assigned_to_decl` only when the binding is an identifier, so a destructuring initializer gets the same namespace identifier that `require()` of an unwrapped package becomes in every other expression position (call argument, assignment right-hand side, `require(...).x`, ...). The case above now bundles to `var { react: react2 } = react;`.
- Why this is correct:
  - The marker exists only for the identifier-binding rewrite in `visit_decls` (rename the generated `import * as ns` to the declared name, drop the declaration). Producing it for a binding that rewrite does not handle was the defect; now it is produced exactly when it is consumed.
  - The namespace identifier is what the existing `cjs2esm/UnwrappedModuleRequireAssigned` test already exercises for the non-declaration positions, and it is right for both target shapes: a wrapped target prints it as `__toESM(require_x(), 1)`, a converted target prints it as the generated namespace object (`exports_react`), which is what the removed path printed for a converted target.
- Deleted, because no `RequireString` with `unwrapped_id` set reaches the printer any more (second commit, no output change): the `was_unwrapped_require` argument of `print_require_or_import_expr` and of the `require_or_import_meta_for_source` callback (`RequireOrImportMetaCallback`, `RequireOrImportMetaSource`, `Options::require_or_import_meta_for_source`), the `RequireOrImportMeta.was_unwrapped_require` field, the printer branch that printed `meta.exports_ref` for it, and the `FORCE_CJS_TO_ESM` special case in `LinkerContext::require_or_import_meta_for_source`, which now returns `exports_ref` only for `wrap == Esm`. `unwrapped_id` itself stays (`visit_decls` reads it); the printer's `ERequireString` arm now `debug_assert`s that it is unset, so the whole bundler suite under a debug build checks the invariant the deletion relies on.
- Verified with `test/bundler/bundler_cjs2esm.test.ts`:
  - `cjs2esm/UnwrappedModuleRequireDestructured` (new): object, renamed and defaulted, nested and array destructuring, a destructuring declarator between two identifier declarators in one statement, and one inside a function body, all against packages that stay wrapped. It asserts both packages are still emitted as `__commonJS(` wrappers and that the destructurings read from an identifier, then runs the bundle. Fails on main on every form (each prints `(__toESM(exports, 1))`), passes with this change.
  - `cjs2esm/UnwrappedModuleRequireDestructuredAndInTry` (from #39169): its comment described the removed marker path, so it is reworded, and it now also covers a defaulted property and an identifier declarator next to a destructuring one, against a package that does convert; the try/catch `require()` it already had covers the ordinary `RequireString` printing that remains. It passes before and after this change.
- Also ran `bundler_cjs2esm`, `bundler_cjs`, `bundler_edgecase`, `bundler_regressions`, `bundler_jsx`, `bundler_splitting`, `bundler_npm` (the `npm/ReactSSR` exact file size is unchanged), `esbuild/default`, `esbuild/splitting`, `esbuild/importstar`, and `transpiler/transpiler.test.js` with the debug build: no failures. `cargo clippy` on `bun_js_printer` and `bun_bundler` is clean.
- Not changed here: `export const X = require("react")` loses its export through the same drop-the-declaration rewrite; that is a separate defect with its own repro and is tracked separately.

### Background
- CommonJS unwrap list: when bundling to ESM, files inside `react`, `react-dom`, `scheduler`, `react-is`, `react-refresh`, `react-client` and `react-server` (`DEFAULT_UNWRAP_COMMONJS_PACKAGES` in `src/bundler/options.rs`) are parsed with `exports.x = ...` turned into ESM exports, and every `require()` that resolves into one of those packages (from any file) is turned into an `import * as ns from "..."` statement plus a reference to `ns`, so the package tree-shakes. The import statements are emitted from the parser's `imports_to_convert_from_require` list at the end of the parse.
- Converted vs wrapped target: a file in one of those packages that only uses `exports.x = ...` becomes ESM and the linker gives it a namespace object (`var exports_react = {}; __export(exports_react, {...})`), which is its `exports_ref`. A file that assigns `module.exports` cannot be converted and is emitted as `var require_react = __commonJS(function(exports, module) {...})`; its `exports_ref` is that callback's `exports` parameter, which only exists inside the callback. `FORCE_CJS_TO_ESM` is set on both kinds of file, so it does not tell the two apart.
- `is_immediately_assigned_to_decl` / `E::RequireString.unwrapped_id`: `visit_decls` passes this flag when visiting a declaration's initializer; `transpose_require` answers it by returning an `E::RequireString` whose `unwrapped_id` indexes the pending import, and `visit_decls` uses that index to rename the import's namespace to the declared identifier and remove the declaration (`const React = require("react")` becomes `import * as React from "react"`). This flag has no other reader.
- `RequireOrImportMeta`: what the printer asks the linker for when printing a bundled `require()`/`import()` of another file: the file's wrapper function (`require_x` for CommonJS, `init_x` for lazily initialized ESM) and, for wrapped ESM, its namespace object, printed as `(init_x(), __toCommonJS(exports_x))`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (bcab5edce)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [970.45ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [492.60ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [414.55ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [516.94ms]
(pass) bundler > cjs2esm/ExportsFunction [520.00ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [561.26ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [493.23ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [911.48ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [760.75ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [632.75ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [1147.96ms]
327 |     },
328 |     onAfterBundle: api => {
329 |       const code = api.readFile("out.js");
330 |       expect(code).toContain("var require_react = __commonJS(");
331 |       expect(code).toCon
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (eabb96de7)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [27.27ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [14.97ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [14.82ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [13.20ms]
(pass) bundler > cjs2esm/ExportsFunction [13.95ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [15.07ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [12.97ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [16.86ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [15.28ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [16.68ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [12.58ms]
327 |     },
328 |     onAfterBundle: api => {
329 |       const code = api.readFile("out.js");
330 |       expect(code).toContain("var require_react = __commonJS(");
331 |       expect(code).toContain("var require_scheduler = __commonJS(");
332 |       expect(code).toMatch(/\{ react: between \} = \w+;/);
                         ^
error: expect(received).toMatch(expect
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (bcab5edce)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [832.08ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [406.44ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [407.36ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [407.23ms]
(pass) bundler > cjs2esm/ExportsFunction [374.57ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [424.60ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [439.04ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [660.31ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [615.42ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [428.53ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [504.46ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireDestructured [774.47ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireDestructuredAndInTry [431.22ms]
(pass) bundler > cjs2esm/ReactSpecificUnwrapping
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4f39150115
  features     baseline

22 deps, 120 codegen, 1175 objects in 707ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1236] gen ErrorCode+*.h
[2/1236] install /workspace/bun
bun install v1.4.0-canary.1 (eabb96de7)

Checked 107 installs across 153 packages (no changes) [15.00ms]
[3/1236] gen bindgenv2
[4/1236] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1236] gen .bind.ts → GeneratedBindings.cpp
[6/1236] fetch tinycc
[tinycc] up to date
[7/1235] fetch zlib
[zlib] up to date
[8/1235] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1235] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (eabb96de7)

Checked 1 install across 2 packages (no changes) [6.00ms]
[10/1235] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (eabb96de7)

Checked 129 installs across 147 packages (no changes) [7.00ms]

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/e.rs                         |  2 +-
 src/bundler/LinkerContext.rs         | 19 ++--------
 src/js_parser/parser.rs              |  3 +-
 src/js_parser/visit/mod.rs           |  6 +++-
 src/js_printer/lib.rs                | 54 ++++++++--------------------
 test/bundler/bundler_cjs2esm.test.ts | 70 ++++++++++++++++++++++++++++++++----
 6 files changed, 88 insertions(+), 66 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/ast/e.rs                              1      2      0
src/bundler/LinkerContext.rs              3      2      0
src/js_parser/parser.rs                   3      3      0
src/js_parser/visit/mod.rs                3      4      0
src/js_printer/lib.rs                     9     14      0
test/bundler/bundler_cjs2esm.test.ts      4      4      0
```

</details>

<!-- robobun:evidence:end -->