### PR TITLE
node:test: cancel subtests still pending when their parent finishes

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -2161,25 +2161,34 @@ function invokeTestFn(fn: Function, arg: unknown) {
   return fn(arg);
 }
 
-type StopController = { promise: Promise<never>; reject: (failure: Error) => void; dispose: () => void };
+type StopController = {
+  promise: Promise<never>;
+  reject: (failure: Error) => void;
+  // Milliseconds of `budget` left; undefined when unbounded.
+  remaining: () => number | undefined;
+  dispose: () => void;
+};
 
 // Node's stopPromise: never resolves, rejects on timeout or reject() (a cancelling parent). Dispose it.
-function createStopController(timeout: number | undefined): StopController {
+function createStopController(timeout: number | undefined, budget: number | undefined = timeout): StopController {
   const { promise, reject } = Promise.withResolvers<never>();
   // Swallow the rejection when nothing is racing it anymore.
   promise.catch(() => {});
   let timer: ReturnType<typeof setTimeout> | undefined;
-  if (typeof timeout === "number" && Number.isFinite(timeout)) {
+  let deadline = Infinity;
+  if (typeof budget === "number" && Number.isFinite(budget)) {
+    deadline = performance.now() + budget;
     // Not unref'd: dispose() always clears it, and on Windows an unref'd timer
     // alone under bun:test leaves the uws loop inactive so auto_tick busy-spins.
     timer = realSetTimeout(
       () => reject(makeTestFailure(`test timed out after ${timeout}ms`, "testTimeoutFailure")),
-      timeout,
+      budget,
     );
   }
   return {
     promise,
     reject,
+    remaining: () => (timer === undefined ? undefined : Math.max(0, deadline - performance.now())),
     dispose() {
       if (timer !== undefined) realClearTimeout(timer);
     },
@@ -2316,6 +2325,9 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     failure = err;
   }
 
+  // What settleSubtests() below may still wait: the whole timeout unless the body phase used some of it.
+  let settleBudget = node.options.timeout;
+
   // Cancelled during the hooks above: the body does not run (Node's stopPromise is born rejected).
   if (failure === undefined && !node.cancelled) {
     // Node arms one stopPromise (timeout + signal) and races both the body
@@ -2359,6 +2371,7 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
       }
     } finally {
       node.stop = undefined;
+      settleBudget = stop.remaining();
       stop.dispose();
       node.plan?.cancel();
     }
@@ -2401,7 +2414,7 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
 
   // Node's postRun(): subtests are cancelled and rolled up after the hooks.
   try {
-    await settleSubtests(node);
+    await settleSubtests(node, settleBudget);
   } catch (err) {
     if (!acceptedXfail) failure ??= err;
   }
@@ -2436,15 +2449,15 @@ function chainSubtest(parent: TestNode, child: TestNode, run: () => unknown): Pr
   return link.then(() => undefined);
 }
 
-// The subtest part of Node's postRun().
-async function settleSubtests(node: TestNode) {
+// The subtest part of Node's postRun(). `budget` is what the body phase left of the test's timeout.
+async function settleSubtests(node: TestNode, budget: number | undefined) {
   if (node.unfinishedSubtests.size > 0) {
     // Node starts bodies inside t.test(); the chain starts them a tick later, so allow one macrotask.
     await new Promise<void>(resolve => realSetImmediate(resolve));
     cancelUnfinishedSubtests(node);
   }
-  // A hook or describe() callback that never settles cannot be cancelled; bound this like the body.
-  const stop = createStopController(node.options.timeout);
+  // A hook or describe() callback that never settles cannot be cancelled; the timeout still bounds it.
+  const stop = createStopController(node.options.timeout, budget);
   try {
     await Promise.race([stop.promise, drainSubtestChain(node)]);
   } finally {

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -619,8 +619,7 @@ function rebuildError(serialized: any, depth = 0): Error {
   return error;
 }
 
-// Like node, the run() parent tells a cancelled test from a failed one by the
-// failure type it was reported with (runner.js kCanceledTests).
+// node's runner.js kCanceledTests.
 function isCancellationFailureType(failureType: unknown) {
   return failureType === "cancelledByParent" || failureType === "testAborted" || failureType === "testTimeoutFailure";
 }
@@ -726,9 +725,8 @@ function reportDirectiveOnlyNode(node: TestNode, mode: "skip" | "todo") {
   });
 }
 
-// Called for every test or inline suite node once `passed`/`error` are final, so
-// subtests report with the same shape as top-level tests. No-op outside a run()
-// child.
+// Called for every test and inline suite once `passed`/`error` are final, so
+// subtests report with the same shape as top-level tests. No-op outside a run() child.
 function reportNodeToRunParent(node: TestNode, startedAt: number) {
   if (!runChildReporterEnabled) return;
   const { skipped, todoFlag, expectFailure, isSuite } = node;
@@ -751,8 +749,7 @@ function reportNodeToRunParent(node: TestNode, startedAt: number) {
   });
 }
 
-// Node's postRun() on a subtest that never got to start: it is failed with
-// cancelledByParent and reported; none of its hooks or body ever run.
+// A subtest cancelled before its turn came: reported, nothing of it runs (Node's postRun()).
 function finishCancelled(node: TestNode) {
   const failure = cancelledByParentFailure();
   node.passed = false;
@@ -1569,16 +1566,13 @@ class TestNode {
   // Inline subtests are serialized through this chain. `concurrency` is
   // validated for Node-compat error codes but subtests always run serially.
   subtestChain: Promise<void> = Promise.resolve();
-  // Node's unfinishedSubtests/subtestsPromise: `subtestsSettled` is created with
-  // the first subtest and resolved the first time none is left unfinished. It is
-  // never re-armed, so after its body settles a test only waits for that first
-  // batch; whatever is still in the set once the test itself is done gets
-  // cancelled (settleSubtests), which is how a forgotten `await t.test()` fails.
+  // Node's unfinishedSubtests and subtestsPromise: `subtestsSettled` is created
+  // with the first subtest and resolved the first time the set empties, never
+  // re-armed; a subtest still in the set once the test is done is cancelled.
   unfinishedSubtests: Set<TestNode> = new Set();
   subtestsSettled: PromiseWithResolvers<void> | undefined = undefined;
   cancelled = false;
-  // Set while the body runs so a cancelling parent can reject the race the body
-  // is in (Node aborts the subtest's signal, which rejects its stopPromise).
+  // Live while the body is raced; cancelUnfinishedSubtests() rejects it.
   stop: StopController | undefined = undefined;
   failedSubtests = 0;
   firstSubtestError: unknown = undefined;
@@ -2171,10 +2165,8 @@ function invokeTestFn(fn: Function, arg: unknown) {
 
 type StopController = { promise: Promise<never>; reject: (failure: Error) => void; dispose: () => void };
 
-// One per test run, raced against the body, the wait for its subtests and
-// plan.check(), matching Node's stopTest()/stopPromise. `promise` never
-// resolves; it rejects when the test's own timeout fires or when the parent
-// cancels the test (cancelUnfinishedSubtests). Callers must dispose().
+// Node's stopTest()/stopPromise: `promise` never resolves, it rejects when the
+// timeout fires or reject() is called (a cancelling parent). Callers must dispose().
 function createStopController(timeout: number | undefined): StopController {
   const { promise, reject } = Promise.withResolvers<never>();
   // Swallow the rejection when nothing is racing it anymore.
@@ -2324,19 +2316,17 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     failure = err;
   }
 
-  // Cancelled while the hooks above were running: Node's stopPromise would be
-  // born rejected, so the body does not get to run here either.
+  // Cancelled during the hooks above: the body does not run (Node's stopPromise is born rejected).
   if (failure === undefined && !node.cancelled) {
-    // Node arms one stopPromise (timeout + signal) and races the body, the wait
-    // for subtests AND the plan wait against it. Arm timeout once here so
-    // plan({wait:true}) is bounded by the same test timeout, not left unbounded.
+    // Node arms one stopPromise (timeout + signal) and races both the body
+    // AND the plan wait against it. Arm timeout once here so plan({wait:true})
+    // is bounded by the same test timeout, not left unbounded.
     const stop = (node.stop = createStopController(node.options.timeout));
     try {
       const runBody = async () => {
         await runWithNode(node, () => invokeTestFn(fn, ctx));
-        // Node's subtestsPromise: wait for the subtests running now, including
-        // ones they schedule in turn, but not for a subtest started after an
-        // earlier batch had already settled: settleSubtests() cancels that one.
+        // Node's subtestsPromise (see TestNode): a subtest started after the
+        // first batch settled is not waited for here, settleSubtests() cancels it.
         await node.subtestsSettled?.promise;
       };
 
@@ -2360,10 +2350,8 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
             // reject `pending` afterward with no one listening.
             pending.catch(() => {});
             await Promise.race([stop.promise, pending]);
-            // A t.test() that fulfilled the plan from an async callback may be
-            // this test's first subtest, scheduled during the wait: give it the
-            // same wait as the body's subtests so its own failure (rather than
-            // a cancellation) reaches failedSubtests below.
+            // A t.test() that fulfilled the plan may be the first subtest, created
+            // during the wait: wait for it like the body's so it reports its own failure.
             const { subtestsSettled } = node;
             if (subtestsSettled !== undefined) await Promise.race([stop.promise, subtestsSettled.promise]);
           }
@@ -2378,9 +2366,8 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     }
   }
 
-  // Node's #cancel() is a fail(): it loses to a failure the body already has.
-  // No await separates this from `finished` below, and cancelUnfinishedSubtests
-  // skips finished nodes, so a cancellation is either seen here or not at all.
+  // Node's #cancel() is a fail(), so an earlier failure wins. Nothing may await
+  // between here and `finished` below: cancelUnfinishedSubtests() skips finished nodes.
   if (node.cancelled) failure ??= cancelledByParentFailure();
 
   const bodyFailure = failure;
@@ -2389,8 +2376,7 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
 
   // Node sets passed/error before running afterEach/after so hooks can
   // introspect the outcome (nodejs/node lib/internal/test_runner/test.js
-  // pass()/fail() precede afterEach). Like there, this is the body's own
-  // outcome: subtest failures are rolled up afterwards, in the postRun step.
+  // pass()/fail() precede afterEach).
   node.passed = failure === undefined;
   node.error = failure ?? (acceptedXfail ? bodyFailure : null);
   // Mark finished before hooks so a late t.test() from an after/afterEach
@@ -2416,12 +2402,13 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     }
   }
 
-  // Node's postRun(): cancel the subtests still unfinished now that the test's
-  // own hooks have run, roll the failed ones up, then reset the mocks.
-  await settleSubtests(node);
+  // Node's postRun(): subtests are cancelled and rolled up after the hooks.
+  try {
+    await settleSubtests(node);
+  } catch (err) {
+    if (!acceptedXfail) failure ??= err;
+  }
   if (!acceptedXfail) {
-    // A before hook created while the test was running failed after the body
-    // had settled (Node fails the test with the hook's error).
     failure ??= node.hookFailure;
     if (failure === undefined && node.failedSubtests > 0) failure = subtestsFailedFailure(node);
   }
@@ -2438,13 +2425,9 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
   return failure;
 }
 
