### PR TITLE
Drop the trailing period from the node-shaped AbortError message

### DIFF
--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -37,7 +37,8 @@
     macro(httpOPTIONS, "OPTIONS") \
     macro(OperationFailed, "The operation failed.") \
     macro(OperationTimedOut, "The operation timed out.") \
-    macro(OperationWasAborted, "The operation was aborted.") \
+    /* node's AbortError default message, which unlike the DOMException one has no trailing period: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L980 */ \
+    macro(OperationWasAborted, "The operation was aborted") \
     macro(httpPATCH, "PATCH") \
     macro(httpPOST, "POST") \
     macro(httpPROPFIND, "PROPFIND") \

--- a/test/js/bun/spawn/spawn-signal.test.ts
+++ b/test/js/bun/spawn/spawn-signal.test.ts
@@ -68,6 +68,7 @@ test("spawn AbortSignal already aborted carries signal.reason as cause", () => {
     expect.objectContaining({
       name: "AbortError",
       code: "ABORT_ERR",
+      message: "The operation was aborted",
       cause: reason,
     }),
   );
@@ -100,6 +101,7 @@ test("spawnSync AbortSignal throws if already aborted", () => {
     expect.objectContaining({
       name: "AbortError",
       code: "ABORT_ERR",
+      message: "The operation was aborted",
       cause: reason,
     }),
   );

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -572,7 +572,7 @@ describe("EventEmitter.on", () => {
     ]);
   });
 
