### PR TITLE
node:fs: validate options.signal in readFile, writeFile and watch like node

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -541,6 +541,7 @@ impl JSGlobalObject {
     }
 
     /// "The {argname} argument must be of type {typename}. Received {value}"
+    /// (a dotted `argname` is a "property", see `InvalidArgTypeName`).
     ///
     /// Accepts `&str`, `&[u8]`, or `b"..."` for `argname`/`typename`.
     pub fn throw_invalid_argument_type_value(
@@ -556,8 +557,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be of type {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be of type {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -565,6 +566,8 @@ impl JSGlobalObject {
         .throw()
     }
 
+    /// Like [`Self::throw_invalid_argument_type_value`], but `typename` is the whole
+    /// phrase after "must be" (e.g. `"an instance of Array"`).
     pub fn throw_invalid_argument_type_value2(
         &self,
         argname: impl AsRef<[u8]>,
@@ -578,8 +581,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -627,8 +630,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be one of type {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be one of type {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -1378,6 +1381,26 @@ pub struct SysErrOptions {
     pub code: NodeErrorCode,
     pub errno: Option<i32>,
     pub name: Option<&'static [u8]>,
+}
+
+/// The subject of Node's `ERR_INVALID_ARG_TYPE` message: `"name" argument`,
+/// `"options.name" property` for a dotted name, or the name verbatim when it
+/// already ends in ` argument` ("first argument"). Same rule as
+/// `Bun::Message::addParameter` in ErrorCode.cpp.
+/// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1407-L1414
+struct InvalidArgTypeName<'a>(&'a [u8]);
+
+impl core::fmt::Display for InvalidArgTypeName<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let name = bstr::BStr::new(self.0);
+        if self.0.ends_with(b" argument") {
+            write!(f, "{name}")
+        } else if strings::contains_char(self.0, b'.') {
+            write!(f, "\"{name}\" property")
+        } else {
+            write!(f, "\"{name}\" argument")
+        }
+    }
 }
 
 // Unified with the crate-root definitions (lib.rs) — re-exported here so

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4074,14 +4074,14 @@ pub mod args {
                     if let Some(flag_) = arg.get_truthy(ctx, "flag")? {
                         flag = FileSystemFlags::from_js(ctx, flag_)?.unwrap_or(flag);
                     }
-                    if let Some(value) = arg.get_truthy(ctx, "signal")? {
+                    if let Some(value) = arg.get(ctx, "signal")? {
                         if let Some(signal) = AbortSignal::ref_from_js(value) {
                             signal.pending_activity_ref();
                             *abort_signal = Some(signal);
                         } else {
-                            return Err(ctx.throw_invalid_argument_type_value(
-                                b"signal",
-                                b"AbortSignal",
+                            return Err(validators::throw_err_invalid_abort_signal(
+                                ctx,
+                                "options.signal",
                                 value,
                             ));
                         }
@@ -4183,14 +4183,14 @@ pub mod args {
                     if let Some(mode_) = arg.get_truthy(ctx, "mode")? {
                         mode = node::mode_from_js(ctx, mode_)?.unwrap_or(mode);
                     }
-                    if let Some(value) = arg.get_truthy(ctx, "signal")? {
+                    if let Some(value) = arg.get(ctx, "signal")? {
                         if let Some(signal) = AbortSignal::ref_from_js(value) {
                             signal.pending_activity_ref();
                             *abort_signal = Some(signal);
                         } else {
-                            return Err(ctx.throw_invalid_argument_type_value(
-                                b"signal",
-                                b"AbortSignal",
+                            return Err(validators::throw_err_invalid_abort_signal(
+                                ctx,
+                                "options.signal",
                                 value,
                             ));
                         }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4075,16 +4075,10 @@ pub mod args {
                         flag = FileSystemFlags::from_js(ctx, flag_)?.unwrap_or(flag);
                     }
                     if let Some(value) = arg.get(ctx, "signal")? {
-                        if let Some(signal) = AbortSignal::ref_from_js(value) {
-                            signal.pending_activity_ref();
-                            *abort_signal = Some(signal);
-                        } else {
-                            return Err(validators::throw_err_invalid_abort_signal(
-                                ctx,
-                                "options.signal",
-                                value,
-                            ));
-                        }
+                        let signal =
+                            validators::validate_abort_signal(ctx, value, "options.signal")?;
+                        signal.pending_activity_ref();
+                        *abort_signal = Some(signal);
                     }
                 }
             }
@@ -4184,16 +4178,10 @@ pub mod args {
                         mode = node::mode_from_js(ctx, mode_)?.unwrap_or(mode);
                     }
                     if let Some(value) = arg.get(ctx, "signal")? {
-                        if let Some(signal) = AbortSignal::ref_from_js(value) {
-                            signal.pending_activity_ref();
-                            *abort_signal = Some(signal);
-                        } else {
-                            return Err(validators::throw_err_invalid_abort_signal(
-                                ctx,
-                                "options.signal",
-                                value,
-                            ));
-                        }
+                        let signal =
+                            validators::validate_abort_signal(ctx, value, "options.signal")?;
+                        signal.pending_activity_ref();
+                        *abort_signal = Some(signal);
                     }
                     if let Some(flush_) = arg.get(ctx, "flush")? {
                         if flush_.is_boolean() || flush_.is_undefined_or_null() {

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -15,7 +15,7 @@ use bun_jsc::JsCell;
 use bun_jsc::abort_signal::AbortListener;
 use bun_jsc::node::PathLike;
 use bun_jsc::{
-    self as jsc, AbortSignal, AbortSignalRef, ArgumentsSlice, CallFrame, CommonAbortReason,
+    self as jsc, AbortSignalRef, ArgumentsSlice, CallFrame, CommonAbortReason,
     CommonAbortReasonExt as _, GlobalRef, JSGlobalObject, JSValue, JsRef, JsResult, SysErrorJsc,
     VirtualMachineRef as VirtualMachine, ZigStringJsc as _,
 };
@@ -641,7 +641,7 @@ pub struct Arguments<'a> {
     pub path: PathLike,
     pub(crate) listener: JSValue,
     pub global_this: &'a JSGlobalObject,
-    pub(crate) signal: Option<&'a AbortSignal>,
+    pub(crate) signal: Option<AbortSignalRef>,
     pub(crate) persistent: bool,
     pub(crate) recursive: bool,
     pub(crate) encoding: Encoding,
@@ -661,7 +661,7 @@ impl<'a> Arguments<'a> {
         // drops `path` automatically.
 
         let mut listener: JSValue = JSValue::ZERO;
-        let mut signal: Option<&AbortSignal> = None;
+        let mut signal: Option<AbortSignalRef> = None;
         let mut persistent: bool = true;
         let mut recursive: bool = false;
         let mut encoding: Encoding = Encoding::Utf8;
@@ -701,24 +701,12 @@ impl<'a> Arguments<'a> {
                     recursive = recursive_.to_boolean();
                 }
 
-                // abort signal
                 if let Some(signal_) = options_or_callable.get(ctx, "signal")? {
-                    if let Some(signal_obj) = AbortSignal::from_js(signal_) {
-                        // Keep it alive
-                        signal_.ensure_still_alive();
-                        // `signal_obj` is the live C++ AbortSignal owned by
-                        // `signal_` (kept reachable for the duration of the call
-                        // by `ensure_still_alive`). `AbortSignal` is an
-                        // `opaque_ffi!` ZST handle; `opaque_ref` is the
-                        // centralised deref proof.
-                        signal = Some(AbortSignal::opaque_ref(signal_obj));
-                    } else {
-                        return Err(validators::throw_err_invalid_abort_signal(
-                            ctx,
-                            "options.signal",
-                            signal_,
-                        ));
-                    }
+                    signal = Some(validators::validate_abort_signal(
+                        ctx,
+                        signal_,
+                        "options.signal",
+                    )?);
                 }
 
                 // listener
@@ -1183,13 +1171,7 @@ impl FSWatcher {
                 ..Default::default()
             }),
             mutex: Mutex::default(),
-            // SAFETY: `args.signal` is a live borrow of the JS AbortSignal (kept
-            // reachable by the caller's frame); `ref_()` bumps the C++ intrusive
-            // refcount and `adopt` takes ownership of that +1.
-            signal: JsCell::new(
-                args.signal
-                    .map(|s| unsafe { AbortSignalRef::adopt(s.ref_()) }),
-            ),
+            signal: JsCell::new(args.signal.clone()),
             persistent: Cell::new(args.persistent),
             path_watcher: Cell::new(None),
             global_this: GlobalRef::from(args.global_this),
@@ -1209,7 +1191,7 @@ impl FSWatcher {
 
         ctx_ref
             .path_watcher
-            .set(if args.signal.is_none_or(|s| !s.aborted()) {
+            .set(if args.signal.as_deref().is_none_or(|s| !s.aborted()) {
                 // The two backends take different arities (the Windows
                 // backend dropped the callback parameters — only one valid
                 // value each), so the call is cfg-split.

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -24,6 +24,7 @@ use bun_sys::{self, SystemErrno};
 use bun_threading::Mutex;
 
 use crate::node::types::{Encoding, PathLikeExt};
+use crate::node::util::validators;
 use crate::webcore::encoding as Encoder;
 
 bun_output::declare_scope!(fs_watch, hidden);
@@ -701,7 +702,7 @@ impl<'a> Arguments<'a> {
                 }
 
                 // abort signal
-                if let Some(signal_) = options_or_callable.get_truthy(ctx, "signal")? {
+                if let Some(signal_) = options_or_callable.get(ctx, "signal")? {
                     if let Some(signal_obj) = AbortSignal::from_js(signal_) {
                         // Keep it alive
                         signal_.ensure_still_alive();
@@ -712,9 +713,11 @@ impl<'a> Arguments<'a> {
                         // centralised deref proof.
                         signal = Some(AbortSignal::opaque_ref(signal_obj));
                     } else {
-                        return Err(ctx.throw_invalid_arguments(format_args!(
-                            "signal is not of type AbortSignal"
-                        )));
+                        return Err(validators::throw_err_invalid_abort_signal(
+                            ctx,
+                            "options.signal",
+                            signal_,
+                        ));
                     }
                 }
 

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -53,6 +53,19 @@ pub(crate) fn throw_err_invalid_arg_type(
     )
 }
 
+/// The error `validateAbortSignal(value, name)` throws. Callers pass every
+/// defined value of the option (`JSValue::get`, not `get_truthy`): like Node,
+/// only `undefined` means "no signal", so `null` or `""` end up here too.
+/// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/validators.js#L444-L451
+#[cold]
+pub(crate) fn throw_err_invalid_abort_signal(
+    global_this: &JSGlobalObject,
+    name: &str,
+    value: JSValue,
+) -> JsError {
+    global_this.throw_invalid_argument_type_value2(name, "an instance of AbortSignal", value)
+}
+
 #[cold]
 fn throw_range_error(global_this: &JSGlobalObject, args: fmt::Arguments<'_>) -> JsError {
     global_this.err(jsc::ErrorCode::OUT_OF_RANGE, args).throw()

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -472,11 +472,8 @@ pub(crate) fn validate_function(
     Ok(value)
 }
 
-/// `validateAbortSignal(value, name)`, returning a ref to the native signal.
-/// Callers skip `undefined` themselves (Node's `options.signal !== undefined`)
-/// and pass everything else, so `null` and `""` are rejected like any other
-/// non-signal. Only a real `AbortSignal` passes: it is the only kind the native
-/// abort paths can listen to.
+/// Node's `validateAbortSignal`, except that an `aborted`-shaped object is rejected
+/// too: the native abort paths need a real `AbortSignal`.
 /// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/validators.js#L444-L451
 pub(crate) fn validate_abort_signal(
     global_this: &JSGlobalObject,

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -1,7 +1,9 @@
 use core::fmt;
 
 use bun_core::ZigString;
-use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsError, JsResult};
+use bun_jsc::{
+    self as jsc, AbortSignal, AbortSignalRef, JSGlobalObject, JSValue, JsError, JsResult,
+};
 
 fn get_type_name(global_object: &JSGlobalObject, value: JSValue) -> ZigString {
     let js_type = value.js_type();
@@ -51,19 +53,6 @@ pub(crate) fn throw_err_invalid_arg_type(
             name, expected_type, actual_type
         ),
     )
-}
-
-/// The error `validateAbortSignal(value, name)` throws. Callers pass every
-/// defined value of the option (`JSValue::get`, not `get_truthy`): like Node,
-/// only `undefined` means "no signal", so `null` or `""` end up here too.
-/// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/validators.js#L444-L451
-#[cold]
-pub(crate) fn throw_err_invalid_abort_signal(
-    global_this: &JSGlobalObject,
-    name: &str,
-    value: JSValue,
-) -> JsError {
-    global_this.throw_invalid_argument_type_value2(name, "an instance of AbortSignal", value)
 }
 
 #[cold]
@@ -481,6 +470,22 @@ pub(crate) fn validate_function(
         return Err(global.throw_invalid_argument_type_value(name, "function", value));
     }
     Ok(value)
+}
+
+/// `validateAbortSignal(value, name)`, returning a ref to the native signal.
+/// Callers skip `undefined` themselves (Node's `options.signal !== undefined`)
+/// and pass everything else, so `null` and `""` are rejected like any other
+/// non-signal. Only a real `AbortSignal` passes: it is the only kind the native
+/// abort paths can listen to.
+/// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/validators.js#L444-L451
+pub(crate) fn validate_abort_signal(
+    global_this: &JSGlobalObject,
+    value: JSValue,
+    name: &str,
+) -> JsResult<AbortSignalRef> {
+    AbortSignal::ref_from_js(value).ok_or_else(|| {
+        global_this.throw_invalid_argument_type_value2(name, "an instance of AbortSignal", value)
+    })
 }
 
 /// Rust has no field reflection; enums opt in via this trait.

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -418,6 +418,99 @@ it("teardown waits for every concurrent in-flight write", async () => {
   expect(fh.fd).toBe(-1);
 });
 
+// node's getOptions() runs validateAbortSignal(options.signal, "options.signal")
+// for readFile, writeFile and appendFile: anything other than undefined that is
+// not a signal is an ERR_INVALID_ARG_TYPE, including null and "".
+// Every expected string below is node v26.3.0's output for the same call.
+describe("options.signal validation matches node", () => {
+  const invalid = received =>
+    `TypeError ERR_INVALID_ARG_TYPE: The "options.signal" property must be an instance of AbortSignal. Received ${received}`;
+
+  function outcome(fn) {
+    try {
+      const result = fn();
+      if (typeof result?.then === "function") {
+        return result.then(
+          () => "resolved",
+          e => `${e.constructor.name} ${e.code}: ${e.message}`,
+        );
+      }
+      return "resolved";
+    } catch (e) {
+      return `${e.constructor.name} ${e.code}: ${e.message}`;
+    }
+  }
+
+  test("readFileSync reports every non-signal value like node", async () => {
+    await using dir = tempDir("fs-signal-values", { "f.txt": "hello" });
+    const file = join(dir, "f.txt");
+    const values = [1, 0, null, "", "abc", true, false, {}, [], new AbortController()];
+    expect(values.map(signal => outcome(() => fs.readFileSync(file, { signal })))).toEqual([
+      invalid("type number (1)"),
+      invalid("type number (0)"),
+      invalid("null"),
+      invalid("type string ('')"),
+      invalid("type string ('abc')"),
+      invalid("type boolean (true)"),
+      invalid("type boolean (false)"),
+      invalid("an instance of Object"),
+      invalid("an instance of Array"),
+      invalid("an instance of AbortController"),
+    ]);
+    // Only undefined means "no signal".
+    expect(fs.readFileSync(file, { signal: undefined, encoding: "utf8" })).toBe("hello");
+    expect(fs.readFileSync(file, { signal: new AbortController().signal, encoding: "utf8" })).toBe("hello");
+  });
+
+  test("every readFile, writeFile and appendFile entry point rejects an invalid signal the same way", async () => {
+    await using dir = tempDir("fs-signal-entry-points", { "in.txt": "hello" });
+    const input = join(dir, "in.txt");
+    const output = join(dir, "out.txt");
+    const bad = { signal: null };
+    const noop = () => {};
+    const fh = await fsPromises.open(input, "r+");
+    let results;
+    try {
+      results = {
+        readFileSync: outcome(() => fs.readFileSync(input, bad)),
+        readFile: outcome(() => fs.readFile(input, bad, noop)),
+        "promises.readFile": await outcome(() => fsPromises.readFile(input, bad)),
+        "promises.readFile(handle)": await outcome(() => fsPromises.readFile(fh, bad)),
+        "handle.readFile": await outcome(() => fh.readFile(bad)),
+        writeFileSync: outcome(() => fs.writeFileSync(output, "x", bad)),
+        writeFile: outcome(() => fs.writeFile(output, "x", bad, noop)),
+        "promises.writeFile": await outcome(() => fsPromises.writeFile(output, "x", bad)),
+        "promises.writeFile(handle)": await outcome(() => fsPromises.writeFile(fh, "x", bad)),
+        appendFileSync: outcome(() => fs.appendFileSync(output, "x", bad)),
+        appendFile: outcome(() => fs.appendFile(output, "x", bad, noop)),
+        "promises.appendFile": await outcome(() => fsPromises.appendFile(output, "x", bad)),
+        "promises.appendFile(handle)": await outcome(() => fsPromises.appendFile(fh, "x", bad)),
+      };
+    } finally {
+      await fh.close();
+    }
+    const rejectedNull = invalid("null");
+    expect(results).toEqual({
+      readFileSync: rejectedNull,
+      readFile: rejectedNull,
+      "promises.readFile": rejectedNull,
+      "promises.readFile(handle)": rejectedNull,
+      "handle.readFile": rejectedNull,
+      writeFileSync: rejectedNull,
+      writeFile: rejectedNull,
+      "promises.writeFile": rejectedNull,
+      "promises.writeFile(handle)": rejectedNull,
+      appendFileSync: rejectedNull,
+      appendFile: rejectedNull,
+      "promises.appendFile": rejectedNull,
+      "promises.appendFile(handle)": rejectedNull,
+    });
+    // The option is validated before any I/O happens.
+    expect(fs.existsSync(output)).toBe(false);
+    expect(fs.readFileSync(input, "utf8")).toBe("hello");
+  });
+});
+
 // node rejects abortable fs APIs with an AbortError (an Error whose code is the
 // string "ABORT_ERR" and whose cause is signal.reason), never with the raw
 // DOMException held in signal.reason (whose .code is the number 20).

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -462,6 +462,32 @@ describe("fs.watch", () => {
     });
   });
 
+  // node validates options.signal in getOptions() before creating the watcher;
+  // the strings below are node v26.3.0's output for the same calls (null
+  // included: only undefined means "no signal").
+  test("a signal option that is not an AbortSignal throws node's ERR_INVALID_ARG_TYPE", () => {
+    const filepath = path.join(testDir, "abort.txt");
+    const invalid = (received: string) =>
+      `TypeError ERR_INVALID_ARG_TYPE: The "options.signal" property must be an instance of AbortSignal. Received ${received}`;
+    const outcome = (signal: unknown) => {
+      try {
+        fs.watch(filepath, { signal } as any).close();
+        return "watcher created";
+      } catch (e: any) {
+        return `${e.constructor.name} ${e.code}: ${e.message}`;
+      }
+    };
+    expect([1, null, "", {}, new AbortController()].map(outcome)).toEqual([
+      invalid("type number (1)"),
+      invalid("null"),
+      invalid("type string ('')"),
+      invalid("an instance of Object"),
+      invalid("an instance of AbortController"),
+    ]);
+    expect(outcome(undefined)).toBe("watcher created");
+    expect(outcome(new AbortController().signal)).toBe("watcher created");
+  });
+
   test("an abort with no 'error' listener only closes; an 'error' listener that throws is an uncaught exception", async () => {
     await using proc = Bun.spawn({
       cmd: [


### PR DESCRIPTION
### Problem

- `fs.writeFileSync(p, "x", { signal: 1 })` throws `The "signal" argument must be of type AbortSignal. Received type number (1)`; node v26.3.0 throws `The "options.signal" property must be an instance of AbortSignal. Received type number (1)`. The code (`ERR_INVALID_ARG_TYPE`) already matches, the text differs in the name and in `of type` vs `an instance of`. Same for `readFile`/`readFileSync`, `writeFile`/`appendFile` and their sync forms, `fs.promises.readFile`/`writeFile`/`appendFile`, and `FileHandle#readFile`.
- `fs.watch(p, { signal: 1 })` throws `signal is not of type AbortSignal` (right code, none of node's wording).
- The same three sites read the option with `get_truthy`, so `{ signal: null }` and `{ signal: "" }` are silently accepted and the operation runs; node rejects them with the same error (`Received null`, `Received type string ('')`), since only `undefined` means "no signal". This is the one user-observable behavior change in the PR.
- Cause: `args::ReadFile::from_js` and `args::WriteFile::from_js_with_default_flag` in `src/runtime/node/node_fs.rs` (lines 4077 and 4186 on main) each brand-check the value themselves and call `throw_invalid_argument_type_value(b"signal", b"AbortSignal", ..)`; `Arguments::from_js` in `src/runtime/node/node_fs_watcher.rs:704` does the same with a hand-written message. Node runs one function for all of them, `validateAbortSignal(options.signal, "options.signal")` from `getOptions()` (`lib/internal/fs/utils.js#L340-L342`, `lib/internal/validators.js#L444-L451`).
- The Rust `ERR_INVALID_ARG_TYPE` renderers (`JSGlobalObject::throw_invalid_argument_type_value*`) always print `"<name>" argument`, so even with the right name they could not produce node's `property`. The C++ renderer (`Message::addParameter` in `ErrorCode.cpp`) already applies node's rule; the Rust one never did.
- No issue reports this; it was found by diffing bun against node while fixing the neighbouring `flush` message. The upstream fs tests in the tree only assert the error code here, so they pass before and after; the tests below are what pins the text.

### Fix

- `validators.rs`: new `validate_abort_signal(ctx, value, name) -> JsResult<AbortSignalRef>`, the port of node's validator: returns a ref to the native signal, otherwise throws `ERR_INVALID_ARG_TYPE` rendered as `an instance of AbortSignal` through `throw_invalid_argument_type_value2`. This is now the only place that decides what counts as a signal for the native fs code and how the rejection reads; #35275 (accepting AbortSignal-shaped objects) would be a change to this one function instead of to three sites.
- The three sites read the option with `get` (undefined or missing means absent, anything else is validated, mirroring node's `options.signal !== undefined`) and call the helper; the per-site brand checks and messages are deleted. `fs.watch`'s `Arguments` now holds the returned `AbortSignalRef` instead of a `&AbortSignal` borrowed from the JS value, and `FSWatcher::init` clones it; this removes the `ensure_still_alive` dance and an `unsafe` adopt, and the refcount stays balanced (2 live `AbortSignal` wrappers after GC for 10,000 watchers created with signals, same as bun 1.4.0; the fixture is in the details below).
- `JSGlobalObject.rs`: the three Rust renderers format the name through `InvalidArgTypeName`, node's rule (`"x" argument`, `"a.b" property`, a name already ending in ` argument` verbatim; `lib/internal/errors.js#L1407-L1414`), the same rule the C++ renderer applies. Side effect: the 15 other Rust call sites that pass a dotted name (listed in the details below; every other caller passes a plain name and is unchanged) now also say `property`. For the node APIs among them that is node's text (`fs.rmSync(p, { maxRetries: "a" })`, `{ retryDelay: "a" }`, `new SocketAddress({ address: 1 })`, `{ flowlabel: "x" }` diff clean against node); no test in the tree pinned the old `"<dotted>" argument` wording. #38663 carries the same renderer change for a different set of callers; the text here is taken from it verbatim, and a trial merge in both orders is conflict-free and ends up with a single `InvalidArgTypeName`. It is duplicated rather than stacked so that neither PR has to wait for the other.
- Why this is correct: for `node:fs` node's output is the contract, and with this change a 40-call matrix (10 bad values through `readFileSync` and `writeFileSync`, `{ signal: 1 }` through every sync/callback/promises/FileHandle entry point, `fs.watch` with `1`, `{}`, `0`, `null`, plus valid and undefined signals) is byte-identical to node v26.3.0, except for two entry points that never reach this code and are fixed elsewhere: `FileHandle#appendFile`/`#writeFile` rebuild their options in JS (#39272) and `fs.promises.watch` validates in JS through the C++ renderer (#38694 fixes its `of type`). Rejecting `null`/`""` happens before any file is opened (the test checks the output file is not created).
- Deliberately not in this PR: node's `getOptions()` also validates `options.signal` for functions that then ignore it (`readdir`, `readlink`, `realpath`, `mkdtemp`, ...); this PR only changes the three sites that use the signal. Accepting AbortSignal-shaped objects stays with #35275, which edits the same three sites on main; whichever of the two lands second has a mechanical rebase (with this PR the change becomes the helper's accept condition).
- Tests (fail on the current release, pass with this change):
  - `test/js/node/fs/promises.test.js`, `options.signal validation matches node`: exact message for ten non-signal values through `readFileSync`; `{ signal: null }` through all 13 entry points that reach the binding (`readFileSync`, `readFile`, `promises.readFile` by path and by handle, `FileHandle#readFile`, `writeFileSync`, `writeFile`, `promises.writeFile` by path and by handle, `appendFileSync`, `appendFile`, `promises.appendFile` by path and by handle); undefined and a real signal still accepted; no I/O performed.
  - `test/js/node/watch/fs.watch.test.ts`: `fs.watch` with `1`, `null`, `""`, `{}` and an `AbortController`; undefined and a real signal still create a watcher.
  - Also run with the change: the rest of `promises.test.js`, `fs.watch.test.ts`, `fs.watch.close-exit.test.ts`, `fs.test.ts`, `socketaddress.spec.ts`, `parse-args.test.mjs`, `scrypt.test.ts`, the `path` tests, `fetch-compress.test.ts`, the abort-signal leak fixture for readFile/writeFile, and the upstream `test-fs-readfile`, `test-fs-promises-readfile`, `test-fs-promises-writefile`, `test-fs-promises-file-handle-readFile`/`-writeFile`, `test-fs-write-file`, `test-fs-writefile-with-fd`, `test-fs-watch`, `test-fs-watch-abort-signal`, `test-fs-watch-recursive-promise`, `test-fs-promises-watch`, `test-fs-rm`, `test-socketaddress`, `test-blocklist`, `test-http2-client-request-options-errors`. `cargo fmt --check` is clean.

### Background

- `ERR_INVALID_ARG_TYPE(name, expected, actual)` in node renders `The <subject> must be <expected>. Received <actual>`. The subject is `"name" argument`, or `"name" property` when the name contains a `.` (an option path such as `options.signal`). A class name as `expected` renders as `an instance of X`; a primitive type name as `of type x`.
- `validateAbortSignal(signal, name)` is node's validator for signal options: `undefined` passes, anything else that is not an object with an `aborted` property throws `ERR_INVALID_ARG_TYPE(name, "AbortSignal", signal)`. `getOptions()` in node's fs layer calls it with `options.signal`, which is why all the entry points above share one message. The native port accepts only a real `AbortSignal`, because that is the only kind the native abort paths can subscribe to; the comment on the helper says so.
- Bun has two `ERR_INVALID_ARG_TYPE` renderers: the C++ one in `ErrorCode.cpp`, used by C++ and by the JS builtins (`$ERR_INVALID_ARG_TYPE`, `validateAbortSignal`), and the Rust helpers on `JSGlobalObject`, used by natively parsed options such as these. `throw_invalid_argument_type_value` prints `of type <typename>`; `throw_invalid_argument_type_value2` takes the whole phrase after `must be`, which is how a class-name expectation is rendered from Rust. `determine_specific_type` (shared with C++) renders the received value.
- `AbortSignalRef` is the intrusive smart pointer over the C++ `AbortSignal` (`ref()` on clone, `unref()` on drop); `AbortSignal::ref_from_js` downcasts a JS value and takes one. `JSValue::get` returns `None` for a missing or `undefined` property; `get_truthy` additionally drops `null` and `""`, which is the filter that let those values through.
- `src/runtime/node/util/validators.rs` is the Rust port of node's `lib/internal/validators.js`; the new helper sits with the other `validate_*` functions there.

<details>
<summary>bun 1.4.0 vs node v26.3.0 for a few of the calls (after this change every bun line equals the node line)</summary>

```
readFileSync(p, { signal: 1 })
  bun:  The "signal" argument must be of type AbortSignal. Received type number (1)
  node: The "options.signal" property must be an instance of AbortSignal. Received type number (1)
readFileSync(p, { signal: null })
  bun:  (reads the file)
  node: The "options.signal" property must be an instance of AbortSignal. Received null
writeFileSync(p, "x", { signal: "" })
  bun:  (writes the file)
  node: The "options.signal" property must be an instance of AbortSignal. Received type string ('')
fs.promises.appendFile(p, "x", { signal: {} })
  bun:  The "signal" argument must be of type AbortSignal. Received an instance of Object
  node: The "options.signal" property must be an instance of AbortSignal. Received an instance of Object
fs.watch(p, { signal: 1 })
  bun:  signal is not of type AbortSignal
  node: The "options.signal" property must be an instance of AbortSignal. Received type number (1)
fs.watch(p, { signal: null })
  bun:  (creates the watcher)
  node: The "options.signal" property must be an instance of AbortSignal. Received null
fs.rmSync(p, { maxRetries: "a" })            (renderer side effect)
  bun:  The "options.maxRetries" argument must be of type number. Received type string ('a')
  node: The "options.maxRetries" property must be of type number. Received type string ('a')
```

</details>

<details>
<summary>Every Rust call site whose text changes from "argument" to "property"</summary>

Found by listing all callers of the three renderers and keeping those whose name contains a `.` (the callers that pass a name through a variable, in `validators.rs`, `csrf_jsc.rs`, `s3/credentials_jsc.rs`, `ffi_body.rs` and `validate_object`, all receive plain names such as `callback`, `expiresIn`, `options`; the only dotted names reaching them are the two `fs.rm` ones).

| call site | name | API |
| --- | --- | --- |
| `node_fs.rs` via `validate_integer` (2) | `options.maxRetries`, `options.retryDelay` | `fs.rm`/`rmSync`/`promises.rm` (matches node) |
| `socket/SocketAddress.rs` (3) | `options.address` (x2), `options.flowlabel` | `net.SocketAddress` (matches node) |
| `api/bun/h2_frame_parser.rs` (6) | `options.silent`, `options.endStream`, `options.exclusive`, `options.parent`, `options.weight`, `options.signal` | native `http2` request options (node's JS validators say `property` for these) |
| `node/node_cluster_binding.rs` (1) | `handle.fd` | cluster IPC handle |
| `socket/socket_body.rs` (2) | `rule.syscall`, `rule.action` | internal socket fault injection |
| `webcore/fetch/compress_body.rs` (1) | `compress.encoding` | `fetch` compress option |

</details>

<details>
<summary>Refcount check for the fs.watch ownership change</summary>

2,000 iterations of: a watcher with a live signal closed explicitly, one created with a pre-aborted signal, one aborted after creation, one call rejected with `{ signal: {} }`, and one whose options object returns a fresh signal from a getter. After `Bun.gc(true)`, `heapStats().objectTypeCounts.AbortSignal` is 2 on this branch and 2 on bun 1.4.0 (debug/ASAN build for this branch).

</details>

<details>
<summary>Earlier revision</summary>

The first push kept the brand check at each of the three sites and only shared the error (`throw_err_invalid_abort_signal`); the watcher still borrowed the signal from the JS value. A review pass pointed out that this left three copies of the accept condition, so the second commit moved check and error into `validate_abort_signal` and made the watcher own its ref. Tests are unchanged between the two revisions.

</details>
