### PR TITLE
bun-types: declare FileSystemRouter.origin as string | null and MatchedRoute.query values as string | string[]

### DIFF
--- a/docs/runtime/file-system-router.mdx
+++ b/docs/runtime/file-system-router.mdx
@@ -59,6 +59,18 @@ router.match("/settings?foo=bar");
 }
 ```
 
+A name that appears more than once in the query string maps to an array of its values.
+
+```ts
+router.match("/settings?foo=bar&foo=baz&page=2").query;
+
+// =>
+{
+  foo: ["bar", "baz"],
+  page: "2"
+}
+```
+
 The router parses URL parameters and returns them in the `params` property:
 
 ```ts
@@ -74,6 +86,18 @@ router.match("/blog/my-cool-post");
   params: {
     slug: "my-cool-post"
   }
+}
+```
+
+`query` also contains the route parameters. A route parameter wins over a query string entry with the same name.
+
+```ts
+router.match("/blog/my-cool-post?slug=other&page=2").query;
+
+// =>
+{
+  slug: "my-cool-post",
+  page: "2"
 }
 ```
 
@@ -111,7 +135,7 @@ interface Bun {
       pathname: string;
       src: string;
       params?: Record<string, string>;
-      query?: Record<string, string>;
+      query?: Record<string, string | string[]>;
     } | null
   }
 }

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8390,7 +8390,11 @@ declare module "bun" {
     match(input: string | Request | Response): MatchedRoute | null;
 
     readonly assetPrefix: string;
-    readonly origin: string;
+    /**
+     * The `origin` passed to the constructor. `null` when the router was
+     * created without one (or with `""`).
+     */
+    readonly origin: string | null;
     readonly style: string;
     readonly routes: Record<string, string>;
 
@@ -8417,7 +8421,24 @@ declare module "bun" {
     readonly params: Record<string, string>;
     readonly filePath: string;
     readonly pathname: string;
-    readonly query: Record<string, string>;
+    /**
+     * The parsed query string, merged with {@link MatchedRoute.params}. A
+     * route parameter wins over a query string entry of the same name. A
+     * name that appears more than once in the query string maps to an array
+     * of its values.
+     *
+     * @example
+     * ```ts
+     * // with a pages/blog/[slug].tsx route:
+     * const router = new FileSystemRouter({
+     *   dir: "/path/to/pages",
+     *   style: "nextjs",
+     * });
+     * router.match("/blog/hello?tag=a&tag=b&page=2")?.query;
+     * // { slug: "hello", tag: ["a", "b"], page: "2" }
+     * ```
+     */
+    readonly query: Record<string, string | string[]>;
     readonly name: string;
     readonly kind: "exact" | "catch-all" | "optional-catch-all" | "dynamic";
     readonly src: string;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,37 +400,6 @@ describe("@types/bun integration test", () => {
     });
   });
 
-  // Also runs on debug builds, where the typeTest cases above are skipped. The assertions
-  // live in fixture/fsrouter.ts; this only points tsc at that one file.
-  describe("Bun.FileSystemRouter", () => {
-    test("fixture/fsrouter.ts type-checks against the packed declarations", async () => {
-      const checkDir = join(TEMP_DIR, "fsrouter-check");
-      const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["fsrouter.ts"];
-      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
-      await mkdir(checkDir, { recursive: true });
-      await makeTree(checkDir, {
-        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
-        "fsrouter.ts": await Bun.file(join(BASE_FIXTURE_DIR, "fsrouter.ts")).text(),
-        "utilities.ts": await Bun.file(join(BASE_FIXTURE_DIR, "utilities.ts")).text(),
-      });
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
-        env: bunEnv,
-        cwd: checkDir,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr.trim()).toBe("");
-      expect(stdout.trim()).toBe("");
-      expect(exitCode).toBe(0);
-    });
-  });
-
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,6 +400,37 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Also runs on debug builds, where the typeTest cases above are skipped. The assertions
+  // live in fixture/fsrouter.ts; this only points tsc at that one file.
+  describe("Bun.FileSystemRouter", () => {
+    test("fixture/fsrouter.ts type-checks against the packed declarations", async () => {
+      const checkDir = join(TEMP_DIR, "fsrouter-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.include = ["fsrouter.ts"];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+        "fsrouter.ts": await Bun.file(join(BASE_FIXTURE_DIR, "fsrouter.ts")).text(),
+        "utilities.ts": await Bun.file(join(BASE_FIXTURE_DIR, "utilities.ts")).text(),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/fsrouter.ts
+++ b/test/integration/bun-types/fixture/fsrouter.ts
@@ -18,5 +18,4 @@ for (const value of Object.values(match!.query)) {
   if (Array.isArray(value)) expectType(value).is<string[]>();
   else expectType(value).is<string>();
 }
-// Route parameters stay single strings.
-expectType(match?.params!).is<Record<string, string>>();
+expectType<Record<string, string>>(match?.params!);

--- a/test/integration/bun-types/fixture/fsrouter.ts
+++ b/test/integration/bun-types/fixture/fsrouter.ts
@@ -6,8 +6,17 @@ const router = new FileSystemRouter({
   style: "nextjs",
 });
 
+// null when the router was constructed without an origin.
+expectType(router.origin).is<string | null>();
+
 const match = router.match("/");
 expectType<string>(match?.name!);
 expectType<string>(match?.pathname!);
-expectType<Record<string, string>>(match?.query!);
-expectType<Record<string, string>>(match?.params!);
+// A query string name given more than once maps to an array of its values.
+expectType(match?.query!).is<Record<string, string | string[]>>();
+for (const value of Object.values(match!.query)) {
+  if (Array.isArray(value)) expectType(value).is<string[]>();
+  else expectType(value).is<string>();
+}
+// Route parameters stay single strings.
+expectType(match?.params!).is<Record<string, string>>();


### PR DESCRIPTION
### Problem
- `bun-types` declares `FileSystemRouter.origin` as `string`, but the getter returns `null` whenever the router was constructed without an `origin` or with `origin: ""` (`get_origin` in `src/runtime/api/filesystem_router.rs:662`; the constructor only stores a non-empty origin, `:325`). `router.origin.length` type-checks and throws at runtime.
- `bun-types` declares `MatchedRoute.query` as `Record<string, string>`, but a query string name that appears more than once is reported as an array of its values: `match("/?a=1&a=2&b=3").query` is `{ a: ["1", "2"], b: "3" }` (`create_query_object` at `:883` hands every value for a name to `putRecord`, which builds a `JSArray` when there is more than one, `src/jsc/bindings/bindings.cpp:2808`). `match.query.a.toUpperCase()` type-checks and throws on a request the client controls.
- Both behaviors date from the commit that introduced `Bun.FileSystemRouter` (d21aee5143); the declarations have never matched them. #12206 (mainly about the param-leak bug) also asks for the array case to be "properly defined".

### Fix
- `FileSystemRouter.origin` is declared `string | null`, with JSDoc saying when it is `null`.
- `MatchedRoute.query` is declared `Record<string, string | string[]>`, with JSDoc describing the array case and that route params are merged in (a param wins over a query entry of the same name, which is what the runtime does on purpose: see the Next.js reference in `QueryStringMap::init_with_scanner`, `src/url/lib.rs:1050`). `docs/runtime/file-system-router.mdx` gets the same type in its reference block plus two examples; every example was run against the released binary (output below).
- The declarations change rather than the runtime because the runtime behavior is deliberate and long-standing: `null` has been the "no origin" value since the API shipped, and the array shape is how the router keeps every value of a repeated name (Next.js, whose `query` this mirrors, types it as `string | string[]` as well). Returning `""` or dropping values would change what existing callers get back; widening the declarations only turns code that already throws at runtime into a type error.
- `MatchedRoute.params` stays `Record<string, string>` on purpose. A catch-all param is one joined string (`rest: "a/b/c"`), and the only ways to get an array there are the param-leak bug that #36680 fixes (#12206, #15554) and a route that names two segments the same (`[a]/[a]`, which Next.js rejects outright). Route shapes are under the author's control; query strings are not, which is why `query` is widened and `params` is not. The existing fixture line keeps pinning `params` to `Record<string, string>`.
- Out of scope, left as they are: `style` is declared `string` and the runtime returns `"nextjs"`, which is imprecise but does not let wrong code type-check, so it is not part of this fix; the `assetPrefix` getter (#33433) and the `scriptSrc` declaration (#39278) are separate gaps owned by those PRs. This PR no longer touches `bun-types.test.ts`, and the fixture edit leaves the line #39278 appends after untouched, so it merges cleanly with #39278 and with #39270 in either order (checked with `git merge-tree`).
- Verified with `test/integration/bun-types/bun-types.test.ts`, run with a release bun as CLAUDE.md describes for `.d.ts` changes: `fixture/fsrouter.ts` now asserts the exact types of `origin` and `query` and narrows a `query` value with `Array.isArray`. With `packages/` at main, 9 of the 15 cases fail with the three `TS2344` errors below; with this change all 15 pass. Under a debug build this file's type-checking cases are skipped on main today; with #39270's whole-fixture case checked out alongside, `bun bd test` on this file fails on the same three errors without the `.d.ts` change and passes with it.

### Background
- `Bun.FileSystemRouter` resolves URL paths against a Next.js-style `pages` directory. `match()` returns a `MatchedRoute` whose `params` are the values of the route's dynamic segments and whose `query` is the parsed query string merged with those params. Both objects are built by the same native helper, which turns a name with one value into a string and a name with several values into an array.
- `origin` is an optional constructor option used to build `MatchedRoute.src`; the getter reports the configured value back.
- `test/integration/bun-types/bun-types.test.ts` packs `packages/bun-types`, installs it into a copy of `test/integration/bun-types/fixture/`, and type-checks the fixture; `fixture/*.ts` files hold the assertions, with `expectType(x).is<T>()` failing unless the type of `x` is exactly `T`. CI runs this file with a release bun (`.github/workflows/bun-types.yml`; Buildkite excludes it), which is where the fixture assertions are checked.

<details>
<summary>Runtime probe (bun 1.4.0 release, unchanged by this PR)</summary>

```
$ mkdir -p pages/blog && echo 'export default 1' > 'pages/blog/[slug].js' && echo 'export default 1' > pages/settings.js
$ bun -e '
const o = { dir: "pages", style: "nextjs" };
console.log(new Bun.FileSystemRouter(o).origin, new Bun.FileSystemRouter({ ...o, origin: "" }).origin, new Bun.FileSystemRouter({ ...o, origin: "https://x.test" }).origin);
const r = new Bun.FileSystemRouter(o);
console.log(JSON.stringify(r.match("/settings?foo=bar&foo=baz&page=2").query));
console.log(JSON.stringify(r.match("/blog/my-cool-post?slug=other&page=2").query));
console.log(JSON.stringify(r.match("/blog/hello?tag=a&tag=b&page=2").query));'
null null https://x.test
{"foo":["bar","baz"],"page":"2"}
{"slug":"my-cool-post","page":"2"}
{"slug":"hello","tag":["a","b"],"page":"2"}
```

`params` probes: `cat/[...rest].js` matched against `/cat/a/b/c` gives `{ rest: "a/b/c" }`; `dup/[a]/[a].js` against `/dup/x/y` gives `{ a: ["x", "y"] }` (the duplicate-name shape discussed above).

</details>

<details>
<summary>Fixture failure against the unchanged declarations</summary>

```
fsrouter.ts(10,30): error TS2344: Type 'string | null' does not satisfy the constraint 'string'.
fsrouter.ts(16,30): error TS2344: Type 'Record<string, string | string[]>' does not satisfy the constraint 'Record<string, string>'.
fsrouter.ts(18,50): error TS2344: Type 'string[]' does not satisfy the constraint 'string & any[]'.
```

`bun test test/integration/bun-types/bun-types.test.ts` (release bun): 9 fail / 6 pass with `packages/` at main, 15 pass with this change. Same three errors, then a pass, from `bun bd test` on this file when #39270's `bun-types.test.ts` is checked out next to it.

</details>

<details>
<summary>Earlier revision</summary>

The first push also added a `describe("Bun.FileSystemRouter")` case to `bun-types.test.ts` that spawned `tsc` over `fixture/fsrouter.ts` so the file had a non-skipped case under debug builds. It duplicated what every release case already checks, and #39270 replaces that pattern with one whole-fixture case plus a lint holding the file at a single spawn site, which the extra case would have tripped once both landed. It was removed; the assertions only ever lived in the fixture.

</details>
