### PR TITLE
shell: name the rejected flag in the builtins' illegal option errors

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -1077,22 +1077,22 @@ impl Builtin {
         e: &ParseError,
         set_wait_err: impl FnOnce(),
     ) -> Yield {
-        let buf: Vec<u8> = match e {
-            ParseError::IllegalOption(_) => Self::fmt_error_arena(
+        let buf: Vec<u8> = match *e {
+            ParseError::IllegalOption(ch) => Self::fmt_error_arena(
                 interp,
                 cmd,
                 Some(kind),
-                format_args!("illegal option -- {}\n", bstr::BStr::new(e.opt())),
+                format_args!("illegal option -- {}\n", bstr::BStr::new(&[ch])),
             )
             .to_vec(),
             ParseError::ShowUsage => kind.usage_string().to_vec(),
-            ParseError::Unsupported(_) => Self::fmt_error_arena(
+            ParseError::Unsupported(name) => Self::fmt_error_arena(
                 interp,
                 cmd,
                 Some(kind),
                 format_args!(
                     "unsupported option, please open a GitHub issue -- {}\n",
-                    bstr::BStr::new(e.opt())
+                    bstr::BStr::new(name)
                 ),
             )
             .to_vec(),

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -3,8 +3,7 @@ use std::sync::Arc;
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinIO, BuiltinInput, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
-    FlagParser, Interpreter, NodeId, ParseFlagResult, illegal_flag, parse_flags, shell_openat,
-    unsupported_flag,
+    FlagParser, Interpreter, NodeId, ParseFlagResult, parse_flags, shell_openat, unsupported_flag,
 };
 use crate::shell::io_reader::{ChildPtr as ReaderChildPtr, IOReader, ReaderTag};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
@@ -411,7 +410,7 @@ impl FlagParser for Opts {
         None
     }
 
-    fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult> {
+    fn parse_short(&mut self, ch: u8) -> Option<ParseFlagResult> {
         match ch {
             b'b' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-b"))),
             b'e' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-e"))),
@@ -420,7 +419,7 @@ impl FlagParser for Opts {
             b't' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-t"))),
             b'u' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-u"))),
             b'v' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-v"))),
-            _ => Some(ParseFlagResult::IllegalOption(illegal_flag(smallflags, i))),
+            _ => Some(ParseFlagResult::IllegalOption(ch)),
         }
     }
 }

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinIO, BuiltinInput, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
-    FlagParser, Interpreter, NodeId, ParseFlagResult, parse_flags, shell_openat, unsupported_flag,
+    FlagParser, Interpreter, NodeId, ParseFlagResult, illegal_flag, parse_flags, shell_openat,
+    unsupported_flag,
 };
 use crate::shell::io_reader::{ChildPtr as ReaderChildPtr, IOReader, ReaderTag};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
@@ -419,7 +420,7 @@ impl FlagParser for Opts {
             b't' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-t"))),
             b'u' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-u"))),
             b'v' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-v"))),
-            _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..=i])),
+            _ => Some(ParseFlagResult::IllegalOption(illegal_flag(smallflags, i))),
         }
     }
 }

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -419,9 +419,7 @@ impl FlagParser for Opts {
             b't' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-t"))),
             b'u' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-u"))),
             b'v' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-v"))),
-            _ => Some(ParseFlagResult::IllegalOption(
-                &raw const smallflags[1 + i..],
-            )),
+            _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..=i])),
         }
     }
 }

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -3,7 +3,7 @@ use bun_paths::resolve_path;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, illegal_flag, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -792,7 +792,7 @@ impl FlagParser for Opts {
         None
     }
 
-    fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult> {
+    fn parse_short(&mut self, ch: u8) -> Option<ParseFlagResult> {
         match ch {
             b'f' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-f"))),
             b'H' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-H"))),
@@ -809,7 +809,7 @@ impl FlagParser for Opts {
                 Some(ParseFlagResult::ContinueParsing)
             }
             b'n' => Some(ParseFlagResult::ContinueParsing),
-            _ => Some(ParseFlagResult::IllegalOption(illegal_flag(smallflags, i))),
+            _ => Some(ParseFlagResult::IllegalOption(ch)),
         }
     }
 }

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -3,7 +3,7 @@ use bun_paths::resolve_path;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, illegal_flag, parse_flags, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -809,7 +809,7 @@ impl FlagParser for Opts {
                 Some(ParseFlagResult::ContinueParsing)
             }
             b'n' => Some(ParseFlagResult::ContinueParsing),
-            _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..=i])),
+            _ => Some(ParseFlagResult::IllegalOption(illegal_flag(smallflags, i))),
         }
     }
 }

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -809,7 +809,7 @@ impl FlagParser for Opts {
                 Some(ParseFlagResult::ContinueParsing)
             }
             b'n' => Some(ParseFlagResult::ContinueParsing),
