### PR TITLE
shell: accept seq --separator=X and --terminator=X

### DIFF
--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -60,8 +60,11 @@ impl Seq {
                 idx += 1;
                 continue;
             }
-            if arg.starts_with(b"-s") && arg.len() > 2 {
-                Self::state_mut(interp, cmd).separator = bun_ptr::RawSlice::new(&arg[2..]);
+            if let Some(bytes) = arg
+                .strip_prefix(b"-s")
+                .or_else(|| arg.strip_prefix(b"--separator="))
+            {
+                Self::state_mut(interp, cmd).separator = bun_ptr::RawSlice::new(bytes);
                 idx += 1;
                 continue;
             }
@@ -75,8 +78,11 @@ impl Seq {
                 idx += 1;
                 continue;
             }
-            if arg.starts_with(b"-t") && arg.len() > 2 {
-                Self::state_mut(interp, cmd).terminator = bun_ptr::RawSlice::new(&arg[2..]);
+            if let Some(bytes) = arg
+                .strip_prefix(b"-t")
+                .or_else(|| arg.strip_prefix(b"--terminator="))
+            {
+                Self::state_mut(interp, cmd).terminator = bun_ptr::RawSlice::new(bytes);
                 idx += 1;
                 continue;
             }

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -66,6 +66,30 @@ describe("seq", async () => {
     .stderr("")
     .runAsTest("--separator works");
 
+  TestBuilder.command`seq --separator=, 0 5`
+    .exitCode(0)
+    .stdout("0,1,2,3,4,5,")
+    .stderr("")
+    .runAsTest("--separator=value works");
+
+  TestBuilder.command`seq --separator= 0 5`
+    .exitCode(0)
+    .stdout("012345")
+    .stderr("")
+    .runAsTest("--separator= sets an empty separator");
+
+  TestBuilder.command`seq --separator=a=b 0 2`
+    .exitCode(0)
+    .stdout("0a=b1a=b2a=b")
+    .stderr("")
+    .runAsTest("--separator=value splits at the first = only");
+
+  TestBuilder.command`seq --separator, 0 5`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: invalid argument\n")
+    .runAsTest("--separator needs = before an attached value");
+
   TestBuilder.command`seq -t, 0 5`.exitCode(0).stdout("0\n1\n2\n3\n4\n5\n,").stderr("").runAsTest("-t works inline");
 
   TestBuilder.command`seq -t , 0 5`.exitCode(0).stdout("0\n1\n2\n3\n4\n5\n,").stderr("").runAsTest("-t works separate");
@@ -76,11 +100,35 @@ describe("seq", async () => {
     .stderr("")
     .runAsTest("--terminator works");
 
+  TestBuilder.command`seq --terminator=, 0 5`
+    .exitCode(0)
+    .stdout("0\n1\n2\n3\n4\n5\n,")
+    .stderr("")
+    .runAsTest("--terminator=value works");
+
+  TestBuilder.command`seq --terminator= 0 2`
+    .exitCode(0)
+    .stdout("0\n1\n2\n")
+    .stderr("")
+    .runAsTest("--terminator= sets an empty terminator");
+
+  TestBuilder.command`seq --terminator, 0 5`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: invalid argument\n")
+    .runAsTest("--terminator needs = before an attached value");
+
   TestBuilder.command`seq -s. -t, 0 5`
     .exitCode(0)
     .stdout("0.1.2.3.4.5.,")
     .stderr("")
     .runAsTest("-s and -t work together");
+
+  TestBuilder.command`seq --separator=. --terminator=, 0 5`
+    .exitCode(0)
+    .stdout("0.1.2.3.4.5.,")
+    .stderr("")
+    .runAsTest("--separator=value and --terminator=value work together");
 
   TestBuilder.command`seq 0`.exitCode(0).stdout("1\n0\n").stderr("").runAsTest("seq 0");
 


### PR DESCRIPTION
### Problem

- In the Bun shell, `seq --separator=, 1 3` and `seq --terminator=X 1 3` exit 1 with `seq: invalid argument`. The other spellings of the same options (`--separator , `, `-s ,`, `-s,`, `--terminator X`) work.
- Cause: the option loop in `src/runtime/shell/builtin/seq.rs` only recognizes the long names by exact comparison (`arg == b"--separator"`, `arg == b"--terminator"`). A `--separator=,` argument matches no arm, the loop breaks, and the argument is then parsed as the first numeric operand, which fails.
- This never worked (the Zig implementation had the same loop), so it is not a regression and there is no issue number.

### Fix

- The arm that takes a value attached to the option (`-s,`) now also strips a `--separator=` prefix, and the `-t,` arm a `--terminator=` prefix. Everything after the first `=` is the value, so `--separator=` sets an empty separator and `--separator=a=b` sets `a=b`.
- Why this is right: `--name=value` and `--name value` are the two spellings getopt_long accepts for a long option with a required argument, and bun's seq already accepts the second one for these options; `.claude/docs/landing-prs.md` (API design) asks for every accepted form of an option to be handled identically, naming exactly this pair. GNU `seq --separator=, 1 3` accepts the `=` spelling too (checked locally; GNU seq has no `--terminator`, that one is BSD's, so the `-t` change only follows the `-s` one). The `=` is required: `--separator,` is still rejected, as getopt_long would reject it.
- The `arg.len() > 2` guard the old arm had was already implied by the exact `-s` arm right above it, which still consumes a bare `-s` (and still reports the missing argument); `strip_prefix(b"-s")` therefore only ever sees a non-empty remainder, so `-sX` behaves as before.
- The value is a sub-slice of the same argv entry, exactly like the existing `-s,` form, so the `RawSlice` borrow documented on the `separator`/`terminator` fields is unchanged.
- Verified by the new cases in `test/js/bun/shell/commands/seq.test.ts`: `--separator=,`, `--separator=` (empty), `--separator=a=b`, `--terminator=,`, `--terminator=`, both options together, and `--separator,` / `--terminator,` staying rejected. Six of the eight fail on bun 1.4.0 (the two rejection pins pass before and after, they pin the shape of the fix); all 40 tests in the file pass with the fix.
- `test/js/bun/shell/pipeline_stack.test.ts`, `exec.test.ts` (`seq --help` still reports an invalid argument) and `shell-seq-condexpr.test.ts` also pass with the fix.

### Background

- `seq` parses its options by hand in `Seq::start` because `-s`/`-t` take values; the shared `parse_flags` helper the other builtins use only handles boolean flags. #39223, which teaches `parse_flags` about `--name=value`, therefore does not reach seq.
- `Seq::separator` / `Seq::terminator` are `bun_ptr::RawSlice`s: non-owning slices into the command's argv, which outlives the builtin. That is why the option loop stores sub-slices of the argument instead of copying.
- The other open seq PRs (#32323, #37923, #37926, #38029, #33995) change other parts of the file (operand parsing, output, the `-w`/`-f` arms, `--`); this change is confined to the two attached-value arms. #37926 adds an exact-match `--format` arm, so once it lands `--format=X` will want the same `=` handling to report the option as unsupported; noted there.
- Found while reviewing the builtins' option parsing, not from a user report.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/seq.test.ts

<!-- robobun:evidence:end -->