### PR TITLE
ci: skip the slowest 1% of test files on the PR darwin lane

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -804,6 +804,13 @@ function getTestBunStep(platform, options, testOptions = {}) {
     args.push("--exclude=internal/source-lints");
   }
 
+  // The untiered darwin lane PR builds get (see prDarwinTestPlatforms) skips
+  // the ~1% of files that take 10s or more; they are ~60% of a shard's wall
+  // time and still run on every other PR lane and on main's darwin lanes.
+  if (os === "darwin" && !platform.tier) {
+    args.push("--skip-slower-than=10000");
+  }
+
   const depends = [];
   if (!buildId) {
     depends.push(`${getTargetKey(platform)}-build-bun`);
@@ -1547,8 +1554,7 @@ async function getPipeline(options = {}) {
   // Untiered: any arm64 mac agent, whatever macOS it runs, can take it.
   /** @type {Platform[]} */
   const prDarwinTestPlatforms = [{ os: "darwin", arch: "aarch64", release: "any" }];
-  const darwinTestsEnabled =
-    isMainBranch() || isBuildManual() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
+  const darwinTestsEnabled = isMainBranch() || isBuildManual() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
   const relevantTestPlatforms = (
     includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan")
   )

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -155,6 +155,10 @@ const { values: options, positionals: filters } = parseArgs({
       multiple: true,
       default: undefined,
     },
+    ["skip-slower-than"]: {
+      type: "string",
+      default: undefined,
+    },
     ["quiet"]: {
       type: "boolean",
       default: false,
@@ -2473,6 +2477,35 @@ async function getVendorTests(cwd) {
 }
 
 /**
+ * Checked-in median wall-clock duration per test file for this lane, from
+ * expected-durations.json (see scripts/update-test-durations.mjs).
+ * @param {string} cwd
+ * @returns {Record<string, number>}
+ */
+function loadExpectedDurations(cwd) {
+  const durations = {};
+  try {
+    const raw = JSON.parse(readFileSync(join(cwd, "expected-durations.json"), "utf8"));
+    const step = options["step"] || "";
+    const lane = step.includes("asan")
+      ? "asan"
+      : step.includes("musl")
+        ? "musl"
+        : isWindows || step.includes("windows")
+          ? "windows"
+          : "default";
+    for (const [path, entry] of Object.entries(raw)) {
+      if (path === "_meta") continue;
+      const ms = entry[lane] ?? entry.default ?? entry.asan ?? entry.musl ?? entry.windows;
+      if (typeof ms === "number") durations[path] = ms;
+    }
+  } catch (e) {
+    console.warn("expected-durations.json not loaded:", e?.message || e);
+  }
+  return durations;
+}
+
+/**
  * @param {string} cwd
  * @param {string[]} testModifiers
  * @param {TestExpectation[]} testExpectations
@@ -2522,6 +2555,22 @@ function getRelevantTests(cwd, testModifiers, testExpectations) {
     }
   }
 
+  // Drop the slowest files by expected duration. Used on lanes that trade a
+  // little coverage for throughput; the same files still run on other lanes.
+  const skipSlowerThan = parseInt(options["skip-slower-than"]);
+  if (skipSlowerThan > 0) {
+    const durations = loadExpectedDurations(cwd);
+    const slow = availableTests.filter(testPath => (durations[testPath.replaceAll("\\", "/")] ?? 0) >= skipSlowerThan);
+    for (const testPath of slow) availableTests.splice(availableTests.indexOf(testPath), 1);
+    !isQuiet &&
+      console.log(
+        `Skipping tests slower than ${skipSlowerThan}ms:`,
+        slow.length,
+        "/",
+        availableTests.length + slow.length,
+      );
+  }
+
   const skipExpectations = testExpectations
     .filter(
       ({ modifiers, expectations }) =>
@@ -2564,25 +2613,7 @@ function getRelevantTests(cwd, testModifiers, testExpectations) {
     // machines without any coordination. Tests absent from the table (new
     // files, or the file failing to load) fall back to the table's median so
     // they spread across shards instead of all landing on shard 0.
-    let durations = {};
-    try {
-      const raw = JSON.parse(readFileSync(join(cwd, "expected-durations.json"), "utf8"));
-      const step = options["step"] || "";
-      const lane = step.includes("asan")
-        ? "asan"
-        : step.includes("musl")
-          ? "musl"
-          : isWindows || step.includes("windows")
-            ? "windows"
-            : "default";
-      for (const [path, entry] of Object.entries(raw)) {
-        if (path === "_meta") continue;
-        const ms = entry[lane] ?? entry.default ?? entry.asan ?? entry.musl ?? entry.windows;
-        if (typeof ms === "number") durations[path] = ms;
-      }
-    } catch (e) {
-      console.warn("expected-durations.json not loaded, sharding by index:", e?.message || e);
-    }
+    const durations = loadExpectedDurations(cwd);
     const known = Object.values(durations).sort((a, b) => a - b);
     const unknownCost = known.length ? known[Math.floor(known.length / 2)] : 100;
     const costOf = testPath => durations[testPath.replaceAll("\\", "/")] ?? unknownCost;


### PR DESCRIPTION
The mac pool is throughput-bound on PR builds. Profiling a real shard of the untiered PR darwin lane (13.5 min): 0.7 min setup, 1.4 min for the 4-wide parallel-safe phase, and **11.2 min of strictly serial test files**. Per `test/expected-durations.json` the distribution is very skewed: the **58 files ≥10s (1.1% of files) account for ~63% of expected time**; the median file is 0.14s.

- `scripts/runner.node.mjs`: new `--skip-slower-than=<ms>` option that drops files whose expected duration is at or above the threshold, using the same durations table LPT sharding already reads (loading moved into a shared `loadExpectedDurations`). Logs how many it skipped.
- `.buildkite/ci.mjs`: passes `--skip-slower-than=10000` **only** for the untiered darwin lane PR builds get. `main`, manual and `[macos tests]` builds run the version-specific darwin lanes without it, and every Linux/Windows PR lane still runs those files, so they stay covered pre-merge on other platforms and post-merge on macOS.

Expected effect: PR mac shards ~13.5 → ~5-6 min, i.e. roughly double the PR builds/hour the mac pool can serve.

Verified with `--dry-run` (PR: `darwin-aarch64-any-test-bun` carries the flag; main: no step does) and a local simulation of the selection against the repo (5,284 files → skips 58, removes 28.9 of 45.9 expected minutes).