### PR TITLE
Honor Bun.file().slice() bounds for unread file streams and in file routes

### DIFF
--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -373,19 +373,22 @@ impl FileRoute {
             }
         });
 
-        let (can_serve_file, size, file_type, pollable): (bool, u64, FileType, bool) = 'brk: {
+        // The blob's window clamped to the file as it is now (a slice past EOF
+        // is cut short or empty), as `RequestContext::do_sendfile` does.
+        let (can_serve_file, offset, size, file_type, pollable) = 'brk: {
             let stat = match bun_sys::fstat(fd) {
                 Ok(s) => s,
                 // file_type is never read because can_serve_file == false
-                Err(_) => break 'brk (false, 0, FileType::File, false),
+                Err(_) => break 'brk (false, 0, 0, FileType::File, false),
             };
 
             let stat_size: u64 = u64::try_from(stat.st_size.max(0)).expect("int cast");
-            let _size: u64 = stat_size.min(this.blob.size.get());
+            let offset: u64 = this.blob.offset.get().min(stat_size);
+            let size: u64 = this.blob.size.get().min(stat_size - offset);
 
             let mode = stat.st_mode as bun_sys::Mode;
             if bun_sys::S::ISDIR(mode) {
-                break 'brk (false, 0, FileType::File, false);
+                break 'brk (false, 0, 0, FileType::File, false);
             }
 
             // `Cell::take` → mutate → `set`: single-threaded event loop, no
@@ -395,14 +398,14 @@ impl FileRoute {
             this.stat_hash.set(sh);
 
             if bun_sys::S::ISFIFO(mode) || bun_sys::S::ISCHR(mode) {
-                break 'brk (true, _size, FileType::Pipe, true);
+                break 'brk (true, offset, size, FileType::Pipe, true);
             }
 
             if bun_sys::S::ISSOCK(mode) {
-                break 'brk (true, _size, FileType::Socket, true);
+                break 'brk (true, offset, size, FileType::Socket, true);
             }
 
-            break 'brk (true, _size, FileType::File, false);
+            break 'brk (true, offset, size, FileType::File, false);
         };
 
         if !can_serve_file {
@@ -466,37 +469,42 @@ impl FileRoute {
             return;
         }
 
+        // A regular file always gets a length (even 0), so the body sent is
+        // exactly the Content-Length written below; pipes and sockets are
+        // read to EOF.
         let (body_offset, body_len): (u64, Option<u64>) = match range {
             RangeRequest::Result::Satisfiable { .. } => {
                 let (start, len) = write_content_range(resp, range, size).unwrap();
-                (this.blob.offset.get() + start, Some(len))
+                (offset + start, Some(len))
             }
             RangeRequest::Result::Unsatisfiable => {
                 write_content_range(resp, range, size);
                 resp.end(b"", resp.should_close_connection());
                 return;
             }
-            RangeRequest::Result::None => (
+            RangeRequest::Result::None => {
                 if file_type == FileType::File {
-                    this.blob.offset.get()
+                    (offset, Some(size))
                 } else {
-                    0
-                },
-                if file_type == FileType::File && this.blob.size.get() > 0 {
-                    Some(size)
-                } else {
-                    None
-                },
-            ),
+                    (0, None)
+                }
+            }
         };
 
-        if file_type == FileType::File && !resp.state().has_written_content_length_header() {
-            resp.write_header_int(b"content-length", body_len.unwrap_or(size));
-            resp.mark_wrote_content_length_header();
+        if let Some(len) = body_len {
+            if !resp.state().has_written_content_length_header() {
+                resp.write_header_int(b"content-length", len);
+                resp.mark_wrote_content_length_header();
+            }
         }
 
         if method == Method::HEAD {
             resp.end_without_body(resp.should_close_connection());
+            return;
+        }
+
+        if body_len == Some(0) {
+            resp.end(b"", resp.should_close_connection());
             return;
         }
 

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -373,8 +373,6 @@ impl FileRoute {
             }
         });
 
