### PR TITLE
bundler: keep exported and using declarations initialized by an unwrapped require()

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -24,9 +24,10 @@ use crate::{
     FindLabelSymbolResult, FnOnlyDataVisit, FnOrArrowDataParse, FnOrArrowDataVisit, FunctionKind,
     IdentifierOpts, ImportItemForNamespaceMap, InvalidLoc, JSXImport, JSXTransformType, Jest,
     LOC_MODULE_SCOPE as loc_module_scope, LocList, MacroState, ParseStatementOptions, ParsedPath,
-    PrependTempRefsOpts, ReactRefresh, Ref, RefMap, RefRefMap, RuntimeImports, ScopeOrder,
-    ScopeOrderList, StrictModeFeature, StringBoolMap, Substitution, TempRef, ThenCatchChain,
-    TransposeState, WrapMode, fs, is_eval_or_arguments, options, statement_cares_about_scope,
+    PrependTempRefsOpts, ReactRefresh, Ref, RefMap, RefRefMap, RequireUnwrap, RuntimeImports,
+    ScopeOrder, ScopeOrderList, StrictModeFeature, StringBoolMap, Substitution, TempRef,
+    ThenCatchChain, TransposeState, WrapMode, fs, is_eval_or_arguments, options,
+    statement_cares_about_scope,
 };
 use bun_ast as js_ast;
 use bun_ast::DeclaredSymbol;
@@ -1147,7 +1148,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // We cannot unwrap a require wrapped in a try/catch because
                     // import statements cannot be wrapped in a try/catch and
                     // require cannot return a promise.
