### PR TITLE
bun-types: type Subprocess stdio properties by what the runtime exposes for each stdio option

### DIFF
--- a/docs/runtime/child-process.mdx
+++ b/docs/runtime/child-process.mdx
@@ -572,7 +572,7 @@ namespace SpawnOptions {
 }
 
 interface Subprocess extends AsyncDisposable {
-  readonly stdin: FileSink | number | undefined | null;
+  readonly stdin: FileSink | ReadableStream | number | undefined | null;
   readonly stdout: ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined | null;
   readonly stderr: ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined | null;
   readonly readable: ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined | null;
@@ -593,8 +593,8 @@ interface Subprocess extends AsyncDisposable {
 }
 
 interface SyncSubprocess {
-  stdout: Buffer | undefined;
-  stderr: Buffer | undefined;
+  stdout: Buffer | number | undefined;
+  stderr: Buffer | number | undefined;
   exitCode: number;
   success: boolean;
   resourceUsage: ResourceUsage;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7436,21 +7436,70 @@ declare module "bun" {
       terminal?: TerminalOptions | Terminal;
     }
 
+    /**
+     * The value of {@link Subprocess.stdout} / {@link Subprocess.stderr} for a given
+     * `stdout` / `stderr` option:
+     *
+     * - `"pipe"`: a {@link ReadableStream} of the process's output
+     * - a file descriptor, as a `number` or as `Bun.file(fd)`: that file descriptor, except
+     *   that the parent's own descriptor for the same stream (`1` for `stdout`, `2` for
+     *   `stderr`) is treated as `"inherit"` and gives `undefined`
+     * - anything else, including `Bun.file(path)`: `undefined`. Bun sends the output where the
+     *   option says; nothing is exposed on the {@link Subprocess}.
+     *
+     * When the process was spawned with the `terminal` option, `stdin`, `stdout` and `stderr`
+     * are all `null` instead.
+     */
     type ReadableToIO<X extends Readable> = X extends "pipe" | undefined
       ? ReadableStream<Uint8Array<ArrayBuffer>>
-      : X extends BunFile | ArrayBufferView | number
-        ? number
+      : X extends number | BunFile
+        ? number | undefined
         : undefined;
 
-    type ReadableToSyncIO<X extends Readable> = X extends "pipe" | undefined ? Buffer : undefined;
+    /**
+     * The value of {@link SyncSubprocess.stdout} / {@link SyncSubprocess.stderr} for a given
+     * `stdout` / `stderr` option:
+     *
+     * - `"pipe"`: everything the process wrote, as a `Buffer`
+     * - a file descriptor, as a `number` or as `Bun.file(fd)`: that file descriptor, except
+     *   that the parent's own descriptor for the same stream (`1` for `stdout`, `2` for
+     *   `stderr`) is treated as `"inherit"` and gives `undefined`
+     * - anything else, including `Bun.file(path)`: `undefined`
+     */
+    type ReadableToSyncIO<X extends Readable> = X extends "pipe" | undefined
+      ? Buffer
+      : X extends number | BunFile
+        ? number | undefined
+        : undefined;
 
-    type WritableIO = FileSink | number | undefined;
+    /**
+     * Every value {@link Subprocess.stdin} can hold. See {@link WritableToIO}.
+     */
+    type WritableIO = FileSink | ReadableStream | number | undefined;
 
+    /**
+     * The value of {@link Subprocess.stdin} for a given `stdin` option:
+     *
+     * - `"pipe"`: a {@link FileSink} that writes to the process's input
+     * - a file descriptor, as a `number` or as `Bun.file(fd)`: that file descriptor, except
+     *   that `0`, the parent's own stdin, is treated as `"inherit"` and gives `undefined`
+     * - a {@link ReadableStream}, or a {@link Request} / {@link Response} whose body is one:
+     *   the stream Bun is piping into the process. A stream Bun can read without piping
+     *   (`blob.stream()`, `Bun.file(path).stream()`), or a `Request` / `Response` whose body is
+     *   not a stream, is handled like the blob or file behind it and gives `undefined`.
+     * - anything else, including `Blob`, `ArrayBufferView` and `Bun.file(path)`: `undefined`.
+     *   Bun feeds the input to the process itself; nothing is exposed on the {@link Subprocess}.
+     *
+     * When the process was spawned with the `terminal` option, `stdin`, `stdout` and `stderr`
+     * are all `null` instead.
+     */
     type WritableToIO<X extends Writable> = X extends "pipe"
       ? FileSink
-      : X extends BunFile | ArrayBufferView | Blob | Request | Response | number
-        ? number
-        : undefined;
+      : X extends number | BunFile
+        ? number | undefined
+        : X extends ReadableStream | Request | Response
+          ? ReadableStream | undefined
+          : undefined;
   }
 
   interface ResourceUsage {
@@ -7544,8 +7593,21 @@ declare module "bun" {
     Out extends SpawnOptions.Readable = SpawnOptions.Readable,
     Err extends SpawnOptions.Readable = SpawnOptions.Readable,
   > extends AsyncDisposable {
+    /**
+     * The process's standard input: a {@link FileSink} with `stdin: "pipe"`, otherwise
+     * whatever {@link Spawn.WritableToIO} lists for the `stdin` option that was passed.
+     */
     readonly stdin: SpawnOptions.WritableToIO<In>;
+    /**
+     * The process's standard output: a {@link ReadableStream} with `stdout: "pipe"` (the default),
+     * otherwise whatever {@link Spawn.ReadableToIO} lists for the `stdout` option that was passed.
+     */
     readonly stdout: SpawnOptions.ReadableToIO<Out>;
+    /**
+     * The process's standard error: a {@link ReadableStream} with `stderr: "pipe"`, otherwise
+     * whatever {@link Spawn.ReadableToIO} lists for the `stderr` option that was passed
+     * (`undefined` for the default, `"inherit"`).
+     */
     readonly stderr: SpawnOptions.ReadableToIO<Err>;
 
     /**
@@ -7680,7 +7742,15 @@ declare module "bun" {
     Out extends SpawnOptions.Readable = SpawnOptions.Readable,
     Err extends SpawnOptions.Readable = SpawnOptions.Readable,
   > {
+    /**
+     * Everything the process wrote to stdout, as a `Buffer`, with `stdout: "pipe"` (the default).
+     * Otherwise whatever {@link Spawn.ReadableToSyncIO} lists for the `stdout` option that was passed.
+     */
     stdout: SpawnOptions.ReadableToSyncIO<Out>;
+    /**
+     * Everything the process wrote to stderr, as a `Buffer`, with `stderr: "pipe"` (the default).
+     * Otherwise whatever {@link Spawn.ReadableToSyncIO} lists for the `stderr` option that was passed.
+     */
     stderr: SpawnOptions.ReadableToSyncIO<Err>;
     exitCode: number;
     success: boolean;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,6 +400,35 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Also runs on debug builds, where the in-process typeTest cases (which cover the whole
+  // fixture directory) are skipped: checks fixture/spawn.ts alone against the packed bun-types.
+  describe("Bun.spawn", () => {
+    test("fixture/spawn.ts type-checks", async () => {
+      const checkDir = join(TEMP_DIR, "spawn-fixture-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.files = [join(BASE_FIXTURE_DIR, "spawn.ts")];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -159,25 +159,102 @@ function depromise<T>(_promise: Promise<T>): T {
   tsd.expectType(proc.stdout).is<undefined>();
   tsd.expectType(proc.stderr).is<undefined>();
 }
+// What each stdio option turns into on the Subprocess. Only a caller-supplied file descriptor
+// (a number or Bun.file(fd)) comes back out as a number, and even that becomes undefined when it
+// is the parent's own standard stream (Bun treats that as "inherit"). A ReadableStream passed as
+// stdin, including the body of a Request/Response, comes back as the stream; inputs Bun copies
+// into the process itself (Blob, ArrayBufferView, Bun.file(path), an in-memory Request/Response
+// body) leave the property undefined.
+declare const fd: number;
+declare const stdinStream: ReadableStream<Uint8Array>;
 {
-  const proc = Bun.spawn(["echo", "hello"], {
-    stdio: [new Request("1"), null, null],
+  const proc = Bun.spawn(["cat"], { stdin: fd, stdout: fd, stderr: fd });
+  tsd.expectType(proc.stdin).is<number | undefined>();
+  tsd.expectType(proc.stdout).is<number | undefined>();
+  tsd.expectType(proc.stderr).is<number | undefined>();
+  tsd.expectType(proc.readable).is<number | undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], { stdin: 0, stdout: 1, stderr: 2 });
+  tsd.expectType(proc.stdin).is<number | undefined>();
+  tsd.expectType(proc.stdout).is<number | undefined>();
+  tsd.expectType(proc.stderr).is<number | undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], {
+    stdin: Bun.file("input.txt"),
+    stdout: Bun.file("output.txt"),
+    stderr: Bun.file(fd),
   });
+  tsd.expectType(proc.stdin).is<number | undefined>();
+  tsd.expectType(proc.stdout).is<number | undefined>();
+  tsd.expectType(proc.stderr).is<number | undefined>();
+  tsd.expectType(proc.readable).is<number | undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], { stdin: new Blob(["hello"]) });
+  tsd.expectType(proc.stdin).is<undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], { stdin: new Uint8Array([1, 2, 3]) });
+  tsd.expectType(proc.stdin).is<undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], { stdio: [new Uint8Array([]), new Uint8Array(64), new Uint8Array(64)] });
+  tsd.expectType(proc.stdin).is<undefined>();
+  tsd.expectType(proc.stdout).is<undefined>();
+  tsd.expectType(proc.stderr).is<undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], { stdin: stdinStream });
+  tsd.expectType(proc.stdin).is<ReadableStream | undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], { stdio: [new Request("1"), null, null] });
+  tsd.expectType(proc.stdin).is<ReadableStream | undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], { stdin: new Response("1") });
+  tsd.expectType(proc.stdin).is<ReadableStream | undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], {
+    stdin: depromise(fetch("https://example.com/")),
+    stdout: "pipe",
+  });
+  tsd.expectType(proc.stdin).is<ReadableStream | undefined>();
+  tsd.expectType(proc.stdout).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+}
+{
+  const proc = Bun.spawnSync(["cat"], { stdout: fd, stderr: Bun.file("errors.txt") });
+  tsd.expectType(proc.stdout).is<number | undefined>();
+  tsd.expectType(proc.stderr).is<number | undefined>();
+}
+{
+  const proc = Bun.spawnSync(["cat"], { stdout: "pipe", stderr: "inherit" });
+  tsd.expectType(proc.stdout).is<Buffer>();
+  tsd.expectType(proc.stderr).is<undefined>();
+}
+{
+  const proc = Bun.spawnSync(["cat"], { stdio: ["ignore", new Uint8Array(64), null] });
+  tsd.expectType(proc.stdout).is<undefined>();
+  tsd.expectType(proc.stderr).is<undefined>();
+}
 
