### PR TITLE
Bun.serve: let idleTimeout reap WebSocket clients the server keeps sending to

### DIFF
--- a/docs/runtime/http/server.mdx
+++ b/docs/runtime/http/server.mdx
@@ -674,6 +674,9 @@ interface WebSocketHandler<T = undefined> {
   /** Seconds before idle timeout */
   idleTimeout?: number;
 
+  /** Whether messages sent by the server restart the idle timeout (default true) */
+  resetIdleTimeoutOnSend?: boolean;
+
   /** Enable per-message deflate compression */
   perMessageDeflate?:
     | boolean

--- a/docs/runtime/http/websockets.mdx
+++ b/docs/runtime/http/websockets.mdx
@@ -286,6 +286,20 @@ Bun.serve({
 });
 ```
 
+The idle timer restarts every time the client sends something. By default, messages the server sends to the client restart it too, so Bun never treats a connection the server keeps pushing to as idle. With `sendPings` enabled (the default), Bun pings the client before the deadline. Bun closes the connection with code `1006` if nothing has come back from the client by the deadline.
+
+Set `resetIdleTimeoutOnSend: false` to count only traffic received from the client. Use this on servers that mostly push data, such as tickers or chat fan-out. Bun then closes a client that has been silent for `idleTimeout` seconds, no matter how much the server sent to it in the meantime.
+
+```ts
+Bun.serve({
+  fetch(req, server) {}, // upgrade logic
+  websocket: {
+    idleTimeout: 30,
+    resetIdleTimeoutOnSend: false, // [!code ++]
+  },
+});
+```
+
 Bun also closes a WebSocket connection if it receives a message larger than 16 MB. Configure this with the `maxPayloadLength` parameter.
 
 ```ts
@@ -355,6 +369,7 @@ namespace Bun {
 
       maxPayloadLength?: number; // default: 16 * 1024 * 1024 = 16 MB
       idleTimeout?: number; // default: 120 (seconds)
+      resetIdleTimeoutOnSend?: boolean; // default: true
       backpressureLimit?: number; // default: 16 * 1024 * 1024 = 16 MB
       closeOnBackpressureLimit?: boolean; // default: false
       sendPings?: boolean; // default: true

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -482,9 +482,35 @@ declare module "bun" {
      * Sets the number of seconds to wait before timing out a connection
      * due to no messages or pings.
      *
+     * The timer restarts whenever the client sends anything (a message, a
+     * ping, or a pong) and, unless {@link resetIdleTimeoutOnSend} is `false`,
+     * whenever the server sends something to the client. With
+     * {@link sendPings} enabled, Bun pings the client before the deadline and
+     * closes the connection (close code `1006`) only if nothing has come back
+     * from the client by the deadline.
+     *
      * @default 120
      */
     idleTimeout?: number;
+
+    /**
+     * Whether messages sent by the server (`ws.send()`, `ws.publish()`,
+     * `server.publish()`, ...) restart the {@link idleTimeout} timer.
+     *
+     * With the default of `true`, a connection the server keeps pushing to
+     * never counts as idle, so a client that stopped reading or answering is
+     * only noticed once the server itself goes quiet for `idleTimeout`
+     * seconds. Set this to `false` to count only traffic received from the
+     * client: a client that has not sent anything for `idleTimeout` seconds
+     * is closed (after being pinged, if {@link sendPings} is enabled), no
+     * matter how much the server sent to it in the meantime.
+     *
+     * Either way, once Bun has pinged a client, only traffic from that client
+     * cancels the pending close.
+     *
+     * @default true
+     */
+    resetIdleTimeoutOnSend?: boolean;
 
     /**
      * Whether `ws.publish()` also sends the message to `ws` (itself), if it is subscribed.

--- a/packages/bun-uws/src/WebSocket.h
+++ b/packages/bun-uws/src/WebSocket.h
@@ -211,11 +211,12 @@ public:
 
         }
 
-        /* Every successful send resets the timeout */
-        if (webSocketContextData->resetIdleTimeoutOnSend) {
+        /* Every successful send resets the timeout, except while onTimeout's ping is waiting for an
+         * answer (hasTimedOut): our own sends prove nothing about the peer, so the ping deadline stands
+         * until the peer sends something (onData) or drains our backpressure (onWritable). Upstream also
+         * clears hasTimedOut here, which lets a server that keeps pushing data hold a dead peer open forever. */
+        if (webSocketContextData->resetIdleTimeoutOnSend && !webSocketData->hasTimedOut) {
             Super::timeout(webSocketContextData->idleTimeoutComponents.first);
-            WebSocketData *webSocketData = (WebSocketData *) Super::getAsyncSocketData();
-            webSocketData->hasTimedOut = false;
         }
 
         /* Return success */

--- a/src/runtime/server/WebSocketServerContext.rs
+++ b/src/runtime/server/WebSocketServerContext.rs
@@ -381,6 +381,18 @@ pub(crate) fn on_create(
         }
     }
 
+    if let Some(value) = object.get(global_object, "resetIdleTimeoutOnSend")? {
+        if !value.is_undefined_or_null() {
+            if !value.is_boolean() {
+                return Err(global_object.throw_invalid_arguments(format_args!(
+                    "websocket expects resetIdleTimeoutOnSend to be a boolean"
+                )));
+            }
+
+            server.reset_idle_timeout_on_send = value.to_boolean();
+        }
+    }
+
     if let Some(value) = object.get(global_object, "publishToSelf")? {
         if !value.is_undefined_or_null() {
             if !value.is_boolean() {

--- a/test/integration/bun-types/fixture/serve-types.test.ts
+++ b/test/integration/bun-types/fixture/serve-types.test.ts
@@ -202,6 +202,8 @@ test("basic + websocket + upgrade + all handlers", {
     },
 
     perMessageDeflate: true,
+    idleTimeout: 30,
+    resetIdleTimeoutOnSend: false,
   },
 });
 

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -678,6 +678,32 @@ describe("Server", () => {
         },
       );
     });
+    describe("resetIdleTimeoutOnSend (validation)", () => {
+      it.each([0, 1, "false", {}])("throws on %p", value => {
+        expect(() => {
+          serve({
+            port: 0,
+            fetch: () => new Response(),
+            websocket: {
+              message() {},
+              // @ts-expect-error
+              resetIdleTimeoutOnSend: value,
+            },
+          });
+        }).toThrow("websocket expects resetIdleTimeoutOnSend to be a boolean");
+      });
+      it.each([true, false, null, undefined])("accepts %p", value => {
+        using server = serve({
+          port: 0,
+          fetch: () => new Response(),
+          websocket: {
+            message() {},
+            resetIdleTimeoutOnSend: value as boolean | undefined,
+          },
+        });
+        expect(server.port).toBeGreaterThan(0);
+      });
+    });
   });
 });
 describe("ServerWebSocket", () => {
@@ -2186,4 +2212,116 @@ describe.concurrent("request handlers run to completion before the callbacks the
     await sockets.closed;
     expect(order).toEqual(["close()", "rest of handler", "microtask"]);
   });
+});
+
+// uws runs idle timeouts on a 4 second tick and splits `idleTimeout` into an
+// idle part and a ping part: once the idle part passes without traffic it pings
+// the client, and if the ping part also passes it closes the socket with
+// 1006 "WebSocket timed out from inactivity". These tests keep the server
+// sending to a client that never writes anything after the handshake (no
+// messages, no pongs), which must still get reaped.
+describe.concurrent("idleTimeout while the server keeps sending", () => {
+  const HANDSHAKE =
+    "GET / HTTP/1.1\r\n" +
+    "Host: x\r\n" +
+    "Upgrade: websocket\r\n" +
+    "Connection: Upgrade\r\n" +
+    "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+    "Sec-WebSocket-Version: 13\r\n\r\n";
+
+  // Raw RFC 6455 client that completes the handshake and then never writes
+  // again, counting the frames the server sends it. `secondPing` rejects when
+  // the server pings again instead of closing, so a server that never reaps
+  // the client fails the test at the next tick instead of at the test timeout.
+  function connectAndGoSilent(port: number) {
+    const upgraded = Promise.withResolvers<void>();
+    const secondPing = Promise.withResolvers<never>();
+    const counts = { pings: 0, messages: 0 };
+    let head: string | null = "";
+    let frames = Buffer.alloc(0);
+    const socket = net.connect({ port, host: "127.0.0.1" }, () => socket.write(HANDSHAKE));
+    socket.on("data", (chunk: Buffer) => {
+      if (head !== null) {
+        head += chunk.toString("latin1");
+        const end = head.indexOf("\r\n\r\n");
+        if (end === -1) return;
+        if (!head.startsWith("HTTP/1.1 101 ")) {
+          upgraded.reject(new Error("upgrade failed: " + head));
+          return;
+        }
+        chunk = Buffer.from(head.slice(end + 4), "latin1");
+        head = null;
+        upgraded.resolve();
+      }
+      frames = Buffer.concat([frames, chunk]);
+      // Server frames are unmasked, and everything this server sends ("tick"
+      // and empty pings) fits the 2 byte header with a 7 bit payload length.
+      while (frames.length >= 2 && frames.length >= 2 + (frames[1] & 0x7f)) {
+        const opcode = frames[0] & 0x0f;
+        if (opcode === 0x9 && ++counts.pings === 2) {
+          secondPing.reject(new Error("server pinged the silent client again instead of closing it"));
+        } else if (opcode === 0x1) {
+          counts.messages++;
+        }
+        frames = frames.subarray(2 + (frames[1] & 0x7f));
+      }
+    });
+    socket.on("error", upgraded.reject);
+    socket.on("close", () => upgraded.reject(new Error("socket closed before the upgrade completed")));
+    return { socket, counts, upgraded: upgraded.promise, secondPing: secondPing.promise };
+  }
+
+  async function reapSilentClient(options: Pick<WebSocketHandler<undefined>, "sendPings" | "resetIdleTimeoutOnSend">) {
+    const closed = Promise.withResolvers<{ code: number; reason: string }>();
+    let pusher: ReturnType<typeof setInterval> | undefined;
+    await using server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, srv) {
+        if (srv.upgrade(req)) return;
+        return new Response("no", { status: 400 });
+      },
+      websocket: {
+        ...options,
+        // The smallest idleTimeout uws accepts.
+        idleTimeout: 8,
+        open(ws) {
+          pusher = setInterval(() => ws.send("tick"), 100);
+        },
+        message() {},
+        close(_, code, reason) {
+          clearInterval(pusher);
+          closed.resolve({ code, reason });
+        },
+      },
+    });
+    const client = connectAndGoSilent(server.port!);
+    try {
+      await client.upgraded;
+      const { code, reason } = await Promise.race([closed.promise, client.secondPing]);
+      return { code, reason, pings: client.counts.pings, serverWasSending: client.counts.messages > 0 };
+    } finally {
+      clearInterval(pusher);
+      client.socket.destroy();
+    }
+  }
+
+  const reaped = { code: 1006, reason: "WebSocket timed out from inactivity", serverWasSending: true };
+
+  // With an 8 second idleTimeout the idle part is a single tick, so the ping
+  // goes out even though every send() re-arms the idle timer. The sends made
+  // after the ping must not cancel the ping deadline: the client never answered.
+  it("a ping the client does not answer closes the connection even though the server keeps sending (default options)", async () => {
+    expect(await reapSilentClient({})).toEqual({ ...reaped, pings: 1 });
+  }, 20_000);
+
+  // Without pings the idle part is the whole 8 seconds (two ticks), which the
+  // default reset-on-send keeps re-arming forever while the server is sending.
+  // resetIdleTimeoutOnSend: false makes only the client's traffic count.
+  it("resetIdleTimeoutOnSend: false closes a silent client on idleTimeout regardless of what the server sends", async () => {
+    expect(await reapSilentClient({ sendPings: false, resetIdleTimeoutOnSend: false })).toEqual({
+      ...reaped,
+      pings: 0,
+    });
+  }, 20_000);
 });


