### PR TITLE
FileReader: apply the slice window on the read_into pull path and end the stream when it is used up

### DIFF
--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -49,10 +49,9 @@ pub struct FileReader {
     pub(crate) fd: Cell<Fd>,
     /// Read-only after construction (set via struct literal in `from_blob_*`).
     pub(crate) start_offset: Option<usize>,
-    /// Length of the blob's slice window, counted from `start_offset`; the
-    /// stream ends there even if the file goes on. Read-only after construction.
+    /// Length of the slice window at `start_offset`; the stream ends there. Read-only after init.
     pub(crate) max_size: Option<usize>,
-    /// Bytes delivered so far, charged against `max_size`; never exceeds it.
+    /// Bytes delivered so far; never exceeds `max_size`.
     pub(crate) total_readed: Cell<usize>,
     pub(crate) started: Cell<bool>,
     pub(crate) waiting_for_on_reader_done: Cell<bool>,
@@ -682,9 +681,7 @@ impl FileReader {
         Some(self.max_size? - self.total_readed.get())
     }
 
-    /// Charges `len` delivered bytes against the slice window. Returns `true` once the window is
-    /// used up: that is this stream's EOF whatever the file still holds, so the caller must
-    /// `end_at_window` after delivering the bytes.
+    /// Charges `len` bytes to the window; `true` once it is used up, which is this stream's EOF.
     fn consume_window(&self, len: usize) -> bool {
         let Some(max_size) = self.max_size else {
             return false;
@@ -695,8 +692,7 @@ impl FileReader {
         total_readed == max_size
     }
 
-    /// Closes the reader as EOF would have; `on_reader_done` then ends the sink or settles a
-    /// parked read, and the next `on_pull` reports `Done`.
+    /// Ends the stream the way EOF does; `on_reader_done` settles whatever is waiting.
     fn end_at_window(&self) {
         if !self.reader().is_done() {
             self.reader().close();

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -49,8 +49,10 @@ pub struct FileReader {
     pub(crate) fd: Cell<Fd>,
     /// Read-only after construction (set via struct literal in `from_blob_*`).
     pub(crate) start_offset: Option<usize>,
-    /// Read-only after construction.
+    /// Length of the blob's slice window, counted from `start_offset`; the
+    /// stream ends there even if the file goes on. Read-only after construction.
     pub(crate) max_size: Option<usize>,
+    /// Bytes delivered so far, charged against `max_size`; never exceeds it.
     pub(crate) total_readed: Cell<usize>,
     pub(crate) started: Cell<bool>,
     pub(crate) waiting_for_on_reader_done: Cell<bool>,
@@ -632,21 +634,14 @@ impl FileReader {
             self.reader().close();
             return false;
         }
-        let mut close = false;
-        let mut has_more = state != ReadState::Eof;
-        if let (Some(max_size), false) = (self.max_size, chunk.is_empty()) {
-            let total_readed = self.total_readed.get();
-            if total_readed >= max_size {
-                return false;
+        let window_exhausted = match self.window_remaining() {
+            Some(remaining) => {
+                chunk.truncate(remaining);
+                self.consume_window(chunk.len())
             }
-            let len = (max_size - total_readed).min(chunk.len());
-            chunk.truncate(len);
-            self.total_readed.set(total_readed + len);
-            if len == 0 {
-                close = true;
-                has_more = false;
-            }
-        }
+            None => false,
+        };
+        let has_more = state != ReadState::Eof && !window_exhausted;
 
         let sink = *self.sink.get();
         let keep_going = if sink.is_some() {
@@ -674,10 +669,38 @@ impl FileReader {
             }
             keep_going
         };
-        if close {
-            self.reader().close();
+        if window_exhausted {
+            // Closed only now: closing first would settle a parked read with `Done` ahead of this chunk.
+            self.end_at_window();
+            return false;
         }
         keep_going
+    }
+
+    /// Bytes the blob's slice window still allows; `None` when the source is unbounded.
+    fn window_remaining(&self) -> Option<usize> {
+        Some(self.max_size? - self.total_readed.get())
+    }
+
+    /// Charges `len` delivered bytes against the slice window. Returns `true` once the window is
+    /// used up: that is this stream's EOF whatever the file still holds, so the caller must
+    /// `end_at_window` after delivering the bytes.
+    fn consume_window(&self, len: usize) -> bool {
+        let Some(max_size) = self.max_size else {
+            return false;
+        };
+        let total_readed = self.total_readed.get() + len;
+        debug_assert!(total_readed <= max_size);
+        self.total_readed.set(total_readed);
+        total_readed == max_size
+    }
+
+    /// Closes the reader as EOF would have; `on_reader_done` then ends the sink or settles a
+    /// parked read, and the next `on_pull` reports `Done`.
+    fn end_at_window(&self) {
+        if !self.reader().is_done() {
+            self.reader().close();
+        }
     }
 
     fn write_chunk_to_sink(&self, sink: SinkHandle, chunk: &[u8], has_more: bool) -> bool {
@@ -828,9 +851,17 @@ impl FileReader {
         }
 
         if !self.reader().has_pending_read() && self.flowing.get() {
+            // `read_into` does not go through `on_read_chunk`, so the slice window is applied here: the read is cut to what is left of it (an empty destination reads nothing).
+            let len = self
+                .window_remaining()
+                .map_or(buffer.len(), |remaining| remaining.min(buffer.len()));
             // SAFETY: the reader cell is live for `self`'s lifetime; `read_into` is the raw re-entrancy-safe entry (EOF/error dispatch runs user JS).
-            let (amount_read, state) = unsafe { IOReader::read_into(self.reader.get(), buffer) };
-            bun_core::scoped_log!(FileReader, "onPull({}) = {}", buffer.len(), amount_read);
+            let (amount_read, state) =
+                unsafe { IOReader::read_into(self.reader.get(), &mut buffer[..len]) };
+            bun_core::scoped_log!(FileReader, "onPull({}) = {}", len, amount_read);
+            if self.consume_window(amount_read) {
+                self.end_at_window();
+            }
             let done = state == ReadState::Eof || self.reader().is_done();
             if amount_read > 0 {
                 let into = streams::IntoArray {

--- a/test/js/bun/util/bun-stdin-slice.test.ts
+++ b/test/js/bun/util/bun-stdin-slice.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 
 // Reading a sliced non-regular file blob (like stdin from a pipe) with a size
@@ -39,4 +39,59 @@ test.skipIf(isWindows)("Bun.stdin.slice(0, N).text() caps reads at N bytes", asy
 
   expect(stdout).toBe("012");
   expect(exitCode).toBe(0);
+});
+
+// Streaming a slice of a pipe is the POSIX path where the chunk that ends the
+// slice is handed to a read that is already waiting (FileReader::on_read_chunk
+// with a parked read); a regular file is read straight into the pull buffer
+// instead. stdin is never closed here, so only the end of the slice can end the
+// stream and let the child exit.
+describe("Bun.stdin.slice(0, N).stream() over a pipe that stays open", () => {
+  function spawnSliceEcho(n: number) {
+    return Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `for await (const chunk of Bun.stdin.slice(0, ${n}).stream()) process.stdout.write(chunk);`,
+      ],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  }
+
+  test.concurrent.skipIf(isWindows)("ends after N bytes of a larger write", async () => {
+    await using proc = spawnSliceEcho(3);
+    proc.stdin.write("0123456789");
+    await proc.stdin.flush();
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "012", stderr: "", exitCode: 0 });
+  });
+
+  test.concurrent.skipIf(isWindows)(
+    "delivers a chunk that leaves the slice open, then ends on the one that fills it",
+    async () => {
+      await using proc = spawnSliceEcho(4);
+      const reader = proc.stdout.getReader();
+      const decoder = new TextDecoder();
+      let stdout = "";
+
+      proc.stdin.write("01");
+      await proc.stdin.flush();
+      // Wait for the first chunk to come back out so the second write is a separate read in the child.
+      for (let r; !stdout.includes("01") && !(r = await reader.read()).done; ) {
+        stdout += decoder.decode(r.value, { stream: true });
+      }
+      expect(stdout).toBe("01");
+
+      proc.stdin.write("23456");
+      await proc.stdin.flush();
+      for (let r; !(r = await reader.read()).done; ) stdout += decoder.decode(r.value, { stream: true });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "0123", stderr: "", exitCode: 0 });
+    },
+  );
 });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -702,8 +702,10 @@ describe("file-backed slice bounds are respected when streaming and serving", ()
     const windows: [start: number, end: number][] = [
       [0, 5], // inside the first read
       [3, 7],
+      [0, 256 * 1024], // exactly the first pull's buffer: the window ends on a read that fills it
       [100, 700_000], // several pulls; the last one has to be cut short
       [size - 10, size], // ends at EOF
+      [size - 10, size + 100], // the file ends first (the slice is taken before the size is known)
       [4096, 4096], // nothing to deliver at all
     ];
 
@@ -713,35 +715,35 @@ describe("file-backed slice bounds are respected when streaming and serving", ()
       return Buffer.concat(chunks);
     }
 
+    // `subarray` clamps at EOF like the stream has to.
+    function expectWindow(delivered: Buffer, start: number, end: number) {
+      const expected = data.subarray(start, end);
+      expect(delivered.length).toBe(expected.length);
+      expect(delivered).toEqual(expected);
+    }
+
     test.each(windows)("Bun.file(path).slice(%d, %d).stream()", async (start, end) => {
       using dir = tempDir("blob-file-slice-stream", { "data.bin": data });
-      const streamed = await collect(Bun.file(`${dir}/data.bin`).slice(start, end).stream());
-      expect(streamed.length).toBe(end - start);
-      expect(streamed).toEqual(data.subarray(start, end));
+      expectWindow(await collect(Bun.file(`${dir}/data.bin`).slice(start, end).stream()), start, end);
     });
 
     // Buffered consumers size their pulls from the slice and need the stream to
     // close once it is delivered (#18192, #31675).
     test.each(windows)("Bun.file(path).slice(%d, %d).stream().bytes()", async (start, end) => {
       using dir = tempDir("blob-file-slice-bytes", { "data.bin": data });
-      const bytes = Buffer.from(await Bun.file(`${dir}/data.bin`).slice(start, end).stream().bytes());
-      expect(bytes.length).toBe(end - start);
-      expect(bytes).toEqual(data.subarray(start, end));
+      const bytes = await Bun.file(`${dir}/data.bin`).slice(start, end).stream().bytes();
+      expectWindow(Buffer.from(bytes), start, end);
     });
 
     test.each(windows)("new Response(Bun.file(path).slice(%d, %d)).body", async (start, end) => {
       using dir = tempDir("blob-file-slice-body", { "data.bin": data });
-      const streamed = await collect(new Response(Bun.file(`${dir}/data.bin`).slice(start, end)).body!);
-      expect(streamed.length).toBe(end - start);
-      expect(streamed).toEqual(data.subarray(start, end));
+      expectWindow(await collect(new Response(Bun.file(`${dir}/data.bin`).slice(start, end)).body!), start, end);
     });
 
     test.each(windows)("HTMLRewriter.transform(new Response(Bun.file(path).slice(%d, %d)))", async (start, end) => {
       using dir = tempDir("blob-file-slice-rewriter", { "data.bin": data });
       const response = new HTMLRewriter().transform(new Response(Bun.file(`${dir}/data.bin`).slice(start, end)));
-      const rewritten = Buffer.from(await response.arrayBuffer());
-      expect(rewritten.length).toBe(end - start);
-      expect(rewritten).toEqual(data.subarray(start, end));
+      expectWindow(Buffer.from(await response.arrayBuffer()), start, end);
     });
 
     // Reading .size gives the unsliced file's stream a window that ends exactly
@@ -750,9 +752,7 @@ describe("file-backed slice bounds are respected when streaming and serving", ()
       using dir = tempDir("blob-file-resolved-size-stream", { "data.bin": data });
       const file = Bun.file(`${dir}/data.bin`);
       expect(file.size).toBe(size);
-      const streamed = await collect(file.stream());
-      expect(streamed.length).toBe(size);
-      expect(streamed).toEqual(data);
+      expectWindow(await collect(file.stream()), 0, size);
     });
   });
 });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -688,6 +688,73 @@ describe("file-backed slice bounds are respected when streaming and serving", ()
     // Serializing resolves the original's size, clamping the window to EOF.
     expect(s.size).toBe(5);
   });
