### PR TITLE
ci: give PR builds one darwin aarch64 test lane that any mac agent can take

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -186,8 +186,9 @@ const testPlatforms = [
   // The darwin test suite runs on real macOS agents against the Linux-built
   // artifacts from the `darwin-<arch>-build-bun` steps (the only darwin build
   // lanes — see buildPlatforms).
-  // All three darwin test lanes run on main and on opt-in only for now (see
-  // darwinTestsEnabled): the mac agent pool cannot keep up with PR volume.
+  // These three version-specific lanes run on main and on opt-in (see
+  // darwinTestsEnabled). PR builds instead get one aarch64 lane that any mac
+  // agent can take (prDarwinTestPlatforms), so the whole arm64 pool serves PRs.
   { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
   { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
   { os: "darwin", arch: "x64", release: "14", tier: "latest" },
@@ -409,7 +410,7 @@ function getTestAgent(platform, options) {
       queue: `test-${os}`,
       os,
       arch,
-      ...(arch === "aarch64" ? { "release-tier": tier } : {}),
+      ...(arch === "aarch64" && tier ? { "release-tier": tier } : {}),
     };
   }
 
@@ -1543,11 +1544,16 @@ async function getPipeline(options = {}) {
   // Tests run on main too so the canary release step below can gate on them.
   // ASAN is PR-only (see includeASAN above), so the asan test lane is dropped
   // on main along with its build.
+  // Untiered: any arm64 mac agent, whatever macOS it runs, can take it.
+  /** @type {Platform[]} */
+  const prDarwinTestPlatforms = [{ os: "darwin", arch: "aarch64", release: "any" }];
   const darwinTestsEnabled =
     isMainBranch() || isBuildManual() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
   const relevantTestPlatforms = (
     includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan")
-  ).filter(({ os }) => os !== "darwin" || darwinTestsEnabled);
+  )
+    .filter(({ os }) => os !== "darwin" || darwinTestsEnabled)
+    .concat(darwinTestsEnabled ? [] : prDarwinTestPlatforms);
   /** @type {string[]} */
   const testStepKeys = [];
   {


### PR DESCRIPTION
#39191 took darwin tests off PR builds because the version-specific lanes were queueing for hours. The arm64 pool is not actually short of capacity for PR volume; it is fragmented: the agents behind the `26` lane sit mostly idle (that lane is main-only) while the `14` lane backs up.

This gives PR builds **one untiered `darwin aarch64` test lane** whose agent selector is just `queue=test-darwin, os=darwin, arch=aarch64`, so every arm64 mac agent serves it regardless of macOS version. `main`, manual builds and `[macos tests]` commits keep the three version-specific lanes. `getTestAgent` only emits `release-tier` when a tier is set, and the untiered lane sets no `EXPECTED_PLATFORM_RELEASE`, so the runner's platform assert checks os/arch only.

`--dry-run`:
```
PR:   darwin-aarch64-any-test-bun  agents={queue: test-darwin, os: darwin, arch: aarch64}                         depends_on=darwin-aarch64-build-bun  parallelism=2
main: darwin-aarch64-26-test-bun   agents={..., release-tier: latest}    EXPECTED_PLATFORM_RELEASE=26
      darwin-aarch64-14-test-bun   agents={..., release-tier: previous}
      darwin-x64-14-test-bun       agents={queue: test-darwin, os: darwin, arch: x64}
```