### PR TITLE
fs.promises: forward options.signal from the FileHandle wrappers and validate it for iterable data

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -457,17 +457,20 @@ function asyncWrap(fn: any, name: string) {
       throwEBADFIfNecessary("writeFile", fd);
       let encoding = "utf8";
       let flush = false;
+      let signal: AbortSignal | undefined = undefined;
       if (options == null || typeof options === "function") {
       } else if (typeof options === "string") {
         encoding = options;
       } else {
         encoding = options?.encoding ?? encoding;
         flush = options?.flush ?? flush;
+        signal = options?.signal;
+        validateAbortSignal(signal, "options.signal");
       }
 
       try {
         this[kRef]();
-        return await writeFile(fd, data, { encoding, flush, flag: this[kFlag] });
+        return await writeFile(fd, data, { encoding, flush, flag: this[kFlag], signal });
       } finally {
         this[kUnref]();
       }
@@ -691,7 +694,8 @@ function asyncWrap(fn: any, name: string) {
         encoding = options;
       } else {
         encoding = options?.encoding ?? encoding;
-        signal = options?.signal ?? undefined;
+        signal = options?.signal;
+        validateAbortSignal(signal, "options.signal");
       }
 
       try {

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -457,7 +457,7 @@ function asyncWrap(fn: any, name: string) {
       throwEBADFIfNecessary("writeFile", fd);
       let encoding = "utf8";
       let flush = false;
-      let signal: AbortSignal | undefined = undefined;
+      let signal;
       if (options == null || typeof options === "function") {
       } else if (typeof options === "string") {
         encoding = options;
@@ -465,7 +465,6 @@ function asyncWrap(fn: any, name: string) {
         encoding = options?.encoding ?? encoding;
         flush = options?.flush ?? flush;
         signal = options?.signal;
-        validateAbortSignal(signal, "options.signal");
       }
 
       try {
@@ -695,7 +694,6 @@ function asyncWrap(fn: any, name: string) {
       } else {
         encoding = options?.encoding ?? encoding;
         signal = options?.signal;
-        validateAbortSignal(signal, "options.signal");
       }
 
       try {
@@ -1571,7 +1569,7 @@ function throwEBADFIfNecessary(fn: string, fd) {
   }
 }
 
-async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: AbortSignal | null) {
+async function writeFileAsyncIteratorInner(fd, iterable, encoding, signal: AbortSignal | undefined) {
   const writer = Bun.file(fd).writer();
 
   const mustRencode = !(encoding === "utf8" || encoding === "utf-8" || encoding === "binary" || encoding === "buffer");
@@ -1612,15 +1610,12 @@ function flagTruncates(flag): boolean {
 
 async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, flag, mode) {
   let encoding;
-  let signal: AbortSignal | null = null;
+  let signal: AbortSignal | undefined;
   if (typeof optionsOrEncoding === "object") {
     encoding = optionsOrEncoding?.encoding ?? (encoding || "utf8");
     flag = optionsOrEncoding?.flag ?? (flag || "w");
     mode = optionsOrEncoding?.mode ?? (mode || 0o666);
-    signal = optionsOrEncoding?.signal ?? null;
-    if (signal?.aborted) {
-      throw $makeAbortError(undefined, { cause: signal.reason });
-    }
+    signal = optionsOrEncoding?.signal;
   } else if (typeof optionsOrEncoding === "string" || optionsOrEncoding == null) {
     encoding = optionsOrEncoding || "utf8";
     flag ??= "w";
@@ -1630,6 +1625,13 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
   if (!Buffer.isEncoding(encoding)) {
     // ERR_INVALID_OPT_VALUE_ENCODING was removed in Node v15.
     throw new TypeError(`Unknown encoding: ${encoding}`);
+  }
+
+  // The native binding validates this for string and Buffer data; iterables
+  // never reach it, so it has to happen here.
+  validateAbortSignal(signal, "options.signal");
+  if (signal?.aborted) {
+    throw $makeAbortError(undefined, { cause: signal.reason });
   }
 
   let mustClose = typeof fdOrPath === "string";

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -1627,8 +1627,6 @@ async function writeFileAsyncIterator(fdOrPath, iterable, optionsOrEncoding, fla
     throw new TypeError(`Unknown encoding: ${encoding}`);
   }
 
-  // The native binding validates this for string and Buffer data; iterables
-  // never reach it, so it has to happen here.
   validateAbortSignal(signal, "options.signal");
   if (signal?.aborted) {
     throw $makeAbortError(undefined, { cause: signal.reason });

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -550,4 +550,102 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     const writeErr = await new Promise(resolve => fs.writeFile(join(dir, "o.txt"), "x", { signal }, resolve));
     expectNodeAbortError(writeErr, signal.reason);
   });
+
+  // FileHandle#appendFile and FileHandle#writeFile rebuild the options they hand
+  // to writeFile(fd, ...); node's are both `writeFile(this, data, options)`, so
+  // the signal has to survive that.
+  test.each([
+    ["appendFile", "a"],
+    ["writeFile", "r+"],
+  ])("FileHandle#%s with a pre-aborted signal leaves the file alone", async (method, flags) => {
+    await using dir = tempDir(`fs-abort-filehandle-${method}`, { "f.txt": "seed" });
+    await using fh = await fsPromises.open(join(dir, "f.txt"), flags);
+    const signal = AbortSignal.abort();
+    expect.assertions(5);
+    try {
+      await fh[method]("data", { signal });
+    } catch (err) {
+      expectNodeAbortError(err, signal.reason);
+    }
+    expect(await fsPromises.readFile(join(dir, "f.txt"), "utf8")).toBe("seed");
+  });
+
+  test("FileHandle#appendFile of an async iterable aborted between chunks", async () => {
+    await using dir = tempDir("fs-abort-filehandle-appendfile-iter", { "f.txt": "seed" });
+    await using fh = await fsPromises.open(join(dir, "f.txt"), "a");
+    const ac = new AbortController();
+    expect.assertions(5);
+    try {
+      await fh.appendFile(
+        (async function* () {
+          yield "a";
+          ac.abort();
+          yield "b";
+        })(),
+        { signal: ac.signal },
+      );
+    } catch (err) {
+      expectNodeAbortError(err, ac.signal.reason);
+    }
+    expect(await fsPromises.readFile(join(dir, "f.txt"), "utf8")).toBe("seeda");
+  });
+
+  test("FileHandle#appendFile with a signal that never aborts appends", async () => {
+    await using dir = tempDir("fs-abort-filehandle-appendfile-live", { "f.txt": "seed" });
+    await using fh = await fsPromises.open(join(dir, "f.txt"), "a");
+    await fh.appendFile("data", { signal: new AbortController().signal });
+    expect(await fsPromises.readFile(join(dir, "f.txt"), "utf8")).toBe("seeddata");
+  });
+});
+
+// node validates options.signal in getOptions() before touching the file, for
+// any kind of data, and names it "options.signal".
+describe.concurrent("FileHandle#appendFile and FileHandle#writeFile validate options.signal", () => {
+  // The middle of the message ("of type" / "an instance of") comes from the
+  // shared ERR_INVALID_ARG_TYPE renderer, not from fs; don't pin it here.
+  function expectInvalidSignal(err, received) {
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(err.message).toStartWith('The "options.signal" property must be ');
+    expect(err.message).toEndWith(` AbortSignal. Received ${received}`);
+  }
+
+  const invalidSignals = [
+    [null, "null"],
+    [1, "type number (1)"],
+    ["", "type string ('')"],
+    [{}, "an instance of Object"],
+  ];
+
+  for (const method of ["appendFile", "writeFile"]) {
+    test.each(invalidSignals)(`FileHandle#${method}(string, { signal: %p }) rejects`, async (signal, received) => {
+      await using dir = tempDir(`fs-filehandle-${method}-bad-signal`, { "f.txt": "seed" });
+      await using fh = await fsPromises.open(join(dir, "f.txt"), "r+");
+      const err = await fh[method]("data", { signal }).then(
+        () => "resolved",
+        e => e,
+      );
+      expectInvalidSignal(err, received);
+      expect(await fsPromises.readFile(join(dir, "f.txt"), "utf8")).toBe("seed");
+    });
+
+    test(`FileHandle#${method}(asyncIterable, { signal: 1 }) rejects without pulling the iterable`, async () => {
+      await using dir = tempDir(`fs-filehandle-${method}-iter-bad-signal`, { "f.txt": "seed" });
+      await using fh = await fsPromises.open(join(dir, "f.txt"), "r+");
+      let pulled = false;
+      const err = await fh[method](
+        (async function* () {
+          pulled = true;
+          yield "data";
+        })(),
+        { signal: 1 },
+      ).then(
+        () => "resolved",
+        e => e,
+      );
+      expectInvalidSignal(err, "type number (1)");
+      expect(pulled).toBe(false);
+      expect(await fsPromises.readFile(join(dir, "f.txt"), "utf8")).toBe("seed");
+    });
+  }
 });

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -599,11 +599,30 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
 });
 
 // node validates options.signal in getOptions() before touching the file, for
-// any kind of data, and names it "options.signal".
-describe.concurrent("FileHandle#appendFile and FileHandle#writeFile validate options.signal", () => {
+// any kind of data. String and Buffer data get that from the native binding;
+// iterable data is written by writeFileAsyncIterator, which every entry point
+// below funnels into.
+describe.concurrent("options.signal is validated before anything is written", () => {
+  const settle = promise =>
+    promise.then(
+      () => "resolved",
+      e => e,
+    );
+
+  // String data: the wrapper used to drop the signal, so the binding never saw
+  // it. Only the code is pinned here; the wording belongs to the binding.
+  test("FileHandle#appendFile forwards the signal to the binding", async () => {
+    await using dir = tempDir("fs-filehandle-appendfile-bad-signal", { "f.txt": "seed" });
+    await using fh = await fsPromises.open(join(dir, "f.txt"), "a");
+    const err = await settle(fh.appendFile("data", { signal: 1 }));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(await fsPromises.readFile(join(dir, "f.txt"), "utf8")).toBe("seed");
+  });
+
   // The middle of the message ("of type" / "an instance of") comes from the
   // shared ERR_INVALID_ARG_TYPE renderer, not from fs; don't pin it here.
-  function expectInvalidSignal(err, received) {
+  function expectInvalidOptionsSignal(err, received) {
     expect(err).toBeInstanceOf(TypeError);
     expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
     expect(err.message).toStartWith('The "options.signal" property must be ');
@@ -617,35 +636,35 @@ describe.concurrent("FileHandle#appendFile and FileHandle#writeFile validate opt
     [{}, "an instance of Object"],
   ];
 
-  for (const method of ["appendFile", "writeFile"]) {
-    test.each(invalidSignals)(`FileHandle#${method}(string, { signal: %p }) rejects`, async (signal, received) => {
-      await using dir = tempDir(`fs-filehandle-${method}-bad-signal`, { "f.txt": "seed" });
-      await using fh = await fsPromises.open(join(dir, "f.txt"), "r+");
-      const err = await fh[method]("data", { signal }).then(
-        () => "resolved",
-        e => e,
-      );
-      expectInvalidSignal(err, received);
-      expect(await fsPromises.readFile(join(dir, "f.txt"), "utf8")).toBe("seed");
-    });
-
-    test(`FileHandle#${method}(asyncIterable, { signal: 1 }) rejects without pulling the iterable`, async () => {
-      await using dir = tempDir(`fs-filehandle-${method}-iter-bad-signal`, { "f.txt": "seed" });
-      await using fh = await fsPromises.open(join(dir, "f.txt"), "r+");
-      let pulled = false;
-      const err = await fh[method](
-        (async function* () {
+  describe.each([
+    [
+      "fsPromises.writeFile(path, iterable)",
+      (fh, path, iterable, options) => fsPromises.writeFile(path, iterable, options),
+    ],
+    [
+      "fsPromises.writeFile(fileHandle, iterable)",
+      (fh, path, iterable, options) => fsPromises.writeFile(fh, iterable, options),
+    ],
+    ["FileHandle#writeFile(iterable)", (fh, path, iterable, options) => fh.writeFile(iterable, options)],
+    ["FileHandle#appendFile(iterable)", (fh, path, iterable, options) => fh.appendFile(iterable, options)],
+  ])("%s", (_, write) => {
+    test.each(invalidSignals)(
+      "{ signal: %p } rejects without opening or pulling anything",
+      async (signal, received) => {
+        await using dir = tempDir("fs-iterable-bad-signal", { "f.txt": "seed" });
+        const path = join(dir, "f.txt");
+        await using fh = await fsPromises.open(path, "r+");
+        let pulled = false;
+        const iterable = (async function* () {
           pulled = true;
           yield "data";
-        })(),
-        { signal: 1 },
-      ).then(
-        () => "resolved",
-        e => e,
-      );
-      expectInvalidSignal(err, "type number (1)");
-      expect(pulled).toBe(false);
-      expect(await fsPromises.readFile(join(dir, "f.txt"), "utf8")).toBe("seed");
-    });
-  }
+        })();
+        const err = await settle(write(fh, path, iterable, { signal }));
+        expectInvalidOptionsSignal(err, received);
+        expect(pulled).toBe(false);
+        // In particular the path form must not have opened (and truncated) the file.
+        expect(await fsPromises.readFile(path, "utf8")).toBe("seed");
+      },
+    );
+  });
 });


### PR DESCRIPTION
### Problem

- `fileHandle.appendFile(data, { signal })` ignores the signal: with `AbortSignal.abort()` it resolves and appends the data (node rejects with `AbortError` / `ABORT_ERR` and writes nothing), an abort during an iterable append is ignored, and `{ signal: 1 }` is accepted (node rejects with `ERR_INVALID_ARG_TYPE`). Node's own test for this method (`test-fs-promises-file-handle-append-file.js`, `doAppendAndCancel`) fails on main; the copy in the tree predates that case.
- `fs.promises.writeFile(pathOrHandle, iterable, { signal: <anything invalid> })`, `fileHandle.writeFile(iterable, ...)` and `fileHandle.appendFile(iterable, ...)` accept `null`, `1`, `""`, `{}` and write the data; node rejects with `ERR_INVALID_ARG_TYPE` before opening or pulling anything.
- Causes, all in `src/js/node/fs.promises.ts`:
  - `FileHandle#appendFile` (line 455) rebuilds the options it passes to `writeFile(fd, ...)` as `{ encoding, flush, flag }`, so the signal never reaches either implementation.
  - `FileHandle#writeFile` (line 694) does `signal = options?.signal ?? undefined`, so an explicit `null` reaches neither implementation as the value the caller passed.
  - `writeFileAsyncIterator` (line 1616), which every iterable entry point funnels into, reads `options.signal` and never validates it. The native binding validates the option for string and Buffer data (#39274 brings its message and its `null` handling in line with node); iterable data never reaches the binding.
- No issue filed; found while working on the native side (#39274), which does not cover these JS paths.

### Fix

- The two `FileHandle` wrappers forward `options.signal` unchanged, the same way they already forward `encoding` and `flush`. No validation in the wrappers: in node both methods are `writeFile(this, data, options)`, and here the value goes to whichever implementation handles the data, which validates it. That keeps one validation per implementation (binding for strings and Buffers, `writeFileAsyncIterator` for iterables) and keeps the binding's existing order of checks (encoding before signal) for string data.
- `writeFileAsyncIterator` runs `validateAbortSignal(signal, "options.signal")` after the encoding check and before `open()`, the same order as node's `getOptions()`, and the pre-open abort check moves next to it. This covers the module-level path and FileHandle forms as well as the two wrappers. `undefined` still means no signal; the `| null` plumbing is gone because the value is now passed through as-is.
- Honoring the signal needed no new code: once it arrives, the binding rejects with node's `AbortError` exactly as `fs.promises.writeFile(path, data, { signal })` does today, and the iterable writer already checked `signal.aborted` between chunks.
- Not changed here, on purpose: string data with `{ signal: null }` or `""` through any entry point, and the wording of the binding's message, are #39274 (native). Once both land, `fileHandle.appendFile("x", { signal: null })` rejects too, via the forwarding added here. #35021 carries a `?? undefined` version of the appendFile forward as a side change of its native work and will need to drop that hunk; #39192 adds `flush` lines next to the lines touched here in `FileHandle#writeFile` and `writeFileAsyncIterator`, so one of the two gets a small textual conflict to resolve.
- Verified with `test/js/node/fs/promises.test.js`: 21 new cases. 19 fail on the unfixed build and all pass with the fix; outcomes match node v26.3.0 for every case (probe matrix below). The two that also pass before the fix are guards (`FileHandle#writeFile` with a pre-aborted signal, `FileHandle#appendFile` with a signal that never aborts).
  - AbortError shape: `FileHandle#appendFile` / `#writeFile` with a pre-aborted signal leave the file untouched; an iterable append aborted between chunks rejects after writing the first chunk; a live signal still appends.
  - Validation: `FileHandle#appendFile("data", { signal: 1 })` reaches the binding (code pinned, wording left to the binding); `null` / `1` / `""` / `{}` through `fs.promises.writeFile(path, iterable)`, `fs.promises.writeFile(handle, iterable)`, `FileHandle#writeFile(iterable)` and `FileHandle#appendFile(iterable)` reject naming `"options.signal"`, without pulling the iterable or opening (truncating) the path form's file. The `FileHandle#writeFile(iterable, { signal: null })` row is the one that exercises the `?? undefined` removal.
- `test/js/node/test/parallel/test-fs-promises-file-handle-append-file.js` refreshed to the node v26.3.0 revision; its new `doAppendAndCancel` case fails on the unfixed build ("Missing expected rejection (AbortError)") and passes with the fix, 5/5 runs.
- Also run with the fix: `test/js/node/fs/fs-promises-writeFile-async-iterator.test.ts`, the `appendFile|writeFile|FileHandle|promises|iterable` subset of `test/js/node/fs/fs.test.ts` (141 tests), and the upstream `test-fs-promises.js`, `-file-handle-writeFile.js`, `-writefile.js`, `-writefile-with-fd.js`, `-writefile-typedarray.js`, `-file-handle-readFile.js`, `-file-handle-dispose.js`, all passing.

### Background

- `FileHandle` is the object `fs.promises.open()` returns. Its `appendFile` and `writeFile` methods are wrappers that pin the fd and call the module-level `fs.promises.writeFile(fd, data, options)`. That function sends strings and Buffers to the native binding (`args::WriteFile::from_js` in `src/runtime/node/node_fs.rs`) and iterables to `writeFileAsyncIterator` in the same JS file; the two implementations validate their own options.
- `validateAbortSignal(value, name)` is node's validator (bun's is `jsFunction_validateAbortSignal` in `NodeValidator.cpp`, already used by `fs.promises.watch` and `FileHandle#writer()` in this file): `undefined` passes, a real `AbortSignal` or any object with an `aborted` property passes, anything else (including `null`) throws `ERR_INVALID_ARG_TYPE` naming `name`.
- Node names fs options `"options.signal" property` (they are read out of the options object) rather than `"signal" argument`; the iterable tests assert that name. The middle of the message ("of type" today, "an instance of" after #38694) comes from the shared renderer and is not asserted.

<details>
<summary>Probe matrix (bun 1.4.0, this branch, node v26.3.0)</summary>

| call | bun 1.4.0 | this branch | node v26.3.0 |
| --- | --- | --- | --- |
| `fh.appendFile("x", { signal: AbortSignal.abort() })` | resolves, writes `x` | AbortError, nothing written | AbortError, nothing written |
| `fh.appendFile(asyncIterable, { signal })`, aborted between chunks | resolves, writes `ab` | AbortError, writes `a` | AbortError, writes `a` |
| `fh.appendFile("x", { signal: 1 })` | resolves, writes `x` | ERR_INVALID_ARG_TYPE | ERR_INVALID_ARG_TYPE |
| `fh.appendFile(asyncIterable, { signal: null / 1 / "" / {} })` | resolves, writes | ERR_INVALID_ARG_TYPE (`options.signal`), not pulled | same |
| `fh.writeFile(asyncIterable, { signal: null / 1 / "" / {} })` | resolves, writes | ERR_INVALID_ARG_TYPE (`options.signal`), not pulled | same |
| `fsp.writeFile(path, asyncIterable, { signal: null / 1 / "" / {} })` | resolves, truncates and writes | ERR_INVALID_ARG_TYPE, file untouched | same |
| `fsp.writeFile(fh, asyncIterable, { signal: null / 1 / "" / {} })` | resolves, writes | ERR_INVALID_ARG_TYPE, file untouched | same |
| `fh.appendFile("x", { signal: new AbortController().signal })` | writes `x` | writes `x` | writes `x` |
| `fh.appendFile("x", "utf8")`, `fh.appendFile("x")` | writes `x` | writes `x` | writes `x` |
| `fh.appendFile("x", { signal: null })`, `fh.writeFile("x", { signal: null })` | resolves, writes | resolves, writes (binding skips null until #39274) | ERR_INVALID_ARG_TYPE |

Wording differences that remain and are owned elsewhere: the binding says `"signal" argument must be of type AbortSignal` until #39274; `validateAbortSignal` says `must be of type` where node says `must be an instance of` (#38694); bun's AbortError message ends with a period.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 29 failed, 5 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/fs/promises.test.js
bun test v1.4.0 (a42889a88)

test/js/node/fs/promises.test.js:
(pass) should exist [3.91ms]
(pass) should be enumerable [1.57ms]
(pass) access > should work [5.38ms]
(pass) access > should fail on non-existant files [17.52ms]
(skip) access > should fail on non-existant modes
(skip) access > should fail on object as the 2nd argument
(pass) open > should work [34.53ms]
(pass) open > should return an object [10.74ms]
(pass) open > should be closable [5.49ms]
(pass) more > is an object [33.62ms]
(pass) more > stat [60.11ms]
(skip) more > statfs
(skip) more > statfs bigint
(skip) more > 
(pass) writing to file in append mode works [57.48ms]
(pass) appendFile with flag 'ax' rejects with EEXIST on an existing file [17.48ms]
(pass) errors from fs.promises include async stack frames [19.47ms]
(pass) fs.promises async stack through Promise subclass [21.57ms]
(pass) fs.promises async stack through custom thenable [12.45ms]
(pass) fs.promises async stack with Promise.all [12.73ms]
(pass) an unused FileHandle.writer
... (truncated)

release without fix: 19 failed, 5 skipped
bun test v1.4.0-canary.1 (eabb96de7)

test/js/node/fs/promises.test.js:
(pass) should exist [0.06ms]
(pass) should be enumerable [0.04ms]
(pass) access > should work [0.67ms]
(pass) access > should fail on non-existant files [0.28ms]
(skip) access > should fail on non-existant modes
(skip) access > should fail on object as the 2nd argument
(pass) open > should work [0.96ms]
(pass) open > should return an object [0.18ms]
(pass) open > should be closable [0.09ms]
(pass) more > is an object [1.12ms]
(pass) more > stat [19.50ms]
(skip) more > statfs
(skip) more > statfs bigint
(skip) more > 
(pass) writing to file in append mode works [30.78ms]
(pass) appendFile with flag 'ax' rejects with EEXIST on an existing file [0.76ms]
(pass) errors from fs.promises include async stack frames [0.28ms]
(pass) fs.promises async stack through Promise subclass [0.59ms]
(pass) fs.promises async stack through custom thenable [0.17ms]
(pass) fs.promises async stack with Promise.all [0.14ms]
(pass) an unused FileHandle.writer() does not prevent close() [1.07ms]
(pass) sources created before close() refuse to use the stale fd [2.09ms]
(pass) rm and promises.rm report ERR_FS_EISDIR for dire
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 5 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/fs/promises.test.js
bun test v1.4.0 (a42889a88)

test/js/node/fs/promises.test.js:
(pass) should exist [3.92ms]
(pass) should be enumerable [1.51ms]
(pass) access > should work [6.39ms]
(pass) access > should fail on non-existant files [16.56ms]
(skip) access > should fail on non-existant modes
(skip) access > should fail on object as the 2nd argument
(pass) open > should work [34.56ms]
(pass) open > should return an object [10.66ms]
(pass) open > should be closable [5.12ms]
(pass) more > is an object [35.32ms]
(pass) more > stat [53.47ms]
(skip) more > statfs
(skip) more > statfs bigint
(skip) more > 
(pass) writing to file in append mode works [52.41ms]
(pass) appendFile with flag 'ax' rejects with EEXIST on an existing file [23.02ms]
(pass) errors from fs.promises include async stack frames [19.19ms]
(pass) fs.promises async stack through Promise subclass [20.60ms]
(pass) fs.promises async stack through custom thenable [12.47ms]
(pass) fs.promises async stack with Promise.all [12.34ms]
(pass) an unused FileHandle.writer
... (truncated)

release with fix: 5 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     8fc6cb3822
  features     baseline

22 deps, 120 codegen, 1175 objects in 734ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1236] gen ErrorCode+*.h
[2/1236] install /workspace/bun
bun install v1.4.0-canary.1 (eabb96de7)

Checked 107 installs across 153 packages (no changes) [21.00ms]
[3/1236] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (eabb96de7)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1236] gen bindgenv2
[5/1236] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (eabb96de7)

Checked 129 installs across 147 packages (no changes) [11.00ms]
[6/1236] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1236] gen .bind.ts → GeneratedBindings.cpp
[8/1236] fetch tinycc
[tinycc] up to date
[9/1235] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1235] fetch zlib
[zlib] up to date
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/fs.promises.ts                         |  20 ++--
 test/js/node/fs/promises.test.js                   | 117 +++++++++++++++++++++
 .../test-fs-promises-file-handle-append-file.js    |  21 +++-
 3 files changed, 147 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/fs.promises.ts                                    8      7      0
test/js/node/fs/promises.test.js                              5      3      0
…st/parallel/test-fs-promises-file-handle-append-file.js      0      0      0
```

</details>

<!-- robobun:evidence:end -->