### PR TITLE
shell: treat a lone `-` as an operand in the builtin option parsers

### DIFF
--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -240,12 +240,9 @@ impl Ls {
     }
 
     fn parse_flag(opts: &mut Opts, flag: &[u8]) -> ParseFlag {
-        if flag.is_empty() || flag[0] != b'-' {
+        // A lone `-` is an operand (a file named `-`), as in getopt(3).
+        if flag.len() < 2 || flag[0] != b'-' {
             return ParseFlag::Done;
-        }
-        // FIXME windows
-        if flag.len() == 1 {
-            return ParseFlag::IllegalOption(Box::from(&b"-"[..]));
         }
         for &ch in &flag[1..] {
             match ch {

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -368,7 +368,8 @@ impl Mv {
     }
 
     fn parse_flag(flag: &[u8]) -> MvFlag {
-        if flag.is_empty() || flag[0] != b'-' {
+        // A lone `-` is an operand (a file named `-`), as in getopt(3).
+        if flag.len() < 2 || flag[0] != b'-' {
             return MvFlag::Done;
         }
         for &ch in &flag[1..] {

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -488,7 +488,8 @@ impl Rm {
     }
 
     fn parse_flag(opts: &mut Opts, flag: &[u8]) -> RmParseFlag {
-        if flag.is_empty() || flag[0] != b'-' {
+        // A lone `-` is an operand (a file named `-`), as in getopt(3).
+        if flag.len() < 2 || flag[0] != b'-' {
             return RmParseFlag::Done;
         }
         if flag.len() > 2 && flag[1] == b'-' {

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2315,7 +2315,7 @@ pub(crate) enum ParseError {
 
 impl ParseError {
     /// Borrow the option-name payload. The pointer borrows either a `'static`
-    /// literal (e.g. `b"-"`) or the owning `Builtin`'s argv storage
+    /// literal (see [`unsupported_flag`]) or the owning `Builtin`'s argv storage
     /// (NUL-terminated `Vec<u8>` in `Cmd::args`, live for the `Builtin`'s
     /// lifetime — see [`Builtin::arg_bytes`](crate::shell::builtin::Builtin::arg_bytes)).
     /// Builtins format the error before any argv mutation.
@@ -2375,11 +2375,9 @@ pub(crate) fn parse_flags<'a, O: FlagParser>(
 }
 
 fn parse_one_flag<O: FlagParser>(opts: &mut O, flag: &[u8]) -> ParseFlagResult {
-    if flag.is_empty() || flag[0] != b'-' {
+    // A lone `-` is an operand, as in getopt(3).
+    if flag.len() < 2 || flag[0] != b'-' {
         return ParseFlagResult::Done;
-    }
-    if flag.len() == 1 {
-        return ParseFlagResult::IllegalOption(std::ptr::from_ref::<[u8]>(b"-"));
     }
     if flag.len() > 2 && flag[1] == b'-' {
         if let Some(r) = opts.parse_long(flag) {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1227,6 +1227,20 @@ ${temp_dir}`
     });
   });
 
+  // A lone `-` is an operand (a file named `-`), as with getopt(3). The option
+  // parsers used to reject it as `illegal option -- -` (rm and mv swallowed it
+  // as an empty flag cluster instead).
+  describe("lone - operand", () => {
+    TestBuilder.command`touch -`.ensureTempDir().stderr("").exitCode(0).fileEquals("-", "").runAsTest("touch -");
+
+    TestBuilder.command`mkdir -p -; echo inside > -/file.txt`
+      .ensureTempDir()
+      .stderr("")
+      .exitCode(0)
+      .fileEquals("-/file.txt", "inside\n")
+      .runAsTest("mkdir -p - creates a directory named -");
+  });
+
   /**
    *
    */

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -13,6 +13,15 @@ const p = process.platform === "win32" ? (s: string) => s.replaceAll("/", "\\") 
 $.nothrow();
 
 describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
+  // A lone `-` is an operand (a file named `-`), as with getopt(3).
+  TestBuilder.command`cp - copy.txt`
+    .ensureTempDir()
+    .file("-", "dash")
+    .stderr("")
+    .exitCode(0)
+    .fileEquals("copy.txt", "dash")
+    .runAsTest("copy a file named -");
+
   TestBuilder.command`cat ${import.meta.filename} > lmao.txt; cp -v lmao.txt lmao2.txt`
     .stdout(p("$TEMP_DIR/lmao.txt -> $TEMP_DIR/lmao2.txt\n"))
     .ensureTempDir()

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -259,6 +259,29 @@ describe.concurrent("bunshell ls", () => {
         .stdout(s => expect(sortedLsOutput(s)).toEqual(["dir1", "dir2"]))
         .run();
     });
+
+    // A lone `-` is an operand (a file named `-`), as with getopt(3), and
+    // ends the flags like any other operand.
+    test("a lone - is an operand", async () => {
+      using tempdir = tempDir("ls-dash-operand", { "-": "", "visible": "" });
+      await TestBuilder.command`ls -a -`.setTempdir(String(tempdir)).stdout("-\n").stderr("").exitCode(0).run();
+      await TestBuilder.command`ls - visible`
+        .setTempdir(String(tempdir))
+        .stdout(s => expect(sortedLsOutput(s)).toEqual(["-", "visible"]))
+        .stderr("")
+        .exitCode(0)
+        .run();
+    });
+
+    test("a lone - names a file that does not exist", async () => {
+      await using tempdir = tempDir("ls-dash-missing", {});
+      await TestBuilder.command`ls -`
+        .setTempdir(tempdir)
+        .stdout("")
+        .stderr("ls: -: No such file or directory\n")
+        .exitCode(1)
+        .run();
+    });
   });
 
   describe("errors", () => {

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -27,6 +27,17 @@ $.nothrow();
 describe("mv", async () => {
   TestBuilder.command`echo foo > a; mv a b`.ensureTempDir().fileEquals("b", "foo\n").runAsTest("move file -> file");
 
+  // A lone `-` is an operand (a file named `-`), as with getopt(3); it used to
+  // be consumed as an empty cluster of flags, leaving mv with one operand.
+  TestBuilder.command`mv - b`
+    .ensureTempDir()
+    .file("-", "dash")
+    .stderr("")
+    .exitCode(0)
+    .fileEquals("b", "dash")
+    .doesNotExist("-")
+    .runAsTest("move a file named -");
+
   TestBuilder.command`touch a; mkdir foo; mv a foo; ls foo`
     .ensureTempDir()
     .stdout("a\n")

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -30,6 +30,31 @@ describe.concurrent("bunshell rm", () => {
     .doesNotExist("node_modules")
     .runAsTest("node_modules");
 
+  // A lone `-` is an operand (a file named `-`), as with getopt(3); it used to
+  // be consumed as an empty cluster of flags, leaving rm without operands.
+  TestBuilder.command`rm -v -`
+    .ensureTempDir()
+    .file("-", "")
+    .stdout("-\n")
+    .stderr("")
+    .exitCode(0)
+    .doesNotExist("-")
+    .runAsTest("rm -v - removes the file named -");
+
+  TestBuilder.command`rm -`
+    .ensureTempDir()
+    .stdout("")
+    .stderr("rm: -: No such file or directory\n")
+    .exitCode(1)
+    .runAsTest("rm - reports the missing file named -");
+
+  TestBuilder.command`rm -f -`
+    .ensureTempDir()
+    .stdout("")
+    .stderr("")
+    .exitCode(0)
+    .runAsTest("rm -f - ignores the missing file named -");
+
   test("force", async () => {
     const files = {
       "existent.txt": "",


### PR DESCRIPTION
### Problem
- The shell builtins reject a lone `-` argument. `mkdir -`, `touch -`, `ls -` (and, where cat and cp run as builtins, `cat -` and `cp - x`) fail with `illegal option -- -`; coreutils act on a file named `-`.
- `rm -` and `mv - x` silently drop the `-` and print usage: their parsers see a flag with no letters in it, so `rm -v -` removes nothing and `mv - x` has one operand too few.
- Cause: `parse_one_flag` in src/runtime/shell/interpreter.rs (shared by cat, cp, mkdir, touch) returns `IllegalOption` for a one-byte `-`; `Ls::parse_flag` (src/runtime/shell/builtin/ls.rs) has a copy of that check; `Rm::parse_flag` and `Mv::parse_flag` loop over `flag[1..]`, which is empty for `-`, and return `ContinueParsing`.

### Fix
- All four parsers treat an argument shorter than two bytes as an operand, which ends option parsing. `--`, `-x` and `-xyz` clusters are unaffected (two bytes or more).
- Correct because it is getopt(3)'s rule for `-`, which is what coreutils follow, and the builtins' operand handling already takes any name, so a file named `-` needs nothing else.
- The lone `-` was the only `'static` payload of `ParseError::IllegalOption`; the doc comment on `ParseError::opt` now points at `unsupported_flag` for the remaining literal payloads.
- The same one-line rule lands in four places because ls, rm and mv still carry their own copies of the shared classifier. Moving them onto `FlagParser` / `parse_flags` / `Builtin::fail_parse` would turn this rule, the `--` rule (#33995) and the option-name reporting into one hunk each; that consolidation is a separate, larger change and is not attempted here.
- Verified: the new tests fail on the 1.4.0 release (`illegal option -- -`, or usage for rm and mv) and pass with a debug build:
  - test/js/bun/shell/bunshell.test.ts, `lone - operand`: `touch -` creates the file, `mkdir -p -` creates the directory (flag before the operand).
  - test/js/bun/shell/commands/ls.test.ts: `ls -a -` lists the file, `ls - visible` lists both, `ls -` on a missing file reports `-`.
  - test/js/bun/shell/commands/rm.test.ts: `rm -v -` removes the file, `rm -` reports the missing file, `rm -f -` exits 0.
  - test/js/bun/shell/commands/mv.test.ts: `mv - b` moves the file.
  - test/js/bun/shell/commands/cp.test.ts: `cp - copy.txt` copies the file. This file only runs where cp is a builtin (Windows); the case fails on the Windows canary and passed with a Windows debug build of this branch (the parser hunks were identical at the time, see below).
- Also run: bunshell, exec, ls, rm and mv test files with the debug build on Linux (the only failures are the two ls permission-denied tests, which fail the same way without this change because the container runs as root); bunshell, bunshell-instance, file-io, yield, exec, pipeline_stack, cp, ls, rm and mv with a Windows debug build (615 pass; the five tilde-expansion failures need `HOME`, which that machine does not set, and fail the same way with the canary).
- Not in this PR: making the builtin cat read stdin for a `-` operand, as cat(1) does. With this change alone `cat -` reports `cat: -: No such file or directory` instead of `illegal option` (it still exits 1). An implementation existed in an earlier revision of this branch (ba5142d7), but it has to rebuild the per-operand reader handling that #37743 reworks (it also removed the `out_done` latch the way #37743 does, and on a reader that fails to start it ran into the same nested-trampoline panic #37743 fixes, `expected Node::Pipeline at Node#2, got Free`, which `true | cat < file` already hits today). The stdin half is better done on top of #37743 (and #39198's operand loop) once those land; this PR is the parser half, which stands on its own.

### Background
- Bun's shell (`Bun.$`) runs some commands as builtins inside the interpreter instead of spawning them. ls, rm, mv, mkdir and touch are builtins on every platform; cat and cp are builtins on Windows and, on POSIX, only when `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` is set in the bun process's environment (`Kind::DISABLED_ON_POSIX` in src/runtime/shell/Builtin.rs). That is why the cp test file is Windows-only and why there is no in-process cat test.
- cat, cp, mkdir and touch parse options through `parse_flags` / `parse_one_flag` in interpreter.rs, each supplying a `FlagParser` for its own letters; ls, rm and mv have their own small parsers of the same shape. Each stops at the first argument that is not an option and hands the rest to the builtin as operands; `parse_one_flag` returning `Done` is that stop.
- getopt(3): an argument that is exactly `-` is not an option; it ends option parsing and is the first operand. Coreutils use it as a file name (cat additionally reads stdin for it).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts test/js/bun/shell/commands/cp.test.ts test/js/bun/shell/commands/ls.test.ts test/js/bun/shell/commands/rm.test.ts

<!-- robobun:evidence:end -->