### PR TITLE
css: do not resolve relative rgb()/hsl()/hwb() colors whose origin is outside the sRGB gamut

### DIFF
--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1069,6 +1069,8 @@ pub trait Colorspace: Copy + Sized + FromAnyColorspace {
 
 /// Gamut behavior — in-gamut check and clipping per color space.
 pub trait ColorGamut: Sized + Copy {
+    /// Whether the space can only hold colors inside its gamut (the lab family and XYZ hold any).
+    const BOUNDED: bool;
     fn in_gamut(&self) -> bool;
     fn clip(&self) -> Self;
 }
@@ -1574,12 +1576,14 @@ macro_rules! define_colorspace {
     // Gamut variants
     (@gamut unbounded $name:ident { $a:ident, $b:ident, $c:ident }) => {
         impl ColorGamut for $name {
+            const BOUNDED: bool = false;
             fn in_gamut(&self) -> bool { true }
             fn clip(&self) -> Self { *self }
         }
     };
     (@gamut bounded $name:ident { $a:ident, $b:ident, $c:ident }) => {
         impl ColorGamut for $name {
+            const BOUNDED: bool = true;
             fn in_gamut(&self) -> bool {
                 self.$a >= 0.0 && self.$a <= 1.0
                     && self.$b >= 0.0 && self.$b <= 1.0
@@ -1597,6 +1601,7 @@ macro_rules! define_colorspace {
     };
     (@gamut hsl_hwb $name:ident { $h:ident, $a:ident, $b:ident }) => {
         impl ColorGamut for $name {
+            const BOUNDED: bool = true;
             fn in_gamut(&self) -> bool {
                 self.$a >= 0.0 && self.$a <= 1.0 && self.$b >= 0.0 && self.$b <= 1.0
             }
@@ -1752,6 +1757,14 @@ impl SRGB {
     pub fn into_rgba(&self) -> RGBA {
         let rgb = self.resolve();
         RGBA::from_floats(rgb.r, rgb.g, rgb.b, rgb.alpha)
+    }
+
+    /// `in_gamut()` with room for the ~1e-6 of noise a boundary color picks up converting from another space.
+    fn is_nearly_in_gamut(&self) -> bool {
+        // 0.03 of an 8-bit step.
+        const TOLERANCE: f32 = 1e-4;
+        let nearly = |v: f32| (-TOLERANCE..=1.0 + TOLERANCE).contains(&v);
+        nearly(self.r) && nearly(self.g) && nearly(self.b)
     }
 }
 
@@ -1933,6 +1946,15 @@ impl ComponentParser {
             input.reset(&state);
             let dark = self.parse_from::<T, C, F>(*dark, input, func)?;
             return Ok(C::light_dark_owned(light, dark));
+        }
+
+        // Browsers keep these unclamped and clip when painting (w3c/csswg-drafts#8444); `resolve()` would not match.
+        if T::BOUNDED
+            // In sRGB rather than `T`: the HSL and HWB conversions gamut map on the way in.
+            && !SRGB::try_from_css_color(&from)
+                .is_some_and(|srgb| srgb.resolve_missing().is_nearly_in_gamut())
+        {
+            return Err(input.new_custom_error(css::ParserError::invalid_value));
         }
 
         let new_from = match T::try_from_css_color(&from) {

--- a/test/bundler/css/wpt/relative_color_out_of_gamut.test.ts
+++ b/test/bundler/css/wpt/relative_color_out_of_gamut.test.ts
@@ -1,6 +1,18 @@
 import { describe } from "bun:test";
 import { itBundled } from "../../expectBundled";
 
+// https://github.com/web-platform-tests/wpt/blob/master/css/css-color/parsing/relative-color-out-of-gamut.html
+//
+// The WPT asserts that a relative rgb()/hsl()/hwb() color whose origin is outside the sRGB
+// gamut computes to the unclamped out-of-gamut color (browsers clip it when painting), so the
+// bundler must not resolve these: gamut mapping the origin gives a different color (the
+// display-p3 green below used to come out as #00f942, browsers paint it as #00ff00). The
+// declaration is left for the browser. What the bundler does do is its usual handling of a
+// wide-gamut color literal inside a value it does not resolve: under the default browser
+// targets the origin gets an sRGB fallback plus an `@supports` tier with the color as written.
+//
+// The lab()/lch()/oklab()/oklch() origins below are written with a number lightness, which
+// does not parse yet (#16727), so those declarations are emitted as written for that reason.
 let i = 0;
 const testname = () => `test-${i++}`;
 describe("relative_color_out_of_gamut", () => {
@@ -18,7 +30,13 @@ h1 {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
 /* a.css */
 h1 {
-    color: #00f942;
+  color: rgb(from #00f942 r g b / alpha);
+}
+
+@supports (color: color(display-p3 0 0 0)) {
+  h1 {
+    color: rgb(from color(display-p3 0 1 0) r g b / alpha);
+  }
 }
 `);
     },
@@ -198,7 +216,13 @@ h1 {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
   /* a.css */
   h1 {
-      color: #00f942;
+    color: hsl(from #00f942 h s l / alpha);
+  }
+
+  @supports (color: color(display-p3 0 0 0)) {
+    h1 {
+      color: hsl(from color(display-p3 0 1 0) h s l / alpha);
+    }
   }
   `);
     },
@@ -378,7 +402,13 @@ h1 {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
   /* a.css */
   h1 {
-      color: #00f942;
+    color: hwb(from #00f942 h w b / alpha);
+  }
+
+  @supports (color: color(display-p3 0 0 0)) {
+    h1 {
+      color: hwb(from color(display-p3 0 1 0) h w b / alpha);
+    }
   }
   `);
     },

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -764,3 +764,60 @@ describe("conversions between color spaces", () => {
     );
   });
 });
+
+// rgb(), hsl() and hwb() cannot hold an origin outside the sRGB gamut. Browsers compute the
+// unclamped color and clip it when painting (w3c/csswg-drafts#8444): the display-p3 green
+// below paints as #00ff00, the lab() one as #ff96ff. These used to be resolved by gamut
+// mapping the origin, to #00f942 and #ffffff, so now they are not resolved at all.
+describe("relative colors with an origin outside the sRGB gamut", () => {
+  test.each([
+    "rgb(from lab(100% 104.3 -50.9) r g b)",
+    "hsl(from color(display-p3 0 1 0) h s l)",
+    "hwb(from oklch(100% 0.399 336.3) h w b)",
+    "rgb(from light-dark(red, color(display-p3 0 1 0)) r g b)",
+    "color-mix(in srgb, rgb(from lab(100% 104.3 -50.9) r g b), red)",
+  ])("%s is not resolved", input => {
+    expect([color(input, "css"), color(input, "hex")]).toEqual([null, null]);
+  });
+
+  test.each([
+    // In-gamut origins resolve as before.
+    ["rgb(from lab(50% 40 -50) r g b)", "#965dcd"],
+    ["hsl(from oklch(50% 0.1 120) h s l)", "#5c6b21"],
+    ["hwb(from color(display-p3 0.4 0.4 0.4) h w b)", "#666"],
+    // The unbounded functions hold any origin, so they still resolve out-of-gamut ones.
+    ["lab(from oklch(100% 0.399 336.3) l a b)", "lab(94.0205% 119.644 -57.6823)"],
+    ["color(from lab(100% 104.3 -50.9) srgb r g b)", "color(srgb 1.5935 .587758 1.40555)"],
+  ])("%s is %s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  // A boundary color written in another space converts back a few 1e-7 outside the gamut.
+  // That is conversion noise, not an out-of-gamut origin: every color on the faces of the
+  // sRGB cube, written as the lab() Bun.color prints for it, still resolves to itself.
+  test("boundary colors written as lab() still resolve", () => {
+    withoutAggressiveGC(() => {
+      const steps = [0, 51, 102, 153, 204, 255];
+      for (const face of [0, 255]) {
+        for (let axis = 0; axis < 3; axis++) {
+          for (const x of steps) {
+            for (const y of steps) {
+              const rgb = [0, 0, 0];
+              rgb[axis] = face;
+              rgb[(axis + 1) % 3] = x;
+              rgb[(axis + 2) % 3] = y;
+              const hex = color({ r: rgb[0], g: rgb[1], b: rgb[2] }, "hex");
+              const lab = color(hex!, "lab");
+              for (const relative of [`rgb(from ${lab} r g b)`, `hsl(from ${lab} h s l)`, `hwb(from ${lab} h w b)`]) {
+                const resolved = color(relative, "hex");
+                if (resolved !== hex) {
+                  throw new Error(`${relative} resolved to ${resolved}, expected ${hex}`);
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7666,6 +7666,63 @@ describe("css tests", () => {
     minify_test(".foo{grid-template-areas:none}", ".foo{grid-template-areas:none}");
   });
 
+  // rgb(), hsl() and hwb() cannot hold an origin outside the sRGB gamut. Browsers keep the
+  // out-of-gamut channels and clip them when painting (w3c/csswg-drafts#8444), so resolving
+  // these by gamut mapping the origin, as before (#fff and #00f942 below), painted a
+  // different color than the unbundled stylesheet. They are left for the browser.
+  describe("relative colors with an origin outside the sRGB gamut", () => {
+    minify_test(
+      ".foo { color: rgb(from lab(100% 104.3 -50.9) r g b) }",
+      ".foo{color:rgb(from lab(100% 104.3 -50.9) r g b)}",
+    );
+    minify_test(
+      ".foo { color: hsl(from color(display-p3 0 1 0) h s l) }",
+      ".foo{color:hsl(from color(display-p3 0 1 0) h s l)}",
+    );
+    minify_test(
+      ".foo { color: hwb(from oklch(100% 0.399 336.3) h w b) }",
+      ".foo{color:hwb(from oklch(100% .399 336.3) h w b)}",
+    );
+    minify_test(
+      ".foo { color: rgb(from lab(100% 104.3 -50.9) r g b / var(--a)) }",
+      ".foo{color:rgb(from lab(100% 104.3 -50.9) r g b/var(--a))}",
+    );
+    // Under targets without lab(), the origin literal gets the fallback tiers any unresolved
+    // value containing it gets; the relative color itself is still left alone in each tier.
+    prefix_test(
+      ".foo { color: rgb(from lab(100% 104.3 -50.9) r g b) }",
+      indoc`
+        .foo {
+          color: rgb(from #fff r g b);
+        }
+
+        @supports (color: lab(0% 0 0)) {
+          .foo {
+            color: rgb(from lab(100% 104.3 -50.9) r g b);
+          }
+        }
+      `,
+      {
+        chrome: 95 << 16,
+      },
+    );
+
+    // In-gamut origins resolve as before, and the unbounded functions resolve any origin.
+    minify_test(".foo { color: rgb(from lab(50% 40 -50) r g b) }", ".foo{color:#965dcd}");
+    minify_test(".foo { color: hsl(from color(display-p3 0.4 0.4 0.4) h s l) }", ".foo{color:#666}");
+    minify_test(
+      ".foo { color: color(from lab(100% 104.3 -50.9) srgb r g b) }",
+      ".foo{color:color(srgb 1.5935 .587758 1.40555)}",
+    );
+    // A boundary color converts back a few 1e-7 outside the gamut; that still resolves.
+    minify_test(".foo { color: rgb(from lab(54.2905% 80.8049 69.891) r g b) }", ".foo{color:red}");
+    minify_test(".foo { color: hsl(from lab(54.2905% 80.8049 69.891) h s l) }", ".foo{color:red}");
+    minify_test(
+      ".foo { color: rgb(from lab(54.2905% 80.8049 69.891) r g b / var(--a)) }",
+      ".foo{color:rgb(255 0 0/var(--a))}",
+    );
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(


### PR DESCRIPTION
### Problem
- A relative `rgb()`, `hsl()` or `hwb()` color is resolved at build time by gamut mapping its origin into sRGB: `color: rgb(from color(display-p3 0 1 0) r g b)` is emitted as `#00f942`, `rgb(from lab(100% 104.3 -50.9) r g b)` as `#fff`, and `Bun.color()` returns the same values. Reproduces on the 1.4.0 release and on main.
- Browsers compute the unclamped color (`color(srgb -0.51 1.02 -0.31)`, `color(srgb 1.59 .59 1.41)`) and clip it per channel when painting, so they paint #00ff00 and #ff96ff. The CSSWG resolved this explicitly (w3c/csswg-drafts#8444), it is what `test/bundler/css/wpt/relative_color_out_of_gamut.test.ts` is derived from, and the resolved color is a visible difference between the bundled and the unbundled stylesheet. It is the behavior Jarred asked to have removed in the review of #33047; of the options listed there this implements the first one, not resolving the color. (24 of the 27 cases in that WPT file currently pass only because their origin is written with a number lightness, which does not parse yet; #39200, stacked on this PR, makes those parse, which is why the two changes are being landed in this order.)
- Cause: `ComponentParser::parse_from` in `src/css/values/color.rs` converts the origin into the target space and calls `resolve()`, which gamut maps it; the HSL and HWB conversions (`From<SRGB> for HSL`/`HWB`) gamut map on their own as well.

### Fix
- `parse_from` fails for a bounded target when the origin is outside the sRGB gamut, which leaves the declaration to the browser exactly like an origin that cannot be converted at all (`rgb(from currentColor r g b)`) does today. `ColorGamut` gets a `BOUNDED` const: true for sRGB, HSL and HWB, the three spaces `parse_from` can be asked to resolve into that cannot hold such a color, false for the lab family, which keeps resolving every origin. `color(from ...)` has its own path that never gamut mapped.
- The check converts the origin to sRGB rather than using the target's `in_gamut()`, because the HSL and HWB conversions have already mapped the color by the time it is in the target space. It allows 1e-4 (0.03 of an 8-bit step) so that a boundary color written in another space, which converts back a few 1e-7 outside the gamut, still resolves as before: `rgb(from lab(54.2905% 80.8049 69.891) r g b)` is still `red`, and the new sweep of the faces of the sRGB cube through `lab()` resolves to itself for all three functions (the largest excursion in it is 8e-6).
- Everything that resolved correctly before still takes the same path: an in-gamut origin passes the check and is resolved by the unchanged code below it; unbounded targets skip the check. What changes is only the out-of-gamut case, in `Bun.color()` (returns `null`), in stylesheets (the declaration is kept; under targets without `lab()`/`color()` the origin literal gets the fallback tiers any unresolved value containing it gets, with the relative color left alone in each tier), and in `color-mix()` or `light-dark()` containing such a relative color (not resolved either). This departs from lightningcss 1.30, which still gamut maps here. `color-mix()` has an analogous problem in its result serialization (`color-mix(in srgb, color(display-p3 0 1 0), ...)` folds to a gamut-mapped hex); that is a separate question about how to serialize an sRGB result and is left out of this PR, as is the operand handling #38508 changes.
- Tests: `test/js/bun/css/color.test.ts` and `test/js/bun/css/css.test.ts` (5 cases each fail on the current build, the rest pin in-gamut origins, unbounded targets, the boundary sweep and the `rgb(... / var(--a))` path in `properties/custom.rs`, which shares `parse_from`), and the 3 display-p3 cases of `test/bundler/css/wpt/relative_color_out_of_gamut.test.ts`, which now get the kept declaration instead of `#00f942`; the other 24 cases of that file are unchanged here and are updated by #39200. The full `css.test.ts`, `color.test.ts` and `test/bundler/css/` pass.
- #38553 (relative color keyword scaling) said it was waiting for "whichever PR lands the gamut policy" before allowing number lightness origins; this is that PR. It does not touch the lines #38553 or #38508 change.

### Background
- Relative color syntax: `rgb(from <origin> r g b)` converts the origin into the function's color space and lets the channels be referenced by keyword. Bun resolves these at build time into a plain color when it can (`ComponentParser::parse_from`); when it cannot, the color fails to parse and the declaration is emitted as written for the browser to evaluate, which is the path this PR reuses.
- Gamut: the set of colors a color space can express. `rgb()`, `hsl()` and `hwb()` are sRGB; `lab()`, `oklch()`, `color(display-p3 ...)` can express colors outside it. Gamut mapping (CSS Color 4 section 13) reduces a color's chroma until it fits, which is how the sRGB fallbacks for wide-gamut colors are produced; clipping, which is what browsers do when painting, clamps each channel instead. The two give different colors (#00f942 vs #00ff00 above).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/wpt/relative_color_out_of_gamut.test.ts test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/66] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/66] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Gl
... (truncated)

release without fix: 21 failed, 67 skipped
bun test v1.4.0-canary.1 (eabb96de7)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [0.08ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.02ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.01ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.08ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [0.54ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [0.03ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.02ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit"))
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256"))
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16"))
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0}
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit")
(pass) color({"r":0,"g":255,"b":0}, "ansi-16")
(pass) color({"r":0,"g":255,"b":0}, "ansi256")
[38;2;0;0;255m[object Object]
(pass) console.log(color({"r":0,"g":0,"b":255}, "ansi-24bit"))
[38;5;
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 68 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/css/wpt/relative_color_out_of_gamut.test.ts test/js/bun/css/color.test.ts test/js/bun/css/css.test.ts
bun test v1.4.0 (bcab5edce)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [2.80ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.51ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.49ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [1.63ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [13.70ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [1.50ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.65ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.30ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.25ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.26ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = 
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     1666aca0b9
  features     baseline

22 deps, 123 codegen, 1176 objects in 737ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (eabb96de7)

Checked 107 installs across 153 packages (no changes) [25.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] gen bindgenv2
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (eabb96de7)

Checked 1 install across 2 packages (no changes) [10.00ms]
[5/1238] fetch zlib
[zlib] up to date
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[11/1237] ins
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/values/color.rs                            | 22 +++++++++
 .../css/wpt/relative_color_out_of_gamut.test.ts    | 36 ++++++++++++--
 test/js/bun/css/color.test.ts                      | 57 ++++++++++++++++++++++
 test/js/bun/css/css.test.ts                        | 57 ++++++++++++++++++++++
 4 files changed, 169 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/css/values/color.rs                                      25     36      0
test/bundler/css/wpt/relative_color_out_of_gamut.test.ts      5      6      0
test/js/bun/css/color.test.ts                                 6      2      0
test/js/bun/css/css.test.ts                                   2      2      0
```

</details>

<!-- robobun:evidence:end -->