### PR TITLE
fs.promises: accept iterable data in appendFile, like writeFile and node

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1592,9 +1592,7 @@ async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: Abort
   }
 }
 
-// Node's fs/promises writeFile and appendFile also accept `data` as an iterable
-// or async iterable of chunks (the sync and callback forms do not). Strings and
-// typed arrays are iterable too, but those take the native path.
+// Strings and typed arrays are iterable too, but those take the native path.
 function isCustomIterable(data): boolean {
   return (
     !$isTypedArrayView(data) &&
@@ -1625,9 +1623,7 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, def
     throw $ERR_INVALID_ARG_VALUE("encoding", encoding, "is invalid encoding");
   }
 
-  // Callers unwrap a FileHandle to its fd. Anything else is a path (string,
-  // Buffer or URL) that has to be opened with `flag` and `mode`; fs.open
-  // rejects the values that are none of those.
+  // A FileHandle arrives here as its fd; anything else is a path for fs.open to open or reject.
   const mustClose = typeof fdOrPath !== "number";
   if (mustClose) {
     fdOrPath = await fs.open(fdOrPath, flag, mode);

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1568,7 +1568,6 @@ async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: Abort
   const writer = Bun.file(fd).writer();
 
   const mustRencode = !(encoding === "utf8" || encoding === "utf-8" || encoding === "binary" || encoding === "buffer");
-  let totalBytesWritten = 0;
 
   try {
     for await (let chunk of iterable) {
@@ -1585,22 +1584,12 @@ async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: Abort
 
       const prom = writer.write(chunk);
       if (prom && $isPromise(prom)) {
-        totalBytesWritten += await prom;
-      } else {
-        totalBytesWritten += prom;
+        await prom;
       }
     }
   } finally {
     await writer.end();
   }
-
-  return totalBytesWritten;
-}
-
-// The only flag spellings whose `open` truncates. `r+` & co. overwrite in place,
-// so resizing the file down to the bytes we wrote would destroy the rest of it.
-function flagTruncates(flag): boolean {
-  return flag === "w" || flag === "w+" || flag === "wx" || flag === "wx+" || flag === "xw" || flag === "xw+";
 }
 
 // Node's fs/promises writeFile and appendFile also accept `data` as an iterable
@@ -1649,24 +1638,15 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, def
     throw $makeAbortError(undefined, { cause: signal.reason });
   }
 
-  let totalBytesWritten = 0;
-
   let error: Error | undefined;
 
   try {
-    totalBytesWritten = await writeFileAsyncIteratorInner(fdOrPath, iterable, encoding, signal);
+    await writeFileAsyncIteratorInner(fdOrPath, iterable, encoding, signal);
   } catch (err) {
     error = err as Error;
   }
 
