### PR TITLE
shell(rm): list only removed entries under -v and ignore every ENOENT under -f

### DIFF
--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -824,10 +824,7 @@ impl ShellRmTask {
         }
     }
 
-    /// Records `path` for `-v` output; call it only after the entry was
-    /// actually removed. An ENOENT that `-f` swallows removed nothing and is
-    /// not recorded; returning `()` keeps such an arm from using this call as
-    /// its success value.
+    /// Records `path` for `-v`; only for an entry this worker actually removed.
     ///
     /// Takes `dir_task` as a raw pointer (not `&mut DirTask`) so callers in
     /// `remove_entry*` — which already hold `&self: &ShellRmTask` and a
@@ -1041,9 +1038,7 @@ impl ShellRmTask {
         let mut i: usize = 0;
         let loop_result: bun_sys::Maybe<()> = loop {
             let current = match iterator.next() {
-                // The directory itself was removed while we were reading it
-                // (another operand of the same rm, or another process); the
-                // rmdir below then sees ENOENT too, and -f ignores both.
+                // overlayfs: the directory was removed under us (e.g. by an overlapping operand).
                 Err(e) if self.opts.force && e.get_errno() == E::ENOENT => break Ok(()),
                 Err(e) => break Err(self.error_with_path(&e, path.as_bytes())),
                 Ok(None) => break Ok(()),

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -824,14 +824,19 @@ impl ShellRmTask {
         }
     }
 
+    /// Records `path` for `-v` output; call it only after the entry was
+    /// actually removed. An ENOENT that `-f` swallows removed nothing and is
+    /// not recorded; returning `()` keeps such an arm from using this call as
+    /// its success value.
+    ///
     /// Takes `dir_task` as a raw pointer (not `&mut DirTask`) so callers in
     /// `remove_entry*` — which already hold `&self: &ShellRmTask` and a
     /// `&ZStr` borrowed from `dir_task.path` — never materialise an aliasing
     /// `&mut DirTask`. Only the disjoint `deleted_entries` field is reborrowed
     /// mutably here.
-    fn verbose_deleted(&self, dir_task: *mut DirTask, path: &[u8]) -> bun_sys::Maybe<()> {
+    fn verbose_deleted(&self, dir_task: *mut DirTask, path: &[u8]) {
         if !self.opts.verbose {
-            return Ok(());
+            return;
         }
         // SAFETY: a DirTask's non-atomic fields are single-owner-at-a-time.
         // Ownership starts on the worker that runs `remove_entry*` and is
@@ -850,7 +855,6 @@ impl ShellRmTask {
         }
         entries.extend_from_slice(path);
         entries.push(b'\n');
-        Ok(())
     }
 
     /// Join into `buf` honoring [`join_style`].
@@ -957,7 +961,10 @@ impl ShellRmTask {
             };
             if state.treat_as_dir {
                 match bun_sys::rmdirat(dirfd, path) {
-                    Ok(()) => return self.verbose_deleted(dir_task, path.as_bytes()),
+                    Ok(()) => {
+                        self.verbose_deleted(dir_task, path.as_bytes());
+                        return Ok(());
+                    }
                     Err(e) => match e.get_errno() {
                         E::ENOENT => {
                             if self.opts.force {
@@ -1034,6 +1041,10 @@ impl ShellRmTask {
         let mut i: usize = 0;
         let loop_result: bun_sys::Maybe<()> = loop {
             let current = match iterator.next() {
+                // The directory itself was removed while we were reading it
+                // (another operand of the same rm, or another process); the
+                // rmdir below then sees ENOENT too, and -f ignores both.
+                Err(e) if self.opts.force && e.get_errno() == E::ENOENT => break Ok(()),
                 Err(e) => break Err(self.error_with_path(&e, path.as_bytes())),
                 Ok(None) => break Ok(()),
                 Ok(Some(ent)) => ent,
@@ -1126,7 +1137,10 @@ impl ShellRmTask {
         }
 
         match bun_sys::unlinkat_with_flags(self.cwd, path, bun_sys::AT_REMOVEDIR) {
-            Ok(()) => self.verbose_deleted(dir_task, path.as_bytes()),
+            Ok(()) => {
+                self.verbose_deleted(dir_task, path.as_bytes());
+                Ok(())
+            }
             Err(e) => match e.get_errno() {
                 E::ENOENT => {
                     if self.opts.force {
@@ -1156,7 +1170,7 @@ impl ShellRmTask {
             if state.treat_as_dir {
                 match bun_sys::rmdirat(dirfd, path) {
                     Ok(()) => {
-                        let _ = self.verbose_deleted(dir_task, path.as_bytes());
+                        self.verbose_deleted(dir_task, path.as_bytes());
                         return Ok(true);
                     }
                     Err(e) => match e.get_errno() {
@@ -1197,7 +1211,10 @@ impl ShellRmTask {
     ) -> bun_sys::Maybe<()> {
         let dirfd = self.cwd;
         match bun_sys::unlinkat_with_flags(dirfd, path, 0) {
-            Ok(()) => self.verbose_deleted(parent_dir_task, path.as_bytes()),
+            Ok(()) => {
+                self.verbose_deleted(parent_dir_task, path.as_bytes());
+                Ok(())
+            }
             Err(e) => match e.get_errno() {
                 E::ENOENT => {
                     if self.opts.force {
@@ -1235,7 +1252,10 @@ impl ShellRmTask {
                                 bun_sys::AT_REMOVEDIR,
                             ) {
                                 // it was empty, we saved a syscall
-                                Ok(()) => self.verbose_deleted(parent_dir_task, path.as_bytes()),
+                                Ok(()) => {
+                                    self.verbose_deleted(parent_dir_task, path.as_bytes());
+                                    Ok(())
+                                }
                                 Err(e2) => match e2.get_errno() {
                                     // not empty, process directory as we would normally
                                     E::ENOTEMPTY => vtable.on_dir_not_empty(
@@ -1244,6 +1264,8 @@ impl ShellRmTask {
                                         is_absolute,
                                         buf,
                                     ),
+                                    // removed between the two calls
+                                    E::ENOENT if self.opts.force => Ok(()),
                                     // actually a file, the error is a permissions error
                                     E::ENOTDIR => Err(self.error_with_path(&e, path.as_bytes())),
                                     _ => Err(self.error_with_path(&e2, path.as_bytes())),

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -957,11 +957,11 @@ impl ShellRmTask {
             };
             if state.treat_as_dir {
                 match bun_sys::rmdirat(dirfd, path) {
-                    Ok(()) => return Ok(()),
+                    Ok(()) => return self.verbose_deleted(dir_task, path.as_bytes()),
                     Err(e) => match e.get_errno() {
                         E::ENOENT => {
                             if self.opts.force {
-                                return self.verbose_deleted(dir_task, path.as_bytes());
+                                return Ok(());
                             }
                             return Err(self.error_with_path(&e, path.as_bytes()));
                         }
@@ -994,7 +994,7 @@ impl ShellRmTask {
             Err(e) => match e.get_errno() {
                 E::ENOENT => {
                     if self.opts.force {
-                        return self.verbose_deleted(dir_task, path.as_bytes());
+                        return Ok(());
                     }
                     return Err(self.error_with_path(&e, path.as_bytes()));
                 }
@@ -1130,7 +1130,7 @@ impl ShellRmTask {
             Err(e) => match e.get_errno() {
                 E::ENOENT => {
                     if self.opts.force {
-                        return self.verbose_deleted(dir_task, path.as_bytes());
+                        return Ok(());
                     }
                     Err(self.error_with_path(&e, path.as_bytes()))
                 }
@@ -1162,7 +1162,6 @@ impl ShellRmTask {
                     Err(e) => match e.get_errno() {
                         E::ENOENT => {
                             if self.opts.force {
-                                let _ = self.verbose_deleted(dir_task, path.as_bytes());
                                 return Ok(true);
                             }
                             return Err(self.error_with_path(&e, path.as_bytes()));
@@ -1202,7 +1201,7 @@ impl ShellRmTask {
             Err(e) => match e.get_errno() {
                 E::ENOENT => {
                     if self.opts.force {
-                        return self.verbose_deleted(parent_dir_task, path.as_bytes());
+                        return Ok(());
                     }
                     Err(self.error_with_path(&e, path.as_bytes()))
                 }

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -824,8 +824,6 @@ impl ShellRmTask {
         }
     }
 
-    /// Records `path` for `-v`; only for an entry this worker actually removed.
-    ///
     /// Takes `dir_task` as a raw pointer (not `&mut DirTask`) so callers in
     /// `remove_entry*` — which already hold `&self: &ShellRmTask` and a
     /// `&ZStr` borrowed from `dir_task.path` — never materialise an aliasing

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -33,6 +33,7 @@ describe.concurrent("bunshell rm", () => {
   test("force", async () => {
     const files = {
       "existent.txt": "",
+      "other.txt": "",
     };
     await using tempdir = tempDir("rmforce", files);
 
@@ -50,6 +51,28 @@ describe.concurrent("bunshell rm", () => {
       expect(stdout.toString()).toEqual(`${tempdir}/existent.txt\n`);
       expect(exitCode).toBe(0);
       expect(await fileExists(`${tempdir}/existent.txt`)).toBeFalse();
+    }
+
+    // A -v line means the entry was removed, so an operand that -f skips
+    // because it does not exist (or whose parent does not exist) is not listed.
+    for (const flags of ["-fv", "-rfv", "-dfv"]) {
+      const { stdout, stderr, exitCode } = await $`rm ${flags} ${tempdir}/non_existent.txt ${tempdir}/no_dir/file.txt`;
+      expect({ flags, stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
+        flags,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+      });
+    }
+
+    {
+      const { stdout, stderr, exitCode } = await $`rm -fv ${tempdir}/non_existent.txt ${tempdir}/other.txt`;
+      expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
+        stdout: `${tempdir}/other.txt\n`,
+        stderr: "",
+        exitCode: 0,
+      });
+      expect(await fileExists(`${tempdir}/other.txt`)).toBeFalse();
     }
   });
 
@@ -130,9 +153,12 @@ foo/
     }
 
     {
-      const { stdout, stderr, exitCode } = await $`rm -d ${tempdir}/sub_dir`;
-      console.log(stderr.toString());
-      expect(exitCode).toBe(0);
+      const { stdout, stderr, exitCode } = await $`rm -dv ${tempdir}/sub_dir`;
+      expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
+        stdout: `${tempdir}/sub_dir\n`,
+        stderr: "",
+        exitCode: 0,
+      });
       expect(await fileExists(`${tempdir}/sub_dir`)).toBeFalse();
     }
 

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { existsSync, mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "path";
 import { createTestBuilder, sortedShellOutput } from "../util";
@@ -73,6 +73,37 @@ describe.concurrent("bunshell rm", () => {
         exitCode: 0,
       });
       expect(await fileExists(`${tempdir}/other.txt`)).toBeFalse();
+    }
+  });
+
+  // Every operand is removed on its own worker, so naming a tree and its
+  // subdirectories in one command makes the workers race each other and
+  // every entry is hit with ENOENT by the workers that lose: at the unlink or
+  // rmdir, when opening the directory, or while reading it (overlayfs fails
+  // the readdir of a removed directory). -f has to swallow all of those, and
+  // -v must list each entry exactly once, by the worker that removed it.
+  // Skipped on Windows: there, unlinking an entry whose deletion is already
+  // pending reports success, so two workers can legitimately both list it.
+  test.skipIf(isWindows)("force: operands that overlap with each other's contents", async () => {
+    const DIRS = 8;
+    const FILES = 4;
+    for (let iteration = 0; iteration < 4; iteration++) {
+      const files: Record<string, string> = {};
+      for (let d = 0; d < DIRS; d++) {
+        for (let f = 0; f < FILES; f++) files[`tree/d${d}/f${f}`] = "";
+      }
+      await using tempdir = tempDir("rmoverlap", files);
+      const tree = `${tempdir}/tree`;
+      const subdirs = Array.from({ length: DIRS }, (_, d) => `${tree}/d${d}`);
+      const expected = [tree, ...subdirs, ...Object.keys(files).map(rel => `${tempdir}/${rel}`)].sort();
+
+      const { stdout, stderr, exitCode } = await $`rm -rfv ${subdirs} ${tree} ${tree}`.quiet();
+      expect({ stdout: sortedShellOutput(stdout.toString()), stderr: stderr.toString(), exitCode }).toEqual({
+        stdout: expected,
+        stderr: "",
+        exitCode: 0,
+      });
+      expect(existsSync(tree)).toBeFalse();
     }
   });
 

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -6,7 +6,7 @@
  */
 import { $ } from "bun";
 import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { existsSync, mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "path";
 import { createTestBuilder, sortedShellOutput } from "../util";
@@ -81,13 +81,16 @@ describe.concurrent("bunshell rm", () => {
   // every entry is hit with ENOENT by the workers that lose: at the unlink or
   // rmdir, when opening the directory, or while reading it (overlayfs fails
   // the readdir of a removed directory). -f has to swallow all of those, and
-  // -v must list each entry exactly once, by the worker that removed it.
-  // Skipped on Windows: there, unlinking an entry whose deletion is already
-  // pending reports success, so two workers can legitimately both list it.
+  // -v must only list an entry for a worker whose unlink or rmdir succeeded.
+  // Linux serializes removals on the parent directory, so there exactly one
+  // worker succeeds per entry and the listing has no duplicates; on macOS two
+  // workers can both be told they removed the same entry, so only the set of
+  // listed entries is checked. Windows reports success for an entry whose
+  // deletion is still pending and is not what this test is about.
   test.skipIf(isWindows)("force: operands that overlap with each other's contents", async () => {
     const DIRS = 8;
     const FILES = 4;
-    for (let iteration = 0; iteration < 4; iteration++) {
+    for (let iteration = 0; iteration < 3; iteration++) {
       const files: Record<string, string> = {};
       for (let d = 0; d < DIRS; d++) {
         for (let f = 0; f < FILES; f++) files[`tree/d${d}/f${f}`] = "";
@@ -98,12 +101,18 @@ describe.concurrent("bunshell rm", () => {
       const expected = [tree, ...subdirs, ...Object.keys(files).map(rel => `${tempdir}/${rel}`)].sort();
 
       const { stdout, stderr, exitCode } = await $`rm -rfv ${subdirs} ${tree} ${tree}`.quiet();
-      expect({ stdout: sortedShellOutput(stdout.toString()), stderr: stderr.toString(), exitCode }).toEqual({
-        stdout: expected,
+      const listed = sortedShellOutput(stdout.toString());
+      expect({
+        listed: isLinux ? listed : [...new Set(listed)],
+        stderr: stderr.toString(),
+        exitCode,
+        treeExists: existsSync(tree),
+      }).toEqual({
+        listed: expected,
         stderr: "",
         exitCode: 0,
+        treeExists: false,
       });
-      expect(existsSync(tree)).toBeFalse();
     }
   });
 


### PR DESCRIPTION
### Problem
- `rm -fv does_not_exist` in the Bun shell prints `does_not_exist` to stdout (exit 0), the same line it prints for a path it unlinked. GNU and BSD `rm` print nothing for an operand that `-f` skips; the `-v` line means the entry was removed.
  ```
  bun -e 'import {$} from "bun"; $.nothrow(); const r = await $`rm -fv does_not_exist`.quiet(); console.log(r.exitCode, JSON.stringify(r.stdout.toString()))'
  # 0 "does_not_exist\n"      (expected: 0 "")
  ```
- Cause: in `src/runtime/shell/builtin/rm.rs` every ENOENT arm that honours `opts.force` returned `self.verbose_deleted(..)`, which appends the path to the `-v` buffer and happens to have the right return type. A missing operand hits the arm in `remove_entry_file` (unlinkat); the same pattern was in `remove_entry_dir` (the `-d` rmdir, the openat, the final rmdir) and in `remove_entry_dir_after_children`, which are reached when an entry disappears while the walk is running, for example because the same `rm` was given a tree and one of its subdirectories: with `rm -rfv tree/d0 .. tree/d7 tree tree` on main, every one of 40 runs listed some entries two or three times.
- Two related `-f` gaps in the same walk, visible in that same overlap case: the readdir error arm in `remove_entry_dir` does not honour `-f` at all, and on overlayfs (Docker, so also CI) reading a directory that another worker has just removed fails with ENOENT, so 30 of those 40 runs printed `rm: tree/d1: No such file or directory`, exited 1 and left the rest of the tree behind (the error aborts every worker). On the EPERM path that macOS and Windows take for directories, an ENOENT from the second `unlinkat` was reported the same way.
- The `-d` rmdir match in `remove_entry_dir` also had the inverse defect: its `Ok` arm was the only removal site that did not call `verbose_deleted`, so `rm -dv emptydir` removed the directory and printed nothing on Linux and Windows (macOS prints it because its EPERM path goes through `remove_entry_file`).

### Fix
- The ENOENT-under-`-f` arms return plain success; the readdir ENOENT and the non-Linux second-unlinkat ENOENT do the same when `force` is set (the readdir one `break`s out of the loop so the child hand-off below it still runs); the `-d` rmdir `Ok` arm records the directory. Without `-f` every error is still reported as before, and entries that were removed are listed as before.
- `verbose_deleted` now returns `()` instead of an always-`Ok` `bun_sys::Maybe<()>`; the success arms call it and return `Ok` themselves. That return type is what let a skipped entry be recorded as removed by `return self.verbose_deleted(..)`, and the open rm PRs (#31337, #36176, #37907) rewrite or add arms of that shape in these hunks; with `()` those spellings no longer compile, so the rebase surfaces them instead of silently bringing the bug back. The compile error is intended.
- Why this is right: a `-v` line is the record that an entry was removed, and `-f` means "ignore nonexistent files". An ENOENT anywhere in the walk means someone else removed the entry, so under `-f` it is neither an error nor something to list, and the `-d` rmdir did remove something. This is what coreutils and BSD rm do (`rm -fv missing` prints nothing, `rm -rf` of overlapping operands succeeds, `rm -dv emptydir` reports the directory).
- Completion accounting is unaffected: a worker that records nothing leaves `deleted_entries` empty, and `post_run` already skips the stdout hop for an empty buffer (the path every non-verbose run takes), so `output_count` / `output_done` stay balanced.
- Verified with `test/js/bun/shell/commands/rm.test.ts`, all of which fail on main and pass with this branch:
  - `force`: `-fv`, `-rfv`, `-dfv` on a missing file and on a file under a missing directory give empty stdout, empty stderr, exit 0; `rm -fv missing existing` lists only `existing` (one silent and one printing worker in the same command).
  - `force: operands that overlap with each other's contents`: `rm -rfv` of a tree's eight subdirectories plus the tree twice, three times over, must exit 0 with empty stderr, remove the tree, and list exactly the tree's entries. On main it lists duplicates in every run and, on overlayfs, fails outright. On Linux the listing must also be duplicate-free: the kernel serializes removals on the parent directory, so exactly one worker's unlink or rmdir succeeds per entry, and 300 runs against the fixed debug build on overlayfs produced no deviation. On macOS two racing workers can both get success back for the same entry (the first CI run of this test listed a few entries twice there, with exit 0 and empty stderr), so there only the set of listed entries is compared. Skipped on Windows, where `DeleteFileBun` reports success for an entry whose deletion is still pending; the Windows lanes cover the changed arms through the `force` and `dir` tests.
  - `dir`: `rm -dv sub_dir` prints `sub_dir`.
- Also run: the whole `rm.test.ts` file and `bunshell.test.ts` with the debug build, `leak.test.ts -t rm`, `cargo check -p bun_runtime --target aarch64-apple-darwin` (the second-unlinkat arm is cfg'd out on Linux), `cargo clippy -p bun_runtime`, and `test/internal/source-lints`.

### Background
- Each `rm` operand becomes a `ShellRmTask` with a root `DirTask` on the work pool; under `-r`, every directory found during the walk becomes a child `DirTask` of its own. Operands therefore run concurrently, and two operands that cover the same entries race each other over every file and directory.
- A top-level operand is always tried as a file first (`remove_entry_file`, unlinkat); EISDIR (EPERM on macOS and Windows, which then try `unlinkat(AT_REMOVEDIR)` before walking) routes it to `remove_entry_dir`. That is why a missing operand only ever reaches the `remove_entry_file` arm, and the directory arms need the entry to vanish during the walk.
- `verbose_deleted(dir_task, path)` appends `path` to the DirTask's `deleted_entries` buffer and bumps `output_count` on the buffer's first entry; when the task finishes, `post_run` posts a non-empty buffer to the main thread, where `write_verbose` writes it to stdout and bumps `output_done`. The command completes once every task is done and `output_done` has caught up with `output_count`.

<details>
<summary>Earlier revision of this PR</summary>

The first push only changed the five `verbose_deleted` ENOENT arms and the `-d` `Ok` arm. Self-review pointed out that the directory arms were untestable because the readdir arm still failed overlapping operands on overlayfs, and that the `Maybe<()>` return of `verbose_deleted` was what made the bug easy to write and easy to reintroduce from the open rm PRs; the second push folds both in, together with the overlap test.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/rm.test.ts

<!-- robobun:evidence:end -->