### PR TITLE
Document that server.publish() compresses by default; pin the compress defaults

### DIFF
--- a/docs/guides/websocket/compression.mdx
+++ b/docs/guides/websocket/compression.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Enable compression
 mode: center
 ---
 
-Set the `perMessageDeflate` parameter to enable the [permessage-deflate](https://tools.ietf.org/html/rfc7692) WebSocket extension. Bun then negotiates compression with clients that support it. Messages sent with `ws.send()` are still uncompressed unless you opt in per message (see below).
+Set the `perMessageDeflate` parameter to enable the [permessage-deflate](https://tools.ietf.org/html/rfc7692) WebSocket extension. Bun then negotiates compression with clients that support it. Messages sent with `ws.send()` and `ws.publish()` are still uncompressed unless you opt in per message (see below). Messages sent with `server.publish()` are compressed unless you opt out per message.
 
 ```ts server.ts icon="/icons/typescript.svg"
 Bun.serve({
@@ -18,7 +18,7 @@ Bun.serve({
 
 ---
 
-To enable compression for individual messages, pass `true` as the second parameter to `ws.send()`. This requires `perMessageDeflate` to be enabled; otherwise Bun sends the message uncompressed.
+To enable compression for individual messages, pass `true` as the last parameter to `ws.send()` or `ws.publish()`. This requires `perMessageDeflate` to be enabled; otherwise Bun sends the message uncompressed.
 
 ```ts server.ts icon="/icons/typescript.svg"
 Bun.serve({
@@ -28,7 +28,32 @@ Bun.serve({
     async message(ws, message) {
       // send a compressed message
       ws.send(message, true);
+      // publish a compressed message to a topic
+      ws.publish("chat", message, true);
     },
   },
 });
+```
+
+---
+
+`server.publish()` compresses by default. Bun deflates the message once for each subscriber that negotiated the extension. Pass `false` as the third parameter to publish a message uncompressed. Short messages grow when deflated, so pass `false` for those.
+
+```ts server.ts icon="/icons/typescript.svg"
+const server = Bun.serve({
+  // ...
+  websocket: {
+    perMessageDeflate: true,
+    open(ws) {
+      ws.subscribe("chat");
+    },
+    message() {},
+  },
+});
+
+// compressed for subscribers that negotiated the extension
+server.publish("chat", JSON.stringify({ type: "snapshot", users: ["alice", "bob", "carol"] }));
+
+// uncompressed for every subscriber
+server.publish("chat", "ping", false);
 ```

--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -601,6 +601,7 @@ interface Server extends Disposable {
 
   /**
    * Publish a message to all WebSocket clients subscribed to a topic.
+   * @param compress Defaults to true (ws.send() and ws.publish() default to false); only applies to clients that negotiated perMessageDeflate
    * @returns Bytes sent, 0 if dropped, -1 if backpressure applied
    */
   publish(

--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -257,11 +257,21 @@ Bun.serve({
 });
 ```
 
-To compress an individual message, pass a `boolean` as the second argument to `.send()`.
+With `perMessageDeflate` set, Bun negotiates the extension with clients that support it. Each send or publish call then decides whether to compress its message. `ws.send()` and `ws.publish()` send the message uncompressed unless you pass `true` as the last argument.
 
 ```ts
 ws.send("Hello world", true);
+ws.publish("the-group-chat", "Hello world", true);
 ```
+
+`server.publish()` is the exception. It compresses the message unless you pass `false` as the third argument. Bun deflates the message once per subscriber. Short messages grow when deflated, so pass `false` for those.
+
+```ts
+server.publish("the-group-chat", "Hello world"); // compressed
+server.publish("the-group-chat", "Hello world", false); // uncompressed
+```
+
+Bun sends the message uncompressed to any client that did not negotiate the extension, whatever the argument says.
 
 For fine-grained control over compression characteristics, refer to the [Reference](#reference).
 
@@ -404,7 +414,7 @@ interface ServerWebSocket {
   close(code?: number, reason?: string): void;
   subscribe(topic: string): boolean;
   unsubscribe(topic: string): boolean;
-  publish(topic: string, message: string | ArrayBuffer | Uint8Array | Blob): void;
+  publish(topic: string, message: string | ArrayBuffer | Uint8Array | Blob, compress?: boolean): number;
   isSubscribed(topic: string): boolean;
   cork(cb: (ws: ServerWebSocket) => void): void;
 }

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -68,7 +68,7 @@ declare module "bun" {
      * Sends a message to the client.
      *
      * @param data The data to send.
-     * @param compress Whether to compress the data. Ignored if the client does not support compression
+     * @param compress Whether to compress the data. Defaults to `false`. Ignored if the client does not support compression
      * @example
      * ```ts
      * ws.send("Hello!");
@@ -82,7 +82,7 @@ declare module "bun" {
      * Sends a text message to the client.
      *
      * @param data The data to send.
-     * @param compress Whether to compress the data. Ignored if the client does not support compression
+     * @param compress Whether to compress the data. Defaults to `false`. Ignored if the client does not support compression
      * @example
      * ```ts
      * ws.send("Hello!");
@@ -95,7 +95,7 @@ declare module "bun" {
      * Sends a binary message to the client.
      *
      * @param data The data to send.
-     * @param compress Whether to compress the data. Ignored if the client does not support compression
+     * @param compress Whether to compress the data. Defaults to `false`. Ignored if the client does not support compression
      * @example
      * ```ts
      * ws.send(new TextEncoder().encode("Hello!"));
@@ -148,7 +148,7 @@ declare module "bun" {
      *
      * @param topic The topic name.
      * @param data The data to send.
-     * @param compress Whether to compress the data. Ignored if the client does not support compression
+     * @param compress Whether to compress the data. Defaults to `false`. Ignored if the client does not support compression
      * @example
      * ```ts
      * ws.publish("chat", "Hello!");
@@ -163,7 +163,7 @@ declare module "bun" {
      *
      * @param topic The topic name.
      * @param data The data to send.
-     * @param compress Whether to compress the data. Ignored if the client does not support compression
+     * @param compress Whether to compress the data. Defaults to `false`. Ignored if the client does not support compression
      * @example
      * ```ts
      * ws.publish("chat", "Hello!");
@@ -177,7 +177,7 @@ declare module "bun" {
      *
      * @param topic The topic name.
      * @param data The data to send.
-     * @param compress Whether to compress the data. Ignored if the client does not support compression
+     * @param compress Whether to compress the data. Defaults to `false`. Ignored if the client does not support compression
      * @example
      * ```ts
      * ws.publish("chat", new TextEncoder().encode("Hello!"));
@@ -1059,13 +1059,16 @@ declare module "bun" {
      *
      * @param topic The topic to publish to
      * @param data The data to send
-     * @param compress Should the data be compressed? Ignored if the client does not support compression.
+     * @param compress Whether to compress the data. Defaults to `true`, unlike {@link ServerWebSocket.send} and
+     * {@link ServerWebSocket.publish}, which default to `false`. Pass `false` to send the data as-is.
+     * Ignored for subscribers that do not support compression (requires `perMessageDeflate`).
      *
      * @returns 0 if the message was dropped for any subscriber (or there were no subscribers), -1 if backpressure was applied for any subscriber, or the number of bytes sent.
      *
      * @example
      *
      * ```js
+     * // compressed for subscribers that negotiated perMessageDeflate
      * server.publish("chat", "Hello World");
      * ```
      *
@@ -1076,7 +1079,8 @@ declare module "bun" {
      *
      * @example
      * ```js
-     * server.publish("chat", new ArrayBuffer(4), true);
+     * // sent uncompressed to every subscriber
+     * server.publish("chat", new ArrayBuffer(4), false);
      * ```
      *
      * @example

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, forceGuardMalloc, isWindows, tempDir } from "harness";
 import net, { isIP } from "node:net";
 import path from "node:path";
+import { constants, inflateRawSync } from "node:zlib";
 
 const strings = [
   {
@@ -1756,6 +1757,193 @@ describe.concurrent("publish() return value reflects subscriber backpressure", (
         sendProbe: 0,
       });
     });
+  });
+});
+
+// The `compress` argument is a per-call hint that only takes effect for
+// subscribers that negotiated permessage-deflate. ws.send() and ws.publish()
+// leave it off unless asked; server.publish() is the one method that compresses
+// unless told not to. Both defaults are documented, so pin them on the wire.
+describe.concurrent("compress argument defaults", () => {
+  type Frame = { text: string; compressed: boolean };
+
+  // Raw RFC 6455 client that records every text frame the server writes to it.
+  // The server negotiates server_no_context_takeover, so each RSV1 payload
+  // inflates on its own.
+  function connectRaw(port: number, pathname: string, offerDeflate: boolean) {
+    type Raw = { negotiated: string; frames(count: number): Promise<Frame[]>; [Symbol.dispose](): void };
+    const upgrade = Promise.withResolvers<Raw>();
+    const frames: Frame[] = [];
+    const waiters: { count: number; settle: PromiseWithResolvers<Frame[]> }[] = [];
+    const settleWaiters = () => {
+      for (let i = waiters.length - 1; i >= 0; i--) {
+        const { count, settle } = waiters[i];
+        if (frames.length < count) continue;
+        waiters.splice(i, 1);
+        settle.resolve(frames.slice(0, count));
+      }
+    };
+    let failure: Error | undefined;
+    let buffer = Buffer.alloc(0);
+    let upgraded = false;
+
+    const socket = net.connect({ port, host: "127.0.0.1" }, () => {
+      socket.write(
+        `GET ${pathname} HTTP/1.1\r\n` +
+          "Host: x\r\n" +
+          "Upgrade: websocket\r\n" +
+          "Connection: Upgrade\r\n" +
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+          "Sec-WebSocket-Version: 13\r\n" +
+          (offerDeflate ? "Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n" : "") +
+          "\r\n",
+      );
+    });
+    const fail = (error: Error) => {
+      failure ??= error;
+      upgrade.reject(failure);
+      for (const { settle } of waiters.splice(0)) settle.reject(failure);
+      socket.destroy();
+    };
+    socket.on("error", fail);
+    socket.on("close", () => fail(new Error(`${pathname}: socket closed after ${frames.length} frame(s)`)));
+    socket.on("data", (chunk: Buffer) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      if (!upgraded) {
+        const end = buffer.indexOf("\r\n\r\n");
+        if (end === -1) return;
+        const head = buffer.subarray(0, end).toString();
+        buffer = buffer.subarray(end + 4);
+        upgraded = true;
+        if (!head.startsWith("HTTP/1.1 101 ")) return fail(new Error(`${pathname}: upgrade failed: ${head}`));
+        upgrade.resolve({
+          negotiated: head.split("\r\n").find(line => /^sec-websocket-extensions:/i.test(line)) ?? "none",
+          frames(count) {
+            if (failure) return Promise.reject(failure);
+            const settle = Promise.withResolvers<Frame[]>();
+            waiters.push({ count, settle });
+            settleWaiters();
+            return settle.promise;
+          },
+          [Symbol.dispose]() {
+            socket.removeAllListeners("close");
+            socket.destroy();
+          },
+        });
+      }
+      // Every message below fits in one unfragmented frame with a 7-bit length.
+      while (buffer.length >= 2) {
+        const length = buffer[1] & 0x7f;
+        if (length >= 126) return fail(new Error(`${pathname}: unexpected extended-length frame`));
+        if (buffer.length < 2 + length) break;
+        const opcode = buffer[0] & 0x0f;
+        const compressed = (buffer[0] & 0x40) !== 0;
+        const payload = buffer.subarray(2, 2 + length);
+        buffer = buffer.subarray(2 + length);
+        if (opcode !== 0x1) continue;
+        frames.push({
+          text: (compressed ? inflateRawSync(payload, { finishFlush: constants.Z_SYNC_FLUSH }) : payload).toString(),
+          compressed,
+        });
+      }
+      settleWaiters();
+    });
+
+    return upgrade.promise;
+  }
+
+  it("server.publish() compresses unless told not to; ws.send() and ws.publish() only when asked", async () => {
+    const sockets: Record<string, ServerWebSocket<string>> = {};
+    const opened = { deflate: Promise.withResolvers<void>(), plain: Promise.withResolvers<void>() };
+    await using server = serve<string, {}>({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, server) {
+        if (server.upgrade(req, { data: new URL(req.url).pathname.slice(1) })) return;
+        return new Response("no upgrade", { status: 400 });
+      },
+      websocket: {
+        perMessageDeflate: true,
+        open(ws) {
+          sockets[ws.data] = ws;
+          ws.subscribe("t");
+          opened[ws.data as keyof typeof opened].resolve();
+        },
+        message() {},
+      },
+    });
+
+    using deflate = await connectRaw(server.port, "/deflate", true);
+    using plain = await connectRaw(server.port, "/plain", false);
+    expect({ deflate: deflate.negotiated, plain: plain.negotiated }).toEqual({
+      deflate: expect.stringMatching(/^Sec-WebSocket-Extensions: permessage-deflate/i),
+      plain: "none",
+    });
+    await Promise.all([opened.deflate.promise, opened.plain.promise]);
+
+    server.publish("t", "server.publish()");
+    server.publish("t", "server.publish(false)", false);
+    server.publish("t", "server.publish(true)", true);
+    // ws.publish() skips the socket it is called on, so publish from the plain
+    // socket and observe the result on the deflating one.
+    sockets.plain.publish("t", "ws.publish()");
+    sockets.plain.publish("t", "ws.publish(true)", true);
+    sockets.deflate.send("ws.send()");
+    sockets.deflate.send("ws.send(true)", true);
+    // Sent last, so once it arrives the plain socket has received everything
+    // that was ever going to reach it.
+    sockets.plain.send("end");
+
+    expect(await deflate.frames(7)).toEqual([
+      { text: "server.publish()", compressed: true },
+      { text: "server.publish(false)", compressed: false },
+      { text: "server.publish(true)", compressed: true },
+      { text: "ws.publish()", compressed: false },
+      { text: "ws.publish(true)", compressed: true },
+      { text: "ws.send()", compressed: false },
+      { text: "ws.send(true)", compressed: true },
+    ]);
+    // A subscriber that did not negotiate the extension gets plain frames
+    // whether the hint is defaulted or explicit.
+    expect(await plain.frames(4)).toEqual([
+      { text: "server.publish()", compressed: false },
+      { text: "server.publish(false)", compressed: false },
+      { text: "server.publish(true)", compressed: false },
+      { text: "end", compressed: false },
+    ]);
+  });
+
+  it("server.publish() sends plain frames when perMessageDeflate is off, even with compress: true", async () => {
+    const opened = Promise.withResolvers<ServerWebSocket<undefined>>();
+    await using server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, server) {
+        if (server.upgrade(req)) return;
+        return new Response("no upgrade", { status: 400 });
+      },
+      websocket: {
+        open(ws) {
+          ws.subscribe("t");
+          opened.resolve(ws);
+        },
+        message() {},
+      },
+    });
+
+    using raw = await connectRaw(server.port, "/", true);
+    expect(raw.negotiated).toBe("none");
+    const ws = await opened.promise;
+
+    server.publish("t", "server.publish()");
+    server.publish("t", "server.publish(true)", true);
+    ws.send("ws.send(true)", true);
+
+    expect(await raw.frames(3)).toEqual([
+      { text: "server.publish()", compressed: false },
+      { text: "server.publish(true)", compressed: false },
+      { text: "ws.send(true)", compressed: false },
+    ]);
   });
 });
 


