### PR TITLE
shell: report the operand as written in cat, touch and mkdir errors

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -1033,6 +1033,7 @@ impl Builtin {
     /// `bun_sys::coreutils_error_map` so output matches GNU coreutils
     /// (e.g. `ENOENT` → "No such file or directory"); falls back to
     /// `"unknown error {errno}"` when unmapped.
+    /// `err.path` is printed as the operand, so builtins that resolve an operand tag it as written.
     pub(crate) fn task_error_to_string<'a>(
         interp: &'a Interpreter,
         cmd: NodeId,

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -294,6 +294,11 @@ impl ShellMkdirTask {
         bun_core::heap::into_raw(task)
     }
 
+    /// The operand as written; `run_from_thread_pool` NUL-terminates an absolute one in place.
+    fn operand(&self) -> &[u8] {
+        self.filepath.strip_suffix(b"\0").unwrap_or(&self.filepath)
+    }
+
     fn run_from_thread_pool(this: &mut ShellMkdirTask) {
         use bun_paths::{Platform, platform, resolve_path};
         // We have to give an absolute path to our mkdir implementation for it
@@ -325,7 +330,7 @@ impl ShellMkdirTask {
                 active: this.opts.verbose,
             };
             if let Err(e) = node_fs.mkdir_recursive_impl(&args, &vtable) {
-                this.err = Some(e.with_path(filepath.as_bytes()));
+                this.err = Some(e.with_path(this.operand()));
                 core::hint::black_box(&node_fs);
             }
         } else {
@@ -338,7 +343,7 @@ impl ShellMkdirTask {
                     }
                 }
                 Err(e) => {
-                    this.err = Some(e.with_path(filepath.as_bytes()));
+                    this.err = Some(e.with_path(this.operand()));
                     core::hint::black_box(&node_fs);
                 }
             }

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -296,12 +296,12 @@ impl ShellTouchTask {
                             break 'out;
                         }
                         Err(e) => {
-                            this.err = Some(e.with_path(filepath.as_bytes()));
+                            this.err = Some(e.with_path(&this.filepath));
                             break 'out;
                         }
                     }
                 }
-                this.err = Some(err.with_path(filepath.as_bytes()));
+                this.err = Some(err.with_path(&this.filepath));
             }
         }
         // Worker→main bounce-back is posted by `shell_task_trampoline` after

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2290,7 +2290,7 @@ pub(crate) fn shell_openat(
         let p = shell_get_path(dir, path, &mut buf)?;
         // No `makeLibUVOwnedForSyscall` here: `bun_sys::open` on Windows
         // routes through `sys_uv` and already yields a uv-owned fd.
-        return bun_sys::open(p, flags, perm);
+        return bun_sys::open(p, flags, perm).map_err(|e| e.with_path(path.as_bytes()));
     }
     #[cfg(not(windows))]
     {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -91,6 +91,89 @@ describe("bunshell", () => {
     );
   });
 
