### PR TITLE
bake: tear down the dev server when its initialization fails

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -122,7 +122,9 @@ impl DevServer {
     // The three transpilers are `MaybeUninit` until `init()` writes them via
     // `Framework::init_transpiler`. Every access after `init()` returns goes
     // through these helpers; the SAFETY contract is that `init()` is the only
-    // constructor and it always populates all three before returning `Ok`.
+    // constructor and it always populates the server and client transpilers
+    // before returning `Ok`. The SSR one only exists when the framework has a
+    // separate SSR graph (`initialized_transpilers == 3`).
     #[inline]
     pub(crate) fn server_transpiler(&self) -> &Transpiler<'static> {
         // SAFETY: written in `init()` before any access.
@@ -145,8 +147,23 @@ impl DevServer {
     }
     #[inline]
     pub(crate) fn ssr_transpiler_mut(&mut self) -> &mut Transpiler<'static> {
-        // SAFETY: written in `init()` before any access.
+        debug_assert!(self.initialized_transpilers == 3);
+        // SAFETY: `init()` only builds the SSR transpiler for a separate SSR
+        // graph, and callers only reach this in that configuration.
         unsafe { self.ssr_transpiler.assume_init_mut() }
+    }
+    /// The transpiler `BundleV2` should use for the SSR graph: the dedicated
+    /// one when it exists, otherwise the server transpiler (the same aliasing
+    /// `BundleV2::init` sets up by itself; the bundler only dereferences it for
+    /// files in a separate SSR graph). Raw because the server transpiler is
+    /// handed to the bundler as `&mut` at the same time.
+    #[inline]
+    fn ssr_transpiler_ptr_for_bundle(&mut self) -> *mut Transpiler<'static> {
+        if self.initialized_transpilers == 3 {
+            self.ssr_transpiler.as_mut_ptr()
+        } else {
+            self.server_transpiler.as_mut_ptr()
+        }
     }
 }
 pub(super) use crate::bake::dev_server::WatcherAtomics;
@@ -397,9 +414,16 @@ pub struct DevServer {
     // `MaybeUninit` until `Framework::init_transpiler` populates them in place
     // (in `init()` below) — `Transpiler` contains a non-nullable `&Arena`, so
     // neither `Default` nor `mem::zeroed()` are sound (PORTING.md §Forbidden).
+    // `ssr_transpiler` stays uninitialized unless the framework has a separate
+    // SSR graph; see `ssr_transpiler_ptr_for_bundle`.
     pub(crate) server_transpiler: ::core::mem::MaybeUninit<Transpiler<'static>>,
     pub(crate) client_transpiler: ::core::mem::MaybeUninit<Transpiler<'static>>,
     pub(crate) ssr_transpiler: ::core::mem::MaybeUninit<Transpiler<'static>>,
+    /// How many of `server_transpiler`, `client_transpiler`, `ssr_transpiler`
+    /// (populated in that order) hold a live `Transpiler`. `init()` bumps it as
+    /// each one is built, so `Drop` tears down exactly the ones that exist
+    /// when initialization fails part-way through.
+    pub(crate) initialized_transpilers: u8,
     /// The log used by all `server_transpiler`, `client_transpiler` and `ssr_transpiler`.
     /// Note that it is rarely correct to write messages into it. Instead, associate
     /// messages with the IncrementalGraph file or Route using `SerializedFailure`
@@ -487,19 +511,50 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         .map(|sc| sc.separate_ssr_graph)
         .unwrap_or(false);
 
-    // Note: `server_transpiler` / `client_transpiler` / `ssr_transpiler` /
-    // `bun_watcher` / `router` / `watcher_atomics` must be assigned after the
-    // heap address is stable. Rust forbids partial struct literals and
-    // `mem::zeroed()` here is UB (`Box<Watcher>` is `NonNull`-backed;
-    // `Transpiler<'a>` carries `&'a Arena`), so use
-    // `Box::new_uninit()` + per-field `addr_of_mut!().write()`, leaving those
-    // fields uninitialized until their real values are computed against
-    // the stable `*mut DevServer`, then `assume_init()` once every field is written.
+    // `bun_watcher` and `watcher_atomics` point back at the server, so they
+    // need its heap address before it exists as a value. Rust forbids partial
+    // struct literals and `mem::zeroed()` here is UB (`Box<Watcher>` is
+    // `NonNull`-backed; `Transpiler<'a>` carries `&'a Arena`), so allocate
+    // uninitialized storage, build those two against its address, then write
+    // every field with `addr_of_mut!().write()` and `assume_init()`.
+    //
+    // Ordering matters for the error paths: `MaybeUninit` never drops what was
+    // written into it, so nothing that owns a resource is written until every
+    // step that can fail before `assume_init()` has passed. The transpilers
+    // (the remaining fallible part of construction) are built after
+    // `assume_init()`, so a failure there tears the server down through
+    // `Drop` like any other failure later in this function.
     use ::core::mem::MaybeUninit;
     use ::core::ptr::addr_of_mut;
 
     let mut dev_uninit: Box<MaybeUninit<DevServer>> = Box::new(MaybeUninit::uninit());
     let p: *mut DevServer = dev_uninit.as_mut_ptr();
+
+    let global = options.vm.global();
+
+    let generic_action = "while initializing development server";
+    // FileSystem is a process-lifetime singleton; `init` interns the path into
+    // the `DirnameStore` (process-lifetime arena) so no caller-side leak is
+    // needed for the `'static` it stores.
+    let _fs = match bun_resolver::fs::FileSystem::init(Some(options.root.as_bytes())) {
+        Ok(fs) => fs,
+        Err(err) => return Err(global.throw_error(err, generic_action)),
+    };
+    let top_level_dir: &'static [u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
+
+    // SAFETY: `Watcher::init` only stores `p` as an opaque `*mut ()` ctx; it does
+    // not dereference it until `start()` spawns the watcher thread, by which point
+    // every `DevServer` field is initialized (`assume_init` below precedes
+    // `bun_watcher.start()`).
+    let bun_watcher = match Watcher::init::<DevServer>(p, top_level_dir) {
+        Ok(w) => w,
+        Err(err) => {
+            return Err(global.throw_error(
+                err,
+                "while initializing file watcher for development server",
+            ));
+        }
+    };
 
     /// `addr_of_mut!((*p).$field).write($value)` — writes a single field of the
     /// partially-initialized `DevServer` without materializing `&mut DevServer`.
@@ -511,9 +566,11 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
 
     // SAFETY: `p` is a freshly-allocated, properly-aligned `*mut DevServer`; each
     // `addr_of_mut!((*p).field)` computes an in-bounds field address without
-    // creating a reference to the (partially-uninit) whole. Every field is written
-    // exactly once before `assume_init()` below.
-    unsafe {
+    // creating a reference to the (partially-uninit) whole. Every field except
+    // the three `MaybeUninit` transpiler slots (valid in any state) is written
+    // exactly once below, and nothing in between can fail, so `assume_init()`
+    // at the end of the block is sound.
+    let mut dev: Box<DevServer> = unsafe {
         w!(magic, Magic::Valid);
         w!(root, Box::from(options.root.as_bytes()));
         w!(vm, bun_ptr::BackRef::new(options.vm));
@@ -605,127 +662,16 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
                 pattern_string_arena: Arena::new(),
             }
         );
-    }
+        w!(bun_watcher, ::core::mem::ManuallyDrop::new(bun_watcher));
+        // `WatcherAtomics::init` / `HotReloadEvent::init_empty` only store `p`
+        // as a BACKREF for later `concurrent_task.from(dev)` / `run`; it is not
+        // dereferenced during construction.
+        w!(watcher_atomics, WatcherAtomics::init(p));
+        w!(bundler_framework_views, Vec::with_capacity(4));
+        w!(initialized_transpilers, 0);
 
-    let global = options.vm.global();
-
-    let generic_action = "while initializing development server";
-    // FileSystem is a process-lifetime singleton; `init` interns the path into
-    // the `DirnameStore` (process-lifetime arena) so no caller-side leak is
-    // needed for the `'static` it stores.
-    let _fs = match bun_resolver::fs::FileSystem::init(Some(options.root.as_bytes())) {
-        Ok(fs) => fs,
-        Err(err) => return Err(global.throw_error(err, generic_action)),
+        dev_uninit.assume_init()
     };
