### PR TITLE
ci: run all darwin test lanes on main / opt-in only for now

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -186,10 +186,8 @@ const testPlatforms = [
   // The darwin test suite runs on real macOS agents against the Linux-built
   // artifacts from the `darwin-<arch>-build-bun` steps (the only darwin build
   // lanes — see buildPlatforms).
-  // The `latest` lane only has two agents behind it right now (the Studios
-  // came back on macOS 15 and can only host 15 guests), so until they are on
-  // 26 it runs on main and on opt-in (see darwinLatestLaneEnabled), not on
-  // every PR push.
+  // All three darwin test lanes run on main and on opt-in only for now (see
+  // darwinTestsEnabled): the mac agent pool cannot keep up with PR volume.
   { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
   { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
   { os: "darwin", arch: "x64", release: "14", tier: "latest" },
@@ -1545,11 +1543,11 @@ async function getPipeline(options = {}) {
   // Tests run on main too so the canary release step below can gate on them.
   // ASAN is PR-only (see includeASAN above), so the asan test lane is dropped
   // on main along with its build.
-  const darwinLatestLaneEnabled =
+  const darwinTestsEnabled =
     isMainBranch() || isBuildManual() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
   const relevantTestPlatforms = (
     includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan")
-  ).filter(({ os, tier }) => os !== "darwin" || tier !== "latest" || darwinLatestLaneEnabled);
+  ).filter(({ os }) => os !== "darwin" || darwinTestsEnabled);
   /** @type {string[]} */
   const testStepKeys = [];
   {


### PR DESCRIPTION
PR builds have been waiting hours for the `darwin 14 aarch64` test lane; the mac agent pool cannot keep up with current PR volume. This extends the existing gate (#37980, which covered only the 26 lane) to every darwin test lane: they run on `main`, on manual builds, or when the commit subject contains `[macos tests]`. darwin still **builds** on every PR, so compile breakage is still caught pre-merge.

`--dry-run`:
```
PR:                 darwin tests: []                                                    darwin build steps: 2
PR + [macos tests]: darwin tests: [26-aarch64, 14-aarch64, x64-14]
main:               darwin tests: [26-aarch64, 14-aarch64, x64-14]                       darwin build steps: 2
```

Revert when the pool can take PR volume again.