### PR TITLE
test: add a harness isRoot and skip the chmod-based ls and Bun.file cases as root

### DIFF
--- a/test/cli/install/bun-add-filter.test.ts
+++ b/test/cli/install/bun-add-filter.test.ts
@@ -1,7 +1,7 @@
 import { file, write } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { chmod, exists, mkdir, rm } from "fs/promises";
-import { VerdaccioRegistry, bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
+import { VerdaccioRegistry, bunEnv, bunExe, isRoot, isWindows, normalizeBunSnapshot } from "harness";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();
@@ -2141,7 +2141,7 @@ test.concurrent("remove --filter --dry-run touches nothing", async () => {
   expect(await exists(join(dir, "node_modules", "no-deps", "package.json"))).toBeTrue();
 });
 
-test.concurrent.skipIf(isWindows || process.getuid?.() === 0)(
+test.concurrent.skipIf(isWindows || isRoot)(
   "an unwritable target is reported by name, the rest is still written, exit code 1",
   async () => {
     const dir = await makeMonorepo();

--- a/test/cli/install/bun-prune.test.ts
+++ b/test/cli/install/bun-prune.test.ts
@@ -1,6 +1,15 @@
 import { file, write } from "bun";
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, runBunInstall, tempDir, VerdaccioRegistry } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isRoot,
+  isWindows,
+  normalizeBunSnapshot,
+  runBunInstall,
+  tempDir,
+  VerdaccioRegistry,
+} from "harness";
 import {
   chmodSync,
   closeSync,
@@ -1974,7 +1983,7 @@ test.concurrent("isolated + publicHoistPattern: hoisted links follow their store
   expect(await file(join(nm, "no-deps", "package.json")).json()).toMatchObject({ version: "1.0.0" });
 });
 
-test.concurrent.skipIf(isWindows || process.getuid?.() === 0)(
+test.concurrent.skipIf(isWindows || isRoot)(
   "a failed deletion is reported, the rest is removed, exit code 1",
   async () => {
     const dir = await setup({ name: "foo", dependencies: { "no-deps": "1.0.0" } });

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -9,6 +9,7 @@ import {
   isASAN,
   isDebug,
   isLinux,
+  isRoot,
   isWindows,
   tempDir,
   tempDirWithFiles,
@@ -1070,12 +1071,7 @@ function hasNobodyUser(): boolean {
   }
 }
 
-const canUseRunuser =
-  isLinux &&
-  typeof process.getuid === "function" &&
-  process.getuid() === 0 &&
-  !!Bun.which("runuser") &&
-  hasNobodyUser();
+const canUseRunuser = isLinux && isRoot && !!Bun.which("runuser") && hasNobodyUser();
 
 test.skipIf(!canUseRunuser)("process.env is preserved when cwd lacks read permission", () => {
   using dir = tempDir("env-eacces", {

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -1,6 +1,6 @@
 import { dlopen, FFIType } from "bun:ffi";
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isMusl, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isMusl, isRoot, isWindows, tempDir } from "harness";
 import { chmodSync, readFileSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 
@@ -219,7 +219,7 @@ test.concurrent.skipIf(!isPosix)(
 // Same as above but the grandchild is spawned with uid/gid. The credential
 // change clears the pdeathsig the spawn armed (prctl(2)), so this proves it
 // gets re-armed after setgid/setuid. Needs root to setuid.
-test.concurrent.skipIf(!isPosix || process.getuid?.() !== 0)(
+test.concurrent.skipIf(!isPosix || !isRoot)(
   "BUN_FEATURE_FLAG_NO_ORPHANS=1: a non-Bun grandchild spawned with uid/gid is reaped",
   async () => {
     const { sh, bunPid, grandchildPid } = await spawnTree("1", "child-nonbun-uid.js");

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -24,6 +24,12 @@ export const isFreeBSD = process.platform === "freebsd";
 export const isAndroid = process.platform === "android";
 export const isPosix = isMacOS || isLinux || isFreeBSD || isAndroid;
 export const isWindows = process.platform === "win32";
+/**
+ * Root bypasses file and directory mode bits, so a test that expects EACCES
+ * from a `chmod 000` fixture cannot pass as uid 0; skip such tests on it.
+ * Always false on Windows, where `process.getuid` does not exist.
+ */
+export const isRoot = process.getuid?.() === 0;
 export const isIntelMacOS = isMacOS && process.arch === "x64";
 export const isArm64 = process.arch === "arm64";
 export const isDebug = Bun.version.includes("debug");

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -25,9 +25,10 @@ export const isAndroid = process.platform === "android";
 export const isPosix = isMacOS || isLinux || isFreeBSD || isAndroid;
 export const isWindows = process.platform === "win32";
 /**
- * Root bypasses file and directory mode bits, so a test that expects EACCES
- * from a `chmod 000` fixture cannot pass as uid 0; skip such tests on it.
- * Always false on Windows, where `process.getuid` does not exist.
+ * Whether the tests are running as uid 0. Root bypasses file and directory
+ * mode bits, so tests that expect EACCES from a `chmod 000` fixture skip on it,
+ * while tests that need to setuid/setgid a child only run on it. Always false
+ * on Windows, where `process.getuid` does not exist.
  */
 export const isRoot = process.getuid?.() === 0;
 export const isIntelMacOS = isMacOS && process.arch === "x64";

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1,7 +1,7 @@
 import { pathToFileURL } from "bun";
 import { describe, expect, it, test } from "bun:test";
 import { chmodSync, chownSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, isLinux, isMacOS, isWindows, joinP, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, isLinux, isMacOS, isRoot, isWindows, joinP, tempDir, tempDirWithFiles } from "harness";
 import { join, resolve, sep } from "path";
 
 const fixture = (...segs: string[]) => resolve(import.meta.dir, "fixtures", ...segs);
@@ -908,7 +908,6 @@ describe.if(isWindows)("#30839 - imports entry pointing at a scoped package", ()
   // Root bypasses DAC, so chmod 0 won't yield EACCES. When running as root on
   // Linux we drop to `nobody` via runuser (and chown the temp dir so the
   // fixture can chmod it back). Otherwise we run the fixture directly.
-  const isRoot = !isWindows && process.getuid?.() === 0;
   const nobody = (() => {
     try {
       // /etc/passwd format: name:x:uid:gid:gecos:home:shell

--- a/test/js/bun/resolve/resolver-permission-denied-ancestor.test.ts
+++ b/test/js/bun/resolve/resolver-permission-denied-ancestor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { chmodSync, rmSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isRoot, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 // An ancestor directory the process may traverse but not read (mode 0o111 —
@@ -8,7 +8,7 @@ import { join } from "path";
 // for readable subtrees: the resolver treats it as an opaque, empty
 // directory. Previously the whole walk failed with "error loading current
 // directory". Root bypasses permission checks, so skip there.
-describe.skipIf(isWindows || process.getuid?.() === 0)("resolver with unreadable ancestor", () => {
+describe.skipIf(isWindows || isRoot)("resolver with unreadable ancestor", () => {
   test("bun run works under an execute-only ancestor", () => {
     using dir = tempDir("xonly-ancestor", {
       "outer/project/package.json": JSON.stringify({

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -8,7 +8,17 @@ import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
 import { chmodSync, mkdirSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
-import { bunExe, isPosix, isWindows, rss, runWithErrorPromise, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import {
+  bunExe,
+  isPosix,
+  isRoot,
+  isWindows,
+  rss,
+  runWithErrorPromise,
+  tempDir,
+  tempDirWithFiles,
+  tmpdirSync,
+} from "harness";
 import { join, sep } from "path";
 import { createTestBuilder, sortedShellOutput } from "./util";
 const TestBuilder = createTestBuilder(import.meta.path);
@@ -54,7 +64,6 @@ afterAll(async () => {
 });
 
 const BUN = bunExe();
-const isRoot = process.getuid?.() === 0;
 
 describe("bunshell", () => {
   describe("exit codes", async () => {

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -3,6 +3,8 @@ import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { isPosix, tempDir, tempDirWithFiles } from "harness";
 import { createTestBuilder } from "../util";
 const TestBuilder = createTestBuilder(import.meta.path);
+// Root bypasses directory mode bits, so chmod 000 cannot produce EACCES for it.
+const isRoot = process.getuid?.() === 0;
 
 const fileExists = async (path: string): Promise<boolean> =>
   $`ls -d ${path}`.then(o => o.stdout.toString() === `${path}\n`);
@@ -301,7 +303,7 @@ describe.concurrent("bunshell ls", () => {
         .run();
     });
 
-    test.if(isPosix)("permission denied directory", async () => {
+    test.if(isPosix && !isRoot)("permission denied directory", async () => {
       await using tempdir = tempDir("ls-permission", {});
       await $`mkdir restricted; chmod 000 restricted`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls restricted`
@@ -312,7 +314,7 @@ describe.concurrent("bunshell ls", () => {
       await $`chmod 755 restricted`.quiet().throws(true).cwd(tempdir); // cleanup
     });
 
-    test.if(isPosix)("permission denied directory recursive", async () => {
+    test.if(isPosix && !isRoot)("permission denied directory recursive", async () => {
       await using tempdir = tempDir("ls-permission-recursive", {});
       // Create 3-level deep directory structure with 3+ items per level
       await $`mkdir -p level1/level2/level3; 

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -1,10 +1,8 @@
 import { $ } from "bun";
 import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { isPosix, tempDir, tempDirWithFiles } from "harness";
+import { isPosix, isRoot, tempDir, tempDirWithFiles } from "harness";
 import { createTestBuilder } from "../util";
 const TestBuilder = createTestBuilder(import.meta.path);
-// Root bypasses directory mode bits, so chmod 000 cannot produce EACCES for it.
-const isRoot = process.getuid?.() === 0;
 
 const fileExists = async (path: string): Promise<boolean> =>
   $`ls -d ${path}`.then(o => o.stdout.toString() === `${path}\n`);

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isPosix } from "harness";
+import { isPosix, isRoot } from "harness";
 import {
   accessSync,
   chmodSync,
@@ -20,7 +20,6 @@ import { join } from "path";
 import { createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const TestBuilder = createTestBuilder(import.meta.path);
-const isRoot = process.getuid?.() === 0;
 
 $.nothrow();
 

--- a/test/js/bun/spawn/spawn-cgroup.test.ts
+++ b/test/js/bun/spawn/spawn-cgroup.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isRoot, tempDir } from "harness";
 import { spawn as cpSpawn, spawnSync as cpSpawnSync, execFile, fork } from "node:child_process";
 import { closeSync, constants, existsSync, mkdirSync, openSync, readFileSync, rmdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -9,7 +9,7 @@ import { dirname, join } from "node:path";
 // controller). v2: a sibling of our own cgroup (children of a populated cgroup
 // can't get controllers). v1: directly under the memory hierarchy root.
 function setupCgroup(): { dir: string; version: 1 | 2; relative: string; canOOM: boolean } | null {
-  if (!isLinux || process.getuid?.() !== 0) return null;
+  if (!isLinux || !isRoot) return null;
   const name = `bun-spawn-test-${process.pid}`;
   const candidates: { dir: string; version: 1 | 2; relative: string }[] = [];
 

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -11,6 +11,7 @@ import {
   isDebug,
   isLinux,
   isPosix,
+  isRoot,
   isWindows,
   shellExe,
   tempDir,
@@ -1593,8 +1594,6 @@ describe("option combinations", () => {
 });
 
 describe("uid/gid", () => {
-  const isRoot = process.getuid?.() === 0;
-
   it.if(isPosix && isRoot)("applies uid and gid to the child", async () => {
     await using proc = spawn({ cmd: ["id", "-u"], uid: 65534, gid: 65534, stdout: "pipe" });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);

--- a/test/js/bun/spawn/spawnSync.test.ts
+++ b/test/js/bun/spawn/spawnSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, bunRun, isLinux, isMusl, isPosix, isWindows } from "harness";
+import { bunEnv, bunExe, bunRun, isLinux, isMusl, isPosix, isRoot, isWindows } from "harness";
 import { join } from "path";
 describe("spawnSync", () => {
   it("should throw a RangeError if timeout is less than 0", () => {
@@ -100,8 +100,6 @@ describe("spawnSync", () => {
 });
 
 describe("uid/gid", () => {
-  const isRoot = process.getuid?.() === 0;
-
   it("rejects a non-integer uid", () => {
     expect(() => Bun.spawnSync({ cmd: [bunExe()], env: bunEnv, uid: 1.5 })).toThrow();
     expect(() => Bun.spawnSync({ cmd: [bunExe()], env: bunEnv, gid: 1.5 })).toThrow();

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -6,6 +6,7 @@ import {
   bunExe,
   isLinux,
   isPosix,
+  isRoot,
   isWindows,
   nodeExe,
   runBunInstall,
@@ -1008,7 +1009,6 @@ done
 });
 
 describe("uid/gid options", () => {
-  const isRoot = process.getuid?.() === 0;
   // 65534 is "nobody" on every Linux distro and on macOS.
   const NOBODY = 65534;
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,7 +1,7 @@
 import { spawnSync, which } from "bun";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isMacOS, isRoot, isWindows, tempDir, tmpdirSync } from "harness";
 import { basename, join, resolve } from "path";
 
 const process_sleep = resolve(import.meta.dir, "process-sleep.js");
@@ -1111,7 +1111,7 @@ describe.concurrent(() => {
     // bmalloc scavenger) had signal-suspended a thread, it could never ack the barrier
     // and the whole process wedged at 0% CPU. The race is probabilistic, so hammer
     // seteuid under GC pressure from many processes at once and require each to exit.
-    it.skipIf(process.platform !== "linux" || process.getuid() !== 0)(
+    it.skipIf(process.platform !== "linux" || !isRoot)(
       "seteuid under GC pressure does not deadlock",
       async () => {
         using dir = tempDir("seteuid-deadlock", {
@@ -2335,21 +2335,18 @@ it("_rawDebug never throws when fd 2 is closed", async () => {
   expect(exitCode).toBe(0);
 });
 
-it.skipIf(isWindows || process.getuid?.() === 0)(
-  "process.initgroups passes an unknown string user straight to initgroups(3)",
-  () => {
-    // Node hands string users to initgroups(3) as-is (no getpwnam pre-resolve),
-    // so as non-root we see the syscall's EPERM, not ERR_UNKNOWN_CREDENTIAL.
-    let err;
-    try {
-      process.initgroups("zz_no_user_zz", 0);
-    } catch (e) {
-      err = e;
-    }
-    expect(err?.code).toBe("EPERM");
-    expect(err?.syscall).toBe("initgroups");
-  },
-);
+it.skipIf(isWindows || isRoot)("process.initgroups passes an unknown string user straight to initgroups(3)", () => {
+  // Node hands string users to initgroups(3) as-is (no getpwnam pre-resolve),
+  // so as non-root we see the syscall's EPERM, not ERR_UNKNOWN_CREDENTIAL.
+  let err;
+  try {
+    process.initgroups("zz_no_user_zz", 0);
+  } catch (e) {
+    err = e;
+  }
+  expect(err?.code).toBe("EPERM");
+  expect(err?.syscall).toBe("initgroups");
+});
 
 it.skipIf(isWindows)("process.initgroups pre-resolves a numeric uid through passwd", () => {
   // Numeric users go through getpwuid_r first, so an unknown uid surfaces

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -6,6 +6,7 @@ import {
   bunRunAsScript,
   isLinux,
   isMacOS,
+  isRoot,
   isWindows,
   tempDir,
   tempDirWithFiles,
@@ -532,8 +533,6 @@ describe("fs.watch", () => {
   // on windows 0o200 will be readable (match nodejs behavior)
   // Root has CAP_DAC_OVERRIDE, so the chmod 0o200 below never yields the
   // EACCES these two tests expect; they only make sense as a non-root user.
-  const isRoot = process.getuid?.() === 0;
-
   test.skipIf(isWindows || isRoot)("should throw if no permission to watch the directory", async () => {
     const filepath = path.join(testDir, "permission-dir");
     fs.mkdirSync(filepath, { recursive: true });
@@ -708,7 +707,7 @@ describe("fs.watch", () => {
   // seccomp. The same `add_one` error branch is reachable with EACCES by
   // watching a tree that contains one unreadable subdirectory as an
   // unprivileged user, so this test drops privileges to trigger it.
-  test.skipIf(!isLinux || process.getuid?.() !== 0)(
+  test.skipIf(!isLinux || !isRoot)(
     "recursive watch surfaces inotify_add_watch failure on a subdirectory as an 'error' event",
     async () => {
       const NOBODY = 65534;

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -13,6 +13,7 @@ import {
   isDebug,
   isFlaky,
   isMacOS,
+  isRoot,
   isWindows,
   rss,
   runFixtureMaxRSS,
@@ -1111,8 +1112,9 @@ describe.concurrent("Bun.file", () => {
     }
   }
 
-  // on Windows the creator of the file will be able to read from it so this test is disabled on it
-  describe.skipIf(isWindows)("bad permissions throws", () => {
+  // on Windows the creator of the file will be able to read from it so this test is disabled on it;
+  // root can read it anywhere, so it is disabled there as well
+  describe.skipIf(isWindows || isRoot)("bad permissions throws", () => {
     const path = join(tmp_dir, "my-new-file");
     beforeAll(async () => {
       await Bun.write(path, "hey");


### PR DESCRIPTION
### Problem
- Run as uid 0, two test files fail on main with both the released binary and a debug build, and are green in CI only because the CI agents are unprivileged:
  - `test/js/bun/shell/commands/ls.test.ts`: `bunshell ls > errors > permission denied directory` and `... permission denied directory recursive` (27 pass / 2 fail; `Expected to contain: "Permission denied"`, `Received: ""`). Both `chmod 000` a directory and expect the `ls` builtin to report EACCES (ls.test.ts:306 and :322 on main).
  - `test/js/web/fetch/fetch.test.ts`: the four `Bun.file > bad permissions throws` cases (fetch.test.ts:1115 on main), which `chmod` a file to 000 and expect every read method to reject with `permission denied` (as root the reads succeed; the `json` case fails with `Failed to parse JSON` because it read the file).
- Root bypasses mode bits, so a `chmod 000` fixture cannot produce EACCES for it. These tests run in the test process itself (the shell ones through `TestBuilder`, which calls `Bun.$` directly), so there is no child process to run as another user; the only correct outcome as root is to skip them.
- The uid 0 check these gates need already exists in the tree, but as 16 separate copies in 14 test files (`const isRoot = process.getuid?.() === 0`, or the same comparison inline in a `skipIf`), while `test/harness.ts` exports every other shared predicate (`isWindows`, `isPosix`, `isMusl`, ...) and has no `isRoot`. Four open shell PRs (#37737, #37688, #39214, #39231) each list the two `ls` failures as known local noise.

### Fix
- `test/harness.ts`: export `isRoot = process.getuid?.() === 0` next to `isPosix`/`isWindows`. It is always false on Windows: `process.getuid` is only installed under `#if !OS(WINDOWS)` (src/jsc/bindings/BunProcess.cpp:4919), so the optional call yields `undefined`.
- `ls.test.ts`: the two cases become `test.if(isPosix && !isRoot)`. `fetch.test.ts`: `describe.skipIf(isWindows)` on `bad permissions throws` becomes `describe.skipIf(isWindows || isRoot)`.
- The 16 existing uid 0 checks now use the export (bunshell, commands/mv, resolve, resolver-permission-denied-ancestor, spawn, spawnSync, spawn-cgroup, child_process, process.test.js x2, fs.watch x2, bun-add-filter, bun-prune, no-orphans, env). Each keeps its condition as it was, only spelled through `isRoot` (`getuid?.() === 0` -> `isRoot`, `getuid?.() !== 0` -> `!isRoot`, env.test.ts's `typeof getuid === "function" && getuid() === 0` -> `isRoot`); about half of them are root-only tests (setuid/setgid, cgroups) rather than skips, which is why the harness comment describes both uses. The larger hunks in `process.test.js` and `bun-prune.test.ts` are prettier reflowing the shortened conditions and the longer import line.
- Why this is right: the property the six newly gated cases check (the runtime surfaces EACCES from the open) is unreachable as uid 0, so skipping there removes a guaranteed false failure and nothing else; every unprivileged run, which includes CI, still executes them, so coverage of the error paths is unchanged. Putting the predicate in the harness and pointing the existing sites at it leaves the check with one spelling, so the next chmod-based test imports it instead of adding another copy.
- Intentionally left alone:
  - `test/js/bun/http/serve.test.ts:2534` (binding port 1003 must fail): that depends on CAP_NET_BIND_SERVICE and `net.ipv4.ip_unprivileged_port_start`, not on mode bits, so `isRoot` would be the wrong predicate for it.
  - Non-gating uses of `process.getuid()` (cache directory names in `bunx.test.ts`/`cc.test.ts`, launchctl paths in `cron.test.ts`, the `process.getuid` API tests themselves, a uid printed inside a child_process fixture).
  - #38745 adds `unprivilegedSpawnOptions()` to the harness for tests that spawn a child and can therefore keep running as root by dropping privileges; that is the right tool for spawn-based tests and does not apply to these in-process ones. It touches a different part of harness.ts and none of the files here, so the two do not conflict. Of the open PRs touching the same test files, #37737 (ls.test.ts, bunshell.test.ts), #39214 (bunshell.test.ts, mv.test.ts) and #38002 (mv.test.ts) merge cleanly with this branch (checked with a three-way merge); #39231 also rewrites the `harness` import line of ls.test.ts, so whichever of the two lands second needs a one-line import merge.
- Verified as root with the debug build: `bun bd test test/js/bun/shell/commands/ls.test.ts` 27 pass / 2 skip (was 27 pass / 2 fail); `bun bd test test/js/web/fetch/fetch.test.ts -t "bad permissions throws"` 4 skip (was 4 fail); a full run of fetch.test.ts on this branch and on main differs only in those four cases going from fail to skip.
- Verified as an unprivileged user (`runuser -u nobody`, debug and release builds): both `ls` cases and all four `fetch` cases still run and pass.
- Verified the 16 converted sites as root with the debug build: every file loads, the root-only tests still run and the non-root tests still skip, with the same statuses as main (details below).
- Test-only change; no runtime code touched.

### Background
- On POSIX systems `chmod 000` removes every permission bit from a file or directory, and opening or listing it fails with EACCES for an ordinary user. The kernel does not apply these checks to uid 0 (on Linux this is the CAP_DAC_OVERRIDE capability root holds), so for root the same path opens normally. Any test that relies on `chmod` to provoke EACCES is therefore only meaningful when run as a non-root user; conversely, tests that setuid/setgid a child can only run as root, which is the other way `isRoot` is used.
- `test/harness.ts` is preloaded into every test file and is where the shared platform predicates live; `test.if(cond)` and `describe.skipIf(cond)` register the affected cases as skipped instead of running them.

<details>
<summary>Per-site results as root (debug build, this branch; identical statuses on main)</summary>

- resolve.test.ts: the two `canTriggerEACCES` tests run via runuser and pass
- resolver-permission-denied-ancestor.test.ts: 2 skip
- bunshell.test.ts: `glob over an unreadable directory`, `cd with EACCES` skip
- commands/mv.test.ts: `unreadable directory across devices` skip
- spawn.test.ts `uid/gid`: 2 pass, `throws EPERM` skip
- spawnSync.test.ts `uid/gid`: 3 pass, `throws EPERM` skip
- spawn-cgroup.test.ts: 8 pass / 5 skip (no writable cgroupfs here), same as main
- child_process.test.ts `uid/gid options`: 3 pass, EPERM case skip
- process.test.js: `seteuid under GC pressure` runs and passes, `initgroups ... unknown string user` skip
- fs.watch.test.ts: the two `no permission to watch` cases skip, the inotify_add_watch case runs and passes
- bun-add-filter.test.ts, bun-prune.test.ts: the unwritable/undeletable cases skip
- env.test.ts: `process.env is preserved when cwd lacks read permission` runs via runuser and passes
- no-orphans.test.ts: the uid/gid case runs as before; it fails here on main as well, because uid 0 in this container has no CAP_KILL so the test's `kill(pid, 0)` liveness check gets EPERM for the `nobody` grandchild. Unrelated to this change and reported separately.

</details>

<details>
<summary>Earlier revisions of this PR</summary>

The first push only added a file-local `const isRoot` to `ls.test.ts` and gated the two shell cases. Self-review pointed out that this was one more copy of a predicate the harness should own and that `fetch.test.ts` had the same class of failure, so the second revision added the export and the fetch gate. Review of that revision asked for the pre-existing local copies to move to the export as well, which the third revision does.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->