-  tsd.expectType<number>(proc.stdin);
-}
-{
-  const proc = Bun.spawn(["echo", "hello"], {
-    stdio: [new Response("1"), null, null],
-  });
-  tsd.expectType<number>(proc.stdin);
-}
-{
-  const proc = Bun.spawn(["echo", "hello"], {
-    stdio: [new Uint8Array([]), null, null],
-  });
-  tsd.expectType<number>(proc.stdin);
-}
+// The unions seen through a Subprocess whose stdio configuration is not known statically.
+tsd.expectType<Bun.Subprocess["stdin"]>().is<FileSink | ReadableStream | number | undefined>();
+tsd.expectType<Bun.Subprocess["stdin"]>().is<Bun.Spawn.WritableIO>();
+tsd.expectType<Bun.Subprocess["stdout"]>().is<ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined>();
+tsd.expectType<Bun.Subprocess["stderr"]>().is<ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined>();
+tsd.expectType<SyncSubprocess["stdout"]>().is<Buffer | number | undefined>();
+tsd.expectType<ReadableSubprocess["stdin"]>().is<FileSink | ReadableStream | number | undefined>();
+tsd.expectType<ReadableSubprocess["stdout"]>().is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+tsd.expectType<WritableSubprocess["stdin"]>().is<FileSink>();
+tsd.expectType<NullSubprocess["stdin"]>().is<undefined>();
+tsd.expectAssignable<Bun.Subprocess>(Bun.spawn([], { stdin: stdinStream, stdout: Bun.file("out.txt"), stderr: fd }));
+tsd.expectAssignable<Bun.Subprocess>(Bun.spawn([], { stdin: new Blob(["hello"]), stdout: "inherit" }));
+tsd.expectAssignable<SyncSubprocess>(Bun.spawnSync([], { stdout: fd, stderr: Bun.file("errors.txt") }));
+
 tsd.expectAssignable<PipedSubprocess>(Bun.spawn([], { stdio: ["pipe", "pipe", "pipe"] }));
 tsd.expectAssignable<ReadableSubprocess>(Bun.spawn([], { stdio: ["ignore", "pipe", "pipe"] }));
 tsd.expectAssignable<ReadableSubprocess>(Bun.spawn([], { stdio: ["pipe", "pipe", "pipe"] }));


