### PR TITLE
test/docker: wait for the docker daemon in the coordinator instead of failing on a one-shot probe

### DIFF
--- a/scripts/agent.mjs
+++ b/scripts/agent.mjs
@@ -105,6 +105,13 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
     }
 
     if (isOpenRc()) {
+      // openrc starts a runlevel's unrelated services one at a time in name
+      // order, so without `after docker` this service ("b") starts, and the
+      // ephemeral agent acquires its job, before the boot has reached "docker";
+      // the shard then begins with no daemon socket at all (routine on the
+      // alpine test agents, occasionally for minutes when a service in between
+      // is slow). `after` is ordering only: images without docker still boot
+      // the agent. Takes effect when the images are next published.
       const servicePath = "/etc/init.d/buildkite-agent";
       const service = `#!/sbin/openrc-run
         name="buildkite-agent"
@@ -123,6 +130,7 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
         depend() {
           need net
           use dns logger
+          after docker
         }
       `;
       writeFile(servicePath, service, { mode: 0o755 });

--- a/scripts/agent.mjs
+++ b/scripts/agent.mjs
@@ -4,6 +4,7 @@
 
 import { copyFileSync, existsSync, readFileSync, realpathSync } from "node:fs";
 import { join } from "node:path";
+import { setTimeout as setTimeoutPromise } from "node:timers/promises";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import {
@@ -21,11 +22,13 @@ import {
   getKernel,
   getOs,
   homedir,
+  isLinux,
   isMacOS,
   isPosix,
   isWindows,
   mkdir,
   spawnSafe,
+  spawnSync,
   which,
   writeFile,
 } from "./utils.mjs";
@@ -111,7 +114,9 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
       // the shard then begins with no daemon socket at all (routine on the
       // alpine test agents, occasionally for minutes when a service in between
       // is slow). `after` is ordering only: images without docker still boot
-      // the agent. Takes effect when the images are next published.
+      // the agent. Alpine's docker service returns as soon as dockerd is
+      // spawned, so start() below additionally waits for the daemon to answer.
+      // Both take effect when the images are next published.
       const servicePath = "/etc/init.d/buildkite-agent";
       const service = `#!/sbin/openrc-run
         name="buildkite-agent"
@@ -398,6 +403,19 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
       .map(([key, value]) => `${key}=${value}`)
       .join(",");
 
+    // The job this machine was booted for starts the moment the agent
+    // registers (acquire-job above), and the Linux test jobs need dockerd. The
+    // init system only orders this service after docker's start script (see
+    // install()), which on alpine returns as soon as dockerd is spawned, so
+    // give the daemon a bounded head start here: registering later only
+    // delays the job, registering before the daemon listens starts the job
+    // against a dead socket (test/docker/index.ts has the history). Past the
+    // budget the agent registers anyway and the job's "--- Docker" section
+    // reports the daemon's state.
+    if (isLinux && which("docker")) {
+      await waitForDockerDaemon(2 * 60_000);
+    }
+
     await spawnSafe(
       [
         command,
@@ -416,6 +434,29 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
   } else if (action === "start") {
     await start();
   }
+}
+
+/**
+ * Polls `docker version` (which fails until the daemon is listening) once a
+ * second for up to `budgetMs`. Returns either way; the outcome is logged.
+ * @param {number} budgetMs
+ */
+async function waitForDockerDaemon(budgetMs) {
+  const startedAt = Date.now();
+  const elapsed = () => `${Math.round((Date.now() - startedAt) / 1000)}s`;
+  const reachable = () => spawnSync(["docker", "version"], { timeout: 10_000 }).exitCode === 0;
+  if (reachable()) {
+    return;
+  }
+  console.log(`Docker daemon is not reachable yet; waiting up to ${Math.round(budgetMs / 1000)}s for it...`);
+  while (Date.now() - startedAt < budgetMs) {
+    await setTimeoutPromise(1_000);
+    if (reachable()) {
+      console.log(`Docker daemon became reachable after ${elapsed()}`);
+      return;
+    }
+  }
+  console.warn(`Docker daemon still unreachable after ${elapsed()}; starting the agent without it`);
 }
 
 /**

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3161,13 +3161,27 @@ export function printEnvironment() {
         const shell = which(["sh", "bash"]);
         if (shell) {
           const { exitCode } = spawnSync([shell, "-c", "docker ps"], { stdio: "inherit" });
-          // On the openrc (alpine) images the job can start before the boot has
-          // reached the docker service; the docker coordinator waits for the
-          // daemon, so this is not fatal, but the service table shows which boot
-          // step the daemon was stuck behind when a shard's container tests end
-          // up waiting or failing.
-          if (exitCode !== 0 && which("rc-status")) {
-            spawnSync([shell, "-c", "rc-status"], { stdio: "inherit" });
+          if (exitCode !== 0) {
+            // The agent can start the job before the boot has brought dockerd
+            // up (scripts/agent.mjs orders and waits for it on images published
+            // after that change; test/docker/coordinator.ts waits for it on
+            // every image, so this is not fatal). On openrc the service table
+            // shows which boot step the daemon was still behind.
+            if (which("rc-status")) {
+              spawnSync([shell, "-c", "rc-status"], { stdio: "inherit" });
+            }
+            // One line per affected job under a single per-build annotation, so
+            // how often this still happens can be read off builds (and compared
+            // across image publishes) without grepping job logs. Info style:
+            // nothing has failed, and `bun run ci:errors` lists only error-style
+            // annotations.
+            reportAnnotationToBuildKite({
+              context: "docker-daemon-not-up-at-job-start",
+              label: "docker daemon not up at job start",
+              content: `- dockerd was not up when [${getBuildLabel()}](${getBuildUrl()}) started on \`${getHostname()}\`\n`,
+              style: "info",
+              priority: 1,
+            });
           }
         }
       });

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3160,7 +3160,15 @@ export function printEnvironment() {
       startGroup("Docker", () => {
         const shell = which(["sh", "bash"]);
         if (shell) {
-          spawnSync([shell, "-c", "docker ps"], { stdio: "inherit" });
+          const { exitCode } = spawnSync([shell, "-c", "docker ps"], { stdio: "inherit" });
+          // On the openrc (alpine) images the job can start before the boot has
+          // reached the docker service; the docker coordinator waits for the
+          // daemon, so this is not fatal, but the service table shows which boot
+          // step the daemon was stuck behind when a shard's container tests end
+          // up waiting or failing.
+          if (exitCode !== 0 && which("rc-status")) {
+            spawnSync([shell, "-c", "rc-status"], { stdio: "inherit" });
+          }
         }
       });
     }

--- a/test/cli/install/bun-install-proxy.test.ts
+++ b/test/cli/install/bun-install-proxy.test.ts
@@ -1,43 +1,38 @@
 import { beforeAll, it } from "bun:test";
-import { exec } from "child_process";
 import { rm } from "fs/promises";