### PR DESCRIPTION
### Problem
- A `Bun.serve` WebSocket server that keeps sending to a client never closes that client on `idleTimeout`, even when the client stops answering the automatic pings. Repro: `websocket: { idleTimeout: 8 }`, `ws.send()` once a second, raw client that completes the handshake and never writes again: still open after 24 s with 5 unanswered pings. Without the sends it is closed at 8 s with `1006 "WebSocket timed out from inactivity"`. Same on 1.3.14 and current main.
- `packages/bun-uws/src/WebSocket.h` `send()` (line 214) re-armed the idle timer and set `hasTimedOut = false` on every outbound frame when `resetIdleTimeoutOnSend` is on. `hasTimedOut` is the "ping sent, waiting for the answer" flag that `onTimeout` (`WebSocketContext.h:412`) checks to decide between pinging and closing, so each push cancelled the pending ping deadline and the next tick just pinged again.
- `src/runtime/server/WebSocketServerContext.rs:242` always passes `reset_idle_timeout_on_send: true` to uws (upstream uWS defaults it to `false`) and there was no `websocket` option to change it, so with `idleTimeout` above 8 a push server never even reaches the ping: every send re-arms the idle part of the timer.

### Fix
- `WebSocket.h` `send()`: skip the re-arm while `hasTimedOut` is set and stop clearing it. Only inbound traffic (`onData`, or `onWritable` draining backpressure) clears it, so an unanswered ping closes the socket at the deadline regardless of what the server sends in between. This is the fixing hunk; it applies to `send`, `publish`, `ping`, `pong` and close frames alike since they all go through `send()`.
- New `websocket.resetIdleTimeoutOnSend?: boolean` option (`WebSocketServerContext.rs`), wired to the existing uws field. Default stays `true`, so nothing changes for existing servers; `false` makes only traffic received from the client count, which is what a push-style server needs to reap dead peers at any `idleTimeout`. Non-boolean values throw like the other boolean options. Types, docs and the bun-types fixture are updated.
- Verified:
  - `test/js/bun/websocket/websocket-server.test.ts`, `idleTimeout while the server keeps sending`: default options now close the silent client after exactly one ping (fails on the unfixed build: second ping arrives at ~8 s), and `{ sendPings: false, resetIdleTimeoutOnSend: false }` closes it with no ping (fails on the unfixed build: never closes). Both pass in ~8 s with `bun bd test`; both fail with the fix stashed and with `USE_SYSTEM_BUN=1`.
  - `resetIdleTimeoutOnSend (validation)`: rejects non-booleans, accepts `true`/`false`/`null`/`undefined`.
  - The repro script against the debug build: default options close at 8.4 s after 1 ping; `idleTimeout: 16, resetIdleTimeoutOnSend: false` closes at 16.3 s after 1 ping; `idleTimeout: 16` with the default still stays open (no ping is ever sent, which is the documented reset-on-send behavior).
  - `bun test test/integration/bun-types/bun-types.test.ts` passes.

