### PR TITLE
bun test --reporter=junit: print testcase time straight from the nanosecond count

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -2929,50 +2929,6 @@ pub fn u64_hex_var_lower(buf: &mut [u8; 16], mut n: u64) -> &[u8] {
 }
 
 // ───────────────────────────────────────────────────────────────────────────
-// TrimmedPrecisionFormatter
-// ───────────────────────────────────────────────────────────────────────────
-
-/// Equivalent to `{d:.<precision>}` but trims trailing zeros
-/// if decimal part is less than `precision` digits.
-pub struct TrimmedPrecisionFormatter<const PRECISION: usize> {
-    pub(crate) num: f64,
-}
-
-impl<const PRECISION: usize> Display for TrimmedPrecisionFormatter<PRECISION> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let whole = self.num.trunc();
-        write!(f, "{}", whole)?;
-        let rem = self.num - whole;
-        if rem != 0.0 {
-            // buf size = "0." + PRECISION digits
-            // Const-generic array length arithmetic is unstable, so use a small
-            // fixed upper bound and const-assert it suffices.
-            const {
-                assert!(
-                    PRECISION + 3 <= 32,
-                    "TrimmedPrecisionFormatter PRECISION too large for fixed buffer"
-                )
-            };
-            let mut buf = [0u8; 32];
-            use std::io::Write;
-            let mut cursor = std::io::Cursor::new(&mut buf[..]);
-            write!(cursor, "{:.1$}", rem, PRECISION).expect("unreachable");
-            let written = cursor.position() as usize;
-            let formatted = &buf[2..written];
-            let trimmed = strings::trim_right(formatted, b"0");
-            write!(f, ".{}", bstr::BStr::new(trimmed))?;
-        }
-        Ok(())
-    }
-}
-
-pub fn trimmed_precision<const PRECISION: usize>(
-    value: f64,
-) -> TrimmedPrecisionFormatter<PRECISION> {
-    TrimmedPrecisionFormatter { num: value }
-}
-
-// ───────────────────────────────────────────────────────────────────────────
 // Duration formatting
 // ───────────────────────────────────────────────────────────────────────────
 

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -684,12 +684,8 @@ impl JunitReporter {
         escape_xml(class_name, &mut self.contents)?;
         self.contents.extend_from_slice(b"\"");
 
-        let elapsed_seconds = elapsed_ms / bun::time::MS_PER_S as f64;
-        let _ = write!(
-            &mut self.contents,
-            " time=\"{}\"",
-            bun_fmt::trimmed_precision::<6>(elapsed_seconds)
-        );
+        let elapsed_seconds = elapsed_ns as f64 / bun::time::NS_PER_S as f64;
+        let _ = write!(&mut self.contents, " time=\"{}\"", elapsed_seconds);
 
         self.contents.extend_from_slice(b" file=\"");
         escape_xml(file, &mut self.contents)?;

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -1,6 +1,6 @@
 import { file, spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { join } from "node:path";
 
 const xml2js = require("xml2js");
@@ -553,6 +553,69 @@ describe("junit reporter", () => {
     // the ESC byte, so a leak would surface as bare CSI residue.
     expect(xmlContent).not.toMatch(/\[[\d;]*[A-HJKSTfm]/);
     expect(exitCode).toBe(1);
+  });
+
+  describe("time attribute", () => {
+    // Runs a file whose report mixes durations that are exactly zero (skipped
+    // tests), measured (the "runs N" tests) and, while describe.skip still
+    // reports its hooks, well under a microsecond. Returns every element's
+    // time="..." text plus the <testcase> ones keyed by name.
+    async function reportTimes() {
+      await using tmpDir = tempDir("junit-time", {
+        "package.json": "{}",
+        "time.test.js": `
+          import { beforeAll, describe, test } from "bun:test";
+          for (let i = 0; i < 12; i++) test("runs " + i, () => {});
+          test.skip("skipped", () => {});
+          describe.skip("skipped suite", () => {
+            beforeAll(() => {});
+            test("never runs", () => {});
+          });
+        `,
+      });
+
+      const junitPath = join(tmpDir, "junit.xml");
+      await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+        cwd: tmpDir,
+        env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(exitCode).toBe(0);
+
+      const xmlContent = await file(junitPath).text();
+      const all = [...xmlContent.matchAll(/ time="([^"]*)"/g)].map(m => m[1]);
+      const testcases = Object.fromEntries(
+        [...xmlContent.matchAll(/<testcase name="([^"]*)"[^>]*? time="([^"]*)"/g)].map(m => [m[1], m[2]]),
+      );
+      return { all, testcases };
+    }
+
+    it("is a plain decimal with at most nanosecond precision on every element", async () => {
+      const { all, testcases } = await reportTimes();
+      // <testsuites>, the file and describe <testsuite>s, and the 14 <testcase>s.
+      expect(all.length).toBeGreaterThanOrEqual(17);
+      // Sub-microsecond durations used to render as time="0.", and a value that
+      // is not formatted straight from the nanosecond count shows up as digits
+      // past the ninth (0.000029999999999999997).
+      expect(all.filter(time => !/^\d+(\.\d{1,9})?$/.test(time))).toEqual([]);
+      expect(testcases["skipped"]).toBe("0");
+      expect(testcases["never runs"]).toBe("0");
+    });
+
+    // The sub-microsecond digits can only be observed where the monotonic clock
+    // itself is finer than a microsecond, which Linux's CLOCK_MONOTONIC is.
+    it.skipIf(!isLinux)("keeps the sub-microsecond digits of a test's duration", async () => {
+      const { testcases } = await reportTimes();
+      const ran = Object.entries(testcases)
+        .filter(([name]) => name.startsWith("runs "))
+        .map(([, time]) => time);
+      expect(ran).toHaveLength(12);
+      // Each duration is an exact nanosecond count; for none of the twelve to
+      // have a sub-microsecond part they would all have to be whole microseconds.
+      expect(ran.some(time => /\.\d{7,9}$/.test(time))).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun test --reporter=junit` can emit `<testcase ... time="0." ...>`, a bare trailing dot, for any testcase whose measured duration is above 0 but below half a microsecond. On the released 1.4.0 the `(unnamed)` hook entries of a `describe.skip` containing a `beforeAll` hit it on every run (50 of 50 in the probe below); exactly 0ns prints `time="0"` and longer durations print e.g. `time="0.00003"`.
- Cause: `write_test_case` (`src/runtime/cli/test_command.rs`) divides `elapsed_ns` by 1e6 and then by 1000. The double rounding makes the value print with noise under `{}` (30us comes out as `0.000029999999999999997`, about a quarter of all nanosecond counts are affected), so the line goes through `bun_fmt::trimmed_precision::<6>` (`src/bun_core/fmt.rs`) to hide that. That formatter prints the truncated whole part and then unconditionally writes `"."` followed by the remainder's `{:.6}` digits with trailing zeros trimmed; a remainder that rounds to `0.000000` leaves `"0."`, and one that rounds up to `1.000000` loses the carry (`0.9999996` prints as `"0."`).
- `write_test_case` is the formatter's only caller. The sibling `time` attributes (`<testsuite>` in `end_test_suite`, `<testsuites>` in `write_to_file` and in `test/parallel/aggregate.rs`) already divide the nanosecond count by `NS_PER_S` once and print it with `{}`, and come out clean (`time="0.004340491"` in the probe below).

### Fix
- `write_test_case` now computes `elapsed_ns as f64 / NS_PER_S as f64` and prints it with `{}`, the same expression the suite attributes use. `trimmed_precision` loses its only caller and is deleted.
- Why this is correct: a single division of an exact integer by 1e9 yields the double nearest to a decimal with at most nine fractional digits, and `{}` prints the shortest representation that round-trips, which is that decimal. So the output is exactly `elapsed_ns` with the decimal point moved nine places, trailing zeros already absent, never a bare dot, never exponent notation (Rust's `Display` for floats does not use it), and `0` for 0ns. A standalone check over every count from 0 to 3,000,000ns and 2,000,000 sampled counts up to 48 hours produced no output outside `^\d+(\.\d{1,9})?$`; the two-step division produced 17-digit noise for 755,899 of the first 3,000,001.
- Observable change besides the bug: testcase times are now reported at the clock's resolution (up to nine fractional digits) instead of being rounded to six, matching the suite attributes in the same report. Nothing in the repo pins six digits: the JUnit snapshots strip `time=`, `scripts/runner.node.mjs` reads only `<testsuite>` times via `[\d.]+`, and the docs state no precision.
- Tests, in `test/js/junit-reporter/junit.test.js`: one run whose report mixes zero, measured and sub-microsecond durations, asserting every `time` attribute on every element matches `^\d+(\.\d{1,9})?$` (rejects both the bare dot and double-rounding noise) and that the skipped entries print `0`; and, on Linux (whose `CLOCK_MONOTONIC` is nanosecond-granular; other platforms' clocks may not be), that at least one of twelve running tests keeps sub-microsecond digits, which the six-digit path can never produce.
  - `bun bd test test/js/junit-reporter/junit.test.js`: 10 pass.
  - Same command with the two `src/` files at `main`: the sub-microsecond test fails (`Expected: true, Received: false`), the other 9 pass.
  - `bun bd test test/regression/issue/26851.test.ts` and the four `--reporter=junit` cases in `test/cli/test/parallel.test.ts` pass.
  - `cargo check -p bun_core`, `cargo clippy -p bun_core`, `cargo fmt --check` clean; `bun test test/internal/source-lints/`: 166 pass.
- Out of scope, handed off separately: the describe-level `<testsuite time>` is also wrong (`Metrics::add` does not sum `elapsed_time`, and each test is truncated to whole milliseconds before summing). That code is untouched here; #36218 is editing the neighbouring lines.

### Background
- JUnit's `time` attribute is a duration in seconds written as a plain decimal; consumers parse it as a float, so nine fractional digits are as valid as six.
- `elapsed_ns` is the integer nanosecond count the test runner measures between a sequence starting and completing; entries that never start (skipped tests) report 0.
- The `(unnamed)` entries in the probe are the hook entries `describe.skip` currently reports as testcases (#35502 removes them); they are only the easiest way to see sub-microsecond durations today, any fast enough testcase rendered the same way.

<details>
<summary>Probe: released bun 1.4.0, 50 describe.skip blocks each containing a beforeAll</summary>

```
$ bun test --reporter=junit --reporter-outfile=j.xml x.test.ts
$ grep -o 'time="[^"]*"' j.xml | sort | uniq -c
    100 time="0"
     50 time="0."
      1 time="0.010527884"
      1 time="0.004340491"
```

Same file with this branch (debug build):

```
    100 time="0"
      4 time="0.000000455"
      3 time="0.000000448"
      ...
      1 time="0.297068396"
      1 time="0.096280521"
```
</details>

<details>
<summary>Earlier version of this PR</summary>

The first push kept the formatter and fixed it (format the whole value with `{:.6}`, then trim), exposing it through `bun:internal-for-testing` to pin the edge cases. Reviewing it showed the formatter only exists to mask the call site's double division, which the sibling attributes avoid by construction, so this version removes the formatter instead of hardening it and needs no test hook.
</details>
