### PR TITLE
css: parse the number form of hsl() and hwb() channels

### DIFF
--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1396,6 +1396,12 @@ pub(crate) fn parse_hsl_hwb<
     })
 }
 
+/// The `<number>` that stands for `100%` in the saturation/lightness of hsl() and the
+/// whiteness/blackness of hwb(): `hsl(120 50 40)` is `hsl(120 50% 40%)`.
+/// https://www.w3.org/TR/css-color-4/#the-hsl-notation
+/// https://www.w3.org/TR/css-color-4/#the-hwb-notation
+const HSL_PERCENT_BASIS: f32 = 100.0;
+
 pub(crate) fn parse_hsl_hwb_components<T>(
     input: &mut css::Parser,
     parser: &mut ComponentParser,
@@ -1408,13 +1414,22 @@ pub(crate) fn parse_hsl_hwb_components<T>(
         && !h.is_nan()
         && input.try_parse(|i| i.expect_comma()).is_ok();
 
-    let a = parser.parse_percentage(input)?.clamp(0.0, 1.0);
+    // Only the legacy comma syntax is limited to `<percentage>`.
+    let parse_channel = |input: &mut css::Parser, parser: &ComponentParser| {
+        if is_legacy_syntax {
+            parser.parse_percentage(input)
+        } else {
+            parser.parse_unit_channel(input, HSL_PERCENT_BASIS)
+        }
+    };
+
+    let a = parse_channel(input, parser)?.clamp(0.0, 1.0);
 
     if is_legacy_syntax {
         input.expect_comma()?;
     }
 
-    let b = parser.parse_percentage(input)?.clamp(0.0, 1.0);
+    let b = parse_channel(input, parser)?.clamp(0.0, 1.0);
 
     if is_legacy_syntax && (a.is_nan() || b.is_nan()) {
         return Err(input.new_custom_error(css::ParserError::invalid_value));
@@ -1992,6 +2007,16 @@ impl ComponentParser {
         } else {
             Err(input.new_custom_error(css::ParserError::invalid_value))
         }
+    }
+
+    /// A channel written as `<percentage> | <number> | none` and stored as a unit value,
+    /// `percent_basis` being the `<number>` that stands for `100%`.
+    fn parse_unit_channel(&self, input: &mut css::Parser, percent_basis: f32) -> CssResult<f32> {
+        if let Ok(number) = input.try_parse(CSSNumberFns::parse) {
+            return Ok(number / percent_basis);
+        }
+
+        self.parse_percentage(input)
     }
 
     fn parse_percentage(&self, input: &mut css::Parser) -> CssResult<f32> {

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -764,3 +764,94 @@ describe("conversions between color spaces", () => {
     );
   });
 });
