### PR TITLE
bake: compute dev server module ids relative to the dev server root

### DIFF
--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -2,7 +2,6 @@ use core::marker::PhantomData;
 use std::borrow::Cow;
 
 use crate::Error;
-use crate::bun_fs as fs;
 use bun_alloc::AstAlloc;
 use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags, ImportRecordTag, Index as AstIndex};
 use bun_ast::{Loc, Log, Range, Source};
@@ -18,14 +17,21 @@ pub(crate) struct HTMLScanner<'a> {
     pub import_records: Vec<ImportRecord>,
     pub log: &'a mut Log,
     pub source: &'a Source,
+    /// `BundleOptions::top_level_dir`: what root-absolute specifiers resolve against.
+    pub top_level_dir: &'a [u8],
 }
 
 impl<'a> HTMLScanner<'a> {
-    pub(crate) fn init(log: &'a mut Log, source: &'a Source) -> HTMLScanner<'a> {
+    pub(crate) fn init(
+        log: &'a mut Log,
+        source: &'a Source,
+        top_level_dir: &'a [u8],
+    ) -> HTMLScanner<'a> {
         HTMLScanner {
             import_records: Vec::new(),
             log,
             source,
+            top_level_dir,
         }
     }
 }
@@ -35,10 +41,7 @@ impl<'a> HTMLScanner<'a> {
         // In HTML, sometimes people do /src/index.js
         // In that case, we don't want to use the absolute filesystem path, we want to use the path relative to the project root
         let path_to_use: &[u8] = if input_path.len() > 1 && input_path[0] == b'/' {
-            resolve_path::join_abs_string::<platform::Auto>(
-                fs::FileSystem::instance().top_level_dir,
-                &[&input_path[1..]],
-            )
+            resolve_path::join_abs_string::<platform::Auto>(self.top_level_dir, &[&input_path[1..]])
         }
         // Check if imports to (e.g) "App.tsx" are actually relative imoprts w/o the "./"
         else if input_path.len() > 2 && input_path[0] != b'.' && input_path[1] != b'/' {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -382,8 +382,24 @@ impl<'a> LinkerContext<'a> {
         path: &bun_paths::fs::Path<'static>,
         arena: &Bump,
     ) -> Result<bun_paths::fs::Path<'static>, BunError> {
-        let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-        generic_path_with_pretty_initialized(path, self.options.target, top_level_dir, arena)
+        generic_path_with_pretty_initialized(
+            path,
+            self.options.target,
+            self.pretty_path_base_dir(),
+            arena,
+        )
+    }
+
+    /// See `BundleV2::pretty_path_base_dir`; the dev server's root reaches the
+    /// linker through the resolver's copy of the bundle options.
+    pub(crate) fn pretty_path_base_dir(&self) -> &[u8] {
+        if self.dev_server.is_some() {
+            let root_dir: &[u8] = &self.resolver().opts.root_dir;
+            debug_assert!(!root_dir.is_empty());
+            root_dir
+        } else {
+            bun_resolver::fs::FileSystem::get().top_level_dir
+        }
     }
 
     pub(crate) fn should_include_part(&self, source_index: crate::IndexInt, part: &Part) -> bool {

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -390,8 +390,7 @@ impl<'a> LinkerContext<'a> {
         )
     }
 
-    /// See `BundleV2::pretty_path_base_dir`; the dev server's root reaches the
-    /// linker through the resolver's copy of the bundle options.
+    /// Same rule as `BundleV2::pretty_path_base_dir`.
     pub(crate) fn pretty_path_base_dir(&self) -> &[u8] {
         if self.dev_server.is_some() {
             let root_dir: &[u8] = &self.resolver().opts.root_dir;

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -382,16 +382,11 @@ impl<'a> LinkerContext<'a> {
         path: &bun_paths::fs::Path<'static>,
         arena: &Bump,
     ) -> Result<bun_paths::fs::Path<'static>, BunError> {
-        generic_path_with_pretty_initialized(
-            path,
-            self.options.target,
-            self.pretty_path_base_dir(),
-            arena,
-        )
+        generic_path_with_pretty_initialized(path, self.options.target, self.top_level_dir(), arena)
     }
 
-    /// Same rule as `BundleV2::pretty_path_base_dir`.
-    pub(crate) fn pretty_path_base_dir(&self) -> &[u8] {
+    /// `BundleOptions::top_level_dir`, read through the resolver's copy of the options.
+    fn top_level_dir(&self) -> &[u8] {
         if self.dev_server.is_some() {
             let root_dir: &[u8] = &self.resolver().opts.root_dir;
             debug_assert!(!root_dir.is_empty());

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1147,7 +1147,7 @@ pub mod parse_worker {
                 // scope the scanner so its `&mut log` / `&source`
                 // borrows release before `new_lazy_export_ast` re-borrows them.
                 let import_records = {
-                    let mut scanner = HTMLScanner::init(log, source);
+                    let mut scanner = HTMLScanner::init(log, source, topts.top_level_dir());
                     scanner.scan(&source.contents)?;
                     scanner.import_records
                 };

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5747,11 +5747,9 @@ pub mod bv2_impl {
             false
         }
 
-        /// The directory `Path.pretty` is relative to. In dev server bundles the
-        /// pretty path is the module id, and the dev server resolves ids against
-        /// its root (`DevServer.root`, installed as the transpilers' `root_dir`),
-        /// which is not the cwd when `app.root` is set or the process chdir()s.
-        /// Keep in sync with `LinkerContext::pretty_path_base_dir`.
+        /// Dev server bundles use the dev server's root (its transpilers' `root_dir`):
+        /// pretty paths are the module ids there, and the dev server resolves ids
+        /// against that root, which is not the cwd under `app.root` or after chdir().
         fn pretty_path_base_dir(&self) -> &[u8] {
             if self.dev_server.is_some() {
                 debug_assert!(!self.transpiler.options.root_dir.is_empty());

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5747,17 +5747,11 @@ pub mod bv2_impl {
             false
         }
 
-        /// The directory `Path.pretty` is computed relative to.
-        ///
-        /// In a dev server bundle the pretty path is the module id the HMR
-        /// runtimes load modules by, and the dev server derives the ids it asks
-        /// them to load from its root (`DevServer.root`, which it installs as
-        /// the `root_dir` of its transpilers). That root is not `top_level_dir`
-        /// when `app.root` is set or the process chdir()s after the server is
-        /// created, so dev server bundles relativize against it. Every other
-        /// build relativizes against the cwd.
-        /// `LinkerContext::pretty_path_base_dir` is the same rule for the
-        /// linking phase.
+        /// The directory `Path.pretty` is relative to. In dev server bundles the
+        /// pretty path is the module id, and the dev server resolves ids against
+        /// its root (`DevServer.root`, installed as the transpilers' `root_dir`),
+        /// which is not the cwd when `app.root` is set or the process chdir()s.
+        /// Keep in sync with `LinkerContext::pretty_path_base_dir`.
         fn pretty_path_base_dir(&self) -> &[u8] {
             if self.dev_server.is_some() {
                 debug_assert!(!self.transpiler.options.root_dir.is_empty());

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2492,9 +2492,7 @@ pub mod bv2_impl {
                 let rel = bun_paths::resolve_path::relative_platform::<
                     bun_paths::resolve_path::platform::Loose,
                     false,
-                >(
-                    bun_resolver::fs::FileSystem::get().top_level_dir, path.text
-                );
+                >(self.pretty_path_base_dir(), path.text);
                 // SAFETY: arena outlives the bundle pass; raw-pointer detour erases the
                 // `&self` lifetime so the resulting `&'static [u8]` doesn't pin `self`.
                 path.pretty =
@@ -5749,6 +5747,26 @@ pub mod bv2_impl {
             false
         }
 
+        /// The directory `Path.pretty` is computed relative to.
+        ///
+        /// In a dev server bundle the pretty path is the module id the HMR
+        /// runtimes load modules by, and the dev server derives the ids it asks
+        /// them to load from its root (`DevServer.root`, which it installs as
+        /// the `root_dir` of its transpilers). That root is not `top_level_dir`
+        /// when `app.root` is set or the process chdir()s after the server is
+        /// created, so dev server bundles relativize against it. Every other
+        /// build relativizes against the cwd.
+        /// `LinkerContext::pretty_path_base_dir` is the same rule for the
+        /// linking phase.
+        fn pretty_path_base_dir(&self) -> &[u8] {
+            if self.dev_server.is_some() {
+                debug_assert!(!self.transpiler.options.root_dir.is_empty());
+                &self.transpiler.options.root_dir
+            } else {
+                self.transpiler.fs().top_level_dir
+            }
+        }
+
         fn path_with_pretty_initialized(
             &self,
             path: &Fs::Path<'static>,
@@ -5761,7 +5779,7 @@ pub mod bv2_impl {
             let out = generic_path_with_pretty_initialized(
                 path,
                 target,
-                self.transpiler.fs().top_level_dir,
+                self.pretty_path_base_dir(),
                 bump,
             )?;
             Ok(out)
@@ -6455,12 +6473,6 @@ pub mod bv2_impl {
                         import_record.source_index = Index::INVALID;
 
                         if let Some(entry) = dev_server.is_file_cached(path.text, bake_graph) {
-                            let rel = bun_paths::resolve_path::relative_platform::<
-                                bun_paths::resolve_path::platform::Loose,
-                                false,
-                            >(
-                                self.transpiler.fs().top_level_dir, path.text
-                            );
                             if loader == Loader::Html && entry.kind == bake_types::CacheKind::Asset
                             {
                                 // Overload `path.text` to point to the final URL
@@ -6486,8 +6498,6 @@ pub mod bv2_impl {
                                 };
                                 import_record.path.is_disabled = false;
                             } else {
-                                import_record.path.text = path.text;
-                                import_record.path.pretty = rel;
                                 import_record.path = path_as_static(
                                     &self
                                         .path_with_pretty_initialized(path, target)
@@ -7568,7 +7578,7 @@ pub mod bv2_impl {
     pub fn generic_path_with_pretty_initialized(
         path: &bun_paths::fs::Path<'static>,
         target: options::Target,
-        top_level_dir: &[u8],
+        base_dir: &[u8],
         bump: &bun_alloc::Arena,
     ) -> crate::Result<bun_paths::fs::Path<'static>> {
         use crate::bun_fs::PathResolverExt as _;
@@ -7590,7 +7600,7 @@ pub mod bv2_impl {
             let rel = bun_paths::resolve_path::relative_platform_buf::<
                 bun_paths::resolve_path::platform::Loose,
                 false,
-            >(&mut **buf2, top_level_dir, path.text);
+            >(&mut **buf2, base_dir, path.text);
             let mut path_clone: crate::bun_fs::Path<'_> = *path;
             if target == options::Target::ServerComponentsSsr {
                 let mut fbs = bun_io::FixedBufferStream::new_mut(&mut buf.0[..]);

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2492,7 +2492,7 @@ pub mod bv2_impl {
                 let rel = bun_paths::resolve_path::relative_platform::<
                     bun_paths::resolve_path::platform::Loose,
                     false,
-                >(self.pretty_path_base_dir(), path.text);
+                >(self.transpiler.options.top_level_dir(), path.text);
                 // SAFETY: arena outlives the bundle pass; raw-pointer detour erases the
                 // `&self` lifetime so the resulting `&'static [u8]` doesn't pin `self`.
                 path.pretty =
@@ -5747,18 +5747,6 @@ pub mod bv2_impl {
             false
         }
 
-        /// Dev server bundles use the dev server's root (its transpilers' `root_dir`):
-        /// pretty paths are the module ids there, and the dev server resolves ids
-        /// against that root, which is not the cwd under `app.root` or after chdir().
-        fn pretty_path_base_dir(&self) -> &[u8] {
-            if self.dev_server.is_some() {
-                debug_assert!(!self.transpiler.options.root_dir.is_empty());
-                &self.transpiler.options.root_dir
-            } else {
-                self.transpiler.fs().top_level_dir
-            }
-        }
-
         fn path_with_pretty_initialized(
             &self,
             path: &Fs::Path<'static>,
@@ -5771,7 +5759,7 @@ pub mod bv2_impl {
             let out = generic_path_with_pretty_initialized(
                 path,
                 target,
-                self.pretty_path_base_dir(),
+                self.transpiler.options.top_level_dir(),
                 bump,
             )?;
             Ok(out)
@@ -6357,12 +6345,13 @@ pub mod bv2_impl {
                                     } else {
                                         #[cfg(windows)]
                                         let mut buf = bun_paths::path_buffer_pool::get();
+                                        // Undo the join `HTMLScanner` did for root-absolute specifiers.
+                                        let top_level_dir = transpiler.options.top_level_dir();
                                         let specifier_to_use: &[u8] = if loader == Loader::Html
-                                            && import_record.path.text.starts_with(
-                                                Fs::FileSystem::instance().top_level_dir,
-                                            ) {
-                                            let specifier_to_use = &import_record.path.text
-                                                [Fs::FileSystem::instance().top_level_dir.len()..];
+                                            && import_record.path.text.starts_with(top_level_dir)
+                                        {
+                                            let specifier_to_use =
+                                                &import_record.path.text[top_level_dir.len()..];
                                             #[cfg(windows)]
                                             {
                                                 &*bun_paths::resolve_path::path_to_posix_buf::<u8>(
@@ -7570,7 +7559,7 @@ pub mod bv2_impl {
     pub fn generic_path_with_pretty_initialized(
         path: &bun_paths::fs::Path<'static>,
         target: options::Target,
-        base_dir: &[u8],
+        top_level_dir: &[u8],
         bump: &bun_alloc::Arena,
     ) -> crate::Result<bun_paths::fs::Path<'static>> {
         use crate::bun_fs::PathResolverExt as _;
@@ -7592,7 +7581,7 @@ pub mod bv2_impl {
             let rel = bun_paths::resolve_path::relative_platform_buf::<
                 bun_paths::resolve_path::platform::Loose,
                 false,
-            >(&mut **buf2, base_dir, path.text);
+            >(&mut **buf2, top_level_dir, path.text);
             let mut path_clone: crate::bun_fs::Path<'_> = *path;
             if target == options::Target::ServerComponentsSsr {
                 let mut fbs = bun_io::FixedBufferStream::new_mut(&mut buf.0[..]);

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -8,7 +8,6 @@ use bun_js_printer::renamer;
 use bun_js_printer::{self as js_printer, PrintResult, PrintResultSuccess};
 
 use crate::analyze_transpiled_module::ModuleInfo;
-use crate::generic_path_with_pretty_initialized;
 use crate::linker_context_mod::{StmtList, StmtListWhich};
 use crate::options::Format as OutputFormat;
 use crate::{Chunk, Index, LinkerContext, Part, PartRange, WrapKind};
@@ -189,13 +188,8 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 source_ref.path.text.as_ptr(),
                 source_ref.path.pretty.as_ptr(),
             ) {
-                let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-                let new_path = bun_core::handle_oom(generic_path_with_pretty_initialized(
-                    &source_ref.path,
-                    c.options.target,
-                    top_level_dir,
-                    arena,
-                ));
+                let new_path =
+                    bun_core::handle_oom(c.path_with_pretty_initialized(&source_ref.path, arena));
                 source_storage = bun_ast::Source {
                     path: new_path,
                     // SAFETY: `source_ref` is `&'static Source`, so re-borrowing its

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1532,10 +1532,8 @@ impl<'a> BundleOptions<'a> {
         !self.dev_server.is_null()
     }
 
-    /// The directory project-relative paths (`Path.pretty`, root-absolute HTML
-    /// specifiers) are relative to. The dev server stores its root in `root_dir`
-    /// and resolves module ids against it; that root is not the process cwd
-    /// under `app.root` or after `process.chdir()`. Other builds use the cwd.
+    /// Base of project-relative paths: the dev server's root (kept in `root_dir`; not
+    /// the cwd under `app.root` or after `process.chdir()`), else the process cwd.
     pub(crate) fn top_level_dir(&self) -> &[u8] {
         if self.has_dev_server() {
             debug_assert!(!self.root_dir.is_empty());

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1532,6 +1532,19 @@ impl<'a> BundleOptions<'a> {
         !self.dev_server.is_null()
     }
 
+    /// The directory project-relative paths (`Path.pretty`, root-absolute HTML
+    /// specifiers) are relative to. The dev server stores its root in `root_dir`
+    /// and resolves module ids against it; that root is not the process cwd
+    /// under `app.root` or after `process.chdir()`. Other builds use the cwd.
+    pub(crate) fn top_level_dir(&self) -> &[u8] {
+        if self.has_dev_server() {
+            debug_assert!(!self.root_dir.is_empty());
+            &self.root_dir
+        } else {
+            Fs::FileSystem::get().top_level_dir
+        }
+    }
+
     pub(crate) const DEFAULT_UNWRAP_COMMONJS_PACKAGES: &'static [&'static [u8]] = &[
         b"react",
         b"react-is",

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -286,8 +286,12 @@ pub struct DevServer {
     /// To validate the DevServer has not been collected, this can be checked.
     /// When freed, this is set to `undefined`. UAF here also trips ASAN.
     pub(crate) magic: Magic,
-    /// Absolute path to project root directory. For the HMR
-    /// runtime, its module IDs are strings relative to this.
+    /// Absolute path to project root directory: `app.root`, or the cwd at the
+    /// time the server was created. The HMR runtimes' module IDs are paths
+    /// relative to this, both the ones the bundler prints into the bundles
+    /// (it is the `root_dir` of the three transpilers below) and the ones this
+    /// server asks the runtimes to load (`relative_path`). It is a snapshot:
+    /// `top_level_dir` follows `process.chdir()` while this does not.
     pub(crate) root: Box<[u8]>,
     /// Unique identifier for this DevServer instance. Used to identify it
     /// when using the debugger protocol.
@@ -610,13 +614,10 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     let global = options.vm.global();
 
     let generic_action = "while initializing development server";
-    // FileSystem is a process-lifetime singleton; `init` interns the path into
-    // the `DirnameStore` (process-lifetime arena) so no caller-side leak is
-    // needed for the `'static` it stores.
-    let _fs = match bun_resolver::fs::FileSystem::init(Some(options.root.as_bytes())) {
-        Ok(fs) => fs,
-        Err(err) => return Err(global.throw_error(err, generic_action)),
-    };
+    // The process-wide `FileSystem` was initialized with the cwd when the VM
+    // started (and follows `process.chdir()`), so `top_level_dir` is not
+    // `options.root`. Everything that needs to be relative to the project root
+    // goes through `dev.root` instead.
     let top_level_dir: &'static [u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
 
     // `.bun_watcher = undefined` → `Watcher.init(DevServer, dev, fs, ...)`
@@ -650,8 +651,8 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     //
     // SAFETY: `init_transpiler` writes the slot via `MaybeUninit::write` (see
     // `bake_body.rs`), so the previous (uninitialized) bytes are never dropped.
-    // `framework`/`log`/`bundler_options` were written above; reborrowing each
-    // individually via `addr_of_mut!` is sound because no `&mut DevServer` exists.
+    // `root`/`framework`/`log`/`bundler_options` were written above; reborrowing
+    // each individually via `addr_of_mut!` is sound because no `&mut DevServer` exists.
     // Note: `Transpiler<'static>` erases the arena lifetime — `options.arena`
     // is the `UserOptions.arena` which is moved into / outlives the `DevServer`
     // box. Widen `'a → 'static` here once.
@@ -664,6 +665,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     // accessed below were each written above and are reborrowed disjointly via
     // `addr_of_mut!`, so no overlapping `&mut` exists.
     unsafe {
+        let root: &[u8] = &**addr_of_mut!((*p).root);
         let framework = &mut *addr_of_mut!((*p).framework);
         let log = &mut *addr_of_mut!((*p).log);
         let bundler_options = &mut *addr_of_mut!((*p).bundler_options);
@@ -673,6 +675,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
             log,
             bake::Mode::Development,
             bake::Graph::Server,
+            root,
             &mut *addr_of_mut!((*p).server_transpiler),
             &bundler_options.server,
         ) {
@@ -684,6 +687,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
             log,
             bake::Mode::Development,
             bake::Graph::Client,
+            root,
             &mut *addr_of_mut!((*p).client_transpiler),
             &bundler_options.client,
         ) {
@@ -696,6 +700,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
                 log,
                 bake::Mode::Development,
                 bake::Graph::Ssr,
+                root,
                 &mut *addr_of_mut!((*p).ssr_transpiler),
                 &bundler_options.ssr,
             ) {

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -286,10 +286,9 @@ pub struct DevServer {
     /// To validate the DevServer has not been collected, this can be checked.
     /// When freed, this is set to `undefined`. UAF here also trips ASAN.
     pub(crate) magic: Magic,
-    /// Absolute path to project root directory (`app.root`, or the cwd when the
-    /// server was created; unlike `top_level_dir` it does not follow chdir).
-    /// Module IDs are paths relative to this, both as printed by the bundler
-    /// (it is the transpilers' `root_dir`) and as computed by `relative_path`.
+    /// Absolute project root: `app.root`, else the cwd at creation (it does not
+    /// follow chdir). Module IDs are relative to this, both as the bundler prints
+    /// them (it is the transpilers' `root_dir`) and as `relative_path` computes them.
     pub(crate) root: Box<[u8]>,
     /// Unique identifier for this DevServer instance. Used to identify it
     /// when using the debugger protocol.

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -286,12 +286,10 @@ pub struct DevServer {
     /// To validate the DevServer has not been collected, this can be checked.
     /// When freed, this is set to `undefined`. UAF here also trips ASAN.
     pub(crate) magic: Magic,
-    /// Absolute path to project root directory: `app.root`, or the cwd at the
-    /// time the server was created. The HMR runtimes' module IDs are paths
-    /// relative to this, both the ones the bundler prints into the bundles
-    /// (it is the `root_dir` of the three transpilers below) and the ones this
-    /// server asks the runtimes to load (`relative_path`). It is a snapshot:
-    /// `top_level_dir` follows `process.chdir()` while this does not.
+    /// Absolute path to project root directory (`app.root`, or the cwd when the
+    /// server was created; unlike `top_level_dir` it does not follow chdir).
+    /// Module IDs are paths relative to this, both as printed by the bundler
+    /// (it is the transpilers' `root_dir`) and as computed by `relative_path`.
     pub(crate) root: Box<[u8]>,
     /// Unique identifier for this DevServer instance. Used to identify it
     /// when using the debugger protocol.
@@ -614,10 +612,6 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     let global = options.vm.global();
 
     let generic_action = "while initializing development server";
-    // The process-wide `FileSystem` was initialized with the cwd when the VM
-    // started (and follows `process.chdir()`), so `top_level_dir` is not
-    // `options.root`. Everything that needs to be relative to the project root
-    // goes through `dev.root` instead.
     let top_level_dir: &'static [u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
 
     // `.bun_watcher = undefined` → `Watcher.init(DevServer, dev, fs, ...)`

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -238,7 +238,7 @@ impl Framework {
         out.options.hot_module_reloading = mode == Mode::Development;
         out.options.code_splitting = mode != Mode::Development;
         out.options.output_dir = Box::default();
-        // Read by the bundler's `pretty_path_base_dir`.
+        // Becomes `BundleOptions::top_level_dir()` for this build.
         out.options.root_dir = root.into();
 
         out.options.react_fast_refresh = mode == Mode::Development

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -196,6 +196,8 @@ impl Framework {
     /// version operates on the keystone `BuildConfigSubset` (which omits
     /// `conditions`/`env`/`define`/`drop` until the schema types are
     /// const-constructible — those paths default).
+    /// `root` is the project root (`DevServer.root`); the bundler relativizes
+    /// the module ids it prints against it.
     /// Returns the arena slot for the `bake_types::Framework` projection; caller must `drop_in_place` it.
     pub(crate) fn init_transpiler<'a>(
         &mut self,
@@ -203,6 +205,7 @@ impl Framework {
         log: &mut bun_ast::Log,
         mode: Mode,
         renderer: Graph,
+        root: &[u8],
         out: &mut core::mem::MaybeUninit<bun_bundler::Transpiler<'a>>,
         bundler_options: &BuildConfigSubset,
     ) -> crate::Result<*mut bun_bundler::bake_types::Framework> {
@@ -236,6 +239,9 @@ impl Framework {
         out.options.hot_module_reloading = mode == Mode::Development;
         out.options.code_splitting = mode != Mode::Development;
         out.options.output_dir = Box::default();
+        // Read back by `pretty_path_base_dir` in the bundler; `sync_resolver_opts`
+        // below copies it to the resolver options the linker reads.
+        out.options.root_dir = root.into();
 
         out.options.react_fast_refresh = mode == Mode::Development
             && renderer == Graph::Client

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -196,8 +196,7 @@ impl Framework {
     /// version operates on the keystone `BuildConfigSubset` (which omits
     /// `conditions`/`env`/`define`/`drop` until the schema types are
     /// const-constructible — those paths default).
-    /// `root` is the project root (`DevServer.root`); the bundler relativizes
-    /// the module ids it prints against it.
+    /// `root` (`DevServer.root`) becomes the directory module ids are relative to.
     /// Returns the arena slot for the `bake_types::Framework` projection; caller must `drop_in_place` it.
     pub(crate) fn init_transpiler<'a>(
         &mut self,
@@ -239,8 +238,7 @@ impl Framework {
         out.options.hot_module_reloading = mode == Mode::Development;
         out.options.code_splitting = mode != Mode::Development;
         out.options.output_dir = Box::default();
-        // Read back by `pretty_path_base_dir` in the bundler; `sync_resolver_opts`
-        // below copies it to the resolver options the linker reads.
+        // Read by the bundler's `pretty_path_base_dir`.
         out.options.root_dir = root.into();
 
         out.options.react_fast_refresh = mode == Mode::Development

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -926,12 +926,17 @@ devTest("app.root that is not the cwd", {
 });
 devTest("process.chdir() after the server was created", {
   files: {
+    // Root-absolute specifiers resolve against the project root, so the second
+    // script also depends on which directory the server considers the root.
     "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
+      scripts: ["index.ts", "/rooted.ts"],
     }),
     "index.ts": `
       console.log("loaded");
       import.meta.hot.accept();
+    `,
+    "rooted.ts": `
+      console.log("rooted loaded");
     `,
     "elsewhere/placeholder.txt": "",
     "bun.app.ts": `
@@ -957,7 +962,7 @@ devTest("process.chdir() after the server was created", {
     await dev.fetch("/chdir").equals("ok");
 
     await using c = await dev.client("/");
-    await c.expectMessage("loaded");
+    await c.expectMessageInAnyOrder("loaded", "rooted loaded");
 
     await dev.write(
       "index.ts",

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -865,3 +865,107 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
   },
 });
+// The dev server addresses modules by their path relative to its root (`app.root`,
+// or the cwd when the server was created), so the bundler has to compute the
+// module ids it prints relative to that same directory rather than to the current
+// cwd. The two tests below make the two directories differ in each of the ways
+// they can: an explicit `app.root` below the cwd, and a chdir() after the server
+// was created.
+devTest("app.root that is not the cwd", {
+  files: {
+    "bun.app.ts": `
+      import path from "node:path";
+      export default {
+        app: {
+          root: path.join(process.cwd(), "app"),
+          framework: {
+            fileSystemRouterTypes: [
+              {
+                root: "app/routes",
+                style: "nextjs-pages",
+                serverEntryPoint: "./app/server.ts",
+                clientEntryPoint: "./app/client.ts",
+              },
+            ],
+          },
+        },
+      };
+    `,
+    "app/server.ts": `
+      export function render(req, meta) {
+        const scripts = meta.modules.map(src => '<script type="module" src="' + src + '"></script>').join("");
+        return new Response("<!DOCTYPE html><html><body><p>" + meta.pageModule.default() + "</p>" + scripts + "</body></html>", {
+          headers: { "Content-Type": "text/html" },
+        });
+      }
+    `,
+    "app/client.ts": `
+      console.log("client loaded");
+    `,
+    "app/message.ts": `
+      export const message = "Hello";
+    `,
+    "app/routes/index.ts": `
+      import { message } from "../message";
+      export default () => message;
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").expect.toInclude("<p>Hello</p>");
+
+    await using c = await dev.client("/");
+    await c.expectMessage("client loaded");
+
+    // Server-side changes make connected clients reload the page.
+    await c.expectReload(async () => {
+      await dev.write("app/message.ts", `export const message = "Updated";`);
+    });
+    await c.expectMessage("client loaded");
+    await dev.fetch("/").expect.toInclude("<p>Updated</p>");
+  },
+});
+devTest("process.chdir() after the server was created", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      console.log("loaded");
+      import.meta.hot.accept();
+    `,
+    "elsewhere/placeholder.txt": "",
+    "bun.app.ts": `
+      import html from "./index.html";
+      export default {
+        routes: {
+          "/": html,
+          "/chdir": () => {
+            process.chdir("elsewhere");
+            return new Response("ok");
+          },
+        },
+        fetch() {
+          return new Response("Not Found", { status: 404 });
+        },
+      };
+    `,
+  },
+  htmlFiles: [],
+  async test(dev) {
+    // Nothing has been bundled yet, so both the initial bundle and the hot
+    // update below are produced after the cwd changed.
+    await dev.fetch("/chdir").equals("ok");
+
+    await using c = await dev.client("/");
+    await c.expectMessage("loaded");
+
+    await dev.write(
+      "index.ts",
+      `
+        console.log("updated");
+        import.meta.hot.accept();
+      `,
+    );
+    await c.expectMessage("updated");
+  },
+});


### PR DESCRIPTION
### Problem

- The dev server and the bundler disagree about which directory the project root is:
  - The dev server's root is `dev.root`: `app.root`, or the cwd at the time `Bun.serve()` ran. Every id it asks the runtimes to load (route modules, the server entry point, the client `main` entry, server component patch lists, error locations) is computed relative to it by `DevServer::relative_path` (`src/runtime/bake/DevServer.rs:5951`).
  - The bundler used `top_level_dir`, the resolver's process-wide cwd, which also follows `process.chdir()` (`src/jsc/VirtualMachine.rs:4968`): the module keys it prints come from `Path.pretty` (`src/js_printer/lib.rs:6611`), relativized against it in `BundleV2::path_with_pretty_initialized` (`src/bundler/bundle_v2.rs:5764`), and root-absolute HTML specifiers (`<script src="/app.ts">`) are joined onto it by `HTMLScanner` (`src/bundler/HTMLScanner.rs:37`).
- Two ways to make the directories differ, both reproduced on 1.4.0 and on a debug build of main:
  - `Bun.serve({ development: true, app: { framework, root } })` with `root` anything but the cwd: every framework route answers 500 with
    ```
    error: Failed to load bundled module 'server.ts'. This is not a dynamic import, and therefore is a bug in Bun's bundler.
          at handleRequest (bake://server-runtime.js)
    ```
  - `Bun.serve({ development: true, routes: { "/": html } })` followed by `process.chdir()` before the first request (no experimental option involved): the client bundle registers its modules as `../index.html`, `../index.ts` but starts at `index.html`, so the browser fails with the same `Failed to load bundled module 'index.html'`; a `<script src="/x.ts">` in the page additionally fails to build with `Could not resolve: "x.ts"` because it is looked up in the new cwd.
- `DevServer::init` calls `FileSystem::init(Some(root))` (`DevServer.rs:616`), apparently so that `top_level_dir` would equal the root, but the runtime initialized that singleton at startup and `init` returns early once it is loaded (`src/resolver/lib.rs:274`), so the call does nothing.

### Fix

- `Framework::init_transpiler` (dev server only) takes the root and stores it in `options.root_dir` of the server, client and ssr transpilers; its existing `sync_resolver_opts()` copies it into the resolver options the linker reads. `root_dir` was unset and unread for dev server bundles until now: the other readers are asset naming in `process_files_to_copy` (only called by the CLI, production and `Bun.build` entry points), `[dir]` in `compute_chunks` (only called by `LinkerContext::link`; the dev server calls `load` and builds its chunks itself) and the HTML import manifest (requires `dev_server.is_none()`).
- `BundleOptions::top_level_dir()` returns `root_dir` when the build has a dev server and the process `top_level_dir` otherwise. It replaces the direct `top_level_dir` reads at the places that compute project-relative paths: both pretty-path sites in `BundleV2`, `HTMLScanner` (passed in from `ParseTask`), and the "Could not resolve" message that strips the scanner's prefix again. `LinkerContext` mirrors the same rule from the resolver's copy of the options for its pretty-path site, which the InternalBakeDev print-time fallback in `generateCodeForFileInChunkJS.rs` now calls instead of relativizing on its own.
- Removes the no-op `FileSystem::init(root)` and a dead cwd-relative `rel` in the dev server's cached-import branch of `resolve_import_records` (overwritten by `path_with_pretty_initialized` on the next line).
- Why this is correct: `dev.root` is the documented base of the dev server's module ids and everything on the dev server's side already uses it; the bundler was the one party using a different, and mutable, directory. `relative_path` and `pretty` both produce posix-style paths relative to the directory they are given, so once they are given the same directory the ids match on every platform exactly as they already do whenever the two directories happen to coincide. The dev server guard keeps `Bun.build` / `bun build` (including `--format=internal_bake_dev` and HTML entry points) on the cwd, so their output is unchanged.
- What is and is not root-relative after this, for the record: module ids and root-absolute HTML specifiers follow `dev.root`; `fileSystemRouterTypes[n].root`, the framework entry points and `builtInModules` paths are still resolved against the cwd when the server is created (`Framework::resolve`), and the watcher is still created with that cwd (files outside it are the watcher's concern, #31695 / #36248). None of those change here.
- Tests, both in `test/bake/dev/bundle.test.ts`: "app.root that is not the cwd" serves a framework app whose `app.root` is a directory below the cwd and checks a server-rendered route, the route's client bundle running in the harness browser, and a server-side hot update; "process.chdir() after the server was created" chdir()s from a route handler before an HTML route with one relative and one root-absolute script is first bundled, and checks that both scripts run and that a hot update is applied. Both fail on the release binary with the errors above and pass with this change.
- Also ran with the debug build: the rest of `test/bake/dev/{bundle,esm,html,css,hot,plugins,sourcemap,server-sourcemap,react-spa,ecosystem,ssg-pages-router}.test.ts`, `test/bake/{framework-router,dev-and-prod,serve-plugins-dev-server}.test.ts`, `test/js/bun/http/bun-serve-html.test.ts`, `test/bundler/{bundler_html,bundler_html_server,html-import-manifest,bundler_edgecase,bun-build-api}.test.ts`, `test/bundler/bundler_loader.test.ts -t internal_bake_dev`. All pass.
- Related PRs: #39188 normalizes the `app.root` value itself and leaves this out of scope (no file overlap). #36604 wants ordinary builds' pretty paths relative to `root_dir` as well and touches the same two `BundleV2` lines and the `LinkerContext` site, so whichever of the two lands second has a small conflict; with this shape #36604 amounts to widening `top_level_dir()`'s condition, and I will rebase this if it goes first. #31927 fixes a different cause of the same runtime error in a neighbouring branch of `resolve_import_records` and picks these ids up automatically.

### Background

- The bake dev server bundles an app into many small modules instead of one file. Each bundle is a JS object literal keyed by module id, and the server and browser HMR runtimes load modules by looking those ids up, so an id the dev server asks for has to be spelled exactly the way the bundler printed it.
- `Path.pretty` is the bundler's display form of a file path: relative, forward slashes, used for `// file.js` comments and metafile entries in normal builds. In dev server bundles (`Format::InternalBakeDev`) it doubles as the module id.
- `top_level_dir` (the process one) is the cwd held by the resolver's process-wide `FileSystem` singleton; it is set at startup and updated by `process.chdir()`.
- `BundleOptions.root_dir` is the bundler's per-build root directory (`Bun.build({ root })` / `bun build --root`); ordinary builds use it to compute `[dir]` in output names. `sync_resolver_opts()` mirrors the bundle options into the resolver, which is how the linking phase reads them.
- `HTMLScanner` turns the `src`/`href` attributes of an HTML entry point into import records; a specifier starting with `/` is treated as project-root-relative rather than as a filesystem path.

<details>
<summary>Earlier revisions of this PR</summary>

The first revision exposed the root through a new slot on the bundler's dev server handle and read it through a raw pointer; self-review pointed out that the bundler already has `root_dir` for this, so the second revision set `root_dir` and added the `process.chdir()` test. The third revision moved the rule onto `BundleOptions::top_level_dir()` and applied it to the HTML scanner as well, after finding that a root-absolute `<script src>` still failed in the chdir scenario.

</details>