### Background
- uws keeps one timeout per socket on a 4 second tick. `idleTimeout` is split into two parts (`WebSocketContextData::calculateIdleTimeoutComponents`): an idle part and a ping margin (4, 8 or 16 s). After the idle part passes with no traffic, `onTimeout` sends a ping, sets `hasTimedOut`, and arms the margin; if the timer fires again with `hasTimedOut` still set, the socket is closed with `1006`. Inbound data (`onData`) re-arms the idle part and clears `hasTimedOut`.
- `resetIdleTimeoutOnSend` is the uws knob that decides whether the server's own sends also re-arm the idle part. Bun has passed `true` since the WebSocket server was added; upstream's default is `false` with the comment "depends on kernel timeouts and is a bad default", because with it on, a peer whose TCP stack still acks but whose application is gone is only ever noticed by TCP itself.
- With `idleTimeout: 8` the idle part is 4 s, a single tick, so the ping goes out even while the server is sending; that is why the repro (and the first test) shows pings at all, and why the first test only needs the `send()` change while the second needs the option.
- This PR does not change the default. Flipping it (for example to `!sendPings`, so servers that send pings would measure idleness on inbound traffic only) would make push servers reap dead clients out of the box but would also start pinging clients of push servers that never saw pings before; that is a one-line follow-up if wanted.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/integration/bun-types/fixture/serve-types.test.ts test/js/bun/websocket/websocket-server.test.ts

<!-- robobun:evidence:end -->