### PR TITLE
bundler: print each stylesheet with the CSS targets it was minified for

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -339,6 +339,30 @@ impl<'a> LinkerContext<'a> {
             && record.source_index.get() != source_index
     }
 
+    /// The targets to print a CSS chunk with. These must be the targets its
+    /// stylesheets were minified with (`ParseTask`): nesting, media range syntax
+    /// and `light-dark()` references are lowered at print time, and the
+    /// `light-dark()` polyfill is only complete when both halves agree.
+    ///
+    /// The stylesheets were minified by the transpiler of the graph the chunk's
+    /// entry point was parsed in. In a server build, an HTML entry point (passed
+    /// directly or imported from server code) and everything it links go
+    /// through the client transpiler, so the chunk is printed for browsers;
+    /// every other entry point's graph uses the build's own target. The entry
+    /// point's AST target is only trusted for `Browser`: a `#!/usr/bin/env bun`
+    /// hashbang marks the entry of a browser build `Bun`, and the separate SSR
+    /// graph marks its files `ServerComponentsSsr`, while the stylesheets of
+    /// both were still minified with the build's target.
+    pub(crate) fn css_targets_for_chunk(&self, chunk: &Chunk) -> crate::bun_css::Targets {
+        let entry_target = self.graph.ast.items_target()[chunk.entry_point.source_index() as usize];
+        let target = if entry_target == Target::Browser {
+            Target::Browser
+        } else {
+            self.options.target
+        };
+        crate::bun_css::Targets::for_bundler_target(target)
+    }
+
     /// Note: this should call a `MimallocArena` debug hook
     /// (`helpCatchMemoryIssues`), but `Graph.heap` is currently
     /// `bun_alloc::Arena = bumpalo::Bump`, which has no such hook, so this is a

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -339,30 +339,6 @@ impl<'a> LinkerContext<'a> {
             && record.source_index.get() != source_index
     }
 
-    /// The targets to print a CSS chunk with. These must be the targets its
-    /// stylesheets were minified with (`ParseTask`): nesting, media range syntax
-    /// and `light-dark()` references are lowered at print time, and the
-    /// `light-dark()` polyfill is only complete when both halves agree.
-    ///
-    /// The stylesheets were minified by the transpiler of the graph the chunk's
-    /// entry point was parsed in. In a server build, an HTML entry point (passed
-    /// directly or imported from server code) and everything it links go
-    /// through the client transpiler, so the chunk is printed for browsers;
-    /// every other entry point's graph uses the build's own target. The entry
-    /// point's AST target is only trusted for `Browser`: a `#!/usr/bin/env bun`
-    /// hashbang marks the entry of a browser build `Bun`, and the separate SSR
-    /// graph marks its files `ServerComponentsSsr`, while the stylesheets of
-    /// both were still minified with the build's target.
-    pub(crate) fn css_targets_for_chunk(&self, chunk: &Chunk) -> crate::bun_css::Targets {
-        let entry_target = self.graph.ast.items_target()[chunk.entry_point.source_index() as usize];
-        let target = if entry_target == Target::Browser {
-            Target::Browser
-        } else {
-            self.options.target
-        };
-        crate::bun_css::Targets::for_bundler_target(target)
-    }
-
     /// Note: this should call a `MimallocArena` debug hook
     /// (`helpCatchMemoryIssues`), but `Graph.heap` is currently
     /// `bun_alloc::Arena = bumpalo::Bump`, which has no such hook, so this is a

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -623,9 +623,7 @@ pub mod parse_worker {
                 .ok_or(AnyError::ParserError)?,
         );
         let mut css = bun_css::BundlerStyleSheet::empty();