-        // The blob's window clamped to the file as it is now (a slice past EOF
-        // is cut short or empty), as `RequestContext::do_sendfile` does.
         let (can_serve_file, offset, size, file_type, pollable) = 'brk: {
             let stat = match bun_sys::fstat(fd) {
                 Ok(s) => s,
@@ -469,9 +467,7 @@ impl FileRoute {
             return;
         }
 
-        // A regular file always gets a length (even 0), so the body sent is
-        // exactly the Content-Length written below; pipes and sockets are
-        // read to EOF.
+        // `None` (read to EOF) is only for pipes and sockets; a file's body is its Content-Length.
         let (body_offset, body_len): (u64, Option<u64>) = match range {
             RangeRequest::Result::Satisfiable { .. } => {
                 let (start, len) = write_content_range(resp, range, size).unwrap();

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -226,6 +226,15 @@ impl ReadableStream {
                 let blobby = self.ptr.file().expect("matched File");
                 if let webcore::file_reader::Lazy::Blob(store) = blobby.lazy.get() {
                     let blob = Blob::init_with_store(store.clone(), global_this);
+                    // `init_with_store` spans the whole store; the window of the
+                    // Blob this stream was made from lives on the reader
+                    // (see `from_blob_copy_ref`).
+                    if let Some(offset) = blobby.start_offset {
+                        blob.offset.set(offset as webcore::blob::SizeType);
+                    }
+                    if let Some(size) = blobby.max_size {
+                        blob.size.set(size as webcore::blob::SizeType);
+                    }
                     // it should be lazy, file shouldn't have opened yet.
                     debug_assert!(!blobby.started.get());
                     self.done(global_this);

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -226,9 +226,7 @@ impl ReadableStream {
                 let blobby = self.ptr.file().expect("matched File");
                 if let webcore::file_reader::Lazy::Blob(store) = blobby.lazy.get() {
                     let blob = Blob::init_with_store(store.clone(), global_this);
-                    // `init_with_store` spans the whole store; the window of the
-                    // Blob this stream was made from lives on the reader
-                    // (see `from_blob_copy_ref`).
+                    // The window `from_blob_copy_ref` moved onto the reader.
                     if let Some(offset) = blobby.start_offset {
                         blob.offset.set(offset as webcore::blob::SizeType);
                     }

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -72,6 +72,15 @@ describe("Bun.file in serve routes", () => {
       }),
       "/partial.txt": new Response(Bun.file(join(tempDir, "partial.txt"))),
       "/partial-slice.txt": new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10)),
+      // An unread Bun.file() stream is turned back into the file Blob when a
+      // route or handler response is built from it; the slice must survive.
+      "/partial-slice-stream.txt": new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10).stream()),
+      "/partial-slice-stream-handler": () => new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10).stream()),
+      "/partial-open-slice-stream-handler": () =>
+        new Response(Bun.file(join(tempDir, "partial.txt")).slice(10).stream()),
+      "/partial-empty-slice-stream-handler": () =>
+        new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 5).stream()),
+      "/partial-stream-handler": () => new Response(Bun.file(join(tempDir, "partial.txt")).stream()),
       "/fd-not-supported.txt": (() => {
         // This would test file descriptors, but they're not supported yet
         return new Response(Bun.file(join(tempDir, "hello.txt")));
@@ -711,6 +720,36 @@ describe("Bun.file in serve routes", () => {
       expect(res.status).toBe(200);
       expect(await res.text()).toBe("56789");
       expect(res.headers.get("Content-Length")).toBe("5");
+    });
+
+    it("serves the slice behind a sliced file's stream as a route", async () => {
+      const res = await fetch(new URL(`/partial-slice-stream.txt`, server.url));
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("56789");
+      expect(res.headers.get("Content-Length")).toBe("5");
+    });
+
+    it("serves the slice behind a sliced file's stream from a handler", async () => {
+      const serve = async (pathname: string) => {
+        const get = await fetch(new URL(pathname, server.url));
+        const head = await fetch(new URL(pathname, server.url), { method: "HEAD" });
+        return {
+          body: await get.text(),
+          contentLength: get.headers.get("Content-Length"),
+          headContentLength: head.headers.get("Content-Length"),
+        };
+      };
+      expect({
+        "slice(5, 10)": await serve("/partial-slice-stream-handler"),
+        "slice(10)": await serve("/partial-open-slice-stream-handler"),
+        "slice(5, 5)": await serve("/partial-empty-slice-stream-handler"),
+        "whole file": await serve("/partial-stream-handler"),
+      }).toEqual({
+        "slice(5, 10)": { body: "56789", contentLength: "5", headContentLength: "5" },
+        "slice(10)": { body: "ABCDEF", contentLength: "6", headContentLength: "6" },
+        "slice(5, 5)": { body: "", contentLength: "0", headContentLength: "0" },
+        "whole file": { body: "0123456789ABCDEF", contentLength: "16", headContentLength: "16" },
+      });
     });
 
     // The slice is shorter than the file, so the byte budget runs out before

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -72,9 +72,8 @@ describe("Bun.file in serve routes", () => {
       }),
       "/partial.txt": new Response(Bun.file(join(tempDir, "partial.txt"))),
       "/partial-slice.txt": new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10)),
