### PR TITLE
feat(bunfig): add test.parallel config option

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -375,7 +375,7 @@ Run test files in parallel worker processes. `true` uses one worker per CPU thre
 parallel = 2
 ```
 
-Equivalent CLI flag: `--parallel`. CLI flags override the `bunfig.toml` value entirely.
+Equivalent CLI flag: `--parallel`. When both values are valid, the CLI value takes precedence. Invalid `test.parallel` values still fail validation.
 
 ### `test.reporter`
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -368,7 +368,7 @@ Equivalent to the `--only-failures` flag.
 
 ### `test.parallel`
 
-Run test files in parallel worker processes. `true` uses one worker per CPU thread, and a positive integer sets the number of workers. Parallel workers run each test file in a fresh global scope, like `--isolate`.
+Run test files in parallel worker processes. `true` uses one worker per CPU thread, and a positive integer sets the number of workers. `false` keeps test files sequential and is the default. A value of `0` is rejected. Parallel workers run each test file in a fresh global scope, like `--isolate`.
 
 ```toml title="bunfig.toml" icon="settings"
 [test]

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -366,6 +366,17 @@ onlyFailures = true
 
 Equivalent to the `--only-failures` flag.
 
+### `test.parallel`
+
+Run test files in parallel worker processes. `true` uses one worker per CPU thread, and a positive integer sets the number of workers. Parallel workers run each test file in a fresh global scope, like `--isolate`.
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+parallel = 2
+```
+
+Equivalent CLI flag: `--parallel`. CLI flags override the `bunfig.toml` value entirely.
+
 ### `test.reporter`
 
 Configure the test reporter settings.

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -258,7 +258,7 @@ rerunEach = 3
 
 #### parallel
 
-Run test files in parallel worker processes. `true` uses one worker per CPU thread, and a positive integer sets the number of workers:
+Run test files in parallel worker processes. `true` uses one worker per CPU thread, and a positive integer sets the number of workers. Parallel workers run each test file in a fresh global scope, equivalent to `--isolate`:
 
 ```toml title="bunfig.toml" icon="settings"
 [test]

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -256,6 +256,17 @@ Re-run each test file multiple times to identify flaky tests:
 rerunEach = 3
 ```
 
+#### parallel
+
+Run test files in parallel worker processes. `true` uses one worker per CPU thread, and a positive integer sets the number of workers:
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+parallel = 2
+```
+
+The `--parallel` CLI flag overrides this setting.
+
 ## Coverage Options
 
 ### Basic Coverage Settings

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -258,14 +258,14 @@ rerunEach = 3
 
 #### parallel
 
-Run test files in parallel worker processes. `true` uses one worker per CPU thread, and a positive integer sets the number of workers. Parallel workers run each test file in a fresh global scope, equivalent to `--isolate`:
+Run test files in parallel worker processes. `true` uses one worker per CPU thread, and a positive integer sets the number of workers. `false` keeps test files sequential and is the default. A value of `0` is rejected. Parallel workers run each test file in a fresh global scope, equivalent to `--isolate`:
 
 ```toml title="bunfig.toml" icon="settings"
 [test]
 parallel = 2
 ```
 
