### PR TITLE
paths: strip C:\\ down to the drive root in without_trailing_slash_windows_path

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -93,6 +93,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "shell.rs": "runtime/shell/shell.rs",
   "sourcemap/InternalSourceMap.rs": "sourcemap/InternalSourceMap.rs",
   "string/immutable/unicode.rs": "bun_core/string/immutable/unicode.rs",
+  "string_paths.rs": "paths/string_paths.rs",
   "subprocess.rs": "runtime/api/bun/subprocess.rs",
   "sys.rs": "sys/sys.rs",
   "sys/Error.rs": "sys/Error.rs",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -738,12 +738,7 @@ export const stringsInternals = {
 };
 
 export const pathsInternals = {
-  /**
-   * `bun_paths::string_paths::without_trailing_slash_windows`, the arm of
-   * `without_trailing_slash_windows_path` (the resolver's directory cache key
-   * normalizer) that its callers only reach on Windows. Bound directly so the
-   * drive-root handling is tested on every platform.
-   */
+  /** The Windows arm of `without_trailing_slash_windows_path` (src/paths/string_paths.rs), callable on every host. */
   withoutTrailingSlashWindows: $newRustFunction("string_paths.rs", "TestingAPIs.withoutTrailingSlashWindows", 1) as (
     path: string,
   ) => string,

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -737,6 +737,18 @@ export const stringsInternals = {
   ) => string,
 };
 
+export const pathsInternals = {
+  /**
+   * `bun_paths::string_paths::without_trailing_slash_windows`, the arm of
+   * `without_trailing_slash_windows_path` (the resolver's directory cache key
+   * normalizer) that its callers only reach on Windows. Bound directly so the
+   * drive-root handling is tested on every platform.
+   */
+  withoutTrailingSlashWindows: $newRustFunction("string_paths.rs", "TestingAPIs.withoutTrailingSlashWindows", 1) as (
+    path: string,
+  ) => string,
+};
+
 /** Seed the connect-path DNS cache for `hostname` via the real `process_results` interleave; returns family order. */
 export const dnsCacheSeed = $newRustFunction("runtime/dns_jsc/dns.rs", "internal.seedCacheForTesting", 2) as (
   hostname: string,

--- a/src/jsc/resolve_path_jsc.rs
+++ b/src/jsc/resolve_path_jsc.rs
@@ -1,6 +1,7 @@
-//! C++ export that joins a path against the VM's cwd. Lives in `jsc/` because
-//! it reaches into `globalObject.bunVM().transpiler.fs`; `paths/` is JSC-free.
-//! Referenced from `PathInlines.h`.
+//! JSC-facing entry points into `bun_paths`, which is itself JSC-free: the C++
+//! export that joins a path against the VM's cwd (it reaches into
+//! `globalObject.bunVM().transpiler.fs`; referenced from `PathInlines.h`), and
+//! the `bun:internal-for-testing` bridges in [`testing_apis`].
 
 use crate::JSGlobalObject;
 use bun_core::String as BunString;
@@ -30,4 +31,32 @@ extern "C" fn ResolvePath__joinAbsStringBufCurrentPlatformBunString(
     );
 
     BunString::clone_utf8(out_slice)
+}
+
+pub mod testing_apis {
+    use crate::bun_string_jsc::to_js;
+    use crate::{CallFrame, JSGlobalObject, JSValue, JsResult};
+    use bun_core::String as BunString;
+
+    /// `pathsInternals.withoutTrailingSlashWindows` in `internal-for-testing.ts`:
+    /// the Windows arm of `without_trailing_slash_windows_path`, which its
+    /// callers only reach on a Windows host.
+    #[bun_jsc::host_fn]
+    pub fn without_trailing_slash_windows(
+        global: &JSGlobalObject,
+        call_frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let path_value = call_frame.argument(0);
+        if !path_value.is_string() {
+            return Err(global.throw(format_args!("expected a string path")));
+        }
+        let path = path_value.to_slice(global)?;
+
+        let output = BunString::clone_utf8(
+            bun_paths::string_paths::without_trailing_slash_windows(path.slice()),
+        );
+        let js = to_js(&output, global);
+        output.deref();
+        js
+    }
 }

