### PR TITLE
Convert scope-object receivers in the chaining functions and inspect.custom fallbacks

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1066,6 +1066,10 @@ impl JSValue {
             None
         }
     }
+    /// `JSValue::toThis` in strict mode (scope objects become `undefined`).
+    pub fn to_this_strict(self, global: &JSGlobalObject) -> JSValue {
+        crate::cpp::Bun__JSValue__toThisStrict(self, global)
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -98,7 +98,7 @@ static JSC::EncodedJSValue jsFunctionAppendOnLoadPluginBody(JSC::JSGlobalObject*
     callback(ctx, globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    return JSValue::encode(callframe->thisValue());
+    return JSValue::encode(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
 }
 
 static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe)
@@ -166,7 +166,7 @@ static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObjec
         moduleLoader->removeEntry(idIdent);
     }
 
-    return JSValue::encode(callframe->thisValue());
+    return JSValue::encode(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
 }
 
 static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe, BunPluginTarget target, BunPlugin::Base& plugin, void* ctx, OnAppendPluginCallback callback)
@@ -219,7 +219,7 @@ static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObje
     callback(ctx, globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 
-    return JSValue::encode(callframe->thisValue());
+    return JSValue::encode(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
 }
 
 static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginGlobal(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe, BunPluginTarget target)

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -1474,7 +1474,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalO
     // from this value instead of the activation-time clock.
     Bun__FakeTimers__setSystemTime(globalObject, ms);
 
-    return JSValue::encode(callframe->thisValue());
+    return JSValue::encode(callframe->thisValue().toThis(globalObject, ECMAMode::strict()));
 }
 
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsRestoreAllMocks, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -6730,6 +6730,11 @@ CPP_DECL [[ZIG_EXPORT(nothrow)]] JSC::EncodedJSValue Bun__JSBoundFunction__bound
     return JSC::JSValue::encode(boundFunction->boundThis());
 }
 
+CPP_DECL [[ZIG_EXPORT(nothrow)]] JSC::EncodedJSValue Bun__JSValue__toThisStrict(JSC::EncodedJSValue value, JSC::JSGlobalObject* globalObject)
+{
+    return JSC::JSValue::encode(JSC::JSValue::decode(value).toThis(globalObject, JSC::ECMAMode::strict()));
+}
+
 CPP_DECL [[ZIG_EXPORT(check_slow)]] void Bun__JSValue__setPrototypeDirect(JSC::EncodedJSValue valueEncoded, JSC::EncodedJSValue prototypeEncoded, JSC::JSGlobalObject* globalObject)
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());