+
+  // A sliced Bun.file() is streamed by FileReader, which hands bytes out two
+  // ways: a JS pull reads straight into the pull buffer, while a native sink
+  // (HTMLRewriter here; also pollable fds and Windows) is fed from the read
+  // loop's on_read_chunk. Both have to stop at the end of the slice while the
+  // file goes on past it, and a used-up slice has to end the stream, not hang it.
+  describe("a slice of a file that continues past it", () => {
+    const size = 1024 * 1024;
+    // 61-byte period: coprime with every chunk size involved, so bytes streamed
+    // from the wrong offset compare unequal, not just a wrong number of them.
+    const data = Buffer.alloc(size, "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXY");
+    const windows: [start: number, end: number][] = [
+      [0, 5], // inside the first read
+      [3, 7],
+      [100, 700_000], // several pulls; the last one has to be cut short
+      [size - 10, size], // ends at EOF
+      [4096, 4096], // nothing to deliver at all
+    ];
+
+    async function collect(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+      const chunks: Uint8Array[] = [];
+      for await (const chunk of stream) chunks.push(chunk);
+      return Buffer.concat(chunks);
+    }
+
+    test.each(windows)("Bun.file(path).slice(%d, %d).stream()", async (start, end) => {
+      using dir = tempDir("blob-file-slice-stream", { "data.bin": data });
+      const streamed = await collect(Bun.file(`${dir}/data.bin`).slice(start, end).stream());
+      expect(streamed.length).toBe(end - start);
+      expect(streamed).toEqual(data.subarray(start, end));
+    });
+
+    // Buffered consumers size their pulls from the slice and need the stream to
+    // close once it is delivered (#18192, #31675).
+    test.each(windows)("Bun.file(path).slice(%d, %d).stream().bytes()", async (start, end) => {
+      using dir = tempDir("blob-file-slice-bytes", { "data.bin": data });
+      const bytes = Buffer.from(await Bun.file(`${dir}/data.bin`).slice(start, end).stream().bytes());
+      expect(bytes.length).toBe(end - start);
+      expect(bytes).toEqual(data.subarray(start, end));
+    });
+
+    test.each(windows)("new Response(Bun.file(path).slice(%d, %d)).body", async (start, end) => {
+      using dir = tempDir("blob-file-slice-body", { "data.bin": data });
+      const streamed = await collect(new Response(Bun.file(`${dir}/data.bin`).slice(start, end)).body!);
+      expect(streamed.length).toBe(end - start);
+      expect(streamed).toEqual(data.subarray(start, end));
+    });
+
+    test.each(windows)("HTMLRewriter.transform(new Response(Bun.file(path).slice(%d, %d)))", async (start, end) => {
+      using dir = tempDir("blob-file-slice-rewriter", { "data.bin": data });
+      const response = new HTMLRewriter().transform(new Response(Bun.file(`${dir}/data.bin`).slice(start, end)));
+      const rewritten = Buffer.from(await response.arrayBuffer());
+      expect(rewritten.length).toBe(end - start);
+      expect(rewritten).toEqual(data.subarray(start, end));
+    });
+
+    // Reading .size gives the unsliced file's stream a window that ends exactly
+    // where the file does; ending the stream there must not drop the last chunk.
+    test("Bun.file(path) with a resolved size still streams the whole file", async () => {
+      using dir = tempDir("blob-file-resolved-size-stream", { "data.bin": data });
+      const file = Bun.file(`${dir}/data.bin`);
+      expect(file.size).toBe(size);
+      const streamed = await collect(file.stream());
+      expect(streamed.length).toBe(size);
+      expect(streamed).toEqual(data);
+    });
+  });
 });
 
 // Blob conversion accepts every ArrayBuffer-like type, both as a direct body