-    let top_level_dir: &'static [u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
-
-    // `.bun_watcher = undefined` → `Watcher.init(DevServer, dev, fs, ...)`
-    // SAFETY: `Watcher::init` only stores `p` as an opaque `*mut ()` ctx; it does
-    // not dereference it until `start()` spawns the watcher thread, by which point
-    // every `DevServer` field is initialized (`assume_init` below precedes
-    // `bun_watcher.start()`).
-    let bun_watcher = match Watcher::init::<DevServer>(p, top_level_dir) {
-        Ok(w) => w,
-        Err(err) => {
-            return Err(global.throw_error(
-                err,
-                "while initializing file watcher for development server",
-            ));
-        }
-    };
-    // SAFETY: per-field write into uninit struct; see `w!` SAFETY above.
-    unsafe { w!(bun_watcher, ::core::mem::ManuallyDrop::new(bun_watcher)) };
-
-    // `.watcher_atomics = undefined` → `WatcherAtomics.init(dev)`
-    // SAFETY: `WatcherAtomics::init` / `HotReloadEvent::init_empty` only store `p`
-    // as a BACKREF for later `concurrent_task.from(dev)` / `run`; not dereferenced
-    // during construction.
-    unsafe { w!(watcher_atomics, WatcherAtomics::init(p)) };
-
-    // This causes a memory leak, but the allocator is otherwise used on multiple threads.
-    // (allocator param dropped — global mimalloc)
-
-    // `.server_transpiler/.client_transpiler/.ssr_transpiler = undefined` →
-    // `Framework.initTranspiler(..., &dev.X_transpiler, ...)`.
-    //
-    // SAFETY: `init_transpiler` writes the slot via `MaybeUninit::write` (see
-    // `bake_body.rs`), so the previous (uninitialized) bytes are never dropped.
-    // `framework`/`log`/`bundler_options` were written above; reborrowing each
-    // individually via `addr_of_mut!` is sound because no `&mut DevServer` exists.
-    // Note: `Transpiler<'static>` erases the arena lifetime — `options.arena`
-    // is the `UserOptions.arena` which is moved into / outlives the `DevServer`
-    // box. Widen `'a → 'static` here once.
-    // SAFETY: `options.arena` outlives every `Transpiler` field it backs (see
-    // `Options::arena` doc — "must live until DevServer drops").
-    let arena: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref(options.arena) };
-    let mut bundler_framework_views: Vec<*mut bun_bundler::bake_types::Framework> =
-        Vec::with_capacity(4);
-    // SAFETY: `p` points into the boxed `MaybeUninit<DevServer>`; the fields
-    // accessed below were each written above and are reborrowed disjointly via
-    // `addr_of_mut!`, so no overlapping `&mut` exists.
-    unsafe {
-        let framework = &mut *addr_of_mut!((*p).framework);
-        let log = &mut *addr_of_mut!((*p).log);
-        let bundler_options = &mut *addr_of_mut!((*p).bundler_options);
-
-        match framework.init_transpiler(
-            arena,
-            log,
-            bake::Mode::Development,
-            bake::Graph::Server,
-            &mut *addr_of_mut!((*p).server_transpiler),
-            &bundler_options.server,
-        ) {
-            Ok(view) => bundler_framework_views.push(view),
-            Err(err) => return Err(global.throw_error(err, generic_action)),
-        }
-        match framework.init_transpiler(
-            arena,
-            log,
-            bake::Mode::Development,
-            bake::Graph::Client,
-            &mut *addr_of_mut!((*p).client_transpiler),
-            &bundler_options.client,
-        ) {
-            Ok(view) => bundler_framework_views.push(view),
-            Err(err) => return Err(global.throw_error(err, generic_action)),
-        }
-        if separate_ssr_graph {
-            match framework.init_transpiler(
-                arena,
-                log,
-                bake::Mode::Development,
-                bake::Graph::Ssr,
-                &mut *addr_of_mut!((*p).ssr_transpiler),
-                &bundler_options.ssr,
-            ) {
-                Ok(view) => bundler_framework_views.push(view),
-                Err(err) => return Err(global.throw_error(err, generic_action)),
-            }
-        } else {
-            // Note: when `!separate_ssr_graph`, `ssr_transpiler` is never
-            // read, but a valid value must still be written before
-            // `assume_init()`. Bitwise-alias the server
-            // transpiler. This is sound only because `Drop for DevServer` gates
-            // `ssr_transpiler.assume_init_drop()` behind the same
-            // `separate_ssr_graph` check (see Drop impl): in the `!separate`
-            // branch the alias is never independently dropped, so there is no
-            // double-free. Do not remove that gate.
-            ::core::ptr::copy_nonoverlapping(
-                addr_of_mut!((*p).server_transpiler).cast_const(),
-                addr_of_mut!((*p).ssr_transpiler),
-                1,
-            );
-        }
-
-        w!(bundler_framework_views, bundler_framework_views);
-    }
-
-    // ── every field is now written ───────────────────────────────────────────
-    // SAFETY: all fields of `*p` were written exactly once above via
-    // `addr_of_mut!().write()` / `copy_nonoverlapping`; no field remains uninit.
-    let mut dev: Box<DevServer> = unsafe { dev_uninit.assume_init() };
-    let dev_ptr: *mut DevServer = &raw mut *dev;
 
     // Note: the graphs are stored by value; `owner()` is provided on
     // `IncrementalGraph` via `offset_of!` so the parent-pointer invariant is
@@ -738,6 +684,42 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     );
 
     let _unlock = dev.graph_safety_lock.guard();
