### PR TITLE
Bump WebKit (oven-sh/WebKit#446 preview): cyclic arrays convert to strings again instead of throwing RangeError

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f0f60fd2324817dae9656d8bf2fcae25ceaccc37";
+export const WEBKIT_VERSION = "autobuild-preview-pr-446-bd6abe59";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc-stress/fixtures/string-conversion-recursion.js
+++ b/test/js/bun/jsc-stress/fixtures/string-conversion-recursion.js
@@ -1,0 +1,267 @@
+// Bun's JavaScriptCore keeps cycle detection for the array to string conversions (StringRecursionChecker):
+// an array whose conversion is already on the stack converts to the empty string instead of recursing
+// until the stack overflows, which is what V8 and SpiderMonkey do, so `a = [1]; a[1] = a; a.join()` is
+// "1," here exactly as in Node.js. Upstream removed the detection (https://bugs.webkit.org/show_bug.cgi?id=320820)
+// and throws a RangeError instead. Everything else follows upstream: only the array conversions take part,
+// so Error.prototype.toString and RegExp.prototype.toString cycles overflow the stack, and a conversion that
+// is deep but not cyclic overflows it too.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: expected ${JSON.stringify(expected)} but got ${JSON.stringify(actual)}`);
+}
+
+function shouldThrow(func, errorConstructor, message) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!error)
+        throw new Error("didn't throw");
+    if (!(error instanceof errorConstructor))
+        throw new Error(`expected ${errorConstructor.name} but got ${error}`);
+    if (message !== undefined)
+        shouldBe(error.message, message);
+}
+
+function selfContaining() {
+    let array = [1];
+    array[1] = array;
+    return array;
+}
+
+// An array that contains itself: the nested conversion of the array is the empty string, through every
+// entry point. Array.prototype.toString and ToString / ToPrimitive of an array go through JSArray::fastToString,
+// Array.prototype.join and Array.prototype.toLocaleString are checked themselves.
+shouldBe(selfContaining().join(), "1,");
+shouldBe(selfContaining().join("-"), "1-");
+shouldBe(selfContaining().join(""), "1");
+shouldBe(selfContaining().toString(), "1,");
+shouldBe(selfContaining().toLocaleString(), "1,");
+shouldBe(String(selfContaining()), "1,");
+shouldBe(`${selfContaining()}`, "1,");
+shouldBe(selfContaining() + "", "1,");
+shouldBe([selfContaining()].join(), "1,");
+
+{
+    let array = [];
+    array[0] = array;
+    shouldBe(array.join(), "");
+    shouldBe(String(array), "");
+    shouldBe(array.toLocaleString(), "");
+}
+
+// Every occurrence of the array being converted becomes empty; the conversion does not fan out.
+{
+    let array = selfContaining();
+    array[2] = array;
+    shouldBe(array.join(), "1,,");
+    shouldBe(String(array), "1,,");
+    shouldBe(array.toLocaleString(), "1,,");
+}
+
+// Only the array whose conversion is in progress becomes empty; everything reachable before the cycle
+// closes is converted normally, so the result depends on where the conversion starts.
+{
+    let a = [1];
+    let b = [2, a];
+    a.push(b);
+    shouldBe(a.join(), "1,2,");
+    shouldBe(b.join(), "2,1,");
+    shouldBe(String(a), "1,2,");
+    shouldBe(String(b), "2,1,");
+    shouldBe(a.toLocaleString(), "1,2,");
+    shouldBe(b.toLocaleString(), "2,1,");
+}
+
+{
+    let array = [1, "webkit"];
+    array[2] = [3, 4, [5, 6, [array]]];
+    shouldBe(array.toString(), "1,webkit,3,4,5,6,");
+    shouldBe(array.join("|"), "1|webkit|3,4,5,6,");
+}
+
+// The cycle may close through user code that converts the array again.
+{
+    let array = ["a"];
+    array.push({ toString() { return array.join("~"); } });
+    shouldBe(array.join("-"), "a-");
+    shouldBe(String(array), "a,");
+}
+
+{
+    let array = ["a"];
+    array.push({ toLocaleString() { return array.toLocaleString(); } });
+    shouldBe(array.toLocaleString(), "a,");
+}
+
+// Array.prototype.toString calling a replaced join still detects the cycle inside that join.
+{
+    let array = selfContaining();
+    array.join = function() { return "J:" + Array.prototype.join.call(this); };
+    shouldBe(array.toString(), "J:1,J:");
+    shouldBe(String(array), "J:1,J:");
+}
+
+// Array-like receivers are tracked too: these take the generic join / toLocaleString paths.
+{
+    let object = { length: 2, 0: "x" };
+    object[1] = { toString() { return Array.prototype.join.call(object, "+"); } };
+    shouldBe(Array.prototype.join.call(object, "-"), "x-");
+}
+
+{
+    let object = { length: 2, 0: 1 };
+    object[1] = { toLocaleString() { return Array.prototype.toLocaleString.call(object); } };
+    shouldBe(Array.prototype.toLocaleString.call(object), "1,");
+}
+
+// Converting the same array twice in a row, or the same array twice within one conversion, is not a cycle.
+{
+    let array = selfContaining();
+    shouldBe(array.join(), "1,");
+    shouldBe(array.join(), "1,");
+    shouldBe(String(array), "1,");
+
+    let shared = [1, 2];
+    shouldBe([shared, shared].toString(), "1,2,1,2");
+    shouldBe([shared, shared].toLocaleString(), "1,2,1,2");
+    shouldBe([shared, shared].join("|"), "1,2|1,2");
+    shouldBe([[1, [2]], [3]].join(), "1,2,3");
+}
+
+// Error.prototype.toString and RegExp.prototype.toString do not take part, so applying them to an array that
+// is being converted, or converting an array-like from inside them, is not a cycle either.
+{
+    let array = [];
+    array[0] = { toString() { return Error.prototype.toString.call(array); } };
+    shouldBe(array.join(), "Error");
+}
+
+{
+    let array = [];
+    array[0] = { toString() { return RegExp.prototype.toString.call(array); } };
+    shouldBe(array.join(), "/undefined/undefined");
+}
+
+{
+    let object = { length: 2, 0: "x", 1: "y" };
+    object.name = { toString() { return Array.prototype.join.call(object, "-"); } };
+    shouldBe(Error.prototype.toString.call(object), "x-y");
+}
+
+{
+    let array = ["a"];
+    array[1] = { toString() { return Array.prototype.toLocaleString.call({ length: 1, 0: "b" }); } };
+    shouldBe(array.join("-"), "a-b");
+}
+
+// A conversion that throws must unregister every array it was converting, whether it was the outermost one
+// or nested inside another; otherwise the next conversion of the same array would be taken for a cycle.
+{
+    let thrower = { toString() { throw new Error("boom"); }, toLocaleString() { throw new Error("locale boom"); } };
+
+    let array = [1, thrower];
+    shouldThrow(() => array.join(), Error, "boom");
+    shouldThrow(() => String(array), Error, "boom");
+    shouldThrow(() => array.toLocaleString(), Error, "locale boom");
+    array[1] = 2;
+    shouldBe(array.join(), "1,2");
+    shouldBe(String(array), "1,2");
+    shouldBe(array.toLocaleString(), "1,2");
+
+    let inner = [thrower];
+    let outer = [inner];
+    shouldThrow(() => outer.join(), Error, "boom");
+    shouldThrow(() => String(outer), Error, "boom");
+    shouldThrow(() => outer.toLocaleString(), Error, "locale boom");
+    shouldThrow(() => Array.prototype.join.call({ length: 1, 0: inner }), Error, "boom");
+    inner[0] = "i";
+    shouldBe(outer.join(), "i");
+    shouldBe(String(outer), "i");
+    shouldBe(outer.toLocaleString(), "i");
+    shouldBe(Array.prototype.join.call({ length: 1, 0: inner }), "i");
+
+    shouldBe(selfContaining().join(), "1,");
+}
+
+// Error.prototype.toString and RegExp.prototype.toString cycles behave as upstream: they overflow the stack.
+shouldThrow(() => {
+    let error = new Error;
+    error.name = error;
+    error.message = error;
+    return `${error}`;
+}, RangeError);
+
+shouldThrow(() => {
+    let error = new Error;
+    error.message = { toString() { return Error.prototype.toString.call(error); } };
+    return `${error}`;
+}, RangeError);
+
+shouldThrow(() => {
+    let regExp = /a/;
+    Object.defineProperty(regExp, "source", { get() { return regExp; } });
+    return `${regExp}`;
+}, RangeError);
+
+shouldThrow(() => {
+    let regExp = /a/;
+    Object.defineProperty(regExp, "flags", { get() { return RegExp.prototype.toString.call(regExp); } });
+    return `${regExp}`;
+}, RangeError);
+
+// Cycle detection does not replace the stack check: a nesting that is deep but acyclic still overflows (the
+// shallowest overflowing depth is around 1000 arrays in a debug ASan build and around 5000 in release), and
+// the overflow unwinding through thousands of conversions leaves every array convertible again.
+{
+    let deepest = [0];
+    let top = deepest;
+    for (let i = 0; i < 100000; ++i)
+        top = [top];
+    let second = top[0];
+
+    shouldThrow(() => String(top), RangeError);
+    shouldThrow(() => top.join(), RangeError);
+    shouldThrow(() => top.toLocaleString(), RangeError);
+
+    top[0] = "top";
+    shouldBe(String(top), "top");
+    second[0] = "second";
+    shouldBe(String([second]), "second");
+    shouldBe([second, deepest].join("-"), "second-0");
+    shouldBe(selfContaining().join(), "1,");
+}
+
+// The DFG and FTL compile Array.prototype.join on an array with the original structure into their own operation
+// and reach ToString / ToPrimitive of an array through their own paths. Warm the call sites up on an acyclic
+// array with the same (contiguous) shape, then the cyclic array must convert exactly as it does in the
+// interpreter, and the acyclic one must still convert afterwards.
+{
+    const join = array => array.join("-");
+    const convert = array => `${array}`;
+    const toLocale = array => array.toLocaleString();
+    noInline(join);
+    noInline(convert);
+    noInline(toLocale);
+
+    let acyclic = [1, [2, 3], "x"];
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBe(join(acyclic), "1-2,3-x");
+        shouldBe(convert(acyclic), "1,2,3,x");
+        shouldBe(toLocale(acyclic), "1,2,3,x");
+    }
+
+    let cyclic = selfContaining();
+    for (let i = 0; i < 10; ++i) {
+        shouldBe(join(cyclic), "1-");
+        shouldBe(convert(cyclic), "1,");
+        shouldBe(toLocale(cyclic), "1,");
+    }
+
+    shouldBe(join(acyclic), "1-2,3-x");
+    shouldBe(convert(acyclic), "1,2,3,x");
+    shouldBe(toLocale(acyclic), "1,2,3,x");
+}

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -121,6 +121,9 @@ const jsFixtures = [
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",
   "licm-no-pre-header.js",
+  // Behavior Bun's WebKit keeps after upstream removed it (oven-sh/WebKit#446):
+  // cyclic arrays convert to strings the way V8 does, in every tier.
+  "string-conversion-recursion.js",
 ];
 
 const wasmFixtures = [

--- a/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
@@ -18,12 +18,14 @@ describe.concurrent("WebKit 3722912ff800 upgrade", () => {
     expect(g().includes(5)).toBe(false);
   });
 
-  test("cyclic Array.prototype.join throws RangeError (f2f2c2ddf637)", () => {
-    // StringRecursionChecker was removed; cyclic join now recurses until the
-    // stack check throws instead of short-circuiting to the empty string.
-    const a: unknown[] = [];
+  test("cyclic Array.prototype.join converts the cycle to the empty string, as in node (f2f2c2ddf637, oven-sh/WebKit#446)", () => {
+    // Upstream f2f2c2ddf637 removed StringRecursionChecker, which made this
+    // throw a RangeError. Bun's WebKit keeps the array cycle detection V8 has
+    // (oven-sh/WebKit#446), so this matches node and Bun 1.3. The full matrix is
+    // test/js/bun/jsc-stress/fixtures/string-conversion-recursion.js.
+    const a: unknown[] = [1];
     a.push(a);
-    expect(() => a.join()).toThrow(RangeError);
+    expect([a.join(), a.join("-"), String(a), `${a}`, a.toLocaleString()]).toEqual(["1,", "1-", "1,", "1,", "1,"]);
   });
 
   test("WebAssembly.Exception gains options.traceStack and stack getter (bf6512f84f7d)", () => {


### PR DESCRIPTION
### Problem
- Since #36794 (WebKit sync to `3722912ff800`), converting an array that contains itself throws `RangeError: Maximum call stack size exceeded`: with `a = [1]; a[1] = a`, `a.join()`, `String(a)`, `` `${a}` `` and `a.toLocaleString()` all throw, for indirect cycles too. Node.js v26 and Bun 1.3.14 return `"1,"` (the nested occurrence of the array being converted becomes the empty string); so do Firefox and every JavaScriptCore before that sync. Found by a minifier equivalence corpus (2 of 600 programs); it also breaks `join()` on graph shaped data and logging helpers that relied on the old behavior. `Bun.inspect` / `console.log` are unaffected, they have their own `[Circular]` handling.
- Cause: upstream WebKit 318399@main removed `StringRecursionChecker` (the visited set behind `Array.prototype.join` / `toString` / `toLocaleString`) as unspecified behavior, leaving only a stack check, so a cycle now recurses natively until the stack runs out. #36794 listed it under its highlights and pinned the new behavior in `test/js/bun/jsc/webkit-upgrade-3722912f.test.ts`, but V8 and SpiderMonkey both still detect the cycle, so for Bun it is a Node.js compatibility regression rather than a spec fix. The open 1.4 upgrade guide (#36463) currently lists it as a breaking change; that line should go once this lands.

### Fix
- oven-sh/WebKit#446 restores the cycle detection for the array conversions only, under `USE(BUN_JSC_ADDITIONS)`: `arrayProtoFuncJoin`, `arrayProtoFuncToLocaleString`, `JSArray::fastToString` (the `toString` / `ToString` / `ToPrimitive` path) and the DFG/FTL `ArrayJoin` operation, which arrived in the same sync and would otherwise make a compiled `join` site return `"1-1,"` where the interpreter returns `"1-"`. A re-entered conversion yields the empty string; everything is keyed on the receiver, which is V8's model, so the results match node byte for byte. `Error.prototype.toString` and `RegExp.prototype.toString` cycles keep throwing, as they do in node. Stack overflow on deep acyclic nesting still throws `RangeError`, as upstream.
- This PR pins `WEBKIT_VERSION` at that PR's preview build (`autobuild-preview-pr-446-bd6abe59`) so CI runs Bun against it. Before landing, oven-sh/WebKit#446 has to merge and `WEBKIT_VERSION` has to be repointed at the resulting main sha. The preview is built on current fork main, so relative to the `f0f60fd2` pin it also carries oven-sh/WebKit#420 (#38040), oven-sh/WebKit#421 (#38091) and oven-sh/WebKit#440 (#38660), which have their own Bun PRs (oven-sh/WebKit#437 was merged and reverted in between, so it is not carried); nothing here depends on them.
- Tests:
  - `test/js/bun/jsc-stress/fixtures/string-conversion-recursion.js`, registered in `jsc-stress.test.ts`: the `JSTests/stress` file from the WebKit PR, unchanged. It covers the self containing array through every entry point (`join` with and without separator, `toString`, `toLocaleString`, `String()`, template literal, `+ ""`, nested in another array), fan out, mutual cycles from either side, cycles closed through user `toString` / `toLocaleString` / a replaced `join`, array-like receivers, acyclic reuse of the same array, unregistration after a conversion throws, `Error` / `RegExp` cycles and a 100000 deep acyclic nesting still throwing `RangeError`, and a `testLoopCount` warm up followed by the cyclic array, whose compiled tier results must equal the interpreter's. Node.js v26 passes the file as is (with `noInline` / `testLoopCount` stubbed).
  - `test/js/bun/jsc/webkit-upgrade-3722912f.test.ts`: the case that pinned the `RangeError` now pins the restored results.
- Fail before: with the current pin (`f0f60fd2`, the baked canary `eabb96de7`), both tests fail with `RangeError: Maximum call stack size exceeded`, the fixture at its first assertion (`selfContaining().join()`).
- Pass after: with this pin, `bun bd test test/js/bun/jsc-stress/jsc-stress.test.ts` and `bun bd test test/js/bun/jsc/webkit-upgrade-3722912f.test.ts` pass (debug + ASAN build; all 116 jsc-stress fixtures pass, the new one takes about 1.5s there; `process.versions.webkit` reports `preview-pr-446-bd6abe59`). The repro below and the larger probe from the report print exactly what node prints. `test/js/web/intl` and `test/js/bun/util/inspect.test.js` also pass against the preview, as a check that the carried fork commits and the ICU data are unaffected.

### Background
- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit; `scripts/build/deps/webkit.ts` pins which build. An engine fix lands as a WebKit PR plus a pin bump here, and `autobuild-preview-pr-*` tags let the bump PR run Bun's suite against the WebKit PR before it merges.
- `test/js/bun/jsc-stress/` runs files taken verbatim from WebKit's `JSTests/stress` under `bun`; `preload.js` supplies the jsc shell globals they use (`noInline`, `testLoopCount`), which is why the engine test can be shared with the WebKit PR as is.
- `Array.prototype.toString` calls `join`, and `ToString(array)` (what `String()`, template literals and `+` do) reaches `JSArray::fastToString` directly; `join` additionally has a DFG/FTL intrinsic since the sync. Those are the four entry points the WebKit PR guards; an element that is itself an array is converted through one of them, which is how a cycle is noticed.

<details>
<summary>Repro</summary>

```js
const a = [1]; a[1] = a;
const b = [1], c = [b]; b.push(c);
const t = f => { try { return f(); } catch (e) { return e.constructor.name; } };
console.log(JSON.stringify([t(() => a.join()), t(() => String(b)), t(() => `${a}`), t(() => a.toLocaleString()), [[1, [2]], [3]].join()]));
```

```
node v26:                ["1,","1,","1,","1,","1,2,3"]
bun 1.4 (f0f60fd2):      ["RangeError","RangeError","RangeError","RangeError","1,2,3"]
this PR:                 ["1,","1,","1,","1,","1,2,3"]
```

</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 0 · 4 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc-stress/jsc-stress.test.ts' 'test/js/bun/jsc/webkit-upgrade-3722912f.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc-stress/jsc-stress.test.ts "test/js/bun/jsc/webkit-upgrade-3722912f.test.ts"
bun test v1.4.0 (88a639883)

test/js/bun/jsc/webkit-upgrade-3722912f.test.ts:
(pass) WebKit 3722912ff800 upgrade > Iterator.prototype.includes is enabled by default (319f94b3db4a) [12.90ms]
(pass) WebKit 3722912ff800 upgrade > cyclic Array.prototype.join converts the cycle to the empty string, as in node (f2f2c2ddf637, oven-sh/WebKit#446) [40.35ms]
(pass) WebKit 3722912ff800 upgrade > WebAssembly.Exception gains options.traceStack and stack getter (bf6512f84f7d) [5.64ms]
(pass) WebKit 3722912ff800 upgrade > typed import attributes resolve through BunTranspiledModule (--isolate) (90b2ecf79ae3) [321.10ms]
(pass) WebKit 3722912ff800 upgrade > indirect, namespace and star re-exports link on the JSC ModuleAnalyzer path (90b2ecf79ae3) [1148.20ms]

test/js/bun/jsc-stress/jsc-stress.test.ts:
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithcos.js [347.28ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsqrt.js [351.28ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsin.js [420.26ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-equality.js [385.51ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithtan.js [457.13ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-library-substring.js [459.79ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-ident-equality.js [502.22ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-strict-equality.js [526.55ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-exec.js [510.65ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-test.js [512.72ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength-inline.js [405.89ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 .../fixtures/string-conversion-recursion.js        | 267 +++++++++++++++++++++
 test/js/bun/jsc-stress/jsc-stress.test.ts          |   3 +
 test/js/bun/jsc/webkit-upgrade-3722912f.test.ts    |  12 +-
 4 files changed, 278 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  2      1      0
…/bun/jsc-stress/fixtures/string-conversion-recursion.js      0      0      0
test/js/bun/jsc-stress/jsc-stress.test.ts                     1      1      0
test/js/bun/jsc/webkit-upgrade-3722912f.test.ts               1      2      0
```

</details>

<!-- robobun:evidence:end -->