### PR TITLE
Compare Temporal objects by value in toMatchObject and Bun.deepMatch

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1177,18 +1177,6 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     return true;
 }
 
-static bool isTemporalObject(JSC::JSObject* object)
-{
-    return object->inherits<JSC::TemporalInstant>()
-        || object->inherits<JSC::TemporalPlainDate>()
-        || object->inherits<JSC::TemporalPlainDateTime>()
-        || object->inherits<JSC::TemporalPlainTime>()
-        || object->inherits<JSC::TemporalZonedDateTime>()
-        || object->inherits<JSC::TemporalPlainYearMonth>()
-        || object->inherits<JSC::TemporalPlainMonthDay>()
-        || object->inherits<JSC::TemporalDuration>();
-}
-
 // Temporal objects keep their state in internal slots and have no own
 // properties, so the generic own-property walk would call any two instances
 // of a class equal. Compare the internal fields instead, the way JSDateType
@@ -1237,7 +1225,7 @@ static std::optional<bool> temporalObjectsDequal(JSC::JSObject* o1, JSC::JSObjec
     }
     // `o1` is not a Temporal object; a Temporal `o2` can then never be equal
     // (and must not reach the own-property walk).
-    if (isTemporalObject(o2))
+    if (JSC::temporalType(o2) != JSC::TemporalType::None)
         return false;
     return std::nullopt;
 }
@@ -1979,6 +1967,11 @@ bool Bun__deepMatch(
     VM& vm = globalObject->vm();
     JSObject* obj = objValue.getObject();
     JSObject* subsetObj = subsetValue.getObject();
+
+    // A Temporal subset has no enumerable properties to walk (its value lives
+    // in internal slots), so the property loop below would accept any object.
+    if (JSC::temporalType(subsetValue) != JSC::TemporalType::None)
+        return temporalObjectsDequal(obj, subsetObj).value();
 
     PropertyNameArrayBuilder subsetProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
     subsetObj->getPropertyNames(globalObject, subsetProps, DontEnumPropertiesMode::Exclude);

--- a/test/js/bun/bun-object/deep-equals-temporal.test.ts
+++ b/test/js/bun/bun-object/deep-equals-temporal.test.ts
@@ -132,6 +132,93 @@ describe("expect().toEqual on Temporal values", () => {
   });
 });
 