### PR DESCRIPTION
### Problem
- `Bun.spawn(cmd, { stdin: Bun.file(path) })`, `{ stdin: new Blob(..) }`, `{ stdin: new Uint8Array(..) }`, `{ stdin: new Response("x") }` and `{ stdout: Bun.file(path) }` all type `proc.stdin` / `proc.stdout` as `number`; at runtime (bun 1.4.0) every one of them is `undefined`.
- `{ stdin: someReadableStream }` (or a `Request`/`Response` with a streaming body) types `proc.stdin` as `undefined`; at runtime it is the stream.
- `{ stdin: 0 }` / `{ stdout: 1 }` / `{ stderr: 2 }` type the property as `number`; at runtime Bun turns the parent's own descriptor into `"inherit"` and the property is `undefined`.
- `Bun.spawnSync(cmd, { stdout: fd })` types `result.stdout` as `undefined`; at runtime it is the fd number.
- Cause: the three mapping types in `packages/bun-types/bun.d.ts` (`Spawn.ReadableToIO`, `ReadableToSyncIO`, `WritableToIO`, around line 7439) list `BunFile | ArrayBufferView | Blob | Request | Response | number` as inputs that yield `number`. The runtime only echoes a caller-supplied fd: `Writable::to_js` (`src/runtime/api/bun/subprocess/Writable.rs:393`) returns a number for `Writable::Fd` and `undefined` for `Buffer` / `Memfd` / `Ignore` / `Inherit`; `Readable::to_js` and `to_buffered_value` (`subprocess/Readable.rs:240`, `:270`) do the same; `Stdio::extract_blob` (`src/runtime/api/bun/spawn/stdio.rs:589`) turns `Bun.file(fd)` into `Stdio::Fd` and `Bun.file(path)` into `Stdio::Path`; a `ReadableStream` stdin is cached as the `stdin` property itself (`js_bun_spawn_bindings.rs:1728`); fds 0/1/2 in their own slot become `Stdio::Inherit` (`stdio.rs:480`).
- `test/integration/bun-types/fixture/spawn.ts:162-180` asserted the wrong `number` claim for `Request`, `Response` and `Uint8Array` stdin.

