### PR TITLE
node:fs: report a bad flush option as "options.flush", render dotted names as properties in ERR_INVALID_ARG_TYPE

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -541,6 +541,7 @@ impl JSGlobalObject {
     }
 
     /// "The {argname} argument must be of type {typename}. Received {value}"
+    /// (a dotted `argname` is a "property", see `InvalidArgTypeName`).
     ///
     /// Accepts `&str`, `&[u8]`, or `b"..."` for `argname`/`typename`.
     pub fn throw_invalid_argument_type_value(
@@ -556,8 +557,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be of type {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be of type {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -565,6 +566,8 @@ impl JSGlobalObject {
         .throw()
     }
 
+    /// Like [`Self::throw_invalid_argument_type_value`], but `typename` is the whole
+    /// phrase after "must be" (e.g. `"an instance of Array"`).
     pub fn throw_invalid_argument_type_value2(
         &self,
         argname: impl AsRef<[u8]>,
@@ -578,8 +581,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -627,8 +630,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be one of type {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be one of type {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -1378,6 +1381,26 @@ pub struct SysErrOptions {
     pub code: NodeErrorCode,
     pub errno: Option<i32>,
     pub name: Option<&'static [u8]>,
+}
+
+/// The subject of Node's `ERR_INVALID_ARG_TYPE` message: `"name" argument`,
+/// `"options.name" property` for a dotted name, or the name verbatim when it
+/// already ends in ` argument` ("first argument"). Same rule as
+/// `Bun::Message::addParameter` in ErrorCode.cpp.
+/// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1407-L1414
+struct InvalidArgTypeName<'a>(&'a [u8]);
+
+impl core::fmt::Display for InvalidArgTypeName<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let name = bstr::BStr::new(self.0);
+        if self.0.ends_with(b" argument") {
+            write!(f, "{name}")
+        } else if strings::contains_char(self.0, b'.') {
+            write!(f, "\"{name}\" property")
+        } else {
+            write!(f, "\"{name}\" argument")
+        }
+    }
 }
 
 // Unified with the crate-root definitions (lib.rs) — re-exported here so

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4199,9 +4199,11 @@ pub mod args {
                         if flush_.is_boolean() || flush_.is_undefined_or_null() {
                             flush = flush_ == JSValue::TRUE;
                         } else {
-                            return Err(
-                                ctx.throw_invalid_argument_type_value(b"flush", b"boolean", flush_)
-                            );
+                            return Err(ctx.throw_invalid_argument_type_value(
+                                b"options.flush",
+                                b"boolean",
+                                flush_,
+                            ));
                         }
                     }
                 }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -2763,6 +2763,89 @@ describe("writeFile/appendFile data argument", () => {
   });
 });
 
