### PR TITLE
css: clip color-mix() results outside the sRGB gamut instead of gamut mapping them

### DIFF
--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -125,6 +125,8 @@ Bun's CSS bundler evaluates these color mixes at build time when all color value
 }
 ```
 
+A mix of wide-gamut operands, such as `display-p3` or `lab()` colors, can produce a result outside the sRGB gamut. A hex color cannot hold that result. Bun emits it as a `color(srgb ...)` value with the out-of-gamut channels kept, and adds the same RGB fallbacks it adds for the `color()` function below.
+
 ### Relative colors
 
 Relative color syntax modifies individual components of an existing color. Adjust attributes like lightness, saturation, or individual channels without recalculating the entire color.

--- a/docs/bundler/css.mdx
+++ b/docs/bundler/css.mdx
@@ -125,8 +125,6 @@ Bun's CSS bundler evaluates these color mixes at build time when all color value
 }
 ```
 
-A mix of wide-gamut operands, such as `display-p3` or `lab()` colors, can produce a result outside the sRGB gamut. A hex color cannot hold that result. Bun emits it as a `color(srgb ...)` value with the out-of-gamut channels kept, and adds the same RGB fallbacks it adds for the `color()` function below.
-
 ### Relative colors
 
 Relative color syntax modifies individual components of an existing color. Adjust attributes like lightness, saturation, or individual channels without recalculating the entire color.

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1742,17 +1742,13 @@ define_colorspace! {
     premultiply = rectangular;
     powerless = none;
     into_css = |srgb: &SRGB| {
-        // An 8-bit color when the color fits in the sRGB gamut (matching upstream
-        // lightningcss), otherwise the `color(srgb ...)` value browsers compute for it, as
-        // `parse_predefined_relative` produces for `color(from ... srgb r g b)`. Gamut
-        // mapping it into an 8-bit color (`into_rgba`) would emit a different color:
-        // browsers keep out-of-gamut channels and clip them when painting.
-        let srgb = srgb.resolve_missing().snap_to_gamut();
-        if srgb.in_gamut() {
-            CssColor::Rgba(RGBA::from_floats(srgb.r, srgb.g, srgb.b, srgb.alpha))
-        } else {
-            CssColor::Predefined(Box::new(PredefinedColor::Srgb(srgb)))
-        }
+        // Serializes through 8-bit RGBA like upstream lightningcss, except that a color
+        // outside the sRGB gamut (a `color-mix()` of wide-gamut operands) is clipped,
+        // which is what browsers paint for it, rather than gamut mapped (`into_rgba`),
+        // which is a different color: gamut mapping is for a fallback that precedes the
+        // real value in the output, whereas this replaces the value.
+        let srgb = srgb.resolve_missing().clip();
+        CssColor::Rgba(RGBA::from_floats(srgb.r, srgb.g, srgb.b, srgb.alpha))
     };
 }
 
@@ -1760,27 +1756,6 @@ impl SRGB {
     pub fn into_rgba(&self) -> RGBA {
         let rgb = self.resolve();
         RGBA::from_floats(rgb.r, rgb.g, rgb.b, rgb.alpha)
-    }
-
-    /// Moves the channels that are within conversion noise of the gamut boundary onto it,
-    /// leaving the others alone: a boundary color written in another space converts back
-    /// a few 1e-6 outside of [0, 1] (`lab(54.2905% 80.8049 69.891)`, which is `#ff0000`,
-    /// comes back with g = -8e-7). The tolerance is 0.03 of an 8-bit step.
-    fn snap_to_gamut(&self) -> SRGB {
-        const TOLERANCE: f32 = 1e-4;
-        let snap = |v: f32| {
-            if (-TOLERANCE..=1.0 + TOLERANCE).contains(&v) {
-                v.clamp(0.0, 1.0)
-            } else {
-                v
-            }
-        };
-        SRGB {
-            r: snap(self.r),
-            g: snap(self.g),
-            b: snap(self.b),
-            alpha: self.alpha,
-        }
     }
 }
 

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1742,9 +1742,17 @@ define_colorspace! {
     premultiply = rectangular;
     powerless = none;
     into_css = |srgb: &SRGB| {
-        // Serializes through 8-bit RGBA, matching upstream lightningcss
-        // (`color(srgb, ...)` would be more precise but would change output).
-        CssColor::Rgba(RGBA::from(*srgb))
+        // An 8-bit color when the color fits in the sRGB gamut (matching upstream
+        // lightningcss), otherwise the `color(srgb ...)` value browsers compute for it, as
+        // `parse_predefined_relative` produces for `color(from ... srgb r g b)`. Gamut
+        // mapping it into an 8-bit color (`into_rgba`) would emit a different color:
+        // browsers keep out-of-gamut channels and clip them when painting.
+        let srgb = srgb.resolve_missing().snap_to_gamut();
+        if srgb.in_gamut() {
+            CssColor::Rgba(RGBA::from_floats(srgb.r, srgb.g, srgb.b, srgb.alpha))
+        } else {
+            CssColor::Predefined(Box::new(PredefinedColor::Srgb(srgb)))
+        }
     };
 }
 
@@ -1752,6 +1760,27 @@ impl SRGB {
     pub fn into_rgba(&self) -> RGBA {
         let rgb = self.resolve();
         RGBA::from_floats(rgb.r, rgb.g, rgb.b, rgb.alpha)
+    }
+
+    /// Moves the channels that are within conversion noise of the gamut boundary onto it,
+    /// leaving the others alone: a boundary color written in another space converts back
+    /// a few 1e-6 outside of [0, 1] (`lab(54.2905% 80.8049 69.891)`, which is `#ff0000`,
+    /// comes back with g = -8e-7). The tolerance is 0.03 of an 8-bit step.
+    fn snap_to_gamut(&self) -> SRGB {
+        const TOLERANCE: f32 = 1e-4;
+        let snap = |v: f32| {
+            if (-TOLERANCE..=1.0 + TOLERANCE).contains(&v) {
+                v.clamp(0.0, 1.0)
+            } else {
+                v
+            }
+        };
+        SRGB {
+            r: snap(self.r),
+            g: snap(self.g),
+            b: snap(self.b),
+            alpha: self.alpha,
+        }
     }
 }
 