-            _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..])),
+            _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..=i])),
         }
     }
 }

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -259,7 +259,7 @@ impl Ls {
                 | b'h' | b'H' | b'i' | b'I' | b'k' | b'L' | b'm' | b'n' | b'N' | b'o' | b'p'
                 | b'q' | b'Q' | b's' | b'S' | b't' | b'T' | b'u' | b'U' | b'v' | b'w' | b'x'
                 | b'X' | b'Z' => {}
-                _ => return ParseFlag::IllegalOption(Box::from(&flag[1..2])),
+                _ => return ParseFlag::IllegalOption(Box::from([ch])),
             }
         }
         ParseFlag::ContinueParsing

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -44,7 +44,8 @@ pub struct ExecState {
 enum ParseFlag {
     ContinueParsing,
     Done,
-    IllegalOption(Box<[u8]>),
+    /// The rejected option byte, as getopt(3) reports it.
+    IllegalOption(u8),
 }
 
 impl Ls {
@@ -72,12 +73,12 @@ impl Ls {
                 // which case we run once with ".".
                 let paths_start = match Self::parse_opts(interp, cmd) {
                     Ok(p) => p,
-                    Err(opt) => {
+                    Err(ch) => {
                         let buf: Vec<u8> = Builtin::fmt_error_arena(
                             interp,
                             cmd,
                             Some(Kind::Ls),
-                            format_args!("illegal option -- {}\n", bstr::BStr::new(&opt[..])),
+                            format_args!("illegal option -- {}\n", bstr::BStr::new(&[ch])),
                         )
                         .to_vec();
                         Self::state_mut(interp, cmd).state = State::WaitingWriteErr;
@@ -221,7 +222,7 @@ impl Ls {
 
     /// Returns the index of the first non-flag arg, or `None` if there are no
     /// positional args. `Err` carries the offending flag byte.
-    fn parse_opts(interp: &Interpreter, cmd: NodeId) -> Result<Option<usize>, Box<[u8]>> {
+    fn parse_opts(interp: &Interpreter, cmd: NodeId) -> Result<Option<usize>, u8> {
         let argc = Builtin::of(interp, cmd).args_slice().len();
         if argc == 0 {
             return Ok(None);
@@ -232,7 +233,7 @@ impl Ls {
             match Self::parse_flag(&mut Self::state_mut(interp, cmd).opts, flag) {
                 ParseFlag::Done => return Ok(Some(idx)),
                 ParseFlag::ContinueParsing => {}
-                ParseFlag::IllegalOption(s) => return Err(s),
+                ParseFlag::IllegalOption(ch) => return Err(ch),
             }
             idx += 1;
         }
@@ -245,7 +246,7 @@ impl Ls {
         }
         // FIXME windows
         if flag.len() == 1 {
-            return ParseFlag::IllegalOption(Box::from(&b"-"[..]));
+            return ParseFlag::IllegalOption(b'-');
         }
         for &ch in &flag[1..] {
             match ch {
@@ -259,7 +260,7 @@ impl Ls {
                 | b'h' | b'H' | b'i' | b'I' | b'k' | b'L' | b'm' | b'n' | b'N' | b'o' | b'p'
                 | b'q' | b'Q' | b's' | b'S' | b't' | b'T' | b'u' | b'U' | b'v' | b'w' | b'x'
                 | b'X' | b'Z' => {}
-                _ => return ParseFlag::IllegalOption(Box::from([ch])),
+                _ => return ParseFlag::IllegalOption(ch),
             }
         }
         ParseFlag::ContinueParsing

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -454,9 +454,7 @@ impl FlagParser for Opts {
                 self.verbose = true;
                 None
             }
-            _ => Some(ParseFlagResult::IllegalOption(
-                &raw const smallflags[1 + i..],
-            )),
+            _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..=i])),
         }
     }
 }

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -4,7 +4,7 @@ use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, illegal_flag, parse_flags, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -454,7 +454,7 @@ impl FlagParser for Opts {
                 self.verbose = true;
                 None
             }
-            _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..=i])),
+            _ => Some(ParseFlagResult::IllegalOption(illegal_flag(smallflags, i))),
         }
     }
 }

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -4,7 +4,7 @@ use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, illegal_flag, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -443,7 +443,7 @@ impl FlagParser for Opts {
         None
     }
 