-// Appends an inline subtest (test, suite or skip directive) to the parent's
-// chain and tracks it in unfinishedSubtests until its link has run; see the
-// field's comment for what the parent does with that.
+// Appends an inline subtest (test, suite or skip directive) to the parent's chain.
 function chainSubtest(parent: TestNode, child: TestNode, run: () => unknown): Promise<undefined> {
-  // A t.test() reaching a parent that is already cancelled (from its still
-  // running body, or an async describe() callback settling late) is cancelled
-  // with it instead of running inside a result that has already been reported.
+  // Added by a cancelled parent's still-running body or describe() callback.
   if (parent.cancelled) child.cancelled = true;
   parent.unfinishedSubtests.add(child);
   const settled = (parent.subtestsSettled ??= Promise.withResolvers<void>());
@@ -2456,32 +2439,31 @@ function chainSubtest(parent: TestNode, child: TestNode, run: () => unknown): Pr
   return link.then(() => undefined);
 }
 
-// The subtest half of Node's postRun(): whatever is still unfinished once the
-// test's own hooks have run is cancelled rather than waited for, and the chain
-// is then drained only so that those cancellations (and a before hook still in
-// flight) are recorded before the test reports; the cancelled bodies themselves
-// are no longer raced. Node starts a subtest's body inside the t.test() call,
-// so one that forgot its await but finishes on microtasks alone (a sync body)
-// is complete by the time Node's postRun() runs; the chain here starts it a
-// tick later, so give such stragglers until the next macrotask before deciding.
-// Anything waiting on a timer or I/O is still pending then, as it is in Node.
+// The subtest part of Node's postRun(): cancels what is still unfinished, then
+// drains the chain so the cancellations are recorded before this test reports.
 async function settleSubtests(node: TestNode) {
   if (node.unfinishedSubtests.size > 0) {
+    // Node starts a subtest's body inside t.test() itself, so a forgotten await
+    // on a subtest that needs no timer or I/O is harmless there; the chain here
+    // starts it a tick later, so it gets until the next macrotask to finish.
     await new Promise<void>(resolve => realSetImmediate(resolve));
     cancelUnfinishedSubtests(node);
   }
-  await drainSubtestChain(node);
+  // Cancellation cannot interrupt a hook or describe() callback that never
+  // settles, so this wait is bounded by the test's timeout like the body was.
+  const stop = createStopController(node.options.timeout);
+  try {
+    await Promise.race([stop.promise, drainSubtestChain(node)]);
+  } finally {
+    stop.dispose();
+  }
 }
 
-// Fails every unfinished subtest with cancelledByParent, recursively. One that
-// has not reached its turn on the chain reports that instead of running
-// (finishCancelled); one whose body is running has its stop promise rejected
-// so that body is no longer waited for; a suite gets the same done to its own
-// pending children, which is what lets its drain finish.
+// A child still queued reports the cancellation when its turn comes (finishCancelled),
+// a running one stops being waited for; recursing is what lets a cancelled suite drain.
 function cancelUnfinishedSubtests(node: TestNode) {
   for (const child of node.unfinishedSubtests) {
-    // `finished` with the link still pending: the result is already decided and
-    // only the after hooks are left, which the parent's drain waits for.
+    // finished: the result is in, only its hooks are left; the drain waits for those.
     if (child.cancelled || child.finished) continue;
     child.cancelled = true;
     child.stop?.reject(cancelledByParentFailure());
@@ -2522,9 +2504,8 @@ function scheduleSubtest(parent: TestNode, child: TestNode, fn: TestFn, ownTodo:
   });
 }
 
