### PR TITLE
bake: resolve app.root against the cwd and require it to be a string

### DIFF
--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -219,8 +219,6 @@ impl UserOptions {
             &arena,
         )?;
 
-        // Absolute with no trailing separator: `DevServer::relative_path` and
-        // `FrameworkRouter` strip it off file paths as a prefix.
         let root: &'static ZStr = {
             let cwd = match bun_sys::getcwd_alloc() {
                 Ok(cwd) => cwd,

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -250,7 +250,11 @@ fn resolve_root(
         &mut buf[..],
         &[user_root.slice()],
     ) else {
-        return Err(global.throw_invalid_arguments(format_args!("'{}.root' is too long", API_NAME)));
+        return Err(global.throw_invalid_arguments(format_args!(
+            "'{}.root' resolves to a path longer than {} bytes",
+            API_NAME,
+            paths::MAX_PATH_BYTES
+        )));
     };
     Ok(arena_dupe_z(
         arena,

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -227,10 +227,7 @@ impl UserOptions {
     }
 }
 
-/// `app.root` defaults to, and a user supplied value is resolved against, the
-/// directory `Framework::resolve` resolves the framework's own paths against.
-/// DevServer strips the result off absolute file paths, so it never ends in a
-/// separator.
+/// Absolute, no trailing separator, resolved against the same directory as `Framework::resolve`.
 fn resolve_root(
     user_root: Option<ZigStringSlice>,
     global: &JSGlobalObject,

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -31,19 +31,6 @@ use super::{dev_server, framework_router};
 // FrameworkRouter` are already provided by the parent `mod.rs` (lines 349/369);
 // re-exporting here triggers E0365 because `bake_body` is a private module.
 
-/// Local shim until `bun_jsc` grows a typed `get_optional`.
-/// Returns `None` for missing/null/undefined.
-fn get_optional_slice(
-    target: JSValue,
-    global: &JSGlobalObject,
-    property: &[u8],
-) -> JsResult<Option<ZigStringSlice>> {
-    match target.get(global, property)? {
-        Some(v) if !v.is_undefined_or_null() => Ok(Some(v.to_slice(global)?)),
-        _ => Ok(None),
-    }
-}
-
 /// `JSValue.getBooleanStrict` — local shim.
 fn get_boolean_strict(
     target: JSValue,
@@ -232,14 +219,35 @@ impl UserOptions {
             &arena,
         )?;
 
-        let root: &[u8] = if let Some(slice) = get_optional_slice(config, global, b"root")? {
-            allocations.track(slice)
-        } else {
-            match bun_sys::getcwd_alloc() {
-                Ok(z) => arena_dupe_z(&arena, z.as_bytes()).as_bytes(),
+        // DevServer and FrameworkRouter strip `root` off absolute file paths to
+        // form module IDs and route patterns, so it must be absolute and must
+        // not end in a separator.
+        let root: &'static ZStr = {
+            let cwd = match bun_sys::getcwd_alloc() {
+                Ok(cwd) => cwd,
                 Err(e) => {
                     return Err(global
                         .throw_error(e.to_zig_err(), "while querying current working directory"));
+                }
+            };
+            match config.get_optional_slice(global, b"root")? {
+                None => arena_dupe_z(&arena, cwd.as_bytes()),
+                Some(user_root) => {
+                    use bun_paths::resolve_path::join_abs_string_buf_checked;
+                    use bun_paths::string_paths::without_trailing_slash_windows_path;
+
+                    let mut buf = paths::path_buffer_pool::get();
+                    let Some(resolved) = join_abs_string_buf_checked::<paths::platform::Auto>(
+                        cwd.as_bytes(),
+                        &mut buf[..],
+                        &[user_root.slice()],
+                    ) else {
+                        return Err(global.throw_invalid_arguments(format_args!(
+                            "'{}.root' is too long",
+                            API_NAME
+                        )));
+                    };
+                    arena_dupe_z(&arena, without_trailing_slash_windows_path(resolved))
                 }
             }
         };
@@ -248,10 +256,8 @@ impl UserOptions {
             bundler_options.parse_plugin_array(plugin_array, global)?;
         }
 
-        let root_z = arena_dupe_z(&arena, root);
-
         Ok(UserOptions {
-            root: root_z,
+            root,
             framework,
             bundler_options,
             allocations,
@@ -334,7 +340,7 @@ impl SplitBundlerOptions {
                 );
             }
 
-            if let Some(slice) = get_optional_slice(plugin_config, global, b"name")? {
+            if let Some(slice) = plugin_config.get_optional_slice(global, b"name")? {
                 if slice.slice().is_empty() {
                     return Err(global.throw_invalid_arguments(format_args!(
                         "Expected plugin to have a non-empty name"
@@ -856,7 +862,7 @@ impl Framework {
                     )));
                 },
                 server_runtime_import: refs.track(
-                    match get_optional_slice(sc, global, b"serverRuntimeImportSource")? {
+                    match sc.get_optional_slice(global, b"serverRuntimeImportSource")? {
                         Some(s) => s,
                         None => {
                             return Err(global.throw_invalid_arguments(format_args!(
@@ -866,7 +872,7 @@ impl Framework {
                     },
                 ),
                 server_register_client_reference: if let Some(slice) =
-                    get_optional_slice(sc, global, b"serverRegisterClientReferenceExport")?
+                    sc.get_optional_slice(global, b"serverRegisterClientReferenceExport")?
                 {
                     refs.track(slice)
                 } else {

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -219,9 +219,8 @@ impl UserOptions {
             &arena,
         )?;
 
-        // DevServer and FrameworkRouter strip `root` off absolute file paths to
-        // form module IDs and route patterns, so it must be absolute and must
-        // not end in a separator.
+        // Absolute with no trailing separator: `DevServer::relative_path` and
+        // `FrameworkRouter` strip it off file paths as a prefix.
         let root: &'static ZStr = {
             let cwd = match bun_sys::getcwd_alloc() {
                 Ok(cwd) => cwd,

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -163,15 +163,7 @@ impl UserOptions {
                 let utf8_string = bunstr.to_utf8();
 
                 if strings::eql(utf8_string.slice(), b"react") {
-                    let root = match bun_sys::getcwd_alloc() {
-                        Ok(z) => arena_dupe_z(&arena, z.as_bytes()),
-                        Err(e) => {
-                            return Err(global.throw_error(
-                                e.to_zig_err(),
-                                "while querying current working directory",
-                            ));
-                        }
-                    };
+                    let root = resolve_root(None, global, &arena)?;
 
                     let framework = Framework::react(&arena)
                         .map_err(|e| throw_core_error(global, e, "Framework::react"))?;
@@ -219,35 +211,7 @@ impl UserOptions {
             &arena,
         )?;
 
-        let root: &'static ZStr = {
-            let cwd = match bun_sys::getcwd_alloc() {
-                Ok(cwd) => cwd,
-                Err(e) => {
-                    return Err(global
-                        .throw_error(e.to_zig_err(), "while querying current working directory"));
-                }
-            };
-            match config.get_optional_slice(global, b"root")? {
-                None => arena_dupe_z(&arena, cwd.as_bytes()),
-                Some(user_root) => {
-                    use bun_paths::resolve_path::join_abs_string_buf_checked;
-                    use bun_paths::string_paths::without_trailing_slash_windows_path;
-
-                    let mut buf = paths::path_buffer_pool::get();
-                    let Some(resolved) = join_abs_string_buf_checked::<paths::platform::Auto>(
-                        cwd.as_bytes(),
-                        &mut buf[..],
-                        &[user_root.slice()],
-                    ) else {
-                        return Err(global.throw_invalid_arguments(format_args!(
-                            "'{}.root' is too long",
-                            API_NAME
-                        )));
-                    };
-                    arena_dupe_z(&arena, without_trailing_slash_windows_path(resolved))
-                }
-            }
-        };
+        let root = resolve_root(config.get_optional_slice(global, b"root")?, global, &arena)?;
 
         if let Some(plugin_array) = config.get(global, "plugins")? {
             bundler_options.parse_plugin_array(plugin_array, global)?;
@@ -261,6 +225,40 @@ impl UserOptions {
             arena,
         })
     }
+}
+
+/// `app.root` defaults to, and a user supplied value is resolved against, the
+/// directory `Framework::resolve` resolves the framework's own paths against.
+/// DevServer strips the result off absolute file paths, so it never ends in a
+/// separator.
+fn resolve_root(
+    user_root: Option<ZigStringSlice>,
+    global: &JSGlobalObject,
+    arena: &Arena,
+) -> JsResult<&'static ZStr> {
+    use bun_paths::resolve_path::join_abs_string_buf_checked;
+    use bun_paths::string_paths::without_trailing_slash_windows_path;
+
+    let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+    let Some(user_root) = user_root else {
+        return Ok(arena_dupe_z(
+            arena,
+            without_trailing_slash_windows_path(top_level_dir),
+        ));
+    };
+
+    let mut buf = paths::path_buffer_pool::get();
+    let Some(resolved) = join_abs_string_buf_checked::<paths::platform::Auto>(
+        top_level_dir,
+        &mut buf[..],
+        &[user_root.slice()],
+    ) else {
+        return Err(global.throw_invalid_arguments(format_args!("'{}.root' is too long", API_NAME)));
+    };
+    Ok(arena_dupe_z(
+        arena,
+        without_trailing_slash_windows_path(resolved),
+    ))
 }
 
 /// Each string stores its allocator since some may hold reference counts to JSC

--- a/test/bake/app-options.test.ts
+++ b/test/bake/app-options.test.ts
@@ -1,0 +1,108 @@
+// Parsing of the `app` option of `Bun.serve({ app })` (src/runtime/bake/bake_body.rs,
+// UserOptions::from_js). The dev server strips `app.root` off absolute file paths to build
+// route patterns and module IDs, so the value the user passes has to be resolved against
+// the cwd and normalized before it gets there.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const appFiles = {
+  "server.ts": `export function render(req, meta) { return meta.pageModule.default(); }`,
+  "routes/index.ts": `export default () => new Response("index route");`,
+};
+
+const framework = `{
+  fileSystemRouterTypes: [{ root: "routes", style: "nextjs-pages", serverEntryPoint: "./server.ts" }],
+}`;
+
+describe("app.root", () => {
+  // Every spelling below names the cwd, which is also what `root` defaults to.
+  test.concurrent.each([".", "./", "routes/..", "<cwd>/"])("routes are served when root is %j", async spelling => {
+    using dir = tempDir("bake-app-root", {
+      ...appFiles,
+      "serve.ts": `
+        const root = process.argv[2].replace("<cwd>", process.cwd());
+        const server = Bun.serve({
+          port: 0,
+          development: true,
+          app: { framework: ${framework}, root },
+          fetch: () => new Response("fallback"),
+        });
+        const res = await fetch(server.url);
+        console.log(JSON.stringify({ status: res.status, body: await res.text() }));
+        await server.stop(true);
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "serve.ts", spelling],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const line = stdout.split("\n").find(l => l.startsWith("{"));
+    expect(line, stderr).toBeDefined();
+    expect(JSON.parse(line!)).toEqual({ status: 200, body: "index route" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("values that cannot be used as a root are rejected while parsing the options", async () => {
+    using dir = tempDir("bake-app-root-invalid", {
+      ...appFiles,
+      "check.ts": `
+        const framework = ${framework};
+        const serverComponents = extra => ({
+          framework: { ...framework, serverComponents: { separateSSRGraph: false, ...extra } },
+        });
+        const apps = {
+          "root: null": { framework, root: null },
+          "root: 123": { framework, root: 123 },
+          "root: 100k chars": { framework, root: Buffer.alloc(100_000, "a").toString() },
+          // The same string check applies to the other optional string options.
+          "plugins[0].name: 123": { framework, plugins: [{ name: 123, setup() {} }] },
+          "serverComponents.serverRuntimeImportSource: 123": serverComponents({ serverRuntimeImportSource: 123 }),
+          "serverComponents.serverRegisterClientReferenceExport: 123": serverComponents({
+            serverRuntimeImportSource: "./server.ts",
+            serverRegisterClientReferenceExport: 123,
+          }),
+        };
+
+        const results = {};
+        for (const [name, app] of Object.entries(apps)) {
+          try {
+            const server = Bun.serve({ port: 0, development: true, app, fetch: () => new Response("") });
+            server.stop(true);
+            results[name] = "accepted";
+          } catch (e) {
+            results[name] = e.message;
+          }
+        }
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "check.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      "root: null": "accepted",
+      "root: 123": 'The "root" property must be of type string, got number',
+      "root: 100k chars": "'app.root' is too long",
+      "plugins[0].name: 123": 'The "name" property must be of type string, got number',
+      "serverComponents.serverRuntimeImportSource: 123":
+        'The "serverRuntimeImportSource" property must be of type string, got number',
+      "serverComponents.serverRegisterClientReferenceExport: 123":
+        'The "serverRegisterClientReferenceExport" property must be of type string, got number',
+    });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/bake/app-options.test.ts
+++ b/test/bake/app-options.test.ts
@@ -1,7 +1,7 @@
 // Parsing of the `app` option of `Bun.serve({ app })` (src/runtime/bake/bake_body.rs,
 // UserOptions::from_js). The dev server strips `app.root` off absolute file paths to build
 // route patterns and module IDs, so the value the user passes has to be resolved against
-// the cwd and normalized before it gets there.
+// the working directory and normalized before it gets there.
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
@@ -15,16 +15,17 @@ const framework = `{
 }`;
 
 describe("app.root", () => {
-  // Every spelling below names the cwd, which is also what `root` defaults to.
-  test.concurrent.each([".", "./", "routes/..", "<cwd>/"])("routes are served when root is %j", async spelling => {
+  // `root` defaults to the cwd; every other spelling below names that same directory.
+  const spellings: (string | undefined)[] = [undefined, "", ".", "./", "routes/..", "<cwd>/"];
+  test.concurrent.each(spellings)("routes are served when root is %p", async spelling => {
     using dir = tempDir("bake-app-root", {
       ...appFiles,
       "serve.ts": `
-        const root = process.argv[2].replace("<cwd>", process.cwd());
+        const { root } = JSON.parse(process.argv[2]);
         const server = Bun.serve({
           port: 0,
           development: true,
-          app: { framework: ${framework}, root },
+          app: { framework: ${framework}, root: root?.replace("<cwd>", process.cwd()) },
           fetch: () => new Response("fallback"),
         });
         const res = await fetch(server.url);
@@ -34,7 +35,7 @@ describe("app.root", () => {
     });
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "serve.ts", spelling],
+      cmd: [bunExe(), "serve.ts", JSON.stringify({ root: spelling })],
       env: bunEnv,
       cwd: String(dir),
       stdout: "pipe",
@@ -48,7 +49,7 @@ describe("app.root", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("values that cannot be used as a root are rejected while parsing the options", async () => {
+  test.concurrent("values that cannot be used as a root are rejected while parsing the options", async () => {
     using dir = tempDir("bake-app-root-invalid", {
       ...appFiles,
       "check.ts": `
@@ -96,7 +97,8 @@ describe("app.root", () => {
     expect(JSON.parse(stdout)).toEqual({
       "root: null": "accepted",
       "root: 123": 'The "root" property must be of type string, got number',
-      "root: 100k chars": "'app.root' is too long",
+      // The limit is the platform's path buffer size (1024 on macOS, 4096 on Linux, larger on Windows).
+      "root: 100k chars": expect.stringMatching(/^'app\.root' resolves to a path longer than \d+ bytes$/),
       "plugins[0].name: 123": 'The "name" property must be of type string, got number',
       "serverComponents.serverRuntimeImportSource: 123":
         'The "serverRuntimeImportSource" property must be of type string, got number',


### PR DESCRIPTION
### Problem

- `Bun.serve({ development: true, app: { framework, root: "." } })` (or any other relative `root`) aborts debug builds at startup:
  ```
  panic: assertion failed: paths::is_absolute(root)
    FrameworkRouter::init_empty   src/runtime/bake/FrameworkRouter.rs:171
    dev_server_body::init         src/runtime/bake/DevServer.rs:995
  ```
- An absolute `root` with a trailing separator (`root: process.cwd() + "/"`) starts, then aborts debug builds on the first request:
  ```
  panic: assertion failed: self.root[self.root.len() - 1] != b'/'
    DevServer::relative_path      src/runtime/bake/DevServer.rs:5956
  ```
- Release builds accept the same configs and misbehave instead: `FrameworkRouter::scan_inner` builds each route pattern by slicing `abs_root.len() - root.len() - 1` bytes off a path it computed relative to `root` (`FrameworkRouter.rs:1575-1597`). With `root: "."` no route matches and every request falls through to `fetch()`; with a `root` longer than the router directory's path the subtraction underflows and the process panics (`range start index 18446744073709451655 out of range`).
- `root: 123` behaves like `root: "123"`: the local `get_optional_slice` shim in `bake_body.rs` coerced any value with `toString`. The Zig it was ported from used `getOptional(.., ZigString.Slice)`, which threw.
- Cause: `UserOptions::from_js` (`src/runtime/bake/bake_body.rs:235` on main) stored the user's string verbatim, while the value it defaults to is an absolute directory. `DevServer` copies the field straight into `dev.root` (`DevServer.rs:518`) and both consumers above require an absolute path with no trailing separator.

### Fix

- `UserOptions::from_js` now produces `root` through one helper, `resolve_root`, in both of its arms (`app: "react"` and the object form):
  - base directory: the resolver's `top_level_dir`. That is the directory `Framework::resolve` already resolves `fileSystemRouterTypes[n].root` and the entry points against, so `app.root` can no longer be derived from a different base than the paths it is compared with (before, it came from a separate `getcwd`). The default (`root` not given) is this directory, stripped of a trailing separator, which is the same string `getcwd` produced before.
  - a user supplied `root` is joined against it with `join_abs_string_buf_checked`, stripped of a trailing separator, and rejected with `'app.root' resolves to a path longer than <MAX_PATH_BYTES> bytes` when it cannot fit in a path buffer.
- The local `get_optional_slice` shim is deleted in favor of `JSValue::get_optional_slice`, which throws `ERR_INVALID_ARG_TYPE` for non-strings, at its four call sites: `root`, `plugins[n].name`, `serverComponents.serverRuntimeImportSource`, `serverComponents.serverRegisterClientReferenceExport`. This restores the pre-port behavior and matches `Bun.build`'s plugin parsing (`JSBundler.rs:500`). The remaining local shims (`get_boolean_*`, `get_function`) return `None` so that bake can raise its own messages; they are unrelated to this bug and unchanged.
- Why this fix should exist, given that today a `root` other than the cwd still fails at request time (the bundler keys modules relative to the cwd, `DevServer` relative to `root`):
  - #39202 is fixing that mismatch and makes `root` a working option; it states that it needs an absolute root and does not touch `bake_body.rs`. This PR is the producer side it relies on: without it, `root: "./app"` still hits the assertions and the pattern arithmetic above.
  - Independently of #39202, `"."`, `"./"` and `dir + "/"` are the natural spellings of the default, and today they are the difference between routes working and every request silently hitting `fetch()`.
  - Relative directories resolving against the working directory is how `Bun.build({ root })`, `Bun.FileSystemRouter({ dir })` and bake's own `fileSystemRouterTypes[n].root` already behave.
  - If instead the option is meant to be removed (it is not declared in `bake.d.ts`), this hunk goes with it; #39202 is proceeding on the basis that it stays.
- Out of scope and tracked separately: the module id mismatch above (#39202); a `fileSystemRouterTypes[n].root` longer than 4 KB panicking in `Framework::resolve`; every `Err` return from `from_js` after `framework.plugins` was parsed leaking the protected plugin cell, because only `UserOptions::Drop` releases it (raised in review, pre-existing on the other error paths). Consumer-side fixes for neighbouring symptoms (#36396 trailing separator after `process.chdir()` on the HTML route path, #38323 root of `/`, #33203 router roots outside the app root) do not overlap with this change.
- Tests: `test/bake/app-options.test.ts` (new file; #39150 adds a file of the same name for other `app` options, whichever lands second appends to it). Unset, `""`, `.`, `./`, `routes/..` and `<cwd>/` are each served end to end, and `root: 123`, a 100k character root, `root: null`, and the three other migrated string options are checked for their exact outcome.
  - `bun bd test test/bake/app-options.test.ts`: 7 pass.
  - Same command with `src/` stashed: everything except the unset spelling fails, the spellings with the two assertions above and the option test with `is_absolute(root)`.
  - `USE_SYSTEM_BUN=1 bun test test/bake/app-options.test.ts` (release): 5 of 7 fail; `""`/`.`/`./`/`routes/..` get `"fallback"` instead of the route and the option test dies on the slice underflow panic (unset and `<cwd>/` pass there: the default always worked, and the trailing separator only trips the debug assertion).
  - Also green on the debug build: `test/bake/dev/plugins.test.ts`, `test/bake/dev/esm.test.ts`, `test/bake/dev/production.test.ts` (`bun build --app` goes through the same `from_js`; the `app: "react"` shortcut was exercised by hand through `bun build --app` and gets past configuration loading).

### Background

- `app` is the experimental Bake dev server config accepted by `Bun.serve` (behind `BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE`, which the test harness sets) and by `bun build --app`. Both parse it through `UserOptions::from_js`; only the dev server reads `root`, `bun build --app` uses the cwd directly.
- `top_level_dir` is the working directory captured by the resolver's process-wide `FileSystem` singleton when the runtime starts; `process.chdir()` updates it (with a trailing separator, which is why the default is stripped). Everything the framework configures is resolved against it.
- `DevServer.root` is the project root: module ids sent to the HMR runtime are file paths with this prefix removed (`DevServer::relative_path`), and `FrameworkRouter` turns files under each `fileSystemRouterTypes[n].root` into URL patterns by the same prefix removal. That is why both hold the absolute, no trailing separator invariant this PR establishes at the point where the value enters.
- `join_abs_string_buf_checked` is bun's `path.resolve` over byte slices: it joins a base directory and parts, normalizes `.`/`..`/separators, and returns `None` instead of overflowing when the result does not fit the caller's buffer. It keeps a trailing separator from its input, hence the explicit strip afterwards.
- `JSValue::get_optional_slice` returns `None` for a missing/`null`/`undefined` property, the UTF-8 bytes for a string, and throws `The "<name>" property must be of type string, got <type>` for anything else.

<details>
<summary>Probe of the release build before this change</summary>

`cwd` holds `server.ts` and `routes/index.tsx`; the script starts the server, fetches `/`, prints the body.

```
root: "/tmp/bake-root-repro"   -> {"status":200,"body":"rendered"}
root: "."                      -> {"status":200,"body":"fallback"}
root: "some/relative/dir"      -> {"status":200,"body":"fallback"}
root: "a".repeat(5000)         -> panic: range start index 18446744073709546642 out of range for slice of length 39
```

Debug build, same script: `"."`, `""`, `123`, `true` abort in `FrameworkRouter::init_empty`; `"/tmp/bake-root-repro/"` starts and aborts in `DevServer::relative_path` on the fetch; `"/tmp/bake-root-repro"` serves the route.

</details>

<details>
<summary>Earlier shape of this PR</summary>

The first revision (84cffc3) resolved a user supplied `root` against a fresh `getcwd()` and left the default on `getcwd()` as before. Review pointed out that this derived the root from a different base than the one `Framework::resolve` uses for the paths it is compared with; c3f6ba5 switched both arms to `top_level_dir` through the shared helper, which also removed the `getcwd` error paths. Tests and behavior for the cases above are unchanged.

</details>
