### PR TITLE
Hoist the lowering of `import ... from "bun"` above the module body at runtime

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1804,6 +1804,29 @@ pub(crate) mod __gated_printer {
             self.print_internal_bun_import(import, Some(b"globalThis.Bun"));
         }
 
+        /// Whether `is_global_bun_import_statement` can be true for any statement of this
+        /// file, answered from the import records so the common case stays a short scan.
+        pub(crate) fn has_global_bun_import_statement(&self) -> bool {
+            IS_BUN_PLATFORM
+                && self.import_records.iter().any(|record| {
+                    record.tag == ImportRecordTag::Bun && record.kind == ImportKind::Stmt
+                })
+        }
+
+        /// Whether `stmt` is an `import ... from "bun"` statement that
+        /// `print_global_bun_import_statement` turns into `var` declarations.
+        pub(crate) fn is_global_bun_import_statement(&self, stmt: &Stmt) -> bool {
+            if !IS_BUN_PLATFORM {
+                return false;
+            }
+            match &stmt.data {
+                StmtData::SImport(s) => {
+                    self.import_record(s.import_record_index as usize).tag == ImportRecordTag::Bun
+                }
+                _ => false,
+            }
+        }
+
         fn print_internal_bun_import(
             &mut self,
             import: &S::Import,
@@ -7526,8 +7549,29 @@ pub fn print_ast<'a, W: WriterTrait, const ASCII_ONLY: bool, const GENERATE_SOUR
         }
     }
 
