### PR TITLE
prune: add --check, a CI gate that exits 1 when anything would be removed

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -1886,6 +1886,13 @@
           "multiple": false
         },
         {
+          "name": "check",
+          "description": "Exit with code 1 if node_modules has packages that can be removed, without deleting anything",
+          "hasValue": false,
+          "required": false,
+          "multiple": false
+        },
+        {
           "name": "os",
           "description": "Prune for a different operating system than the current one",
           "hasValue": true,
@@ -1950,7 +1957,7 @@
           "type": "string"
         }
       ],
-      "examples": ["bun prune", "bun prune --production", "bun prune --dry-run"],
+      "examples": ["bun prune", "bun prune --production", "bun prune --dry-run", "bun prune --check"],
       "usage": "Usage: bun prune [flags]",
       "documentationUrl": "https://bun.com/docs/pm/cli/prune.",
       "dynamicCompletions": {}

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -105,7 +105,7 @@ _bun_completions() {
     PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]="-c -y -p -f -g";
 
     PACKAGE_OPTIONS[DEDUPE_OPTIONS_LONG]="--check";
-    PACKAGE_OPTIONS[PRUNE_OPTIONS_LONG]="--production --prod --omit --filter --dry-run --os --cpu --linker --silent --cwd --help";
+    PACKAGE_OPTIONS[PRUNE_OPTIONS_LONG]="--production --prod --omit --filter --dry-run --check --os --cpu --linker --silent --cwd --help";
     PACKAGE_OPTIONS[PRUNE_OPTIONS_SHORT]="-p -P -F -h";
     PACKAGE_OPTIONS[AUDIT_OPTIONS_LONG]="--json --audit-level --ignore --prod --production --omit --dry-run --latest --cwd --help";
     PACKAGE_OPTIONS[AUDIT_OPTIONS_SHORT]="-L";

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -220,6 +220,7 @@ complete -c bun -n "__fish_seen_subcommand_from audit" -l "ignore" -r -d "Ignore
 complete -c bun -n "__fish_seen_subcommand_from audit" -l "prod" -d "Omit devDependencies" -f
 complete -c bun -n "__fish_seen_subcommand_from audit prune" -l "omit" -r -a "dev optional peer" -d "Omit the given dependency type" -f
 complete -c bun -n "__fish_seen_subcommand_from audit prune" -l "dry-run" -d "Print what would change without changing anything" -f
