### PR TITLE
bun test: apply setDefaultTimeout() when a test or hook starts, so calling it from beforeAll works

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1042,7 +1042,7 @@ impl CommandLineReporter {
                 | bun_test::Execution::Result::FailBecauseHookTimeoutWithDoneCallback => {
                     if Output::is_github_action() {
                         Output::print_error(format_args!(
-                            "::error title=error: a beforeEach/afterEach hook timed out for test \"{}\"::\n",
+                            "::error title=error: a hook timed out for test \"{}\"::\n",
                             bun_fmt::github_action_property(display_label)
                         ));
                         Output::flush();

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1027,14 +1027,23 @@ impl CommandLineReporter {
                     Output::flush();
                 }
                 bun_test::Execution::Result::FailBecauseTimeout
-                | bun_test::Execution::Result::FailBecauseHookTimeout
-                | bun_test::Execution::Result::FailBecauseTimeoutWithDoneCallback
-                | bun_test::Execution::Result::FailBecauseHookTimeoutWithDoneCallback => {
+                | bun_test::Execution::Result::FailBecauseTimeoutWithDoneCallback => {
                     if Output::is_github_action() {
                         Output::print_error(format_args!(
                             "::error title=error: Test \"{}\" timed out after {}ms::\n",
                             bun_fmt::github_action_property(display_label),
                             test_entry.timeout
+                        ));
+                        Output::flush();
+                    }
+                }
+                // No `test_entry.timeout` here: it is the test's, and a test whose beforeEach timed out never got one.
+                bun_test::Execution::Result::FailBecauseHookTimeout
+                | bun_test::Execution::Result::FailBecauseHookTimeoutWithDoneCallback => {
+                    if Output::is_github_action() {
+                        Output::print_error(format_args!(
+                            "::error title=error: a beforeEach/afterEach hook timed out for test \"{}\"::\n",
+                            bun_fmt::github_action_property(display_label)
                         ));
                         Output::flush();
                     }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -619,11 +619,13 @@ impl Execution {
         }
 
         let _g = group_begin!();
+        entry.timeout = entry
+            .explicit_timeout
+            .unwrap_or_else(|| super::jest::Jest::runner().map_or(0, |runner| runner.default_timeout()));
+        group_log::log(format_args!("-> entry.timeout: {}", entry.timeout));
         if entry.timeout != 0 {
-            group_log::log(format_args!("-> entry.timeout: {}", entry.timeout));
             entry.timespec = Timespec::ms_from_now_force_real_time(entry.timeout as i64);
         } else {
-            group_log::log(format_args!("-> entry.timeout: 0"));
             entry.timespec = Timespec::EPOCH;
         }
     }

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -525,7 +525,8 @@ pub struct ParseArgumentsResult {
 
 #[derive(Default, Clone, Copy)]
 pub struct ParseArgumentsOptions {
-    pub(crate) timeout: u32,
+    /// Only the timeout passed to this call; the file default is applied when the entry starts.
+    pub(crate) timeout: Option<u32>,
     pub(crate) retry: Option<u32>,
     pub(crate) repeats: u32,
 }
@@ -736,10 +737,7 @@ pub(crate) fn parse_arguments(
         return Err(global.throw(format_args!("{}(): Cannot set both retry and repeats", signature)));
     }
 
-    result.options.timeout = match timeout_option {
-        Some(timeout) => timeout as u32,
-        None => jest::Jest::runner().map_or(0, |runner| runner.default_timeout()),
-    };
+    result.options.timeout = timeout_option.map(|timeout| timeout as u32);
 
     Ok(result)
 }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1883,8 +1883,8 @@ pub enum HookTag {
 
 #[derive(Copy, Clone, Default)]
 pub struct ExecutionEntryCfg {
-    /// 0 = unlimited timeout
-    pub(crate) timeout: u32,
+    /// The entry's own timeout (0 = unlimited); `None` = the file's default when the entry starts.
+    pub(crate) timeout: Option<u32>,
     pub(crate) has_done_parameter: bool,
     /// Number of times to retry a failed test (0 = no retries)
     pub(crate) retry_count: u32,
@@ -1902,7 +1902,9 @@ pub enum AddedInPhase {
 pub struct ExecutionEntry {
     pub(crate) base: BaseScope,
     pub callback: Option<Strong>,
-    /// 0 = unlimited timeout
+    /// See `ExecutionEntryCfg::timeout`.
+    pub(crate) explicit_timeout: Option<u32>,
+    /// Timeout this run of the entry started with (0 = unlimited); set by `Execution::on_entry_started`.
     pub(crate) timeout: u32,
     pub(crate) has_done_parameter: bool,
     /// '.epoch' = not set
@@ -1931,7 +1933,8 @@ impl ExecutionEntry {
         let mut entry = Box::new(ExecutionEntry {
             base: BaseScope::init(base, name_not_owned, parent, cb.is_some()),
             callback: None,
-            timeout: cfg.timeout,
+            explicit_timeout: cfg.timeout,
+            timeout: 0,
             has_done_parameter: cfg.has_done_parameter,
             added_in_phase: phase,
             retry_count: cfg.retry_count,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -888,6 +888,25 @@ describe("bun test", () => {
       });
       expect(stderr).toMatch(/::error title=error: Test \"time out\" timed out after \d+ms::/);
     });
+    test("should annotate a hook timeout", () => {
+      const stderr = runTest({
+        input: `
+          import { beforeEach, test } from "bun:test";
+          beforeEach(async () => {
+            await Bun.sleep(1000);
+          }, 1);
+          test("never starts", () => {});
+        `,
+        env: {
+          FORCE_COLOR: "1",
+          GITHUB_ACTIONS: "true",
+        },
+      });
+      const annotations = stderr.split("\n").filter(line => line.startsWith("::error"));
+      expect(annotations).toEqual([
+        `::error title=error: a beforeEach/afterEach hook timed out for test "never starts"::`,
+      ]);
+    });
   });
   describe(".each", () => {
     test("should run tests with test.each", () => {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -903,9 +903,7 @@ describe("bun test", () => {
         },
       });
       const annotations = stderr.split("\n").filter(line => line.startsWith("::error"));
-      expect(annotations).toEqual([
-        `::error title=error: a beforeEach/afterEach hook timed out for test "never starts"::`,
-      ]);
+      expect(annotations).toEqual([`::error title=error: a hook timed out for test "never starts"::`]);
     });
   });
   describe(".each", () => {

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { copyFileSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 
@@ -568,6 +568,134 @@ test("jest.setTimeout will change default timeout", () => {
   const err = stderr!.toString();
   expect(err).not.toContain("error:");
   expect(exitCode).toBe(0);
+});
+
+describe.concurrent("setDefaultTimeout() is read when a test or hook starts, not when it is registered", () => {
+  // `args` names the files as `./x.test.ts` so bun runs exactly those, in that order, instead of
+  // treating the names as filters.
+  async function runFixture(files: Record<string, string>, args: string[]) {
+    using dir = tempDir("set-default-timeout", files);
+    await using proc = spawn({
+      cmd: [bunExe(), "test", ...args],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stderr: normalizeBunSnapshot(stderr), exitCode };
+  }
+
+  test.each([
+    ["at the top level", "setDefaultTimeout(60_000);"],
+    ["inside beforeAll", "beforeAll(() => { setDefaultTimeout(60_000); }, 60_000);"],
+  ])("raising the default %s applies to tests and hooks without their own timeout", async (_, setDefault) => {
+    // --timeout is 10ms; the hook and the test each sleep well past it, so they only pass
+    // if the 60s default set by the fixture is the one applied to them.
+    const code = /* ts */ `
+      import { beforeAll, beforeEach, setDefaultTimeout, test } from "bun:test";
+      ${setDefault}
+      beforeEach(async () => { await Bun.sleep(50); });
+      test("outlives --timeout", async () => { await Bun.sleep(50); });
+    `;
+    expect(await runFixture({ "fixture.test.ts": code }, ["--timeout", "10", "./fixture.test.ts"]))
+      .toMatchInlineSnapshot(`
+      {
+        "exitCode": 0,
+        "stderr": 
+      "fixture.test.ts:
+      (pass) outlives --timeout
+
+       1 pass
+       0 fail
+      Ran 1 test across 1 file."
+      ,
+      }
+    `);
+  });
+
+  test("lowering the default inside beforeAll applies to that file's tests without their own timeout", async () => {
+    const files = {
+      "a.test.ts": /* ts */ `
+        import { beforeAll, jest, test } from "bun:test";
+        beforeAll(() => { jest.setTimeout(50); }, 60_000);
+        const hang = () => new Promise(() => {});
+        test("uses the default set in beforeAll", hang);
+        test("keeps its own timeout", hang, 75);
+      `,
+      "b.test.ts": /* ts */ `
+        import { test } from "bun:test";
+        test("next file is back on --timeout", () => new Promise(() => {}));
+      `,
+    };
+    expect(await runFixture(files, ["--timeout", "100", "./a.test.ts", "./b.test.ts"])).toMatchInlineSnapshot(`
+      {
+        "exitCode": 1,
+        "stderr": 
+      "a.test.ts:
+      (fail) uses the default set in beforeAll
+        ^ this test timed out after 50ms.
+      (fail) keeps its own timeout
+        ^ this test timed out after 75ms.
+
+      b.test.ts:
+      (fail) next file is back on --timeout
+        ^ this test timed out after 100ms.
+
+       0 pass
+       3 fail
+      Ran 3 tests across 2 files."
+      ,
+      }
+    `);
+  });
+
+  // Preload hooks run in every file (registered once per global, or once per file under --isolate),
+  // and a preload's setDefaultTimeout() is the default every file starts from. So the hooks must get
+  // it in every file, including files after the first and the run-level afterAll (which runs in the
+  // last file, or in every file when the worker cannot know which file is its last).
+  test.each([
+    ["one shared global", []],
+    ["--isolate", ["--isolate"]],
+    // The huge scale-up delay keeps the run on one worker, so that worker runs both files.
+    ["--parallel --no-isolate", ["--parallel=2", "--parallel-delay=1000000", "--no-isolate"]],
+    ["--parallel", ["--parallel=2", "--parallel-delay=1000000"]],
+  ])("hooks registered by a preload get the preload's default in every file: %s", async (_, flags) => {
+    const files = {
+      "preload.ts": /* ts */ `
+        import { afterAll, beforeEach, setDefaultTimeout } from "bun:test";
+        // Registered before the call on purpose: only the value in effect when a hook runs may matter.
+        beforeEach(async () => { await Bun.sleep(50); });
+        afterAll(async () => { await Bun.sleep(50); });
+        setDefaultTimeout(60_000);
+      `,
+      "a.test.ts": /* ts */ `
+        import { test } from "bun:test";
+        test("a", () => {});
+      `,
+      "b.test.ts": /* ts */ `
+        import { test } from "bun:test";
+        test("b", () => {});
+      `,
+    };
+    const args = [...flags, "--timeout", "10", "--preload", "./preload.ts", "./a.test.ts", "./b.test.ts"];
+    expect(await runFixture(files, args)).toMatchInlineSnapshot(`
+      {
+        "exitCode": 0,
+        "stderr": 
+      "a.test.ts:
+      (pass) a
+
+      b.test.ts:
+      (pass) b
+
+       2 pass
+       0 fail
+      Ran 2 tests across 2 files."
+      ,
+      }
+    `);
+  });
 });
 
 it("expect().toEqual() on objects with property indices doesn't print undefined", () => {


### PR DESCRIPTION
Stacked on #39235 (this PR's base branch); merge that first. The diff shown here is only this PR's change.

### Problem
- `setDefaultTimeout(ms)` (and its alias `jest.setTimeout(ms)`) is a silent no-op when called from a `beforeAll` hook: every test in the file keeps the `--timeout` / 5000 ms default and fails with `this test timed out after 5000ms`.
- Several of our own test files call it from `beforeAll` and so are not getting the timeout they ask for (`test/js/bun/shell/commands/rm.test.ts`, `ls.test.ts`, `test/js/node/dns/node-dns.test.js`, `test/integration/esbuild/esbuild.test.ts`, `test/integration/expo-app/expo.test.ts`, and the fixture behind the existing `jest.setTimeout will change default timeout` test, which passes either way).
- Cause: `parse_arguments` (`src/runtime/test_runner/ScopeFunctions.rs`) resolved `explicit || setDefaultTimeout value || --timeout` while `test()` / `beforeEach()` etc. were being registered and stored the result on the entry. `js_set_default_timeout` (`src/runtime/test_runner/jest.rs`) only writes `TestRunner.default_timeout_override`, which nothing read after collection. Hooks run after the whole file has been collected, so a call from a hook lands too late.
- This is how it has behaved since the test runner rewrite in #22534. #10687, which added `jest.setTimeout`, resolved the default when the test ran (`TestScope.run`), which is why the in-tree `beforeAll` usages were written that way.

### Fix
- `ParseArgumentsOptions.timeout` / `ExecutionEntryCfg.timeout` become `Option<u32>`: only a timeout passed to the test or hook itself. `ExecutionEntry` keeps it as `explicit_timeout`.
- `parse_arguments` no longer calls `TestRunner::default_timeout()` (#39235's fallback chain: the file's `setDefaultTimeout()`, else the preloads', else `--timeout`); `Execution::on_entry_started` does, for entries with no `explicit_timeout`, and arms the deadline from the result as before. The reporter keeps printing `entry.timeout`, which is now the value the entry actually ran with.
- Why this is right: the precedence (own timeout, then the file's `setDefaultTimeout`, then the preloads', then `--timeout`, `0` = unlimited) is unchanged, only the moment it is read moves to entry start. That is the point at which the deadline is armed anyway, it is what the `setDefaultTimeout` JSDoc promises ("all tests in the current file"), and it restores the semantics #10687 shipped with. The per-file reset of the file's value happens after a file has finished executing, so a call in one file still does not leak into the next (covered by the test).
- **Semantics change to sign off on:** a top-level call now also applies to tests registered above it in the same file (since #22534 it only applied to tests registered after it). This is the whole-file behaviour the JSDoc describes and the one Jest has (jest-circus reads `jest.setTimeout`'s value once per file when the run starts, so position in the file does not matter there either). Every in-tree caller calls it once per file, so none is affected beyond the `beforeAll` ones starting to work.
- Why it is stacked on #39235: hooks registered by a preload are registered once and run in every file, and they too now read the default when they run. On main the only slot is reset to unset after each file, so on its own this change would move those hooks from the preload's value to `--timeout` in every file after the first (and for the run-level `afterAll`, which runs in the last file). #39235 keeps the preload's value on `BunTestRoot` for as long as the preload hooks themselves, so with it underneath the hooks get the preload's default in every file; a test here pins that in the default run, `--isolate`, `--parallel --no-isolate` and `--parallel`.
- Known limitation, left for a follow-up: a `setDefaultTimeout()` call made from inside a hook that a preload registered is attributed to the file the hook runs in (`js_set_default_timeout` routes on `vm.is_in_preload`, which is only true while the preload script itself evaluates), so from a preload's `beforeAll` it reaches the first file only. Before this PR it reached nothing; a call at the preload's top level applies to every file. Routing it by the phase of the running entry needs the current sequence (the hook may have awaited, so `on_stack_entry` is not enough), which is more than this fix should carry.
- The GitHub Actions annotation for a hook timeout (`FailBecauseHookTimeout*`) now says `a hook timed out for test "..."` instead of `Test "..." timed out after Nms`. `N` there was the test's own timeout, not the hook's, and a test whose `beforeEach` timed out never starts, so with this change it has no resolved timeout to print. It says "a hook" because `beforeAll`/`afterAll` timeouts take the same path; the plain-text reporter's pre-existing `beforeEach/afterEach` wording for those is left alone here.
- Tests:
  - `test/js/bun/test/test-test.test.ts`: raising the default above `--timeout` from the top level and from `beforeAll` (a `beforeEach` and a test without their own timeout must survive); lowering it from `beforeAll` across two files (the test without its own timeout reports the `beforeAll` value, a test with its own timeout keeps it, the next file is back on `--timeout`); preload-registered `beforeEach`/`afterAll` getting the preload's default in both files, in all four run modes. All but the top-level case fail on the current release.
  - `test/cli/test/bun-test.test.ts`: the hook-timeout annotation.
  - Also ran `bun_test.test.ts`, `test-failing.test.ts`, `jest-hooks.test.ts`, `test-retry-repeats-basic.test.ts`, `failure-skip.test.ts`, `regression/issue/23865.test.ts`, `js/node/test_runner/node-test.test.ts`, `cli/test/test-timeout-behavior.test.ts`, `cli/test/isolation.test.ts`, `cli/test/parallel.test.ts`, `concurrent.test.ts`, all of `cli/test/bun-test.test.ts` (including #39235's cases), and the shell `rm`/`ls` tests with the debug build.

### Background
- `bun test` runs a file in two phases. Collection evaluates the module, and `test()` / `describe()` / `beforeAll()` etc. register entries (`ExecutionEntry`) into a tree. Execution then walks that tree; `Execution::on_entry_started` runs right before each entry's callback is invoked and arms its deadline (`entry.timespec`), which the runner's timer checks against.
- `TestRunner` (`jest.rs`) is the per-process runner state. `default_timeout_ms` is `--timeout` (5000 by default); `default_timeout_override` is what a test file's `setDefaultTimeout()` writes (`u32::MAX` = unset), reset after every file. With #39235, a call made while the preloads evaluate goes to `BunTestRoot.preload_default_timeout_override` instead, which lives as long as the preload hooks (cleared only when `--isolate` swaps the global).
- Preload scripts (`--preload`, or `preload` under `[test]` in bunfig) are evaluated once per global, so without `--isolate` the hooks they register live in `BunTestRoot::hook_scope` and are scheduled into every file (`beforeEach`/`afterEach`), or into the first/last file (`beforeAll`/`afterAll`; every file in a `--parallel --no-isolate` worker, which does not know which file is its last).
- Hooks and tests share `ExecutionEntry`, so the same resolution covers every kind of hook registered without its own timeout.
