### PR TITLE
test(shell): stop the ls/rm/bunshell tests from running bun install against the registry

### DIFF
--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1121,6 +1121,15 @@ booga"
       expect(stdout.toString()).toEqual(`${temp_dir}\n${process.cwd().replaceAll("\\", "/")}\n`);
     });
 
+    test("cd applies to external commands run afterwards", async () => {
+      const { stdout, stderr, exitCode } = await $`cd ${temp_dir} && ${BUN} -e ${"console.log(process.cwd())"}`.quiet();
+      expect({ stdout: stdout.toString().replaceAll("\\", "/"), stderr: stderr.toString(), exitCode }).toEqual({
+        stdout: `${temp_dir.replaceAll("\\", "/")}\n`,
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
     test("cd with no args goes to $HOME", async () => {
       const { stdout, stderr, exitCode } = await $`pwd && cd && pwd`
         .env({ ...bunEnv, HOME: temp_dir, USERPROFILE: temp_dir })
@@ -2726,28 +2735,6 @@ if [[ "123abc" == *?(a)bc ]]; then echo ok 43; else echo bad 43; fi
 });
 
 describe("subshell", () => {
-  const sharppkgjson = /* json */ `{
-    "name": "sharp-test",
-    "module": "index.ts",
-    "type": "module",
-    "dependencies": {
-      "sharp": "0.33.3"
-    }
-  }`;
-
-  TestBuilder.command /* sh */ `
-  mkdir sharp-test
-  cd sharp-test
-  echo ${sharppkgjson} > package.json
-  ${BUN} i
-  `
-    .ensureTempDir()
-    .stdout(out => expect(out).toInclude("+ sharp@0.33.3"))
-    .stderr(() => {})
-    .exitCode(0)
-    .env(bunEnv)
-    .runAsTest("sharp");
-
   TestBuilder.command /* sh */ `( ( ( ( echo HI! ) ) ) )`.stdout("HI!\n").runAsTest("multiple levels");
   TestBuilder.command /* sh */ `(
     echo HELLO! ;

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -1,23 +1,15 @@
 import { $ } from "bun";
-import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { isPosix, tempDir, tempDirWithFiles } from "harness";
-import { createTestBuilder } from "../util";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { DirectoryTree, isPosix, tempDir, tempDirWithFiles } from "harness";
+import { symlinkSync } from "node:fs";
+import { join, posix } from "node:path";
+import { createTestBuilder, nodeModulesTree } from "../util";
 const TestBuilder = createTestBuilder(import.meta.path);
 
 const fileExists = async (path: string): Promise<boolean> =>
   $`ls -d ${path}`.then(o => o.stdout.toString() === `${path}\n`);
 
 $.nothrow();
-
-beforeAll(() => {
-  setDefaultTimeout(1000 * 60 * 5);
-});
-
-const BUN = process.argv0;
-const DEV_NULL = process.platform === "win32" ? "NUL" : "/dev/null";
-
-let node_modules_tempdir: string;
-let nodeModulesSetup: Promise<string[]>;
 
 let tempdir: string;
 let allFiles: string[] = [];
@@ -41,39 +33,51 @@ const sortedLsOutput = (s: string) =>
     )
     .sort();
 
+/**
+ * What `ls -RA .` prints for a directory created from `tree`, in `sortedLsOutput`
+ * form: every file and directory once under its parent, plus a `./dir:` header for
+ * every directory below the root. Values in these trees are file contents or `{}`
+ * for an empty directory.
+ */
+const expectedRecursiveListing = (tree: DirectoryTree): string[] => {
+  const paths = new Set<string>();
+  const dirs = new Set<string>();
+  for (const [file, contents] of Object.entries(tree)) {
+    const parts = file.split("/");
+    let prefix = "";
+    for (let i = 0; i < parts.length; i++) {
+      prefix = i === 0 ? parts[0] : `${prefix}/${parts[i]}`;
+      paths.add(prefix);
+      if (i < parts.length - 1 || typeof contents !== "string") dirs.add(prefix);
+    }
+  }
+  return [...Array.from(paths, p => posix.basename(p)), ...Array.from(dirs, dir => `./${dir}:`)].sort();
+};
+
 describe.concurrent("bunshell ls", () => {
   beforeAll(async () => {
-    node_modules_tempdir = tempDirWithFiles("ls-node_modules", {});
     tempdir = tempDirWithFiles("ls", {});
-    // Kick off the expensive `bun install` without awaiting so the other 26 tests
-    // (which don't depend on it) can run concurrently while it completes.
-    nodeModulesSetup = $`echo ${packagejson()} > package.json; ${BUN} install &> ${DEV_NULL}`
-      .quiet()
-      .throws(true)
-      .cwd(node_modules_tempdir)
-      .then(() =>
-        isPosix
-          ? Bun.$`ls -RA .`
-              .quiet()
-              .throws(true)
-              .cwd(node_modules_tempdir)
-              .text()
-              .then(s => sortedLsOutput(s))
-          : [],
-      );
-    // Avoid an unhandled rejection if install fails before the node_modules test awaits it.
-    nodeModulesSetup.catch(() => {});
     await $`touch a b c; mkdir foo; touch foo/a foo/b foo/c`.quiet().throws(true).cwd(tempdir);
 
     allFiles = ["./foo:", "a", "a", "b", "b", "c", "c", "foo"];
   });
 
   describe("recursive", () => {
-    test.if(isPosix)("node_modules", async () => {
-      const allNodeModuleFiles = await nodeModulesSetup;
-      const s = await Bun.$`ls -RA .`.quiet().throws(true).cwd(node_modules_tempdir).text();
-      const lines = sortedLsOutput(s);
-      expect(lines).toEqual(allNodeModuleFiles);
+    test("node_modules", async () => {
+      const tree: DirectoryTree = { ...nodeModulesTree(), "outside/keep.txt": "" };
+      using dir = tempDir("ls-node_modules", tree);
+      const expected = expectedRecursiveListing(tree);
+      if (isPosix) {
+        // A symlink to a directory is listed but not descended into.
+        symlinkSync("../outside", join(String(dir), "node_modules", "linked"));
+        expected.push("linked");
+        expected.sort();
+      }
+
+      const { stdout, stderr, exitCode } = await $`ls -RA .`.quiet().cwd(String(dir));
+      expect(stderr.toString()).toBe("");
+      expect(sortedLsOutput(stdout.toString())).toEqual(expected);
+      expect(exitCode).toBe(0);
     });
 
     test("basic", async () => {
@@ -370,29 +374,3 @@ describe.concurrent("bunshell ls", () => {
     });
   });
 });
-
-function packagejson() {
-  return `{
-  "name": "dummy",
-  "dependencies": {
-    "@biomejs/biome": "^1.5.3",
-    "@vscode/debugadapter": "^1.61.0",
-    "esbuild": "^0.17.15",
-    "eslint": "^8.20.0",
-    "eslint-config-prettier": "^8.5.0",
-    "mitata": "^0.1.3",
-    "peechy": "0.4.34",
-    "prettier": "3.2.2",
-    "react": "next",
-    "react-dom": "next",
-    "source-map-js": "^1.0.2",
-    "typescript": "^5.0.2"
-  },
-  "devDependencies": {
-    "@types/react": "^18.0.25",
-    "@typescript-eslint/eslint-plugin": "^5.31.0",
-    "@typescript-eslint/parser": "^5.31.0"
-  },
-  "version": "0.0.0"
-}`;
-}

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -66,13 +66,10 @@ describe.concurrent("bunshell ls", () => {
     test("node_modules", async () => {
       const tree: DirectoryTree = { ...nodeModulesTree(), "outside/keep.txt": "" };
       using dir = tempDir("ls-node_modules", tree);
-      const expected = expectedRecursiveListing(tree);
-      if (isPosix) {
-        // A symlink to a directory is listed but not descended into.
-        symlinkSync("../outside", join(String(dir), "node_modules", "linked"));
-        expected.push("linked");
-        expected.sort();
-      }
+      // A link to a directory is listed but not descended into ("junction" is
+      // ignored on POSIX and needs no privilege on Windows).
+      symlinkSync("../outside", join(String(dir), "node_modules", "linked"), "junction");
+      const expected = [...expectedRecursiveListing(tree), "linked"].sort();
 
       const { stdout, stderr, exitCode } = await $`ls -RA .`.quiet().cwd(String(dir));
       expect(stderr.toString()).toBe("");

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -5,11 +5,11 @@
  * This code is licensed under the MIT License: https://opensource.org/licenses/MIT
  */
 import { $ } from "bun";
-import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
 import { existsSync, mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "path";
-import { createTestBuilder, sortedShellOutput } from "../util";
+import { createTestBuilder, nodeModulesTree, sortedShellOutput } from "../util";
 const TestBuilder = createTestBuilder(import.meta.path);
 
 const fileExists = async (path: string): Promise<boolean> =>
@@ -17,18 +17,33 @@ const fileExists = async (path: string): Promise<boolean> =>
 
 $.nothrow();
 
-beforeAll(() => {
-  setDefaultTimeout(1000 * 60 * 5);
-});
-
-const BUN = bunExe();
-const DEV_NULL = process.platform === "win32" ? "NUL" : "/dev/null";
-
 describe.concurrent("bunshell rm", () => {
-  TestBuilder.command`echo ${packagejson()} > package.json; ${BUN} install --linker hoisted &> ${DEV_NULL}; rm -rf node_modules/`
-    .ensureTempDir()
-    .doesNotExist("node_modules")
-    .runAsTest("node_modules");
+  test("node_modules", async () => {
+    using dir = tempDir("rm-node_modules", { ...nodeModulesTree(), "outside/keep.txt": "" });
+    const nodeModules = path.join(String(dir), "node_modules");
+    if (isPosix) {
+      symlinkSync("../outside", path.join(nodeModules, "linked-dir"));
+      symlinkSync("../pkg-0/lib/mod0.js", path.join(nodeModules, ".bin", "linked-bin"));
+      symlinkSync("./does-not-exist", path.join(nodeModules, "dangling"));
+    }
+
+    const { stdout, stderr, exitCode } = await $`rm -rf node_modules/`.cwd(String(dir));
+
+    expect({
+      stdout: stdout.toString(),
+      stderr: stderr.toString(),
+      exitCode,
+      nodeModulesExists: existsSync(nodeModules),
+      // rm -rf must delete the symlink itself, not what it points at.
+      keptFileOutsideTree: existsSync(path.join(String(dir), "outside", "keep.txt")),
+    }).toEqual({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+      nodeModulesExists: false,
+      keptFileOutsideTree: true,
+    });
+  });
 
   test("force", async () => {
     const files = {
@@ -211,32 +226,6 @@ foo/
     expect(exitCode).toBe(0);
   }, 120_000);
 });
-
-function packagejson() {
-  return `{
-  "name": "dummy",
-  "dependencies": {
-    "@biomejs/biome": "^1.5.3",
-    "@vscode/debugadapter": "^1.61.0",
-    "esbuild": "^0.17.15",
-    "eslint": "^8.20.0",
-    "eslint-config-prettier": "^8.5.0",
-    "mitata": "^0.1.3",
-    "peechy": "0.4.34",
-    "prettier": "3.2.2",
-    "react": "next",
-    "react-dom": "next",
-    "source-map-js": "^1.0.2",
-    "typescript": "^5.0.2"
-  },
-  "devDependencies": {
-    "@types/react": "^18.0.25",
-    "@typescript-eslint/eslint-plugin": "^5.31.0",
-    "@typescript-eslint/parser": "^5.31.0"
-  },
-  "version": "0.0.0"
-}`;
-}
 
 // Recursive `rm -rf` classifies each entry as a directory from readdir, then
 // later re-opens it by path on a worker thread. If that path is replaced by a

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -21,8 +21,10 @@ describe.concurrent("bunshell rm", () => {
   test("node_modules", async () => {
     using dir = tempDir("rm-node_modules", { ...nodeModulesTree(), "outside/keep.txt": "" });
     const nodeModules = path.join(String(dir), "node_modules");
+    // A directory link on every platform ("junction" is ignored on POSIX and
+    // needs no privilege on Windows); file and dangling symlinks need one there.
+    symlinkSync("../outside", path.join(nodeModules, "linked-dir"), "junction");
     if (isPosix) {
-      symlinkSync("../outside", path.join(nodeModules, "linked-dir"));
       symlinkSync("../pkg-0/lib/mod0.js", path.join(nodeModules, ".bin", "linked-bin"));
       symlinkSync("./does-not-exist", path.join(nodeModules, "dangling"));
     }
@@ -34,7 +36,7 @@ describe.concurrent("bunshell rm", () => {
       stderr: stderr.toString(),
       exitCode,
       nodeModulesExists: existsSync(nodeModules),
-      // rm -rf must delete the symlink itself, not what it points at.
+      // rm -rf must delete the link itself, not what it points at.
       keptFileOutsideTree: existsSync(path.join(String(dir), "outside", "keep.txt")),
     }).toEqual({
       stdout: "",

--- a/test/js/bun/shell/util.ts
+++ b/test/js/bun/shell/util.ts
@@ -1,4 +1,5 @@
 import { ShellOutput, ShellPromise } from "bun";
+import type { DirectoryTree } from "harness";
 import { createTestBuilder } from "./test_builder";
 
 export { createTestBuilder };
@@ -30,3 +31,34 @@ export const redirect = (opts?: Partial<typeof defaultRedirect>): typeof default
 
 export const sortedShellOutput = (output: string | string[]): string[] =>
   (Array.isArray(output) ? output : output.split("\n").filter(s => s.length > 0)).sort();
+
+/**
+ * A `node_modules`-shaped tree for the recursive `ls` and `rm` tests: 4 top-level
+ * packages, each nesting its own `node_modules` two levels deep, with scoped
+ * packages, dotfiles and empty directories (28 packages, ~280 files). Built
+ * locally so those tests do not depend on `bun install` or a registry.
+ *
+ * Keys are `/`-separated paths relative to the tree root in the shape `tempDir()`
+ * accepts; a `{}` value is an empty directory.
+ */
+export function nodeModulesTree(): DirectoryTree {
+  const tree: DirectoryTree = { "node_modules/.package-lock.json": "{}" };
+  const addPackage = (dir: string, name: string, depth: number) => {
+    tree[`${dir}/package.json`] = JSON.stringify({ name });
+    tree[`${dir}/.npmignore`] = "";
+    tree[`${dir}/empty`] = {};
+    for (let i = 0; i < 4; i++) {
+      tree[`${dir}/lib/mod${i}.js`] = "";
+      tree[`${dir}/dist/types/mod${i}.d.ts`] = "";
+    }
+    if (depth > 0) {
+      addPackage(`${dir}/node_modules/dep`, "dep", depth - 1);
+      addPackage(`${dir}/node_modules/@scope/dep`, "@scope/dep", depth - 1);
+    }
+  };
+  for (let i = 0; i < 4; i++) {
+    addPackage(`node_modules/pkg-${i}`, `pkg-${i}`, 2);
+    tree[`node_modules/.bin/pkg-${i}`] = "";
+  }
+  return tree;
+}

--- a/test/js/bun/shell/util.ts
+++ b/test/js/bun/shell/util.ts
@@ -35,8 +35,9 @@ export const sortedShellOutput = (output: string | string[]): string[] =>
 /**
  * A `node_modules`-shaped tree for the recursive `ls` and `rm` tests: 4 top-level
  * packages, each nesting its own `node_modules` two levels deep, with scoped
- * packages, dotfiles and empty directories (28 packages, ~280 files). Built
- * locally so those tests do not depend on `bun install` or a registry.
+ * packages, dotfiles, empty directories and one directory too wide to read in a
+ * single batch (28 packages, ~580 files). Built locally so those tests do not
+ * depend on `bun install` or a registry.
  *
  * Keys are `/`-separated paths relative to the tree root in the shape `tempDir()`
  * accepts; a `{}` value is an empty directory.
@@ -59,6 +60,13 @@ export function nodeModulesTree(): DirectoryTree {
   for (let i = 0; i < 4; i++) {
     addPackage(`node_modules/pkg-${i}`, `pkg-${i}`, 2);
     tree[`node_modules/.bin/pkg-${i}`] = "";
+  }
+  // 300 entries with 33-byte names are at least 56 bytes each as getdents64 /
+  // getdirentries64 records and 136 bytes as FILE_DIRECTORY_INFORMATION, so this
+  // directory overflows bun_sys::dir_iterator's 8 KiB buffer on every platform
+  // and `ls -R` / `rm -r` have to refill it part-way through the directory.
+  for (let i = 0; i < 300; i++) {
+    tree[`node_modules/pkg-0/lib/rules/rule-${String(i).padStart(3, "0")}-no-unused-expressions.js`] = "";
   }
   return tree;
 }

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -67,7 +67,6 @@ test/js/bun/resolve/import-custom-condition.test.ts
 test/js/bun/s3/s3.leak.test.ts
 test/js/bun/s3/s3-stream-cancel-leak.test.ts
 test/js/bun/shell/bunshell.test.ts
-test/js/bun/shell/commands/ls.test.ts
 test/js/bun/shell/leak.test.ts
 test/js/bun/shell/lex.test.ts
 test/js/bun/spawn/spawn-stdin-destroy.test.ts

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -66,7 +66,6 @@ test/js/bun/import-attributes/import-attributes.test.ts
 test/js/bun/resolve/import-custom-condition.test.ts
 test/js/bun/s3/s3.leak.test.ts
 test/js/bun/s3/s3-stream-cancel-leak.test.ts
-test/js/bun/shell/bunshell.test.ts
 test/js/bun/shell/leak.test.ts
 test/js/bun/shell/lex.test.ts
 test/js/bun/spawn/spawn-stdin-destroy.test.ts


### PR DESCRIPTION
### Problem
- Three shell tests run a real `bun install` against the public registry: the `node_modules` tests in `test/js/bun/shell/commands/rm.test.ts` and `ls.test.ts` (15 packages: eslint, typescript, biome, ...) and `subshell > sharp` in `test/js/bun/shell/bunshell.test.ts` (sharp@0.33.3). Tests must not contact the registry (test/CLAUDE.md), and all three run under the 5000ms default timeout.
- `rm.test.ts` and `ls.test.ts` call `setDefaultTimeout(5 min)` inside a module-level `beforeAll`. The runner copies the default into each test when `test()` is registered (`src/runtime/test_runner/ScopeFunctions.rs:746`); `beforeAll` runs after the whole file is registered, so the call changes nothing.
- Debug build, cold install cache (`rm -rf ~/.bun/install/cache`), bcba4722b8: `(fail) bunshell ls > recursive > node_modules [5000.26ms]`, `this test timed out after 5000ms.`; the rm variant passed at 2.8s and has been seen failing the same way at 5004ms.
- The assertions were also weak: `ls` compared bun's `ls -RA` output of the installed tree with bun's own output of the same tree; `rm` discarded the install's exit status (`&> /dev/null; rm -rf node_modules/`), so `doesNotExist("node_modules")` held even when nothing was installed.
- Test-only change; nothing under `src/` is touched.

### Fix
- `nodeModulesTree()` in `test/js/bun/shell/util.ts` builds a `node_modules`-shaped tree (4 top-level packages with nested `node_modules` two levels deep, scoped packages, `.bin`, dotfiles, empty directories; 28 packages, ~580 files) in the form `tempDir()` accepts. Both `node_modules` tests build it locally; the dead `beforeAll`/`setDefaultTimeout` blocks and `packagejson()` helpers are deleted.
- One directory in the tree (`pkg-0/lib/rules`, 300 entries with 33-byte names) is wider than the 8 KiB that `bun_sys::dir_iterator` reads per call (`src/sys/lib.rs:111`): about 16.8 KiB of `getdents64`/`getdirentries64` records, about 40 KiB of `FILE_DIRECTORY_INFORMATION`. The installed tree used to have such directories (eslint's `lib/rules` has ~290 entries), and `rm -r` unlinking entries between refills (`src/runtime/shell/builtin/rm.rs`, which unlike `Dir::delete_tree` has no `ENOTEMPTY` retry) is otherwise covered by nothing in-tree, so the generated tree keeps that property.
- `ls`: `ls -RA .` is asserted against a listing derived from the tree (`expectedRecursiveListing`: each entry once under its parent plus one `./dir:` header per directory). Checked once against coreutils `ls -RA` on the same tree (before the wide directory was added): identical, 621 lines. The test was `test.if(isPosix)` only because of the install and now runs on Windows too.
- `rm`: `rm -rf node_modules/` must exit 0 with empty output, remove the tree, and leave the file behind a directory link in place; on POSIX a file symlink and a dangling symlink are removed as well.
- The directory link in both tests is created with `symlinkSync(target, link, "junction")`: the type is ignored on POSIX (`node_fs.rs:3153`) and on Windows it creates a junction without needing `SeCreateSymbolicLinkPrivilege` (relative target resolved against the link's directory, `node_fs.rs:7938`). That gives "listed but not descended" (ls) and "unlinked, target kept" (rm) their first Windows coverage; before this PR every link test in shell rm was `skipIf(win32)`.
- `bunshell.test.ts`: the sharp test is replaced by `cd & pwd > cd applies to external commands run afterwards` (`cd dir && bun -e 'console.log(process.cwd())'`). Running an external command after `cd` was the only shell behavior it covered that no other test in the file does; `mkdir`/`cd`/redirect are covered by `redirect to file` and the `cd & pwd` block.
- `test/no-validate-leaksan.txt`: the `ls.test.ts` and `bunshell.test.ts` entries are removed. Both were listed in 45760cd53c ("root cause unclear") and both were the files whose tests asserted on a child `bun install`'s exit status (`.throws(true)` / `.exitCode(0)`); the child inherits `detect_leaks=1` and can abort with exit 134. `rm.test.ts`, which ran the same install but discarded its status, was never listed. Neither file runs an install any more. `test/parallel-allowlist.json` and `expected-durations.json` are generated from CI data and left alone.
- Verified on Linux (debug, ASAN): `bun bd test test/js/bun/shell/commands/rm.test.ts test/js/bun/shell/commands/ls.test.ts` passes apart from the two pre-existing `permission denied` tests, which fail here only because the container runs as root; the rewritten tests took 0.3s (rm) and 0.8s (ls) on an idle machine before the wide directory was added, 0.6s and 1.6s with it on a machine at load average ~40. `bun bd test test/js/bun/shell/bunshell.test.ts`: 423 pass, 0 fail.
- Verified the LSAN removals as a non-root user with the runner's exact environment (`BUN_DESTRUCT_VM_ON_EXIT=1`, `ASAN_OPTIONS=...detect_leaks=1:abort_on_error=1`, `LSAN_OPTIONS=...suppressions=test/leaksan.supp`, cwd = repo root, debug ASAN build): `ls.test.ts` 8/8 runs 29 pass, `rm.test.ts` 2/2 runs 7 pass, `bunshell.test.ts` 3/3 runs 426 pass (about 76s each, the same as without LSAN); exit 0 and no sanitizer output in every run. The child processes those files spawn run under the same options, so they were leak-checked too.
- Verified on windows-x64 with the current canary build: both command files pass with the final fixture (28 pass, 8 POSIX-only skips) and the new `cd` test passes. A probe confirmed `lstat` reports the junction as a link, `ls -RA` lists `linked` without a `linked:` header, and `rm -rf` removes it while `outside/keep.txt` survives.
- Not changed here: `test/js/node/dns/node-dns.test.js`, `test/integration/expo-app/expo.test.ts` and `test/integration/esbuild/esbuild.test.ts` use the same no-op `beforeAll(() => setDefaultTimeout(...))`, and the runner's `test/js/bun/test/setTimeout-test-fixture.js` relies on it without its test being able to notice. They pass with the default today; whether the runner should honor hook-time calls again or the files should move the call to module scope is a runner question being handled separately. The other shell entries in `no-validate-leaksan.txt` (`leak`, `lex`, `env.positionals`, `shell-hang`) never ran an install, so the reasoning above says nothing about them; they are not touched.

### Background
- `setDefaultTimeout(ms)` (alias `jest.setTimeout`) sets a per-file override that `test()`/hook registration copies into each entry's timeout. Before the test runner rewrite (#22534) the override was read when a test started, so calling it from `beforeAll` worked; that PR moved the lookup to registration time and converted `bun-install-registry.test.ts` to a module-scope call, but these files kept the old pattern.
- `bun test` first collects a file (runs the module body, registering tests and hooks) and then executes it (runs hooks and tests). A module-level `beforeAll` belongs to the execution phase, so nothing it does can affect how tests were registered.
- `tempDir(prefix, tree)` from `test/harness.ts` materializes an object of `relative/path: contents` entries (an object value creates an empty directory) in a fresh temporary directory and removes it when the `using` binding goes out of scope.
- A junction is the Windows directory-link type that unprivileged users can create; like a symlink it is a reparse point that `lstat` reports as a link, and `ls -R`/`rm -r` are expected to treat it as an entry rather than descend into it.
- `test/no-validate-leaksan.txt` lists test files that the ASAN CI lanes run without LeakSanitizer; every other file runs with `detect_leaks=1` and the VM torn down at exit so leaks are reported.

<details>
<summary>Repro of the no-op on its own</summary>

```ts
import { beforeAll, setDefaultTimeout, test } from "bun:test";
beforeAll(() => setDefaultTimeout(10_000));
test("sleeps 6s", () => Bun.sleep(6000));
```

`bun test` on 1.3.13, 1.3.14 and 1.4.0: `this test timed out after 5000ms.` Moving the call to module scope makes it pass.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->