+complete -c bun -n "__fish_seen_subcommand_from prune" -l "check" -d "Exit with code 1 if node_modules has packages that can be removed, without deleting anything" -f
 complete -c bun -n "__fish_seen_subcommand_from audit; and __fish_seen_subcommand_from fix" -s "L" -l "latest" -d "Also apply fixes that fall outside the ranges declared in package.json or catalogs" -f
 complete -c bun -n "__fish_seen_subcommand_from prune" -s "p" -l "production" -d "Also remove packages that are only needed by devDependencies" -f
 complete -c bun -n "__fish_seen_subcommand_from prune" -s "P" -l "prod" -d "Also remove packages that are only needed by devDependencies" -f

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -737,6 +737,7 @@ _bun_prune_completion() {
         '--prod[Also remove packages that are only needed by devDependencies]' \
         '*--omit[Also remove packages that are only needed by the given dependency types]:type:(dev optional peer)' \
         '--dry-run[Print what would be removed without deleting anything]' \
+        '--check[Exit with code 1 if node_modules has packages that can be removed, without deleting anything]' \
         '*--os[Prune for a different operating system than the current one]:os' \
         '*--cpu[Prune for a different CPU architecture than the current one]:cpu' \
         '--linker[Prune a node_modules installed with the given linker]:linker:(isolated hoisted)' \

--- a/docs/pm/cli/prune.mdx
+++ b/docs/pm/cli/prune.mdx
@@ -51,6 +51,14 @@ bun prune v1.4.0 (abc12345)
   bun prune --production
 ```
 
+### `--check`
+
+Print the same report as `--dry-run`, but exit `1` if anything would be removed. Use it in CI:
+
+```bash terminal icon="terminal"
+bun prune --production --check
+```
+
 ### `--filter`
 
 Prune only the selected workspaces' `node_modules` folders (same patterns as [`bun install --filter`](/pm/filter)). Bun also cleans shared locations: the root `node_modules`, or `node_modules/.bun` with the isolated linker. In those locations, Bun keeps anything an unselected workspace still needs.

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -429,6 +429,9 @@ static PRUNE_PARAMS: &[ParamType] = concat_params![
     SHARED_PARAMS,
     &[
         clap::param!(
+            "--check                                Exit with code 1 if node_modules has packages that can be removed, without deleting anything"
+        ),
+        clap::param!(
             "-F, --filter <STR>...                  Only prune the node_modules folders of the matching workspaces"
         ),
         clap::param!("<POS> ...                              "),
@@ -441,6 +444,9 @@ const PRUNE_HELP_PARAMS: &[ParamType] = &[
     ),
     clap::param!(
         "--omit <dev|optional|peer>...          Also remove packages that are only needed by the given dependency types"
+    ),
+    clap::param!(
+        "--check                                Exit with code 1 if node_modules has packages that can be removed, without deleting anything"
     ),
     clap::param!(
         "--dry-run                              Print what would be removed without deleting anything"
@@ -1158,6 +1164,9 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/dedupe<r
   <d>Show what would be removed without deleting anything<r>
   <b><green>bun prune<r> <cyan>--dry-run<r>
 
+  <d>Only report what would be removed; exit code 1 if there is anything (for CI)<r>
+  <b><green>bun prune<r> <cyan>--check<r>
+
   <d>Only prune what the app workspace no longer needs<r>
   <b><green>bun prune<r> <cyan>--production --filter app<r>
 
@@ -1359,7 +1368,7 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             // cli.json_output = args.flag(b"--json");
         }
 
-        if subcommand == Subcommand::Dedupe && args.flag(b"--check") {
+        if matches!(subcommand, Subcommand::Dedupe | Subcommand::Prune) && args.flag(b"--check") {
             cli.check = true;
             cli.dry_run = true;
         }

--- a/src/install/prune.rs
+++ b/src/install/prune.rs
@@ -341,7 +341,7 @@ pub fn prune(manager: &mut PackageManager, original_cwd: &[u8]) -> crate::Result
             print_elapsed();
             print_apply_hint();
         }
-        return Ok(());
+        Global::exit(manager.options.check as u32);
     }
 
     let failed = execute(&plan, quiet);
@@ -398,7 +398,7 @@ fn print_apply_hint() {
         .skip_while(|arg| **arg != *b"prune")
         .skip(1)
     {
-        if arg.starts_with(b"--dry-run") {
+        if arg.starts_with(b"--dry-run") || arg.starts_with(b"--check") {
             continue;
         }
         bun_core::pretty!(" {}", BStr::new(arg));

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -436,6 +436,42 @@ test.concurrent("--dry-run prints without deleting; --silent deletes without pri
   expect(clean.exitCode).toBe(0);
 });
 
+// `--check` is the CI gate: the same report as `--dry-run`, but exits 1 when anything would be removed, like `bun dedupe --check`.
+test.concurrent("--check reports and exits 1 without deleting", async () => {
+  const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });
+  const junk = plant(dir, "node_modules/junk");
+
+  const check = await prune(dir, "--check");
+  expect(lines(check.stdout)).toStrictEqual([BANNER, "", "- junk", CAN_BE_REMOVED(1, 2), APPLY_HINT()]);
+  expect(check.stderr).toBe("");
+  expect(existsSync(junk)).toBeTrue();
+  expect(check.exitCode).toBe(1);
+
+  // The report is identical to --dry-run; only the exit code differs.
+  const dryRun = await prune(dir, "--dry-run");
+  expect(out(dryRun.stdout)).toBe(out(check.stdout));
+  expect(dryRun.exitCode).toBe(0);
+
+  // The hint omits both flags, so it stays copy-pasteable.
+  const both = await prune(dir, "--dry-run", "--check");
+  expect(lines(both.stdout)).toStrictEqual(lines(check.stdout));
+  expect(both.exitCode).toBe(1);
+
+  const silent = await prune(dir, "--check", "--silent");
+  expect(silent.stdout).toBe("");
+  expect(silent.stderr).toBe("");
+  expect(existsSync(junk)).toBeTrue();
+  expect(silent.exitCode).toBe(1);
+
+  const apply = await prune(dir);
+  expect(apply.exitCode).toBe(0);
+  expect(existsSync(junk)).toBeFalse();
+
+  const clean = await prune(dir, "--check");
+  expect(lines(clean.stdout)).toStrictEqual([BANNER, "", NOTHING(1, 1)]);
+  expect(clean.exitCode).toBe(0);
+});
+
 test.concurrent("nothing to prune when node_modules is missing or clean", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
   await write(packageJson, JSON.stringify({ name: "foo", dependencies: { "no-deps": "1.0.0" } }));
@@ -3340,6 +3376,7 @@ test.concurrent("--help lists every flag; -F is --filter, -p is --production", a
     Flags:
       -p, --production      Also remove packages that are only needed by devDependencies (alias: --prod)
           --omit=<val>      Also remove packages that are only needed by the given dependency types
+          --check           Exit with code 1 if node_modules has packages that can be removed, without deleting anything
           --dry-run         Print what would be removed without deleting anything
           --os=<val>        Prune for a different operating system than the current one
           --cpu=<val>       Prune for a different CPU architecture than the current one
@@ -3358,6 +3395,9 @@ test.concurrent("--help lists every flag; -F is --filter, -p is --production", a
 
       Show what would be removed without deleting anything
       bun prune --dry-run
+
+      Only report what would be removed; exit code 1 if there is anything (for CI)
+      bun prune --check
 
       Only prune what the app workspace no longer needs
       bun prune --production --filter app


### PR DESCRIPTION
### Problem

- `bun prune` has no CI gate: `bun prune --production --dry-run` exits 0 even when it would remove packages, so nothing equivalent to `bun dedupe --check` exists for prune (#39212).
- Reaching for `--check` by analogy with dedupe is actively destructive today: the unknown flag is silently ignored and `bun prune --production --check` performs a real prune (node_modules mutated, exit 0).

### Fix

- Adds `--check` to `bun prune`: prints the same report as `--dry-run`, deletes nothing, exits 1 if anything would be removed and 0 when clean, exactly mirroring `bun dedupe --check` (same `check`/`dry_run` flag plumbing, same `exit(check as u32)` on the report path).
- The copy-pasteable apply hint omits `--check` the same way it already omits `--dry-run`.
- Help text, docs (`docs/pm/cli/prune.mdx`), and shell completions (bash/zsh/fish/`bun-cli.json`) updated.
- Verified by `test/cli/install/bun-prune.test.ts` ("--check reports and exits 1 without deleting"): report matches `--dry-run` byte for byte, exit codes 1/0, `--silent --check` stays quiet but still gates, nothing is deleted. The help snapshot test covers the new flag and example. Full `bun-prune.test.ts` (111 pass) and `bun-dedupe.test.ts` (76 pass) are green with the debug build; the new test fails on a build without the change.

The issue's other two suggestions are intentional, test-asserted behavior and are left alone: `dedupe --check` and `--dry-run` printing the same report with only the exit code differing matches how `prune --check`/`--dry-run` now behave too (asserted in `bun-dedupe.test.ts`, "--dry-run prints what --check prints and exits 0"), and `dedupe --frozen-lockfile` keeps its gate semantics for configs/CI environments that inherit it.

### Background

- `bun dedupe` and `bun prune` landed together (#38333) with parallel flag sets; `--check` on dedupe was the CI gate ("is the lockfile deduplicated?"). This extends the same gate to prune ("is node_modules exactly what bun.lock would install?"), e.g. for catching stray packages or leftover devDependencies in a production image.
- Unknown flags being ignored is pre-existing, CLI-wide parser behavior (e.g. `bun dedupe --bogus-flag` is also accepted); this PR removes the one case where that turned a read-only intention into a destructive command, rather than changing the parser.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-prune.test.ts

<!-- robobun:evidence:end -->