### PR TITLE
test(node:fs): give the fs/promises writeFile test its own temp directory

### DIFF
--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -4037,7 +4037,8 @@ describe("fs/promises", () => {
   });
 
   it("writeFile", async () => {
-    const path = `${tmpdir()}/fs.test.ts/${Date.now()}.writeFile.txt`;
+    using dir = tempDir("fs-promises-writeFile", {});
+    const path = join(String(dir), "writeFile.txt");
     await writeFile(path, "File written successfully");
     expect(readFileSync(path, "utf8")).toBe("File written successfully");
   });


### PR DESCRIPTION
### Problem
- Running `bun test test/js/node/fs/fs.test.ts -t "^fs/promises writeFile$"` on a clean tmpdir fails with `ENOENT: no such file or directory, open '/tmp/fs.test.ts/<timestamp>.writeFile.txt'` at `test/js/node/fs/fs.test.ts:4041` (`await writeFile(path, ...)`).
- The test builds its path under `${tmpdir()}/fs.test.ts/` (`fs.test.ts:4040`) but never creates that directory. It only exists when the `copyFileSync` tests earlier in the file have run, because their `tmpdirTestMkdir()` helper (`fs.test.ts:83-97`) does a recursive mkdir under it. So the full file passes, and any run that filters the test out of that order (`-t`, `--randomize`, `test.only`) fails.
- Test-only change; nothing under `src/` is involved.

### Fix
- The test now creates its own directory with `tempDir()` from the harness and writes `writeFile.txt` inside it. This is the pattern the rest of the file already uses (about 70 other tests in it), and `using` removes the file afterwards, which the old version never did.
- `tmpdirTestMkdir()` and `fstat on a large file` (`fs.test.ts:4494`) also use the `${tmpdir()}/fs.test.ts/` name, but both create the directory themselves and pass on their own, so they are left as they are. Nothing else in the file depends on the directory: with this change every test in the file passes when run by itself (see below).
- Verified:
  - `test/js/node/fs/fs.test.ts -t "^fs/promises writeFile$"` with an empty `TMPDIR`: fails with the ENOENT above on main, passes with this change (checked with both `bun bd test` and the released bun).
  - `bun bd test test/js/node/fs/fs.test.ts`: 512 pass, 6 skip, 0 fail.
  - Every test in the file run alone with the released bun (one process per test name, each with its own empty `TMPDIR`): before this change `fs/promises > writeFile` was the only failure; after it there are none.

<details>
<summary>Per-test isolation sweep</summary>

For each name printed by a full run of the file, run `bun test test/js/node/fs/fs.test.ts -t "^<escaped name>$"` with `TMPDIR` pointing at a fresh empty directory.

Before (main):

```
collected 512 unique test names
FAIL(1): fs/promises > writeFile
---- 1 failing in isolation ----
```

After (this branch): 0 failing in isolation.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->