### PR TITLE
test(install): establish the warm manifest cache before the unmet peer test re-resolves

### DIFF
--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1768,15 +1768,25 @@ describe.each(["hoisted", "isolated"] as const)("peer no published version satis
     expect(err).not.toContain("Ignoring lockfile");
     expect(await file(lockfilePath).text()).toBe(lockfile);
 
-    // Resolve from scratch again. Both manifests are cached now, so the peer
-    // is looked up synchronously instead of through a network task.
-    await rm(lockfilePath);
-    await rm(join(String(dir), "node_modules"), { recursive: true });
-    registry.requests.length = 0;
-    ({ err } = await install(String(dir)));
-    expect(err).toContain(unmetPeerWarning);
+    // Resolve from scratch again with both manifests cached: the peer is then
+    // looked up synchronously instead of through a network task (the lookup that
+    // used to loop forever) and the registry is not contacted at all. A cache
+    // entry is written by a thread pool task that bun install does not wait for
+    // (#37203), and peer-target's manifest is the last thing the first install
+    // fetches, so on a heavily loaded machine about one install in ten exits
+    // before that entry is on disk. A resolve that had to fetch the manifest
+    // again writes the entry again, with the same small chance of losing it, so
+    // allow a few attempts.
+    for (let attempt = 1; ; attempt++) {
+      await rm(lockfilePath);
+      await rm(join(String(dir), "node_modules"), { recursive: true });
+      registry.requests.length = 0;
+      ({ err } = await install(String(dir)));
+      expect(err).toContain(unmetPeerWarning);
+      expect(await file(lockfilePath).text()).toBe(lockfile);
+      if (registry.requests.length === 0 || attempt === 5) break;
+    }
     expect(registry.requests).toEqual([]);
-    expect(await file(lockfilePath).text()).toBe(lockfile);
   });
 
   it.concurrent("declared by the root package and a workspace", async () => {

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1777,14 +1777,15 @@ describe.each(["hoisted", "isolated"] as const)("peer no published version satis
     // before that entry is on disk. A resolve that had to fetch the manifest
     // again writes the entry again, with the same small chance of losing it, so
     // allow a few attempts.
-    for (let attempt = 1; ; attempt++) {
+    const maxAttempts = 5;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
       await rm(lockfilePath);
       await rm(join(String(dir), "node_modules"), { recursive: true });
       registry.requests.length = 0;
       ({ err } = await install(String(dir)));
       expect(err).toContain(unmetPeerWarning);
       expect(await file(lockfilePath).text()).toBe(lockfile);
-      if (registry.requests.length === 0 || attempt === 5) break;
+      if (registry.requests.length === 0) break;
     }
     expect(registry.requests).toEqual([]);
   });

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -1721,7 +1721,7 @@ describe.each(["hoisted", "isolated"] as const)("peer no published version satis
       // The request assertions below need a cache of their own per project: the
       // environment's cache dir takes precedence over bunfig, and a package
       // extracted there by one of the concurrent tests is not downloaded again.
-      env: { ...env, BUN_INSTALL_CACHE_DIR: join(cwd, ".bun-cache") },
+      env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir(cwd) },
       stdout: "pipe",
       stderr: "pipe",
       // Only matters if an install never returns.
@@ -1730,6 +1730,19 @@ describe.each(["hoisted", "isolated"] as const)("peer no published version satis
     const [out, err, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ args, err, code }).toMatchObject({ args, err: expect.not.stringContaining("error:"), code: 0 });
     return { out, err };
+  }
+
+  function cacheDir(cwd: string) {
+    return join(cwd, ".bun-cache");
+  }
+
+  // How many manifests the project's installs have written to its cache. The
+  // entries are written by a thread pool task that bun install does not wait
+  // for before exiting (`save_async` in src/install/npm.rs), so the last
+  // manifest an install fetches is occasionally missing. An install that has
+  // to fetch it again writes it again.
+  function cachedManifests(cwd: string) {
+    return Array.from(new Bun.Glob("*.npm").scanSync(cacheDir(cwd))).length;
   }
 
   it.concurrent("declared by a registry package", async () => {
@@ -1768,26 +1781,25 @@ describe.each(["hoisted", "isolated"] as const)("peer no published version satis
     expect(err).not.toContain("Ignoring lockfile");
     expect(await file(lockfilePath).text()).toBe(lockfile);
 
-    // Resolve from scratch again with both manifests cached: the peer is then
-    // looked up synchronously instead of through a network task (the lookup that
-    // used to loop forever) and the registry is not contacted at all. A cache
-    // entry is written by a thread pool task that bun install does not wait for
-    // (#37203), and peer-target's manifest is the last thing the first install
-    // fetches, so on a heavily loaded machine about one install in ten exits
-    // before that entry is on disk. A resolve that had to fetch the manifest
-    // again writes the entry again, with the same small chance of losing it, so
-    // allow a few attempts.
-    const maxAttempts = 5;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // The resolve below needs both manifests cached. peer-target's was the last
+    // thing the first install fetched, and nothing was left to do after it, so
+    // its entry is the one that is occasionally missing (see cachedManifests);
+    // resolving without the lockfile fetches and writes it again.
+    for (let retries = 5; retries > 0 && cachedManifests(String(dir)) < 2; retries--) {
       await rm(lockfilePath);
-      await rm(join(String(dir), "node_modules"), { recursive: true });
-      registry.requests.length = 0;
-      ({ err } = await install(String(dir)));
-      expect(err).toContain(unmetPeerWarning);
-      expect(await file(lockfilePath).text()).toBe(lockfile);
-      if (registry.requests.length === 0) break;
+      await install(String(dir));
     }
+    expect(cachedManifests(String(dir))).toBe(2);
+
+    // Resolve from scratch again. Both manifests are cached now, so the peer
+    // is looked up synchronously instead of through a network task.
+    await rm(lockfilePath);
+    await rm(join(String(dir), "node_modules"), { recursive: true });
+    registry.requests.length = 0;
+    ({ err } = await install(String(dir)));
+    expect(err).toContain(unmetPeerWarning);
     expect(registry.requests).toEqual([]);
+    expect(await file(lockfilePath).text()).toBe(lockfile);
   });
 
   it.concurrent("declared by the root package and a workspace", async () => {


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-lock.test.ts` > "peer no published version satisfies" > "declared by a registry package" (added in #38851) is flaky: its last step resolves from scratch and asserts `expect(registry.requests).toEqual([])`, and it received `["/peer-target"]` in 3 of the last 30 main builds (98704 on Windows, 98827 on macOS, 98850 on Linux) and on build 98343 for #39127.
- That step needs both manifests in the project's manifest cache. A cache entry is written by `Serializer::save_async` (src/install/npm.rs:1245), a thread pool task that `bun install` deliberately does not count as pending, and nothing joins the pool before the command exits. peer-target's manifest is the last thing the first install fetches and nothing is downloaded after it, so under load the process exits before the entry is renamed into place and the write is lost.
- The `--frozen-lockfile` install in between does not look the peer up (with the entry deleted it makes no request), so the from-scratch resolve is the first install to notice and fetches `/peer-target` again.
- Measured with a release build on 16 vCPUs under 32 busy loops: 52 of 400 first installs exited with peer-target's entry missing (has-unmet-peer's entry was present every time); under 64 busy loops 41 of 400 (40 missing peer-target, 1 missing has-unmet-peer). Deleting peer-target's entry after the frozen install reproduces the CI failure output exactly, with either linker.
- The sibling case "declared by the root package and a workspace" only asserts requests after the cold first install, and its frozen install makes no request whether or not the entry exists, so it does not depend on the write and is unchanged.

### Fix
- Before the from-scratch resolve, the test counts the `.npm` entries in the project's cache (`cachedManifests`, next to the `install` helper, whose comment names `save_async` as the reason) and, while there are fewer than two, removes the lockfile and installs again, at most five times; an install that has to fetch the missing manifest writes its entry again. It then asserts the count is two and runs the from-scratch resolve exactly once, with its zero-requests assertion unchanged.
- Correct because the retry re-establishes the precondition the step needs and checks it directly on disk; the step under test is not retried, so a resolve that contacts the registry despite a warm cache still fails on the first run, and the count assertion fails after the retries if the entries never appear (checked with `install.cache.disableManifest`: fails with `Expected: 2, Received: 0` on both linkers).
- Test-side on purpose: #37203 added an install-side wait for these writes and reverted it, keeping the write fire-and-forget and fixing the affected test instead; #38580 and #39034 (`setupWithCachedManifests`, same count-and-reinstall shape) do the same for two other tests. A harness-set flag that made `save_async` write inline for test-spawned installs would cover all of these tests at once (the shape of `BUN_DISABLE_SLOW_FILESYSTEM_WARNING` from #37000); that adds a test hook to `bun install` itself, so it is left as a separate decision and not attempted here.
- Verified: `bun bd test test/cli/install/bun-lock.test.ts`, 40 pass, the retry loop not entered. With the lost write simulated (peer-target's entry removed after the frozen install) the test at main fails with the output above and this version passes after one extra install; with the manifest cache disabled it fails at the count assertion. Test-only change, so there is no build on which the unmodified test fails deterministically; the evidence is the probe and the simulation.

### Background
- Manifest cache: every registry manifest `bun install` fetches is serialized into `<BUN_INSTALL_CACHE_DIR>/<hash>.npm` together with the response's `max-age`; within that window later installs resolve the package from that file without creating a network task. The test registry sends `max-age=300` and each project gets its own cache directory, so the count of `.npm` files is the number of manifests that project has cached.
- `save_async` clones the parsed manifest into a thread pool task that writes a temporary file and renames it into the cache directory. Its doc comment says the cache is optional and the task is not tracked, so a write still in flight when the process exits is lost and the next install simply fetches the manifest again. In a normal install the tarball downloads that follow the manifests give the writes plenty of time; this test's last manifest has nothing after it.
- Why the test wants a warm cache: the loop fixed in #38851 only occurred when the peer's manifest was already cached (the peer pass then looks it up synchronously); with a cold cache the unfixed code exited silently. The zero-requests assertion is what shows the test went through the cached lookup.

<details>
<summary>Probe and simulation</summary>

Probe: the test's registry and project, one fresh project and cache directory per iteration, counting `.npm` files in the cache after `bun install` exits, with N `while :; do :; done` loops running alongside.

| load | first installs missing an entry | which entry |
| --- | --- | --- |
| none | 0 / 1200 | |
| 32 busy loops | 52 / 400 | peer-target 52 |
| 64 busy loops | 41 / 400 | peer-target 40, has-unmet-peer 1 |

Simulation with the debug build at 7d50fe5a91, removing peer-target's entry after the first install:

```
install #1: requests ["/has-unmet-peer", "/has-unmet-peer-1.0.0.tgz", "/peer-target"], cache has both entries
(entry removed)
install #2 --frozen-lockfile: exit 0, requests []
install #3 without the lockfile: exit 0, warns, requests ["/peer-target"], cache has both entries again
```

The same removal inserted into the test: the version on main fails both linkers with `+ "/peer-target"`; this version passes both, with one extra install each. With `install.cache.disableManifest = true` instead, this version fails both linkers at `expect(cachedManifests(...)).toBe(2)` after five extra installs.

</details>

<details>
<summary>Earlier shape of this PR</summary>

The first version wrapped the from-scratch resolve itself in a loop that repeated it until an attempt made no requests. Review pointed out that this retried the step carrying the assertion, so a resolve that intermittently contacted the registry with a warm cache would have been retried rather than reported. The current version retries only the setup and runs the resolve once.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->