### PR TITLE
shell(touch): name --time in its unsupported option message

### DIFF
--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -357,9 +357,7 @@ impl FlagParser for Opts {
             b"--reference" => Some(ParseFlagResult::Unsupported(unsupported_flag(
                 b"--reference=FILE",
             ))),
-            b"--time" => Some(ParseFlagResult::Unsupported(unsupported_flag(
-                b"--reference=FILE",
-            ))),
+            b"--time" => Some(ParseFlagResult::Unsupported(unsupported_flag(b"--time"))),
             _ => None,
         }
     }

--- a/test/js/bun/shell/commands/touch.test.ts
+++ b/test/js/bun/shell/commands/touch.test.ts
@@ -1,0 +1,36 @@
+import { $ } from "bun";
+import { describe } from "bun:test";
+import { createTestBuilder } from "../test_builder";
+const TestBuilder = createTestBuilder(import.meta.path);
+
+$.nothrow();
+
+describe.concurrent("bunshell touch", () => {
+  describe("unsupported options are reported under the name they were given", () => {
+    // option as typed -> how the error names it (--reference's usage suffix predates this table)
+    const unsupported = {
+      "--no-create": "--no-create",
+      "--date": "--date",
+      "--reference": "--reference=FILE",
+      "--time": "--time",
+      "-a": "-a",
+      "-c": "-c",
+      "-d": "-d",
+      "-h": "-h",
+      "-m": "-m",
+      "-r": "-r",
+      "-t": "-t",
+    };
+
+    for (const [option, reported] of Object.entries(unsupported)) {
+      TestBuilder.command`touch ${option} file`
+        .ensureTempDir()
+        .quiet()
+        .stdout("")
+        .stderr(`touch: unsupported option, please open a GitHub issue -- ${reported}\n`)
+        .exitCode(1)
+        .doesNotExist("file")
+        .runAsTest(option);
+    }
+  });
+});


### PR DESCRIPTION
### Problem
- `touch --time x` in the Bun shell fails with `touch: unsupported option, please open a GitHub issue -- --reference=FILE`, naming an option the user did not pass.
- The `--time` arm of `parse_long` in `src/runtime/shell/builtin/touch.rs:360` passes the `--reference=FILE` literal copied from the `--reference` arm above it. The same line was in the Zig version, so this is not a port regression.
- Exit code 1 is already right; only the text is wrong.

### Fix
- The `--time` arm now reports `--time`.
- The message exists to tell the user which option is unsupported so they can report it or drop it; the other arms in this table name the option that was given (`--no-create`, `--date`, `-a`, ...), and `--date`, the arm most like `--time` (both take a value in GNU touch), is reported bare, so `--time` follows it.
- `--reference` still reports `--reference=FILE`: it names the option that was passed, so it is left alone here; #39227, which is stacked on this PR and handles the `--option=VALUE` spellings, is where that suffix would be reconsidered.
- This is deliberately one row of the table. The other wrong rows of the same kind are each in flight already: `mkdir -m` (trailing space) in #39223, `cp -p` (reported as `-P`) in #35616 / #35705, and the `illegal option` payload of the `_` arms of cat/touch/mkdir/cp in #39230. Deriving the reported name from argv in the shared `FlagParser`, which would retire all of these literals at once, touches the functions those PRs are editing, so it is a follow-up for after they land; it would delete this line along with the others and keep this PR's test.
- Verified with `test/js/bun/shell/commands/touch.test.ts`, a table pinning stdout, stderr and exit code for all 11 unsupported touch options (4 long, 7 short) and checking the operand is not created. On the released `bun` (1.4.0) only the `--time` case fails; on this branch all 11 pass. #38379 and #38002 also create this file (different tests); whichever lands later combines the describe blocks.
- Also ran `test/js/bun/shell/exec.test.ts` (`--help` table) and the `exit codes` block of `test/js/bun/shell/bunshell.test.ts` against the debug build; both still pass.

### Background
- The shell builtins `touch`, `mkdir`, `cat` and `cp` parse their flags through the shared `FlagParser` trait in `src/runtime/shell/interpreter.rs`. A builtin returns `ParseFlagResult::Unsupported(name)` for an option it recognizes but does not implement, and `Builtin::fail_parse` formats `name` into the `unsupported option, please open a GitHub issue -- <name>` line, so the text after `--` is whatever literal the builtin chose to pass, not the argv entry.
- `touch` is a shell builtin on every platform (unlike `cat` and `cp`, which defer to the system binary on POSIX), so the test needs no platform gating.
