### PR TITLE
http2: return the write_all result from the frame serializers instead of a bool

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -1,5 +1,3 @@
-[bun_ast]
-
 [bun_bundler]
 "defaulted_failure:src/bundler/bundle_v2.rs" = 2
 "narrowed_two_ways:src/bundler/bundle_v2.rs" = 1
@@ -31,7 +29,6 @@
 "defaulted_failure:src/runtime/server/RequestContext.rs" = 1
 "defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4
 "error_collapsed_to_bool:src/runtime/api/bun/Terminal.rs" = 1
-"error_collapsed_to_bool:src/runtime/api/bun/h2_frame_parser.rs" = 32
 "error_collapsed_to_bool:src/runtime/ffi/ffi_body.rs" = 1
 "field_valid_only_when:src/runtime/shell/builtin/rm.rs" = 1
 "reimplemented_helper:src/runtime/api/bun/Terminal.rs" = 1
@@ -43,8 +40,6 @@
 "unchecked_construction:src/runtime/cli/pack_command.rs" = 2
 "unchecked_construction:src/runtime/server/HTMLBundle.rs" = 2
 "unchecked_construction:src/runtime/server/server_body.rs" = 5
-
-[bun_sql_jsc]
 
 [bun_sys]
 "error_collapsed_to_bool:src/sys/lib.rs" = 4

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -294,13 +294,13 @@ impl UInt31WithReserved {
         self.0
     }
     #[inline]
-    fn write(self, writer: &mut impl WireWriter) -> bool {
+    fn write(self, writer: &mut impl WireWriter) -> bun_io::Result<()> {
         let mut value: u32 = self.uint31();
         if self.reserved() {
             value |= 0x8000_0000;
         }
         value = value.swap_bytes();
-        writer.write_all(&value.to_ne_bytes()).is_ok()
+        writer.write_all(&value.to_ne_bytes())
     }
 }
 