+
+    // `Transpiler<'static>` erases the arena lifetime — `options.arena` is the
+    // `UserOptions.arena`, which outlives the `DevServer` box.
+    // SAFETY: `options.arena` outlives every `Transpiler` field it backs (see
+    // `Options::arena` doc — "must live until DevServer drops").
+    let arena: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref(options.arena) };
+    // Same order as `initialized_transpilers` counts them. `init_transpiler`
+    // leaves the slot uninitialized when it fails, so the count is still right
+    // for `Drop` when the `?` below drops `dev`.
+    let graphs: &[bake::Graph] = if separate_ssr_graph {
+        &[bake::Graph::Server, bake::Graph::Client, bake::Graph::Ssr]
+    } else {
+        &[bake::Graph::Server, bake::Graph::Client]
+    };
+    for &graph in graphs {
+        let (slot, config) = match graph {
+            bake::Graph::Server => (&mut dev.server_transpiler, &dev.bundler_options.server),
+            bake::Graph::Client => (&mut dev.client_transpiler, &dev.bundler_options.client),
+            bake::Graph::Ssr => (&mut dev.ssr_transpiler, &dev.bundler_options.ssr),
+        };
+        let view = dev
+            .framework
+            .init_transpiler(
+                arena,
+                &mut dev.log,
+                bake::Mode::Development,
+                graph,
+                slot,
+                config,
+            )
+            .map_err(|err| global.throw_error(err, generic_action))?;
+        dev.bundler_framework_views.push(view);
+        dev.initialized_transpilers += 1;
+    }
+
+    let dev_ptr: *mut DevServer = &raw mut *dev;
 
     if let Err(err) = dev.bun_watcher.start() {
         return Err(global.throw_error(
@@ -1054,6 +1036,7 @@ impl Drop for DevServer {
                 server_transpiler: _,
                 client_transpiler: _,
                 ssr_transpiler: _,
+                initialized_transpilers: _,
                 log: _,
                 plugin_state: _,
                 current_bundle: _,
@@ -1176,18 +1159,19 @@ impl Drop for DevServer {
             ));
         }
 
-        let separate_ssr_graph = self
-            .framework
-            .server_components
-            .as_ref()
-            .is_some_and(|sc| sc.separate_ssr_graph);
-        // SAFETY: each transpiler is initialized exactly once in `init()`.
-        unsafe {
-            self.server_transpiler.assume_init_drop();
-            self.client_transpiler.assume_init_drop();
-            if separate_ssr_graph {
-                self.ssr_transpiler.assume_init_drop();
-            }
+        // `init()` may have failed before building all of them (or, without a
+        // separate SSR graph, never builds the third one).
+        let initialized = usize::from(self.initialized_transpilers);
+        debug_assert!(initialized <= 3);
+        let slots = [
+            &mut self.server_transpiler,
+            &mut self.client_transpiler,
+            &mut self.ssr_transpiler,
+        ];
+        for slot in slots.into_iter().take(initialized) {
+            // SAFETY: `init()` populates the slots in this order and counts each
+            // one it populated; none of them is dropped anywhere else.
+            unsafe { slot.assume_init_drop() };
         }
 
         for &ptr in &self.bundler_framework_views {
@@ -3203,25 +3187,23 @@ impl DevServer {
         // `CurrentBundle` (which also owns `bv2`); the boxed arena's address
         // is stable for the lifetime of `bv2.graph.heap`'s borrow.
         let heap_ptr: *const bun_alloc::Arena = &raw const *heap;
-        // Note: split `&mut self` into disjoint field reborrows so
-        // `server_transpiler` (`&'a mut`) and `client/ssr_transpiler`
-        // (NonNull) don't trip the single-`&mut self` rule.
-        let self_ptr = std::ptr::from_mut::<Self>(self);
+        // `BundleV2` keeps these as raw pointers into `*self` (which outlives
+        // `bv2`, held in `current_bundle`) and never moves them. Taken as raw
+        // pointers up front so the server transpiler can be both the `&mut`
+        // argument and, without a separate SSR graph, the SSR alias.
+        let ssr_ptr = self.ssr_transpiler_ptr_for_bundle();
+        let client_ptr = self.client_transpiler.as_mut_ptr();
+        let server_ptr = self.server_transpiler.as_mut_ptr();
         let mut bv2: Box<BundleV2<'static>> = BundleV2::init(
-            // SAFETY: `server_transpiler` outlives `bv2` (held by `self`).
-            unsafe { (*self_ptr).server_transpiler.assume_init_mut() },
+            // SAFETY: populated in `init()`; `self` holds no other reference to
+            // it while the bundle is set up.
+            unsafe { &mut *server_ptr },
             Some(bundler::bundle_v2::BakeOptions {
                 framework: self.framework.as_bundler_view(),
-                // SAFETY: sibling fields of `*self`; `BundleV2` stores them as
-                // raw pointers and never moves them.
-                client_transpiler: unsafe {
-                    ::core::ptr::NonNull::from((*self_ptr).client_transpiler.assume_init_mut())
-                },
-                // SAFETY: sibling field of `*self`; `BundleV2` stores it as a raw
-                // pointer and never moves it.
-                ssr_transpiler: unsafe {
-                    ::core::ptr::NonNull::from((*self_ptr).ssr_transpiler.assume_init_mut())
-                },
+                // SAFETY: addresses of fields of `*self`, so never null.
+                client_transpiler: unsafe { ::core::ptr::NonNull::new_unchecked(client_ptr) },
+                // SAFETY: same as above.
+                ssr_transpiler: unsafe { ::core::ptr::NonNull::new_unchecked(ssr_ptr) },
                 plugins: self.bundler_options.plugin,
             }),
             // SAFETY: see `heap_ptr` note above.

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -139,8 +139,7 @@ impl DevServer {
     pub(crate) fn ssr_transpiler_mut(&mut self) -> &mut Transpiler<'static> {
         self.ssr_transpiler.get_mut()
     }
-    /// Without a separate SSR graph this is the server transpiler, the alias
-    /// `BundleV2` would set up on its own and never dereferences.
+    /// Falls back to the server transpiler, which the bundler never dereferences as SSR.
     #[inline]
     fn ssr_transpiler_ptr_for_bundle(&mut self) -> *mut Transpiler<'static> {
         if self.ssr_transpiler.is_initialized() {
@@ -486,9 +485,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         .map(|sc| sc.separate_ssr_graph)
         .unwrap_or(false);
 
-    // Field by field because the watcher needs the server's address first and the
-    // ~15 KiB struct should not be built on the stack (see `Fallback::new_boxed`).
-    // Nothing fallible may run between the first write and `assume_init()`.
+    // Field by field: the watcher needs the address first, and ~15 KiB is too big for the stack.
     use ::core::mem::MaybeUninit;
     use ::core::ptr::addr_of_mut;
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -119,8 +119,6 @@ impl DevServer {
     }
 
     // ── transpiler accessors ───────────────────────────────────────────────
-    // `init()` fills the server and client slots before it returns `Ok`; the
-    // SSR slot only when the framework has a separate SSR graph.
     #[inline]
     pub(crate) fn server_transpiler(&self) -> &Transpiler<'static> {
         self.server_transpiler.get()
@@ -141,11 +139,8 @@ impl DevServer {
     pub(crate) fn ssr_transpiler_mut(&mut self) -> &mut Transpiler<'static> {
         self.ssr_transpiler.get_mut()
     }
-    /// The transpiler `BundleV2` should use for the SSR graph: the dedicated
-    /// one when it exists, otherwise the server transpiler (the same aliasing
-    /// `BundleV2::init` sets up by itself; the bundler only dereferences it for
-    /// files in a separate SSR graph). Raw because the server transpiler is
-    /// handed to the bundler as `&mut` at the same time.
+    /// Without a separate SSR graph this is the server transpiler, the alias
+    /// `BundleV2` would set up on its own and never dereferences.
     #[inline]
     fn ssr_transpiler_ptr_for_bundle(&mut self) -> *mut Transpiler<'static> {
         if self.ssr_transpiler.is_initialized() {
@@ -400,11 +395,9 @@ pub struct DevServer {
     // `CurrentBundle.bv2`). `Transpiler<'a>` borrows the global
     // `Fs::FileSystem` singleton + `dot_env::Loader`, both of which outlive
     // the server.
-    // Empty until `Framework::init_transpiler` fills them in `init()` below;
-    // `ssr_transpiler` stays empty unless the framework has a separate SSR
-    // graph (see `ssr_transpiler_ptr_for_bundle`).
     pub(crate) server_transpiler: bake::TranspilerSlot<'static>,
     pub(crate) client_transpiler: bake::TranspilerSlot<'static>,
+    /// Only filled when the framework has a separate SSR graph.
     pub(crate) ssr_transpiler: bake::TranspilerSlot<'static>,
     /// The log used by all `server_transpiler`, `client_transpiler` and `ssr_transpiler`.
     /// Note that it is rarely correct to write messages into it. Instead, associate
@@ -493,18 +486,9 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         .map(|sc| sc.separate_ssr_graph)
         .unwrap_or(false);
 
-    // `bun_watcher` and `watcher_atomics` point back at the server, so they
-    // need its heap address before it exists as a value, and the struct is
-    // ~15 KiB (three inline transpiler slots plus the deferred request pool),
-    // which a struct literal would build on the stack and copy (see the note
-    // on `hive_array::Fallback::new_boxed`). Instead: allocate uninitialized
-    // storage, build those two against its address, write every field with
-    // `addr_of_mut!().write()`, `assume_init()`.
-    //
-    // `MaybeUninit` never drops what was written into it, so the steps that
-    // can fail come either before anything is written (below) or after
-    // `assume_init()`, where a failure drops the `Box<DevServer>` and `Drop`
-    // tears down whatever exists, like any later failure in this function.
+    // Field by field because the watcher needs the server's address first and the
+    // ~15 KiB struct should not be built on the stack (see `Fallback::new_boxed`).
+    // Nothing fallible may run between the first write and `assume_init()`.
     use ::core::mem::MaybeUninit;
     use ::core::ptr::addr_of_mut;
 
@@ -514,19 +498,14 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     let global = options.vm.global();
 
     let generic_action = "while initializing development server";
-    // FileSystem is a process-lifetime singleton; `init` interns the path into
-    // the `DirnameStore` (process-lifetime arena) so no caller-side leak is
-    // needed for the `'static` it stores.
+    // Process-lifetime singleton; the root it interns is never freed.
     let _fs = match bun_resolver::fs::FileSystem::init(Some(options.root.as_bytes())) {
         Ok(fs) => fs,
         Err(err) => return Err(global.throw_error(err, generic_action)),
     };
     let top_level_dir: &'static [u8] = bun_resolver::fs::FileSystem::get().top_level_dir;
 
-    // SAFETY: `Watcher::init` only stores `p` as an opaque `*mut ()` ctx; it does
-    // not dereference it until `start()` spawns the watcher thread, by which point
-    // every `DevServer` field is initialized (`assume_init` below precedes
-    // `bun_watcher.start()`).
+    // Only stores `p`; nothing dereferences it before `bun_watcher.start()` below.
     let bun_watcher = match Watcher::init::<DevServer>(p, top_level_dir) {
         Ok(w) => w,
         Err(err) => {
@@ -545,11 +524,8 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         };
     }
 
-    // SAFETY: `p` is a freshly-allocated, properly-aligned `*mut DevServer`; each
-    // `addr_of_mut!((*p).field)` computes an in-bounds field address without
-    // creating a reference to the (partially-uninit) whole. Every field is
-    // written exactly once below and nothing in between can fail, so the
-    // `assume_init()` at the end of the block is sound.
+    // SAFETY: `p` is fresh, aligned storage and `w!` never forms a reference to the
+    // whole; every field is written exactly once below and nothing in between fails.
     let mut dev: Box<DevServer> = unsafe {
         w!(magic, Magic::Valid);
         w!(root, Box::from(options.root.as_bytes()));
@@ -643,9 +619,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
             }
         );
         w!(bun_watcher, ::core::mem::ManuallyDrop::new(bun_watcher));
-        // `WatcherAtomics::init` / `HotReloadEvent::init_empty` only store `p`
-        // as a BACKREF for later `concurrent_task.from(dev)` / `run`; it is not
-        // dereferenced during construction.
+        // Only stores `p` as a back-reference.
         w!(watcher_atomics, WatcherAtomics::init(p));
         w!(bundler_framework_views, Vec::with_capacity(4));
         w!(server_transpiler, bake::TranspilerSlot::uninit());
@@ -667,10 +641,8 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
 
     let _unlock = dev.graph_safety_lock.guard();
 
-    // `Transpiler<'static>` erases the arena lifetime — `options.arena` is the
-    // `UserOptions.arena`, which outlives the `DevServer` box.
-    // SAFETY: `options.arena` outlives every `Transpiler` field it backs (see
-    // `Options::arena` doc — "must live until DevServer drops").
+    // SAFETY: `options.arena` outlives the `DevServer` (see `Options::arena`), and
+    // with it every `Transpiler<'static>` built from it below.
     let arena: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref(options.arena) };
     let graphs: &[bake::Graph] = if separate_ssr_graph {
         &[bake::Graph::Server, bake::Graph::Client, bake::Graph::Ssr]
@@ -678,10 +650,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         &[bake::Graph::Server, bake::Graph::Client]
     };
     for &graph in graphs {
-        // The bundler crate (lower tier) reads the framework through its own
-        // projection, which the transpiler borrows for as long as it lives.
-        // Registered with `dev` before the call so that `Drop` destroys it
-        // whether or not the transpiler gets built.
+        // Registered before the call so `Drop` destroys it even if the transpiler is never built.
         let view: *mut bun_bundler::bake_types::Framework =
             arena.alloc(dev.framework.as_bundler_view());
         dev.bundler_framework_views.push(view);
@@ -697,8 +666,8 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
                 bake::Mode::Development,
                 graph,
                 slot,
-                // SAFETY: a fresh slot in `arena`, which outlives `dev`; it is only
-                // dropped in place by `Drop for DevServer`, after the transpilers.
+                // SAFETY: fresh arena slot; only `Drop for DevServer` destroys it, after
+                // the transpilers.
                 unsafe { &*view },
                 config,
             )
@@ -3162,16 +3131,12 @@ impl DevServer {
         // `CurrentBundle` (which also owns `bv2`); the boxed arena's address
         // is stable for the lifetime of `bv2.graph.heap`'s borrow.
         let heap_ptr: *const bun_alloc::Arena = &raw const *heap;
-        // `BundleV2` keeps these as raw pointers into `*self` (which outlives
-        // `bv2`, held in `current_bundle`) and never moves them. Taken as raw
-        // pointers up front so the server transpiler can be both the `&mut`
-        // argument and, without a separate SSR graph, the SSR alias.
+        // Raw because `ssr_ptr` may alias the server transpiler passed as `&mut` below.
         let ssr_ptr = self.ssr_transpiler_ptr_for_bundle();
         let client_ptr = self.client_transpiler.as_mut_ptr();
         let server_ptr = self.server_transpiler.as_mut_ptr();
         let mut bv2: Box<BundleV2<'static>> = BundleV2::init(
-            // SAFETY: populated in `init()`; `self` holds no other reference to
-            // it while the bundle is set up.
+            // SAFETY: filled in `init()`; `*self` outlives `bv2` and nothing else borrows it here.
             unsafe { &mut *server_ptr },
             Some(bundler::bundle_v2::BakeOptions {
                 framework: self.framework.as_bundler_view(),

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -119,38 +119,27 @@ impl DevServer {
     }
 
     // ── transpiler accessors ───────────────────────────────────────────────
-    // The three transpilers are `MaybeUninit` until `init()` writes them via
-    // `Framework::init_transpiler`. Every access after `init()` returns goes
-    // through these helpers; the SAFETY contract is that `init()` is the only
-    // constructor and it always populates the server and client transpilers
-    // before returning `Ok`. The SSR one only exists when the framework has a
-    // separate SSR graph (`initialized_transpilers == 3`).
+    // `init()` fills the server and client slots before it returns `Ok`; the
+    // SSR slot only when the framework has a separate SSR graph.
     #[inline]
     pub(crate) fn server_transpiler(&self) -> &Transpiler<'static> {
-        // SAFETY: written in `init()` before any access.
-        unsafe { self.server_transpiler.assume_init_ref() }
+        self.server_transpiler.get()
     }
     #[inline]
     pub(crate) fn server_transpiler_mut(&mut self) -> &mut Transpiler<'static> {
-        // SAFETY: written in `init()` before any access.
-        unsafe { self.server_transpiler.assume_init_mut() }
+        self.server_transpiler.get_mut()
     }
     #[inline]
     pub(crate) fn client_transpiler(&self) -> &Transpiler<'static> {
-        // SAFETY: written in `init()` before any access.
-        unsafe { self.client_transpiler.assume_init_ref() }
+        self.client_transpiler.get()
     }
     #[inline]
     pub(crate) fn client_transpiler_mut(&mut self) -> &mut Transpiler<'static> {
-        // SAFETY: written in `init()` before any access.
-        unsafe { self.client_transpiler.assume_init_mut() }
+        self.client_transpiler.get_mut()
     }
     #[inline]
     pub(crate) fn ssr_transpiler_mut(&mut self) -> &mut Transpiler<'static> {
-        debug_assert!(self.initialized_transpilers == 3);
-        // SAFETY: `init()` only builds the SSR transpiler for a separate SSR
-        // graph, and callers only reach this in that configuration.
-        unsafe { self.ssr_transpiler.assume_init_mut() }
+        self.ssr_transpiler.get_mut()
     }
     /// The transpiler `BundleV2` should use for the SSR graph: the dedicated
     /// one when it exists, otherwise the server transpiler (the same aliasing
@@ -159,7 +148,7 @@ impl DevServer {
     /// handed to the bundler as `&mut` at the same time.
     #[inline]
     fn ssr_transpiler_ptr_for_bundle(&mut self) -> *mut Transpiler<'static> {
-        if self.initialized_transpilers == 3 {
+        if self.ssr_transpiler.is_initialized() {
             self.ssr_transpiler.as_mut_ptr()
         } else {
             self.server_transpiler.as_mut_ptr()
@@ -411,19 +400,12 @@ pub struct DevServer {
     // `CurrentBundle.bv2`). `Transpiler<'a>` borrows the global
     // `Fs::FileSystem` singleton + `dot_env::Loader`, both of which outlive
     // the server.
-    // `MaybeUninit` until `Framework::init_transpiler` populates them in place
-    // (in `init()` below) — `Transpiler` contains a non-nullable `&Arena`, so
-    // neither `Default` nor `mem::zeroed()` are sound (PORTING.md §Forbidden).
-    // `ssr_transpiler` stays uninitialized unless the framework has a separate
-    // SSR graph; see `ssr_transpiler_ptr_for_bundle`.
-    pub(crate) server_transpiler: ::core::mem::MaybeUninit<Transpiler<'static>>,
-    pub(crate) client_transpiler: ::core::mem::MaybeUninit<Transpiler<'static>>,
-    pub(crate) ssr_transpiler: ::core::mem::MaybeUninit<Transpiler<'static>>,
-    /// How many of `server_transpiler`, `client_transpiler`, `ssr_transpiler`
-    /// (populated in that order) hold a live `Transpiler`. `init()` bumps it as
-    /// each one is built, so `Drop` tears down exactly the ones that exist
-    /// when initialization fails part-way through.
-    pub(crate) initialized_transpilers: u8,
+    // Empty until `Framework::init_transpiler` fills them in `init()` below;
+    // `ssr_transpiler` stays empty unless the framework has a separate SSR
+    // graph (see `ssr_transpiler_ptr_for_bundle`).
+    pub(crate) server_transpiler: bake::TranspilerSlot<'static>,
+    pub(crate) client_transpiler: bake::TranspilerSlot<'static>,
+    pub(crate) ssr_transpiler: bake::TranspilerSlot<'static>,
     /// The log used by all `server_transpiler`, `client_transpiler` and `ssr_transpiler`.
     /// Note that it is rarely correct to write messages into it. Instead, associate
     /// messages with the IncrementalGraph file or Route using `SerializedFailure`
@@ -512,18 +494,17 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         .unwrap_or(false);
 
     // `bun_watcher` and `watcher_atomics` point back at the server, so they
-    // need its heap address before it exists as a value. Rust forbids partial
-    // struct literals and `mem::zeroed()` here is UB (`Box<Watcher>` is
-    // `NonNull`-backed; `Transpiler<'a>` carries `&'a Arena`), so allocate
-    // uninitialized storage, build those two against its address, then write
-    // every field with `addr_of_mut!().write()` and `assume_init()`.
+    // need its heap address before it exists as a value, and the struct is
+    // ~15 KiB (three inline transpiler slots plus the deferred request pool),
+    // which a struct literal would build on the stack and copy (see the note
+    // on `hive_array::Fallback::new_boxed`). Instead: allocate uninitialized
+    // storage, build those two against its address, write every field with
+    // `addr_of_mut!().write()`, `assume_init()`.
     //
-    // Ordering matters for the error paths: `MaybeUninit` never drops what was
-    // written into it, so nothing that owns a resource is written until every
-    // step that can fail before `assume_init()` has passed. The transpilers
-    // (the remaining fallible part of construction) are built after
-    // `assume_init()`, so a failure there tears the server down through
-    // `Drop` like any other failure later in this function.
+    // `MaybeUninit` never drops what was written into it, so the steps that
+    // can fail come either before anything is written (below) or after
+    // `assume_init()`, where a failure drops the `Box<DevServer>` and `Drop`
+    // tears down whatever exists, like any later failure in this function.
     use ::core::mem::MaybeUninit;
     use ::core::ptr::addr_of_mut;
 
@@ -566,10 +547,9 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
 
     // SAFETY: `p` is a freshly-allocated, properly-aligned `*mut DevServer`; each
     // `addr_of_mut!((*p).field)` computes an in-bounds field address without
-    // creating a reference to the (partially-uninit) whole. Every field except
-    // the three `MaybeUninit` transpiler slots (valid in any state) is written
-    // exactly once below, and nothing in between can fail, so `assume_init()`
-    // at the end of the block is sound.
+    // creating a reference to the (partially-uninit) whole. Every field is
+    // written exactly once below and nothing in between can fail, so the
+    // `assume_init()` at the end of the block is sound.
     let mut dev: Box<DevServer> = unsafe {
         w!(magic, Magic::Valid);
         w!(root, Box::from(options.root.as_bytes()));
@@ -668,7 +648,9 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         // dereferenced during construction.
         w!(watcher_atomics, WatcherAtomics::init(p));
         w!(bundler_framework_views, Vec::with_capacity(4));
-        w!(initialized_transpilers, 0);
+        w!(server_transpiler, bake::TranspilerSlot::uninit());
+        w!(client_transpiler, bake::TranspilerSlot::uninit());
+        w!(ssr_transpiler, bake::TranspilerSlot::uninit());
 
         dev_uninit.assume_init()
     };
@@ -690,33 +672,37 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     // SAFETY: `options.arena` outlives every `Transpiler` field it backs (see
     // `Options::arena` doc — "must live until DevServer drops").
     let arena: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref(options.arena) };
-    // Same order as `initialized_transpilers` counts them. `init_transpiler`
-    // leaves the slot uninitialized when it fails, so the count is still right
-    // for `Drop` when the `?` below drops `dev`.
     let graphs: &[bake::Graph] = if separate_ssr_graph {
         &[bake::Graph::Server, bake::Graph::Client, bake::Graph::Ssr]
     } else {
         &[bake::Graph::Server, bake::Graph::Client]
     };
     for &graph in graphs {
+        // The bundler crate (lower tier) reads the framework through its own
+        // projection, which the transpiler borrows for as long as it lives.
+        // Registered with `dev` before the call so that `Drop` destroys it
+        // whether or not the transpiler gets built.
+        let view: *mut bun_bundler::bake_types::Framework =
+            arena.alloc(dev.framework.as_bundler_view());
+        dev.bundler_framework_views.push(view);
         let (slot, config) = match graph {
             bake::Graph::Server => (&mut dev.server_transpiler, &dev.bundler_options.server),
             bake::Graph::Client => (&mut dev.client_transpiler, &dev.bundler_options.client),
             bake::Graph::Ssr => (&mut dev.ssr_transpiler, &dev.bundler_options.ssr),
         };
-        let view = dev
-            .framework
+        dev.framework
             .init_transpiler(
                 arena,
                 &mut dev.log,
                 bake::Mode::Development,
                 graph,
                 slot,
+                // SAFETY: a fresh slot in `arena`, which outlives `dev`; it is only
+                // dropped in place by `Drop for DevServer`, after the transpilers.
+                unsafe { &*view },
                 config,
             )
             .map_err(|err| global.throw_error(err, generic_action))?;
-        dev.bundler_framework_views.push(view);
-        dev.initialized_transpilers += 1;
     }
 
     let dev_ptr: *mut DevServer = &raw mut *dev;
@@ -921,9 +907,9 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
                 &mut buf[..],
                 &[&fsr.root],
             );
-            // SAFETY: `server_transpiler` was fully initialized by `init_transpiler`
-            // above; `.resolver` is disjoint from `framework`.
-            let Some(entry) = unsafe { (*dev_ptr).server_transpiler.assume_init_mut() }
+            // SAFETY: `server_transpiler` is disjoint from `framework`.
+            let Some(entry) = unsafe { &mut (*dev_ptr).server_transpiler }
+                .get_mut()
                 .resolver
                 .read_dir_info_ignore_error(joined_root)
             else {
@@ -1036,7 +1022,6 @@ impl Drop for DevServer {
                 server_transpiler: _,
                 client_transpiler: _,
                 ssr_transpiler: _,
-                initialized_transpilers: _,
                 log: _,
                 plugin_state: _,
                 current_bundle: _,
@@ -1159,20 +1144,10 @@ impl Drop for DevServer {
             ));
         }
 
-        // `init()` may have failed before building all of them (or, without a
-        // separate SSR graph, never builds the third one).
-        let initialized = usize::from(self.initialized_transpilers);
-        debug_assert!(initialized <= 3);
-        let slots = [
-            &mut self.server_transpiler,
-            &mut self.client_transpiler,
-            &mut self.ssr_transpiler,
-        ];
-        for slot in slots.into_iter().take(initialized) {
-            // SAFETY: `init()` populates the slots in this order and counts each
-            // one it populated; none of them is dropped anywhere else.
-            unsafe { slot.assume_init_drop() };
-        }
+        // The transpilers borrow the views, so they go first.
+        self.server_transpiler.clear();
+        self.client_transpiler.clear();
+        self.ssr_transpiler.clear();
 
         for &ptr in &self.bundler_framework_views {
             // SAFETY: each ptr is a unique arena slot written once in `init()`.

--- a/src/runtime/bake/dev_server/memory_cost.rs
+++ b/src/runtime/bake/dev_server/memory_cost.rs
@@ -75,6 +75,7 @@ pub(crate) fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
             server_transpiler: _,
             client_transpiler: _,
             ssr_transpiler: _,
+            initialized_transpilers: _,
             log: _,
             plugin_state: _,
             current_bundle: _,
@@ -101,6 +102,7 @@ pub(crate) fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
     //   .frontend_only
     //   .generation
     //   .graph_safety_lock
+    //   .initialized_transpilers
     //   .magic
     //   .memory_visualizer_timer
     //   .plugin_state

--- a/src/runtime/bake/dev_server/memory_cost.rs
+++ b/src/runtime/bake/dev_server/memory_cost.rs
@@ -75,7 +75,6 @@ pub(crate) fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
             server_transpiler: _,
             client_transpiler: _,
             ssr_transpiler: _,
-            initialized_transpilers: _,
             log: _,
             plugin_state: _,
             current_bundle: _,
@@ -102,7 +101,6 @@ pub(crate) fn memory_cost_detailed(dev: &DevServer) -> MemoryCost {
     //   .frontend_only
     //   .generation
     //   .graph_safety_lock
-    //   .initialized_transpilers
     //   .magic
     //   .memory_visualizer_timer
     //   .plugin_state

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -454,9 +454,9 @@ impl HotReloadEvent {
 
                 // Bust resolution cache, but since Bun does not watch all
                 // directories in a codebase, this only targets the following resolutions
-                // SAFETY: server_transpiler is initialized in DevServer::init before any
-                // HotReloadEvent can fire.
-                let _ = unsafe { dev.server_transpiler.assume_init_mut() }
+                let _ = dev
+                    .server_transpiler
+                    .get_mut()
                     .resolver
                     .bust_dir_cache(changed_dir);
 
@@ -478,7 +478,9 @@ impl HotReloadEvent {
                         // `specifier` points into the dep's owned `Box<[u8]>`, which is
                         // not mutated until after `resolve` returns.
                         // SAFETY: see `Dep` doc — neither slice is mutated mid-resolve.
-                        let resolved = unsafe { dev.server_transpiler.assume_init_mut() }
+                        let resolved = dev
+                            .server_transpiler
+                            .get_mut()
                             .resolver
                             .resolve(
                                 bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
@@ -1384,19 +1386,20 @@ impl DirectoryWatchStore {
         });
 
         // Try to use an existing open directory handle
-        // SAFETY: server_transpiler is initialized by Framework::init_transpiler
-        // before DevServer accepts requests; `dev` is a valid *mut DevServer.
-        let cache_fd: Option<bun_sys::Fd> =
-            match unsafe { (*dev).server_transpiler.assume_init_mut() }
-                .resolver
-                .read_dir_info(dir_name_to_watch)
-            {
-                Ok(Some(cache)) => {
-                    let fd = cache.get_file_descriptor();
-                    if fd.is_valid() { Some(fd) } else { None }
-                }
-                Ok(None) | Err(_) => None,
-            };
+        // SAFETY: `dev` is the live DevServer owning this store;
+        // `server_transpiler` is disjoint from `directory_watchers` so this
+        // `&mut` does not alias `&mut self`.
+        let cache_fd: Option<bun_sys::Fd> = match unsafe { &mut (*dev).server_transpiler }
+            .get_mut()
+            .resolver
+            .read_dir_info(dir_name_to_watch)
+        {
+            Ok(Some(cache)) => {
+                let fd = cache.get_file_descriptor();
+                if fd.is_valid() { Some(fd) } else { None }
+            }
+            Ok(None) | Err(_) => None,
+        };
 
         let (fd, owned_fd): (bun_sys::Fd, bool) = if bun_watcher::REQUIRES_FILE_DESCRIPTORS {
             if let Some(fd) = cache_fd {

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -197,8 +197,11 @@ impl Framework {
     /// `conditions`/`env`/`define`/`drop` until the schema types are
     /// const-constructible — those paths default).
     /// Returns the arena slot for the `bake_types::Framework` projection; caller must `drop_in_place` it.
+    ///
+    /// On `Err`, `out` is left uninitialized: whatever was built into it is
+    /// dropped again here, so the caller has nothing to tear down.
     pub(crate) fn init_transpiler<'a>(
-        &mut self,
+        &self,
         arena: &'a bun_alloc::Arena,
         log: &mut bun_ast::Log,
         mode: Mode,
@@ -206,17 +209,55 @@ impl Framework {
         out: &mut core::mem::MaybeUninit<bun_bundler::Transpiler<'a>>,
         bundler_options: &BuildConfigSubset,
     ) -> crate::Result<*mut bun_bundler::bake_types::Framework> {
-        use bun_options_types::schema as bun_schema;
-
         let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(arena);
         let _ast_scope = ast_memory_allocator.enter();
 
-        let out: &mut bun_bundler::Transpiler = out.write(bun_bundler::Transpiler::init(
+        // Nothing has been written into `out` yet if this fails.
+        let transpiler = out.write(bun_bundler::Transpiler::init(
             arena,
             log,
-            bun_schema::api::TransformOptions::default(),
+            bun_options_types::schema::api::TransformOptions::default(),
             None,
         )?);
+        // The bundler crate (lower tier) carries a TYPE_ONLY
+        // projection (`bake_types::Framework`); construct it here and give it
+        // arena lifetime so `BundleOptions<'a>` can borrow it for the bundle pass.
+        let framework_view: *mut bun_bundler::bake_types::Framework =
+            arena.alloc(self.as_bundler_view());
+
+        if let Err(err) = self.configure_transpiler(
+            transpiler,
+            framework_view,
+            log,
+            mode,
+            renderer,
+            bundler_options,
+            arena,
+        ) {
+            // SAFETY: `out` was written above and the `transpiler` borrow ended
+            // with the call. The transpiler goes first because its
+            // `options.framework` points at `framework_view`; the view is a
+            // fresh arena slot nothing else references.
+            unsafe {
+                out.assume_init_drop();
+                core::ptr::drop_in_place(framework_view);
+            }
+            return Err(err);
+        }
+        Ok(framework_view)
+    }
+
+    fn configure_transpiler<'a>(
+        &self,
+        out: &mut bun_bundler::Transpiler<'a>,
+        framework_view: *mut bun_bundler::bake_types::Framework,
+        log: &mut bun_ast::Log,
+        mode: Mode,
+        renderer: Graph,
+        bundler_options: &BuildConfigSubset,
+        arena: &'a bun_alloc::Arena,
+    ) -> crate::Result<()> {
+        use bun_options_types::schema as bun_schema;
 
         out.options.target = match renderer {
             Graph::Client => bun_ast::Target::Browser,
@@ -266,12 +307,7 @@ impl Framework {
         out.options.minify_identifiers = mode != Mode::Development;
         out.options.minify_whitespace = mode != Mode::Development;
         out.options.css_chunking = true;
-        // The bundler crate (lower tier) carries a TYPE_ONLY
-        // projection (`bake_types::Framework`); construct it here and give it
-        // arena lifetime so `BundleOptions<'a>` can borrow it for the bundle pass.
-        let framework_view: *mut bun_bundler::bake_types::Framework =
-            arena.alloc(self.as_bundler_view());
-        // SAFETY: `arena.alloc` returns a non-null, initialized pointer backed by `arena: &'a Arena`,
+        // SAFETY: `framework_view` is a non-null, initialized slot backed by `arena: &'a Arena`,
         // which outlives `out: &mut Transpiler<'a>`, so borrowing it as `&'a Framework` is sound.
         out.options.framework = Some(unsafe { &*framework_view });
         out.options.inline_entrypoint_import_meta_main = true;
@@ -346,7 +382,7 @@ impl Framework {
         // Re-sync after define/naming mutations so the
         // resolver sees the final option set.
         out.sync_resolver_opts();
-        Ok(framework_view)
+        Ok(())
     }
 
     /// Resolves built-in module

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -196,8 +196,6 @@ impl Framework {
     /// version operates on the keystone `BuildConfigSubset` (which omits
     /// `conditions`/`env`/`define`/`drop` until the schema types are
     /// const-constructible — those paths default).
-    ///
-    /// `framework_view` is `self.as_bundler_view()`, borrowed for the transpiler's lifetime.
     pub(crate) fn init_transpiler<'a>(
         &self,
         arena: &'a bun_alloc::Arena,
@@ -458,8 +456,7 @@ impl Framework {
     }
 }
 
-/// A `Transpiler` built in place by `Framework::init_transpiler` (once configured
-/// it points into its own fields), or nothing yet; drops whichever it holds.
+/// In-place home of a `Transpiler` (configured, it points into its own fields); drops it if filled.
 pub(crate) struct TranspilerSlot<'a> {
     transpiler: core::mem::MaybeUninit<bun_bundler::Transpiler<'a>>,
     initialized: bool,

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -197,10 +197,7 @@ impl Framework {
     /// `conditions`/`env`/`define`/`drop` until the schema types are
     /// const-constructible — those paths default).
     ///
-    /// `framework_view` is the caller's projection of `self` (see
-    /// `as_bundler_view`); the transpiler borrows it for as long as it lives.
-    /// On `Err`, `out` may already hold the partially configured transpiler;
-    /// the slot drops it.
+    /// `framework_view` is `self.as_bundler_view()`, borrowed for the transpiler's lifetime.
     pub(crate) fn init_transpiler<'a>(
         &self,
         arena: &'a bun_alloc::Arena,
@@ -461,10 +458,8 @@ impl Framework {
     }
 }
 
-/// Storage that a `Framework::init_transpiler*` fills in place (a configured
-/// `Transpiler` points into its own fields, so it cannot be built and moved)
-/// and that knows whether it was filled. Owners that can stop part-way through
-/// building several of them (`DevServer::init`) just drop their slots.
+/// A `Transpiler` built in place by `Framework::init_transpiler` (once configured
+/// it points into its own fields), or nothing yet; drops whichever it holds.
 pub(crate) struct TranspilerSlot<'a> {
     transpiler: core::mem::MaybeUninit<bun_bundler::Transpiler<'a>>,
     initialized: bool,
@@ -492,34 +487,30 @@ impl<'a> TranspilerSlot<'a> {
         transpiler
     }
 
-    /// Panics if the slot was never filled (`init_transpiler` did not return `Ok` for it).
+    /// Panics if the slot is empty.
     pub(crate) fn get(&self) -> &bun_bundler::Transpiler<'a> {
         assert!(self.initialized, "transpiler slot is empty");
-        // SAFETY: `initialized` is only set by `write`, once it has stored the
-        // transpiler, and only cleared by `clear`, which drops it.
+        // SAFETY: `initialized` is set by `write` after it stores the transpiler and
+        // cleared by `clear` as it drops it.
         unsafe { self.transpiler.assume_init_ref() }
     }
 
-    /// See `get`.
+    /// Panics if the slot is empty.
     pub(crate) fn get_mut(&mut self) -> &mut bun_bundler::Transpiler<'a> {
         assert!(self.initialized, "transpiler slot is empty");
         // SAFETY: see `get`.
         unsafe { self.transpiler.assume_init_mut() }
     }
 
-    /// For handing the transpiler to code that keeps raw pointers to it
-    /// (`BundleV2`), or for reaching one of its fields without forming a
-    /// reference to the whole transpiler. Only valid to dereference while the
-    /// slot is initialized.
+    /// Only valid to dereference while the slot is filled.
     pub(crate) fn as_mut_ptr(&mut self) -> *mut bun_bundler::Transpiler<'a> {
         self.transpiler.as_mut_ptr()
     }
 
-    /// Drops the transpiler, if there is one, leaving the slot empty.
     pub(crate) fn clear(&mut self) {
         if core::mem::take(&mut self.initialized) {
-            // SAFETY: `initialized` was set, so the slot holds a transpiler, and
-            // it was just cleared, so nothing drops it a second time.
+            // SAFETY: the flag was set, so a transpiler is stored; it is already
+            // cleared, so nothing drops the transpiler again.
             unsafe { self.transpiler.assume_init_drop() };
         }
     }

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -196,68 +196,32 @@ impl Framework {
     /// version operates on the keystone `BuildConfigSubset` (which omits
     /// `conditions`/`env`/`define`/`drop` until the schema types are
     /// const-constructible — those paths default).
-    /// Returns the arena slot for the `bake_types::Framework` projection; caller must `drop_in_place` it.
     ///
-    /// On `Err`, `out` is left uninitialized: whatever was built into it is
-    /// dropped again here, so the caller has nothing to tear down.
+    /// `framework_view` is the caller's projection of `self` (see
+    /// `as_bundler_view`); the transpiler borrows it for as long as it lives.
+    /// On `Err`, `out` may already hold the partially configured transpiler;
+    /// the slot drops it.
     pub(crate) fn init_transpiler<'a>(
         &self,
         arena: &'a bun_alloc::Arena,
         log: &mut bun_ast::Log,
         mode: Mode,
         renderer: Graph,
-        out: &mut core::mem::MaybeUninit<bun_bundler::Transpiler<'a>>,
+        out: &mut TranspilerSlot<'a>,
+        framework_view: &'a bun_bundler::bake_types::Framework,
         bundler_options: &BuildConfigSubset,
-    ) -> crate::Result<*mut bun_bundler::bake_types::Framework> {
+    ) -> crate::Result<()> {
+        use bun_options_types::schema as bun_schema;
+
         let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(arena);
         let _ast_scope = ast_memory_allocator.enter();
 
-        // Nothing has been written into `out` yet if this fails.
-        let transpiler = out.write(bun_bundler::Transpiler::init(
+        let out: &mut bun_bundler::Transpiler = out.write(bun_bundler::Transpiler::init(
             arena,
             log,
-            bun_options_types::schema::api::TransformOptions::default(),
+            bun_schema::api::TransformOptions::default(),
             None,
         )?);
-        // The bundler crate (lower tier) carries a TYPE_ONLY
-        // projection (`bake_types::Framework`); construct it here and give it
-        // arena lifetime so `BundleOptions<'a>` can borrow it for the bundle pass.
-        let framework_view: *mut bun_bundler::bake_types::Framework =
-            arena.alloc(self.as_bundler_view());
-
-        if let Err(err) = self.configure_transpiler(
-            transpiler,
-            framework_view,
-            log,
-            mode,
-            renderer,
-            bundler_options,
-            arena,
-        ) {
-            // SAFETY: `out` was written above and the `transpiler` borrow ended
-            // with the call. The transpiler goes first because its
-            // `options.framework` points at `framework_view`; the view is a
-            // fresh arena slot nothing else references.
-            unsafe {
-                out.assume_init_drop();
-                core::ptr::drop_in_place(framework_view);
-            }
-            return Err(err);
-        }
-        Ok(framework_view)
-    }
-
-    fn configure_transpiler<'a>(
-        &self,
-        out: &mut bun_bundler::Transpiler<'a>,
-        framework_view: *mut bun_bundler::bake_types::Framework,
-        log: &mut bun_ast::Log,
-        mode: Mode,
-        renderer: Graph,
-        bundler_options: &BuildConfigSubset,
-        arena: &'a bun_alloc::Arena,
-    ) -> crate::Result<()> {
-        use bun_options_types::schema as bun_schema;
 
         out.options.target = match renderer {
             Graph::Client => bun_ast::Target::Browser,
@@ -307,9 +271,7 @@ impl Framework {
         out.options.minify_identifiers = mode != Mode::Development;
         out.options.minify_whitespace = mode != Mode::Development;
         out.options.css_chunking = true;
-        // SAFETY: `framework_view` is a non-null, initialized slot backed by `arena: &'a Arena`,
-        // which outlives `out: &mut Transpiler<'a>`, so borrowing it as `&'a Framework` is sound.
-        out.options.framework = Some(unsafe { &*framework_view });
+        out.options.framework = Some(framework_view);
         out.options.inline_entrypoint_import_meta_main = true;
         if let Some(ignore) = bundler_options.ignore_dce_annotations {
             out.options.ignore_dce_annotations = ignore;
@@ -496,6 +458,76 @@ impl Framework {
             ),
             ..Default::default()
         });
+    }
+}
+
+/// Storage that a `Framework::init_transpiler*` fills in place (a configured
+/// `Transpiler` points into its own fields, so it cannot be built and moved)
+/// and that knows whether it was filled. Owners that can stop part-way through
+/// building several of them (`DevServer::init`) just drop their slots.
+pub(crate) struct TranspilerSlot<'a> {
+    transpiler: core::mem::MaybeUninit<bun_bundler::Transpiler<'a>>,
+    initialized: bool,
+}
+
+impl<'a> TranspilerSlot<'a> {
+    pub(crate) const fn uninit() -> Self {
+        Self {
+            transpiler: core::mem::MaybeUninit::uninit(),
+            initialized: false,
+        }
+    }
+
+    pub(crate) fn is_initialized(&self) -> bool {
+        self.initialized
+    }
+
+    fn write(
+        &mut self,
+        transpiler: bun_bundler::Transpiler<'a>,
+    ) -> &mut bun_bundler::Transpiler<'a> {
+        debug_assert!(!self.initialized);
+        let transpiler = self.transpiler.write(transpiler);
+        self.initialized = true;
+        transpiler
+    }
+
+    /// Panics if the slot was never filled (`init_transpiler` did not return `Ok` for it).
+    pub(crate) fn get(&self) -> &bun_bundler::Transpiler<'a> {
+        assert!(self.initialized, "transpiler slot is empty");
+        // SAFETY: `initialized` is only set by `write`, once it has stored the
+        // transpiler, and only cleared by `clear`, which drops it.
+        unsafe { self.transpiler.assume_init_ref() }
+    }
+
+    /// See `get`.
+    pub(crate) fn get_mut(&mut self) -> &mut bun_bundler::Transpiler<'a> {
+        assert!(self.initialized, "transpiler slot is empty");
+        // SAFETY: see `get`.
+        unsafe { self.transpiler.assume_init_mut() }
+    }
+
+    /// For handing the transpiler to code that keeps raw pointers to it
+    /// (`BundleV2`), or for reaching one of its fields without forming a
+    /// reference to the whole transpiler. Only valid to dereference while the
+    /// slot is initialized.
+    pub(crate) fn as_mut_ptr(&mut self) -> *mut bun_bundler::Transpiler<'a> {
+        self.transpiler.as_mut_ptr()
+    }
+
+    /// Drops the transpiler, if there is one, leaving the slot empty.
+    pub(crate) fn clear(&mut self) {
+        if core::mem::take(&mut self.initialized) {
+            // SAFETY: `initialized` was set, so the slot holds a transpiler, and
+            // it was just cleared, so nothing drops it a second time.
+            unsafe { self.transpiler.assume_init_drop() };
+        }
+    }
+}
+
+impl Drop for TranspilerSlot<'_> {
+    fn drop(&mut self) {
+        self.clear();
     }
 }
 

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -1,4 +1,5 @@
-import { bunEnv, bunExe } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "node:path";
 
 test("dev server deinitializes itself", () => {
@@ -13,3 +14,63 @@ test("dev server deinitializes itself", () => {
   // The child runs a whole `bun test` suite (nine GC-heavy cases plus leak
   // reporting at exit), which takes longer than the 5s default under ASAN.
 }, 60_000);
+
+test("dev server deinitializes itself when its initialization fails", async () => {
+  using dir = tempDir("dev-server-init-failure", {
+    // The define's value is parsed while the dev server configures its
+    // bundlers, which is where this one fails: "{" is not valid JSON.
+    "bunfig.toml": `[serve.static]\ndefine = { "BROKEN_DEFINE" = "{" }\n`,
+    "index.html": `<!DOCTYPE html><html><body><script src="./app.ts"></script></body></html>`,
+    "app.ts": `console.log(BROKEN_DEFINE);`,
+    "init-failure-fixture.ts": `
+      import { getDevServerDeinitCount } from "bun:internal-for-testing";
+      import html from "./index.html";
+
+      function serveAndFail(options) {
+        const before = getDevServerDeinitCount();
+        let message = "Bun.serve() did not throw";
+        try {
+          Bun.serve({ port: 0, development: true, fetch: () => new Response("unreachable"), ...options }).stop(true);
+        } catch (e) {
+          message = e.message;
+        }
+        return { message, deinits: getDevServerDeinitCount() - before };
+      }
+
+      console.log(
+        JSON.stringify({
+          // Fails while the per-graph bundlers are configured (the bunfig define).
+          bundlerConfig: serveAndFail({ routes: { "/": html } }),
+          // Gets further: fails when the framework's entry points are resolved.
+          frameworkResolve: serveAndFail({
+            app: {
+              framework: {
+                fileSystemRouterTypes: [{ root: "pages", style: "nextjs-pages", serverEntryPoint: "./missing-entry.ts" }],
+              },
+            },
+          }),
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "init-failure-fixture.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Each failed Bun.serve() must tear down the dev server it was building.
+  expect(JSON.parse(stdout)).toEqual({
+    bundlerConfig: { message: "ParserError while initializing development server", deinits: 1 },
+    frameworkResolve: { message: "Framework is missing required files!", deinits: 1 },
+  });
+  expect(stderr).toContain("Failed to resolve './missing-entry.ts' for framework (server side entrypoint)");
+  // Under ASAN, LeakSanitizer turns anything the failed servers left behind
+  // into a non-zero exit here.
+  expect(exitCode).toBe(0);
+  // The child's LeakSanitizer pass at exit alone takes a few seconds under ASAN.
+}, 30_000);

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -72,5 +72,4 @@ test("dev server deinitializes itself when its initialization fails", async () =
   // Under ASAN, LeakSanitizer turns anything the failed servers left behind
   // into a non-zero exit here.
   expect(exitCode).toBe(0);
-  // The child's LeakSanitizer pass at exit alone takes a few seconds under ASAN.
-}, 30_000);
+});


### PR DESCRIPTION
### Problem
- `DevServer::init` builds the server inside a `Box<MaybeUninit<DevServer>>` and returned early on failure. `MaybeUninit` never drops what was written into it, so every early return between the first field write and `assume_init()` leaked the half-built server: framework, log, the placeholder router, the `Box<Watcher>`, the `WatcherAtomics` allocation, and whatever transpiler had been built (`src/runtime/bake/DevServer.rs`, the `init_transpiler` returns before `assume_init()`). `Framework::init_transpiler` (`src/runtime/bake/mod.rs`) had the same shape one level down: it wrote the `Transpiler` into its slot and then `?`-returned from every later step, leaving a configured transpiler in a slot the caller never dropped.
- User-reachable: a `bunfig.toml` `[serve.static] define` whose value is not valid JSON fails inside `init_transpiler` on every `Bun.serve()` that has an HTML route (`Bun.serve()` throws `ParserError while initializing development server`). Measured on the release build: 300 such calls grow RSS by 64 MiB, about 130 to 220 KiB per call depending on the allocator; `getDevServerDeinitCount()` never moves; under ASAN, LeakSanitizer reports 561 leaked allocations for 3 calls. `Watcher::init` failing (`EMFILE` from `inotify_init1`) took the same path. With this change the same loop shows no per-call growth (ASAN build with the quarantine disabled: a constant 10 MiB after 100 and after 300 calls, versus 24 MiB and 50 MiB before).
- This started from a CI flake of `test/bake/deinitialization.test.ts` whose crash (`Segmentation fault at address 0xFFFFFFFFFFFFFFF8` dropping a `DynamicBitSetUnmanaged` under `DevServer::init`) looked like a zeroed `DevServer` being dropped on the init error path. That crash does not reproduce on main: the pattern matches the inline `WatcherAtomics` use-after-free fixed by #36247 (which landed after the flake), and the `Framework::resolve` failure path is clean under ASAN. What is still wrong in that function is the leak above.

### Fix
- `init` now does the two steps that can fail before the box is valid (`FileSystem::init`, `Watcher::init`) before writing any field, then writes every field and calls `assume_init()` in one block. From there on every failure (transpiler configuration, watcher start, `Framework::resolve`, router setup, route scan) returns with `?` and drops the `Box<DevServer>`, so `Drop for DevServer` runs the one teardown that already exists: `Watcher::shutdown`, freeing the atomics, the transpilers, the log, the framework, and so on. This is the right shape because `Drop` is the only place that knows how to take a `DevServer` apart, and the only reason the error paths could not use it was that the value did not exist yet; any failure added to `init` later is covered without an errdefer-style list to keep in sync.
- The three transpiler fields become `bake::TranspilerSlot`, a `MaybeUninit<Transpiler>` plus a flag that drops its transpiler itself. `init_transpiler` fills the slot (`Framework::init_transpiler` takes `&mut TranspilerSlot` and the caller's framework projection, and returns `()`), and `DevServer::init` registers the projection in `bundler_framework_views` before the call, so a transpiler that fails half-way through configuration and its projection are both torn down by the same `Drop`. The slot also replaces the `copy_nonoverlapping` that bitwise-copied the server transpiler into the SSR field when the framework has no separate SSR graph (it existed only so the field held something for `assume_init()`, and `Drop` had to recompute the condition to avoid a double drop): the SSR slot now stays empty in that configuration, and `start_async_bundle` hands the bundler the server transpiler instead, which is what `production.rs` already does and what `BundleV2::init` sets up for itself when it gets no SSR transpiler (the bundler only dereferences that pointer for files in a separate SSR graph). The accessors go through the slot, so the `assume_init_*` calls scattered over `DevServer.rs` and `dev_server/mod.rs` are gone, and reading an empty slot is a panic instead of undefined behaviour.
- The per-field `addr_of_mut!().write()` block stays: `bun_watcher` and `watcher_atomics` need the server's heap address before it exists, and the struct is about 15 KiB (three inline transpiler slots plus the deferred request pool), which a struct literal would build on the stack and copy; the comment on the block now says so (see also `hive_array::Fallback::new_boxed`).
- Intentionally not in this PR: the production build's `init_transpiler_with_options` has the same leak-on-error shape; #38233 is already converting it to a slot of this exact shape, so whichever of the two lands second should use the other's `TranspilerSlot` rather than keep two. `Watcher::shutdown` on a watcher whose thread never started frees the `Box` but does not close the inotify instance, and a started thread is not woken; #30644 / #36253 change `shutdown` for both cases, and this PR is what makes `shutdown` run on these paths at all. The app plugin handle is released by #37837; that PR defers the `bundler_options` write in `init` to dodge the leak fixed here, so on a rebase over this PR its `init()` hunks can be dropped and the plain field write kept.
- Verified with `test/bake/deinitialization.test.ts` (new test "dev server deinitializes itself when its initialization fails"): a child process fails `Bun.serve()` once in transpiler configuration (the bunfig define) and once in `Framework::resolve`, and asserts `getDevServerDeinitCount()` grows by one each time. On main the first case reports 0; with the fix both report 1. In ASAN lanes the child inherits `detect_leaks=1`, so anything still left behind fails the test through its exit code; locally the child is LeakSanitizer-clean with the CI settings (`BUN_DESTRUCT_VM_ON_EXIT=1`, `test/leaksan.supp`), and so is a script that fails `Framework::resolve` ten times across the separate and shared SSR graph configurations.
- Also run against the debug ASAN build: `test/bake/dev/esm.test.ts` and `test/bake/dev/bundle.test.ts` (server components without a separate SSR graph, i.e. the changed SSR pointer), `test/bake/dev/react-response.test.ts` (separate SSR graph, three transpilers), `test/js/bun/http/bun-serve-html.test.ts`, `cargo clippy -p bun_runtime`.

### Background
- `DevServer` is the native object behind `Bun.serve({ development: true })` with HTML routes or an `app` framework. It is heap-allocated once, and the file watcher and the `WatcherAtomics` hot-reload slots store its address before it is fully built, which is why `init` constructs it through `MaybeUninit` and per-field writes instead of a struct literal.
- `MaybeUninit<T>` is storage that may or may not hold a `T`; dropping it does nothing, and `assume_init()` turns it into a value whose `Drop` will run. Everything inside the box has to be a valid value at that point, which is what the `TranspilerSlot` (valid whether or not it holds a transpiler) provides for the fields that are filled in later.
- The dev server has one `Transpiler` per bundle graph: server, client, and (only for frameworks that render server components in a separate SSR graph) SSR. A `Transpiler` becomes self-referential once configured (`configure_linker` stores pointers into its own fields), so it has to be built directly in its final slot rather than built and moved, which is why the slots are filled in place.
- `bundler_framework_views` holds the arena-allocated projections of the framework that each transpiler's options point at; `Drop for DevServer` destroys them in place after the transpilers, and the arena itself belongs to the server config, which outlives the dev server.
- `getDevServerDeinitCount()` (`bun:internal-for-testing`) counts `Drop for DevServer` runs; it is the hook the existing deinitialization tests use.

<details>
<summary>First version of this PR</summary>

The first push tracked liveness with an `initialized_transpilers: u8` on `DevServer` that `init` bumped per transpiler and `Drop` used to drop that many slots, and split `init_transpiler` into a write step and a `configure_transpiler` body so it could drop a half-configured transpiler before returning the error. Review pointed out that this duplicated the slot type #38233 introduces for the production build, so the count and the split were replaced by `TranspilerSlot` as described above; the init reordering, the removal of the SSR alias copy, and the test are unchanged.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/deinitialization.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/174] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[2/174] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[3/174] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/r
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (eabb96de7)

test/bake/deinitialization.test.ts:
bun test v1.4.0-canary.1 (eabb96de7)

test.ts:
(pass) baseline: stopped server wrapper collects [0.03ms]
(pass) flags:  [2.83ms]
WebSocket opened
(pass) flags: websocket=1 [1.57ms]
WebSocket closed
WebSocket opened
WebSocket closed
(pass) flags: closeActiveConnections websocket=1 [251.92ms]
Bundled page in 253ms: index.html
(pass) flags: sendAnyRequests [256.93ms]
WebSocket opened
Bundled page in 252ms: index.html
WebSocket closed
(pass) flags: sendAnyRequests websocket=1 [255.49ms]
Bundled page in 253ms: index.html
(pass) flags: closeActiveConnections sendAnyRequests [503.45ms]
WebSocket opened
WebSocket closed
Bundled page in 252ms: index.html
(pass) flags: closeActiveConnections sendAnyRequests websocket=1 [504.49ms]
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket closed
(pass) flags: websocket=8 [2.33ms]
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSo
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/deinitialization.test.ts
bun test v1.4.0 (5998546ae)

test/bake/deinitialization.test.ts:
bun test v1.4.0 (5998546ae)

test.ts:
(pass) baseline: stopped server wrapper collects [2.11ms]
(pass) flags:  [54.59ms]
WebSocket opened
(pass) flags: websocket=1 [63.03ms]
WebSocket closed
WebSocket opened
WebSocket closed
(pass) flags: closeActiveConnections websocket=1 [279.47ms]
Bundled page in 423ms: index.html
(pass) flags: sendAnyRequests [509.29ms]
WebSocket opened
Bundled page in 294ms: index.html
WebSocket closed
(pass) flags: sendAnyRequests websocket=1 [342.64ms]
Bundled page in 276ms: index.html
(pass) flags: closeActiveConnections sendAnyRequests [565.16ms]
WebSocket opened
WebSocket closed
Bundled page in 293ms: index.html
(pass) flags: closeActiveConnections sendAnyRequests websocket=1 [558.91ms]
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
(pass) flags: websocket=8 [34.82ms]
WebSocket closed
WebSocket closed
WebSocket closed
WebSo
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     af0543b89a
  features     baseline

22 deps, 123 codegen, 1176 objects in 679ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (eabb96de7)

Checked 107 installs across 153 packages (no changes) [11.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (eabb96de7)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1238] gen bindgenv2
[5/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (eabb96de7)

Checked 129 installs across 147 packages (no changes) [11.00ms]
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] fetch zlib
[zlib] up to date
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/DevServer.rs      | 289 +++++++++++++------------------------
 src/runtime/bake/dev_server/mod.rs |  37 ++---
 src/runtime/bake/mod.rs            |  82 +++++++++--
 test/bake/deinitialization.test.ts |  62 +++++++-
 4 files changed, 254 insertions(+), 216 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/runtime/bake/DevServer.rs          26     44      0
src/runtime/bake/dev_server/mod.rs      3      4      0
src/runtime/bake/mod.rs                11     20      0
test/bake/deinitialization.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->