### PR TITLE
feat(bunfig): add test.timeout config option

### DIFF
--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -390,13 +390,13 @@ junit = "test-results.xml"
 
 CI systems and other tools can consume the report.
 
-### `test.testTimeout`
+### `test.timeout`
 
 Default per-test timeout in milliseconds. Tests that take longer than this fail with a timeout error. Default `5000`.
 
 ```toml title="bunfig.toml" icon="settings"
 [test]
-testTimeout = 10000
+timeout = 10000
 ```
 
 Equivalent CLI flag: `--timeout`. CLI flags override the `bunfig.toml` value entirely.

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -390,6 +390,17 @@ junit = "test-results.xml"
 
 CI systems and other tools can consume the report.
 
+### `test.testTimeout`
+
+Default per-test timeout in milliseconds. Tests that take longer than this fail with a timeout error. Default `5000`.
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+testTimeout = 10000
+```
+
+Equivalent CLI flag: `--timeout`. CLI flags override the `bunfig.toml` value entirely.
+
 ## Package manager
 
 The `[install]` section configures the behavior of `bun install`.

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -399,7 +399,7 @@ Default per-test timeout in milliseconds. Tests that take longer than this fail 
 timeout = 10000
 ```
 
-Equivalent CLI flag: `--timeout`. CLI flags override the `bunfig.toml` value entirely.
+Equivalent CLI flag: `--timeout`. When both values are valid, the CLI value takes precedence. Invalid `test.timeout` values still fail validation.
 
 ## Package manager
 

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -256,6 +256,17 @@ Re-run each test file multiple times to identify flaky tests:
 rerunEach = 3
 ```
 
+#### testTimeout
+
+Default per-test timeout in milliseconds. Tests that take longer than this fail with a timeout error:
+
+```toml title="bunfig.toml" icon="settings"
+[test]
+testTimeout = 10000
+```
+
+The `--timeout` CLI flag overrides this setting.
+
 ## Coverage Options
 
 ### Basic Coverage Settings

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -258,7 +258,7 @@ rerunEach = 3
 
 #### testTimeout
 
-Default per-test timeout in milliseconds. Tests that take longer than this fail with a timeout error:
+Default per-test timeout in milliseconds. Tests that take longer than this fail with a timeout error. Default `5000` milliseconds:
 
 ```toml title="bunfig.toml" icon="settings"
 [test]

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -256,13 +256,13 @@ Re-run each test file multiple times to identify flaky tests:
 rerunEach = 3
 ```
 
-#### testTimeout
+#### timeout
 
 Default per-test timeout in milliseconds. Tests that take longer than this fail with a timeout error. Default `5000` milliseconds:
 
 ```toml title="bunfig.toml" icon="settings"
 [test]
-testTimeout = 10000
+timeout = 10000
 ```
 
 The `--timeout` CLI flag overrides this setting.

--- a/docs/test/configuration.mdx
+++ b/docs/test/configuration.mdx
@@ -265,7 +265,7 @@ Default per-test timeout in milliseconds. Tests that take longer than this fail 
 timeout = 10000
 ```
 