-    fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult> {
+    fn parse_short(&mut self, ch: u8) -> Option<ParseFlagResult> {
         match ch {
             b'm' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-m "))),
             b'p' => {
@@ -454,7 +454,7 @@ impl FlagParser for Opts {
                 self.verbose = true;
                 None
             }
-            _ => Some(ParseFlagResult::IllegalOption(illegal_flag(smallflags, i))),
+            _ => Some(ParseFlagResult::IllegalOption(ch)),
         }
     }
 }

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -46,7 +46,8 @@ pub enum MvState {
 
 /// mv uses its own simpler parser.
 enum MvParseError {
-    IllegalOption(&'static [u8]),
+    /// The rejected option byte.
+    IllegalOption(u8),
     ShowUsage,
 }
 
@@ -94,11 +95,11 @@ impl Mv {
             Tag::Idle => {
                 if let Err(e) = Self::parse_opts(interp, cmd) {
                     let buf: Vec<u8> = match e {
-                        MvParseError::IllegalOption(s) => Builtin::fmt_error_arena(
+                        MvParseError::IllegalOption(ch) => Builtin::fmt_error_arena(
                             interp,
                             cmd,
                             Some(Kind::Mv),
-                            format_args!("illegal option -- {}\n", bstr::BStr::new(s)),
+                            format_args!("illegal option -- {}\n", bstr::BStr::new(&[ch])),
                         )
                         .to_vec(),
                         MvParseError::ShowUsage => Kind::Mv.usage_string().to_vec(),
@@ -360,7 +361,7 @@ impl Mv {
                     return Ok(());
                 }
                 MvFlag::ContinueParsing => {}
-                MvFlag::IllegalOption(s) => return Err(MvParseError::IllegalOption(s)),
+                MvFlag::IllegalOption(ch) => return Err(MvParseError::IllegalOption(ch)),
             }
             idx += 1;
         }
@@ -374,7 +375,7 @@ impl Mv {
         for &ch in &flag[1..] {
             match ch {
                 b'f' | b'h' | b'i' | b'n' | b'v' => {}
-                _ => return MvFlag::IllegalOption(b"-"),
+                _ => return MvFlag::IllegalOption(ch),
             }
         }
         MvFlag::ContinueParsing
@@ -396,7 +397,8 @@ impl Drop for Mv {
 enum MvFlag {
     ContinueParsing,
     Done,
-    IllegalOption(&'static [u8]),
+    /// The rejected option byte.
+    IllegalOption(u8),
 }
 
 /// `openat(target, O_RDONLY|O_DIRECTORY)`

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -92,8 +92,10 @@ pub enum PromptBehaviour {
 enum RmParseFlag {
     ContinueParsing,
     Done,
+    /// Unknown `--long` option.
     IllegalOption,
-    IllegalOptionWithFlag,
+    /// Unknown short option: the rejected byte.
+    IllegalOptionWithFlag(u8),
 }
 
 impl Rm {
@@ -248,7 +250,7 @@ impl Rm {
                                 b"rm: illegal option -- -\n",
                             );
                         }
-                        RmParseFlag::IllegalOptionWithFlag => {
+                        RmParseFlag::IllegalOptionWithFlag(ch) => {
                             if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
                                 Self::state_mut(interp, cmd).state = RmState::ParseOpts {
                                     idx,
@@ -258,10 +260,7 @@ impl Rm {
                                 return Builtin::of_mut(interp, cmd).stderr.enqueue_fmt(
                                     child,
                                     Some(Kind::Rm),
-                                    format_args!(
-                                        "illegal option -- {}\n",
-                                        bstr::BStr::new(&arg[1..])
-                                    ),
+                                    format_args!("illegal option -- {}\n", bstr::BStr::new(&[ch])),
                                     safeguard,
                                 );
                             }
@@ -269,7 +268,7 @@ impl Rm {
                                 interp,
                                 cmd,
                                 Some(Kind::Rm),
-                                format_args!("illegal option -- {}\n", bstr::BStr::new(&arg[1..])),
+                                format_args!("illegal option -- {}\n", bstr::BStr::new(&[ch])),
                             )
                             .to_vec();
                             let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, &buf);
@@ -532,7 +531,7 @@ impl Rm {
                 b'd' => opts.remove_empty_dirs = true,
                 b'i' => opts.prompt_behaviour = PromptBehaviour::Once { removed_count: 0 },
                 b'I' => opts.prompt_behaviour = PromptBehaviour::Always,
-                _ => return RmParseFlag::IllegalOptionWithFlag,
+                _ => return RmParseFlag::IllegalOptionWithFlag(ch),
             }
         }
         RmParseFlag::ContinueParsing

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -92,10 +92,8 @@ pub enum PromptBehaviour {
 enum RmParseFlag {
     ContinueParsing,
     Done,
-    /// Unknown `--long` option.
-    IllegalOption,
-    /// Unknown short option: the rejected byte.
-    IllegalOptionWithFlag(u8),
+    /// The rejected option byte, as getopt(3) reports it (`-` for an unknown `--long` option).
+    IllegalOption(u8),
 }
 
 impl Rm {
@@ -242,28 +240,7 @@ impl Rm {
                             });
                             continue;
                         }
-                        RmParseFlag::IllegalOption => {
-                            return Self::write_err_literal(
-                                interp,
-                                cmd,
-                                idx,
-                                b"rm: illegal option -- -\n",
-                            );
-                        }
-                        RmParseFlag::IllegalOptionWithFlag(ch) => {
-                            if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
-                                Self::state_mut(interp, cmd).state = RmState::ParseOpts {
-                                    idx,
-                                    wait_write_err: true,
-                                };
-                                let child = ChildPtr::new(cmd, WriterTag::Builtin);
-                                return Builtin::of_mut(interp, cmd).stderr.enqueue_fmt(
-                                    child,
-                                    Some(Kind::Rm),
-                                    format_args!("illegal option -- {}\n", bstr::BStr::new(&[ch])),
-                                    safeguard,
-                                );
-                            }
+                        RmParseFlag::IllegalOption(ch) => {
                             let buf = Builtin::fmt_error_arena(
                                 interp,
                                 cmd,
@@ -271,8 +248,7 @@ impl Rm {
                                 format_args!("illegal option -- {}\n", bstr::BStr::new(&[ch])),
                             )
                             .to_vec();
-                            let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, &buf);
-                            return Builtin::done(interp, cmd, 1);
+                            return Self::write_err_literal(interp, cmd, idx, &buf);
                         }
                     }
                 }
@@ -517,7 +493,7 @@ impl Rm {
                     opts.prompt_behaviour = PromptBehaviour::Always;
                     RmParseFlag::ContinueParsing
                 }
-                _ => RmParseFlag::IllegalOption,
+                _ => RmParseFlag::IllegalOption(b'-'),
             };
         }
         for &ch in &flag[1..] {
@@ -531,7 +507,7 @@ impl Rm {
                 b'd' => opts.remove_empty_dirs = true,
                 b'i' => opts.prompt_behaviour = PromptBehaviour::Once { removed_count: 0 },
                 b'I' => opts.prompt_behaviour = PromptBehaviour::Always,
-                _ => return RmParseFlag::IllegalOptionWithFlag(ch),
+                _ => return RmParseFlag::IllegalOption(ch),
             }
         }
         RmParseFlag::ContinueParsing

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -2,7 +2,7 @@ use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, illegal_flag, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -364,7 +364,7 @@ impl FlagParser for Opts {
         }
     }
 
-    fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult> {
+    fn parse_short(&mut self, ch: u8) -> Option<ParseFlagResult> {
         match ch {
             b'a' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-a"))),
             b'c' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-c"))),
@@ -373,7 +373,7 @@ impl FlagParser for Opts {
             b'm' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-m"))),
             b'r' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-r"))),
             b't' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-t"))),
-            _ => Some(ParseFlagResult::IllegalOption(illegal_flag(smallflags, i))),
+            _ => Some(ParseFlagResult::IllegalOption(ch)),
         }
     }
 }

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -2,7 +2,7 @@ use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, illegal_flag, parse_flags, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -373,7 +373,7 @@ impl FlagParser for Opts {
             b'm' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-m"))),
             b'r' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-r"))),
             b't' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-t"))),
-            _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..=i])),
+            _ => Some(ParseFlagResult::IllegalOption(illegal_flag(smallflags, i))),
         }
     }
 }

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -373,9 +373,7 @@ impl FlagParser for Opts {
             b'm' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-m"))),
             b'r' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-r"))),
             b't' => Some(ParseFlagResult::Unsupported(unsupported_flag(b"-t"))),
-            _ => Some(ParseFlagResult::IllegalOption(
-                &raw const smallflags[1 + i..],
-            )),
+            _ => Some(ParseFlagResult::IllegalOption(&raw const smallflags[i..=i])),
         }
     }
 }

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2348,6 +2348,11 @@ pub trait FlagParser {
     /// Handle a `--long` flag. Return `None` to fall through to short parsing.
     fn parse_long(&mut self, flag: &[u8]) -> Option<ParseFlagResult>;
     /// Handle one byte of a `-abc` cluster. Return `None` to keep iterating.
+    ///
+    /// `smallflags` is the argument minus its leading `-` and `ch == smallflags[i]`.
+    /// An unknown byte is reported as `IllegalOption(&raw const smallflags[i..=i])`:
+    /// the message names that one byte, as getopt(3) does, and the slice borrows
+    /// argv, which outlives the error (see [`ParseError::opt`]).
     fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult>;
 }
 

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2343,16 +2343,19 @@ pub(crate) const fn unsupported_flag(name: &'static [u8]) -> *const [u8] {
     std::ptr::from_ref::<[u8]>(name)
 }
 
