### PR TITLE
Lint the RedisClient class in redis.d.ts against the valkey.classes.ts tables

### DIFF
--- a/.github/workflows/source-lints.yml
+++ b/.github/workflows/source-lints.yml
@@ -13,7 +13,10 @@ on:
     branches: [main]
     paths:
       - "src/**/*.rs"
+      - "src/**/*.classes.ts"
+      - "src/codegen/class-definitions.ts"
       - "src/jsc/bindings/**"
+      - "packages/bun-types/redis.d.ts"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
       - "scripts/utils.mjs"
@@ -28,7 +31,10 @@ on:
   pull_request:
     paths:
       - "src/**/*.rs"
+      - "src/**/*.classes.ts"
+      - "src/codegen/class-definitions.ts"
       - "src/jsc/bindings/**"
+      - "packages/bun-types/redis.d.ts"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
       - "scripts/utils.mjs"

--- a/src/runtime/valkey_jsc/valkey.classes.ts
+++ b/src/runtime/valkey_jsc/valkey.classes.ts
@@ -12,6 +12,8 @@ export default [
     configurable: false,
     JSType: "0b11101110",
     memoryCost: true,
+    // Every member here needs a declaration in packages/bun-types/redis.d.ts;
+    // test/internal/source-lints/redis-client-types.test.ts checks the two match.
     proto: {
       connected: {
         getter: "getConnected",

--- a/test/internal/source-lints/README.md
+++ b/test/internal/source-lints/README.md
@@ -16,4 +16,9 @@ The workflow runs on a bare checkout (no `bun install`), so tests here may
 only import built-ins, relative paths, and `harness` (resolved via
 `test/tsconfig.json` paths).
 
+The workflow only triggers for the `paths:` listed in it. A lint that reads
+files outside those paths (for example `packages/bun-types/bun.d.ts` or the
+docs) needs them added there, or a change to those files is only checked by
+whichever later PR happens to trigger the workflow.
+
 To run locally: `bun test test/internal/source-lints/`.

--- a/test/internal/source-lints/redis-client-types.test.ts
+++ b/test/internal/source-lints/redis-client-types.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import valkeyClasses from "../../../src/runtime/valkey_jsc/valkey.classes.ts";
+
+// `class RedisClient` in packages/bun-types/redis.d.ts is a hand-written mirror
+// of the `proto` table in src/runtime/valkey_jsc/valkey.classes.ts, which is
+// what the class codegen installs on RedisClient.prototype. Nothing else
+// compares the two: five commands registered by the first Bun.redis commit were
+// still undeclared fourteen redis.d.ts commits later, so calling them works at
+// runtime and fails to type-check. This lint loads the same module the codegen
+// loads and requires the class body to declare exactly the members the tables
+// install.
+
+// Registered members that are not declared yet, each with the open PR that
+// declares it. Delete the entry when that PR lands: the lint fails while a name
+// listed here is declared (or is no longer registered).
+const pendingDeclarations: Record<string, string> = {
+  pubsub: "#39208",
+  select: "#39208",
+  script: "#29339",
+  // Not usable until #35521 lands: psubscribe() takes no listener today, so
+  // every pmessage the server sends is dropped.
+  psubscribe: "#35521",
+  punsubscribe: "#35521",
+};
+
+const classesFile = "src/runtime/valkey_jsc/valkey.classes.ts";
+const dtsFile = "packages/bun-types/redis.d.ts";
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+const definition = valkeyClasses.find(c => c.name === "RedisClient");
+if (definition === undefined) throw new Error(`${classesFile} no longer defines RedisClient`);
+
+// Every member the codegen installs: prototype members by name, `klass` (static)
+// members as "static name". A well-known symbol stays in the table's `@@x`
+// spelling; parseClassBody maps the class body's `[Symbol.x]` onto it.
+const registered = new Set<string>();
+for (const [table, prefix] of [
+  [definition.proto, ""],
+  [definition.klass, "static "],
+] as const) {
+  for (const [name, field] of Object.entries(table)) {
+    // Installed under a private name or a Symbol.for() symbol, or (internal)
+    // not installed at all; none of these has a declaration to mirror.
+    if ("internal" in field || "privateSymbol" in field || "publicSymbol" in field) continue;
+    registered.add(prefix + name);
+  }
+}
+if (definition.construct) registered.add("constructor");
+
+const { declared, unrecognized } = parseClassBody(readFileSync(path.join(root, dtsFile), "utf8"));
+
+function parseClassBody(dts: string): { declared: Set<string>; unrecognized: string[] } {
+  const open = /^  export class RedisClient \{$/m.exec(dts);
+  if (open === null) throw new Error(`${dtsFile} no longer declares \`export class RedisClient {\``);
+  const bodyStart = open.index + open[0].length;
+  const bodyEnd = dts.indexOf("\n  }\n", bodyStart);
+  if (bodyEnd === -1) throw new Error(`${dtsFile}: unterminated class RedisClient body`);
+
+  const body = dts
+    .slice(bodyStart, bodyEnd)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^[ \t]*\/\/.*$/gm, "");
+
+  const declared = new Set<string>();
+  const unrecognized: string[] = [];
+  // Members start at the class body's four-space indent. The only other lines
+  // at that indent are the `): ...;` closers of multi-line signatures, which
+  // start with punctuation, so everything else at that indent is a member and
+  // has to parse: a declaration shape this does not know is reported rather
+  // than skipped.
+  const member = /^(static )?(?:readonly )?(?:(?:get|set) )?(?:\[Symbol\.(\w+)\]|([A-Za-z_$][\w$]*))\s*\??\s*[(:<]/;
+  for (const [line] of body.matchAll(/^    [^\s)\]}>].*$/gm)) {
+    const m = member.exec(line.slice(4));
+    if (m === null) {
+      unrecognized.push(line.trim());
+      continue;
+    }
+    const name = m[2] !== undefined ? `@@${m[2]}` : m[3];
+    declared.add((m[1] ?? "") + name);
+  }
+  return { declared, unrecognized };
+}
+
+test(`every member of class RedisClient in ${dtsFile} has a shape this lint can read`, () => {
+  expect(unrecognized).toEqual([]);
+});
+
+test(`${dtsFile} declares every RedisClient member ${classesFile} installs`, () => {
+  const undeclared = [...registered]
+    .filter(name => !declared.has(name) && !Object.hasOwn(pendingDeclarations, name))
+    .sort();
+  expect(undeclared).toEqual([]);
+});
+
+test(`${dtsFile} declares no RedisClient member ${classesFile} does not install`, () => {
+  const phantom = [...declared].filter(name => !registered.has(name)).sort();
+  expect(phantom).toEqual([]);
+});
+
+test("pendingDeclarations lists only members that are still registered and still undeclared", () => {
+  const stale = Object.entries(pendingDeclarations)
+    .flatMap(([name, pr]) => {
+      if (!registered.has(name)) return [`${name} (${pr}) is no longer registered in ${classesFile}`];
+      if (declared.has(name)) return [`${name} (${pr}) is declared in ${dtsFile} now; delete its entry`];
+      return [];
+    })
+    .sort();
+  expect(stale).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- `class RedisClient` in `packages/bun-types/redis.d.ts` is a hand-written copy of the `proto` table in `src/runtime/valkey_jsc/valkey.classes.ts`, and nothing compares the two. A command added to the table and not to the d.ts works at runtime and fails to type-check (`Property 'pubsub' does not exist on type 'RedisClient'`).
- On main, 5 of the 167 table entries are undeclared: `psubscribe`, `pubsub`, `punsubscribe`, `script`, `select`. All five have been registered since the commit that introduced `Bun.redis` (ec87a27d87, #18812) and stayed undeclared through the 14 redis.d.ts commits since, including the 614-line batch in #23116, so the gap is systematic rather than a one-off.
- Each of the five is already being declared by an open PR: `pubsub` and `select` by #39208, `script` by #29339, `psubscribe`/`punsubscribe` by #35521 (which also adds the listener routing they are missing; today `psubscribe()` drops every pmessage). This PR adds the check, not the declarations.

### Fix
- `test/internal/source-lints/redis-client-types.test.ts` imports `valkey.classes.ts` (the module the codegen reads; `class-definitions.ts` has no dependencies), collects the members the codegen installs (`proto` entries by name, `klass` entries as `static name`, `constructor` when `construct` is set, skipping `internal`/`privateSymbol`/`publicSymbol` entries, which the codegen does not install under an identifier), parses the member names declared in the `class RedisClient` body of `redis.d.ts` (`[Symbol.x]` maps onto the table's `@@x` spelling), and requires the two sets to be equal. Each direction is its own test, so a table entry without a declaration and a declaration without a table entry are both reported by name.
- The five names missing today sit in a `pendingDeclarations` table keyed by the PR that declares each. A fourth test fails as soon as a listed name is declared or unregistered, so the entry gets deleted when its PR lands (whichever of this PR and #39208/#29339/#35521 lands second trips it on rebase, and the message says which entry to delete). A name that is neither declared nor listed fails the lint outright.
- Declaration lines the parser does not recognize are reported as failures rather than skipped, so a new d.ts shape cannot silently hide a member from the comparison.
- `.github/workflows/source-lints.yml` gains `src/**/*.classes.ts`, `src/codegen/class-definitions.ts` and `packages/bun-types/redis.d.ts` as triggers: the workflow is path-filtered and those are the files this lint reads, so without them the edits it guards would not run it. The directory README now states that rule; a comment on the `proto` table points at the lint.
- Scope is RedisClient only. A checker for every `*.classes.ts` needs a class-to-declaration mapping and inheritance handling and is a separate project.
- Verified:
  - `bun test test/internal/source-lints/redis-client-types.test.ts` passes on this branch (4 tests); the whole directory is 170 green.
  - With `pendingDeclarations` emptied, the lint fails against main's files naming exactly `psubscribe`, `pubsub`, `punsubscribe`, `script`, `select` (output below).
  - Simulated the eight drift shapes in the details block (new table entry, pending name declared, phantom declaration, pending name unregistered, unparseable member, `@@asyncDispose` + a `klass` entry with and without declarations, `internal`/`privateSymbol` entries); each fails the intended test or passes as intended.
- No runtime code changes: the `valkey.classes.ts` hunk is a comment and produces identical codegen output. This PR has no src/packages diff for a fail-before run to strip; the fail-before evidence is the emptied-pending-table run above.

### Background
- `*.classes.ts` files are the input of `src/codegen/generate-classes.ts`. `define({ proto, klass, construct })` describes a native class: `proto` entries become properties of the prototype (`fn` methods, `getter`/`setter` accessors), `klass` entries become statics, and `construct: true` makes it newable. Entries with `internal`, `privateSymbol` or `publicSymbol` are installed under private names or `Symbol.for()` symbols (or not at all), and keys spelled `@@x` are installed under the well-known symbol `Symbol.x`.
- `packages/bun-types` is the published `@types/bun` surface; it is hand-written, not generated from the class definitions, which is why it can drift.
- `test/internal/source-lints/` holds tests that only read the source tree; `.buildkite/ci.mjs` excludes the directory from the binary lanes and `source-lints.yml` runs it against a released bun on a bare checkout, so tests there may only import built-ins and relative paths.

<details>
<summary>Lint output against main's files with the pending table emptied, and the simulated drift shapes</summary>

```
(pass) every member of class RedisClient in packages/bun-types/redis.d.ts has a shape this lint can read
(fail) packages/bun-types/redis.d.ts declares every RedisClient member src/runtime/valkey_jsc/valkey.classes.ts installs
    - []
    + [
    +   "psubscribe",
    +   "pubsub",
    +   "punsubscribe",
    +   "script",
    +   "select",
    + ]
(pass) packages/bun-types/redis.d.ts declares no RedisClient member src/runtime/valkey_jsc/valkey.classes.ts does not install
(pass) pendingDeclarations lists only members that are still registered and still undeclared
```

```
### proto gains waitaof, d.ts untouched
    +   "waitaof",
    (fail) packages/bun-types/redis.d.ts declares every RedisClient member src/runtime/valkey_jsc/valkey.classes.ts installs
### d.ts declares select while it is still pending
    +   "select (#39208) is declared in packages/bun-types/redis.d.ts now; delete its entry",
    (fail) pendingDeclarations lists only members that are still registered and still undeclared
### d.ts declares flushall, which is not registered
    +   "flushall",
    (fail) packages/bun-types/redis.d.ts declares no RedisClient member src/runtime/valkey_jsc/valkey.classes.ts does not install
### proto drops script while it is still pending
    +   "script (#29339) is no longer registered in src/runtime/valkey_jsc/valkey.classes.ts",
    (fail) pendingDeclarations lists only members that are still registered and still undeclared
### d.ts gains `private brand: never;`
    +   "private brand: never;",
    (fail) every member of class RedisClient in packages/bun-types/redis.d.ts has a shape this lint can read
### proto gains "@@asyncDispose" and a klass entry, d.ts declares [Symbol.asyncDispose]() and the static
    4 pass
### same, with nothing declared
    +   "@@asyncDispose",
    +   "static parseURL",
    (fail) packages/bun-types/redis.d.ts declares every RedisClient member src/runtime/valkey_jsc/valkey.classes.ts installs
### proto gains an `internal: true` entry and a `privateSymbol` entry, d.ts untouched
    4 pass
```

</details>
