### PR TITLE
shell(rm): reject -i/-I/--interactive by name through the shared unsupported-option path

### DIFF
--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -84,9 +84,7 @@ pub enum PromptBehaviour {
     /// `-f`, `--interactive=never` (default)
     #[default]
     Never,
-    /// `-i`/`--interactive=always` (before every removal) or `-I`/`--interactive=once`.
-    /// Prompting is not implemented: once the flags are parsed this is rejected,
-    /// naming the option as it was given.
+    /// `-i`, `-I`, `--interactive=once|always`, spelled as given so the rejection can name it.
     Prompt { flag: &'static [u8] },
 }
 
@@ -159,8 +157,7 @@ impl Rm {
                                     opts.remove_empty_dirs = true;
                                 }
                             }
-                            // Checked only once every flag is parsed so that a later
-                            // `-f` still cancels an earlier `-i`.
+                            // After all flags, so a later `-f` cancels an earlier `-i`.
                             if let PromptBehaviour::Prompt { flag } =
                                 Self::state_mut(interp, cmd).opts.prompt_behaviour
                             {

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -7,7 +7,8 @@ use bun_sys::{E, FdExt, dir_iterator};
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, IoKind, Kind};
 use crate::shell::interpreter::{
-    EventLoopHandle, Interpreter, NodeId, ShellTask, WorkPoolTask, shell_openat,
+    EventLoopHandle, Interpreter, NodeId, ParseError, ShellTask, WorkPoolTask, shell_openat,
+    unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -80,13 +81,13 @@ impl Default for Opts {
 
 #[derive(Default, Clone, Copy)]
 pub enum PromptBehaviour {
-    /// `--interactive=never` (default)
+    /// `-f`, `--interactive=never` (default)
     #[default]
     Never,
-    /// `-I`, `--interactive=once`
-    Once { removed_count: u32 },
-    /// `-i`, `--interactive=always`
-    Always,
+    /// `-i`/`--interactive=always` (before every removal) or `-I`/`--interactive=once`.
+    /// Prompting is not implemented: once the flags are parsed this is rejected,
+    /// naming the option as it was given.
+    Prompt { flag: &'static [u8] },
 }
 
 enum RmParseFlag {
@@ -158,12 +159,23 @@ impl Rm {
                                     opts.remove_empty_dirs = true;
                                 }
                             }
-                            if !matches!(
-                                Self::state_mut(interp, cmd).opts.prompt_behaviour,
-                                PromptBehaviour::Never
-                            ) {
-                                let buf: &[u8] = b"rm: \"-i\" is not supported yet";
-                                return Self::write_err_literal(interp, cmd, idx, buf);
+                            // Checked only once every flag is parsed so that a later
+                            // `-f` still cancels an earlier `-i`.
+                            if let PromptBehaviour::Prompt { flag } =
+                                Self::state_mut(interp, cmd).opts.prompt_behaviour
+                            {
+                                return Builtin::fail_parse(
+                                    interp,
+                                    cmd,
+                                    Kind::Rm,
+                                    &ParseError::Unsupported(unsupported_flag(flag)),
+                                    || {
+                                        Self::state_mut(interp, cmd).state = RmState::ParseOpts {
+                                            idx,
+                                            wait_write_err: true,
+                                        }
+                                    },
+                                );
                             }
 
                             let args_start = idx as usize;
@@ -511,11 +523,15 @@ impl Rm {
                     RmParseFlag::ContinueParsing
                 }
                 b"--interactive=once" => {
-                    opts.prompt_behaviour = PromptBehaviour::Once { removed_count: 0 };
+                    opts.prompt_behaviour = PromptBehaviour::Prompt {
+                        flag: b"--interactive=once",
+                    };
                     RmParseFlag::ContinueParsing
                 }
                 b"--interactive=always" => {
-                    opts.prompt_behaviour = PromptBehaviour::Always;
+                    opts.prompt_behaviour = PromptBehaviour::Prompt {
+                        flag: b"--interactive=always",
+                    };
                     RmParseFlag::ContinueParsing
                 }
                 _ => RmParseFlag::IllegalOption,
@@ -530,8 +546,8 @@ impl Rm {
                 b'r' | b'R' => opts.recursive = true,
                 b'v' => opts.verbose = true,
                 b'd' => opts.remove_empty_dirs = true,
-                b'i' => opts.prompt_behaviour = PromptBehaviour::Once { removed_count: 0 },
-                b'I' => opts.prompt_behaviour = PromptBehaviour::Always,
+                b'i' => opts.prompt_behaviour = PromptBehaviour::Prompt { flag: b"-i" },
+                b'I' => opts.prompt_behaviour = PromptBehaviour::Prompt { flag: b"-I" },
                 _ => return RmParseFlag::IllegalOptionWithFlag,
             }
         }

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -145,6 +145,77 @@ foo/
     }
   });
 
