### PR TITLE
bun test: keep a failing beforeAll from skipping concurrent tests outside its describe

### DIFF
--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -291,6 +291,7 @@ impl Execution {
     pub(crate) fn load_from_order(&mut self, order: &mut Order::Order) {
         debug_assert!(self.groups.is_empty());
         debug_assert!(self.sequences.is_empty());
+        order.assert_skip_ranges_stay_in_scope();
         self.groups = core::mem::take(&mut order.groups).into_boxed_slice();
         self.sequences = core::mem::take(&mut order.sequences).into_boxed_slice();
     }

--- a/src/runtime/test_runner/Order.rs
+++ b/src/runtime/test_runner/Order.rs
@@ -251,13 +251,17 @@ impl AllOrderResult {
     pub(crate) const EMPTY: AllOrderResult = AllOrderResult { start: 0, end: 0 };
 
     pub(crate) fn set_failure_skip_to(&self, this: &mut Order) {
-        if self.start == 0 && self.end == 0 {
+        if self.start == self.end {
             return;
         }
         let skip_to = this.groups.len();
         for group in &mut this.groups[self.start..self.end] {
             group.failure_skip_to = skip_to;
         }
+        // The skipped range ends with the last group scheduled so far. A concurrent test scheduled
+        // after it must open a new group instead of extending that one, or a failing hook would skip
+        // it too even though it belongs to an enclosing scope.
+        this.previous_group_was_concurrent = false;
     }
 }
 

--- a/src/runtime/test_runner/Order.rs
+++ b/src/runtime/test_runner/Order.rs
@@ -240,6 +240,46 @@ impl Order {
             .push(ConcurrentGroup::init(sequences_start, sequences_end, failure_skip_to)); // otherwise, add a new concurrentgroup to order
         Ok(())
     }
+
+    /// Checks, once the whole file is scheduled, that every sequence a failing hook skips over
+    /// belongs to the scope that declared the hook. `AllOrderResult::set_failure_skip_to` keeps
+    /// this true by closing the concurrent group that ends the skipped range.
+    pub(crate) fn assert_skip_ranges_stay_in_scope(&self) {
+        if !bun_core::Environment::CI_ASSERT {
+            return;
+        }
+        for (index, group) in self.groups.iter().enumerate() {
+            if group.failure_skip_to <= index + 1 {
+                continue; // a test group, or a hook with nothing to skip
+            }
+            // Only hook groups skip past the next group, and `generate_all_order` gives each hook a
+            // group of its own.
+            debug_assert_eq!(group.sequence_end - group.sequence_start, 1);
+            let Some(hook) = self.sequences[group.sequence_start].first_entry else {
+                continue;
+            };
+            // SAFETY: entries and the describe tree their `base.parent` chains point into are owned
+            // by the collection, which outlives the `Order` built from it.
+            let owner = unsafe { hook.as_ref() }.base.parent;
+            for skipped in &self.groups[index + 1..group.failure_skip_to] {
+                for sequence in &self.sequences[skipped.sequence_start..skipped.sequence_end] {
+                    let Some(entry) = sequence.test_entry.or(sequence.first_entry) else {
+                        continue;
+                    };
+                    // SAFETY: see above.
+                    let mut scope = unsafe { entry.as_ref() }.base.parent;
+                    while let Some(current) = scope {
+                        if Some(current) == owner {
+                            break;
+                        }
+                        // SAFETY: see above.
+                        scope = unsafe { (*current).base.parent };
+                    }
+                    debug_assert!(scope.is_some(), "a failing hook would skip an entry outside of its scope");
+                }
+            }
+        }
+    }
 }
 
 pub(crate) struct AllOrderResult {

--- a/src/runtime/test_runner/Order.rs
+++ b/src/runtime/test_runner/Order.rs
@@ -241,9 +241,7 @@ impl Order {
         Ok(())
     }
 
-    /// Checks, once the whole file is scheduled, that every sequence a failing hook skips over
-    /// belongs to the scope that declared the hook. `AllOrderResult::set_failure_skip_to` keeps
-    /// this true by closing the concurrent group that ends the skipped range.
+    /// Every sequence a failing hook skips over must belong to the scope that declared the hook.
     pub(crate) fn assert_skip_ranges_stay_in_scope(&self) {
         if !bun_core::Environment::CI_ASSERT {
             return;
@@ -252,8 +250,7 @@ impl Order {
             if group.failure_skip_to <= index + 1 {
                 continue; // a test group, or a hook with nothing to skip
             }
-            // Only hook groups skip past the next group, and `generate_all_order` gives each hook a
-            // group of its own.
+            // only hook groups skip further than the next group, and each of them holds a single hook
             debug_assert_eq!(group.sequence_end - group.sequence_start, 1);
             let Some(hook) = self.sequences[group.sequence_start].first_entry else {
                 continue;
@@ -298,9 +295,7 @@ impl AllOrderResult {
         for group in &mut this.groups[self.start..self.end] {
             group.failure_skip_to = skip_to;
         }
-        // The skipped range ends with the last group scheduled so far. A concurrent test scheduled
-        // after it must open a new group instead of extending that one, or a failing hook would skip
-        // it too even though it belongs to an enclosing scope.
+        // seal the last skipped group; a concurrent test scheduled next must not extend it
         this.previous_group_was_concurrent = false;
     }
 }

--- a/src/runtime/test_runner/debug.rs
+++ b/src/runtime/test_runner/debug.rs
@@ -73,8 +73,8 @@ pub(crate) fn dump_order(this: &Execution) -> JsResult<()> {
 
     for (group_index, group_value) in this.groups.iter().enumerate() {
         let _guard = group::begin_msg(format_args!(
-            "{} ConcurrentGroup ({}-{})",
-            group_index, group_value.sequence_start, group_value.sequence_end,
+            "{} ConcurrentGroup ({}-{}, failure_skip_to={})",
+            group_index, group_value.sequence_start, group_value.sequence_end, group_value.failure_skip_to,
         ));
 
         for (sequence_index, sequence) in group_value.sequences_const(this).iter().enumerate() {

--- a/test/js/bun/test/failure-skip.test.ts
+++ b/test/js/bun/test/failure-skip.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { join } from "node:path";
 
 async function testFailureSkip(failurePoints: string[]): Promise<string[]> {
   const result = await Bun.spawn({
@@ -69,5 +70,153 @@ describe("failure-skip", async () => {
     expect(await testFailureSkip(["afterall2"])).toMatchInlineSnapshot(
       `"beforeall1,beforeall2,beforeeach1,beforeeach2,test1,aftereach1,aftereach2,beforeeach1,beforeeach2,test2,aftereach1,aftereach2,afterall1,afterall2"`,
     );
+  });
+});
+
+// Every test body below logs its name, so stdout lists exactly the tests whose bodies ran.
+async function runTestFile(source: string, args: string[] = []) {
+  using dir = tempDir("failure-skip-describe", { "fixture.test.ts": source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", ...args, join(String(dir), "fixture.test.ts")],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: normalizeBunSnapshot(stdout), stderr, exitCode };
+}
+
+describe("a failing beforeAll skips only the tests of its own describe", () => {
+  const siblingDescribesAndTopLevelTest = `
+    import { beforeAll, describe, it } from "bun:test";
+    describe("a", () => {
+      beforeAll(() => {
+        throw new Error("a beforeAll failed");
+      });
+      it("a1", () => console.log("ran a1"));
+    });
+    describe("b", () => {
+      beforeAll(async () => {
+        throw new Error("b beforeAll failed");
+      });
+      it("b1", () => console.log("ran b1"));
+    });
+    describe("c", () => {
+      it("c1", () => console.log("ran c1"));
+    });
+    it("d", () => console.log("ran d"));
+  `;
+
+  test.concurrent.each([[[]], [["--concurrent"]]])("sibling describes and top-level tests still run %p", async args => {
+    const { stdout, stderr, exitCode } = await runTestFile(siblingDescribesAndTopLevelTest, args);
+    expect(stdout).toMatchInlineSnapshot(`
+      "bun test <version> (<revision>)
+      ran c1
+      ran d"
+    `);
+    expect(stderr).toContain("a beforeAll failed");
+    expect(stderr).toContain("b beforeAll failed");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("describe.concurrent sibling", async () => {
+    const { stdout, exitCode } = await runTestFile(`
+      import { beforeAll, describe, it } from "bun:test";
+      describe.concurrent("a", () => {
+        beforeAll(() => {
+          throw new Error("a beforeAll failed");
+        });
+        it("a1", () => console.log("ran a1"));
+      });
+      describe.concurrent("b", () => {
+        it("b1", () => console.log("ran b1"));
+      });
+    `);
+    expect(stdout).toMatchInlineSnapshot(`
+      "bun test <version> (<revision>)
+      ran b1"
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("it.concurrent sibling", async () => {
+    const { stdout, exitCode } = await runTestFile(`
+      import { beforeAll, describe, it } from "bun:test";
+      describe("a", () => {
+        beforeAll(() => {
+          throw new Error("a beforeAll failed");
+        });
+        it.concurrent("a1", () => console.log("ran a1"));
+      });
+      it.concurrent("b", () => console.log("ran b"));
+    `);
+    expect(stdout).toMatchInlineSnapshot(`
+      "bun test <version> (<revision>)
+      ran b"
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("nested describes: the skip ends with the describe that owns the hook", async () => {
+    const { stdout, exitCode } = await runTestFile(
+      `
+        import { beforeAll, describe, it } from "bun:test";
+        describe("outer", () => {
+          describe("a", () => {
+            beforeAll(() => {
+              throw new Error("a beforeAll failed");
+            });
+            it("a1", () => console.log("ran a1"));
+            describe("inner", () => {
+              it("a2", () => console.log("ran a2"));
+            });
+          });
+          it("outer1", () => console.log("ran outer1"));
+        });
+        it("top", () => console.log("ran top"));
+      `,
+      ["--concurrent"],
+    );
+    expect(stdout).toMatchInlineSnapshot(`
+      "bun test <version> (<revision>)
+      ran outer1
+      ran top"
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  // The tests of a describe with a beforeAll form their own concurrent group (as they already do
+  // for a describe with an afterAll), so a failing hook can never skip past the describe. Tests
+  // after it still share a group with each other.
+  test.concurrent("a describe with a beforeAll ends its concurrent group", async () => {
+    const { stdout, stderr, exitCode } = await runTestFile(
+      `
+        import { beforeAll, describe, it } from "bun:test";
+        const yieldToEventLoop = () => new Promise(resolve => setImmediate(resolve));
+        async function body(name: string) {
+          console.log("start " + name);
+          await yieldToEventLoop();
+          console.log("end " + name);
+        }
+        describe("a", () => {
+          beforeAll(() => {});
+          it("a1", () => body("a1"));
+        });
+        it("b", () => body("b"));
+        it("c", () => body("c"));
+      `,
+      ["--concurrent"],
+    );
+    expect(stdout).toMatchInlineSnapshot(`
+      "bun test <version> (<revision>)
+      start a1
+      end a1
+      start b
+      start c
+      end b
+      end c"
+    `);
+    expect(stderr).toContain(" 3 pass\n");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- With `bun test --concurrent` (or `describe.concurrent` / `it.concurrent` siblings), a `describe` whose `beforeAll` throws or rejects skips its own tests as documented, but also every concurrent test scheduled after the describe, up to the next hook or serial test (or the end of the file). Those tests neither run nor get reported: the repro below prints `0 pass, 1 fail` with `--concurrent` and `2 pass, 1 fail` without it.
- Cause: `generate_order_describe` (`src/runtime/test_runner/Order.rs:110`) records the hooks' `failure_skip_to` as the index just past the describe's last group, but leaves `previous_group_was_concurrent` as the describe's last test set it. The next concurrent test of the enclosing scope then goes through `append_or_extend_concurrent_group` (`Order.rs:229`) and extends the describe's last group instead of opening a new one, so it sits inside the skip range, and `step_group` (`Execution.rs:865`) jumps over it when the hook fails.
- Only describes with a `beforeAll` and no `afterAll` are affected: scheduling an `afterAll` already resets the flag (`generate_all_order`, `Order.rs:75`). Bun's own suite has the affected layout, for example `test/cli/run/env.test.ts` (`describe.concurrent("--env-file")` with a `beforeAll`, followed by more `describe.concurrent` blocks).

### Fix
- `AllOrderResult::set_failure_skip_to` clears `previous_group_was_concurrent` when it records a skip range, so the group that ends the range cannot be extended; the next test opens a new group at exactly the recorded `failure_skip_to` index.
- This is the right place because a skip range is a range of group indices and this is the one function that records one: the only way a later test could end up inside the range is by extending its last group. A describe with an `afterAll` already ends on a group boundary (the afterAll group); a describe with only a `beforeAll` now does too. Describes without either still merge with the concurrent tests that follow them, so the ordering snapshot in `test/js/bun/test/concurrent.test.ts` is unchanged.
- The early return now checks `start == end` instead of matching the `EMPTY` constant: a describe with hooks enabled but no `beforeAll` produces an empty `{n, n}` range, which must not close a group either.
- Serial files schedule exactly as before. The only visible change for concurrent files is that tests after a describe with a `beforeAll` start once that describe's tests have finished.
- `Order::assert_skip_ranges_stay_in_scope` (assertion builds only, run from `Execution::load_from_order`) walks every hook's skip range and checks that each skipped test or hook has the hook's describe as an ancestor. With the fix removed it fires on the repro and on `test/cli/run/env.test.ts` and `test/js/bun/http/proxy.test.js`, so the invariant is checked by the existing suite rather than only by the new fixtures. `dump_order` now prints each group's `failure_skip_to` alongside its sequence range.
- #32817 (reporting jumped-over tests as skipped) only touches `step_group` and composes with this change.
- Verified with the new describe block in `test/js/bun/test/failure-skip.test.ts`: `--concurrent`, `describe.concurrent` siblings, `it.concurrent` siblings, a nested describe (sibling inside and outside the parent), and an ordering test showing the describe's group closes while the tests after it still share a group. Five of the six new tests fail on the release binary and pass with the fix; the serial variant passes on both and is the control.
- Also ran with the fix: `test/js/bun/test/`, `test/cli/test/` and `test/js/node/test_runner/` (94 files, the assertion never fired; the 6 failures in that run fail the same way or flake on a build without this change), plus `test/cli/run/env.test.ts` and `test/js/bun/http/proxy.test.js`.

### Background
- `Order.rs` turns the collected describe tree of a file into a list of `ConcurrentGroup`s. Each group is a range of `ExecutionSequence`s (one per test, or one per `beforeAll`/`afterAll` hook). Groups run one after another; the sequences inside a group run concurrently. `Execution::load_from_order` takes the finished list over for the execution phase.
- A concurrent test is appended to the previous group when that group was also built from concurrent tests (`previous_group_was_concurrent`); describe boundaries do not matter for this. A serial test or a hook always starts a new group.
- Every group carries a `failure_skip_to` group index that `step_group` jumps to when every sequence in the group failed. For ordinary groups it is the next group. For a describe's `beforeAll` hook groups it is filled in after the describe's children have been scheduled, pointing just past them, which is how a failing hook skips the describe's tests.
- Tests and hooks point at the describe that declared them through `base.parent`; the file's root scope points at the preload hook scope, so preload hooks pass the same ancestor check. `Environment::CI_ASSERT` is true in debug, ASAN and assertion-enabled canary builds, which is what CI runs the suite with; `Order.rs` already uses it for its other structural asserts.

<details>
<summary>Repro</summary>

```ts
import { it, describe, beforeAll } from "bun:test";

describe("a", () => {
  beforeAll(() => {
    throw new Error("a's beforeAll failed");
  });
  it("a1 must be skipped", () => {});
});
describe("b", () => {
  it("b1 must run", () => {});
});
it("top-level c must run", () => {});
```

`bun test skip.test.ts` (1.4.0-canary.1, eabb96de7):

```
(fail) a > (unnamed)
(pass) b > b1 must run
(pass) top-level c must run

 2 pass
 1 fail
```

`bun test --concurrent skip.test.ts`:

```
(fail) a > (unnamed)

 0 pass
 1 fail
Ran 1 test across 1 file.
```

With this change the `--concurrent` run matches the serial one. The group layout for the file goes from `[a beforeAll] [a1, b1, c]` (skip range covers the second group) to `[a beforeAll] [a1] [b1, c]`.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/failure-skip.test.ts
bun test v1.4.0 (c21d95a46)

test/js/bun/test/failure-skip.test.ts:
(pass) failure-skip > none [2952.82ms]
(pass) failure-skip > beforeall1 [2719.41ms]
(pass) failure-skip > beforeall2 [3128.56ms]
(pass) failure-skip > beforeeach1 [2801.01ms]
(pass) failure-skip > beforeeach2 [2926.74ms]
(pass) failure-skip > test1 [3218.90ms]
(pass) failure-skip > test2 [3164.67ms]
(pass) failure-skip > aftereach1 [2581.02ms]
(pass) failure-skip > aftereach2 [2238.33ms]
(pass) failure-skip > afterall1 [2059.89ms]
(pass) failure-skip > afterall2 [2071.93ms]
148 |         });
149 |         it.concurrent("a1", () => console.log("ran a1"));
150 |       });
151 |       it.concurrent("b", () => console.log("ran b"));
152 |     `);
153 |     expect(stdout).toMatchInlineSnapshot(`
                         ^
error: expect(received).toMatchInlineSnapshot(expected)

- 
- "bun test <version> (<revision>)
- ran b"
- 
+ "bun test <version> (<revision>)"

- Expected  - 4
+ Received  + 1

      at <anonymous> (/workspace/bun/test
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (a19f6f300)

test/js/bun/test/failure-skip.test.ts:
(pass) failure-skip > none [41.82ms]
(pass) failure-skip > beforeall1 [37.87ms]
(pass) failure-skip > beforeall2 [39.50ms]
(pass) failure-skip > beforeeach1 [39.11ms]
(pass) failure-skip > beforeeach2 [38.56ms]
(pass) failure-skip > test1 [45.17ms]
(pass) failure-skip > test2 [43.77ms]
(pass) failure-skip > aftereach1 [39.61ms]
(pass) failure-skip > aftereach2 [37.31ms]
(pass) failure-skip > afterall1 [38.66ms]
(pass) failure-skip > afterall2 [48.28ms]
(pass) a failing beforeAll skips only the tests of its own describe > sibling describes and top-level tests still run [] [38.10ms]
(pass) a failing beforeAll skips only the tests of its own describe > a describe with a beforeAll ends its concurrent group [47.43ms]
(pass) a failing beforeAll skips only the tests of its own describe > describe.concurrent sibling [59.77ms]
(pass) a failing beforeAll skips only the tests of its own describe > nested describes: the skip ends with the describe that owns the hook [70.58ms]
(pass) a failing beforeAll skips only the tests of its own describe > sibling describes and top-level tests still run [ "--concu
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/failure-skip.test.ts
bun test v1.4.0 (c21d95a46)

test/js/bun/test/failure-skip.test.ts:
(pass) failure-skip > none [2256.35ms]
(pass) failure-skip > beforeall1 [2445.06ms]
(pass) failure-skip > beforeall2 [2124.88ms]
(pass) failure-skip > beforeeach1 [2099.50ms]
(pass) failure-skip > beforeeach2 [2297.09ms]
(pass) failure-skip > test1 [2147.48ms]
(pass) failure-skip > test2 [2219.52ms]
(pass) failure-skip > aftereach1 [2168.68ms]
(pass) failure-skip > aftereach2 [2153.00ms]
(pass) failure-skip > afterall1 [2170.76ms]
(pass) failure-skip > afterall2 [2160.01ms]
(pass) a failing beforeAll skips only the tests of its own describe > nested describes: the skip ends with the describe that owns the hook [2135.71ms]
(pass) a failing beforeAll skips only the tests of its own describe > it.concurrent sibling [2159.74ms]
(pass) a failing beforeAll skips only the tests of its own describe > sibling describes and top-level tests still run [ "--concurrent" ] [2185.95ms]
(pass) a failing beforeAll skips only the tests of its own des
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 715ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/126] gen cpp.rs (cppbind)
[2/126] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/Execution.rs  |   1 +
 src/runtime/test_runner/Order.rs      |  41 ++++++++-
 src/runtime/test_runner/debug.rs      |   4 +-
 test/js/bun/test/failure-skip.test.ts | 151 +++++++++++++++++++++++++++++++++-
 4 files changed, 193 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/runtime/test_runner/Execution.rs       2      1      0
src/runtime/test_runner/Order.rs           3      8      0
src/runtime/test_runner/debug.rs           1      1      0
test/js/bun/test/failure-skip.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->