### PR TITLE
shell(mkdir): accept --verbose instead of the misspelling --vebose

### DIFF
--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -435,8 +435,7 @@ impl FlagParser for Opts {
             self.parents = true;
             return Some(ParseFlagResult::ContinueParsing);
         }
-        // Note: the `--vebose` typo is intentional (kept for compatibility).
-        if flag == b"--vebose" {
+        if flag == b"--verbose" {
             self.verbose = true;
             return Some(ParseFlagResult::ContinueParsing);
         }

--- a/test/js/bun/shell/commands/mkdir.test.ts
+++ b/test/js/bun/shell/commands/mkdir.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isMacOS, tempDir } from "harness";
+import { tempDir } from "harness";
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
@@ -60,11 +60,12 @@ describe.concurrent("bunshell mkdir", () => {
       using dir = tempDir("mkdir-verbose-eexist", { dir: {} });
       const cwd = String(dir);
 
-      // The builtins use the host's strerror text for EEXIST.
-      const eexist = isMacOS ? "File or folder exists" : "File exists";
+      // Whether the message names the operand or the resolved path, and the
+      // macOS wording of EEXIST (bun_core's coreutils_error_map), are decided
+      // elsewhere; this only checks that verbose output stays off on failure.
       expect(await mkdir(cwd, flags, "dir")).toEqual({
         stdout: "",
-        stderr: `mkdir: ${join(cwd, "dir")}: ${eexist}\n`,
+        stderr: expect.stringMatching(/^mkdir: (?:.*[\\/])?dir: File (?:or folder )?exists\n$/),
         exitCode: 1,
       });
     });

--- a/test/js/bun/shell/commands/mkdir.test.ts
+++ b/test/js/bun/shell/commands/mkdir.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { isMacOS, tempDir } from "harness";
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
@@ -60,9 +60,11 @@ describe.concurrent("bunshell mkdir", () => {
       using dir = tempDir("mkdir-verbose-eexist", { dir: {} });
       const cwd = String(dir);
 
+      // The builtins use the host's strerror text for EEXIST.
+      const eexist = isMacOS ? "File or folder exists" : "File exists";
       expect(await mkdir(cwd, flags, "dir")).toEqual({
         stdout: "",
-        stderr: `mkdir: ${join(cwd, "dir")}: File exists\n`,
+        stderr: `mkdir: ${join(cwd, "dir")}: ${eexist}\n`,
         exitCode: 1,
       });
     });