@@ -1762,7 +1791,7 @@ define_colorspace! {
     gamut = hsl_hwb;
     premultiply = polar;
     powerless = hsl;
-    into_css = |c: &HSL| CssColor::Rgba(RGBA::from(*c));
+    into_css = |c: &HSL| SRGB::from(*c).into_css_color();
 }
 
 define_colorspace! {
@@ -1772,7 +1801,7 @@ define_colorspace! {
     gamut = hsl_hwb;
     premultiply = polar;
     powerless = hwb;
-    into_css = |c: &HWB| CssColor::Rgba(RGBA::from(*c));
+    into_css = |c: &HWB| SRGB::from(*c).into_css_color();
 }
 
 define_colorspace! {

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1742,8 +1742,7 @@ define_colorspace! {
     premultiply = rectangular;
     powerless = none;
     into_css = |srgb: &SRGB| {
-        // Clipped, not gamut mapped like the fallbacks (`into_rgba`): this replaces the
-        // value, so an out-of-gamut `color-mix()` result must be what browsers paint for it.
+        // Not `into_rgba()`: browsers clip an out-of-gamut `color-mix()` result, not gamut map it.
         let srgb = srgb.resolve_missing().clip();
         CssColor::Rgba(RGBA::from_floats(srgb.r, srgb.g, srgb.b, srgb.alpha))
     };

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1742,11 +1742,8 @@ define_colorspace! {
     premultiply = rectangular;
     powerless = none;
     into_css = |srgb: &SRGB| {
-        // Serializes through 8-bit RGBA like upstream lightningcss, except that a color
-        // outside the sRGB gamut (a `color-mix()` of wide-gamut operands) is clipped,
-        // which is what browsers paint for it, rather than gamut mapped (`into_rgba`),
-        // which is a different color: gamut mapping is for a fallback that precedes the
-        // real value in the output, whereas this replaces the value.
+        // Clipped, not gamut mapped like the fallbacks (`into_rgba`): this replaces the
+        // value, so an out-of-gamut `color-mix()` result must be what browsers paint for it.
         let srgb = srgb.resolve_missing().clip();
         CssColor::Rgba(RGBA::from_floats(srgb.r, srgb.g, srgb.b, srgb.alpha))
     };

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1742,7 +1742,7 @@ define_colorspace! {
     premultiply = rectangular;
     powerless = none;
     into_css = |srgb: &SRGB| {
-        // Not `into_rgba()`: browsers clip an out-of-gamut `color-mix()` result, not gamut map it.
+        // Not `into_rgba()`: an sRGB screen shows an out-of-gamut `color-mix()` result clipped, not gamut mapped.
         let srgb = srgb.resolve_missing().clip();
         CssColor::Rgba(RGBA::from_floats(srgb.r, srgb.g, srgb.b, srgb.alpha))
     };

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -681,109 +681,82 @@ describe("rgb() channel order and legacy syntax", () => {
   });
 });
 
-// color-mix(in srgb, ...) prints its result as an 8-bit color when it fits in the sRGB
-// gamut. A result outside of it (css-color-4 interpolates out-of-gamut channels as they
-// are) is printed as the color(srgb ...) value browsers compute for it, the same value
-// color(from <operand> srgb r g b) prints; it used to be gamut mapped into a different
-// 8-bit color (a mix of two display-p3 greens came out as #00f942, browsers paint it as
-// #00ff00 on an sRGB screen and as the display-p3 green on a wider one).
-describe("color-mix() results outside the sRGB gamut", () => {
-  const srgbChannels = (css: string | null) => {
-    expect(css).toStartWith("color(srgb ");
-    return css!
-      .slice("color(srgb ".length, -1)
-      .split(/ \/ | /)
-      .map(Number);
-  };
-  const expectSrgb = (input: string, expected: number[]) => {
-    const actual = srgbChannels(color(input, "css"));
-    expect(actual).toHaveLength(expected.length);
-    for (let i = 0; i < expected.length; i++) {
-      expect(actual[i]).toBeCloseTo(expected[i], 3);
-    }
-  };
-
-  // References are the css-color-4 conversions in double precision. These go through
-  // pow(), so they are compared numerically.
-  const p3Green = [-0.5116, 1.01827, -0.31067];
-  test("a display-p3 operand mixed with itself", () => {
-    expectSrgb("color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0))", p3Green);
-    expectSrgb("color-mix(in srgb, color(display-p3 0 1 0) 100%, red)", p3Green);
-    expectSrgb("color-mix(in srgb, color(display-p3 0 1 0 / 0.5), color(display-p3 0 1 0 / 0.5))", [...p3Green, 0.5]);
-  });
-
-  test("the mix is the same value the relative color form prints", () => {
-    expect(color("color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0))", "css")).toBe(
-      color("color(from color(display-p3 0 1 0) srgb r g b)", "css")!,
-    );
-  });
-
-  // lab(100% 104.3 -50.9) is color(srgb 1.5935 0.58776 1.40555); browsers paint the mix as
-  // rgb(255, 75, 179). It used to fold to #ff9fbc.
-  test("a lab() operand pushes the mix out of gamut", () => {
-    expectSrgb("color-mix(in srgb, lab(100% 104.3 -50.9), red)", [1.29675, 0.29388, 0.70277]);
-  });
-
-  // 12.92 * channel is the linear segment of the sRGB transfer function, so these
-  // srgb-linear operands convert to srgb exactly: -0.003 is -0.03876, -0.001 is -0.01292.
+// color-mix(in srgb, ...) folds to an 8-bit color. css-color-4 interpolates out-of-gamut
+// channels as they are, so wide-gamut operands can leave the result outside the sRGB
+// gamut; browsers paint such a result by clipping each channel, and the fold clips too.
+// It used to gamut map the result (the chroma reduction used for the #rrggbb fallback of
+// a wide-gamut color), which is a different color: #00f942 for display-p3 green, or
+// plain white for the bright magentas below. The display-p3 green, lab() and oklch()
+// operands are the ones of WPT css/css-color/parsing/color-mix-out-of-gamut.html; the
+// expected colors are the computed values it lists (color(srgb 1.59343 0.58802 1.40564)
+// for lab(100% 104.3 -50.9)) clipped to 8 bits. The other unclipped results are noted inline.
+describe("color-mix() results outside the sRGB gamut are clipped", () => {
   test.each([
-    ["color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.003 1 0))", "color(srgb -.03876 1 0)"],
-    ["color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.001 1 0))", "color(srgb -.02584 1 0)"],
-    ["color-mix(in srgb, color(srgb-linear -0.003 1 0) 25%, lime)", "color(srgb -.00969 1 0)"],
-    ["color-mix(in srgb, color(srgb-linear 0 0 -0.003), color(srgb-linear 0 0 0.001))", "color(srgb 0 0 -.01292)"],
+    // color(display-p3 0 1 0) is color(srgb -0.5116 1.0183 -0.3107); used to be #00f942.
+    ["color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0))", "#0f0"],
+    ["color-mix(in srgb, color(display-p3 0 1 0) 100%, red)", "#0f0"],
+    ["color-mix(in srgb, color(display-p3 0 1 0 / 0.5), color(display-p3 0 1 0 / 0.5))", "#00ff0080"],
+    // color(srgb 1 1 -0.346) and color(srgb 1.093 -0.227 -0.150); used to be #fdfe00 and #ff0f0e.
+    ["color-mix(in srgb, color(display-p3 1 1 0), color(display-p3 1 1 0))", "#ff0"],
+    ["color-mix(in srgb, color(display-p3 1 0 0), color(display-p3 1 0 0))", "red"],
+    // color(srgb 1.593 0.359 1.386) and color(srgb 1.593 0.588 1.406): the oklch lightness of
+    // these is above 1, which the gamut mapping turned into plain white.
+    ["color-mix(in srgb, oklch(100% 0.399 336.3), oklch(100% 0.399 336.3))", "#ff5bff"],
+    ["color-mix(in srgb, oklch(100% 0.399 336.3) 80%, white)", "#ff7cff"],
+    ["color-mix(in srgb, oklch(100% 0.399 336.3) 50%, white)", "#ffadff"],
+    ["color-mix(in srgb, lab(100% 104.3 -50.9), lab(100% 104.3 -50.9))", "#ff96ff"],
+    ["color-mix(in srgb, lab(100% 104.3 -50.9), red)", "#ff4bb3"],
+    // color(srgb 0.351 -0.214 0.300); used to be #2a0022.
+    ["color-mix(in srgb, lab(0% 104.3 -50.9), lab(0% 104.3 -50.9))", "#5a004c"],
+    // color(srgb -1.207 1.316 -0.489); used to be #a7ffc3 and #d5ffd4.
+    ["color-mix(in srgb, color(xyz 0 1 0) 75%, lime)", "#0f0"],
+    ["color-mix(in srgb, color(xyz 0 1 0) 50%, white)", "#00ff41"],
+    // color(srgb 0 1.194 0) and color(srgb 1.353 1.353 0); used to be #edffea and white.
+    ["color-mix(in srgb, color(srgb-linear 0 1.5 0), color(srgb-linear 0 1.5 0))", "#0f0"],
+    ["color-mix(in srgb, color(srgb-linear 0 1.5 0 / 0.5), color(srgb-linear 0 1.5 0 / 0.5))", "#00ff0080"],
+    ["color-mix(in srgb, color(srgb-linear 2 2 0), color(srgb-linear 2 2 0))", "#ff0"],
     [
-      "color-mix(in srgb, color(srgb-linear -0.003 1 0 / 0.5), color(srgb-linear -0.003 1 0 / 0.5))",
-      "color(srgb -.03876 1 0 / .5)",
+      "color-mix(in srgb, light-dark(color(display-p3 0 1 0), red), light-dark(color(display-p3 0 1 0), blue))",
+      "light-dark(#0f0, purple)",
     ],
-    [
-      "color-mix(in srgb, light-dark(color(srgb-linear -0.003 1 0), red), light-dark(color(srgb-linear -0.003 1 0), blue))",
-      "light-dark(color(srgb -.03876 1 0), purple)",
-    ],
+    // The inner mix is folded to 8 bits before the outer one uses it, as an in-gamut inner mix
+    // is too; browsers mix the unclipped inner result and get rgb(0, 130, 0) here.
+    ["color-mix(in srgb, color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0)), black)", "green"],
   ])("%s is %s", (input, expected) => {
     expect(color(input, "css")).toBe(expected);
   });
 
-  test("the output is a color Bun.color parses back unchanged", () => {
-    for (const input of [
-      "color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.001 1 0))",
-      "color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0))",
-      "color-mix(in srgb, color(display-p3 0 0 1), color(display-p3 0 0 1))",
-    ]) {
-      const css = color(input, "css") as string;
-      expect(color(css, "css")).toBe(css);
-    }
-  });
-
-  describe("channels within conversion noise of the gamut are snapped onto it", () => {
-    // Converting this lab() red back to srgb leaves g and b around -1e-6.
-    test("a boundary color converted from lab() still folds to the 8-bit color", () => {
-      expect(color("color-mix(in srgb, lab(54.2905% 80.8049 69.891), lab(54.2905% 80.8049 69.891))", "css")).toBe(
-        "red",
-      );
-    });
-
-    // display-p3 blue is color(srgb 0 -2e-7 1.04202): the blue channel is kept and the
-    // noise in the green channel is dropped rather than printed.
-    test("only the channels that are out of gamut keep their value", () => {
-      expect(color("color-mix(in srgb, color(display-p3 0 0 1), color(display-p3 0 0 1))", "css")).toMatch(
-        /^color\(srgb 0 0 1\.042\d*\)$/,
-      );
-      expect(color("color-mix(in srgb, color(display-p3 1 1 0), color(display-p3 1 1 0))", "css")).toMatch(
-        /^color\(srgb 1 1 -\.346\d*\)$/,
-      );
-    });
-
-    test("the tolerance is 1e-4", () => {
-      // 12.92 * -0.00001 = -0.0001292 is out of gamut.
-      expect(color("color-mix(in srgb, color(srgb-linear -0.00001 1 0), color(srgb-linear -0.00001 1 0))", "css")).toBe(
-        "color(srgb -.0001292 1 0)",
-      );
-      // 12.92 * -0.000005 / 2 = -0.0000323 is noise.
-      expect(color("color-mix(in srgb, color(srgb-linear -0.000005 1 0), lime)", "css")).toBe("#0f0");
+  test("every output format gets the clipped color", () => {
+    const mix = "color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0))";
+    expect({
+      rgb: color(mix, "{rgb}"),
+      rgba: color(mix, "[rgba]"),
+      hex: color(mix, "hex"),
+      number: color(mix, "number"),
+      ansi: color(mix, "ansi-16m"),
+      hsl: color(mix, "hsl"),
+    }).toEqual({
+      rgb: { r: 0, g: 255, b: 0 },
+      rgba: [0, 255, 0, 255],
+      hex: "#00ff00",
+      number: 0x00ff00,
+      ansi: "\u001b[38;2;0;255;0m",
+      hsl: "hsl(120, 100%, 50%)",
     });
   });
 
+  // The gamut mapping already clipped a result whose clipped color is within its
+  // just-noticeable difference, so results that are only slightly out of gamut fold to the
+  // same color as before. The oklch() operands are Tailwind v4 palette entries in the shape
+  // of its color-mix() fallback declarations.
   test.each([
+    ["color-mix(in srgb, oklch(57.7% 0.245 27.325) 50%, transparent)", "#e7000b80"],
+    ["color-mix(in srgb, oklch(69.6% 0.17 162.48) 30%, transparent)", "#00bc7d4d"],
+    ["color-mix(in srgb, color(display-p3 0 1 0) 75%, white)", "#00ff04"],
+    ["color-mix(in srgb, color(display-p3 0 1 0) 25%, white)", "#9fffab"],
+    ["color-mix(in srgb, color(display-p3 0 0 1), color(display-p3 0 0 1))", "#00f"],
+    // Converting this lab() red back to srgb leaves g and b around -1e-6.
+    ["color-mix(in srgb, lab(54.2905% 80.8049 69.891), lab(54.2905% 80.8049 69.891))", "red"],
     ["color-mix(in srgb, red, blue)", "purple"],
     ["color-mix(in srgb, red 25%, blue)", "#4000bf"],
     ["color-mix(in srgb, rgb(255 0 0 / 0.5), blue)", "#5500aac0"],
@@ -794,7 +767,9 @@ describe("color-mix() results outside the sRGB gamut", () => {
     ["color-mix(in hsl, hsl(none 100% 50%), hsl(none 100% 50%))", "red"],
     ["color-mix(in hwb, red, blue)", "#f0f"],
     ["color-mix(in hwb, hwb(120 0% 0% / 0.5), hwb(240 0% 0%))", "#00ffffc0"],
-  ])("%s still folds to %s", (input, expected) => {
+    ["rgb(none 0 0)", "#000"],
+    ["hsl(none 100% 50%)", "red"],
+  ])("%s is still %s", (input, expected) => {
     expect(color(input, "css")).toBe(expected);
   });
 });

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -683,9 +683,10 @@ describe("rgb() channel order and legacy syntax", () => {
 
 // color-mix(in srgb, ...) folds to an 8-bit color. css-color-4 interpolates out-of-gamut
 // channels as they are, so wide-gamut operands can leave the result outside the sRGB
-// gamut; browsers paint such a result by clipping each channel, and the fold clips too.
-// It used to gamut map the result (the chroma reduction used for the #rrggbb fallback of
-// a wide-gamut color), which is a different color: #00f942 for display-p3 green, or
+// gamut; an sRGB screen shows such a result with each channel clipped (a wider screen
+// shows it as is, which an 8-bit fold cannot express), so the fold clips. It used to gamut
+// map the result (the chroma reduction used for the #rrggbb fallback of a wide-gamut
+// color), which is a different color on every screen: #00f942 for display-p3 green, or
 // plain white for the bright magentas below. The display-p3 green, lab() and oklch()
 // operands are the ones of WPT css/css-color/parsing/color-mix-out-of-gamut.html; the
 // expected colors are the computed values it lists (color(srgb 1.59343 0.58802 1.40564)

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -681,6 +681,124 @@ describe("rgb() channel order and legacy syntax", () => {
   });
 });
 
+// color-mix(in srgb, ...) prints its result as an 8-bit color when it fits in the sRGB
+// gamut. A result outside of it (css-color-4 interpolates out-of-gamut channels as they
+// are) is printed as the color(srgb ...) value browsers compute for it, the same value
+// color(from <operand> srgb r g b) prints; it used to be gamut mapped into a different
+// 8-bit color (a mix of two display-p3 greens came out as #00f942, browsers paint it as
+// #00ff00 on an sRGB screen and as the display-p3 green on a wider one).
+describe("color-mix() results outside the sRGB gamut", () => {
+  const srgbChannels = (css: string | null) => {
+    expect(css).toStartWith("color(srgb ");
+    return css!
+      .slice("color(srgb ".length, -1)
+      .split(/ \/ | /)
+      .map(Number);
+  };
+  const expectSrgb = (input: string, expected: number[]) => {
+    const actual = srgbChannels(color(input, "css"));
+    expect(actual).toHaveLength(expected.length);
+    for (let i = 0; i < expected.length; i++) {
+      expect(actual[i]).toBeCloseTo(expected[i], 3);
+    }
+  };
+
+  // References are the css-color-4 conversions in double precision. These go through
+  // pow(), so they are compared numerically.
+  const p3Green = [-0.5116, 1.01827, -0.31067];
+  test("a display-p3 operand mixed with itself", () => {
+    expectSrgb("color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0))", p3Green);
+    expectSrgb("color-mix(in srgb, color(display-p3 0 1 0) 100%, red)", p3Green);
+    expectSrgb("color-mix(in srgb, color(display-p3 0 1 0 / 0.5), color(display-p3 0 1 0 / 0.5))", [...p3Green, 0.5]);
+  });
+
+  test("the mix is the same value the relative color form prints", () => {
+    expect(color("color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0))", "css")).toBe(
+      color("color(from color(display-p3 0 1 0) srgb r g b)", "css")!,
+    );
+  });
+
+  // lab(100% 104.3 -50.9) is color(srgb 1.5935 0.58776 1.40555); browsers paint the mix as
+  // rgb(255, 75, 179). It used to fold to #ff9fbc.
+  test("a lab() operand pushes the mix out of gamut", () => {
+    expectSrgb("color-mix(in srgb, lab(100% 104.3 -50.9), red)", [1.29675, 0.29388, 0.70277]);
+  });
+
+  // 12.92 * channel is the linear segment of the sRGB transfer function, so these
+  // srgb-linear operands convert to srgb exactly: -0.003 is -0.03876, -0.001 is -0.01292.
+  test.each([
+    ["color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.003 1 0))", "color(srgb -.03876 1 0)"],
+    ["color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.001 1 0))", "color(srgb -.02584 1 0)"],
+    ["color-mix(in srgb, color(srgb-linear -0.003 1 0) 25%, lime)", "color(srgb -.00969 1 0)"],
+    ["color-mix(in srgb, color(srgb-linear 0 0 -0.003), color(srgb-linear 0 0 0.001))", "color(srgb 0 0 -.01292)"],
+    [
+      "color-mix(in srgb, color(srgb-linear -0.003 1 0 / 0.5), color(srgb-linear -0.003 1 0 / 0.5))",
+      "color(srgb -.03876 1 0 / .5)",
+    ],
+    [
+      "color-mix(in srgb, light-dark(color(srgb-linear -0.003 1 0), red), light-dark(color(srgb-linear -0.003 1 0), blue))",
+      "light-dark(color(srgb -.03876 1 0), purple)",
+    ],
+  ])("%s is %s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  test("the output is a color Bun.color parses back unchanged", () => {
+    for (const input of [
+      "color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.001 1 0))",
+      "color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0))",
+      "color-mix(in srgb, color(display-p3 0 0 1), color(display-p3 0 0 1))",
+    ]) {
+      const css = color(input, "css") as string;
+      expect(color(css, "css")).toBe(css);
+    }
+  });
+
+  describe("channels within conversion noise of the gamut are snapped onto it", () => {
+    // Converting this lab() red back to srgb leaves g and b around -1e-6.
+    test("a boundary color converted from lab() still folds to the 8-bit color", () => {
+      expect(color("color-mix(in srgb, lab(54.2905% 80.8049 69.891), lab(54.2905% 80.8049 69.891))", "css")).toBe(
+        "red",
+      );
+    });
+
+    // display-p3 blue is color(srgb 0 -2e-7 1.04202): the blue channel is kept and the
+    // noise in the green channel is dropped rather than printed.
+    test("only the channels that are out of gamut keep their value", () => {
+      expect(color("color-mix(in srgb, color(display-p3 0 0 1), color(display-p3 0 0 1))", "css")).toMatch(
+        /^color\(srgb 0 0 1\.042\d*\)$/,
+      );
+      expect(color("color-mix(in srgb, color(display-p3 1 1 0), color(display-p3 1 1 0))", "css")).toMatch(
+        /^color\(srgb 1 1 -\.346\d*\)$/,
+      );
+    });
+
+    test("the tolerance is 1e-4", () => {
+      // 12.92 * -0.00001 = -0.0001292 is out of gamut.
+      expect(color("color-mix(in srgb, color(srgb-linear -0.00001 1 0), color(srgb-linear -0.00001 1 0))", "css")).toBe(
+        "color(srgb -.0001292 1 0)",
+      );
+      // 12.92 * -0.000005 / 2 = -0.0000323 is noise.
+      expect(color("color-mix(in srgb, color(srgb-linear -0.000005 1 0), lime)", "css")).toBe("#0f0");
+    });
+  });
+
+  test.each([
+    ["color-mix(in srgb, red, blue)", "purple"],
+    ["color-mix(in srgb, red 25%, blue)", "#4000bf"],
+    ["color-mix(in srgb, rgb(255 0 0 / 0.5), blue)", "#5500aac0"],
+    ["color-mix(in srgb, rgb(none 0 0), rgb(none 0 0))", "#000"],
+    ["color-mix(in srgb, color(srgb-linear 1 0.2 0.001), color(srgb-linear 1 0.2 0.001))", "#ff7c03"],
+    ["color-mix(in hsl, red, blue)", "#f0f"],
+    ["color-mix(in hsl, hsl(120 100% 50% / 0.5), hsl(240 100% 50%))", "#00ffffc0"],
+    ["color-mix(in hsl, hsl(none 100% 50%), hsl(none 100% 50%))", "red"],
+    ["color-mix(in hwb, red, blue)", "#f0f"],
+    ["color-mix(in hwb, hwb(120 0% 0% / 0.5), hwb(240 0% 0%))", "#00ffffc0"],
+  ])("%s still folds to %s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+});
+
 describe("conversions between color spaces", () => {
   // Each case converts a color whose channels all differ, so a channel landing
   // in another channel's place shows up in the output. Mixing a color with

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7633,138 +7633,122 @@ describe("css tests", () => {
     );
   });
 
-  // color-mix() in srgb, hsl or hwb folds to an 8-bit color, which can only hold colors inside
-  // the sRGB gamut. css-color-4 interpolates out-of-gamut channels as they are, so operands
-  // from a wider space can produce a result outside of it; that result is emitted as the
-  // color(srgb ...) value browsers compute (the value color(from <operand> srgb r g b) emits,
-  // with the fallbacks any color() gets) instead of being gamut mapped into a different 8-bit
-  // color. Browsers clip it per channel when painting to an sRGB screen.
-  //
-  // The srgb-linear operands convert to srgb exactly (12.92 * channel is the linear segment
-  // of the transfer function: -0.003 is -0.03876, -0.001 is -0.01292), so those expectations
-  // are exact strings. display-p3 and lab() go through pow() and are compared numerically.
-  describe("color-mix() results outside the sRGB gamut", () => {
+  // color-mix() in srgb (and hsl/hwb) folds to an 8-bit color. css-color-4 interpolates
+  // out-of-gamut channels as they are, so wide-gamut operands can leave the result outside the
+  // sRGB gamut; browsers paint such a result by clipping each channel, and the fold clips too.
+  // It used to gamut map the result (the chroma reduction used for the #rrggbb fallback of a
+  // wide-gamut color), which is a different color: #00f942 for display-p3 green, plain white
+  // for the bright magentas below. The display-p3 green, lab() and oklch() operands are the ones
+  // of WPT css/css-color/parsing/color-mix-out-of-gamut.html; the expected colors are the
+  // computed values it lists (color(srgb 1.59343 0.58802 1.40564) for lab(100% 104.3 -50.9))
+  // clipped to 8 bits. The other unclipped results are noted inline.
+  describe("color-mix() results outside the sRGB gamut are clipped", () => {
+    // color(display-p3 0 1 0) is color(srgb -0.5116 1.0183 -0.3107).
     minify_test(
-      ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.003 1 0)) }",
-      ".foo{color:color(srgb -.03876 1 0)}",
+      ".foo { color: color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0)) }",
+      ".foo{color:#0f0}",
+    );
+    minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0) 100%, red) }", ".foo{color:#0f0}");
+    minify_test(
+      ".foo { color: color-mix(in srgb, color(display-p3 0 1 0 / 0.5), color(display-p3 0 1 0 / 0.5)) }",
+      ".foo{color:#00ff0080}",
+    );
+    // color(srgb 1 1 -0.346) and color(srgb 1.093 -0.227 -0.150); used to be #fdfe00 and #ff0f0e.
+    minify_test(
+      ".foo { color: color-mix(in srgb, color(display-p3 1 1 0), color(display-p3 1 1 0)) }",
+      ".foo{color:#ff0}",
     );
     minify_test(
-      ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.001 1 0)) }",
-      ".foo{color:color(srgb -.02584 1 0)}",
+      ".foo { color: color-mix(in srgb, color(display-p3 1 0 0), color(display-p3 1 0 0)) }",
+      ".foo{color:red}",
+    );
+    // color(srgb 1.593 0.359 1.386) and color(srgb 1.593 0.588 1.406): the oklch lightness of these
+    // is above 1, which the gamut mapping turned into plain white.
+    minify_test(
+      ".foo { color: color-mix(in srgb, oklch(100% 0.399 336.3), oklch(100% 0.399 336.3)) }",
+      ".foo{color:#ff5bff}",
+    );
+    minify_test(".foo { color: color-mix(in srgb, oklch(100% 0.399 336.3) 80%, white) }", ".foo{color:#ff7cff}");
+    minify_test(".foo { color: color-mix(in srgb, oklch(100% 0.399 336.3) 50%, white) }", ".foo{color:#ffadff}");
+    minify_test(
+      ".foo { color: color-mix(in srgb, lab(100% 104.3 -50.9), lab(100% 104.3 -50.9)) }",
+      ".foo{color:#ff96ff}",
+    );
+    minify_test(".foo { color: color-mix(in srgb, lab(100% 104.3 -50.9), red) }", ".foo{color:#ff4bb3}");
+    // color(srgb 0.351 -0.214 0.300); used to be #2a0022.
+    minify_test(".foo { color: color-mix(in srgb, lab(0% 104.3 -50.9), lab(0% 104.3 -50.9)) }", ".foo{color:#5a004c}");
+    // color(srgb -1.207 1.316 -0.489); used to be #a7ffc3 and #d5ffd4.
+    minify_test(".foo { color: color-mix(in srgb, color(xyz 0 1 0) 75%, lime) }", ".foo{color:#0f0}");
+    minify_test(".foo { color: color-mix(in srgb, color(xyz 0 1 0) 50%, white) }", ".foo{color:#00ff41}");
+    // color(srgb 0 1.194 0) and color(srgb 1.353 1.353 0); used to be #edffea and white.
+    minify_test(
+      ".foo { color: color-mix(in srgb, color(srgb-linear 0 1.5 0), color(srgb-linear 0 1.5 0)) }",
+      ".foo{color:#0f0}",
     );
     minify_test(
-      ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0) 25%, lime) }",
-      ".foo{color:color(srgb -.00969 1 0)}",
+      ".foo { color: color-mix(in srgb, color(srgb-linear 0 1.5 0 / 0.5), color(srgb-linear 0 1.5 0 / 0.5)) }",
+      ".foo{color:#00ff0080}",
     );
     minify_test(
-      ".foo { color: color-mix(in srgb, color(srgb-linear 0 0 -0.003), color(srgb-linear 0 0 0.001)) }",
-      ".foo{color:color(srgb 0 0 -.01292)}",
+      ".foo { color: color-mix(in srgb, color(srgb-linear 2 2 0), color(srgb-linear 2 2 0)) }",
+      ".foo{color:#ff0}",
     );
     minify_test(
-      ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0 / 0.5), color(srgb-linear -0.003 1 0 / 0.5)) }",
-      ".foo{color:color(srgb -.03876 1 0/.5)}",
+      ".foo { color: color-mix(in srgb, light-dark(color(display-p3 0 1 0), red), light-dark(color(display-p3 0 1 0), blue)) }",
+      ".foo{color:light-dark(#0f0,purple)}",
     );
     minify_test(
-      ".foo { color: color-mix(in srgb, light-dark(color(srgb-linear -0.003 1 0), red), light-dark(color(srgb-linear -0.003 1 0), blue)) }",
-      ".foo{color:light-dark(color(srgb -.03876 1 0),purple)}",
+      ".foo { background: linear-gradient(color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0)), red) }",
+      ".foo{background:linear-gradient(#0f0,red)}",
     );
+    // The inner mix is folded to 8 bits before the outer one uses it, as an in-gamut inner mix is
+    // too; browsers mix the unclipped inner result and get rgb(0, 130, 0) here.
     minify_test(
-      ".foo { background: linear-gradient(color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.003 1 0)), red) }",
-      ".foo{background:linear-gradient(color(srgb -.03876 1 0),red)}",
+      ".foo { color: color-mix(in srgb, color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0)), black) }",
+      ".foo{color:green}",
     );
-    // The same value written out by hand.
-    minify_test(".foo { color: color(srgb -0.03876 1 0) }", ".foo{color:color(srgb -.03876 1 0)}");
-
-    const srgbChannels = (source: string) => {
-      const output = minify_test_with_options(source, "");
-      expect(output).toStartWith(".foo{color:color(srgb ");
-      return output.slice(".foo{color:color(srgb ".length, -")}".length).split(/\/| /).map(Number);
-    };
-    const expectSrgb = (source: string, expected: number[]) => {
-      const actual = srgbChannels(source);
-      expect(actual).toHaveLength(expected.length);
-      for (let i = 0; i < expected.length; i++) {
-        expect(actual[i]).toBeCloseTo(expected[i], 3);
+    // The fold is still one 8-bit declaration, whatever the targets are.
+    prefix_test(
+      ".foo { color: color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0)) }",
+      `.foo {
+        color: #0f0;
       }
-    };
+      `,
+      { chrome: Some(90 << 16) },
+    );
+    prefix_test(
+      ".foo { color: color-mix(in srgb, light-dark(color(display-p3 0 1 0), red), light-dark(color(display-p3 0 1 0), blue)) }",
+      `.foo {
+        color: var(--buncss-light, #0f0) var(--buncss-dark, purple);
+      }
+      `,
+      { chrome: Some(90 << 16) },
+    );
 
-    // References are the css-color-4 conversions in double precision. These used to fold to
-    // #00f942 (browsers paint the mix as #00ff00) and #ff9fbc (browsers: rgb(255, 75, 179)).
-    test("display-p3 green mixed with itself", () => {
-      expectSrgb(
-        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0)) }",
-        [-0.5116, 1.01827, -0.31067],
+    // The gamut mapping already clipped a result whose clipped color is within its just-noticeable
+    // difference, so results that are only slightly out of gamut fold to the same color as before.
+    // The oklch() operands are Tailwind v4 palette entries in the shape of its color-mix() fallback
+    // declarations.
+    describe("results inside or close to the gamut fold to the same color as before", () => {
+      minify_test(
+        ".foo { color: color-mix(in srgb, oklch(57.7% 0.245 27.325) 50%, transparent) }",
+        ".foo{color:#e7000b80}",
       );
-      expectSrgb(
-        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0 / 0.5), color(display-p3 0 1 0 / 0.5)) }",
-        [-0.5116, 1.01827, -0.31067, 0.5],
+      minify_test(
+        ".foo { color: color-mix(in srgb, oklch(69.6% 0.17 162.48) 30%, transparent) }",
+        ".foo{color:#00bc7d4d}",
       );
-    });
-    test("lab(100% 104.3 -50.9) mixed with red", () => {
-      expectSrgb(".foo { color: color-mix(in srgb, lab(100% 104.3 -50.9), red) }", [1.29675, 0.29388, 0.70277]);
-    });
-
-    describe("channels within conversion noise of the gamut are snapped onto it", () => {
+      minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0) 75%, white) }", ".foo{color:#00ff04}");
+      minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0) 25%, white) }", ".foo{color:#9fffab}");
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(display-p3 0 0 1), color(display-p3 0 0 1)) }",
+        ".foo{color:#00f}",
+      );
       // Converting this lab() red back to srgb leaves g and b around -1e-6.
       minify_test(
         ".foo { color: color-mix(in srgb, lab(54.2905% 80.8049 69.891), lab(54.2905% 80.8049 69.891)) }",
         ".foo{color:red}",
       );