+/// `IllegalOption` payload for the byte `FlagParser::parse_short` is rejecting:
+/// that one byte (all getopt(3) names either), borrowed from argv.
+#[inline]
+pub(crate) fn illegal_flag(smallflags: &[u8], i: usize) -> *const [u8] {
+    &raw const smallflags[i..=i]
+}
+
 /// Per-builtin opts type implements this to plug into `FlagParser::parse_flags`.
 pub trait FlagParser {
     /// Handle a `--long` flag. Return `None` to fall through to short parsing.
     fn parse_long(&mut self, flag: &[u8]) -> Option<ParseFlagResult>;
-    /// Handle one byte of a `-abc` cluster. Return `None` to keep iterating.
-    ///
-    /// `smallflags` is the argument minus its leading `-` and `ch == smallflags[i]`.
-    /// An unknown byte is reported as `IllegalOption(&raw const smallflags[i..=i])`:
-    /// the message names that one byte, as getopt(3) does, and the slice borrows
-    /// argv, which outlives the error (see [`ParseError::opt`]).
+    /// Handle one byte of a `-abc` cluster (`ch == smallflags[i]`). Return `None`
+    /// to keep iterating; reject an unknown byte with [`illegal_flag`].
     fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult>;
 }
 

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2343,8 +2343,7 @@ pub(crate) const fn unsupported_flag(name: &'static [u8]) -> *const [u8] {
     std::ptr::from_ref::<[u8]>(name)
 }
 
