### PR TITLE
shell(touch): report --date=, --reference= and --time= as unsupported options

### DIFF
--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -349,10 +349,15 @@ pub struct Opts {}
 
 impl FlagParser for Opts {
     fn parse_long(&mut self, flag: &[u8]) -> Option<ParseFlagResult> {
-        match flag {
-            b"--no-create" => Some(ParseFlagResult::Unsupported(unsupported_flag(
-                b"--no-create",
-            ))),
+        // `--option=VALUE` spells the same option as `--option VALUE`.
+        let (name, value) = match bun_core::strings::split_once_char(flag, b'=') {
+            Some((name, value)) => (name, Some(value)),
+            None => (flag, None),
+        };
+        match name {
+            b"--no-create" if value.is_none() => Some(ParseFlagResult::Unsupported(
+                unsupported_flag(b"--no-create"),
+            )),
             b"--date" => Some(ParseFlagResult::Unsupported(unsupported_flag(b"--date"))),
             b"--reference" => Some(ParseFlagResult::Unsupported(unsupported_flag(
                 b"--reference=FILE",

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -357,9 +357,7 @@ impl FlagParser for Opts {
             b"--reference" => Some(ParseFlagResult::Unsupported(unsupported_flag(
                 b"--reference=FILE",
             ))),
-            b"--time" => Some(ParseFlagResult::Unsupported(unsupported_flag(
-                b"--reference=FILE",
-            ))),
+            b"--time" => Some(ParseFlagResult::Unsupported(unsupported_flag(b"--time"))),
             _ => None,
         }
     }

--- a/test/js/bun/shell/commands/touch.test.ts
+++ b/test/js/bun/shell/commands/touch.test.ts
@@ -1,0 +1,36 @@
+import { $ } from "bun";
+import { describe } from "bun:test";
+import { createTestBuilder } from "../test_builder";
+const TestBuilder = createTestBuilder(import.meta.path);
+
+$.nothrow();
+
+describe.concurrent("bunshell touch", () => {
+  describe("unsupported options are reported under the name they were given", () => {
+    // option as typed -> how the error names it (--reference's usage suffix predates this table)
+    const unsupported = {
+      "--no-create": "--no-create",
+      "--date": "--date",
+      "--reference": "--reference=FILE",
+      "--time": "--time",
+      "-a": "-a",
+      "-c": "-c",
+      "-d": "-d",
+      "-h": "-h",
+      "-m": "-m",
+      "-r": "-r",
+      "-t": "-t",
+    };
+
+    for (const [option, reported] of Object.entries(unsupported)) {
+      TestBuilder.command`touch ${option} file`
+        .ensureTempDir()
+        .quiet()
+        .stdout("")
+        .stderr(`touch: unsupported option, please open a GitHub issue -- ${reported}\n`)
+        .exitCode(1)
+        .doesNotExist("file")
+        .runAsTest(option);
+    }
+  });
+});

--- a/test/js/bun/shell/commands/touch.test.ts
+++ b/test/js/bun/shell/commands/touch.test.ts
@@ -1,5 +1,5 @@
 import { $ } from "bun";
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { createTestBuilder } from "../test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
 
@@ -13,6 +13,11 @@ describe.concurrent("bunshell touch", () => {
       "--date": "--date",
       "--reference": "--reference=FILE",
       "--time": "--time",
+      // --date, --reference and --time take a value, which GNU touch also accepts as `--option=VALUE`.
+      "--date=@0": "--date",
+      "--date=": "--date",
+      "--reference=other": "--reference=FILE",
+      "--time=atime": "--time",
       "-a": "-a",
       "-c": "-c",
       "-d": "-d",
@@ -32,5 +37,18 @@ describe.concurrent("bunshell touch", () => {
         .doesNotExist("file")
         .runAsTest(option);
     }
+  });
+
+  describe("options that take no value do not accept one", () => {
+    // `--no-create` is a plain flag, so `--no-create=VALUE` is not a spelling of it. Which bytes the
+    // illegal option message quotes is up to the shared flag parser, so only the classification is pinned.
+    TestBuilder.command`touch --no-create=1 file`
+      .ensureTempDir()
+      .quiet()
+      .stdout("")
+      .stderr(stderr => expect(stderr).toStartWith("touch: illegal option -- "))
+      .exitCode(1)
+      .doesNotExist("file")
+      .runAsTest("--no-create=1");
   });
 });


### PR DESCRIPTION
### Problem
- In the Bun shell, `touch --date=x f`, `touch --reference=f g` and `touch --time=atime f` fail with `touch: illegal option -- date=x` (`reference=f`, `time=atime`), as if the option did not exist. The bare spellings of the same options (`touch --date x f`) already fail with `touch: unsupported option, please open a GitHub issue -- --date`.
- `parse_long` in `src/runtime/shell/builtin/touch.rs` compares the whole argument against `--date`, `--reference` and `--time`, so `--date=x` matches nothing, `parse_long` returns `None`, and the shared parser (`parse_one_flag` in `src/runtime/shell/interpreter.rs`) falls through to short option parsing of `-date=x`, whose first byte `-` is reported as an illegal option.
- Exit code 1 is already right; only the stderr text is wrong. The same comparison was in the Zig version, so this is not a port regression. Found by reading the option table, not from a report.

### Fix
- `parse_long` splits the argument at its first `=` into a name and an optional value and matches the name, so `--date x` and `--date=x` are both reported as the unsupported `--date` (likewise `--reference=FILE` and `--time`). The reported names are unchanged.
- `--no-create` takes no value, so its arm only matches when there is none: `--no-create=x` is not a spelling of it and stays an illegal option (GNU touch rejects it too).
- Why this is right: `--option VALUE` and `--option=VALUE` are the two spellings getopt_long accepts for an option that takes a value, and these three take one in GNU touch, so both spellings name the same option and should get the same answer. The two messages mean different things to the user: "unsupported" says the option is known and not implemented (and asks for an issue), "illegal" says it does not exist.
- Scope: the `=VALUE` split is done in touch's own table, the same way #39223 does it for `mkdir --mode=`; these are the only two `FlagParser` implementations with long options (`cat` and `cp` have none). Doing the split once in `parse_one_flag` instead would be the tidier end state, but `parse_one_flag`, the `FlagParser` trait and mkdir's `parse_long` are each being edited by open PRs right now (#39214, #33995, #39230, #39221, #39223), so this PR stays inside touch.rs; a later consolidation deletes this hunk and keeps the test rows.
- Stacked on #39219 (its commit is the first of the two here): that PR fixes the name the bare `--time` arm reports and adds the table test this PR extends. If #39219 lands first this rebases to just the second commit.
- Verified with `test/js/bun/shell/commands/touch.test.ts`: the table gains `--date=@0`, `--date=`, `--reference=other` and `--time=atime`, plus a case checking `--no-create=1` is still classified as an illegal option (only the classification is pinned: #39230 changes which bytes that message quotes, and this case passes either way). On the released `bun` (1.4.0) the four `=VALUE` cases fail (and #39219's `--time` case); on this branch all 16 cases pass.
- Also ran `test/js/bun/shell/exec.test.ts` (pins `touch --help` as an illegal option, unaffected because `--help` is not in the table) and the `exit codes` block of `test/js/bun/shell/bunshell.test.ts` against the debug build; both pass.

### Background
- The shell builtins `touch`, `mkdir`, `cat` and `cp` parse their flags through the `FlagParser` trait in `src/runtime/shell/interpreter.rs`. For an argument starting with `--`, `parse_one_flag` first offers the whole argument to the builtin's `parse_long`; if that returns `None` it treats the bytes after the first `-` as a cluster of short flags, which is where the `illegal option -- date=x` text comes from.
- A builtin returns `ParseFlagResult::Unsupported(name)` for an option it recognizes but does not implement; `Builtin::fail_parse` formats `name` (a literal chosen by the builtin, not the argv entry) into the `unsupported option, please open a GitHub issue -- <name>` line and exits 1. `IllegalOption` produces the `illegal option -- <bytes>` line, also exit 1.
- `touch` is a shell builtin on every platform (only `cat` and `cp` defer to the system binary on POSIX), so the test needs no platform gating.