### PR TITLE
Bump WebKit (oven-sh/WebKit#448 preview): find cgroup limits when /proc/self/cgroup has lines before the 0:: one

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f0f60fd2324817dae9656d8bf2fcae25ceaccc37";
+export const WEBKIT_VERSION = "autobuild-preview-pr-448-5a758cc7";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,7 +1,7 @@
 import { spawnSync, which } from "bun";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { basename, join, resolve } from "path";
 
 const process_sleep = resolve(import.meta.dir, "process-sleep.js");
@@ -2545,4 +2545,66 @@ it("no socket close handler runs after the 'exit' event", async () => {
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
   expect(stdout).toBe("exit\n");
   expect(exitCode).toBe(0);
+});
+
+// process.constrainedMemory() and navigator.hardwareConcurrency come from the
+// cgroup the process is in: its path is read from /proc/self/cgroup and the
+// limits from /sys/fs/cgroup/<path>/{memory.max,cpu.max}. Both locations can be
+// faked without privileges wherever unprivileged user namespaces are enabled:
+// inside a user+mount namespace, bind-mount our own file over /proc/self/cgroup
+// and our own directory over /sys/fs/cgroup, then exec bun from the pid that
+// did the mounting so that its /proc/self/cgroup is the bind-mounted file.
+// 256 MiB and 1 cpu are below any host's resources, so the expected output is
+// the same on every machine.
+const fakeCgroupLimits = { "memory.max": "268435456\n", "cpu.max": "100000 100000\n" };
+const fakeCgroupLimitsReport = "268435456 1\n";
+
+function reportLimitsWithFakeCgroups(unshare, procSelfCgroup, sysFsCgroup) {
+  using dir = tempDir("fake-cgroup", { cgroup: procSelfCgroup, sys: sysFsCgroup });
+  return spawnSync({
+    cmd: [
+      unshare,
+      "-U",
+      "-r",
+      "-m",
+      "sh",
+      "-c",
+      'mount --bind "$1" /proc/self/cgroup && mount --bind "$2" /sys/fs/cgroup && ' +
+        'exec "$3" -e "console.log(process.constrainedMemory(), navigator.hardwareConcurrency)"',
+      "sh",
+      join(String(dir), "cgroup"),
+      join(String(dir), "sys"),
+      bunExe(),
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+// The layout every container runtime produces on a cgroup v2 host doubles as
+// the probe for whether this machine lets us fake cgroups at all.
+const unshare = isLinux ? which("unshare") : null;
+const canFakeCgroups =
+  unshare !== null &&
+  reportLimitsWithFakeCgroups(unshare, "0::/\n", fakeCgroupLimits).stdout.toString() === fakeCgroupLimitsReport;
+
+describe.skipIf(!canFakeCgroups)("cgroup limits when /proc/self/cgroup has more than the cgroup v2 line", () => {
+  // A cgroup v1 hierarchy mounted with only a name (cgroupfs-mount,
+  // docker-in-docker and LXC hosts do this) coexists with cgroup v2 and is
+  // listed before the "0::" line. Detection used to require "0::" at the very
+  // start of the file and otherwise reported the host's RAM and core count.
+  it("named cgroup v1 hierarchy listed before the 0:: line", () => {
+    const { stdout, exitCode } = reportLimitsWithFakeCgroups(unshare, "1:name=systemd:/\n0::/\n", fakeCgroupLimits);
+    expect(stdout.toString()).toBe(fakeCgroupLimitsReport);
+    expect(exitCode).toBe(0);
+  });
+
+  it("named cgroup v1 hierarchy listed before a nested 0:: path", () => {
+    const { stdout, exitCode } = reportLimitsWithFakeCgroups(unshare, "1:name=systemd:/\n0::/docker/abc\n", {
+      docker: { abc: fakeCgroupLimits },
+    });
+    expect(stdout.toString()).toBe(fakeCgroupLimitsReport);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -2551,60 +2551,77 @@ it("no socket close handler runs after the 'exit' event", async () => {
 // cgroup the process is in: its path is read from /proc/self/cgroup and the
 // limits from /sys/fs/cgroup/<path>/{memory.max,cpu.max}. Both locations can be
 // faked without privileges wherever unprivileged user namespaces are enabled:
-// inside a user+mount namespace, bind-mount our own file over /proc/self/cgroup
-// and our own directory over /sys/fs/cgroup, then exec bun from the pid that
-// did the mounting so that its /proc/self/cgroup is the bind-mounted file.
+// inside a user+mount namespace, bind-mount a file of ours over the shell's
+// /proc/<pid>/cgroup and a directory of ours over /sys/fs/cgroup, then exec bun
+// from that shell so it keeps the pid whose cgroup file was replaced. (It has to
+// be the shell's $$: /proc/self inside `mount` would be mount's own pid.)
 // 256 MiB and 1 cpu are below any host's resources, so the expected output is
 // the same on every machine.
 const fakeCgroupLimits = { "memory.max": "268435456\n", "cpu.max": "100000 100000\n" };
-const fakeCgroupLimitsReport = "268435456 1\n";
+const nestedFakeCgroupLimits = { a: { b: fakeCgroupLimits } };
+const fakeCgroupLimitsReport = { stdout: "268435456 1\n", stderr: "", exitCode: 0 };
+const unshare = isLinux ? which("unshare") : null;
 
-function reportLimitsWithFakeCgroups(unshare, procSelfCgroup, sysFsCgroup) {
+function fakeCgroupsCmd(dir) {
+  return [
+    unshare,
+    "-U",
+    "-r",
+    "-m",
+    "sh",
+    "-c",
+    'mount --bind "$1" /proc/$$/cgroup && mount --bind "$2" /sys/fs/cgroup && ' +
+      'exec "$3" -e "console.log(process.constrainedMemory(), navigator.hardwareConcurrency)"',
+    "sh",
+    join(dir, "cgroup"),
+    join(dir, "sys"),
+    bunExe(),
+  ];
+}
+
+async function reportLimitsWithFakeCgroups(procSelfCgroup, sysFsCgroup) {
   using dir = tempDir("fake-cgroup", { cgroup: procSelfCgroup, sys: sysFsCgroup });
-  return spawnSync({
-    cmd: [
-      unshare,
-      "-U",
-      "-r",
-      "-m",
-      "sh",
-      "-c",
-      'mount --bind "$1" /proc/self/cgroup && mount --bind "$2" /sys/fs/cgroup && ' +
-        'exec "$3" -e "console.log(process.constrainedMemory(), navigator.hardwareConcurrency)"',
-      "sh",
-      join(String(dir), "cgroup"),
-      join(String(dir), "sys"),
-      bunExe(),
-    ],
+  await using proc = Bun.spawn({ cmd: fakeCgroupsCmd(String(dir)), env: bunEnv, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// Run the plain cgroup v2 layout up front. Its exit code only says whether the
+// namespace and both mounts worked and bun ran (the mounts are chained with &&
+// and the script bun runs always exits 0), and that is all that gates the
+// block; what bun printed is asserted by the first test, so a wrong answer
+// fails instead of skipping. The nested path makes sure the answer can only
+// have come from the faked /proc/<pid>/cgroup, not from the real one.
+const fakeCgroupsProbe = (() => {
+  if (unshare === null) return null;
+  using dir = tempDir("fake-cgroup", { cgroup: "0::/a/b\n", sys: nestedFakeCgroupLimits });
+  const { stdout, stderr, exitCode } = spawnSync({
+    cmd: fakeCgroupsCmd(String(dir)),
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-}
+  return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
+})();
 
-// The layout every container runtime produces on a cgroup v2 host doubles as
-// the probe for whether this machine lets us fake cgroups at all.
-const unshare = isLinux ? which("unshare") : null;
-const canFakeCgroups =
-  unshare !== null &&
-  reportLimitsWithFakeCgroups(unshare, "0::/\n", fakeCgroupLimits).stdout.toString() === fakeCgroupLimitsReport;
+describe.skipIf(fakeCgroupsProbe?.exitCode !== 0)("cgroup limits read through /proc/self/cgroup", () => {
+  it("0:: line only, as container runtimes produce it", () => {
+    expect(fakeCgroupsProbe).toEqual(fakeCgroupLimitsReport);
+  });
 
-describe.skipIf(!canFakeCgroups)("cgroup limits when /proc/self/cgroup has more than the cgroup v2 line", () => {
   // A cgroup v1 hierarchy mounted with only a name (cgroupfs-mount,
   // docker-in-docker and LXC hosts do this) coexists with cgroup v2 and is
   // listed before the "0::" line. Detection used to require "0::" at the very
   // start of the file and otherwise reported the host's RAM and core count.
-  it("named cgroup v1 hierarchy listed before the 0:: line", () => {
-    const { stdout, exitCode } = reportLimitsWithFakeCgroups(unshare, "1:name=systemd:/\n0::/\n", fakeCgroupLimits);
-    expect(stdout.toString()).toBe(fakeCgroupLimitsReport);
-    expect(exitCode).toBe(0);
+  it.concurrent("named cgroup v1 hierarchy listed before the 0:: line", async () => {
+    expect(await reportLimitsWithFakeCgroups("1:name=systemd:/\n0::/\n", fakeCgroupLimits)).toEqual(
+      fakeCgroupLimitsReport,
+    );
   });
 
-  it("named cgroup v1 hierarchy listed before a nested 0:: path", () => {
-    const { stdout, exitCode } = reportLimitsWithFakeCgroups(unshare, "1:name=systemd:/\n0::/docker/abc\n", {
-      docker: { abc: fakeCgroupLimits },
-    });
-    expect(stdout.toString()).toBe(fakeCgroupLimitsReport);
-    expect(exitCode).toBe(0);
+  it.concurrent("named cgroup v1 hierarchy listed before a nested 0:: path", async () => {
+    expect(await reportLimitsWithFakeCgroups("1:name=systemd:/\n0::/a/b\n", nestedFakeCgroupLimits)).toEqual(
+      fakeCgroupLimitsReport,
+    );
   });
 });


### PR DESCRIPTION
### Problem
- In a container with `--memory` / `--cpus` limits, bun sizes itself from the host whenever `/proc/self/cgroup` has any line in front of the `0::` one: `process.constrainedMemory()` returns host RAM, `navigator.hardwareConcurrency` / `os.availableParallelism()` return host cores, JSC paces its heap against host RAM, and bun's own thread pools and JSC's GC/JIT threads are sized from host cores. Measured on such a host with a 60 MB-live workload: ~230 MB RSS under a working 256 MiB detection, OOM-killed below 768 MiB once detection is defeated; `--cpus=1` goes from 6 to 71 threads.
- That layout is produced by a cgroup v1 hierarchy mounted with only a name (`mount -t cgroup -o none,name=foo`, which cgroupfs-mount, docker-in-docker and LXC style setups do) on an otherwise cgroup v2 host. It adds a `1:name=foo:/` line, and the kernel lists hierarchies by descending id, so `0::` is no longer the first line.
- Cause: all of the values above come from `WTF::ramSize()` and `WTF::numberOfProcessorCores()`, which read the limits in WebKit's `Source/WTF/wtf/uv_get_constrained_memory.cpp`. Both readers decided between cgroup v1 and v2 with `strncmp(buf, "0::/", 4)` on the start of the file, took the v1 path, found no `memory` / `cpu` controller there and reported no limit. Bun has no other copy of this logic (`memory_pressure.rs` already scans for the `0::` line).

### Fix
- oven-sh/WebKit#448 makes both readers find the `0::` line anywhere in the file, with a v1 line listing the controller still taking precedence (cgroup v1 and hybrid hosts keep their current behaviour). Its description has a before/after table over 13 synthetic `/proc/self/cgroup` layouts.
- This PR points `WEBKIT_VERSION` at that PR's preview build (`autobuild-preview-pr-448-5a758cc7`) so CI runs against it. Before landing, oven-sh/WebKit#448 has to merge and `WEBKIT_VERSION` has to be repointed at the resulting main sha.
- Test: `test/js/node/process/process.test.js`, block "cgroup limits read through /proc/self/cgroup". Each case runs a child bun in an unprivileged user+mount namespace (`unshare -U -r -m`), bind-mounts a test-written file over the shell's `/proc/<pid>/cgroup` and a test-written directory (`memory.max` = 256 MiB, `cpu.max` = 1 cpu) over `/sys/fs/cgroup`, execs bun from that shell, and expects `process.constrainedMemory()` and `navigator.hardwareConcurrency` to print `268435456 1`. Cases: `0::/a/b` alone (also the probe: its exit code says whether the namespace and mounts work on the machine and gates the block; its output is asserted like the others), `1:name=systemd:/` before `0::/`, and `1:name=systemd:/` before `0::/a/b`.
- Fail-before, recorded in CI with the test pushed ahead of the bump (build 98812, current pin): the probe case passed and both named-hierarchy cases failed with host values on debian 13 x64 / x64-asan / aarch64 and alpine 3.23 x64 / aarch64 (for example `8168341504 4` instead of `268435456 1`). Machines without unprivileged user namespaces skip the block; this includes docker containers without `CAP_SYS_ADMIN`.
- Local: bun built against the preview reports the same values as before for the plain layout in this (normally laid out) container, and `process.test.js` is otherwise unchanged in outcome.

### Background
- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit; `scripts/build/deps/webkit.ts` pins which build. A fix in WTF lands as a WebKit PR plus a bump here, and `autobuild-preview-pr-*` tags are how a bump PR runs bun's suite against a WebKit PR before it merges.
- `/proc/self/cgroup` has one line per mounted hierarchy, `id:controllers:path`. v1 hierarchies have id >= 1 and list their controllers (or `name=foo` when they have none); the unified v2 hierarchy is always `0::<path>` and, being id 0, always the last line. A controller lives in exactly one hierarchy, which is why a v1 line listing it decides where the limits are read from.
- `WTF::ramSize()` is `min(cgroup memory limit, sysinfo total)`; JSC's `Heap` copies it into `m_ramSize` and uses it for `proportionalHeapSize()` and the critical-memory threshold, which is where the RAM-proportional growth comes from. `WTF::numberOfProcessorCores()` is `min(online cpus, affinity, cgroup cpu quota)`; JSC derives GC marker and compiler thread counts from it and bun's `bun_core::util` thread counts call it through `WTF__numberOfProcessorCores()`.
- The test mounts over `/proc/$$/cgroup` rather than `/proc/self/cgroup` because `/proc/self` inside the `mount` binary is mount's own pid; the first version of the test made that mistake, and only the `/sys/fs/cgroup` half of the fixture was in effect (build 98797).
- Workaround on current releases: `BUN_JSC_forceRAMSize=$(cat /sys/fs/cgroup/memory.max)` restores the heap pacing and `WTF_numberOfProcessorCores=<n>` the thread counts; the values reported to JS stay wrong until the bump.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->