+describe("writeFile/appendFile flush option", () => {
+  // Node validates it as `options.flush`, so ERR_INVALID_ARG_TYPE calls it a
+  // property, not an argument. Every string/Buffer entry point shares one
+  // native options parser, so they all have to agree.
+  const invalidArgType = (received: string) =>
+    expect.objectContaining({
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "options.flush" property must be of type boolean. Received ${received}`,
+    });
+  const cases: [flush: unknown, received: string][] = [
+    ["yes", "type string ('yes')"],
+    [1, "type number (1)"],
+    [{}, "an instance of Object"],
+  ];
+
+  it.each(cases)("sync and callback forms throw for { flush: %p }", (flush, received) => {
+    using dir = tempDir("fs-flush-option", { "f.txt": "keep" });
+    const file = join(String(dir), "f.txt");
+    const options = { flush } as any;
+
+    expect(() => writeFileSync(file, "x", options)).toThrow(invalidArgType(received));
+    expect(() => writeFileSync(file, Buffer.from("x"), options)).toThrow(invalidArgType(received));
+    expect(() => fs.appendFileSync(file, "x", options)).toThrow(invalidArgType(received));
+    expect(() => fs.writeFile(file, "x", options, () => {})).toThrow(invalidArgType(received));
+    expect(() => fs.appendFile(file, "x", options, () => {})).toThrow(invalidArgType(received));
+    const fd = openSync(file, "r+");
+    try {
+      expect(() => writeFileSync(fd, "x", options)).toThrow(invalidArgType(received));
+    } finally {
+      closeSync(fd);
+    }
+
+    expect(readFileSync(file, "utf8")).toBe("keep");
+  });
+
+  it.each(cases)("promise forms reject for { flush: %p }", async (flush, received) => {
+    using dir = tempDir("fs-flush-option", { "f.txt": "keep" });
+    const file = join(String(dir), "f.txt");
+    const options = { flush } as any;
+
+    await expect(promises.writeFile(file, "x", options)).rejects.toThrow(invalidArgType(received));
+    await expect(promises.writeFile(file, Buffer.from("x"), options)).rejects.toThrow(invalidArgType(received));
+    await expect(promises.appendFile(file, "x", options)).rejects.toThrow(invalidArgType(received));
+    await using handle = await promises.open(file, "r+");
+    await expect(handle.appendFile("x", options)).rejects.toThrow(invalidArgType(received));
+
+    expect(readFileSync(file, "utf8")).toBe("keep");
+  });
+
+  it("accepts the values node accepts", () => {
+    using dir = tempDir("fs-flush-option", {});
+    const file = join(String(dir), "f.txt");
+    for (const flush of [undefined, null, false, true]) {
+      writeFileSync(file, "a", { flush } as any);
+      fs.appendFileSync(file, "b", { flush } as any);
+      expect(readFileSync(file, "utf8")).toBe("ab");
+    }
+  });
+});
+
+describe("ERR_INVALID_ARG_TYPE names an option as a property and a parameter as an argument", () => {
+  // Same renderer as the flush errors above; these pin the naming rule for a
+  // dotted name reached through the validators and for a plain name.
+  it("dotted option name", () => {
+    using dir = tempDir("fs-arg-type-name", { "f.txt": "" });
+    expect(() => rmSync(join(String(dir), "f.txt"), { maxRetries: "a" } as any)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "options.maxRetries" property must be of type number. Received type string ('a')`,
+      }),
+    );
+  });
+
+  it("plain parameter name", () => {
+    expect(() => fs.fsyncSync("x" as any)).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "fd" argument must be of type number. Received type string ('x')`,
+      }),
+    );
+  });
+});
+
 function triggerDOMJIT(target: fs.Stats, fn: (..._: any[]) => any, result: any) {
   for (let i = 0; i < 9999; i++) {
     if (fn.apply(target) !== result) {


### PR DESCRIPTION
### Problem

- `fs.writeFileSync(p, "ab", { flush: "yes" })` throws `ERR_INVALID_ARG_TYPE` with the message `The "flush" argument must be of type boolean. Received type string ('yes')`. Node v26.3.0 throws the same code with `The "options.flush" property must be of type boolean. Received type string ('yes')`.
- The same text comes out of every entry point that takes string or Buffer data, because they share one native options parser (`args::WriteFile::from_js_with_default_flag`): `fs.writeFile`, `writeFileSync`, `appendFile`, `appendFileSync`, `fs.promises.writeFile`, `fs.promises.appendFile`, `FileHandle#appendFile`.
- Two causes:
  - `src/runtime/node/node_fs.rs:4203` passes the bare name `flush`. Node validates the option as `options.flush` (`validateBoolean(flush, 'options.flush')` in `lib/fs.js` and `lib/internal/fs/promises.js`).
  - `JSGlobalObject::throw_invalid_argument_type_value` (`src/jsc/JSGlobalObject.rs:559`) hardcodes `The "<name>" argument`, so even a dotted name renders as an argument. Other callers already pass dotted names and hit the same thing: `fs.rmSync(p, { maxRetries: "a" })` and `new net.SocketAddress({ address: 1 })` say `"options.maxRetries" argument` / `"options.address" argument` where node says `property`.
- The vendored node tests for this (`test-fs-write-file-flush.js`, `test-fs-append-file-flush.js`) only check the code, which was already right, so they did not catch it.

### Fix

- `node_fs.rs`: the flush error names the option `options.flush`.
- `JSGlobalObject.rs`: the three Rust `ERR_INVALID_ARG_TYPE` renderers (`throw_invalid_argument_type_value`, `..._value2`, `..._one_of`) format the name through `InvalidArgTypeName`, which applies node's subject rule: `"x" argument`, `"a.b" property`, or the name verbatim when it already ends in ` argument`. This is the rule `Bun::Message::addParameter` in `ErrorCode.cpp` already applies to every C++ caller, so the Rust and C++ renderers now agree.
- Why this is right: for `node:fs` errors node's text is the contract (#32355 landed the same argument-to-property correction for another Rust helper), and these messages are byte-identical to node v26.3.0. A script exercising the 7 flush entry points (string and Buffer data, path and fd targets), `rmSync` retry options and `SocketAddress` options diffs clean between this build and a local `node`, apart from things this PR leaves alone: `FileHandle#writeFile` does not forward `flush` on main (#39192 adds it), the `signal` option error (#39274), and the `mkdir`/`readdir` `recursive` and `rm` `recursive`/`force` errors, which go through two other helpers and are tracked separately.
- Blast radius of the renderer change: only names containing a `.` change output. The dotted names currently passed to these renderers are `options.flush` (this PR), `options.retryDelay` / `options.maxRetries` (`fs.rm`), `options.address` / `options.flowlabel` (`net.SocketAddress`), `options.silent` / `endStream` / `exclusive` / `parent` / `weight` / `signal` (http2 priority and request options), `handle.fd` (cluster), and Bun's own `compress.encoding` (fetch) and `rule.syscall` / `rule.action` (socket fault injection). All of the node ones render as `property` in node; no test in the repo pinned the old wording for any of them. No Rust caller passes a name ending in ` argument`. Names without a dot render exactly as before.
- Overlap: the `JSGlobalObject.rs` hunk is the one from #38663 (validators message parity), and #39274 (`options.signal`, which edits the same `WriteFile` parser a few lines above this hunk) carries it verbatim too. Trial merges of this PR with either of them, and of all three together, are conflict-free and end up with a single `InvalidArgTypeName`; whichever lands first carries the renderer change and the others reduce to their own call sites. Neither of them touches the flush name. This stays a separate PR because it only changes text, while #39274 also changes which values are accepted.
- Verified:
  - `test/js/node/fs/fs.test.ts`: new `writeFile/appendFile flush option` block covers all 7 entry points (path and fd, string and Buffer) for three `Received` shapes, plus the accepted values; a second block pins a dotted name reached through the validators (`rmSync` `options.maxRetries`) and a plain name (`fsyncSync` `fd`) still rendering as an argument. 7 of the 9 new tests fail on the released build, all pass with this change; the whole file passes (521 pass).
  - Existing tests that pin plain-name output from each renderer still pass: `test-crypto-random.js` and `test/js/web/fetch/wasm-streaming.test.ts` (`..._value2`), `test/js/node/child_process/child_process-node.test.js` (`..._one_of`).
  - Vendored `test-fs-write-file-flush.js`, `test-fs-append-file-flush.js`, `test-fs-rm.js`, `test-socketaddress.js`, and `test/js/node/net/socketaddress.spec.ts`, `test/js/web/fetch/fetch-compress.test.ts` pass.

### Background

- `ERR_INVALID_ARG_TYPE(name, expected, actual)` in node's `lib/internal/errors.js` renders `The <subject> must be <expected>. Received <description of actual>`. The subject is `"name" argument`, unless the name contains a `.`, in which case it is an option path such as `options.flush` and renders as `"name" property`; a name that already ends in ` argument` (such as `first argument`) is used verbatim.
- Bun renders these messages in two places: C++ (`ErrorCode.cpp`, used by the JS builtins through `$ERR_INVALID_ARG_TYPE` and by C++ bindings) and the Rust helpers on `JSGlobalObject` used by natively implemented modules. The `Received ...` half is shared (the Rust helpers call the C++ `determineSpecificType`), which is why only the subject differed.
