### PR TITLE
shell(cp): name the operand as written in the builtin's stat errors

### DIFF
--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -569,22 +569,20 @@ impl ShellCpTask {
             .is_some_and(|&c| resolve_path::Platform::AUTO.is_separator(c))
     }
 
-    /// `path` is `operand` resolved against the shell's cwd; the error names
-    /// `operand` as the user wrote it, which is what the message prints.
-    fn is_dir(path: &bun_core::ZStr, operand: &[u8]) -> bun_sys::Maybe<bool> {
+    fn is_dir(path: &bun_core::ZStr) -> bun_sys::Maybe<bool> {
         #[cfg(windows)]
         {
             match bun_sys::get_file_attributes(path) {
                 Some(attrs) => Ok(attrs.is_directory),
                 None => Err(
                     bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::copyfile)
-                        .with_path(operand),
+                        .with_path(path.as_bytes()),
                 ),
             }
         }
         #[cfg(not(windows))]
         {
-            let st = bun_sys::lstat(path).map_err(|e| e.with_path(operand))?;
+            let st = bun_sys::lstat(path)?;
             Ok(bun_sys::S::ISDIR(st.st_mode as _))
         }
     }
@@ -627,9 +625,12 @@ impl ShellCpTask {
         //   folder -> folder
         // We need to check dest to see what it is; if it doesn't exist we
         // need to create it.
-        let src_is_dir = match Self::is_dir(src, &self.src) {
+        //
+        // Errors about an operand name it as the user wrote it (like the other
+        // builtins), not the resolved path the check ran on.
+        let src_is_dir = match Self::is_dir(src) {
             Ok(x) => x,
-            Err(e) => return Some(ShellErr::new_sys(&e)),
+            Err(e) => return Some(ShellErr::new_sys(&e.with_path(&self.src))),
         };
 
         // Any source directory without -R is an error.
@@ -652,13 +653,13 @@ impl ShellCpTask {
             ));
         }
 
