### PR TITLE
Report unknown node: builtins in static imports with "No such built-in module" on every transpile path

### DIFF
--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -524,12 +524,8 @@ impl Linker {
         Ok(())
     }
 
-    /// `import_record` is a `node:` specifier that is not a builtin. Same text as
-    /// `ResolveMessage::fmt`: files transpiled off the JS thread skip this linker
-    /// and get their error from the runtime resolve hook instead.
-    ///
-    /// Takes the disjoint pieces explicitly rather than `&mut self` plus
-    /// overlapping sub-borrows of `result`.
+    // Same text as `ResolveMessage::fmt`: files transpiled off the JS thread skip
+    // this linker and get this error from the runtime resolve hook instead.
     fn when_builtin_not_found(
         log: &mut Log,
         import_record: &mut ImportRecord,

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -449,11 +449,8 @@ impl Linker {
                         if strings::starts_with(import_record.path.text, b"node:") {
                             // if a module is not found here, it is not found at
                             // all so we can just disable it
-                            had_resolve_errors = Self::when_builtin_not_found::<IS_BUN>(
-                                self.log_mut(),
-                                import_record,
-                                source,
-                            );
+                            had_resolve_errors =
+                                Self::when_builtin_not_found(self.log_mut(), import_record, source);
 
                             if had_resolve_errors {
                                 return Err(crate::Error::ResolveMessage);
@@ -537,7 +534,7 @@ impl Linker {
     ///
     /// Takes the disjoint pieces explicitly rather than `&mut self` plus
     /// overlapping sub-borrows of `result`.
-    fn when_builtin_not_found<const IS_BUN: bool>(
+    fn when_builtin_not_found(
         log: &mut Log,
         import_record: &mut ImportRecord,
         source: &bun_ast::Source,
@@ -553,14 +550,12 @@ impl Linker {
             return false;
         }
 
-        if IS_BUN {
-            // make these happen at runtime
-            if import_record.kind == ImportKind::Require
-                || import_record.kind == ImportKind::RequireResolve
-                || import_record.kind == ImportKind::Dynamic
-            {
-                return false;
-            }
+        // make these happen at runtime
+        if import_record.kind == ImportKind::Require
+            || import_record.kind == ImportKind::RequireResolve
+            || import_record.kind == ImportKind::Dynamic
+        {
+            return false;
         }
 
         log.add_resolve_error(

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -524,8 +524,6 @@ impl Linker {
         Ok(())
     }
 
-    // Same text as `ResolveMessage::fmt`: files transpiled off the JS thread skip
-    // this linker and get this error from the runtime resolve hook instead.
     fn when_builtin_not_found(
         log: &mut Log,
         import_record: &mut ImportRecord,

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -524,13 +524,9 @@ impl Linker {
         Ok(())
     }
 
-    /// `import_record` is a `node:` specifier that is not in the builtin table.
-    /// Returns whether an error was logged.
-    ///
-    /// The message is the one the runtime resolve hook produces for the same
-    /// specifier (`ResolveMessage::fmt`, Node's `ERR_UNKNOWN_BUILTIN_MODULE`
-    /// text); files transpiled off the JS thread skip this linker and get
-    /// theirs from the hook, so the two have to agree.
+    /// `import_record` is a `node:` specifier that is not a builtin. Same text as
+    /// `ResolveMessage::fmt`: files transpiled off the JS thread skip this linker
+    /// and get their error from the runtime resolve hook instead.
     ///
     /// Takes the disjoint pieces explicitly rather than `&mut self` plus
     /// overlapping sub-borrows of `result`.

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -449,12 +449,11 @@ impl Linker {
                         if strings::starts_with(import_record.path.text, b"node:") {
                             // if a module is not found here, it is not found at
                             // all so we can just disable it
-                            had_resolve_errors = Self::when_module_not_found::<IS_BUN>(
+                            had_resolve_errors = Self::when_builtin_not_found::<IS_BUN>(
                                 self.log_mut(),
-                                target,
                                 import_record,
                                 source,
-                            )?;
+                            );
 
                             if had_resolve_errors {
                                 return Err(crate::Error::ResolveMessage);
@@ -528,14 +527,21 @@ impl Linker {
         Ok(())
     }
 
-    // Takes the disjoint pieces explicitly rather than `&mut self` plus
-    // overlapping sub-borrows of `result`.
-    fn when_module_not_found<const IS_BUN: bool>(
+    /// `import_record` is a `node:` specifier that is not in the builtin table.
+    /// Returns whether an error was logged.
+    ///
+    /// The message is the one the runtime resolve hook produces for the same
+    /// specifier (`ResolveMessage::fmt`, Node's `ERR_UNKNOWN_BUILTIN_MODULE`
+    /// text); files transpiled off the JS thread skip this linker and get
+    /// theirs from the hook, so the two have to agree.
+    ///
+    /// Takes the disjoint pieces explicitly rather than `&mut self` plus
+    /// overlapping sub-borrows of `result`.
+    fn when_builtin_not_found<const IS_BUN: bool>(
         log: &mut Log,
-        target: BundleTarget,
         import_record: &mut ImportRecord,
         source: &bun_ast::Source,
-    ) -> crate::Result<bool> {
+    ) -> bool {
         if import_record
             .flags
             .contains(ImportRecordFlags::HANDLES_IMPORT_ERRORS)
@@ -544,7 +550,7 @@ impl Linker {
             import_record
                 .flags
                 .insert(ImportRecordFlags::WAS_UNRESOLVED);
-            return Ok(false);
+            return false;
         }
 
         if IS_BUN {
@@ -553,52 +559,22 @@ impl Linker {
                 || import_record.kind == ImportKind::RequireResolve
                 || import_record.kind == ImportKind::Dynamic
             {
-                return Ok(false);
+                return false;
             }
         }
 
-        if !import_record.path.text.is_empty() && resolver::is_package_path(import_record.path.text)
-        {
-            if target == BundleTarget::Browser && options::is_node_builtin(import_record.path.text)
-            {
-                log.add_resolve_error(
-                    Some(source),
-                    import_record.range,
-                    format_args!(
-                        "Could not resolve: \"{}\". Try setting --target=\"node\"",
-                        bstr::BStr::new(import_record.path.text)
-                    ),
-                    import_record.path.text,
-                    import_record.kind,
-                    bun_ast::Error::ModuleNotFound,
-                );
-            } else {
-                log.add_resolve_error(
-                    Some(source),
-                    import_record.range,
-                    format_args!(
-                        "Could not resolve: \"{}\". Maybe you need to \"bun install\"?",
-                        bstr::BStr::new(import_record.path.text)
-                    ),
-                    import_record.path.text,
-                    import_record.kind,
-                    bun_ast::Error::ModuleNotFound,
-                );
-            }
-        } else {
-            log.add_resolve_error(
-                Some(source),
-                import_record.range,
-                format_args!(
-                    "Could not resolve: \"{}\"",
-                    bstr::BStr::new(import_record.path.text)
-                ),
-                import_record.path.text,
-                import_record.kind,
-                bun_ast::Error::ModuleNotFound,
-            );
-        }
-        Ok(true)
+        log.add_resolve_error(
+            Some(source),
+            import_record.range,
+            format_args!(
+                "No such built-in module: {}",
+                bstr::BStr::new(import_record.path.text)
+            ),
+            import_record.path.text,
+            import_record.kind,
+            bun_ast::Error::ModuleNotFound,
+        );
+        true
     }
 
     pub(crate) fn generate_import_path(

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import path from "node:path";
 
 describe("ResolveMessage", () => {
@@ -281,5 +281,123 @@ describe.concurrent("tsconfig paths wildcard with overlapping prefix/suffix", ()
 
   it("xy*xy vs xy", async () => {
     await run("xy*xy", "xy");
+  });
+});
+
+// A file containing a static `import "node:<unknown>"` is rejected at transpile
+// time when it is transpiled on the JS thread (require(), plugin onLoad
+// sources, import() with the concurrent transpiler disabled), and by the
+// runtime resolve hook when the concurrent transpiler handled it (import()).
+// Both must throw the same Node-shaped ERR_UNKNOWN_BUILTIN_MODULE error.
+describe.concurrent("static import of an unknown node: builtin", () => {
+  const specifier = "node:this_builtin_does_not_exist";
+  const pick = `(e) => ({ code: e.code, specifier: e.specifier, importKind: e.importKind, message: e.message })`;
+  const expected = {
+    code: "ERR_UNKNOWN_BUILTIN_MODULE",
+    specifier,
+    importKind: "import-statement",
+    message: `No such built-in module: ${specifier}`,
+  };
+
+  async function loadFixtures(env: Record<string, string>) {
+    using dir = tempDir("unknown-builtin-import", {
+      // One file per load so no two loads share a module registry entry.
+      "import-a.ts": `import "${specifier}";\n`,
+      "import-b.ts": `import "${specifier}";\n`,
+      "reexport-a.ts": `export * from "${specifier}";\n`,
+      "reexport-b.ts": `export * from "${specifier}";\n`,
+      "main.ts": `
+        const pick = ${pick};
+        const errors = {};
+        try { require("./import-a.ts"); } catch (e) { errors["require import"] = pick(e); }
+        try { await import("./import-b.ts"); } catch (e) { errors["import() import"] = pick(e); }
+        try { require("./reexport-a.ts"); } catch (e) { errors["require reexport"] = pick(e); }
+        try { await import("./reexport-b.ts"); } catch (e) { errors["import() reexport"] = pick(e); }
+        console.log(JSON.stringify(errors));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: { ...bunEnv, ...env },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  const expectedForEveryLoad = {
+    "require import": expected,
+    "import() import": expected,
+    "require reexport": expected,
+    "import() reexport": expected,
+  };
+
+  it("require() and import() of the importing file throw the same error", async () => {
+    expect(await loadFixtures({})).toEqual(expectedForEveryLoad);
+  });
+
+  it("import() throws the same error when the importing file is transpiled on the JS thread", async () => {
+    expect(await loadFixtures({ BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1" })).toEqual(expectedForEveryLoad);
+  });
+
+  it("source provided by a plugin onLoad callback throws the same error", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        Bun.plugin({
+          name: "virtual",
+          setup(build) {
+            build.onResolve({ filter: /.*/, namespace: "virtual" }, ({ path }) => ({ path, namespace: "virtual" }));
+            build.onLoad({ filter: /.*/, namespace: "virtual" }, () => ({
+              contents: 'import "${specifier}";',
+              loader: "ts",
+            }));
+          },
+        });
+        try {
+          await import("virtual:entry");
+        } catch (e) {
+          console.log(JSON.stringify((${pick})(e)));
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual(expected);
+    expect(exitCode).toBe(0);
+  });
+
+  it("entry point reports the same message at the import's position", async () => {
+    using dir = tempDir("unknown-builtin-entry", {
+      "entry.ts": `import "${specifier}";\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "1 | import "node:this_builtin_does_not_exist";
+                 ^
+      error: No such built-in module: node:this_builtin_does_not_exist
+          at <dir>/entry.ts:1:8
+
+      Bun v<bun-version>"
+    `);
+    expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
### Problem
- A file containing a static `import "node:<unknown>"` rejects with a different `.message` depending on which thread transpiled it:
  - `require("./dep.ts")` (and any other file transpiled on the JS thread: plugin `onLoad` sources, `import()` with `BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER=1`, the entry point): `Could not resolve: "node:x". Maybe you need to "bun install"?`
  - `import("./dep.ts")` (concurrent transpiler): `No such built-in module: node:x`
- `.code` is `ERR_UNKNOWN_BUILTIN_MODULE` in both cases; only the text differs, and `bun install` cannot fix a `node:` specifier (#24444 quotes this hint for a builtin Bun does not ship; that module is still missing after this PR, the hint is what changes).
- Cause: `Linker::link` (`src/bundler/linker.rs`) routes every `node:` specifier that is not in the builtin table to `when_module_not_found`, which logged the generic bare-package text. The concurrent transpiler's copy of this pass has no such branch, so there the import reaches the runtime resolve hook, whose message (`ResolveMessage::fmt` in `src/jsc/ResolveMessage.rs`) already uses Node's text.

### Fix
- `when_module_not_found` has one caller, the `node:` branch inside `link`'s `if IS_BUN` block (true since before the Rust port as well), so it becomes `when_builtin_not_found` and logs `No such built-in module: <specifier>`, the same text as the resolve hook. The parts only a different caller could reach are removed: the browser (`--target="node"` hint) and non-package message branches, the `target` parameter, the `IS_BUN` const generic (always true there) and the never-failing `Result` return. The `handles_import_errors` early-out and the deferral of `require` / `require.resolve` / `import()` to runtime are unchanged.
- Correct because the message now matches Node's `ERR_UNKNOWN_BUILTIN_MODULE` text (which `.code` already claimed) and no longer depends on the transpile path. The linker path still attaches the import's source position, which the hook path does not have. `.specifier` / `.code` still work because they locate the specifier inside the message text, which contains it.
- Scope is the text of this one branch. The two copies of the pre-pass have other behavioral differences that are not message text (a `mock.module` / `build.module` registered for a `node:` name is only honored on the concurrent path because this branch fails first; `require.resolve("fs")` returns `"node:fs"` on the concurrent path and `"fs"` on this one); those are filed separately, and whether this branch should eventually be removed in favor of the hook is decided there. This change is compatible with either outcome.
- `bun build` is untouched: the bundler has its own copy of the `bun install` message in `bundle_v2.rs`, and `test/bundler/bundler_browser.test.ts` still pins it.
- Verified with `test/js/bun/resolve/resolve-error.test.ts` (new `static import of an unknown node: builtin` block: `require()` vs `import()`, both again with the concurrent transpiler disabled, an `export * from` re-export, plugin `onLoad` source, and the entry point's stderr). All four fail on the released binary with exactly the old text and pass with this change; the rest of the file, `test/js/node/missing-module.test.js`, `test/regression/issue/25707.test.ts`, `test/js/bun/resolve/import-meta.test.js`, `test/js/node/test/parallel/test-stream-iter-disabled.js`, `test-require-node-prefix.js` and `test/bundler/bundler_browser.test.ts` still pass.
- Found while working on #39182, which changes the referrer of these errors and does not touch their text.

### Background
- Runtime module loading transpiles each file either on the JS thread (`require()`, the entry point, plugin-provided sources, or everything when the concurrent transpiler is disabled) or on the concurrent transpiler (`import()` and static imports of files, `src/jsc/RuntimeTranspilerStore.rs`). Each path runs its own copy of a small pre-pass over the file's import records: both rewrite known builtins through the hardcoded alias table and strip `bun:`; only the JS-thread copy (`Linker::link`) additionally fails the module up front for `node:` names the table does not know. That early failure is what produced the text this PR changes.
- The runtime resolve hook is what JSC calls when it links a module's imports at evaluation time. It is where an unknown `node:` import in a concurrently transpiled file fails, and it formats its errors with `ResolveMessage::fmt`.
- `ResolveMessage` is the error object thrown on both paths; `.code` and `.specifier` are derived from the specifier's position inside the message text (`BabyString`), which is why the text must contain the specifier.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/resolve-error.test.ts

<!-- robobun:evidence:end -->