### PR TITLE
css: parse the number lightness and percentage a/b/chroma of lab(), lch(), oklab() and oklch()

### DIFF
--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1129,18 +1129,34 @@ pub(crate) fn parse_color_function(
     let mut parser = ComponentParser::new(true);
 
     crate::match_ignore_ascii_case! { function, {
-        b"lab" => parse_lab::<LAB>(input, &mut parser, |l, a, b, alpha| {
-            LABColor::Lab(LAB { l, a, b, alpha })
-        }),
-        b"oklab" => parse_lab::<OKLAB>(input, &mut parser, |l, a, b, alpha| {
-            LABColor::Oklab(OKLAB { l, a, b, alpha })
-        }),
-        b"lch" => parse_lch::<LCH>(input, &mut parser, |l, c, h, alpha| {
-            LABColor::Lch(LCH { l, c, h, alpha })
-        }),
-        b"oklch" => parse_lch::<OKLCH>(input, &mut parser, |l, c, h, alpha| {
-            LABColor::Oklch(OKLCH { l, c, h, alpha })
-        }),
+        b"lab" => parse_lab::<LAB>(
+            input,
+            &mut parser,
+            LAB_L_BASIS,
+            LAB_AB_BASIS,
+            |l, a, b, alpha| LABColor::Lab(LAB { l, a, b, alpha }),
+        ),
+        b"oklab" => parse_lab::<OKLAB>(
+            input,
+            &mut parser,
+            OKLAB_L_BASIS,
+            OKLAB_AB_BASIS,
+            |l, a, b, alpha| LABColor::Oklab(OKLAB { l, a, b, alpha }),
+        ),
+        b"lch" => parse_lch::<LCH>(
+            input,
+            &mut parser,
+            LAB_L_BASIS,
+            LCH_C_BASIS,
+            |l, c, h, alpha| LABColor::Lch(LCH { l, c, h, alpha }),
+        ),
+        b"oklch" => parse_lch::<OKLCH>(
+            input,
+            &mut parser,
+            OKLAB_L_BASIS,
+            OKLCH_C_BASIS,
+            |l, c, h, alpha| LABColor::Oklch(OKLCH { l, c, h, alpha }),
+        ),
         b"color" => parse_predefined(input, &mut parser),
         b"hsl" | b"hsla" => parse_hsl_hwb::<HSL>(input, &mut parser, true, |h, s, l, a| {
             let hsl = HSL { h, s, l, alpha: a };
@@ -1325,9 +1341,19 @@ fn delta_eok<T: Into<OKLAB>>(a_: T, b_: OKLCH) -> f32 {
     (delta_l.powi(2) + delta_a.powi(2) + delta_b.powi(2)).sqrt()
 }
 
+// What `100%` stands for in each channel of the lab family: https://www.w3.org/TR/css-color-4/#specifying-lab-lch
+const LAB_L_BASIS: f32 = 100.0;
+const LAB_AB_BASIS: f32 = 125.0;
+const LCH_C_BASIS: f32 = 150.0;
+const OKLAB_L_BASIS: f32 = 1.0;
+const OKLAB_AB_BASIS: f32 = 0.4;
+const OKLCH_C_BASIS: f32 = 0.4;
+
 pub(crate) fn parse_lab<T>(
     input: &mut css::Parser,
     parser: &mut ComponentParser,
+    l_basis: f32,
+    ab_basis: f32,
     func: fn(f32, f32, f32, f32) -> LABColor,
 ) -> CssResult<CssColor>
 where
@@ -1337,9 +1363,9 @@ where
     input.parse_nested_block(|i| {
         parser.parse_relative::<T, CssColor, _>(i, |i, p| {
             // f32::max() does not propagate NaN, so use clamp for now until f32::maximum() is stable.
-            let l = p.parse_percentage(i)?.clamp(0.0, f32::MAX);
-            let a = p.parse_number(i)?;
-            let b = p.parse_number(i)?;
+            let l = p.parse_unit_channel(i, l_basis)?.clamp(0.0, f32::MAX);
+            let a = p.parse_number_channel(i, ab_basis)?;
+            let b = p.parse_number_channel(i, ab_basis)?;
             let alpha = parse_alpha(i, p)?;
             let lab = func(l, a, b, alpha);
             Ok(CssColor::Lab(Box::new(lab)))
@@ -1350,8 +1376,11 @@ where
 pub(crate) fn parse_lch<T: Colorspace + ColorGamut + Into<OKLCH> + From<OKLCH> + Into<OKLAB>>(
     input: &mut css::Parser,
     parser: &mut ComponentParser,
+    l_basis: f32,
+    c_basis: f32,
     func: fn(f32, f32, f32, f32) -> LABColor,
 ) -> CssResult<CssColor> {
+    // https://www.w3.org/TR/css-color-4/#funcdef-lch
     input.parse_nested_block(|i| {
         parser.parse_relative::<T, CssColor, _>(i, |i, p| {
             if let Some(from) = &mut p.from {
@@ -1363,8 +1392,8 @@ pub(crate) fn parse_lch<T: Colorspace + ColorGamut + Into<OKLCH> + From<OKLCH> +
                 }
             }
 
-            let l = p.parse_percentage(i)?.clamp(0.0, f32::MAX);
-            let c = p.parse_number(i)?.clamp(0.0, f32::MAX);
+            let l = p.parse_unit_channel(i, l_basis)?.clamp(0.0, f32::MAX);
+            let c = p.parse_number_channel(i, c_basis)?.clamp(0.0, f32::MAX);
             let h = parse_angle_or_number(i, p)?;
             let alpha = parse_alpha(i, p)?;
             let lab = func(l, c, h, alpha);
@@ -2016,6 +2045,16 @@ impl ComponentParser {
         }
     }
 
+    /// A channel written as `<percentage> | <number> | none` and stored as a unit value,
+    /// `percent_basis` being the `<number>` that stands for `100%`.
+    fn parse_unit_channel(&self, input: &mut css::Parser, percent_basis: f32) -> CssResult<f32> {
+        if let Ok(number) = input.try_parse(CSSNumberFns::parse) {
+            return Ok(number / percent_basis);
+        }
+
+        self.parse_percentage(input)
+    }
+
     fn parse_percentage(&self, input: &mut css::Parser) -> CssResult<f32> {
         if let Some(from) = &self.from {
             if let Ok(res) = input.try_parse(|i| RelativeComponentParser::parse_percentage(i, from))
@@ -2049,6 +2088,15 @@ impl ComponentParser {
         } else {
             Err(input.new_custom_error(css::ParserError::invalid_value))
         }
+    }
+
+    /// `<number> | <percentage> | none` stored as the number (lab a/b, lch chroma); `100%` is `percent_basis`.
+    fn parse_number_channel(&self, input: &mut css::Parser, percent_basis: f32) -> CssResult<f32> {
+        if let Ok(number) = input.try_parse(|i| self.parse_number(i)) {
+            return Ok(number);
+        }
+
+        Ok(Percentage::parse(input)?.v * percent_basis)
     }
 }
 

--- a/test/bundler/css/wpt/relative_color_out_of_gamut.test.ts
+++ b/test/bundler/css/wpt/relative_color_out_of_gamut.test.ts
@@ -4,573 +4,117 @@ import { itBundled } from "../../expectBundled";
 // https://github.com/web-platform-tests/wpt/blob/master/css/css-color/parsing/relative-color-out-of-gamut.html
 //
 // The WPT asserts that a relative rgb()/hsl()/hwb() color whose origin is outside the sRGB
-// gamut computes to the unclamped out-of-gamut color (browsers clip it when painting), so the
-// bundler must not resolve these: gamut mapping the origin gives a different color (the
-// display-p3 green below used to come out as #00f942, browsers paint it as #00ff00). The
-// declaration is left for the browser. What the bundler does do is its usual handling of a
-// wide-gamut color literal inside a value it does not resolve: under the default browser
-// targets the origin gets an sRGB fallback plus an `@supports` tier with the color as written.
+// gamut computes to the unclamped out-of-gamut color (browsers clip it when painting), so
+// the bundler must not resolve these: gamut mapping the origin gives a different color
+// (`rgb(from lab(100 104.3 -50.9) r g b)` would become `#fff`; browsers compute
+// `color(srgb 1.5935 .587758 1.40555)` and paint it clipped, #ff96ff). The declaration is
+// left for the browser. What the bundler does do is its usual handling of a wide-gamut color
+// literal inside a value it does not resolve: under the default browser targets the origin
+// is downleveled into an sRGB fallback plus `@supports` tiers, with the losslessly converted
+// origin in the widest tier. Every browser with relative color syntax supports that tier.
 //
-// The lab()/lch()/oklab()/oklch() origins below are written with a number lightness, which
-// does not parse yet (#16727), so those declarations are emitted as written for that reason.
-let i = 0;
-const testname = () => `test-${i++}`;
-describe("relative_color_out_of_gamut", () => {
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-h1 {
-  color: rgb(from color(display-p3 0 1 0) r g b / alpha);
-}
-      `,
-    },
-    outfile: "out.css",
+// Until the lab family accepted a number lightness, the 24 lab()/lch()/oklab()/oklch() cases
+// were emitted as written only because their origin did not parse at all; now every origin
+// parses and all 27 cases take the same path.
+const origins: { origin: string; alpha?: string; srgb: string; p3: string; lab?: string }[] = [
+  { origin: "color(display-p3 0 1 0)", alpha: " / alpha", srgb: "#00f942", p3: "color(display-p3 0 1 0)" },
+  {
+    origin: "lab(100 104.3 -50.9)",
+    srgb: "#fff",
+    p3: "color(display-p3 1.47874 .658561 1.37055)",
+    lab: "lab(100% 104.3 -50.9)",
+  },
+  {
+    origin: "lab(0 104.3 -50.9)",
+    srgb: "#2a0022",
+    p3: "color(display-p3 .306769 -.199656 .283743)",
+    lab: "lab(0% 104.3 -50.9)",
+  },
+  {
+    origin: "lch(100 116 334)",
+    srgb: "#fff",
+    p3: "color(display-p3 1.47862 .658765 1.3702)",
+    lab: "lab(100% 104.26 -50.851)",
+  },
+  {
+    origin: "lch(0 116 334)",
+    srgb: "#2a0022",
+    p3: "color(display-p3 .306711 -.199586 .283484)",
+    lab: "lab(0% 104.26 -50.851)",
+  },
+  {
+    origin: "oklab(1 0.365 -0.16)",
+    srgb: "#fff",
+    p3: "color(display-p3 1.46907 .484456 1.34749)",
+    lab: "lab(94.0295% 119.52 -57.5484)",
+  },
+  {
+    origin: "oklab(0 0.365 -0.16)",
+    srgb: "#000",
+    p3: "color(display-p3 .0601419 -.041443 .0865066)",
+    lab: "lab(-.452515% 13.4914 -12.4407)",
+  },
+  {
+    origin: "oklch(1 0.399 336.3)",
+    srgb: "#fff",
+    p3: "color(display-p3 1.46933 .483415 1.34835)",
+    lab: "lab(94.0205% 119.644 -57.6823)",
+  },
+  {
+    origin: "oklch(0 0.399 336.3)",
+    srgb: "#000",
+    p3: "color(display-p3 .0602585 -.0416396 .0869713)",
+    lab: "lab(-.455916% 13.5528 -12.5395)",
+  },
+];
 
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
+const functions: [name: string, channels: string][] = [
+  ["rgb", "r g b"],
+  ["hsl", "h s l"],
+  ["hwb", "h w b"],
+];
+
+describe("relative_color_out_of_gamut", () => {
+  for (const [fn, channels] of functions) {
+    for (const { origin, alpha = "", srgb, p3, lab } of origins) {
+      const input = `${fn}(from ${origin} ${channels}${alpha})`;
+      const relative = (from: string) => `${fn}(from ${from} ${channels}${alpha})`;
+
+      itBundled(input, {
+        files: {
+          "/a.css": /* css */ `
+h1 {
+  color: ${input};
+}
+          `,
+        },
+        outfile: "out.css",
+
+        onAfterBundle(api) {
+          api.expectFile("/out.css").toEqualIgnoringWhitespace(`
 /* a.css */
 h1 {
-  color: rgb(from #00f942 r g b / alpha);
+  color: ${relative(srgb)};
 }
 
 @supports (color: color(display-p3 0 0 0)) {
   h1 {
-    color: rgb(from color(display-p3 0 1 0) r g b / alpha);
+    color: ${relative(p3)};
   }
 }
-`);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
+${
+  lab === undefined
+    ? ""
+    : `
+@supports (color: lab(0% 0 0)) {
   h1 {
-    color: rgb(from lab(100 104.3 -50.9) r g b);
+    color: ${relative(lab)};
   }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: rgb(from lab(100 104.3 -50.9) r g b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: rgb(from lab(0 104.3 -50.9) r g b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: rgb(from lab(0 104.3 -50.9) r g b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: rgb(from lch(100 116 334) r g b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: rgb(from lch(100 116 334) r g b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: rgb(from lch(0 116 334) r g b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: rgb(from lch(0 116 334) r g b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: rgb(from oklab(1 0.365 -0.16) r g b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: rgb(from oklab(1 .365 -.16) r g b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: rgb(from oklab(0 0.365 -0.16) r g b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: rgb(from oklab(0 .365 -.16) r g b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: rgb(from oklch(1 0.399 336.3) r g b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: rgb(from oklch(1 .399 336.3) r g b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: rgb(from oklch(0 0.399 336.3) r g b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: rgb(from oklch(0 .399 336.3) r g b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hsl(from color(display-p3 0 1 0) h s l / alpha);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-    color: hsl(from #00f942 h s l / alpha);
-  }
-
-  @supports (color: color(display-p3 0 0 0)) {
-    h1 {
-      color: hsl(from color(display-p3 0 1 0) h s l / alpha);
+}
+`
+}`);
+        },
+      });
     }
   }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hsl(from lab(100 104.3 -50.9) h s l);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hsl(from lab(100 104.3 -50.9) h s l);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hsl(from lab(0 104.3 -50.9) h s l);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hsl(from lab(0 104.3 -50.9) h s l);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hsl(from lch(100 116 334) h s l);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hsl(from lch(100 116 334) h s l);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hsl(from lch(0 116 334) h s l);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hsl(from lch(0 116 334) h s l);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hsl(from oklab(1 0.365 -0.16) h s l);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hsl(from oklab(1 .365 -.16) h s l);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hsl(from oklab(0 0.365 -0.16) h s l);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hsl(from oklab(0 .365 -.16) h s l);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hsl(from oklch(1 0.399 336.3) h s l);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hsl(from oklch(1 .399 336.3) h s l);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hsl(from oklch(0 0.399 336.3) h s l);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hsl(from oklch(0 .399 336.3) h s l);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hwb(from color(display-p3 0 1 0) h w b / alpha);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-    color: hwb(from #00f942 h w b / alpha);
-  }
-
-  @supports (color: color(display-p3 0 0 0)) {
-    h1 {
-      color: hwb(from color(display-p3 0 1 0) h w b / alpha);
-    }
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hwb(from lab(100 104.3 -50.9) h w b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hwb(from lab(100 104.3 -50.9) h w b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hwb(from lab(0 104.3 -50.9) h w b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hwb(from lab(0 104.3 -50.9) h w b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hwb(from lch(100 116 334) h w b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hwb(from lch(100 116 334) h w b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hwb(from lch(0 116 334) h w b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hwb(from lch(0 116 334) h w b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hwb(from oklab(1 0.365 -0.16) h w b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hwb(from oklab(1 .365 -.16) h w b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hwb(from oklab(0 0.365 -0.16) h w b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hwb(from oklab(0 .365 -.16) h w b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hwb(from oklch(1 0.399 336.3) h w b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hwb(from oklch(1 .399 336.3) h w b);
-  }
-  `);
-    },
-  });
-
-  itBundled(testname(), {
-    files: {
-      "/a.css": /* css */ `
-  h1 {
-    color: hwb(from oklch(0 0.399 336.3) h w b);
-  }
-        `,
-    },
-    outfile: "/out.css",
-
-    onAfterBundle(api) {
-      api.expectFile("/out.css").toEqualIgnoringWhitespace(`
-  /* a.css */
-  h1 {
-      color: hwb(from oklch(0 .399 336.3) h w b);
-  }
-  `);
-    },
-  });
 });

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -821,3 +821,66 @@ describe("relative colors with an origin outside the sRGB gamut", () => {
     });
   });
 });
+
+// Every channel of lab(), lch(), oklab() and oklch() is `<percentage> | <number> | none`.
+// 100% of the lightness is the number 100 in lab()/lch() and 1 in oklab()/oklch(); 100% of
+// a/b is 125 in lab() and 0.4 in oklab(); 100% of the chroma is 150 in lch() and 0.4 in
+// oklch(). Only the percentage lightness with number a/b/chroma used to parse (#16727).
+// https://www.w3.org/TR/css-color-4/#specifying-lab-lch
+// https://www.w3.org/TR/css-color-4/#specifying-oklab-oklch
+// lightningcss 1.30 produces the same values for every input below.
+describe("lab-family channels written as numbers or percentages", () => {
+  test.each([
+    ["lab(50 40 -50)", "lab(50% 40 -50)", "#965dcd"],
+    ["lch(50 60 120)", "lch(50% 60 120)", "#548404"],
+    ["oklab(0.5 0.1 -0.1)", "oklab(50% .1 -.1)", "#81459a"],
+    ["oklch(0.5 0.1 120)", "oklch(50% .1 120)", "#5c6b21"],
+    // Tailwind v4's red-500, which is documented as #fb2c36.
+    ["oklch(0.637 0.237 25.331)", "oklch(63.7% .237 25.331)", "#fb2c36"],
+    ["lab(50% 32% -40%)", "lab(50% 40 -50)", "#965dcd"],
+    ["lch(50% 40% 120)", "lch(50% 60 120)", "#548404"],
+    ["oklab(50% 25% -25%)", "oklab(50% .1 -.1)", "#81459a"],
+    ["oklch(50% 25% 120)", "oklch(50% .1 120)", "#5c6b21"],
+    ["lab(50 32% -50)", "lab(50% 40 -50)", "#965dcd"],
+    // The example in the Bun.color docs.
+    ["lab(50% 50% 50%)", "lab(50% 62.5 62.5)", "#db3702"],
+    ["lab(50 40 -50 / 0.5)", "lab(50% 40 -50 / .5)", "#965dcd"],
+    ["lab(calc(50) 40 -50)", "lab(50% 40 -50)", "#965dcd"],
+    ["lab(50% calc(32%) -50)", "lab(50% 40 -50)", "#965dcd"],
+    ["lab(50 none none)", "lab(50% none none)", "#777777"],
+    ["color-mix(in oklch, oklch(0.5 0.1 120), oklch(50% 0.1 120))", "oklch(50% .1 120)", "#5c6b21"],
+    // A negative lightness or chroma clamps to 0, like the forms that already parsed.
+    ["lab(-10 0 0)", "lab(0% 0 0)", "#000000"],
+    ["lch(50 -20% 120)", "lch(50% 0 120)", "#777777"],
+  ])("%s", (input, css, hex) => {
+    expect([color(input, "css"), color(input, "hex")]).toEqual([css, hex]);
+  });
+
+  test.each(["lab(50 40)", "lab(50, 40, -50)", "oklch(0.5 0.1 120 0.5)", "lab(50deg 0 0)", "lch(50 60 120%)"])(
+    "%s is still invalid",
+    input => {
+      expect(color(input, "css")).toBeNull();
+    },
+  );
+});
+
+describe("relative colors in the lab family", () => {
+  test.each([
+    ["oklch(from red 0.5 c h)", "oklch(50% .257683 29.2339)"],
+    ["lab(from red 50 a b)", "lab(50% 80.8049 69.891)"],
+    ["lab(from red l 50% b)", "lab(54.2905% 62.5 69.891)"],
+    // The channel keywords resolve as before, unscaled.
+    ["lab(from red l a b)", "lab(54.2905% 80.8049 69.891)"],
+    ["lab(from lab(50% 20 30) calc(l * 1.2) a b)", "lab(60% 20 30)"],
+    // Origins written this way parse now too: an in-gamut one resolves, an out-of-gamut one
+    // resolves into the unbounded functions only.
+    ["rgb(from oklch(0.5 0.1 120) r g b)", "#5c6b21"],
+    ["hsl(from lab(50 40 -50) h s l)", "#965dcd"],
+    ["lab(from oklch(1 0.399 336.3) l a b)", "lab(94.0205% 119.644 -57.6823)"],
+    ["color(from lab(100 104.3 -50.9) srgb r g b)", "color(srgb 1.5935 .587758 1.40555)"],
+    ["rgb(from lab(100 104.3 -50.9) r g b)", null],
+    ["hwb(from oklch(1 0.399 336.3) h w b)", null],
+  ])("%s is %s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7666,6 +7666,58 @@ describe("css tests", () => {
     minify_test(".foo{grid-template-areas:none}", ".foo{grid-template-areas:none}");
   });
 
+  // Every channel of the lab family is `<percentage> | <number> | none`; only the percentage
+  // lightness with number a/b/chroma used to parse, so the other spellings (the number
+  // lightness is what Tailwind v4 emits) went through as unknown tokens and got no fallbacks.
+  // https://www.w3.org/TR/css-color-4/#specifying-lab-lch
+  describe("lab-family colors written as numbers or percentages", () => {
+    minify_test(".foo { color: lab(50 40 -50) }", ".foo{color:lab(50% 40 -50)}");
+    minify_test(".foo { color: lch(50 60 120) }", ".foo{color:lch(50% 60 120)}");
+    minify_test(".foo { color: oklab(0.5 0.1 -0.1) }", ".foo{color:oklab(50% .1 -.1)}");
+    minify_test(".foo { color: oklch(0.5 0.1 120) }", ".foo{color:oklch(50% .1 120)}");
+    minify_test(".foo { color: lab(50% 32% -40%) }", ".foo{color:lab(50% 40 -50)}");
+    minify_test(".foo { color: lch(50% 40% 120) }", ".foo{color:lch(50% 60 120)}");
+    minify_test(".foo { color: oklab(50% 25% -25%) }", ".foo{color:oklab(50% .1 -.1)}");
+    minify_test(".foo { color: oklch(50% 25% 120) }", ".foo{color:oklch(50% .1 120)}");
+    minify_test(".foo { color: var(--x, oklch(0.5 0.1 120)) }", ".foo{color:var(--x,oklch(50% .1 120))}");
+
+    // Both spellings get the same fallbacks for targets without oklch().
+    for (const lightness of ["0.5", "50%"]) {
+      prefix_test(
+        `.foo { color: oklch(${lightness} 0.1 120) }`,
+        indoc`
+          .foo {
+            color: #5c6b21;
+            color: lab(42.8512% -14.3178 37.8447);
+          }
+        `,
+        {
+          chrome: 95 << 16,
+        },
+      );
+    }
+
+    describe("relative colors", () => {
+      minify_test(".foo { color: lab(from lab(50 20 30) l a b) }", ".foo{color:lab(50% 20 30)}");
+      minify_test(".foo { color: oklch(from red 0.5 c h) }", ".foo{color:oklch(50% .257683 29.2339)}");
+      minify_test(".foo { color: rgb(from oklch(0.5 0.1 120) r g b) }", ".foo{color:#5c6b21}");
+      minify_test(
+        ".foo { color: color(from lab(100 104.3 -50.9) srgb r g b) }",
+        ".foo{color:color(srgb 1.5935 .587758 1.40555)}",
+      );
+      // An out-of-gamut origin is left alone like its percentage spelling; it is a parsed
+      // color now, which is why it comes back out serialized.
+      minify_test(
+        ".foo { color: rgb(from lab(100 104.3 -50.9) r g b) }",
+        ".foo{color:rgb(from lab(100% 104.3 -50.9) r g b)}",
+      );
+      minify_test(
+        ".foo { color: hwb(from oklch(1 0.399 336.3) h w b) }",
+        ".foo{color:hwb(from oklch(100% .399 336.3) h w b)}",
+      );
+    });
+  });
+
   // rgb(), hsl() and hwb() cannot hold an origin outside the sRGB gamut. Browsers keep the
   // out-of-gamut channels and clip them when painting (w3c/csswg-drafts#8444), so resolving
   // these by gamut mapping the origin, as before (#fff and #00f942 below), painted a


### PR DESCRIPTION
Stacked on #39261 (this PR's base branch); the diff shown here is the grammar change only.

### Problem
- `lab()`, `lch()`, `oklab()` and `oklch()` only parse when the lightness is a percentage and a/b (or chroma) are numbers. `Bun.color("oklch(0.5 0.1 120)", "hex")` is `null` while `"oklch(50% 0.1 120)"` is `"#5c6b21"`; `Bun.color("lab(50% 50% 50%)")`, the example in the `Bun.color` docs, is `null` (#16727).
- CSS Color 4 defines every channel of these functions as `<percentage> | <number> | none`: 100% of the lightness is 100 in `lab()`/`lch()` and 1 in `oklab()`/`oklch()`, 100% of a/b is 125 (`lab()`) or 0.4 (`oklab()`), 100% of the chroma is 150 (`lch()`) or 0.4 (`oklch()`). The number lightness is the form Tailwind v4 emits for its whole palette.
- In stylesheets the color goes through as unknown tokens: `bun build` turns `color: oklch(50% 0.1 120)` into an sRGB fallback plus the original under the default targets, but emits `color: oklch(.5 .1 120)` alone, which browsers without `oklch()` drop. It also cannot be the origin of a relative color or an operand of `color-mix()`.
- Cause: `parse_lab` and `parse_lch` in `src/css/values/color.rs` read the lightness with `ComponentParser::parse_percentage` and the other channels with `parse_number`, each of which accepts only its own token type.
- This is stacked on #39261 because 24 of the 27 cases in `test/bundler/css/wpt/relative_color_out_of_gamut.test.ts` were only passing because these origins did not parse; once they do, the gamut change in #39261 is what keeps them unresolved.

### Fix
- `parse_lab`/`parse_lch` take the percent basis of each channel (the constants above `parse_lab`) and read the lightness with `ComponentParser::parse_unit_channel` (a `<number>` divided by the basis, otherwise the existing percentage path) and a/b/chroma with `parse_number_channel` (the existing number path, otherwise a literal `<percentage>` times the basis). Inputs that parsed before take exactly the paths they took before, so their values and serialization are unchanged; only literal number and percentage tokens are new. Relative color keywords (`lab(from red l a b)`) still resolve through their own typed path and are never scaled; a literal percentage in an a/b slot is accepted only as a literal, because on main a keyword in that slot is still typed as a percentage and would otherwise be scaled too. Once #38553 retypes the keywords, `parse_number_channel` can collapse into its basis-taking `parse_number_or_percentage`.
- `parse_unit_channel` is byte for byte the helper #39205 adds for `hsl()`/`hwb()` (same name, doc comment, body and position), so whichever of the two lands second rebases onto the other's copy with no change; it is also the helper #38553 extends for the relative case. The constants follow #39205's `HSL_PERCENT_BASIS`.
- Why this is right: the grammar, the bases and the serializations are CSS Color 4's, and lightningcss 1.30.2 produces the same value for every input in the new tests (`oklch(0.637 0.237 25.331)`, Tailwind's red-500, comes out as its documented `#fb2c36`). An out-of-gamut origin written this way now gets the same treatment as its percentage spelling, from #39261; `color-mix()` operands written this way likewise fold exactly as their percentage spellings already do.
- Tests: `test/js/bun/css/color.test.ts` (25 of the 34 cases in the two new blocks fail without this change), `test/js/bun/css/css.test.ts` (16 of 17), and `test/bundler/css/wpt/relative_color_out_of_gamut.test.ts`, rewritten table-driven over the same 27 WPT cases now that all of them take the same path (the 24 lab-family rows fail without this change, since their origin is emitted unparsed). The full `css.test.ts`, `color.test.ts`, `doesnt_crash.test.ts`, `test/bundler/css/` and the other WPT color files pass.

### Background
- Percent basis: the number a percentage stands for in a given channel. The lab-family structs store the lightness as a unit value (0.5 for both `50%` and `50`) and a/b and chroma as the number written, so a percentage in those slots is multiplied out (`lab(50% 32% -40%)` stores a = 40, b = -50) and serializes as the number, which is also how lightningcss serializes it.
- Relative color syntax: `lab(from <origin> l a b)` converts the origin into the function's space and lets the channels be referenced by keyword; `ComponentParser` resolves the keywords through `parse_percentage`/`parse_number` according to the channel's type, which is why the new helpers add the literal tokens around those calls instead of replacing them.

<details>
<summary>Earlier shape of this PR</summary>

The first revision also contained the relative color gamut change, now #39261, under this title. It was split out after review so that the behavior change has its own sign-off surface and so that #38553, which was waiting on it, can rebase onto it independently of this grammar change.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 65 failed, 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/wpt/relative_color_out_of_gamut.test.ts test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (bcab5edce)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [5.55ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [6.22ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [2.25ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [2.44ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [21.98ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [2.74ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.83ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.38ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.34ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.32ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = 
... (truncated)

release without fix: 65 failed, 67 skipped
bun test v1.4.0-canary.1 (1666aca0b)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [0.09ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.02ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.02ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.04ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [0.55ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [0.03ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.01ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.01ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256"))
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16"))
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.01ms]
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit")
(pass) color({"r":0,"g":255,"b":0}, "ansi-16")
(pass) color({"r":0,"g":255,"b":0}, "ansi256")
[38;2;0;0;255m[object Object]
(pass) console.log(color({"r":0,"g":0,"b":255}, "ans
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/wpt/relative_color_out_of_gamut.test.ts test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (bcab5edce)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [4.02ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.28ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.46ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [1.72ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [14.01ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [4.65ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.44ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.33ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.26ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.25ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = 
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 692ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/values/color.rs                            |  82 ++-
 .../css/wpt/relative_color_out_of_gamut.test.ts    | 648 +++------------------
 test/js/bun/css/color.test.ts                      |  63 ++
 test/js/bun/css/css.test.ts                        |  52 ++
 4 files changed, 276 insertions(+), 569 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/css/values/color.rs                                      25     36      0
test/bundler/css/wpt/relative_color_out_of_gamut.test.ts      5      6      0
test/js/bun/css/color.test.ts                                 6      2      0
test/js/bun/css/css.test.ts                                   2      2      0
```

</details>

<!-- robobun:evidence:end -->