### PR TITLE
node:test: republish run() child events at the child's nesting

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -378,15 +378,17 @@ async function runFiles(opts: ReturnType<typeof validateRunOptions>, reporter: T
     if (typeof opts.setup === "function") await opts.setup(reporter);
 
     const files = opts.files ?? [];
+    // Node's root numbers its FileTest subtests in order, so a file node's
+    // testId and testNumber are both the file's 1-based position in the run.
     let i = 0;
     for (; i < files.length; i++) {
       if (opts.signal?.aborted) break;
-      await runOneFile(files[i], opts, reporter, counts);
+      await runOneFile(files[i], i + 1, opts, reporter, counts);
     }
     // Node cancels each not-yet-started FileTest with cancelledByParent rather
     // than silently dropping it; an aborted run must not report success:true.
     for (; i < files.length; i++) {
-      reportCancelledFile(files[i], opts, reporter, counts);
+      reportCancelledFile(files[i], i + 1, opts, reporter, counts);
     }
 
     reporter.plan({ __proto__: null, nesting: 0, count: counts.topLevel });
@@ -408,6 +410,7 @@ async function runFiles(opts: ReturnType<typeof validateRunOptions>, reporter: T
 
 function reportCancelledFile(
   file: string,
+  ordinal: number,
   opts: ReturnType<typeof validateRunOptions>,
   reporter: TestsStream,
   counts: Record<string, number>,
@@ -418,7 +421,7 @@ function reportCancelledFile(
     nesting: 0,
     name: file,
     type: "test",
-    testId: 1,
+    testId: ordinal,
     parentId: 0,
     tags: [],
     line: 1,
@@ -433,10 +436,10 @@ function reportCancelledFile(
     __proto__: null,
     ...fileNode,
     type: undefined,
-    testNumber: 1,
+    testNumber: ordinal,
     details: { ...details, passed: false },
   });
-  reporter.fail({ __proto__: null, ...fileNode, type: undefined, testNumber: 1, details });
+  reporter.fail({ __proto__: null, ...fileNode, type: undefined, testNumber: ordinal, details });
   counts.tests++;
   counts.cancelled++;
   counts.topLevel++;
@@ -444,6 +447,7 @@ function reportCancelledFile(
 
 async function runOneFile(
   file: string,
+  ordinal: number,
   opts: ReturnType<typeof validateRunOptions>,
   reporter: TestsStream,
   counts: Record<string, number>,
@@ -463,7 +467,7 @@ async function runOneFile(
     nesting: 0,
     name: file,
     type: "test",
-    testId: 1,
+    testId: ordinal,
     parentId: 0,
     tags: [],
     line: 1,
@@ -584,7 +588,7 @@ async function runOneFile(
         __proto__: null,
         ...fileNode,
         type: undefined,
-        testNumber: 1,
+        testNumber: ordinal,
         details: {
           __proto__: null,
           duration_ms: fileDuration,
@@ -595,9 +599,9 @@ async function runOneFile(
       });
       const details = { __proto__: null, duration_ms: fileDuration, type: "test", error };
       if (fileFailed) {
-        reporter.fail({ __proto__: null, ...fileNode, type: undefined, testNumber: 1, details });
+        reporter.fail({ __proto__: null, ...fileNode, type: undefined, testNumber: ordinal, details });
       } else {
-        reporter.pass({ __proto__: null, ...fileNode, type: undefined, testNumber: 1, details });
+        reporter.pass({ __proto__: null, ...fileNode, type: undefined, testNumber: ordinal, details });
       }
     }
     addRunCounts(counts, fileCounts);
@@ -618,6 +622,9 @@ function rebuildError(serialized: any, depth = 0): Error {
   return error;
 }
 
+// Events keep the child's `nesting`: node's FileTest forwards it unchanged, so a
+// file's top-level tests are nesting 0 under run() too; the file node is not
+// their parent.
 function republishChildEvent(
   event: { type: string; data: any },
   file: string,
@@ -627,7 +634,6 @@ function republishChildEvent(
   const { type, data } = event;
   Object.setPrototypeOf(data, null);
   data.file = file;
-  data.nesting = (data.nesting ?? 0) + 1;
   if (type === "test:pass" || type === "test:fail") {
     const isSuite = data.type === "suite";
     // node counts a suite in `suites` and stops there: a skipped or todo suite

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -378,8 +378,6 @@ async function runFiles(opts: ReturnType<typeof validateRunOptions>, reporter: T
     if (typeof opts.setup === "function") await opts.setup(reporter);
 
     const files = opts.files ?? [];
-    // Node's root numbers its FileTest subtests in order, so a file node's
-    // testId and testNumber are both the file's 1-based position in the run.
     let i = 0;
     for (; i < files.length; i++) {
       if (opts.signal?.aborted) break;
@@ -622,9 +620,7 @@ function rebuildError(serialized: any, depth = 0): Error {
   return error;
 }
 
-// Events keep the child's `nesting`: node's FileTest forwards it unchanged, so a
-// file's top-level tests are nesting 0 under run() too; the file node is not
-// their parent.
+// `nesting` is forwarded as-is: the file node is not the parent of the file's tests.
 function republishChildEvent(
   event: { type: string; data: any },
   file: string,

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { join } from "node:path";
 
 describe("node:test", () => {
@@ -343,6 +343,97 @@ async function runTests(filenames: string[], env: Record<string, string> = {}, a
   ]);
   return { exitCode, stdout, stderr };
 }
+
+describe("node:test run()", () => {
+  // Expected values are what node v26.3.0 reports for the same files.
+  // run() spawns one debug+ASAN `bun test` child per file, sequentially, hence
+  // the same headroom as the multi-file tests above.
+  test.concurrent(
+    "republishes a file's events at the child's nesting and numbers the file node by its position in the run",
+    async () => {
+      using dir = tempDir("node-test-run-nesting", {
+        "nested.js": `
+          const { test } = require("node:test");
+          test("top", async t => {
+            await t.test("sub", () => {});
+          });
+          test("failing", () => {
+            throw new Error("boom");
+          });
+          test("skipped", { skip: true }, () => {});
+        `,
+        "empty.js": "",
+        "driver.mjs": `
+          import { run } from "node:test";
+
+          const verdicts = [];
+          for await (const { type, data } of run({ files: ["nested.js", "empty.js"] })) {
+            if (type === "test:pass" || type === "test:fail") {
+              const { name, nesting, testNumber, testId } = data;
+              verdicts.push({ type, name, nesting, testNumber, testId });
+            }
+          }
+          console.log(JSON.stringify(verdicts));
+        `,
+      });
+
+      await using proc = spawn({
+        cmd: [bunExe(), "driver.mjs"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      const verdicts = JSON.parse(stdout);
+
+      // A file's top-level tests are nesting 0 under run(), exactly as when the
+      // file runs on its own; only a file with nothing to report (empty.js) is
+      // reported through its own file-level node.
+      expect(verdicts.map(({ type, name, nesting }) => [type, name, nesting])).toEqual([
+        ["test:pass", "sub", 1],
+        ["test:pass", "top", 0],
+        ["test:fail", "failing", 0],
+        ["test:pass", "skipped", 0],
+        ["test:pass", "empty.js", 0],
+      ]);
+      // The file node is the run's second file, not file number 1 every time.
+      expect(verdicts.at(-1)).toEqual({ type: "test:pass", name: "empty.js", nesting: 0, testNumber: 2, testId: 2 });
+    },
+    30_000,
+  );
+
+  test.concurrent("numbers the file nodes of an aborted run by their position too", async () => {
+    // Nothing is spawned: the run is aborted before its first file starts, so
+    // every file is reported as cancelled (the files need not even exist).
+    await using proc = spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { run } = require("node:test");
+          const verdicts = [];
+          for await (const { type, data } of run({ files: ["a.js", "b.js"], signal: AbortSignal.abort() })) {
+            if (type === "test:fail") verdicts.push([data.name, data.testNumber, data.testId]);
+          }
+          console.log(JSON.stringify(verdicts));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual([
+      ["a.js", 1, 1],
+      ["b.js", 2, 2],
+    ]);
+  });
+});
 
 describe("node:test mock", () => {
   const { mock } = require("node:test");


### PR DESCRIPTION
### Problem
- Under `run({ files })` from `node:test`, every republished `test:pass` / `test:fail` event carries a `nesting` one higher than node's: a file's top-level tests come out at nesting 1 and their subtests at nesting 2. Node v26.3.0 reports 0 and 1, exactly what the file reports when run on its own.
- Cause: `republishChildEvent()` in `src/js/node/test.ts` did `data.nesting = (data.nesting ?? 0) + 1` on every event it forwarded from the child process. Node's `FileTest#handleReportItem` (`lib/internal/test_runner/runner.js`) forwards the child's nesting unchanged.
- The file node that run() reports for a file (its `test:enqueue` / `test:dequeue`, and its verdict when the file had nothing else to report, failed, or was cancelled) always carried `testId: 1` and `testNumber: 1`, whatever its position in the run. Node gives the second file 2, and so on.

### Fix
- `republishChildEvent()` forwards the child's `nesting` as-is.
- `runFiles()` passes each file's 1-based position to `runOneFile()` / `reportCancelledFile()`, which use it as the file node's `testId` and `testNumber`.
- Why this is correct: it matches node. Node's root creates one FileTest per file and numbers them in order; under process isolation it does not treat the file node as the parent of the file's tests, so the child's nesting values are the run's nesting values. Verified against node v26.3.0 on the test's files: the verdict sequence with its nesting column, and `empty.js` reporting as `testNumber: 2, testId: 2`, are node's output line for line (details below).
- Counting is unchanged: `topLevel` and the run-level `test:plan` still count one item per file. Node counts the file's nesting-0 verdicts instead, but bun's child does not yet report top-level `describe()` suites (#39331 adds that), so counting nesting-0 verdicts here would report 0 top-level items for a describe-only file; that recount belongs with #39331. Subtest `testNumber` (node forwards the child's value; bun's child sends 0) is also unchanged.
- Verified: `test/js/node/test_runner/node-test.test.ts`, new `node:test run()` block (two cases: a two-file run pinning the nesting column and the file node's number, and a run aborted before it starts, pinning both cancelled file nodes' numbers). Both fail on main (nesting 2/1/1/1, file node number 1) and pass with the fix. The other 45 cases in the file and the vendored `run()` tests (`test-runner-todo-skip-tests.js`, `test-runner-expect-error.js`, `test-runner-expect-error-but-pass.js`, `test-runner-filetest-location.js`, `test-runner-tags-experimental-warning.mjs`) still pass.
- #34515 rewrites this code path as part of a much larger change and also drops the `+1`; this is the standalone fix for the bug on main today.

### Background
- `run()` is node:test's programmatic runner. With the default `isolation: 'process'` it runs each file in a child process; the child reports its tests as events and the parent republishes them on the `TestsStream` that `run()` returned, then appends the run-level `test:plan`, diagnostics and `test:summary`. Bun's `run()` does the same with a `bun test` child that prints one JSON event per line.
- `nesting` is a test's depth in the event stream: a file's top-level tests are 0, `t.test()` subtests inside them are 1, and so on. Reporters indent by it. Under process isolation node keeps the child's values; the file node that the parent synthesizes for each file also sits at nesting 0.
- The file node is node's FileTest: a test-shaped entry per file, enqueued and dequeued as the file starts, and given a verdict of its own only when the file had nothing else to report or the process itself failed (`FileTest#skipReporting`); a file whose tests merely failed is represented by those tests. Its `testId` and `testNumber` are its position among the run's files.

<details>
<summary>node v26.3.0 vs bun for the files used in the test</summary>

`nested.js` (`top` with subtest `sub`, a failing test, a skipped test) and `empty.js` (no tests), run in that order. Columns: event, name, nesting.

```
node v26.3.0                    bun main                        bun with this change
test:pass  sub        1         test:pass  sub        2         test:pass  sub        1
test:pass  top        0         test:pass  top        1         test:pass  top        0
test:fail  failing    0         test:fail  failing    1         test:fail  failing    0
test:pass  skipped    0         test:pass  skipped    1         test:pass  skipped    0
test:pass  empty.js   0         test:pass  empty.js   0         test:pass  empty.js   0
  (testNumber 2, testId 2)        (testNumber 1, testId 1)        (testNumber 2, testId 2)
```

</details>

<details>
<summary>Earlier revision of this PR</summary>

The first push also moved `topLevel` / `testNumber` onto node's model on the parent side: each nesting-0 verdict counted as a top-level item and was numbered across files, and the file node only counted when reported. That is right once the child reports every top-level item, but today a top-level `describe()` emits no verdict (#39331 adds it), so a describe-only file would have reported `test:plan` count 0 and `topLevel: 0` where main and node both report 1. That part was dropped from this PR; the counting on main is unchanged.

</details>