+    // `import ... from "bun"` is printed as `var` declarations reading `globalThis.Bun`,
+    // which the engine does not hoist like the import statement it replaces. The parser
+    // leaves import statements where they were written when not bundling, so print these
+    // declarations ahead of the module body to keep their bindings initialized before any
+    // statement that uses them.
+    let hoist_bun_imports = printer.has_global_bun_import_statement();
+    if hoist_bun_imports {
+        for part in tree.parts.iter() {
+            for stmt in slice_of(part.stmts).iter() {
+                if printer.is_global_bun_import_statement(stmt) {
+                    printer.print_stmt(*stmt)?;
+                    printer.writer.get_error()?;
+                    printer.print_semicolon_if_needed();
+                }
+            }
+        }
+    }
+
     for part in tree.parts.iter() {
         for stmt in slice_of(part.stmts).iter() {
+            if hoist_bun_imports && printer.is_global_bun_import_statement(stmt) {
+                continue;
+            }
             printer.print_stmt(*stmt)?;
             printer.writer.get_error()?;
             printer.print_semicolon_if_needed();

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: The `var` declarations that `import ... from "bun"` is lowered to are
+/// printed ahead of the module body, like the import statement they replace would be
+/// hoisted; entries written before that still have them at the import's position.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, bunRun, tempDir } from "harness";
+import { join } from "node:path";
 
 test("use strict causes CommonJS", () => {
   const { stdout, exitCode } = Bun.spawnSync({
@@ -251,4 +252,76 @@ describe("unterminated string literals in large files", () => {
     expect(stderr).toContain("Unterminated string literal");
     expect(exitCode).toBe(1);
   });
+});
+
+// A literal `import ... from "bun"` is not loaded through the module loader: the transpiler lowers the statement to
+// `var` declarations reading globalThis.Bun. Import bindings are usable by code written above the import statement,
+// so those declarations have to end up ahead of the rest of the module, wherever the statement was written.
+describe('import ... from "bun"', () => {
+  test.concurrent("bindings are initialized before code written above the import statement (-e)", async () => {
+    const { stdout, stderr, exitCode } = await bunRun([
+      "-e",
+      `
+        const { sep } = require("node:path");
+        const before = {
+          named: typeof escapeHTML,
+          call: escapeHTML("<a>"),
+          default: typeof BunDefault,
+          namespace: typeof ns,
+          other: typeof basename,
+        };
+        import { escapeHTML } from "bun";
+        import { basename } from "node:path";
+        import BunDefault from "bun";
+        import * as ns from "bun";
+        console.log(
+          JSON.stringify({
+            before,
+            defaultIsBun: BunDefault === Bun,
+            namespaceEscapeHTML: ns.escapeHTML === Bun.escapeHTML,
+            sep: typeof sep,
+          }),
+        );
+      `,
+    ]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      before: { named: "function", call: "&lt;a&gt;", default: "object", namespace: "object", other: "function" },
+      defaultIsBun: true,
+      namespaceEscapeHTML: true,
+      sep: "string",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent.each(["mjs", "ts"])(
+    "bindings are initialized before code written above the import statement (entry.%s)",
+    async ext => {
+      const bunImports =
+        ext === "ts"
+          ? [`import type { BunFile } from "bun";`, `import { type Server, stringWidth } from "bun";`]
+          : [`import { stringWidth } from "bun";`];
+      // One statement per line: line 2 is checked against the stack trace below, which goes through the file's
+      // source map once the transpiled output no longer lines up with the source.
+      const source = [
+        `const before = { named: typeof stringWidth, call: stringWidth("abc"), default: typeof BunDefault, namespace: typeof ns, other: typeof basename };`,
+        `const line = Number(/entry\\.\\w+:(\\d+):\\d+/.exec(new Error().stack)[1]);`,
+        ...bunImports,
+        `import { basename } from "node:path";`,
+        `import BunDefault from "bun";`,
+        `import * as ns from "bun";`,
+        `console.log(JSON.stringify({ before, line, defaultIsBun: BunDefault === Bun, namespaceStringWidth: ns.stringWidth === Bun.stringWidth }));`,
+      ].join("\n");
+      using dir = tempDir("import-bun-before-statement", { [`entry.${ext}`]: source });
+      const { stdout, stderr, exitCode } = await bunRun(join(String(dir), `entry.${ext}`));
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        before: { named: "function", call: 3, default: "object", namespace: "object", other: "function" },
+        line: 2,
+        defaultIsBun: true,
+        namespaceStringWidth: true,
+      });
+      expect(exitCode).toBe(0);
+    },
+  );
 });


### PR DESCRIPTION
### Problem
- At runtime, a binding from `import { x } from "bun"` is `undefined` in any code written above the import statement. `import { readFileSync } from "fs"` in the same position works, so only the `"bun"` specifier is affected.
  ```js
  console.log(typeof escapeHTML); // "undefined", expected "function"
  import { escapeHTML } from "bun";
  ```
  With a real use instead of `typeof`: `TypeError: escapeHTML is not a function. (In 'escapeHTML("<a>")', 'escapeHTML' is undefined)`.
- Reproduces with bun 1.4.0 and a debug build of main, for `bun file.mjs`, `.ts`, `.cjs`, `bun -e` and `bun test` files alike. `bun build --target=bun` is not affected.
- Cause: the runtime transpiler does not load `"bun"` as a module. The printer replaces the statement with `var` declarations (`src/js_printer/lib.rs`, `SImport` arm of `print_stmt` calling `print_global_bun_import_statement`), and it prints them where the statement was written. The parser only moves import statements to the front of the file when bundling (`src/js_parser/parse/parse_entry.rs`, `SImport` case in `_parse`); at runtime it keeps them in place because real import statements are hoisted by the engine anyway. A `var` initialized at the statement's position is not, so the binding exists but is still `undefined` when earlier statements run. Transpiled output before this change:
  ```js
  const before = typeof color;
  var {color } = globalThis.Bun;
  console.log({ before, after: typeof color });
  ```

### Fix
- `print_ast` (the runtime transpiler's printing entry point) now prints the `"bun"` import statements of a file before the rest of the module, then skips them while printing the parts in order. The output for the example above starts with `var {color } = globalThis.Bun;`. Files without such an import are detected from the import records and take the single loop they took before.
- Why this is the right place: the lowering itself is a printer decision, and `print_ast` is only used for the non-bundled path, which is the only path that leaves imports in place. The bundler (`bun build --target=bun`) already emits these declarations at the top of the module, and the Bake dev server likewise binds builtin imports at the top of its module wrapper, so this makes the runtime agree with them. The import records are tagged by two different runtime paths (`Linker::link` and `RuntimeTranspilerStore`), and both print through `print_ast`, so both are covered by one change. Printing through the existing `SImport` arm keeps the output text, source mappings and module record data identical to before; only the position moves.
- Why it is correct: the declarations only read `globalThis.Bun`, which exists before any user module runs, and an ES module's imported modules are all evaluated before its own body starts, so the front of the body is the earliest point in the module and still after every dependency. This is also the position the statement would have been hoisted to had it stayed an import. The one observable difference besides the fix is a module that assigns to `Bun.*` and only then, further down, imports that name from `"bun"`: it now gets the value from before the assignment, which is what `bun build` and a real import give it too.
- The runtime transpiler cache version is bumped (`src/jsc/RuntimeTranspilerCache.rs`, 25 to 26) because cached output for files with a late `"bun"` import would otherwise keep the old layout after upgrading. #35739, #37730 and #36297 also bump this constant, so whichever of these lands later needs a one-line rebase there.
- Scope, and the alternative: this fixes the statement-order divergence without changing what the lowering produces. The underlying cause is the lowering itself (it predates the loader's real `"bun"` module), and the same lowering also still differs from a real import in an import cycle (an exported function called before this module's body has run sees the binding as `undefined`; `bun build` shares that limitation), for `mock.module("bun", ...)`, and for `import { default as B } from "bun"` (binds `undefined`, runtime and bundler alike; reported separately). The alternative that fixes all of those at once is to stop lowering the statement at runtime (keep the `SImport` rewrite only when `options.bundling`) and let the loader link the existing native module; it is about as small as this change and would delete it, and the tests here are written against the imported values rather than the lowering, so they carry over unchanged. It is not done here because it is user visible in two ways this change is not: `import * as ns from "bun"` becomes a module namespace (`ns !== Bun`) and importing a name the `Bun` object does not have becomes a link-time `SyntaxError` instead of `undefined`. That is the same trade #37730 proposes for `import("bun")`; if that direction is taken for static imports too, this PR becomes unnecessary. The bug itself was found while working on something else, not from a user report; none of the roughly 500 files in this repository that import from `"bun"` uses a binding above the statement, so this is a correctness fix rather than a reported breakage.
- Verification: `test/bundler/transpiler/runtime-transpiler.test.ts`, new `import ... from "bun"` block. Three cases (`bun -e`, `entry.mjs`, `entry.ts`) use named, default and namespace imports above their import statements, interleaved with a `node:path` import, a `require()` call (which shares the hoisting spot with the `var {require}=import.meta;` declaration) and, for TypeScript, `import type` and inline `type` specifiers. The file cases also check that a stack trace line number still maps to the source once the output no longer lines up with it. All three fail on the released bun with the `TypeError` above and pass with this change.
- Also run on this build: the rest of `runtime-transpiler.test.ts`, `test/js/bun/resolve/import-meta.test.js`, `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`, `test/cli/run/transpiler-cache.test.ts`, `test/cli/run/run-eval.test.ts`, `test/bundler/bundler_bun.test.ts`, `test/cli/inspect/debugger-buntranspiledmodule.test.ts` (`bun test --isolate`, which is the path that records module info while printing), `test/cli/inspect/BunFrontendDevServer.test.ts`. Manually checked the printed output for a multi-line import, `import "bun"`, `import B, { x } from "bun"`, `import * as ns from "bun"`, a file that also uses `require`, a `.cjs` file, a file with a top-level `using`, and `export { x } from "bun"` (a real re-export, untouched).

### Background
- `"bun"` imports at runtime: when the runtime transpiler resolves a file's imports, the specifier `"bun"` is matched against the builtin alias table and its import record is tagged `ImportRecordTag::Bun`. The printer turns such a statement into `var` declarations reading `globalThis.Bun` (`var {x} = globalThis.Bun`, `var B = globalThis.Bun`) instead of printing an import, so the module loader never sees the specifier. `require("bun")` and `import("bun")` are inlined the same way as expressions and are not affected by this PR.
- Import hoisting: in an ES module, import statements are processed while the module is linked, before any statement of its body runs, so imported bindings are usable anywhere in the file regardless of where the statement is written. A `var` is different: its name exists from the start but it only gets its value when execution reaches the declaration.
- Parts: the parser splits a non-bundled file into one part per top-level statement, in source order, and `print_ast` prints them in that order. When bundling, the parser moves import parts to the front, which is why the bundler never had this problem.
- Runtime transpiler cache: bun caches the printed output of source files on disk under a version constant; bumping it discards entries whose printed output would differ now.

<details>
<summary>Probes</summary>

```console
$ cat hoist3.mjs
const before = typeof color;
import { color } from "bun";
console.log({ before, after: typeof color });

$ bun hoist3.mjs            # 1.4.0
{ before: "undefined", after: "function" }

$ bun-debug hoist3.mjs      # this branch
{ before: "function", after: "function" }
```

Transpiled output on this branch for a file combining the shapes (debug build source dump):

```js
var {require}=import.meta;var {
  escapeHTML, 
  stringWidth: sw
} = globalThis.Bun;
var B = globalThis.Bun;
var {stringWidth } = B;
var ns =globalThis.Bun;

export class Foo {
}
const { sep } = require("node:path");
const before = [typeof escapeHTML, typeof stringWidth, typeof B, typeof ns, typeof basename];
import { basename } from "node:path";
export default escapeHTML;
console.log(before, typeof sw, B === Bun, ns === Bun, typeof sep);
```

(`export class Foo {}` is moved up by the parser independently of this change; the `"use strict"` directive the file started with is dropped by the parser for ES modules, also independently of this change.)

</details>
