### PR TITLE
FileSystemRouter: match / against a root-level optional catch-all route

### DIFF
--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1140,13 +1140,28 @@ pub mod pattern {
     }
 
     impl Pattern {
-        /// Match a filesystem route pattern to a URL path.
+        /// Match a filesystem route pattern to a URL path. On `false`, `params` is
+        /// truncated to its entry length so the next candidate starts clean.
         pub(crate) fn match_<'a, const ALLOW_OPTIONAL_CATCH_ALL: bool>(
             // `path` must be lowercased and have no leading slash
             path: &'a [u8],
             // case-sensitive, must not have a leading slash
             name: &'a [u8],
             // case-insensitive, must not have a leading slash
+            match_name: &[u8],
+            params: &mut route_param::List<'a>,
+        ) -> bool {
+            let params_len = params.len();
+            if Self::match_inner::<ALLOW_OPTIONAL_CATCH_ALL>(path, name, match_name, params) {
+                return true;
+            }
+            params.truncate(params_len);
+            false
+        }
+
+        fn match_inner<'a, const ALLOW_OPTIONAL_CATCH_ALL: bool>(
+            path: &'a [u8],
+            name: &'a [u8],
             match_name: &[u8],
             params: &mut route_param::List<'a>,
         ) -> bool {
@@ -1161,7 +1176,6 @@ pub mod pattern {
                         let segment = &path_
                             [0..strings::index_of_char_usize(path_, b'/').unwrap_or(path_.len())];
                         if !str_.eql_bytes(segment) {
-                            params.clear(); // shrinkRetainingCapacity(0)
                             return false;
                         }
 
@@ -1178,7 +1192,6 @@ pub mod pattern {
                     Value::Dynamic(dynamic) => {
                         // `[x]` takes one non-empty segment: `docs/[x]` serves neither "docs" nor "docs//a".
                         if path_.is_empty() || path_[0] == b'/' {
-                            params.clear();
                             return false;
                         }
 
@@ -1190,7 +1203,6 @@ pub mod pattern {
                             path_ = &path_[i + 1..];
 
                             if pattern.is_end(name) {
-                                params.clear(); // shrinkRetainingCapacity(0)
                                 return false;
                             }
 
@@ -1214,7 +1226,6 @@ pub mod pattern {
                                 return true;
                             }
 
-                            params.clear(); // shrinkRetainingCapacity(0)
                             return false;
                         }
 
@@ -1852,6 +1863,41 @@ mod tests {
                 params.is_empty(),
                 "Pattern \"{}\" left params behind after rejecting \"{}\"",
                 bstr::BStr::new(pattern),
+                bstr::BStr::new(pathname)
+            );
+        }
+    }
+
+    #[test]
+    fn pattern_no_match_truncates_params_to_entry_length() {
+        // Each pattern records a param and then fails through a different exit.
+        let no_match: &[(&[u8], &[u8])] = &[
+            // catch-all with nothing left to take
+            (b"[org]/settings/[...rest]", b"acme/settings"),
+            // pattern exhausted while the URL still has segments
+            (b"[user]/settings", b"alice/settings/extra"),
+            // dynamic segment exhausted while the URL still has segments
+            (b"[user]/[id]", b"alice/1/extra"),
+            // static segment mismatch
+            (b"[user]/settings", b"alice/profile"),
+        ];
+        let seeded = Param {
+            name: b"seeded",
+            value: b"kept",
+        };
+        for (pattern, pathname) in no_match {
+            let mut params: route_param::List<'static> = vec![seeded];
+            assert!(
+                !Pattern::match_::<true>(pathname, pattern, pattern, &mut params),
+                "Expected pattern \"{}\" not to match \"{}\"",
+                bstr::BStr::new(pattern),
+                bstr::BStr::new(pathname)
+            );
+            assert!(
+                params.len() == 1 && params[0].name == seeded.name,
+                "Pattern \"{}\" left {} param(s) after rejecting \"{}\"",
+                bstr::BStr::new(pattern),
+                params.len(),
                 bstr::BStr::new(pathname)
             );
         }

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -308,9 +308,7 @@ impl Routes {
         let pathname = strings::trim_left(pathname_, b"/");
 
         if pathname.is_empty() {
-            // "/" is index.js when there is one. Otherwise it can still be
-            // served by a root-level optional catch-all ([[...slug]].js), the
-            // only dynamic pattern that accepts an empty path.
+            // Without an index.js, a root-level `[[...slug]].js` still serves "/".
             if let Some(index) = self.index {
                 return Some(index.as_ptr().cast_const());
             }
@@ -1178,8 +1176,7 @@ pub mod pattern {
                         }
                     }
                     Value::Dynamic(dynamic) => {
-                        // A dynamic segment needs a non-empty URL segment: `docs/[page]` does not
-                        // match "docs", and `a/[x]/[y]` does not match "a//b".
+                        // `[x]` takes one non-empty segment: `docs/[x]` serves neither "docs" nor "docs//a".
                         if path_.is_empty() || path_[0] == b'/' {
                             params.clear();
                             return false;

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1178,8 +1178,9 @@ pub mod pattern {
                         }
                     }
                     Value::Dynamic(dynamic) => {
-                        // Out of URL segments: `foo/[id]` must not match "foo" with an empty id.
-                        if path_.is_empty() {
+                        // A dynamic segment needs a non-empty URL segment: `docs/[page]` does not
+                        // match "docs", and `a/[x]/[y]` does not match "a//b".
+                        if path_.is_empty() || path_[0] == b'/' {
                             params.clear();
                             return false;
                         }
@@ -1693,6 +1694,14 @@ mod tests {
             (b"404/[[...slug]]", b"404", &[]),
             (b"404a/[[...slug]]", b"404a", &[]),
             (
+                b"docs/[page]/[[...rest]]",
+                b"docs/intro",
+                &[Entry {
+                    name: b"page",
+                    value: b"intro",
+                }],
+            ),
+            (
                 b"[teamSlug]/lemon/[project]/[[...slug]]",
                 b"team/lemon/lemon/slugggg",
                 &[
@@ -1819,14 +1828,19 @@ mod tests {
     }
 
     #[test]
-    fn pattern_does_not_match_a_path_that_ends_before_a_dynamic_segment() {
+    fn pattern_rejects_empty_dynamic_segment() {
         let no_match: &[(&[u8], &[u8])] = &[
+            // the URL ends where the dynamic segment starts
             (b"[teamSlug]", b""),
             (b"[teamSlug]/[[...slug]]", b""),
             (b"[...slug]", b""),
             (b"hi/[teamSlug]", b"hi"),
             (b"hi/[teamSlug]/[[...slug]]", b"hi"),
             (b"[teamSlug]/hi/[project]", b"team/hi"),
+            // the URL has an empty segment where the dynamic segment is
+            (b"blog/[slug]/[id]", b"blog//42"),
+            (b"blog/[slug]/[[...rest]]", b"blog//42"),
+            (b"[teamSlug]/[project]", b"team//"),
         ];
         let mut params = route_param::List::default();
         for (pattern, pathname) in no_match {

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -260,25 +260,9 @@ impl Routes {
         }
         let _ = redirect;
 
-        if path.is_empty() {
-            if let Some(index_ptr) = self.index {
-                // SAFETY: points into a Box<Route> owned by self.list; valid for &self.
-                let index = unsafe { index_ptr.as_ref() };
-                return Some(Match {
-                    params: std::ptr::from_mut(params),
-                    name: index.name,
-                    pathname: url_path.pathname,
-                    file_path: index.abs_path.as_bytes(),
-                    query_string: url_path.query_string,
-                });
-            }
-
-            return None;
-        }
-
         if let Some(route_ptr) = self.match_(path, params) {
-            // SAFETY: pointers from static_/dynamic alias Box<Route> stored in
-            // self.list, which outlives self.
+            // SAFETY: pointers from index/static_/dynamic alias Box<Route>
+            // stored in self.list, which outlives self.
             let route = unsafe { &*route_ptr };
             return Some(Match {
                 params: std::ptr::from_mut(params),
@@ -324,7 +308,13 @@ impl Routes {
         let pathname = strings::trim_left(pathname_, b"/");
 
         if pathname.is_empty() {
-            return self.index.map(|p| p.as_ptr().cast_const());
+            // "/" is index.js when there is one. Otherwise it can still be
+            // served by a root-level optional catch-all ([[...slug]].js), the
+            // only dynamic pattern that accepts an empty path.
+            if let Some(index) = self.index {
+                return Some(index.as_ptr().cast_const());
+            }
+            return self.match_dynamic(pathname, params);
         }
 
         self.static_
@@ -1188,6 +1178,12 @@ pub mod pattern {
                         }
                     }
                     Value::Dynamic(dynamic) => {
+                        // Out of URL segments: `foo/[id]` must not match "foo" with an empty id.
+                        if path_.is_empty() {
+                            params.clear();
+                            return false;
+                        }
+
                         if let Some(i) = strings::index_of_char_usize(path_, b'/') {
                             params.push(Param {
                                 name: dynamic.str(name),
@@ -1693,6 +1689,7 @@ mod tests {
 
         let optional_catch_all: &[(&[u8], &[u8], &[Entry])] = &[
             (b"404", b"404", &[]),
+            (b"[[...slug]]", b"", &[]),
             (b"404/[[...slug]]", b"404", &[]),
             (b"404a/[[...slug]]", b"404a", &[]),
             (
@@ -1818,6 +1815,34 @@ mod tests {
         match catch_all.value {
             pattern::Value::CatchAll(p) => assert_eq!(p.str(pattern), b"catch_all"),
             _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn pattern_does_not_match_a_path_that_ends_before_a_dynamic_segment() {
+        let no_match: &[(&[u8], &[u8])] = &[
+            (b"[teamSlug]", b""),
+            (b"[teamSlug]/[[...slug]]", b""),
+            (b"[...slug]", b""),
+            (b"hi/[teamSlug]", b"hi"),
+            (b"hi/[teamSlug]/[[...slug]]", b"hi"),
+            (b"[teamSlug]/hi/[project]", b"team/hi"),
+        ];
+        let mut params = route_param::List::default();
+        for (pattern, pathname) in no_match {
+            params.clear();
+            assert!(
+                !Pattern::match_::<true>(pathname, pattern, pattern, &mut params),
+                "Expected pattern \"{}\" not to match \"{}\"",
+                bstr::BStr::new(pattern),
+                bstr::BStr::new(pathname)
+            );
+            assert!(
+                params.is_empty(),
+                "Pattern \"{}\" left params behind after rejecting \"{}\"",
+                bstr::BStr::new(pattern),
+                bstr::BStr::new(pathname)
+            );
         }
     }
 }

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1140,8 +1140,7 @@ pub mod pattern {
     }
 
     impl Pattern {
-        /// Match a filesystem route pattern to a URL path. On `false`, `params` is
-        /// truncated to its entry length so the next candidate starts clean.
+        /// Match a route pattern to a URL path; on `false`, `params` is as it was on entry.
         pub(crate) fn match_<'a, const ALLOW_OPTIONAL_CATCH_ALL: bool>(
             // `path` must be lowercased and have no leading slash
             path: &'a [u8],

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -1176,6 +1176,65 @@ it("a dynamic route that rejects a URL leaves it to the routes tried after it", 
   }
 });
 
+// Every candidate that fails must leave params as it found them, whichever way it
+// fails; the next candidate pushes into the same list. A leaked param used to come
+// back duplicated when the winning route has a param of that name, and crashed
+// .params when it does not.
+it("a rejected route leaves no params behind, whichever segment rejected the URL", () => {
+  const pick = (match: ReturnType<FileSystemRouter["match"]>) => match && { name: match.name, params: match.params };
+
+  {
+    // [org]/settings/[...id] records org, then its catch-all has nothing to take.
+    const { dir } = make(["[org]/settings/[...id].tsx", "[org]/[...rest].tsx"]);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+    expect(pick(router.match("/acme/settings"))).toEqual({
+      name: "/[org]/[...rest]",
+      params: { org: "acme", rest: "settings" },
+    });
+    expect(pick(router.match("/acme/settings/1/2"))).toEqual({
+      name: "/[org]/settings/[...id]",
+      params: { org: "acme", id: "1/2" },
+    });
+  }
+
+  {
+    // [user]/settings records user and matches its last segment, but the URL goes on.
+    const { dir } = make(["[user]/settings.tsx", "[user]/[...rest].tsx"]);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+    expect(pick(router.match("/alice/settings/extra"))).toEqual({
+      name: "/[user]/[...rest]",
+      params: { user: "alice", rest: "settings/extra" },
+    });
+    expect(pick(router.match("/alice/settings"))).toEqual({
+      name: "/[user]/settings",
+      params: { user: "alice" },
+    });
+  }
+
+  {
+    // Two candidates reject in a row before a route without an org param wins:
+    // [org]/settings/[id] used to take this URL with an empty id, and once it
+    // rejects it, [org]/settings/[...rest] records org and rejects too.
+    const { dir } = make(["[org]/settings/[id].tsx", "[org]/settings/[...rest].tsx", "[[...slug]].tsx"]);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+    expect(pick(router.match("/acme/settings"))).toEqual({
+      name: "/[[...slug]]",
+      params: { slug: "acme/settings" },
+    });
+    expect(pick(router.match("/acme/settings/7"))).toEqual({
+      name: "/[org]/settings/[id]",
+      params: { org: "acme", id: "7" },
+    });
+    expect(pick(router.match("/acme/settings/7/8"))).toEqual({
+      name: "/[org]/settings/[...rest]",
+      params: { org: "acme", rest: "7/8" },
+    });
+  }
+});
+
 it.skipIf(isWindows || isMacOS)(
   "src is computed for a route whose path is longer than the fast-path buffer",
   async () => {

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -201,6 +201,96 @@ it("should support optional catch-all routes", () => {
   }
 });
 
+it("a root-level optional catch-all route matches / when there is no index route", () => {
+  const { dir } = make(["[[...slug]].tsx", "about.tsx"]);
+
+  const router = new Bun.FileSystemRouter({
+    dir,
+    style: "nextjs",
+  });
+
+  // Every spelling of the root path resolves to the optional catch-all with no params,
+  // just like `/posts` resolves to `posts/[[...slug]].tsx`.
+  for (const pathname of ["/", "", "/index", "/index/", "//", "/?q=1"]) {
+    const match = router.match(pathname);
+    expect({
+      pathname,
+      match: match && {
+        name: match.name,
+        kind: match.kind,
+        filePath: match.filePath,
+        pathname: match.pathname,
+        params: match.params,
+        query: match.query,
+      },
+    }).toEqual({
+      pathname,
+      match: {
+        name: "/[[...slug]]",
+        kind: "optional-catch-all",
+        filePath: `${dir}/[[...slug]].tsx`,
+        pathname: pathname === "" ? "/" : pathname,
+        params: {},
+        query: pathname === "/?q=1" ? { q: "1" } : {},
+      },
+    });
+  }
+
+  // Static routes still take precedence, and non-empty paths still populate the param.
+  expect(router.match("/about")).toMatchObject({ name: "/about", params: {} });
+  expect(router.match("/a")).toMatchObject({ name: "/[[...slug]]", params: { slug: "a" } });
+  expect(router.match("/a/b?q=1")).toMatchObject({
+    name: "/[[...slug]]",
+    params: { slug: "a/b" },
+    query: { slug: "a/b", q: "1" },
+  });
+});
+
+it("the index route wins over a root-level optional catch-all route for /", () => {
+  const { dir } = make(["index.tsx", "[[...slug]].tsx"]);
+
+  const router = new Bun.FileSystemRouter({
+    dir,
+    style: "nextjs",
+  });
+
+  for (const pathname of ["/", "/index", "/?q=1"]) {
+    expect({ pathname, match: router.match(pathname) }).toMatchObject({
+      pathname,
+      match: { name: "/", filePath: `${dir}/index.tsx`, params: {} },
+    });
+  }
+  expect(router.match("/a/b")).toMatchObject({ name: "/[[...slug]]", params: { slug: "a/b" } });
+});
+
+it("only a root-level optional catch-all route can match / without an index route", () => {
+  // None of these patterns accepts an empty path: a dynamic segment needs a value and a
+  // catch-all needs at least one segment, so / stays unmatched.
+  const dynamicOnly = ["[id].tsx", "[...rest].tsx", "[team]/[[...rest]].tsx", "docs/[[...slug]].tsx"];
+  {
+    const { dir } = make(dynamicOnly);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+    for (const pathname of ["/", "/index", "//"]) {
+      expect({ pathname, match: router.match(pathname) }).toEqual({ pathname, match: null });
+    }
+  }
+
+  // Adding the root-level optional catch-all makes / resolve to it, and only to it, even
+  // though the other dynamic routes are tried first.
+  {
+    const { dir } = make([...dynamicOnly, "[[...slug]].tsx"]);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+    for (const pathname of ["/", "/index", "//"]) {
+      const match = router.match(pathname);
+      expect({ pathname, match: match && { name: match.name, params: match.params } }).toEqual({
+        pathname,
+        match: { name: "/[[...slug]]", params: {} },
+      });
+    }
+    expect(router.match("/x")).toMatchObject({ name: "/[id]", params: { id: "x" } });
+  }
+});
+
 it("should support catch-all routes", () => {
   // set up the test
   const { dir } = make([
@@ -969,6 +1059,9 @@ it("match() returns null when the URL has fewer segments than a dynamic route re
       params: { org: "acme", id: "x" },
     });
     expect(router.match("/acme")).toBeNull();
+    // One segment short: the trailing dynamic segment must not match as "".
+    expect(router.match("/acme/settings")).toBeNull();
+    expect(router.match("/acme/settings/")).toBeNull();
   }
 
   {
@@ -983,6 +1076,49 @@ it("match() returns null when the URL has fewer segments than a dynamic route re
       params: { team: "acme", rest: "a/b" },
     });
     expect(router.match("/acme")).toBeNull();
+  }
+
+  {
+    const { dir } = make(["posts/[id].tsx"]);
+    const router = new Bun.FileSystemRouter({
+      dir,
+      style: "nextjs",
+    });
+
+    expect(router.match("/posts/1")).toMatchObject({ name: "/posts/[id]", params: { id: "1" } });
+    for (const pathname of ["/posts", "/posts/", "/posts/index"]) {
+      expect({ pathname, match: router.match(pathname) }).toEqual({ pathname, match: null });
+    }
+  }
+
+  {
+    // A dynamic segment followed by an optional catch-all still needs the dynamic segment.
+    const { dir } = make(["posts/[id]/[[...rest]].tsx"]);
+    const router = new Bun.FileSystemRouter({
+      dir,
+      style: "nextjs",
+    });
+
+    expect(router.match("/posts/1")!.params).toEqual({ id: "1" });
+    expect(router.match("/posts/1/a/b")!.params).toEqual({ id: "1", rest: "a/b" });
+    for (const pathname of ["/posts", "/posts/"]) {
+      expect({ pathname, match: router.match(pathname) }).toEqual({ pathname, match: null });
+    }
+  }
+
+  {
+    // The rejected candidate must not leave its params behind for the route that does match.
+    const { dir } = make(["[org]/settings/[id].tsx", "[[...slug]].tsx"]);
+    const router = new Bun.FileSystemRouter({
+      dir,
+      style: "nextjs",
+    });
+
+    const match = router.match("/acme/settings")!;
+    expect({ name: match.name, params: match.params }).toEqual({
+      name: "/[[...slug]]",
+      params: { slug: "acme/settings" },
+    });
   }
 });
 

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -1059,9 +1059,6 @@ it("match() returns null when the URL has fewer segments than a dynamic route re
       params: { org: "acme", id: "x" },
     });
     expect(router.match("/acme")).toBeNull();
-    // One segment short: the trailing dynamic segment must not match as "".
-    expect(router.match("/acme/settings")).toBeNull();
-    expect(router.match("/acme/settings/")).toBeNull();
   }
 
   {
@@ -1077,47 +1074,104 @@ it("match() returns null when the URL has fewer segments than a dynamic route re
     });
     expect(router.match("/acme")).toBeNull();
   }
+});
+
+// A [param] segment stands for one non-empty URL segment, as in Next.js. The matcher
+// used to accept an empty one, both when the URL ended right before the dynamic
+// segment (params: { page: "" }) and when the URL had an empty segment in its place
+// ("/blog//42").
+it("match() does not give a dynamic segment an empty value", () => {
+  const cases: {
+    files: string[];
+    expected: Record<string, { name: string; params: Record<string, string> } | null>;
+  }[] = [
+    {
+      files: ["docs/[page].tsx"],
+      expected: {
+        "/docs/intro": { name: "/docs/[page]", params: { page: "intro" } },
+        "/docs": null,
+        "/docs/": null,
+        "/docs//": null,
+        "/docs/index": null,
+        "/docs?page=intro": null,
+      },
+    },
+    {
+      files: ["docs/[page]/[[...rest]].tsx"],
+      expected: {
+        "/docs/intro": { name: "/docs/[page]/[[...rest]]", params: { page: "intro" } },
+        "/docs/intro/a/b": { name: "/docs/[page]/[[...rest]]", params: { page: "intro", rest: "a/b" } },
+        "/docs": null,
+        "/docs/": null,
+      },
+    },
+    {
+      files: ["[org]/settings/[id].tsx"],
+      expected: {
+        "/acme/settings/7": { name: "/[org]/settings/[id]", params: { org: "acme", id: "7" } },
+        "/acme/settings": null,
+        "/acme/settings/": null,
+      },
+    },
+    {
+      files: ["blog/[slug]/[id].tsx"],
+      expected: {
+        "/blog/hello/42": { name: "/blog/[slug]/[id]", params: { slug: "hello", id: "42" } },
+        "/blog//42": null,
+        "/blog/hello": null,
+      },
+    },
+    {
+      files: ["blog/[slug]/[[...rest]].tsx"],
+      expected: {
+        "/blog/hello": { name: "/blog/[slug]/[[...rest]]", params: { slug: "hello" } },
+        "/blog//42": null,
+      },
+    },
+  ];
+
+  for (const { files, expected } of cases) {
+    const { dir } = make(files);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+    const actual: typeof expected = {};
+    for (const input of Object.keys(expected)) {
+      const match = router.match(input);
+      actual[input] = match && { name: match.name, params: match.params };
+    }
+    expect({ files, ...actual }).toEqual({ files, ...expected });
+  }
+});
+
+it("a dynamic route that rejects a URL leaves it to the routes tried after it", () => {
+  const pick = (match: ReturnType<FileSystemRouter["match"]>) => match && { name: match.name, params: match.params };
 
   {
-    const { dir } = make(["posts/[id].tsx"]);
-    const router = new Bun.FileSystemRouter({
-      dir,
-      style: "nextjs",
-    });
+    const { dir } = make(["docs/[page].tsx", "docs/[[...rest]].tsx"]);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
 
-    expect(router.match("/posts/1")).toMatchObject({ name: "/posts/[id]", params: { id: "1" } });
-    for (const pathname of ["/posts", "/posts/", "/posts/index"]) {
-      expect({ pathname, match: router.match(pathname) }).toEqual({ pathname, match: null });
-    }
+    // docs/[page] is tried first; it must reject "/docs" so that the optional
+    // catch-all, which does accept an empty remainder, gets to see it.
+    expect(pick(router.match("/docs"))).toEqual({ name: "/docs/[[...rest]]", params: {} });
+    expect(pick(router.match("/docs/"))).toEqual({ name: "/docs/[[...rest]]", params: {} });
+    expect(pick(router.match("/docs/intro"))).toEqual({ name: "/docs/[page]", params: { page: "intro" } });
+    expect(pick(router.match("/docs/a/b"))).toEqual({ name: "/docs/[[...rest]]", params: { rest: "a/b" } });
   }
 
   {
-    // A dynamic segment followed by an optional catch-all still needs the dynamic segment.
-    const { dir } = make(["posts/[id]/[[...rest]].tsx"]);
-    const router = new Bun.FileSystemRouter({
-      dir,
-      style: "nextjs",
+    const { dir } = make(["[org]/settings/[id].tsx", "[org]/[...rest].tsx"]);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+    // [org]/settings/[id] records org before it rejects "/acme/settings". That param
+    // must not survive into the catch-all's match, or org would come back as
+    // ["acme", "acme"].
+    expect(pick(router.match("/acme/settings"))).toEqual({
+      name: "/[org]/[...rest]",
+      params: { org: "acme", rest: "settings" },
     });
-
-    expect(router.match("/posts/1")!.params).toEqual({ id: "1" });
-    expect(router.match("/posts/1/a/b")!.params).toEqual({ id: "1", rest: "a/b" });
-    for (const pathname of ["/posts", "/posts/"]) {
-      expect({ pathname, match: router.match(pathname) }).toEqual({ pathname, match: null });
-    }
-  }
-
-  {
-    // The rejected candidate must not leave its params behind for the route that does match.
-    const { dir } = make(["[org]/settings/[id].tsx", "[[...slug]].tsx"]);
-    const router = new Bun.FileSystemRouter({
-      dir,
-      style: "nextjs",
-    });
-
-    const match = router.match("/acme/settings")!;
-    expect({ name: match.name, params: match.params }).toEqual({
-      name: "/[[...slug]]",
-      params: { slug: "acme/settings" },
+    expect(pick(router.match("/acme/settings/7"))).toEqual({
+      name: "/[org]/settings/[id]",
+      params: { org: "acme", id: "7" },
     });
   }
 });


### PR DESCRIPTION
### Problem
- With `pages/[[...slug]].tsx` and no `pages/index.tsx`, `router.match("/")` returns `null` (same for `""`, `/index`, `//`, `/?q=1`). `/x` matches the route with `{ slug: "x" }`, and the nested form `pages/docs/[[...slug]].tsx` already matches `/docs` with no params.
- Cause: `Routes::match_` (`src/router/lib.rs`) returns early on an empty path: the index route if there is one, otherwise `None`. The dynamic route list is never consulted for `/`. `match_page_with_allocator` carried a second copy of the same early return.
- Letting `/` reach the dynamic list exposes a second bug in `Pattern::match_`: the `Dynamic` arm never checks that there is a URL segment for the parameter to take, so a root-level `pages/[id].tsx` would start matching `/` with `{ id: "" }`.
- That second bug is already reachable one level down: `pages/docs/[page].tsx` matches `/docs` with `{ page: "" }` (shadowing a `docs/[[...rest]].tsx` next to it), `pages/[org]/settings/[id].tsx` matches `/acme/settings` with `{ org: "acme", id: "" }`, and `pages/blog/[slug]/[id].tsx` matches `/blog//42` with `{ slug: "" }`. #39294 was opened for this half and closed into this PR; its empty-segment case and tests are carried here.
- Rejecting those URLs exposes a third bug: `match_dynamic` hands every candidate the same `params` list, and `Pattern::match_` only emptied it on some of its failure exits. A candidate that records a param and then fails because its catch-all has nothing left to take, or because the URL goes on past its last segment, left the param in the list. The next route to match then reports it too: as `org: ["acme", "acme"]` when that route has a param of the same name, as a crash in `.params` when it does not (the name is looked up in the winning route's name). Today this needs the leaking route to be the first one tried; with the rejection above, `[org]/settings/[id].tsx` + `[org]/settings/[...rest].tsx` + `[[...slug]].tsx` would take `/acme/settings` from a (wrong) match on the first route to a crash via the second, so the rejection is not safe without fixing this as well.
- Found while working on #39291; no issue reports the first two symptoms. The third is the leak behind #12206 and #15554.

### Fix
- `Routes::match_`: on an empty path, return the index route if there is one, otherwise fall through to `match_dynamic`. `match_page_with_allocator` now always goes through `match_`; its own empty-path branch built the same `Match`.
- `Pattern::match_`: the `Dynamic` arm rejects the candidate when the remaining URL is empty or starts with `/`, i.e. when the segment the parameter would take is missing or empty.
- `Pattern::match_` now records `params.len()` on entry and truncates back to it whenever the candidate fails; the body moves to `match_inner` and its per-exit `params.clear()` calls are removed. Every failure exit is covered by the one truncate, including the two that had none. This is the same shape as #36680, which fixes the leak on its own together with a separate single-character-segment bug; whichever of the two lands second rebases onto an identical hunk.
- Matches Next.js's pages router: `pages/[[...slug]].js` serves `/` (with `slug` undefined) when there is no `pages/index.js`; `[param]` compiles to `([^/]+?)`, so `pages/foo/[id].js` serves neither `/foo` nor `/foo//x`.
- Makes the root level behave like every nested directory, where `posts/[[...slug]].tsx` already serves `/posts`.
- After the change an empty path is accepted only by a route whose entire pattern is one optional catch-all: a static segment never equals `""`, a dynamic segment now rejects it, and `[...slug]` already required a segment. So no other route can start matching `/`.
- The index route still wins for `/` when both exist. That is the layout in `docs/runtime/file-system-router.mdx`, and the rule the existing `posts.tsx` + `posts/[[...id]].tsx` test asserts one level down.
- Results that change, for release notes: `/` resolves to a root-level optional catch-all when there is no index route; URLs whose dynamic segment was matched against nothing fall to the next candidate or return `null`; a route that failed to match no longer contributes params to the route that does. Nothing else moves (checked by diffing a 12-tree matrix between the released binary and this build). #37120 proposes the same empty-segment rule for bake's `FrameworkRouter`.
- Verified: `test/js/bun/util/filesystem_router.test.ts` gains six tests: root optional catch-all without an index route, with one, a tree containing `[id]`, `[...rest]`, `[team]/[[...rest]]` and `docs/[[...slug]]` where `/` must resolve to `[[...slug]]` and nothing else, a table of five trees asserting the exact `{ name, params }` or `null` for the short, trailing-slash, `//` and control URLs, the fall-through to `docs/[[...rest]]` and to `[org]/[...rest]`, and one tree per previously uncleared exit plus the three-route tree above (all asserted with exact params, so a leak shows up as a duplicated value rather than a crash). Five of them fail on the released `bun` 1.4.0; all 39 tests in the file pass with `bun bd test`.
- Verified: `src/router/lib.rs` unit tables gain the `[[...slug]]` vs `""` and `docs/[page]/[[...rest]]` vs `docs/intro` rows, `pattern_rejects_empty_dynamic_segment`, and `pattern_no_match_truncates_params_to_entry_length`, which seeds the list before each failing match to pin the entry-length contract. `cargo check -p bun_router --tests` and `cargo clippy -p bun_router --no-deps` are clean (the crate's test binary does not link outside the full build, as before).

### Background
- `Bun.FileSystemRouter` (`style: "nextjs"`) maps a directory to routes: `index.tsx` is the index route `/`, `[id].tsx` a dynamic segment, `[...slug].tsx` a catch-all (one or more segments), `[[...slug]].tsx` an optional catch-all (zero or more). Directories nest, so `posts/[[...slug]].tsx` serves `/posts` and everything below it.
- `Routes` holds three lookups: `index` (stored on its own), `static_` (hash map of parameterless routes) and the sorted dynamic tail of the route list. `match_` normalizes the path and tries them in that order; `match_dynamic` runs each dynamic route's `Pattern::match_` against the path in turn and returns the first that matches.
- `Pattern::match_` walks the route name segment by segment, consuming the URL and pushing each parameter into the `params` list that `match_dynamic` shares across all candidates. The path it sees has no leading slash, so a remaining path that starts with `/` means the next segment is empty.
- `MatchedRoute.params` is built by locating each recorded param name inside the matched route's name, which is why a param recorded by a different route either merges with a same-named one or crashes.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/filesystem_router.test.ts

<!-- robobun:evidence:end -->