### PR TITLE
feat(bunfig): add test.concurrent config option

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -342,6 +342,17 @@ retry = 3
 
 The `--retry` CLI flag overrides this setting.
 
+### `test.concurrent`
+
+Treat all tests as `test.concurrent()` tests, as if you passed the `--concurrent` flag. Default `false`.
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+concurrent = true
+```
+
+Equivalent CLI flag: `--concurrent`. CLI flags override the `bunfig.toml` value entirely.
+
 ### `test.concurrentTestGlob`
 
 Test files matching this glob pattern run all of their tests concurrently, as if you passed the `--concurrent` flag.

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -351,7 +351,7 @@ Treat all tests as `test.concurrent()` tests, as if you passed the `--concurrent
 concurrent = true
 ```
 
-Equivalent CLI flag: `--concurrent`. CLI flags override the `bunfig.toml` value entirely.
+Equivalent CLI flag: `--concurrent`. When both values are valid, the CLI value takes precedence. Invalid `test.concurrent` values still fail validation.
 
 ### `test.concurrentTestGlob`
 

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -226,7 +226,7 @@ Treat all tests as `test.concurrent()` tests, as if you passed the `--concurrent
 concurrent = true
 ```
 
-The `--concurrent` CLI flag overrides this setting.
+When both values are valid, the `--concurrent` CLI flag overrides this setting. Invalid `test.concurrent` values still fail validation.
 
 #### randomize
 

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -217,6 +217,17 @@ Test files matching the pattern behave as if you passed the `--concurrent` flag:
 
 The `--concurrent` CLI flag overrides this setting, forcing all tests to run concurrently regardless of the glob pattern.
 
+#### concurrent
+
+Treat all tests as `test.concurrent()` tests, as if you passed the `--concurrent` flag:
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+concurrent = true
+```
+
+The `--concurrent` CLI flag overrides this setting.
+
 #### randomize
 
 Run tests in random order to identify tests with hidden dependencies:

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -219,7 +219,7 @@ The `--concurrent` CLI flag overrides this setting, forcing all tests to run con
 
 #### concurrent
 