+
+// In the modern (space separated) syntax, the saturation and lightness of hsl()
+// and the whiteness and blackness of hwb() are <percentage> | <number> | none,
+// and the number is the percentage without its sign: hsl(120 50 40) is
+// hsl(120 50% 40%). The legacy comma syntax takes only percentages.
+// https://www.w3.org/TR/css-color-4/#the-hsl-notation
+// https://www.w3.org/TR/css-color-4/#the-hwb-notation
+describe("hsl() and hwb() number channels", () => {
+  // Every expected value is what the same color spelled with percentages gives,
+  // and what lightningcss 1.30 emits for the number spelling.
+  test.each([
+    ["hsl(120 50 40)", "#393"],
+    ["hsl(120 50 40%)", "#393"],
+    ["hsl(120 50% 40)", "#393"],
+    ["hsl(120deg 50 40)", "#393"],
+    ["hsla(120 50 40)", "#393"],
+    ["hsl(120 50 40 / 0.5)", "#33993380"],
+    ["hsl(120 50 40 / 50%)", "#33993380"],
+    ["hsla(120 50 40 / 0.5)", "#33993380"],
+    ["hsl(120 none 40)", "#666"],
+    ["hsl(120 50 none)", "#000"],
+    ["hsl(none 50 40)", "#933"],
+    ["hsl(120.5 50.5 40.5)", "#339b34"],
+    ["hsl(120 .5 40)", "#656765"],
+    ["hsl(120 1e1 40)", "#5c705c"],
+    ["hsl(120 calc(25 * 2) 40)", "#393"],
+    ["hsl(120 calc(25% * 2) 40)", "#393"],
+    ["hsl(120 50 calc(20 * 2))", "#393"],
+    ["hwb(120 20 30)", "#33b333"],
+    ["hwb(120 20 30%)", "#33b333"],
+    ["hwb(120 20% 30)", "#33b333"],
+    ["hwb(120deg 20 30)", "#33b333"],
+    ["hwb(120 20 30 / 0.5)", "#33b33380"],
+    ["hwb(120 none 30)", "#00b300"],
+    ["hwb(120 20 none)", "#3f3"],
+    ["hwb(120 0 0)", "#0f0"],
+    ["hwb(120 100 0)", "#fff"],
+    ["hwb(120 0 100)", "#000"],
+    ["hwb(120 calc(10 * 2) 30)", "#33b333"],
+    // Relative color syntax is the modern syntax, so it takes numbers too, as
+    // do the origin colors and the operands of color-mix().
+    ["hsl(from red h 50 l)", "#bf4040"],
+    ["hwb(from red h 20 b)", "#f33"],
+    ["hsl(from hsl(120 50 40) h s l)", "#393"],
+    ["hwb(from hwb(120 20 30) h w b)", "#33b333"],
+    ["rgb(from hsl(120 50 40) r g b)", "#393"],
+    ["color-mix(in hsl, hsl(120 50 40), hwb(120 20 30))", "#33a633"],
+  ])("%s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  // Out-of-range numbers clamp exactly like the corresponding percentages:
+  // hsl() to 0..100, hwb() to 0..100 and then w + b is normalized to 100.
+  test.each([
+    ["hsl(120 150 40)", "hsl(120 150% 40%)", "#00cc00"],
+    ["hsl(120 -50 40)", "hsl(120 -50% 40%)", "#666666"],
+    ["hsl(120 50 140)", "hsl(120 50% 140%)", "#ffffff"],
+    ["hsl(120 50 -40)", "hsl(120 50% -40%)", "#000000"],
+    ["hwb(120 60 60)", "hwb(120 60% 60%)", "#808080"],
+    ["hwb(120 -20 30)", "hwb(120 -20% 30%)", "#00b300"],
+    ["hwb(120 20 130)", "hwb(120 20% 130%)", "#2a2a2a"],
+  ])("%s is %s", (numbers, percentages, expected) => {
+    expect(color(numbers, "hex")).toBe(expected);
+    expect(color(percentages, "hex")).toBe(expected);
+  });
+
+  test.each([
+    "hsl(120, 50, 40)",
+    "hsl(120, 50%, 40)",
+    "hsl(120, 50, 40%)",
+    "hsla(120, 50, 40, 0.5)",
+    // hwb() has no legacy syntax at all.
+    "hwb(120, 20, 30)",
+    "hwb(120, 20%, 30%)",
+    "hsl(120 50, 40)",
+    "hsl(120 50 40 60)",
+    // The legacy rgb() percentage form shares the percentage parser and still
+    // does not take numbers.
+    "rgb(10%, 20, 30)",
+  ])("%s is invalid", input => {
+    expect(color(input, "css")).toBeNull();
+  });
+
+  test.each([
+    ["hsl(120, 50%, 40%)", "#393"],
+    ["hsla(120, 50%, 40%, 0.5)", "#33993380"],
+    ["rgb(10%, 20%, 30%)", "#1a334d"],
+  ])("%s still parses", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7666,6 +7666,96 @@ describe("css tests", () => {
     minify_test(".foo{grid-template-areas:none}", ".foo{grid-template-areas:none}");
   });
 
+  describe("hsl() and hwb() number channels", () => {
+    // In the modern syntax the saturation/lightness and whiteness/blackness are
+    // <percentage> | <number> | none, and the number is the percentage without
+    // its sign; only the legacy comma syntax is limited to percentages.
+    // https://www.w3.org/TR/css-color-4/#the-hsl-notation
+    // https://www.w3.org/TR/css-color-4/#the-hwb-notation
+    // Every output below is what the percentage spelling already produced and
+    // what lightningcss 1.30 emits for the number spelling.
+    minify_test(".foo { color: hsl(120 50 40) }", ".foo{color:#393}");
+    minify_test(".foo { color: hsl(120 50 40%) }", ".foo{color:#393}");
+    minify_test(".foo { color: hsl(120 50% 40) }", ".foo{color:#393}");
+    minify_test(".foo { color: hsl(120deg 50 40) }", ".foo{color:#393}");
+    minify_test(".foo { color: hsla(120 50 40) }", ".foo{color:#393}");
+    minify_test(".foo { color: hsl(120 50 40 / 0.5) }", ".foo{color:#33993380}");
+    minify_test(".foo { color: hsla(120 50 40 / 50%) }", ".foo{color:#33993380}");
+    minify_test(".foo { color: hsl(120 none 40) }", ".foo{color:#666}");
+    minify_test(".foo { color: hsl(120 50 none) }", ".foo{color:#000}");
+    minify_test(".foo { color: hsl(120 150 40) }", ".foo{color:#0c0}");
+    minify_test(".foo { color: hsl(120 -50 40) }", ".foo{color:#666}");
+    minify_test(".foo { color: hsl(120 50 140) }", ".foo{color:#fff}");
+    minify_test(".foo { color: hsl(120.5 50.5 40.5) }", ".foo{color:#339b34}");
+    minify_test(".foo { color: hsl(120 .5 40) }", ".foo{color:#656765}");
+    minify_test(".foo { color: hsl(120 calc(25 * 2) 40) }", ".foo{color:#393}");
+    minify_test(".foo { color: hsl(120 calc(25% * 2) 40) }", ".foo{color:#393}");
+    minify_test(".foo { color: hwb(120 20 30) }", ".foo{color:#33b333}");
+    minify_test(".foo { color: hwb(120 20 30%) }", ".foo{color:#33b333}");
+    minify_test(".foo { color: hwb(120 20% 30) }", ".foo{color:#33b333}");
+    minify_test(".foo { color: hwb(120deg 20 30) }", ".foo{color:#33b333}");
+    minify_test(".foo { color: hwb(120 20 30 / 0.5) }", ".foo{color:#33b33380}");
+    minify_test(".foo { color: hwb(120 none 30) }", ".foo{color:#00b300}");
+    minify_test(".foo { color: hwb(120 20 none) }", ".foo{color:#3f3}");
+    minify_test(".foo { color: hwb(120 60 60) }", ".foo{color:gray}");
+    minify_test(".foo { color: hwb(120 -20 30) }", ".foo{color:#00b300}");
+    minify_test(".foo { color: hwb(120 20 130) }", ".foo{color:#2a2a2a}");
+    minify_test(".foo { color: hwb(120 calc(10 * 2) 30) }", ".foo{color:#33b333}");
+
+    // Relative color syntax is the modern syntax; the origin of a relative
+    // color, the operands of color-mix() and colors nested in other values go
+    // through the same parser.
+    minify_test(".foo { color: hsl(from red h 50 l) }", ".foo{color:#bf4040}");
+    minify_test(".foo { color: hwb(from red h 20 b) }", ".foo{color:#f33}");
+    minify_test(".foo { color: rgb(from hsl(120 50 40) r g b) }", ".foo{color:#393}");
+    minify_test(".foo { color: color-mix(in hsl, hsl(120 50 40), hwb(120 20 30)) }", ".foo{color:#33a633}");
+    minify_test(
+      ".foo { background: linear-gradient(hsl(120 50 40), hwb(120 20 30)) }",
+      ".foo{background:linear-gradient(#393,#33b333)}",
+    );
+    // Colors inside token lists (custom properties, var() fallbacks).
+    minify_test(".foo { --c: hsl(120 50 40) }", ".foo{--c:#393}");
+    minify_test(".foo { --c: hwb(120 20 30) }", ".foo{--c:#33b333}");
+    minify_test(".foo { color: var(--c, hsl(120 50 40)) }", ".foo{color:var(--c,#393)}");
+    // An hsl() whose alpha cannot be resolved keeps its channels, which are
+    // always written as percentages.
+    minify_test(".foo { color: hsl(120 50 40 / var(--a)) }", ".foo{color:hsl(120 50% 40%/var(--a))}");
+    minify_test(".foo { color: hsl(120 50 40% / var(--a)) }", ".foo{color:hsl(120 50% 40%/var(--a))}");
+
+    // Downleveling for targets without the space separated syntax works from
+    // the parsed color, so it is the same as for the percentage spelling.
+    prefix_test(
+      `.foo {
+        color: hsl(120 50 40 / 0.5);
+        border-color: hsl(120 50 40 / var(--a));
+        background: hwb(120 20 30 / 0.5);
+      }`,
+      indoc`
+        .foo {
+          color: rgba(51, 153, 51, .5);
+          border-color: hsla(120, 50%, 40%, var(--a));
+          background: rgba(51, 179, 51, .5);
+        }
+      `,
+      { chrome: Some(60 << 16) },
+    );
+
+    // The legacy comma syntax takes only percentages, and hwb() has no legacy
+    // syntax, so these are left for the browser to reject, as before.
+    minify_test(".foo { color: hsl(120, 50, 40) }", ".foo{color:hsl(120,50,40)}");
+    minify_test(".foo { color: hsl(120, 50%, 40) }", ".foo{color:hsl(120,50%,40)}");
+    minify_test(".foo { color: hsl(120, 50, 40%) }", ".foo{color:hsl(120,50,40%)}");
+    minify_test(".foo { color: hsla(120, 50, 40, 0.5) }", ".foo{color:hsla(120,50,40,.5)}");
+    minify_test(".foo { color: hwb(120, 20, 30) }", ".foo{color:hwb(120,20,30)}");
+    minify_test(".foo { color: hsl(120 50, 40) }", ".foo{color:hsl(120 50,40)}");
+    minify_test(".foo { color: hsl(120 50 40 60) }", ".foo{color:hsl(120 50 40 60)}");
+    minify_test(".foo { --c: hsl(120, 50, 40) }", ".foo{--c:hsl(120,50,40)}");
+    // The legacy rgb() percentage form shares the percentage parser.
+    minify_test(".foo { color: rgb(10%, 20, 30) }", ".foo{color:rgb(10%,20,30)}");
+    minify_test(".foo { color: hsl(120, 50%, 40%) }", ".foo{color:#393}");
+    minify_test(".foo { color: rgb(10%, 20%, 30%) }", ".foo{color:#1a334d}");
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(


### PR DESCRIPTION
### Problem
- `hsl()` and `hwb()` do not parse when the saturation/lightness (whiteness/blackness) are written as numbers: `Bun.color("hsl(120 50 40)", "hex")` is `null` while `"hsl(120 50% 40%)"` is `"#339933"`; `Bun.color("hwb(120 20 30)", "hex")` is `null` while the percentage spelling is `"#33b333"`.
- In a stylesheet the same colors go through `bun build` as unknown tokens: `a{color:hsl(120 50 40)}` is emitted as written instead of `#393`, so it is not minified, gets no fallback for older targets, and cannot be the origin of a relative color or an operand of `color-mix()`. `hsl(120 50 40 / var(--a))` is left alone too.
- CSS Color 4 makes these channels `<percentage> | <number> | none` in the modern (space separated) syntax, the number meaning that many percent; the legacy comma syntax takes only percentages (https://www.w3.org/TR/css-color-4/#the-hsl-notation, https://www.w3.org/TR/css-color-4/#the-hwb-notation). Chrome 111, Safari 16.4 and Firefox 113 accept the number form, and lightningcss 1.30 minifies it to `#393` / `#33b333`.
- Cause: `parse_hsl_hwb_components` in `src/css/values/color.rs` reads both channels with `ComponentParser::parse_percentage`, which accepts a percentage token, `none` or a relative color keyword, never a number.
- This is one of three places in `color.rs` that read a `<percentage> | <number> | none` channel with `parse_percentage`. The other two are the lightness of `parse_lab` and `parse_lch`, which #39200 fixes (their a/b/chroma have the mirror image gap, a missing percentage form, also in #39200). `rgb()` and `color()` already go through `parse_number_or_percentage`.

### Fix
- `ComponentParser::parse_unit_channel(input, percent_basis)` reads such a channel: a `<number>` (`CSSNumberFns::parse`, so `calc(25 * 2)` works as well) divided by the basis, otherwise the existing `parse_percentage` path. `parse_hsl_hwb_components` calls it with `HSL_PERCENT_BASIS` (100) in the modern syntax and keeps calling `parse_percentage` in the legacy syntax, which the existing comma check already identifies.
- Why this is right: the stored value is the unit value the percentage spelling produces, so clamping, `none`, the `hwb()` w + b normalization, serialization and downleveling are shared with the percentage spelling. Every expected value in the new tests is what the percentage spelling already produced, and byte for byte what lightningcss 1.30.2 emits for the number spelling.
- Why a shared, basis taking helper rather than a private `/ 100`: the lab family needs the same function with bases of 100 (`lab()`, `lch()`) and 1 (`oklab()`, `oklch()`), which is also how lightningcss structures it. #39200 currently adds its own copy (`parse_lab_lightness`, same body) and #38553 adds one under this name and signature for the relative color case; with this helper on main, #39200's rebase replaces its copy with `parse_unit_channel(i, l_basis)`, and #38553's adds its relative keyword branch in front of the number branch here and drops its own copy and its own `HSL_PERCENT_BASIS`. If either of them lands first instead, this PR rebases onto its helper the same way. None of the three PRs depends on the others to be correct; this one is the smallest and has no gamut coupling (the number spelled colors are in gamut by construction), which is why it is kept separate rather than folded into #39200.
- Legacy spellings: `hsl(120, 50, 40)` and `hsla(120, 50, 40, .5)` stay rejected as the spec and browsers require (lightningcss 1.30 accepts them; resolving a declaration that browsers drop would change what the page paints, so the tests pin the rejection). `hwb()` has no legacy syntax, so `hwb(120, 20, 30)` stays rejected. `parse_percentage` itself is unchanged, so the legacy `rgb(10%, 20%, 30%)` form, which also uses it, still rejects `rgb(10%, 20, 30)`.
- Nothing that parsed before changes path: a percentage, `none` or a keyword is not a number, so the number attempt fails without consuming input. `calc()` is the only token both attempts descend into; a failed `calc()` is not recorded as unrecoverable (only the type independent functions such as `atan2()` are), and the `rgb()` channels have always tried number then percentage the same way.
- The helper is not gated on relative syntax because css-color-5 relative `hsl()`/`hwb()` take the same channel grammar: `hsl(from red h 50 l)` now resolves (`#bf4040`, as in lightningcss). That and `hwb(from red h 20 b)` are the only rows that overlap with #38553's tests. One interaction to be aware of: a number spelled origin such as `hsl(from hsl(120 50 40) h calc(s + 10) l)` now parses and therefore reaches the keyword arithmetic bug #38553 fixes, exactly as the percentage spelled origin already does today.
- Both callers are covered: `parse_color_function` (`Bun.color`, stylesheet colors, relative color origins, `color-mix()`, token lists such as custom properties and `var()` fallbacks) and `UnresolvedColor::parse` in `src/css/properties/custom.rs` (`hsl(... / var(--a))`), which now emits `hsl(120 50% 40%/var(--a))`, or `hsla(120, 50%, 40%, var(--a))` for old targets, exactly like the percentage spelling.
- Tests: `test/js/bun/css/color.test.ts` (`Bun.color`: number and mixed spellings, `hsla()`, alpha, `none`, `calc()`, out of range values next to their percentage spellings, relative colors, `color-mix()`, the spellings that stay invalid) and `test/js/bun/css/css.test.ts` (the same through the minifier, plus custom properties, a `var()` fallback, a gradient, the `var(--a)` alpha path and a downlevel `prefix_test`). On the released binary 79 of the 102 new cases fail (41 of 53 and 38 of 49); the rest pin what must keep parsing or keep being rejected. With the change both files pass.
- Also run unchanged: the rest of `test/js/bun/css/` and `test/bundler/css/` (including the WPT color and relative color files); `cargo clippy -p bun_css` and `cargo fmt` are clean.

### Background
- Modern and legacy syntax: CSS Color 4 has two grammars for `hsl()`. The legacy one is comma separated (`hsl(120, 50%, 40%)`) and takes only percentages; the modern one is space separated (`hsl(120 50% 40%)`, `hsl(120 50 40)`, optional `/ alpha`) and takes percentages or numbers. `hwb()`, relative colors (`hsl(from red h s l)`) and `hsla()` written with spaces all use the modern grammar. The parser tells them apart by whether a comma follows the hue.
- Unit value and percent basis: the `HSL`/`HWB` structs store these channels as fractions of 1 (`50%` is 0.5), and every later stage (clamping, conversion to `RGBA`, printing) works on that. The percent basis of a channel is the `<number>` that means `100%` in its function, 100 here, so a number is stored as `n / basis` and becomes indistinguishable from the percentage spelling.
- `ComponentParser`: parses one channel of any color function. With a `from` origin it first resolves channel keywords and `calc()` of keywords against the origin, then falls back to a literal. `parse_hsl_hwb_components` is shared by `parse_color_function` (complete colors) and `properties/custom.rs`, which uses it for an `hsl()` whose alpha is a token list it cannot resolve, such as `var(--a)`.

<details>
<summary>Earlier revision</summary>

The first push implemented the number branch as a private `parse_hsl_hwb_channel` free function with the 100 hard coded. Review pointed out that this was a third copy of the helper #39200 and #38553 each add to the same file, so it was reshaped into the shared `ComponentParser::parse_unit_channel` described above. The tests are unchanged.

</details>