-/// `IllegalOption` payload for the byte `FlagParser::parse_short` is rejecting:
-/// that one byte (all getopt(3) names either), borrowed from argv.
+/// `IllegalOption` payload for `parse_short`: just the rejected byte, as getopt(3) reports it.
 #[inline]
 pub(crate) fn illegal_flag(smallflags: &[u8], i: usize) -> *const [u8] {
     &raw const smallflags[i..=i]
@@ -2354,8 +2353,7 @@ pub(crate) fn illegal_flag(smallflags: &[u8], i: usize) -> *const [u8] {
 pub trait FlagParser {
     /// Handle a `--long` flag. Return `None` to fall through to short parsing.
     fn parse_long(&mut self, flag: &[u8]) -> Option<ParseFlagResult>;
-    /// Handle one byte of a `-abc` cluster (`ch == smallflags[i]`). Return `None`
-    /// to keep iterating; reject an unknown byte with [`illegal_flag`].
+    /// Handle one byte of a `-abc` cluster: `None` keeps iterating, [`illegal_flag`] rejects it.
     fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult>;
 }
 

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2303,58 +2303,34 @@ pub(crate) fn shell_openat(
 // ────────────────────────────────────────────────────────────────────────────
 
 /// Custom parse error for invalid options.
-///
-/// Payload slices borrow from the builtin's argv (NUL-terminated arena strings)
-/// or are `'static` literals; the builtin formats them into an error message
-/// before the next argv mutation, so a raw fat pointer is safe.
 pub(crate) enum ParseError {
-    IllegalOption(*const [u8]),
-    Unsupported(*const [u8]),
+    /// The rejected option byte, as getopt(3) reports it.
+    IllegalOption(u8),
+    Unsupported(&'static [u8]),
     ShowUsage,
-}
-
-impl ParseError {
-    /// Borrow the option-name payload. The pointer borrows either a `'static`
-    /// literal (e.g. `b"-"`) or the owning `Builtin`'s argv storage
-    /// (NUL-terminated `Vec<u8>` in `Cmd::args`, live for the `Builtin`'s
-    /// lifetime — see [`Builtin::arg_bytes`](crate::shell::builtin::Builtin::arg_bytes)).
-    /// Builtins format the error before any argv mutation.
-    #[inline]
-    pub(crate) fn opt(&self) -> &[u8] {
-        match self {
-            // SAFETY: see doc comment.
-            ParseError::IllegalOption(s) | ParseError::Unsupported(s) => unsafe { &**s },
-            ParseError::ShowUsage => b"",
-        }
-    }
 }
 
 pub enum ParseFlagResult {
     ContinueParsing,
     Done,
-    IllegalOption(*const [u8]),
-    Unsupported(*const [u8]),
+    /// The rejected option byte, as getopt(3) reports it.
+    IllegalOption(u8),
+    Unsupported(&'static [u8]),
 }
 
 /// Returns just `name` and lets the caller's `fmt_error_arena` add the
 /// "unsupported option" prefix once.
 #[inline]
-pub(crate) const fn unsupported_flag(name: &'static [u8]) -> *const [u8] {
-    std::ptr::from_ref::<[u8]>(name)
-}
-
-/// `IllegalOption` payload for `parse_short`: just the rejected byte, as getopt(3) reports it.
-#[inline]
-pub(crate) fn illegal_flag(smallflags: &[u8], i: usize) -> *const [u8] {
-    &raw const smallflags[i..=i]
+pub(crate) const fn unsupported_flag(name: &'static [u8]) -> &'static [u8] {
+    name
 }
 
 /// Per-builtin opts type implements this to plug into `FlagParser::parse_flags`.
 pub trait FlagParser {
     /// Handle a `--long` flag. Return `None` to fall through to short parsing.
     fn parse_long(&mut self, flag: &[u8]) -> Option<ParseFlagResult>;
-    /// Handle one byte of a `-abc` cluster: `None` keeps iterating, [`illegal_flag`] rejects it.
-    fn parse_short(&mut self, ch: u8, smallflags: &[u8], i: usize) -> Option<ParseFlagResult>;
+    /// Handle one byte of a `-abc` cluster. Return `None` to keep iterating.
+    fn parse_short(&mut self, ch: u8) -> Option<ParseFlagResult>;
 }
 
 /// Returns the trailing non-flag args (`args[idx..]`) on success.
@@ -2385,16 +2361,15 @@ fn parse_one_flag<O: FlagParser>(opts: &mut O, flag: &[u8]) -> ParseFlagResult {
         return ParseFlagResult::Done;
     }
     if flag.len() == 1 {
-        return ParseFlagResult::IllegalOption(std::ptr::from_ref::<[u8]>(b"-"));
+        return ParseFlagResult::IllegalOption(b'-');
     }
     if flag.len() > 2 && flag[1] == b'-' {
         if let Some(r) = opts.parse_long(flag) {
             return r;
         }
     }
-    let small_flags = &flag[1..];
-    for (i, &ch) in small_flags.iter().enumerate() {
-        if let Some(r) = opts.parse_short(ch, small_flags, i) {
+    for &ch in &flag[1..] {
+        if let Some(r) = opts.parse_short(ch) {
             return r;
         }
     }

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -288,17 +288,11 @@ describe.concurrent("bunshell ls", () => {
     });
 
     test("invalid flag", async () => {
-      await TestBuilder.command`ls -z`
-        .exitCode(1)
-        .stderr(s => expect(s).toContain("illegal option"))
-        .run();
+      await TestBuilder.command`ls -z`.exitCode(1).stderr("ls: illegal option -- z\n").run();
     });
 
     test("invalid combined flags", async () => {
-      await TestBuilder.command`ls -az`
-        .exitCode(1)
-        .stderr(s => expect(s).toContain("illegal option"))
-        .run();
+      await TestBuilder.command`ls -az`.exitCode(1).stderr("ls: illegal option -- z\n").run();
     });
 
     test.if(isPosix)("permission denied directory", async () => {

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -30,6 +30,13 @@ describe.concurrent("bunshell rm", () => {
     .doesNotExist("node_modules")
     .runAsTest("node_modules");
 
+  // With .quiet() stderr is a buffer rather than an fd, the other way a parse error gets written.
+  test("illegal option in a cluster", async () => {
+    const { stderr, exitCode } = await $`rm -rz`.quiet();
+    expect(stderr.toString()).toBe("rm: illegal option -- z\n");
+    expect(exitCode).toBe(1);
+  });
+
   test("force", async () => {
     const files = {
       "existent.txt": "",

--- a/test/js/bun/shell/exec.test.ts
+++ b/test/js/bun/shell/exec.test.ts
@@ -98,6 +98,22 @@ describe("bun exec", () => {
     }
   });
 
+  // Recognised but unimplemented options take the other branch of the same parser result.
+  describe.concurrent("unsupported option names the option", () => {
+    for (const [program, option] of [
+      ["cat", "-n"],
+      ["touch", "--no-create"],
+      ["cp", "-i"],
+    ]) {
+      TestBuilder.command`${BUN} exec ${`${program} ${option}`}`
+        .env({ ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" })
+        .exitCode(1)
+        .stderr(`${program}: unsupported option, please open a GitHub issue -- ${option}\n`)
+        .stdout("")
+        .runAsTest(`${program} ${option}`);
+    }
+  });
+
   TestBuilder.command`${BUN} exec cd`
     .env(bunEnv)
     .exitCode(0)

--- a/test/js/bun/shell/exec.test.ts
+++ b/test/js/bun/shell/exec.test.ts
@@ -46,8 +46,8 @@ describe("bun exec", () => {
     // prettier-ignore
     const programs = [
       // ["cat",    1, "", ""],
-      ["touch",  1, "touch: illegal option -- help\n", ""],
-      ["mkdir",  1, "mkdir: illegal option -- help\n", ""],
+      ["touch",  1, "touch: illegal option -- -\n", ""],
+      ["mkdir",  1, "mkdir: illegal option -- -\n", ""],
       // ["cd",     1, "cd: no such file or directory: --help\n", ""],
       ["echo",   0, "", "--help\n"],
       ["pwd",    1, "pwd: too many arguments\n", ""],
@@ -68,6 +68,33 @@ describe("bun exec", () => {
         .stderr(stderr)
         .stdout(stdout)
         .runAsTest(item);
+    }
+  });
+
+  // Like getopt(3), the message names the one byte that was rejected, wherever
+  // it sits in a cluster of short flags. An unknown --long option is rejected
+  // at its second `-`, so it is reported as `-` (what BSD getopt prints too).
+  describe("illegal option names the rejected flag", () => {
+    // prettier-ignore
+    const programs: [program: string, cases: [args: string, rejected: string][]][] = [
+      ["cat",   [["-z", "z"], ["-zb", "z"],                 ["--bogus", "-"]]],
+      ["touch", [["-z", "z"], ["-za", "z"],                 ["--bogus", "-"]]],
+      ["mkdir", [["-z", "z"], ["-pz", "z"], ["-zp", "z"],   ["--bogus", "-"]]],
+      ["cp",    [["-z", "z"], ["-zR", "z"],                 ["--bogus", "-"]]],
+      ["ls",    [["-z", "z"], ["-az", "z"], ["-za", "z"],   ["--bogus", "-"]]],
+      ["rm",    [["-z", "z"], ["-rz", "z"], ["-zr", "z"],   ["--bogus", "-"]]],
+      ["mv",    [["-z", "z"], ["-fz", "z"], ["-zf", "z"],   ["--bogus", "-"]]],
+    ];
+    for (const [program, cases] of programs) {
+      const script = cases.map(([args]) => `${program} ${args}`).join("; ");
+      const stderr = cases.map(([, rejected]) => `${program}: illegal option -- ${rejected}\n`).join("");
+      TestBuilder.command`${BUN} exec ${script}`
+        // cat and cp are builtins only on Windows unless this flag is set.
+        .env({ ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" })
+        .exitCode(1)
+        .stderr(stderr)
+        .stdout("")
+        .runAsTest(program);
     }
   });
 

--- a/test/js/bun/shell/exec.test.ts
+++ b/test/js/bun/shell/exec.test.ts
@@ -74,7 +74,7 @@ describe("bun exec", () => {
   // Like getopt(3), the message names the one byte that was rejected, wherever
   // it sits in a cluster of short flags. An unknown --long option is rejected
   // at its second `-`, so it is reported as `-` (what BSD getopt prints too).
-  describe("illegal option names the rejected flag", () => {
+  describe.concurrent("illegal option names the rejected flag", () => {
     // prettier-ignore
     const programs: [program: string, cases: [args: string, rejected: string][]][] = [
       ["cat",   [["-z", "z"], ["-zb", "z"],                 ["--bogus", "-"]]],
@@ -86,15 +86,15 @@ describe("bun exec", () => {
       ["mv",    [["-z", "z"], ["-fz", "z"], ["-zf", "z"],   ["--bogus", "-"]]],
     ];
     for (const [program, cases] of programs) {
-      const script = cases.map(([args]) => `${program} ${args}`).join("; ");
-      const stderr = cases.map(([, rejected]) => `${program}: illegal option -- ${rejected}\n`).join("");
-      TestBuilder.command`${BUN} exec ${script}`
-        // cat and cp are builtins only on Windows unless this flag is set.
-        .env({ ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" })
-        .exitCode(1)
-        .stderr(stderr)
-        .stdout("")
-        .runAsTest(program);
+      for (const [args, rejected] of cases) {
+        TestBuilder.command`${BUN} exec ${`${program} ${args}`}`
+          // cat and cp are builtins only on Windows unless this flag is set.
+          .env({ ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" })
+          .exitCode(1)
+          .stderr(`${program}: illegal option -- ${rejected}\n`)
+          .stdout("")
+          .runAsTest(`${program} ${args}`);
+      }
     }
   });
 


### PR DESCRIPTION
### Problem
- The shell builtins reject an unknown flag with `<name>: illegal option -- X`, but `X` is usually not the flag that was rejected:
  - `mkdir -z` prints `mkdir: illegal option -- ` (empty) and `mkdir -zp` prints `mkdir: illegal option -- p`. `touch` and `cat` (a builtin on Windows, or with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`) do the same.
  - `ls -az` prints `a`: it always names the first flag of the cluster.
  - `mv -z` prints `-`, whatever the flag was (the message quoted in #26749, which is about `-T` itself and stays open).
  - `cp -zq` prints `zq` and `rm -rz` prints `rz`: the rest of the cluster (`cp: illegal option -- rv` is quoted in #14595).
- Cause: every parser builds the payload by hand. The four `FlagParser` builtins get `parse_short(ch, smallflags, i)` and slice `smallflags` themselves: cat/touch/mkdir use `smallflags[1 + i..]` (`src/runtime/shell/builtin/cat.rs:423`, `touch.rs:377`, `mkdir.rs:458`), which starts one byte past the rejected one because `smallflags` already has the leading `-` stripped (`interpreter.rs:2389`); cp uses `smallflags[i..]` (`cp.rs:812`). ls uses `flag[1..2]` (`ls.rs:262`), mv a literal `b"-"` (`mv.rs:377`), rm `arg[1..]` (`rm.rs:263`).
- All of this was ported as-is from the Zig implementation, so it is not a regression.

### Fix
- The parser result carries the rejected byte itself: `ParseFlagResult::IllegalOption(u8)` / `ParseError::IllegalOption(u8)`, and `parse_short` now receives only `ch`. The shared loop in `parse_one_flag` is the one place that knows which byte it stopped on, and an impl can no longer name anything else; `Builtin::fail_parse` formats the byte.
- `Unsupported` becomes `&'static [u8]` (every payload already was one, via `unsupported_flag`), so the `*const [u8]` payloads, `ParseError::opt()` and its `unsafe` go away. `unsupported_flag` stays as the identity so its 26 call sites (and the open PRs that touch them) are left alone.
- ls, mv and rm carry the byte the same way (`u8` instead of a `Box<[u8]>`, a static `b"-"` and no payload). rm's two illegal-option variants and its second copy of the format string collapse into one arm that goes through its existing `write_err_literal`.
- An unknown `--long` option is reported as `illegal option -- -`: the parsers fall back to reading it as a `-` cluster and reject its second `-`, which is what BSD getopt prints and what rm, ls and mv already printed. touch and mkdir used to print `illegal option -- long` for these by the same off-by-one; the `--help` table in `exec.test.ts` is updated accordingly.
- Why this is correct: the builtins copy the BSD message format, and getopt(3), which produces that message in the real tools, names exactly the option character it stopped on, wherever it sits in the cluster. The byte the loop is currently on is that character by construction.
- Only the text of an error that already exited 1 changes; no flag is accepted or rejected differently, and the unsupported-option text is unchanged.
- Verification:
  - `test/js/bun/shell/exec.test.ts`: `-z`, `-z` after a valid flag, `-z` before one, and `--bogus` through each of the seven builtins, one `bun exec` per case (with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` so cat and cp are builtins on every platform), plus the two updated `--help` rows and three unsupported-option cases for the retyped `Unsupported` payload. On bun 1.4.0, 18 of the 25 illegal-option cases and both `--help` rows fail; with this branch the file passes.
  - `test/js/bun/shell/commands/rm.test.ts`: `rm -rz` under `.quiet()`, which writes the message through the buffered (non-fd) path; fails on 1.4.0 (`rz`), passes here.
  - `test/js/bun/shell/commands/ls.test.ts`: the two invalid-flag tests assert the exact message instead of `toContain("illegal option")`; `ls -az` fails on 1.4.0, passes here.
  - `bunshell.test.ts`, `commands/{rm,mv,cp}.test.ts` pass with the debug build.
- Known overlaps with open PRs, all one-line conflicts: #39214 deletes the lone-`-` branches this PR retypes in `interpreter.rs` and `ls.rs`; #35616 / #35705 (cp), #39225 / #39224 (rm) edit the arms next to the changed `_` arms. The pre-existing cp bug where `-Rv` stops parsing after `R` is fixed by those cp PRs and is deliberately not touched here, which is why the cp row tests `-zR` but not `-Rz`.

### Background
- Shell builtins: `Bun.$` implements cat, touch, mkdir, cp, ls, rm and mv itself instead of spawning them. cat and cp are only used on Windows unless `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` is set; the others are used everywhere.
- `FlagParser` (`src/runtime/shell/interpreter.rs`): the shared option parser used by cat, touch, mkdir and cp. For an argument `-abc`, `parse_one_flag` calls `parse_short` once per byte; an argument starting with `--` is offered to `parse_long` first and, if that declines, read as a cluster too (so its second `-` is the first byte seen). ls, rm and mv have their own loops of the same shape. `Builtin::fail_parse` (`Builtin.rs`) turns the `ParseError` into the message for the four `FlagParser` builtins.
- Builtins write errors one of two ways: through an `IOWriter` when stderr is a real fd (the default, and what `bun exec` uses) or straight into a buffer when the shell's output is captured without an fd (`.quiet()`), hence the extra `.quiet()` test for rm, the only builtin whose message used to be formatted separately on each path.
- getopt(3) behaviour being matched: `mkdir -pz` prints `mkdir: illegal option -- z` on BSD/macOS (`invalid option -- 'z'` on GNU), and `mkdir --bogus` prints `mkdir: illegal option -- -` on BSD.

<details>
<summary>Before / after for every builtin (bun 1.4.0 vs this branch, <code>BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1</code>)</summary>

```
command          before                          after
mkdir -z         mkdir: illegal option --        mkdir: illegal option -- z
mkdir -pz        mkdir: illegal option --        mkdir: illegal option -- z
mkdir -zp        mkdir: illegal option -- p      mkdir: illegal option -- z
mkdir --foo      mkdir: illegal option -- foo    mkdir: illegal option -- -
touch -z         touch: illegal option --        touch: illegal option -- z
touch -zq        touch: illegal option -- q      touch: illegal option -- z
touch --foo      touch: illegal option -- foo    touch: illegal option -- -
cat -z           cat: illegal option --          cat: illegal option -- z
cat -zq          cat: illegal option -- q        cat: illegal option -- z
cat --foo        cat: illegal option -- foo      cat: illegal option -- -
cp -z            cp: illegal option -- z         cp: illegal option -- z
cp -zq           cp: illegal option -- zq        cp: illegal option -- z
cp --foo         cp: illegal option -- -foo      cp: illegal option -- -
ls -z            ls: illegal option -- z         ls: illegal option -- z
ls -az           ls: illegal option -- a         ls: illegal option -- z
ls --foo         ls: illegal option -- -         ls: illegal option -- -
rm -z            rm: illegal option -- z         rm: illegal option -- z
rm -rz           rm: illegal option -- rz        rm: illegal option -- z
rm --foo         rm: illegal option -- -         rm: illegal option -- -
mv -z            mv: illegal option -- -         mv: illegal option -- z
mv -fz           mv: illegal option -- -         mv: illegal option -- z
mv --foo         mv: illegal option -- -         mv: illegal option -- -
```

Exit code is 1 in every row, before and after.
</details>

<details>
<summary>Earlier shape of this PR</summary>

The first version kept the raw-pointer payloads and fixed each impl's slice to `smallflags[i..=i]` (then via a shared `illegal_flag` helper). Review pointed out that the only consumer of `smallflags`/`i` was that payload and that every other payload was already `'static`, so the current version moves the byte into the result type instead and deletes the pointer plumbing. Behaviour and the before/after table are the same in both versions.
</details>