### Fix
- `ReadableToIO` / `ReadableToSyncIO`: `number | BunFile` maps to `number | undefined`; everything other than `"pipe"` maps to `undefined`. `WritableToIO`: same, plus `ReadableStream | Request | Response` maps to `ReadableStream | undefined`. `WritableIO` (the union of everything `stdin` can hold) gains `ReadableStream` to stay equal to `WritableToIO<Writable>`.
- Why `number | undefined` rather than `number` for fd inputs: `Bun.file(path)` and `Bun.file(fd)` are the same static type but give `undefined` and a number, and a raw `0`/`1`/`2` in its own slot gives `undefined`; `number` alone is wrong for the most common `Bun.file()` usage. Why `| undefined` on the stream arm: a `Request`/`Response` with an in-memory body, and streams Bun can read as a blob (`blob.stream()`, `Bun.file(p).stream()`), give `undefined`. The holder-type unions stay the same shape except for the additions above: `Subprocess["stdout"]` is still `ReadableStream | number | undefined`, `Subprocess["stdin"]` becomes `FileSink | ReadableStream | number | undefined`, `SyncSubprocess["stdout"]` becomes `Buffer | number | undefined`; the fixture pins all three.
- Blast radius check: `cd test && bun run typecheck` (bun's own test suite, which spawns constantly) before and after the change adds no diagnostic to any line that type-checked before; the only new ones are the three fixture lines that encoded the old claim and a second diagnostic on `test/js/node/process/process-stdout-write-after-end.test.ts:65`, which already failed to type-check (`.text()` on `number | ReadableStream`). `scripts/build` type-checks identically before and after.
- JSDoc on the mapping types and on `Subprocess.stdin/stdout/stderr` and `SyncSubprocess.stdout/stderr` states the mapping (these properties had no JSDoc, and the alias JSDoc is not what the IDE shows when hovering `proc.stdin`). The Reference block in `docs/runtime/child-process.mdx` gets the two changed unions.
- Tests: `test/integration/bun-types/fixture/spawn.ts` asserts the exact property type for fd, `0`/`1`/`2`, `Bun.file()`, `Blob`, `ArrayBufferView`, `ReadableStream`, `Request`, `Response` and `fetch()` stdin, fd / `Bun.file()` / `ArrayBufferView` stdout and stderr (`spawn` and `spawnSync`), `readable`, and the holder-type unions. Against the unfixed `bun.d.ts` the fixture produces 25 diagnostics (lines 172-250); with the fix `bun test test/integration/bun-types/bun-types.test.ts` passes all 16 cases (no-lib.dom, lib.dom, tsgo).
- The in-process type-checking cases in `bun-types.test.ts` are skipped on debug builds, so a small case that runs `tsc` over `fixture/spawn.ts` is added so `bun bd test` exercises the fixture too. It is the same case #39279 adds (byte-identical, so the two merge cleanly), and both become redundant if #39270 (which type-checks the whole fixture on debug builds) lands first.
- Related open PRs, not duplicates: #39279 declares `Subprocess.writable` and asserts `stdin: 0` / `stdout: 1` give `number`, which this PR changes to `number | undefined`; whichever lands second needs that one assertion updated. #34864 adds an `ArrayBufferView` arm to `ReadableToSyncIO` for a new spawnSync feature and will need a trivial rebase over this.
- Out of scope, left as is: `ReadableToIO<undefined>` says `ReadableStream`, which is right for `stdout` (default `"pipe"`) but not for `Bun.spawn`'s `stderr` (default `"inherit"`); fixing that needs the mapping to know which slot it is for, and is tracked separately.

### Background
- `Bun.spawn` infers three type parameters (`In`, `Out`, `Err`) from the `stdin` / `stdout` / `stderr` (or `stdio`) options, and `Subprocess<In, Out, Err>` computes the type of each stdio property from them with a conditional type: `WritableToIO<In>` for stdin, `ReadableToIO<Out>` / `<Err>` for stdout and stderr; `SyncSubprocess` uses `ReadableToSyncIO`. With a literal option (`stdin: "pipe"`) the property gets the exact type; with the unconstrained default (`Bun.Subprocess` used as a holder type) the conditional distributes over the whole option union, so the property becomes the union of every arm. That is why the PR pins the holder-type unions: they are what code that stores a `Subprocess` without knowing its configuration sees.
- On the runtime side each stdio slot is parsed into a `Stdio` variant (`spawn/stdio.rs`) and then into a `Readable` / `Writable` variant owned by the `Subprocess`; the JS getters (`subprocess.rs` `get_stdin` etc., cached on first read) convert that variant to a value. `Fd` is the only variant that produces a number. Inputs Bun copies into the child itself (`Blob`, `ArrayBufferView`, memfd, a path it opens) produce `undefined` because there is nothing for the caller to hold; a `"pipe"` produces a `FileSink` (stdin) or `ReadableStream` (stdout/stderr); a `ReadableStream` stdin is piped by Bun and the stream object itself is stored in the `stdin` property slot.

<details>
<summary>Runtime probe (bun 1.4.0, linux x64): what each option produces</summary>

```
stdin: "pipe"                             -> FileSink
stdin: fd number                          -> number(7)
stdin: 0 (own stdin fd)                   -> undefined
stdin: Bun.file(path)                     -> undefined
stdin: Bun.file(fd)                       -> number(8)
stdin: Blob                               -> undefined
stdin: empty Blob                         -> undefined
stdin: Uint8Array                         -> undefined
stdin: empty Uint8Array                   -> undefined
stdin: Response(string)                   -> undefined
stdin: Response(null body)                -> undefined
stdin: Response(Bun.file(path))           -> undefined
stdin: Response(ReadableStream)           -> ReadableStream
stdin: Request(string body)               -> undefined
stdin: Request(no body)                   -> undefined
stdin: ReadableStream                     -> ReadableStream
stdin: Bun.file(path).stream()            -> undefined
stdin: Blob.stream()                      -> undefined
stdin: "inherit" / "ignore" / null / undefined -> undefined
stdout: "pipe" / undefined                -> ReadableStream
stdout: fd number                         -> number(9)
stdout: 1 (own stdout fd)                 -> undefined
stdout: 2 (own stderr fd, as stdout)      -> number(2)
stdout: Bun.file(path)                    -> undefined
stdout: Bun.file(fd)                      -> number(10)
stdout: Uint8Array(64)                    -> throws ERR_INVALID_ARG_TYPE "ArrayBufferView cannot be used for stdout/stderr yet"
stdout: empty Uint8Array                  -> undefined
stdout: "inherit" / "ignore" / null       -> undefined
stderr: undefined (spawn default)         -> undefined
terminal: {...}                           -> stdin, stdout, stderr all null
spawnSync stdout: "pipe" / undefined      -> Buffer
spawnSync stdout: fd number               -> number(7)
spawnSync stdout: 1 (own stdout)          -> undefined
spawnSync stdout: Bun.file(fd)            -> number(8)
spawnSync stdout: Bun.file(path) / "inherit" / "ignore" / null -> undefined
```

The fd numbers are unchanged after the child exits and on a first read after exit.
</details>

<details>
<summary>Diagnostics the new fixture produces against the unfixed bun.d.ts</summary>

```
spawn.ts(172,33): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(173,34): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(174,34): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(175,36): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(179,33): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(180,34): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(181,34): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(189,33): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(190,34): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(191,34): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(192,36): error TS2344: Type 'number | undefined' does not satisfy the constraint 'number'.
spawn.ts(196,33): error TS2344: Type 'undefined' does not satisfy the constraint 'number'.
spawn.ts(200,33): error TS2344: Type 'undefined' does not satisfy the constraint 'number'.
spawn.ts(204,33): error TS2344: Type 'undefined' does not satisfy the constraint 'number'.
spawn.ts(205,34): error TS2344: Type 'undefined' does not satisfy the constraint 'number'.
spawn.ts(206,34): error TS2344: Type 'undefined' does not satisfy the constraint 'number'.
spawn.ts(210,33): error TS2344: Type 'ReadableStream<any> | undefined' does not satisfy the constraint 'undefined'.
spawn.ts(214,33): error TS2344: Type 'ReadableStream<any> | undefined' does not satisfy the constraint 'number'.
spawn.ts(218,33): error TS2344: Type 'ReadableStream<any> | undefined' does not satisfy the constraint 'number'.
spawn.ts(225,33): error TS2344: Type 'ReadableStream<any> | undefined' does not satisfy the constraint 'number'.
spawn.ts(230,34): error TS2344: Type 'number | undefined' does not satisfy the constraint 'undefined'.
spawn.ts(231,34): error TS2344: Type 'number | undefined' does not satisfy the constraint 'undefined'.
spawn.ts(245,46): error TS2344: Type 'number | FileSink | ReadableStream<any> | undefined' does not satisfy the constraint 'number | FileSink | undefined'.
spawn.ts(249,47): error TS2344: Type 'number | Buffer<ArrayBufferLike> | undefined' does not satisfy the constraint 'Buffer<ArrayBufferLike> | undefined'.
spawn.ts(250,50): error TS2344: Type 'number | FileSink | ReadableStream<any> | undefined' does not satisfy the constraint 'number | FileSink | undefined'.
```
</details>