-// A skip-only subtest never runs, but Node still tracks it as a subtest: it
-// takes part in the parent's first settle and is cancelled like any other (and
-// then, unlike a runtime t.skip(), counts against the parent).
+// Node tracks a skip-only subtest like any other: it counts toward the parent's
+// first settle, and if cancelled it counts against the parent (unlike a runtime t.skip()).
 function scheduleSkippedSubtest(parent: TestNode, child: TestNode, ownTodo: boolean): Promise<undefined> {
   child.skipped = true;
   return chainSubtest(parent, child, () => {
@@ -2573,10 +2554,8 @@ function scheduleSuiteSubtest(parent: TestNode, suite: TestNode, build: unknown,
         recordSuiteFailure(suite, err);
       }
     }
-    // Node's Suite.run() checks for cancellation once the build has settled: a
-    // suite cancelled by then runs no hooks at all, one cancelled while its
-    // children run still gets its after hooks. Either way the children are
-    // drained first: the cancelled ones report themselves as they come up.
+    // Node's Suite.run(): cancelled by the time the build settled means no hooks
+    // at all; cancelled while the children run still gets the after hooks.
     const runHooks = !suite.cancelled;
     if (runHooks) {
       try {
@@ -2598,8 +2577,7 @@ function scheduleSuiteSubtest(parent: TestNode, suite: TestNode, build: unknown,
       }
     }
     suite.finished = true;
-    // A cancelled suite reports the cancellation itself (Node), not the
-    // failures of the children cancelled along with it.
+    // A cancelled suite reports the cancellation, not its cancelled children (Node).
     let failure: unknown;
     if (suite.cancelled) failure = cancelledByParentFailure();
     else if (suite.failedSubtests > 0) failure = subtestsFailedFailure(suite);

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -28,6 +28,7 @@ const kDefaultFunction = () => {};
 // globals, so capture them at module load like Node's runner does.
 const realSetTimeout = setTimeout;
 const realClearTimeout = clearTimeout;
+const realSetImmediate = setImmediate;
 const kDefaultOptions = kEmptyObject;
 // Matches Node's internal/timers TIMEOUT_MAX.
 const kTimeoutMax = 2 ** 31 - 1;
@@ -425,7 +426,7 @@ function reportCancelledFile(
     column: 1,
     file: absolute,
   };
-  const error = makeTestFailure("test did not finish before its parent and was cancelled", "cancelledByParent");
+  const error = cancelledByParentFailure();
   const details = { __proto__: null, duration_ms: 0, type: "test", error };
   reporter.enqueue({ __proto__: null, ...fileNode });
   reporter.dequeue({ __proto__: null, ...fileNode });
@@ -549,7 +550,7 @@ async function runOneFile(
     // A nonzero exit with no child-reported failures means the file itself died
     // (top-level throw); child-reported failures are already covered by the
     // republished events and need no file-level verdict.
-    const fileFailed = exitCode !== 0 && fileCounts.failed === 0;
+    const fileFailed = exitCode !== 0 && fileCounts.failed === 0 && fileCounts.cancelled === 0;
     const fileDuration = Date.now() - fileStarted;
     // Node's FileTest.#skipReporting(): no file-level complete/pass/fail when
     // the child reported at least one test and the only error is subtestsFailed
@@ -572,7 +573,7 @@ async function runOneFile(
     } else {
       reporter.summary({
         __proto__: null,
-        success: fileCounts.failed === 0,
+        success: fileCounts.failed === 0 && fileCounts.cancelled === 0,
         counts: { __proto__: null, ...fileCounts },
         duration_ms: fileDuration,
         file: absolute,
@@ -618,6 +619,12 @@ function rebuildError(serialized: any, depth = 0): Error {
   return error;
 }
 
+// Like node, the run() parent tells a cancelled test from a failed one by the
+// failure type it was reported with (runner.js kCanceledTests).
+function isCancellationFailureType(failureType: unknown) {
+  return failureType === "cancelledByParent" || failureType === "testAborted" || failureType === "testTimeoutFailure";
+}
+
 function republishChildEvent(
   event: { type: string; data: any },
   file: string,
@@ -638,6 +645,7 @@ function republishChildEvent(
       if (data.skip) counts.skipped++;
       else if (data.todo) counts.todo++;
       else if (type === "test:pass") counts.passed++;
+      else if (isCancellationFailureType(data.error?.failureType)) counts.cancelled++;
       else counts.failed++;
     }
     // node carries the node kind on `details`, not on the event itself.
@@ -718,13 +726,14 @@ function reportDirectiveOnlyNode(node: TestNode, mode: "skip" | "todo") {
   });
 }
 
-// Called for every test node as its result is finalized, so subtests report
-// with the same shape as top-level tests. No-op outside a run() child.
+// Called for every test or inline suite node once `passed`/`error` are final, so
+// subtests report with the same shape as top-level tests. No-op outside a run()
+// child.
 function reportNodeToRunParent(node: TestNode, startedAt: number) {
-  if (!runChildReporterEnabled || node.isSuite) return;
-  const { skipped, todoFlag, expectFailure } = node;
+  if (!runChildReporterEnabled) return;
+  const { skipped, todoFlag, expectFailure, isSuite } = node;
   // node reports the xfail label when there is one, otherwise `true`.
-  const xfail = !skipped && expectFailure ? (expectFailure.label ?? true) : undefined;
+  const xfail = !isSuite && !skipped && expectFailure ? (expectFailure.label ?? true) : undefined;
   // node spreads a `directive` into the event: `skip: true` / `todo: true`, with
   // the other key absent entirely.
   emitRunChildEvent(node.passed ? "test:pass" : "test:fail", {
@@ -733,12 +742,24 @@ function reportNodeToRunParent(node: TestNode, startedAt: number) {
     nesting: nestingOf(node),
     testNumber: 0,
     duration_ms: performance.now() - startedAt,
+    type: isSuite ? "suite" : "test",
     skip: skipped ? (node.message ?? true) : undefined,
     todo: !skipped && todoFlag ? (node.message ?? true) : undefined,
     expectFailure: xfail,
     tags: node.tags,
     error: node.passed ? undefined : serializeRunError(node.error),
   });
+}
+
+// Node's postRun() on a subtest that never got to start: it is failed with
+// cancelledByParent and reported; none of its hooks or body ever run.
+function finishCancelled(node: TestNode) {
+  const failure = cancelledByParentFailure();
+  node.passed = false;
+  node.error = failure;
+  node.finished = true;
+  reportNodeToRunParent(node, runChildReporterEnabled ? performance.now() : 0);
+  return failure;
 }
 
 // -----------------------------------------------------------------------------
@@ -1386,6 +1407,10 @@ function makeTestFailure(message: string, failureType?: string) {
   return error;
 }
 
+function cancelledByParentFailure() {
+  return makeTestFailure("test did not finish before its parent and was cancelled", "cancelledByParent");
+}
+
 class TestPlan {
   expected: number;
   actual = 0;
@@ -1544,6 +1569,17 @@ class TestNode {
   // Inline subtests are serialized through this chain. `concurrency` is
   // validated for Node-compat error codes but subtests always run serially.
   subtestChain: Promise<void> = Promise.resolve();
+  // Node's unfinishedSubtests/subtestsPromise: `subtestsSettled` is created with
+  // the first subtest and resolved the first time none is left unfinished. It is
+  // never re-armed, so after its body settles a test only waits for that first
+  // batch; whatever is still in the set once the test itself is done gets
+  // cancelled (settleSubtests), which is how a forgotten `await t.test()` fails.
+  unfinishedSubtests: Set<TestNode> = new Set();
+  subtestsSettled: PromiseWithResolvers<void> | undefined = undefined;
+  cancelled = false;
+  // Set while the body runs so a cancelling parent can reject the race the body
+  // is in (Node aborts the subtest's signal, which rejects its stopPromise).
+  stop: StopController | undefined = undefined;
   failedSubtests = 0;
   firstSubtestError: unknown = undefined;
   // First failure from a before hook created while this test was running.
@@ -2133,22 +2169,29 @@ function invokeTestFn(fn: Function, arg: unknown) {
   return fn(arg);
 }
 
-// A single timeout armed once per test and raced against both the body and
+type StopController = { promise: Promise<never>; reject: (failure: Error) => void; dispose: () => void };
+
+// One per test run, raced against the body, the wait for its subtests and
 // plan.check(), matching Node's stopTest()/stopPromise. `promise` never
-// resolves; it only rejects with the timeout error. Callers must dispose().
-function createStopController(timeout: number | undefined) {
-  if (typeof timeout !== "number" || !Number.isFinite(timeout)) {
-    return undefined;
-  }
-  let timer: ReturnType<typeof setTimeout>;
-  const promise = new Promise<never>((_, reject) => {
+// resolves; it rejects when the test's own timeout fires or when the parent
+// cancels the test (cancelUnfinishedSubtests). Callers must dispose().
+function createStopController(timeout: number | undefined): StopController {
+  const { promise, reject } = Promise.withResolvers<never>();
+  // Swallow the rejection when nothing is racing it anymore.
+  promise.catch(() => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  if (typeof timeout === "number" && Number.isFinite(timeout)) {
     // Not unref'd: dispose() always clears it, and on Windows an unref'd timer
     // alone under bun:test leaves the uws loop inactive so auto_tick busy-spins.
     timer = realSetTimeout(() => reject(makeTestFailure(`test timed out after ${timeout}ms`)), timeout);
-  });
-  // Swallow the rejection when nothing is racing it anymore.
-  promise.catch(() => {});
-  return { promise, dispose: () => realClearTimeout(timer) };
+  }
+  return {
+    promise,
+    reject,
+    dispose() {
+      if (timer !== undefined) realClearTimeout(timer);
+    },
+  };
 }
 
 // Runs `run` racing Node's test timeout; the timer starts before the body so a
@@ -2281,21 +2324,24 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     failure = err;
   }
 
-  if (failure === undefined) {
-    // Node arms one stopPromise (timeout + signal) and races both the body
-    // AND the plan wait against it. Arm timeout once here so plan({wait:true})
-    // is bounded by the same test timeout, not left unbounded.
-    const stop = createStopController(node.options.timeout);
+  // Cancelled while the hooks above were running: Node's stopPromise would be
+  // born rejected, so the body does not get to run here either.
+  if (failure === undefined && !node.cancelled) {
+    // Node arms one stopPromise (timeout + signal) and races the body, the wait
+    // for subtests AND the plan wait against it. Arm timeout once here so
+    // plan({wait:true}) is bounded by the same test timeout, not left unbounded.
+    const stop = (node.stop = createStopController(node.options.timeout));
     try {
       const runBody = async () => {
         await runWithNode(node, () => invokeTestFn(fn, ctx));
-        // Wait for inline subtests created during the body (awaited or not),
-        // including ones scheduled while earlier subtests were running.
-        await drainSubtestChain(node);
+        // Node's subtestsPromise: wait for the subtests running now, including
+        // ones they schedule in turn, but not for a subtest started after an
+        // earlier batch had already settled: settleSubtests() cancels that one.
+        await node.subtestsSettled?.promise;
       };
 
       try {
-        await (stop === undefined ? runBody() : Promise.race([stop.promise, runBody()]));
+        await Promise.race([stop.promise, runBody()]);
       } catch (err) {
         // A body that throws or rejects with a nullish value must still fail.
         failure = err ?? makeTestFailure("test failed");
@@ -2313,34 +2359,29 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
             // Defuse: if stop wins the race, plan's own wait-timeout may still
             // reject `pending` afterward with no one listening.
             pending.catch(() => {});
-            await (stop === undefined ? pending : Promise.race([stop.promise, pending]));
-            // A t.test() that fulfilled the plan from an async callback was
-            // scheduled onto subtestChain during the wait; drain again so its
-            // failure reaches failedSubtests below (Node fails the parent).
-            const drain = drainSubtestChain(node);
-            await (stop === undefined ? drain : Promise.race([stop.promise, drain]));
+            await Promise.race([stop.promise, pending]);
+            // A t.test() that fulfilled the plan from an async callback may be
+            // this test's first subtest, scheduled during the wait: give it the
+            // same wait as the body's subtests so its own failure (rather than
+            // a cancellation) reaches failedSubtests below.
+            const { subtestsSettled } = node;
+            if (subtestsSettled !== undefined) await Promise.race([stop.promise, subtestsSettled.promise]);
           }
         } catch (err) {
           failure = err;
         }
       }
     } finally {
-      stop?.dispose();
+      node.stop = undefined;
+      stop.dispose();
       node.plan?.cancel();
     }
-
-    const { failedSubtests, firstSubtestError } = node;
-    if (failure === undefined && failedSubtests > 0) {
-      const error = makeTestFailure(
-        `${failedSubtests} subtest${failedSubtests > 1 ? "s" : ""} failed`,
-        "subtestsFailed",
-      );
-      if (firstSubtestError !== undefined) {
-        (error as { cause?: unknown }).cause = firstSubtestError;
-      }
-      failure = error;
-    }
   }
+
+  // Node's #cancel() is a fail(): it loses to a failure the body already has.
+  // No await separates this from `finished` below, and cancelUnfinishedSubtests
+  // skips finished nodes, so a cancellation is either seen here or not at all.
+  if (node.cancelled) failure ??= cancelledByParentFailure();
 
   const bodyFailure = failure;
   failure = applyExpectFailure(node, failure);
@@ -2348,7 +2389,8 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
 
   // Node sets passed/error before running afterEach/after so hooks can
   // introspect the outcome (nodejs/node lib/internal/test_runner/test.js
-  // pass()/fail() precede afterEach).
+  // pass()/fail() precede afterEach). Like there, this is the body's own
+  // outcome: subtest failures are rolled up afterwards, in the postRun step.
   node.passed = failure === undefined;
   node.error = failure ?? (acceptedXfail ? bodyFailure : null);
   // Mark finished before hooks so a late t.test() from an after/afterEach
@@ -2374,6 +2416,16 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     }
   }
 
+  // Node's postRun(): cancel the subtests still unfinished now that the test's
+  // own hooks have run, roll the failed ones up, then reset the mocks.
+  await settleSubtests(node);
+  if (!acceptedXfail) {
+    // A before hook created while the test was running failed after the body
+    // had settled (Node fails the test with the hook's error).
+    failure ??= node.hookFailure;
+    if (failure === undefined && node.failedSubtests > 0) failure = subtestsFailedFailure(node);
+  }
+
   try {
     node.mockTracker?.reset();
   } catch (err) {
@@ -2386,30 +2438,106 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
   return failure;
 }
 
+// Appends an inline subtest (test, suite or skip directive) to the parent's
+// chain and tracks it in unfinishedSubtests until its link has run; see the
+// field's comment for what the parent does with that.
+function chainSubtest(parent: TestNode, child: TestNode, run: () => unknown): Promise<undefined> {
+  // A t.test() reaching a parent that is already cancelled (from its still
+  // running body, or an async describe() callback settling late) is cancelled
+  // with it instead of running inside a result that has already been reported.
+  if (parent.cancelled) child.cancelled = true;
+  parent.unfinishedSubtests.add(child);
+  const settled = (parent.subtestsSettled ??= Promise.withResolvers<void>());
+  const finish = () => {
+    parent.unfinishedSubtests.delete(child);
+    if (parent.unfinishedSubtests.size === 0) settled.resolve();
+  };
+  const link = (parent.subtestChain = parent.subtestChain.then(run).then(finish, finish));
+  return link.then(() => undefined);
+}
+
+// The subtest half of Node's postRun(): whatever is still unfinished once the
+// test's own hooks have run is cancelled rather than waited for, and the chain
+// is then drained only so that those cancellations (and a before hook still in
+// flight) are recorded before the test reports; the cancelled bodies themselves
+// are no longer raced. Node starts a subtest's body inside the t.test() call,
+// so one that forgot its await but finishes on microtasks alone (a sync body)
+// is complete by the time Node's postRun() runs; the chain here starts it a
+// tick later, so give such stragglers until the next macrotask before deciding.
+// Anything waiting on a timer or I/O is still pending then, as it is in Node.
+async function settleSubtests(node: TestNode) {
+  if (node.unfinishedSubtests.size > 0) {
+    await new Promise<void>(resolve => realSetImmediate(resolve));
+    cancelUnfinishedSubtests(node);
+  }
+  await drainSubtestChain(node);
+}
+
+// Fails every unfinished subtest with cancelledByParent, recursively. One that
+// has not reached its turn on the chain reports that instead of running
+// (finishCancelled); one whose body is running has its stop promise rejected
+// so that body is no longer waited for; a suite gets the same done to its own
+// pending children, which is what lets its drain finish.
+function cancelUnfinishedSubtests(node: TestNode) {
+  for (const child of node.unfinishedSubtests) {
+    // `finished` with the link still pending: the result is already decided and
+    // only the after hooks are left, which the parent's drain waits for.
+    if (child.cancelled || child.finished) continue;
+    child.cancelled = true;
+    child.stop?.reject(cancelledByParentFailure());
+    cancelUnfinishedSubtests(child);
+  }
+}
+
+function subtestsFailedFailure(node: TestNode) {
+  const { failedSubtests, firstSubtestError } = node;
+  const error = makeTestFailure(`${failedSubtests} subtest${failedSubtests > 1 ? "s" : ""} failed`, "subtestsFailed");
+  if (firstSubtestError !== undefined) {
+    (error as { cause?: unknown }).cause = firstSubtestError;
+  }
+  return error;
+}
+
 function scheduleSubtest(parent: TestNode, child: TestNode, fn: TestFn, ownTodo: boolean): Promise<undefined> {
-  const run = async () => {
-    if (child.options.skip) {
-      child.finished = true;
-      child.passed = true;
-      return;
-    }
+  return chainSubtest(parent, child, async () => {
     let failure: unknown;
-    try {
-      await runOwnBeforeHooks(parent);
-      failure = await executeTestNode(child, fn);
-    } catch (err) {
-      failure = err;
+    if (child.cancelled) {
+      failure = finishCancelled(child);
+    } else {
+      try {
+        await runOwnBeforeHooks(parent);
+        failure = await executeTestNode(child, fn);
+      } catch (err) {
+        failure = err;
+      }
+      if (child.skipped) return;
     }
     // Check the child's own todo declaration (options.todo or test.todo(...)),
     // not the inherited todoFlag: a subtest that threw must still fail a
     // {todo:true} parent so bun:test under --todo reports Todo (failure rolls up).
-    if (failure !== undefined && !ownTodo && !child.skipped) {
+    if (failure !== undefined && !ownTodo) {
       parent.failedSubtests++;
       parent.firstSubtestError ??= failure;
     }
-  };
-  const result = (parent.subtestChain = parent.subtestChain.then(run));
-  return result.then(() => undefined);
+  });
+}
+
+// A skip-only subtest never runs, but Node still tracks it as a subtest: it
+// takes part in the parent's first settle and is cancelled like any other (and
+// then, unlike a runtime t.skip(), counts against the parent).
+function scheduleSkippedSubtest(parent: TestNode, child: TestNode, ownTodo: boolean): Promise<undefined> {
+  child.skipped = true;
+  return chainSubtest(parent, child, () => {
+    if (!child.cancelled) {
+      reportDirectiveOnlyNode(child, "skip");
+      return;
+    }
+    const failure = finishCancelled(child);
+    if (!ownTodo) {
+      parent.failedSubtests++;
+      parent.firstSubtestError ??= failure;
+    }
+  });
 }
 
 function recordSuiteFailure(suite: TestNode, err: unknown) {
@@ -2434,7 +2562,8 @@ function scheduleSuiteSubtest(parent: TestNode, suite: TestNode, build: unknown,
   // A describe()/suite() created while a test is running becomes a suite
   // subtest: its children were collected eagerly when the callback ran and are
   // already chained on the suite's own subtestChain; failures roll up here.
-  const run = async () => {
+  return chainSubtest(parent, suite, async () => {
+    const started = runChildReporterEnabled ? performance.now() : 0;
     if (build !== undefined) {
       try {
         // An async describe() callback that rejects fails the suite (Node
@@ -2444,51 +2573,45 @@ function scheduleSuiteSubtest(parent: TestNode, suite: TestNode, build: unknown,
         recordSuiteFailure(suite, err);
       }
     }
-    try {
-      await runOwnBeforeHooks(suite);
-    } catch (err) {
-      // A failing suite-level before hook fails the suite, like Node.
-      recordSuiteFailure(suite, err);
-    }
-    // Wait for children created during the callback and any they schedule.
-    await drainSubtestChain(suite);
-    for (const hook of suite.hooks.after) {
+    // Node's Suite.run() checks for cancellation once the build has settled: a
+    // suite cancelled by then runs no hooks at all, one cancelled while its
+    // children run still gets its after hooks. Either way the children are
+    // drained first: the cancelled ones report themselves as they come up.
+    const runHooks = !suite.cancelled;
+    if (runHooks) {
       try {
-        await runHook(hook, suite, suite.getSuiteCtx());
+        await runOwnBeforeHooks(suite);
       } catch (err) {
+        // A failing suite-level before hook fails the suite, like Node.
         recordSuiteFailure(suite, err);
       }
     }
+    // Wait for children created during the callback and any they schedule.
+    await drainSubtestChain(suite);
+    if (runHooks) {
+      for (const hook of suite.hooks.after) {
+        try {
+          await runHook(hook, suite, suite.getSuiteCtx());
+        } catch (err) {
+          recordSuiteFailure(suite, err);
+        }
+      }
+    }
     suite.finished = true;
-    suite.passed = suite.failedSubtests === 0;
-    if (runChildReporterEnabled) {
-      emitRunChildEvent(suite.passed ? "test:pass" : "test:fail", {
-        __proto__: null,
-        name: suite.name,
-        nesting: nestingOf(suite),
-        testNumber: 0,
-        duration_ms: 0,
-        type: "suite",
-        tags: suite.tags,
-        todo: suite.todoFlag ? (suite.message ?? true) : undefined,
-        error: suite.passed
-          ? undefined
-          : serializeRunError(
-              makeTestFailure(
-                `${suite.failedSubtests} subtest${suite.failedSubtests > 1 ? "s" : ""} failed`,
-                "subtestsFailed",
-              ),
-            ),
-      });
-    }
+    // A cancelled suite reports the cancellation itself (Node), not the
+    // failures of the children cancelled along with it.
+    let failure: unknown;
+    if (suite.cancelled) failure = cancelledByParentFailure();
+    else if (suite.failedSubtests > 0) failure = subtestsFailedFailure(suite);
+    suite.passed = failure === undefined;
+    suite.error = failure ?? null;
+    reportNodeToRunParent(suite, started);
     // A todo suite's failures do not fail the owning test (Node).
-    if (suite.failedSubtests > 0 && !ownTodo) {
+    if (failure !== undefined && !ownTodo) {
       parent.failedSubtests++;
-      parent.firstSubtestError ??= suite.firstSubtestError;
+      parent.firstSubtestError ??= suite.firstSubtestError ?? failure;
     }
-  };
-  const result = (parent.subtestChain = parent.subtestChain.then(run));
-  return result.then(() => undefined);
+  });
 }
 
 // -----------------------------------------------------------------------------
@@ -2575,14 +2698,10 @@ function addTest(
       // Subtest of a running test (or of an inline suite created inside one).
       const child = new TestNode(name, runningNode, options, false, true);
       child.ownTags = ownTags;
-      if (mode === "skip" || options.skip) {
-        // Chain onto subtestChain so the directive lands after earlier siblings.
-        const chained = (runningNode.subtestChain = runningNode.subtestChain.then(() =>
-          reportDirectiveOnlyNode(child, "skip"),
-        ));
-        return chained.then(() => undefined);
-      }
       const ownTodo = mode === "todo" || !!options.todo;
+      if (mode === "skip" || options.skip) {
+        return scheduleSkippedSubtest(runningNode, child, ownTodo);
+      }
       if (ownTodo) child.todoFlag = true;
       return scheduleSubtest(runningNode, child, fn, ownTodo);
     }
@@ -2671,14 +2790,10 @@ function addSuite(
   if (runningNode !== undefined && runningNode.isRunning()) {
     const suite = new TestNode(name, runningNode, options, true, true);
     suite.ownTags = ownTags;
-    if (mode === "skip" || options.skip) {
-      // Chain onto subtestChain so the directive lands after earlier siblings.
-      const chained = (runningNode.subtestChain = runningNode.subtestChain.then(() =>
-        reportDirectiveOnlyNode(suite, "skip"),
-      ));
-      return chained.then(() => undefined);
-    }
     const ownTodo = mode === "todo" || !!options.todo;
+    if (mode === "skip" || options.skip) {
+      return scheduleSkippedSubtest(runningNode, suite, ownTodo);
+    }
     if (ownTodo) suite.todoFlag = true;
     // The suite's children must run after the parent's previously scheduled
     // subtests AND after the describe callback's own returned promise settles

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -619,9 +619,9 @@ function rebuildError(serialized: any, depth = 0): Error {
   return error;
 }
 
-// node's runner.js kCanceledTests.
+// node's runner.js kCanceledTests, minus testAborted: t.signal never aborts here.
 function isCancellationFailureType(failureType: unknown) {
-  return failureType === "cancelledByParent" || failureType === "testAborted" || failureType === "testTimeoutFailure";
+  return failureType === "cancelledByParent" || failureType === "testTimeoutFailure";
 }
 
 function republishChildEvent(
@@ -725,8 +725,8 @@ function reportDirectiveOnlyNode(node: TestNode, mode: "skip" | "todo") {
   });
 }
 
-// Called for every test and inline suite once `passed`/`error` are final, so
-// subtests report with the same shape as top-level tests. No-op outside a run() child.
+// Called for every test node as its result is finalized, so subtests report
+// with the same shape as top-level tests. No-op outside a run() child.
 function reportNodeToRunParent(node: TestNode, startedAt: number) {
   if (!runChildReporterEnabled) return;
   const { skipped, todoFlag, expectFailure, isSuite } = node;
@@ -1566,9 +1566,7 @@ class TestNode {
   // Inline subtests are serialized through this chain. `concurrency` is
   // validated for Node-compat error codes but subtests always run serially.
   subtestChain: Promise<void> = Promise.resolve();
-  // Node's unfinishedSubtests and subtestsPromise: `subtestsSettled` is created
-  // with the first subtest and resolved the first time the set empties, never
-  // re-armed; a subtest still in the set once the test is done is cancelled.
+  // Node's unfinishedSubtests and subtestsPromise; the latter is never re-armed once resolved.
   unfinishedSubtests: Set<TestNode> = new Set();
   subtestsSettled: PromiseWithResolvers<void> | undefined = undefined;
   cancelled = false;
@@ -2165,8 +2163,7 @@ function invokeTestFn(fn: Function, arg: unknown) {
 
 type StopController = { promise: Promise<never>; reject: (failure: Error) => void; dispose: () => void };
 
-// Node's stopTest()/stopPromise: `promise` never resolves, it rejects when the
-// timeout fires or reject() is called (a cancelling parent). Callers must dispose().
+// Node's stopPromise: never resolves, rejects on timeout or reject() (a cancelling parent). Dispose it.
 function createStopController(timeout: number | undefined): StopController {
   const { promise, reject } = Promise.withResolvers<never>();
   // Swallow the rejection when nothing is racing it anymore.
@@ -2175,7 +2172,10 @@ function createStopController(timeout: number | undefined): StopController {
   if (typeof timeout === "number" && Number.isFinite(timeout)) {
     // Not unref'd: dispose() always clears it, and on Windows an unref'd timer
     // alone under bun:test leaves the uws loop inactive so auto_tick busy-spins.
-    timer = realSetTimeout(() => reject(makeTestFailure(`test timed out after ${timeout}ms`)), timeout);
+    timer = realSetTimeout(
+      () => reject(makeTestFailure(`test timed out after ${timeout}ms`, "testTimeoutFailure")),
+      timeout,
+    );
   }
   return {
     promise,
@@ -2325,8 +2325,7 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     try {
       const runBody = async () => {
         await runWithNode(node, () => invokeTestFn(fn, ctx));
-        // Node's subtestsPromise (see TestNode): a subtest started after the
-        // first batch settled is not waited for here, settleSubtests() cancels it.
+        // Node's subtestsPromise: a subtest started after it resolved is cancelled in settleSubtests().
         await node.subtestsSettled?.promise;
       };
 
@@ -2350,8 +2349,7 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
             // reject `pending` afterward with no one listening.
             pending.catch(() => {});
             await Promise.race([stop.promise, pending]);
-            // A t.test() that fulfilled the plan may be the first subtest, created
-            // during the wait: wait for it like the body's so it reports its own failure.
+            // A t.test() created during the wait may be the first subtest: await it like the body's.
             const { subtestsSettled } = node;
             if (subtestsSettled !== undefined) await Promise.race([stop.promise, subtestsSettled.promise]);
           }
@@ -2366,8 +2364,7 @@ async function executeTestNode(node: TestNode, fn: TestFn): Promise<unknown> {
     }
   }
 
-  // Node's #cancel() is a fail(), so an earlier failure wins. Nothing may await
-  // between here and `finished` below: cancelUnfinishedSubtests() skips finished nodes.
+  // Like Node's #cancel(), an earlier failure wins. Nothing may await before `finished` is set below.
   if (node.cancelled) failure ??= cancelledByParentFailure();
 
   const bodyFailure = failure;
@@ -2439,18 +2436,14 @@ function chainSubtest(parent: TestNode, child: TestNode, run: () => unknown): Pr
   return link.then(() => undefined);
 }
 
-// The subtest part of Node's postRun(): cancels what is still unfinished, then
-// drains the chain so the cancellations are recorded before this test reports.
+// The subtest part of Node's postRun().
 async function settleSubtests(node: TestNode) {
   if (node.unfinishedSubtests.size > 0) {
-    // Node starts a subtest's body inside t.test() itself, so a forgotten await
-    // on a subtest that needs no timer or I/O is harmless there; the chain here
-    // starts it a tick later, so it gets until the next macrotask to finish.
+    // Node starts bodies inside t.test(); the chain starts them a tick later, so allow one macrotask.
     await new Promise<void>(resolve => realSetImmediate(resolve));
     cancelUnfinishedSubtests(node);
   }
-  // Cancellation cannot interrupt a hook or describe() callback that never
-  // settles, so this wait is bounded by the test's timeout like the body was.
+  // A hook or describe() callback that never settles cannot be cancelled; bound this like the body.
   const stop = createStopController(node.options.timeout);
   try {
     await Promise.race([stop.promise, drainSubtestChain(node)]);
@@ -2459,8 +2452,7 @@ async function settleSubtests(node: TestNode) {
   }
 }
 
-// A child still queued reports the cancellation when its turn comes (finishCancelled),
-// a running one stops being waited for; recursing is what lets a cancelled suite drain.
+// A queued child reports the cancellation when its turn comes; a running one stops being waited for.
 function cancelUnfinishedSubtests(node: TestNode) {
   for (const child of node.unfinishedSubtests) {
     // finished: the result is in, only its hooks are left; the drain waits for those.
@@ -2504,8 +2496,7 @@ function scheduleSubtest(parent: TestNode, child: TestNode, fn: TestFn, ownTodo:
   });
 }
 
-// Node tracks a skip-only subtest like any other: it counts toward the parent's
-// first settle, and if cancelled it counts against the parent (unlike a runtime t.skip()).
+// Node tracks a skipped subtest like any other: it settles the first batch and fails the parent if cancelled.
 function scheduleSkippedSubtest(parent: TestNode, child: TestNode, ownTodo: boolean): Promise<undefined> {
   child.skipped = true;
   return chainSubtest(parent, child, () => {
@@ -2554,8 +2545,7 @@ function scheduleSuiteSubtest(parent: TestNode, suite: TestNode, build: unknown,
         recordSuiteFailure(suite, err);
       }
     }
-    // Node's Suite.run(): cancelled by the time the build settled means no hooks
-    // at all; cancelled while the children run still gets the after hooks.
+    // Node's Suite.run(): no hooks if cancelled before the build settled, after hooks if cancelled later.
     const runHooks = !suite.cancelled;
     if (runHooks) {
       try {

--- a/test/js/node/test_runner/fixtures/30-cancelled-subtests.js
+++ b/test/js/node/test_runner/fixtures/30-cancelled-subtests.js
@@ -1,0 +1,109 @@
+// A parent waits for its inline subtests only until the first time every
+// subtest created so far has finished (Node's subtestsPromise). A subtest that
+// is still unfinished when the parent's own result is in, and was started after
+// that point, fails with cancelledByParent and fails the parent, instead of
+// being waited for. node-test.test.ts asserts the exact counts and the markers
+// printed below; `node --test` on v26.3.0 fails and passes the same tests.
+const { test, describe } = require("node:test");
+
+const never = () => new Promise(() => {});
+const tick = () => new Promise(resolve => setImmediate(resolve));
+
+// ---- Cancelled (these tests fail) -------------------------------------------
+
+test("FAIL: an unawaited subtest started after an earlier one settled is cancelled", async t => {
+  await t.test("first", () => {});
+  t.test("slow", async st => {
+    // Node runs the after hooks of a cancelled subtest right away, with the
+    // cancellation visible as its error.
+    st.after(() => console.log(`SLOW_AFTER_HOOK failureType=${st.error?.failureType} passed=${st.passed}`));
+    await never();
+  });
+});
+
+test("FAIL: subtests queued behind the cancelled one are cancelled without running", async t => {
+  await t.test("first", () => {});
+  t.test("slow", never);
+  t.test("queued test", () => console.log("QUEUED_TEST_RAN"));
+  describe("queued suite", () => {
+    test("queued suite child", () => console.log("QUEUED_SUITE_CHILD_RAN"));
+  });
+});
+
+test("FAIL: a parent that throws cancels its in-flight subtest too", async t => {
+  t.test("in flight", async st => {
+    st.after(() => console.log(`IN_FLIGHT_AFTER_HOOK failureType=${st.error?.failureType}`));
+    await never();
+  });
+  throw new Error("parent body failed");
+});
+
+test("FAIL: a skipped subtest settles the first batch like any other", async t => {
+  await t.test("skipped", { skip: true }, () => {});
+  t.test("slow", never);
+});
+
+// ---- Waited for (these tests pass) ------------------------------------------
+
+test("PASS: a sync parent waits for an unawaited subtest", t => {
+  t.test("slow", async () => {
+    await tick();
+    console.log("SYNC_PARENT_SUBTEST_FINISHED");
+  });
+});
+
+test("PASS: an async parent waits for its first unawaited subtest", async t => {
+  t.test("slow", async () => {
+    await tick();
+    console.log("ASYNC_PARENT_SUBTEST_FINISHED");
+  });
+});
+
+test("PASS: every subtest of the first batch is waited for", async t => {
+  t.test("a", tick);
+  t.test("b", async () => {
+    await tick();
+    console.log("SECOND_OF_BATCH_FINISHED");
+  });
+});
+
+test("PASS: a later subtest that finishes before the parent does is not cancelled", async t => {
+  await t.test("first", () => {});
+  t.test("second", tick);
+  await tick();
+  await tick();
+});
+
+test("PASS: a cancelled todo subtest does not fail its parent", async t => {
+  await t.test("first", () => {});
+  t.test("pending todo", { todo: true }, never);
+});
+
+// Node starts a subtest's body inside the t.test() call, so a forgotten await
+// on a subtest that needs no timer or I/O to finish is harmless there.
+test("PASS: a later unawaited subtest with a sync body still completes", async t => {
+  await t.test("first", () => {});
+  t.test("second", () => console.log("LATER_SYNC_SUBTEST_RAN"));
+});
+
+test("PASS: a later unawaited subtest that only awaits microtasks still completes", async t => {
+  await t.test("first", () => {});
+  t.test("second", async () => {
+    await null;
+    console.log("LATER_MICROTASK_SUBTEST_FINISHED");
+  });
+});
+
+// Node cancels in postRun(), after the parent's own after hooks: a straggler
+// that finishes while they run is not cancelled.
+test("PASS: a later subtest finishing during the parent's after hook is not cancelled", async t => {
+  t.after(async () => {
+    await tick();
+    await tick();
+  });
+  await t.test("first", () => {});
+  t.test("second", async () => {
+    await tick();
+    console.log("STRAGGLER_FINISHED_DURING_AFTER_HOOK");
+  });
+});

--- a/test/js/node/test_runner/fixtures/31-timeout-bounds-hanging-hook.js
+++ b/test/js/node/test_runner/fixtures/31-timeout-bounds-hanging-hook.js
@@ -1,8 +1,8 @@
-// A before hook that never settles blocks the test's subtest chain, and
-// cancelling the subtest queued behind it cannot unblock it. The test's own
-// timeout must still end both tests with node:test's timeout error instead of
-// leaving them to bun:test's (much later) watchdog. node-test.test.ts asserts
-// the error text and the counts.
+// Hooks that never settle block a test's subtest chain, and cancelling the
+// subtests involved cannot unblock them. The test's own timeout must still end
+// every test here with node:test's timeout error instead of leaving it to
+// bun:test's (much later) watchdog. node-test.test.ts asserts the error text,
+// the counts, and that run() counts the timeouts as cancelled like node does.
 const { test } = require("node:test");
 
 const never = () => new Promise(() => {});
@@ -19,4 +19,14 @@ test("a subtest stuck behind a hanging before hook", { timeout: 100 }, t => {
 // failure is reported, and a hook that never settles therefore times out.
 test("a hanging before hook and nothing else", { timeout: 100 }, t => {
   t.before(never);
+});
+
+// The subtest's result is already in (it passed), so it is not cancelled; only
+// its after hook is outstanding. node abandons the hook and cancels the
+// subtest; bun waits for it up to the parent's timeout.
+test("a later subtest stuck in its own after hook", { timeout: 100 }, async t => {
+  await t.test("first", () => {});
+  t.test("stuck in after", st => {
+    st.after(never);
+  });
 });

--- a/test/js/node/test_runner/fixtures/31-timeout-bounds-hanging-hook.js
+++ b/test/js/node/test_runner/fixtures/31-timeout-bounds-hanging-hook.js
@@ -1,0 +1,22 @@
+// A before hook that never settles blocks the test's subtest chain, and
+// cancelling the subtest queued behind it cannot unblock it. The test's own
+// timeout must still end both tests with node:test's timeout error instead of
+// leaving them to bun:test's (much later) watchdog. node-test.test.ts asserts
+// the error text and the counts.
+const { test } = require("node:test");
+
+const never = () => new Promise(() => {});
+
+// node v26.3.0 fails this one the same way: the subtest is unfinished, so the
+// parent waits for it and times out.
+test("a subtest stuck behind a hanging before hook", { timeout: 100 }, t => {
+  t.before(never);
+  t.test("stuck", () => {});
+});
+
+// With nothing depending on the hook, node does not wait for it at all and
+// passes; bun always waits for a before hook created on a running test so its
+// failure is reported, and a hook that never settles therefore times out.
+test("a hanging before hook and nothing else", { timeout: 100 }, t => {
+  t.before(never);
+});

--- a/test/js/node/test_runner/fixtures/run-events.js
+++ b/test/js/node/test_runner/fixtures/run-events.js
@@ -1,0 +1,24 @@
+// Runs one file through run({ files }) and prints a JSON summary of its
+// test:pass/test:fail events plus the run-level counts, for node-test.test.ts.
+const { run } = require("node:test");
+
+const events = [];
+const stream = run({ files: [process.argv[2]] });
+for (const type of ["test:pass", "test:fail"]) {
+  stream.on(type, data => {
+    events.push({
+      type,
+      name: data.name,
+      nesting: data.nesting,
+      kind: data.details.type,
+      failureType: data.details.error?.failureType,
+      skip: data.skip,
+      todo: data.todo,
+    });
+  });
+}
+stream.on("test:summary", data => {
+  if (data.file !== undefined) return;
+  console.log(JSON.stringify({ events, counts: data.counts, success: data.success }));
+});
+stream.resume();

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -314,6 +314,82 @@ describe("node:test", () => {
     });
   });
 
+  test("should cancel subtests still pending when their parent settles after an earlier batch, like node", async () => {
+    const { exitCode, stdout, stderr } = await runTests(["30-cancelled-subtests.js"]);
+    // A cancelled in-flight subtest is not waited for: its after hooks run at
+    // once and see the cancellation; subtests queued behind it never run.
+    expect(stdout).toContain("SLOW_AFTER_HOOK failureType=cancelledByParent passed=false");
+    expect(stdout).toContain("IN_FLIGHT_AFTER_HOOK failureType=cancelledByParent");
+    expect(stdout).not.toContain("QUEUED_TEST_RAN");
+    expect(stdout).not.toContain("QUEUED_SUITE_CHILD_RAN");
+    // The first batch of subtests is still waited for, and so is a later one
+    // that needs no timer or I/O to finish, or finishes during the parent's
+    // after hooks.
+    expect(stdout).toContain("SYNC_PARENT_SUBTEST_FINISHED");
+    expect(stdout).toContain("ASYNC_PARENT_SUBTEST_FINISHED");
+    expect(stdout).toContain("SECOND_OF_BATCH_FINISHED");
+    expect(stdout).toContain("LATER_SYNC_SUBTEST_RAN");
+    expect(stdout).toContain("LATER_MICROTASK_SUBTEST_FINISHED");
+    expect(stdout).toContain("STRAGGLER_FINISHED_DURING_AFTER_HOOK");
+    expect(stderr).toContain("test did not finish before its parent and was cancelled");
+    // slow + queued test + queued suite.
+    expect(stderr).toContain("error: 3 subtests failed");
+    expect(stderr).toContain("8 pass");
+    expect({ exitCode, stderr }).toMatchObject({
+      exitCode: 1,
+      stderr: expect.stringContaining("4 fail"),
+    });
+  });
+
+  // run() spawns a second `bun test` child, so this pays two debug+ASAN
+  // startups; give it the same headroom as the heavy fixtures above.
+  test.concurrent(
+    "should report cancelled subtests and suites as cancelled through run()",
+    async () => {
+      const fixture = (name: string) => join(import.meta.dirname, "fixtures", name);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), fixture("run-events.js"), fixture("30-cancelled-subtests.js")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const { events, counts, success } = JSON.parse(stdout.trim());
+      const cancelled = events.filter((e: { failureType?: string }) => e.failureType === "cancelledByParent");
+      // The same cancellations, in the same order, that node v26.3.0 reports
+      // for this fixture.
+      expect(cancelled.map(({ type, name, kind, todo }: any) => ({ type, name, kind, todo }))).toEqual([
+        { type: "test:fail", name: "slow", kind: "test", todo: undefined },
+        { type: "test:fail", name: "slow", kind: "test", todo: undefined },
+        { type: "test:fail", name: "queued test", kind: "test", todo: undefined },
+        { type: "test:fail", name: "queued suite child", kind: "test", todo: undefined },
+        { type: "test:fail", name: "queued suite", kind: "suite", todo: undefined },
+        { type: "test:fail", name: "in flight", kind: "test", todo: undefined },
+        { type: "test:fail", name: "slow", kind: "test", todo: undefined },
+        { type: "test:fail", name: "pending todo", kind: "test", todo: true },
+      ]);
+      // node's totals for the fixture: the cancelled suite counts under
+      // `suites` and the cancelled todo under `todo`, the other six under
+      // `cancelled`; the four parents are the failures.
+      expect({ counts, success }).toEqual({
+        counts: {
+          tests: 35,
+          suites: 1,
+          passed: 23,
+          failed: 4,
+          cancelled: 6,
+          skipped: 1,
+          todo: 1,
+          topLevel: expect.any(Number),
+        },
+        success: false,
+      });
+      expect(exitCode).toBe(0);
+    },
+    30_000,
+  );
+
   test("should resolve the promise of a test that a name pattern filters out", async () => {
     const { exitCode, stderr } = await runTests(["23-filtered-test-promise.js"], {}, ["-t", "should resolve"]);
     expect(stderr).not.toContain("timed out");

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -314,35 +314,40 @@ describe("node:test", () => {
     });
   });
 
-  test("should cancel subtests still pending when their parent settles after an earlier batch, like node", async () => {
-    const { exitCode, stdout, stderr } = await runTests(["30-cancelled-subtests.js"]);
-    // A cancelled in-flight subtest is not waited for: its after hooks run at
-    // once and see the cancellation; subtests queued behind it never run.
-    expect(stdout).toContain("SLOW_AFTER_HOOK failureType=cancelledByParent passed=false");
-    expect(stdout).toContain("IN_FLIGHT_AFTER_HOOK failureType=cancelledByParent");
-    expect(stdout).not.toContain("QUEUED_TEST_RAN");
-    expect(stdout).not.toContain("QUEUED_SUITE_CHILD_RAN");
-    // The first batch of subtests is still waited for, and so is a later one
-    // that needs no timer or I/O to finish, or finishes during the parent's
-    // after hooks.
-    expect(stdout).toContain("SYNC_PARENT_SUBTEST_FINISHED");
-    expect(stdout).toContain("ASYNC_PARENT_SUBTEST_FINISHED");
-    expect(stdout).toContain("SECOND_OF_BATCH_FINISHED");
-    expect(stdout).toContain("LATER_SYNC_SUBTEST_RAN");
-    expect(stdout).toContain("LATER_MICROTASK_SUBTEST_FINISHED");
-    expect(stdout).toContain("STRAGGLER_FINISHED_DURING_AFTER_HOOK");
-    expect(stderr).toContain("test did not finish before its parent and was cancelled");
-    // slow + queued test + queued suite.
-    expect(stderr).toContain("error: 3 subtests failed");
-    expect(stderr).toContain("8 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 1,
-      stderr: expect.stringContaining("4 fail"),
-    });
-  });
+  // 30-cancelled-subtests.js drives 12 node:test cases, and the run() variant
+  // pays a second debug+ASAN startup for the `bun test` child run() spawns, so
+  // both get the same headroom as the heavy fixtures at the top of this file.
+  test.concurrent(
+    "should cancel subtests still pending when their parent settles after an earlier batch, like node",
+    async () => {
+      const { exitCode, stdout, stderr } = await runTests(["30-cancelled-subtests.js"]);
+      // A cancelled in-flight subtest is not waited for: its after hooks run at
+      // once and see the cancellation; subtests queued behind it never run.
+      expect(stdout).toContain("SLOW_AFTER_HOOK failureType=cancelledByParent passed=false");
+      expect(stdout).toContain("IN_FLIGHT_AFTER_HOOK failureType=cancelledByParent");
+      expect(stdout).not.toContain("QUEUED_TEST_RAN");
+      expect(stdout).not.toContain("QUEUED_SUITE_CHILD_RAN");
+      // The first batch of subtests is still waited for, and so is a later one
+      // that needs no timer or I/O to finish, or finishes during the parent's
+      // after hooks.
+      expect(stdout).toContain("SYNC_PARENT_SUBTEST_FINISHED");
+      expect(stdout).toContain("ASYNC_PARENT_SUBTEST_FINISHED");
+      expect(stdout).toContain("SECOND_OF_BATCH_FINISHED");
+      expect(stdout).toContain("LATER_SYNC_SUBTEST_RAN");
+      expect(stdout).toContain("LATER_MICROTASK_SUBTEST_FINISHED");
+      expect(stdout).toContain("STRAGGLER_FINISHED_DURING_AFTER_HOOK");
+      expect(stderr).toContain("test did not finish before its parent and was cancelled");
+      // slow + queued test + queued suite.
+      expect(stderr).toContain("error: 3 subtests failed");
+      expect(stderr).toContain("8 pass");
+      expect({ exitCode, stderr }).toMatchObject({
+        exitCode: 1,
+        stderr: expect.stringContaining("4 fail"),
+      });
+    },
+    30_000,
+  );
 
-  // run() spawns a second `bun test` child, so this pays two debug+ASAN
-  // startups; give it the same headroom as the heavy fixtures above.
   test.concurrent(
     "should report cancelled subtests and suites as cancelled through run()",
     async () => {

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -395,6 +395,17 @@ describe("node:test", () => {
     30_000,
   );
 
+  test("should end a test whose subtest chain is stuck behind a hanging hook with the test's own timeout", async () => {
+    const { exitCode, stderr } = await runTests(["31-timeout-bounds-hanging-hook.js"]);
+    expect(stderr).toContain("test timed out after 100ms");
+    expect(stderr).not.toContain("timed out after 5000ms");
+    expect(stderr).toContain("0 pass");
+    expect({ exitCode, stderr }).toMatchObject({
+      exitCode: 1,
+      stderr: expect.stringContaining("2 fail"),
+    });
+  });
+
   test("should resolve the promise of a test that a name pattern filters out", async () => {
     const { exitCode, stderr } = await runTests(["23-filtered-test-promise.js"], {}, ["-t", "should resolve"]);
     expect(stderr).not.toContain("timed out");

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -351,20 +351,11 @@ describe("node:test", () => {
   test.concurrent(
     "should report cancelled subtests and suites as cancelled through run()",
     async () => {
-      const fixture = (name: string) => join(import.meta.dirname, "fixtures", name);
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), fixture("run-events.js"), fixture("30-cancelled-subtests.js")],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      const { events, counts, success } = JSON.parse(stdout.trim());
-      const cancelled = events.filter((e: { failureType?: string }) => e.failureType === "cancelledByParent");
+      const { events, counts, success } = await runEvents("30-cancelled-subtests.js");
+      const cancelled = events.filter(e => e.failureType === "cancelledByParent");
       // The same cancellations, in the same order, that node v26.3.0 reports
       // for this fixture.
-      expect(cancelled.map(({ type, name, kind, todo }: any) => ({ type, name, kind, todo }))).toEqual([
+      expect(cancelled.map(({ type, name, kind, todo }) => ({ type, name, kind, todo }))).toEqual([
         { type: "test:fail", name: "slow", kind: "test", todo: undefined },
         { type: "test:fail", name: "slow", kind: "test", todo: undefined },
         { type: "test:fail", name: "queued test", kind: "test", todo: undefined },
@@ -390,21 +381,53 @@ describe("node:test", () => {
         },
         success: false,
       });
-      expect(exitCode).toBe(0);
     },
     30_000,
   );
 
-  test("should end a test whose subtest chain is stuck behind a hanging hook with the test's own timeout", async () => {
-    const { exitCode, stderr } = await runTests(["31-timeout-bounds-hanging-hook.js"]);
-    expect(stderr).toContain("test timed out after 100ms");
-    expect(stderr).not.toContain("timed out after 5000ms");
-    expect(stderr).toContain("0 pass");
-    expect({ exitCode, stderr }).toMatchObject({
-      exitCode: 1,
-      stderr: expect.stringContaining("2 fail"),
-    });
-  });
+  // Every test in this fixture ends on its own 100ms timeout; the children of
+  // the first and third can never report.
+  test.concurrent(
+    "should end a test whose subtest chain is stuck behind a hanging hook with the test's own timeout",
+    async () => {
+      const { exitCode, stderr } = await runTests(["31-timeout-bounds-hanging-hook.js"]);
+      expect(stderr).toContain("test timed out after 100ms");
+      expect(stderr).not.toContain("timed out after 5000ms");
+      expect(stderr).toContain("0 pass");
+      expect({ exitCode, stderr }).toMatchObject({
+        exitCode: 1,
+        stderr: expect.stringContaining("3 fail"),
+      });
+    },
+    30_000,
+  );
+
+  test.concurrent(
+    "should count timed out tests as cancelled through run(), like node",
+    async () => {
+      const { events, counts, success } = await runEvents("31-timeout-bounds-hanging-hook.js");
+      expect(events.map(({ type, name, failureType }) => ({ type, name, failureType }))).toEqual([
+        { type: "test:fail", name: "a subtest stuck behind a hanging before hook", failureType: "testTimeoutFailure" },
+        { type: "test:fail", name: "a hanging before hook and nothing else", failureType: "testTimeoutFailure" },
+        { type: "test:pass", name: "first", failureType: undefined },
+        { type: "test:fail", name: "a later subtest stuck in its own after hook", failureType: "testTimeoutFailure" },
+      ]);
+      expect({ counts, success }).toEqual({
+        counts: {
+          tests: 4,
+          suites: 0,
+          passed: 1,
+          failed: 0,
+          cancelled: 3,
+          skipped: 0,
+          todo: 0,
+          topLevel: expect.any(Number),
+        },
+        success: false,
+      });
+    },
+    30_000,
+  );
 
   test("should resolve the promise of a test that a name pattern filters out", async () => {
     const { exitCode, stderr } = await runTests(["23-filtered-test-promise.js"], {}, ["-t", "should resolve"]);
@@ -434,6 +457,24 @@ async function runTests(filenames: string[], env: Record<string, string> = {}, a
     new Response(stderrStream).text(),
   ]);
   return { exitCode, stdout, stderr };
+}
+
+type RunEvent = { type: string; name: string; kind: string; failureType?: string; skip?: unknown; todo?: unknown };
+
+// Runs one fixture through node:test's run() (fixtures/run-events.js) and
+// returns its pass/fail events and the run-level summary.
+async function runEvents(filename: string) {
+  const fixture = (name: string) => join(import.meta.dirname, "fixtures", name);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture("run-events.js"), fixture(filename)],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout.trim()) as { events: RunEvent[]; counts: Record<string, number>; success: boolean };
 }
 
 describe("node:test mock", () => {


### PR DESCRIPTION
### Problem
- An inline subtest whose `await` was forgotten is always waited for by `bun test`, so this file reports `2 pass, 0 fail` and exits 0; `node --test` (v26.3.0) reports `slow subtest` as `'test did not finish before its parent and was cancelled'` (`failureType: 'cancelledByParent'`), fails the parent with `1 subtest failed`, and exits 1:
  ```js
  import { test } from "node:test";
  test("parent", async t => {
    await t.test("first", async () => {});
    t.test("slow subtest", async () => { await new Promise(r => setTimeout(r, 50)); }); // missing await
  });
  ```
- Cause: `executeTestNode()` in `src/js/node/test.ts` ran `drainSubtestChain(node)` after the body, i.e. it waited for every subtest ever scheduled. Node's `Test#run` waits on `subtestsPromise`, which is created with the first subtest and resolved the first time no subtest is left unfinished, and is never re-armed; `postRun()` then cancels whatever is still unfinished. So the earlier awaited `t.test()` is what arms the check: a sync parent, or an async parent whose only unawaited subtest is the first one, is waited for in Node too (verified, and covered by the PASS cases in the fixture).

### Fix
- `TestNode` tracks `unfinishedSubtests` and `subtestsSettled` (Node's `unfinishedSubtests` / `subtestsPromise`). Every inline subtest (test, inline suite, and skip directive, which Node also counts toward the first settle) is scheduled through one `chainSubtest()` that maintains them. After the body (and after a `plan({ wait })` wait) the test awaits `subtestsSettled` instead of draining the chain.
- `settleSubtests()` is the subtest half of Node's `postRun()`, and runs where Node runs it, after the test's own afterEach/after hooks: whatever is still unfinished is cancelled and the chain is drained only so the cancellations get recorded. `cancelUnfinishedSubtests()` marks the subtree; a subtest that has not reached its turn on the chain reports the cancellation instead of running (`finishCancelled()`, no hooks or body), a running body has its stop promise rejected so the parent stops waiting for it (Node aborts the subtest's signal, which rejects its `stopPromise`), and a cancelled inline suite skips its hooks, drains its already cancelled children, and reports `cancelledByParent` itself, as in Node. The stop controller therefore exists for every run, not only when a timeout is set.
- A hook or `describe()` callback that never settles cannot be cancelled, and neither can a subtest that is only waiting on its own after hooks (its result is already in and is kept). The drain is therefore raced against a second stop controller armed with whatever the body phase left of the test's `timeout` (the hooks in between stay exempt), which is the bound the drain had before when it ran inside the body race: such a test still fails with its own `test timed out after Nms`, within one timeout, instead of waiting for bun:test's watchdog (`fixtures/31-timeout-bounds-hanging-hook.js`). That timeout error now carries `failureType: 'testTimeoutFailure'` like Node's; the hook timeout does not, because Node reports a hook timeout as a hook failure.
- Node starts a subtest's body synchronously inside `t.test()`, so a forgotten await on a subtest that finishes on microtasks alone (a sync body) is already complete when Node's `postRun()` runs; bun's chain starts it a tick later. `settleSubtests()` yields one `setImmediate` before cancelling when something is still pending, so those complete here too, while anything waiting on a timer or I/O is cancelled like in Node. Known remaining difference, on the lenient side only: a straggler that needs exactly one `setImmediate` (or a handful of microtasks more than Node's own continuation) completes here and is cancelled by Node; nothing Node passes is cancelled here.
- Rolling failed subtests into the parent now also happens in the postRun position, so like in Node, a parent's after hooks see `t.passed === true` when only a subtest failed (previously false), and an `expectFailure` parent is no longer satisfied by a failing subtest alone.
- `run()`: a child's `cancelledByParent` or `testTimeoutFailure` result is counted under `counts.cancelled` (Node's runner keys this off the failure type as well, `kCanceledTests`; `testAborted` is left out because `t.signal` never aborts in this shim), and the per-file summary treats cancellations as failures. Suites report through the same `reportNodeToRunParent()` as tests, so a cancelled suite carries the cancellation error.
- Verified with `test/js/node/test_runner/fixtures/30-cancelled-subtests.js` (4 cancellation cases that must fail, 8 waiting cases that must pass) via two new tests in `test/js/node/test_runner/node-test.test.ts`: `bun test` counts/markers, and the `run()` event stream and counts. `node --test` v26.3.0 fails and passes exactly the same tests of the fixture and reports the same eight cancellations in the same order. Two more tests run `fixtures/31-timeout-bounds-hanging-hook.js` under `bun test` (every test ends with its own timeout error) and under `run()` (the timeouts land in `counts.cancelled`). Without the fix the cancellation cases of fixture 30 hang until the 5s bun:test timeout and its two tests fail; with it `node-test.test.ts` passes 49/49, and the ported `test/js/node/test/parallel/test-runner-*` files are unchanged (24 pass; `test-runner-mock-timers-scheduler.js` fails its 100ms wall-clock bound under the debug build with or without this change).
- Related: #34583 handles the sibling shape where `t.test()` is called after the parent already finished; this PR is about subtests that exist but are unfinished when the parent finishes. The two touch different paths of `addTest()`.
- Overlap: #39287 (opened at the same time, from a different report) implements the same `postRun()` sweep for the case where the parent is stopped by its timeout or `signal`, plus the actual aborting of `t.signal`, and also changes `createStopController()` and adds fixtures numbered 30 and 31, so the two conflict textually and one of them has to be rebased onto the other. The sweep here already covers the timeout trigger (a parent whose body race times out cancels its pending subtests the same way; fixture 31 exercises it), so if this lands first, #39287 reduces to owning the `AbortController` on `TestNode`, aborting it from `cancelUnfinishedSubtests()` and at the end of `executeTestNode()`, and adding the `signal` option to the stop controller. If #39287 lands first, the first-settle tracking, the grace hop, the bounded drain and the `run()` counting from here get rebased onto its `cancel()` / `cancelSubtests()` instead; either order works, and I will do the rebase of whichever one is second.

### Background
- node:test in bun is a shim over bun:test: top-level `test()` calls register bun:test tests; a `t.test()` inside a running test is an inline subtest, run by the shim itself. Inline subtests of one parent are serialized through `subtestChain`, a promise chain each subtest appends a link to; `drainSubtestChain()` waits until that chain goes idle. A parent's result under `bun test` is its own body outcome plus `N subtests failed` when any subtest failed.
- `executeTestNode()` runs one test: inherited beforeEach hooks, the body raced against a stop controller (one promise that rejects on the test's timeout, now also when the parent cancels the test), the plan check, the verdict, afterEach/after hooks, and now the postRun step. Node's `postRun()` is the step after a test's hooks where it cancels unfinished subtests, counts failed ones, and reports.
- `run()` is node:test's programmatic runner: it spawns `bun test` per file with `NODE_TEST_CONTEXT` set, the child prints one JSON event per finished test (`reportNodeToRunParent()`), and the parent rebuilds Node's event stream and counters from them (`republishChildEvent()`).

<details>
<summary>Node v26.3.0 probes behind the design</summary>

```
# The rule is "first settle", not "async parent":
sync parent, one unawaited 50ms subtest           -> node waits, pass
async parent, one unawaited 50ms subtest          -> node waits, pass
await t.test(first); unawaited 50ms subtest       -> cancelled, parent fails   (the report)

# What is cancelled at postRun (everything unfinished, recursively):
in-flight test, queued {skip} test, queued inline suite (+ child), empty suite, queued {todo} test
-> all reported cancelledByParent; parent "4 subtests failed" (todo excluded); suite's hooks and child never run

# Timing of postRun:
await t.test(first); unawaited sync body          -> pass
await t.test(first); unawaited body awaiting null -> pass
await t.test(first); unawaited body with 5 awaits -> cancelled
await t.test(first); unawaited setImmediate body  -> cancelled
30ms t.after() hook + unawaited 10ms subtest      -> pass (finishes during the hook)
parent body throws with an in-flight subtest      -> subtest cancelled; its after hook runs at once and sees passed=false, error=cancelledByParent
parent whose awaited subtest failed               -> t.after() sees passed=true, error=null; parent fails afterwards
```

The debug build with this change gives the same verdicts for all of the above except the two "cancelled" microtask/setImmediate lines, which pass (the lenient difference described under Fix).
</details>
