### PR TITLE
bundler: report an unresolvable relative import longer than the path buffer instead of panicking in watch mode

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2470,13 +2470,12 @@ impl<'a> Resolver<'a> {
             return false;
         }
 
-        // `specifier` is arbitrary source text. A path that does not fit in a
-        // path buffer cannot be in either cache, so there is nothing to bust.
         let source_dir = bun_paths::dirname_platform(import_source_file, bun_paths::Platform::AUTO);
         let mut buf = bun_paths::path_buffer_pool::get();
         let Some(joined) = bun_paths::resolve_path::join_abs_string_buf_checked::<
             bun_paths::platform::Auto,
         >(source_dir, &mut buf.0, &[specifier]) else {
+            // Longer than any cache key (see `dir_info_cached_maybe_log`).
             return false;
         };
         let dir = bun_paths::dirname_platform(joined, bun_paths::Platform::AUTO);

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -102,18 +102,6 @@ mod bun_paths {
             |P| ::bun_paths::resolve_path::join_abs_string_buf::<P>(cwd, buf, parts)
         )
     }
-    pub(super) fn join_abs(cwd: &[u8], platform: Platform, part: &[u8]) -> &'static [u8] {
-        // NOTE: `resolve_path::join_abs` ties the result lifetime to `cwd`, but the
-        // returned slice always points into the threadlocal `PARSER_JOIN_INPUT_BUFFER`
-        // (or is `cwd` itself when `parts.is_empty()`, which never happens here — we
-        // pass exactly one part). Re-erase to `'static` so the resolver can hold it
-        // across `&mut self` calls.
-        let s = dispatch_platform!(platform, |P| ::bun_paths::resolve_path::join_abs::<P>(
-            cwd, part
-        ));
-        // SAFETY: see NOTE — slice borrows threadlocal storage, valid 'static per-thread.
-        unsafe { bun_ptr::detach_lifetime(s) }
-    }
     pub(super) fn join(parts: &[&[u8]], platform: Platform) -> &'static [u8] {
         dispatch_platform!(platform, |P| ::bun_paths::resolve_path::join::<P>(parts))
     }
@@ -2482,11 +2470,15 @@ impl<'a> Resolver<'a> {
             return false;
         }
 
-        let joined = bun_paths::join_abs(
-            bun_paths::dirname_platform(import_source_file, bun_paths::Platform::AUTO),
-            bun_paths::Platform::AUTO,
-            specifier,
-        );
+        // `specifier` is arbitrary source text. A path that does not fit in a
+        // path buffer cannot be in either cache, so there is nothing to bust.
+        let source_dir = bun_paths::dirname_platform(import_source_file, bun_paths::Platform::AUTO);
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let Some(joined) = bun_paths::resolve_path::join_abs_string_buf_checked::<
+            bun_paths::platform::Auto,
+        >(source_dir, &mut buf.0, &[specifier]) else {
+            return false;
+        };
         let dir = bun_paths::dirname_platform(joined, bun_paths::Platform::AUTO);
 
         let a = self.bust_dir_cache(dir);

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -102,6 +102,18 @@ mod bun_paths {
             |P| ::bun_paths::resolve_path::join_abs_string_buf::<P>(cwd, buf, parts)
         )
     }
+    /// Like `join_abs_string_buf`, but returns `None` when the normalized
+    /// result does not fit in `buf`. Use it when `parts` may be arbitrarily long.
+    pub(super) fn join_abs_string_buf_checked<'b>(
+        cwd: &'b [u8],
+        buf: &'b mut [u8],
+        parts: &[&[u8]],
+        platform: Platform,
+    ) -> Option<&'b [u8]> {
+        dispatch_platform!(platform, |P| {
+            ::bun_paths::resolve_path::join_abs_string_buf_checked::<P>(cwd, buf, parts)
+        })
+    }
     pub(super) fn join(parts: &[&[u8]], platform: Platform) -> &'static [u8] {
         dispatch_platform!(platform, |P| ::bun_paths::resolve_path::join::<P>(parts))
     }
@@ -2470,11 +2482,13 @@ impl<'a> Resolver<'a> {
             return false;
         }
 
-        let source_dir = bun_paths::dirname_platform(import_source_file, bun_paths::Platform::AUTO);
         let mut buf = bun_paths::path_buffer_pool::get();
