### PR TITLE
bake: report router roots that do not fit the path buffer and skip such route entries instead of panicking

### DIFF
--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1797,22 +1797,13 @@ impl JSFrameworkRouter {
         // `Style` owns a `Strong` (Drop type), so `?` on any error path below
         // drops it automatically.
 
-        let abs_root: Box<[u8]> = {
-            let mut buf = paths::path_buffer_pool::get();
-            let Some(joined) =
-                paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Auto>(
-                    bun_resolver::fs::FileSystem::get().top_level_dir,
-                    &mut buf[..],
-                    &[root.slice()],
-                )
-            else {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "options.root resolves to a path longer than {} bytes",
-                    MAX_PATH_BYTES
-                )));
-            };
-            strings::without_trailing_slash(joined).into()
+        let Some(joined_root) = crate::bake::bake_body::join_router_root(root.slice()) else {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "options.root must resolve to a path shorter than {} bytes",
+                MAX_PATH_BYTES
+            )));
         };
+        let abs_root: Box<[u8]> = strings::without_trailing_slash(&joined_root).into();
 
         let types: Box<[Type]> = Box::new([Type {
             abs_root: abs_root.clone(),

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1797,14 +1797,22 @@ impl JSFrameworkRouter {
         // `Style` owns a `Strong` (Drop type), so `?` on any error path below
         // drops it automatically.
 
-        let abs_root: Box<[u8]> = strings::without_trailing_slash(paths::resolve_path::join_abs::<
-            paths::platform::Auto,
-        >(
-            // SAFETY: FileSystem::instance() returns the process-global singleton; live for the program.
-            bun_resolver::fs::FileSystem::get().top_level_dir,
-            root.slice(),
-        ))
-        .into();
+        let abs_root: Box<[u8]> = {
+            let mut buf = paths::path_buffer_pool::get();
+            let Some(joined) =
+                paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Auto>(
+                    bun_resolver::fs::FileSystem::get().top_level_dir,
+                    &mut buf[..],
+                    &[root.slice()],
+                )
+            else {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "options.root resolves to a path longer than {} bytes",
+                    MAX_PATH_BYTES
+                )));
+            };
+            strings::without_trailing_slash(joined).into()
+        };
 
         let types: Box<[Type]> = Box::new([Type {
             abs_root: abs_root.clone(),

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -1471,6 +1471,15 @@ impl bun_collections::zig_hash_map::HashContext<Box<[u8]>> for ZigStringHashCont
     }
 }
 
+/// The scanned entry's absolute path, or `None` when it is too long to open, in which case the scan skips the entry.
+fn entry_abs_path<'b>(
+    fs: &bun_resolver::fs::FileSystem,
+    entry: &bun_resolver::fs::Entry,
+    buf: &'b mut PathBuffer,
+) -> Option<&'b [u8]> {
+    fs.abs_buf_checked(&[entry.dir, entry.base()], &mut buf[..MAX_PATH_BYTES - 1])
+}
+
 impl FrameworkRouter {
     pub(crate) fn scan(
         &mut self,
@@ -1555,9 +1564,15 @@ impl FrameworkRouter {
                             }
                         }
 
-                        if let Some(child_info) =
-                            r.read_dir_info_ignore_error(fs_ref.abs(&[file.dir, file.base()]))
-                        {
+                        let child_info = {
+                            let mut abs_path_buf = paths::path_buffer_pool::get();
+                            let Some(abs_path) = entry_abs_path(fs_ref, file, &mut abs_path_buf)
+                            else {
+                                continue 'outer;
+                            };
+                            r.read_dir_info_ignore_error(abs_path)
+                        };
+                        if let Some(child_info) = child_info {
                             self.scan_inner(t_index, r, &child_info, arena_state, ctx)?;
                         }
                     }
@@ -1580,15 +1595,18 @@ impl FrameworkRouter {
                             }
                         }
 
+                        let mut abs_path_buf = paths::path_buffer_pool::get();
+                        let Some(abs_path) = entry_abs_path(fs_ref, file, &mut abs_path_buf) else {
+                            continue 'outer;
+                        };
+
                         let mut rel_path_buf = PathBuffer::uninit();
                         let full_rel_path_len = {
                             let full_rel_path = paths::resolve_path::relative_normalized_buf::<
                                 paths::platform::Auto,
                                 true,
                             >(
-                                &mut rel_path_buf[1..],
-                                &self.root,
-                                fs_ref.abs(&[file.dir, file.base()]),
+                                &mut rel_path_buf[1..], &self.root, abs_path
                             );
                             full_rel_path.len()
                         };
@@ -1676,7 +1694,7 @@ impl FrameworkRouter {
                                 t_index,
                                 InsertPattern::Dynamic(pattern),
                                 file_kind,
-                                fs_ref.abs(&[file.dir, file.base()]),
+                                abs_path,
                                 ctx,
                                 &mut out_colliding_file_id,
                             )
@@ -1707,7 +1725,7 @@ impl FrameworkRouter {
                                 t_index,
                                 InsertPattern::Static(pattern),
                                 file_kind,
-                                fs_ref.abs(&[file.dir, file.base()]),
+                                abs_path,
                                 ctx,
                                 &mut out_colliding_file_id,
                             )