### PR DESCRIPTION
### Problem
- `server.publish(topic, data)` with the `compress` argument omitted deflates the message for every subscriber that negotiated permessage-deflate. `ws.send()`, `ws.publish()` and their text/binary variants send uncompressed unless `compress` is `true`.
- The `true` default comes from `compress_value.unwrap_or(JSValue::TRUE)` in `src/runtime/server/server_body.rs:1680`; the `ServerWebSocket` methods go through `parse_compress_arg` in `src/runtime/server/ServerWebSocket.rs:298`, which yields `false` when the argument is missing. `server.publish()` has behaved this way since it was added (8753c483ff, 2022).
- Neither default is stated anywhere. The `.d.ts` and the docs describe compression as something you pass `true` to get, so code calling `server.publish()` on small messages compresses without the author knowing: a 23 byte payload goes out as 29 bytes with RSV1 set, and uWS deflates it once per subscriber (`packages/bun-uws/src/App.h:244` and `:470` call `ws->send(..., compress)` per subscriber).

### Fix
- This PR documents the existing behavior rather than changing it. Flipping the default would silently stop compressing for existing callers; #24593, for example, is a user relying on `server.publish()` compressing ~109 KB broadcasts with no third argument. If the default should change instead, it is the one line in `server_body.rs` above plus inverting the new test.
- `packages/bun-types/serve.d.ts`: `Server.publish` JSDoc says `compress` defaults to `true` and points at the `ServerWebSocket` methods that default to `false`; its explicit-`true` example becomes an explicit-`false` one. The six `ServerWebSocket` send/publish methods say `compress` defaults to `false`.
- `docs/runtime/http/websockets.mdx`, `docs/guides/websocket/compression.mdx`, `docs/runtime/http/server.mdx`: the compression sections state both defaults and show `server.publish(topic, data, false)`. The reference block in `websockets.mdx` also gains the `compress` parameter and `number` return type that `ws.publish()` already has.
- `test/js/bun/websocket/websocket-server.test.ts`, `describe("compress argument defaults")`: a raw TCP client negotiates permessage-deflate and records the RSV1 bit of each text frame the server writes (inflating the compressed ones). It checks `server.publish()` with the argument omitted / `false` / `true`, `ws.publish()` omitted / `true`, and `ws.send()` omitted / `true`, plus a second subscriber without the extension and a second test with `perMessageDeflate` off, where every frame is plain regardless of the argument.
- Verified: the new tests pass with `bun bd test` and with the released 1.4.0; changing the `server.publish()` expectation to `compressed: false` makes the test fail, so it pins the default. `bun test test/integration/bun-types/bun-types.test.ts` passes.

### Background
- permessage-deflate (RFC 7692) is a WebSocket extension negotiated during the upgrade. Bun's server offers it when `websocket.perMessageDeflate` is set; whether a given message is actually deflated is decided per `send`/`publish` call via the `compress` argument, and a compressed message is marked by the RSV1 bit in the first byte of its frame. The argument has no effect on a connection that did not negotiate the extension.
- `server.publish()` and `ws.publish()` both fan out through the uWS topic tree, which calls the per-socket `send()` once per subscriber with the same `compress` flag, so a compressed publish costs one deflate per subscriber rather than one per message.