-        let (tgt_is_dir, tgt_exists) = match Self::is_dir(tgt, &self.tgt) {
+        let (tgt_is_dir, tgt_exists) = match Self::is_dir(tgt) {
             Ok(is_dir) => (is_dir, true),
             Err(e) if e.get_errno() == bun_sys::E::ENOENT => {
                 // If it has a trailing directory separator, it's a directory.
                 (Self::has_trailing_sep(tgt.as_bytes()), false)
             }
-            Err(e) => return Some(ShellErr::new_sys(&e)),
+            Err(e) => return Some(ShellErr::new_sys(&e.with_path(&self.tgt))),
         };
 
         let mut _copying_many = false;

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -569,20 +569,22 @@ impl ShellCpTask {
             .is_some_and(|&c| resolve_path::Platform::AUTO.is_separator(c))
     }
 
-    fn is_dir(path: &bun_core::ZStr) -> bun_sys::Maybe<bool> {
+    /// `path` is `operand` resolved against the shell's cwd; the error names
+    /// `operand` as the user wrote it, which is what the message prints.
+    fn is_dir(path: &bun_core::ZStr, operand: &[u8]) -> bun_sys::Maybe<bool> {
         #[cfg(windows)]
         {
             match bun_sys::get_file_attributes(path) {
                 Some(attrs) => Ok(attrs.is_directory),
                 None => Err(
                     bun_sys::Error::from_code(bun_sys::E::ENOENT, bun_sys::Tag::copyfile)
-                        .with_path(path.as_bytes()),
+                        .with_path(operand),
                 ),
             }
         }
         #[cfg(not(windows))]
         {
-            let st = bun_sys::lstat(path)?;
+            let st = bun_sys::lstat(path).map_err(|e| e.with_path(operand))?;
             Ok(bun_sys::S::ISDIR(st.st_mode as _))
         }
     }
@@ -625,7 +627,7 @@ impl ShellCpTask {
         //   folder -> folder
         // We need to check dest to see what it is; if it doesn't exist we
         // need to create it.
-        let src_is_dir = match Self::is_dir(src) {
+        let src_is_dir = match Self::is_dir(src, &self.src) {
             Ok(x) => x,
             Err(e) => return Some(ShellErr::new_sys(&e)),
         };
@@ -650,7 +652,7 @@ impl ShellCpTask {
             ));
         }
 
-        let (tgt_is_dir, tgt_exists) = match Self::is_dir(tgt) {
+        let (tgt_is_dir, tgt_exists) = match Self::is_dir(tgt, &self.tgt) {
             Ok(is_dir) => (is_dir, true),
             Err(e) if e.get_errno() == bun_sys::E::ENOENT => {
                 // If it has a trailing directory separator, it's a directory.

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -625,9 +625,6 @@ impl ShellCpTask {
         //   folder -> folder
         // We need to check dest to see what it is; if it doesn't exist we
         // need to create it.
-        //
-        // Errors about an operand name it as the user wrote it (like the other
-        // builtins), not the resolved path the check ran on.
         let src_is_dir = match Self::is_dir(src) {
             Ok(x) => x,
             Err(e) => return Some(ShellErr::new_sys(&e.with_path(&self.src))),

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -171,6 +171,84 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
   });
+});
+
+// The builtin stats each operand after resolving it against the cwd and used to
+// put the resolved path in the error; the message has to name the operand as
+// written, like ls/rm/mv and the system cp do. Runs in a child process because
+// the builtin is off by default on POSIX (builtinDisabled above), where the env
+// var turns it on.
+test("stat errors name the operand as written", async () => {
+  using dir = tempDir("cp-operand-as-written", {
+    "f.txt": "source",
+    "g.txt": "not a directory",
+    "sub": {},
+    "dir": {},
+  });
+  const cases = {
+    missingSource: ["missing.txt", "dest.txt"],
+    missingSourceInSubdir: ["sub/missing.txt", "dest.txt"],
+    unnormalizedSource: ["./missing.txt", "dest.txt"],
+    missingSourceRecursive: ["-R", "missing", "dest"],
+    // Each source is its own task and reports its own operand; f.txt is still copied.
+    missingSourcesAmongOthers: ["missing1.txt", "f.txt", "missing2.txt", "dir"],
+    // A target is only an error when the failure is something other than
+    // ENOENT (a missing target is created). On Windows the builtin reports
+    // every stat failure as ENOENT, so these two exist on POSIX only.
+    ...(isWindows
+      ? {}
+      : {
+          fileAsSourceDirectory: ["f.txt/x", "dest.txt"],
+          fileAsTargetDirectory: ["f.txt", "g.txt/x"],
+        }),
+  };
+  const script = /* ts */ `
+    import { $ } from "bun";
+    import { existsSync } from "node:fs";
+    $.nothrow();
+    const results = {};
+    for (const [name, args] of Object.entries(${JSON.stringify(cases)})) {
+      const { exitCode, stderr } = await $\`cp \${args}\`.quiet();
+      results[name] = { exitCode, stderr: stderr.toString() };
+    }
+    results.missingSourcesAmongOthers.otherCopied = existsSync("dir/f.txt");
+    console.log(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const results = JSON.parse(stdout);
+  // The two failing sources finish in whichever order the pool runs them.
+  results.missingSourcesAmongOthers.stderr = sortedShellOutput(results.missingSourcesAmongOthers.stderr);
+
+  const failed = (operand: string, message = "No such file or directory") => ({
+    exitCode: 1,
+    stderr: `cp: ${message}: ${operand}\n`,
+  });
+  expect(results).toEqual({
+    missingSource: failed("missing.txt"),
+    missingSourceInSubdir: failed("sub/missing.txt"),
+    unnormalizedSource: failed("./missing.txt"),
+    missingSourceRecursive: failed("missing"),
+    missingSourcesAmongOthers: {
+      exitCode: 1,
+      stderr: sortedShellOutput(failed("missing1.txt").stderr + failed("missing2.txt").stderr),
+      otherCopied: true,
+    },
+    ...(isWindows
+      ? {}
+      : {
+          fileAsSourceDirectory: failed("f.txt/x", "Not a directory"),
+          fileAsTargetDirectory: failed("g.txt/x", "Not a directory"),
+        }),
+  });
+  expect(exitCode).toBe(0);
 });
 
 function expectSortedOutput(expected: string) {


### PR DESCRIPTION
### Problem
- The shell `cp` builtin (on by default on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on POSIX) names the path it resolved instead of the operand the user typed when an operand cannot be stat-ed. With cwd `/tmp/x`, on bun 1.4.0:
  ```
  $ cp missing.txt dest.txt
  cp: No such file or directory: /tmp/x/missing.txt
  $ cp f.txt g.txt/x          # g.txt is a file
  cp: Not a directory: /tmp/x/g.txt/x
  ```
  GNU cp prints `cp: cannot stat 'missing.txt': No such file or directory`, BSD cp prints `cp: missing.txt: No such file or directory`, and bun's `ls`, `rm` and `mv` builtins print `missing.txt` (#39189 does the same for cat, touch and mkdir). cp's own messages for the other operand problems (`X is a directory (not copied)`, `directory X does not exist`, ...) already use the operand as written, so one command mixes both forms.
- Found while probing the builtin's error output; there is no user report of it.
- Cause: `ShellCpTask::run_from_thread_pool_impl` (`src/runtime/shell/builtin/cp.rs`) joins `self.src` / `self.tgt` onto the cwd and stats the joined paths through `is_dir`, whose error carries the path it stat-ed (`lstat` tags it on POSIX, the Windows branch tags it explicitly). The two `Err` arms pass that error to `ShellErr::new_sys` unchanged, and `Builtin::shell_err_to_string` prints whatever path it carries.

### Fix
- The two `Err` arms that report a stat failure (source check and target check) re-tag the error with the operand, `e.with_path(&self.src)` / `e.with_path(&self.tgt)`, before it becomes a `ShellErr`. Two lines; `is_dir` is unchanged.
- Correct because the operand is what the user typed and can act on, and it is the form every other builtin and both system cps print. `with_path` copies errno and syscall, so the target arm that treats ENOENT as "target does not exist yet" (matched before this arm) is unaffected, and the exit code is still 1.
- The re-tag lives at the report sites rather than inside `is_dir` for two reasons: that is where `ls` and `rm` tag theirs (`error_with_path`), and several open PRs restructure the stat calls themselves (#38162 resolves the operands through a new helper, #37954 stats the source directly, #37956 classifies the target through symlinks) while leaving these two `Err` arms as they are, so the change merges with each of them either way. The test pins the message for whichever lands later.
- The Windows EBUSY pass compares error paths against `src_absolute` / `tgt_absolute`, but those are set only after both checks pass, so a stat error was never a candidate for it and is not now. Errors from the copy itself (`cp_on_finish`) still carry the absolute paths that pass relies on.
- Not changed here: the word order of cp's sys errors (`cp: <message>: <path>`, where the other builtins print `<path>: <message>`) and the absolute paths in errors raised during the copy. Both would change messages that the open cp PRs above pin in their tests, and the second needs the copied tree's paths mapped back onto the operands; they are separate changes if wanted.
- Test: `test/js/bun/shell/commands/cp.test.ts`, "stat errors name the operand as written". Runs the builtin in a child process with the flag set (the in-process suite in that file is skipped on POSIX) and covers a missing source spelled `missing.txt`, `sub/missing.txt` and `./missing.txt` (as written, not normalized), a missing source with `-R`, two missing sources around a good one (each line names its own operand, the good one is still copied, exit 1), and on POSIX the non-ENOENT case at both sites: `f.txt/x` as source and `g.txt/x` as target, both `Not a directory`. On Windows the builtin maps every stat failure to ENOENT, so the target arm cannot be reached there and those two cases are POSIX-only.
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/cp.test.ts`: the new test fails; every case differs only by the path in the message.
  - `bun bd test test/js/bun/shell/commands/cp.test.ts`: passes.
  - A 22-case probe (all three synopses with and without `-v`, trailing slashes, identical files, the Custom messages, an empty operand, resulting file trees) gives identical output on 1.4.0 and this build except for the six stat-error messages, which now name the operand; list below.
  - `cargo clippy -p bun_runtime --no-deps`, `cargo fmt --check` and `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` pass.

### Background
- Shell builtins live in `src/runtime/shell/builtin/` and run in-process. `cp` is dispatched by default on Windows only; on POSIX it needs `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`, otherwise the system binary is spawned.
- `ShellCpTask` is created per source operand and runs on a work-pool thread. It resolves both operands to absolute paths (the node:fs copy it hands off to does not know the shell's cwd), stats them to pick the POSIX cp synopsis, then calls `fs.cp`. Those two stat checks are the only place the builtin itself reports an error about an operand; everything after that is reported by node:fs with the paths it was given.
- `bun_sys::Error` carries an errno, a syscall tag and a path; `with_path` returns a copy with a different path. `ShellErr::Sys` is how builtins report such errors; for cp it is rendered by `shell_err_to_string` as `cp: <coreutils message>: <path>` and turned into exit code 1.

<details>
<summary>Probe: output identical on bun 1.4.0 and this build except for these six lines</summary>

Run with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on Linux in a directory with files `a`, `b`, directories `dir` and `sub/inner` (containing `c`); exit code, stdout, stderr and the resulting tree compared for:
`cp -v a new`, `cp -v a b`, `cp -v a dir`, `cp -v a dir/`, `cp -v a b dir`, `cp a b new`, `cp a ./a`, `cp -R sub dir`, `cp -R sub newdir`, `cp -R sub/ newdir2`, `cp -R a dir2`, `cp -R a b nodir`, `cp sub x`, `cp missing x`, `cp ./missing x`, `cp sub/missing x`, `cp /no-such-dir/missing x`, `cp a/x y`, `cp a b/x`, `cp -R a b/x`, `cp a b dir/nope`, `cp "" x`.

```
-cp: No such file or directory: <cwd>/w/missing        (cp missing x)
+cp: No such file or directory: missing
-cp: No such file or directory: <cwd>/w/missing        (cp ./missing x)
+cp: No such file or directory: ./missing
-cp: No such file or directory: <cwd>/w/sub/missing    (cp sub/missing x)
+cp: No such file or directory: sub/missing
-cp: Not a directory: <cwd>/w/a/x                      (cp a/x y)
+cp: Not a directory: a/x
-cp: Not a directory: <cwd>/w/b/x                      (cp a b/x)
+cp: Not a directory: b/x
-cp: Not a directory: <cwd>/w/b/x                      (cp -R a b/x)
+cp: Not a directory: b/x
```
</details>

<details>
<summary>Earlier shape of this PR</summary>

The first revision gave `is_dir` an `operand` parameter and tagged the error inside it, on both platform branches. Self-review pointed out that the open PRs listed above replace or remove the `is_dir` calls while keeping the two `Err` arms, so the re-tag moved to the arms and `is_dir` went back to what it is on main. The behavior and the test are the same in both revisions.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->