--- a/test/js/bun/shell/commands/mkdir.test.ts
+++ b/test/js/bun/shell/commands/mkdir.test.ts
@@ -1,0 +1,82 @@
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+$.nothrow();
+
+async function mkdir(cwd: string, flags: string, operand: string) {
+  const words = flags.split(" ").filter(Boolean);
+  const { stdout, stderr, exitCode } = await $`mkdir ${words} ${operand}`.cwd(cwd).quiet();
+  return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
+}
+
+describe.concurrent("bunshell mkdir", () => {
+  describe("verbose", () => {
+    // A verbose mkdir prints the path of every directory it creates, one per
+    // line. `--verbose` is the long spelling of `-v`; the parser used to
+    // accept only the misspelling `--vebose`.
+    test.each([
+      ["-v", "dir", ["dir"]],
+      ["--verbose", "dir", ["dir"]],
+      ["-pv", "a/b", ["a", "a/b"]],
+      ["-p --verbose", "a/b", ["a", "a/b"]],
+      ["--parents --verbose", "a/b", ["a", "a/b"]],
+      ["--verbose --parents", "a/b", ["a", "a/b"]],
+      ["--verbose -p", "a/b", ["a", "a/b"]],
+    ])("mkdir %s %s prints %j", async (flags, operand, created) => {
+      using dir = tempDir("mkdir-verbose", {});
+      const cwd = String(dir);
+
+      expect(await mkdir(cwd, flags, operand)).toEqual({
+        stdout: created.map(name => `${join(cwd, name)}\n`).join(""),
+        stderr: "",
+        exitCode: 0,
+      });
+      expect(statSync(join(cwd, operand)).isDirectory()).toBeTrue();
+    });
+
+    test.each(["--parents", "-p", ""])("mkdir %s a/b prints nothing without a verbose flag", async flags => {
+      using dir = tempDir("mkdir-quiet", { a: {} });
+      const cwd = String(dir);
+
+      expect(await mkdir(cwd, flags, "a/b")).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+      expect(statSync(join(cwd, "a", "b")).isDirectory()).toBeTrue();
+    });
+
+    test.each(["--verbose --parents", "-pv"])(
+      "mkdir %s on an existing directory creates and prints nothing",
+      async flags => {
+        using dir = tempDir("mkdir-verbose-existing", { dir: {} });
+        const cwd = String(dir);
+
+        expect(await mkdir(cwd, flags, "dir")).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+        expect(readdirSync(cwd)).toEqual(["dir"]);
+      },
+    );
+
+    test.each(["--verbose", "-v"])("mkdir %s on an existing directory fails and prints nothing", async flags => {
+      using dir = tempDir("mkdir-verbose-eexist", { dir: {} });
+      const cwd = String(dir);
+
+      expect(await mkdir(cwd, flags, "dir")).toEqual({
+        stdout: "",
+        stderr: `mkdir: ${join(cwd, "dir")}: File exists\n`,
+        exitCode: 1,
+      });
+    });
+
+    test("the misspelling --vebose is rejected like any other unknown option", async () => {
+      using dir = tempDir("mkdir-vebose", {});
+      const cwd = String(dir);
+
+      expect(await mkdir(cwd, "--vebose", "dir")).toEqual({
+        stdout: "",
+        stderr: expect.stringMatching(/^mkdir: illegal option -- /),
+        exitCode: 1,
+      });
+      expect(readdirSync(cwd)).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
### Problem

- In the Bun shell, `mkdir --verbose dir` exits 1 with `mkdir: illegal option -- verbose` and creates nothing, while `mkdir -v dir` and `mkdir --parents dir` work.
- `parse_long` in `src/runtime/shell/builtin/mkdir.rs:438` matches the misspelling `--vebose` instead of `--verbose`, so the real flag falls through to short-flag parsing of `-verbose`, which rejects the leading `-`.
- The misspelling dates back to the first version of the builtin; the `Opts` doc comment right above it says `-v, --verbose`. The comment calling the typo intentional was added when the file was ported and only reflects keeping the port faithful: `--vebose` was never documented, and GNU and BSD mkdir reject it.
- Reproduces on Linux and Windows with bun 1.4.0 (mkdir is a builtin on every platform).

### Fix

- `parse_long` matches `--verbose` and sets `verbose`, the same thing `-v` does. `--vebose` is no longer accepted and is reported like any other unknown option.
- Correct because `--verbose` is the long form of `-v` both in the builtin's own `Opts` documentation and in the coreutils `mkdir` these builtins mirror. No other long flag under `src/runtime/shell/builtin/` is misspelled (checked every `--` literal there), so this is the only site.
- Verified with the new `test/js/bun/shell/commands/mkdir.test.ts`: 8 of its 15 cases fail on bun 1.4.0 (every `--verbose` case plus the `--vebose` rejection) and all 15 pass with this change, on Linux and on Windows. `test/js/bun/shell/exec.test.ts`, which pins `mkdir --help` as an illegal option, still passes.
- The test covers `--verbose` alone, combined with `-p` / `--parents` in both orders, the silent output without a verbose flag, `--verbose --parents` on an existing directory (nothing created, nothing printed), the EEXIST failure (nothing printed, exit 1), and `--vebose` being rejected with nothing created.
- Two assertions deliberately pin less than the whole stderr line because the rest of it belongs to other in-flight changes: the `--vebose` case pins the `mkdir: illegal option -- ` prefix (the option text echoed after it is being corrected separately), and the EEXIST cases accept the path either resolved or as written (#39189 switches mkdir's errors to the operand as written) and either wording of EEXIST (the macOS table in `bun_core`'s coreutils error map says `File or folder exists`, which is being fixed separately). Empty stdout and the exit code, the part this PR is responsible for, stay exact.
- Other open PRs that touch this file: #39223 (mkdir `--mode` / `-m` messages) edits the same `impl FlagParser` a few lines away and, like #38002 and #38379, also creates `test/js/bun/shell/commands/mkdir.test.ts`. The `mkdir.rs` hunks do not overlap; the test files share the same helper and wrapper, so whichever lands later keeps both blocks.

### Background

- The `mkdir`, `touch`, `cat` and `cp` builtins parse their options through `parse_flags` in `src/runtime/shell/interpreter.rs`. For an argument starting with `--` it first offers the whole word to the builtin's `FlagParser::parse_long`; if that returns `None`, the word is parsed again as a cluster of short flags (`-verbose` becomes `-`, `v`, `e`, ...), and the first unknown letter produces the `illegal option` error. A missing long-flag arm therefore shows up as an "illegal option", not as a dedicated message.
- A verbose `mkdir` prints the absolute path of every directory it created, one per line (with `-p`, the intermediate directories too). That output code is shared by `-v` and `--verbose`; this change only affects which spellings turn it on.
- Builtin error lines are `<builtin>: <path>: <message>`, where the message comes from Bun's own errno-to-coreutils-text table (`coreutils_error_map` in `src/bun_core/result.rs`), not from the host's `strerror`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/mkdir.test.ts
bun test v1.4.0 (eff1f3e4b)

test/js/bun/shell/commands/mkdir.test.ts:
27 |       ["--verbose -p", "a/b", ["a", "a/b"]],
28 |     ])("mkdir %s %s prints %j", async (flags, operand, created) => {
29 |       using dir = tempDir("mkdir-verbose", {});
30 |       const cwd = String(dir);
31 | 
32 |       expect(await mkdir(cwd, flags, operand)).toEqual({
                                                    ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": 
- "/tmp/mkdir-verbose_4vOQKx/dir
+   "exitCode": 1,
+   "stderr": 
+ "mkdir: illegal option -- verbose
  "
  ,
+   "stdout": "",
  }

- Expected  - 4
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/bun/shell/commands/mkdir.test.ts:32:48)
(fail) bunshell mkdir > verbose > mkdir --verbose dir prints ["dir"] [25.85ms]
27 |       ["--verbose -p", "a/b", ["a", "a/b"]],
28 |     ])("mkdir %s %s prints %j", async (flags, operand, created) => {
29 |       using dir = tempDir("mkdir-verbose", {}
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (eabb96de7)

test/js/bun/shell/commands/mkdir.test.ts:
27 |       ["--verbose -p", "a/b", ["a", "a/b"]],
28 |     ])("mkdir %s %s prints %j", async (flags, operand, created) => {
29 |       using dir = tempDir("mkdir-verbose", {});
30 |       const cwd = String(dir);
31 | 
32 |       expect(await mkdir(cwd, flags, operand)).toEqual({
                                                    ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
-   "stderr": "",
-   "stdout": 
- "/tmp/mkdir-verbose_A8Up5B/dir
+   "exitCode": 1,
+   "stderr": 
+ "mkdir: illegal option -- verbose
  "
  ,
+   "stdout": "",
  }

- Expected  - 4
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/bun/shell/commands/mkdir.test.ts:32:48)
(fail) bunshell mkdir > verbose > mkdir --verbose dir prints ["dir"] [0.83ms]
27 |       ["--verbose -p", "a/b", ["a", "a/b"]],
28 |     ])("mkdir %s %s prints %j", async (flags, operand, created) => {
29 |       using dir = tempDir("mkdir-verbose", {});
30 |       const cwd = String(dir);
31 | 
32 |       expect(await mkdir(cwd, flags, operand)).toEqual({
                                                    ^
error
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/commands/mkdir.test.ts
bun test v1.4.0 (eff1f3e4b)

test/js/bun/shell/commands/mkdir.test.ts:
(pass) bunshell mkdir > verbose > mkdir -v dir prints ["dir"] [119.83ms]
(pass) bunshell mkdir > verbose > mkdir --verbose dir prints ["dir"] [50.17ms]
(pass) bunshell mkdir > verbose > mkdir -pv a/b prints ["a","a/b"] [48.73ms]
(pass) bunshell mkdir > verbose > mkdir -p --verbose a/b prints ["a","a/b"] [58.10ms]
(pass) bunshell mkdir > verbose > mkdir --parents --verbose a/b prints ["a","a/b"] [59.70ms]
(pass) bunshell mkdir > verbose > mkdir --verbose --parents a/b prints ["a","a/b"] [45.67ms]
(pass) bunshell mkdir > verbose > mkdir --verbose -p a/b prints ["a","a/b"] [53.85ms]
(pass) bunshell mkdir > verbose > mkdir --parents a/b prints nothing without a verbose flag [53.48ms]
(pass) bunshell mkdir > verbose > mkdir -p a/b prints nothing without a verbose flag [55.42ms]
(pass) bunshell mkdir > verbose > mkdir  a/b prints nothing without a verbose flag [53.96ms]
(pass) bunshell mkdir > verbose > the misspelling --vebose is 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 929ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[2/13] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[3/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[4/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[5/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[6/13] cxx obj/src/jsc/bindings/bindings.cpp.o
[7/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[8/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[9/13] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[9/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_shell_parser v0.0.0 (/workspace/bun/src/shell_parser)
[1m[92m   Compiling[0m bun_uws_sys v0.0.0 (/workspace/bun/src/uws_sys)
[1m[92m   Compiling[0m bun_ast v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/shell/builtin/mkdir.rs       |  3 +-
 test/js/bun/shell/commands/mkdir.test.ts | 85 ++++++++++++++++++++++++++++++++
 2 files changed, 86 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/runtime/shell/builtin/mkdir.rs            1      1      0
test/js/bun/shell/commands/mkdir.test.ts      1      6      0
```

</details>

**root cause** · written by the author bot

The mkdir builtin's long-flag parser matched the misspelled literal `--vebose` instead of `--verbose`, so `mkdir --verbose` fell through to short-flag parsing of `-verbose`, failed on the first byte, and exited 1 without creating anything. The fix corrects the literal in `parse_long` to `--verbose` (dropping the misspelling and the comment that described it as intentional), so the flag now sets the same verbose state as `-v`, and a new test file covers `-v` and `--verbose` alone and combined with `-p`/`--parents`, along with rejection of the old spelling.

<!-- robobun:evidence:end -->