-        // There is nothing to minify, but the linker still prints this sheet
-        // (wrapped in the conditions of the `@import` that reached it) with the
-        // sheet's targets, so record the ones `minify` would have used.
+        // Never minified, but its `@import` conditions are still printed with the sheet's targets.
         css.targets = bun_css::Targets::for_bundler_target(target);
         ast.css = Some(crate::bundled_ast::CssAstRef::from_bump(bump.alloc(css)));
         Ok(ast)

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -604,7 +604,7 @@ pub mod parse_worker {
     // (`get_ast`, `run_with_source_code`) may also hold a raw pointer to
     // `(*transpiler).resolver`; materializing `&mut Transpiler` here would assert
     // exclusive access to the whole struct and invalidate that sibling pointer.
-    // We only touch the disjoint `options.define` field.
+    // We only touch the disjoint `options` field.
     fn get_empty_css_ast(
         log: &mut Log,
         transpiler: *mut Transpiler,
@@ -615,14 +615,19 @@ pub mod parse_worker {
         let root = Expr::init(E::Object::default(), Loc { start: 0 });
         // SAFETY: `transpiler` is a live worker-owned `*mut Transpiler`; `options`
         // is disjoint from any other field the caller may hold a pointer to.
+        let target = unsafe { (*transpiler).options.target };
+        // SAFETY: see above.
         let define = unsafe { &mut (*transpiler).options.define };
         let mut ast = JSAst::init(
             js_parser::new_lazy_export_ast(bump, define, opts, log, root, source, b"")?
                 .ok_or(AnyError::ParserError)?,
         );
-        ast.css = Some(crate::bundled_ast::CssAstRef::from_bump(
-            bump.alloc(bun_css::BundlerStyleSheet::empty()),
-        ));
+        let mut css = bun_css::BundlerStyleSheet::empty();
+        // There is nothing to minify, but the linker still prints this sheet
+        // (wrapped in the conditions of the `@import` that reached it) with the
+        // sheet's targets, so record the ones `minify` would have used.
+        css.targets = bun_css::Targets::for_bundler_target(target);
+        ast.css = Some(crate::bundled_ast::CssAstRef::from_bump(bump.alloc(css)));
         Ok(ast)
     }
 

--- a/src/bundler/linker_context/generateCompileResultForCssChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForCssChunk.rs
@@ -103,14 +103,12 @@ fn generate_compile_result_for_css_chunk_impl(
         )
     };
 
-    let targets = c.css_targets_for_chunk(chunk);
-
     match &css_import.kind {
         CssImportOrderKind::Layers(_) => {
             let printer_options = PrinterOptions {
                 // TODO: make this more configurable
                 minify: c.options.minify_whitespace,
-                targets,
+                targets: css.targets,
                 ..Default::default()
             };
             match css.to_css_with_writer(
@@ -153,7 +151,7 @@ fn generate_compile_result_for_css_chunk_impl(
             let printer_options = PrinterOptions {
                 // TODO: make this more configurable
                 minify: c.options.minify_whitespace,
-                targets,
+                targets: css.targets,
                 ..Default::default()
             };
             match css.to_css_with_writer(
@@ -186,7 +184,7 @@ fn generate_compile_result_for_css_chunk_impl(
         }
         CssImportOrderKind::SourceIndex(idx) => {
             let printer_options = PrinterOptions {
-                targets,
+                targets: css.targets,
                 // TODO: make this more configurable
                 minify: c.options.minify_whitespace
                     || c.options.minify_syntax

--- a/src/bundler/linker_context/generateCompileResultForCssChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForCssChunk.rs
@@ -5,7 +5,7 @@ use bun_ast::ImportRecord;
 use bun_collections::VecExt;
 use bun_threading::thread_pool as ThreadPoolLib;
 
-use crate::bun_css::{BundlerStyleSheet, ImportInfo, LocalsResultsMap, PrinterOptions, Targets};
+use crate::bun_css::{BundlerStyleSheet, ImportInfo, LocalsResultsMap, PrinterOptions};
 
 use crate::chunk::{Content, CssImportOrderKind};
 use crate::linker_context_mod::LinkerContext;
@@ -103,12 +103,14 @@ fn generate_compile_result_for_css_chunk_impl(
         )
     };
 
+    let targets = c.css_targets_for_chunk(chunk);
+
     match &css_import.kind {
         CssImportOrderKind::Layers(_) => {
             let printer_options = PrinterOptions {
                 // TODO: make this more configurable
                 minify: c.options.minify_whitespace,
-                targets: Targets::for_bundler_target(c.options.target),
+                targets,
                 ..Default::default()
             };
             match css.to_css_with_writer(
@@ -151,7 +153,7 @@ fn generate_compile_result_for_css_chunk_impl(
             let printer_options = PrinterOptions {
                 // TODO: make this more configurable
                 minify: c.options.minify_whitespace,
-                targets: Targets::for_bundler_target(c.options.target),
+                targets,
                 ..Default::default()
             };
             match css.to_css_with_writer(
@@ -184,7 +186,7 @@ fn generate_compile_result_for_css_chunk_impl(
         }
         CssImportOrderKind::SourceIndex(idx) => {
             let printer_options = PrinterOptions {
-                targets: Targets::for_bundler_target(c.options.target),
+                targets,
                 // TODO: make this more configurable
                 minify: c.options.minify_whitespace
                     || c.options.minify_syntax

--- a/src/bundler/linker_context/prepareCssAstsForChunk.rs
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.rs
@@ -10,7 +10,7 @@ use crate::bun_css::css_parser::{
     BundlerSupportsRule, ImportRule, LayerName, LayerStatementRule, Location, ParserOptions,
     SmallList,
 };
-use crate::bun_css::{BundlerStyleSheet, ImportConditions, ImportInfo, PrinterOptions};
+use crate::bun_css::{BundlerStyleSheet, ImportConditions, ImportInfo, PrinterOptions, Targets};
 use crate::bun_fs::Path;
 use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags, ImportRecordTag, Index as AstIndex};
 use bun_ast::{Loc, Range};
@@ -18,7 +18,7 @@ use bun_collections::VecExt;
 use bun_core::strings;
 use bun_resolver::DataURL;
 
-use crate::chunk::{Content, CssImportOrderKind};
+use crate::chunk::{Content, CssImportOrder, CssImportOrderKind};
 
 // Raw pointers rather than `&mut` / `&` so that
 // (a) the container_of `container_of` recovery of `*mut BundleV2` from
@@ -84,7 +84,6 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
     // across the log write below (split borrow).
     let parse_graph = unsafe { &*c.parse_graph };
     let asts = c.graph.ast.items_css();
-    let targets = c.css_targets_for_chunk(chunk);
 
     // Prepare CSS asts
     // Remove duplicate rules across files. This must be done in serial, not
@@ -98,6 +97,7 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
         let Content::Css(css_chunk) = &mut chunk.content else {
             unreachable!()
         };
+        let targets = chunk_targets(&css_chunk.imports_in_chunk_in_order, asts);
         let mut i: usize = css_chunk.imports_in_chunk_in_order.len() as usize;
         while i != 0 {
             i -= 1;
@@ -150,6 +150,7 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
                         source_map_urls: Default::default(),
                         license_comments: Default::default(),
                         options: ParserOptions::default(None),
+                        targets,
                         composes: Default::default(),
                         ..BundlerStyleSheet::empty()
                     };
@@ -325,6 +326,7 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
                         source_map_urls: Default::default(),
                         license_comments: Default::default(),
                         options: ParserOptions::default(None),
+                        targets,
                         composes: Default::default(),
                         ..BundlerStyleSheet::empty()
                     };
@@ -432,6 +434,26 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
             }
         }
     }
+}
+
+/// The targets for the style sheets this pass synthesizes for a chunk (layer
+/// statements, external `@import`s and their `data:` URL wrappers). Every
+/// stylesheet in a chunk comes from the same module graph and so carries the
+/// same `StyleSheet::targets`; the first one speaks for the chunk. A chunk
+/// always contains at least one stylesheet, so the default is never reached.
+fn chunk_targets(order: &[CssImportOrder], asts: &[crate::bundled_ast::CssCol]) -> Targets {
+    order
+        .iter()
+        .find_map(|entry| match entry.kind {
+            CssImportOrderKind::SourceIndex(idx) => Some(
+                asts[idx.get() as usize]
+                    .as_deref()
+                    .expect("css ast present")
+                    .targets,
+            ),
+            _ => None,
+        })
+        .unwrap_or_default()
 }
 
 /// Builds a `BundlerCssRuleList` whose backing storage is arena-owned.

--- a/src/bundler/linker_context/prepareCssAstsForChunk.rs
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.rs
@@ -436,11 +436,7 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
     }
 }
 
-/// The targets for the style sheets this pass synthesizes for a chunk (layer
-/// statements, external `@import`s and their `data:` URL wrappers). Every
-/// stylesheet in a chunk comes from the same module graph and so carries the
-/// same `StyleSheet::targets`; the first one speaks for the chunk. A chunk
-/// always contains at least one stylesheet, so the default is never reached.
+/// All of a chunk's stylesheets come from one module graph, so the first one's targets are the chunk's.
 fn chunk_targets(order: &[CssImportOrder], asts: &[crate::bundled_ast::CssCol]) -> Targets {
     order
         .iter()

--- a/src/bundler/linker_context/prepareCssAstsForChunk.rs
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.rs
@@ -10,7 +10,7 @@ use crate::bun_css::css_parser::{
     BundlerSupportsRule, ImportRule, LayerName, LayerStatementRule, Location, ParserOptions,
     SmallList,
 };
-use crate::bun_css::{BundlerStyleSheet, ImportConditions, ImportInfo, PrinterOptions, Targets};
+use crate::bun_css::{BundlerStyleSheet, ImportConditions, ImportInfo, PrinterOptions};
 use crate::bun_fs::Path;
 use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags, ImportRecordTag, Index as AstIndex};
 use bun_ast::{Loc, Range};
@@ -84,6 +84,7 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
     // across the log write below (split borrow).
     let parse_graph = unsafe { &*c.parse_graph };
     let asts = c.graph.ast.items_css();
+    let targets = c.css_targets_for_chunk(chunk);
 
     // Prepare CSS asts
     // Remove duplicate rules across files. This must be done in serial, not
@@ -221,7 +222,7 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
                             });
 
                             let printer_options = PrinterOptions {
-                                targets: Targets::for_bundler_target(c.options.target),
+                                targets,
                                 // TODO: make this more configurable
                                 minify: c.options.minify_whitespace
                                     || c.options.minify_syntax

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2341,12 +2341,7 @@ pub struct StyleSheet<AtRule> {
     pub license_comments: Vec<&'static [u8]>, // TODO: lifetime — arena
     pub options: ParserOptions<'static>,      // TODO: lifetime
     pub layer_names: Vec<LayerName>,
-    /// The targets the style sheet is compiled for. [`StyleSheet::minify`]
-    /// records the targets it ran with; until then this is `Targets::default()`.
-    /// Printing finishes what minifying started for these targets (compiling
-    /// nesting, lowering media ranges, rewriting the `light-dark()` references
-    /// whose fallback variables `minify` declared), so the sheet must be printed
-    /// with the same targets.
+    /// Recorded by [`StyleSheet::minify`]; printing must lower for these same targets.
     pub targets: Targets,
 
     /// Used when css modules is enabled. Maps `local name string` -> `Ref`.

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2341,6 +2341,13 @@ pub struct StyleSheet<AtRule> {
     pub license_comments: Vec<&'static [u8]>, // TODO: lifetime — arena
     pub options: ParserOptions<'static>,      // TODO: lifetime
     pub layer_names: Vec<LayerName>,
+    /// The targets the style sheet is compiled for. [`StyleSheet::minify`]
+    /// records the targets it ran with; until then this is `Targets::default()`.
+    /// Printing finishes what minifying started for these targets (compiling
+    /// nesting, lowering media ranges, rewriting the `light-dark()` references
+    /// whose fallback variables `minify` declared), so the sheet must be printed
+    /// with the same targets.
+    pub targets: Targets,
 
     /// Used when css modules is enabled. Maps `local name string` -> `Ref`.
     pub local_scope: LocalScope,
@@ -2360,6 +2367,7 @@ impl<AtRule> StyleSheet<AtRule> {
             license_comments: Vec::new(),
             options: ParserOptions::default(None),
             layer_names: Vec::new(),
+            targets: Targets::default(),
             local_scope: LocalScope::default(),
             local_properties: LocalPropertyUsage::default(),
             composes: ComposesMap::default(),
@@ -2386,6 +2394,7 @@ mod stylesheet_impl {
         where
             AtRule: for<'b> generic::DeepClone<'b>,
         {
+            self.targets = options.targets;
             let ctx = PropertyHandlerContext::new(arena, &options.targets, &options.unused_symbols);
             let mut handler = DeclarationHandler::new(arena);
             let mut important_handler = DeclarationHandler::new(arena);
@@ -2672,6 +2681,7 @@ mod stylesheet_impl {
                     license_comments,
                     options,
                     layer_names,
+                    targets: Targets::default(),
                     local_scope: parser_extra.local_scope,
                     local_properties,
                     composes,

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -692,6 +692,43 @@ devTest("css import before create project relative", {
   },
 });
 
+devTest("css linked from html is printed for the browser targets it was minified for", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: ["styles.css"],
+      body: `<div class="a"><div class="b">hello</div></div>`,
+    }),
+    "styles.css": `
+      :root {
+        color-scheme: light dark;
+      }
+      .a {
+        color: light-dark(white, black);
+        .b {
+          color: blue;
+        }
+      }
+      @media (width >= 600px) {
+        .a {
+          color: green;
+        }
+      }
+    `,
+  },
+  async test(dev) {
+    const html = await (await dev.fetch("/")).text();
+    const href = html.match(/<link rel="stylesheet"[^>]*href="([^"]+)"/)?.[1];
+    if (!href) throw new Error("no stylesheet is linked from the served html: " + html);
+    const css = await (await dev.fetch(href)).text();
+    expect(css).toContain(".a .b {");
+    expect(css).toContain("--buncss-light: initial;");
+    expect(css).toContain("var(--buncss-light, #fff) var(--buncss-dark, #000)");
+    expect(css).not.toContain("light-dark(");
+    expect(css).toContain("@media (min-width: 600px)");
+    expect(css).not.toContain(">=");
+  },
+});
+
 function extractCssUrl(backgroundImage: string): string {
   const url = backgroundImage.match(/url\((['"])(.*?)\1\)/);
   if (!url) {

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1014,10 +1014,10 @@ body {
 
   // A stylesheet linked from an HTML file is built for the browser even when the
   // build itself targets bun or node (the HTML is imported from server code for
-  // Bun.serve, or passed to a server build as an entry point). Minifying already
-  // used the default browser targets; printing has to use them too, since
-  // nesting, media range syntax and light-dark() are only lowered while
-  // printing. This fixture reaches every place the linker prints CSS:
+  // Bun.serve, or passed to a server build as an entry point), so it is minified
+  // for the default browser targets. It has to be printed for the same targets:
+  // nesting, media range syntax and light-dark() references are only lowered
+  // while printing. This fixture reaches every place the linker prints CSS:
   //
   // - the stylesheet itself (nesting, the @media range, light-dark() references)
   // - the preserved external @import, whose media condition is printed on its own
@@ -1025,6 +1025,8 @@ body {
   //   printed into a data: URL stylesheet while the chunk is prepared
   // - the bare "@layer foo;" left behind by the deduplicated layer import,
   //   printed together with its wrapping media condition
+  // - an empty stylesheet (which the bundler never minifies), whose import
+  //   conditions are still printed around it as "@layer bar;"
   const browserTargetFiles = {
     "/index.html": `
 <!DOCTYPE html>
@@ -1040,6 +1042,7 @@ body {
 @import "./other.css";
 @import "./dup.css" layer(foo) (width >= 600px);
 @import "./nested.css" (width >= 700px);
+@import "./empty.css" layer(bar) (width >= 1000px);
 :root {
   color-scheme: light dark;
 }
@@ -1059,6 +1062,7 @@ body {
     "/nested.css": `
 @import "https://example.com/nested.css" (width >= 900px);
 .nested { color: red; }`,
+    "/empty.css": "",
   };
 
   function expectPrintedForBrowsers(css: string) {
@@ -1071,7 +1075,23 @@ body {
       '@import "data:text/css,@import \\"https://example.com/nested.css\\" (min-width: 900px);" (min-width: 700px);',
     );
     expect(css).toContain("@media (min-width: 600px) {\n  @layer foo;\n}");
+    expect(css).toContain("@media (min-width: 1000px) {\n  @layer bar;\n}");
     expect(css).not.toContain(">=");
+  }
+
+  // The same fixture printed for targets that support everything it uses.
+  function expectPrintedAsWritten(css: string) {
+    expect(css).toContain("& .b {");
+    expect(css).toContain("color: light-dark(#fff, #000);");
+    expect(css).not.toContain("--buncss-");
+    expect(css).toContain("@media (width >= 800px)");
+    expect(css).toContain('@import "https://example.com/external.css" screen and (width >= 500px);');
+    expect(css).toContain(
+      '@import "data:text/css,@import \\"https://example.com/nested.css\\" (width >= 900px);" (width >= 700px);',
+    );
+    expect(css).toContain("@media (width >= 600px) {\n  @layer foo;\n}");
+    expect(css).toContain("@media (width >= 1000px) {\n  @layer bar;\n}");
+    expect(css).not.toContain("min-width");
   }
 
   function readLinkedStylesheet(api: BundlerTestBundleAPI, htmlFile: string) {
@@ -1118,31 +1138,33 @@ console.log(html);`,
     },
   });
 
-  // The same stylesheet imported by the server code itself is part of the bun
-  // build, not of the browser one: it keeps the build's own (runtime) CSS
-  // targets for both minifying and printing.
-  itBundled("html/css-browser-targets/imported-by-server-code-keeps-runtime-targets", {
+  // When the server code also imports the stylesheet itself, that copy belongs to
+  // the server build and is minified for whatever targets the build uses for its
+  // own target. Which targets those are is not pinned here; what matters is that
+  // each of the two emitted copies is printed for the targets it was minified
+  // for. The light-dark() polyfill shows which half ran: minifying declares the
+  // --buncss-* variables and printing rewrites the references, and either half
+  // on its own is broken.
+  itBundled("html/css-browser-targets/stylesheet-shared-with-server-code", {
     outdir: "out/",
     target: "bun",
     files: {
       ...browserTargetFiles,
       "/server.ts": `
+import html from "./index.html";
 import "./styles.css";
-console.log("server");`,
+console.log(html);`,
     },
     entryPoints: ["/server.ts"],
     onAfterBundle(api) {
-      const css = api.readFile("out/server.css");
-      expect(css).toContain("& .b {");
-      expect(css).toContain("color: light-dark(#fff, #000);");
-      expect(css).not.toContain("--buncss-light");
-      expect(css).toContain("@media (width >= 800px)");
-      expect(css).toContain('@import "https://example.com/external.css" screen and (width >= 500px);');
-      expect(css).toContain(
-        '@import "data:text/css,@import \\"https://example.com/nested.css\\" (width >= 900px);" (width >= 700px);',
-      );
-      expect(css).toContain("@media (width >= 600px) {\n  @layer foo;\n}");
-      expect(css).not.toContain("min-width");
+      expectPrintedForBrowsers(readLinkedStylesheet(api, "out/index.html"));
+
+      const serverCopy = api.readFile("out/server.css");
+      if (serverCopy.includes("--buncss-light: initial;")) {
+        expectPrintedForBrowsers(serverCopy);
+      } else {
+        expectPrintedAsWritten(serverCopy);
+      }
     },
   });
 });

--- a/test/bundler/bundler_html.test.ts
+++ b/test/bundler/bundler_html.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test";
-import { itBundled } from "./expectBundled";
+import { type BundlerTestBundleAPI, itBundled } from "./expectBundled";
 
 describe("bundler", () => {
   // Basic test for bundling HTML with JS and CSS
@@ -1009,6 +1009,140 @@ body {
       // The webmanifest reference should be rewritten to a hashed filename
       expect(htmlContent).not.toContain("site.webmanifest");
       expect(htmlContent).toMatch(/href=".*\.webmanifest"/);
+    },
+  });
+
+  // A stylesheet linked from an HTML file is built for the browser even when the
+  // build itself targets bun or node (the HTML is imported from server code for
+  // Bun.serve, or passed to a server build as an entry point). Minifying already
+  // used the default browser targets; printing has to use them too, since
+  // nesting, media range syntax and light-dark() are only lowered while
+  // printing. This fixture reaches every place the linker prints CSS:
+  //
+  // - the stylesheet itself (nesting, the @media range, light-dark() references)
+  // - the preserved external @import, whose media condition is printed on its own
+  // - the external @import behind a conditional internal @import, which is
+  //   printed into a data: URL stylesheet while the chunk is prepared
+  // - the bare "@layer foo;" left behind by the deduplicated layer import,
+  //   printed together with its wrapping media condition
+  const browserTargetFiles = {
+    "/index.html": `
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="./styles.css">
+  </head>
+  <body></body>
+</html>`,
+    "/styles.css": `
+@import "https://example.com/external.css" screen and (width >= 500px);
+@import "./dup.css" layer(foo) (width >= 600px);
+@import "./other.css";
+@import "./dup.css" layer(foo) (width >= 600px);
+@import "./nested.css" (width >= 700px);
+:root {
+  color-scheme: light dark;
+}
+.a {
+  color: light-dark(white, black);
+  .b {
+    color: blue;
+  }
+}
+@media (width >= 800px) {
+  .c {
+    color: green;
+  }
+}`,
+    "/dup.css": ".dup { color: red; }",
+    "/other.css": ".other { color: red; }",
+    "/nested.css": `
+@import "https://example.com/nested.css" (width >= 900px);
+.nested { color: red; }`,
+  };
+
+  function expectPrintedForBrowsers(css: string) {
+    expect(css).toContain(".a .b {");
+    expect(css).toContain("var(--buncss-light, #fff) var(--buncss-dark, #000)");
+    expect(css).not.toContain("light-dark(");
+    expect(css).toContain("@media (min-width: 800px)");
+    expect(css).toContain('@import "https://example.com/external.css" screen and (min-width: 500px);');
+    expect(css).toContain(
+      '@import "data:text/css,@import \\"https://example.com/nested.css\\" (min-width: 900px);" (min-width: 700px);',
+    );
+    expect(css).toContain("@media (min-width: 600px) {\n  @layer foo;\n}");
+    expect(css).not.toContain(">=");
+  }
+
+  function readLinkedStylesheet(api: BundlerTestBundleAPI, htmlFile: string) {
+    const href = api.readFile(htmlFile).match(/href="(.*?\.css)"/)?.[1];
+    if (!href) throw new Error(`No stylesheet is linked from ${htmlFile}`);
+    return api.readFile("out/" + href);
+  }
+
+  // Reference: what a browser build prints. The server builds below must print
+  // the same stylesheet the same way.
+  itBundled("html/css-browser-targets/browser-build", {
+    outdir: "out/",
+    files: browserTargetFiles,
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      expectPrintedForBrowsers(readLinkedStylesheet(api, "out/index.html"));
+    },
+  });
+
+  for (const target of ["bun", "node"] as const) {
+    itBundled(`html/css-browser-targets/imported-from-${target}-build`, {
+      outdir: "out/",
+      target,
+      files: {
+        ...browserTargetFiles,
+        "/server.ts": `
+import html from "./index.html";
+console.log(html);`,
+      },
+      entryPoints: ["/server.ts"],
+      onAfterBundle(api) {
+        expectPrintedForBrowsers(readLinkedStylesheet(api, "out/index.html"));
+      },
+    });
+  }
+
+  itBundled("html/css-browser-targets/html-entry-point-of-bun-build", {
+    outdir: "out/",
+    target: "bun",
+    files: browserTargetFiles,
+    entryPoints: ["/index.html"],
+    onAfterBundle(api) {
+      expectPrintedForBrowsers(readLinkedStylesheet(api, "out/index.html"));
+    },
+  });
+
+  // The same stylesheet imported by the server code itself is part of the bun
+  // build, not of the browser one: it keeps the build's own (runtime) CSS
+  // targets for both minifying and printing.
+  itBundled("html/css-browser-targets/imported-by-server-code-keeps-runtime-targets", {
+    outdir: "out/",
+    target: "bun",
+    files: {
+      ...browserTargetFiles,
+      "/server.ts": `
+import "./styles.css";
+console.log("server");`,
+    },
+    entryPoints: ["/server.ts"],
+    onAfterBundle(api) {
+      const css = api.readFile("out/server.css");
+      expect(css).toContain("& .b {");
+      expect(css).toContain("color: light-dark(#fff, #000);");
+      expect(css).not.toContain("--buncss-light");
+      expect(css).toContain("@media (width >= 800px)");
+      expect(css).toContain('@import "https://example.com/external.css" screen and (width >= 500px);');
+      expect(css).toContain(
+        '@import "data:text/css,@import \\"https://example.com/nested.css\\" (width >= 900px);" (width >= 700px);',
+      );
+      expect(css).toContain("@media (width >= 600px) {\n  @layer foo;\n}");
+      expect(css).not.toContain("min-width");
     },
   });
 });


### PR DESCRIPTION
### Problem
- `bun build --target=bun ./server.ts` where `server.ts` imports `index.html` (the `Bun.serve` fullstack pattern) emits the stylesheet linked from the HTML with CSS nesting, media range syntax (`(width >= 600px)`) and `light-dark()` left as written. `bun build --target=browser ./index.html` lowers all three for the default browser targets (`.a .b {`, `(min-width: 600px)`, `var(--buncss-light, ...)`). Same with `--target=node`, with the HTML passed directly as an entry point of a `--target=bun` build, and for stylesheets linked from HTML served by the dev server.
- The emitted stylesheet is also internally inconsistent: minifying already ran with browser targets (vendor prefixes such as `:-webkit-full-screen` are added, and the `--buncss-light`/`--buncss-dark` definitions of the `light-dark()` polyfill are injected), but the `light-dark()` references that printing is supposed to rewrite are left as is, so the polyfill definitions are dead weight.
- Cause: the HTML and everything it links are parsed and minified by the client transpiler (`Target::Browser`; minify targets come from that transpiler's target in `src/bundler/ParseTask.rs`), but the four places the linker prints CSS built their `PrinterOptions` from `Targets::for_bundler_target(c.options.target)`, the build-wide target copied from the server transpiler (`src/bundler/linker_context/generateCompileResultForCssChunk.rs`, three arms, and `src/bundler/linker_context/prepareCssAstsForChunk.rs`). `for_bundler_target(Bun | Node)` has no browser list, under which every print-gated transform counts as supported.

### Fix
- `StyleSheet` gets a `targets` field that `StyleSheet::minify` fills in with the targets it ran with (`src/css/css_parser.rs`). The bundler's one unminified stylesheet, the empty sheet it creates for an empty CSS file (`get_empty_css_ast`), records its transpiler's targets the same way, because its `@import` conditions still get printed around it.
- The linker prints every stylesheet with the targets it carries. The sheets `prepareCssAstsForChunk` synthesizes for a chunk (bare `@layer` statements, preserved external `@import`s and the `data:` URL wrapper for nested import conditions) take the targets of the chunk's first stylesheet; all stylesheets in a chunk come from the same module graph, so they all carry the same ones. The linker no longer consults the build target for CSS printing at all.
- Why this is correct: the print-time transforms (compiling nesting, lowering media ranges, rewriting `light-dark()` references) complete what minify did for the same targets, and the `light-dark()` polyfill is only right when both halves agree. Printing with what minify recorded makes that hold by construction for every sheet, whichever transpiler minified it. A stylesheet imported by the server code itself therefore keeps printing with the runtime targets it is minified with today; printing it for browsers would produce the opposite half-polyfill (references rewritten to variables that were never declared, which drops the declaration). Browser builds are unchanged since minify and print already agreed there.
- Relationship to open PRs: #37051 makes bake builds minify every stylesheet for browsers regardless of graph and rewrites the same four print sites to a build-wide `css_target`; it deliberately leaves plain `--target=bun` builds alone, which is the case fixed here. With this change its minify half flows through to printing on its own, so on rebase it can drop its print-side hunks (`LinkerOptions.css_target` and the four print sites); keeping them would reintroduce a build-wide print target. #39245 (CLI `--compile --target=browser` standalone HTML) and #38594 (HTML entries registered through plugins or `files:`) fix which transpiler the HTML goes through; this PR fixes how the resulting stylesheets are printed, and applies to the entries those PRs route to the browser graph as well.
- Tests in `test/bundler/bundler_html.test.ts` (`html/css-browser-targets/*`). One fixture reaches every print site: the stylesheet itself (nesting, media range, `light-dark()`), a preserved external `@import` with a media condition, an external `@import` behind a conditional internal `@import` (printed into a `data:` URL while preparing the chunk), the bare `@layer foo;` left by a deduplicated layer import, and an empty imported stylesheet whose `layer(bar)` and media conditions are printed around it (the unminified path). The same assertions run against a browser build (reference, passes before and after), an HTML import from a `--target=bun` entry, the same from `--target=node`, and an HTML entry point of a `--target=bun` build; a fifth build imports the HTML and the stylesheet itself from `server.ts` and checks that the HTML copy is printed for browsers and that the server copy is printed for whatever targets it was minified for (the polyfill's definitions and references must come together). The four server cases fail on the current release and pass with this change.
- `test/bake/dev/css.test.ts` gets a test that a stylesheet linked from an HTML route is served flattened and lowered with the full polyfill, since the dev server's printing changes in the same way (fails on the current release: it served the half-polyfill output shown above).
- Also run against a debug build with this change: `bundler_html` (27), `html-import-manifest`, `bundler_html_server`, `bun-build-api`, `standalone`, `metafile`, `bundler_edgecase`, `bundler/css/*`, `js/bun/css/*` (the local-only `css-fuzz` file and a few bound tests hit their 5s/10s timeouts under the debug build in this environment and pass alone or are skipped in CI; reported separately), `js/bun/http/bun-serve-html`, `bun-serve-html-manifest`, and `bake/dev/css.test.ts` (16). In `bake/dev/production.test.ts` three React server component tests that do not involve CSS hit the 5s default timeout under the debug build here and pass on rerun; the other nine pass.

### Background
- A server build (`--target=bun`/`node`) that contains HTML keeps two module graphs, one per target, each with its own transpiler. The HTML file and every script and stylesheet it links are registered in the browser graph and parsed by a client transpiler cloned from the server one with `target = browser`; server modules importing the HTML get an import manifest instead. The dev server works the same way for its HTML routes.
- CSS targets (`bun_css::Targets`) are a browser version list. The bundler uses the default list (chrome 87, safari 14, firefox 78, edge 88) for the browser target and an empty list for bun and node; with an empty list every feature counts as supported and nothing is lowered.
- The CSS pipeline applies targets twice. `StyleSheet::minify` runs once per file while parsing and decides vendor prefixes and selector fallbacks and injects the `light-dark()` polyfill definitions; printing runs in the linker once per chunk entry and compiles nesting, lowers media interval syntax, and rewrites `light-dark(a, b)` to `var(--buncss-light, a) var(--buncss-dark, b)`. Before this change the two took their targets from unrelated places.
- A CSS chunk is a list of entries: the stylesheets reachable from one entry point, plus entries the bundler synthesizes for external `@import`s that have to be hoisted to the top and for the `@layer` statements a deduplicated import leaves behind. `prepareCssAstsForChunk` builds a `StyleSheet` for each entry (shallow copies of the real ones, fresh ones for the synthesized entries), then `generateCompileResultForCssChunk` prints each of them.

<details>
<summary>Earlier revision of this PR</summary>

The first push added `LinkerContext::css_targets_for_chunk`, which re-derived the print targets in the linker: browser targets when the chunk's entry point had been parsed for `Target::Browser`, the build target otherwise. Review pointed out that this recomputes the decision minify already made (with caveats for entries whose AST target differs from the transpiler that minified them, such as a `#!/usr/bin/env bun` hashbang or the separate SSR graph) and that recording the minify targets on the stylesheet makes print and minify agree by construction, also for the bake builds #37051 changes. The current revision does that; the test that pinned the server copy's runtime targets was reframed to check minify/print agreement, and the empty-stylesheet case was added after it turned up while moving to the recorded targets.
</details>
