### PR TITLE
watch: reap child processes inherited across a --watch restart

### DIFF
--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -436,17 +436,18 @@ fn kill_descendants() {
     }
 }
 
-/// Linux-only: enumerate our direct children into `out`. Used by `spawnPosix`
-/// to snapshot pre-existing siblings before arming subreaper, so the post-wait
-/// `kill_subreaper_adoptees` can tell adopted orphans apart from `Bun.spawn`
-/// siblings (both have ppid==us). Returns the slice written; empty on
-/// non-Linux or enumeration failure.
+/// Enumerate our direct children (running or zombie) into `out`. Used by
+/// `spawnPosix` to snapshot pre-existing siblings before arming subreaper, so
+/// the post-wait `kill_subreaper_adoptees` can tell adopted orphans apart from
+/// `Bun.spawn` siblings (both have ppid==us), and by `--watch` startup to find
+/// the children inherited across the execve restart. Returns the slice
+/// written; empty on platforms without an enumeration or on failure.
 pub fn snapshot_children(out: &mut [libc::pid_t]) -> &[libc::pid_t] {
-    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    #[cfg(not(unix))]
     {
         return &out[..0];
     }
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(unix)]
     {
         let self_pid = getpid();
         let n = list_child_pids(self_pid, out).unwrap_or(0);

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -189,6 +189,16 @@ impl HotReloaderCtx for VirtualMachine {
         // via `heap::alloc` and is live for the VM's lifetime.
         self.transpiler.resolver.watcher = Some(unsafe { (*watcher_ptr).get_resolve_watcher() });
 
+        if reload_immediately {
+            // `--watch` reloads by execve'ing in place, so this image starts out
+            // owning whatever the previous one spawned. Nothing has been spawned
+            // yet at this point (the entry point has not run), so every existing
+            // child is inherited.
+            bun_spawn::Process::reap_inherited_children(crate::EventLoopHandle::init(
+                self.event_loop().cast::<()>(),
+            ));
+        }
+
         watcher_ptr
     }
 

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -1690,6 +1690,71 @@ impl SpawnResultExt for PosixSpawnResult {
     }
 }
 
