### PR TITLE
bundler: keep a let/var initialized by an unwrapped require() when it is rebound later

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -759,8 +759,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
         }
-        // `T` fixes the variant at each (inlined) call site, so this compiles to
-        // nothing except where a binary or unary expression is built.
+        // `T` fixes the variant, so this compiles to nothing except where a binary
+        // or unary expression is built, and to a check of the operator there.
         match expr.data {
             js_ast::ExprData::EBinary(bin)
                 if js_ast::op::Code::binary_assign_target(bin.op) != js_ast::AssignTarget::None =>
@@ -783,10 +783,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// a `for (... in/of)` loop, so it is either an identifier, a member expression (which
     /// rebinds nothing), or a destructuring pattern. Defaults inside a pattern (`[x = 1] = y`)
     /// are assignment expressions of their own and were recorded when they were built.
+    #[inline]
     pub(crate) fn record_rebound_target(&mut self, target: Expr) {
-        if !self.should_unwrap_common_js_to_esm() {
-            return;
+        if self.should_unwrap_common_js_to_esm() {
+            self.record_rebound_names_in(target);
         }
+    }
+
+    fn record_rebound_names_in(&mut self, target: Expr) {
         match target.data {
             js_ast::ExprData::EIdentifier(id) => {
                 let name = self.load_name_from_ref(id.ref_);
@@ -794,17 +798,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             js_ast::ExprData::EArray(array) => {
                 for item in array.items.slice() {
-                    self.record_rebound_target(*item);
+                    self.record_rebound_names_in(*item);
                 }
             }
             js_ast::ExprData::EObject(object) => {
                 for property in object.properties.slice() {
                     if let Some(value) = property.value {
-                        self.record_rebound_target(value);
+                        self.record_rebound_names_in(value);
                     }
                 }
             }
-            js_ast::ExprData::ESpread(spread) => self.record_rebound_target(spread.value),
+            js_ast::ExprData::ESpread(spread) => self.record_rebound_names_in(spread.value),
             _ => {}
         }
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -280,12 +280,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Used with unwrap_commonjs_packages
     pub(crate) imports_to_convert_from_require: List<'a, DeferredImportNamespace>,
     pub(crate) unwrap_all_requires: bool,
-    /// Names this file assigns to (`x = ...`, `x++`, `[x] = ...`, `for (x of ...)`) or
-    /// declares more than once. `visit_decls` has to decide whether `var x = require("pkg")`
-    /// can become the import binding itself before the rest of the file has been visited,
-    /// so this is collected during the parse pass, where identifiers are still names rather
-    /// than symbols. A binding whose name is in here stays an ordinary variable. Only
-    /// filled when unwrapping.
+    /// Names this file assigns to or declares twice, collected while parsing (hence by name)
+    /// so `visit_decls` knows whether `var x = require("pkg")` is rebound later in the file.
     pub(crate) rebound_names: HashMap<&'a [u8], ()>,
 
     pub(crate) commonjs_named_exports: bun_ast::ast_result::CommonJSNamedExports,
@@ -759,8 +755,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
         }
-        // `T` fixes the variant, so this compiles to nothing except where a binary
-        // or unary expression is built, and to a check of the operator there.
         match expr.data {
             js_ast::ExprData::EBinary(bin)
                 if js_ast::op::Code::binary_assign_target(bin.op) != js_ast::AssignTarget::None =>
@@ -778,11 +772,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         expr
     }
 
-    /// Adds every identifier that `target` rebinds to [`rebound_names`](Self::rebound_names).
-    /// `target` is the left side of an assignment, the operand of `++`/`--`, or the head of
-    /// a `for (... in/of)` loop, so it is either an identifier, a member expression (which
-    /// rebinds nothing), or a destructuring pattern. Defaults inside a pattern (`[x = 1] = y`)
-    /// are assignment expressions of their own and were recorded when they were built.
+    /// `target` is an assignment target, `++`/`--` operand or `for (... in/of)` head; a default
+    /// inside a pattern (`[x = 1] = y`) is an assignment of its own and records itself when built.
     #[inline]
     pub(crate) fn record_rebound_target(&mut self, target: Expr) {
         if self.should_unwrap_common_js_to_esm() {
@@ -813,7 +804,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Adds a name that is declared a second time to [`rebound_names`](Self::rebound_names).
     fn record_redeclared_name(&mut self, name: &'a [u8]) {
         if self.should_unwrap_common_js_to_esm() {
             self.rebound_names.insert(name, ());

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -280,6 +280,13 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Used with unwrap_commonjs_packages
     pub(crate) imports_to_convert_from_require: List<'a, DeferredImportNamespace>,
     pub(crate) unwrap_all_requires: bool,
+    /// Names this file assigns to (`x = ...`, `x++`, `[x] = ...`, `for (x of ...)`) or
+    /// declares more than once. `visit_decls` has to decide whether `var x = require("pkg")`
+    /// can become the import binding itself before the rest of the file has been visited,
+    /// so this is collected during the parse pass, where identifiers are still names rather
+    /// than symbols. A binding whose name is in here stays an ordinary variable. Only
+    /// filled when unwrapping.
+    pub(crate) rebound_names: HashMap<&'a [u8], ()>,
 
     pub(crate) commonjs_named_exports: bun_ast::ast_result::CommonJSNamedExports,
     pub(crate) commonjs_named_exports_deoptimized: bool,
@@ -752,7 +759,61 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
             }
         }
+        // `T` fixes the variant at each (inlined) call site, so this compiles to
+        // nothing except where a binary or unary expression is built.
+        match expr.data {
+            js_ast::ExprData::EBinary(bin)
+                if js_ast::op::Code::binary_assign_target(bin.op) != js_ast::AssignTarget::None =>
+            {
+                self.record_rebound_target(bin.left);
+            }
+            js_ast::ExprData::EUnary(unary)
+                if js_ast::op::Code::unary_assign_target(unary.op)
+                    != js_ast::AssignTarget::None =>
+            {
+                self.record_rebound_target(unary.value);
+            }
+            _ => {}
+        }
         expr
+    }
+
+    /// Adds every identifier that `target` rebinds to [`rebound_names`](Self::rebound_names).
+    /// `target` is the left side of an assignment, the operand of `++`/`--`, or the head of
+    /// a `for (... in/of)` loop, so it is either an identifier, a member expression (which
+    /// rebinds nothing), or a destructuring pattern. Defaults inside a pattern (`[x = 1] = y`)
+    /// are assignment expressions of their own and were recorded when they were built.
+    pub(crate) fn record_rebound_target(&mut self, target: Expr) {
+        if !self.should_unwrap_common_js_to_esm() {
+            return;
+        }
+        match target.data {
+            js_ast::ExprData::EIdentifier(id) => {
+                let name = self.load_name_from_ref(id.ref_);
+                self.rebound_names.insert(name, ());
+            }
+            js_ast::ExprData::EArray(array) => {
+                for item in array.items.slice() {
+                    self.record_rebound_target(*item);
+                }
+            }
+            js_ast::ExprData::EObject(object) => {
+                for property in object.properties.slice() {
+                    if let Some(value) = property.value {
+                        self.record_rebound_target(value);
+                    }
+                }
+            }
+            js_ast::ExprData::ESpread(spread) => self.record_rebound_target(spread.value),
+            _ => {}
+        }
+    }
+
+    /// Adds a name that is declared a second time to [`rebound_names`](Self::rebound_names).
+    fn record_redeclared_name(&mut self, name: &'a [u8]) {
+        if self.should_unwrap_common_js_to_esm() {
+            self.rebound_names.insert(name, ());
+        }
     }
 
     #[inline]
@@ -3091,6 +3152,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if let Some(member_in_scope) =
                             _scope.get_member_with_hash(name, hash.unwrap())
                         {
+                            self.record_redeclared_name(name);
                             let existing_idx = member_in_scope.ref_.inner_index() as usize;
                             let existing_kind = self.symbols[existing_idx].kind;
 
@@ -4587,6 +4649,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // arena-owned `Scope` map.
         let entry = unsafe { scope.members.get_or_put_borrowed(name) };
         if entry.found_existing {
+            self.record_redeclared_name(name);
             let existing: js_ast::scope::Member = *entry.value_ptr;
             let symbol_idx = existing.ref_.inner_index() as usize;
 
@@ -8793,6 +8856,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             runtime_imports: RuntimeImports::default(),
             imports_to_convert_from_require: BumpVec::new_in(arena),
             unwrap_all_requires,
+            rebound_names: Default::default(),
             commonjs_named_exports: Default::default(),
             commonjs_module_exports_assigned_deoptimized: false,
             commonjs_named_exports_needs_conversion: u32::MAX,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -811,8 +811,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    /// Binds the recorded targets on first use, which is during the visit pass (hoisting is done)
-    /// and only in files where a `require()` of an unwrapped package initializes a `let`/`var`.
+    /// Binds the recorded targets on first use, after hoisting; most files never ask.
     pub(crate) fn binding_is_rebound(&mut self, binding: Ref) -> bool {
         for (scope, name_ref) in core::mem::take(&mut self.unresolved_rebound_targets) {
             let name = self.load_name_from_ref(name_ref);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -280,8 +280,10 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Used with unwrap_commonjs_packages
     pub(crate) imports_to_convert_from_require: List<'a, DeferredImportNamespace>,
     pub(crate) unwrap_all_requires: bool,
-    /// Names this file assigns to or declares twice; filled while parsing, read in `visit_decls`.
-    pub(crate) rebound_names: HashMap<&'a [u8], ()>,
+    /// Bindings this file declares twice or assigns to; see [`Self::binding_is_rebound`].
+    pub(crate) rebound_refs: RefMap,
+    /// Assignment targets as (scope, name), bound to symbols only once hoisting has run.
+    pub(crate) unresolved_rebound_targets: Vec<(js_ast::StoreRef<Scope>, Ref)>,
 
     pub(crate) commonjs_named_exports: bun_ast::ast_result::CommonJSNamedExports,
     pub(crate) commonjs_named_exports_deoptimized: bool,
@@ -775,37 +777,56 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     #[inline]
     pub(crate) fn record_rebound_target(&mut self, target: Expr) {
         if self.should_unwrap_common_js_to_esm() {
-            self.record_rebound_names_in(target);
+            self.record_rebound_targets_in(target);
         }
     }
 
-    fn record_rebound_names_in(&mut self, target: Expr) {
+    fn record_rebound_targets_in(&mut self, target: Expr) {
         match target.data {
             js_ast::ExprData::EIdentifier(id) => {
-                let name = self.load_name_from_ref(id.ref_);
-                self.rebound_names.insert(name, ());
+                self.unresolved_rebound_targets
+                    .push((self.current_scope, id.ref_));
             }
             js_ast::ExprData::EArray(array) => {
                 for item in array.items.slice() {
-                    self.record_rebound_names_in(*item);
+                    self.record_rebound_targets_in(*item);
                 }
             }
             js_ast::ExprData::EObject(object) => {
                 for property in object.properties.slice() {
                     if let Some(value) = property.value {
-                        self.record_rebound_names_in(value);
+                        self.record_rebound_targets_in(value);
                     }
                 }
             }
-            js_ast::ExprData::ESpread(spread) => self.record_rebound_names_in(spread.value),
+            js_ast::ExprData::ESpread(spread) => self.record_rebound_targets_in(spread.value),
             _ => {}
         }
     }
 
-    fn record_redeclared_name(&mut self, name: &'a [u8]) {
+    fn record_redeclared(&mut self, existing: Ref, redeclaration: Ref) {
         if self.should_unwrap_common_js_to_esm() {
-            self.rebound_names.insert(name, ());
+            self.rebound_refs.insert(existing, ());
+            self.rebound_refs.insert(redeclaration, ());
         }
+    }
+
+    /// Binds the recorded targets on first use, which is during the visit pass (hoisting is done)
+    /// and only in files where a `require()` of an unwrapped package initializes a `let`/`var`.
+    pub(crate) fn binding_is_rebound(&mut self, binding: Ref) -> bool {
+        for (scope, name_ref) in core::mem::take(&mut self.unresolved_rebound_targets) {
+            let name = self.load_name_from_ref(name_ref);
+            let hash = Scope::get_member_hash(name);
+            let mut scope = Some(scope);
+            while let Some(current) = scope {
+                if let Some(member) = current.get_member_with_hash(name, hash) {
+                    self.rebound_refs.insert(member.ref_, ());
+                    break;
+                }
+                scope = current.parent;
+            }
+        }
+        self.rebound_refs.contains_key(&binding)
     }
 
     #[inline]
@@ -3144,7 +3165,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         if let Some(member_in_scope) =
                             _scope.get_member_with_hash(name, hash.unwrap())
                         {
-                            self.record_redeclared_name(name);
+                            self.record_redeclared(member_in_scope.ref_, value.ref_);
                             let existing_idx = member_in_scope.ref_.inner_index() as usize;
                             let existing_kind = self.symbols[existing_idx].kind;
 
@@ -4641,7 +4662,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // arena-owned `Scope` map.
         let entry = unsafe { scope.members.get_or_put_borrowed(name) };
         if entry.found_existing {
-            self.record_redeclared_name(name);
             let existing: js_ast::scope::Member = *entry.value_ptr;
             let symbol_idx = existing.ref_.inner_index() as usize;
 
@@ -4685,6 +4705,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 MR::OverwriteWithNew => {}
             }
+            self.record_redeclared(existing.ref_, ref_);
         }
         *entry.value_ptr = js_ast::scope::Member { ref_, loc };
         Ok(ref_)
@@ -8848,7 +8869,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             runtime_imports: RuntimeImports::default(),
             imports_to_convert_from_require: BumpVec::new_in(arena),
             unwrap_all_requires,
-            rebound_names: Default::default(),
+            rebound_refs: RefMap::default(),
+            unresolved_rebound_targets: Vec::new(),
             commonjs_named_exports: Default::default(),
             commonjs_module_exports_assigned_deoptimized: false,
             commonjs_named_exports_needs_conversion: u32::MAX,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -280,8 +280,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Used with unwrap_commonjs_packages
     pub(crate) imports_to_convert_from_require: List<'a, DeferredImportNamespace>,
     pub(crate) unwrap_all_requires: bool,
-    /// Names this file assigns to or declares twice, collected while parsing (hence by name)
-    /// so `visit_decls` knows whether `var x = require("pkg")` is rebound later in the file.
+    /// Names this file assigns to or declares twice; filled while parsing, read in `visit_decls`.
     pub(crate) rebound_names: HashMap<&'a [u8], ()>,
 
     pub(crate) commonjs_named_exports: bun_ast::ast_result::CommonJSNamedExports,
@@ -772,8 +771,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         expr
     }
 
-    /// `target` is an assignment target, `++`/`--` operand or `for (... in/of)` head; a default
-    /// inside a pattern (`[x = 1] = y`) is an assignment of its own and records itself when built.
+    /// A default inside a pattern (`[x = 1] = y`) is an assignment of its own and records itself.
     #[inline]
     pub(crate) fn record_rebound_target(&mut self, target: Expr) {
         if self.should_unwrap_common_js_to_esm() {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1242,6 +1242,10 @@ impl<'a> Parser<'a> {
                             deferred_import.import_record_id,
                         )
                     };
+                    debug_assert!(
+                        !p.symbols.as_slice()[ns_ref.inner_index() as usize].has_been_assigned_to(),
+                        "visit_decls turned an assigned variable into its import"
+                    );
                     let (import_part_stmts, rest) = remaining_stmts.split_at_mut(1);
                     remaining_stmts = rest;
 

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -604,6 +604,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             if !matches!(expr.data, js_ast::ExprData::EIdentifier(_)) {
                                 bad_async_range = None;
                             }
+                            // "for (x of y)" / "for (x in y)" assign to x on every iteration.
+                            if p.lexer.token == T::TIn || p.lexer.is_contextual_keyword(b"of") {
+                                p.record_rebound_target(expr);
+                            }
                             init_ = Some(p.s(
                                 S::SExpr {
                                     value: expr,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -366,9 +366,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         let deferred = &mut self.imports_to_convert_from_require
                                             [unwrapped_id.get_usize()];
                                         if is_rebound {
-                                            // Keep the variable and initialize it from the
-                                            // import's namespace, as require() in any other
-                                            // expression position is.
+                                            // Stays a variable, holding the import's namespace.
                                             decl.value = Some(Expr::init_identifier(
                                                 deferred.namespace.ref_,
                                                 value.loc,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -359,12 +359,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             if let Some(value) = decl.value {
                                 if let ExprData::ERequireString(req) = value.data {
                                     if let Some(unwrapped_id) = req.unwrapped_id.get() {
+                                        let is_rebound = !was_const
+                                            && self
+                                                .rebound_names
+                                                .contains(&self.load_name_from_ref(ref_));
                                         let deferred = &mut self.imports_to_convert_from_require
                                             [unwrapped_id.get_usize()];
-                                        deferred.namespace.ref_ = ref_;
-                                        self.import_items_for_namespace
-                                            .insert(ref_, ImportItemForNamespaceMap::default());
-                                        continue 'outer;
+                                        if is_rebound {
+                                            // Keep the variable and initialize it from the
+                                            // import's namespace, as require() in any other
+                                            // expression position is.
+                                            decl.value = Some(Expr::init_identifier(
+                                                deferred.namespace.ref_,
+                                                value.loc,
+                                            ));
+                                        } else {
+                                            deferred.namespace.ref_ = ref_;
+                                            self.import_items_for_namespace
+                                                .insert(ref_, ImportItemForNamespaceMap::default());
+                                            continue 'outer;
+                                        }
                                     }
                                 }
                             }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -359,10 +359,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             if let Some(value) = decl.value {
                                 if let ExprData::ERequireString(req) = value.data {
                                     if let Some(unwrapped_id) = req.unwrapped_id.get() {
-                                        let is_rebound = !was_const
-                                            && self
-                                                .rebound_names
-                                                .contains(&self.load_name_from_ref(ref_));
+                                        let is_rebound =
+                                            !was_const && self.binding_is_rebound(ref_);
                                         let deferred = &mut self.imports_to_convert_from_require
                                             [unwrapped_id.get_usize()];
                                         if is_rebound {

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -14,6 +14,22 @@ const fakeReactNodeModules = {
   `,
 };
 
+// An unwrapped package whose module converts to ESM (it assigns `exports.x`, not
+// `module.exports`). `unused` is only there to show whether the package was tree-shaken.
+const convertedReactNodeModules = {
+  "/node_modules/react/index.js": /* js */ `
+    exports.react = "react";
+    exports.unused = "REMOVE";
+  `,
+  "/node_modules/react/package.json": /* json */ `
+    {
+      "name": "react",
+      "version": "2.0.0",
+      "main": "index.js"
+    }
+  `,
+};
+
 describe("bundler", () => {
   itBundled("cjs2esm/ModuleExportsFunction", {
     files: {
@@ -282,6 +298,174 @@ describe("bundler", () => {
     },
     run: {
       stdout: "react\nreact\nreact\nreact\nundefined\nreact\nreact\nreact\nreact\nreact\nreact\n1 react\nreact\nreact",
+    },
+  });
+  // A let/var initialized by require() of an unwrapped package is only an alias of the
+  // package while nothing assigns to it. Every variable here is assigned later in some
+  // form, so each one has to stay a real variable initialized from the import; the
+  // expected output is what running entry.js unbundled prints.
+  itBundled("cjs2esm/UnwrappedModuleRequireRebound", {
+    files: {
+      "/entry.js": /* js */ `
+        let a = require("react");
+        console.log(a.react);
+        a = { react: "a" };
+        console.log(a.react);
+
+        var b = require("react");
+        b = { react: "b" };
+        console.log(b.react);
+
+        c = { react: "c before" };
+        console.log(c.react);
+        var c = require("react");
+        console.log(c.react);
+        c = { react: "c after" };
+        console.log(c.react);
+
+        let d = require("react");
+        function rebindD() {
+          d = { react: "d" };
+        }
+        rebindD();
+        console.log(d.react);
+
+        function inner() {
+          let e = require("react");
+          const before = e.react;
+          e = { react: "e" };
+          return before + " " + e.react;
+        }
+        console.log(inner());
+
+        let f = require("react");
+        f += "";
+        console.log(typeof f, f.react);
+
+        let g = require("react");
+        g++;
+        console.log(typeof g, g.react);
+
+        let h = require("react");
+        [h] = [{ react: "h" }];
+        console.log(h.react);
+
+        let i = require("react");
+        ({ i } = { i: { react: "i" } });
+        console.log(i.react);
+
+        let j = require("react");
+        ({ ...j } = { react: "j" });
+        console.log(j.react);
+
+        let k = require("react");
+        [...k] = [{ react: "k" }];
+        console.log(k.length, k[0].react);
+
+        let l = require("react");
+        for (l of [{ react: "l" }]) {}
+        console.log(l.react);
+
+        let m = require("react");
+        for (m in { key: 1 }) {}
+        console.log(m, m.react);
+
+        // react-dom stays a CommonJS wrapper, so this one worked before as well.
+        let n = require("react-dom");
+        console.log(n.dom);
+        n = { dom: "n" };
+        console.log(n.dom);
+      `,
+      ...convertedReactNodeModules,
+      "/node_modules/react-dom/index.js": /* js */ `
+        module.exports = { dom: "dom" };
+      `,
+      "/node_modules/react-dom/package.json": /* json */ `
+        {
+          "name": "react-dom",
+          "version": "2.0.0",
+          "main": "index.js"
+        }
+      `,
+    },
+    run: {
+      stdout: [
+        "react",
+        "a",
+        "b",
+        "c before",
+        "react",
+        "c after",
+        "d",
+        "react e",
+        "string undefined",
+        "number undefined",
+        "h",
+        "i",
+        "j",
+        "1 k",
+        "l",
+        "key undefined",
+        "dom",
+        "n",
+      ].join("\n"),
+    },
+  });
+  // Declaring the variable a second time rebinds it too, whether the second
+  // declaration is in the same scope or is a var hoisted out of a nested block.
+  itBundled("cjs2esm/UnwrappedModuleRequireRedeclared", {
+    files: {
+      "/entry.js": /* js */ `
+        var a = require("react");
+        console.log(a.react);
+        var a = { react: "a" };
+        console.log(a.react);
+
+        var b = require("react");
+        console.log(b.react);
+        if (a) {
+          var b = { react: "b" };
+        }
+        console.log(b.react);
+      `,
+      ...convertedReactNodeModules,
+    },
+    run: {
+      stdout: "react\na\nreact\nb",
+    },
+  });
+  // Variables that are never rebound still become the import itself, including a
+  // let inside a function and a const whose name is assigned in an unrelated scope, so
+  // the package is still tree-shaken: `unused` must not survive for any of them.
+  itBundled("cjs2esm/UnwrappedModuleRequireNotReboundIsTreeShaken", {
+    files: {
+      "/entry.js": /* js */ `
+        var top = require("react");
+        console.log(top.react);
+
+        function inFunction() {
+          let local = require("react");
+          return local.react;
+        }
+        console.log(inFunction());
+
+        const fixed = require("react");
+        console.log(fixed.react);
+
+        function unrelated() {
+          let fixed = 1;
+          fixed = 2;
+          let top = "shadow";
+          return fixed + " " + top;
+        }
+        console.log(unrelated());
+      `,
+      ...convertedReactNodeModules,
+    },
+    dce: true,
+    treeShaking: true,
+    run: {
+      stdout: "react\nreact\nreact\n2 shadow",
     },
   });
   // A require() of an unwrapped package that initializes a destructuring

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -370,6 +370,13 @@ describe("bundler", () => {
         for (m in { key: 1 }) {}
         console.log(m, m.react);
 
+        // The declaration only reaches module scope by being hoisted out of the block.
+        if (a) {
+          var o = require("react");
+        }
+        o = { react: "o" };
+        console.log(o.react);
+
         // react-dom stays a CommonJS wrapper, so this one worked before as well.
         let n = require("react-dom");
         console.log(n.dom);
@@ -406,6 +413,7 @@ describe("bundler", () => {
         "1 k",
         "l",
         "key undefined",
+        "o",
         "dom",
         "n",
       ].join("\n"),
@@ -434,9 +442,11 @@ describe("bundler", () => {
       stdout: "react\na\nreact\nb",
     },
   });
-  // Variables that are never rebound still become the import itself, including a
-  // let inside a function and a const whose name is assigned in an unrelated scope, so
-  // the package is still tree-shaken: `unused` must not survive for any of them.
+  // Variables that are never rebound still become the import itself, so the package is
+  // still tree-shaken: `unused` must not survive. Minified code reuses the same short
+  // names in every function, so only assignments and redeclarations that resolve to the
+  // variable itself may count, not ones that hit a same-named parameter, local, block
+  // binding or arrow default.
   itBundled("cjs2esm/UnwrappedModuleRequireNotReboundIsTreeShaken", {
     files: {
       "/entry.js": /* js */ `
@@ -452,11 +462,40 @@ describe("bundler", () => {
         const fixed = require("react");
         console.log(fixed.react);
 
+        function parameter(top) {
+          top = { react: "parameter" };
+          return top.react;
+        }
+        console.log(parameter(0));
+
+        function hoisted() {
+          for (var top = 0; top < 2;) {
+            top++;
+          }
+          // Assigned after the block closed; the var it hits is hoisted out of the block.
+          top = top * 10;
+          return top;
+        }
+        console.log(hoisted());
+
+        function redeclared(top) {
+          var top = "again";
+          return top;
+        }
+        console.log(redeclared(0));
+
+        {
+          let top = "block";
+          top += "!";
+          console.log(top);
+        }
+
+        console.log(((top = "arrow") => top)());
+
         function unrelated() {
           let fixed = 1;
           fixed = 2;
-          let top = "shadow";
-          return fixed + " " + top;
+          return fixed;
         }
         console.log(unrelated());
       `,
@@ -465,7 +504,7 @@ describe("bundler", () => {
     dce: true,
     treeShaking: true,
     run: {
-      stdout: "react\nreact\nreact\n2 shadow",
+      stdout: ["react", "react", "react", "parameter", "20", "again", "block!", "arrow", "2"].join("\n"),
     },
   });
   // A require() of an unwrapped package that initializes a destructuring


### PR DESCRIPTION
### Problem
- `bun build` (ESM output, the default) loses later assignments to a `let`/`var` that was initialized by a `require()` of a package on the CommonJS unwrap list (`react`, `react-dom`, `scheduler`, ...) when the required module converts to ESM (it uses `exports.x = ...`, not `module.exports = ...`). Same on 1.4.0 and main:
  ```js
  let r = require("scheduler");   // node_modules/scheduler/index.js: exports.sched = "sched"
  console.log(r.sched);           // sched
  r = { sched: "replaced" };
  console.log(r.sched);           // unbundled: replaced      bundled: sched
  ```
  bundles to
  ```js
  console.log($sched);
  exports_scheduler = { sched: "replaced" };
  console.log($sched);
  ```
- Every way of rebinding the variable is affected: `r = ...`, `r += ...`, `r++`, `[r] = ...`, `({ r } = ...)`, `for (r of ...)`, an assignment inside a function, an assignment that precedes the declaration (`var` hoisting), and a declaration that itself reaches module scope by being hoisted out of a block. Declaring the variable a second time (`var r = require("react"); ... var r = {...}`, or a `var r` in a nested block) bundles to code that throws `TypeError: undefined is not an object (evaluating 'exports_react.react')`: the package's namespace object is never emitted, but the redeclared variable has been renamed to it.
- This is the shape old Rollup builds emit for a default import of React: `var React = require('react'); React = React && React.hasOwnProperty('default') ? React['default'] : React;`.
- Cause: `visit_decls` (`src/js_parser/visit/mod.rs`) visits every declarator's initializer with `is_immediately_assigned_to_decl`; `transpose_require` (`src/js_parser/p.rs`) answers it with an `E::RequireString` marker, and `visit_decls` consumes the marker by renaming the pending `import * as ns` to the declared variable and deleting the declarator. From then on `r.sched` is rewritten into a named import of `sched` and `r` itself is the import namespace. That treats the variable as an immutable alias of the module, which holds for `const` and for a variable nothing else touches, but not for one the file assigns to or declares again. When `visit_decls` runs, the rest of the file has not been visited yet, so it cannot tell the two apart from what it has seen. (When the target stays a CommonJS wrapper the namespace happens to print as `var r = __toESM(require_x(), 1)`, a real variable, which is why only converted targets show it.)

### Fix
- While parsing, the parser records what the file rebinds:
  - the target of every assignment and update expression (`new_expr`, using the same `binary_assign_target` / `unary_assign_target` classifiers as the visit pass, looking through destructuring patterns) and the head of every `for (x in/of ...)` (`parse_stmt`), as `(scope it was parsed in, name)` in `unresolved_rebound_targets`. Identifiers are not bound to symbols until the visit pass, so this is all that is known at that point;
  - every redeclaration, as the symbols involved, in `rebound_refs`: a second declaration in the same scope (`declare_symbol`, which also covers a `var` sharing a parameter's name, since parameters are copied into the body scope) and a nested `var` hoisted into a scope that already has the name (`hoist_symbols`).
- When `visit_decls` meets the marker for a non-`const` declarator it calls `binding_is_rebound`, which first binds the recorded targets by walking each one's scope chain (hoisting has run by then, so a `var` declared later or inside a block is found where it ends up) and adds the symbols they hit to `rebound_refs`, then asks whether the declarator's own symbol is in the set. If it is, the declarator is kept and its initializer becomes the import's namespace, which is what `transpose_require` returns for a `require()` in any other expression position: `var r = exports_scheduler;` for a converted target, `var ns = __toESM(require_x(), 1); var r = ns;` for a wrapped one, with `r.sched` left as a property read of the variable. Otherwise the declarator takes the unchanged replace-with-import path.
- The import-emitting loop in `parse_entry.rs` now `debug_assert!`s that no namespace symbol was assigned to. A fresh namespace never is, so this only fires if `visit_decls` replaced a variable that the visit pass later saw assigned, i.e. if the recording above ever misses a form of assignment (redeclaration has no symbol flag to check).
- Why this is correct:
  - Recording happens for the whole file before anything is visited, so the answer does not depend on where the rebinding sits relative to the declaration. Binding the targets is deferred to the first question because that is the first point at which the scope tree is final; an assignment whose name resolves to nothing (an undeclared global) is dropped, since it cannot be one of this file's declarations.
  - Resolution is by symbol, so a same-named parameter, local, block binding, arrow default, or a `var` hoisted into some other function does not count. That matters because minified CommonJS looks exactly like that (`var e=require("react")` at the top, `e` reused as a local in every function): a first version of this change keyed the set by bare name and therefore kept all of react in such bundles; `cjs2esm/UnwrappedModuleRequireNotReboundIsTreeShaken` fails on that version. With this version a tsdx-shaped consumer of the real react 18.3.1 bundles byte-for-byte the same as on 1.4.0 (1093 bytes minified, no namespace object), and `npm/ReactSSR` (byte positions in the real react-dom 18.3.1 output, whose own `var React = require('react')` / `var Scheduler = require('scheduler')` depend on this rewrite) is unchanged.
  - `const` declarators skip the question: they cannot be assigned or redeclared, and this keeps the TypeScript-emitted `const react_1 = require("react")` shape from binding the file's targets at all.
  - The check sits where the marker is consumed rather than where the flag is passed (#39184 and #39244 gate the flag) because binding the recorded targets costs time proportional to the file's assignments; doing it at the flag would do that work in every file with a `let`/`var`, doing it here confines it to files that actually have such a declarator. The marker does not survive either way, it is replaced by the namespace identifier before the declarator continues down the normal path.
  - Cost: in ESM bundling, one 16-byte push per identifier that is an assignment or update target (member targets such as `exports.x = ...` push nothing), freed when the targets are bound or when the parser is dropped; two hash inserts per redeclaration; the binding walk only in files with a non-`const` unwrapped `require()` declarator. Outside ESM bundling nothing is recorded: `record_rebound_target` is an inlined flag test, and in the optimized assembly the `new_expr` match leaves code only in the `E::Binary` / `E::Unary` constructor paths (a range check on the operator, then the flag test for assignment operators only), nothing in any other instantiation. `P` grows by an empty `RefMap` and an empty `Vec`.
- Verified with `test/bundler/bundler_cjs2esm.test.ts`:
  - `cjs2esm/UnwrappedModuleRequireRebound`: the forms listed above against a converted package, plus one against a wrapped package, checked against what the entry prints unbundled. 14 of its 19 lines are wrong on the current release, including the declaration hoisted out of a block.
  - `cjs2esm/UnwrappedModuleRequireRedeclared`: same-scope redeclaration and a hoisted block-level `var`; the current release's bundle throws. Removing only the `hoist_symbols` hook fails exactly the second case, removing only the for-in/of hook fails exactly the `for` lines of the first test.
  - `cjs2esm/UnwrappedModuleRequireNotReboundIsTreeShaken` (passes on main, fails on the name-keyed version): a top-level `var`, a `let` inside a function and a `const` all still become the import (`dce` pins that the package's unused export is gone) while the same name is assigned as a parameter, assigned after being hoisted out of a `for` inside another function, redeclared over a parameter, assigned as a block-level `let`, and used as an arrow default.
  - Also ran `bundler_cjs`, `bundler_edgecase`, `bundler_regressions`, `bundler_jsx`, `bundler_npm`, `esbuild/default`, `esbuild/importstar`, `esbuild/dce`, `esbuild/ts` and `transpiler/transpiler.test.js` with the debug build (so with the new assertion armed): no failures.
- Related, each fixing a different symptom of the same rewrite: #39184 (destructuring declarators), #39244 (`export`ed and `using` declarators). Both change which declarators get the marker; this one changes what happens to a marker for an identifier declarator, so the three compose. #39244 keeps a local `was_const` in `visit_decls`, which is what this change reads.

### Background
- CommonJS unwrap list: when the output format is ESM, files inside the packages in `DEFAULT_UNWRAP_COMMONJS_PACKAGES` (`src/bundler/options.rs`) are parsed with `exports.x = ...` turned into ESM exports, and every `require()` that resolves into one of them, from any file, becomes an `import * as ns from "..."` statement (emitted at the end of the parse from `imports_to_convert_from_require`) plus a reference to `ns`. `ns.x` is then rewritten into a named import of `x`, so a file that only reads properties never needs the namespace object and the package tree-shakes. esbuild has no equivalent: there `require()` of CommonJS stays a call to the `__commonJS` wrapper, and the namespace machinery this reuses only ever applies to real `import * as ns` bindings, which cannot be assigned to (that is a bundling error).
- Converted vs wrapped target: a required file that only assigns `exports.x` converts to ESM, and its namespace prints as the namespace object the linker generates for it (`exports_scheduler`), shared by every importer. A file that assigns `module.exports` stays a CommonJS wrapper, and each importer gets its own `var ns = __toESM(require_x(), 1)`.
- `is_immediately_assigned_to_decl` / `E::RequireString.unwrapped_id`: the handshake between `visit_decls` and `transpose_require`. The flag asks for the marker; the marker's `unwrapped_id` indexes the pending import; `visit_decls` uses it to rename the import's namespace to the declared variable and drop the declarator, which is how `const React = require("react")` becomes `import * as React from "react"`.
- Parse pass vs visit pass: the parser first builds the whole file's AST (identifiers are stored as names) while declaring each scope's symbols into `Scope::members`; `hoist_symbols` then moves nested `var`s up into their function or module scope; only the visit pass binds identifiers to symbols and performs rewrites such as this one, in source order. Walking `Scope::parent` and checking `members` is the same lookup the visit pass's `find_symbol` performs, which is why binding the recorded targets after hoisting reproduces what the visit pass will bind them to.
- `Symbol::has_been_assigned_to`: a flag the visit pass sets on a symbol when it visits an assignment to it (HMR uses it to decide which exports need live bindings). It is final once the visit pass is over, which is when the import-emitting loop runs, so it can double-check the decisions made earlier.

<details>
<summary>Earlier revision of this PR</summary>

The first revision recorded bare names (`rebound_names: HashMap<&[u8], ()>`) and compared the declarator's name against them. That is correct but over-approximate: an assignment to a same-named variable in any scope disabled the rewrite, and since minified CommonJS reuses the same short names in every function, it kept all of react in bundles that 1.4.0 tree-shakes. The current revision records scopes alongside the names and binds them to symbols instead, and adds the tree-shaking test cases that distinguish the two.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/172] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/172] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 8 sinks, 96 exported symbols
Generating /workspace/bun/build/debug/codegen/JSSink.lut.h from /workspace/bun/build/debug/codegen/JSSink.lut.txt
[3/172] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 field
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (eabb96de7)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [21.84ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [14.49ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [12.75ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [14.63ms]
(pass) bundler > cjs2esm/ExportsFunction [14.62ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [15.61ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [14.80ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [17.71ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [15.46ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [13.94ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [17.27ms]
runtime failed file: /tmp/bun-build-tests/bun-Hna8UT/cjs2esm/UnwrappedModuleRequireRebound/out.js
stdout output:
react
react
react
c before
react
react
react
react react
string react
number react
react
react
react
undefined k
react
key react
react
dom
n
---
expected stdout:
react
a
b
c before
react
c after
d
react e
string undefined
number undefined
h
i
j
1 k
l
key unde
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/bundler/bundler_cjs2esm.test.ts"
bun test v1.4.0 (f81643299)

test/bundler/bundler_cjs2esm.test.ts:
(pass) bundler > cjs2esm/ModuleExportsFunction [1016.25ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJSModuleRef [577.19ms]
(pass) bundler > cjs2esm/ImportNamedFromExportStarCJS [444.94ms]
(pass) bundler > cjs2esm/BadNamedImportNamedReExportedFromCommonJS [413.08ms]
(pass) bundler > cjs2esm/ExportsFunction [422.65ms]
(pass) bundler > cjs2esm/ModuleExportsFunctionTreeShaking [472.95ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRequire [421.11ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvProduction [610.88ms]
(pass) bundler > cjs2esm/ModuleExportsBasedOnNodeEnvDevelopment [626.87ms]
(pass) bundler > cjs2esm/ModuleExportsEqualsRuntimeCondition [504.92ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireAssigned [1031.23ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireRebound [614.39ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireRedeclared [445.64ms]
(pass) bundler > cjs2esm/UnwrappedModuleRequireNotReboundIsTr
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     5dbd732c3d
  features     baseline

22 deps, 123 codegen, 1176 objects in 961ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (eabb96de7)

Checked 107 installs across 153 packages (no changes) [17.00ms]
[2/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (eabb96de7)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1238] gen bindgenv2
[4/1238] gen ErrorCode+*.h
[5/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (eabb96de7)

Checked 129 installs across 147 packages (no changes) [17.00ms]
[6/1238] fetch zlib
[zlib] up to date
[7/1238] gen .bind.ts → GeneratedBindings.cpp
[8/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1238] fetch tinycc
[tinycc] up to date
[10/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                   |  77 ++++++++++++
 src/js_parser/parse/parse_entry.rs   |   4 +
 src/js_parser/parse/parse_stmt.rs    |   4 +
 src/js_parser/visit/mod.rs           |  18 ++-
 test/bundler/bundler_cjs2esm.test.ts | 223 +++++++++++++++++++++++++++++++++++
 5 files changed, 322 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/js_parser/p.rs                       26     25      0
src/js_parser/parse/parse_entry.rs        5      3      0
src/js_parser/parse/parse_stmt.rs         1      1      0
src/js_parser/visit/mod.rs                6      5      0
test/bundler/bundler_cjs2esm.test.ts      4      7      0
```

</details>

<!-- robobun:evidence:end -->