-                    && !handles_import_errors;
+                    && !handles_import_errors
+                    && state.require_unwrap != RequireUnwrap::Disabled;
 
                 if should_unwrap_require {
                     let import_record_index = self.add_import_record_by_range_and_path(
@@ -1190,7 +1192,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         .insert(namespace_ref, ImportItemForNamespaceMap::default());
                     self.record_usage(namespace_ref);
 
-                    if !state.is_require_immediately_assigned_to_decl {
+                    if state.require_unwrap != RequireUnwrap::IntoDecl {
                         return self.new_expr(
                             E::Identifier {
                                 ref_: namespace_ref,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -691,11 +691,23 @@ pub struct VisitDeclOpts {
     pub(crate) could_be_macro: bool,
 }
 
+/// What a `require()` of a package on the CommonJS unwrap list becomes at the visited position.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum RequireUnwrap {
+    /// A reference to the namespace of the `import * as ns` it becomes.
+    #[default]
+    Namespace,
+    /// `const x = require("pkg")`: the import takes over `x` and `visit_decls` drops the declarator.
+    IntoDecl,
+    /// Stays a plain `require()`, as inside a try/catch: `using` disposes the required value itself.
+    Disabled,
+}
+
 #[derive(Clone, Copy)]
 pub struct TransposeState {
     pub(crate) is_await_target: bool,
     pub(crate) is_then_catch_target: bool,
-    pub(crate) is_require_immediately_assigned_to_decl: bool,
+    pub(crate) require_unwrap: RequireUnwrap,
     pub(crate) loc: bun_ast::Loc,
     pub(crate) import_record_tag: Option<bun_ast::ImportRecordTag>,
     pub(crate) import_loader: Option<bun_ast::Loader>,
@@ -707,7 +719,7 @@ impl Default for TransposeState {
         Self {
             is_await_target: false,
             is_then_catch_target: false,
-            is_require_immediately_assigned_to_decl: false,
+            require_unwrap: RequireUnwrap::Namespace,
             loc: bun_ast::Loc::EMPTY,
             import_record_tag: None,
             import_loader: None,
@@ -1011,9 +1023,8 @@ pub struct ExprIn {
     /// tests.
     pub(crate) assign_target: js_ast::AssignTarget,
 
-    /// Currently this is only used when unwrapping a call to `require()`
-    /// with `__toESM()`.
-    pub(crate) is_immediately_assigned_to_decl: bool,
+    /// Set by `visit_decls` when the expression initializes a declarator.
+    pub(crate) require_unwrap: RequireUnwrap,
 
     pub(crate) property_access_for_method_call_maybe_should_replace_with_undefined: bool,
 }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -10,8 +10,8 @@ use crate::lexer as js_lexer;
 use crate::p::{LowerUsingDeclarationsContext, P};
 use crate::parser::{
     ExprIn, FnOnlyDataVisit, FnOrArrowDataVisit, ImportItemForNamespaceMap, PrependTempRefsOpts,
-    Ref, RelocateVarsMode, ScopeOrder, StmtsKind, StrictModeFeature, StringVoidMap, VisitArgsOpts,
-    VisitDeclOpts, is_eval_or_arguments,
+    Ref, RelocateVarsMode, RequireUnwrap, ScopeOrder, StmtsKind, StrictModeFeature, StringVoidMap,
+    VisitArgsOpts, VisitDeclOpts, is_eval_or_arguments,
 };
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast as js_ast;
@@ -242,8 +242,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub(crate) fn visit_decls<const IS_POSSIBLY_DECL_TO_REMOVE: bool>(
         &mut self,
         decls: &mut [G::Decl],
-        was_const: bool,
+        kind: LocalKind,
+        is_export: bool,
     ) -> usize {
+        let was_const = kind == LocalKind::KConst;
+        let require_unwrap = if kind.is_using() {
+            RequireUnwrap::Disabled
+        } else if is_export {
+            RequireUnwrap::Namespace
+        } else {
+            RequireUnwrap::IntoDecl
+        };
         let mut j: usize = 0;
         // Iterate by index so kept entries can be written back through `decls[j]`
         // while scanning ahead.
@@ -320,7 +329,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.visit_expr_in_out(
                     &mut val,
                     ExprIn {
-                        is_immediately_assigned_to_decl: true,
+                        require_unwrap,
                         ..Default::default()
                     },
                 );

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -9,7 +9,8 @@ use crate::lexer as js_lexer;
 use crate::p::P;
 use crate::parser::{
     ExprIn, FnOrArrowDataVisit, IdentifierOpts, PrependTempRefsOpts, ReactRefresh, Ref,
-    StrictModeFeature, ThenCatchChain, TransposeState, VisitArgsOpts, float_to_int32, prefill,
+    RequireUnwrap, StrictModeFeature, ThenCatchChain, TransposeState, VisitArgsOpts,
+    float_to_int32, prefill,
 };
 use crate::scan::scan_side_effects::SideEffects;
 use bun_alloc::ArenaVecExt as _;
@@ -2019,8 +2020,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if e_.args.len_u32() == 1 {
                 let first = e_.args.slice()[0];
                 let state = TransposeState {
-                    is_require_immediately_assigned_to_decl: in_.is_immediately_assigned_to_decl
-                        && matches!(first.data, Data::EString(..)),
+                    require_unwrap: match in_.require_unwrap {
+                        // Only a string literal can take over the declaration.
+                        RequireUnwrap::IntoDecl if !matches!(first.data, Data::EString(..)) => {
+                            RequireUnwrap::Namespace
+                        }
+                        mode => mode,
+                    },
                     ..Default::default()
                 };
                 match &first.data {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -1132,11 +1132,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.cur_scope().is_after_const_local_prefix = was_after_after_const_local_prefix;
 
         // visit_decls returns the surviving decl count; truncate `data.decls.len` to it.
-        let was_const = data.kind == S::Kind::KConst;
         let new_len = if !(data.is_export && p.options.features.replace_exports.entries.len() > 0) {
-            p.visit_decls::<false>(data.decls.slice_mut(), was_const)
+            p.visit_decls::<false>(data.decls.slice_mut(), data.kind, data.is_export)
         } else {
-            p.visit_decls::<true>(data.decls.slice_mut(), was_const)
+            p.visit_decls::<true>(data.decls.slice_mut(), data.kind, data.is_export)
         };
         // Drop the whole statement when every decl was
         // eliminated; otherwise we'd emit an empty `var;`/`let;`/`const;`.

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -320,6 +320,124 @@ describe("bundler", () => {
       stdout: "react\nreact",
     },
   });
+  // `const x = require("react")` is normally replaced by the import it becomes.
+  // An exported declaration has to survive as a declaration, or the export is
+  // dropped with it.
+  itBundled("cjs2esm/UnwrappedModuleRequireExported", {
+    files: {
+      "/entry.js": /* js */ `
+        import { constReact, varReact, letReact, first, second, third } from "./lib.js";
+        import { importEquals, NS } from "./lib-ts.ts";
+        console.log(constReact.react, varReact.react, letReact.react);
+        console.log(first.react, second, third.react);
+        console.log(importEquals.react, NS.react.react);
+      `,
+      "/lib.js": /* js */ `
+        export const constReact = require("react");
+        export var varReact = require("react");
+        export let letReact = require("react");
+        export const first = require("react"),
+          second = "second",
+          third = require("react");
+      `,
+      "/lib-ts.ts": /* ts */ `
+        export import importEquals = require("react");
+        export namespace NS {
+          export const react = require("react");
+        }
+      `,
+      ...fakeReactNodeModules,
+    },
+    run: {
+      stdout: "react react react\nreact second react\nreact react",
+    },
+  });
+  // Same against a package that converts to ESM. The unexported declaration is
+  // still folded into the import; the exported one stays a declaration.
+  itBundled("cjs2esm/UnwrappedModuleRequireExportedConverted", {
+    files: {
+      "/entry.js": /* js */ `
+        import { exported } from "./lib.js";
+        console.log(exported.react);
+      `,
+      "/lib.js": /* js */ `
+        export const exported = require("react");
+        const unexported = require("react");
+        console.log(unexported.react);
+      `,
+      "/node_modules/react/index.js": /* js */ `
+        exports.react = "react";
+      `,
+      "/node_modules/react/package.json": /* json */ `
+        {
+          "name": "react",
+          "version": "2.0.0",
+          "main": "index.js"
+        }
+      `,
+    },
+    onAfterBundle: api => {
+      const code = api.readFile("out.js");
+      expect(code).toMatch(/var exported = \(?exports_react\)?;/);
+      expect(code).not.toContain("unexported");
+    },
+    run: {
+      stdout: "react\nreact",
+    },
+  });
+  // A `using` declaration disposes the required value itself, so its require()
+  // is not unwrapped at all: the import namespace __toESM() builds has no
+  // symbol-keyed properties and only getters. The expected output is what the
+  // entry prints unbundled.
+  itBundled("cjs2esm/UnwrappedModuleRequireUsing", {
+    files: {
+      "/entry.js": /* js */ `
+        import reactExports from "react";
+        import schedulerExports from "scheduler";
+        {
+          using react = require("react");
+          await using scheduler = require("scheduler");
+          using conditional = require(Math.random() < 2 ? "react" : "scheduler");
+          console.log(react.react, scheduler.scheduler, conditional.react);
+          console.log(react === reactExports, scheduler === schedulerExports, conditional === reactExports);
+        }
+        console.log("after", reactExports.disposed, schedulerExports.disposed);
+      `,
+      "/node_modules/react/index.js": /* js */ `
+        module.exports = {
+          react: "react",
+          [Symbol.dispose]() {
+            this.disposed = true;
+            console.log("dispose react");
+          },
+        };
+      `,
+      "/node_modules/react/package.json": /* json */ `
+        {
+          "name": "react",
+          "version": "2.0.0",
+          "main": "index.js"
+        }
+      `,
+      "/node_modules/scheduler/index.js": /* js */ `
+        exports.scheduler = "scheduler";
+        exports[Symbol.asyncDispose] = async function () {
+          this.disposed = true;
+          console.log("dispose scheduler");
+        };
+      `,
+      "/node_modules/scheduler/package.json": /* json */ `
+        {
+          "name": "scheduler",
+          "version": "1.0.0",
+          "main": "index.js"
+        }
+      `,
+    },
+    run: {
+      stdout: "react scheduler react\ntrue true true\ndispose react\ndispose scheduler\ndispose react\nafter true true",
+    },
+  });
   itBundled("cjs2esm/ReactSpecificUnwrapping", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
### Problem
- `bun build` (ESM output, the default) drops the export of a declaration initialized by a `require()` of a package on the CommonJS unwrap list (`react`, `react-dom`, `scheduler`, ...). Same on 1.4.0 and main:
  ```js
  // lib.js
  export const React = require("react");
  // entry.js
  import { React } from "./lib.js";   // error: No matching export in "lib.js" for import "React"
  ```
  Bundling `lib.js` alone prints `var React = __toESM(require_react(), 1);` with no `export { React }`.
- Affected the same way: `export var`/`export let`, the other declarators of a multi-declarator `export const`, TypeScript `export import React = require("react")`, `export const` inside a TypeScript namespace (the `NS.React = ...` assignment disappears), and all of these when the required file converts to ESM instead of staying wrapped.
- `using x = require("react")` / `await using` lose their disposal the same way: the bundle prints a hoisted `var` and the value is never disposed.
- Cause: `visit_decls` (`src/js_parser/visit/mod.rs`) visits every initializer with `ExprIn.is_immediately_assigned_to_decl`. `transpose_require` (`src/js_parser/p.rs`, unwrap branch) answers the flag with an `E::RequireString` marker, and `visit_decls` consumes it by renaming the pending `import * as ns` to the declared name and removing the declarator. With every declarator gone, `s_local` (`src/js_parser/visit/visit_stmt.rs`) drops the whole `S::Local`, and with it the `export` keyword (`scan_imports` records exports from the `S::Local` statements that survive the visit) or the `using` kind (nothing is left to lower). For a plain `const x = require("react")` that is the intended rewrite; an import statement cannot stand in for an exported or `using` declaration.

### Fix
- The bool becomes a three-state `RequireUnwrap` (`src/js_parser/parser.rs`), carried through `ExprIn` and `TransposeState` exactly where the bool was. `visit_decls` now takes the statement's `kind` and `is_export` (it took `was_const`, now derived from `kind`) and picks the mode once per statement:
  - exported: `Namespace`. `transpose_require` takes its existing other branch and returns the import namespace identifier, which is what a `require()` of an unwrapped package already becomes in every non-declaration position. The declaration survives with that initializer, so the export is recorded. Exports inside a namespace need nothing extra: `is_export` is set there too, and `s_local`'s namespace branch emits the `NS.x = ...` assignment once the declaration survives.
  - `using` / `await using`: `Disabled`. `transpose_require` ANDs it into `should_unwrap_require` next to the existing try/catch condition, so the `require()` stays an ordinary require and the declaration binds the module's own exports value. It flows through `require(a ? "x" : "y")` as well, since `maybe_transpose_if_require` passes the same state to both branches.
  - everything else: `IntoDecl`, the previous behavior. `visit_expr` still downgrades it to `Namespace` when the argument is not a string literal (the old `&& first is EString`).
- Why these shapes:
  - The marker exists only so `visit_decls` can replace the declaration, so the decision belongs where the marker is produced. Gating the consumer instead would leave the marker in the tree for the printer, whose fallback for a surviving marker is the path #39184 is fixing.
  - For exports, binding the namespace is correct for both target shapes and is what every other position prints: wrapped gives `var react = __toESM(require_react(), 1); var React = react;`, converted gives `var React = exports_react;`. Keeping the fold and synthesizing an `export { x }` instead would save the alias and, when the export is unused by other files, let the file's own `x.foo` reads tree-shake the package (measured: 3 exports retained vs 1). That case was only "optimal" before because the export was silently missing; when the export is consumed, both shapes materialize the namespace object (measured identical apart from the alias line); and folding `export let x = require(..)` would extend the existing mishandling of later `x = ...` assignments to exports. Not worth a second code path in this fix.
  - For `using`, binding the namespace is not enough: `__toESM()` copies only string-keyed own properties, as getters, and a converted module's namespace object has no symbols at all, so `module.exports = { [Symbol.dispose]() {} }` or `exports[Symbol.asyncDispose] = ...` (the shapes a disposable CommonJS module actually has; both stay wrapped) would throw `TypeError: Object not disposable` in the bundle while working unbundled. Treating the site like a try/catch is the existing mechanism for "this require() must stay a require()", and the bundle then prints exactly what the source does unbundled (verified: the new test's expected stdout is the unbundled output of its entry).
  - Plain declarations are unchanged: pinned by the `unexported` assertion in the new converted test and by the existing `cjs2esm/UnwrappedModuleRequireAssigned` and `npm/ReactSSR` tests (the React packages have no `export` keywords, and their `exports.x = require(...)` statements are rewritten in `s_expr` after the expression visit, so they never reach this path; `npm/ReactSSR`'s exact output is unchanged).
- Verified with `test/bundler/bundler_cjs2esm.test.ts`; the three new tests fail on the current release and pass with this change:
  - `cjs2esm/UnwrappedModuleRequireExported`: `export const`/`var`/`let`, a multi-declarator `export const`, `export import x = require()` and an export inside a namespace, imported and read from an entry (before: `No matching export` for each).
  - `cjs2esm/UnwrappedModuleRequireExportedConverted`: `export const` against a package that converts to ESM prints `var exported = exports_react;`; a non-exported declaration in the same file is still folded into the import.
  - `cjs2esm/UnwrappedModuleRequireUsing`: `using`, `await using` and a `using` of a conditional `require()` against modules with own `Symbol.dispose` / `Symbol.asyncDispose` hooks: the bound values are identical to the modules' exports (`=== ` against an `import` of the same packages), the hooks run at block exit with the module as `this`, and the output equals the unbundled run (before: `TypeError: Object not disposable`).
- Also ran `bundler_cjs2esm`, `bundler_cjs`, `bundler_edgecase`, `bundler_regressions`, `bundler_npm`, `bundler_bun`, `bundler_minify`, `esbuild/default` and `transpiler/transpiler.test.js` with the debug build: no failures.
- Related: #39184 (open) restricts the same site to identifier bindings (destructuring, a different symptom); in terms of this PR that is `IntoDecl` only for `B::Identifier` bindings. Whichever lands second rebases the one site in `visit_decls` plus the `ExprIn` comment.

### Background
- CommonJS unwrap list: when bundling to ESM, files inside the packages in `DEFAULT_UNWRAP_COMMONJS_PACKAGES` (`src/bundler/options.rs`) are parsed with `exports.x = ...` turned into ESM exports, and every `require()` resolving into one of those packages, from any file, becomes an `import * as ns from "..."` statement (emitted at the end of the parse from `imports_to_convert_from_require`) plus a reference to `ns`. This is what lets React tree-shake. A `require()` inside a try/catch is the existing exception: it stays a plain require because an import cannot be caught.
- Wrapped vs converted target: a required file that assigns `module.exports` (or anything else the converter cannot express, such as a symbol-keyed `exports[...] = ...`) stays CommonJS and is emitted as `var require_x = __commonJS(...)`; a plain `require()` of it prints `require_x()` and its import namespace prints `__toESM(require_x(), 1)`. A file that only uses `exports.x = ...` converts, and its namespace prints as the linker's generated namespace object (`exports_x`).
- `E::RequireString.unwrapped_id`: the marker `transpose_require` returns in `IntoDecl` mode; it indexes the pending import, and `visit_decls` uses it to rename that import's namespace to the declared binding and drop the declarator, turning `const React = require("react")` into `import * as React from "react"`. Nothing else produces or reads it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/167] gen JS modules (bundle-modules)
Preprocess modules (9205ms)
Bundle modules (54ms)
Postprocesss modules (175ms)
Bundle Functions (653ms)
Generate Code (12ms)

[10.12s] Bundled "src/js" for development
  2825 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[1/166] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[98/166] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcrypto-2.cpp.o
FAILED: obj/unified/UnifiedSource-src_jsc_bindings_webcrypto-2.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -glldb -g3 -gz=zstd -fno-standalone-debug -fsanitize=address -fno-exceptions -fno-c++-static-destructors -fno-rtti -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fvisibility=hidden -fvisibility-inlines-hidden -fno-unwind-tables -fno-asynchronous-unwind-tables -
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (eabb96de7)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [27.43ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [14.14ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [14.53ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [13.87ms]
(pass) bundler > cjs2esm/ExportsFunction [14.99ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [14.55ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [13.84ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [17.62ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [16.68ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [16.62ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [16.44ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireDestructuredAndInTry [15.05ms]
1363 |             }
1364 | 
1365 |             return testRef(id, opts);
1366 |           }
1367 | 
1368 |           throw new Error("Bundle Failed\n" + [...allErrors].map(formatError).join("\n"));
                           ^
error: Bundle Failed
/entry.js:1:10: No matching export in "lib.js
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (cdd2d05c6)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [893.18ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [442.29ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [422.11ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [407.01ms]
(pass) bundler > cjs2esm/ExportsFunction [416.19ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [405.07ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [398.94ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [587.96ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [598.13ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [424.41ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [489.29ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireDestructuredAndInTry [796.37ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireExported [456.27ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireExpor
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 713ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/130] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/130] gen cpp.rs (cppbind)
[3/130] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2Fra
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                   |  12 ++--
 src/js_parser/parser.rs              |  21 +++++--
 src/js_parser/visit/mod.rs           |  17 +++--
 src/js_parser/visit/visit_expr.rs    |  12 +++-
 src/js_parser/visit/visit_stmt.rs    |   5 +-
 test/bundler/bundler_cjs2esm.test.ts | 118 +++++++++++++++++++++++++++++++++++
 6 files changed, 165 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/js_parser/p.rs                        3      3      0
src/js_parser/parser.rs                   5      6      0
src/js_parser/visit/mod.rs                4      6      0
src/js_parser/visit/visit_expr.rs         4      3      0
src/js_parser/visit/visit_stmt.rs         2      2      0
test/bundler/bundler_cjs2esm.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->