-  test("AbortController", () => {
+  test("AbortController", async () => {
     const { on, EventEmitter } = require("node:events");
 
     const ac = new AbortController();
@@ -584,32 +584,35 @@ describe("EventEmitter.on", () => {
       ee.emit("foo", 42);
       ee.emit("foo", "baz");
     });
-    (async () => {
+    const consumed = (async () => {
       try {
         for await (const event of on(ee, "foo", { signal: ac.signal })) {
           output.push([1, event]);
         }
-        console.log("unreachable");
+        output.push(["unreachable"]);
       } catch (error: any) {
-        const { code, message } = error;
-        output.push([2, { code, message }]);
-
-        expect(output).toEqual([
-          [1, ["bar"]],
-          [1, [42]],
-          [1, ["baz"]],
-          [
-            2,
-            {
-              code: "ABORT_ERR",
-              message: "The operation was aborted.",
-            },
-          ],
-        ]);
+        const { name, code, message, cause } = error;
+        output.push([2, { name, code, message, cause }]);
       }
     })();
 
     process.nextTick(() => ac.abort());
+    await consumed;
+
+    expect(output).toEqual([
+      [1, ["bar"]],
+      [1, [42]],
+      [1, ["baz"]],
+      [
+        2,
+        {
+          name: "AbortError",
+          code: "ABORT_ERR",
+          message: "The operation was aborted",
+          cause: ac.signal.reason,
+        },
+      ],
+    ]);
   });
 
   // Checks for potential issues with FixedQueue size

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -419,8 +419,9 @@ it("teardown waits for every concurrent in-flight write", async () => {
 });
 
 // node rejects abortable fs APIs with an AbortError (an Error whose code is the
-// string "ABORT_ERR" and whose cause is signal.reason), never with the raw
-// DOMException held in signal.reason (whose .code is the number 20).
+// string "ABORT_ERR", whose message has no trailing period, and whose cause is
+// signal.reason), never with the raw DOMException held in signal.reason (whose
+// .code is the number 20 and whose message ends in a period).
 describe("AbortSignal rejections use node's AbortError shape", () => {
   function expectNodeAbortError(err, reason) {
     expect(err).toBeInstanceOf(Error);
@@ -428,7 +429,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     expect({ name: err.name, code: err.code, message: err.message }).toEqual({
       name: "AbortError",
       code: "ABORT_ERR",
-      message: "The operation was aborted.",
+      message: "The operation was aborted",
     });
     expect(err.cause).toBe(reason);
   }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -708,7 +708,12 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             await promise;
             expect("unreachable").toBe(true);
           } catch (err) {
-            expect(err.code).toBe("ABORT_ERR");
+            expect({ name: err.name, code: err.code, message: err.message, cause: err.cause }).toEqual({
+              name: "AbortError",
+              code: "ABORT_ERR",
+              message: "The operation was aborted",
+              cause: abortController.signal.reason,
+            });
           }
         });
         it("aborted event should work with abortController", async () => {

--- a/test/js/node/stream/node-stream.test.js
+++ b/test/js/node/stream/node-stream.test.js
@@ -1713,6 +1713,38 @@ describe("pipeline real error overrides AbortError (nodejs/node#62113)", () => {
   });
 });
 
+// Symbol.asyncDispose destroys an unfinished stream with `new AbortError()`:
+// node's default message has no trailing period and, with no signal involved,
+// no cause (https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L980).
+describe("Symbol.asyncDispose destroys with node's default AbortError", () => {
+  const cases = [
+    ["Readable", () => new Readable({ read() {} })],
+    [
+      "Writable",
+      () =>
+        new Writable({
+          write(chunk, encoding, cb) {
+            cb();
+          },
+        }),
+    ],
+  ];
+
+  it.each(cases)("%s", async (_, create) => {
+    const stream = create();
+    const errored = new Promise(resolve => stream.once("error", resolve));
+    await stream[Symbol.asyncDispose]();
+    const err = await errored;
+    expect(err).toBeInstanceOf(Error);
+    expect({ name: err.name, code: err.code, message: err.message, hasCause: "cause" in err }).toEqual({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      message: "The operation was aborted",
+      hasCause: false,
+    });
+  });
+});
+
 describe("stream operators argument validation (nodejs/node#59529)", () => {
   it("map/filter throw synchronously with the validateFunction message", () => {
     for (const method of ["map", "filter"]) {

--- a/test/js/node/test/parallel/test-timers-promises-scheduler.js
+++ b/test/js/node/test/parallel/test-timers-promises-scheduler.js
@@ -33,7 +33,7 @@ async function testCancelableWait1() {
   ac.abort();
   await rejects(wait, {
     code: 'ABORT_ERR',
-    message: 'The operation was aborted.',
+    message: 'The operation was aborted',
   });
 }
 
@@ -43,7 +43,7 @@ async function testCancelableWait2() {
   const wait = scheduler.wait(10000, { signal: AbortSignal.abort() });
   await rejects(wait, {
     code: 'ABORT_ERR',
-    message: 'The operation was aborted.',
+    message: 'The operation was aborted',
   });
 }
 

--- a/test/js/node/timers.promises/timers.promises.test.ts
+++ b/test/js/node/timers.promises/timers.promises.test.ts
@@ -87,6 +87,64 @@ describe("setImmediate", () => {
   });
 });
 
+// node rejects with its own AbortError class (lib/internal/errors.js), whose
+// default message has no trailing period. The DOMException stored in
+// signal.reason keeps the WebIDL text with the period; it is only the cause.
+describe("AbortError shape matches node", () => {
+  function nodeAbortError(signal: AbortSignal) {
+    return {
+      name: "AbortError",
+      code: "ABORT_ERR",
+      message: "The operation was aborted",
+      cause: signal.reason,
+    };
+  }
+
+  async function shapeOf(promise: Promise<unknown>) {
+    const err: any = await promise.then(
+      () => {
+        throw new Error("expected a rejection");
+      },
+      e => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(DOMException);
+    return { name: err.name, code: err.code, message: err.message, cause: err.cause };
+  }
+
+  it("setTimeout with an already aborted signal", async () => {
+    const signal = AbortSignal.abort();
+    expect(await shapeOf(setTimeout(10, undefined, { signal }))).toEqual(nodeAbortError(signal));
+    expect(signal.reason.message).toBe("The operation was aborted.");
+  });
+
+  it("setTimeout aborted while pending", async () => {
+    const controller = new AbortController();
+    const promise = setTimeout(10_000, undefined, { signal: controller.signal });
+    controller.abort();
+    expect(await shapeOf(promise)).toEqual(nodeAbortError(controller.signal));
+  });
+
+  it("setTimeout aborted with a custom reason", async () => {
+    const reason = new Error("custom reason");
+    const signal = AbortSignal.abort(reason);
+    expect(await shapeOf(setTimeout(10, undefined, { signal }))).toEqual({ ...nodeAbortError(signal), cause: reason });
+  });
+
+  it("setImmediate with an already aborted signal", async () => {
+    const signal = AbortSignal.abort();
+    expect(await shapeOf(setImmediate(undefined, { signal }))).toEqual(nodeAbortError(signal));
+  });
+
+  it("setInterval with an already aborted signal", async () => {
+    const signal = AbortSignal.abort();
+    const iterate = (async () => {
+      for await (const _ of setInterval(1, undefined, { signal })) break;
+    })();
+    expect(await shapeOf(iterate)).toEqual(nodeAbortError(signal));
+  });
+});
+
 describe("setInterval", () => {
   it("ends the iterator even when another listener stopped propagation", async () => {
     const abortController = new AbortController();

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -933,15 +933,18 @@ describe("fs.promises.watch", () => {
     const watcher = fs.promises.watch(filepath, { signal: ac.signal });
 
     const promise = (async () => {
-      try {
-        for await (const _ of watcher);
-      } catch (e: any) {
-        expect(e.message).toBe("The operation was aborted.");
-      }
+      for await (const _ of watcher);
     })();
     await Bun.sleep(10);
     ac.abort();
-    await promise;
+    await expect(promise).rejects.toThrow(
+      expect.objectContaining({
+        name: "AbortError",
+        code: "ABORT_ERR",
+        message: "The operation was aborted",
+        cause: ac.signal.reason,
+      }),
+    );
   });
 
   test("Signal aborted before creating the watcher", async () => {
@@ -949,13 +952,18 @@ describe("fs.promises.watch", () => {
 
     const signal = AbortSignal.abort();
     const watcher = fs.promises.watch(filepath, { signal });
-    await (async () => {
-      try {
+    await expect(
+      (async () => {
         for await (const _ of watcher);
-      } catch (e: any) {
-        expect(e.message).toBe("The operation was aborted.");
-      }
-    })();
+      })(),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        name: "AbortError",
+        code: "ABORT_ERR",
+        message: "The operation was aborted",
+        cause: signal.reason,
+      }),
+    );
   });
 
   test("Signal aborted before creating the watcher does not keep the process alive", async () => {


### PR DESCRIPTION
### Problem
- Every node-compat API that rejects or emits node's `AbortError` (`name: "AbortError"`, `code: "ABORT_ERR"`, `cause: signal.reason`) uses the message `"The operation was aborted."`. Node's message is `"The operation was aborted"`, with no period (`lib/internal/errors.js`, `class AbortError`, [v26.3.0 L979-L988](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L979-L988)).
- Affected: `timers/promises`, `fs`/`fs.promises` `{ signal }`, `fs.promises.watch`, `events.once`/`on`, streams (`addAbortSignal`, `finished`, `Symbol.asyncDispose`, ...), `child_process`, `net`, `http2` client requests, and `Bun.spawn({ signal })`, since they all build the error through `$makeAbortError` or `Bun__wrapAbortError`.
- Cause: both helpers (`src/jsc/bindings/ErrorCode.cpp:1748`, `:1751`, `:1769`, `:1772`) take their default message from the `OperationWasAborted` common string, defined with the period in `src/jsc/bindings/BunCommonStrings.h:40`.
- History: before #17179, `$makeAbortError` defaulted to the period-less text. That PR introduced the common string (with the period) because it was also used for the `CommonAbortReason::UserAbort` error, whose WebIDL text does end in a period, and patched the two tests that noticed. The `CommonAbortReason` path has since moved to `createDOMException` with its own literals (`ErrorCode.cpp:1781-1787`, `DOMException.cpp:53`), so the common string is now only read by the two node-shaped paths.

```
$ node -e "require('timers/promises').setTimeout(10,null,{signal:AbortSignal.abort()}).catch(e=>console.log(JSON.stringify(e.message)))"
"The operation was aborted"
$ bun  -e "require('timers/promises').setTimeout(10,null,{signal:AbortSignal.abort()}).catch(e=>console.log(JSON.stringify(e.message)))"
"The operation was aborted."
```

### Fix
- `BunCommonStrings.h`: the `OperationWasAborted` literal loses its period; that is the whole runtime change. Both consumers (`$makeAbortError` with and without arguments, `Bun__wrapAbortError` with and without a cause) read this one string, so every caller listed above changes together.
- Correct because the string's only readers produce node's `AbortError`, and for those node's observed text is the spec. The DOMException defaults (`signal.reason`, `fetch` aborts, `AbortSignal.timeout`) are separate literals and keep their period; the tests asserting them (`test/js/web/abort`, `test/js/web/fetch`, the callback `fs.watch` tests, `undici`, `serve`) are unchanged and still pass.
- Tests updated for the new text, each of which fails on the unfixed build with only the message differing:
  - `test/js/node/test/parallel/test-timers-promises-scheduler.js`: restored to the upstream text byte for byte (blob `7caf92fdf6`, the pre-#17179 version).
  - `test/js/node/fs/promises.test.js` (`Bun__wrapAbortError` via `node_fs`: pre-aborted, in flight, default and custom reasons, callback API).
  - `test/js/node/events/event-emitter.test.ts`: the `on()` abort test now awaits its iteration and asserts name/code/message/cause; previously the assertion ran in a detached async function.
  - `test/js/node/watch/fs.watch.test.ts` (`fs.promises.watch`): the two assertions now use `rejects.toThrow` instead of an `expect` inside a `catch`.
  - `test/js/node/timers.promises/timers.promises.test.ts`: new block for the repro above plus `setImmediate`/`setInterval`, in-flight abort, custom reason, and a check that `signal.reason.message` still has its period.
  - `test/js/node/stream/node-stream.test.js`: `Readable`/`Writable[Symbol.asyncDispose]`, the `$makeAbortError()` no-argument path (node: no period, no `cause`).
  - `test/js/node/http2/node-http2.test.js` and `test/js/bun/spawn/spawn-signal.test.ts`: the existing abort assertions gain the message (`Bun__wrapAbortError` via the http2 parser and via spawn).
- Verified: `bun bd test` on the seven `.test.*` files above passes; `bun bd test/js/node/test/parallel/test-timers-promises-scheduler.js` and `test-child-process-exec-abortcontroller-promisified.js` exit 0; `USE_SYSTEM_BUN=1` (1.4.0) fails each modified file on the message only. `git grep "operation was aborted" test` leaves only DOMException assertions, all unchanged.

### Background
- Two different "AbortError"s exist. The Web one is a `DOMException` with `name === "AbortError"` and numeric `code === 20`; it is what `AbortController.abort()` stores in `signal.reason`, and WebIDL defines its default message as `"The operation was aborted."`. Node's is a plain `Error` subclass with string `code === "ABORT_ERR"`; node's abortable APIs reject with it and attach `signal.reason` as `cause`, and its default message has no period.
- `$makeAbortError` is the private global bun's built-in JS modules call to construct node's `AbortError` (implemented by `jsFunctionMakeAbortError` in `ErrorCode.cpp`); `Bun__wrapAbortError` is the same constructor exported to Rust (`AbortSignal::node_abort_error_if_aborted`, the http2 parser).
- `BunCommonStrings.h` lists string literals that are created once per global object and reused, so an error can be built without allocating its message each time; changing the literal changes every consumer.