-Treat all tests as `test.concurrent()` tests, as if you passed the `--concurrent` flag:
+Treat all tests as `test.concurrent()` tests, as if you passed the `--concurrent` flag. Default `false` (tests run sequentially):
 
 ```toml title="bunfig.toml" icon="settings"
 [test]

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -581,8 +581,8 @@ impl<'a> Parser<'a> {
                 }
 
                 if let Some(expr) = test.get(b"concurrent") {
+                    self.expect(&expr, ExprTag::EBoolean)?;
                     if !self.ctx.test_options.concurrent_from_cli {
-                        self.expect(&expr, ExprTag::EBoolean)?;
                         self.ctx.test_options.concurrent =
                             expr.as_bool().expect("infallible: type checked");
                     }

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -580,6 +580,14 @@ impl<'a> Parser<'a> {
                         num_to_u32(expr.as_number().expect("infallible: type checked"));
                 }
 
+                if let Some(expr) = test.get(b"concurrent") {
+                    if !self.ctx.test_options.concurrent_from_cli {
+                        self.expect(&expr, ExprTag::EBoolean)?;
+                        self.ctx.test_options.concurrent =
+                            expr.as_bool().expect("infallible: type checked");
+                    }
+                }
+
                 if let Some(expr) = test.get(b"concurrentTestGlob") {
                     match &expr.data {
                         ExprData::EString(s) => {

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -404,6 +404,9 @@ pub struct TestOptions {
     pub only: bool,
     pub pass_with_no_tests: bool,
     pub concurrent: bool,
+    /// Set when `--concurrent` is passed on the CLI; `bunfig.toml` `[test]`
+    /// `concurrent` then does not override it.
+    pub concurrent_from_cli: bool,
     pub randomize: bool,
     pub seed: Option<u32>,
     pub concurrent_test_glob: Option<Vec<Box<[u8]>>>,
@@ -488,6 +491,7 @@ impl Default for TestOptions {
             only: false,
             pass_with_no_tests: false,
             concurrent: false,
+            concurrent_from_cli: false,
             randomize: false,
             seed: None,
             concurrent_test_glob: None,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1966,7 +1966,9 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
     ctx.test_options.run_todo = args.flag(b"--todo");
     ctx.test_options.only = args.flag(b"--only");
     ctx.test_options.pass_with_no_tests = args.flag(b"--pass-with-no-tests");
-    ctx.test_options.concurrent = args.flag(b"--concurrent");
+    let concurrent = args.flag(b"--concurrent");
+    ctx.test_options.concurrent = concurrent;
+    ctx.test_options.concurrent_from_cli = concurrent;
     ctx.test_options.randomize = args.flag(b"--randomize");
     let no_isolate = args.flag(b"--no-isolate");
     ctx.test_options.isolate = args.flag(b"--isolate") && !no_isolate;

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
 
 describe("bunfig.toml test options", () => {
   test("randomize with seed produces consistent order", async () => {
@@ -195,5 +196,107 @@ describe("bunfig.toml test options", () => {
     const output = stdout + stderr;
     // 2 tests * 2 reruns = 4 total test runs
     expect(output).toContain("4 pass");
+  });
+
+  test.concurrent("test.concurrent option runs all tests concurrently", async () => {
+    const testFile = (tag: string) => `
+import { test, expect } from "bun:test";
+import { appendFileSync } from "fs";
+import { join } from "path";
+
+const logFile = join(import.meta.dir, "execution.log");
+
+test("${tag}-1", async () => {
+  appendFileSync(logFile, "${tag}-1-start\\n");
+  await Bun.sleep(50);
+  appendFileSync(logFile, "${tag}-1-end\\n");
+  expect(1).toBe(1);
+});
+
+test("${tag}-2", async () => {
+  appendFileSync(logFile, "${tag}-2-start\\n");
+  await Bun.sleep(50);
+  appendFileSync(logFile, "${tag}-2-end\\n");
+  expect(2).toBe(2);
+});
+`;
+
+    using dir = tempDir("bunfig-test-concurrent", {
+      "bunfig.toml": `[test]\nconcurrent = true`,
+      "a.test.ts": testFile("a"),
+      "b.test.ts": testFile("b"),
+      "execution.log": "",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout + stderr).toContain("4 pass");
+
+    // With concurrent execution, each file's tests start before either finishes.
+    const logPath = join(String(dir), "execution.log");
+    const lines = (await Bun.file(logPath).text()).trim().split("\n").filter(Boolean);
+    const firstEndIndex = lines.findIndex(line => line.includes("-end"));
+    const startsBeforeFirstEnd = lines.slice(0, firstEndIndex).filter(line => line.includes("-start")).length;
+    expect(startsBeforeFirstEnd).toBeGreaterThan(1);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("CLI --concurrent overrides test.concurrent", async () => {
+    const testFile = (tag: string) => `
+import { test, expect } from "bun:test";
+import { appendFileSync } from "fs";
+import { join } from "path";
+
+const logFile = join(import.meta.dir, "override.log");
+
+test("${tag}-1", async () => {
+  appendFileSync(logFile, "${tag}-1-start\\n");
+  await Bun.sleep(50);
+  appendFileSync(logFile, "${tag}-1-end\\n");
+  expect(1).toBe(1);
+});
+
+test("${tag}-2", async () => {
+  appendFileSync(logFile, "${tag}-2-start\\n");
+  await Bun.sleep(50);
+  appendFileSync(logFile, "${tag}-2-end\\n");
+  expect(2).toBe(2);
+});
+`;
+
+    using dir = tempDir("bunfig-test-concurrent-cli", {
+      "bunfig.toml": `[test]\nconcurrent = false`,
+      "a.test.ts": testFile("a"),
+      "b.test.ts": testFile("b"),
+      "override.log": "",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--concurrent"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout + stderr).toContain("4 pass");
+
+    // The CLI flag wins: tests run concurrently even though the config says false.
+    const logPath = join(String(dir), "override.log");
+    const lines = (await Bun.file(logPath).text()).trim().split("\n").filter(Boolean);
+    const firstEndIndex = lines.findIndex(line => line.includes("-end"));
+    const startsBeforeFirstEnd = lines.slice(0, firstEndIndex).filter(line => line.includes("-start")).length;
+    expect(startsBeforeFirstEnd).toBeGreaterThan(1);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
-import { join } from "path";
 
 describe("bunfig.toml test options", () => {
   test("randomize with seed produces consistent order", async () => {
@@ -199,32 +198,34 @@ describe("bunfig.toml test options", () => {
   });
 
   test.concurrent("test.concurrent option runs all tests concurrently", async () => {
-    const testFile = (tag: string) => `
+    const testFile = `
 import { test, expect } from "bun:test";
-import { appendFileSync } from "fs";
+import { appendFileSync, readFileSync } from "fs";
 import { join } from "path";
 
 const logFile = join(import.meta.dir, "execution.log");
 
-test("${tag}-1", async () => {
-  appendFileSync(logFile, "${tag}-1-start\\n");
-  await Bun.sleep(50);
-  appendFileSync(logFile, "${tag}-1-end\\n");
-  expect(1).toBe(1);
+test("test-1", async () => {
+  appendFileSync(logFile, "test-1-start\\n");
+  const deadline = Date.now() + 3000;
+  while (!readFileSync(logFile, "utf8").includes("test-2-start")) {
+    if (Date.now() > deadline) break;
+    await Bun.sleep(20);
+  }
+  expect(readFileSync(logFile, "utf8")).toContain("test-2-start");
+  appendFileSync(logFile, "test-1-end\\n");
 });
 
-test("${tag}-2", async () => {
-  appendFileSync(logFile, "${tag}-2-start\\n");
-  await Bun.sleep(50);
-  appendFileSync(logFile, "${tag}-2-end\\n");
+test("test-2", async () => {
+  appendFileSync(logFile, "test-2-start\\n");
+  appendFileSync(logFile, "test-2-end\\n");
   expect(2).toBe(2);
 });
 `;
 
     using dir = tempDir("bunfig-test-concurrent", {
       "bunfig.toml": `[test]\nconcurrent = true`,
-      "a.test.ts": testFile("a"),
-      "b.test.ts": testFile("b"),
+      "a.test.ts": testFile,
       "execution.log": "",
     });
 