+  // touch and mkdir (everywhere) and cat (on Windows) resolve the operand
+  // against the cwd before the syscall; the error must still name the operand
+  // as the user wrote it, like ls/rm/mv and the system coreutils do. The flag
+  // turns the builtin cat on outside Windows; touch and mkdir are always
+  // builtins.
+  test("builtins name a failing operand as written", async () => {
+    using dir = tempDir("builtin-operand-as-written", { sub: {}, afile: "" });
+    const enoent = "No such file or directory";
+    const enotdir = "Not a directory";
+    // The operand is the last word of each command; stderr must be exactly
+    // `<builtin>: <operand>: <message>`.
+    const rows: [command: string[], message: string][] = [
+      [["cat", "missing.txt"], enoent],
+      [["cat", "sub/missing.txt"], enoent],
+      [["cat", "/bunshell-missing-operand/missing.txt"], enoent],
+      [["cat", join(String(dir), "missing.txt")], enoent],
+      [["touch", "nodir/file.txt"], enoent],
+      [["touch", "sub/nodir/file.txt"], enoent],
+      [["touch", "/bunshell-missing-operand/file.txt"], enoent],
+      [["touch", join(String(dir), "nodir", "file.txt")], enoent],
+      // A missing parent fails in the open() touch falls back to; a file in
+      // the way already fails in utimes() (Windows reports that as ENOENT too).
+      [["touch", "afile/file.txt"], isWindows ? enoent : enotdir],
+      [["mkdir", "nodir/child"], enoent],
+      [["mkdir", "sub/nodir/child"], enoent],
+      [["mkdir", "/bunshell-missing-operand/child"], enoent],
+      [["mkdir", join(String(dir), "nodir", "child")], enoent],
+      // -p is a separate code path; like before, it names the operand rather
+      // than the component that failed.
+      [["mkdir", "-p", "afile/child"], enotdir],
+    ];
+    // The first row of each builtin is also run with stderr redirected to a
+    // file, which takes the builtins' other output path.
+    const redirected = ["cat", "touch", "mkdir"].map(builtin => rows.find(([command]) => command[0] === builtin)!);
+
+    const script = /* ts */ `
+      import { $ } from "bun";
+      $.nothrow();
+      const results = {};
+      const record = async (key, promise) => {
+        const r = await promise.quiet();
+        results[key] = { stdout: r.stdout.toString(), stderr: r.stderr.toString(), exitCode: r.exitCode };
+      };
+      for (const command of ${JSON.stringify(rows.map(([command]) => command))}) {
+        const words = command.slice(0, -1).join(" ");
+        const operand = command[command.length - 1];
+        await record(command.join(" "), $\`\${{ raw: words }} \${operand}\`);
+      }
+      for (const command of ${JSON.stringify(redirected.map(([command]) => command))}) {
+        const words = command.slice(0, -1).join(" ");
+        const operand = command[command.length - 1];
+        const errFile = "err-" + command[0] + ".txt";
+        await record(command.join(" ") + " 2> " + errFile, $\`\${{ raw: words }} \${operand} 2> \${{ raw: errFile }}\`);
+      }
+      console.log(JSON.stringify(results));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [BUN, "-e", script],
+      env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+
+    const errorLine = (command: string[], message: string) =>
+      `${command[0]}: ${command[command.length - 1]}: ${message}\n`;
+    const results = JSON.parse(stdout);
+    const expected: Record<string, unknown> = {};
+    for (const [command, message] of rows) {
+      expected[command.join(" ")] = { stdout: "", stderr: errorLine(command, message), exitCode: 1 };
+    }
+    for (const [command, message] of redirected) {
+      const errFile = `err-${command[0]}.txt`;
+      expected[`${command.join(" ")} 2> ${errFile}`] = { stdout: "", stderr: "", exitCode: 1 };
+      expected[errFile] = errorLine(command, message);
+      results[errFile] = await Bun.file(join(String(dir), errFile)).text();
+    }
+    expect(results).toEqual(expected);
+    expect(exitCode).toBe(0);
+  });
+
   describe("concurrency", () => {
     test("writing to stdout", async () => {
       await Promise.all([
@@ -560,9 +643,7 @@ describe("bunshell", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    // On Windows the message carries the absolute path (shell_openat only
-    // re-tags the error with the argument as written on POSIX).
-    const missingFileError = expect.stringMatching(/^cat: (.*[\\/])?missing\.txt: No such file or directory\n$/);
+    const missingFileError = "cat: missing.txt: No such file or directory\n";
     expect(JSON.parse(stdout)).toEqual({
       "captured": { stdout: "hi\n", stderr: "", exitCode: 0 },
       "stdout to fd": { stdout: "", stderr: "", exitCode: 0 },


### PR DESCRIPTION
### Problem

- Three shell builtins report the path they resolved instead of the operand the user typed. With cwd `/tmp/x`:
  - `mkdir nodir/a` prints `mkdir: /tmp/x/nodir/a: No such file or directory` (every platform, mkdir is always a builtin)
  - `touch nodir/f` prints `touch: /tmp/x/nodir/f: No such file or directory` (every platform, touch is always a builtin)
  - `cat missing.txt` prints `cat: C:\...\x\missing.txt: No such file or directory` (Windows only, where cat is a builtin by default; on POSIX both system cat and the builtin print `cat: missing.txt: ...`)
- ls, rm, mv and the system coreutils print the operand as written (`ls: missing: No such file or directory`), so this is one message family with three stragglers.
- Causes, one per builtin:
  - `shell_openat` (src/runtime/shell/interpreter.rs), Windows file branch: it resolves the operand against the cwd with `shell_get_path` and returns the `bun_sys::open` error unchanged, so `err.path` is the resolved path. The POSIX branch, both Windows `O_DIRECTORY` branches and `shell_statat` already re-tag with the caller's path. The builtin cat is the only caller of that branch that prints `err.path`.
  - `ShellTouchTask::run_from_thread_pool` (src/runtime/shell/builtin/touch.rs): the local `filepath` is the operand joined onto the cwd and both error sites tag with it; the operand is `this.filepath`.
  - `ShellMkdirTask::run_from_thread_pool` (src/runtime/shell/builtin/mkdir.rs): same shadowing at both error sites (`-p` and plain). Its absolute branch additionally NUL-terminates `this.filepath` in place.
- `Builtin::task_error_to_string` (src/runtime/shell/Builtin.rs) prints `<builtin>: <err.path>: <message>`, so whatever path is tagged is what the user sees.
- Surfaced on the Windows lanes of #39147, whose test (now on main) had to accept either form; nothing else on main checks these messages.

### Fix

- `shell_openat`'s Windows file branch re-tags the error with `path` like its sibling branches (`.map_err(|e| e.with_path(path.as_bytes()))`).
- touch tags `&this.filepath` at both sites; mkdir tags `self.operand()` at both sites, a two-line helper returning `filepath` minus the NUL its absolute branch may have appended.
- One doc line on `task_error_to_string` states the contract: `err.path` is printed as the operand, so a builtin that resolves an operand tags the error with it as written.
- Why this is the right direction: it is what ls, rm, mv and cat-on-POSIX already do and what GNU and BSD coreutils do; `with_path` keeps errno and syscall tag and replaces only the path, so only the operand part of the message changes. Already-absolute operands come out unchanged (cat and mkdir passed them through verbatim before; touch printed them normalized). `mkdir -p` keeps naming the whole operand when an intermediate component is what failed, as it did before; only resolved vs as-written changes.
- Deliberately unchanged:
  - the builtin cp (`ShellCpTask::is_dir` in cp.rs, on by default only on Windows) has the same defect with a different layout (`cp: No such file or directory: /tmp/x/missing.txt`). #38162 is rewriting exactly that code, so cp is left for a follow-up on top of it (noted there).
  - `mkdir -v` and `cp -v` print the created/copied paths resolved. That is output rather than an error message and cp's form is pinned by existing tests, so it stays as is.
- Related in-flight PRs: #38379 (touch/mkdir long operands) asserts the joined path in its new tests and adds one more tag site on the resolved path; whichever of the two lands second flips those to the operand (noted there). #39221 (mkdir `--verbose`) already accepts either form of the EEXIST line and needs nothing. #39198 can tighten its relaxed `cat: ... missing.txt` regex the same way this PR tightens #39147's. The one code line in interpreter.rs merges cleanly into #38365 (checked with `git merge-tree`).
- Tests (test/js/bun/shell/bunshell.test.ts):
  - `builtins name a failing operand as written`: one child process with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` (so cat is the builtin on every platform) runs cat, touch and mkdir against a relative operand, one with a subdirectory component, a rooted one (`/bunshell-missing-operand/...`) and an absolute one, plus `touch afile/file.txt` (utimes() itself fails, the second touch site) and `mkdir -p afile/child` (the `-p` site), and each builtin's first row again with `2> err-<builtin>.txt`; every row asserts the exact `<builtin>: <operand>: <message>` line. That reaches all five changed tag sites.
  - `builtin cat finishes from its reader and writer completions` (from #39147): the `cat: ... missing.txt` matcher that had to accept the absolute path is now the exact string.
  - linux-x64, `USE_SYSTEM_BUN=1` (main): the table test fails on its 8 touch/mkdir rows (including both new ones); the cat test passes, as expected on POSIX
  - windows-x64, `USE_SYSTEM_BUN=1` (canary built from main): the table test fails on 13 rows and the cat test on 2; output below
  - linux-x64, `bun bd test` of both tests at 91a0fa0: pass; bunshell.test.ts + commands/ on the previous revision: 565 pass, 3 unrelated failures (ls permission-denied tests, which fail the same way on main because the container runs as root, and one ls test that hit its 5 s budget in the parallel run and passes alone)
  - windows-x64, `bun bd test test/js/bun/shell/bunshell.test.ts test/js/bun/shell/commands/` at 91a0fa0: 580 pass, 0 fail

### Background

- Shell builtins (`cat`, `ls`, `mkdir`, ...) are implemented in-process under src/runtime/shell/builtin/. `cat` and `cp` are builtins by default only on Windows (`posix_disabled` in Builtin.rs); elsewhere they are spawned unless `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` is set. touch and mkdir are builtins everywhere.
- `shell_openat(dir, path, ...)` is the shell's openat: the shell holds its cwd as an fd and opens operands relative to it. POSIX uses `openat(2)`; libuv has no openat on Windows, so `shell_get_path` first turns the operand into an absolute path and a plain `open` is used. touch and mkdir do not go through it: they run on a worker thread and join the operand onto the cwd string themselves.
- touch calls utimes() first and only falls back to creating the file when that reports ENOENT, which is why a missing parent and a file in the way fail at two different sites (POSIX reports the latter as ENOTDIR; Windows reports it as ENOENT as well, which the test accounts for).
- `bun_sys::Error` is the syscall error: errno, syscall tag and an optional `path`. `Error::with_path` copies errno and tag and replaces the path. `Builtin::task_error_to_string` turns it into the `<builtin>: <path>: <message>` line, mapping errno through the coreutils message table.

<details>
<summary>Fail-before on windows-x64 (system bun, canary built from main)</summary>

```
error: expect(received).toEqual(expected)
- "cat: /bunshell-missing-operand/missing.txt: No such file or directory
+ "cat: C:\bunshell-missing-operand/missing.txt: No such file or directory
- "cat: missing.txt: No such file or directory
+ "cat: C:\Users\azureuser\AppData\Local\Temp\builtin-operand-as-written_JUO1Bg\missing.txt: No such file or directory
- "cat: sub/missing.txt: No such file or directory
+ "cat: C:\Users\azureuser\AppData\Local\Temp\builtin-operand-as-written_JUO1Bg\sub\missing.txt: No such file or directory
- "mkdir: nodir/child: No such file or directory
+ "mkdir: C:\Users\azureuser\AppData\Local\Temp\builtin-operand-as-written_JUO1Bg\nodir\child: No such file or directory
- "mkdir: afile/child: Not a directory
+ "mkdir: C:\Users\azureuser\AppData\Local\Temp\builtin-operand-as-written_JUO1Bg\afile\child: Not a directory
- "mkdir: sub/nodir/child: No such file or directory
+ "mkdir: C:\Users\azureuser\AppData\Local\Temp\builtin-operand-as-written_JUO1Bg\sub\nodir\child: No such file or directory
- "touch: /bunshell-missing-operand/file.txt: No such file or directory
+ "touch: \bunshell-missing-operand\file.txt: No such file or directory
- "touch: afile/file.txt: No such file or directory
+ "touch: C:\Users\azureuser\AppData\Local\Temp\builtin-operand-as-written_JUO1Bg\afile\file.txt: No such file or directory
- "touch: nodir/file.txt: No such file or directory
+ "touch: C:\Users\azureuser\AppData\Local\Temp\builtin-operand-as-written_JUO1Bg\nodir\file.txt: No such file or directory
- "touch: sub/nodir/file.txt: No such file or directory
+ "touch: C:\Users\azureuser\AppData\Local\Temp\builtin-operand-as-written_JUO1Bg\sub\nodir\file.txt: No such file or directory
- Expected  - 13
+ Received  + 13
(fail) bunshell > builtins name a failing operand as written
error: expect(received).toEqual(expected)
- "cat: missing.txt: No such file or directory
+ "cat: C:\Users\azureuser\AppData\Local\Temp\builtin-cat_zub5Qr\missing.txt: No such file or directory
- Expected  - 2
+ Received  + 2
(fail) bunshell > builtin cat finishes from its reader and writer completions
```

(the `err-<builtin>.txt` rows repeat the first-row lines and are omitted above)

</details>

<details>
<summary>Fail-before on linux-x64 (system bun, main)</summary>

```
- "mkdir: nodir/child: No such file or directory
+ "mkdir: /tmp/builtin-operand-as-written_qcqlee/nodir/child: No such file or directory
- "mkdir: afile/child: Not a directory
+ "mkdir: /tmp/builtin-operand-as-written_qcqlee/afile/child: Not a directory
- "mkdir: sub/nodir/child: No such file or directory
+ "mkdir: /tmp/builtin-operand-as-written_qcqlee/sub/nodir/child: No such file or directory
- "touch: afile/file.txt: Not a directory
+ "touch: /tmp/builtin-operand-as-written_qcqlee/afile/file.txt: Not a directory
- "touch: nodir/file.txt: No such file or directory
+ "touch: /tmp/builtin-operand-as-written_qcqlee/nodir/file.txt: No such file or directory
- "touch: sub/nodir/file.txt: No such file or directory
+ "touch: /tmp/builtin-operand-as-written_qcqlee/sub/nodir/file.txt: No such file or directory
(fail) bunshell > builtins name a failing operand as written
(pass) bunshell > builtin cat finishes from its reader and writer completions
```

</details>

<details>
<summary>Earlier shapes of this PR</summary>

The first revision fixed only the `shell_openat` line (cat on Windows) with a cat-only test, which could only fail on Windows. Review turned up touch and mkdir doing the same thing on every platform, and #38379 about to assert the joined-path form for them, so the PR was widened to the three builtins and the contract line moved from `shell_openat`'s doc comment (which conflicted with #38365) to the printer. A second review pass pointed out that the table only reached two of the four touch/mkdir sites, which added the `touch afile/file.txt` and `mkdir -p afile/child` rows; the branch was then rebased onto main so that #39147's merged test could be tightened here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->