-  // Handle cleanup outside of try-catch
   if (mustClose) {
-    if (flagTruncates(flag)) {
-      try {
-        await fs.ftruncate(fdOrPath, totalBytesWritten);
-      } catch {}
-    }
-
     await fs.close(fdOrPath);
   }
 

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -251,6 +251,9 @@ const exports = {
   access: asyncWrap(fs.access, "access"),
   appendFile: async function (fileHandleOrFdOrPath, ...args) {
     fileHandleOrFdOrPath = fileHandleOrFdOrPath?.[kFd] ?? fileHandleOrFdOrPath;
+    if (isCustomIterable(args[0])) {
+      return writeFileAsyncIterator(fileHandleOrFdOrPath, args[0], args[1], "a");
+    }
     return _appendFile(fileHandleOrFdOrPath, ...args);
   },
   close: asyncWrap(fs.close, "close"),
@@ -311,15 +314,9 @@ const exports = {
   },
   writeFile: async function (fileHandleOrFdOrPath, ...args: any[]) {
     fileHandleOrFdOrPath = fileHandleOrFdOrPath?.[kFd] ?? fileHandleOrFdOrPath;
-    if (
-      !$isTypedArrayView(args[0]) &&
-      typeof args[0] !== "string" &&
-      ($isCallable(args[0]?.[Symbol.iterator]) || $isCallable(args[0]?.[Symbol.asyncIterator]))
-    ) {
+    if (isCustomIterable(args[0])) {
       $debug("fs.promises.writeFile async iterator slow path!");
-      // Node accepts an arbitrary async iterator here
-      // @ts-expect-error
-      return writeFileAsyncIterator(fileHandleOrFdOrPath, ...args);
+      return writeFileAsyncIterator(fileHandleOrFdOrPath, args[0], args[1], "w");
     }
     return _writeFile(fileHandleOrFdOrPath, ...args);
   },
@@ -1606,31 +1603,44 @@ function flagTruncates(flag): boolean {
   return flag === "w" || flag === "w+" || flag === "wx" || flag === "wx+" || flag === "xw" || flag === "xw+";
 }
 
-async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, flag, mode) {
+// Node's fs/promises writeFile and appendFile also accept `data` as an iterable
+// or async iterable of chunks (the sync and callback forms do not). Strings and
+// typed arrays are iterable too, but those take the native path.
+function isCustomIterable(data): boolean {
+  return (
+    !$isTypedArrayView(data) &&
+    typeof data !== "string" &&
+    ($isCallable(data?.[Symbol.iterator]) || $isCallable(data?.[Symbol.asyncIterator]))
+  );
+}
+
+async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, defaultFlag: "w" | "a") {
   let encoding;
+  let flag = defaultFlag;
+  let mode = 0o666;
   let signal: AbortSignal | null = null;
   if (typeof optionsOrEncoding === "object") {
-    encoding = optionsOrEncoding?.encoding ?? (encoding || "utf8");
-    flag = optionsOrEncoding?.flag ?? (flag || "w");
-    mode = optionsOrEncoding?.mode ?? (mode || 0o666);
+    encoding = optionsOrEncoding?.encoding ?? "utf8";
+    // Node: `options.flag || 'w'`, so an empty flag falls back to the default too.
+    flag = optionsOrEncoding?.flag || defaultFlag;
+    mode = optionsOrEncoding?.mode ?? mode;
     signal = optionsOrEncoding?.signal ?? null;
     if (signal?.aborted) {
       throw $makeAbortError(undefined, { cause: signal.reason });
     }
   } else if (typeof optionsOrEncoding === "string" || optionsOrEncoding == null) {
     encoding = optionsOrEncoding || "utf8";
-    flag ??= "w";
-    mode ??= 0o666;
   }
 
   if (!Buffer.isEncoding(encoding)) {
-    // ERR_INVALID_OPT_VALUE_ENCODING was removed in Node v15.
-    throw new TypeError(`Unknown encoding: ${encoding}`);
+    throw $ERR_INVALID_ARG_VALUE("encoding", encoding, "is invalid encoding");
   }
 
-  let mustClose = typeof fdOrPath === "string";
+  // Callers unwrap a FileHandle to its fd. Anything else is a path (string,
+  // Buffer or URL) that has to be opened with `flag` and `mode`; fs.open
+  // rejects the values that are none of those.
+  const mustClose = typeof fdOrPath !== "number";
   if (mustClose) {
-    // Rely on fs.open for further argument validaiton.
     fdOrPath = await fs.open(fdOrPath, flag, mode);
   }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -57,6 +57,8 @@ import fs, {
 } from "node:fs";
 import * as os from "node:os";
 import path, { dirname, relative, resolve } from "node:path";
+import { Readable } from "node:stream";
+import { pathToFileURL } from "node:url";
 import { inspect, promisify } from "node:util";
 
 import _promises, { type FileHandle } from "node:fs/promises";
@@ -783,6 +785,243 @@ describe("appendFile honors an explicit 'w' flag", () => {
     expect(readFileSync(path, "utf8")).toBe("abcd");
     fs.appendFileSync(path, "e", {});
     expect(readFileSync(path, "utf8")).toBe("abcde");
+  });
+});
+
+// In node, fs/promises writeFile and appendFile take `data` as an iterable or
+// async iterable of chunks as well as a string or buffer (the sync and callback
+// forms take only the latter two). promises.appendFile handed every kind of data
+// to the native binding, which rejected the iterables.
+describe("promises.appendFile with iterable data", () => {
+  const iterables: [string, () => Iterable<any> | AsyncIterable<any>][] = [
+    ["an array of strings", () => ["ab", "cd"]],
+    ["a String object", () => new String("abcd")],
+    ["an array of buffers", () => [Buffer.from("ab"), new Uint8Array([0x63, 0x64])]],
+    [
+      "a generator",
+      () =>
+        (function* () {
+          yield "ab";
+          yield Buffer.from("cd");
+        })(),
+    ],
+    [
+      "an async generator",
+      () =>
+        (async function* () {
+          yield "ab";
+          yield Buffer.from("cd");
+        })(),
+    ],
+    ["a Readable", () => Readable.from(["ab", "cd"])],
+  ];
+
+  it.each(iterables)("appends %s to an existing file", async (_, data) => {
+    using dir = tempDir("append-iterable", { "f.txt": "0123" });
+    const path = join(String(dir), "f.txt");
+    await expect(promises.appendFile(path, data() as any)).resolves.toBeUndefined();
+    expect(readFileSync(path, "utf8")).toBe("0123abcd");
+  });
+
+  it("creates the file when it does not exist", async () => {
+    using dir = tempDir("append-iterable-create", {});
+    const path = join(String(dir), "f.txt");
+    await promises.appendFile(path, ["ab", "cd"]);
+    expect(readFileSync(path, "utf8")).toBe("abcd");
+  });
+
+  it.skipIf(isWindows)("creates the file with options.mode", async () => {
+    using dir = tempDir("append-iterable-mode", {});
+    const path = join(String(dir), "f.txt");
+    await promises.appendFile(path, ["ab"], { mode: 0o600 });
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  it("encodes string chunks with the encoding argument or option, utf8 by default", async () => {
+    using dir = tempDir("append-iterable-encoding", {});
+    const asArgument = join(String(dir), "argument.txt");
+    const asOption = join(String(dir), "option.txt");
+    const byDefault = join(String(dir), "default.txt");
+    await promises.appendFile(asArgument, ["\u00e9"], "latin1");
+    await promises.appendFile(asOption, ["\u00e9"], { encoding: "latin1" });
+    await promises.appendFile(byDefault, ["\u00e9"]);
+    expect({
+      asArgument: [...readFileSync(asArgument)],
+      asOption: [...readFileSync(asOption)],
+      byDefault: [...readFileSync(byDefault)],
+    }).toEqual({ asArgument: [0xe9], asOption: [0xe9], byDefault: [0xc3, 0xa9] });
+  });
+
+  it("honors an explicit flag, and falls back to appending for an empty one", async () => {
+    using dir = tempDir("append-iterable-flag", { "w.txt": "0123456789", "empty.txt": "0123" });
+    const truncated = join(String(dir), "w.txt");
+    const appended = join(String(dir), "empty.txt");
+    await promises.appendFile(truncated, ["ZZ"], { flag: "w" });
+    await promises.appendFile(appended, ["ab"], { flag: "" });
+    expect({ truncated: readFileSync(truncated, "utf8"), appended: readFileSync(appended, "utf8") }).toEqual({
+      truncated: "ZZ",
+      appended: "0123ab",
+    });
+  });
+
+  it.each([
+    ["a Buffer", (p: string) => Buffer.from(p)],
+    ["a file URL", (p: string) => pathToFileURL(p)],
+  ])("appends when the path is %s", async (_, wrap) => {
+    using dir = tempDir("append-iterable-path", { "f.txt": "0123" });
+    const path = join(String(dir), "f.txt");
+    await promises.appendFile(wrap(path), ["ab", "cd"]);
+    expect(readFileSync(path, "utf8")).toBe("0123abcd");
+  });
+
+  it("writes through a FileHandle and leaves it open", async () => {
+    using dir = tempDir("append-iterable-handle", {});
+    const path = join(String(dir), "f.txt");
+    await using handle = await promises.open(path, "w");
+    await promises.appendFile(handle, ["ab"]);
+    await handle.appendFile(["cd"]);
+    await promises.appendFile(
+      handle,
+      (async function* () {
+        yield "ef";
+      })(),
+    );
+    expect((await handle.stat()).size).toBe(6);
+    expect(readFileSync(path, "utf8")).toBe("abcdef");
+  });
+
+  it("rejects with an AbortError before pulling from the iterable when the signal is already aborted", async () => {
+    using dir = tempDir("append-iterable-abort", { "f.txt": "0123" });
+    const path = join(String(dir), "f.txt");
+    let pulled = false;
+    const data = {
+      *[Symbol.iterator]() {
+        pulled = true;
+        yield "ab";
+      },
+    };
+    await expect(promises.appendFile(path, data, { signal: AbortSignal.abort() })).rejects.toMatchObject({
+      name: "AbortError",
+      code: "ABORT_ERR",
+    });
+    expect({ pulled, contents: readFileSync(path, "utf8") }).toEqual({ pulled: false, contents: "0123" });
+  });
+
+  it("propagates an error thrown by the iterable and keeps the chunks written before it", async () => {
+    using dir = tempDir("append-iterable-throws", { "f.txt": "0123" });
+    const path = join(String(dir), "f.txt");
+    const data = (function* () {
+      yield "ab";
+      throw new Error("stop");
+    })();
+    await expect(promises.appendFile(path, data)).rejects.toThrow("stop");
+    expect(readFileSync(path, "utf8")).toBe("0123ab");
+  });
+
+  it("closes the file it opened, also when the iterable throws", async () => {
+    using dir = tempDir("append-iterable-fds", {});
+    const path = join(String(dir), "f.txt");
+    const maxFD = getMaxFD();
+    for (let i = 0; i < 16; i++) {
+      await promises.appendFile(Buffer.from(path), ["ab"]);
+      await expect(
+        promises.appendFile(
+          pathToFileURL(path),
+          (function* () {
+            yield "cd";
+            throw new Error("stop");
+          })(),
+        ),
+      ).rejects.toThrow("stop");
+    }
+    expect(readFileSync(path, "utf8")).toBe(Buffer.alloc(16 * 4, "abcd").toString());
+    expect(getMaxFD() - maxFD).toBeLessThan(5);
+  });
+
+  it("rejects an unknown encoding with ERR_INVALID_ARG_VALUE, as the string path does", async () => {
+    using dir = tempDir("iterable-bad-encoding", {});
+    const path = join(String(dir), "f.txt");
+    const expected = {
+      code: "ERR_INVALID_ARG_VALUE",
+      message: "The argument 'encoding' is invalid encoding. Received 'bogus'",
+    };
+    await expect(promises.appendFile(path, ["ab"], "bogus" as any)).rejects.toMatchObject(expected);
+    await expect(promises.writeFile(path, ["ab"], "bogus" as any)).rejects.toMatchObject(expected);
+    await expect(promises.appendFile(path, "ab", "bogus" as any)).rejects.toMatchObject({ code: expected.code });
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("still rejects data that is neither a string, a buffer nor iterable", async () => {
+    using dir = tempDir("append-not-iterable", {});
+    const path = join(String(dir), "f.txt");
+    await expect(promises.appendFile(path, 42 as any)).rejects.toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+    await expect(promises.appendFile(path, {} as any)).rejects.toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("the sync and callback forms still reject iterables", () => {
+    using dir = tempDir("append-iterable-sync", {});
+    const path = join(String(dir), "f.txt");
+    expect(() => fs.appendFileSync(path, ["ab"] as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(() => fs.appendFile(path, ["ab"] as any, () => {})).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(() => fs.writeFileSync(path, ["ab"] as any)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(() => fs.writeFile(path, ["ab"] as any, () => {})).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+    expect(existsSync(path)).toBe(false);
+  });
+});
+
+// The iterable slow path shared by promises.writeFile and promises.appendFile
+// only opened string paths itself. A Buffer or URL path went to
+// Bun.file().writer(), which ignores `flag` and `mode` and overwrites the file in
+// place without truncating it.
+describe("promises.writeFile with iterable data and a Buffer or URL path", () => {
+  const pathKinds: [string, (p: string) => Buffer | URL][] = [
+    ["a Buffer", p => Buffer.from(p)],
+    ["a file URL", p => pathToFileURL(p)],
+  ];
+
+  it.each(pathKinds)("truncates the existing file when the path is %s", async (_, wrap) => {
+    using dir = tempDir("write-iterable-path", { "f.txt": "0123456789" });
+    const path = join(String(dir), "f.txt");
+    await promises.writeFile(wrap(path), ["ZZ"]);
+    expect(readFileSync(path, "utf8")).toBe("ZZ");
+  });
+
+  it.each(pathKinds)("honors flag 'a' when the path is %s", async (_, wrap) => {
+    using dir = tempDir("write-iterable-path-a", { "f.txt": "0123" });
+    const path = join(String(dir), "f.txt");
+    await promises.writeFile(wrap(path), ["ab", "cd"], { flag: "a" });
+    expect(readFileSync(path, "utf8")).toBe("0123abcd");
+  });
+
+  it.each(pathKinds)("honors flag 'wx' when the path is %s", async (_, wrap) => {
+    using dir = tempDir("write-iterable-path-wx", { "f.txt": "0123" });
+    const path = join(String(dir), "f.txt");
+    await expect(promises.writeFile(wrap(path), ["ZZ"], { flag: "wx" })).rejects.toMatchObject({
+      code: "EEXIST",
+      syscall: "open",
+    });
+    expect(readFileSync(path, "utf8")).toBe("0123");
+  });
+
+  it.skipIf(isWindows).each(pathKinds)("creates the file with options.mode when the path is %s", async (_, wrap) => {
+    using dir = tempDir("write-iterable-path-mode", {});
+    const path = join(String(dir), "f.txt");
+    await promises.writeFile(wrap(path), ["ab"], { mode: 0o600 });
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  it("rejects a path of the wrong type without pulling from the iterable", async () => {
+    let pulled = false;
+    const data = {
+      *[Symbol.iterator]() {
+        pulled = true;
+        yield "ab";
+      },
+    };
+    await expect(promises.writeFile({} as any, data)).rejects.toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+    await expect(promises.appendFile({} as any, data)).rejects.toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
+    expect(pulled).toBe(false);
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -652,8 +652,7 @@ describe("writeFile with a non-truncating flag", () => {
     expect(readFileSync(path, "utf8")).toBe("ZZ23456789");
   });
 
-  // An iterable `data` takes a separate slow path in fs.promises, with its own
-  // truncate.
+  // An iterable `data` takes a separate slow path in fs.promises.
   it.each(["r+", "rs+"])("promises.writeFile of an async iterable with flag %p overwrites in place", async flag => {
     const path = join(tmpdirSync(), "in-place-async-iter.txt");
     writeFileSync(path, "0123456789");
@@ -1023,6 +1022,40 @@ describe("promises.writeFile with iterable data and a Buffer or URL path", () =>
     await expect(promises.appendFile({} as any, data)).rejects.toMatchObject({ code: "ERR_INVALID_ARG_TYPE" });
     expect(pulled).toBe(false);
   });
+});
+
+// After writing, the iterable path used to ftruncate() the file to the sum of
+// the FileSink.write() return values. That sum over-counts once the sink starts
+// flushing (every 4 KiB, 16 KiB on Apple Silicon), so a stream of small chunks
+// came out padded with NUL bytes. The truncating flags already empty the file at
+// open, so the file has to end up exactly as long as the data.
+describe("promises.writeFile and appendFile of many small chunks", () => {
+  const chunk = Buffer.alloc(1024, "0123456789").toString();
+  const chunkCount = 32;
+  const expected = Buffer.alloc(chunk.length * chunkCount, chunk).toString();
+  function* chunks() {
+    for (let i = 0; i < chunkCount; i++) yield chunk;
+  }
+
+  const paths: [string, (p: string) => string | Buffer | URL][] = [
+    ["a string", p => p],
+    ["a Buffer", p => Buffer.from(p)],
+    ["a file URL", p => pathToFileURL(p)],
+  ];
+  const writers: [string, (path: string | Buffer | URL) => Promise<void>][] = [
+    ["promises.writeFile", path => promises.writeFile(path, chunks())],
+    ["promises.appendFile with flag 'w'", path => promises.appendFile(path, chunks(), { flag: "w" })],
+    ["promises.appendFile", path => promises.appendFile(path, chunks())],
+  ];
+
+  for (const [writerName, write] of writers) {
+    it.each(paths)(`${writerName} to %s writes exactly the data`, async (_, wrap) => {
+      using dir = tempDir("iterable-exact-size", {});
+      const path = join(String(dir), "out.txt");
+      await write(wrap(path));
+      expect(readFileSync(path, "utf8")).toBe(expected);
+    });
+  }
 });
 
 // A write that dies partway through must not leave the old tail sitting behind


### PR DESCRIPTION
### Problem

- `fs.promises.appendFile(path, ["a", "b"])` (or a `String` object, a generator, a `Readable`) rejects with `ERR_INVALID_ARG_TYPE: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView`. Node v26 appends `ab`; `fs.promises.writeFile` with the same data already works in Bun.
- Cause: `exports.appendFile` in `src/js/node/fs.promises.ts:252` hands `data` straight to the native binding, whose `args::WriteFile::from_js` (`src/runtime/node/node_fs.rs:4220`) only takes strings and buffers. Only `exports.writeFile` (`fs.promises.ts:312`) has the branch that sends iterables to `writeFileAsyncIterator`.
- Two more defects in that shared iterable path, both of which appendFile would inherit:
  - It only opened `string` paths itself (`mustClose = typeof fdOrPath === "string"`, `fs.promises.ts:1628`). A `Buffer` or `URL` path went to `Bun.file(path).writer()`, which ignores `flag` and `mode` and overwrites in place: `promises.writeFile(new URL(...), ["ZZ"])` on a file holding `0123456789` leaves `ZZ23456789`, `{ flag: "a" }` does not append, `{ flag: "wx" }` does not fail on an existing file.
  - After writing, it ran `ftruncate(fd, totalBytesWritten)` (`fs.promises.ts:1654`), where the total is the sum of the `FileSink.write()` return values. That sum over-counts once the sink starts flushing, so `promises.writeFile(path, 500 x "0123456789")` produces a 9090 byte file (5000 bytes of data plus NUL padding) on a string path. The same bug and fix as #35513. Sending Buffer and URL paths, and `appendFile(..., { flag: "w" })`, through this code would have extended the padding to them (measured: 9090 bytes for all of them with only the first fix applied), so this PR removes the truncate as well.

### Fix

- `exports.appendFile` sends iterable data through `writeFileAsyncIterator` with `"a"` as the default flag; `exports.writeFile` passes `"w"`. The iterable test moves into a shared `isCustomIterable` (same predicate as node's: iterable, not an `ArrayBufferView`, not a string). String and buffer data still take the native path, and `appendFileSync` / callback `appendFile` are unchanged: node rejects iterables there too.
- `writeFileAsyncIterator` opens anything that is not already an fd with `fs.open(path, flag, mode)`, so string, `Buffer` and `URL` paths behave the same; `fs.open` rejects anything else with `ERR_INVALID_ARG_TYPE`. A `FileHandle` is unwrapped to its fd by the callers as before and is neither opened nor closed here.
- The post-write `ftruncate`, the byte counter feeding it and the `flagTruncates` helper are removed. The flags it fired for (`w`, `w+`, `wx`, ...) all carry `O_TRUNC` (`src/runtime/node/types.rs:1708`), and on Windows the create disposition is derived from `O_TRUNC` too (`src/sys/lib.rs:6997`), so the file is empty when writing starts and ends up exactly as long as the data. Node does not truncate after writing on this path either.
- Two details made consistent while the function was restructured: an empty `flag` falls back to the default (node's `options.flag || 'a'` / `|| 'w'`, also what the native path does via a truthiness check), and an unknown encoding rejects with node's `ERR_INVALID_ARG_VALUE` instead of a plain `TypeError`, which is the code `appendFile` already produced for that input via the native path. The undocumented positional `flag` and `mode` arguments that only the iterable path of `promises.writeFile` read are gone; node and Bun's native path both ignore arguments past `options`.
- Why this is right: node's `fsPromises.appendFile` is literally `options.flag ||= 'a'; return writeFile(path, data, options)`, and its `writeFile` opens whatever path kind it gets and drains `isCustomIterable(data)` into it without resizing afterwards. This makes appendFile the same thin wrapper over the same writer, and the writer itself behaves the same for every path kind.
- Verified with `test/js/node/fs/fs.test.ts`, 37 new cases in three groups: `promises.appendFile with iterable data` (array, String object, buffers, sync and async generators, `Readable`; file creation and `mode`; encoding as argument and option; explicit and empty `flag`; Buffer and URL paths; FileHandle left open; pre-aborted signal; error from the iterable; fd count stable across 32 opens including failing ones; bad encoding; non-iterable data and the sync/callback forms still rejected), `promises.writeFile with iterable data and a Buffer or URL path` (truncation, `flag: "a"`, `flag: "wx"`, `mode`, invalid path rejected before iterating), and `promises.writeFile and appendFile of many small chunks` (32 x 1 KiB chunks through writeFile, appendFile with `flag: "w"` and plain appendFile, each to a string, Buffer and URL path, asserting the exact contents; 32 KiB clears the sink's 16 KiB flush size on Apple Silicon). 32 of the 37 fail on the released build; the 5 that pass there guard behavior that must not change, and the Buffer/URL exact-size ones are the cases that failed with only the first fix applied.
- Also run: the rest of `fs.test.ts`, `fs-promises-writeFile-async-iterator.test.ts`, `promises.test.js` (580 pass across the three files), and node's `test-fs-append-file*`, `test-fs-promises-file-handle-append-file`, `test-fs-promises-file-handle-writeFile`, `test-fs-promises-writefile*`.
- Not changed here: the iterable path still ignores `{ flush: true }` (it did for writeFile before as well; #39192 adds it), it still drains through `Bun.file(fd).writer()` (#35520 is about replacing that), and the per-chunk type error messages differ from node's wording as before.

### Background

- `fs.promises.writeFile` / `appendFile` in Bun have two implementations. String and buffer data go to the native binding (`_writeFile` / `_appendFile`, Rust), which opens, writes and closes in one call. Iterable data goes to `writeFileAsyncIterator` in `fs.promises.ts`, which opens the path with `fs.open`, drains the iterable into `Bun.file(fd).writer()` (a `FileSink`), and closes the fd. `FileHandle#writeFile` and `FileHandle#appendFile` call `exports.writeFile` with the handle's fd, so they already reached the iterable path.
- `FileSink` buffers small writes and flushes once the buffer reaches 4 KiB (16 KiB on Apple Silicon, `src/io/PipeWriter.rs:650`). `write()` returns the bytes a call pushed out, which on a flushing call includes bytes earlier calls already reported, so summing the return values over-counts. The removed `ftruncate` was the only consumer of that sum.
- In node, `data` for the promise versions is documented as `string | Buffer | TypedArray | DataView | AsyncIterable | Iterable | Stream`; each chunk is written in order (a string chunk is encoded with the `encoding` option). A `String` object qualifies because it is iterable (one chunk per character). The sync and callback versions take only strings and buffers.
- `fs.open` here is the promise-returning native binding; it accepts string, `Buffer` and `URL` paths, honors `flag` and `mode`, and throws `ERR_INVALID_ARG_TYPE` for anything else, which is why every non-fd value can be handed to it.

<details>
<summary>Probe against node v26.3.0 (released bun 1.4.0 on the left; this branch matches node on every line)</summary>

```
promises.appendFile(path, array of strings):   bun: ERR_INVALID_ARG_TYPE    node: "0ab"
promises.appendFile(path, String wrapper):     bun: ERR_INVALID_ARG_TYPE    node: "0ab"
promises.appendFile(path, array of buffers):   bun: ERR_INVALID_ARG_TYPE    node: "0ab"
promises.appendFile(path, Set):                bun: ERR_INVALID_ARG_TYPE    node: "0ab"
promises.appendFile(path, async generator):    bun: ERR_INVALID_ARG_TYPE    node: "0xyz"
promises.appendFile(path, Readable):           bun: ERR_INVALID_ARG_TYPE    node: "0ab"
promises.appendFile(path, []):                 bun: ERR_INVALID_ARG_TYPE    node: "0"
promises.appendFile(path, ['é'], 'latin1'):    bun: ERR_INVALID_ARG_TYPE    node: [0x30, 0xe9]
promises.appendFile(path, ['a'], {flag:'w'}):  bun: ERR_INVALID_ARG_TYPE    node: "a"
promises.appendFile(missing, ['a'], {mode:0o600}): bun: ERR_INVALID_ARG_TYPE  node: mode 600
promises.appendFile(path, ['a'], {signal: aborted}): bun: ERR_INVALID_ARG_TYPE  node: AbortError
promises.appendFile(Buffer path, ['a','b']):   bun: ERR_INVALID_ARG_TYPE    node: "0ab"
promises.appendFile(URL path, ['a','b']):      bun: ERR_INVALID_ARG_TYPE    node: "0ab"
promises.appendFile(FileHandle, ['a','b']):    bun: ERR_INVALID_ARG_TYPE    node: "0ab"
FileHandle#appendFile(['a','b']):              bun: "0ab"                   node: "0ab"
fs.appendFileSync(path, ['a','b']):            bun: ERR_INVALID_ARG_TYPE    node: ERR_INVALID_ARG_TYPE
fs.appendFile(path, ['a','b'], cb):            bun: ERR_INVALID_ARG_TYPE    node: ERR_INVALID_ARG_TYPE

file held "0123" before each of these; data is ["a"] (or ["a", "b"] for the flag 'a' rows):
promises.writeFile(Buffer path, iterable, {flag:'a'}):   bun: "ab23"       node: "0123ab"
promises.writeFile(URL path, iterable, {flag:'a'}):      bun: "ab23"       node: "0123ab"
promises.writeFile(Buffer path, iterable, {flag:'wx'}):  bun: "a123"       node: EEXIST
promises.writeFile(URL path, iterable, {flag:'r'}):      bun: "a123"       node: EBADF
promises.writeFile(missing URL, iterable, {mode:0o600}): bun: mode 644     node: mode 600
promises.writeFile(string path, ...same four...):        bun: matches node already

resulting file size for 500 x "0123456789" (node: 5000 for every row)
                                  bun 1.4.0   first fix only   this branch
promises.writeFile(string)        9090        9090             5000
promises.writeFile(Buffer)        5000        9090             5000
promises.writeFile(URL)           5000        9090             5000
promises.appendFile(string)       throws      5000             5000
promises.appendFile({flag:'w'})   throws      9090             5000
promises.appendFile(Buffer)       throws      5000             5000
```

</details>