### PR DESCRIPTION
### Problem
- `new Response(Bun.file(path).slice(0, 5)).body` and `Bun.file(path).slice(0, 5).stream()` deliver the whole file from the slice offset: 100 bytes for a 100-byte file, 1 MiB for a 1 MiB file. A zero-length slice streams to EOF. `test/js/web/fetch/blob.test.ts` "streams only the slice" fails on main (`Expected: 5, Received: 100`). Regressed in #38886.
- Cause: the slice window (`FileReader.max_size` / `total_readed`) is only applied in `FileReader::on_read_chunk` (`src/runtime/webcore/FileReader.rs:637`). #38886 made `FileReader::on_pull` read straight into the pull buffer with `IOReader::read_into` (`FileReader.rs:832`), which does not go through `on_read_chunk`, and on POSIX that is the path every pull of a regular file takes.
- Pre-existing, same mechanism: when the window was used up, `on_read_chunk` returned `false` without closing the reader, so a slice of a file that continues past it never finished on the paths that still go through `on_read_chunk` (native sinks such as HTMLRewriter, pollable fds, Windows), and before #38886 on every path (#18192, #31675).

### Fix
- Both delivery paths share one window (`window_remaining` / `consume_window`): `on_pull` cuts the `read_into` destination to what is left of the window and charges what was read; `on_read_chunk` truncates the chunk to it, as before.
- Whichever path uses the window up closes the reader (`end_at_window`), after the bytes have been handed over. This is the same sequence as a real EOF on that path (the final chunk, then `on_reader_done`), so sinks, parked reads and the JS adapter end the stream the way they already do at EOF. A zero-length window closes on the first pull without a read (`read_into` reads nothing into an empty destination).
- Correct because the window is the blob's contract: `ReadableStream::from_blob_copy_ref` sets `start_offset`/`max_size` from the slice's offset and size, and `.text()` / `.arrayBuffer()` on the same slice already return exactly that window. The reader's offset was still honored (`pread` from `start_offset`); only the end of the window was lost.
- Fixes #18192 and #31675 as a consequence: the window end now ends the stream instead of leaving the reader open.
- Verified: `bun bd test test/js/web/fetch/blob.test.ts test/js/bun/util/bun-stdin-slice.test.ts` (108 pass). The new `blob.test.ts` cases under "a slice of a file that continues past it" cover `.stream()` + `for await`, `.stream().bytes()`, `Response(...).body` (all `read_into` pulls on POSIX, `on_read_chunk` on Windows) and `HTMLRewriter.transform(new Response(slice))` (native sink, `on_read_chunk`), each with a window inside the first read, of exactly the first pull buffer, spanning several pulls, ending at EOF, running past EOF, and empty, plus an unsliced file whose resolved size gives it a window ending at EOF. The new `bun-stdin-slice.test.ts` cases stream `Bun.stdin.slice(0, N)` over a pipe that is never closed, in one write and in two, which is the parked-read branch of `on_read_chunk`. Against a build with main's `FileReader.rs`, 20 of the 29 `blob.test.ts` cases fail (wrong byte counts, or a timeout where the stream never ends; the nine that pass are the EOF-bounded windows and the resolved-size guard) and both stdin cases time out.
- Also run with the fix: `test/js/web/streams/streams.test.js`, `test/js/bun/util/bun-file*.test.ts`, `bun-stdin-slice.test.ts`, `test/js/workerd/html-rewriter.test.js`, the `spawn` stdio stream tests, `child_process.test.ts`, `process-stdin.test.ts`, `fetch-file-upload.test.ts`, `bun-serve-file.test.ts`; manual checks of `Bun.stdin.stream()` / `process.stdin` over a pipe and a file redirect, a FIFO slice whose writer stays open, and `/dev/zero` / `/dev/urandom` slices (now deliver exactly the slice; previously unbounded on main, hung before #38886). `cargo check -p bun_runtime` for the Windows and macOS targets.
- Not a replacement for #31680 or #33601: both predate #38886 and carry a patch of the old `on_read_chunk` block for the window-end hang, which this PR makes unnecessary, but the `read_into` path this PR is about did not exist when they were written. Their main changes (#31680: buffered reads of character devices in `read_file.rs`; #33601: negative `slice()` indices in `Blob::get_slice`) are independent of this.

### Background
- `FileReader` is the native source behind a file-backed `ReadableStream` (`Bun.file().stream()`, `new Response(file).body`, and the stream HTMLRewriter or fetch wire up for a file body). A file Blob carries an `offset` and a `size`; for a slice these describe the window, and `from_blob_copy_ref` copies them into the reader as `start_offset` and `max_size`.
- It gets bytes two ways. A JS pull (`on_pull`) may read synchronously straight into the pull buffer via `BufferedReader::read_into`. Everything else comes from the `BufferedReader` read loop, which delivers through `on_read_chunk`: native sinks (`pull_into_sink`), pollable fds whose poll fired, and all reads on Windows, where reads complete through libuv.
- The stream only ends when the reader reports done: `reader().close()` runs `on_reader_done`, which ends an attached sink or settles a parked read and tells the JS adapter to close; `on_pull` returns `Done` once `reader().is_done()`. A reader that is merely no longer being read from leaves the stream open forever, which is what the old window-exhausted `return false` did.