-      // display-p3 blue is color(srgb 0 -2e-7 1.04202) and display-p3 yellow is
-      // color(srgb 1 1 -0.346268): the noise is dropped, the out-of-gamut channel is kept.
-      test("only the channels that are out of gamut keep their value", () => {
-        expect(
-          minify_test_with_options(
-            ".foo { color: color-mix(in srgb, color(display-p3 0 0 1), color(display-p3 0 0 1)) }",
-            "",
-          ),
-        ).toMatch(/^\.foo\{color:color\(srgb 0 0 1\.042\d*\)\}$/);
-        expect(
-          minify_test_with_options(
-            ".foo { color: color-mix(in srgb, color(display-p3 1 1 0), color(display-p3 1 1 0)) }",
-            "",
-          ),
-        ).toMatch(/^\.foo\{color:color\(srgb 1 1 -\.346\d*\)\}$/);
-      });
-      // 12.92 * -0.00001 = -0.0001292 is out of gamut; 12.92 * -0.000005 / 2 = -0.0000323 is noise.
-      minify_test(
-        ".foo { color: color-mix(in srgb, color(srgb-linear -0.00001 1 0), color(srgb-linear -0.00001 1 0)) }",
-        ".foo{color:color(srgb -.0001292 1 0)}",
-      );
-      minify_test(".foo { color: color-mix(in srgb, color(srgb-linear -0.000005 1 0), lime) }", ".foo{color:#0f0}");
-    });
-
-    describe("the result gets the fallbacks of a color() value", () => {
-      prefix_test(
-        ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.003 1 0)) }",
-        `.foo {
-          color: #0f0;
-          color: color(srgb -.03876 1 0);
-        }
-        `,
-        { chrome: Some(90 << 16) },
-      );
-      prefix_test(
-        ".foo { color: color-mix(in srgb, light-dark(color(srgb-linear -0.003 1 0), red), light-dark(color(srgb-linear -0.003 1 0), blue)) }",
-        `.foo {
-          color: var(--buncss-light, #0f0) var(--buncss-dark, purple);
-          color: var(--buncss-light, color(srgb -.03876 1 0)) var(--buncss-dark, purple);
-        }
-        `,
-        { chrome: Some(90 << 16) },
-      );
-      // Every browser with color-mix() has color(), so targets that have it get the value alone.
-      prefix_test(
-        ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.003 1 0)) }",
-        `.foo {
-          color: color(srgb -.03876 1 0);
-        }
-        `,
-        { chrome: Some(111 << 16) },
-      );
-    });
-
-    describe("results inside the gamut still fold to an 8-bit color", () => {
       minify_test(".foo { color: color-mix(in srgb, red, blue) }", ".foo{color:purple}");
       minify_test(".foo { color: color-mix(in srgb, red 25%, blue) }", ".foo{color:#4000bf}");
       minify_test(".foo { color: color-mix(in srgb, rgb(255 0 0 / 0.5), blue) }", ".foo{color:#5500aac0}");
@@ -7773,7 +7757,6 @@ describe("css tests", () => {
         ".foo { color: color-mix(in srgb, color(srgb-linear 1 0.2 0.001), color(srgb-linear 1 0.2 0.001)) }",
         ".foo{color:#ff7c03}",
       );
-      minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0) 0%, red) }", ".foo{color:red}");
       minify_test(".foo { color: color-mix(in hsl, red, blue) }", ".foo{color:#f0f}");
       minify_test(
         ".foo { color: color-mix(in hsl, hsl(120 100% 50% / 0.5), hsl(240 100% 50%)) }",
@@ -7782,14 +7765,10 @@ describe("css tests", () => {
       minify_test(".foo { color: color-mix(in hsl, hsl(none 100% 50%), hsl(none 100% 50%)) }", ".foo{color:red}");
       minify_test(".foo { color: color-mix(in hwb, red, blue) }", ".foo{color:#f0f}");
       minify_test(".foo { color: color-mix(in hwb, hwb(120 0% 0% / 0.5), hwb(240 0% 0%)) }", ".foo{color:#00ffffc0}");
-      prefix_test(
-        ".foo { color: color-mix(in srgb, red, blue) }",
-        `.foo {
-          color: purple;
-        }
-        `,
-        { chrome: Some(90 << 16) },
-      );
+      // rgb()/hsl()/hwb() with a none channel are printed through the same code.
+      minify_test(".foo { color: rgb(none 0 0) }", ".foo{color:#000}");
+      minify_test(".foo { color: hsl(none 100% 50%) }", ".foo{color:red}");
+      minify_test(".foo { color: hwb(120 none 0%) }", ".foo{color:#0f0}");
     });
   });
 

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7635,10 +7635,11 @@ describe("css tests", () => {
 
   // color-mix() in srgb (and hsl/hwb) folds to an 8-bit color. css-color-4 interpolates
   // out-of-gamut channels as they are, so wide-gamut operands can leave the result outside the
-  // sRGB gamut; browsers paint such a result by clipping each channel, and the fold clips too.
-  // It used to gamut map the result (the chroma reduction used for the #rrggbb fallback of a
-  // wide-gamut color), which is a different color: #00f942 for display-p3 green, plain white
-  // for the bright magentas below. The display-p3 green, lab() and oklch() operands are the ones
+  // sRGB gamut; an sRGB screen shows such a result with each channel clipped (a wider screen shows
+  // it as is, which an 8-bit fold cannot express), so the fold clips. It used to gamut map the
+  // result (the chroma reduction used for the #rrggbb fallback of a wide-gamut color), which is a
+  // different color on every screen: #00f942 for display-p3 green, plain white for the bright
+  // magentas below. The display-p3 green, lab() and oklch() operands are the ones
   // of WPT css/css-color/parsing/color-mix-out-of-gamut.html; the expected colors are the
   // computed values it lists (color(srgb 1.59343 0.58802 1.40564) for lab(100% 104.3 -50.9))
   // clipped to 8 bits. The other unclipped results are noted inline.

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7633,6 +7633,166 @@ describe("css tests", () => {
     );
   });
 
+  // color-mix() in srgb, hsl or hwb folds to an 8-bit color, which can only hold colors inside
+  // the sRGB gamut. css-color-4 interpolates out-of-gamut channels as they are, so operands
+  // from a wider space can produce a result outside of it; that result is emitted as the
+  // color(srgb ...) value browsers compute (the value color(from <operand> srgb r g b) emits,
+  // with the fallbacks any color() gets) instead of being gamut mapped into a different 8-bit
+  // color. Browsers clip it per channel when painting to an sRGB screen.
+  //
+  // The srgb-linear operands convert to srgb exactly (12.92 * channel is the linear segment
+  // of the transfer function: -0.003 is -0.03876, -0.001 is -0.01292), so those expectations
+  // are exact strings. display-p3 and lab() go through pow() and are compared numerically.
+  describe("color-mix() results outside the sRGB gamut", () => {
+    minify_test(
+      ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.003 1 0)) }",
+      ".foo{color:color(srgb -.03876 1 0)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.001 1 0)) }",
+      ".foo{color:color(srgb -.02584 1 0)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0) 25%, lime) }",
+      ".foo{color:color(srgb -.00969 1 0)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in srgb, color(srgb-linear 0 0 -0.003), color(srgb-linear 0 0 0.001)) }",
+      ".foo{color:color(srgb 0 0 -.01292)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0 / 0.5), color(srgb-linear -0.003 1 0 / 0.5)) }",
+      ".foo{color:color(srgb -.03876 1 0/.5)}",
+    );
+    minify_test(
+      ".foo { color: color-mix(in srgb, light-dark(color(srgb-linear -0.003 1 0), red), light-dark(color(srgb-linear -0.003 1 0), blue)) }",
+      ".foo{color:light-dark(color(srgb -.03876 1 0),purple)}",
+    );
+    minify_test(
+      ".foo { background: linear-gradient(color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.003 1 0)), red) }",
+      ".foo{background:linear-gradient(color(srgb -.03876 1 0),red)}",
+    );
+    // The same value written out by hand.
+    minify_test(".foo { color: color(srgb -0.03876 1 0) }", ".foo{color:color(srgb -.03876 1 0)}");
+
+    const srgbChannels = (source: string) => {
+      const output = minify_test_with_options(source, "");
+      expect(output).toStartWith(".foo{color:color(srgb ");
+      return output.slice(".foo{color:color(srgb ".length, -")}".length).split(/\/| /).map(Number);
+    };
+    const expectSrgb = (source: string, expected: number[]) => {
+      const actual = srgbChannels(source);
+      expect(actual).toHaveLength(expected.length);
+      for (let i = 0; i < expected.length; i++) {
+        expect(actual[i]).toBeCloseTo(expected[i], 3);
+      }
+    };
+
+    // References are the css-color-4 conversions in double precision. These used to fold to
+    // #00f942 (browsers paint the mix as #00ff00) and #ff9fbc (browsers: rgb(255, 75, 179)).
+    test("display-p3 green mixed with itself", () => {
+      expectSrgb(
+        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0)) }",
+        [-0.5116, 1.01827, -0.31067],
+      );
+      expectSrgb(
+        ".foo { color: color-mix(in srgb, color(display-p3 0 1 0 / 0.5), color(display-p3 0 1 0 / 0.5)) }",
+        [-0.5116, 1.01827, -0.31067, 0.5],
+      );
+    });
+    test("lab(100% 104.3 -50.9) mixed with red", () => {
+      expectSrgb(".foo { color: color-mix(in srgb, lab(100% 104.3 -50.9), red) }", [1.29675, 0.29388, 0.70277]);
+    });
+
+    describe("channels within conversion noise of the gamut are snapped onto it", () => {
+      // Converting this lab() red back to srgb leaves g and b around -1e-6.
+      minify_test(
+        ".foo { color: color-mix(in srgb, lab(54.2905% 80.8049 69.891), lab(54.2905% 80.8049 69.891)) }",
+        ".foo{color:red}",
+      );
+      // display-p3 blue is color(srgb 0 -2e-7 1.04202) and display-p3 yellow is
+      // color(srgb 1 1 -0.346268): the noise is dropped, the out-of-gamut channel is kept.
+      test("only the channels that are out of gamut keep their value", () => {
+        expect(
+          minify_test_with_options(
+            ".foo { color: color-mix(in srgb, color(display-p3 0 0 1), color(display-p3 0 0 1)) }",
+            "",
+          ),
+        ).toMatch(/^\.foo\{color:color\(srgb 0 0 1\.042\d*\)\}$/);
+        expect(
+          minify_test_with_options(
+            ".foo { color: color-mix(in srgb, color(display-p3 1 1 0), color(display-p3 1 1 0)) }",
+            "",
+          ),
+        ).toMatch(/^\.foo\{color:color\(srgb 1 1 -\.346\d*\)\}$/);
+      });
+      // 12.92 * -0.00001 = -0.0001292 is out of gamut; 12.92 * -0.000005 / 2 = -0.0000323 is noise.
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb-linear -0.00001 1 0), color(srgb-linear -0.00001 1 0)) }",
+        ".foo{color:color(srgb -.0001292 1 0)}",
+      );
+      minify_test(".foo { color: color-mix(in srgb, color(srgb-linear -0.000005 1 0), lime) }", ".foo{color:#0f0}");
+    });
+
+    describe("the result gets the fallbacks of a color() value", () => {
+      prefix_test(
+        ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.003 1 0)) }",
+        `.foo {
+          color: #0f0;
+          color: color(srgb -.03876 1 0);
+        }
+        `,
+        { chrome: Some(90 << 16) },
+      );
+      prefix_test(
+        ".foo { color: color-mix(in srgb, light-dark(color(srgb-linear -0.003 1 0), red), light-dark(color(srgb-linear -0.003 1 0), blue)) }",
+        `.foo {
+          color: var(--buncss-light, #0f0) var(--buncss-dark, purple);
+          color: var(--buncss-light, color(srgb -.03876 1 0)) var(--buncss-dark, purple);
+        }
+        `,
+        { chrome: Some(90 << 16) },
+      );
+      // Every browser with color-mix() has color(), so targets that have it get the value alone.
+      prefix_test(
+        ".foo { color: color-mix(in srgb, color(srgb-linear -0.003 1 0), color(srgb-linear -0.003 1 0)) }",
+        `.foo {
+          color: color(srgb -.03876 1 0);
+        }
+        `,
+        { chrome: Some(111 << 16) },
+      );
+    });
+
+    describe("results inside the gamut still fold to an 8-bit color", () => {
+      minify_test(".foo { color: color-mix(in srgb, red, blue) }", ".foo{color:purple}");
+      minify_test(".foo { color: color-mix(in srgb, red 25%, blue) }", ".foo{color:#4000bf}");
+      minify_test(".foo { color: color-mix(in srgb, rgb(255 0 0 / 0.5), blue) }", ".foo{color:#5500aac0}");
+      minify_test(".foo { color: color-mix(in srgb, rgb(none 0 0), rgb(none 0 0)) }", ".foo{color:#000}");
+      minify_test(
+        ".foo { color: color-mix(in srgb, color(srgb-linear 1 0.2 0.001), color(srgb-linear 1 0.2 0.001)) }",
+        ".foo{color:#ff7c03}",
+      );
+      minify_test(".foo { color: color-mix(in srgb, color(display-p3 0 1 0) 0%, red) }", ".foo{color:red}");
+      minify_test(".foo { color: color-mix(in hsl, red, blue) }", ".foo{color:#f0f}");
+      minify_test(
+        ".foo { color: color-mix(in hsl, hsl(120 100% 50% / 0.5), hsl(240 100% 50%)) }",
+        ".foo{color:#00ffffc0}",
+      );
+      minify_test(".foo { color: color-mix(in hsl, hsl(none 100% 50%), hsl(none 100% 50%)) }", ".foo{color:red}");
+      minify_test(".foo { color: color-mix(in hwb, red, blue) }", ".foo{color:#f0f}");
+      minify_test(".foo { color: color-mix(in hwb, hwb(120 0% 0% / 0.5), hwb(240 0% 0%)) }", ".foo{color:#00ffffc0}");
+      prefix_test(
+        ".foo { color: color-mix(in srgb, red, blue) }",
+        `.foo {
+          color: purple;
+        }
+        `,
+        { chrome: Some(90 << 16) },
+      );
+    });
+  });
+
   describe("font-palette-values", () => {
     minify_test(
       "@font-palette-values --x{font-family:Foo;base-palette:2}",


### PR DESCRIPTION
### Problem
- `color-mix(in srgb, ...)` is folded to an 8-bit color at build time (CSS bundler, `Bun.build`, `Bun.color()`). When the mix lands outside the sRGB gamut, the folded color is not the one browsers paint: `color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0))` folds to `#00f942`, browsers compute `color(srgb -0.51 1.02 -0.31)` and paint `#00ff00`; `color-mix(in srgb, oklch(100% 0.399 336.3), oklch(100% 0.399 336.3))` folds to plain white, browsers paint `rgb(255, 91, 255)`; `color-mix(in srgb, lab(100% 104.3 -50.9), red)` folds to `#ff9fbc`, browsers paint `rgb(255, 75, 179)`. Same on the 1.4.0 release, main and lightningcss 1.30.
- Cause: the `into_css` closure of `SRGB` in `src/css/values/color.rs` (`HSL`/`HWB` reach the same code through `RGBA::from`) serializes the interpolation result with `SRGB::into_rgba`, i.e. `resolve()` -> `map_gamut`: the css-color-4 section 13 chroma reduction (plus its "oklch lightness >= 1 is white" shortcut) that the bundler uses to derive the `#rrggbb` fallback of a wide-gamut color. css-color-4 interpolates out-of-gamut channels as they are, and browsers clip the result per channel when painting (WPT `css/css-color/parsing/color-mix-out-of-gamut.html` lists the unclipped computed values for these operands), so the fold and the browser disagree whenever the clipped and the mapped color differ.
- This is the `color-mix()` side of what Jarred asked for in the review of #33047 (his third option there, clipping, is the one a fold that stays an 8-bit value can take); #39261 is the relative-color side and leaves this path alone.

### Fix
- The `SRGB` `into_css` closure clips the result (`resolve_missing().clip()`, then `RGBA::from_floats`) instead of calling `into_rgba()`. The `HSL` and `HWB` closures go through it too; their results are always in gamut today because operands are clamped on the way in, so this only makes the three closures share the rule.
- Why clipping is the right value: the fold replaces the declaration, so it has to be the color the browser would have painted, and on an sRGB screen that is the per-channel clip; gamut mapping is only appropriate for the fallback declaration the bundler emits in front of a value the browser renders itself (`to_rgb` / `SRGB::into_rgba`, unchanged here). The fold stays one 8-bit declaration, so nothing changes in output size, targets handling or the typed `Bun.color()` formats.
- What the 8-bit fold gives up, deliberately: on a wide-gamut screen a browser shows the unbundled result as is (more saturated than any 8-bit sRGB color), and a fold to hex cannot express that; it could not before this PR either, and the mapped color was wrong on every screen. Keeping the exact value instead (the first revision of this PR, below) costs three declarations for every slightly out-of-gamut mix, which is what the Tailwind palette produces in bulk, for a color whose 8-bit value does not change; folding `color-mix()` to an 8-bit value is the existing contract of this fold (it is also what lightningcss does), and clipping is the value of that contract that matches the browser. Authors who want the wide-gamut result keep it by mixing in a space the fold prints exactly (`in oklab`, `in srgb-linear`, ...) or by using `var()` operands, which are never folded.
- What changes and what does not: in-gamut results take the same `from_floats` path as before and are byte-identical. `map_gamut` already returned the clip whenever the clipped color was within its just-noticeable difference, so results that are only slightly out of gamut are byte-identical too; this includes Tailwind v4's `color-mix(in srgb, oklch(...) N%, transparent)` fallback declarations, which are the common real-world input here: a project built through `bun-plugin-tailwind` produces identical CSS before and after (checked with tailwindcss 4.x, five utilities with opacity modifiers). Only results far enough out of gamut that the chroma reduction kicked in change, and they change to the clip of the exact result. Of 1057 distinct generated `color-mix()` inputs across srgb/hsl/hwb/lab spaces, 3 change, all with a `lab()` operand (`#e5fcff1f` -> `#d0ffff1f` for a result of `color(srgb .815 1.005 1.110 / .12)`, etc.); the 15 stylesheets under `test/js/bun/css/files/` bundle byte-identically.
- A mix nested in another mix is folded to 8 bits before the outer mix uses it, as an in-gamut inner mix already is, so `color-mix(in srgb, color-mix(in srgb, <p3 green>, <p3 green>), black)` gives `#008000` where a browser, mixing the unclipped inner value, gets `rgb(0, 130, 0)`; pinned in the tests as a known limit of folding.
- Not changed here: converting an operand into hsl or hwb still gamut maps it (`From<SRGB> for HSL`/`HWB` call `resolve()`, as lightningcss does), so `color-mix(in hsl, color(display-p3 0 1 0), ...)` still folds to `#00f942`; that is an operand-side question like the ones #38508 handles and is filed separately. #38508 itself changes other lines of `interpolate`; its two tests asserting that the result "is still gamut mapped" (`#fff`, `#ff8886`) become `#0f0` and `#ff8080` once both land.
- Verified: `test/js/bun/css/css.test.ts` ("color-mix() results outside the sRGB gamut are clipped": 40 cases, 21 fail on the unfixed build) and `test/js/bun/css/color.test.ts` (same name: 37 cases, 19 fail unfixed, including one asserting that `{rgb}`, `[rgba]`, `hex`, `number`, `ansi-16m` and `hsl` all return the clipped color). The expected values for the WPT operands are the computed values that file lists, clipped; the cases that must not change pin the Tailwind-shaped inputs, slightly out-of-gamut mixes, a boundary color converted from `lab()`, in-gamut srgb/hsl/hwb mixes, `none` channels and the chrome 90 targets output (still one declaration). Full `css.test.ts` + `color.test.ts` (2256 pass), `test/bundler/css/wpt/`, the css regression tests and `doesnt_crash.test.ts` pass with the debug build; `cargo fmt` and `cargo clippy -p bun_css` are clean.

### Background
- `color-mix(in X, a, b)` converts both operands into space X, interpolates per channel and yields a color in X. `CssColor::interpolate` does this generically and calls `Colorspace::into_css_color` on the result; for srgb that is the `into_css` closure in the `define_colorspace!` invocation for `SRGB`. The same closure prints `CssColor::Float` (an `rgb()`/`hsl()`/`hwb()` with a `none` channel, always in gamut).
- Gamut: the colors a space can express. `#rrggbb`, `rgb()`, `hsl()` and `hwb()` hold 8-bit sRGB; `color(display-p3 ...)`, `lab()`, `oklch()`, `color(srgb-linear ...)` can hold colors outside it, and a mix in srgb of such colors is a set of srgb channels outside 0..1. Clipping clamps each channel; gamut mapping (`map_gamut`, css-color-4 section 13) searches for a nearby in-gamut color by reducing chroma (keeping lightness, which is why a bright out-of-gamut magenta maps to white). Browsers clip when painting to an sRGB screen. The bundler uses gamut mapping for the `#rrggbb` fallback it writes in front of a wide-gamut value for browsers that cannot parse that value; a fold has no such value behind it.

<details>
<summary>Before / after (Bun.color(input, "css"); the bundler emits the same values)</summary>

```
input                                                                              main       this PR    unclipped result
color-mix(in srgb, color(display-p3 0 1 0), color(display-p3 0 1 0))               #00f942    #0f0       color(srgb -.5116 1.0183 -.3107)
color-mix(in srgb, color(display-p3 1 1 0), color(display-p3 1 1 0))               #fdfe00    #ff0       color(srgb 1 1 -.3463)
color-mix(in srgb, color(display-p3 1 0 0), color(display-p3 1 0 0))               #ff0f0e    red        color(srgb 1.0931 -.2267 -.1501)
color-mix(in srgb, oklch(100% 0.399 336.3), oklch(100% 0.399 336.3))               #fff       #ff5bff    color(srgb 1.5933 .3586 1.3865)
color-mix(in srgb, oklch(100% 0.399 336.3) 50%, white)                             #ffe2ff    #ffadff
color-mix(in srgb, lab(100% 104.3 -50.9), lab(100% 104.3 -50.9))                   #fff       #ff96ff    color(srgb 1.5935 .5878 1.4056)
color-mix(in srgb, lab(100% 104.3 -50.9), red)                                     #ff9fbc    #ff4bb3    color(srgb 1.2968 .2939 .7028)
color-mix(in srgb, lab(0% 104.3 -50.9), lab(0% 104.3 -50.9))                       #2a0022    #5a004c    color(srgb .3514 -.2139 .2995)
color-mix(in srgb, color(xyz 0 1 0) 50%, white)                                    #d5ffd4    #00ff41
color-mix(in srgb, color(srgb-linear 0 1.5 0), color(srgb-linear 0 1.5 0))         #edffea    #0f0       color(srgb 0 1.1942 0)
color-mix(in srgb, color(display-p3 0 1 0 / 0.5), color(display-p3 0 1 0 / 0.5))   #00f94280  #00ff0080
color-mix(in srgb, oklch(57.7% 0.245 27.325) 50%, transparent)   (Tailwind red-600/50)   #e7000b80  #e7000b80  color(srgb .9065 -.0959 .0422)
color-mix(in srgb, oklch(69.6% 0.17 162.48) 30%, transparent)    (emerald-500/30)        #00bc7d4d  #00bc7d4d  color(srgb -.2167 .7388 .4893)
color-mix(in srgb, color(display-p3 0 1 0) 25%, white)                             #9fffab    #9fffab
color-mix(in srgb, lab(54.2905% 80.8049 69.891), lab(54.2905% 80.8049 69.891))     red        red        (g, b about -1e-6)
color-mix(in srgb, red, blue)                                                      purple     purple
```
</details>

<details>
<summary>Earlier revision of this PR</summary>

The first revision emitted an out-of-gamut result as the exact `color(srgb ...)` value (a `CssColor::Predefined`) and only folded in-gamut results to hex. Reviewing it showed that this tripled the declarations the bundler emits for the Tailwind fallback declarations above without changing their 8-bit value (`#e7000b80` plus a `display-p3` and a `color(srgb ...)` line), made the typed `Bun.color()` formats return a string for such a mix until #38488 lands, and exposed the `--1e-7` printer bug (#38516) in the derived `display-p3` line. Clipping has none of those costs and gives the same painted color, so the PR was reworked to it; the wide-gamut fidelity the exact value would have kept is the only thing given up.
</details>