+  // Prompting is not implemented. A prompting option still in effect after all
+  // flags are parsed is rejected under the name it was given and the operand is
+  // left alone; a later -f or --interactive=never cancels it, as in GNU rm.
+  describe("interactive flags", () => {
+    const unsupported = (flag: string) => `rm: unsupported option, please open a GitHub issue -- ${flag}\n`;
+
+    // flags as given -> the option the message names (the last prompting option given)
+    const rejected: [flags: string[], reported: string][] = [
+      [["-i"], "-i"],
+      [["-I"], "-I"],
+      [["--interactive=always"], "--interactive=always"],
+      [["--interactive=once"], "--interactive=once"],
+      [["-ri"], "-i"],
+      [["-rfI"], "-I"],
+      [["-fi"], "-i"],
+      [["-iI"], "-I"],
+      [["-I", "-i"], "-i"],
+      [["--interactive=once", "-i"], "-i"],
+      [["-i", "--interactive=once"], "--interactive=once"],
+      [["--interactive=always", "-I"], "-I"],
+      [["-I", "--interactive=always"], "--interactive=always"],
+    ];
+    for (const [flags, reported] of rejected) {
+      const name = `rm ${flags.join(" ")} file`;
+      // Not quiet: stderr is a real fd and the message is written asynchronously.
+      TestBuilder.command`rm ${flags} file`
+        .file("file", "keep")
+        .stdout("")
+        .stderr(unsupported(reported))
+        .exitCode(1)
+        .fileEquals("file", "keep")
+        .runAsTest(name);
+      // Quiet: stderr is captured into a buffer and written synchronously.
+      TestBuilder.command`rm ${flags} file`
+        .quiet()
+        .file("file", "keep")
+        .stdout("")
+        .stderr(unsupported(reported))
+        .exitCode(1)
+        .fileEquals("file", "keep")
+        .runAsTest(`${name} (quiet)`);
+    }
+
+    const cancelled: string[][] = [
+      ["-if"],
+      ["-i", "-f"],
+      ["-I", "-f"],
+      ["-Irf"],
+      ["--interactive=once", "-f"],
+      ["--interactive=always", "-f"],
+      ["-i", "--interactive=never"],
+      ["-I", "--interactive=never"],
+    ];
+    for (const flags of cancelled) {
+      TestBuilder.command`rm ${flags} file`
+        .file("file", "")
+        .stdout("")
+        .stderr("")
+        .exitCode(0)
+        .doesNotExist("file")
+        .runAsTest(`rm ${flags.join(" ")} file removes the file`);
+    }
+
+    // With no operand the usage error comes first, as for any other flags.
+    TestBuilder.command`rm -i`
+      .stdout("")
+      .stderr("usage: rm [-f | -i] [-dIPRrvWx] file ...\n       unlink [--] file\n")
+      .exitCode(1)
+      .runAsTest("rm -i without an operand prints usage");
+  });
+
   // The DirTask parent/child hand-off had a lost-wakeup window between
   // `subtask_count.load() > 1` and `need_to_wait.store(true)`: the last
   // child could decrement and read `need_to_wait == false` in between,


