### PR TITLE
ci: run Miri crates concurrently, and shrink the one 7-minute test under Miri

### DIFF
--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -17,12 +17,13 @@
  * the bugs we care about.
  *
  * Usage:
- *   bun run rust:miri              # default safe crate set
- *   bun run rust:miri -p bun_foo   # extra args go straight to cargo miri test
+ *   bun run rust:miri              # default crate set, crates run concurrently
+ *   bun run rust:miri -p bun_foo   # extra args go straight to one `cargo miri test`
  */
 
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import { availableParallelism } from "node:os";
 import { resolve } from "node:path";
 
 const repo = resolve(import.meta.dirname, "..");
@@ -32,17 +33,21 @@ const repo = resolve(import.meta.dirname, "..");
 // runtime only call `extern "C"` functions Miri has shims for (libc's futex and
 // thread APIs are; vendored C is not) — otherwise Miri reports
 // `unsupported operation: can't call foreign function`.
+//
+// Ordered longest-running first (bun_ast ~8 min, bun_collections ~3 min,
+// bun_paths ~1 min under Miri; the rest are seconds) so the concurrent run
+// below starts the long poles immediately.
 const MIRI_CRATES = [
   "bun_ast",
+  "bun_collections",
+  "bun_paths",
+  "bun_hash",
   "bun_base64",
   "bun_clap",
-  "bun_collections",
   "bun_dispatch",
   "bun_errno",
-  "bun_hash",
   "bun_http_types",
   "bun_md",
-  "bun_paths",
   "bun_ptr",
   "bun_resolve_builtins",
   "bun_shell_parser",
@@ -79,14 +84,65 @@ if (!existsSync(buildOptionsRs) || !existsSync(lolhtmlCargo)) {
   }
 }
 
-const extraArgs = process.argv.slice(2);
-const crateArgs = extraArgs.length > 0 ? extraArgs : MIRI_CRATES.flatMap(c => ["-p", c]);
+const env = {
+  ...process.env,
+  MIRIFLAGS: ["-Zmiri-tree-borrows", process.env.MIRIFLAGS ?? ""].join(" ").trim(),
+};
 
-console.log(`\x1b[36m[miri]\x1b[0m cargo miri test ${crateArgs.join(" ")}`);
-const r = run("cargo", ["miri", "test", ...crateArgs], {
-  env: {
-    ...process.env,
-    MIRIFLAGS: ["-Zmiri-tree-borrows", process.env.MIRIFLAGS ?? ""].join(" ").trim(),
-  },
-});
-process.exit(r.status ?? 1);
+// Explicit args: one plain `cargo miri test`, output straight through.
+const extraArgs = process.argv.slice(2);
+if (extraArgs.length > 0) {
+  console.log(`\x1b[36m[miri]\x1b[0m cargo miri test ${extraArgs.join(" ")}`);
+  process.exit(run("cargo", ["miri", "test", ...extraArgs], { env }).status ?? 1);
+}
+
+// Default set: Miri interprets one test at a time per process, so a single
+// `cargo miri test -p a -p b ...` is serial end to end. Build everything once,
+// then run one `cargo miri test -p <crate>` per crate concurrently.
+const allCrates = MIRI_CRATES.flatMap(c => ["-p", c]);
+console.log(`\x1b[36m[miri]\x1b[0m cargo miri test --no-run ${allCrates.join(" ")}`);
+if (run("cargo", ["miri", "test", "--no-run", ...allCrates], { env }).status !== 0) process.exit(1);
+
+type Result = { crate: string; ok: boolean; seconds: number; output: string };
+
+function testCrate(crate: string): Promise<Result> {
+  return new Promise(done => {
+    const started = Date.now();
+    const chunks: Buffer[] = [];
+    const child = spawn("cargo", ["miri", "test", "-p", crate, "--color", "always"], { cwd: repo, env });
+    child.stdout.on("data", chunk => chunks.push(chunk));
+    child.stderr.on("data", chunk => chunks.push(chunk));
+    child.on("close", code =>
+      done({ crate, ok: code === 0, seconds: (Date.now() - started) / 1000, output: Buffer.concat(chunks).toString() }),
+    );
+  });
+}
+
+const width = Math.max(1, Math.min(availableParallelism(), MIRI_CRATES.length));
+console.log(`\x1b[36m[miri]\x1b[0m ${MIRI_CRATES.length} crates, ${width} at a time`);
+const queue = [...MIRI_CRATES];
+const results: Result[] = [];
+const inActions = !!process.env.GITHUB_ACTIONS;
+
+async function worker() {
+  for (let crate = queue.shift(); crate; crate = queue.shift()) {
+    const result = await testCrate(crate);
+    results.push(result);
+    const status = result.ok ? "\x1b[32mok\x1b[0m" : "\x1b[31mFAILED\x1b[0m";
+    console.log(`\x1b[36m[miri]\x1b[0m ${result.crate} ${status} ${result.seconds.toFixed(0)}s`);
+    if (!result.ok || !inActions) {
+      console.log(result.output);
+    } else {
+      console.log(`::group::${result.crate} output\n${result.output}\n::endgroup::`);
+    }
+  }
+}
+
+await Promise.all(Array.from({ length: width }, worker));
+
+const failed = results.filter(r => !r.ok).map(r => r.crate);
+if (failed.length) {
+  console.error(`\x1b[31m[miri]\x1b[0m failed: ${failed.join(", ")}`);
+  process.exit(1);
+}
+console.log(`\x1b[36m[miri]\x1b[0m all ${results.length} crates passed`);

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -34,12 +34,11 @@ const repo = resolve(import.meta.dirname, "..");
 // thread APIs are; vendored C is not) — otherwise Miri reports
 // `unsupported operation: can't call foreign function`.
 //
