### PR TITLE
stream: end a zero-length slice of a pipe without waiting for a byte

### DIFF
--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -572,8 +572,10 @@ impl FileReader {
                 _ => {}
             }
         }
-        if reader_done || self.done.get() {
+        if reader_done || self.done.get() || self.window_remaining() == Some(0) {
+            // Detach first: closing the reader would otherwise end the sink from on_reader_done as well.
             self.sink.set(SinkHandle::None);
+            self.end_at_window();
             sink.end(None);
             return;
         }

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -846,6 +846,14 @@ impl FileReader {
             return streams::Result::Done;
         }
 
+        // A used-up window ends the stream before any read: on a pollable fd the
+        // poll is already armed, so waiting for it would park until a byte
+        // arrives (and drop it) or until EOF.
+        if self.window_remaining() == Some(0) {
+            self.end_at_window();
+            return streams::Result::Done;
+        }
+
         if !self.reader().has_pending_read() && self.flowing.get() {
             // `read_into` does not go through `on_read_chunk`, so the slice window is applied here: the read is cut to what is left of it (an empty destination reads nothing).
             let len = self

--- a/test/js/bun/util/bun-stdin-slice.test.ts
+++ b/test/js/bun/util/bun-stdin-slice.test.ts
@@ -69,22 +69,25 @@ describe("Bun.stdin.slice(0, N).stream() over a pipe that stays open", () => {
   });
 
   // Same, through a native sink (HTMLRewriter pulls the stream itself) instead of a JS reader.
-  test.concurrent.skipIf(isWindows)("a zero-length slice piped into a native sink ends without waiting for a byte", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const res = new HTMLRewriter().transform(new Response(Bun.stdin.slice(0, 0).stream()));
+  test.concurrent.skipIf(isWindows)(
+    "a zero-length slice piped into a native sink ends without waiting for a byte",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const res = new HTMLRewriter().transform(new Response(Bun.stdin.slice(0, 0).stream()));
          process.stdout.write(String((await res.arrayBuffer()).byteLength));`,
-      ],
-      env: bunEnv,
-      stdin: "pipe",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "0", stderr: "", exitCode: 0 });
-  });
+        ],
+        env: bunEnv,
+        stdin: "pipe",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "0", stderr: "", exitCode: 0 });
+    },
+  );
 
   test.concurrent.skipIf(isWindows)("ends after N bytes of a larger write", async () => {
     await using proc = spawnSliceEcho(3);

--- a/test/js/bun/util/bun-stdin-slice.test.ts
+++ b/test/js/bun/util/bun-stdin-slice.test.ts
@@ -68,6 +68,24 @@ describe("Bun.stdin.slice(0, N).stream() over a pipe that stays open", () => {
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
   });
 
+  // Same, through a native sink (HTMLRewriter pulls the stream itself) instead of a JS reader.
+  test.concurrent.skipIf(isWindows)("a zero-length slice piped into a native sink ends without waiting for a byte", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const res = new HTMLRewriter().transform(new Response(Bun.stdin.slice(0, 0).stream()));
+         process.stdout.write(String((await res.arrayBuffer()).byteLength));`,
+      ],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "0", stderr: "", exitCode: 0 });
+  });
+
   test.concurrent.skipIf(isWindows)("ends after N bytes of a larger write", async () => {
     await using proc = spawnSliceEcho(3);
     proc.stdin.write("0123456789");

--- a/test/js/bun/util/bun-stdin-slice.test.ts
+++ b/test/js/bun/util/bun-stdin-slice.test.ts
@@ -61,6 +61,13 @@ describe("Bun.stdin.slice(0, N).stream() over a pipe that stays open", () => {
     });
   }
 
+  test.concurrent.skipIf(isWindows)("a zero-length slice ends without waiting for a byte", async () => {
+    await using proc = spawnSliceEcho(0);
+    // Nothing is ever written; the stream must still end and let the child exit.
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  });
+
   test.concurrent.skipIf(isWindows)("ends after N bytes of a larger write", async () => {
     await using proc = spawnSliceEcho(3);
     proc.stdin.write("0123456789");


### PR DESCRIPTION
Follow-up to #39201.

Bun.stdin.slice(0, 0).stream() over a pipe (or a FIFO/tty) did not end until a byte arrived, which it then dropped, or until EOF. On a pollable fd the poll is armed in on_start, so on_pull's read_into path (where a zero window ended immediately for regular files) was never reached and the pull parked.

on_pull now ends the stream when the window is already used up, before the poll gate. Adds a case to bun-stdin-slice.test.ts that spawns a child streaming Bun.stdin.slice(0, 0) with stdin left open and nothing written; it timed out before this change and passes now.