### PR DESCRIPTION
### Problem
- `rm -i file` in the Bun shell fails with `rm: "-i" is not supported yet` and no trailing newline, so whatever is written to stderr next is glued onto the same line (`rm: "-i" is not supported yetnext line`). Every other `rm` diagnostic (usage, `illegal option -- x`, `No such file or directory`, `may not be removed`) ends in a newline.
- The message says `-i` whichever option was given (`-I`, `--interactive=once` and `--interactive=always` all print it), and it is a one-off string: the other builtins report options they do not implement through `Builtin::fail_parse`, as `<cmd>: unsupported option, please open a GitHub issue -- <option as given>\n`.
- Cause: the `RmParseFlag::Done` arm of `Rm::next` (`src/runtime/shell/builtin/rm.rs`) writes that literal whenever `opts.prompt_behaviour` is not `Never`. The `PromptBehaviour` enum it checks had `Once { removed_count }` / `Always` variants that nothing else read, and the short-flag arms of `parse_flag` set them the opposite way round from their doc comments and from the `--interactive=once` / `--interactive=always` arms (`-i` selected `Once`, `-I` selected `Always`; GNU rm's `-i` prompts before every removal and `-I` prompts once). Both the literal and the inverted arms date from the original implementation of the builtin.

### Fix
- `PromptBehaviour` is now `Never` or `Prompt { flag }`, where `flag` is the option as the user spelled it (`-i`, `-I`, `--interactive=once`, `--interactive=always`); `-f` and `--interactive=never` still set `Never`.
- The `Done` arm rejects a remaining `Prompt` through `Builtin::fail_parse` with `ParseError::Unsupported`, so `rm --interactive=once file` prints `rm: unsupported option, please open a GitHub issue -- --interactive=once` plus a newline, exits 1 and leaves the operand alone. The message text and the newline come from the shared formatter; rm's private literal is deleted.
- Why this shape: naming the option as given is what the other builtins do (`touch --date` reports `--date`, an unknown short flag reports the letter), so the user sees the option they typed. Tracking the spelling is all the builtin needs today; the once/always distinction and `removed_count` had no consumer, which is how the inverted arms went unnoticed, so they are removed rather than flipped. Whoever implements prompting adds the modes back together with the code that reads them. The check stays after flag parsing (not inside `parse_flag`) so that a later `-f` or `--interactive=never` still cancels an earlier prompting option, as in GNU rm; `rm -if file` and `rm -i -f file` keep removing the file.
- Verified with `test/js/bun/shell/commands/rm.test.ts` ("interactive flags"): 13 rejected combinations (each spelling, clustered `-ri` / `-rfI` / `-fi` / `-iI`, and pairs where the option given last is the one named), each run with stderr as a real fd and with `.quiet()` (the two branches of `write_failing_error`); 8 cancelled combinations that must remove the file silently; `rm -i` alone still prints usage. The 26 rejection cases fail on the current release (`USE_SYSTEM_BUN=1`: old text, no newline); the whole file and `test/js/bun/shell/bunshell.test.ts` pass on the debug build.
- Overlap with open rm PRs: #39225 also edits the four prompting arms (it adds `opts.force = false;` to each) and #39230 edits the `_ =>` arm directly below them, so whichever of these lands later gets a conflict confined to those lines; the resolution is to keep both sides (this PR's `Prompt { flag }` assignments plus their added statements). #39224's new `--force` arm assigns `PromptBehaviour::Never`, which still exists, and merges cleanly.

### Background
- `rm` is a builtin of the Bun shell on every platform (`src/runtime/shell/builtin/rm.rs`), so this message is Bun's own, not the system `rm`'s.
- The builtin walks argv one word at a time in its `ParseOpts` state, calling `parse_flag` on each; the first non-flag word returns `RmParseFlag::Done`, which is where the collected options are validated before any operand is removed. "Last flag wins" for `-f` vs `-i` falls out of each arm overwriting `prompt_behaviour`, which is why the rejection has to happen at `Done` rather than when `-i` is seen.
- `Builtin::fail_parse` (`src/runtime/shell/Builtin.rs`) is the shared failure path for option parsing: given a `ParseError` it formats the `illegal option` / usage / `unsupported option` message, lets the builtin mark its state as waiting for the stderr write, then writes the message and exits 1. `cat`, `cp`, `mkdir` and `touch` report their unimplemented options through it; `rm` now does too.
- A builtin's stderr is either a real fd (the message is queued on the IOWriter and the builtin finishes from the write callback; what a non-quiet `$` uses) or a capture buffer (written synchronously; `.quiet()`). The tests run every rejection through both.

<details>
<summary>Earlier revision</summary>

The first push kept the `Once` / `Always` variants, swapped the `-i` / `-I` arms, and named the mode's short flag in the message (`--interactive=once` was reported as `-I`). Self-review pointed out that every other builtin names the option as typed and that the once/always model had no reader, so this revision records the spelling instead and drops the unused variants.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/rm.test.ts

<!-- robobun:evidence:end -->