+// Subset matching walks the expected object's enumerable properties, and a
+// Temporal object has none, so without dedicated handling a Temporal expected
+// value accepted any received object.
+describe("subset matching on Temporal values", () => {
+  const cases: [name: string, makeA: () => unknown, makeB: () => unknown][] = [
+    [
+      "Instant",
+      () => Temporal.Instant.from("2024-06-15T12:34:56Z"),
+      () => Temporal.Instant.from("2024-06-15T12:34:56.000000001Z"),
+    ],
+    [
+      "PlainDateTime",
+      () => Temporal.PlainDateTime.from("2024-06-15T12:34:56"),
+      () => Temporal.PlainDateTime.from("2024-06-15T12:34:57"),
+    ],
+    ["PlainDate", () => Temporal.PlainDate.from("2024-01-01"), () => Temporal.PlainDate.from("2099-12-31")],
+    ["PlainTime", () => Temporal.PlainTime.from("12:34:56"), () => Temporal.PlainTime.from("12:34:56.000000001")],
+    [
+      "ZonedDateTime",
+      () => Temporal.ZonedDateTime.from("2024-06-15T12:34:56+02:00[Europe/Berlin]"),
+      () => Temporal.ZonedDateTime.from("2024-06-15T10:34:56+00:00[UTC]"),
+    ],
+    ["PlainYearMonth", () => Temporal.PlainYearMonth.from("2024-06"), () => Temporal.PlainYearMonth.from("2024-07")],
+    ["PlainMonthDay", () => Temporal.PlainMonthDay.from("06-15"), () => Temporal.PlainMonthDay.from("06-16")],
+    ["Duration", () => Temporal.Duration.from("PT1H"), () => Temporal.Duration.from("PT60M")],
+  ];
+
+  describe.each(cases)("%s", (_, makeA, makeB) => {
+    it("toMatchObject compares a Temporal property by value", () => {
+      expect({ when: makeA(), other: 1 }).toMatchObject({ when: makeA() });
+      expect({ when: makeA(), other: 1 }).not.toMatchObject({ when: makeB() });
+      expect([makeA()]).toMatchObject([makeA()]);
+      expect([makeA()]).not.toMatchObject([makeB()]);
+    });
+
+    it("toMatchObject compares a Temporal received value by value", () => {
+      expect(makeA()).toMatchObject(makeA());
+      expect(makeA()).not.toMatchObject(makeB());
+    });
+
+    it("expect.objectContaining compares a Temporal pattern by value", () => {
+      expect(makeA()).toEqual(expect.objectContaining(makeA()));
+      expect(makeA()).not.toEqual(expect.objectContaining(makeB()));
+    });
+
+    it("Bun.deepMatch compares Temporal values by value", () => {
+      expect(Bun.deepMatch({ when: makeA() }, { when: makeA(), other: 1 })).toBe(true);
+      expect(Bun.deepMatch({ when: makeB() }, { when: makeA(), other: 1 })).toBe(false);
+      expect(Bun.deepMatch(makeA(), makeA())).toBe(true);
+      expect(Bun.deepMatch(makeB(), makeA())).toBe(false);
+    });
+  });
+
+  it("a Temporal expected value does not match a different class or a plain object", () => {
+    const date = Temporal.PlainDate.from("2024-06-15");
+    const dateTime = Temporal.PlainDateTime.from("2024-06-15T00:00:00");
+    expect({ when: dateTime }).not.toMatchObject({ when: date });
+    expect({ when: {} }).not.toMatchObject({ when: date });
+    expect(Bun.deepMatch(date, dateTime)).toBe(false);
+    expect(Bun.deepMatch(date, {})).toBe(false);
+  });
+
+  it("a plain expected object still matches a Temporal received value through its getters", () => {
+    const date = Temporal.PlainDate.from("2024-06-15");
+    expect({ when: date }).toMatchObject({ when: {} });
+    expect(date).toMatchObject({ year: 2024, month: 6, day: 15 });
+    expect(date).not.toMatchObject({ year: 2025 });
+    expect(Bun.deepMatch({ year: 2024 }, date)).toBe(true);
+    expect(Bun.deepMatch({ year: 2025 }, date)).toBe(false);
+  });
+
+  it("extra own properties are ignored, matching toEqual", () => {
+    const withExtra = Object.assign(Temporal.PlainDate.from("2024-06-15"), { extra: 1 });
+    expect({ when: withExtra }).toMatchObject({ when: Temporal.PlainDate.from("2024-06-15") });
+    expect({ when: Temporal.PlainDate.from("2024-06-15") }).toMatchObject({ when: withExtra });
+    expect({ when: withExtra }).not.toMatchObject({ when: Temporal.PlainDate.from("2024-06-16") });
+  });
+
+  it("snapshot property matchers compare a Temporal property by value", () => {
+    const received = { when: Temporal.PlainDate.from("2024-01-01"), id: 1 };
+    // The property matchers are checked before the snapshot itself is compared.
+    expect(() =>
+      expect(received).toMatchInlineSnapshot({ when: Temporal.PlainDate.from("2099-12-31") }, "not compared"),
+    ).toThrow("to match properties from received object");
+  });
+});
+
 describe("util.isDeepStrictEqual on Temporal values", () => {
   it("compares by value", () => {
     expect(isDeepStrictEqual(Temporal.PlainDate.from("2024-06-15"), Temporal.PlainDate.from("2024-06-15"))).toBe(true);


### PR DESCRIPTION
### Problem
- A Temporal value used as the expected side of a subset match accepts any received object. On bun 1.4.0 all of these pass / return true:
  ```js
  expect({ d: Temporal.PlainDate.from("2024-01-01") }).toMatchObject({ d: Temporal.PlainDate.from("2024-01-02") });
  expect(Temporal.Duration.from("PT60M")).toMatchObject(Temporal.Duration.from("PT1H"));
  expect({ d: {} }).toMatchObject({ d: Temporal.PlainDate.from("2024-01-01") });
  Bun.deepMatch({ d: Temporal.PlainDate.from("2024-01-02") }, { d: Temporal.PlainDate.from("2024-01-01") });
  expect({ d: Temporal.PlainDate.from("2024-01-01") }).toMatchSnapshot({ d: Temporal.PlainDate.from("2099-12-31") });
  ```
- `toEqual`, `toStrictEqual` and `Bun.deepEquals` have compared Temporal values by their internal fields since #37024, so the matchers disagree with each other inside one test file.
- Cause: `Bun__deepMatch` (`src/jsc/bindings/bindings.cpp`, shared by `toMatchObject`, `Bun.deepMatch`, `expect.objectContaining`, and the property matchers of `toMatchSnapshot` / `toMatchInlineSnapshot`) collects the expected value's enumerable properties and checks each against the received value. A Temporal object has none (its fields are internal slots behind non-enumerable prototype getters), so the loop runs zero times and returns true.

### Fix
- At the top of `Bun__deepMatch`, an expected value that `JSC::temporalType()` classifies as Temporal is compared with `temporalObjectsDequal`, the comparator `deepEquals` already uses, instead of the property walk. Same class and same fields match; a different class, a different value, or a non-Temporal received value does not. Extra own properties are ignored, as `toEqual` already does for Temporal and `Date`.
- Only the expected side is checked, so a plain expected object keeps its current behavior against a Temporal received value: `{}` still matches, and `expect(plainDate).toMatchObject({ year: 2024 })` still reads the prototype getter.
- The local `isTemporalObject` helper is replaced by `JSC::temporalType`, which performs the same eight-class check (this is the same replacement #37043 makes, so the two merge cleanly in either order).
- The new code does not run JS, so no exception checks are needed; the file also passes `BUN_JSC_validateExceptionChecks=1`.
- Verified:
  - `test/js/bun/bun-object/deep-equals-temporal.test.ts`: new `subset matching on Temporal values` block covering all eight classes through `toMatchObject` (nested, in arrays, and top level), `expect.objectContaining`, `Bun.deepMatch`, cross-class and plain-object expected values, extra own properties, and snapshot property matchers. 35 of the new cases fail on bun 1.4.0 (also with `CI=true`), all 113 pass with this change.
  - `test/js/bun/test/expect.test.js` (415 pass), `deep-match.spec.ts`, `snapshot-tests/bun-snapshots.test.ts`, `node/assert/deep-equal.test.ts`, both TOML suites and `web/temporal/temporal.test.ts`: unchanged.
- Intentionally not in this PR: the same vacuous match for `Date` / `Error` / `Set` / `Map` expected values is #32870, and for `Headers` / `URLSearchParams` it is #37904; both are separate decisions about how those leaves should compare. The snapshot text itself (`PlainDate {}` for every value, so a snapshot of a Temporal value never fails, and `toEqual` failures print an empty diff) is the pretty-format side and is addressed by #37043; after this PR a mismatching Temporal property matcher fails, but the diff printed for it still looks empty until #37043 lands.

### Background
- Subset matching is the Jest semantic behind `toMatchObject`: the expected value lists properties the received value must have; extra received properties are fine. In Bun it is implemented once in `Bun__deepMatch` and reused by `Bun.deepMatch(subset, object)`, `expect.objectContaining`, and the optional property-matchers argument of the snapshot matchers.
- Temporal objects (`Instant`, `PlainDate`, `PlainDateTime`, `PlainTime`, `ZonedDateTime`, `PlainYearMonth`, `PlainMonthDay`, `Duration`) are immutable values whose state lives in JSC internal slots; `year`, `epochNanoseconds`, etc. are non-enumerable getters on the prototype. Any property-based comparison therefore sees two instances of the same class as identical. `Date` has the same shape, which is why `deepEquals` special-cases both.
- `temporalObjectsDequal` is the field comparison added in #37024: same class required, then exact time for `Instant`, ISO fields plus calendar for the plain types, exact time plus time zone plus calendar for `ZonedDateTime`, and unit-by-unit for `Duration` (so `PT1H` and `PT60M` stay different).
- `JSC::temporalType(JSValue)` is JSC's classifier for these eight classes (returns `TemporalType::None` for anything else); Bun already uses it for TOML serialization.

<details>
<summary>Entry points probed on bun 1.4.0 before the change</summary>

Value-blind (a different Temporal value on the expected side was accepted):

- `toMatchObject`, nested property and top level
- `toMatchObject` with a plain object received and a Temporal expected value
- `toMatchObject` across classes (`PlainDateTime` received, `PlainDate` expected, same fields)
- `toMatchObject` on `Duration` `PT60M` vs `PT1H`
- `.not.toMatchObject`
- `Bun.deepMatch`
- `toMatchSnapshot(propertyMatchers)`
- `expect.objectContaining(temporalValue)` used as the whole pattern

Already correct: a Temporal value nested inside an `expect.objectContaining({...})` pattern, because nested `objectContaining` properties are compared with `deepEquals`, which #37024 fixed.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 35 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/bun-object/deep-equals-temporal.test.ts
bun test v1.4.0 (8c5296ac4)

test/js/bun/bun-object/deep-equals-temporal.test.ts:
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [6.93ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [16.88ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [3.49ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [2.73ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [242.66ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [2.88ms]
(pass) Bun.deepEquals on Temporal values (st
... (truncated)

release without fix: 35 FAILED
bun test v1.4.0-canary.1 (eabb96de7)

test/js/bun/bun-object/deep-equals-temporal.test.ts:
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [0.12ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [4.62ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [0.06ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [0.03ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [4.81ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [0.84ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [0.05ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately const
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/bun-object/deep-equals-temporal.test.ts
bun test v1.4.0 (8c5296ac4)

test/js/bun/bun-object/deep-equals-temporal.test.ts:
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [4.66ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [9.39ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [2.49ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [1.68ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [154.73ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [2.47ms]
(pass) Bun.deepEquals on Temporal values (str
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 749ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/src/jsc/bindings/bindings.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 3m 26s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.0-canary.1+3d880fffe
[build] done
bun test v1.4.0-canary.1 (3d880fffe)

test/js/bun/bun-object/deep-equals-temporal.test.ts:
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [0.07ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([Function]) [2.62ms]
(pass) Bun.deepEquals on Temporal values (strict: true) > two separately constructed instances of the same value are equal ([
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/bindings.cpp                      | 19 ++---
 .../js/bun/bun-object/deep-equals-temporal.test.ts | 87 ++++++++++++++++++++++
 2 files changed, 93 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/jsc/bindings/bindings.cpp                            6      6      0
test/js/bun/bun-object/deep-equals-temporal.test.ts      1      4      0
```

</details>

<!-- robobun:evidence:end -->