@@ -320,10 +320,10 @@ const _: () = assert!(core::mem::size_of::<StreamPriority>() == StreamPriority::
 impl StreamPriority {
     pub(crate) const BYTE_SIZE: usize = 5;
     #[inline]
-    fn write(self, writer: &mut impl WireWriter) -> bool {
+    fn write(self, writer: &mut impl WireWriter) -> bun_io::Result<()> {
         let mut swap = self;
         swap.stream_identifier = swap.stream_identifier.swap_bytes();
-        writer.write_all(bytemuck::bytes_of(&swap)).is_ok()
+        writer.write_all(bytemuck::bytes_of(&swap))
     }
 }
 
@@ -350,7 +350,7 @@ impl Default for FrameHeader {
 impl FrameHeader {
     pub const BYTE_SIZE: usize = 9;
     #[inline]
-    fn write(&self, writer: &mut impl WireWriter, frames_sent: &Cell<u64>) -> bool {
+    fn write(&self, writer: &mut impl WireWriter, frames_sent: &Cell<u64>) -> bun_io::Result<()> {
         frames_sent.set(frames_sent.get() + 1);
         let mut buf = [0u8; Self::BYTE_SIZE];
         buf[0] = ((self.length >> 16) & 0xFF) as u8;
@@ -359,7 +359,7 @@ impl FrameHeader {
         buf[3] = self.type_;
         buf[4] = self.flags;
         buf[5..9].copy_from_slice(&self.stream_identifier.to_be_bytes());
-        writer.write_all(&buf).is_ok()
+        writer.write_all(&buf)
     }
     /// Decode a complete 9-byte big-endian frame header.
     ///
@@ -1427,7 +1427,9 @@ impl Stream {
                     length: 0,
                 };
                 owned_frame = Some(frame);
-                break 'brk data_header.write(&mut writer, &client.frames_sent_legacy);
+                break 'brk data_header
+                    .write(&mut writer, &client.frames_sent_legacy)
+                    .is_ok();
             } else {
                 let max_size = frame_remaining
                     .min(


### PR DESCRIPTION
### Problem
- `FrameHeader::write`, `StreamPriority::write` and `UInt31WithReserved::write` in `src/runtime/api/bun/h2_frame_parser.rs` each wrap one `writer.write_all(..)` call and return `.is_ok()`, turning the writer's `bun_core::Error` into a bool.
- 31 of the 32 call sites discard that bool (`let _ = frame.write(..)`). The one reader, `Stream::flush_queue`, uses it as a backpressure flag, the same thing its sibling branches compute with `writer.write_all(..).is_ok()` directly.
- This is the `error_collapsed_to_bool:src/runtime/api/bun/h2_frame_parser.rs = 32` entry in `mordant-baseline.toml`.

### Fix
- The three methods return the `bun_io::Result<()>` they get from `write_all`, matching the signature of what they wrap (and of `DirectWriterStruct::write_all` / `write_padded` further down the file). The `let _ =` call sites compile unchanged; `flush_queue` appends `.is_ok()`.
- No behavior change: every site either discarded the value before and still does, or (`flush_queue`) maps the same `write_all` outcome to the same bool. Discarding is intentional at those sites: the writers are either a stack `FixedBufferStream` sized for the frame, which cannot fail, or `DirectWriterStruct`, whose `Err` means the bytes were buffered for a later flush, and the rest of the frame still has to be written in order.
- `mordant-baseline.toml` regenerated with `bun run rust:mordant:baseline`: the 32-count entry is gone. The regeneration also drops two empty crate tables (`[bun_ast]`, `[bun_sql_jsc]`) that earlier hand edits had left in the file (the generated file never contains empty tables); `bun run rust:mordant` then reports nothing over the baseline.
- Verified on the debug build after each rebase: `test/js/node/http2/node-http2.test.js` (361 pass, 6 skip; the `describe.concurrent` detached-payload block times out intermittently at its 5 s default on debug builds, the pre-existing flake #38078 covers, and does so without this change too), plus `h2-conformance.test.ts`, `node-http2-continuation.test.ts`, `node-http2-invalid-padding.test.ts` and `node-http2-streams-rehash.test.ts` (88 pass). `cargo fmt --check` clean. Buildkite build 100195 ran this same diff on the previous rebase and passed fully.
- No new test: nothing observable from JS changes, so no runtime test can distinguish before from after. The regression guard is the lowered baseline itself: the `mordant` CI job fails if a `write_all` result is collapsed to a bool in this file again.

### Background
- These three types serialize the fixed-size parts of outbound HTTP/2 frames (the 9-byte frame header, the 5-byte PRIORITY payload, a 31-bit id with its reserved bit) into a `bun_io::Write` sink.
- Two sinks are used: `bun_io::FixedBufferStream` over a stack array sized to the frame, and `DirectWriterStruct`, which forwards to `H2FrameParser::write`. That function returns false when the socket did not take the bytes; they are kept in the parser's write buffer and flushed later, so `Err` from these serializers means backpressure, not lost data.
- `mordant-baseline.toml` is the per-(lint, file) count of accepted findings for the repo's Rust lint pack; CI fails only on findings above it, and fixing some means regenerating the file so the count stays down.

<details>
<summary>Rebase note</summary>

Rebased onto main after #39448 removed the dead inbound half of this file. The only conflict was the deleted `UInt31WithReserved::from_bytes` sitting next to the changed `write` signature; resolved by keeping the deletion. #39448 also removed the unused `FullSettingsPayload::write`, which an earlier version of this description mentioned leaving alone. The baseline was regenerated again on the rebased tree and came out identical to the merged result.

Rebased a second time when other sweep PRs changed `mordant-baseline.toml` (the only conflicting file). Resolved by taking main's copy and running `bun run rust:mordant:baseline` again on the rebased tree; the result is main's current baseline minus this file's entry and the two empty tables. The source change applied cleanly.

</details>