-The `--parallel` CLI flag overrides this setting.
+When both values are valid, the `--parallel` CLI flag overrides this setting. Invalid `test.parallel` values still fail validation.
 
 ## Coverage Options
 

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -581,34 +581,40 @@ impl<'a> Parser<'a> {
                 }
 
                 if let Some(expr) = test.get(b"parallel") {
-                    if !self.ctx.test_options.parallel_from_cli {
-                        match expr.data {
-                            ExprData::EBoolean(b) => {
-                                if b.value {
-                                    self.ctx.test_options.parallel =
-                                        u32::from(bun_core::get_thread_count().max(1));
-                                    self.ctx.test_options.isolate = true;
-                                }
-                            }
-                            ExprData::ENumber(n) => {
-                                let parsed = num_to_u32(n.value());
-                                if parsed == 0 {
-                                    self.add_error(
-                                        expr.loc,
-                                        b"\"parallel\" must be a positive integer or boolean",
-                                    )?;
-                                    return Ok(());
-                                }
-                                self.ctx.test_options.parallel = parsed;
+                    match expr.data {
+                        ExprData::EBoolean(b) => {
+                            if b.value && !self.ctx.test_options.parallel_from_cli {
+                                self.ctx.test_options.parallel =
+                                    u32::from(bun_core::get_thread_count().max(1));
                                 self.ctx.test_options.isolate = true;
                             }
-                            _ => {
+                        }
+                        ExprData::ENumber(n) => {
+                            let value = n.value();
+                            // `as u32` would silently truncate fractions and
+                            // saturate overflow, so validate before converting.
+                            if !value.is_finite()
+                                || value < 1.0
+                                || value.fract() != 0.0
+                                || value > u32::MAX as f64
+                            {
                                 self.add_error(
                                     expr.loc,
-                                    b"\"parallel\" must be a boolean or a positive integer",
+                                    b"\"parallel\" must be a positive integer or boolean",
                                 )?;
                                 return Ok(());
                             }
+                            if !self.ctx.test_options.parallel_from_cli {
+                                self.ctx.test_options.parallel = value as u32;
+                                self.ctx.test_options.isolate = true;
+                            }
+                        }
+                        _ => {
+                            self.add_error(
+                                expr.loc,
+                                b"\"parallel\" must be a positive integer or boolean",
+                            )?;
+                            return Ok(());
                         }
                     }
                 }

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -598,9 +598,13 @@ impl<'a> Parser<'a> {
                                 || value.fract() != 0.0
                                 || value > u32::MAX as f64
                             {
-                                self.add_error(
+                                self.add_error_format(
                                     expr.loc,
-                                    b"\"parallel\" must be a positive integer or boolean",
+                                    format_args!(
+                                        "\"parallel\" must be a finite integer in the range 1..={} or a boolean; received {}",
+                                        u32::MAX,
+                                        value
+                                    ),
                                 )?;
                                 return Ok(());
                             }

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -580,6 +580,39 @@ impl<'a> Parser<'a> {
                         num_to_u32(expr.as_number().expect("infallible: type checked"));
                 }
 
+                if let Some(expr) = test.get(b"parallel") {
+                    if !self.ctx.test_options.parallel_from_cli {
+                        match expr.data {
+                            ExprData::EBoolean(b) => {
+                                if b.value {
+                                    self.ctx.test_options.parallel =
+                                        u32::from(bun_core::get_thread_count().max(1));
+                                    self.ctx.test_options.isolate = true;
+                                }
+                            }
+                            ExprData::ENumber(n) => {
+                                let parsed = num_to_u32(n.value());
+                                if parsed == 0 {
+                                    self.add_error(
+                                        expr.loc,
+                                        b"\"parallel\" must be a positive integer or boolean",
+                                    )?;
+                                    return Ok(());
+                                }
+                                self.ctx.test_options.parallel = parsed;
+                                self.ctx.test_options.isolate = true;
+                            }
+                            _ => {
+                                self.add_error(
+                                    expr.loc,
+                                    b"\"parallel\" must be a boolean or a positive integer",
+                                )?;
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+
                 if let Some(expr) = test.get(b"concurrentTestGlob") {
                     match &expr.data {
                         ExprData::EString(s) => {

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -426,6 +426,9 @@ pub struct TestOptions {
     /// `bun test --parallel[=N]`: run test files across N worker
     /// processes. 0 means not requested. Implies `isolate` in workers.
     pub parallel: u32,
+    /// Set when `--parallel` is passed on the CLI; `bunfig.toml` `[test]`
+    /// `parallel` then does not override it.
+    pub parallel_from_cli: bool,
     /// `bun test --parallel-delay=MS`: how long the first worker must be
     /// busy before spawning the rest. None = use the built-in default.
     pub parallel_delay_ms: Option<u32>,
@@ -506,6 +509,7 @@ impl Default for TestOptions {
             max_concurrency: if bun_core::env::ENABLE_ASAN { 5 } else { 20 },
             isolate: false,
             parallel: 0,
+            parallel_from_cli: false,
             parallel_delay_ms: None,
             test_worker: false,
             changed: None,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1995,6 +1995,7 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
         }
         ctx.test_options.parallel = parsed;
         ctx.test_options.isolate = !no_isolate;
+        ctx.test_options.parallel_from_cli = true;
     }
 
     if let Some(delay_str) = args.option(b"--parallel-delay") {

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -196,4 +196,77 @@ describe("bunfig.toml test options", () => {
     // 2 tests * 2 reruns = 4 total test runs
     expect(output).toContain("4 pass");
   });
+
+  test.concurrent("test.parallel option runs test files across worker processes", async () => {
+    const fixture = `import { test } from "bun:test"; test("t", async () => { console.log("PID=" + process.pid); await Bun.sleep(200); });`;
+    using dir = tempDir("bunfig-test-parallel", {
+      "bunfig.toml": `[test]\nparallel = 2`,
+      "a.test.ts": fixture,
+      "b.test.ts": fixture,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      // Spawn both workers eagerly so the two files run on distinct PIDs.
+      env: { ...bunEnv, BUN_TEST_PARALLEL_SCALE_MS: "0" },
+      cwd: dir,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const output = stdout + stderr;
+
+    // The coordinator banner shows the configured parallelism.
+    expect(output).toContain("2x PARALLEL");
+    // Each file ran in its own worker process.
+    const pids = [...output.matchAll(/PID=(\d+)/g)].map(m => m[1]);
+    expect(new Set(pids).size).toBe(2);
+    expect(output).toContain("2 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("test.parallel = true uses the CPU thread count", async () => {
+    using dir = tempDir("bunfig-test-parallel-true", {
+      "bunfig.toml": `[test]\nparallel = true`,
+      "a.test.ts": `import { test, expect } from "bun:test"; test("a", () => expect(1).toBe(1));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: dir,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("PARALLEL");
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("CLI --parallel overrides test.parallel", async () => {
+    using dir = tempDir("bunfig-test-parallel-cli", {
+      "bunfig.toml": `[test]\nparallel = 2`,
+      "a.test.ts": `import { test, expect } from "bun:test"; test("a", () => expect(1).toBe(1));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--parallel=8"],
+      env: bunEnv,
+      cwd: dir,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The CLI flag wins over the bunfig value.
+    expect(stdout).toContain("8x PARALLEL");
+    expect(stdout).not.toContain("2x PARALLEL");
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -269,4 +269,27 @@ describe("bunfig.toml test options", () => {
     expect(stderr).toContain("1 pass");
     expect(exitCode).toBe(0);
   });
+
+  test.concurrent.each(["0", "1.5", "-1", "inf", "nan", "4294967296"])(
+    "test.parallel rejects invalid value %s",
+    async value => {
+      using dir = tempDir("bunfig-test-parallel-invalid", {
+        "bunfig.toml": `[test]\nparallel = ${value}`,
+        "a.test.ts": `import { test, expect } from "bun:test"; test("a", () => expect(1).toBe(1));`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test"],
+        env: bunEnv,
+        cwd: dir,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout + stderr).toContain("parallel");
+      expect(exitCode).toBe(1);
+    },
+  );
 });


### PR DESCRIPTION
Adds a `parallel` key to the `[test]` section of `bunfig.toml`, matching the `--parallel` CLI flag.

```toml title="bunfig.toml"
[test]
parallel = 2          # run test files across 2 worker processes
parallel = true       # one worker per CPU thread
parallel = false      # default: run test files sequentially
```

Semantics mirror the CLI flag exactly:

- `parallel = true` behaves like `--parallel` with no number: one worker per CPU thread, implying isolation.
- `parallel = <n>` behaves like `--parallel=<n>`: `n` worker processes, implying isolation.
- `0` is rejected with a bunfig parse error, like the CLI rejects `--parallel=0`.
- CLI flags override the `bunfig.toml` value entirely: when `--parallel` is passed, the config key is ignored (same pattern as `pathIgnorePatterns` / `--path-ignore-patterns`).

Closes the `parallel` part of https://github.com/oven-sh/bun/issues/38728.

Tests: `test/cli/bunfig-test-options.test.ts` — new cases assert the `Nx PARALLEL` coordinator banner for `parallel = 2` and `parallel = true`, distinct worker PIDs for `parallel = 2`, and that `--parallel` on the CLI overrides the config value. The full file passes.