-// Ordered longest-running first (bun_ast ~8 min, bun_collections ~3 min,
-// bun_paths ~1 min under Miri; the rest are seconds) so the concurrent run
-// below starts the long poles immediately.
+// Ordered longest-running-under-Miri first so the concurrent run below starts
+// the long poles immediately; everything after bun_hash takes seconds.
 const MIRI_CRATES = [
-  "bun_ast",
   "bun_collections",
+  "bun_ast",
   "bun_paths",
   "bun_hash",
   "bun_base64",

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3384,14 +3384,18 @@ mod line_column_tracker_tests {
     #[test]
     fn line_column_tracker_interleaved_diagnostic_streams_match_full_scan() {
         let statement = b"try {} catch ([a,a,a,a,a,a,a,a,a,a,a,a, `]) {}\n";
+        // Every lookup below re-scans from an earlier line, so cost grows with
+        // the square of the statement count; under Miri 4 statements still
+        // interleave forward and backward jumps across lines at ~1/9 the work.
+        let statements: usize = if cfg!(miri) { 4 } else { 12 };
         let mut contents = Vec::new();
-        for _ in 0..12 {
+        for _ in 0..statements {
             contents.extend_from_slice(statement);
         }
         let source = Source::init_path_string(b"tracker-test.js" as &[u8], contents.as_slice());
 
         let mut offsets = Vec::new();
-        for statement_index in 0..12usize {
+        for statement_index in 0..statements {
             let start = statement_index * statement.len();
             let first_binding = start + 15;
             offsets.push(start + statement.len() - 6);


### PR DESCRIPTION
The `cargo miri test` job takes ~14-15 min while clippy/mordant take 2. From the last run's log, ~13.5 min of it is 150 tests interpreted one at a time, and it is very top-heavy:

| test | time |
|---|---|
| `bun_ast::line_column_tracker_tests::line_column_tracker_interleaved_diagnostic_streams_match_full_scan` | **451s** |
| `bun_collections::static_hash_map::tests::static_hash_map_put_get_delete_grow` | 163s |
| `bun_paths::string_paths::tests::fits_in_wide_path_buffer_bounds` | 27s |
| the other 147 tests | ~3 min total |

Two changes, no new tools or downloads:

**`scripts/rust-miri.ts`: run crates concurrently.** Miri interprets one test at a time per process, so one `cargo miri test -p a -p b …` is serial end to end. The script now builds the crate set once (`cargo miri test --no-run …`), then runs one `cargo miri test -p <crate>` per crate, `availableParallelism()` at a time, longest crates first, buffering each crate's output and printing it as the crate finishes (grouped on Actions, expanded on failure). Passing explicit args (`bun run rust:miri -p bun_foo`) still runs a single plain `cargo miri test`. Same `MIRIFLAGS`, same crate list.

**`src/ast/lib.rs`: size the tracker test for Miri.** With crates in parallel the floor is `bun_ast`, and `bun_ast` is almost entirely that one test. Its cost is quadratic in the number of repeated statements because every lookup re-scans from an earlier line (which is the behaviour under test). Under `cfg!(miri)` it now uses 4 statements instead of 12: still multiple statements with interleaved forward/backward jumps across lines, ~1/9 the interpreted work. Native `cargo test` is unchanged. Happy to drop this half if you'd rather keep the full size under Miri.

Expected: ~14.5 → ~4-5 min (new floor: the 163s `static_hash_map` test, which is already `cfg!(miri)`-reduced and whose 512 is the capacity under test, so it is left alone). Verification is this PR's own `cargo miri test` check.