### PR TITLE
shell(cat): keep going after an operand it cannot open or read (stacked on #35337)

### DIFF
--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -35,6 +35,8 @@ pub enum CatState {
         chunks_done: usize,
         out_done: bool,
         in_done: bool,
+        /// 1 once an operand failed; reported when the operands run out.
+        exit_code: ExitCode,
     },
     WaitingWriteErr,
 }
@@ -81,6 +83,7 @@ impl Cat {
                 chunks_done: 0,
                 out_done: false,
                 in_done: false,
+                exit_code: 0,
             }
         };
 
@@ -104,9 +107,16 @@ impl Cat {
         Builtin::done(interp, cmd, exit_code)
     }
 
-    /// `Some(yield)` if a chunk was enqueued on fd-backed stdout, `None` if written synchronously.
-    fn write_buf_to_stdout(interp: &Interpreter, cmd: NodeId, buf: &[u8]) -> Option<Yield> {
-        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+    /// `Some(yield)` if a chunk was enqueued on an fd-backed stream, `None` if written synchronously.
+    fn write_buf(interp: &Interpreter, cmd: NodeId, io_kind: IoKind, buf: &[u8]) -> Option<Yield> {
+        fn stream(builtin: &mut Builtin, io_kind: IoKind) -> &mut BuiltinIO {
+            match io_kind {
+                IoKind::Stdout => &mut builtin.stdout,
+                IoKind::Stderr => &mut builtin.stderr,
+                IoKind::Stdin => unreachable!("cat writes to stdout and stderr only"),
+            }
+        }
+        if let Some(safeguard) = stream(Builtin::of_mut(interp, cmd), io_kind).needs_io() {
             match &mut Self::state_mut(interp, cmd).state {
                 CatState::ExecStdin {
                     in_done,
@@ -125,13 +135,22 @@ impl Cat {
             }
             let child = ChildPtr::new(cmd, WriterTag::Builtin);
             return Some(
-                Builtin::of_mut(interp, cmd)
-                    .stdout
-                    .enqueue(child, buf, safeguard),
+                stream(Builtin::of_mut(interp, cmd), io_kind).enqueue(child, buf, safeguard),
             );
         }
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, buf);
+        let _ = Builtin::write_no_io(interp, cmd, io_kind, buf);
         None
+    }
+
+    /// The message is booked as the operand's output, so its completion moves on to the next operand.
+    fn fail_operand(interp: &Interpreter, cmd: NodeId, err: &bun_sys::Error) -> Option<Yield> {
+        let buf = Builtin::task_error_to_string(interp, cmd, Kind::Cat, err).to_vec();
+        if let CatState::ExecFilepathArgs { exit_code, .. } =
+            &mut Self::state_mut(interp, cmd).state
+        {
+            *exit_code = 1;
+        }
+        Self::write_buf(interp, cmd, IoKind::Stderr, &buf)
     }
 
     pub(crate) fn next(interp: &Interpreter, cmd: NodeId) -> Yield {
@@ -162,7 +181,7 @@ impl Cat {
                         // Copy stdin bytes so the &mut on `stdout`/`write_no_io`
                         // doesn't overlap a borrow of `stdin`.
                         let buf = Builtin::read_stdin_no_io(interp, cmd).to_vec();
-                        return Self::write_buf_to_stdout(interp, cmd, &buf)
+                        return Self::write_buf(interp, cmd, IoKind::Stdout, &buf)
                             .unwrap_or_else(|| Builtin::done(interp, cmd, 0));
                     }
                     // Clone the `Arc<IOReader>`
@@ -176,7 +195,7 @@ impl Cat {
                     // The fd stays owned by `Builtin::stdin`.
                     if let Some(result) = slurp_regular_file(reader.fd()) {
                         return match result {
-                            Ok(buf) => Self::write_buf_to_stdout(interp, cmd, &buf)
+                            Ok(buf) => Self::write_buf(interp, cmd, IoKind::Stdout, &buf)
                                 .unwrap_or_else(|| Builtin::done(interp, cmd, 0)),
                             Err(e) => {
                                 let buf = Builtin::task_error_to_string(interp, cmd, Kind::Cat, &e)
@@ -196,13 +215,18 @@ impl Cat {
                     let argc = Builtin::of(interp, cmd).args_slice().len();
                     let n_files = argc - args_start;
                     if idx >= n_files {
+                        let mut exit_code = 0;
                         // Drop the reader if any.
-                        if let CatState::ExecFilepathArgs { reader, .. } =
-                            &mut Self::state_mut(interp, cmd).state
+                        if let CatState::ExecFilepathArgs {
+                            reader,
+                            exit_code: code,
+                            ..
+                        } = &mut Self::state_mut(interp, cmd).state
                         {
                             *reader = None;
+                            exit_code = *code;
                         }
-                        return Builtin::done(interp, cmd, 0);
+                        return Builtin::done(interp, cmd, exit_code);
                     }
                     if let CatState::ExecFilepathArgs {
                         reader,
@@ -231,26 +255,23 @@ impl Cat {
                     let dir = Builtin::cwd(interp, cmd);
                     let fd = match shell_openat(dir, path, bun_sys::O::RDONLY, 0) {
                         Ok(fd) => fd,
-                        Err(e) => {
-                            let buf =
-                                Builtin::task_error_to_string(interp, cmd, Kind::Cat, &e).to_vec();
-                            // The reader was already taken to `None` above.
-                            return Self::write_failing_error(interp, cmd, &buf, 1);
-                        }
+                        Err(e) => match Self::fail_operand(interp, cmd, &e) {
+                            Some(y) => return y,
+                            None => continue,
+                        },
                     };
 
                     if let Some(result) = slurp_regular_file(fd) {
                         let _ = bun_sys::close(fd);
-                        match result {
-                            Ok(buf) => match Self::write_buf_to_stdout(interp, cmd, &buf) {
-                                Some(y) => return y,
-                                None => continue,
-                            },
+                        let written = match result {
+                            Ok(buf) => Self::write_buf(interp, cmd, IoKind::Stdout, &buf),
                             Err(e) => {
-                                let buf = Builtin::task_error_to_string(interp, cmd, Kind::Cat, &e)
-                                    .to_vec();
-                                return Self::write_failing_error(interp, cmd, &buf, 1);
+                                Self::fail_operand(interp, cmd, &e.with_path(path.as_bytes()))
                             }
+                        };
+                        match written {
+                            Some(y) => return y,
+                            None => continue,
                         }
                     }
 

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isPosix, tempDir } from "harness";
 import path from "node:path";
 
 // On POSIX, `cat` falls through to the subprocess path unless
@@ -147,5 +147,68 @@ describe.concurrent("cat (builtin)", () => {
     expect(stderr).toBe("");
     expect(stdout).toBe(expected);
     expect(exitCode).toBe(0);
+  });
+
+  // Like cat(1), an operand that cannot be opened is reported, the operands
+  // after it are still copied, and the exit status is 1 once they are done.
+  // On Windows the message currently names the operand by its absolute path,
+  // hence the optional directory prefix.
+  const notFound = (...operands: string[]) => {
+    const lines = operands.map(
+      operand => `cat: (.*[\\\\/])?${operand.replaceAll(".", "\\.")}: No such file or directory\\n`,
+    );
+    return new RegExp(`^${lines.join("")}$`);
+  };
+
+  test("keeps going after an operand that does not exist", async () => {
+    using dir = tempDir("shell-cat-missing-between", { "a.txt": "A\n", "b.txt": "B\n" });
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat a.txt missing.txt b.txt");
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "A\nB\n",
+      stderr: expect.stringMatching(notFound("missing.txt")),
+      exitCode: 1,
+    });
+  });
+
+  test("reports every operand that does not exist", async () => {
+    using dir = tempDir("shell-cat-all-missing", {});
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat missing1.txt missing2.txt");
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: expect.stringMatching(notFound("missing1.txt", "missing2.txt")),
+      exitCode: 1,
+    });
+  });
+
+  // With stderr on an fd each message is an IOWriter chunk whose completion
+  // has to move cat on to the next operand.
+  test("keeps going with stderr redirected to a file", async () => {
+    using dir = tempDir("shell-cat-missing-stderr-file", { "a.txt": "A\n" });
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat missing1.txt a.txt missing2.txt 2> err.txt");
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "A\n", stderr: "", exitCode: 1 });
+    expect(await Bun.file(path.join(String(dir), "err.txt")).text()).toMatch(notFound("missing1.txt", "missing2.txt"));
+  });
+
+  test("keeps going with stderr on a pipe", async () => {
+    using dir = tempDir("shell-cat-missing-stderr-pipe", {});
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat missing1.txt missing2.txt 2>&1 | cat");
+    // The pipeline's status is the second cat's.
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: expect.stringMatching(notFound("missing1.txt", "missing2.txt")),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // /proc/self/mem is a regular file whose read() fails (EIO at offset 0), so
+  // this takes the read-error arm of the synchronous file path.
+  test.if(isLinux)("keeps going after an operand that cannot be read", async () => {
+    using dir = tempDir("shell-cat-unreadable-between", { "a.txt": "A\n", "b.txt": "B\n" });
+    const { stdout, stderr, exitCode } = await runShell(String(dir), "cat a.txt /proc/self/mem b.txt");
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "A\nB\n",
+      stderr: "cat: /proc/self/mem: Input/output error\n",
+      exitCode: 1,
+    });
   });
 });


### PR DESCRIPTION
Stacked on #35337 (base branch `farm/0ea30161/shell-ioreader-regular-file`); the diff here is only the last commit. Once #35337 lands this retargets to main on its own.

### Problem
- The shell's builtin `cat` (the `cat` every Bun shell script gets on Windows; on POSIX only with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`) stops at the first operand it cannot open: `cat a.txt missing.txt b.txt` prints `A`, writes `cat: missing.txt: No such file or directory`, exits 1 and never prints `b.txt`; `cat missing1.txt missing2.txt` reports only `missing1.txt`. With #35337 the same happens for a regular file whose read fails.
- GNU and BSD cat (what the same script runs on POSIX without the flag) report the operand, go on with the remaining ones and exit 1 once they are done.
- Cause: both failure arms of `Cat::next`, `Branch::FileArg` (src/runtime/shell/builtin/cat.rs: the `shell_openat` error and, from #35337, the `slurp_regular_file` error) end the command through `write_failing_error`. Nothing moves on to the next operand or remembers the failure.

### Fix
- `CatState::ExecFilepathArgs` gets an `exit_code` that a failed operand sets to 1; the command finishes with it when the operands run out, so an operand that works afterwards does not turn the status back into 0.
- #35337's one-shot emitter `write_buf_to_stdout` becomes `write_buf(.., IoKind, ..)` so the same code writes to stderr. Both failure arms now call `fail_operand`, which formats the message, sets `exit_code` and emits it through `write_buf`: a captured, ignored or buffer stderr takes it synchronously and the arm does `continue` in the operand loop #35337 already has; an fd stderr (`2> file`, `2>&1` in a pipeline, inherited) gets it as a queued chunk booked with `in_done = true`, so the existing `on_io_writer_chunk` bookkeeping moves to the next operand exactly as it does after a file's output. No second completion path, and `next` is only entered once the previous operand's chunks have drained, so the completion that arrives is this message's.
- The read-error message now names the operand (`e.with_path`); before it was just `cat: Input/output error`, which is useless once cat keeps going.
- Why this is the right behavior: it is what cat(1) does, so a script behaves the same whether the shell runs the builtin (Windows) or the system cat (POSIX). The stdin form (`cat < file` failing to read) is unchanged: there is nothing to continue with, so it still reports and exits 1 through `write_failing_error`.
- Out of scope: an operand that opens but whose async reader fails (a directory, or on Windows any unreadable file, since the synchronous path in #35337 is POSIX-only) still ends the command; #37743 is reworking that arm and can apply the same `exit_code` rule.
- Verification: five tests added to #35337's test/js/bun/shell/commands/cat.test.ts: a missing operand between two files (`A`, `B`, exit 1), two missing operands, stderr redirected to a file around a readable operand (exercises the fd completion path; on Windows that is libuv's async file write), stderr down a pipe (a pollable fd), and on Linux `cat a.txt /proc/self/mem b.txt` for the read-error arm (a regular file whose `read()` fails with EIO). On #35337's tree without the cat.rs change exactly those five fail (Linux debug build; the four non-Linux ones also fail with the Windows canary); with it all 16 pass on Linux and on a Windows debug build. bunshell, yield, shell-pipe-read-fault and epipe test files pass on Linux; bunshell and file-io on Windows (apart from the 5 tilde tests that need `HOME`, unset on that machine, failing identically with the canary).
- The message regex in the tests allows a directory prefix because on Windows the open error currently carries the absolute path; #39189 fixes that separately.

### Background
- Builtins are state machines driven by a trampoline: every step returns a `Yield`. `IOWriter::enqueue` returns the chunk's completion when the write finished synchronously (regular files on POSIX) and `Yield::suspended()` when it completes later from the event loop (pipes, ttys, every fd on Windows); either way the builtin's `on_io_writer_chunk` runs once per chunk, so with stderr on an fd cat has to wait for that completion before touching the next operand.
- `BuiltinIO::needs_io()` separates the two kinds of streams: captured output (the `$` default), `2> ${buffer}` and ignored streams take bytes immediately through `write_no_io`; `Fd` streams go through an IOWriter.
- `ExecFilepathArgs` tracks the operand being copied with `chunks_queued` / `chunks_done` and `in_done` (no more input for this operand); `next` runs once both are satisfied. #35337's `write_buf` sets `in_done` and queues one chunk for an operand it read in one go; an error message is the same shape of output.

<details>
<summary>Earlier shape of this PR</summary>

The first version was a standalone change on main: it added the same `exit_code`, replaced the open-failure arm with its own stderr emitter and wrapped the operand handling in a loop, and tested it from bunshell.test.ts (the file-content case only on Windows, because on main the builtin cannot read regular files on Linux). Review pointed out that #35337 introduces the loop and a one-shot emitter already and adds a second failure arm that needs the same treatment, so the change was restacked on top of it; that cut it to the diff above and let the tests read real files on every platform.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cat.test.ts

<!-- robobun:evidence:end -->