### PR TITLE
Add --why to bun dedupe to show one level of dependents under each row

### DIFF
--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -1843,6 +1843,13 @@
           "hasValue": false,
           "required": false,
           "multiple": false
+        },
+        {
+          "name": "why",
+          "description": "Also list each version's dependents and the ranges they asked for",
+          "hasValue": false,
+          "required": false,
+          "multiple": false
         }
       ],
       "positionalArgs": [

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -104,7 +104,7 @@ _bun_completions() {
     PACKAGE_OPTIONS[SHARED_OPTIONS_LONG]="--config --yarn --production --frozen-lockfile --no-save --dry-run --force --cache-dir --no-cache --silent --verbose --global --cwd --backend --link-native-bins --help";
     PACKAGE_OPTIONS[SHARED_OPTIONS_SHORT]="-c -y -p -f -g";
 
-    PACKAGE_OPTIONS[DEDUPE_OPTIONS_LONG]="--check";
+    PACKAGE_OPTIONS[DEDUPE_OPTIONS_LONG]="--check --why";
     PACKAGE_OPTIONS[PRUNE_OPTIONS_LONG]="--production --prod --omit --filter --dry-run --os --cpu --linker --silent --cwd --help";
     PACKAGE_OPTIONS[PRUNE_OPTIONS_SHORT]="-p -P -F -h";
     PACKAGE_OPTIONS[AUDIT_OPTIONS_LONG]="--json --audit-level --ignore --prod --production --omit --dry-run --latest --cwd --help";

--- a/completions/bun.fish
+++ b/completions/bun.fish
@@ -167,6 +167,9 @@ complete -c bun \
 	-n "__fish_seen_subcommand_from dedupe" -l 'check' -d 'Exit with code 1 if the lockfile has duplicate versions that can be removed, without changing anything'
 
 complete -c bun \
+	-n "__fish_seen_subcommand_from dedupe" -l 'why' -d "Also list each version's dependents and the ranges they asked for"
+
+complete -c bun \
 	-n "__fish_seen_subcommand_from add" -d 'Popular' -a '(__fish__get_bun_packages)'
 
 complete -c bun \

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -693,6 +693,7 @@ _bun_dedupe_completion() {
     _arguments -s -C \
         '1: :->cmd1' \
         '--check[Exit with code 1 if the lockfile has duplicate versions that can be removed, without changing anything]' \
+        '--why[Also list each version'"'"'s dependents and the ranges they asked for]' \
         '-c[Load config(bunfig.toml)]: :->config' \
         '--config[Load config(bunfig.toml)]: :->config' \
         '-y[Write a yarn.lock file (yarn v1)]' \

--- a/docs/pm/cli/dedupe.mdx
+++ b/docs/pm/cli/dedupe.mdx
@@ -44,6 +44,27 @@ bun dedupe v1.4.0 (abc12345)
 
 `--lockfile-only` rewrites `bun.lock` without installing.
 
+### `--why`
+
+`--why` adds one level of dependents under each row: the packages whose dependency edges pointed at the removed version or at the version(s) it moved to, grouped by the range they asked for.
+
+```bash terminal icon="terminal"
+bun dedupe --dry-run --why
+```
+
+```
+bun dedupe v1.4.0 (abc12345)
+
+↳ esbuild 0.15.10 → 0.15.11
+    wanted ^0.15.7 by esbuild-loader, tsup, vite +1 more
+    wanted ^0.15.8 by my-app
+
+1 duplicate version can be removed (checked 5 packages in bun.lock) [9.00ms]
+  bun dedupe
+```
+
+This shows at a glance why a version moved where it did: here `my-app`'s `^0.15.8` keeps `0.15.11` alive, and the `^0.15.7` edges are satisfied by it too. When a row ends in `→ (removed)` (the version is dropped because nothing reachable needs it anymore), its listed dependents are themselves removed versions, written as `name@version`. Use [`bun why`](/pm/cli/why) for the full dependency paths of a single package.
+
 ### Notes
 
 - Bun respects overrides and catalogs. It re-points each dependency using its effective range.

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -427,6 +427,9 @@ static DEDUPE_PARAMS: &[ParamType] = concat_params![
         clap::param!(
             "--check                                Exit with code 1 if the lockfile has duplicate versions that can be removed, without changing anything"
         ),
+        clap::param!(
+            "--why                                  Also list each version's dependents and the ranges they asked for"
+        ),
         clap::param!("<POS> ...                              "),
     ]
 ];
@@ -437,6 +440,9 @@ const DEDUPE_HELP_PARAMS: &[ParamType] = &[
     ),
     clap::param!(
         "--dry-run                              Print the duplicate versions that would be removed without changing anything"
+    ),
+    clap::param!(
+        "--why                                  Also list each version's dependents and the ranges they asked for"
     ),
     clap::param!("--lockfile-only                        Rewrite bun.lock without installing"),
     clap::param!(
@@ -515,6 +521,7 @@ pub struct CommandLineArguments {
     pub(crate) no_save: bool,
     pub(crate) dry_run: bool,
     pub(crate) check: bool,
+    pub(crate) why: bool,
     pub(crate) force: bool,
     pub(crate) no_cache: bool,
     pub log_level: Options::LogLevel,
@@ -617,6 +624,7 @@ impl Default for CommandLineArguments {
             no_save: false,
             dry_run: false,
             check: false,
+            why: false,
             force: false,
             no_cache: false,
             log_level: Options::LogLevel::default(),
@@ -1173,6 +1181,9 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/why<r>.
   <d>Show what would be removed without changing anything<r>
   <b><green>bun dedupe<r> <cyan>--dry-run<r>
 
+  <d>Show which dependents wanted each version<r>
+  <b><green>bun dedupe<r> <cyan>--dry-run<r> <cyan>--why<r>
+
   <d>Rewrite bun.lock without installing<r>
   <b><green>bun dedupe<r> <cyan>--lockfile-only<r>
 
@@ -1405,9 +1416,12 @@ Full documentation is available at <magenta>https://bun.com/docs/pm/cli/prune<r>
             // cli.json_output = args.flag(b"--json");
         }
 
-        if subcommand == Subcommand::Dedupe && args.flag(b"--check") {
-            cli.check = true;
-            cli.dry_run = true;
+        if subcommand == Subcommand::Dedupe {
+            if args.flag(b"--check") {
+                cli.check = true;
+                cli.dry_run = true;
+            }
+            cli.why = args.flag(b"--why");
         }
 
         if matches!(

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -33,6 +33,7 @@ pub struct Options {
     pub(crate) update: DependencyGroup,
     pub dry_run: bool,
     pub check: bool,
+    pub why: bool,
     pub(crate) link_workspace_packages: bool,
     pub(crate) remote_package_features: Features,
     pub local_package_features: Features,
@@ -117,6 +118,7 @@ impl Default for Options {
             update: DependencyGroup::default(),
             dry_run: false,
             check: false,
+            why: false,
             link_workspace_packages: true,
             remote_package_features: Features {
                 optional_dependencies: true,
@@ -729,6 +731,7 @@ impl Options {
                 self.do_.set(Do::SAVE_LOCKFILE, false);
             }
             self.check = cli.check;
+            self.why = cli.why;
 
             if cli.no_summary || cli.log_level.is_silent() {
                 self.do_.set(Do::SUMMARY, false);

--- a/src/install/dedupe.rs
+++ b/src/install/dedupe.rs
@@ -308,6 +308,52 @@ pub(crate) fn label(lockfile: &Lockfile, id: PackageID) -> Vec<u8> {
     label
 }
 
+const MAX_DEPENDENTS_SHOWN: usize = 3;
+
+// Biggest group first, dependents in name order, versioned only when the name alone is ambiguous.
+fn format_wanted(
+    lockfile: &Lockfile,
+    group_of: &[u32],
+    mut groups: Vec<(Box<[u8]>, Vec<PackageID>)>,
+) -> Vec<Wanted> {
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let names = lockfile.packages.items_name();
+    index_sort::sort_vec_by(&mut groups, |(range_a, owners_a), (range_b, owners_b)| {
+        owners_b
+            .len()
+            .cmp(&owners_a.len())
+            .then_with(|| strings::order(range_a, range_b))
+    });
+    groups
+        .into_iter()
+        .map(|(range, mut owners)| {
+            index_sort::sort_vec_by(&mut owners, |&a, &b| {
+                strings::order(names[a as usize].slice(buf), names[b as usize].slice(buf))
+                    .then(a.cmp(&b))
+            });
+            let shown = owners.len().min(MAX_DEPENDENTS_SHOWN);
+            let mut dependents = Vec::new();
+            for (i, &owner) in owners[..shown].iter().enumerate() {
+                if i > 0 {
+                    dependents.extend_from_slice(b", ");
+                }
+                if group_of[owner as usize] == u32::MAX {
+                    dependents.extend_from_slice(names[owner as usize].slice(buf));
+                } else {
+                    dependents.extend_from_slice(&label(lockfile, owner));
+                }
+            }
+            if owners.len() > shown {
+                let _ = write!(dependents, " +{} more", owners.len() - shown);
+            }
+            Wanted {
+                range,
+                dependents: dependents.into_boxed_slice(),
+            }
+        })
+        .collect()
+}
+
 fn order_by_name_then_version(lockfile: &Lockfile, a: PackageID, b: PackageID) -> Ordering {
     let buf = lockfile.buffers.string_bytes.as_slice();
     let names = lockfile.packages.items_name();
@@ -325,6 +371,12 @@ fn sort_by_name_then_version(lockfile: &Lockfile, ids: &mut [PackageID]) {
     index_sort::sort_indices(ids, &mut |a, b| order_by_name_then_version(lockfile, a, b));
 }
 
+// One `wanted <range> by <dependents>` line under a row (`--why`).
+struct Wanted {
+    range: Box<[u8]>,
+    dependents: Box<[u8]>,
+}
+
 struct Row {
     name: Box<[u8]>,
     /// The removed version.
@@ -333,6 +385,7 @@ struct Row {
     to: Box<[u8]>,
     /// Every survivor is a lower major than `from`.
     downgrade: bool,
+    wanted: Vec<Wanted>,
 }
 
 #[derive(Default)]
@@ -346,7 +399,7 @@ fn plural(n: usize) -> &'static str {
     if n == 1 { "" } else { "s" }
 }
 
-fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
+fn dedupe_lockfile(lockfile: &mut Lockfile, why: bool) -> Report {
     let buf = lockfile.buffers.string_bytes.as_slice();
     let pkg_res = lockfile.packages.items_resolution();
     let checked = pkg_res.len();
@@ -543,10 +596,59 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
     }
 
     let names = lockfile.packages.items_name();
+
+    // Per row: dependents whose edges targeted the removed version or one of its survivors, by requested range.
+    let mut wanted: Vec<Vec<(Box<[u8]>, Vec<PackageID>)>> = vec![Vec::new(); removed.len()];
+    if why {
+        let deps = lockfile.buffers.dependencies.as_slice();
+        // A version explains the rows it was removed by and the rows whose edges moved onto it.
+        let mut explains: Vec<Vec<u32>> = vec![Vec::new(); pkg_res.len()];
+        for (i, &id) in removed.iter().enumerate() {
+            explains[id as usize].push(i as u32);
+        }
+        for (i, survivors) in targets.iter().enumerate() {
+            for &s in survivors {
+                explains[s as usize].push(i as u32);
+            }
+        }
+        // Owners come from the pre-dedupe tree so a dropped version's (themselves removed) dependents still show.
+        for (owner, slice) in lockfile.packages.items_dependencies().iter().enumerate() {
+            if !initial.is_set(owner) {
+                continue;
+            }
+            for dep_id in slice.begin() as usize..slice.end() as usize {
+                let Some(rows) = explains.get(original[dep_id] as usize) else {
+                    continue;
+                };
+                if rows.is_empty() {
+                    continue;
+                }
+                let dep = &deps[dep_id];
+                let literal = effective_version(lockfile, dep_id as DependencyID, dep)
+                    .map(|version| version.literal)
+                    .unwrap_or(dep.version.literal);
+                let range = literal.slice(buf);
+                for &r in rows {
+                    let groups = &mut wanted[r as usize];
+                    match groups.iter_mut().find(|(g, _)| strings::eql(g, range)) {
+                        Some((_, owners)) => {
+                            // Two aliases in one package can produce identical edges; list the owner once.
+                            if !owners.contains(&(owner as PackageID)) {
+                                owners.push(owner as PackageID);
+                            }
+                        }
+                        None => groups.push((Box::from(range), vec![owner as PackageID])),
+                    }
+                }
+            }
+        }
+    }
+
     let rows: Vec<Row> = removed
         .iter()
         .zip(&targets)
-        .map(|(&id, moved_to)| {
+        .zip(wanted)
+        .map(|((&id, moved_to), wanted)| {
             let from_version = pkg_res[id as usize].npm().version;
             let mut from: Vec<u8> = Vec::new();
             let _ = write!(from, "{}", from_version.fmt(buf));
@@ -572,6 +674,7 @@ fn dedupe_lockfile(lockfile: &mut Lockfile) -> Report {
                 from: from.into_boxed_slice(),
                 to: to.into_boxed_slice(),
                 downgrade,
+                wanted: format_wanted(lockfile, &group_of, wanted),
             }
         })
         .collect();
@@ -813,6 +916,17 @@ fn print_rows(report: &Report) {
                 BStr::new(&row.to)
             );
         }
+        let width = row.wanted.iter().map(|w| w.range.len()).max().unwrap_or(0);
+        for w in &row.wanted {
+            let mut range = Vec::with_capacity(width);
+            range.extend_from_slice(&w.range);
+            range.resize(width, b' ');
+            bun_core::prettyln!(
+                "    <d>wanted<r> {} <d>by<r> {}",
+                BStr::new(&range),
+                BStr::new(&w.dependents)
+            );
+        }
     }
     print_kept(&report.kept);
 }
@@ -855,7 +969,7 @@ pub fn dedupe_after_differ(manager: &mut PackageManager) {
         refuse_out_of_date(manager);
     }
 
-    let report = dedupe_lockfile(&mut manager.lockfile);
+    let report = dedupe_lockfile(&mut manager.lockfile, manager.options.why);
     if report.rows.is_empty() {
         report_already_deduplicated(manager, &report);
     }

--- a/test/cli/install/bun-dedupe.test.ts
+++ b/test/cli/install/bun-dedupe.test.ts
@@ -314,6 +314,119 @@ test.concurrent("--dry-run prints what --check prints and exits 0", async () => 
   expect(await nodeModulesVersion(packageDir, "one-range-dep", "node_modules", "no-deps")).toBe("1.1.0");
 });
 
+// A `wanted <range> by <dependents>` line under a row; ranges are padded to the row's widest range.
+const wanted = (range: string, by: string, width = range.length) => `    wanted ${range.padEnd(width)} by ${by}`;
+
+test.concurrent("--why lists one level of dependents grouped by requested range", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+  await Promise.all(
+    ["a", "b", "c", "d"].map(name =>
+      write(
+        join(packageDir, "packages", name, "package.json"),
+        JSON.stringify({ name, dependencies: { "no-deps": "^1.0.0" } }),
+      ),
+    ),
+  );
+  const lockfile = await installTwice(
+    packageDir,
+    packageJson,
+    { name: "root", workspaces: ["packages/*"] },
+    { name: "root", workspaces: ["packages/*"], dependencies: { "no-deps": "1.0.0" } },
+  );
+  expect(lockfile).toContain('"no-deps@1.0.0"');
+  expect(lockfile).toContain('"no-deps@1.1.0"');
+
+  // The larger group first, dependents in name order, capped at three with a count of the rest.
+  const checked = lockPackageCount(lockfile);
+  const rows = [
+    "~ no-deps 1.1.0 -> 1.0.0",
+    wanted("^1.0.0", "a, b, c +1 more"),
+    wanted("1.0.0", "root", "^1.0.0".length),
+  ];
+  const check = await dedupe(packageDir, "--check", "--why");
+  expect(lines(check.stdout)).toStrictEqual([HEADER, ...rows, "", wouldRemove(1, checked), HINT]);
+  expect(check.stderr).toBe("");
+  expect(check.exitCode).toBe(1);
+  expect(await lock(packageDir)).toBe(lockfile);
+
+  // Without --why the rows stay terse.
+  const plain = await dedupe(packageDir, "--check");
+  expectWouldRemove(plain, "no-deps 1.1.0 -> 1.0.0", checked);
+  expect(plain.stdout).not.toContain("wanted");
+
+  // Applying with --why prints the same block before the summary.
+  const { stdout, stderr, exitCode } = await dedupe(packageDir, "--why");
+  const out = lines(stdout);
+  expect(out.slice(-5, -1)).toStrictEqual([...rows, ""]);
+  expect(out.at(-1)).toMatch(removedSummary(1, checked));
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+  expect(await lock(packageDir)).not.toContain('"no-deps@1.1.0"');
+  await runBunInstall(installEnv(packageDir), packageDir, { frozenLockfile: true });
+});
+
+// The dropped no-deps@2.0.0 has no surviving dependent: --why shows the removed one-fixed-dep@2.0.0, versioned because the name is ambiguous.
+test.concurrent("--why explains a dropped version through its removed dependent", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+  const lockfile = await installTwice(
+    packageDir,
+    packageJson,
+    { name: "foo", dependencies: { "one-fixed-dep": ">=1.0.0" } },
+    { name: "foo", dependencies: { "one-fixed-dep": ">=1.0.0", "ofd": "npm:one-fixed-dep@1.0.0" } },
+  );
+  for (const label of ['"one-fixed-dep@1.0.0"', '"one-fixed-dep@2.0.0"', '"no-deps@1.0.0"', '"no-deps@2.0.0"']) {
+    expect(lockfile).toContain(label);
+  }
+
+  const checked = lockPackageCount(lockfile);
+  const check = await dedupe(packageDir, "--check", "--why");
+  expect(lines(check.stdout)).toStrictEqual([
+    HEADER,
+    "~ no-deps 2.0.0 -> (removed)",
+    wanted("2.0.0", "one-fixed-dep@2.0.0"),
+    "~ one-fixed-dep 2.0.0 -> 1.0.0 (downgrade)",
+    wanted(">=1.0.0", "foo", "npm:one-fixed-dep@1.0.0".length),
+    wanted("npm:one-fixed-dep@1.0.0", "foo"),
+    "",
+    wouldRemove(2, checked),
+    HINT,
+  ]);
+  expect(check.stderr).toBe("");
+  expect(check.exitCode).toBe(1);
+  expect(await lock(packageDir)).toBe(lockfile);
+});
+
+// Two aliases produce two identical edges from one package; --why lists the dependent once.
+test.concurrent("--why lists a dependent once when two aliases share the same range", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+  const lockfile = await installTwice(
+    packageDir,
+    packageJson,
+    { name: "foo", dependencies: { "one-range-dep": "1.0.0" } },
+    {
+      name: "foo",
+      dependencies: { "one-range-dep": "1.0.0", "nd1": "npm:no-deps@1.0.0", "nd2": "npm:no-deps@1.0.0" },
+    },
+  );
+  expect(lockfile).toContain('"no-deps@1.0.0"');
+  expect(lockfile).toContain('"no-deps@1.1.0"');
+
+  const checked = lockPackageCount(lockfile);
+  const check = await dedupe(packageDir, "--check", "--why");
+  expect(lines(check.stdout)).toStrictEqual([
+    HEADER,
+    "~ no-deps 1.1.0 -> 1.0.0",
+    wanted("^1.0.0", "one-range-dep", "npm:no-deps@1.0.0".length),
+    wanted("npm:no-deps@1.0.0", "foo"),
+    "",
+    wouldRemove(1, checked),
+    HINT,
+  ]);
+  expect(check.stderr).toBe("");
+  expect(check.exitCode).toBe(1);
+  expect(await lock(packageDir)).toBe(lockfile);
+});
+
 test.concurrent("--no-summary keeps the rows and the hint but drops the count line", async () => {
   const { packageDir, packageJson } = await registry.createTestDir();
   const lockBefore = await setupRangeDuplicate(packageDir, packageJson);
@@ -501,6 +614,7 @@ test.concurrent("--help", async () => {
   expect(flagLines.map(line => line.match(/--[\w-]+/)![0])).toStrictEqual([
     "--check",
     "--dry-run",
+    "--why",
     "--lockfile-only",
     "--frozen-lockfile",
     "--linker",


### PR DESCRIPTION
### Problem

- `bun dedupe` reports what moved but never who wanted it. A three-major downgrade (`@types/node 25.9.1 → 22.19.19`) renders exactly like a patch bump, and a dropped version prints with no arrow and no reason. Answering "why" today means one `bun why` run per row (fixes #39213).

### Fix

- Adds a `--why` flag to `bun dedupe`. Under each row it prints one level of dependents, grouped by the range they asked for:

  ```
  ~ no-deps 1.1.0 -> 1.0.0
      wanted ^1.0.0 by a, b, c +1 more
      wanted 1.0.0  by root
  ```

- For each removed version, the listed dependents are the packages whose edges pointed at it or at the version(s) it moved to, taken from the pre-dedupe tree. That makes a downgrade self-justifying (the pinning range shows up next to the movable ones) and explains a dropped row through its own dependents, which are themselves removed and therefore printed as `name@version`.
- One level only, by design: the issue measured inlining full `bun why` trees at 27k lines for a single real-world row. Groups are sorted largest first, dependents alphabetically and capped at three with a `+N more` count.
- Ranges are the effective ones (after overrides and catalog resolution), using the same `effective_version` helper dedupe already re-points edges with. A dependent is versioned only when its name is ambiguous (several versions in the lockfile).
- Behind a flag so the default output stays terse and stable; with `--why` off, collection is skipped entirely and output is byte-identical to before.
- Verified with `bun bd test test/cli/install/bun-dedupe.test.ts` (79 pass): three new tests cover grouping, the `+N more` cap, range padding, the dropped-version case, the `npm:` alias literal and its dedup, and that plain `--check` output is unchanged.
- Also updates the dedupe docs page, `--help` text, and the bash, zsh, fish, and JSON completions.

### Background

- `bun dedupe` collapses duplicate lockfile versions onto the smallest surviving set, then prints one row per removed version: `name removed -> survivor(s)`, or no arrow when the version became unreachable and was dropped outright.
- Dedupe decides placements in `dedupe_lockfile` (src/install/dedupe.rs) while it still holds the lockfile; printing happens later (after the install step), so the new dependent lines are formatted into the `Report` at decision time rather than recomputed at print time.
- A "dependency edge" here is one entry in a package's dependency list together with the package ID it resolved to; the original (pre-dedupe) resolutions are what `--why` walks, so dependents that the run itself removes still appear.

### Rebase note

Rebased onto main after #38952 landed. That PR turned the row tuple into a `Row` struct with a `downgrade` flag, added the `-> (removed)` and `(downgrade)` markers, and changed the summary wording to "in bun.lock". Resolution: the `Row` struct now carries both its `downgrade` field and this PR's `wanted` lines, `print_rows` keeps its three row branches and appends the `wanted` lines after each row, and the `--why` tests and docs example use the new markers and wording. All 79 tests in `test/cli/install/bun-dedupe.test.ts` pass after the rebase.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-dedupe.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-dedupe.test.ts:
342 |     "~ no-deps 1.1.0 -> 1.0.0",
343 |     wanted("^1.0.0", "a, b, c +1 more"),
344 |     wanted("1.0.0", "root", "^1.0.0".length),
345 |   ];
346 |   const check = await dedupe(packageDir, "--check", "--why");
347 |   expect(lines(check.stdout)).toStrictEqual([HEADER, ...rows, "", wouldRemove(1, checked), HINT]);
                                    ^
error: expect(received).toStrictEqual(expected)

  [
    "bun dedupe <version> (<revision>)",
    "~ no-deps 1.1.0 -> 1.0.0",
-   "    wanted ^1.0.0 by a, b, c +1 more",
-   "    wanted 1.0.0  by root",
    "",
    "1 duplicate version can be removed (checked 7 packages in bun.lock)",
    "  bun dedupe",
  ]

- Expected  - 2
+ Received  + 0

      at <anonymous> (/workspace/bun/test/cli/install/bun-dedupe.test.ts:347:31)
(fail) --why lists one level of dependents grouped by requested range [680.05ms]
(pass) --check reports and exits 1 without writing [735.80ms]
(pass) collapses a ran
... (truncated)

release without fix: 64 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/cli/install/bun-dedupe.test.ts:
609 |   expect(stdout).toContain("Usage: bun dedupe [flags]");
610 |   const out = lines(stdout);
611 |   const flagsStart = out.indexOf("Flags:") + 1;
612 |   expect(flagsStart).toBeGreaterThan(0);
613 |   const flagLines = out.slice(flagsStart, out.indexOf("", flagsStart));
614 |   expect(flagLines.map(line => line.match(/--[\w-]+/)![0])).toStrictEqual([
                                                                  ^
error: expect(received).toStrictEqual(expected)

  [
    "--check",
    "--dry-run",
-   "--why",
    "--lockfile-only",
    "--frozen-lockfile",
    "--linker",
    "--silent",
    "--cwd",
    "--help",
  ]

- Expected  - 1
+ Received  + 0

      at <anonymous> (/workspace/bun/test/cli/install/bun-dedupe.test.ts:614:61)
(fail) --help [21.91ms]
(pass) errors without a lockfile [25.12ms]
(pass) rejects positional arguments [89.72ms]
118 |   expect(stderr).not.toContain("error:");
119 | }
120 | 
121 | // One line, one duration, nothing saved: the same on `--check` and on a plain `bun dedupe`.
122 | function expectNoDuplicates({ stdout, stderr, exitCode }: Result, checked?: n
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-dedupe.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-dedupe.test.ts:
(pass) --check reports and exits 1 without writing [873.74ms]
(pass) collapses a range onto the exact version that satisfies every edge [1012.28ms]
(pass) prefers the highest version when several satisfy every edge [1222.20ms]
(pass) --dry-run prints what --check prints and exits 0 [1221.57ms]
(pass) --why explains a dropped version through its removed dependent [603.28ms]
(pass) --why lists one level of dependents grouped by requested range [1520.36ms]
(pass) --why lists a dependent once when two aliases share the same range [900.86ms]
(pass) --no-summary keeps the rows and the hint but drops the count line [921.82ms]
(pass) a no-op prints one summary line (isolated linker) [1001.94ms]
(pass) a no-op prints one summary line (hoisted linker) [1076.89ms]
(pass) keeps versions that no single version can replace [770.67ms]
(pass) errors without a lockfile [410.42ms]
(pass) already deduplicated [1832.04ms]
(pass) rejects positional argumen
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 679ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_install_jsc v0.0.0 (/workspace/bun/s
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
completions/bun-cli.json                           |   7 ++
 completions/bun.bash                               |   2 +-
 completions/bun.fish                               |   3 +
 completions/bun.zsh                                |   1 +
 docs/pm/cli/dedupe.mdx                             |  21 ++++
 src/install/PackageManager/CommandLineArguments.rs |  20 +++-
 .../PackageManager/PackageManagerOptions.rs        |   3 +
 src/install/dedupe.rs                              | 120 ++++++++++++++++++++-
 test/cli/install/bun-dedupe.test.ts                | 114 ++++++++++++++++++++
 9 files changed, 284 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
completions/bun-cli.json                                 1      1      0
completions/bun.bash                                     1      2      0
completions/bun.fish                                     1      2      0
completions/bun.zsh                                      1      2      0
docs/pm/cli/dedupe.mdx                                   2      3      0
src/install/PackageManager/CommandLineArguments.rs       2      3      0
src/install/PackageManager/PackageManagerOptions.rs      2      2      0
src/install/dedupe.rs                                    4     14      0
test/cli/install/bun-dedupe.test.ts                      2      4      0
```

</details>

<!-- robobun:evidence:end -->