-        let Some(joined) = bun_paths::resolve_path::join_abs_string_buf_checked::<
-            bun_paths::platform::Auto,
-        >(source_dir, &mut buf.0, &[specifier]) else {
+        let Some(joined) = bun_paths::join_abs_string_buf_checked(
+            bun_paths::dirname_platform(import_source_file, bun_paths::Platform::AUTO),
+            &mut buf.0,
+            &[specifier],
+            bun_paths::Platform::AUTO,
+        ) else {
             // Longer than any cache key (see `dir_info_cached_maybe_log`).
             return false;
         };

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -1273,8 +1273,6 @@ impl DirectoryWatchStore {
             _ => debug_assert!(false),
         }
 
-        // `specifier` is arbitrary source text. A path that does not fit in a
-        // path buffer cannot exist, so there is no directory to watch for it.
         let mut buf = bun_paths::path_buffer_pool::get();
         let Some(joined) =
             bun_paths::resolve_path::join_abs_string_buf_checked::<bun_paths::platform::Auto>(
@@ -1283,6 +1281,7 @@ impl DirectoryWatchStore {
                 &[specifier],
             )
         else {
+            // Same outcome as the NameTooLong case in `insert`: nothing to watch.
             return Ok(());
         };
         let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(joined);

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -1273,12 +1273,18 @@ impl DirectoryWatchStore {
             _ => debug_assert!(false),
         }
 
+        // `specifier` is arbitrary source text. A path that does not fit in a
+        // path buffer cannot exist, so there is no directory to watch for it.
         let mut buf = bun_paths::path_buffer_pool::get();
-        let joined = bun_paths::resolve_path::join_abs_string_buf::<bun_paths::platform::Auto>(
-            bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(import_source),
-            &mut buf.0,
-            &[specifier],
-        );
+        let Some(joined) =
+            bun_paths::resolve_path::join_abs_string_buf_checked::<bun_paths::platform::Auto>(
+                bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(import_source),
+                &mut buf.0,
+                &[specifier],
+            )
+        else {
+            return Ok(());
+        };
         let dir = bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(joined);
 
         // The `import_source` parameter is not a stable string. Since the

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1,5 +1,6 @@
 // Bundle tests are tests concerning bundling bugs that only occur in DevServer.
 import { expect } from "bun:test";
+import { isWindows } from "harness";
 import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 devTest("import identifier doesnt get renamed", {
@@ -863,5 +864,48 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
+  },
+});
+
+// Resolution failures are tracked so the import is retried when its directory
+// changes (Resolver.bust_dir_cache_from_specifier, then
+// DirectoryWatchStore.track_resolution_failure). Both joined the importer's
+// directory with the specifier into a fixed-size path buffer; a specifier that
+// did not fit aborted the whole process with
+// "panic: range end index N out of range for slice of length M" instead of
+// reporting the unresolved import. The buffer is MAX_PATH_BYTES: 4 KiB on
+// Linux, 1 KiB on macOS and about 96 KiB on Windows.
+const specifierLongerThanPathBuffer = Buffer.alloc((isWindows ? 96 : 4) * 1024 + 1024, "a").toString();
+
+devTest("unresolvable relative import longer than the path buffer is a bundling error", {
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": `
+      import './${specifierLongerThanPathBuffer}';
+      console.log('loaded');
+    `,
+  },
+  async test(dev) {
+    expect((await dev.fetch("/")).status).toBe(500);
+    await dev.write("index.ts", `console.log('fixed');`);
+    expect((await dev.fetch("/")).status).toBe(200);
+  },
+});
+
+// A CSS url() without "./" skips the resolver's directory cache busting, so
+// this only reaches DirectoryWatchStore.track_resolution_failure.
+devTest("unresolvable css url() longer than the path buffer is a bundling error", {
+  files: {
+    "index.html": emptyHtmlFile({ styles: ["styles.css"] }),
+    "styles.css": `
+      body {
+        background-image: url(${specifierLongerThanPathBuffer});
+      }
+    `,
+  },
+  async test(dev) {
+    expect((await dev.fetch("/")).status).toBe(500);
+    await dev.write("styles.css", `body { color: blue; }`);
+    expect((await dev.fetch("/")).status).toBe(200);
   },
 });

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -486,8 +486,10 @@ test("--watch reports an unresolvable relative import longer than the path buffe
   // When watching, an unresolved relative import busts the resolver's directory
   // cache for the path it would have resolved to. That path used to be joined
   // into a 4 KiB buffer, so a longer specifier aborted the process with
-  // "panic: range end index N out of range for slice of length 4095".
-  const specifier = "./" + Buffer.alloc(5 * 1024, "a").toString();
+  // "panic: range end index N out of range for slice of length 4095". It is now
+  // joined into a MAX_PATH_BYTES buffer (4 KiB on Linux, 1 KiB on macOS, about
+  // 96 KiB on Windows), so exceed that too and the bust is skipped everywhere.
+  const specifier = "./" + Buffer.alloc((isWindows ? 96 : 4) * 1024 + 1024, "a").toString();
   using dir = tempDir("build-watch-long-specifier", {
     "entry.ts": `import "${specifier}";\nconsole.log("entry");`,
   });

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -466,6 +466,50 @@ test("multi-entry build writes each entry point into the output directory", asyn
   expect(b).toContain('"B"');
 });
 
+async function readUntil(stream: ReadableStream<Uint8Array>, needle: string): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let output = "";
+  try {
+    while (!output.includes(needle)) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error(`stream closed before ${JSON.stringify(needle)} appeared. Output:\n${output}`);
+      output += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return output;
+}
+
+test("--watch reports an unresolvable relative import longer than the path buffer and keeps watching", async () => {
+  // When watching, an unresolved relative import busts the resolver's directory
+  // cache for the path it would have resolved to. That path used to be joined
+  // into a 4 KiB buffer, so a longer specifier aborted the process with
+  // "panic: range end index N out of range for slice of length 4095".
+  const specifier = "./" + Buffer.alloc(5 * 1024, "a").toString();
+  using dir = tempDir("build-watch-long-specifier", {
+    "entry.ts": `import "${specifier}";\nconsole.log("entry");`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--watch", "entry.ts", "--outdir", "dist"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  await readUntil(proc.stderr, `error: Could not resolve: "${specifier}"`);
+  expect(proc.exitCode).toBeNull();
+
+  // The failed build left the watcher running: fixing the file triggers a rebuild.
+  await Bun.write(path.join(String(dir), "entry.ts"), `console.log("fixed");`);
+  expect(await readUntil(proc.stdout, "entry.js")).toContain("Bundled 1 module");
+  expect(await Bun.file(path.join(String(dir), "dist", "entry.js")).text()).toContain("fixed");
+});
+
 describe("CLI argument error messages", () => {
   test("--format with an unrecognized value echoes the value back", async () => {
     using dir = tempDir("build-format-err", { "in.js": "console.log(1)" });


### PR DESCRIPTION
### Problem
- `bun build --watch` and the dev server (`Bun.serve` with an HTML route in development, or a bake framework route) abort when a bundled file imports a relative specifier that does not resolve and is longer than a path buffer:
  `panic: range end index 5017 out of range for slice of length 4095` (top frames: `normalize_string_generic_tz` -> `normalize_string_buf` -> `_join_abs_string_buf` -> `join_abs_string_buf`). A plain `bun build` or `bun run` of the same file prints `error: Could not resolve: "./aaa..."`.
- Two call sites join `dirname(importer)` + the specifier (arbitrary source text) into a fixed-size buffer with the unchecked `join_abs_string_buf`, which indexes past the buffer when the normalized path does not fit:
  - `src/resolver/resolver.rs`, `Resolver::bust_dir_cache_from_specifier`: 4 KiB thread-local buffer (`join_abs`). Reached from `bundle_v2` on every `ModuleNotFound` whenever a watcher is attached, so it crashes both `bun build --watch` and the dev server, on every platform, for any `./` or `../` specifier over 4 KiB.
  - `src/runtime/bake/dev_server/mod.rs`, `DirectoryWatchStore::track_resolution_failure`: pooled `PathBuffer` (`MAX_PATH_BYTES`). Runs right after the first site in the dev server; also reached directly by CSS/HTML specifiers without a `./` prefix, which the first site ignores.

### Fix
- Both sites use `resolve_path::join_abs_string_buf_checked`, which returns `None` when the normalized path does not fit, and then skip the directory work: the resolver returns `false` (nothing busted), the dev server returns `Ok(())` (nothing watched). The import is still reported through the existing `Could not resolve` error and the process keeps running.
- Why this is correct: both caches and the watcher only ever hold paths shorter than `MAX_PATH_BYTES` (`dir_info_cached_maybe_log` refuses longer paths, and `DirectoryWatchStore::insert` already ignores them as `NameTooLong`), so a path that does not fit cannot be cached or watched and skipping it changes nothing. `_checked` normalizes before measuring, so a long specifier that normalizes to a short path (`./a/../a/../x`) keeps its bust and watch. `Platform::AUTO` is kept at both sites, so the joined paths are unchanged for everything that fits; the resolver's buffer grows from a fixed 4 KiB to `MAX_PATH_BYTES`, which only matters on Windows (paths between 4 KiB and 96 KiB were panicking there too, now they are busted normally).
- In the resolver the call goes through a value-dispatched `join_abs_string_buf_checked` shim in its `mod bun_paths` block, like every other path helper that file uses; the shim is the same text #38428 adds for its own site, so whichever of the two lands second rebases onto an identical function. The old `join_abs` shim had no other callers and is removed.
- Origin: found by auditing for unchecked joins of source text, not from a user report. #27492 converted the resolver's own specifier joins to the checked variant; these are the two watch-mode joins of the same input that it did not cover.
- Scope: this PR covers the two sites that run on a resolution failure in watch mode, which share one trigger and one fix shape (a path that cannot be cached or watched is skipped). Three other unchecked joins of source-text paths reproduce too and are left to the open PRs that already cover them:
  - `HTMLScanner::create_import_record` (`src/bundler/HTMLScanner.rs:38`, `:60`): a `/`-prefixed or bare `<script src>` longer than 4 KiB panics even in plain `bun build index.html`. #35860 fixes it inside the shared thread-local join helpers by spilling to the heap. That spill would also silence the resolver site here, but the dev server site is not reached through those helpers, and skipping is the direct answer for both sites, so the two PRs are independent and do not touch the same lines.
  - `FileMap::resolve` (`src/bundler/bundle_v2.rs:1007`): `Bun.build({ files })` with a long relative or bare import. #38650 rewrites that function with the checked join and rejects over-long keys when the map is built.
  - `Resolver::load_as_file` (`src/resolver/resolver.rs:5879`): any absolute import longer than `MAX_PATH_BYTES`, watcher or not. Both #35857 and #35860 add that bound.
- Textual overlap with other open PRs: #38428 (same shim added in `resolver.rs`, see above) and #31695 (also appends tests to `test/bake/dev/bundle.test.ts`); both are rebase-only.
- Verified:
  - `test/bake/dev/bundle.test.ts`: a JS `import './aaa...'` (crashes at the resolver site without the fix) and a CSS `url(aaa...)` (skips the resolver site, crashes at the dev server site) both get a 500 and the server rebuilds after the file is fixed. Both fail with `USE_SYSTEM_BUN=1` (panic, then `ECONNRESET`) and pass with `bun bd test`; whole file 23/23 with the fix, including the existing directory-cache-bust tests.
  - `test/bundler/cli.test.ts`: `bun build --watch` prints the resolve error, stays alive, and rebuilds after the import is removed. Fails with `USE_SYSTEM_BUN=1` (stderr ends in the panic), passes with `bun bd test`, 15/15 on rerun.

### Background
- Directory cache busting: when an import fails to resolve in watch mode, the resolver drops its cached directory listing for the directory the import would have resolved into, so the next rebuild re-reads it and picks up a file created in the meantime. `bust_dir_cache_from_specifier` computes that directory from the importer and the specifier.
- `DirectoryWatchStore`: the dev server's list of directories being watched because an import into them failed; when one changes, the importers are rebundled. `track_resolution_failure` is the entry point called for each failed import.
- `PathBuffer` / `MAX_PATH_BYTES`: Bun's fixed-size path scratch buffer, sized to the OS path limit (4096 bytes on Linux, 1024 on macOS, about 96 KiB on Windows). `join_abs_string_buf` assumes the result fits; `join_abs_string_buf_checked` is the variant for caller-controlled input and returns `None` instead of overflowing.