-      // An unread Bun.file() stream is turned back into the file Blob when a
-      // route or handler response is built from it; the slice must survive.
-      "/partial-slice-stream.txt": new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10).stream()),
+      // Rendering a handler response built from an unread Bun.file() stream
+      // turns the stream back into the file Blob; the slice must survive that.
       "/partial-slice-stream-handler": () => new Response(Bun.file(join(tempDir, "partial.txt")).slice(5, 10).stream()),
       "/partial-open-slice-stream-handler": () =>
         new Response(Bun.file(join(tempDir, "partial.txt")).slice(10).stream()),
@@ -722,13 +721,6 @@ describe("Bun.file in serve routes", () => {
       expect(res.headers.get("Content-Length")).toBe("5");
     });
 
-    it("serves the slice behind a sliced file's stream as a route", async () => {
-      const res = await fetch(new URL(`/partial-slice-stream.txt`, server.url));
-      expect(res.status).toBe(200);
-      expect(await res.text()).toBe("56789");
-      expect(res.headers.get("Content-Length")).toBe("5");
-    });
-
     it("serves the slice behind a sliced file's stream from a handler", async () => {
       const serve = async (pathname: string) => {
         const get = await fetch(new URL(pathname, server.url));
@@ -1199,6 +1191,85 @@ test.skipIf(isWindows)("Response(Bun.file(FIFO)) frames the body as chunked, not
   } finally {
     closeSync(writerFd);
   }
+});
+
+// A file route serves the window of the Bun.file() slice it was built from,
+// given either the slice or its unread stream (which is turned back into the
+// slice). FileRoute used to clamp the window to the file size without taking
+// the offset off, and to send an empty window to EOF: on this 16-byte file
+// slice(10) declared Content-Length: 16 and sent 6 bytes, slice(5, 5) declared
+// 0 and sent 11. Only the wire shows that (RFC 9112 6.3); fetch() drops bytes
+// past the declared length and turns a short body into a connection error.
+test("file routes frame a slice that reaches or starts past EOF by the bytes they serve", async () => {
+  using dir = tempDir("serve-file-route-slice-framing", { "partial.txt": "0123456789ABCDEF" });
+  const file = () => Bun.file(join(String(dir), "partial.txt"));
+  const windows = {
+    "slice(5, 10)": () => file().slice(5, 10),
+    "slice(10)": () => file().slice(10),
+    "slice(10, 100)": () => file().slice(10, 100),
+    "slice(5, 5)": () => file().slice(5, 5),
+    "slice(100)": () => file().slice(100),
+    "whole file": () => file(),
+  };
+  const names = Object.keys(windows) as (keyof typeof windows)[];
+  await using server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    routes: Object.fromEntries(
+      names.flatMap((name, i) => [
+        [`/blob/${i}`, new Response(windows[name]())],
+        [`/stream/${i}`, new Response(windows[name]().stream())],
+      ]),
+    ),
+    fetch: () => new Response("fallback", { status: 404 }),
+  });
+
+  // One GET on its own connection; `Connection: close` makes the server hang
+  // up once it considers the response finished, so `body` is every byte that
+  // followed the head, however many the head declared.
+  async function wire(path: string) {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    let captured = "";
+    await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      socket: {
+        open(socket) {
+          socket.write(`GET ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n`);
+        },
+        data(_socket, chunk) {
+          captured += Buffer.from(chunk).toString("latin1");
+        },
+        close() {
+          resolve(captured);
+        },
+        error() {
+          resolve(captured);
+        },
+      },
+    });
+    const raw = await promise;
+    const headEnd = raw.indexOf("\r\n\r\n");
+    return {
+      contentLength: /^content-length:\s*(\d+)/im.exec(raw.slice(0, headEnd))?.[1] ?? null,
+      body: raw.slice(headEnd + 4),
+    };
+  }
+
+  const results: Record<string, unknown> = {};
+  for (const [i, name] of names.entries()) {
+    results[name] = { blob: await wire(`/blob/${i}`), stream: await wire(`/stream/${i}`) };
+  }
+
+  const exactly = (body: string) => ({ contentLength: String(body.length), body });
+  expect(results).toEqual({
+    "slice(5, 10)": { blob: exactly("56789"), stream: exactly("56789") },
+    "slice(10)": { blob: exactly("ABCDEF"), stream: exactly("ABCDEF") },
+    "slice(10, 100)": { blob: exactly("ABCDEF"), stream: exactly("ABCDEF") },
+    "slice(5, 5)": { blob: exactly(""), stream: exactly("") },
+    "slice(100)": { blob: exactly(""), stream: exactly("") },
+    "whole file": { blob: exactly("0123456789ABCDEF"), stream: exactly("0123456789ABCDEF") },
+  });
 });
 
 // A request that declares a body arms the request-body (onData) callback on

