### PR TITLE
shell: report --name=value spellings of unsupported builtin options as unsupported

### DIFF
--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -445,7 +445,7 @@ impl FlagParser for Opts {
 
     fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult> {
         match ch {
-            b'm' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-m "))),
+            b'm' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-m"))),
             b'p' => {
                 self.parents = true;
                 None

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2345,7 +2345,7 @@ pub(crate) const fn unsupported_flag(name: &'static [u8]) -> *const [u8] {
 
 /// Per-builtin opts type implements this to plug into `FlagParser::parse_flags`.
 pub trait FlagParser {
-    /// Handle a `--long` flag. Return `None` to fall through to short parsing.
+    /// Handle a `--long` flag (minus any `=value`). Return `None` to fall through to short parsing.
     fn parse_long(&mut self, flag: &[u8]) -> Option<ParseFlagResult>;
     /// Handle one byte of a `-abc` cluster. Return `None` to keep iterating.
     fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult>;
@@ -2382,8 +2382,17 @@ fn parse_one_flag<O: FlagParser>(opts: &mut O, flag: &[u8]) -> ParseFlagResult {
         return ParseFlagResult::IllegalOption(std::ptr::from_ref::<[u8]>(b"-"));
     }
     if flag.len() > 2 && flag[1] == b'-' {
-        if let Some(r) = opts.parse_long(flag) {
-            return r;
+        let (name, has_value) = match bun_core::strings::split_once_char(flag, b'=') {
+            Some((name, _value)) => (name, true),
+            None => (flag, false),
+        };
+        match opts.parse_long(name) {
+            Some(r @ (ParseFlagResult::Unsupported(_) | ParseFlagResult::IllegalOption(_))) => {
+                return r;
+            }
+            Some(r) if !has_value => return r,
+            // No long option takes a value; with one, even an accepted name is rejected below.
+            Some(_) | None => {}
         }
     }
     let small_flags = &flag[1..];

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
-import { chmodSync, mkdirSync } from "fs";
+import { chmodSync, mkdirSync, readdirSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
 import { bunExe, isPosix, isWindows, rss, runWithErrorPromise, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { join, sep } from "path";
@@ -3239,4 +3239,58 @@ test.skipIf(isWindows)("external command resolution uses the PATH from the shell
     expect(stdout.toString()).toBe("from-onlyintool\n");
     expect(exitCode).toBe(0);
   }
+});
+
+describe.concurrent("options a builtin rejects", () => {
+  const unsupported = (builtin: string, option: string) =>
+    `${builtin}: unsupported option, please open a GitHub issue -- ${option}\n`;
+  const illegal = (builtin: string) => expect.stringMatching(new RegExp(`^${builtin}: illegal option -- `));
+
+  // `--name=value` used to be offered to the builtin as one token, so it
+  // matched none of its options and was reported as an illegal option; the
+  // `-m` message used to end in a space.
+  test.each([
+    ["mkdir -m 755 d", unsupported("mkdir", "-m")],
+    ["mkdir -m755 d", unsupported("mkdir", "-m")],
+    ["mkdir -pm 755 d", unsupported("mkdir", "-m")],
+    ["mkdir --mode 755 d", unsupported("mkdir", "--mode")],
+    ["mkdir --mode=755 d", unsupported("mkdir", "--mode")],
+    ["mkdir --mode= d", unsupported("mkdir", "--mode")],
+    ["mkdir -p --mode=755 d", unsupported("mkdir", "--mode")],
+    ["touch --date x d", unsupported("touch", "--date")],
+    ["touch --date=x d", unsupported("touch", "--date")],
+    // Unsupported in any spelling, even one the real touch would reject.
+    ["touch --no-create=1 d", unsupported("touch", "--no-create")],
+    // Options the builtin does not have, and a value on one it implements but
+    // which takes none, are still illegal options.
+    ["mkdir --modes d", illegal("mkdir")],
+    ["mkdir --bogus=1 d", illegal("mkdir")],
+    ["mkdir --parents=1 d", illegal("mkdir")],
+  ])("%s fails without touching the filesystem", async (command, stderr) => {
+    using dir = tempDir("builtin-unsupported-option", {});
+    const cwd = String(dir);
+
+    const result = await $`${command.split(" ")}`.cwd(cwd).quiet();
+
+    expect({
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+      exitCode: result.exitCode,
+      created: readdirSync(cwd),
+    }).toEqual({ stdout: "", stderr, exitCode: 1, created: [] });
+  });
+
+  test("the spelling without a value is still accepted", async () => {
+    using dir = tempDir("builtin-long-option", {});
+    const cwd = String(dir);
+
+    const result = await $`mkdir --parents d`.cwd(cwd).quiet();
+
+    expect({
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+      exitCode: result.exitCode,
+      created: readdirSync(cwd),
+    }).toEqual({ stdout: "", stderr: "", exitCode: 0, created: ["d"] });
+  });
 });


### PR DESCRIPTION
### Problem

- The shell builtins that share `parse_flags` (mkdir, touch, cat, cp) reject the options they do not implement with `unsupported option, please open a GitHub issue -- <option>`, but only when the option is spelled without a value. `mkdir --mode=755 d` prints `mkdir: illegal option -- mode=755`, and `touch --date=x f`, `--reference=f`, `--time=atime` likewise print `illegal option`, as if the option did not exist; `mkdir --mode 755 d` and `touch --date x f` already print the unsupported message.
- Cause: `parse_one_flag` (`src/runtime/shell/interpreter.rs:2384`) offers the whole `--name=value` token to the builtin's `parse_long`, which compares it against its option names, matches nothing, and returns `None`; the dispatcher then reparses the token as the short cluster `-name=value`, whose first byte is rejected as an illegal option. Every builtin with a value-taking unsupported option (mkdir `--mode`, touch `--date`/`--reference`/`--time`) has the gap, because the `=` is never handled anywhere.
- Separately, `mkdir -m 755 d` prints `-- -m ` with a trailing space: the literal in mkdir's `parse_short` is `b"-m "` (`src/runtime/shell/builtin/mkdir.rs:448`). Every other `unsupported_flag` literal in the builtins is clean.
- Exit code is 1 in all of these cases before and after; only the stderr text changes. Both bugs were carried over from the Zig implementation, so this is not a regression.

### Fix

- `parse_one_flag` splits a `--` token at its first `=` and offers the name to `parse_long`. A rejection (`Unsupported`, `IllegalOption`) is returned whether or not a value was given; an acceptance is returned only when no value was given. With a value, an accepted name falls through to the short-cluster path and is rejected exactly as today (`mkdir --parents=1` stays an illegal option), and so does an unknown name (`--bogus=1`). The fixing lines are the `split_once_char` and the `if !has_value` guard; the other builtins' `parse_long` implementations are unchanged.
- Why this is right: `--name=value` and `--name value` are the two spellings getopt_long accepts for the same option, so both must classify the same way, and the builtin's answer about the name ("I do not implement this") holds whatever follows the `=`. Handling the `=` in the dispatcher fixes all four options at once and means a builtin only ever matches option names; no long option any of these builtins accepts takes a value, so the dispatcher can also keep rejecting values on accepted options without asking the builtin. One consequence is deliberate: an unsupported option is reported as unsupported even in a spelling the real tool would reject (`touch --no-create=1` now says unsupported `--no-create`, previously illegal), since the option is unimplemented either way; this is pinned in the test.
- mkdir's `-m` literal loses its trailing space.
- Unchanged, and checked by hand with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`: cat and cp have no long options, so every `--x` and `--x=y` they get still falls through byte for byte as before; `mkdir --help`/`touch --help` (pinned in `exec.test.ts`) and `--=x` are unaffected.
- Verified by the new `options a builtin rejects` block in `test/js/bun/shell/bunshell.test.ts`: 14 cases covering `-m 755`, `-m755`, `-pm 755`, `--mode 755`, `--mode=755`, `--mode=`, `-p --mode=755`, `touch --date x`, `--date=x`, `--no-create=1`, plus `--modes`, `--bogus=1` and `--parents=1` staying illegal and `--parents` still working; each also checks nothing was created. 8 of the 14 fail on the unfixed build (the 7 whose message changes plus `--no-create=1`), all pass with the fix. The rest of `bunshell.test.ts` (437 tests) and `exec.test.ts` pass with the fix.
- The test lives in `bunshell.test.ts` rather than a new `commands/mkdir.test.ts` because it covers the shared parser, and because #38002, #38379 and #39221 each already add that file.
- Not changed here, on purpose: the names touch reports for `--reference`/`--time` (`--reference=FILE`; #39219 fixes `--time`), cp reporting `-p` as `-P` (#35616/#35705), and which byte the illegal-option message names (#39230). #39227 fixes the touch spellings inside touch's own `parse_long`; with this change that becomes unnecessary, noted there.

### Background

- Option parsing for these builtins: `parse_flags` in `interpreter.rs` walks argv until the first non-option and calls `parse_one_flag` per token, which offers `--x` tokens to the builtin's `FlagParser::parse_long` and otherwise iterates the token's bytes through `parse_short`. A `None` from `parse_long` means "not one of my long options" and falls into the byte loop, where the token's second `-` is what gets rejected; that fall-through is what produced the `illegal option` text here and is what this change still relies on for the cases it leaves unchanged.
- `ParseFlagResult::Unsupported` carries a static option name chosen by the builtin, which `Builtin::fail_parse` prints after `unsupported option, please open a GitHub issue -- `; `IllegalOption` produces `illegal option -- <bytes>`. Both exit 1, so the only user-visible difference between them is whether the message says the option is known.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->