-import { bunEnv, bunExe, dockerExe, isDockerEnabled, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isDockerEnabled, tempDirWithFiles } from "harness";
 import { join } from "path";
-import { promisify } from "util";
-const execAsync = promisify(exec);
-const dockerCLI = dockerExe() as string;
-const SQUID_URL = "http://127.0.0.1:3128";
+import { ensure } from "../../docker/index.ts";
+
+let SQUID_URL: string;
 if (isDockerEnabled()) {
+  // The compose `squid` service is the same ubuntu/squid image this file used
+  // to `docker run` itself on a fixed host port. Going through ensure() means
+  // the shard's coordinator starts it (and waits for the docker daemon if the
+  // job began before it was up) and it gets a free port like every other
+  // test service.
   beforeAll(async () => {
-    async function isSquidRunning() {
-      const text = await fetch(SQUID_URL)
-        .then(res => res.text())
-        .catch(() => {});
-      return text?.includes("squid") ?? false;
+    const squid = await ensure("squid");
+    SQUID_URL = `http://${squid.host}:${squid.ports[3128]}`;
+    // The container counts as healthy once the squid process exists. Like the
+    // isSquidRunning() loop this replaces, wait until it answers HTTP (a plain
+    // GET of the proxy itself gets squid's own error page) before installing
+    // through it.
+    const squidAnswers = async () => {
+      const body = await fetch(SQUID_URL, { signal: AbortSignal.timeout(5_000) }).then(
+        res => res.text(),
+        () => "",
+      );
+      return body.includes("squid");
+    };
+    const deadline = Date.now() + 30_000;
+    while (!(await squidAnswers())) {
+      if (Date.now() > deadline) throw new Error(`squid at ${SQUID_URL} did not answer within 30s`);
+      await Bun.sleep(250);
     }
-    if (!(await isSquidRunning())) {
-      // try to create or error if is already created
-      await execAsync(
-        `${dockerCLI} run -d --name squid-container -e TZ=UTC -p 3128:3128 ubuntu/squid:5.2-22.04_beta`,
-      ).catch(() => {});
-
-      async function waitForSquid(max_wait = 60_000) {
-        const start = Date.now();
-        while (true) {
-          if (await isSquidRunning()) {
-            return;
-          }
-          if (Date.now() - start > max_wait) {
-            throw new Error("Squid did not start in time");
-          }
-
-          await Bun.sleep(1000);
-        }
-      }
-      // wait for squid to start
-      await waitForSquid();
-    }
-  });
+    // Same hook budget as describeWithContainer(): a cold start is a `compose
+    // build` plus `up --wait` with a 180s wait-timeout.
+  }, 240_000);
 
   it("bun install with proxy with big packages", async () => {
     const files = {

--- a/test/docker/coordinator.ts
+++ b/test/docker/coordinator.ts
@@ -17,13 +17,18 @@
  * predicts which services argv's tests need and starts them at launch, so
  * they're healthy by the time the first test asks.
  *
+ * It is also the one place that waits for the docker daemon itself: the agent
+ * can start the shard while dockerd is still coming up, and every request
+ * (prestart or test) blocks on the shared wait below instead of failing on a
+ * one-shot probe.
+ *
  * Lifetime is tied to the runner: stdin is a pipe from it, and EOF means the
  * runner is gone.
  */
 
 import { unlinkSync } from "node:fs";
 import * as net from "node:net";
-import { ensure, type ServiceInfo, type ServiceName } from "./index.ts";
+import { ensure, waitForDockerDaemon, type ServiceInfo, type ServiceName } from "./index.ts";
 import { prestartMap as prestartMapRaw } from "./prestart-map.mjs";
 
 // Keys are paths relative to test/ — that's the shape runner.node.mjs passes
@@ -43,6 +48,28 @@ if (!socketPath) {
 // never proxy to another coordinator whose socket leaked in through the
 // environment.
 delete process.env.BUN_DOCKER_COORDINATOR;
+
+// The shard may start before dockerd has finished coming up (see
+// waitForDockerDaemon); start polling for it right away so the wait overlaps
+// the non-container tests the runner schedules first. The window is well past
+// the latest the daemon has been seen to appear in CI (up by ~7 minutes into
+// the job); once it closes, requests fail immediately, so a host whose daemon
+// never comes up costs the shard one window rather than a full wait per file
+// attempt. The per-request cap is the budget scripts/runner.node.mjs gives the
+// hook that is typically awaiting the request (--timeout = testTimeout / 2), so
+// a request either gets the daemon or a clear error within the time its caller
+// has anyway, and the 3-minute file budget keeps room for `compose up` and the
+// tests after it. A file whose request hits the cap is retried by the runner,
+// and the retry's request gets a fresh cap against the same shared wait, so a
+// file's four attempts together cover ~6 minutes of daemon lateness from the
+// file's first request (container-backed files are also scheduled late in the
+// shard, see prestart-map.mjs).
+const awaitDockerDaemon = waitForDockerDaemon({
+  windowMs: 10 * 60_000,
+  pollMs: 1_000,
+  log: message => console.log(`coordinator: ${message}`),
+});
+const DAEMON_WAIT_PER_REQUEST_MS = 90_000;
 
 // Collapse concurrent requests for one service onto a single ensureServiceNow(),
 // and remember the last ServiceInfo a successful ensure produced. The full
@@ -97,6 +124,7 @@ async function ensureServiceNow(service: ServiceName): Promise<ServiceInfo> {
 
   console.log(`coordinator: ensuring ${service}`);
   try {
+    await awaitDockerDaemon(DAEMON_WAIT_PER_REQUEST_MS);
     const info = await ensure(service);
     console.log(`coordinator: ${service} ready`);
     lastGood.set(service, info);

--- a/test/docker/coordinator.ts
+++ b/test/docker/coordinator.ts
@@ -56,9 +56,11 @@ delete process.env.BUN_DOCKER_COORDINATOR;
 // the job); once it closes, requests fail immediately, so a host whose daemon
 // never comes up costs the shard one window rather than a full wait per file
 // attempt. The per-request cap is the budget scripts/runner.node.mjs gives the
-// hook that is typically awaiting the request (--timeout = testTimeout / 2), so
-// a request either gets the daemon or a clear error within the time its caller
-// has anyway, and the 3-minute file budget keeps room for `compose up` and the
+// hook that is typically awaiting the request (--timeout = testTimeout / 2 on
+// the release lanes; the ASAN lanes get three times that but run on systemd
+// images, where the daemon has always been up at job start), so a request
+// either gets the daemon or a clear error within the time its caller has
+// anyway, and the 3-minute file budget keeps room for `compose up` and the
 // tests after it. A file whose request hits the cap is retried by the runner,
 // and the retry's request gets a fresh cap against the same shared wait, so a
 // file's four attempts together cover ~6 minutes of daemon lateness from the

--- a/test/docker/index.ts
+++ b/test/docker/index.ts
@@ -130,13 +130,18 @@ function serviceFromEnv(service: ServiceName): ServiceInfo | null {
  * accepts connections on its socket, so this is the daemon readiness signal.
  * (`docker compose version` is not: compose is a CLI plugin and succeeds with
  * no daemon at all, which is why scripts/runner.node.mjs can use it to decide
- * whether to start the coordinator before the daemon is up.)
+ * whether to start the coordinator before the daemon is up.) A daemon that
+ * accepts the connection but never answers would otherwise hang the CLI, and
+ * with it every wait built on this probe, so the CLI is killed after
+ * `timeoutMs` and counted as unreachable; a healthy round trip takes well
+ * under a second.
  */
-async function isDockerDaemonReachable(): Promise<boolean> {
+export async function isDockerDaemonReachable(timeoutMs = 10_000): Promise<boolean> {
   const proc = spawn({
     cmd: ["docker", "version"],
     stdout: "ignore",
     stderr: "ignore",
+    timeout: timeoutMs,
   });
   return (await proc.exited) === 0;
 }
@@ -160,16 +165,20 @@ export interface DockerDaemonWaitOptions {
  * caller that retries later gets the daemon as soon as it is up, and callers
  * arriving after the window has closed fail immediately.
  *
- * Linux CI agents can pick up a job before dockerd has finished starting. On
- * the openrc (alpine) images the buildkite-agent service is not ordered after
- * docker, so a shard routinely starts with no /var/run/docker.sock yet; the
- * daemon usually appears within ~10s, but in builds 97891, 98647, 98707 and
- * 98746 it was still down 3-4.5 minutes into the job and up by 5-7 minutes,
- * and the coordinator's one-shot probe failed every container-backed test
- * file in those shards (all in-shard retries included, since they run within
- * seconds of each other). When a probe succeeds on the first try, which is the
- * case on every systemd image, nothing is logged and `waitFor` costs nothing
- * beyond that probe.
+ * Linux CI agents can pick up a job before dockerd has finished starting. The
+ * openrc (alpine) images published before scripts/agent.mjs ordered the agent
+ * service after docker routinely start a shard with no /var/run/docker.sock
+ * yet; the daemon usually appears within ~10s, but in builds 97891, 98647,
+ * 98707 and 98746 it was still down 3-4.5 minutes into the job and up by 5-7
+ * minutes, and the coordinator's one-shot probe failed every container-backed
+ * test file in those shards (all in-shard retries included, since they run
+ * within seconds of each other). The boot-ordering fix in agent.mjs is the
+ * primary fix once images are republished; this keeps shards green on the
+ * current images and covers whatever dockerd start-up time is left after it
+ * (the runner's `--- Docker` job section records how often that still
+ * happens). When a probe succeeds on the first try, which is the case on every
+ * systemd image, nothing is logged and `waitFor` costs nothing beyond that
+ * probe.
  */
 export function waitForDockerDaemon({
   windowMs,

--- a/test/docker/index.ts
+++ b/test/docker/index.ts
@@ -125,6 +125,95 @@ function serviceFromEnv(service: ServiceName): ServiceInfo | null {
   return info;
 }
 
+/**
+ * One `docker version` round trip. The CLI exits non-zero until the daemon
+ * accepts connections on its socket, so this is the daemon readiness signal.
+ * (`docker compose version` is not: compose is a CLI plugin and succeeds with
+ * no daemon at all, which is why scripts/runner.node.mjs can use it to decide
+ * whether to start the coordinator before the daemon is up.)
+ */
+async function isDockerDaemonReachable(): Promise<boolean> {
+  const proc = spawn({
+    cmd: ["docker", "version"],
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return (await proc.exited) === 0;
+}
+
+export interface DockerDaemonWaitOptions {
+  /** Stop polling, and fail every waiter, once the daemon has stayed unreachable this long. */
+  windowMs: number;
+  /** Delay between probes. */
+  pollMs: number;
+  /** Replaces the `docker version` probe; tests script it. */
+  probe?: () => Promise<boolean>;
+  /** Where the "waiting" / "reachable after Ns" / "giving up" lines go. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Starts polling for the docker daemon and returns `waitFor(capMs)`, which
+ * resolves once a probe has succeeded and rejects if the daemon is still
+ * unreachable after `capMs`, or once `windowMs` has passed in total. Every
+ * caller shares the one poll loop: a rejected `waitFor` does not stop it, so a
+ * caller that retries later gets the daemon as soon as it is up, and callers
+ * arriving after the window has closed fail immediately.
+ *
+ * Linux CI agents can pick up a job before dockerd has finished starting. On
+ * the openrc (alpine) images the buildkite-agent service is not ordered after
+ * docker, so a shard routinely starts with no /var/run/docker.sock yet; the
+ * daemon usually appears within ~10s, but in builds 97891, 98647, 98707 and
+ * 98746 it was still down 3-4.5 minutes into the job and up by 5-7 minutes,
+ * and the coordinator's one-shot probe failed every container-backed test
+ * file in those shards (all in-shard retries included, since they run within
+ * seconds of each other). When a probe succeeds on the first try, which is the
+ * case on every systemd image, nothing is logged and `waitFor` costs nothing
+ * beyond that probe.
+ */
+export function waitForDockerDaemon({
+  windowMs,
+  pollMs,
+  probe = isDockerDaemonReachable,
+  log = console.log,
+}: DockerDaemonWaitOptions): (capMs: number) => Promise<void> {
+  const startedAt = Date.now();
+  const unreachableFor = () => `${Math.round((Date.now() - startedAt) / 1000)}s`;
+
+  const ready: Promise<void> = (async () => {
+    if (await probe()) return;
+    log(`docker daemon is not reachable yet; waiting up to ${Math.round(windowMs / 1000)}s for it to come up`);
+    while (Date.now() - startedAt < windowMs) {
+      await Bun.sleep(pollMs);
+      if (await probe()) {
+        log(`docker daemon became reachable after ${unreachableFor()}`);
+        return;
+      }
+    }
+    const message = `Docker daemon still unreachable after ${unreachableFor()} (\`docker version\` kept failing); not waiting for it any longer`;
+    log(message);
+    throw new Error(message);
+  })();
+  // The window can close while no request is waiting; each waiter gets the
+  // rejection through the race below, so it must not also be reported as an
+  // unhandled rejection here.
+  ready.catch(() => {});
+
+  return function waitFor(capMs: number): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const cap = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(
+          new Error(
+            `Docker daemon not reachable (unreachable for ${unreachableFor()} so far); gave up waiting for it after ${Math.round(capMs / 1000)}s for this request`,
+          ),
+        );
+      }, capMs);
+    });
+    return Promise.race([ready, cap]).finally(() => clearTimeout(timer));
+  };
+}
+
 interface DockerComposeOptions {
   projectName?: string;
   composeFile?: string;
@@ -174,15 +263,7 @@ class DockerComposeHelper {
   }
 
   async ensureDocker(): Promise<void> {
-    // Check Docker is available
-    const dockerCheck = spawn({
-      cmd: ["docker", "version"],
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const exitCode = await dockerCheck.exited;
-    if (exitCode !== 0) {
+    if (!(await isDockerDaemonReachable())) {
       throw new Error("Docker is not available. Please ensure Docker is installed and running.");
     }
 

--- a/test/docker/prestart-map.mjs
+++ b/test/docker/prestart-map.mjs
@@ -25,6 +25,7 @@ export const prestartMap = {
   "js/bun/s3/": ["minio"],
   "js/web/websocket/autobahn": ["autobahn"],
   "js/web/websocket/websocket-proxy": ["squid"],
+  "cli/install/bun-install-proxy": ["squid"],
   "integration/mysql2/": ["mysql_plain", "mysql_native_password"],
   "regression/issue/21311": ["postgres_plain"],
   "regression/issue/24850": ["mysql_plain"],

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1110,6 +1110,16 @@ export function isDockerEnabled(): boolean {
     return false;
   }
 
+  // The CI runner sets this once test/docker/coordinator.ts is up; it owns the
+  // daemon from then on and waits for it if the agent started the shard before
+  // dockerd finished coming up (routine on the openrc images). Probing the
+  // daemon here as well would fail the whole file at import time during that
+  // window, and costs a `docker info` per file. describeWithContainer() and
+  // test/js/valkey/test-utils.ts already trust the coordinator the same way.
+  if (process.env.BUN_DOCKER_COORDINATOR) {
+    return true;
+  }
+
   try {
     const info = execSync(`"${dockerCLI}" info`, { stdio: ["ignore", "pipe", "inherit"] });
     return info.toString().indexOf("Server Version:") !== -1;

--- a/test/internal/docker-coordinator.test.ts
+++ b/test/internal/docker-coordinator.test.ts
@@ -1,0 +1,291 @@
+/**
+ * test/docker/coordinator.ts is spawned by scripts/runner.node.mjs at the start
+ * of every Linux CI shard and owns `docker compose` for the container-backed
+ * test files in it. The agent can start a shard before dockerd has finished
+ * coming up (on the openrc images the agent service is not ordered after
+ * docker), and until the coordinator waited for the daemon, its one-shot
+ * `docker version` answered every request, and so failed every container-backed
+ * test file in the shard including the in-shard retries, with "Docker is not
+ * available" (builds 97891, 98647, 98707, 98746: the daemon was still down 3-4.5
+ * minutes into the job and came up a few minutes after that).
+ *
+ * The wait is driven here with a scripted probe and millisecond timings. The
+ * two tests at the end use a fake `docker` on PATH whose daemon is still
+ * starting: one for isDockerEnabled() in test/harness.ts, which used to probe
+ * the daemon at import time of ~25 test files and so failed them the same way,
+ * and one running the real coordinator end to end.
+ */
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { chmodSync, existsSync, readFileSync } from "node:fs";
+import { connect } from "node:net";
+import { join } from "node:path";
+
+import { waitForDockerDaemon } from "../docker/index.ts";
+
+/** Answers `outcomes` in order, then `finalOutcome` forever. */
+function scriptedProbe(outcomes: boolean[], finalOutcome: boolean) {
+  const remaining = [...outcomes];
+  const probe = async () => {
+    probe.calls++;
+    return remaining.length ? remaining.shift()! : finalOutcome;
+  };
+  probe.calls = 0;
+  return probe;
+}
+
+const rejection = (promise: Promise<unknown>) =>
+  promise.then(
+    () => {
+      throw new Error("expected the wait to fail");
+    },
+    (error: Error) => error,
+  );
+
+test("a daemon that is already up costs one probe and logs nothing", async () => {
+  const probe = scriptedProbe([], true);
+  const log: string[] = [];
+  const waitFor = waitForDockerDaemon({ windowMs: 10_000, pollMs: 1, probe, log: m => log.push(m) });
+
+  await waitFor(1_000);
+
+  expect(probe.calls).toBe(1);
+  expect(log).toEqual([]);
+});
+
+test("requests made while the daemon is starting wait for it on one shared poll loop", async () => {
+  const probe = scriptedProbe([false, false, false], true);
+  const log: string[] = [];
+  const waitFor = waitForDockerDaemon({ windowMs: 10_000, pollMs: 1, probe, log: m => log.push(m) });
+
+  // Two services requested at once, as the prestart does.
+  await Promise.all([waitFor(5_000), waitFor(5_000)]);
+
+  expect(probe.calls).toBe(4);
+  expect(log).toEqual([
+    "docker daemon is not reachable yet; waiting up to 10s for it to come up",
+    expect.stringMatching(/^docker daemon became reachable after \d+s$/),
+  ]);
+
+  // From now on requests neither probe nor wait.
+  await waitFor(0);
+  expect(probe.calls).toBe(4);
+});
+
+test("a request that hits its cap fails by itself; polling continues so a retry gets the daemon", async () => {
+  let up = false;
+  let calls = 0;
+  const probe = async () => {
+    calls++;
+    return up;
+  };
+  const waitFor = waitForDockerDaemon({ windowMs: 10_000, pollMs: 1, probe, log: () => {} });
+
+  const error = await rejection(waitFor(20));
+  expect(error.message).toMatch(
+    /^Docker daemon not reachable \(unreachable for \d+s so far\); gave up waiting for it after 0s for this request$/,
+  );
+
+  // The runner retries the file whose request just failed; by then the daemon
+  // may be up, and the retry's request must see that.
+  const callsAtCap = calls;
+  up = true;
+  await waitFor(5_000);
+  expect(calls).toBeGreaterThan(callsAtCap);
+});
+
+test("a request pending when the window closes gets the window failure", async () => {
+  const probe = scriptedProbe([], false);
+  const log: string[] = [];
+  const waitFor = waitForDockerDaemon({ windowMs: 30, pollMs: 1, probe, log: m => log.push(m) });
+
+  const error = await rejection(waitFor(5_000));
+  expect(error.message).toMatch(
+    /^Docker daemon still unreachable after \d+s \(`docker version` kept failing\); not waiting for it any longer$/,
+  );
+  // The same line goes to the shard log, so the log explains the failures even
+  // when they surface in test files much later.
+  expect(log).toEqual(["docker daemon is not reachable yet; waiting up to 0s for it to come up", error.message]);
+});
+
+test("after the window closes with nothing waiting, later requests fail at once instead of waiting out their cap", async () => {
+  const probe = scriptedProbe([], false);
+  const { promise: windowClosed, resolve: onWindowClosed } = Promise.withResolvers<string>();
+  const waitFor = waitForDockerDaemon({
+    windowMs: 30,
+    pollMs: 1,
+    probe,
+    log: message => {
+      if (message.startsWith("Docker daemon still unreachable")) onWindowClosed(message);
+    },
+  });
+
+  // Nobody is waiting while the window closes. The log line is emitted just
+  // before the shared promise rejects, so let the event loop turn once: if the
+  // wait let that rejection escape, bun:test reports it as an unhandled error
+  // here, before any request attaches to it.
+  const message = await windowClosed;
+  await new Promise<void>(resolve => setImmediate(resolve));
+  const callsAtClose = probe.calls;
+
+  const error = await rejection(waitFor(60_000));
+  expect(error.message).toBe(message);
+  expect(probe.calls).toBe(callsAtClose);
+});
+
+// A `docker` CLI whose daemon is still starting: `docker info` fails, `docker
+// version` fails the first time it is run and succeeds from then on, `docker
+// compose ... port <service> <port>` answers with a fixed host port, and the
+// other compose subcommands (version, build, ps, up) succeed silently. Every
+// invocation is appended to calls.log in the directory above bin/.
+const fakeDocker = `#!/bin/sh
+state=$(dirname "$0")/..
+echo "$*" >> "$state/calls.log"
+case "$1" in
+  info)
+    exit 1
+    ;;
+  version)
+    if [ -e "$state/probed-once" ]; then exit 0; fi
+    : > "$state/probed-once"
+    echo "Cannot connect to the Docker daemon at unix:///var/run/docker.sock" >&2
+    exit 1
+    ;;
+  compose)
+    for arg in "$@"; do
+      if [ "$arg" = port ]; then echo "0.0.0.0:54321"; exit 0; fi
+    done
+    ;;
+esac
+exit 0
+`;
+
+function fakeDockerDir() {
+  // Short name: the coordinator socket created inside it has to fit in
+  // sun_path (104 bytes on macOS).
+  const dir = tempDir("coord", { "bin/docker": fakeDocker });
+  chmodSync(join(String(dir), "bin", "docker"), 0o755);
+  return dir;
+}
+
+const calls = (dir: string) => (existsSync(join(dir, "calls.log")) ? readFileSync(join(dir, "calls.log"), "utf8") : "");
+
+// isDockerEnabled() looks the CLI up in the environment the process started
+// with (Bun.which and Bun.spawn both read that, not later edits to
+// process.env), so the fake CLI has to be on PATH of a fresh process.
+async function isDockerEnabledWith(dir: string, coordinator: string | undefined): Promise<unknown> {
+  const env = { ...bunEnv, PATH: `${join(dir, "bin")}:${bunEnv.PATH}` };
+  delete env.BUN_DOCKER_COORDINATOR;
+  if (coordinator !== undefined) env.BUN_DOCKER_COORDINATOR = coordinator;
+  const harness = JSON.stringify(join(import.meta.dir, "..", "harness.ts"));
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { isDockerEnabled } from ${harness};
+       let result;
+       try { result = isDockerEnabled(); } catch (error) { result = "threw: " + error.message; }
+       console.log(JSON.stringify(result));`,
+    ],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
+
+// On Linux arm64 isDockerEnabled() is false before it looks at anything else.
+test.concurrent.skipIf(isWindows || (isLinux && process.arch === "arm64"))(
+  "isDockerEnabled() trusts the shard's coordinator instead of probing the daemon from every test file",
+  async () => {
+    using withCoordinator = fakeDockerDir();
+    using withoutCoordinator = fakeDockerDir();
+    const [enabled, enabledWithout] = await Promise.all([
+      isDockerEnabledWith(String(withCoordinator), join(String(withCoordinator), "coordinator.sock")),
+      isDockerEnabledWith(String(withoutCoordinator), undefined),
+    ]);
+
+    expect(enabled).toBe(true);
+    expect(calls(String(withCoordinator))).toBe("");
+
+    // Without a coordinator the daemon is probed as before, and this one is
+    // down: false, or on Linux CI the harness's own "docker is required" error.
+    expect(enabledWithout).not.toBe(true);
+    expect(calls(String(withoutCoordinator))).toBe("info\n");
+  },
+);
+
+test.concurrent.skipIf(isWindows)(
+  "the coordinator answers a request made while the daemon is still starting",
+  async () => {
+    using dir = fakeDockerDir();
+    const socketPath = join(String(dir), "coordinator.sock");
+
+    // ensure() answers from BUN_TEST_SERVICE_<name> without touching docker, and
+    // BUN_DOCKER_* / COMPOSE_* change what it runs; this run has to reach the fake CLI.
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(bunEnv)) {
+      if (value !== undefined && !/^(BUN_TEST_SERVICE_|BUN_DOCKER_|COMPOSE_)/.test(key)) env[key] = value;
+    }
+    env.PATH = `${join(String(dir), "bin")}:${env.PATH}`;
+    env.BUN_DOCKER_COORDINATOR_SOCKET = socketPath;
+
+    await using coordinator = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "..", "docker", "coordinator.ts")],
+      env,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // The runner connects tests to the socket only after this line.
+    let stdout = "";
+    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+    const stdoutDrained = (async () => {
+      for await (const chunk of coordinator.stdout) {
+        stdout += Buffer.from(chunk).toString();
+        if (stdout.includes(`COORDINATOR_READY ${socketPath}\n`)) onListening();
+      }
+    })();
+    await listening;
+
+    // What ensureViaCoordinator() in test/docker/index.ts sends and reads back.
+    const reply = await new Promise<string>((resolve, reject) => {
+      const socket = connect(socketPath, () =>
+        socket.write(JSON.stringify({ type: "ensure", service: "postgres_plain" }) + "\n"),
+      );
+      let buffer = "";
+      socket.setEncoding("utf8");
+      socket.on("data", chunk => {
+        buffer += chunk;
+        const newline = buffer.indexOf("\n");
+        if (newline !== -1) {
+          socket.end();
+          resolve(buffer.slice(0, newline));
+        }
+      });
+      socket.on("error", reject);
+    });
+    expect(JSON.parse(reply)).toEqual({ ok: true, info: { host: "127.0.0.1", ports: { 5432: 54321 } } });
+
+    // The probe that failed, the poll that found the daemon, and only then any
+    // compose invocation.
+    const invocations = calls(String(dir)).trim().split("\n");
+    expect(invocations.slice(0, 2)).toEqual(["version", "version"]);
+    expect(invocations.findIndex(call => call.startsWith("compose "))).toBeGreaterThanOrEqual(2);
+    expect(invocations).toContainEqual(
+      expect.stringMatching(/^compose .* up -d --wait --wait-timeout 180 postgres_plain$/),
+    );
+
+    // EOF on stdin is how the coordinator learns the shard is over.
+    coordinator.stdin.end();
+    expect(await coordinator.exited).toBe(0);
+    await stdoutDrained;
+    expect(stdout).toMatch(/^coordinator: docker daemon became reachable after \d+s$/m);
+    expect(stdout).toContain("coordinator: postgres_plain ready\n");
+    expect(existsSync(socketPath)).toBeFalse();
+  },
+);

--- a/test/internal/docker-coordinator.test.ts
+++ b/test/internal/docker-coordinator.test.ts
@@ -241,14 +241,20 @@ test.concurrent.skipIf(isWindows)(
       stderr: "pipe",
     });
 
-    // The runner connects tests to the socket only after this line.
+    // The runner connects tests to the socket only after this line. stdout has
+    // to be read incrementally for that, so it is collected by hand; a
+    // coordinator that exits before printing it fails the test right away.
     let stdout = "";
-    const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+    const stderr = coordinator.stderr.text();
+    const { promise: listening, resolve: onListening, reject: onExitedFirst } = Promise.withResolvers<void>();
     const stdoutDrained = (async () => {
       for await (const chunk of coordinator.stdout) {
         stdout += Buffer.from(chunk).toString();
         if (stdout.includes(`COORDINATOR_READY ${socketPath}\n`)) onListening();
       }
+      onExitedFirst(
+        new Error(`coordinator exited before COORDINATOR_READY\nstdout:\n${stdout}\nstderr:\n${await stderr}`),
+      );
     })();
     await listening;
 
@@ -268,6 +274,7 @@ test.concurrent.skipIf(isWindows)(
         }
       });
       socket.on("error", reject);
+      socket.on("close", () => reject(new Error(`coordinator closed the socket without replying; got: ${buffer}`)));
     });
     expect(JSON.parse(reply)).toEqual({ ok: true, info: { host: "127.0.0.1", ports: { 5432: 54321 } } });
 
@@ -282,10 +289,12 @@ test.concurrent.skipIf(isWindows)(
 
     // EOF on stdin is how the coordinator learns the shard is over.
     coordinator.stdin.end();
-    expect(await coordinator.exited).toBe(0);
+    const exitCode = await coordinator.exited;
     await stdoutDrained;
     expect(stdout).toMatch(/^coordinator: docker daemon became reachable after \d+s$/m);
     expect(stdout).toContain("coordinator: postgres_plain ready\n");
+    expect(await stderr).toBe("");
+    expect(exitCode).toBe(0);
     expect(existsSync(socketPath)).toBeFalse();
   },
 );

--- a/test/internal/docker-coordinator.test.ts
+++ b/test/internal/docker-coordinator.test.ts
@@ -10,10 +10,12 @@
  * minutes into the job and came up a few minutes after that).
  *
  * The wait is driven here with a scripted probe and millisecond timings. The
- * two tests at the end use a fake `docker` on PATH whose daemon is still
- * starting: one for isDockerEnabled() in test/harness.ts, which used to probe
- * the daemon at import time of ~25 test files and so failed them the same way,
- * and one running the real coordinator end to end.
+ * tests after that put a fake `docker` on PATH: one whose CLI hangs, to pin
+ * the probe's own bound (everything above assumes a probe returns), and one
+ * whose daemon is still starting, used both for isDockerEnabled() in
+ * test/harness.ts (which used to probe the daemon at import time of ~25 test
+ * files and so failed them the same way) and to run the real coordinator end
+ * to end.
  */
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
@@ -160,42 +162,78 @@ esac
 exit 0
 `;
 
-function fakeDockerDir() {
+// A `docker` CLI stuck talking to a daemon that accepted the connection but
+// never answers.
+const hangingDocker = `#!/bin/sh
+if [ "$1" = version ]; then exec sleep 15; fi
+exit 0
+`;
+
+function fakeDockerDir(script = fakeDocker) {
   // Short name: the coordinator socket created inside it has to fit in
   // sun_path (104 bytes on macOS).
-  const dir = tempDir("coord", { "bin/docker": fakeDocker });
+  const dir = tempDir("coord", { "bin/docker": script });
   chmodSync(join(String(dir), "bin", "docker"), 0o755);
   return dir;
 }
 
 const calls = (dir: string) => (existsSync(join(dir, "calls.log")) ? readFileSync(join(dir, "calls.log"), "utf8") : "");
 
-// isDockerEnabled() looks the CLI up in the environment the process started
+// The docker helpers look the CLI up in the environment their process started
 // with (Bun.which and Bun.spawn both read that, not later edits to
-// process.env), so the fake CLI has to be on PATH of a fresh process.
-async function isDockerEnabledWith(dir: string, coordinator: string | undefined): Promise<unknown> {
-  const env = { ...bunEnv, PATH: `${join(dir, "bin")}:${bunEnv.PATH}` };
-  delete env.BUN_DOCKER_COORDINATOR;
-  if (coordinator !== undefined) env.BUN_DOCKER_COORDINATOR = coordinator;
-  const harness = JSON.stringify(join(import.meta.dir, "..", "harness.ts"));
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `import { isDockerEnabled } from ${harness};
-       let result;
-       try { result = isDockerEnabled(); } catch (error) { result = "threw: " + error.message; }
-       console.log(JSON.stringify(result));`,
-    ],
-    env,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+// process.env), so the fake CLI has to be first on PATH of a fresh process.
+// ensure() also answers from BUN_TEST_SERVICE_<name> without touching docker,
+// and BUN_DOCKER_* / COMPOSE_* change what it runs, so none of those may leak
+// in from the machine running this file.
+function envWithFakeDocker(dir: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(bunEnv)) {
+    if (value !== undefined && !/^(BUN_TEST_SERVICE_|BUN_DOCKER_|COMPOSE_)/.test(key)) env[key] = value;
+  }
+  env.PATH = `${join(dir, "bin")}:${env.PATH}`;
+  return env;
+}
+
+/** Runs `script` (which must print one JSON value) in a fresh bun with the fake docker on PATH. */
+async function evalWithFakeDocker(env: Record<string, string>, script: string): Promise<unknown> {
+  await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env, stdout: "pipe", stderr: "pipe" });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
   return JSON.parse(stdout);
 }
+
+const harnessPath = JSON.stringify(join(import.meta.dir, "..", "harness.ts"));
+const dockerIndexPath = JSON.stringify(join(import.meta.dir, "..", "docker", "index.ts"));
+
+function isDockerEnabledWith(dir: string, coordinator: string | undefined): Promise<unknown> {
+  const env = envWithFakeDocker(dir);
+  if (coordinator !== undefined) env.BUN_DOCKER_COORDINATOR = coordinator;
+  return evalWithFakeDocker(
+    env,
+    `import { isDockerEnabled } from ${harnessPath};
+     let result;
+     try { result = isDockerEnabled(); } catch (error) { result = "threw: " + error.message; }
+     console.log(JSON.stringify(result));`,
+  );
+}
+
+test.concurrent.skipIf(isWindows)(
+  "a probe whose docker CLI hangs counts as unreachable instead of hanging the wait",
+  async () => {
+    using dir = fakeDockerDir(hangingDocker);
+    const result = await evalWithFakeDocker(
+      envWithFakeDocker(String(dir)),
+      `import { isDockerDaemonReachable } from ${dockerIndexPath};
+     const startedAt = Date.now();
+     const reachable = await isDockerDaemonReachable(250);
+     console.log(JSON.stringify({ reachable, tookMs: Date.now() - startedAt }));`,
+    );
+    // Without the bound the probe returns only when the fake CLI's 15s sleep ends.
+    expect(result).toEqual({ reachable: false, tookMs: expect.any(Number) });
+    expect((result as { tookMs: number }).tookMs).toBeLessThan(15_000);
+  },
+);
 
 // On Linux arm64 isDockerEnabled() is false before it looks at anything else.
 test.concurrent.skipIf(isWindows || (isLinux && process.arch === "arm64"))(
@@ -224,13 +262,7 @@ test.concurrent.skipIf(isWindows)(
     using dir = fakeDockerDir();
     const socketPath = join(String(dir), "coordinator.sock");
 
-    // ensure() answers from BUN_TEST_SERVICE_<name> without touching docker, and
-    // BUN_DOCKER_* / COMPOSE_* change what it runs; this run has to reach the fake CLI.
-    const env: Record<string, string> = {};
-    for (const [key, value] of Object.entries(bunEnv)) {
-      if (value !== undefined && !/^(BUN_TEST_SERVICE_|BUN_DOCKER_|COMPOSE_)/.test(key)) env[key] = value;
-    }
-    env.PATH = `${join(String(dir), "bin")}:${env.PATH}`;
+    const env = envWithFakeDocker(String(dir));
     env.BUN_DOCKER_COORDINATOR_SOCKET = socketPath;
 
     await using coordinator = Bun.spawn({


### PR DESCRIPTION
### Problem
- `test/js/sql/postgres-prepared-pipeline-reorder.test.ts` went red on `:alpine: 3.23 x64` in build 98746 with `Failed to start service postgres_plain (via coordinator): Docker is not available. Please ensure Docker is installed and running.` (thrown at `test/docker/index.ts:336`), on all four in-shard attempts. The same shard shape hit `postgres-simple-query-pipeline` and `sql-onconnect-onclose-throw` (98647), `integration/mysql2` (98707) and `sql.test.ts` (97891); the second form of the failure is `A functional \`docker\` is required in CI for some tests.` from `isDockerEnabled()` in `test/harness.ts`.
- Every one of those jobs is an alpine agent whose job started before dockerd was listening: the runner's `--- Docker` section prints `dial unix /var/run/docker.sock: no such file or directory`, the coordinator's prestart fails at ~+20s, the test files fail at +140..270s (the daemon is still down at the last of those), and in the three logs that run long enough the daemon is up by +305..405s. In build 98746, 6 of the 24 alpine jobs had no daemon at job start (5 of them got one within the next ~10s); all 116 debian/ubuntu jobs had one.
- Root cause: `scripts/agent.mjs` installs the openrc `buildkite-agent` service with no ordering against `docker`. openrc starts a runlevel's unrelated services one at a time in name order, so the agent ("b") starts and acquires its job before the boot reaches "docker"; usually that is seconds later, and when a service in between is slow it is minutes. systemd images start everything in parallel, which is why this is alpine-only. Alpine's docker service also returns as soon as dockerd is spawned, so ordering alone still leaves dockerd's own start-up time.
- Why it fails the tests: `test/docker/coordinator.ts` (since #32033) runs a single `docker version` per request and fails the request on the spot, and the runner's retries of a file run within seconds of each other, so a late daemon fails the file four times; `isDockerEnabled()` additionally runs `docker info` at import time of ~25 test files and throws in CI when the daemon is down.
- No single commit to revert: the probe has been one-shot since the coordinator was introduced and the unit has been unordered since it was written; the daemon has been getting later on the alpine images recently. #34480 was an earlier attempt (30s poll in the runner, then exit 75 to re-run the shard on a new VM); closed as superseded by this PR.

### Fix
Two layers, plus a way to see which one is doing the work:

- Boot (the root-cause fix; `scripts/agent.mjs`, active from the next image publish): the openrc unit gets `after docker`, and `start()`, which is the boot command of the Linux images, polls `docker version` for up to two minutes before it starts `buildkite-agent`. The machine already holds its job (`--acquire-job`), so this only moves the job's start, and it covers everything in the job that talks to the daemon, including the few tests that call `docker` directly and the runner's own `docker ps`. Ordering is `after`, not `need`, so images without docker still boot; the poll is bounded, so a dead daemon delays a job by two minutes instead of never starting it. Activating it needs a `[publish linux images]` run per the flow documented in `.buildkite/ci.mjs` (no bootstrap version bump is needed for an agent.mjs change; #35996 was the same kind of republish). I have not triggered a publish from this PR since it replaces the live images; happy to amend the subject if a maintainer wants it done here, otherwise it rides along with the next publish.
- Test infrastructure (what fixes CI on the images running today, and covers whatever daemon start-up time remains after the republish):
  - `test/docker/index.ts`: `waitForDockerDaemon()` runs one poll loop over `docker version` (each probe killed after 10s, so a CLI stuck on a half-up daemon counts as unreachable instead of stalling the loop) and returns `waitFor(capMs)`: resolves once a probe succeeds, rejects a caller after its own cap while the loop keeps going, and after the 10-minute window every later caller fails immediately. A daemon that is up costs one probe and logs nothing.
  - `test/docker/coordinator.ts`: starts the wait at launch, so it overlaps the non-container tests the runner schedules first, and every ensure (prestart and test requests) awaits it for up to 90s before running compose. 90s is the per-test budget the runner gives the hook that is usually awaiting the request (`--timeout` = `testTimeout / 2` on the release lanes), so a request gets the daemon or a clear error within the time its caller has anyway, the 3-minute file budget keeps room for `compose up` and the tests, and a file's four attempts cover ~6 minutes of lateness from its first request (container-backed files are also scheduled late in the shard), which covers every arrival seen above. The 10-minute window is well past the latest arrival seen (~6.7 minutes into the job) and bounds the cost of a daemon that never comes up to one window per shard instead of 4 x 90s per file.
  - `test/harness.ts`: `isDockerEnabled()` returns true when `BUN_DOCKER_COORDINATOR` is set (after the existing CLI and linux-arm64 checks) instead of probing the daemon itself, as `describeWithContainer()` and `test/js/valkey/test-utils.ts` already do; this is what lets `sql.test.ts`, `sql-mysql.test.ts`, `s3.test.ts`, autobahn, ... benefit from the wait, and it removes a `docker info` per file. Files that then use `docker` directly: `bun-install-proxy.test.ts` (converted below) and the four `js/bun/test/parallel/test-docker-build-*.ts` files, which the runner only runs after every other file in the shard has finished.
  - `test/cli/install/bun-install-proxy.test.ts` + `test/docker/prestart-map.mjs`: this file gated on `isDockerEnabled()` but then ran `docker run -p 3128:3128 ubuntu/squid` itself, so with the harness change it would have failed on its own 60s squid poll instead of at import. It now starts the compose `squid` service (built from the same image) through `ensure()`, keeps an HTTP readiness poll as before (the service's healthcheck only checks the process exists; each probe is bounded), and is in the prestart map so it runs late with squid prestarted, like `websocket-proxy`. It is in this PR because the harness change is what makes it necessary; #34175 touches the same file and will need a small rebase, noted there.
- Visibility (`scripts/utils.mjs`): when `docker ps` fails in the job's `--- Docker` section, print `rc-status` (which boot step the daemon was behind) and append one info-style line to a per-build annotation, so the rate of jobs starting without the daemon can be read off builds before and after the republish. If it drops to zero after the publish, the coordinator wait is pure insurance and could be simplified; if not, it is still load-bearing. Info style keeps it out of `bun run ci:errors`, which lists error-style annotations only.
- Why this shape: the daemon being up is a condition to wait for, and the two places to wait are where the invariant belongs (agent start-up, which needs a publish to reach the fleet) and the one process per shard that already owns docker and lives for the whole shard (which fixes the builds failing now and overlaps the wait with tests that do not need docker). Compared with #34480, nothing is added to the Buildkite retry rules (since rewritten to cover agent loss only), no shard is thrown away, and a 30s poll would not have covered any of the four builds above.
- Unchanged behavior: local runs without a coordinator still fail fast in `ensureDocker()`; `isDockerEnabled()` still returns false on linux-arm64 and still probes when no coordinator is set; the runner still decides whether to spawn the coordinator from `docker compose version`, which does not need a daemon, so a late daemon still gets a coordinator; the systemd unit is untouched (the daemon has been up at job start on all 116 debian/ubuntu jobs sampled, and the `start()` poll covers those images too once published).
- Verified: `bun bd test test/internal/docker-coordinator.test.ts` (8 pass). Scripted-probe tests cover a daemon that is up, concurrent waiters sharing one loop, a capped request followed by a successful retry, a request pending when the window closes, and the window closing with nobody waiting (fails with an escaped rejection if the internal catch is removed); a docker on PATH that sleeps pins the probe bound (fails without it); a fake docker whose first `version` fails checks `isDockerEnabled()` in a fresh process with and without the coordinator variable, and runs the real coordinator end to end (request answered with the port mapping; `calls.log` shows probe, probe, then compose). With `test/docker/coordinator.ts` reverted the end-to-end test fails with exactly the CI error; with `test/harness.ts` reverted the harness test fails with `threw: A functional \`docker\` is required in CI for some tests.`. The agent.mjs poll was run standalone against a docker that answers on the second probe (returns after 1s) and against none (returns at the budget); `printEnvironment()` was run with a fake `rc-status` and a fake `buildkite-agent` on PATH and produced the rc-status dump and the expected `annotate --append --style info` call; `node --check` passes on both scripts. `bun-install-proxy.test.ts` has no docker here, so its hook was exercised by pointing `BUN_TEST_SERVICE_squid` at a local `Bun.serve` stand-in: the hook resolves and the installs go through the stand-in's port. On the earlier CI runs of this branch the new test file passed on alpine x64, debian ASAN and darwin aarch64 (checked in the job logs), and an alpine shard's `postgres-listen-notify` log shows it getting postgres through the coordinator.

### Background
- Test-service coordinator: `scripts/runner.node.mjs` spawns `test/docker/coordinator.ts` once per Linux shard and exports its unix socket as `BUN_DOCKER_COORDINATOR`. `ensure(service)` in `test/docker/index.ts`, used by `describeWithContainer()` and the sql/valkey/s3 tests, sends the service name over that socket and gets back the container's host port mapping; the coordinator is the only process that runs `docker compose up`, and it prestarts the services the shard's files are known to need (`prestart-map.mjs`, which the runner also uses to schedule those files last). Without the variable (local runs) `ensure()` runs compose itself.
- Runner retries and budgets: in CI a failing test file is re-run up to 3 more times immediately (`--retries=3`); each file's process gets 3 minutes (`testTimeout`), and `bun test --timeout` is set to half of that for individual tests and hooks (three times as much on ASAN lanes).
- `docker version` vs `docker compose version`: the former talks to the daemon and exits non-zero until it is listening; the latter only checks the compose CLI plugin and succeeds with no daemon at all.
- Ephemeral agents and images: each Linux test job gets a fresh VM booted from a pre-baked image whose boot command is `scripts/agent.mjs start`; the agent starts with `--acquire-job` and takes its job the moment it registers, so anything the boot has not finished by then races the job. Image contents (including agent.mjs) change only when images are republished (`[publish images]` on a PR, see `.buildkite/ci.mjs`).
- openrc: Alpine's init system. Unless `rc_parallel` is enabled (it is not on these images) a runlevel's services start one at a time, ordered by declared dependencies and otherwise by name; `after X` orders a service after X when X is in the runlevel without making it a hard dependency. Alpine's docker service runs dockerd under `supervise-daemon`, so its start returns as soon as dockerd is spawned.
- Buildkite annotations: `buildkite-agent annotate --append --context X` appends to one annotation per build, so many jobs appending a line each yields a single list per build.

<details>
<summary>Timelines from the four builds (seconds after job start)</summary>

```
98746  alpine 3.23 x64  (ip-172-31-33-40-1)
  +11s  --- Docker: dial unix /var/run/docker.sock: no such file or directory
  +22s  COORDINATOR_READY; redis_unified, mysql_plain prestart fail: Docker is not available
 +170s  postgres-prepared-pipeline-reorder: 4 attempts, all "Docker is not available" (+170, +179, +190, +205)
 +210s  valkey: redis_unified request fails           <- still down
 +405s  coordinator: ensuring redis_unified -> ready at +416s   <- up
 +416s  coordinator: ensuring mysql_plain   -> ready at +445s

98647  alpine 3.23 x64
  +10s  --- Docker: socket missing;  +21s prestart fails
 +207..238s  postgres_plain requests fail;  +243..267s sql-onconnect-onclose-throw: isDockerEnabled() throws
 +310s  coordinator: postgres_plain ready                <- up (down at +267s)

98707  alpine 3.23 aarch64
  +10s  socket missing;  +18s prestart of 6 services fails
 +143..172s  mysql_plain / mysql_native_password / redis_unified requests fail
 +365s  coordinator: redis_unified ready                 <- up (down at +172s)

97891  alpine 3.23 x64
  +11s  socket missing;  +22s prestart fails
 +190..222s  sql.test.ts x4: isDockerEnabled() throws ("A functional `docker` is required in CI")

98746, all 140 Linux test jobs: daemon missing at job start on 6/24 alpine jobs (5 recovered within
~10s, before the coordinator's first probe), 0/116 debian + ubuntu jobs.
```
</details>