-The `--timeout` CLI flag overrides this setting.
+When both values are valid, the `--timeout` CLI flag overrides this setting. Invalid `test.timeout` values still fail validation.
 
 ## Coverage Options
 

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -581,10 +581,23 @@ impl<'a> Parser<'a> {
                 }
 
                 if let Some(expr) = test.get(b"testTimeout") {
+                    self.expect(&expr, ExprTag::ENumber)?;
+                    let value = expr.as_number().expect("infallible: type checked");
+                    // `as u32` would silently truncate fractions and saturate
+                    // overflow, so validate before converting.
+                    if !value.is_finite()
+                        || value < 0.0
+                        || value.fract() != 0.0
+                        || value > u32::MAX as f64
+                    {
+                        self.add_error(
+                            expr.loc,
+                            b"\"testTimeout\" must be a non-negative integer (milliseconds)",
+                        )?;
+                        return Ok(());
+                    }
                     if !self.ctx.test_options.timeout_from_cli {
-                        self.expect(&expr, ExprTag::ENumber)?;
-                        self.ctx.test_options.default_timeout_ms =
-                            num_to_u32(expr.as_number().expect("infallible: type checked"));
+                        self.ctx.test_options.default_timeout_ms = value as u32;
                     }
                 }
 

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -590,9 +590,13 @@ impl<'a> Parser<'a> {
                         || value.fract() != 0.0
                         || value > u32::MAX as f64
                     {
-                        self.add_error(
+                        self.add_error_format(
                             expr.loc,
-                            b"\"timeout\" must be a non-negative integer (milliseconds)",
+                            format_args!(
+                                "\"timeout\" must be a finite integer in the range 0..={} milliseconds; received {}",
+                                u32::MAX,
+                                value
+                            ),
                         )?;
                         return Ok(());
                     }

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -580,7 +580,7 @@ impl<'a> Parser<'a> {
                         num_to_u32(expr.as_number().expect("infallible: type checked"));
                 }
 
-                if let Some(expr) = test.get(b"testTimeout") {
+                if let Some(expr) = test.get(b"timeout") {
                     self.expect(&expr, ExprTag::ENumber)?;
                     let value = expr.as_number().expect("infallible: type checked");
                     // `as u32` would silently truncate fractions and saturate
@@ -592,7 +592,7 @@ impl<'a> Parser<'a> {
                     {
                         self.add_error(
                             expr.loc,
-                            b"\"testTimeout\" must be a non-negative integer (milliseconds)",
+                            b"\"timeout\" must be a non-negative integer (milliseconds)",
                         )?;
                         return Ok(());
                     }

--- a/src/bunfig/bunfig.rs
+++ b/src/bunfig/bunfig.rs
@@ -580,6 +580,14 @@ impl<'a> Parser<'a> {
                         num_to_u32(expr.as_number().expect("infallible: type checked"));
                 }
 
+                if let Some(expr) = test.get(b"testTimeout") {
+                    if !self.ctx.test_options.timeout_from_cli {
+                        self.expect(&expr, ExprTag::ENumber)?;
+                        self.ctx.test_options.default_timeout_ms =
+                            num_to_u32(expr.as_number().expect("infallible: type checked"));
+                    }
+                }
+
                 if let Some(expr) = test.get(b"concurrentTestGlob") {
                     match &expr.data {
                         ExprData::EString(s) => {

--- a/src/options_types/context.rs
+++ b/src/options_types/context.rs
@@ -397,6 +397,9 @@ pub enum HotReload {
 
 pub struct TestOptions {
     pub default_timeout_ms: u32,
+    /// Set when `--timeout` is passed on the CLI; `bunfig.toml` `[test]`
+    /// `testTimeout` then does not override it.
+    pub timeout_from_cli: bool,
     pub update_snapshots: bool,
     pub repeat_count: u32,
     pub retry: u32,
@@ -481,6 +484,7 @@ impl Default for TestOptions {
         Self {
             // 5 seconds
             default_timeout_ms: 5 * 1000,
+            timeout_from_cli: false,
             update_snapshots: false,
             repeat_count: 0,
             retry: 0,

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1737,6 +1737,7 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
                     Global::exit(1);
                 }
             };
+            ctx.test_options.timeout_from_cli = true;
         }
     }
 

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -196,4 +196,58 @@ describe("bunfig.toml test options", () => {
     // 2 tests * 2 reruns = 4 total test runs
     expect(output).toContain("4 pass");
   });
+
+  test.concurrent("test.testTimeout option applies a default timeout", async () => {
+    using dir = tempDir("bunfig-test-timeout", {
+      "bunfig.toml": `[test]\ntestTimeout = 200`,
+      "a.test.ts": `
+        import { test, expect } from "bun:test";
+        test("slow", async () => {
+          await Bun.sleep(1000);
+          expect(1).toBe(1);
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout + stderr).toContain("timed out after");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test.concurrent("CLI --timeout overrides test.testTimeout", async () => {
+    using dir = tempDir("bunfig-test-timeout-cli", {
+      "bunfig.toml": `[test]\ntestTimeout = 200`,
+      "a.test.ts": `
+        import { test, expect } from "bun:test";
+        test("slow", async () => {
+          await Bun.sleep(1000);
+          expect(1).toBe(1);
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--timeout=5000"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The CLI flag wins: the 1000ms test passes under the 5000ms CLI timeout
+    // instead of the 200ms config timeout.
+    expect(stdout + stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -197,9 +197,9 @@ describe("bunfig.toml test options", () => {
     expect(output).toContain("4 pass");
   });
 
-  test.concurrent("test.testTimeout option applies a default timeout", async () => {
+  test.concurrent("test.timeout option applies a default timeout", async () => {
     using dir = tempDir("bunfig-test-timeout", {
-      "bunfig.toml": `[test]\ntestTimeout = 200`,
+      "bunfig.toml": `[test]\ntimeout = 200`,
       "a.test.ts": `
         import { test, expect } from "bun:test";
         test("slow", async () => {
@@ -223,9 +223,9 @@ describe("bunfig.toml test options", () => {
     expect(exitCode).not.toBe(0);
   });
 
-  test.concurrent("CLI --timeout overrides test.testTimeout", async () => {
+  test.concurrent("CLI --timeout overrides test.timeout", async () => {
     using dir = tempDir("bunfig-test-timeout-cli", {
-      "bunfig.toml": `[test]\ntestTimeout = 200`,
+      "bunfig.toml": `[test]\ntimeout = 200`,
       "a.test.ts": `
         import { test, expect } from "bun:test";
         test("slow", async () => {
@@ -251,9 +251,9 @@ describe("bunfig.toml test options", () => {
     expect(exitCode).toBe(0);
   });
 
-  test.concurrent.each(["1.5", "-1"])("test.testTimeout rejects invalid value %s", async value => {
+  test.concurrent.each(["1.5", "-1"])("test.timeout rejects invalid value %s", async value => {
     using dir = tempDir("bunfig-test-timeout-invalid", {
-      "bunfig.toml": `[test]\ntestTimeout = ${value}`,
+      "bunfig.toml": `[test]\ntimeout = ${value}`,
       "a.test.ts": `import { test, expect } from "bun:test"; test("a", () => expect(1).toBe(1));`,
     });
 
@@ -267,13 +267,13 @@ describe("bunfig.toml test options", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout + stderr).toContain("testTimeout");
+    expect(stdout + stderr).toContain("timeout");
     expect(exitCode).toBe(1);
   });
 
-  test.concurrent("test.testTimeout rejects non-number values even with --timeout", async () => {
+  test.concurrent("test.timeout rejects non-number values even with --timeout", async () => {
     using dir = tempDir("bunfig-test-timeout-type", {
-      "bunfig.toml": `[test]\ntestTimeout = "abc"`,
+      "bunfig.toml": `[test]\ntimeout = "abc"`,
       "a.test.ts": `import { test, expect } from "bun:test"; test("a", () => expect(1).toBe(1));`,
     });
 

--- a/test/cli/bunfig-test-options.test.ts
+++ b/test/cli/bunfig-test-options.test.ts
@@ -250,4 +250,45 @@ describe("bunfig.toml test options", () => {
     expect(stdout + stderr).toContain("1 pass");
     expect(exitCode).toBe(0);
   });
+
+  test.concurrent.each(["1.5", "-1"])("test.testTimeout rejects invalid value %s", async value => {
+    using dir = tempDir("bunfig-test-timeout-invalid", {
+      "bunfig.toml": `[test]\ntestTimeout = ${value}`,
+      "a.test.ts": `import { test, expect } from "bun:test"; test("a", () => expect(1).toBe(1));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout + stderr).toContain("testTimeout");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("test.testTimeout rejects non-number values even with --timeout", async () => {
+    using dir = tempDir("bunfig-test-timeout-type", {
+      "bunfig.toml": `[test]\ntestTimeout = "abc"`,
+      "a.test.ts": `import { test, expect } from "bun:test"; test("a", () => expect(1).toBe(1));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--timeout=5000"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The type is validated even when --timeout overrides the value.
+    expect(stdout + stderr).toContain("expected number but received string");
+    expect(exitCode).toBe(1);
+  });
 });


### PR DESCRIPTION
Adds a `timeout` key to the `[test]` section of `bunfig.toml`, setting the default per-test timeout in milliseconds. The key lives inside the `[test]` table, so it is named `timeout` — matching the `--timeout` CLI flag and the request in https://github.com/oven-sh/bun/issues/38728 (the Vitest-style `testTimeout` name was proposed in https://github.com/oven-sh/bun/issues/7789; `timeout` keeps the config consistent with the flag).

```toml title="bunfig.toml"
[test]
timeout = 10000
```

Semantics mirror the `--timeout` CLI flag exactly: it sets the default timeout every test runs under (default `5000`), and tests exceeding it fail with a timeout error. CLI flags override the `bunfig.toml` value entirely: when `--timeout` is passed, the config key is ignored (same pattern as `pathIgnorePatterns` / `--path-ignore-patterns`).

Resolves https://github.com/oven-sh/bun/issues/7789 and the `timeout` part of https://github.com/oven-sh/bun/issues/38728.

Tests: `test/cli/bunfig-test-options.test.ts` — new cases assert a test sleeping 1000ms fails with "timed out after" under `timeout = 200`, that `--timeout=5000` on the CLI overrides the config value so the same test passes, and that invalid values (`1.5`, `-1`, non-number) are rejected. The full file passes (10/10).