### PR TITLE
bun-types: declare MatchedRoute.scriptSrc

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8421,6 +8421,11 @@ declare module "bun" {
     readonly name: string;
     readonly kind: "exact" | "catch-all" | "optional-catch-all" | "dynamic";
     readonly src: string;
+    /**
+     * Legacy name for {@link MatchedRoute.src} (same value)
+     * @deprecated Use src instead
+     */
+    readonly scriptSrc: string;
   }
 
   /**

--- a/test/integration/bun-types/fixture/fsrouter.ts
+++ b/test/integration/bun-types/fixture/fsrouter.ts
@@ -8,6 +8,9 @@ const router = new FileSystemRouter({
 
 const match = router.match("/");
 expectType<string>(match?.name!);
+// scriptSrc is the runtime's legacy name for src.
+expectType<string>(match?.src!);
+expectType<string>(match?.scriptSrc!);
 expectType<string>(match?.pathname!);
 expectType<Record<string, string>>(match?.query!);
 expectType<Record<string, string>>(match?.params!);


### PR DESCRIPTION
### Problem
- `router.match(...)` returns a `MatchedRoute` whose prototype has a `scriptSrc` getter next to `src` (`src/runtime/api/filesystem_router.classes.ts:86-93`; both are backed by `get_script_src` in `src/runtime/api/filesystem_router.rs:933` and share one cache slot), so `match.scriptSrc` is a real string at runtime: on bun 1.4.0, `r.match("/").scriptSrc` is `"index.js"` and `=== r.match("/").src`.
- `interface MatchedRoute` in `packages/bun-types/bun.d.ts:8400` does not declare it, so code that reads it fails to compile with `error TS2339: Property 'scriptSrc' does not exist on type 'MatchedRoute'`.
- Found by comparing the `*.classes.ts` proto tables against `bun-types`, not from a report; the alias has been installed and undeclared since `Bun.FileSystemRouter` was added (d21aee5143). The same comparison shows `FileSystemRouter.assetPrefix` declared but missing at runtime; that half is being fixed by #33433 (a runtime getter), so the `assetPrefix` declaration is left alone here. #39282 fixes the return types of `origin` and `query` in the same two declarations; the three PRs do not overlap, and this one merges cleanly with #39282 in either order.

### Fix
- Declare `readonly scriptSrc: string` on `MatchedRoute`, marked `@deprecated` in favor of `src`, in the same shape as `WebSocket.URL` (`bun.d.ts:4656`).
- Declaring rather than removing: the getter is installed on the prototype and reachable by users, and the declarations are meant to mirror what the runtime installs. The proto table keeps it for old `bun-framework-next` versions, so the declaration points at `src` instead of presenting it as a second supported name.
- Test: `test/integration/bun-types/fixture/fsrouter.ts` reads `src` and `scriptSrc`. Every type-checking case in `test/integration/bun-types/bun-types.test.ts` (with and without `lib.dom`, no lib, tsgo) checks that fixture, which is what `.github/workflows/bun-types.yml` runs on a release bun.
  - Without the `bun.d.ts` hunk: 9 of the file's 15 cases fail, all with the TS2339 above (`fsrouter.ts(13,27)`). With it: 15 of 15 pass.
  - Under a debug build the file reports 3 pass / 12 skip with or without the hunk: the type-checking cases are `skipIf(isDebug)`, and this file is verified with a release bun by design (CLAUDE.md's `bun-types` note). No `tsc`-spawning case is added for debug builds: #39270 is replacing the one such block in the file with a whole-fixture run plus a lint allowing exactly one compiler spawn, so a new block would conflict with it and then fail the lint. The assertions live only in the fixture, which is the shape #39270 asks types PRs to use, and this PR merges cleanly with it.

### Background
- `src/**/*.classes.ts` files are the input to `src/codegen/generate-classes.ts`; each `proto` entry becomes a property of the generated prototype, so the `MatchedRoute` proto table is the list of members the runtime installs.
- `packages/bun-types` is the published `@types/bun` surface. It is written by hand, not generated from the class tables, which is how a member can exist at runtime without being declared (or the reverse, as with `assetPrefix`).
- `test/integration/bun-types/bun-types.test.ts` packs `bun-types` and type-checks `fixture/*.ts` against it through the TypeScript language service in-process; those cases are skipped under debug builds because driving that API in a debug build is very slow.

<details>
<summary>Earlier revision</summary>

The first push also refactored the `Bun.mmap` block in `bun-types.test.ts` into a shared `tsc()` helper and added a `Bun.FileSystemRouter` case that spawned `tsc` over a three-line program, so that a debug-build run of the file exercised the declaration. That hunk conflicted with #39270 (which deletes the block it refactored and lints the file down to one spawn site) and duplicated the fixture assertions, so it was dropped. The declaration is unchanged from that revision; the fixture lines moved up two lines so the file also merges cleanly with #39282.

</details>