+impl Process {
+    /// Wait on every child this process already has.
+    ///
+    /// `--watch` restarts by `execve`'ing in place, so the children the previous
+    /// image spawned (cluster workers, `unref()`'d subprocesses, ...) are still
+    /// this process's children, but nothing in the new image waits on them: once
+    /// they exit they stay zombies for as long as the watcher lives. Each one is
+    /// registered with the regular exit poller, unref'd so it never keeps the
+    /// event loop alive, and reaped like a child spawned by this image.
+    ///
+    /// Must run before this image spawns anything itself: every child found here
+    /// is treated as inherited, and waiting on a pid that a live `Process` is
+    /// also waiting on would steal its exit status.
+    pub fn reap_inherited_children(event_loop: EventLoopHandle) {
+        #[cfg(not(unix))]
+        {
+            let _ = event_loop;
+        }
+        #[cfg(unix)]
+        {
+            let mut pids = [0 as PidT; 4096];
+            for &pid in ParentDeathWatchdog::snapshot_children(&mut pids) {
+                if pid <= 1 {
+                    continue;
+                }
+                bun_core::scoped_log!(PROCESS, "reaping inherited child {}", pid);
+                Self::adopt_inherited(pid, event_loop);
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn adopt_inherited(pid: PidT, event_loop: EventLoopHandle) {
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        let pidfd = match PosixSpawnResult::pidfd_for_child(pid) {
+            Ok(pidfd) => Some(pidfd),
+            // Without a pidfd only the waiter thread can watch this child; if
+            // that isn't armed either there is no way to observe its exit.
+            Err(_) if WaiterThread::should_use_waiter_thread() => None,
+            Err(_) => return,
+        };
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        let pidfd = None;
+
+        let mut spawned = PosixSpawnResult::default();
+        spawned.pid = pid;
+        spawned.pidfd = pidfd;
+        let process = spawned.to_process(event_loop);
+        // SAFETY: `process` was just created with the one ref released at the end
+        // of this block. `watch()` takes its own ref for the registration, which
+        // the exit dispatch releases (`on_wait_pid_from_event_loop_task` /
+        // `on_wait_pid_from_waiter_thread`), so the poller is the sole owner
+        // afterwards. A child that is already a zombie is readable on its pidfd
+        // right away; kqueue refuses to attach to one (ESRCH), which makes
+        // `watch_or_reap` wait on it inline, and the deref below frees it.
+        unsafe {
+            match (*process).watch_or_reap() {
+                Ok(_) => (*process).disable_keeping_event_loop_alive(),
+                Err(_) => (*process).close(),
+            }
+            Process::deref(process);
+        }
+    }
+}
+
 #[cfg(unix)]
 pub type SpawnOptions = PosixSpawnOptions;
 #[cfg(windows)]

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -499,7 +499,7 @@ impl PosixSpawnResult {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn pidfd_flags_for_linux() -> u32 {
         // PIDFD_NONBLOCK is only supported on kernel 5.10+ (the EINVAL retry
-        // in `pifd_from_pid` still covers misdetection by retrying with 0).
+        // in `pidfd_for_child` still covers misdetection by retrying with 0).
         let kernel = bun_core::linux_kernel_version();
         if (kernel.major, kernel.minor) >= (5, 10) {
             bun_sys::O::NONBLOCK as u32
@@ -508,8 +508,12 @@ impl PosixSpawnResult {
         }
     }
 
+    /// `pidfd_open(2)` for a child of ours. Arms the process-wide waiter-thread
+    /// fallback when the failure means pidfds are unusable here (old kernel,
+    /// gVisor, seccomp), in which case the child can still be waited on via
+    /// `WaiterThread`; any other error is returned as-is.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    pub(crate) fn pifd_from_pid(&mut self) -> bun_sys::Result<PidFdType> {
+    pub fn pidfd_for_child(pid: PidT) -> bun_sys::Result<PidFdType> {
         if crate::waiter_thread_flag::get() {
             return Err(bun_sys::Error::from_code(
                 bun_sys::E::ENOSYS,
@@ -520,11 +524,11 @@ impl PosixSpawnResult {
         let pidfd_flags = Self::pidfd_flags_for_linux();
 
         let attempt = 'brk: {
-            let rc = bun_sys::pidfd_open(self.pid, pidfd_flags);
+            let rc = bun_sys::pidfd_open(pid, pidfd_flags);
             if let Err(e) = &rc {
                 if e.get_errno() == bun_sys::E::EINVAL {
                     // Retry once, incase they don't support PIDFD_NONBLOCK.
-                    break 'brk bun_sys::pidfd_open(self.pid, 0);
+                    break 'brk bun_sys::pidfd_open(pid, 0);
                 }
             }
             rc
@@ -542,35 +546,40 @@ impl PosixSpawnResult {
                     | bun_sys::E::EACCES
                     | bun_sys::E::EINVAL => {
                         crate::waiter_thread_flag::set();
-                        return Err(err);
                     }
-
-                    // No such process can happen if it exited between the time we got the pid and called pidfd_open
-                    // Until we switch to CLONE_PIDFD, this needs to be handled separately.
-                    bun_sys::E::ESRCH => {}
-
-                    // For all other cases, ensure we don't leak the child process on error
-                    // That would cause Zombie processes to accumulate.
-                    _ => {
-                        loop {
-                            let mut status: i32 = 0;
-                            // SAFETY: libc wait4
-                            let rc = unsafe {
-                                libc::wait4(self.pid, &raw mut status, 0, core::ptr::null_mut())
-                            };
-                            match bun_sys::get_errno(rc as isize) {
-                                bun_sys::E::SUCCESS => {}
-                                bun_sys::E::EINTR => continue,
-                                _ => {}
-                            }
-                            break;
-                        }
-                    }
+                    _ => {}
                 }
                 Err(err)
             }
             Ok(fd) => Ok(fd.native()),
         }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub(crate) fn pifd_from_pid(&mut self) -> bun_sys::Result<PidFdType> {
+        let result = Self::pidfd_for_child(self.pid);
+        if let Err(err) = &result {
+            // Waiter thread armed: it waits for this child instead. ESRCH: the child
+            // exited between spawn and pidfd_open (the caller reaps it via `has_exited`).
+            // Until we switch to CLONE_PIDFD, this needs to be handled separately.
+            // For all other cases, ensure we don't leak the child process on error
+            // That would cause Zombie processes to accumulate.
+            if !crate::waiter_thread_flag::get() && err.get_errno() != bun_sys::E::ESRCH {
+                loop {
+                    let mut status: i32 = 0;
+                    // SAFETY: libc wait4
+                    let rc =
+                        unsafe { libc::wait4(self.pid, &raw mut status, 0, core::ptr::null_mut()) };
+                    match bun_sys::get_errno(rc as isize) {
+                        bun_sys::E::SUCCESS => {}
+                        bun_sys::E::EINTR => continue,
+                        _ => {}
+                    }
+                    break;
+                }
+            }
+        }
+        result
     }
 }
 

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -11,13 +11,23 @@ function stdoutWaiter(proc: Subprocess<"ignore", "pipe", any>) {
   const reader = proc.stdout.getReader();
   const decoder = new TextDecoder();
   let output = "";
+  const readUntil = async (predicate: () => boolean) => {
+    while (!predicate()) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error(`stream closed, output so far: ${JSON.stringify(output)}`);
+      output += decoder.decode(value, { stream: true });
+    }
+  };
   return {
-    waitFor: async (needle: string) => {
-      while (!output.includes(needle)) {
-        const { value, done } = await reader.read();
-        if (done) throw new Error(`stream closed, output so far: ${JSON.stringify(output)}`);
-        output += decoder.decode(value, { stream: true });
-      }
+    waitFor: (needle: string) => readUntil(() => output.includes(needle)),
+    /** Waits for the whole line containing `needle` and returns it. */
+    waitForLine: async (needle: string) => {
+      await readUntil(() => {
+        const start = output.indexOf(needle);
+        return start !== -1 && output.indexOf("\n", start) !== -1;
+      });
+      const start = output.lastIndexOf("\n", output.indexOf(needle)) + 1;
+      return output.slice(start, output.indexOf("\n", start));
     },
     release: () => reader.releaseLock(),
   };
@@ -319,6 +329,91 @@ it("NODE_COMPILE_CACHE persists across a --watch reload", async () => {
   const entries = readdirSync(cacheDir, { recursive: true, withFileTypes: true });
   expect(entries.filter(e => e.isFile()).length).toBeGreaterThan(0);
 }, 30000);
+
+// --watch reloads by execve'ing in place, so children spawned before the
+// reload are still children of the reloaded process. It has to wait on them
+// once they exit, otherwise every one of them (e.g. every node:cluster worker,
+// on every save) stays a zombie for as long as the watcher lives.
+it.skipIf(isWindows)(
+  "children spawned before a --watch reload are reaped by the reloaded process",
+  async () => {
+    // `early` exits as soon as the reload closes its stdin pipe, so it is
+    // usually already a zombie when the new image starts; `late` is told to
+    // exit by the new image, so it is still running when that image starts.
+    // Both self-destruct so a failure elsewhere in the test cannot leak them.
+    const exitOnRequest = `
+      setInterval(() => { if (require("fs").existsSync("exit-now")) process.exit(0); }, 10);
+      setTimeout(() => process.exit(1), 30_000);
+    `;
+    using dir = tempDir("watch-reap-inherited-children", {
+      "app.js": `
+        const fs = require("fs");
+        if (!fs.existsSync("children.json")) {
+          const early = Bun.spawn({
+            cmd: [process.execPath, "-e", 'process.stdin.on("end", () => process.exit(0)); process.stdin.resume();' + ${JSON.stringify(exitOnRequest)}],
+            stdin: "pipe",
+            stdout: "ignore",
+            stderr: "inherit",
+          });
+          const late = Bun.spawn({
+            cmd: [process.execPath, "-e", ${JSON.stringify(exitOnRequest)}],
+            stdin: "ignore",
+            stdout: "ignore",
+            stderr: "inherit",
+          });
+          fs.writeFileSync("children.json", JSON.stringify([early.pid, late.pid]));
+          console.log("iter first");
+        } else {
+          const pids = JSON.parse(fs.readFileSync("children.json", "utf8"));
+          fs.writeFileSync("exit-now", "");
+          // kill(pid, 0) keeps succeeding for a zombie; it only fails with
+          // ESRCH once the pid has been waited on.
+          const deadline = Date.now() + 10_000;
+          const timer = setInterval(() => {
+            const remaining = pids.filter(pid => {
+              try {
+                process.kill(pid, 0);
+                return true;
+              } catch {
+                return false;
+              }
+            });
+            if (remaining.length === 0) {
+              console.log("iter second: reaped");
+            } else if (Date.now() < deadline) {
+              return;
+            } else {
+              console.log("iter second: still have " + JSON.stringify(remaining));
+            }
+            clearInterval(timer);
+          }, 10);
+        }
+        setInterval(() => {}, 1000);
+      `,
+    });
+    const path = join(String(dir), "app.js");
+
+    watchee = spawn({
+      cmd: [bunExe(), "--watch", "app.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
+
+    const { waitFor, waitForLine, release } = stdoutWaiter(watchee);
+    await waitFor("iter first");
+    await Bun.write(path, (await Bun.file(path).text()) + "\n// touched");
+    const verdict = await waitForLine("iter second: ");
+    release();
+    watchee.kill("SIGKILL");
+    await watchee.exited;
+
+    expect(verdict).toBe("iter second: reaped");
+  },
+  30000,
+);
 
 // NODE_CHANNEL_FD survives in environ across execve; the fd it names must
 // survive too, so the reloaded image re-attaches to a live socket instead


### PR DESCRIPTION
### Problem
- `bun --watch` never reaps a child process that exits after a reload: it stays in `Z` state for as long as the watcher lives, one zombie per child per reload. With `node:cluster` that is every worker on every save: `primary pid=N children=18 zombies=16` after 8 saves on 1.4.0, where `node --watch` reports `children=2 zombies=0`.
- `--watch` reloads by `execve`'ing the same pid (`reload_process`, src/bun_core/util.rs). The old image's children are therefore still children of the new image, but every `Process` that was waiting on them died with the old image, so nothing ever calls `wait4` for them. Same for the crash auto-reload and `bun test --watch`.
- Sibling of #35095 (old children keep running), which kills children before the `execve`. This PR is about children that cross the exec boundary either way: cluster workers exit on their own a few ms after the reload, `unref()`'d children, anything that outlives #35095's 100 ms window. The two compose.

### Fix
- `Process::reap_inherited_children(event_loop)` (src/spawn/process.rs) enumerates the direct children the process has right now and hands each one to the regular exit poller. `install_bun_watcher` on the VM calls it when the exec-restart reloader is installed (src/jsc/hot_reloader.rs). That covers `bun --watch` and `bun test --watch`, and runs before the entry point or any test file, so every child that exists at that point is inherited; on the first generation the list is empty.
- Each child becomes a plain `Process` built from its pid (pidfd + `FilePoll` on Linux, `EVFILT_PROC` on macOS, waiter thread where pidfds are unavailable). `watch_or_reap` registers it, or waits on it inline when kqueue refuses to attach to a child that is already a zombie; it is unref'd so it never keeps the loop alive; the normal exit dispatch reaps and frees it. A child still running at the next reload is adopted again by the next image.
- Enumeration reuses `ParentDeathWatchdog::snapshot_children` (src/io/ParentDeathWatchdog.rs), now enabled on macOS too; its Linux caller is unchanged. Both enumerations list zombies as well as running children.
- `PosixSpawnResult::pidfd_for_child` (src/spawn_sys/spawn_process.rs) is the existing `pifd_from_pid` without its blocking `wait4` arm, which `pifd_from_pid` keeps for the spawn path. Adoption must never block: with an inherited `sleep 1000` and a `pidfd_open` failure such as `EMFILE`, the old code would have hung startup. Such a child is skipped instead (previous behavior). #35924 removes the same blocking arm from the spawn path.
- Verified with the new test in `test/cli/watch/watch.test.ts`: fails on 1.4.0 with `iter second: still have [pid, pid]`, passes with this build, also with `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1`. The cluster repro from the report goes from +2 zombies per save to `children=2 zombies=0` once the new image's loop ticks. `cli/watch`, `cli/hot/watch*`, `cli/test/test-changed` (`--changed --watch`), `cli/run/no-orphans` and `bun/spawn/spawn.test.ts` pass; the touched crates `cargo check` on the darwin, windows, freebsd and android targets.

### Background
- An exited process stays in the process table as a zombie, holding its pid, until its parent calls `wait4`/`waitpid` on it. The kernel only releases it by itself when the parent dies, and `--watch`'s process never dies: `execve` replaces the program image but keeps the pid and the parent/child links.
- `bun_spawn::Process` is the per-child object behind `Bun.spawn`, `child_process`, the shell and lifecycle scripts. Its poller is a pidfd in epoll on Linux, an `EVFILT_PROC` kqueue filter on macOS, or a single waiter thread calling `wait4(pid, WNOHANG)` on kernels without pidfd. When it fires, `Process` calls `wait4` for that pid (which reaps it), runs the exit handler (none here) and drops the reference the registration held.
- `ParentDeathWatchdog` (`--no-orphans`) already had a child enumeration for its exit-time cleanup: `/proc/<pid>/task/*/children` on Linux, `proc_listchildpids` on macOS.

<details>
<summary>Cluster repro from the report, 4 saves</summary>

`z.cjs` forks two cluster workers and prints how many children of the primary are in `Z` state, once synchronously at boot and once 500 ms later.

```
# bun 1.4.0
primary pid=17111 children=2 zombies=0
primary pid=17111 children=4 zombies=2
primary pid=17111 children=6 zombies=3    after 500ms: children=6 zombies=4
primary pid=17111 children=8 zombies=6
primary pid=17111 children=10 zombies=8

# this branch
primary pid=17432 children=2 zombies=0
primary pid=17432 children=4 zombies=2    after 500ms: children=2 zombies=0
primary pid=17432 children=4 zombies=2    after 500ms: children=2 zombies=0
primary pid=17432 children=4 zombies=2    after 500ms: children=2 zombies=0
primary pid=17432 children=4 zombies=2    after 500ms: children=2 zombies=0
```

The synchronous line still sees the previous workers as zombies because it runs before the new image's event loop has ticked; they are reaped on the first tick.

</details>
