### PR TITLE
watcher: free the owned path of evicted watchlist entries

### DIFF
--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -990,12 +990,7 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
 
     /// Remove the specified item from the list, swapping the last
     /// item in the list into its position. Fast, but does not
-    /// retain list ordering.
-    ///
-    /// Returns the removed element, whose fields the caller now owns (as with
-    /// [`pop`](Self::pop)). Nothing else ever runs a removed row's destructor:
-    /// `Drop` for this list is slab-only and
-    /// [`drop_elements`](Self::drop_elements) only sees rows still in the list.
+    /// retain list ordering. Returns the removed element, like [`pop`](Self::pop).
     pub fn swap_remove(&mut self, index: usize) -> T {
         assert!(
             index < self.len,
@@ -1010,10 +1005,7 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     }
 
     /// Remove the specified item from the list, shifting items
-    /// after it to preserve order.
-    ///
-    /// Returns the removed element; ownership semantics as in
-    /// [`swap_remove`](Self::swap_remove).
+    /// after it to preserve order. Returns the removed element, like [`pop`](Self::pop).
     pub fn ordered_remove(&mut self, index: usize) -> T {
         assert!(
             index < self.len,
@@ -1449,9 +1441,7 @@ mod tests {
         n: u32,
     }
 
-    // Under Miri (`bun run rust:miri`) this also checks that a removed row's
-    // heap payload is freed exactly once: by the caller dropping the returned
-    // element, not again by `drop_elements`.
+    // Under Miri this also checks that every `name` is freed exactly once.
     #[test]
     fn remove_returns_owned_element() {
         let mut list = MultiArrayList::<Owning>::default();

--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -991,28 +991,40 @@ impl<T, A: Allocator> MultiArrayList<T, A> {
     /// Remove the specified item from the list, swapping the last
     /// item in the list into its position. Fast, but does not
     /// retain list ordering.
-    pub fn swap_remove(&mut self, index: usize) {
+    ///
+    /// Returns the removed element, whose fields the caller now owns (as with
+    /// [`pop`](Self::pop)). Nothing else ever runs a removed row's destructor:
+    /// `Drop` for this list is slab-only and
+    /// [`drop_elements`](Self::drop_elements) only sees rows still in the list.
+    pub fn swap_remove(&mut self, index: usize) -> T {
         assert!(
             index < self.len,
             "MultiArrayList::swap_remove: index out of bounds"
         );
         let last = self.len - 1;
         let mut s = self.slice();
+        let removed = s.gather(index);
         s.copy_rows_within(last, index, 1);
         self.len -= 1;
+        removed
     }
 
     /// Remove the specified item from the list, shifting items
     /// after it to preserve order.
-    pub fn ordered_remove(&mut self, index: usize) {
+    ///
+    /// Returns the removed element; ownership semantics as in
+    /// [`swap_remove`](Self::swap_remove).
+    pub fn ordered_remove(&mut self, index: usize) -> T {
         assert!(
             index < self.len,
             "MultiArrayList::ordered_remove: index out of bounds"
         );
         let tail = self.len - 1 - index;
         let mut s = self.slice();
+        let removed = s.gather(index);
         s.copy_rows_within(index + 1, index, tail);
         self.len -= 1;
+        removed
     }
 
     /// Attempt to reduce allocated capacity to `new_len`.
@@ -1422,10 +1434,50 @@ mod tests {
             .unwrap();
         }
         assert_eq!(list.items::<"a", u32>(), &[0, 1, 2, 3, 4, 5]);
-        list.ordered_remove(2);
+        assert_eq!(list.ordered_remove(2), Foo { a: 2, b: 2, c: 2 });
         assert_eq!(list.items::<"a", u32>(), &[0, 1, 3, 4, 5]);
-        list.swap_remove(1);
+        assert_eq!(list.swap_remove(1), Foo { a: 1, b: 1, c: 1 });
         assert_eq!(list.items::<"a", u32>(), &[0, 5, 3, 4]);
+        assert_eq!(list.items::<"c", u64>(), &[0, 5, 3, 4]);
+        // Removing the last row swaps it with itself.
+        assert_eq!(list.swap_remove(3), Foo { a: 4, b: 4, c: 4 });
+        assert_eq!(list.items::<"a", u32>(), &[0, 5, 3]);
+    }
+
+    struct Owning {
+        name: Box<[u8]>,
+        n: u32,
+    }
+
+    // Under Miri (`bun run rust:miri`) this also checks that a removed row's
+    // heap payload is freed exactly once: by the caller dropping the returned
+    // element, not again by `drop_elements`.
+    #[test]
+    fn remove_returns_owned_element() {
+        let mut list = MultiArrayList::<Owning>::default();
+        for i in 0..4u32 {
+            list.push(Owning {
+                name: vec![b'a' + i as u8; 3].into_boxed_slice(),
+                n: i,
+            })
+            .unwrap();
+        }
+
+        let removed = list.swap_remove(1);
+        assert_eq!(&*removed.name, b"bbb");
+        assert_eq!(removed.n, 1);
+        assert_eq!(list.items::<"n", u32>(), &[0, 3, 2]);
+        drop(removed);
+
+        let removed = list.ordered_remove(0);
+        assert_eq!(&*removed.name, b"aaa");
+        assert_eq!(list.items::<"n", u32>(), &[3, 2]);
+        assert_eq!(&*list.items::<"name", Box<[u8]>>()[0], b"ddd");
+        assert_eq!(&*list.items::<"name", Box<[u8]>>()[1], b"ccc");
+        drop(removed);
+
+        list.drop_elements();
+        assert_eq!(list.len(), 0);
     }
 
     #[test]

--- a/src/collections/multi_array_list.rs
+++ b/src/collections/multi_array_list.rs
@@ -1431,9 +1431,11 @@ mod tests {
         assert_eq!(list.swap_remove(1), Foo { a: 1, b: 1, c: 1 });
         assert_eq!(list.items::<"a", u32>(), &[0, 5, 3, 4]);
         assert_eq!(list.items::<"c", u64>(), &[0, 5, 3, 4]);
-        // Removing the last row swaps it with itself.
+        // Removing the last row swaps it with itself / shifts nothing.
         assert_eq!(list.swap_remove(3), Foo { a: 4, b: 4, c: 4 });
         assert_eq!(list.items::<"a", u32>(), &[0, 5, 3]);
+        assert_eq!(list.ordered_remove(2), Foo { a: 3, b: 3, c: 3 });
+        assert_eq!(list.items::<"a", u32>(), &[0, 5]);
     }
 
     struct Owning {

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -1053,9 +1053,9 @@ impl fmt::Display for Op {
 // ─── WatchItem ────────────────────────────────────────────────────────────
 
 pub struct WatchItem {
-    /// `Borrowed` from an interned, process-lifetime path, or `Owned` when the
-    /// entry was added with `CLONE_FILE_PATH`; an owned path lives until
-    /// `flush_evictions` removes the entry.
+    /// `Owned` when the entry was added with `CLONE_FILE_PATH`, and freed when
+    /// `flush_evictions` removes the entry. Otherwise `Borrowed`, and the caller
+    /// must keep the bytes alive for as long as the entry exists.
     pub file_path: Cow<'static, [u8]>,
     // filepath hash for quick comparison
     pub hash: u32,

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -1052,8 +1052,7 @@ impl fmt::Display for Op {
 // ─── WatchItem ────────────────────────────────────────────────────────────
 
 pub struct WatchItem {
-    /// `Owned` for `CLONE_FILE_PATH` entries (freed by `flush_evictions`);
-    /// otherwise the caller keeps the bytes alive for as long as the entry exists.
+    /// Freed by `flush_evictions` when `Owned`; borrowed bytes must outlive the entry.
     pub file_path: Cow<'static, [u8]>,
     // filepath hash for quick comparison
     pub hash: u32,

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -438,8 +438,7 @@ impl Watcher {
             if item == last_item || self.watchlist.len() <= item as usize {
                 continue;
             }
-            // Dropping the removed row frees the `file_path` that
-            // `CLONE_FILE_PATH` entries own; the fd was already closed above.
+            // Frees an owned `file_path`; the fd was closed in the first pass.
             drop(self.watchlist.swap_remove(item as usize));
 
             // swapRemove put a different entry at `item`, but its kqueue registration still
@@ -1053,9 +1052,8 @@ impl fmt::Display for Op {
 // ─── WatchItem ────────────────────────────────────────────────────────────
 
 pub struct WatchItem {
-    /// `Owned` when the entry was added with `CLONE_FILE_PATH`, and freed when
-    /// `flush_evictions` removes the entry. Otherwise `Borrowed`, and the caller
-    /// must keep the bytes alive for as long as the entry exists.
+    /// `Owned` for `CLONE_FILE_PATH` entries (freed by `flush_evictions`);
+    /// otherwise the caller keeps the bytes alive for as long as the entry exists.
     pub file_path: Cow<'static, [u8]>,
     // filepath hash for quick comparison
     pub hash: u32,

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -438,7 +438,9 @@ impl Watcher {
             if item == last_item || self.watchlist.len() <= item as usize {
                 continue;
             }
-            self.watchlist.swap_remove(item as usize);
+            // Dropping the removed row frees the `file_path` that
+            // `CLONE_FILE_PATH` entries own; the fd was already closed above.
+            drop(self.watchlist.swap_remove(item as usize));
 
             // swapRemove put a different entry at `item`, but its kqueue registration still
             // carries its old `udata` (= pre-swap index). Rewrite it so subsequent kevents
@@ -1051,6 +1053,9 @@ impl fmt::Display for Op {
 // ─── WatchItem ────────────────────────────────────────────────────────────
 
 pub struct WatchItem {
+    /// `Borrowed` from an interned, process-lifetime path, or `Owned` when the
+    /// entry was added with `CLONE_FILE_PATH`; an owned path lives until
+    /// `flush_evictions` removes the entry.
     pub file_path: Cow<'static, [u8]>,
     // filepath hash for quick comparison
     pub hash: u32,

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -186,77 +186,63 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
   // Editing dep.js raises an inotify event on lib/, which makes the reloader
   // evict dep's watchlist entry; the reload then re-adds it with a fresh heap
   // copy of the path. Eviction used to discard the evicted entry's copy
-  // without freeing it, so every edit leaked one path. The leak is only
-  // observable through LSan (ASAN builds); logLevel=debug makes the reloader
-  // print "Removing file" per eviction, which guards against a reload cycle
-  // that stopped evicting passing this vacuously.
-  test.skipIf(!isLinux || !isASAN)(
-    "evicting watchlist entries does not leak their paths",
-    async () => {
-      const edits = 3;
-      await using dir = tempDir("hot-evict-leak", {
-        "bunfig.toml": `logLevel = "debug"\n`,
-        "lib/dep.js": `export const value = 0;`,
-        "entry.js": `
-          import { lsanDoLeakCheck } from "bun:internal-for-testing";
-          import { value } from "./lib/dep.js";
-          console.log("RELOAD", value);
-          if (value === ${edits}) {
-            lsanDoLeakCheck();
-            console.log("LEAKCHECK");
-          }
-        `,
-      });
+  // without freeing it, so every edit leaked one path, which LSan reports when
+  // the process exits (the same check CI's ASAN lane applies to every test
+  // process). logLevel=debug makes the reloader log each eviction, so a reload
+  // cycle that stopped evicting cannot pass this vacuously.
+  test.skipIf(!isLinux || !isASAN)("evicting watchlist entries does not leak their paths", async () => {
+    const edits = 3;
+    await using dir = tempDir("hot-evict-leak", {
+      "bunfig.toml": `logLevel = "debug"\n`,
+      "lib/dep.js": `export const value = 0;`,
+      "entry.js": `
+        import { value } from "./lib/dep.js";
+        console.log("RELOAD", value);
+        if (value === ${edits}) process.exit(0);
+      `,
+    });
 
-      await using proc = spawn({
-        cmd: [bunExe(), "--hot", "entry.js"],
-        cwd: String(dir),
-        env: {
-          ...bunEnv,
-          // Bun's built-in ASAN defaults disable LSan. entry.js runs the check
-          // itself once the edits are done; the process is killed afterwards,
-          // so the at-exit check is not needed.
-          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-          // verbosity=1 makes the check announce itself on stderr.
-          LSAN_OPTIONS: "leak_check_at_exit=0:malloc_context_size=30:verbosity=1",
-        },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const stderrText = proc.stderr.text();
+    await using proc = spawn({
+      cmd: [bunExe(), "--hot", "entry.js"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        // Bun's built-in ASAN defaults turn LSan off. Destructing the VM on exit
+        // frees what JS still referenced, so only lost allocations get reported.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        // verbosity=1 makes the exit-time check announce itself on stderr.
+        LSAN_OPTIONS: [bunEnv.LSAN_OPTIONS, "verbosity=1"].filter(Boolean).join(":"),
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stderrText = proc.stderr.text();
 
-      const iter = forEachLine(proc.stdout);
-      const waitForLine = async (expected: string) => {
-        while (true) {
-          const { value: line, done } = await iter.next();
-          if (done) throw new Error(`--hot exited before printing "${expected}" (exit ${proc.exitCode})`);
-          if (line === expected) return;
-        }
-      };
-
-      await waitForLine("RELOAD 0");
-      for (let i = 1; i <= edits; i++) {
-        writeFileSync(join(dir, "lib", "dep.js"), `export const value = ${i};`);
-        await waitForLine(`RELOAD ${i}`);
+    const iter = forEachLine(proc.stdout);
+    const waitForLine = async (expected: string) => {
+      while (true) {
+        const { value: line, done } = await iter.next();
+        if (done) throw new Error(`--hot exited before printing "${expected}" (exit ${proc.exitCode})`);
+        if (line === expected) return;
       }
-      await waitForLine("LEAKCHECK");
-      proc.kill();
-      const stderr = await stderrText;
+    };
 
-      expect(stderr).toContain("LeakSanitizer: checking for leaks");
-      // One edit can produce more than one directory event, so this is a lower bound.
-      const evictions = stderr.split("\n").filter(line => line.includes("Removing file:")).length;
-      expect(evictions).toBeGreaterThanOrEqual(edits);
+    await waitForLine("RELOAD 0");
+    for (let i = 1; i <= edits; i++) {
+      writeFileSync(join(dir, "lib", "dep.js"), `export const value = ${i};`);
+      await waitForLine(`RELOAD ${i}`);
+    }
+    const [stderr, exitCode] = await Promise.all([stderrText, proc.exited]);
 
-      // LSan prints one blank-line-separated block per leaking allocation
-      // stack. A leaked watchlist path is allocated by bun_watcher's append_*
-      // functions; leaks from elsewhere are not this test's concern.
-      const watcherLeaks = stderr
-        .split(/\n\s*\n/)
-        .filter(block => /^(?:Direct|Indirect) leak of /.test(block) && block.includes("bun_watcher::"));
-      expect(watcherLeaks).toEqual([]);
-    },
-    // Debug + ASAN: three reloads plus symbolizing the LSan report take a few seconds.
-    30_000,
-  );
+    // One edit can produce more than one directory event, so this is a lower bound.
+    const evictions = stderr.split("\n").filter(line => line.includes("Removing file:")).length;
+    expect(evictions).toBeGreaterThanOrEqual(edits);
+    expect(stderr).toContain("LeakSanitizer: checking for leaks");
+    // LSan prints one blank-line-separated block per leaking allocation stack
+    // (each naming its allocation site) and then fails the exit.
+    const leaks = stderr.split(/\n\s*\n/).filter(block => /^(?:Direct|Indirect) leak of /.test(block));
+    expect(leaks).toEqual([]);
+    expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 0, signalCode: null });
+  });
 });

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -182,4 +182,81 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
     },
     60000,
   );
+
+  // Editing dep.js raises an inotify event on lib/, which makes the reloader
+  // evict dep's watchlist entry; the reload then re-adds it with a fresh heap
+  // copy of the path. Eviction used to discard the evicted entry's copy
+  // without freeing it, so every edit leaked one path. The leak is only
+  // observable through LSan (ASAN builds); logLevel=debug makes the reloader
+  // print "Removing file" per eviction, which guards against a reload cycle
+  // that stopped evicting passing this vacuously.
+  test.skipIf(!isLinux || !isASAN)(
+    "evicting watchlist entries does not leak their paths",
+    async () => {
+      const edits = 3;
+      await using dir = tempDir("hot-evict-leak", {
+        "bunfig.toml": `logLevel = "debug"\n`,
+        "lib/dep.js": `export const value = 0;`,
+        "entry.js": `
+          import { lsanDoLeakCheck } from "bun:internal-for-testing";
+          import { value } from "./lib/dep.js";
+          console.log("RELOAD", value);
+          if (value === ${edits}) {
+            lsanDoLeakCheck();
+            console.log("LEAKCHECK");
+          }
+        `,
+      });
+
+      await using proc = spawn({
+        cmd: [bunExe(), "--hot", "entry.js"],
+        cwd: String(dir),
+        env: {
+          ...bunEnv,
+          // Bun's built-in ASAN defaults disable LSan. entry.js runs the check
+          // itself once the edits are done; the process is killed afterwards,
+          // so the at-exit check is not needed.
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+          // verbosity=1 makes the check announce itself on stderr.
+          LSAN_OPTIONS: "leak_check_at_exit=0:malloc_context_size=30:verbosity=1",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const stderrText = proc.stderr.text();
+
+      const iter = forEachLine(proc.stdout);
+      const waitForLine = async (expected: string) => {
+        while (true) {
+          const { value: line, done } = await iter.next();
+          if (done) throw new Error(`--hot exited before printing "${expected}" (exit ${proc.exitCode})`);
+          if (line === expected) return;
+        }
+      };
+
+      await waitForLine("RELOAD 0");
+      for (let i = 1; i <= edits; i++) {
+        writeFileSync(join(dir, "lib", "dep.js"), `export const value = ${i};`);
+        await waitForLine(`RELOAD ${i}`);
+      }
+      await waitForLine("LEAKCHECK");
+      proc.kill();
+      const stderr = await stderrText;
+
+      expect(stderr).toContain("LeakSanitizer: checking for leaks");
+      // One edit can produce more than one directory event, so this is a lower bound.
+      const evictions = stderr.split("\n").filter(line => line.includes("Removing file:")).length;
+      expect(evictions).toBeGreaterThanOrEqual(edits);
+
+      // LSan prints one blank-line-separated block per leaking allocation
+      // stack. A leaked watchlist path is allocated by bun_watcher's append_*
+      // functions; leaks from elsewhere are not this test's concern.
+      const watcherLeaks = stderr
+        .split(/\n\s*\n/)
+        .filter(block => /^(?:Direct|Indirect) leak of /.test(block) && block.includes("bun_watcher::"));
+      expect(watcherLeaks).toEqual([]);
+    },
+    // Debug + ASAN: three reloads plus symbolizing the LSan report take a few seconds.
+    30_000,
+  );
 });

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -363,7 +363,6 @@ test/bake/dev/server-sourcemap.test.ts
 # Watcher Thread
 test/bake/dev-and-prod.test.ts
 test/bake/dev/bundle.test.ts
-test/bake/dev/css.test.ts
 test/bake/dev/esm.test.ts
 test/bake/dev/hot.test.ts
 test/bake/dev/react-spa.test.ts


### PR DESCRIPTION
### Problem
- Every eviction of a watchlist entry whose path is heap-owned leaks that path. LSan on the unfixed build, after saving an imported file three times under `bun --hot`:
  `Direct leak of 111 byte(s) in 3 object(s) allocated from: ... <bun_watcher::watcher_impl::Watcher>::append_file_assume_capacity::<true> src/watcher/Watcher.rs:543` (full report below).
- Cause: `Watcher::flush_evictions` (`src/watcher/Watcher.rs:441`) removes entries with `MultiArrayList::swap_remove`, and `swap_remove` (`src/collections/multi_array_list.rs:994`) only copies the last row over the removed one. The removed row's `WatchItem.file_path: Cow<'static, [u8]>` is never dropped, and the list's own `Drop` is slab-only by design, so nothing else frees it either.
- Heap-owned paths are every entry added with `CLONE_FILE_PATH = true`: the modules `--hot` watches from the runtime transpiler (`src/jsc/RuntimeTranspilerStore.rs:939`, `:967`, `src/runtime/jsc_hooks.rs:3603`, `:3717`), the entrypoint (`add_file_by_path_slow`), plugin-loaded files in `BundleV2`, dev server directory watches (`add_directory::<true>`), and every entry on Windows.
- Under `--hot`, saving a watched file raises a directory event that evicts the file's entry (`src/jsc/hot_reloader.rs:1218`) and the reload re-adds it with a new copy, so a long-running session leaks one path per save. `Borrowed` entries were never affected.
- Related, not fixed: #11083 (`--hot` RSS growth per reload). Its loop hits this leak too, but only for a few dozen bytes per reload, so the growth reported there is mostly something else.

### Fix
- `MultiArrayList::swap_remove` and `ordered_remove` return the removed element, transferring ownership to the caller exactly as `pop` already does. `flush_evictions` drops the returned `WatchItem`; dropping frees an `Owned` path and is a no-op for a `Borrowed` one.
- The row is gathered before the other rows are copied over it and `len` shrinks, so the list never refers to it again: neither `drop_elements` nor `Drop` (both of which only cover rows still in the list) can free it a second time. The new `remove_returns_owned_element` unit test checks this under Miri.
- Nothing holds a pointer into an evicted path when it is freed: both `on_file_update` implementations (`src/jsc/hot_reloader.rs`, `src/runtime/bake/DevServer.rs`) read the `file_path` column only before their deferred `flush_evictions` and copy whatever they keep (`StringSet` / `StringArrayHashMap` / `StringHashMap` keys are owned), the Windows event scan indexes live rows only, and `src/runtime/bake/dev_server/mod.rs:1439` already documents that the watcher owns the copy until eviction runs.
- The fix is in the collection because that is where the ownership was dropped; the only other production caller of either function is `src/http/lib.rs` (`header_entries`, a `Copy` element type), which compiles and behaves unchanged. `set()` intentionally keeps overwriting without dropping: `append_assume_capacity` uses it on slots that hold no element.
- Out of scope: a `Watcher` dropped while it still has live entries leaks them too. That is the teardown path #30644 covers with `impl Drop for Watcher`; this PR only changes eviction.
- `--hot` / `append_file` coverage: new test in `test/cli/hot/watch-many-dirs.test.ts` ("evicting watchlist entries does not leak their paths", Linux + ASAN builds only). It runs `bun --hot` with LSan enabled, saves an import three times, lets the child exit, and asserts that the reloader logged the evictions (so the cycle cannot stop evicting and pass vacuously), that the exit-time leak check ran, and that it reported nothing and the exit code is 0. On the unfixed build it fails with exactly one report block, the one quoted below; with the fix it passes (5 of 5 runs, about 0.5 s each).
- Dev server / `append_directory` coverage: `test/bake/dev/css.test.ts` is removed from `test/no-validate-leaksan.txt`, so CI's ASAN lane now applies its exit-time leak check to that file. Without the fix, css-13 ("changing html file with link tag works") and css-14 ("css import before create") fail there with `Direct leak of 30 byte(s)` from `append_directory_assume_capacity::<true>` via `DirectoryWatchStore::insert` (`src/runtime/bake/dev_server/mod.rs:1447`); with the fix all 15 cases pass under the same environment. The file was excluded in the same batch as the rest of the "Watcher Thread" block, with no css-specific reason. The other entries in that block are left alone: `bundle.test.ts` still has an unrelated leak (#38004), and the rest are not affected by this change.
- Also run with the fix: `cargo test -p bun_collections`, `bun run rust:miri -p bun_collections`, `bun bd test test/cli/hot/` (17 pass), `test/bake/dev/bundle.test.ts` (dev server file and `DirectoryWatchStore` evictions, 21 pass), `test/bake/dev/hot.test.ts`, `test/bake/dev/incremental-graph-edge-deletion.test.ts`, `test/js/web/fetch/fetch-redirect.test.ts` (the `ordered_remove` caller, 30 pass); `cargo clippy -p bun_collections -p bun_watcher` is clean.

### Background
- `MultiArrayList<T>` is a struct-of-arrays list: each field of `T` lives in its own column, so a row is never a single `T` in memory. Removing a row is a byte copy per column, and the list's `Drop` frees only the backing slab (bitwise clones of a list can share columns, see the comment on the `Drop` impl), so element destructors run only when a caller asks for them: `pop`, `drop_elements`, and now the two `*_remove` functions.
- The watcher stores one `WatchItem` per watched file or directory in such a list. `file_path` is a `Cow`: callers whose path string is interned for the life of the process store a borrow (`CLONE_FILE_PATH = false`); callers holding a transient buffer store a heap copy (`true`).
- Eviction is two-phase. `remove_at_index` only records an index in `evict_list`; `flush_evictions`, run on the watcher thread at the end of each `on_file_update` batch, closes the entries' fds and then `swap_remove`s the rows, largest index first so the remaining recorded indices stay valid.
- LSan (LeakSanitizer) ships inside the ASAN build and, when the process exits, reports heap blocks that nothing references any more, with their allocation stacks. Bun's `__asan_default_options` turns it off; CI's ASAN lane turns it back on for every test process not listed in `test/no-validate-leaksan.txt` (together with `BUN_DESTRUCT_VM_ON_EXIT=1`, which tears the VM down first so allocations still referenced from JS are not reported). The new `--hot` test sets the same variables itself so it also works under a plain `bun bd test`.

<details>
<summary>LSan report from the unfixed build (3 saves of lib/dep.js)</summary>

```
Direct leak of 111 byte(s) in 3 object(s) allocated from:
    #0 0x00000820f5c8 in malloc crtstuff.c
    ...
    #16 0x00001367ff6b in <[u8]>::to_vec
    #17 0x0000119a10fd in <bun_watcher::watcher_impl::Watcher>::append_file_assume_capacity::<true> src/watcher/Watcher.rs:543:34
    #18 0x0000119a01a3 in <bun_watcher::watcher_impl::Watcher>::append_file_maybe_lock::<true, false> src/watcher/Watcher.rs:740:20
    #19 0x0000119a2c75 in <bun_watcher::watcher_impl::Watcher>::add_file::<true> src/watcher/Watcher.rs:902:22
    #20 0x00000f2055a2 in <bun_jsc::hot_reloader::ImportWatcher>::add_file::<true> src/jsc/hot_reloader.rs:90:18
    #21 0x00000f362cf2 in <bun_jsc::runtime_transpiler_store::TranspilerJob>::run src/jsc/RuntimeTranspilerStore.rs:967:60
    #22 0x00000f35febd in <bun_jsc::runtime_transpiler_store::TranspilerJob>::run_from_worker_thread src/jsc/RuntimeTranspilerStore.rs:626:30
    #23 0x000012e3753e in <bun_threading::thread_pool::Thread>::run src/threading/ThreadPool.rs:1249:26
```

One 37-byte object per save (the length of the temp dir path of `lib/dep.js`); five saves give five objects.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/hot/watch-many-dirs.test.ts

<!-- robobun:evidence:end -->