### PR TITLE
valkey: finish on_close() even when rejecting the pending commands fails

### DIFF
--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -655,11 +655,12 @@ impl ValkeyClient {
 
     /// Handle connection closed event
     ///
-    /// Always ends in `on_valkey_close()` or `on_valkey_reconnect()`: they release the ref
-    /// the socket held on the client and arm the retry, so they run even when rejecting the
-    /// pending commands returns `Err` (a promise cannot be settled once the VM's termination
-    /// is pending, e.g. a worker stopped while commands were in flight). That `Err` is still
-    /// the one returned, as in `fail_with_js_value`.
+    /// Always ends in `on_valkey_close()` or `on_valkey_reconnect()`: that is where the close
+    /// completes (connect() settled and `onclose` run, or the retry armed) and where the ref
+    /// the socket held on the client is released, so they run even when rejecting the pending
+    /// commands returns `Err` (a promise cannot be settled once the VM's termination is
+    /// pending, e.g. a worker stopped while commands were in flight). That `Err` is still the
+    /// one returned, as in `fail_with_js_value`.
     pub fn on_close(&mut self) -> JsResult<()> {
         self.unregister_auto_flusher();
         self.write_buffer.clear_and_free();

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -654,53 +654,51 @@ impl ValkeyClient {
     }
 
     /// Handle connection closed event
+    ///
+    /// Always ends in `on_valkey_close()` or `on_valkey_reconnect()`: they release the ref
+    /// the socket held on the client and arm the retry, so they run even when rejecting the
+    /// pending commands returns `Err` (a promise cannot be settled once the VM's termination
+    /// is pending, e.g. a worker stopped while commands were in flight). That `Err` is still
+    /// the one returned, as in `fail_with_js_value`.
     pub fn on_close(&mut self) -> JsResult<()> {
         self.unregister_auto_flusher();
         self.write_buffer.clear_and_free();
 
         // If manually closing, don't attempt to reconnect
-        if self.flags.is_manually_closed {
+        let reason: &[u8] = if self.flags.is_manually_closed {
             debug!("skip reconnecting since the connection is manually closed");
-            self.fail(b"Connection closed", RedisError::ConnectionClosed)?;
-            self.on_valkey_close()?;
-            return Ok(());
-        }
-
-        // If auto reconnect is disabled, just fail
-        if !self.flags.enable_auto_reconnect {
+            b"Connection closed"
+        } else if !self.flags.enable_auto_reconnect {
             debug!("skip reconnecting since auto reconnect is disabled");
-            self.fail(b"Connection closed", RedisError::ConnectionClosed)?;
-            self.on_valkey_close()?;
-            return Ok(());
-        }
+            b"Connection closed"
+        } else {
+            // Calculate reconnection delay with exponential backoff
+            self.retry_attempts += 1;
+            let delay_ms = self.get_reconnect_delay();
 
-        // Calculate reconnection delay with exponential backoff
-        self.retry_attempts += 1;
-        let delay_ms = self.get_reconnect_delay();
+            if delay_ms != 0 && self.retry_attempts <= self.max_retries {
+                debug!(
+                    "reconnect in {}ms (attempt {}/{})",
+                    delay_ms, self.retry_attempts, self.max_retries
+                );
 
-        if delay_ms == 0 || self.retry_attempts > self.max_retries {
+                self.flags.is_reconnecting = true;
+                self.flags.is_selecting_db_internal = false;
+
+                let rejected = self
+                    .reject_in_flight_commands(b"Connection closed", RedisError::ConnectionClosed);
+                // Signal reconnect timer should be started, whatever `rejected` is
+                self.on_valkey_reconnect();
+                return rejected;
+            }
+
             debug!("Max retries reached or retry strategy returned 0, giving up reconnection");
-            self.fail(
-                b"Max reconnection attempts reached",
-                RedisError::ConnectionClosed,
-            )?;
-            self.on_valkey_close()?;
-            return Ok(());
-        }
+            b"Max reconnection attempts reached"
+        };
 
-        debug!(
-            "reconnect in {}ms (attempt {}/{})",
-            delay_ms, self.retry_attempts, self.max_retries
-        );
-
-        self.flags.is_reconnecting = true;
-        self.flags.is_selecting_db_internal = false;
-
-        self.reject_in_flight_commands(b"Connection closed", RedisError::ConnectionClosed)?;
-
-        // Signal reconnect timer should be started
-        self.on_valkey_reconnect();
-        Ok(())
+        let failed = self.fail(reason, RedisError::ConnectionClosed);
+        let closed = self.on_valkey_close(); // unconditionally, whatever `failed` is
+        failed.and(closed)
     }
 
     pub(crate) fn send_next_command(&mut self) {

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -654,10 +654,6 @@ impl ValkeyClient {
     }
 
     /// Handle connection closed event
-    ///
-    /// Ends in `on_valkey_close()` / `on_valkey_reconnect()` even when rejecting the pending
-    /// commands returns `Err` (a stopping VM): they complete the close and release the ref the
-    /// socket held on the client. The `Err` is returned afterwards.
     pub fn on_close(&mut self) -> JsResult<()> {
         self.unregister_auto_flusher();
         self.write_buffer.clear_and_free();
@@ -685,7 +681,7 @@ impl ValkeyClient {
 
                 let rejected = self
                     .reject_in_flight_commands(b"Connection closed", RedisError::ConnectionClosed);
-                // Signal reconnect timer should be started, whatever `rejected` is
+                // Whatever `rejected` is: arms the retry and releases the socket's ref.
                 self.on_valkey_reconnect();
                 return rejected;
             }
@@ -695,7 +691,8 @@ impl ValkeyClient {
         };
 
         let failed = self.fail(reason, RedisError::ConnectionClosed);
-        let closed = self.on_valkey_close(); // unconditionally, whatever `failed` is
+        // Whatever `failed` is: runs `onclose` and releases the socket's ref (see `close()`).
+        let closed = self.on_valkey_close();
         failed.and(closed)
     }
 

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -655,12 +655,9 @@ impl ValkeyClient {
 
     /// Handle connection closed event
     ///
-    /// Always ends in `on_valkey_close()` or `on_valkey_reconnect()`: that is where the close
-    /// completes (connect() settled and `onclose` run, or the retry armed) and where the ref
-    /// the socket held on the client is released, so they run even when rejecting the pending
-    /// commands returns `Err` (a promise cannot be settled once the VM's termination is
-    /// pending, e.g. a worker stopped while commands were in flight). That `Err` is still the
-    /// one returned, as in `fail_with_js_value`.
+    /// Ends in `on_valkey_close()` / `on_valkey_reconnect()` even when rejecting the pending
+    /// commands returns `Err` (a stopping VM): they complete the close and release the ref the
+    /// socket held on the client. The `Err` is returned afterwards.
     pub fn on_close(&mut self) -> JsResult<()> {
         self.unregister_auto_flusher();
         self.write_buffer.clear_and_free();

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 import net from "node:net";
+import { join } from "node:path";
 
 // Fuzzer found a heap-use-after-free: connect()'s tls_ctx_failed branch
 // called on_valkey_close() before the socket keep-alive ref was taken, so
@@ -40,6 +41,85 @@ test.concurrent("RedisClient survives a failed custom-TLS context without freein
   expect(stdout.trim()).toBe("OK");
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
+});
+
+// The socket's close event (ValkeyClient::on_close) rejects the commands the
+// connection still owed replies for, then releases the ref the socket held on
+// the client and settles connect()/onclose or arms the retry. Rejecting a
+// promise fails once the VM's termination is pending, which is the state a
+// terminated worker's teardown closes its sockets in, and on_close() used to
+// return at that point, so every RedisClient terminated with commands in flight
+// leaked its Box<JSValkeyClient>. One case per branch of on_close(): retry
+// scheduled, autoReconnect off, retries exhausted. LSan sees the box only when
+// the worker's VM has been torn down, hence the worker; the parent's own VM is
+// torn down too (BUN_DESTRUCT_VM_ON_EXIT) so its server socket is not reported.
+describe.skipIf(!isASAN)("worker.terminate() with commands in flight does not leak the RedisClient", () => {
+  async function terminateWorkerWithCommandsInFlight(options: object) {
+    const src = `
+      const { Worker } = require("node:worker_threads");
+      const HELLO = "%1\\r\\n$5\\r\\nproto\\r\\n:3\\r\\n";
+      // Answers HELLO, then never replies: every command sent stays in flight.
+      // Resolves once the commands have reached the server, so they are in the
+      // client's in-flight queue (not merely queued) when the worker is stopped.
+      const { promise: commandsInFlight, resolve: onCommands } = Promise.withResolvers();
+      const server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: {
+          open(s) { s.data = { hello: false }; },
+          data(s, chunk) {
+            const text = chunk.toString("latin1");
+            if (!s.data.hello && text.includes("HELLO")) { s.data.hello = true; s.write(HELLO); }
+            if (text.includes("INCR")) onCommands();
+          },
+          close() {},
+          error() {},
+        },
+      });
+      // The client is created from a macrotask on purpose: allocations made
+      // while the worker's module body is still on the stack match the
+      // module-evaluation entries of leaksan.supp, and a leaked client would
+      // then go unreported.
+      const worker = new Worker(
+        \`const { workerData } = require("node:worker_threads");
+        setImmediate(() => {
+          const client = new Bun.RedisClient(workerData.url, workerData.options);
+          globalThis.client = client;
+          client.connect().then(() => {
+            for (let i = 0; i < 4; i++) client.incr("k").catch(() => {});
+          });
+        });\`,
+        { eval: true, workerData: { url: "redis://127.0.0.1:" + server.port, options: ${JSON.stringify(options)} } },
+      );
+      worker.on("error", (err) => { console.error(err); process.exit(2); });
+      worker.on("exit", (code) => { console.error("worker exited on its own with " + code); process.exit(3); });
+      await commandsInFlight;
+      worker.removeAllListeners("exit");
+      console.log("terminated", await worker.terminate());
+      server.stop(true);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "terminated 1\n", stderr: "", exitCode: 0 });
+  }
+
+  // Symbolizing a leak report takes LSan several seconds on a debug binary.
+  const timeout = 60_000;
+  test.concurrent("retry scheduled", () => terminateWorkerWithCommandsInFlight({}), timeout);
+  test.concurrent("autoReconnect off", () => terminateWorkerWithCommandsInFlight({ autoReconnect: false }), timeout);
+  test.concurrent("retries exhausted", () => terminateWorkerWithCommandsInFlight({ maxRetries: 0 }), timeout);
 });
 
 // Fuzzer found a heap-use-after-free that survived the ScopedRef refactor:

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -66,11 +66,11 @@ describe.skipIf(!isASAN)("worker.terminate() with commands in flight does not le
         hostname: "127.0.0.1",
         port: 0,
         socket: {
-          open(s) { s.data = { hello: false }; },
+          open(s) { s.data = { buf: "", hello: false }; },
           data(s, chunk) {
-            const text = chunk.toString("latin1");
-            if (!s.data.hello && text.includes("HELLO")) { s.data.hello = true; s.write(HELLO); }
-            if (text.includes("INCR")) onCommands();
+            s.data.buf += chunk.toString("latin1");
+            if (!s.data.hello && s.data.buf.includes("HELLO")) { s.data.hello = true; s.write(HELLO); }
+            if (s.data.buf.includes("INCR")) onCommands();
           },
           close() {},
           error() {},


### PR DESCRIPTION
### Problem
- `worker.terminate()` on a worker whose `Bun.RedisClient` has commands in flight leaks the client. LSan on the unfixed build: `Direct leak of 880 byte(s) ... Box<bun_runtime::valkey_jsc::js_valkey::JSValkeyClient>::new`, on every branch of `on_close()` (retry scheduled, `autoReconnect: false`, `maxRetries` exhausted).
- Every branch of `ValkeyClient::on_close()` used `?` on `fail()` (`src/runtime/valkey_jsc/valkey.rs:664`, `:672`, `:683` on main) or on `reject_in_flight_commands()` (`:699`) before calling `on_valkey_close()` / `on_valkey_reconnect()`, so when rejecting a command's promise returned `Err`, neither ran.
- Those two calls are what releases the socket ref (`js_valkey.rs:1349` and `:1361`), and for a retry `on_valkey_reconnect()` is also what arms the reconnect timer. Skipping them leaves the client's refcount stuck at 1 (verified with `BUN_DEBUG_ref_count=1`: the finalizer's deref takes it from 2 to 1 and it never reaches 0); on the retry branch `is_reconnecting` is additionally left set with no timer armed, which `update_poll_ref()` (`js_valkey.rs:1652`) counts as activity, so the poll ref stays held.
- Rejecting a promise returns `Err` whenever the VM's termination is pending (`src/jsc/JSPromise.rs:367`). That is the state a terminated worker's teardown is in when it closes the remaining sockets (`VirtualMachine::teardown`: `forbid_script()` then `close_all_socket_groups()`), which is why the leak is deterministic there. Pre-existing on main; found while reviewing #37993, which does not touch these lines. #34829 (omnibus, currently conflicting) lists the same `on_close` release among its changes.

### Fix
- `on_close()` decides between giving up and retrying first, then runs `fail()` + `on_valkey_close()` (or `reject_in_flight_commands()` + `on_valkey_reconnect()`) unconditionally and returns the rejection's result afterwards (`failed.and(closed)`), the same shape `fail_with_js_value()` already uses for its own `close()`.
- Correct because the socket ref is released exactly once per close either way: the retry branch still returns before `on_valkey_close()`, so `on_valkey_reconnect()` remains its sole releaser, and the give-up branches still reach `on_valkey_close()` once. `Err(Thrown)` means one exception is pending, so returning the first error after the callback ran reports the same exception the callers (the socket trampoline's fold) reported before; under a pending termination, `on_valkey_close()`'s own promise reject and `onclose` call return/no-op on that same exception, as they already do today when `fail()` had nothing to reject.
- Merges cleanly with #37993 (checked against its current head, 890824df4a); its `ValkeyDeferredClose` takes a ref in the socket's place and relies on `on_close()` always releasing it, which this makes true.
- Self-review found nothing blocking. Its one suggestion is a follow-up, not a change here: the socket ref is still adopted at the two leaves rather than taken into a guard at the close-event entry (the way `RefCountedTimer::take_fire_ref` and the `Bun.connect` close teardowns do it; #34874 proposes essentially that for the over-release case). That would make the release structural; `on_close()` still has to reach the leaves unconditionally either way, since they also settle connect()/`onclose` and arm the retry, which is what this PR guarantees.
- Verified: `test/js/valkey/valkey-gc.test.ts`, new `describe` "worker.terminate() with commands in flight does not leak the RedisClient" (ASan lanes only; one case per branch of `on_close()`). The child runs with `detect_leaks=1` and `BUN_DESTRUCT_VM_ON_EXIT=1`; the client is created from `setImmediate` because allocations made during module evaluation match `leaksan.supp`'s module-loader entries and would be suppressed.
  - Without the `src/` change all three cases fail with the LSan report above; with it all three pass.
  - `bun bd test test/js/valkey/valkey-gc.test.ts`: 12 pass, also with `BUN_JSC_validateExceptionChecks=1`.
  - `valkey-tls-verify.test.ts`, `reliability/{connection-failures,recovery,error-handling}.test.ts` (the server-less parts; the docker-backed ones skip here) and the redis case of `worker-terminate-lifetime.test.ts` pass.

### Background
- Socket keep-alive ref: `JSValkeyClient` is intrusively refcounted. `connect()` takes one ref for the socket and forgets it; the close path adopts and releases it in `on_valkey_close()` / `on_valkey_reconnect()` (`ScopedRef::adopt`), so a close that reaches neither leaks the allocation.
- `JsResult` / `Err(Thrown)`: native code that settles promises or calls back into JS returns `Err` when it left an exception pending on the VM; the outermost dispatcher (here the uSockets trampoline) takes and reports it, or stands the loop down if it is the termination exception. Settling a promise is itself such a call, see the comment above `JSPromise::resolve` in `src/jsc/JSPromise.rs`.
- Termination: `worker.terminate()` (and a worker's `process.exit()`) stops script by making every JS entry and promise settlement fail; teardown then closes the worker's sockets natively, so their close handlers run in exactly that state.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-gc.test.ts
bun test v1.4.0 (bcab5edce)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [388.41ms]
(pass) RedisClient survives connection-timeout + reconnect churn against an under-replying server [1270.38ms]
(pass) RedisClient survives GC after a command throws during argument validation [478.82ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [415.97ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [2366.81ms]
(pass) RedisClient survives GC across many short-lived instances [790.71ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [453.41ms]
(pass) getBuffer replies survive GC with adopted backing stores intact [2191.30ms]
(pass) RedisClient read buffer stays bounded when every socket read ends with a partial reply [2773.08ms]
110 |       stdout: "pipe",
111 |       stderr: "pipe",
112 |     });
113 | 
114 |     const [stdout
... (truncated)

release without fix: 3 skipped
bun test v1.4.0-canary.1 (1290e2e3f)

test/js/valkey/valkey-gc.test.ts:
(skip) worker.terminate() with commands in flight does not leak the RedisClient > retry scheduled
(skip) worker.terminate() with commands in flight does not leak the RedisClient > autoReconnect off
(skip) worker.terminate() with commands in flight does not leak the RedisClient > retries exhausted
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [9.12ms]
(pass) RedisClient survives GC after a command throws during argument validation [9.29ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [8.69ms]
(pass) RedisClient survives GC across many short-lived instances [9.13ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [14.80ms]
(pass) getBuffer replies survive GC with adopted backing stores intact [52.01ms]
(pass) RedisClient read buffer stays bounded when every socket read ends with a partial reply [160.68ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [432.96ms]
(pass) RedisClient survives connection-timeout + reconnect churn against an under-
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-gc.test.ts
bun test v1.4.0 (bcab5edce)

test/js/valkey/valkey-gc.test.ts:
(pass) RedisClient survives a failed custom-TLS context without freeing the live client [398.22ms]
(pass) RedisClient survives connection-timeout + reconnect churn against an under-replying server [1575.75ms]
(pass) RedisClient survives GC after a command throws during argument validation [523.59ms]
(pass) custom setter with a foreign receiver throws instead of corrupting the heap [498.03ms]
(pass) RedisClient survives GC across many short-lived instances [625.72ms]
(pass) worker.terminate() with commands in flight does not leak the RedisClient > autoReconnect off [3509.11ms]
(pass) worker.terminate() with commands in flight does not leak the RedisClient > retries exhausted [3558.73ms]
(pass) RedisClient survives subscribe() + close() against a server that resets the connection [3247.37ms]
(pass) rejects a RESP simple-string reply whose line terminator never arrives [449.39ms]
(pass) worker.terminate() with commands in flight does not leak t
... (truncated)

release with fix: 3 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 948ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/126] gen cpp.rs (cppbind)
[2/126] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/valkey_jsc/valkey.rs | 67 +++++++++++++++-----------------
 test/js/valkey/valkey-gc.test.ts | 82 +++++++++++++++++++++++++++++++++++++++-
 2 files changed, 111 insertions(+), 38 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                              reads  edits  tests
src/runtime/valkey_jsc/valkey.rs      6      8      0
test/js/valkey/valkey-gc.test.ts      4      3      0
```

</details>

<!-- robobun:evidence:end -->