### PR TITLE
bun:jsc: percentAvailableMemoryInUse() returns the reading again instead of null

### DIFF
--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -139,27 +139,14 @@ declare module "bun:jsc" {
   function memoryUsage(): MemoryUsage;
 
   /**
-   * Returns how much of the memory available to the process is in use, as a
-   * fraction from `0` to `1`: the process's physical memory footprint divided
-   * by the amount of memory JavaScriptCore sizes its heap against (the cgroup
-   * memory limit when running in a container that has one, otherwise the
-   * machine's RAM), clamped to `1`.
+   * Returns the reading JavaScriptCore's garbage collector compares against its
+   * critical memory threshold (0.8 by default; `BUN_JSC_criticalGCMemoryThreshold`
+   * changes it) to decide whether to collect more aggressively: the process's
+   * memory footprint divided by `process.constrainedMemory()`, clamped to `1`.
    *
-   * This is the same reading JavaScriptCore's garbage collector uses to decide
-   * the process is running out of memory: above 0.8 by default, it collects
-   * much more aggressively. For the footprint in bytes, use
-   * {@link memoryUsage}.
-   *
-   * Returns `null` on Windows, where JavaScriptCore does not take this
-   * measurement.
-   *
-   * @example
-   * ```ts
-   * import { percentAvailableMemoryInUse } from "bun:jsc";
-   *
-   * const inUse = percentAvailableMemoryInUse();
-   * if (inUse !== null && inUse > 0.9) console.warn(`${Math.round(inUse * 100)}% of available memory in use`);
-   * ```
+   * Returns `null` on Windows and FreeBSD, where JavaScriptCore does not take
+   * this reading. To monitor a program's own memory use, prefer
+   * `process.memoryUsage()` or {@link memoryUsage}.
    */
   function percentAvailableMemoryInUse(): number | null;
 

--- a/packages/bun-types/jsc.d.ts
+++ b/packages/bun-types/jsc.d.ts
@@ -139,6 +139,31 @@ declare module "bun:jsc" {
   function memoryUsage(): MemoryUsage;
 
   /**
+   * Returns how much of the memory available to the process is in use, as a
+   * fraction from `0` to `1`: the process's physical memory footprint divided
+   * by the amount of memory JavaScriptCore sizes its heap against (the cgroup
+   * memory limit when running in a container that has one, otherwise the
+   * machine's RAM), clamped to `1`.
+   *
+   * This is the same reading JavaScriptCore's garbage collector uses to decide
+   * the process is running out of memory: above 0.8 by default, it collects
+   * much more aggressively. For the footprint in bytes, use
+   * {@link memoryUsage}.
+   *
+   * Returns `null` on Windows, where JavaScriptCore does not take this
+   * measurement.
+   *
+   * @example
+   * ```ts
+   * import { percentAvailableMemoryInUse } from "bun:jsc";
+   *
+   * const inUse = percentAvailableMemoryInUse();
+   * if (inUse !== null && inUse > 0.9) console.warn(`${Math.round(inUse * 100)}% of available memory in use`);
+   * ```
+   */
+  function percentAvailableMemoryInUse(): number | null;
+
+  /**
    * Returns the seed of the pseudo-random number generator behind
    * `Math.random()`. The seed is chosen at random when Bun starts; see
    * {@link setRandomSeed}.

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -964,8 +964,10 @@ JSC_DEFINE_HOST_FUNCTION(functionPercentAvailableMemoryInUse, (JSGlobalObject*, 
 {
 #if USE(MEMORY_FOOTPRINT_API)
     return JSValue::encode(jsNumber(WTF::percentAvailableMemoryInUse()));
-#else
+#elif OS(WINDOWS) || OS(FREEBSD)
     return JSValue::encode(jsNull());
+#else
+#error "USE(MEMORY_FOOTPRINT_API) is off on a platform that had it: WebKit renamed the gate again, or this platform belongs in the null branch above"
 #endif
 }
 

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/VMTrapsInlines.h>
 #include <algorithm>
 #include <cstddef>
+#include <wtf/AvailableMemory.h>
 #include <wtf/FileSystem.h>
 #include <wtf/MemoryFootprint.h>
 #include <wtf/text/WTFString.h>
@@ -958,23 +959,15 @@ JSC_DEFINE_HOST_FUNCTION(functionEstimateDirectMemoryUsageOf, (JSGlobalObject * 
     return JSValue::encode(jsNumber(0));
 }
 
-#if USE(BMALLOC_MEMORY_FOOTPRINT_API)
-
-#include <bmalloc/bmalloc.h>
-
-JSC_DEFINE_HOST_FUNCTION(functionPercentAvailableMemoryInUse, (JSGlobalObject * globalObject, CallFrame* callFrame))
+// Same gate and same reading as JSC::Heap::overCriticalMemoryThreshold().
+JSC_DEFINE_HOST_FUNCTION(functionPercentAvailableMemoryInUse, (JSGlobalObject*, CallFrame*))
 {
-    return JSValue::encode(jsDoubleNumber(bmalloc::api::percentAvailableMemoryInUse()));
-}
-
+#if USE(MEMORY_FOOTPRINT_API)
+    return JSValue::encode(jsNumber(WTF::percentAvailableMemoryInUse()));
 #else
-
-JSC_DEFINE_HOST_FUNCTION(functionPercentAvailableMemoryInUse, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
     return JSValue::encode(jsNull());
-}
-
 #endif
+}
 
 // clang-format off
 /* Source for BunJSCModuleTable.lut.h

--- a/test/integration/bun-types/fixture/jsc.ts
+++ b/test/integration/bun-types/fixture/jsc.ts
@@ -13,6 +13,7 @@ import {
   noOSRExitFuzzing,
   numberOfDFGCompiles,
   optimizeNextInvocation,
+  percentAvailableMemoryInUse,
   profile,
   reoptimizationRetryCount,
   serialize,
@@ -45,6 +46,7 @@ expectType(stats.protectedObjectTypeCounts).is<Record<string, number>>();
 
 expectType(memoryUsage().current).is<number>();
 expectType(memoryUsage().pageFaults).is<number>();
+expectType(percentAvailableMemoryInUse()).is<number | null>();
 
 expectType(callerSourceOrigin()).is<string | null>();
 

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -25,7 +25,7 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBuildKite, isMacOS, isWindows } from "harness";
+import { bunEnv, bunExe, isBuildKite, isFreeBSD, isMacOS, isWindows } from "harness";
 
 describe("bun:jsc", () => {
   function count() {
@@ -68,17 +68,16 @@ describe("bun:jsc", () => {
   });
   it("percentAvailableMemoryInUse", () => {
     const inUse = percentAvailableMemoryInUse();
-    if (isWindows) {
-      // JavaScriptCore does not measure the process footprint on Windows.
+    if (isWindows || isFreeBSD) {
+      // JavaScriptCore does not take this reading (USE(MEMORY_FOOTPRINT_API)) there.
       expect(inUse).toBeNull();
       return;
     }
-    // The process's footprint as a fraction of the memory JavaScriptCore sizes
-    // its heap against (physical RAM, or the cgroup limit), clamped to 1.
+    // The process footprint divided by process.constrainedMemory(), clamped to 1.
     expect(inUse).toBeNumber();
     expect(inUse).toBeGreaterThanOrEqual(0);
     expect(inUse).toBeLessThanOrEqual(1);
-    // On Linux the footprint half of the ratio is currently parsed as 0
+    // On Linux, WTF currently parses the footprint out of /proc/self/statm as 0
     // (oven-sh/WebKit#449); on macOS it comes from task_info and a running
     // process always has one.
     if (isMacOS) expect(inUse).toBeGreaterThan(0);

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -15,6 +15,7 @@ import {
   memoryUsage,
   numberOfDFGCompiles,
   optimizeNextInvocation,
+  percentAvailableMemoryInUse,
   profile,
   releaseWeakRefs,
   reoptimizationRetryCount,
@@ -24,7 +25,7 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
+import { bunEnv, bunExe, isBuildKite, isMacOS, isWindows } from "harness";
 
 describe("bun:jsc", () => {
   function count() {
@@ -64,6 +65,23 @@ describe("bun:jsc", () => {
     const usage = memoryUsage();
     expect(usage.current).toBeGreaterThan(0);
     expect(usage.peak).toBeGreaterThan(0);
+  });
+  it("percentAvailableMemoryInUse", () => {
+    const inUse = percentAvailableMemoryInUse();
+    if (isWindows) {
+      // JavaScriptCore does not measure the process footprint on Windows.
+      expect(inUse).toBeNull();
+      return;
+    }
+    // The process's footprint as a fraction of the memory JavaScriptCore sizes
+    // its heap against (physical RAM, or the cgroup limit), clamped to 1.
+    expect(inUse).toBeNumber();
+    expect(inUse).toBeGreaterThanOrEqual(0);
+    expect(inUse).toBeLessThanOrEqual(1);
+    // On Linux the footprint half of the ratio is currently parsed as 0
+    // (oven-sh/WebKit#449); on macOS it comes from task_info and a running
+    // process always has one.
+    if (isMacOS) expect(inUse).toBeGreaterThan(0);
   });
   it("getRandomSeed", () => {
     expect(getRandomSeed()).toBeDefined();


### PR DESCRIPTION
### Problem
- `require("bun:jsc").percentAvailableMemoryInUse()` returns `null` on every platform. Up to 1.3.8 it returned a number on Linux and macOS.
- Cause: `src/jsc/modules/BunJSCModule.h` wrapped the implementation in `#if USE(BMALLOC_MEMORY_FOOTPRINT_API)` and called `bmalloc::api::percentAvailableMemoryInUse()`. Upstream WebKit moved that code from bmalloc into WTF (`wtf/AvailableMemory.h`) and renamed the gate to `USE(MEMORY_FOOTPRINT_API)`; the WebKit bump in #26667 (1.3.9) brought that in, no header has defined the old macro since, and only the `#else` branch (`return jsNull()`) has been compiled.
- Nobody reported it: the export was added in #16023 without a declaration or test, and I found it while working on the WTF side of the same reading (oven-sh/WebKit#449). Its use is diagnostic: it is the one way to see from JS the number JSC's collector acts on, for example when checking how bun behaves under a container memory limit.

### Fix
- Gate on `USE(MEMORY_FOOTPRINT_API)` and return `WTF::percentAvailableMemoryInUse()`. This is the same `#if` and the same call `JSC::Heap::overCriticalMemoryThreshold()` (`heap/Heap.cpp`) is built from, so the function reports exactly the value JSC compares against `criticalGCMemoryThreshold`, on exactly the platforms where JSC takes it. Per `wtf/PlatformUse.h` that is Linux (including Android) and macOS; Windows and FreeBSD return `null` from an explicit `#elif`, and any other platform without the gate is a compile error rather than a silent `null`, since a silent fallback is how this regression went unnoticed for six releases.
- `jsNumber` rather than `jsDoubleNumber` (#22476): the value is a clamped fraction that can be exactly `0` or `1`.
- Declares the function in `packages/bun-types/jsc.d.ts` as `number | null`, documented as what it is: the reading JSC's collector compares against its critical threshold, with `process.constrainedMemory()` as the denominator (bun implements that as `WTF::ramSize()`, which is the same `availableMemory()` value WTF divides by). The other exports #38711 left undeclared are not touched.
- Test: `test/js/bun/jsc/bun-jsc.test.ts`, "percentAvailableMemoryInUse": `null` on Windows and FreeBSD, otherwise a number in `[0, 1]`, and `> 0` on macOS. On the released binary it fails with `expect(received).toBeNumber() Received: null`; with this change the file passes (37/37). `bun test test/integration/bun-types/bun-types.test.ts`: 15 pass.
- Why the Linux assertion is only `>= 0`: on the current WebKit pin WTF's Linux footprint reader parses `/proc/self/statm` to 0, so the function returns `0` there (oven-sh/WebKit#449 fixes the reader). Same tree, same container, built against both: pin f0f60fd2 prints `0`; the #449 preview prints `0.01008`, against `memoryUsage().current / process.constrainedMemory()` of `0.00994` measured a moment later. So the bun side is complete with this PR, the Linux `0` is WTF's, and the bump that takes #449 can tighten the assertion to `> 0` on Linux as well, which makes this test that bump's proof. Keeping the two separate also fixes macOS now, independently of when #449 lands.

### Background
- `bun:jsc` is a module of host functions over JavaScriptCore internals, defined in `BunJSCModule.h`.
- `WTF::percentAvailableMemoryInUse()` is the process footprint (RSS from `/proc/self/statm` on Linux, `phys_footprint` from `task_info` on macOS) divided by `WTF::availableMemory()` (the cgroup limit when there is one, otherwise physical RAM), clamped to 1. `WTF::ramSize()` returns the same number, and it is what JSC scales heap growth to.
- `Heap::overCriticalMemoryThreshold()` compares this value against `Options::criticalGCMemoryThreshold()` (0.80 by default); above it JSC caps eden size, runs only full collections and sweeps synchronously.
- `USE(X)` macros come from WTF's `PlatformUse.h`. Bun's C++ sees the same values JSC was built with because `root.h` includes the prebuilt JSC's `cmakeconfig.h` (which defines `USE_BUN_JSC_ADDITIONS`, part of the `USE_MEMORY_FOOTPRINT_API` condition).

<details>
<summary>Probe output on both WebKit builds</summary>

Same tree (this branch), Linux x64 debug build, 32 GiB cgroup limit:

```
# WEBKIT_VERSION = f0f60fd2 (current pin)
{"percentAvailableMemoryInUse":0,"rss":342700032,"constrainedMemory":34359738368,"rssOverConstrained":0.00997}

# --webkit-version=autobuild-preview-pr-449-f40c7429
{"percentAvailableMemoryInUse":0.01008,"rss":341544960,"constrainedMemory":34359738368,"rssOverConstrained":0.00994}
```

The first revision of this PR returned `null` only under a bare `#else`; the explicit Windows/FreeBSD branch and the shorter JSDoc were added after review.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/jsc/bun-jsc.test.ts

<!-- robobun:evidence:end -->