@@ -238,44 +239,42 @@ test("${tag}-2", async () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout + stderr).toContain("4 pass");
-
-    // With concurrent execution, each file's tests start before either finishes.
-    const logPath = join(String(dir), "execution.log");
-    const lines = (await Bun.file(logPath).text()).trim().split("\n").filter(Boolean);
-    const firstEndIndex = lines.findIndex(line => line.includes("-end"));
-    const startsBeforeFirstEnd = lines.slice(0, firstEndIndex).filter(line => line.includes("-start")).length;
-    expect(startsBeforeFirstEnd).toBeGreaterThan(1);
+    expect(stdout + stderr).toContain("2 pass");
+    // With concurrent execution both tests start together, so test-1 observes
+    // test-2's start marker. In serial mode test-1 hits the poll deadline,
+    // its expectation fails, and the run exits non-zero.
     expect(exitCode).toBe(0);
   });
 
   test.concurrent("CLI --concurrent overrides test.concurrent", async () => {
-    const testFile = (tag: string) => `
+    const testFile = `
 import { test, expect } from "bun:test";
-import { appendFileSync } from "fs";
+import { appendFileSync, readFileSync } from "fs";
 import { join } from "path";
 
 const logFile = join(import.meta.dir, "override.log");
 
-test("${tag}-1", async () => {
-  appendFileSync(logFile, "${tag}-1-start\\n");
-  await Bun.sleep(50);
-  appendFileSync(logFile, "${tag}-1-end\\n");
-  expect(1).toBe(1);
+test("test-1", async () => {
+  appendFileSync(logFile, "test-1-start\\n");
+  const deadline = Date.now() + 3000;
+  while (!readFileSync(logFile, "utf8").includes("test-2-start")) {
+    if (Date.now() > deadline) break;
+    await Bun.sleep(20);
+  }
+  expect(readFileSync(logFile, "utf8")).toContain("test-2-start");
+  appendFileSync(logFile, "test-1-end\\n");
 });
 
-test("${tag}-2", async () => {
-  appendFileSync(logFile, "${tag}-2-start\\n");
-  await Bun.sleep(50);
-  appendFileSync(logFile, "${tag}-2-end\\n");
+test("test-2", async () => {
+  appendFileSync(logFile, "test-2-start\\n");
+  appendFileSync(logFile, "test-2-end\\n");
   expect(2).toBe(2);
 });
 `;
 
     using dir = tempDir("bunfig-test-concurrent-cli", {
       "bunfig.toml": `[test]\nconcurrent = false`,
-      "a.test.ts": testFile("a"),
-      "b.test.ts": testFile("b"),
+      "a.test.ts": testFile,
       "override.log": "",
     });
 
@@ -289,14 +288,29 @@ test("${tag}-2", async () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout + stderr).toContain("4 pass");
-
+    expect(stdout + stderr).toContain("2 pass");
     // The CLI flag wins: tests run concurrently even though the config says false.
-    const logPath = join(String(dir), "override.log");
-    const lines = (await Bun.file(logPath).text()).trim().split("\n").filter(Boolean);
-    const firstEndIndex = lines.findIndex(line => line.includes("-end"));
-    const startsBeforeFirstEnd = lines.slice(0, firstEndIndex).filter(line => line.includes("-start")).length;
-    expect(startsBeforeFirstEnd).toBeGreaterThan(1);
     expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("test.concurrent rejects non-boolean values even with --concurrent", async () => {
+    using dir = tempDir("bunfig-test-concurrent-invalid", {
+      "bunfig.toml": `[test]\nconcurrent = "true"`,
+      "a.test.ts": `import { test, expect } from "bun:test"; test("a", () => expect(1).toBe(1));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--concurrent"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The type is validated even when --concurrent overrides the value.
+    expect(stdout + stderr).toContain("expected boolean but received string");
+    expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
Adds a `concurrent` key to the `[test]` section of `bunfig.toml`, matching the `--concurrent` CLI flag.

```toml title="bunfig.toml"
[test]
concurrent = true   # run every test in every file concurrently
concurrent = false  # default
```

Semantics mirror the CLI flag exactly: `true` treats all tests as `test.concurrent()` tests, exactly like passing `--concurrent`. CLI flags override the `bunfig.toml` value entirely: when `--concurrent` is passed, the config key is ignored (same pattern as `pathIgnorePatterns` / `--path-ignore-patterns`).

Closes the config-gap family of https://github.com/oven-sh/bun/issues/38728.

Tests: `test/cli/bunfig-test-options.test.ts` — new cases assert tests interleave under `concurrent = true` (start/end log pattern from the existing `concurrentTestGlob` tests) and that `--concurrent` on the CLI overrides a `concurrent = false` config value. The full file passes.