--- a/test/js/web/fetch/body.test.ts
+++ b/test/js/web/fetch/body.test.ts
@@ -1,6 +1,6 @@
 import { file, spawn, version, type Socket } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, exampleSite } from "harness";
+import { bunEnv, bunExe, exampleSite, tempDir } from "harness";
 import net from "net";
 
 const exampleServer = exampleSite("http");
@@ -286,6 +286,59 @@ for (const { body, fn } of bodyTypes) {
         expect(subject.body).toBeInstanceOf(ReadableStream);
         expect(await subject.text()).toBe("bye");
         expect(subject.bodyUsed).toBe(true);
+      });
+
+      // The readers move an unread Bun.file() stream back into a Blob the same
+      // way. That Blob has to cover the slice the stream was made from, not
+      // the whole file. (text() is not in here: it pumps the stream instead.)
+      describe("made from a sliced Bun.file()", () => {
+        const alphabet = "abcdefghijklmnopqrstuvwxyz";
+
+        test("bytes() returns the window of the slice the stream was made from", async () => {
+          using dir = tempDir("body-file-slice-stream", { "data.txt": alphabet });
+          const file = () => Bun.file(`${dir}/data.txt`);
+          const bytesOf = async (blob: Blob) => Buffer.from(await fn(blob.stream()).bytes()).toString();
+          expect({
+            "slice(3, 8)": await bytesOf(file().slice(3, 8)),
+            "slice(21)": await bytesOf(file().slice(21)),
+            "slice(3, 1000)": await bytesOf(file().slice(3, 1000)),
+            "slice(4, 4)": await bytesOf(file().slice(4, 4)),
+            "slice(3, 20).slice(2, 6)": await bytesOf(file().slice(3, 20).slice(2, 6)),
+            "whole file": await bytesOf(file()),
+          }).toEqual({
+            "slice(3, 8)": "defgh",
+            "slice(21)": "vwxyz",
+            "slice(3, 1000)": "defghijklmnopqrstuvwxyz",
+            "slice(4, 4)": "",
+            "slice(3, 20).slice(2, 6)": "fghi",
+            "whole file": alphabet,
+          });
+        });
+
+        test("arrayBuffer() and blob() return the slice too", async () => {
+          using dir = tempDir("body-file-slice-stream-readers", { "data.txt": alphabet });
+          const slice = () => Bun.file(`${dir}/data.txt`).slice(3, 8);
+          const blob = await fn(slice().stream()).blob();
+          expect({
+            arrayBuffer: Buffer.from(await fn(slice().stream()).arrayBuffer()).toString(),
+            blob: [blob.size, await blob.text()],
+          }).toEqual({
+            arrayBuffer: "defgh",
+            blob: [5, "defgh"],
+          });
+        });
+
+        test("json() parses only the slice", async () => {
+          using dir = tempDir("body-file-slice-stream-json", { "data.json": `--{"ok":true}--` });
+          expect(await fn(Bun.file(`${dir}/data.json`).slice(2, 13).stream()).json()).toEqual({ ok: true });
+        });
+
+        test("bytes() after the body getter turned a sliced Bun.file() body into a stream", async () => {
+          using dir = tempDir("body-file-slice-body-getter", { "data.txt": alphabet });
+          const subject = fn(Bun.file(`${dir}/data.txt`).slice(3, 8));
+          expect(subject.body).toBeInstanceOf(ReadableStream);
+          expect([Buffer.from(await subject.bytes()).toString(), subject.bodyUsed]).toEqual(["defgh", true]);
+        });
       });
     });
     for (const { string, buffer } of utf8) {


### PR DESCRIPTION
Fixes #40096

### Problem

- `Bun.file(path).slice(3, 8).stream()` delivers the whole file wherever the stream is converted straight back into a Blob instead of being read: a `Bun.serve` handler returning `new Response(sliceStream)` (body and `Content-Length` are the whole file, HEAD too), `routes: { "/x": new Response(sliceStream) }`, and `arrayBuffer()` / `bytes()` / `blob()` / `json()` / `formData()` on a `Response` or `Request` built from the stream (`blob()` resolves to a Blob whose `size` is the file's). Reading `new Response(Bun.file(p).slice(3, 8)).body` and then `bytes()` hits it as well, because the body getter turns the slice into one of these streams. Reproduces on the released 1.4.0.
- `text()`, `for await`, `Bun.readableStreamTo*()` pump the stream and do not take this path. (The pump has its own end-of-window bug from #38886, fixed separately in #39201; the two do not overlap.)
- Cause 1: the `Source::File` arm of `ReadableStream::to_any_blob` (src/runtime/webcore/ReadableStream.rs:227) builds the result with `Blob::init_with_store(store)`, which is offset 0 and the whole store. The window is not on the store: `from_blob_copy_ref` (ReadableStream.rs:529) moved it from the source Blob onto the `FileReader` as `start_offset` / `max_size`, and the arm never reads those. The `Source::Blob` arm copies its window back (`ByteBlobLoader::to_any_blob`, ByteBlobLoader.rs:157), which is why `new Blob([..]).slice().stream()` is unaffected.
- Cause 2 (found while reviewing cause 1, and reachable on 1.4.0 with a plain slice): `FileRoute::on` (src/runtime/server/FileRoute.rs:384) clamps the served size to the file size without taking the slice offset off, and sends a zero-length window to EOF (FileRoute.rs:485). On a 16-byte file, a route built from `Bun.file(p).slice(10)` or `.slice(10, 100)` declares `Content-Length: 16` and sends 6 bytes (the client waits, then sees the connection close); `.slice(5, 5)` declares `0` and then puts 11 body bytes on the wire, which a keep-alive client reads as the start of the next response. Fixing cause 1 alone would have routed `.slice(10).stream()` routes from "whole file" into this.

### Fix

- `to_any_blob`, `File` arm: set `offset` / `size` on the rebuilt Blob from the reader's `start_offset` / `max_size`, the inverse of `from_blob_copy_ref` and what the `Blob` arm already does. The conversion stands in for reading the stream, and the stream would have read exactly `[start_offset, start_offset + max_size)`, so the Blob has to describe that range. The rebuilt Blob then has the same `offset` / `size` as the Blob `.stream()` was called on, so every consumer behaves as it does when given that Blob directly (`new Response(Bun.file(p).slice(3, 8))`): sendfile offset and length, `Content-Length`, `Blob::do_read_file`. An unsliced `Bun.file(p).stream()` has `start_offset == Some(0)` and `max_size == None` and comes out as before.
- `FileRoute::on`: clamp the offset to the file size and the length to what is left after it (the arithmetic `RequestContext::do_sendfile` uses for handler responses, RequestContext.rs:1820), give every regular file a length so `Content-Length` and the bytes sent come from the same number, and end a zero-length body without starting the file stream (as `do_sendfile` does at RequestContext.rs:1902). A `Range` request against a sliced route is now resolved against the bytes the slice really has. Whole-file routes are unchanged: their Blob has offset 0 and the unknown-size sentinel, which clamps to the file size as before.
- Not fixed here: `Bun.spawn({ stdin: sliceStream })` still sends the whole file. It receives the windowed Blob now, but spawn's `extract_blob` (src/runtime/api/bun/spawn/stdio.rs:597) redirects any file-backed Blob by path or fd, for a directly passed `Bun.file().slice()` too; that is #31931. The same `to_any_blob` arm also drops a user-set `type` on the rebuilt Blob; pre-existing, unrelated to slicing, left alone. #31674 carries the same `to_any_blob` change inside a larger rework of the Response/file-stream paths.
- Tests, all of which fail on 1.4.0 and on a debug build without the `src/` changes and pass with them:
  - `test/js/web/fetch/body.test.ts`, `blob-backed stream bodies > made from a sliced Bun.file()` (run for both `Request` and `Response`): `bytes()` over a bounded, open-ended, past-EOF, empty and nested slice plus a whole-file control; `arrayBuffer()` and `blob()` (size and bytes); `json()`; the body-getter case. Fail as "whole file" / `Failed to parse JSON`.
  - `test/js/bun/http/bun-serve-file.test.ts`, `File slicing`: a handler returning the stream of a bounded, open-ended and empty slice plus a whole-file control, GET and HEAD.
  - `test/js/bun/http/bun-serve-file.test.ts`, `file routes frame a slice ...`: routes built from `slice(5, 10)`, `slice(10)`, `slice(10, 100)`, `slice(5, 5)`, `slice(100)` and the whole file, each as the Blob and as its stream, read with a raw socket so that the declared `Content-Length` can be compared with every byte that followed the head. On 1.4.0 the Blob forms of the out-of-range cells show the framing bug (`Content-Length: 16` with 6 or 0 bytes, `0` with 11 bytes) and the stream forms show the whole file.
- Also run on the patched build: the rest of both files (467 and 107 passing), bun-serve-static, bun-serve-routes, serve-directory-routes, serve-file-slice-read-error, bun-serve-headers, serve.test.ts (4 failures that need IPv6 / a non-root user, identical without these changes), blob.test.ts (only the pre-existing #39201 failure, identical without these changes), spawn, fetch body consumption, wasm-streaming, html-rewriter, streams, body-clone, stream-fast-path, response: passing.

### Background

- A `Blob` is a view (`offset`, `size`) onto a refcounted `Blob.Store`; `slice()` shares the store and only changes the view. A file-backed store holds the path and a stat cache, and reports its size as `MAX_SIZE` ("unknown"), so a Blob built from the store alone means "the whole file", and an unsliced `Bun.file(p)` carries `size == MAX_SIZE` until something resolves it.
- `blob.stream()` on a file-backed Blob (`from_blob_copy_ref`) creates a `FileReader` source that holds the store plus the view as `start_offset` / `max_size`; nothing is opened until the stream is first read.
- `to_any_blob` is a shortcut used by consumers that can work from a Blob (Bun.serve response rendering, `FileRoute::from_js` for routes, the Body readers other than `text()`, `WebAssembly.compileStreaming`): if a native stream has not been read yet, they take the Blob it was made from instead of pumping it.
- A `FileRoute` is the object behind `routes: { "/x": new Response(Bun.file(p)) }`. Per request it re-opens and fstats the file, writes `Content-Length` itself, and hands the fd to `FileResponseStream` with an offset and either a byte count or "read to EOF" (meant for pipes and sockets, whose size is unknown). Handler responses go through `RequestContext::do_sendfile` instead, which already clamped correctly; that is why the same slices work from a handler.

<details>
<summary>Probe: 1.4.0 vs this build</summary>

26-byte file `abcdefghijklmnopqrstuvwxyz`, every line uses `Bun.file(p).slice(3, 8).stream()`:

```
                                        1.4.0                   this build
Bun.serve handler, GET body / CL        whole file / 26         "defgh" / 5
Bun.serve handler, HEAD CL              26                      5
new Response(stream).arrayBuffer()      whole file              "defgh"
new Response(stream).bytes()            whole file              "defgh"
new Response(stream).blob()             size 26                 size 5, "defgh"
new Request(url, {body: stream}).bytes  whole file              "defgh"
new Response(slice); .body; .bytes()    whole file              "defgh"
Bun.spawn({ stdin: stream })            whole file              whole file (#31931)
```

16-byte file `0123456789ABCDEF` served as routes, `GET` with `Connection: close`, `cl` is the declared Content-Length:

```
route body                  1.4.0                                   this build
slice(5, 10)                cl=5  "56789"                           cl=5 "56789"
slice(5, 10).stream()       cl=16 whole file                        cl=5 "56789"
slice(10)                   cl=16, 6 bytes, connection closed       cl=6 "ABCDEF"
slice(10).stream()          cl=16 whole file                        cl=6 "ABCDEF"
slice(10, 100)              cl=16, 6 bytes, connection closed       cl=6 "ABCDEF"
slice(5, 5)                 cl=0 followed by "56789ABCDEF"          cl=0, nothing
slice(5, 5).stream()        cl=16 whole file                        cl=0, nothing
whole file (both forms)     cl=16 whole file                        cl=16 whole file
```

`WebAssembly.compileStreaming` on a Response built from such a stream re-streams the converted Blob: on 1.4.0 it fails at byte 0 (the file's leading bytes), with this change it starts at the slice; the end of the window on that re-streamed read is #39201's.

</details>

<details>
<summary>Earlier revision</summary>

The first push only had the `to_any_blob` change. Reviewing it turned up cause 2: with the window restored, a route built from an out-of-range slice's stream went from serving the whole file to the framing mismatch that routes built from the slice itself already had, so the `FileRoute` change and the route matrix were added.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-file.test.ts test/js/web/fetch/body.test.ts

<!-- robobun:evidence:end -->