@@ -1797,13 +1815,12 @@ impl JSFrameworkRouter {
         // `Style` owns a `Strong` (Drop type), so `?` on any error path below
         // drops it automatically.
 
-        let Some(joined_root) = crate::bake::bake_body::join_router_root(root.slice()) else {
+        let Some(abs_root) = crate::bake::bake_body::resolve_dir_option(root.slice()) else {
             return Err(global.throw_invalid_arguments(format_args!(
                 "options.root must resolve to a path shorter than {} bytes",
                 MAX_PATH_BYTES
             )));
         };
-        let abs_root: Box<[u8]> = strings::without_trailing_slash(&joined_root).into();
 
         let types: Box<[Type]> = Box::new([Type {
             abs_root: abs_root.clone(),

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -501,13 +501,9 @@ impl Default for Framework {
     }
 }
 
-/// Resolves `fileSystemRouterTypes[index].root` against the project directory
-/// for both `Framework::resolve` implementations. The root is user input of any
-/// length, so the join is checked: a resolved path that does not fit in a
-/// `PathBuffer` cannot name a directory and is reported the same way
-/// `resolve_helper` reports an unresolvable entry point. Every root that
-/// resolves therefore fits in the `PathBuffer` that `DevServer::init` and
-/// `bun build --app` later re-join it into.
+/// Resolves `fileSystemRouterTypes[index].root` for both `Framework::resolve`
+/// implementations. A root that does not fit in a `PathBuffer` cannot name a
+/// directory: it is reported like an unresolvable entry point and `None` is returned.
 pub(crate) fn resolve_router_root(index: usize, root: &[u8]) -> Option<Box<[u8]>> {
     let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
     let mut buf = paths::path_buffer_pool::get();

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -501,9 +501,7 @@ impl Default for Framework {
     }
 }
 
-/// Resolves `fileSystemRouterTypes[index].root` for both `Framework::resolve`
-/// implementations. A root that does not fit in a `PathBuffer` cannot name a
-/// directory: it is reported like an unresolvable entry point and `None` is returned.
+/// Resolves `fileSystemRouterTypes[index].root`; reports it and returns `None` when it does not fit in a `PathBuffer`.
 pub(crate) fn resolve_router_root(index: usize, root: &[u8]) -> Option<Box<[u8]>> {
     let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
     let mut buf = paths::path_buffer_pool::get();

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -501,23 +501,29 @@ impl Default for Framework {
     }
 }
 
-/// Resolves `fileSystemRouterTypes[index].root`; reports it and returns `None` when it does not fit in a `PathBuffer`.
-pub(crate) fn resolve_router_root(index: usize, root: &[u8]) -> Option<Box<[u8]>> {
+/// Resolves a router root; `None` once it is `MAX_PATH_BYTES` long, the length from which `Resolver::read_dir_info` rejects it too.
+pub(crate) fn join_router_root(root: &[u8]) -> Option<Box<[u8]>> {
     let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
     let mut buf = paths::path_buffer_pool::get();
-    let resolved = paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Auto>(
+    paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Auto>(
         top_level_dir,
-        &mut buf[..],
+        &mut buf[..paths::MAX_PATH_BYTES - 1],
         &[root],
-    );
+    )
+    .map(Box::from)
+}
+
+/// `join_router_root` for `fileSystemRouterTypes[index]`; a too-long root is reported like an unresolvable entry point.
+pub(crate) fn resolve_router_root(index: usize, root: &[u8]) -> Option<Box<[u8]>> {
+    let resolved = join_router_root(root);
     if resolved.is_none() {
         Output::err(
             "ENAMETOOLONG",
-            "Failed to resolve 'fileSystemRouterTypes[{}].root' for framework: the resolved path is longer than {} bytes",
+            "Failed to resolve 'fileSystemRouterTypes[{}].root' for framework: the resolved path must be shorter than {} bytes",
             (index, paths::MAX_PATH_BYTES),
         );
     }
-    resolved.map(Box::from)
+    resolved
 }
 
 impl Framework {

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -501,6 +501,31 @@ impl Default for Framework {
     }
 }
 
+/// Resolves `fileSystemRouterTypes[index].root` against the project directory
+/// for both `Framework::resolve` implementations. The root is user input of any
+/// length, so the join is checked: a resolved path that does not fit in a
+/// `PathBuffer` cannot name a directory and is reported the same way
+/// `resolve_helper` reports an unresolvable entry point. Every root that
+/// resolves therefore fits in the `PathBuffer` that `DevServer::init` and
+/// `bun build --app` later re-join it into.
+pub(crate) fn resolve_router_root(index: usize, root: &[u8]) -> Option<Box<[u8]>> {
+    let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
+    let mut buf = paths::path_buffer_pool::get();
+    let resolved = paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Auto>(
+        top_level_dir,
+        &mut buf[..],
+        &[root],
+    );
+    if resolved.is_none() {
+        Output::err(
+            "ENAMETOOLONG",
+            "Failed to resolve 'fileSystemRouterTypes[{}].root' for framework: the resolved path is longer than {} bytes",
+            (index, paths::MAX_PATH_BYTES),
+        );
+    }
+    resolved.map(Box::from)
+}
+
 impl Framework {
     /// Bun provides built-in support for using React as a framework.
     /// Depends on externally provided React
@@ -681,11 +706,11 @@ impl Framework {
             // self.resolve_helper(client, &mut sc.client_runtime_import, &mut had_errors);
         }
 
-        for fsr in clone.file_system_router_types.iter_mut() {
-            let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-            fsr.root = arena_erase(arena.alloc_slice_copy(paths::resolve_path::join_abs::<
-                paths::platform::Auto,
-            >(top_level_dir, fsr.root)));
+        for (i, fsr) in clone.file_system_router_types.iter_mut().enumerate() {
+            match resolve_router_root(i, fsr.root) {
+                Some(root) => fsr.root = arena_erase(arena.alloc_slice_copy(&root)),
+                None => had_errors = true,
+            }
             if let Some(entry_client) = &mut fsr.entry_client {
                 self.resolve_helper(
                     client,

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -501,21 +501,23 @@ impl Default for Framework {
     }
 }
 
-/// Resolves a router root; `None` once it is `MAX_PATH_BYTES` long, the length from which `Resolver::read_dir_info` rejects it too.
-pub(crate) fn join_router_root(root: &[u8]) -> Option<Box<[u8]>> {
+/// Resolves a directory from the app options; `None` once it is `MAX_PATH_BYTES` long, the length from which `Resolver::read_dir_info` rejects it too.
+pub(crate) fn resolve_dir_option(dir: &[u8]) -> Option<Box<[u8]>> {
     let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
     let mut buf = paths::path_buffer_pool::get();
-    paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Auto>(
+    let resolved = paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Auto>(
         top_level_dir,
         &mut buf[..paths::MAX_PATH_BYTES - 1],
-        &[root],
-    )
-    .map(Box::from)
+        &[dir],
+    )?;
+    Some(Box::from(
+        paths::string_paths::without_trailing_slash_windows_path(resolved),
+    ))
 }
 
-/// `join_router_root` for `fileSystemRouterTypes[index]`; a too-long root is reported like an unresolvable entry point.
+/// `resolve_dir_option` for `fileSystemRouterTypes[index].root`; a too-long root is reported like an unresolvable entry point.
 pub(crate) fn resolve_router_root(index: usize, root: &[u8]) -> Option<Box<[u8]>> {
-    let resolved = join_router_root(root);
+    let resolved = resolve_dir_option(root);
     if resolved.is_none() {
         Output::err(
             "ENAMETOOLONG",

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -378,15 +378,11 @@ impl Framework {
                 b"server components runtime",
             );
         }
-        for fsr in self.file_system_router_types.iter_mut() {
-            let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-            fsr.root = Cow::Owned(
-                bun_paths::resolve_path::join_abs::<bun_paths::platform::Auto>(
-                    top_level_dir,
-                    &fsr.root,
-                )
-                .to_vec(),
-            );
+        for (i, fsr) in self.file_system_router_types.iter_mut().enumerate() {
+            match bake_body::resolve_router_root(i, &fsr.root) {
+                Some(root) => fsr.root = Cow::Owned(root.into_vec()),
+                None => had_errors = true,
+            }
             let _ = arena;
             if let Some(entry_client) = &mut fsr.entry_client {
                 Self::resolve_helper(

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -545,7 +545,10 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     };
 
     for fsr in &framework.file_system_router_types {
-        let joined_root = resolve_path::join_abs::<platform::Auto>(cwd, fsr.root);
+        // `fsr.root` is absolute and fits in a `PathBuffer`: see `resolve_router_root`.
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let joined_root =
+            resolve_path::join_abs_string_buf::<platform::Auto>(cwd, &mut buf[..], &[fsr.root]);
         let Some(entry) = server_transpiler
             .resolver
             .read_dir_info_ignore_error(joined_root)

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -1,6 +1,6 @@
 import { frameworkRouterInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 const { parseRoutePattern, FrameworkRouter } = frameworkRouterInternals;
@@ -131,5 +131,124 @@ test("discovers from filesystem paths", () => {
         children: [],
       },
     ],
+  });
+});
+
+describe.concurrent("fileSystemRouterTypes[n].root longer than the path buffer", () => {
+  // 100 KB is longer than PATH_MAX on every platform (4 KB on Linux, 1 KB on
+  // macOS, ~96 KB on Windows), so the resolved root cannot fit in a path buffer.
+  const tooLongRoot = `Buffer.alloc(100_000, "a").toString()`;
+  const tooLongRootError = "ENAMETOOLONG: Failed to resolve 'fileSystemRouterTypes[0].root' for framework";
+  const serverEntryPoint = `
+    export function render(req, meta) {
+      return meta.pageModule.default(req, meta);
+    }
+  `;
+  const serveOrReport = (options: string) => `
+    try {
+      const server = Bun.serve({
+        port: 0,
+        development: true,
+        ${options},
+        fetch: () => new Response(""),
+      });
+      server.stop(true);
+      console.log("started");
+    } catch (e) {
+      console.log("threw: " + e.message);
+    }
+  `;
+
+  async function run(dir: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  for (const [kind, root] of [
+    ["relative", tooLongRoot],
+    ["absolute", `"/" + ${tooLongRoot}`],
+  ]) {
+    test(`Bun.serve({ app }) reports the root (${kind}) instead of crashing`, async () => {
+      using dir = tempDir(`fsr-long-root-app-${kind}`, {
+        "server.ts": serverEntryPoint,
+        "start.ts": serveOrReport(`
+          app: {
+            framework: {
+              fileSystemRouterTypes: [
+                { root: ${root}, style: "nextjs-pages", serverEntryPoint: "./server.ts" },
+              ],
+            },
+          }
+        `),
+      });
+      const { stdout, stderr, exitCode } = await run(String(dir), "start.ts");
+      expect(stderr).toContain(tooLongRootError);
+      expect(stdout).toBe("threw: Framework is missing required files!\n");
+      expect(exitCode).toBe(0);
+    });
+  }
+
+  test("Bun.serve({ routes: { '/*': { dir, style } } }) reports the root instead of crashing", async () => {
+    using dir = tempDir("fsr-long-root-routes", {
+      "start.ts": serveOrReport(`routes: { "/*": { dir: ${tooLongRoot}, style: "nextjs-pages" } }`),
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), "start.ts");
+    expect(stderr).toContain(tooLongRootError);
+    expect(stdout).toBe("threw: Framework is missing required files!\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun build --app reports the root instead of crashing", async () => {
+    using dir = tempDir("fsr-long-root-build", {
+      "server.ts": serverEntryPoint,
+      "bun.app.ts": `
+        export default {
+          app: {
+            framework: {
+              fileSystemRouterTypes: [
+                { root: ${tooLongRoot}, style: "nextjs-pages", serverEntryPoint: "./server.ts" },
+              ],
+            },
+          },
+        };
+      `,
+    });
+    const { stderr, exitCode } = await run(String(dir), "build", "--app");
+    expect(stderr).toContain(tooLongRootError);
+    expect(exitCode).toBe(1);
+  });
+
+  test("a root that only normalizes down to a path that fits is served", async () => {
+    using dir = tempDir("fsr-long-root-normalizes", {
+      "server.ts": serverEntryPoint,
+      "routes/index.ts": `export default () => new Response("hello from routes");`,
+      "start.ts": `
+        // 100 KB as written, "routes" once the ".." segments are resolved.
+        const root = "routes" + Buffer.alloc(100_000, "/../routes").toString();
+        using server = Bun.serve({
+          port: 0,
+          development: true,
+          app: {
+            framework: {
+              fileSystemRouterTypes: [{ root, style: "nextjs-pages", serverEntryPoint: "./server.ts" }],
+            },
+          },
+          fetch: () => new Response("not routed", { status: 404 }),
+        });
+        const res = await fetch(\`http://localhost:\${server.port}/\`);
+        console.log(res.status, await res.text());
+      `,
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), "start.ts");
+    expect(stderr).not.toContain("ENAMETOOLONG");
+    expect(stdout).toBe("200 hello from routes\n");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -196,12 +196,14 @@ describe.concurrent("fileSystemRouterTypes[n].root that does not fit in a path b
     return { stdout, stderr, exitCode };
   }
 
-  // Loading any --app config trips the exception check validator until #38949 lands; keep it out of the child.
+  // Every `bun build --app` trips the exception check validator while loading its config (until #38949) and
+  // leaks its transpilers at exit (until #38233), which is why production.test.ts is exempt from both checks.
   const build = (dir: string) =>
     run(dir, ["build", "--app"], {
       ...bunEnv,
       BUN_JSC_validateExceptionChecks: undefined,
       BUN_JSC_dumpSimulatedThrows: undefined,
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
     });
 
   test("the internal FrameworkRouter constructor throws instead of crashing", () => {

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -139,6 +139,13 @@ describe.concurrent("fileSystemRouterTypes[n].root longer than the path buffer",
   // macOS, ~96 KB on Windows), so the resolved root cannot fit in a path buffer.
   const tooLongRoot = `Buffer.alloc(100_000, "a").toString()`;
   const tooLongRootError = "ENAMETOOLONG: Failed to resolve 'fileSystemRouterTypes[0].root' for framework";
+
+  test("the internal FrameworkRouter constructor throws instead of crashing", () => {
+    const root = Buffer.alloc(100_000, "a").toString();
+    expect(() => new FrameworkRouter({ root, style: "nextjs-pages" })).toThrow(
+      /options\.root resolves to a path longer than \d+ bytes/,
+    );
+  });
   const serverEntryPoint = `
     export function render(req, meta) {
       return meta.pageModule.default(req, meta);

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -1,6 +1,6 @@
 import { frameworkRouterInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import path from "path";
 
 const { parseRoutePattern, FrameworkRouter } = frameworkRouterInternals;
@@ -134,39 +134,57 @@ test("discovers from filesystem paths", () => {
   });
 });
 
-describe.concurrent("fileSystemRouterTypes[n].root longer than the path buffer", () => {
-  // 100 KB is longer than PATH_MAX on every platform (4 KB on Linux, 1 KB on
-  // macOS, ~96 KB on Windows), so the resolved root cannot fit in a path buffer.
-  const tooLongRoot = `Buffer.alloc(100_000, "a").toString()`;
-  const tooLongRootError = "ENAMETOOLONG: Failed to resolve 'fileSystemRouterTypes[0].root' for framework";
+// MAX_PATH_BYTES in src/bun_core/util.rs: a resolved router root must be shorter than this.
+const maxPathBytes = isWindows ? 32767 * 3 + 1 : isLinux ? 4096 : 1024;
 
-  test("the internal FrameworkRouter constructor throws instead of crashing", () => {
-    const root = Buffer.alloc(100_000, "a").toString();
-    expect(() => new FrameworkRouter({ root, style: "nextjs-pages" })).toThrow(
-      /options\.root resolves to a path longer than \d+ bytes/,
-    );
-  });
+describe.concurrent("fileSystemRouterTypes[n].root that does not fit in a path buffer", () => {
+  // Longer than maxPathBytes on every platform.
+  const tooLongRoot = `Buffer.alloc(100_000, "a").toString()`;
+  // An absolute root resolves to itself, so this resolves to exactly `length` bytes
+  // ("/aaa..." on POSIX, "C:\\aaa..." on Windows). Evaluated inside the fixture.
+  const absoluteRootOfLength = (length: number) =>
+    `(prefix => prefix + Buffer.alloc(${length} - prefix.length, "a").toString())(path.parse(process.cwd()).root)`;
+  const rootError = (index: number) =>
+    `ENAMETOOLONG: Failed to resolve 'fileSystemRouterTypes[${index}].root' for framework: the resolved path must be shorter than ${maxPathBytes} bytes`;
+  const rejected = "threw: Framework is missing required files!";
+
   const serverEntryPoint = `
     export function render(req, meta) {
       return meta.pageModule.default(req, meta);
     }
   `;
-  const serveOrReport = (options: string) => `
-    try {
-      const server = Bun.serve({
-        port: 0,
-        development: true,
-        ${options},
-        fetch: () => new Response(""),
-      });
-      server.stop(true);
-      console.log("started");
-    } catch (e) {
-      console.log("threw: " + e.message);
+  const appWithRoots = (...roots: string[]) => `{
+    app: {
+      framework: {
+        fileSystemRouterTypes: [
+          ${roots.map(root => `{ root: ${root}, style: "nextjs-pages", serverEntryPoint: "./server.ts" },`).join("\n")}
+        ],
+      },
+    },
+  }`;
+  // Prints one line per attempt: "started" if Bun.serve accepted the options, "threw: <message>" otherwise.
+  const serveFixture = (...attempts: string[]) => `
+    import path from "path";
+    for (const options of [${attempts.join(", ")}]) {
+      try {
+        const server = Bun.serve({ port: 0, development: true, ...options, fetch: () => new Response("") });
+        server.stop(true);
+        console.log("started");
+      } catch (e) {
+        console.log("threw: " + e.message);
+      }
     }
   `;
 
-  async function run(dir: string, args: string[], env: NodeJS.Dict<string> = bunEnv) {
+  const buildFixture = (root: string) => ({
+    "server.ts": serverEntryPoint,
+    "bun.app.ts": `
+      import path from "path";
+      export default ${appWithRoots(root)};
+    `,
+  });
+
+  async function run(dir: string, args: string[], env = bunEnv) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), ...args],
       cwd: dir,
@@ -178,66 +196,74 @@ describe.concurrent("fileSystemRouterTypes[n].root longer than the path buffer",
     return { stdout, stderr, exitCode };
   }
 
-  for (const [kind, root] of [
-    ["relative", tooLongRoot],
-    ["absolute", `"/" + ${tooLongRoot}`],
-  ]) {
-    test(`Bun.serve({ app }) reports the root (${kind}) instead of crashing`, async () => {
-      using dir = tempDir(`fsr-long-root-app-${kind}`, {
-        "server.ts": serverEntryPoint,
-        "start.ts": serveOrReport(`
-          app: {
-            framework: {
-              fileSystemRouterTypes: [
-                { root: ${root}, style: "nextjs-pages", serverEntryPoint: "./server.ts" },
-              ],
-            },
-          }
-        `),
-      });
-      const { stdout, stderr, exitCode } = await run(String(dir), ["start.ts"]);
-      expect(stderr).toContain(tooLongRootError);
-      expect(stdout).toBe("threw: Framework is missing required files!\n");
-      expect(exitCode).toBe(0);
-    });
-  }
-
-  test("Bun.serve({ routes: { '/*': { dir, style } } }) reports the root instead of crashing", async () => {
-    using dir = tempDir("fsr-long-root-routes", {
-      "start.ts": serveOrReport(`routes: { "/*": { dir: ${tooLongRoot}, style: "nextjs-pages" } }`),
-    });
-    const { stdout, stderr, exitCode } = await run(String(dir), ["start.ts"]);
-    expect(stderr).toContain(tooLongRootError);
-    expect(stdout).toBe("threw: Framework is missing required files!\n");
-    expect(exitCode).toBe(0);
-  });
-
-  test("bun build --app reports the root instead of crashing", async () => {
-    using dir = tempDir("fsr-long-root-build", {
-      "server.ts": serverEntryPoint,
-      "bun.app.ts": `
-        export default {
-          app: {
-            framework: {
-              fileSystemRouterTypes: [
-                { root: ${tooLongRoot}, style: "nextjs-pages", serverEntryPoint: "./server.ts" },
-              ],
-            },
-          },
-        };
-      `,
-    });
-    // Loading any --app config trips JSC's exception check validation in
-    // BakeGetDefaultExportFromModule before the framework is resolved (the
-    // reason test/bake/dev/production.test.ts is in no-validate-exceptions.txt),
-    // so the ASAN lane's validator must not leak into this child.
-    const { stderr, exitCode } = await run(String(dir), ["build", "--app"], {
+  // Loading any --app config trips the exception check validator until #38949 lands; keep it out of the child.
+  const build = (dir: string) =>
+    run(dir, ["build", "--app"], {
       ...bunEnv,
       BUN_JSC_validateExceptionChecks: undefined,
       BUN_JSC_dumpSimulatedThrows: undefined,
     });
-    expect(stderr).toContain(tooLongRootError);
+
+  test("the internal FrameworkRouter constructor throws instead of crashing", () => {
+    const prefix = path.parse(process.cwd()).root;
+    const root = prefix + Buffer.alloc(maxPathBytes - prefix.length, "a").toString();
+    expect(() => new FrameworkRouter({ root, style: "nextjs-pages" })).toThrow(
+      `options.root must resolve to a path shorter than ${maxPathBytes} bytes`,
+    );
+  });
+
+  test("Bun.serve({ app }) reports every root that does not fit instead of crashing", async () => {
+    using dir = tempDir("fsr-long-root-app", {
+      "server.ts": serverEntryPoint,
+      "start.ts": serveFixture(appWithRoots(tooLongRoot, `"/" + ${tooLongRoot}`)),
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), ["start.ts"]);
+    expect(stderr).toContain(rootError(0));
+    expect(stderr).toContain(rootError(1));
+    expect(stdout).toBe(`${rejected}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("Bun.serve({ routes: { '/*': { dir, style } } }) reports the root instead of crashing", async () => {
+    using dir = tempDir("fsr-long-root-routes", {
+      "start.ts": serveFixture(`{ routes: { "/*": { dir: ${tooLongRoot}, style: "nextjs-pages" } } }`),
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), ["start.ts"]);
+    expect(stderr).toContain(rootError(0));
+    expect(stdout).toBe(`${rejected}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("Bun.serve({ app }) accepts a root one byte below the limit and rejects one at the limit", async () => {
+    using dir = tempDir("fsr-root-at-limit-app", {
+      "server.ts": serverEntryPoint,
+      "start.ts": serveFixture(
+        // The directory does not exist, so the accepted root is skipped like any other missing root.
+        appWithRoots(absoluteRootOfLength(maxPathBytes - 1)),
+        appWithRoots(absoluteRootOfLength(maxPathBytes)),
+      ),
+    });
+    const { stdout, stderr, exitCode } = await run(String(dir), ["start.ts"]);
+    expect(stdout).toBe(`started\n${rejected}\n`);
+    expect(stderr).toContain(rootError(0));
+    expect(stderr.match(/ENAMETOOLONG/g) ?? []).toHaveLength(1);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun build --app fails on a root at the limit instead of crashing", async () => {
+    using dir = tempDir("fsr-root-at-limit-build", buildFixture(absoluteRootOfLength(maxPathBytes)));
+    const { stderr, exitCode } = await build(String(dir));
+    expect(stderr).toContain(rootError(0));
     expect(exitCode).toBe(1);
+  });
+
+  test("bun build --app looks up a root one byte below the limit like any other missing directory", async () => {
+    using dir = tempDir("fsr-root-below-limit-build", buildFixture(absoluteRootOfLength(maxPathBytes - 1)));
+    const { stdout, stderr, exitCode } = await build(String(dir));
+    expect(stderr).not.toContain("ENAMETOOLONG");
+    expect(stderr).toContain("Bundling routes");
+    expect(stdout).toContain("done");
+    expect(exitCode).toBe(0);
   });
 
   test("a root that only normalizes down to a path that fits is served", async () => {
@@ -250,11 +276,7 @@ describe.concurrent("fileSystemRouterTypes[n].root longer than the path buffer",
         using server = Bun.serve({
           port: 0,
           development: true,
-          app: {
-            framework: {
-              fileSystemRouterTypes: [{ root, style: "nextjs-pages", serverEntryPoint: "./server.ts" }],
-            },
-          },
+          ...${appWithRoots("root")},
           fetch: () => new Response("not routed", { status: 404 }),
         });
         const res = await fetch(\`http://localhost:\${server.port}/\`);

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -159,11 +159,11 @@ describe.concurrent("fileSystemRouterTypes[n].root longer than the path buffer",
     }
   `;
 
-  async function run(dir: string, ...args: string[]) {
+  async function run(dir: string, args: string[], env: NodeJS.Dict<string> = bunEnv) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), ...args],
       cwd: dir,
-      env: bunEnv,
+      env,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -188,7 +188,7 @@ describe.concurrent("fileSystemRouterTypes[n].root longer than the path buffer",
           }
         `),
       });
-      const { stdout, stderr, exitCode } = await run(String(dir), "start.ts");
+      const { stdout, stderr, exitCode } = await run(String(dir), ["start.ts"]);
       expect(stderr).toContain(tooLongRootError);
       expect(stdout).toBe("threw: Framework is missing required files!\n");
       expect(exitCode).toBe(0);
@@ -199,7 +199,7 @@ describe.concurrent("fileSystemRouterTypes[n].root longer than the path buffer",
     using dir = tempDir("fsr-long-root-routes", {
       "start.ts": serveOrReport(`routes: { "/*": { dir: ${tooLongRoot}, style: "nextjs-pages" } }`),
     });
-    const { stdout, stderr, exitCode } = await run(String(dir), "start.ts");
+    const { stdout, stderr, exitCode } = await run(String(dir), ["start.ts"]);
     expect(stderr).toContain(tooLongRootError);
     expect(stdout).toBe("threw: Framework is missing required files!\n");
     expect(exitCode).toBe(0);
@@ -220,7 +220,15 @@ describe.concurrent("fileSystemRouterTypes[n].root longer than the path buffer",
         };
       `,
     });
-    const { stderr, exitCode } = await run(String(dir), "build", "--app");
+    // Loading any --app config trips JSC's exception check validation in
+    // BakeGetDefaultExportFromModule before the framework is resolved (the
+    // reason test/bake/dev/production.test.ts is in no-validate-exceptions.txt),
+    // so the ASAN lane's validator must not leak into this child.
+    const { stderr, exitCode } = await run(String(dir), ["build", "--app"], {
+      ...bunEnv,
+      BUN_JSC_validateExceptionChecks: undefined,
+      BUN_JSC_dumpSimulatedThrows: undefined,
+    });
     expect(stderr).toContain(tooLongRootError);
     expect(exitCode).toBe(1);
   });
@@ -246,7 +254,7 @@ describe.concurrent("fileSystemRouterTypes[n].root longer than the path buffer",
         console.log(res.status, await res.text());
       `,
     });
-    const { stdout, stderr, exitCode } = await run(String(dir), "start.ts");
+    const { stdout, stderr, exitCode } = await run(String(dir), ["start.ts"]);
     expect(stderr).not.toContain("ENAMETOOLONG");
     expect(stdout).toBe("200 hello from routes\n");
     expect(exitCode).toBe(0);

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -1,6 +1,7 @@
 import { frameworkRouterInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { mkdirSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isWindows, MAX_PATH_BYTES, tempDir } from "harness";
 import path from "path";
 
 const { parseRoutePattern, FrameworkRouter } = frameworkRouterInternals;
@@ -134,18 +135,15 @@ test("discovers from filesystem paths", () => {
   });
 });
 
-// MAX_PATH_BYTES in src/bun_core/util.rs: a resolved router root must be shorter than this.
-const maxPathBytes = isWindows ? 32767 * 3 + 1 : isLinux ? 4096 : 1024;
-
 describe.concurrent("fileSystemRouterTypes[n].root that does not fit in a path buffer", () => {
-  // Longer than maxPathBytes on every platform.
+  // Longer than MAX_PATH_BYTES on every platform.
   const tooLongRoot = `Buffer.alloc(100_000, "a").toString()`;
   // An absolute root resolves to itself, so this resolves to exactly `length` bytes
   // ("/aaa..." on POSIX, "C:\\aaa..." on Windows). Evaluated inside the fixture.
   const absoluteRootOfLength = (length: number) =>
     `(prefix => prefix + Buffer.alloc(${length} - prefix.length, "a").toString())(path.parse(process.cwd()).root)`;
   const rootError = (index: number) =>
-    `ENAMETOOLONG: Failed to resolve 'fileSystemRouterTypes[${index}].root' for framework: the resolved path must be shorter than ${maxPathBytes} bytes`;
+    `ENAMETOOLONG: Failed to resolve 'fileSystemRouterTypes[${index}].root' for framework: the resolved path must be shorter than ${MAX_PATH_BYTES} bytes`;
   const rejected = "threw: Framework is missing required files!";
 
   const serverEntryPoint = `
@@ -208,10 +206,44 @@ describe.concurrent("fileSystemRouterTypes[n].root that does not fit in a path b
 
   test("the internal FrameworkRouter constructor throws instead of crashing", () => {
     const prefix = path.parse(process.cwd()).root;
-    const root = prefix + Buffer.alloc(maxPathBytes - prefix.length, "a").toString();
+    const root = prefix + Buffer.alloc(MAX_PATH_BYTES - prefix.length, "a").toString();
     expect(() => new FrameworkRouter({ root, style: "nextjs-pages" })).toThrow(
-      `options.root must resolve to a path shorter than ${maxPathBytes} bytes`,
+      `options.root must resolve to a path shorter than ${MAX_PATH_BYTES} bytes`,
     );
+  });
+
+  // Windows' own path limit is below MAX_PATH_BYTES, so such a tree cannot be created there.
+  test.skipIf(isWindows)("scanning a root skips the entries whose paths do not fit instead of crashing", () => {
+    using dir = tempDir("fsr-scan-long-entries", {});
+    // 200 bytes below the limit: the root's own short files fit, entries with a maximum-length name do not.
+    let root = String(dir);
+    while (root.length < MAX_PATH_BYTES - 200) {
+      const part = Math.min(200, MAX_PATH_BYTES - 200 - root.length - 1);
+      root = path.join(root, Buffer.alloc(part, "d").toString());
+    }
+    mkdirSync(root, { recursive: true });
+    writeFileSync(path.join(root, "index.ts"), "");
+    // The OS rejects their absolute paths too, so these can only be created relative to the root.
+    const longName = Buffer.alloc(252, "x").toString();
+    const create = Bun.spawnSync({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          import { mkdirSync, writeFileSync } from "fs";
+          writeFileSync(${JSON.stringify(`${longName}.ts`)}, "");
+          mkdirSync(${JSON.stringify(`${longName}dir`)});
+          writeFileSync(${JSON.stringify(`${longName}dir/index.ts`)}, "");
+        `,
+      ],
+      cwd: root,
+      env: bunEnv,
+    });
+    expect(create.stderr.toString()).toBe("");
+    expect(create.exitCode).toBe(0);
+
+    const router = new FrameworkRouter({ root, style: "nextjs-pages" });
+    expect(router.toJSON()).toEqual({ part: "/", page: path.join(root, "index.ts"), layout: null, children: [] });
   });
 
   test("Bun.serve({ app }) reports every root that does not fit instead of crashing", async () => {
@@ -241,8 +273,8 @@ describe.concurrent("fileSystemRouterTypes[n].root that does not fit in a path b
       "server.ts": serverEntryPoint,
       "start.ts": serveFixture(
         // The directory does not exist, so the accepted root is skipped like any other missing root.
-        appWithRoots(absoluteRootOfLength(maxPathBytes - 1)),
-        appWithRoots(absoluteRootOfLength(maxPathBytes)),
+        appWithRoots(absoluteRootOfLength(MAX_PATH_BYTES - 1)),
+        appWithRoots(absoluteRootOfLength(MAX_PATH_BYTES)),
       ),
     });
     const { stdout, stderr, exitCode } = await run(String(dir), ["start.ts"]);
@@ -253,14 +285,14 @@ describe.concurrent("fileSystemRouterTypes[n].root that does not fit in a path b
   });
 
   test("bun build --app fails on a root at the limit instead of crashing", async () => {
-    using dir = tempDir("fsr-root-at-limit-build", buildFixture(absoluteRootOfLength(maxPathBytes)));
+    using dir = tempDir("fsr-root-at-limit-build", buildFixture(absoluteRootOfLength(MAX_PATH_BYTES)));
     const { stderr, exitCode } = await build(String(dir));
     expect(stderr).toContain(rootError(0));
     expect(exitCode).toBe(1);
   });
 
   test("bun build --app looks up a root one byte below the limit like any other missing directory", async () => {
-    using dir = tempDir("fsr-root-below-limit-build", buildFixture(absoluteRootOfLength(maxPathBytes - 1)));
+    using dir = tempDir("fsr-root-below-limit-build", buildFixture(absoluteRootOfLength(MAX_PATH_BYTES - 1)));
     const { stdout, stderr, exitCode } = await build(String(dir));
     expect(stderr).not.toContain("ENAMETOOLONG");
     expect(stderr).toContain("Bundling routes");

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -215,10 +215,11 @@ describe.concurrent("fileSystemRouterTypes[n].root that does not fit in a path b
   // Windows' own path limit is below MAX_PATH_BYTES, so such a tree cannot be created there.
   test.skipIf(isWindows)("scanning a root skips the entries whose paths do not fit instead of crashing", () => {
     using dir = tempDir("fsr-scan-long-entries", {});
-    // 200 bytes below the limit: the root's own short files fit, entries with a maximum-length name do not.
+    // About 200 bytes below the limit: the root's own short files fit, entries with a maximum-length name do not.
+    // Every segment adds at least two bytes (separator included), so this terminates whatever length `dir` has.
     let root = String(dir);
     while (root.length < MAX_PATH_BYTES - 200) {
-      const part = Math.min(200, MAX_PATH_BYTES - 200 - root.length - 1);
+      const part = Math.max(1, Math.min(200, MAX_PATH_BYTES - 200 - root.length - 1));
       root = path.join(root, Buffer.alloc(part, "d").toString());
     }
     mkdirSync(root, { recursive: true });

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -24,6 +24,11 @@ export const isFreeBSD = process.platform === "freebsd";
 export const isAndroid = process.platform === "android";
 export const isPosix = isMacOS || isLinux || isFreeBSD || isAndroid;
 export const isWindows = process.platform === "win32";
+/**
+ * Size of bun's fixed path buffers (`MAX_PATH_BYTES` in `src/bun_core/util.rs`). A path longer than this does not
+ * fit in one, which code taking a path from the user has to report rather than overflow the buffer.
+ */
+export const MAX_PATH_BYTES = isWindows ? 32767 * 3 + 1 : isLinux || isAndroid ? 4096 : 1024;
 export const isIntelMacOS = isMacOS && process.arch === "x64";
 export const isArm64 = process.arch === "arm64";
 export const isDebug = Bun.version.includes("debug");


### PR DESCRIPTION
### Problem
- A bake router root longer than about 4 KB aborts the process instead of producing an error:
  `panic: range end index 5010 out of range for slice of length 4095` (exit 134).
- Reachable from `Bun.serve({ routes: { "/*": { dir, style } } })` in every release (the `dir` becomes a router root and that path has no feature gate), and from `Bun.serve({ app: { framework } })` and `bun build --app` on canary or with `BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE=1`. The `bun:internal-for-testing` `FrameworkRouter` constructor has the same join on its `root` option.
- Cause: both `Framework::resolve` implementations (`src/runtime/bake/mod.rs:384` for the dev server, `src/runtime/bake/bake_body.rs:686` for `bun build --app`) and `JSFrameworkRouter::constructor` (`src/runtime/bake/FrameworkRouter.rs:1800`) resolve the root with `resolve_path::join_abs`, which normalizes into a fixed 4096 byte thread-local buffer (`src/paths/resolve_path.rs:15`) and indexes past its end when the result does not fit. The root is user input of arbitrary length.
- The route scan has the same shape one step later: `FrameworkRouter::scan_inner` joined every directory and file under the root with `FileSystem::abs` (the same thread-local buffer), so a root that is itself acceptable but contains an entry whose full path does not fit aborted during the scan (`panic: range end index 4151 out of range for slice of length 4095`). Such entries exist: the OS limits the path you pass to a syscall, not how deep a tree can get.
- `src/runtime/bake/production.rs:548` re-joined the resolved root into the same thread-local buffer.

### Fix
- The three root sites resolve through `bake_body::resolve_dir_option`: a `join_abs_string_buf_checked` into `MAX_PATH_BYTES - 1` bytes of a pooled `PathBuffer`, with the trailing separator stripped (previously only the constructor did that). `MAX_PATH_BYTES - 1` is the limit `Resolver::read_dir_info` already applies to a directory path (`src/resolver/resolver.rs:4191`), so a root is rejected exactly when no directory lookup could succeed for it. #39188 resolves `app.root` and can use the same helper.
- The two `resolve()` implementations call it through `resolve_router_root`, which prints `ENAMETOOLONG: Failed to resolve 'fileSystemRouterTypes[n].root' for framework: the resolved path must be shorter than N bytes` and sets `had_errors`, the same path an unresolvable entry point takes, so `Bun.serve` throws its existing "Framework is missing required files!" error, `bun build --app` exits 1 with its existing summary line, and every bad root is still reported in one pass. The internal constructor throws an invalid-arguments error instead, since it is a JS constructor rather than a batch resolver.
- An error rather than a silent skip is correct for a root because it is a broken configuration value, unlike a root that merely does not exist yet, which bake skips on purpose.
- The scan joins each entry with the same checked join (`entry_abs_path`) and skips entries that do not fit, both for recursing into a directory and for registering a file. Skipping is the right outcome there: nothing could open such an entry, and `read_dir_info` returns `None` for the directory case already. Everything else under the root is still served.
- With roots and entries both bounded by `MAX_PATH_BYTES - 1`, the re-joins into a full `PathBuffer` in dev server init (`DevServer.rs`, unchanged) and the production build (now a pooled `PathBuffer` instead of the 4 KB thread-local buffer, which is smaller than a `PathBuffer` on Windows) always fit.
- The checked join compares the normalized length, so a root that is long as written but normalizes down to something that fits (`routes/../routes/...`) is still accepted; the old code accepted it too and a test pins that.
- Not changed here: a root resolving outside the project root (#33203), and the thread-local join helpers themselves, which other open PRs (#38368, #37457, #38392) are teaching to spill instead of overflow; this PR only removes bake's callers of the overflowing form.
- Verified with `test/bake/framework-router.test.ts`. On the released binary the constructor test fails and the scan test aborts with the second panic above; with the scan test removed, the two `Bun.serve` tests abort with the first panic and the at-limit tests are wrongly accepted. With this change all pass: the internal constructor at exactly `MAX_PATH_BYTES`, a scan of a root 200 bytes below the limit holding `index.ts` plus a file and a directory with maximum-length names (only `index.ts` is discovered; skipped on Windows, whose own path limit is below `MAX_PATH_BYTES`), a two-entry framework reporting `[0].root` and `[1].root`, a `routes` `dir`, and `Bun.serve` plus `bun build --app` with roots of exactly `MAX_PATH_BYTES` (reported) and `MAX_PATH_BYTES - 1` (looked up and skipped like any missing directory, so the re-joins run on a maximum-length root), plus the normalizing root. The per-platform limit comes from a new `MAX_PATH_BYTES` export in `test/harness.ts` (the same lines #38749 adds) and is asserted in the error text, so the table is checked against the binary.
- The `bun build --app` children are spawned without `BUN_JSC_validateExceptionChecks` and with leak detection off: loading any `--app` config trips a pre-existing unchecked exception in `BakeGetDefaultExportFromModule` before the framework is resolved, and every successful `--app` build leaks its transpilers at exit. These are the reasons `test/bake/dev/production.test.ts` is exempt from both checks; #38949 and #38233 fix them, after which the override can go. The tests stay in this file rather than `production.test.ts` because that file's existing tests run close to the default per-test timeout on a debug build.
- `bun bd test test/bake/dev/bundle.test.ts` still passes (real router roots and trees through the dev server scan); a root written as `routes/` is still served.

### Background
- Bake frameworks declare router types; each has a `root` directory that bake scans for route files. Bake keeps two copies of the `Framework` struct (`mod.rs` for the dev server, `bake_body.rs` for `bun build --app`), each with its own `resolve()` that turns the user's root into an absolute path; that is why the fix touches two call sites through one helper. `FrameworkRouter::scan_inner` is the walk over that directory that both of them, and the internal constructor, run afterwards.
- `resolve_path::join_abs` (and `FileSystem::abs`, which wraps it) is bun's `path.resolve`: it joins against a base directory and normalizes into a caller-independent 4096 byte thread-local scratch buffer. `join_abs_string_buf_checked` is the variant for input of unknown length: it joins into a caller-provided buffer and returns `None` when the normalized result would not fit.
- `PathBuffer` is bun's `[u8; MAX_PATH_BYTES]` path scratch type (4096 bytes on Linux, 1024 on macOS, 98302 on Windows), drawn from a per-thread pool so it does not live on the stack. A path of `MAX_PATH_BYTES` bytes leaves no room for the NUL terminator, which is why the resolver and this change both treat that length as already too long.
- Missing router roots are not errors in bake: the built-in React framework declares a `pages` root that a project may not have, so `read_dir_info_ignore_error` returning `None` skips the router type. That is the behavior this change deliberately does not extend to over-long roots, and the behavior it does extend to over-long entries inside a root.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/framework-router.test.ts

<!-- robobun:evidence:end -->