### PR TITLE
node errors: stringify AbortError and HPE_* errors without the [code] bracket like node

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -137,7 +137,11 @@ static JSC::JSObject* createErrorPrototype(JSC::VM& vm, JSC::JSGlobalObject* glo
 
     prototype->putDirect(vm, vm.propertyNames->name, jsString(vm, String(name)), 0);
     prototype->putDirect(vm, WebCore::builtinNames(vm).codePublicName(), jsString(vm, String(code)), 0);
-    prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), 0);
+    // Node's `name [code]: message` toString() belongs to the ERR_* errors of lib/internal/errors.js.
+    // The other codes in ErrorCode.ts (ABORT_ERR, HPE_*, ...) are plain Errors carrying a `code` in
+    // Node and stringify through Error.prototype.toString.
+    if (StringView(code).startsWith("ERR_"_s))
+        prototype->putDirect(vm, vm.propertyNames->toString, JSC::JSFunction::create(vm, globalObject, 0, "toString"_s, NodeError_proto_toString, JSC::ImplementationVisibility::Private), 0);
 
     return prototype;
 }

--- a/test/js/node/errors/error-code-toString.test.ts
+++ b/test/js/node/errors/error-code-toString.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter, once } from "node:events";
+import { readFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { AddressInfo, connect } from "node:net";
+import { setTimeout as sleepWithSignal } from "node:timers/promises";
+
+// Node only overrides toString() (to `${name} [${code}]: ${message}`) on the
+// ERR_* errors defined in lib/internal/errors.js. Everything else that carries
+// a `code`, such as AbortError (ABORT_ERR) or the llhttp HPE_* parse errors, is
+// a plain Error and stringifies through Error.prototype.toString.
+function expectPlainErrorToString(err: any) {
+  expect(err).toBeInstanceOf(Error);
+  expect(err.toString).toBe(Error.prototype.toString);
+  expect(String(err)).toBe(`${err.name}: ${err.message}`);
+  // The .stack header already had node's shape; toString() has to agree with it.
+  expect(err.stack.split("\n")[0]).toBe(String(err));
+}
+
+function expectNodeAbortError(err: any, reason: unknown) {
+  expect({ name: err.name, code: err.code, cause: err.cause }).toEqual({
+    name: "AbortError",
+    code: "ABORT_ERR",
+    cause: reason,
+  });
+  expect(String(err)).toStartWith("AbortError: The operation was aborted");
+  expect(String(err)).not.toContain("[ABORT_ERR]");
+  expectPlainErrorToString(err);
+}
+
+function rejection(promise: Promise<unknown>) {
+  return promise.then(
+    () => {
+      throw new Error("expected the promise to reject");
+    },
+    err => err,
+  );
+}
+
+function thrown(fn: () => unknown) {
+  try {
+    fn();
+  } catch (err) {
+    return err as any;
+  }
+  throw new Error("expected the function to throw");
+}
+
+describe.concurrent("AbortError toString() matches node", () => {
+  test("timers/promises setTimeout({ signal })", async () => {
+    const signal = AbortSignal.abort();
+    const err = await rejection(sleepWithSignal(1, undefined, { signal }));
+    expectNodeAbortError(err, signal.reason);
+  });
+
+  test("events.once({ signal })", async () => {
+    const reason = new Error("stop");
+    const signal = AbortSignal.abort(reason);
+    const err = await rejection(once(new EventEmitter(), "never", { signal }));
+    expectNodeAbortError(err, reason);
+  });
+
+  // fs.promises.readFile checks the signal in native code, so this covers the
+  // AbortError created from native code rather than from the JS builtins.
+  test("fs.promises.readFile({ signal })", async () => {
+    const signal = AbortSignal.abort();
+    const err = await rejection(readFile(import.meta.path, { signal }));
+    expectNodeAbortError(err, signal.reason);
+  });
+});
+
+test("http clientError HPE_* errors stringify like node's plain Error", async () => {
+  const { promise, resolve } = Promise.withResolvers<any>();
+  await using server = createServer(() => {});
+  server.on("clientError", (err, socket) => {
+    socket.destroy();
+    resolve(err);
+  });
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const socket = connect(port, "127.0.0.1", () => socket.write("BOGUS\r\n\r\n"));
+  socket.on("error", () => {});
+  const err = await promise;
+  socket.destroy();
+
+  expect({ name: err.name, code: err.code }).toEqual({ name: "Error", code: "HPE_INVALID_METHOD" });
+  expect(String(err)).toBe("Error: Parse Error: Invalid method encountered");
+  expectPlainErrorToString(err);
+});
+
+test("ERR_* errors keep node's bracketed toString()", () => {
+  const rangeError = thrown(() => Buffer.alloc(-1));
+  expect({ name: rangeError.name, code: rangeError.code }).toEqual({ name: "RangeError", code: "ERR_OUT_OF_RANGE" });
+  expect(rangeError.toString).not.toBe(Error.prototype.toString);
+  expect(String(rangeError)).toBe(`RangeError [ERR_OUT_OF_RANGE]: ${rangeError.message}`);
+
+  const typeError = thrown(() => new EventEmitter().on("x", 1 as any));
+  expect({ name: typeError.name, code: typeError.code }).toEqual({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" });
+  expect(String(typeError)).toBe(`TypeError [ERR_INVALID_ARG_TYPE]: ${typeError.message}`);
+});


### PR DESCRIPTION
### Problem
- `String(err)` on the `AbortError` that `timers/promises`, `events.once`, `fs.promises`, `stream`, `child_process`, `Bun.spawn({ signal })` etc. reject with is `AbortError [ABORT_ERR]: The operation was aborted.`; Node prints `AbortError: The operation was aborted`.
- Same for the `clientError` parse errors of `node:http`: Bun prints `Error [HPE_INVALID_METHOD]: Parse Error: Invalid method encountered`, Node prints `Error: Parse Error: Invalid method encountered`.
- Cause: `createErrorPrototype` (src/jsc/bindings/ErrorCode.cpp:140) installs `NodeError_proto_toString`, which always renders `name [code]: message`, on the prototype of every code listed in src/jsc/bindings/ErrorCode.ts, including `ABORT_ERR`, `HPE_*` and `MODULE_NOT_FOUND`.
- `err.stack` was already right (`AbortError: ...`), only `toString()` disagreed with it.

### Fix
- `createErrorPrototype` installs the bracketed `toString` only when the code starts with `ERR_`; the other codes inherit `Error.prototype.toString`.
- Matches Node: the bracketed `toString` is added by `makeNodeErrorWithCode`, i.e. only to codes registered in `lib/internal/errors.js`, and all 298 of those start with `ERR_` (checked on v26.3.0 with `--expose-internals`). `AbortError` is a plain `class AbortError extends Error` that sets `code`, and the `HPE_*` / `MODULE_NOT_FOUND` errors are plain `Error`s with a `code` property, so none of them has the bracket.
- Same rule #35934 uses to decide which errors get the bracket in the `.stack` header, so the two agree once both land.
- `err.name`, `err.code`, `err.cause`, `err.stack` and the `ERR_*` errors are unchanged. Nothing in `src/` or `test/` depended on the bracketed form of these codes (only `ERR_*` forms are asserted anywhere).
- Test: test/js/node/errors/error-code-toString.test.ts covers the JS-created AbortError (`timers/promises`, `events.once`), the natively created one (`fs.promises.readFile`), an `HPE_*` error from `clientError`, and keeps an `ERR_*` control that still gets the bracket. Every assertion in it was also run as a script against Node v26.3.0.
  - `USE_SYSTEM_BUN=1 bun test test/js/node/errors/error-code-toString.test.ts`: 4 fail / 1 pass
  - `bun bd test test/js/node/errors/error-code-toString.test.ts`: 5 pass
  - `bun bd test` on events, timers.promises, fs/promises, stream, spawn-signal, http parser / transfer-encoding, readline, child_process-node: 373 pass, 0 fail
  - The 91 vendored Node tests under test/js/node/test/parallel that mention `AbortError`, `ABORT_ERR` or `HPE_` pass with the debug build, except one wall-clock assertion in test-runner-mock-timers-scheduler.js that is unrelated and passes on the release binary.

### Background
- `ErrorCode.ts` is the table of `code` strings Bun's node compatibility layer throws. For each code, `ErrorCode.cpp` lazily builds one prototype object (holding `name`, `code` and, until now, `toString`) and one `Structure`, cached in `ErrorCodeCache`; every error with that code is an `ErrorInstance` using that structure. `$makeAbortError` (JS builtins) and `Bun__wrapAbortError` (Rust callers such as `fs` and `Bun.spawn`) both create `ABORT_ERR` errors through it, which is why one conditional covers every API listed above.
- In Node, `makeNodeErrorWithCode` is what turns an `ERR_*` entry of `lib/internal/errors.js` into an error; it defines the `name [code]: message` `toString` on the error. Errors that merely carry a `code` (`AbortError`, the llhttp `HPE_*` errors, `MODULE_NOT_FOUND`) do not go through it and use `Error.prototype.toString`, which renders `name: message`.
- Out of scope and tracked elsewhere: `code` being an own property of the instance (#35926), and the `[ERR_*]` bracket in the `.stack` header (#35934).