--- a/src/jsc/resolve_path_jsc.rs
+++ b/src/jsc/resolve_path_jsc.rs
@@ -1,7 +1,5 @@
-//! JSC-facing entry points into `bun_paths`, which is itself JSC-free: the C++
-//! export that joins a path against the VM's cwd (it reaches into
-//! `globalObject.bunVM().transpiler.fs`; referenced from `PathInlines.h`), and
-//! the `bun:internal-for-testing` bridges in [`testing_apis`].
+//! JSC entry points into the JSC-free `bun_paths`: the cwd join that
+//! `PathInlines.h` calls, and the `bun:internal-for-testing` bridges.
 
 use crate::JSGlobalObject;
 use bun_core::String as BunString;
@@ -38,9 +36,7 @@ pub mod testing_apis {
     use crate::{CallFrame, JSGlobalObject, JSValue, JsResult};
     use bun_core::String as BunString;
 
-    /// `pathsInternals.withoutTrailingSlashWindows` in `internal-for-testing.ts`:
-    /// the Windows arm of `without_trailing_slash_windows_path`, which its
-    /// callers only reach on a Windows host.
+    /// `pathsInternals.withoutTrailingSlashWindows` in `internal-for-testing.ts`.
     #[bun_jsc::host_fn]
     pub fn without_trailing_slash_windows(
         global: &JSGlobalObject,

--- a/src/jsc/resolve_path_jsc.rs
+++ b/src/jsc/resolve_path_jsc.rs
@@ -1,5 +1,6 @@
-//! JSC entry points into the JSC-free `bun_paths`: the cwd join that
-//! `PathInlines.h` calls, and the `bun:internal-for-testing` bridges.
+//! C++ export that joins a path against the VM's cwd. Lives in `jsc/` because
+//! it reaches into `globalObject.bunVM().transpiler.fs`; `paths/` is JSC-free.
+//! Referenced from `PathInlines.h`.
 
 use crate::JSGlobalObject;
 use bun_core::String as BunString;

--- a/src/paths/string_paths.rs
+++ b/src/paths/string_paths.rs
@@ -460,8 +460,7 @@ pub fn without_trailing_slash_windows_path(input: &[u8]) -> &[u8] {
     without_trailing_slash_windows(input)
 }
 
-/// Windows rules on any host: strips trailing separators, but a drive root keeps
-/// its own (`C:\foo\` -> `C:\foo`, `C:\\` -> `C:\`; a bare `C:` is not the root).
+/// Windows rules on any host: trailing separators go, a drive root's own stays (`C:\\` -> `C:\`).
 pub fn without_trailing_slash_windows(input: &[u8]) -> &[u8] {
     if input.len() < 3 || input[1] != b':' {
         return without_trailing_slash(input);

--- a/src/paths/string_paths.rs
+++ b/src/paths/string_paths.rs
@@ -452,13 +452,25 @@ pub fn starts_with_windows_drive_letter_t<T: Ch>(s: &[T]) -> bool {
 
 pub use crate::strings::without_trailing_slash;
 
-/// Does not strip the device root (C:\ or \\Server\Share\ portion off of the path)
+/// Host-dispatched: [`without_trailing_slash_windows`] on Windows,
+/// [`without_trailing_slash`] elsewhere.
 pub fn without_trailing_slash_windows_path(input: &[u8]) -> &[u8] {
-    if cfg!(unix) || input.len() < 3 || input[1] != b':' {
+    if cfg!(unix) {
+        return without_trailing_slash(input);
+    }
+    without_trailing_slash_windows(input)
+}
+
+/// [`without_trailing_slash`] that keeps a drive root's separator: `C:\foo\`
+/// becomes `C:\foo`, while `C:\` and `C:\\` both become `C:\` (`C:` alone would
+/// name the drive's current directory). Applies Windows rules on every host;
+/// paths without a drive letter are stripped like [`without_trailing_slash`].
+pub fn without_trailing_slash_windows(input: &[u8]) -> &[u8] {
+    if input.len() < 3 || input[1] != b':' {
         return without_trailing_slash(input);
     }
 
-    let root_len = resolve_path::windows_filesystem_root(input).len() + 1;
+    let root_len = resolve_path::windows_filesystem_root(input).len();
 
     let mut path = input;
     while path.len() > root_len && matches!(path[path.len() - 1], b'/' | b'\\') {
@@ -720,5 +732,64 @@ mod tests {
         assert!(!fits_in_wide_path_buffer(&vec![0x80u8; 98300]));
         assert!(fits_in_wide_path_buffer(&vec![0x80u8; 32758]));
         assert!(fits_in_wide_path_buffer(&vec![0x80u8; 32757]));
+    }
+
+    fn check_without_trailing_slash_windows(cases: &[(&str, &str)]) {
+        for (input, expected) in cases {
+            assert_eq!(
+                bstr::BStr::new(without_trailing_slash_windows(input.as_bytes())),
+                bstr::BStr::new(expected.as_bytes()),
+                "input {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn without_trailing_slash_windows_strips_below_a_drive() {
+        check_without_trailing_slash_windows(&[
+            ("C:\\foo\\", "C:\\foo"),
+            ("C:\\foo\\\\", "C:\\foo"),
+            ("C:/foo/", "C:/foo"),
+            ("C:\\foo/\\", "C:\\foo"),
+            ("C:\\a\\", "C:\\a"),
+            ("C:\\foo", "C:\\foo"),
+            // Separators before the last component are not the helper's job.
+            ("C:\\\\foo\\", "C:\\\\foo"),
+            // Drive-relative: `C:` is the root and `foo` is relative to it.
+            ("C:foo\\", "C:foo"),
+            ("C:foo", "C:foo"),
+        ]);
+    }
+
+    #[test]
+    fn without_trailing_slash_windows_keeps_exactly_the_drive_root() {
+        check_without_trailing_slash_windows(&[
+            ("C:\\", "C:\\"),
+            ("C:/", "C:/"),
+            ("c:\\", "c:\\"),
+            // Extra separators after the root used to survive, producing a
+            // second spelling of the root (`C:\\`) that no cache key may have.
+            ("C:\\\\", "C:\\"),
+            ("C://", "C:/"),
+            ("C:\\/", "C:\\"),
+            ("C:\\\\\\\\", "C:\\"),
+        ]);
+    }
+
+    #[test]
+    fn without_trailing_slash_windows_strips_paths_without_a_drive_like_posix() {
+        check_without_trailing_slash_windows(&[
+            ("\\\\server\\share\\dir\\", "\\\\server\\share\\dir"),
+            // UNC roots are keyed without the slash (Resolver::assert_valid_cache_key).
+            ("\\\\server\\share\\", "\\\\server\\share"),
+            ("\\dir\\", "\\dir"),
+            ("dir\\", "dir"),
+            ("dir/", "dir"),
+            ("\\", "\\"),
+            ("/", "/"),
+            ("//", "/"),
+            ("C:", "C:"),
+            ("", ""),
+        ]);
     }
 }

--- a/src/paths/string_paths.rs
+++ b/src/paths/string_paths.rs
@@ -452,8 +452,7 @@ pub fn starts_with_windows_drive_letter_t<T: Ch>(s: &[T]) -> bool {
 
 pub use crate::strings::without_trailing_slash;
 
-/// Host-dispatched: [`without_trailing_slash_windows`] on Windows,
-/// [`without_trailing_slash`] elsewhere.
+/// [`without_trailing_slash_windows`] on Windows, [`without_trailing_slash`] elsewhere.
 pub fn without_trailing_slash_windows_path(input: &[u8]) -> &[u8] {
     if cfg!(unix) {
         return without_trailing_slash(input);
@@ -461,10 +460,8 @@ pub fn without_trailing_slash_windows_path(input: &[u8]) -> &[u8] {
     without_trailing_slash_windows(input)
 }
 
-/// [`without_trailing_slash`] that keeps a drive root's separator: `C:\foo\`
-/// becomes `C:\foo`, while `C:\` and `C:\\` both become `C:\` (`C:` alone would
-/// name the drive's current directory). Applies Windows rules on every host;
-/// paths without a drive letter are stripped like [`without_trailing_slash`].
+/// Windows rules on any host: strips trailing separators, but a drive root keeps
+/// its own (`C:\foo\` -> `C:\foo`, `C:\\` -> `C:\`; a bare `C:` is not the root).
 pub fn without_trailing_slash_windows(input: &[u8]) -> &[u8] {
     if input.len() < 3 || input[1] != b':' {
         return without_trailing_slash(input);
@@ -767,8 +764,7 @@ mod tests {
             ("C:\\", "C:\\"),
             ("C:/", "C:/"),
             ("c:\\", "c:\\"),
-            // Extra separators after the root used to survive, producing a
-            // second spelling of the root (`C:\\`) that no cache key may have.
+            // These used to keep one extra separator.
             ("C:\\\\", "C:\\"),
             ("C://", "C:/"),
             ("C:\\/", "C:\\"),

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -44,6 +44,7 @@ pub use bun_jsc::virtual_machine_exports::Bun__setSyntheticAllocationLimitForTes
 pub use bun_jsc::bun_string_jsc::js_escape_reg_exp as string_escape_reg_exp_js_escape_reg_exp;
 pub use bun_jsc::bun_string_jsc::js_escape_reg_exp_for_package_name_matching as string_escape_reg_exp_js_escape_reg_exp_for_package_name_matching;
 pub use bun_jsc::bun_string_jsc::unicode_testing_apis::to_utf16_alloc_sentinel as bun_core_string_immutable_unicode_testing_ap_is_to_utf16_alloc_sentinel;
+pub use bun_jsc::resolve_path_jsc::testing_apis::without_trailing_slash_windows as paths_string_paths_testing_ap_is_without_trailing_slash_windows;
 
 pub use bun_patch_jsc::testing::patch_apply as patch_patch_testing_ap_is_apply;
 pub use bun_patch_jsc::testing::patch_make_diff as patch_patch_testing_ap_is_make_diff;

--- a/test/internal/string-paths.test.ts
+++ b/test/internal/string-paths.test.ts
@@ -1,0 +1,66 @@
+// `without_trailing_slash_windows_path` (src/paths/string_paths.rs) produces
+// the resolver's directory cache keys: no trailing separator, except that a
+// drive root keeps its one separator (`C:\`), see
+// `Resolver::assert_valid_cache_key`. Its drive-letter arm only runs on
+// Windows hosts, so it is bound directly through `bun:internal-for-testing`
+// and pinned here on every platform.
+//
+// It used to stop stripping one byte past `windows_filesystem_root`, so `C:\\`
+// (the root plus one more separator) came back unchanged: a second spelling of
+// the root, which the cache key assertion rejects in debug builds and which
+// names a cache entry nothing else reads or busts in release builds.
+//
+// Namespace import: on a build without the binding, `pathsInternals` is
+// undefined and each test below fails, instead of the file failing to link.
+import * as internals from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+
+function withoutTrailingSlashWindows(path: string): string {
+  return internals.pathsInternals.withoutTrailingSlashWindows(path);
+}
+
+describe("without_trailing_slash_windows_path", () => {
+  test.each([
+    ["C:\\", "C:\\"],
+    ["C:/", "C:/"],
+    ["c:\\", "c:\\"],
+    ["C:\\\\", "C:\\"],
+    ["C://", "C:/"],
+    ["C:\\/", "C:\\"],
+    ["C:\\\\\\\\", "C:\\"],
+  ])("%s is the drive root %s", (input, expected) => {
+    expect(withoutTrailingSlashWindows(input)).toBe(expected);
+  });
+
+  test.each([
+    ["C:\\foo\\", "C:\\foo"],
+    ["C:\\foo\\\\", "C:\\foo"],
+    ["C:/foo/", "C:/foo"],
+    ["C:\\foo/\\", "C:\\foo"],
+    ["C:\\a\\", "C:\\a"],
+    ["C:\\foo", "C:\\foo"],
+    // Only trailing separators are stripped.
+    ["C:\\\\foo\\", "C:\\\\foo"],
+    // Drive-relative: `C:` is the root.
+    ["C:foo\\", "C:foo"],
+    ["C:foo", "C:foo"],
+  ])("%s below a drive root becomes %s", (input, expected) => {
+    expect(withoutTrailingSlashWindows(input)).toBe(expected);
+  });
+
+  test.each([
+    ["\\\\server\\share\\dir\\", "\\\\server\\share\\dir"],
+    // UNC roots are keyed without the separator.
+    ["\\\\server\\share\\", "\\\\server\\share"],
+    ["\\dir\\", "\\dir"],
+    ["dir\\", "dir"],
+    ["dir/", "dir"],
+    ["\\", "\\"],
+    ["/", "/"],
+    ["//", "/"],
+    ["C:", "C:"],
+    ["", ""],
+  ])("%s without a drive letter becomes %s", (input, expected) => {
+    expect(withoutTrailingSlashWindows(input)).toBe(expected);
+  });
+});

--- a/test/internal/string-paths.test.ts
+++ b/test/internal/string-paths.test.ts
@@ -2,13 +2,15 @@
 // the resolver's directory cache keys: no trailing separator, except that a
 // drive root keeps its one separator (`C:\`), see
 // `Resolver::assert_valid_cache_key`. Its drive-letter arm only runs on
-// Windows hosts, so it is bound directly through `bun:internal-for-testing`
-// and pinned here on every platform.
+// Windows hosts, and the only thing that observes its result there is that
+// assertion (debug and ASAN builds; see "directory cache key computation at
+// the drive root" in test/js/bun/resolve/resolve.test.ts), so the arm is bound
+// directly through `bun:internal-for-testing` and its results pinned here on
+// every platform. The same table runs under `cargo test -p bun_paths`.
 //
 // It used to stop stripping one byte past `windows_filesystem_root`, so `C:\\`
-// (the root plus one more separator) came back unchanged: a second spelling of
-// the root, which the cache key assertion rejects in debug builds and which
-// names a cache entry nothing else reads or busts in release builds.
+// (the root plus one more separator) came back unchanged and failed the
+// assertion.
 //
 // Namespace import: on a build without the binding, `pathsInternals` is
 // undefined and each test below fails, instead of the file failing to link.

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -334,6 +334,19 @@ it.if(isWindows)("directory cache key computation", () => {
   expect(import(`\\\\\\Test\\doesnotexist.ts\\\\` as any)).rejects.toThrow();
 });
 
+// After a failed resolution the directory cache is busted for the specifier's
+// dirname, which for `C:\\\x` is `C:\\`. The drive root is the one cache key
+// that keeps its separator, and stripping used to leave one extra separator
+// behind, so the key `C:\\` tripped the cache key assertion and took the
+// process down (debug and ASAN builds) instead of the import rejecting.
+it.if(isWindows)("directory cache key computation at the drive root", async () => {
+  const drive = process.cwd().slice(0, 2);
+  for (const separators of [2, 3, 4]) {
+    await expect(import(drive + "\\".repeat(separators) + "doesnotexist.ts")).rejects.toThrow();
+  }
+  await expect(import(`${drive}///doesnotexist.ts`)).rejects.toThrow();
+});
+
 describe("NODE_PATH test", () => {
   const prepareTest = () => {
     const tempDir = tempDirWithFiles("node_path", {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -334,11 +334,9 @@ it.if(isWindows)("directory cache key computation", () => {
   expect(import(`\\\\\\Test\\doesnotexist.ts\\\\` as any)).rejects.toThrow();
 });
 
-// After a failed resolution the directory cache is busted for the specifier's
-// dirname, which for `C:\\\x` is `C:\\`. The drive root is the one cache key
-// that keeps its separator, and stripping used to leave one extra separator
-// behind, so the key `C:\\` tripped the cache key assertion and took the
-// process down (debug and ASAN builds) instead of the import rejecting.
+// The failed resolution busts the directory cache for the dirname, which for
+// `C:\\\x` is `C:\\`. That used to reach the cache as-is and fail the cache key
+// assertion (debug and ASAN builds) instead of the import rejecting.
 it.if(isWindows)("directory cache key computation at the drive root", async () => {
   const drive = process.cwd().slice(0, 2);
   for (const separators of [2, 3, 4]) {


### PR DESCRIPTION
### Problem
- On a Windows debug build, `import("C:\\\\\\doesnotexist.ts")` (a drive letter followed by three separators) from any file crashes instead of rejecting:
  ```
  panic: Internal Assertion Failure: Invalid cache key "C:\\"
  See Resolver.assertValidCacheKey for details.
  Crashed while resolving a module
  ```
- After a failed resolution, `VirtualMachine.rs` (~4441) and `jsc_hooks.rs` (~5248) bust the directory cache for the specifier's dirname. `dirname` of `C:\\\x` is `C:\\` (src/paths/Path.rs `dirname_windows` keeps the root's own separator plus the one it stopped on), and `without_trailing_slash_windows_path` (src/paths/string_paths.rs), which every cache key site uses to get the canonical spelling, handed it back unchanged: it floored the strip at `windows_filesystem_root(input).len() + 1`, i.e. at 4 bytes for a `C:\`-rooted path, so `C:\\` and `C://` survived and `C:\\\\` only shrank to `C:\\`. The drive root `C:\` is the one key that is allowed to end in a separator; a second spelling of it fails `Resolver::assert_valid_cache_key` (src/resolver/resolver.rs ~2430).
- Observable only in builds with assertions (debug, and the ASAN builds CI tests with). Release builds are not affected: both caches are `BSSMapInner<_, 2048, true>` (src/resolver/dir_info.rs, src/resolver/lib.rs) whose `key_hash` (src/bun_alloc/lib.rs) trims trailing native separators before hashing, so `C:\\` and `C:\` already reach the same entry there.
- The `+ 1` dates from #14901, which replaced a `while (len > 3)` loop (a floor of 3 bytes, the root's length) with the root-relative form. #39211 makes raw import specifiers reach this helper directly (`import "C://"` under `bun build --watch` and the dev server) and names this fix as its prerequisite; that is how it was found.

### Fix
- Floor the strip at `windows_filesystem_root(input).len()`. The root is exactly the prefix that has to survive (`C:\`, or `C:` for a drive-relative `C:foo`), so its length is the floor.
- This changes the result for exactly one shape, drive root plus extra separators. By root length `R`: `R == 3` (`X:` + separator) differs only when byte 3 is another separator, which is the bug; `R == 2` means byte 2 is not a separator by definition; `R <= 1` means the byte after the root is the `:` at index 1; UNC and device roots never enter this arm because it requires `input[1] == ':'`. `C:\\foo\` still becomes `C:\\foo`, since only trailing separators are stripped.
- The drive-letter arm moves into `without_trailing_slash_windows`, which applies the Windows rules on any host; `without_trailing_slash_windows_path` keeps its 20 callers and its host dispatch (`cfg!(unix)` still returns `without_trailing_slash`), so non-Windows behavior is unchanged. The split is what lets the arm be tested anywhere other than a Windows debug build.
- Tests:
  - src/paths/string_paths.rs: three tables over `without_trailing_slash_windows` (drive roots, paths below a drive, paths without a drive letter). `bun_paths` is in the Miri crate set (scripts/rust-miri.ts), so they run in CI; with the `+ 1` put back, `without_trailing_slash_windows_keeps_exactly_the_drive_root` fails on `C:\\` and the other two tables still pass, which pins that nothing else changes. All 21 crate tests pass with the fix, under `cargo test` and `cargo miri test`.
  - test/js/bun/resolve/resolve.test.ts, "directory cache key computation at the drive root" (Windows only, next to the existing cache key test from #14901): the `import()` shapes above through the real caller. On a Windows x64 debug build of this branch with the `+ 1` put back it dies with the panic quoted above; with the fix both cache key tests pass. It discriminates only where the assertion is compiled in; release lanes pass it either way.
  - test/internal/string-paths.test.ts: the same 26 rows through a `bun:internal-for-testing` binding of `without_trailing_slash_windows` (`pathsInternals`, same shape as `stringsInternals.toUTF16AllocSentinel`: one `host_fn` in resolve_path_jsc.rs, one `rustIdentifierPaths` entry, one `dispatch_js2native.rs` re-export). This is the only test that checks the arm's output from `bun test` on every host, including the Windows lanes, where `cargo test -p bun_paths` does not currently link (#37575). With the binding present but the `+ 1` put back, exactly the four root-plus-extra-separator rows fail and the other 22 pass; all 26 pass with the fix on Linux and Windows debug builds. The cargo tables do not depend on it, so it can be dropped if the binding is not wanted; the fix and its coverage stand without it.
- Also run: test/js/bun/resolve/resolve.test.ts and test/js/bun/util/toUTF16Alloc.test.ts on Linux, test/internal/source-lints, `cargo fmt`, `cargo clippy -p bun_paths -p bun_jsc`, oxlint, prettier.
- #38053 adds a sibling helper a few lines below this one in the same file (with the `.len()` floor); whichever lands second needs a trivial rebase.

### Background
- Directory cache keys: the resolver caches one `DirInfo` and one directory listing per directory, keyed by the directory's absolute path. `Resolver::assert_valid_cache_key` documents the one spelling a key may have: no trailing separator, except that a drive root keeps its single separator (`C:\`), because `C:` on its own means "the current directory of drive C", not its root. Every site that reads, writes or busts these caches runs its path through `without_trailing_slash_windows_path` first; the assertion is the check that they all produced that spelling.
- `windows_filesystem_root` (src/paths/resolve_path.rs) returns the root prefix of a Windows path: `C:\` for a drive-rooted path, `C:` for a drive-relative one, `\\server\share\` for UNC.
- Cache busting after a failed resolution: when an import does not resolve, the runtime drops the cached listing of the directory the import would have been found in and retries once, so a file created after the directory was first listed is still found. That bust is the caller that reaches this helper with the un-normalized dirname.
- `bun:internal-for-testing` is the module bun's own tests use to reach internal functions; `$newRustFunction(file, symbol, argc)` in src/js/internal-for-testing.ts binds a Rust `host_fn`, and for crates outside `bun_runtime` the generated thunk reaches it through the re-export table in src/runtime/dispatch_js2native.rs.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->