### PR TITLE
test runner: don't crash pretty-printing a Map or Set whose size property is not a number

### DIFF
--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1718,7 +1718,7 @@ impl<'a> Formatter<'a> {
                     let length_value = value
                         .get(self.global_this, "size")?
                         .unwrap_or_else(|| JSValue::js_number_from_int32(0));
-                    let length = length_value.to_int32();
+                    let length = length_value.coerce_to_i32(self.global_this)?;
 
                     let prev_quote_strings = self.quote_strings;
                     self.quote_strings = true;
@@ -1762,7 +1762,7 @@ impl<'a> Formatter<'a> {
                     let length_value = value
                         .get(self.global_this, "size")?
                         .unwrap_or_else(|| JSValue::js_number_from_int32(0));
-                    let length = length_value.to_int32();
+                    let length = length_value.coerce_to_i32(self.global_this)?;
 
                     let prev_quote_strings = self.quote_strings;
                     self.quote_strings = true;

--- a/test/js/bun/test/expect-map-set-size-crash.test.ts
+++ b/test/js/bun/test/expect-map-set-size-crash.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+
+test("failing matcher on a Map or Set whose size is not a number still reports the mismatch", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { expect } = require("bun:test");
+const weakSet = new WeakSet();
+weakSet.size = {};
+const weakMap = new WeakMap();
+weakMap.size = "abc";
+const set = new Set([1, 2]);
+Object.defineProperty(set, "size", { value: {} });
+const map = new Map([[1, 2]]);
+Object.defineProperty(map, "size", { value: null });
+for (const value of [weakSet, weakMap, set, map]) {
+  try {
+    expect(value).toEqual(1);
+  } catch (e) {
+    console.log(e.message);
+  }
+}`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+    "expect(received).toEqual(expected)
+
+    Expected: 1
+    Received: WeakSet {}
+
+    expect(received).toEqual(expected)
+
+    Expected: 1
+    Received: WeakMap {}
+
+    expect(received).toEqual(expected)
+
+    Expected: 1
+    Received: Set {}
+
+    expect(received).toEqual(expected)
+
+    Expected: 1
+    Received: Map {}"
+  `);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/test/expect-map-set-size-crash.test.ts
+++ b/test/js/bun/test/expect-map-set-size-crash.test.ts
@@ -15,7 +15,9 @@ const set = new Set([1, 2]);
 Object.defineProperty(set, "size", { value: {} });
 const map = new Map([[1, 2]]);
 Object.defineProperty(map, "size", { value: null });
-for (const value of [weakSet, weakMap, set, map]) {
+const selfSized = new WeakMap();
+selfSized.size = selfSized;
+for (const value of [weakSet, weakMap, set, map, { nested: selfSized }]) {
   try {
     expect(value).toEqual(1);
   } catch (e) {
@@ -49,7 +51,17 @@ for (const value of [weakSet, weakMap, set, map]) {
     expect(received).toEqual(expected)
 
     Expected: 1
-    Received: Map {}"
+    Received: Map {}
+
+    expect(received).toEqual(expected)
+
+    - 1
+    + {
+    +   "nested": WeakMap {},
+    + }
+
+    - Expected  - 1
+    + Received  + 3"
   `);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Found by fuzzing. A failing matcher on a `Map`, `Set`, `WeakMap` or `WeakSet` that carries a non-numeric `size` property took down the process while the failure message was being built.

```js
const { expect } = require("bun:test");
const ws = new WeakSet();
ws.size = {};
expect(ws).toEqual(1);
```

Debug build:

```
ASSERTION FAILED: isInt32()
JavaScriptCore/JSCJSValue.h(683) : int32_t JSC::JSValue::asInt32() const
```

Release build: the matcher message is replaced by a bare `TypeError: Type error` for `WeakSet`/`WeakMap` (the garbage length is non-zero, so the formatter tries to iterate a non-iterable), and a `Set`/`Map` whose `size` was shadowed happens to print by accident.

### Cause

The `Tag::Map` and `Tag::Set` branches of the jest pretty formatter (`src/runtime/test_runner/pretty_format.rs`, used for `expect()` diffs and snapshots) read `size` with an ordinary property get and then called `to_int32()` on it. `to_int32()` only handles numbers; for anything else it falls through to `JSC__JSValue__toInt32`, which is a plain `asInt32()`. `size` is only a prototype getter, so an own property of any type shadows it. This predates the Rust port, the Zig version had the same `toInt32()` call.

`console.log` / `Bun.inspect` (`ConsoleObject.rs`) read the same property but run it through `coerce_to_i32`, which is why they never crashed on the same values.

### Fix

Use `coerce_to_i32(global)?` in both branches, matching `ConsoleObject.rs`. A non-numeric `size` now coerces the way it does for `console.log` (`{}` -> 0, `"2"` -> 2), and a `size` whose `valueOf` throws propagates the exception the same way a throwing `size` getter already did.

With the fix the repro above reports a normal matcher failure:

```
expect(received).toEqual(expected)

Expected: 1
Received: WeakSet {}
```

### How did you verify your code works?

- The fuzzer repro and the `WeakMap`, shadowed `Set` and shadowed `Map` variants all print a matcher failure and exit 1 with the debug build instead of aborting.
- New test `test/js/bun/test/expect-map-set-size-crash.test.ts` fails on the current release (`"Type error"` messages) and on an unfixed debug build (abort), passes with `bun bd test`.
- `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts` (covers `Map`/`Set`/`WeakMap`/`WeakSet` pretty printing) and `expect-formdata-tojson-crash.test.ts` still pass with the debug build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-map-set-size-crash.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/test/expect-map-set-size-crash.test.ts:
29 |     stderr: "pipe",
30 |   });
31 | 
32 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
33 | 
34 |   expect(stderr).toBe("");
                      ^
error: expect(received).toBe(expected)

- ""
+ "ASSERTION FAILED: isInt32()
+ /root/.bun/build-cache/webkit-76882271d74a6e7f-debug-asan/include/JavaScriptCore/JSCJSValue.h(683) : int32_t JSC::JSValue::asInt32() const
+ no stacktrace available"

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/test/expect-map-set-size-crash.test.ts:34:18)
(fail) failing matcher on a Map or Set whose size is not a number still reports the mismatch [506.12ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [2.54s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (adc354d99)

test/js/bun/test/expect-map-set-size-crash.test.ts:
30 |   });
31 | 
32 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
33 | 
34 |   expect(stderr).toBe("");
35 |   expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
                                            ^
error: expect(received).toMatchInlineSnapshot(expected)

  
- "expect(received).toEqual(expected)
- 
- Expected: 1
- Received: WeakSet {}
- 
+ "Type error
+ Type error
  expect(received).toEqual(expected)
  
- Expected: 1
- Received: WeakMap {}
+ - 1
+ + Set {
+ +   1,
+ +   2,
+ + }
  
- expect(received).toEqual(expected)
- 
- Expected: 1
- Received: Set {}
- 
- expect(received).toEqual(expected)
- 
- Expected: 1
- Received: Map {}
+ - Expected  - 1
+ + Received  + 4
  
  expect(received).toEqual(expected)
  
  - 1
- + {
- +   "nested": WeakMap {},
+ + Map {
+ +   1 => 2,
  + }
  
  - Expected  - 1
- + Received  + 3"
- 
+ + Received  + 3
+ 
+ Type error"
+ 

- Expected  - 20
+ Received  + 15

      at <anonymous> (/workspace/bun/test/js/bun/test/expect-map-set-size-crash.test.ts:35:40)
(fail) fail
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-map-set-size-crash.test.ts
bun test v1.4.1 (adc354d99)

test/js/bun/test/expect-map-set-size-crash.test.ts:
(pass) failing matcher on a Map or Set whose size is not a number still reports the mismatch [419.12ms]

 1 pass
 0 fail
 1 snapshots, 3 expect() calls
Ran 1 test across 1 file. [2.41s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 589ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 116 exports (host=5, lazy=10, generic=101, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_react_compiler v0.0.0 (/workspace/bun/src/react_compiler)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/pretty_format.rs           |  4 +-
 test/js/bun/test/expect-map-set-size-crash.test.ts | 67 ++++++++++++++++++++++
 2 files changed, 69 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/runtime/test_runner/pretty_format.rs                4      2      0
test/js/bun/test/expect-map-set-size-crash.test.ts      2      7      0
```

</details>

<!-- robobun:evidence:end -->