### PR TITLE
Bun.Image: reject a byte-backed Blob passed to write(dest) instead of panicking

### DIFF
--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1899,12 +1899,12 @@ impl PipelineTask {
                         // valid for the JS thread; `ArgumentsSlice::init` wants `&`.
                         let args = [dest_js];
                         let mut arg_slice = jsc::ArgumentsSlice::init(global.bun_vm(), &args);
-                        let mut path_or_blob = match crate::node::PathOrBlob::from_js_no_copy(
+                        let mut path_or_blob = match crate::webcore::blob::write_destination_from_js(
                             global,
                             &mut arg_slice,
                         ) {
                             Ok(p) => p,
-                            Err(_) => return promise.reject(global, Err(jsc::JsError::Thrown)),
+                            Err(e) => return promise.reject(global, Err(e)),
                         };
                         // `PathOrBlob::Path` owns its `PathOrFileDescriptor`
                         // and frees on Drop — no explicit `path.deinit()` needed.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4897,7 +4897,8 @@ pub(crate) fn write_file_with_source_destination(
 /// ## Errors
 /// - If `path_or_blob` is a detached blob
 /// ## Panics
-/// - If `path_or_blob` is a `Blob` backed by a byte store
+/// - If `path_or_blob` is a `Blob` backed by a byte store. A destination that
+///   comes from JS must go through [`write_destination_from_js`] first.
 pub(crate) fn write_file_internal(
     global_this: &JSGlobalObject,
     path_or_blob_: &mut PathOrBlob,
@@ -5232,6 +5233,21 @@ fn validate_writable_blob(global_this: &JSGlobalObject, blob: &Blob) -> JsResult
     Ok(())
 }
 
+/// Parses the destination argument of `Bun.write` (shared by `Image.write`):
+/// a path, a file descriptor, or a `Bun.file()` / S3 blob. A `Blob` that is
+/// not backed by a file or S3 is rejected here; that is the precondition
+/// [`write_file_internal`] relies on for a `PathOrBlob::Blob` destination.
+pub(crate) fn write_destination_from_js(
+    global_this: &JSGlobalObject,
+    args: &mut jsc::ArgumentsSlice,
+) -> JsResult<PathOrBlob> {
+    let path_or_blob = PathOrBlob::from_js_no_copy(global_this, args)?;
+    if let PathOrBlob::Blob(ref blob) = path_or_blob {
+        validate_writable_blob(global_this, blob)?;
+    }
+    Ok(path_or_blob)
+}
+
 /// Applies a write-path `options.type` override to `blob`. Throws if the
 /// value is not a string; an invalid blob type is silently ignored.
 fn set_content_type_from_js(
@@ -5261,13 +5277,7 @@ pub(crate) fn write_file(global_this: &JSGlobalObject, callframe: &CallFrame) ->
     // SAFETY: `bun_vm()` returns a live VM pointer for the calling JS context.
     let mut args = jsc::ArgumentsSlice::init(global_this.bun_vm(), arguments);
 
-    // accept a path or a blob
-    // `defer if (.path) path.deinit()` → `Drop for PathLike` (via PathOrBlob).
-    let mut path_or_blob = PathOrBlob::from_js_no_copy(global_this, &mut args)?;
-    // "Blob" must actually be a BunFile, not a webcore blob.
-    if let PathOrBlob::Blob(ref blob) = path_or_blob {
-        validate_writable_blob(global_this, blob)?;
-    }
+    let mut path_or_blob = write_destination_from_js(global_this, &mut args)?;
 
     let Some(data) = args.next_eat() else {
         return Err(global_this.throw_invalid_arguments(format_args!(

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1046,6 +1046,31 @@ describe("Bun.Image", () => {
       await expect(new Bun.Image(cornersPng).png().write(String(dir))).rejects.toThrow();
     });
 
+    test(".write(dest) refuses the Blob destinations Bun.write refuses, with the same error", async () => {
+      using dir = tempDir("image-write-blob-dest", { "src.png": Buffer.from(cornersPng) });
+      const caught = async (fn: () => unknown): Promise<any> => {
+        try {
+          await fn();
+        } catch (e) {
+          return e;
+        }
+        throw new Error("did not throw or reject");
+      };
+      const errorShape = (e: any) => ({ name: e.name, code: e.code, message: e.message });
+      // A Blob backed by bytes and a Blob with no store at all. Bun.write()
+      // throws for both; .write() used to hand them to the file write path
+      // unchecked, which aborted the process for the byte-backed one.
+      for (const dest of [new Blob(["not a file"]), new Blob([])] as any[]) {
+        const expected = await caught(() => Bun.write(dest, "x"));
+        // An in-memory source and a Bun.file() source enter the pipeline
+        // through different schedulers; both deliver to the same write step.
+        for (const source of [cornersPng, Bun.file(join(String(dir), "src.png"))]) {
+          const actual = await caught(() => new Bun.Image(source).png().write(dest));
+          expect(errorShape(actual)).toEqual(errorShape(expected));
+        }
+      }
+    });
+
     test(".toBase64() produces valid base64", async () => {
       const b64 = await new Bun.Image(cornersPng).png().toBase64();
       expect(typeof b64).toBe("string");

--- a/test/js/web/fetch/blob-write.test.ts
+++ b/test/js/web/fetch/blob-write.test.ts
@@ -9,6 +9,18 @@ test("blob.write() throws for data-backed blob", () => {
   );
 });
 
+test("Bun.write() throws for a data-backed blob destination", () => {
+  const blob = new Blob(["Hello, world!"]) as any;
+  expect(() => Bun.write(blob, "x")).toThrowErrorMatchingInlineSnapshot(
+    `"Cannot write to a Blob backed by bytes, which are always read-only"`,
+  );
+  // The destination is checked before the data argument is.
+  // @ts-expect-error the data argument is left out on purpose
+  expect(() => Bun.write(blob)).toThrowErrorMatchingInlineSnapshot(
+    `"Cannot write to a Blob backed by bytes, which are always read-only"`,
+  );
+});
+
 test("Bun.file(path).write() does not throw", async () => {
   const file = Bun.file(path.join(tempDirWithFiles("bun-write", { a: "Hello, world!" }), "a"));
   expect(() => file.write(new Blob(["Hello, world!!"]))).not.toThrow();


### PR DESCRIPTION
### Problem
- `await new Bun.Image(png).png().write(new Blob(["x"]))` aborts the process. Release: `panic: internal error: entered unreachable code: Data::as_file on non-File variant` (exit 134). Debug build: `panic: assertion failed: !matches!(blob_store.data, store::Data::Bytes(_))` at `src/runtime/webcore/Blob.rs:4918` in `write_file_internal`, reached from the `Deliver::WriteDest` arm of `PipelineTask::then` (`src/runtime/image/Image.rs:1911`).
- `write_file_internal` documents that a `PathOrBlob::Blob` destination must not be backed by bytes and leaves the check to its callers. `Bun.write` (`write_file`) and `blob.write()` (`do_write`) call `validate_writable_blob` first; the Image write step built its destination with `PathOrBlob::from_js_no_copy` and called `write_file_internal` directly, so a plain `Blob` went through. On POSIX the byte store takes the small-write fast path and hits `as_file()`; on Windows (and for outputs over 256 KiB) it reaches the store dispatch on the slow path instead. Either way the process dies instead of the promise rejecting.
- `new Blob([])` (a Blob with no store) did not crash, but rejected with a different error than `Bun.write` gives for the same destination (`Blob is detached` vs `Cannot write to a detached Blob`).

### Fix
- `src/runtime/webcore/Blob.rs`: new `write_destination_from_js`, which is `Bun.write`'s existing destination handling (`PathOrBlob::from_js_no_copy` followed by `validate_writable_blob` for a Blob) moved into one `pub(crate)` function. `write_file` calls it; argument order and error priority of `Bun.write` are unchanged (destination is still checked before the data argument). The `write_file_internal` doc now names the function that establishes its precondition.
- `src/runtime/image/Image.rs`: the write step calls `write_destination_from_js` instead of `from_js_no_copy`, and rejects the promise with the thrown error. A byte-backed or store-less Blob destination now rejects with exactly the error `Bun.write` throws for it. Destinations `Bun.write` accepts (path, fd, `Bun.file()`, S3) behave as before.
- Why this is the right place: `.write(dest)` is documented (types and the comment on the arm) as handing `dest` to `Bun.write`'s implementation, so the destination has to pass the same check. It stays a rejection rather than a synchronous throw because every other destination error of `.write()` (wrong type, fs errors) is already surfaced as a rejection at this step. Sharing one function rather than copying the two-line check means a future caller of `write_file_internal` that parses a JS destination gets the check as well.
- Verified:
  - `test/js/bun/image/image.test.ts` `.write(dest) refuses the Blob destinations Bun.write refuses, with the same error`: byte-backed and store-less Blob destinations, each with an in-memory source and a `Bun.file()` source (the two ways a pipeline is scheduled). Aborts the test process on main (both the release binary and a debug build with `src/` stashed), passes with this change.
  - `test/js/web/fetch/blob-write.test.ts` `Bun.write() throws for a data-backed blob destination`: pins `Bun.write`'s own error and its destination-before-data priority across the refactor (passes before and after).
  - `bun bd test` on `test/js/bun/image/image.test.ts` (95 pass, 2 skip) and `test/js/web/fetch/blob-write.test.ts` (15 pass); `test/internal/source-lints` (166 pass); `test/js/bun/io/bun-write.test.js` passes apart from the pre-existing `copyFileRange is not available > on large files` 5s timeout, which also times out here without this change.
  - Ad hoc: `Bun.write(s3file, ...)` and `new Bun.Image(..).write(s3file)` against a local `Bun.serve` S3 stub both still issue the PUT.

### Background
- A `Blob`'s data lives in a `Store`, whose `Data` is one of `Bytes` (an in-memory `new Blob([...])`), `File` (`Bun.file()` / fd) or `S3` (`Bun.s3()`); a `Blob` with no store at all is what `new Blob([])` produces. Only the `File` and `S3` kinds can be written to, which is what `validate_writable_blob` checks.
- `PathOrBlob` is the parsed form of a "destination" argument: either a path / fd or a borrowed view of a Blob argument. `write_file_internal` is the shared implementation behind `Bun.write`, `blob.write()`, the S3 write entry points and `Image.write()`; it takes a `PathOrBlob` and assumes any Blob in it has already passed the check above.
- `Image.write(dest)` encodes on a worker thread and, back on the JS thread (`PipelineTask::then`, `Deliver::WriteDest`), wraps the encoded bytes as a Buffer and passes them with `dest` to `write_file_internal`, resolving the image's promise with the write's promise. That arm is the only caller that parsed a JS destination without the check.