--- a/src/jsc/bindings/webcore/JSDOMURL.cpp
+++ b/src/jsc/bindings/webcore/JSDOMURL.cpp
@@ -750,7 +750,7 @@ JSC_DEFINE_HOST_FUNCTION(jsDOMURLPrototypeFunction_inspectCustom, (JSGlobalObjec
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSDOMURL>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/JSPerformanceEntry.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceEntry.cpp
@@ -260,7 +260,7 @@ JSC_DEFINE_HOST_FUNCTION(jsPerformanceEntryPrototypeFunction_inspectCustom, (JSG
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
 
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     double depth = callFrame->argument(0).toNumber(lexicalGlobalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
     auto* entry = dynamicDowncast<JSObject>(thisValue);

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -194,7 +194,7 @@ JSC_DEFINE_HOST_FUNCTION(jsURLSearchParamsPrototypeFunction_inspectCustom, (JSGl
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSURLSearchParams>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
@@ -156,7 +156,7 @@ JSC_DEFINE_HOST_FUNCTION(jsByteLengthQueuingStrategyPrototype_inspectCustom, (JS
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSByteLengthQueuingStrategy>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
@@ -156,7 +156,7 @@ JSC_DEFINE_HOST_FUNCTION(jsCountQueuingStrategyPrototype_inspectCustom, (JSGloba
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSCountQueuingStrategy>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -224,7 +224,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableByteStreamControllerPrototype_inspectCustom, 
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSReadableByteStreamController>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -380,7 +380,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamPrototype_inspectCustom, (JSGlobalObjec
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSReadableStream>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -259,7 +259,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBReaderPrototype_inspectCustom, (JSG
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSReadableStreamBYOBReader>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
@@ -103,7 +103,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamBYOBRequestPrototype_inspectCustom, (JS
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSReadableStreamBYOBRequest>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -170,7 +170,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultControllerPrototype_inspectCusto
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSReadableStreamDefaultController>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -562,7 +562,7 @@ JSC_DEFINE_HOST_FUNCTION(jsReadableStreamDefaultReaderPrototype_inspectCustom, (
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSReadableStreamDefaultReader>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -187,7 +187,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTransformStreamPrototype_inspectCustom, (JSGlobalObje
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSTransformStream>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -147,7 +147,7 @@ JSC_DEFINE_HOST_FUNCTION(jsTransformStreamDefaultControllerPrototype_inspectCust
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSTransformStreamDefaultController>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -166,7 +166,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamPrototype_inspectCustom, (JSGlobalObjec
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSWritableStream>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -172,7 +172,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultControllerPrototype_inspectCusto
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSWritableStreamDefaultController>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -286,7 +286,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWritableStreamDefaultWriterPrototype_inspectCustom, (
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSWritableStreamDefaultWriter>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
+++ b/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
@@ -272,7 +272,7 @@ JSC_DEFINE_HOST_FUNCTION(jsCryptoKeyPrototype_inspectCustom, (JSGlobalObject * l
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisValue = callFrame->thisValue();
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     auto* thisObject = dynamicDowncast<JSCryptoKey>(thisValue);
     if (!thisObject) [[unlikely]]
         return JSValue::encode(thisValue);

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -391,7 +391,7 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
     // This is used by testing-library/react to detect if jest.advanceTimersByTime should be called.
     set_fake_timer_marker(global, true)?;
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -403,7 +403,7 @@ fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
     // Remove the setTimeout.clock marker when switching back to real timers.
     set_fake_timer_marker(global, false)?;
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -412,7 +412,7 @@ fn advance_timers_to_next_timer(global: &JSGlobalObject, frame: &CallFrame) -> J
 
     FakeTimers::execute_next(global)?;
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -448,7 +448,7 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
     CURRENT_TIME.set(global, &target, None);
     advanced?;
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -457,7 +457,7 @@ fn run_only_pending_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
 
     FakeTimers::execute_only_pending_timers(global)?;
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -466,7 +466,7 @@ fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValu
 
     FakeTimers::execute_all_timers(global)?;
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -487,7 +487,7 @@ fn clear_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
     let cleared = unsafe { (*timer_all()).fake_timers.clear() };
     cleared.release(global.bun_vm_ptr());
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -731,6 +731,31 @@ it("import(...) without __esModule", async () => {
   expect(mod).toBe("world");
 });
 
+it("builder methods return the builder only when called as methods", () => {
+  plugin({
+    name: "builder receiver",
+    setup(builder) {
+      const options = { filter: /.*/, namespace: "builder-receiver" };
+      const virtualModule = () => ({ exports: {}, loader: "object" }) as const;
+      expect([
+        builder.onResolve(options, () => undefined),
+        builder.onLoad(options, () => undefined),
+        builder.module("builder-receiver-virtual-module", virtualModule),
+      ]).toEqual([builder, builder, builder]);
+
+      const { onResolve, onLoad, module: defineModule } = builder;
+      // Closed-over bindings make JSC pass the scope object as the raw receiver
+      // of these calls; it must not come back as the return value.
+      const bare = () => [
+        onResolve(options, () => undefined),
+        onLoad(options, () => undefined),
+        defineModule("builder-receiver-virtual-module-bare", virtualModule),
+      ];
+      expect(bare()).toEqual([undefined, undefined, undefined]);
+    },
+  });
+});
+
 it("recursion throws stack overflow", () => {
   expect(() => {
     require("recursion:recursion");

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -105,8 +105,15 @@ test("chainable timer functions return their receiver only when called as a meth
     useRealTimers(),
   ];
   try {
-    expect(jest.useFakeTimers()).toBe(jest);
-    expect(jest.setSystemTime()).toBe(jest);
+    expect([
+      jest.useFakeTimers(),
+      jest.advanceTimersByTime(0),
+      jest.advanceTimersToNextTimer(),
+      jest.runOnlyPendingTimers(),
+      jest.runAllTimers(),
+      jest.clearAllTimers(),
+      jest.setSystemTime(),
+    ]).toEqual(new Array(7).fill(jest));
     expect(bare()).toEqual(new Array(8).fill(undefined));
   } finally {
     expect(jest.useRealTimers()).toBe(jest);

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, jest, setSystemTime, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { once } from "node:events";
 import http from "node:http";
@@ -77,6 +78,38 @@ test("setSystemTime accepts pre-epoch and epoch times and resets with no argumen
     expect(Date.now()).toBeGreaterThanOrEqual(realBefore);
   } finally {
     jest.useRealTimers();
+  }
+});
+
+test("chainable timer functions return their receiver only when called as a method", () => {
+  // Inside `bare`, every callee is a closed-over binding (setSystemTime is a module
+  // binding), so JSC hands the native function the scope object as its raw receiver.
+  // None of that may leak back out as a return value.
+  const {
+    useFakeTimers,
+    advanceTimersByTime,
+    advanceTimersToNextTimer,
+    runOnlyPendingTimers,
+    runAllTimers,
+    clearAllTimers,
+    useRealTimers,
+  } = jest;
+  const bare = () => [
+    useFakeTimers(),
+    advanceTimersByTime(0),
+    advanceTimersToNextTimer(),
+    runOnlyPendingTimers(),
+    runAllTimers(),
+    clearAllTimers(),
+    setSystemTime(),
+    useRealTimers(),
+  ];
+  try {
+    expect(jest.useFakeTimers()).toBe(jest);
+    expect(jest.setSystemTime()).toBe(jest);
+    expect(bare()).toEqual(new Array(8).fill(undefined));
+  } finally {
+    expect(jest.useRealTimers()).toBe(jest);
   }
 });
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -503,6 +503,37 @@ it("Bun.inspect.custom exists", () => {
   expect(Bun.inspect.custom).toBe(util.inspect.custom);
 });
 
+it("native inspect.custom functions do not return the scope object of a bare call", () => {
+  const classes = [
+    ByteLengthQueuingStrategy,
+    CountQueuingStrategy,
+    CryptoKey,
+    ReadableByteStreamController,
+    ReadableStream,
+    ReadableStreamBYOBReader,
+    ReadableStreamBYOBRequest,
+    ReadableStreamDefaultController,
+    ReadableStreamDefaultReader,
+    TransformStream,
+    TransformStreamDefaultController,
+    URL,
+    URLSearchParams,
+    WritableStream,
+    WritableStreamDefaultController,
+    WritableStreamDefaultWriter,
+  ];
+  const results = classes.map(klass => {
+    const inspectCustom = klass.prototype[util.inspect.custom];
+    // Closing over the binding makes the bare call below pass a scope object as `this`.
+    const bare = () => inspectCustom(2, {});
+    return [klass.name, typeof inspectCustom, bare()];
+  });
+  expect(results).toEqual(classes.map(klass => [klass.name, "function", undefined]));
+
+  const inspectURL = URL.prototype[util.inspect.custom];
+  expect(inspectURL.call(new URL("http://example.com/"), 2, {})).toContain("http://example.com/");
+});
+
 describe("Functions with names", () => {
   const closures = [
     () => function f() {},

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -508,6 +508,7 @@ it("native inspect.custom functions do not return the scope object of a bare cal
     ByteLengthQueuingStrategy,
     CountQueuingStrategy,
     CryptoKey,
+    PerformanceEntry,
     ReadableByteStreamController,
     ReadableStream,
     ReadableStreamBYOBReader,
@@ -525,7 +526,8 @@ it("native inspect.custom functions do not return the scope object of a bare cal
   const results = classes.map(klass => {
     const inspectCustom = klass.prototype[util.inspect.custom];
     // Closing over the binding makes the bare call below pass a scope object as `this`.
-    const bare = () => inspectCustom(2, {});
+    // A negative depth takes the early-return path in every one of these functions.
+    const bare = () => inspectCustom(-1, {});
     return [klass.name, typeof inspectCustom, bare()];
   });
   expect(results).toEqual(classes.map(klass => [klass.name, "function", undefined]));

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -528,9 +528,13 @@ it("native inspect.custom functions do not return the scope object of a bare cal
     // Closing over the binding makes the bare call below pass a scope object as `this`.
     // A negative depth takes the early-return path in every one of these functions.
     const bare = () => inspectCustom(-1, {});
-    return [klass.name, typeof inspectCustom, bare()];
+    // An ordinary wrong receiver must still come back unchanged: util.inspect relies on
+    // that to fall through to its default formatting.
+    const ordinaryReceiver = {};
+    const roundTripped = inspectCustom.call(ordinaryReceiver, -1, {}) === ordinaryReceiver;
+    return [klass.name, typeof inspectCustom, bare(), roundTripped];
   });
-  expect(results).toEqual(classes.map(klass => [klass.name, "function", undefined]));
+  expect(results).toEqual(classes.map(klass => [klass.name, "function", undefined, true]));
 
   const inspectURL = URL.prototype[util.inspect.custom];
   expect(inspectURL.call(new URL("http://example.com/"), 2, {})).toContain("http://example.com/");


### PR DESCRIPTION
### What does this PR do?

Found by fuzzing (`bun fuzzilli`, fingerprint `3e01338eb67e0977`). This is the remaining part of the fix for that class of crash. The mock functions themselves were converted in #39509, StringDecoder, `fs.Stats`, Node-API and the V8 shim in #39525. This PR covers the sites those two left out: the chaining functions and the `inspect.custom` fallbacks.

When a function is called through a binding that lives in a scope object rather than a stack slot (a variable closed over by another function, a module-level binding, an eval binding), JSC passes that scope object as the raw `this` value of the call (`FunctionCallResolveNode::emitBytecode`). JS callees fix this up in `op_to_this`; native functions are expected to call `JSValue::toThis()`, which maps any `JSScope` to `undefined`/`globalThis`.

The functions that return their receiver did not do that, so a bare call handed a `JSLexicalEnvironment` or `JSModuleEnvironment` back to user code:

- `setSystemTime` and the seven fake timer functions on `jest`/`vi` (`useFakeTimers`, `useRealTimers`, `advanceTimersByTime`, `advanceTimersToNextTimer`, `runOnlyPendingTimers`, `runAllTimers`, `clearAllTimers`)
- the plugin builder's `onLoad`, `onResolve` and `module`
- the 17 native `[util.inspect.custom]` functions (web streams, `URL`, `URLSearchParams`, `CryptoKey`, `PerformanceEntry`), which return a receiver that is not an instance of their class unchanged (`PerformanceEntry`'s, added in #39921, only downcasts to `JSObject`, which a scope object is, so its negative-depth early return handed the scope object back too)

```js
import { setSystemTime } from "bun:test";
console.log(setSystemTime()); // [native code: JSModuleEnvironment]
```

Property reads on such an object go through `symbolTableGet`, which returns the raw slot contents. For a binding still in its TDZ that is an empty `JSValue`, which is a null cell as far as the rest of the engine is concerned, so `typeof scope.x` dereferences null (UBSAN: `member call on null pointer of type 'JSC::JSCell'`), and `Object.getOwnPropertyDescriptor(scope, "x")` trips `ASSERTION FAILED: value` in `PropertyDescriptor::setDescriptor`. The fuzzer reached this through `mockReturnThis()` (fixed in #39509); every function listed above gives user code the same object.

The fix converts the receiver with `toThis(globalObject, ECMAMode::strict())` at each site. The Rust sites in `FakeTimers.rs` go through a new `JSValue::to_this_strict`, a thin wrapper over the same call exported from `bindings.cpp`. Strict mode maps scope objects (including the global object itself, which is also a `JSScope`) to `undefined` and leaves every other value, primitives included, untouched, so:

- a bare call now returns `undefined`, the same thing a call through a local variable already returned
- `jest.setSystemTime()`, `jest.useFakeTimers()`, `build.onLoad(...)` and the rest still return their receiver for chaining
- the inspect.custom functions keep returning ordinary wrong receivers as-is (util.inspect relies on that to fall back to default formatting, see the existing test in `custom-inspect.test.js`); only scope objects now come back as `undefined`

The other `return this` sites I found (`JSECDHPrototype.cpp`, `DiffieHellmanFunctions.h`, and the Rust class methods in `Image.rs`, `cron.rs`, `html_rewriter.rs`, `quic/stream.rs`, `TimeoutObject.rs`) throw when the receiver is not an instance of their class, or run behind a generated binding that does, so a scope object cannot reach their return statement. They are left alone.

The webcore and webcrypto files touched here are checked-in sources, not build output: nothing in the tree regenerates them (the `generate-bindings.pl` banner on three of them is a leftover from their import from WebKit), and the inspect.custom functions were added to them by hand in #34660 and #34431.

### How did you verify your code works?

- `bun bd test` on `test/js/bun/test/test-timers.test.ts`, `test/js/bun/plugin/plugins.test.ts` and `test/js/bun/util/inspect.test.js` passes (together with `mock-fn.test.js`: 214 tests). Each new test fails on an unfixed release build (1.3.14): the bare calls return `[native code]` entries where `undefined` is expected, for all 8 timer functions, all 3 builder methods and all 17 inspect.custom functions (the inspect test passes a negative depth so the `PerformanceEntry` early return is the path under test). The method-call halves of the same tests check that the receiver is still returned.
- `custom-inspect.test.js`, `globals.test.js`, `perf_hooks.test.ts`, the URL and URLSearchParams tests, and node's `test-webstream-encoding-inspect`, `test-whatwg-webstreams-coverage` and `test-whatwg-url-custom-inspect` still pass.
- Rebased onto main after #39509 and #39525 landed. The only overlap was the `jsMockFunctionCall` line, which is now main's; the test this PR had for it is dropped in favor of the one #39509 added.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->
