### PR TITLE
fs.promises: validate options.flush for iterable data and FileHandles, sync like node

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1634,9 +1634,7 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
     throw new TypeError(`Unknown encoding: ${encoding}`);
   }
 
-  // Callers unwrap a FileHandle to its fd. Anything else is a path (string,
-  // Buffer or URL) that has to be opened with `flag` and `mode`; fs.open
-  // rejects the values that are none of those.
+  // Callers already unwrapped a FileHandle to its fd; fs.open validates everything else.
   const mustClose = typeof fdOrPath !== "number";
   if (mustClose) {
     fdOrPath = await fs.open(fdOrPath, flag, mode);
@@ -1664,8 +1662,7 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
     } catch {}
   }
 
-  // Like node, only sync data that was fully written; a failed write rejects
-  // with its own error, and an fsync failure rejects the promise.
+  // Node only syncs a write that succeeded; a failed one rejects with its own error.
   if (flush && error === undefined) {
     try {
       await fs.fsync(fdOrPath);

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -684,6 +684,7 @@ function asyncWrap(fn: any, name: string) {
       const fd = this[kFd];
       throwEBADFIfNecessary("writeFile", fd);
       let encoding: string = "utf8";
+      let flush = false;
       let signal: AbortSignal | undefined = undefined;
 
       if (options == null || typeof options === "function") {
@@ -691,6 +692,7 @@ function asyncWrap(fn: any, name: string) {
         encoding = options;
       } else {
         encoding = options?.encoding ?? encoding;
+        flush = options?.flush ?? flush;
         signal = options?.signal ?? undefined;
       }
 
@@ -698,6 +700,7 @@ function asyncWrap(fn: any, name: string) {
         this[kRef]();
         return await writeFile(fd, data, {
           encoding,
+          flush,
           flag: this[kFlag],
           signal,
         });

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -241,6 +241,16 @@ const _readFile = fs.readFile.bind(fs);
 const _writeFile = fs.writeFile.bind(fs);
 const _appendFile = fs.appendFile.bind(fs);
 
+// Node validates `flush` for a FileHandle but only ever syncs a file it opened
+// itself; the native binding would sync any descriptor it is handed.
+function dropFlushForDescriptor(args: any[]) {
+  const options = args[1];
+  const flush = typeof options === "object" && options !== null ? options.flush : undefined;
+  if (flush == null) return;
+  validateBoolean(flush, "options.flush");
+  if (flush) args[1] = { ...options, flush: false };
+}
+
 // Argument validation must run at the first .next(), not at call time: Node's
 // fs/promises glob is an async generator whose body constructs Glob lazily.
 async function* glob(pattern, options) {
@@ -251,6 +261,7 @@ const exports = {
   access: asyncWrap(fs.access, "access"),
   appendFile: async function (fileHandleOrFdOrPath, ...args) {
     fileHandleOrFdOrPath = fileHandleOrFdOrPath?.[kFd] ?? fileHandleOrFdOrPath;
+    if (typeof fileHandleOrFdOrPath === "number") dropFlushForDescriptor(args);
     return _appendFile(fileHandleOrFdOrPath, ...args);
   },
   close: asyncWrap(fs.close, "close"),
@@ -321,6 +332,7 @@ const exports = {
       // @ts-expect-error
       return writeFileAsyncIterator(fileHandleOrFdOrPath, ...args);
     }
+    if (typeof fileHandleOrFdOrPath === "number") dropFlushForDescriptor(args);
     return _writeFile(fileHandleOrFdOrPath, ...args);
   },
   readlink: asyncWrap(fs.readlink, "readlink"),

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1666,8 +1666,7 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
       } catch {}
     }
 
-    // Like node, `flush` syncs the file this call opened (never a caller's
-    // FileHandle), and only after a write that succeeded.
+    // Node syncs only a file it opened itself, and only after a successful write.
     if (flush && !failed) {
       try {
         await fs.fsync(fdOrPath);

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -241,8 +241,7 @@ const _readFile = fs.readFile.bind(fs);
 const _writeFile = fs.writeFile.bind(fs);
 const _appendFile = fs.appendFile.bind(fs);
 
-// Node validates `flush` for a FileHandle but only ever syncs a file it opened
-// itself; the native binding would sync any descriptor it is handed.
+// Node's promises API validates `flush` for a FileHandle but never syncs one; the binding would.
 function dropFlushForDescriptor(args: any[]) {
   const options = args[1];
   const flush = typeof options === "object" && options !== null ? options.flush : undefined;

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1647,40 +1647,46 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
 
   let totalBytesWritten = 0;
 
-  let error: Error | undefined;
+  // Tracked separately from `error`: an iterable may throw a falsy value.
+  let failed = false;
+  let error: unknown;
 
   try {
     totalBytesWritten = await writeFileAsyncIteratorInner(fdOrPath, iterable, encoding, signal);
   } catch (err) {
-    error = err as Error;
+    failed = true;
+    error = err;
   }
 
   // Handle cleanup outside of try-catch
-  if (mustClose && flagTruncates(flag)) {
-    try {
-      await fs.ftruncate(fdOrPath, totalBytesWritten);
-    } catch {}
-  }
-
-  // Node only syncs a write that succeeded; a failed one rejects with its own error.
-  if (flush && error === undefined) {
-    try {
-      await fs.fsync(fdOrPath);
-    } catch (err) {
-      error = err as Error;
-    }
-  }
-
   if (mustClose) {
+    if (flagTruncates(flag)) {
+      try {
+        await fs.ftruncate(fdOrPath, totalBytesWritten);
+      } catch {}
+    }
+
+    // Like node, `flush` syncs the file this call opened (never a caller's
+    // FileHandle), and only after a write that succeeded.
+    if (flush && !failed) {
+      try {
+        await fs.fsync(fdOrPath);
+      } catch (err) {
+        failed = true;
+        error = err;
+      }
+    }
+
     await fs.close(fdOrPath);
   }
 
   // Abort signal shadows other errors
   if (signal?.aborted) {
+    failed = true;
     error = $makeAbortError(undefined, { cause: signal.reason });
   }
 
-  if (error) {
+  if (failed) {
     throw error;
   }
 }

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1609,10 +1609,13 @@ function flagTruncates(flag): boolean {
 async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, flag, mode) {
   let encoding;
   let signal: AbortSignal | null = null;
+  let flush = false;
   if (typeof optionsOrEncoding === "object") {
     encoding = optionsOrEncoding?.encoding ?? (encoding || "utf8");
     flag = optionsOrEncoding?.flag ?? (flag || "w");
     mode = optionsOrEncoding?.mode ?? (mode || 0o666);
+    flush = optionsOrEncoding?.flush ?? false;
+    validateBoolean(flush, "options.flush");
     signal = optionsOrEncoding?.signal ?? null;
     if (signal?.aborted) {
       throw $makeAbortError(undefined, { cause: signal.reason });
@@ -1628,9 +1631,11 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
     throw new TypeError(`Unknown encoding: ${encoding}`);
   }
 
-  let mustClose = typeof fdOrPath === "string";
+  // Callers unwrap a FileHandle to its fd. Anything else is a path (string,
+  // Buffer or URL) that has to be opened with `flag` and `mode`; fs.open
+  // rejects the values that are none of those.
+  const mustClose = typeof fdOrPath !== "number";
   if (mustClose) {
-    // Rely on fs.open for further argument validaiton.
     fdOrPath = await fs.open(fdOrPath, flag, mode);
   }
 
@@ -1650,13 +1655,23 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
   }
 
   // Handle cleanup outside of try-catch
-  if (mustClose) {
-    if (flagTruncates(flag)) {
-      try {
-        await fs.ftruncate(fdOrPath, totalBytesWritten);
-      } catch {}
-    }
+  if (mustClose && flagTruncates(flag)) {
+    try {
+      await fs.ftruncate(fdOrPath, totalBytesWritten);
+    } catch {}
+  }
 
+  // Like node, only sync data that was fully written; a failed write rejects
+  // with its own error, and an fsync failure rejects the promise.
+  if (flush && error === undefined) {
+    try {
+      await fs.fsync(fdOrPath);
+    } catch (err) {
+      error = err as Error;
+    }
+  }
+
+  if (mustClose) {
     await fs.close(fdOrPath);
   }
 

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -219,12 +219,10 @@ const dir = process.argv[2];
 const file = name => dir + "/" + name + ".txt";
 const fsyncs = () => (fs.existsSync(process.env.FSYNC_LOG) ? fs.statSync(process.env.FSYNC_LOG).size : 0);
 const report = {};
+const describeError = err => (err.syscall ? err.code + " from " + err.syscall : err.code ?? err.message);
 async function section(name, run) {
   const before = fsyncs();
-  const result = await run().then(
-    value => value ?? "resolved",
-    err => err.syscall ? err.code + " from " + err.syscall : err.code ?? err.message,
-  );
+  const result = await run().then(value => value ?? "resolved", describeError);
   report[name] = { fsyncs: fsyncs() - before, result };
 }
 const contents = name => fs.readFileSync(file(name), "utf8");
@@ -309,24 +307,28 @@ console.log(JSON.stringify(report));
       });
     });
 
-    test.concurrent("failure rejects the promise after the file has been closed", async () => {
+    test.concurrent("failure rejects the promise; the descriptor is closed on every error path", async () => {
       await using dir = tempDir("writeFile-iterable-fsync-fail", {
         "shim.c": shimSource,
         "fixture.mjs": `${fixturePrelude}
 // Warm up the code path so lazily created internal descriptors don't show up
-// in the leak check below.
+// in the leak checks below.
 await fsp.writeFile(file("warmup"), ["1"], { flush: false });
 const openFds = () => fs.readdirSync("/proc/self/fd").length;
 const fdsBefore = openFds();
-await section("string path", () => fsp.writeFile(file("a"), ["1", "2"], { flush: true }));
-report["string path"].contents = contents("a");
-report["string path"].leakedFds = openFds() - fdsBefore;
-await section("flush: false", () => fsp.writeFile(file("b"), ["1", "2"], { flush: false }));
+const leakCheck = name => {
+  report[name].leakedFds = openFds() - fdsBefore;
+};
+await section("fsync fails", () => fsp.writeFile(file("a"), ["1", "2"], { flush: true }));
+report["fsync fails"].contents = contents("a");
+leakCheck("fsync fails");
+await section("flush: false never reaches fsync", () => fsp.writeFile(file("b"), ["1", "2"], { flush: false }));
 await section("iterable throws", () => fsp.writeFile(file("c"), failing(), { flush: true }));
+leakCheck("iterable throws");
 await section("FileHandle", async () => {
   const fh = await fsp.open(file("d"), "w");
   try {
-    const result = await fsp.writeFile(fh, ["1", "2"], { flush: true }).then(() => "resolved", err => err.code + " from " + err.syscall);
+    const result = await fsp.writeFile(fh, ["1", "2"], { flush: true }).then(() => "resolved", describeError);
     // writeFile must not close a descriptor it did not open.
     return result + ", handle still has " + (await fh.stat()).size + " bytes";
   } finally {
@@ -338,9 +340,9 @@ console.log(JSON.stringify(report));
       });
 
       expect(await runFixture(String(dir), { FSYNC_FAIL: "1" })).toEqual({
-        "string path": { fsyncs: 1, result: "EIO from fsync", contents: "12", leakedFds: 0 },
-        "flush: false": { fsyncs: 0, result: "resolved" },
-        "iterable throws": { fsyncs: 0, result: "boom" },
+        "fsync fails": { fsyncs: 1, result: "EIO from fsync", contents: "12", leakedFds: 0 },
+        "flush: false never reaches fsync": { fsyncs: 0, result: "resolved" },
+        "iterable throws": { fsyncs: 0, result: "boom", leakedFds: 0 },
         "FileHandle": { fsyncs: 1, result: "EIO from fsync, handle still has 2 bytes" },
       });
     });

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -1,6 +1,8 @@
-import { expect, mock, test } from "bun:test";
-import { writeFile } from "fs/promises";
-import { tempDir } from "harness";
+import { describe, expect, mock, test } from "bun:test";
+import { existsSync } from "fs";
+import { open, readFile, writeFile } from "fs/promises";
+import { bunEnv, bunExe, isGlibc, tempDir } from "harness";
+import { join } from "path";
 test("fs.promises.writeFile async iterator", async () => {
   await using dir = tempDir("fs-promises-writeFile-async-iterator", {
     "file1.txt": "0 Hello, world!",
@@ -50,4 +52,289 @@ test("fs.promises.writeFile async iterator throws on invalid input", async () =>
   };
   expect(() => writeFile(String(dir), fn)).toThrow();
   expect(fn[Symbol.asyncIterator]).not.toBeCalled();
+});
+
+// Node validates and honors `options.flush` for every kind of data, including
+// the (async) iterable path; Bun used to read it only for string/Buffer data.
+describe("fs.promises.writeFile async iterator: options.flush", () => {
+  const invalidMessage = (received: string) =>
+    `ERR_INVALID_ARG_TYPE: The "options.flush" property must be of type boolean. Received ${received}`;
+
+  test.concurrent("rejects a non-boolean flush before opening the file or reading the iterable", async () => {
+    await using dir = tempDir("writeFile-iterable-flush-type", {});
+    const results: string[] = [];
+    for (const flush of ["yes", 1, 0, "", [], {}]) {
+      let pulled = false;
+      const iterable = {
+        *[Symbol.iterator]() {
+          pulled = true;
+          yield "x";
+        },
+      };
+      const path = join(String(dir), `${results.length}.txt`);
+      const err = await writeFile(path, iterable, { flush } as any).then(
+        () => null,
+        e => e,
+      );
+      results.push(`${err?.code}: ${err?.message} | pulled=${pulled} | created=${existsSync(path)}`);
+    }
+    expect(results).toEqual(
+      [
+        "type string ('yes')",
+        "type number (1)",
+        "type number (0)",
+        "type string ('')",
+        "an instance of Array",
+        "an instance of Object",
+      ].map(received => `${invalidMessage(received)} | pulled=false | created=false`),
+    );
+  });
+
+  test.concurrent("validates flush when the iterable is written through a FileHandle", async () => {
+    await using dir = tempDir("writeFile-iterable-flush-type-fh", { "a.txt": "" });
+    const file = join(String(dir), "a.txt");
+    const fh = await open(file, "w");
+    try {
+      const results = await Promise.all([
+        writeFile(fh, ["x"], { flush: "yes" } as any).then(
+          () => "resolved",
+          e => `${e.code}: ${e.message}`,
+        ),
+        fh.appendFile(["x"] as any, { flush: "yes" } as any).then(
+          () => "resolved",
+          e => `${e.code}: ${e.message}`,
+        ),
+      ]);
+      expect(results).toEqual([invalidMessage("type string ('yes')"), invalidMessage("type string ('yes')")]);
+    } finally {
+      await fh.close();
+    }
+    expect(await readFile(file, "utf8")).toBe("");
+  });
+
+  test.concurrent("accepts every flush value node accepts", async () => {
+    await using dir = tempDir("writeFile-iterable-flush-values", {});
+    const results: Record<string, string> = {};
+    for (const flush of [undefined, null, false, true]) {
+      const path = join(String(dir), `${String(flush)}.txt`);
+      await writeFile(path, ["a", "b"], { flush } as any);
+      results[String(flush)] = await readFile(path, "utf8");
+    }
+    expect(results).toEqual({ undefined: "ab", null: "ab", false: "ab", true: "ab" });
+  });
+
+  // Buffer and URL paths used to skip fs.open and hand the path straight to
+  // Bun.file().writer(), so flag/mode were ignored, the old tail of the file
+  // survived and there was no descriptor to fsync. Runs in a child process:
+  // the old Bun.file(buffer) route trips a debug-only GC assertion, which
+  // would otherwise take the whole test runner down instead of failing here.
+  test.concurrent("string, Buffer and URL paths all go through open(flag) and honor flush", async () => {
+    await using dir = tempDir("writeFile-iterable-flush-paths", {
+      "string.txt": "seed seed seed",
+      "buffer.txt": "seed seed seed",
+      "url.txt": "seed seed seed",
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+const dir = ${JSON.stringify(String(dir))};
+const targets = {
+  string: join(dir, "string.txt"),
+  buffer: Buffer.from(join(dir, "buffer.txt")),
+  url: pathToFileURL(join(dir, "url.txt")),
+};
+const results = {};
+for (const [kind, target] of Object.entries(targets)) {
+  await writeFile(target, ["a", "b"], { flush: true });
+  const truncated = await readFile(target, "utf8");
+  await writeFile(target, ["c"], { flag: "a", flush: true });
+  results[kind] = [truncated, await readFile(target, "utf8")];
+}
+console.log(JSON.stringify(results));
+`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ results: stdout && JSON.parse(stdout), stderr, exitCode }).toEqual({
+      results: {
+        string: ["ab", "abc"],
+        buffer: ["ab", "abc"],
+        url: ["ab", "abc"],
+      },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // The fsync itself is issued from native code, so observe it by interposing
+  // fsync(2) with an LD_PRELOAD shim. Every call appends one byte to
+  // $FSYNC_LOG; with $FSYNC_FAIL set it also fails with EIO instead of syncing.
+  const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+  describe.skipIf(!isGlibc || !cc)("fsync(2)", () => {
+    const shimSource = `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+int fsync(int fd) {
+  const char *log = getenv("FSYNC_LOG");
+  if (log) {
+    int logfd = open(log, O_WRONLY | O_APPEND | O_CREAT, 0644);
+    if (logfd >= 0) {
+      write(logfd, "x", 1);
+      close(logfd);
+    }
+  }
+  if (getenv("FSYNC_FAIL")) {
+    errno = EIO;
+    return -1;
+  }
+  return ((int (*)(int))dlsym(RTLD_NEXT, "fsync"))(fd);
+}
+`;
+    // Shared by both fixtures: section() runs one operation and records how many
+    // fsync(2) calls it made plus what it resolved or rejected with.
+    const fixturePrelude = `
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+const dir = process.argv[2];
+const file = name => dir + "/" + name + ".txt";
+const fsyncs = () => (fs.existsSync(process.env.FSYNC_LOG) ? fs.statSync(process.env.FSYNC_LOG).size : 0);
+const report = {};
+async function section(name, run) {
+  const before = fsyncs();
+  const result = await run().then(
+    value => value ?? "resolved",
+    err => err.syscall ? err.code + " from " + err.syscall : err.code ?? err.message,
+  );
+  report[name] = { fsyncs: fsyncs() - before, result };
+}
+const contents = name => fs.readFileSync(file(name), "utf8");
+function* failing() {
+  yield "1";
+  throw new Error("boom");
+}
+`;
+
+    async function runFixture(dir: string, extraEnv: Record<string, string>) {
+      const shim = join(dir, "shim.so");
+      await using ccProc = Bun.spawn({
+        cmd: [cc!, "-shared", "-fPIC", "-o", shim, join(dir, "shim.c"), "-ldl"],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [ccErr, ccExit] = await Promise.all([ccProc.stderr.text(), ccProc.exited]);
+      if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr}`);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(dir, "fixture.mjs"), dir],
+        env: {
+          ...bunEnv,
+          LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shim}:${bunEnv.LD_PRELOAD}` : shim,
+          FSYNC_LOG: join(dir, "fsync.log"),
+          ...extraEnv,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout);
+    }
+
+    test.concurrent("is called once after the data is written, only when flush is true", async () => {
+      await using dir = tempDir("writeFile-iterable-fsync-count", {
+        "shim.c": shimSource,
+        "fixture.mjs": `${fixturePrelude}
+await section("no options", () => fsp.writeFile(file("a"), ["1", "2"]));
+await section("flush: false", () => fsp.writeFile(file("b"), ["1", "2"], { flush: false }));
+await section("string path", () => fsp.writeFile(file("c"), ["1", "2"], { flush: true }).then(() => contents("c")));
+await section("URL path", () => fsp.writeFile(pathToFileURL(file("d")), ["1", "2"], { flush: true }).then(() => contents("d")));
+await section("Buffer path", () => fsp.writeFile(Buffer.from(file("e")), ["1", "2"], { flush: true }).then(() => contents("e")));
+await section("async iterable", () => fsp.writeFile(file("f"), (async function* () { yield "1"; yield "2"; })(), { flush: true }).then(() => contents("f")));
+await section("FileHandle", async () => {
+  const fh = await fsp.open(file("g"), "w");
+  try {
+    await fsp.writeFile(fh, ["1", "2"], { flush: true });
+  } finally {
+    await fh.close();
+  }
+  return contents("g");
+});
+await section("FileHandle.appendFile", async () => {
+  fs.writeFileSync(file("h"), "0");
+  const fh = await fsp.open(file("h"), "a");
+  try {
+    await fh.appendFile(["1", "2"], { flush: true });
+  } finally {
+    await fh.close();
+  }
+  return contents("h");
+});
+await section("iterable throws", () => fsp.writeFile(file("i"), failing(), { flush: true }));
+console.log(JSON.stringify(report));
+`,
+      });
+
+      expect(await runFixture(String(dir), {})).toEqual({
+        "no options": { fsyncs: 0, result: "resolved" },
+        "flush: false": { fsyncs: 0, result: "resolved" },
+        "string path": { fsyncs: 1, result: "12" },
+        "URL path": { fsyncs: 1, result: "12" },
+        "Buffer path": { fsyncs: 1, result: "12" },
+        "async iterable": { fsyncs: 1, result: "12" },
+        "FileHandle": { fsyncs: 1, result: "12" },
+        "FileHandle.appendFile": { fsyncs: 1, result: "012" },
+        "iterable throws": { fsyncs: 0, result: "boom" },
+      });
+    });
+
+    test.concurrent("failure rejects the promise after the file has been closed", async () => {
+      await using dir = tempDir("writeFile-iterable-fsync-fail", {
+        "shim.c": shimSource,
+        "fixture.mjs": `${fixturePrelude}
+// Warm up the code path so lazily created internal descriptors don't show up
+// in the leak check below.
+await fsp.writeFile(file("warmup"), ["1"], { flush: false });
+const openFds = () => fs.readdirSync("/proc/self/fd").length;
+const fdsBefore = openFds();
+await section("string path", () => fsp.writeFile(file("a"), ["1", "2"], { flush: true }));
+report["string path"].contents = contents("a");
+report["string path"].leakedFds = openFds() - fdsBefore;
+await section("flush: false", () => fsp.writeFile(file("b"), ["1", "2"], { flush: false }));
+await section("iterable throws", () => fsp.writeFile(file("c"), failing(), { flush: true }));
+await section("FileHandle", async () => {
+  const fh = await fsp.open(file("d"), "w");
+  try {
+    const result = await fsp.writeFile(fh, ["1", "2"], { flush: true }).then(() => "resolved", err => err.code + " from " + err.syscall);
+    // writeFile must not close a descriptor it did not open.
+    return result + ", handle still has " + (await fh.stat()).size + " bytes";
+  } finally {
+    await fh.close();
+  }
+});
+console.log(JSON.stringify(report));
+`,
+      });
+
+      expect(await runFixture(String(dir), { FSYNC_FAIL: "1" })).toEqual({
+        "string path": { fsyncs: 1, result: "EIO from fsync", contents: "12", leakedFds: 0 },
+        "flush: false": { fsyncs: 0, result: "resolved" },
+        "iterable throws": { fsyncs: 0, result: "boom" },
+        "FileHandle": { fsyncs: 1, result: "EIO from fsync, handle still has 2 bytes" },
+      });
+    });
+  });
 });

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -90,22 +90,29 @@ describe("fs.promises.writeFile async iterator: options.flush", () => {
     );
   });
 
-  test.concurrent("validates flush when the iterable is written through a FileHandle", async () => {
+  test.concurrent("validates flush on every FileHandle entry point", async () => {
     await using dir = tempDir("writeFile-iterable-flush-type-fh", { "a.txt": "" });
     const file = join(String(dir), "a.txt");
     const fh = await open(file, "w");
+    const outcome = (promise: Promise<unknown>) =>
+      promise.then(
+        () => "resolved",
+        e => `${e.code}: ${e.message}`,
+      );
     try {
-      const results = await Promise.all([
-        writeFile(fh, ["x"], { flush: "yes" } as any).then(
-          () => "resolved",
-          e => `${e.code}: ${e.message}`,
-        ),
-        fh.appendFile(["x"] as any, { flush: "yes" } as any).then(
-          () => "resolved",
-          e => `${e.code}: ${e.message}`,
-        ),
-      ]);
-      expect(results).toEqual([invalidMessage("type string ('yes')"), invalidMessage("type string ('yes')")]);
+      const results = {
+        "writeFile(handle, iterable)": await outcome(writeFile(fh, ["x"], { flush: "yes" } as any)),
+        "handle.writeFile(iterable)": await outcome(fh.writeFile(["x"] as any, { flush: "yes" } as any)),
+        "handle.appendFile(iterable)": await outcome(fh.appendFile(["x"] as any, { flush: "yes" } as any)),
+        // String data takes the native path, whose message is worded differently.
+        "handle.writeFile(string)": (await outcome(fh.writeFile("x", { flush: "yes" } as any))).split(":")[0],
+      };
+      expect(results).toEqual({
+        "writeFile(handle, iterable)": invalidMessage("type string ('yes')"),
+        "handle.writeFile(iterable)": invalidMessage("type string ('yes')"),
+        "handle.appendFile(iterable)": invalidMessage("type string ('yes')"),
+        "handle.writeFile(string)": "ERR_INVALID_ARG_TYPE",
+      });
     } finally {
       await fh.close();
     }
@@ -264,25 +271,23 @@ await section("string path", () => fsp.writeFile(file("c"), ["1", "2"], { flush:
 await section("URL path", () => fsp.writeFile(pathToFileURL(file("d")), ["1", "2"], { flush: true }).then(() => contents("d")));
 await section("Buffer path", () => fsp.writeFile(Buffer.from(file("e")), ["1", "2"], { flush: true }).then(() => contents("e")));
 await section("async iterable", () => fsp.writeFile(file("f"), (async function* () { yield "1"; yield "2"; })(), { flush: true }).then(() => contents("f")));
-await section("FileHandle", async () => {
-  const fh = await fsp.open(file("g"), "w");
+// Each FileHandle case opens its own file (pre-filled with "0" when appending),
+// runs the write with the handle, closes it and reports the file's contents.
+const withHandle = (name, flag, write) => section(name, async () => {
+  if (flag === "a") fs.writeFileSync(file(name), "0");
+  const fh = await fsp.open(file(name), flag);
   try {
-    await fsp.writeFile(fh, ["1", "2"], { flush: true });
+    await write(fh);
   } finally {
     await fh.close();
   }
-  return contents("g");
+  return contents(name);
 });
-await section("FileHandle.appendFile", async () => {
-  fs.writeFileSync(file("h"), "0");
-  const fh = await fsp.open(file("h"), "a");
-  try {
-    await fh.appendFile(["1", "2"], { flush: true });
-  } finally {
-    await fh.close();
-  }
-  return contents("h");
-});
+await withHandle("writeFile(handle)", "w", fh => fsp.writeFile(fh, ["1", "2"], { flush: true }));
+await withHandle("handle.writeFile(iterable)", "w", fh => fh.writeFile(["1", "2"], { flush: true }));
+await withHandle("handle.writeFile(string)", "w", fh => fh.writeFile("12", { flush: true }));
+await withHandle("handle.writeFile(iterable) without flush", "w", fh => fh.writeFile(["1", "2"]));
+await withHandle("handle.appendFile(iterable)", "a", fh => fh.appendFile(["1", "2"], { flush: true }));
 await section("iterable throws", () => fsp.writeFile(file("i"), failing(), { flush: true }));
 console.log(JSON.stringify(report));
 `,
@@ -295,8 +300,11 @@ console.log(JSON.stringify(report));
         "URL path": { fsyncs: 1, result: "12" },
         "Buffer path": { fsyncs: 1, result: "12" },
         "async iterable": { fsyncs: 1, result: "12" },
-        "FileHandle": { fsyncs: 1, result: "12" },
-        "FileHandle.appendFile": { fsyncs: 1, result: "012" },
+        "writeFile(handle)": { fsyncs: 1, result: "12" },
+        "handle.writeFile(iterable)": { fsyncs: 1, result: "12" },
+        "handle.writeFile(string)": { fsyncs: 1, result: "12" },
+        "handle.writeFile(iterable) without flush": { fsyncs: 0, result: "12" },
+        "handle.appendFile(iterable)": { fsyncs: 1, result: "012" },
         "iterable throws": { fsyncs: 0, result: "boom" },
       });
     });

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { existsSync } from "fs";
-import { open, readFile, writeFile } from "fs/promises";
+import { appendFile, open, readFile, writeFile } from "fs/promises";
 import { bunEnv, bunExe, isGlibc, isLinux, tempDir } from "harness";
 import { devNull } from "os";
 import { join } from "path";
@@ -102,19 +102,25 @@ describe("fs.promises.writeFile async iterator: options.flush", () => {
         e => `${e.code}: ${e.message}`,
       );
     try {
+      const bad = { flush: "yes" } as any;
       const results = {
-        "writeFile(handle, iterable)": await outcome(writeFile(fh, ["x"], { flush: "yes" } as any)),
-        "handle.writeFile(iterable)": await outcome(fh.writeFile(["x"] as any, { flush: "yes" } as any)),
-        "handle.appendFile(iterable)": await outcome(fh.appendFile(["x"] as any, { flush: "yes" } as any)),
-        "handle.writeFile(string)": await outcome(fh.writeFile("x", { flush: "yes" } as any)),
+        "writeFile(handle, iterable)": await outcome(writeFile(fh, ["x"], bad)),
+        "writeFile(handle, string)": await outcome(writeFile(fh, "x", bad)),
+        "appendFile(handle, string)": await outcome(appendFile(fh, "x", bad)),
+        "handle.writeFile(iterable)": await outcome(fh.writeFile(["x"] as any, bad)),
+        "handle.writeFile(string)": await outcome(fh.writeFile("x", bad)),
+        "handle.appendFile(iterable)": await outcome(fh.appendFile(["x"] as any, bad)),
+        "handle.appendFile(string)": await outcome(fh.appendFile("x", bad)),
       };
+      const rejected = invalidMessage("type string ('yes')");
       expect(results).toEqual({
-        "writeFile(handle, iterable)": invalidMessage("type string ('yes')"),
-        "handle.writeFile(iterable)": invalidMessage("type string ('yes')"),
-        "handle.appendFile(iterable)": invalidMessage("type string ('yes')"),
-        // String data is validated by the native binding, which still words the
-        // name as an argument where node says `"options.flush" property`.
-        "handle.writeFile(string)": `ERR_INVALID_ARG_TYPE: The "flush" argument must be of type boolean. Received type string ('yes')`,
+        "writeFile(handle, iterable)": rejected,
+        "writeFile(handle, string)": rejected,
+        "appendFile(handle, string)": rejected,
+        "handle.writeFile(iterable)": rejected,
+        "handle.writeFile(string)": rejected,
+        "handle.appendFile(iterable)": rejected,
+        "handle.appendFile(string)": rejected,
       });
     } finally {
       await fh.close();
@@ -343,10 +349,26 @@ const withHandle = (name, flag, write) => section(name, async () => {
   return contents(name);
 });
 await withHandle("writeFile(handle, iterable)", "w", fh => fsp.writeFile(fh, ["1", "2"], { flush: true }));
+await withHandle("writeFile(handle, string)", "w", fh => fsp.writeFile(fh, "12", { flush: true }));
+await withHandle("appendFile(handle, string)", "a", fh => fsp.appendFile(fh, "12", { flush: true }));
 await withHandle("handle.writeFile(iterable)", "w", fh => fh.writeFile(["1", "2"], { flush: true }));
+await withHandle("handle.writeFile(string)", "w", fh => fh.writeFile("12", { flush: true }));
 await withHandle("handle.appendFile(iterable)", "a", fh => fh.appendFile(["1", "2"], { flush: true }));
+await withHandle("handle.appendFile(string)", "a", fh => fh.appendFile("12", { flush: true }));
 await section("iterable throws", () => fsp.writeFile(file("i"), failing(), { flush: true }));
 await section("iterable throws undefined", () => fsp.writeFile(file("j"), failingWith(undefined), { flush: true }));
+// Controls for the native binding, which this file does not change: a path and
+// (through the callback-style API, where node syncs the caller's fd too) a bare fd.
+await section("native: string path", () => fsp.writeFile(file("k"), "12", { flush: true }).then(() => contents("k")));
+await section("native: writeFileSync(fd)", async () => {
+  const fd = fs.openSync(file("l"), "w");
+  try {
+    fs.writeFileSync(fd, "12", { flush: true });
+  } finally {
+    fs.closeSync(fd);
+  }
+  return contents("l");
+});
 console.log(JSON.stringify(report));
 `,
       });
@@ -358,12 +380,18 @@ console.log(JSON.stringify(report));
         "URL path": { fsyncs: 1, result: "12" },
         "Buffer path": { fsyncs: 1, result: "12" },
         "async iterable": { fsyncs: 1, result: "12" },
-        // Node validates flush for a FileHandle but never syncs one.
+        // Node validates flush for a FileHandle but never syncs one, whatever the data is.
         "writeFile(handle, iterable)": { fsyncs: 0, result: "12" },
+        "writeFile(handle, string)": { fsyncs: 0, result: "12" },
+        "appendFile(handle, string)": { fsyncs: 0, result: "012" },
         "handle.writeFile(iterable)": { fsyncs: 0, result: "12" },
+        "handle.writeFile(string)": { fsyncs: 0, result: "12" },
         "handle.appendFile(iterable)": { fsyncs: 0, result: "012" },
+        "handle.appendFile(string)": { fsyncs: 0, result: "012" },
         "iterable throws": { fsyncs: 0, result: "boom" },
         "iterable throws undefined": { fsyncs: 0, result: "rejected with undefined" },
+        "native: string path": { fsyncs: 1, result: "12" },
+        "native: writeFileSync(fd)": { fsyncs: 1, result: "12" },
       });
     });
 

--- a/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
+++ b/test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, mock, test } from "bun:test";
 import { existsSync } from "fs";
 import { open, readFile, writeFile } from "fs/promises";
-import { bunEnv, bunExe, isGlibc, tempDir } from "harness";
+import { bunEnv, bunExe, isGlibc, isLinux, tempDir } from "harness";
+import { devNull } from "os";
 import { join } from "path";
 test("fs.promises.writeFile async iterator", async () => {
   await using dir = tempDir("fs-promises-writeFile-async-iterator", {
@@ -54,8 +55,9 @@ test("fs.promises.writeFile async iterator throws on invalid input", async () =>
   expect(fn[Symbol.asyncIterator]).not.toBeCalled();
 });
 
-// Node validates and honors `options.flush` for every kind of data, including
-// the (async) iterable path; Bun used to read it only for string/Buffer data.
+// Node validates `options.flush` for every kind of data and, when it is true,
+// fsyncs the file it opened for a path; Bun's (async) iterable path used to
+// ignore the option entirely.
 describe("fs.promises.writeFile async iterator: options.flush", () => {
   const invalidMessage = (received: string) =>
     `ERR_INVALID_ARG_TYPE: The "options.flush" property must be of type boolean. Received ${received}`;
@@ -104,14 +106,15 @@ describe("fs.promises.writeFile async iterator: options.flush", () => {
         "writeFile(handle, iterable)": await outcome(writeFile(fh, ["x"], { flush: "yes" } as any)),
         "handle.writeFile(iterable)": await outcome(fh.writeFile(["x"] as any, { flush: "yes" } as any)),
         "handle.appendFile(iterable)": await outcome(fh.appendFile(["x"] as any, { flush: "yes" } as any)),
-        // String data takes the native path, whose message is worded differently.
-        "handle.writeFile(string)": (await outcome(fh.writeFile("x", { flush: "yes" } as any))).split(":")[0],
+        "handle.writeFile(string)": await outcome(fh.writeFile("x", { flush: "yes" } as any)),
       };
       expect(results).toEqual({
         "writeFile(handle, iterable)": invalidMessage("type string ('yes')"),
         "handle.writeFile(iterable)": invalidMessage("type string ('yes')"),
         "handle.appendFile(iterable)": invalidMessage("type string ('yes')"),
-        "handle.writeFile(string)": "ERR_INVALID_ARG_TYPE",
+        // String data is validated by the native binding, which still words the
+        // name as an argument where node says `"options.flush" property`.
+        "handle.writeFile(string)": `ERR_INVALID_ARG_TYPE: The "flush" argument must be of type boolean. Received type string ('yes')`,
       });
     } finally {
       await fh.close();
@@ -128,6 +131,62 @@ describe("fs.promises.writeFile async iterator: options.flush", () => {
       results[String(flush)] = await readFile(path, "utf8");
     }
     expect(results).toEqual({ undefined: "ab", null: "ab", false: "ab", true: "ab" });
+  });
+
+  test.concurrent("rejects with whatever the iterable threw, even a falsy value", async () => {
+    await using dir = tempDir("writeFile-iterable-flush-falsy-throw", {});
+    const results: unknown[] = [];
+    for (const thrown of [0, null, undefined, false, ""]) {
+      function* failing() {
+        yield "p";
+        throw thrown;
+      }
+      const path = join(String(dir), `${results.length}.txt`);
+      results.push(
+        await writeFile(path, failing(), { flush: true }).then(
+          () => "resolved",
+          rejectedWith => ({ rejectedWith }),
+        ),
+      );
+    }
+    expect(results).toEqual([
+      { rejectedWith: 0 },
+      { rejectedWith: null },
+      { rejectedWith: undefined },
+      { rejectedWith: false },
+      { rejectedWith: "" },
+    ]);
+  });
+
+  // /dev/null cannot be fsynced (EINVAL), which makes it observable whether a
+  // sync was attempted: node syncs a path it opened itself and never syncs a
+  // caller's FileHandle. fsync's errno on other platforms is not pinned down.
+  test.skipIf(!isLinux)("syncs a path it opened, not a caller's FileHandle, like node", async () => {
+    const outcome = (promise: Promise<unknown>) =>
+      promise.then(
+        () => "resolved",
+        e => `${e.code} from ${e.syscall}`,
+      );
+    const fh = await open(devNull, "w");
+    let results;
+    try {
+      results = {
+        "writeFile(handle, iterable)": await outcome(writeFile(fh, ["x"], { flush: true })),
+        "handle.writeFile(iterable)": await outcome(fh.writeFile(["x"] as any, { flush: true } as any)),
+        "handle.appendFile(iterable)": await outcome(fh.appendFile(["x"] as any, { flush: true } as any)),
+        "writeFile(path, iterable)": await outcome(writeFile(devNull, ["x"], { flush: true })),
+        "writeFile(path, iterable) without flush": await outcome(writeFile(devNull, ["x"])),
+      };
+    } finally {
+      await fh.close();
+    }
+    expect(results).toEqual({
+      "writeFile(handle, iterable)": "resolved",
+      "handle.writeFile(iterable)": "resolved",
+      "handle.appendFile(iterable)": "resolved",
+      "writeFile(path, iterable)": "EINVAL from fsync",
+      "writeFile(path, iterable) without flush": "resolved",
+    });
   });
 
   // Buffer and URL paths used to skip fs.open and hand the path straight to
@@ -219,17 +278,19 @@ const dir = process.argv[2];
 const file = name => dir + "/" + name + ".txt";
 const fsyncs = () => (fs.existsSync(process.env.FSYNC_LOG) ? fs.statSync(process.env.FSYNC_LOG).size : 0);
 const report = {};
-const describeError = err => (err.syscall ? err.code + " from " + err.syscall : err.code ?? err.message);
+const describeError = err =>
+  err instanceof Error ? (err.syscall ? err.code + " from " + err.syscall : err.code ?? err.message) : "rejected with " + err;
 async function section(name, run) {
   const before = fsyncs();
   const result = await run().then(value => value ?? "resolved", describeError);
   report[name] = { fsyncs: fsyncs() - before, result };
 }
 const contents = name => fs.readFileSync(file(name), "utf8");
-function* failing() {
+function* failingWith(thrown) {
   yield "1";
-  throw new Error("boom");
+  throw thrown;
 }
+const failing = () => failingWith(new Error("boom"));
 `;
 
     async function runFixture(dir: string, extraEnv: Record<string, string>) {
@@ -281,12 +342,11 @@ const withHandle = (name, flag, write) => section(name, async () => {
   }
   return contents(name);
 });
-await withHandle("writeFile(handle)", "w", fh => fsp.writeFile(fh, ["1", "2"], { flush: true }));
+await withHandle("writeFile(handle, iterable)", "w", fh => fsp.writeFile(fh, ["1", "2"], { flush: true }));
 await withHandle("handle.writeFile(iterable)", "w", fh => fh.writeFile(["1", "2"], { flush: true }));
-await withHandle("handle.writeFile(string)", "w", fh => fh.writeFile("12", { flush: true }));
-await withHandle("handle.writeFile(iterable) without flush", "w", fh => fh.writeFile(["1", "2"]));
 await withHandle("handle.appendFile(iterable)", "a", fh => fh.appendFile(["1", "2"], { flush: true }));
 await section("iterable throws", () => fsp.writeFile(file("i"), failing(), { flush: true }));
+await section("iterable throws undefined", () => fsp.writeFile(file("j"), failingWith(undefined), { flush: true }));
 console.log(JSON.stringify(report));
 `,
       });
@@ -298,12 +358,12 @@ console.log(JSON.stringify(report));
         "URL path": { fsyncs: 1, result: "12" },
         "Buffer path": { fsyncs: 1, result: "12" },
         "async iterable": { fsyncs: 1, result: "12" },
-        "writeFile(handle)": { fsyncs: 1, result: "12" },
-        "handle.writeFile(iterable)": { fsyncs: 1, result: "12" },
-        "handle.writeFile(string)": { fsyncs: 1, result: "12" },
-        "handle.writeFile(iterable) without flush": { fsyncs: 0, result: "12" },
-        "handle.appendFile(iterable)": { fsyncs: 1, result: "012" },
+        // Node validates flush for a FileHandle but never syncs one.
+        "writeFile(handle, iterable)": { fsyncs: 0, result: "12" },
+        "handle.writeFile(iterable)": { fsyncs: 0, result: "12" },
+        "handle.appendFile(iterable)": { fsyncs: 0, result: "012" },
         "iterable throws": { fsyncs: 0, result: "boom" },
+        "iterable throws undefined": { fsyncs: 0, result: "rejected with undefined" },
       });
     });
 
@@ -325,8 +385,10 @@ leakCheck("fsync fails");
 await section("flush: false never reaches fsync", () => fsp.writeFile(file("b"), ["1", "2"], { flush: false }));
 await section("iterable throws", () => fsp.writeFile(file("c"), failing(), { flush: true }));
 leakCheck("iterable throws");
+await section("iterable throws null", () => fsp.writeFile(file("d"), failingWith(null), { flush: true }));
+leakCheck("iterable throws null");
 await section("FileHandle", async () => {
-  const fh = await fsp.open(file("d"), "w");
+  const fh = await fsp.open(file("e"), "w");
   try {
     const result = await fsp.writeFile(fh, ["1", "2"], { flush: true }).then(() => "resolved", describeError);
     // writeFile must not close a descriptor it did not open.
@@ -343,7 +405,8 @@ console.log(JSON.stringify(report));
         "fsync fails": { fsyncs: 1, result: "EIO from fsync", contents: "12", leakedFds: 0 },
         "flush: false never reaches fsync": { fsyncs: 0, result: "resolved" },
         "iterable throws": { fsyncs: 0, result: "boom", leakedFds: 0 },
-        "FileHandle": { fsyncs: 1, result: "EIO from fsync, handle still has 2 bytes" },
+        "iterable throws null": { fsyncs: 0, result: "rejected with null", leakedFds: 0 },
+        "FileHandle": { fsyncs: 0, result: "resolved, handle still has 2 bytes" },
       });
     });
   });


### PR DESCRIPTION
### Problem

- `fs.promises.writeFile(path, ["a", "b"], { flush: true })` resolves without ever calling `fsync(2)`; node syncs the file once. `{ flush: "yes" }` is accepted; node rejects with `ERR_INVALID_ARG_TYPE`. With string or Buffer data the same calls already validate and sync in Bun, so whether the option does anything depends on the type of `data`. No issue report; found by probing node's `flush` behavior against Bun (this is the JS-layer half of that probe, #36485 is the native half).
- Cause: iterable data is written by `writeFileAsyncIterator` in `src/js/node/fs.promises.ts` (line 1609 before this change), which reads `encoding`, `flag`, `mode` and `signal` from the options but not `flush`, and never fsyncs the descriptor it opened. Only the native path for string/Buffer data (`args::WriteFile::from_js`, `src/runtime/node/node_fs.rs:4205`) reads the option.
- `writeFile(fileHandle, iterable, { flush })` and `FileHandle#appendFile(iterable, { flush })` reach the same function and have the same gap. `FileHandle#writeFile` has it for every kind of data: it rebuilds its options as `{ encoding, flag, signal }` (line 699), so `flush` never reaches either implementation, while the adjacent `FileHandle#appendFile` forwards it. In the other direction, the handle entry points that did reach the native binding with string data (`writeFile(handle, "x", { flush: true })`, `handle.appendFile("x", { flush: true })`) fsynced the caller's descriptor, which node's promises API never does.
- Also in this function, a `Buffer` or `URL` path took the fd branch (`mustClose = typeof fdOrPath === "string"`) and was handed to `Bun.file(path).writer()`, so there was no descriptor to sync, `flag`/`mode` were ignored and the old tail of the file survived (`"seed seed seed"` overwritten with `["a", "b"]` reads back `"abed seed seed"`). And an iterable that throws a falsy value (`throw null`) made `writeFile` resolve, because the result was tested with `if (error)`; node rejects with the thrown value.

### Fix

- `writeFileAsyncIterator` reads `options.flush ?? false` and runs it through `validateBoolean(flush, "options.flush")`, the validator and name node uses, so code and message match node for every value node rejects (`"yes"`, `1`, `0`, `""`, `[]`, `{}`) and `null`/`undefined` still mean `false`. This happens before the file is opened and before the iterable is touched, as in node.
- When it opened the file itself and the write succeeded, it awaits `fs.fsync(fd)` before closing; an fsync error becomes the rejection, a failed write rejects with its own error and is not synced. A caller's FileHandle is validated but not synced. This is exactly node's `fsPromises.writeFile`: `validateBoolean` up front, an early return for `FileHandle` targets, then `handleFdSync` / `handleFdClose` for paths. Syncing handles too was tried in an earlier revision and is observably different from node: `handle.writeFile(iterable, { flush: true })` on a `/dev/null` handle rejected with `EINVAL` where node (and Bun 1.4.0) resolve, while for a `/dev/null` path node does reject with `EINVAL from fsync`, and so does this branch now.
- `FileHandle#writeFile` forwards `flush` exactly like `FileHandle#appendFile` already does, so the option reaches the same code for both kinds of data.
- The same FileHandle rule is applied to string/Buffer data: `exports.writeFile` / `exports.appendFile` (which `FileHandle#writeFile` / `#appendFile` call with the handle's fd) validate `options.flush` in JS when the target is a descriptor and hand the native binding a copy with `flush: false` (`dropFlushForDescriptor`). The binding itself is untouched: it syncs any descriptor it is given, which is correct for `fs.writeFileSync(fd, ...)` and the callback form, where node syncs the caller's fd too (`EINVAL from fsync` on a `/dev/null` fd in node for all four sync/callback variants), so gating the sync inside the binding would have broken those. Before this, `fsp.writeFile(handle, "x", { flush: true })` and `handle.appendFile("x", { flush: true })` performed an extra fsync node does not do (its error was discarded), and `handle.writeFile` would have started doing so through the forwarding above; now every promises entry point behaves the same for string and iterable data. The validation error for these entry points now carries node's wording as well.
- Success and failure are tracked in a separate `failed` flag instead of the truthiness of the caught value, so a falsy rejection propagates like in node and is never followed by an fsync.
- Every non-fd argument (string, `Buffer`, `URL`) is now opened with `fs.open(path, flag, mode)`; `fs.open` rejects anything else with `ERR_INVALID_ARG_TYPE`. This is what makes the fsync (and `flag`/`mode`) apply to Buffer and URL paths.
- Intentionally unchanged: the `ftruncate` after the write still ignores its error (the `O_TRUNC` open already emptied the file, and on `/dev/null`, FIFOs and ttys that call is expected to fail with `EINVAL`; the native path has the same policy), and the final `fs.close` is not wrapped because Bun's close binding reports nothing but `EBADF` (`src/sys/fd.rs`), which cannot happen on a descriptor this function opened itself. The native binding's `"flush" argument` error wording (node says `"options.flush" property`; after this PR it is still what path targets with string/Buffer data get) is a separate one-line change in `node_fs.rs` and is reported separately.
- Overlap with #39186 (open, appendFile iterables): both PRs touch `writeFileAsyncIterator` and the `exports.writeFile` / `appendFile` dispatch. #39186 restructures the option parsing, makes the same `mustClose` change, removes the `ftruncate` block and adds the iterable branch to `appendFile`; this PR adds the `flush` lines to the option parsing, the fsync block to the cleanup, the `failed` flag and the one-line `dropFlushForDescriptor` call in each dispatch function. Each merges cleanly with main; whichever lands second has a small mechanical rebase (re-adding those lines, or dropping the duplicate `mustClose` hunk). The two are cross-linked and #39186 explicitly leaves `flush` to this PR. A larger cleanup that parses the options once at `exports.writeFile`/`appendFile` and lets the FileHandle methods pass them through (node's shape) would retire this whole class of per-method field picking; both PRs are compatible steps toward it and it is not attempted here.
- Verified with `test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts` (7 of the 10 tests fail with main's `fs.promises.ts` and on the released build, all pass with this one): validation (node's message text, file not created, iterable not consumed) for paths and for all seven handle entry points (`writeFile`/`appendFile` given a handle, `handle.writeFile`, `handle.appendFile`, each with string and iterable data where both exist); accepted values; falsy rejections; the `/dev/null` path-vs-handle matrix above; string/Buffer/URL paths truncating and appending; and, on glibc with a C compiler, an `LD_PRELOAD` shim around `fsync(2)` that counts exactly one call for string, URL, Buffer and async-iterable paths with `flush: true`, zero for the seven handle entry points, zero without the option and zero when the iterable throws (an Error or `undefined`), one for the untouched native binding on a path and on a bare fd through `writeFileSync` (controls), and that makes `fsync` fail with `EIO` to check the rejection (`code: "EIO", syscall: "fsync"`), that the data was still written, that the descriptor is closed after fsync failures and after thrown (including falsy) values, and that a caller's handle stays open.
- Also run with the fix: `test/js/node/fs/promises.test.js`, `test/js/node/fs/fs.test.ts`, node's `test-fs-write-file-flush`, `test-fs-append-file-flush`, `test-fs-promises-writefile`, `test-fs-promises-writefile-with-fd`, `test-fs-promises-file-handle-writeFile`, `test-fs-promises-file-handle-append-file`.

### Background

- `fs.promises.writeFile` in Bun has two implementations: string and buffer data go to the native binding in one call (open, write, optional fsync, close); iterable data (arrays, generators, streams) goes to `writeFileAsyncIterator`, which opens the path with the promise-returning native binding (`fs` in this file), drains the iterable into `Bun.file(fd).writer()` and closes the fd. `FileHandle#writeFile` / `#appendFile` call the module-level `writeFile` with the handle's fd and an options object they build themselves, so they reach the same two paths.
- `{ flush: true }` (node 21+) means: after the data has been written, call `fsync` on the descriptor before resolving, so the bytes are on disk rather than only in the page cache. Node's promise implementation validates the option for every call, returns early for a `FileHandle` target (the caller owns that descriptor and can call `handle.sync()`), and for a path wraps the write in `handleFdSync`, which awaits `sync()` only when the write succeeded and propagates either error, then `handleFdClose`.
- `Bun.file(fd).writer()` writes through a `dup()` of the fd and closes only the duplicate, which is why the function can still truncate, fsync and close the original descriptor after the writer has ended; `fsync` is per open file, so it covers the bytes written through the duplicate.
- The `LD_PRELOAD` shim in the test is needed because the fsync happens in native code, out of reach of `jest.spyOn`; the same technique is used elsewhere in `test/js/node/fs/fs.test.ts`. `/dev/null` is used as a second, compiler-free observer: `fsync` on it fails with `EINVAL` on Linux, so a rejection proves a sync was attempted. The path test runs its writes in a child process because the pre-fix `Bun.file(buffer)` route trips an unrelated debug-only GC assertion that would otherwise abort the test runner instead of failing the test (reported separately).

<details>
<summary>Probe on released bun 1.4.0 vs node v26.3.0 (this branch matches node on every row except the last two, which are the native binding's own error handling, see #36485)</summary>

```
writeFile(path, ["a","b"], { flush: true })             bun: resolves, 0 fsync     node: resolves, 1 fsync
writeFile(path, ["a","b"], { flush: "yes" })            bun: resolves               node: ERR_INVALID_ARG_TYPE "options.flush"
writeFile(path, "ab", { flush: "yes" })                 bun: ERR_INVALID_ARG_TYPE   node: ERR_INVALID_ARG_TYPE   (native path, control)
writeFile(fileHandle, ["a"], { flush: "yes" })          bun: resolves               node: ERR_INVALID_ARG_TYPE
fh.writeFile(["a"], { flush: "yes" })                   bun: resolves               node: ERR_INVALID_ARG_TYPE
fh.writeFile("ab", { flush: "yes" })                    bun: resolves               node: ERR_INVALID_ARG_TYPE
fh.appendFile(["a"], { flush: "yes" })                  bun: resolves               node: ERR_INVALID_ARG_TYPE
fh.appendFile("ab", { flush: "yes" })                   bun: ERR_INVALID_ARG_TYPE   node: ERR_INVALID_ARG_TYPE   (already forwarded, control)
writeFile(new URL(...), ["a","b"]) over "seed\n"        bun: "abed\n"               node: "ab"
writeFile(Buffer path, ["a","b"], { flag: "a" })        bun: "abed\n"               node: "seed\nab"
writeFile(path, iterable that throws null)              bun: resolves               node: rejects with null
/dev/null handle, any entry point, string or iterable data, { flush: true }
                                                        bun: resolve                node: resolve (no sync)
regular-file handle, string data, { flush: true }       bun: 1 fsync                node: 0 fsync
writeFile("/dev/null", ["x"], { flush: true })          bun: resolves               node: EINVAL from fsync
writeFile("/dev/null", "x", { flush: true })            bun: resolves               node: EINVAL from fsync      (native binding discards the error)
writeFileSync(devNullFd, "x", { flush: true })          bun: resolves               node: EINVAL from fsync      (same; node syncs bare fds here, so the binding's sync is right)
```

</details>

<details>
<summary>Earlier revisions of this PR</summary>

- First push: `writeFileAsyncIterator` only. Review pointed out that `FileHandle#writeFile` drops `flush` before calling into it; the second commit forwards it there and adds the `handle.writeFile` cases to the tests.
- Second revision synced FileHandle targets too, on the grounds that the native path does. A review pass with the `/dev/null` matrix above showed that this rejects where node and Bun 1.4.0 resolve, so the third revision follows node and syncs only the file this call opened; the same pass found the falsy-rejection problem.
- Third revision left string data on handles syncing through the native binding, so `handle.writeFile(data, { flush: true })` depended on the type of `data`. The current revision adds `dropFlushForDescriptor` so the promises API never syncs a handle for either kind of data, with the sync/callback binding behavior left as is.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts

<!-- robobun:evidence:end -->