### PR TITLE
FileSystemRouter: order dynamic routes by per-segment precedence like Next.js

### DIFF
--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -980,8 +980,7 @@ pub(crate) mod sorter {
         }
     }
 
-    /// Next.js's `getSortedRoutes` order, which is also the match order, except that
-    /// fully static routes lead as a group because `load_all` splits the list there.
+    /// Next.js's `getSortedRoutes` order, but static routes lead: `load_all` splits the list there.
     pub(crate) fn compare(a: &Route, b: &Route) -> Ordering {
         let a_name = a.match_name.as_bytes();
         let b_name = b.match_name.as_bytes();

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -311,8 +311,7 @@ impl Routes {
             if Pattern::match_::<true>(path, &case_sensitive_name[1..], name, params) {
                 return Some(&raw const **route);
             }
-            // A rejected candidate may have recorded the segments it did match
-            // (https://github.com/oven-sh/bun/issues/12206); the next one starts clean.
+            // Not every rejection inside `match_` drops the params it pushed (#12206).
             params.clear();
         }
 
@@ -499,8 +498,6 @@ impl<'a> RouteLoader<'a> {
             .set_capacity(this.all_routes.len())
             .expect("unreachable");
 
-        // `sorter::compare` puts every static route (the index route included)
-        // ahead of the first dynamic one, so the dynamic routes are one suffix.
         let mut dynamic_start: Option<usize> = None;
 
         for (i, route) in this.all_routes.into_iter().enumerate() {
@@ -970,11 +967,7 @@ pub(crate) mod sorter {
     use super::pattern::Tag;
     use super::*;
 
-    /// Sort key of one `/`-delimited segment of a route name. `Tag`'s numeric
-    /// order is the precedence order; static segments also order by name so
-    /// the list stays grouped by directory, parameter names never matter.
-    /// The prefixes are the ones `Pattern::init` dispatches on, and every name
-    /// reaching the sorter already passed `Pattern::validate`.
+    /// `Tag`'s numeric order is the precedence order; parameter names never matter.
     fn segment_key(segment: &[u8]) -> (u8, &[u8]) {
         if segment.starts_with(b"[[...") {
             (Tag::OptionalCatchAll as u8, b"")
@@ -987,18 +980,10 @@ pub(crate) mod sorter {
         }
     }
 
-    /// List order is match order (`Routes::match_dynamic` returns the first
-    /// route that matches), so this is Next.js's `getSortedRoutes` precedence:
-    /// routes are compared one segment at a time, the first segment whose kind
-    /// differs decides (static beats `[x]` beats `[...x]` beats `[[...x]]`), and
-    /// a route that ends first comes first. `opt/[[...rest]]` beats `[slug]`
-    /// for `/opt` because `opt` beats `[slug]` at depth one; that the former
-    /// ends in an optional catch-all (its `Route::kind`) is irrelevant.
-    ///
-    /// The only use of `kind` is to sort the fully static routes ahead of
-    /// everything else as a group, because `RouteLoader::load_all` splits the
-    /// list there; they are matched through `Routes::static_`, so their
-    /// relative order is cosmetic.
+    /// Match order: `Routes::match_dynamic` takes the first hit. Fully static routes
+    /// lead because `load_all` splits the list there; the rest follow Next.js's
+    /// `getSortedRoutes`: per segment, static before `[x]` before `[...x]` before
+    /// `[[...x]]`, and a route that ends first comes first.
     pub(crate) fn compare(a: &Route, b: &Route) -> Ordering {
         let a_name = a.match_name.as_bytes();
         let b_name = b.match_name.as_bytes();
@@ -1009,8 +994,7 @@ pub(crate) mod sorter {
                     .map(segment_key)
                     .cmp(strings::tokenize(b_name, b"/").map(segment_key))
             })
-            // Only differing parameter names remain (`[a]/x` vs `[b]/x`); keep
-            // the winner deterministic instead of up to directory order.
+            // Only parameter names differ at this point; keep the order deterministic.
             .then_with(|| a_name.cmp(b_name))
     }
 }

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -489,23 +489,20 @@ impl<'a> RouteLoader<'a> {
         }
 
         this.all_routes
-            .sort_unstable_by(|a, b| sorter::sort_by_name_cmp(a, b));
+            .sort_unstable_by(|a, b| sorter::compare(a, b));
 
         let mut route_list = RouteIndexList::default();
         route_list
             .set_capacity(this.all_routes.len())
             .expect("unreachable");
 
+        // `sorter::compare` puts every static route (the index route included)
+        // ahead of the first dynamic one, so the dynamic routes are one suffix.
         let mut dynamic_start: Option<usize> = None;
-        let mut index_id: Option<usize> = None;
 
         for (i, route) in this.all_routes.into_iter().enumerate() {
             if (route.kind as u8) > (pattern::Tag::Static as u8) && dynamic_start.is_none() {
                 dynamic_start = Some(i);
-            }
-
-            if route.full_hash == INDEX_ROUTE_HASH {
-                index_id = Some(i);
             }
 
             let (filepath, match_name) = (route.abs_path.as_bytes(), route.match_name.as_bytes());
@@ -517,17 +514,7 @@ impl<'a> RouteLoader<'a> {
             });
         }
 
-        let mut dynamic_len: usize = 0;
-        if let Some(dynamic_i) = dynamic_start {
-            dynamic_len = route_list.len() - dynamic_i;
-            if let Some(index_i) = index_id {
-                if index_i > dynamic_i {
-                    // Due to the sorting order, the index route can be the last route.
-                    // We don't want to attempt to match the index route or different stuff will break.
-                    dynamic_len -= 1;
-                }
-            }
-        }
+        let dynamic_len = dynamic_start.map_or(0, |dynamic_i| route_list.len() - dynamic_i);
 
         Routes {
             list: route_list,
@@ -977,72 +964,51 @@ impl Route {
 }
 
 pub(crate) mod sorter {
+    use super::pattern::Tag;
     use super::*;
 
-    const fn build_sort_table() -> [u8; 256] {
-        let mut table = [0u8; 256];
-        let mut i = 0usize;
-        while i < 256 {
-            table[i] = i as u8;
-            i += 1;
+    /// Sort key of one `/`-delimited segment of a route name. `Tag`'s numeric
+    /// order is the precedence order; static segments also order by name so
+    /// the list stays grouped by directory, parameter names never matter.
+    /// The prefixes are the ones `Pattern::init` dispatches on, and every name
+    /// reaching the sorter already passed `Pattern::validate`.
+    fn segment_key(segment: &[u8]) -> (u8, &[u8]) {
+        if segment.starts_with(b"[[...") {
+            (Tag::OptionalCatchAll as u8, b"")
+        } else if segment.starts_with(b"[...") {
+            (Tag::CatchAll as u8, b"")
+        } else if segment.starts_with(b"[") {
+            (Tag::Dynamic as u8, b"")
+        } else {
+            (Tag::Static as u8, segment)
         }
-        // move dynamic routes to the bottom
-        table[b'[' as usize] = 252;
-        table[b']' as usize] = 253;
-        // of each segment
-        table[b'/' as usize] = 254;
-        table
     }
 
-    static SORT_TABLE: [u8; 256] = build_sort_table();
-
-    pub(crate) fn sort_by_name_string(lhs: &[u8], rhs: &[u8]) -> bool {
-        let n = lhs.len().min(rhs.len());
-        for (lhs_i, rhs_i) in lhs[0..n].iter().zip(&rhs[0..n]) {
-            match SORT_TABLE[*lhs_i as usize].cmp(&SORT_TABLE[*rhs_i as usize]) {
-                Ordering::Equal => continue,
-                Ordering::Less => return true,
-                Ordering::Greater => return false,
-            }
-        }
-        lhs.len().cmp(&rhs.len()) == Ordering::Less
-    }
-
-    pub(crate) fn sort_by_name(a: &Route, b: &Route) -> bool {
+    /// List order is match order (`Routes::match_dynamic` returns the first
+    /// route that matches), so this is Next.js's `getSortedRoutes` precedence:
+    /// routes are compared one segment at a time, the first segment whose kind
+    /// differs decides (static beats `[x]` beats `[...x]` beats `[[...x]]`), and
+    /// a route that ends first comes first. `opt/[[...rest]]` beats `[slug]`
+    /// for `/opt` because `opt` beats `[slug]` at depth one; that the former
+    /// ends in an optional catch-all (its `Route::kind`) is irrelevant.
+    ///
+    /// The only use of `kind` is to sort the fully static routes ahead of
+    /// everything else as a group, because `RouteLoader::load_all` splits the
+    /// list there; they are matched through `Routes::static_`, so their
+    /// relative order is cosmetic.
+    pub(crate) fn compare(a: &Route, b: &Route) -> Ordering {
         let a_name = a.match_name.as_bytes();
         let b_name = b.match_name.as_bytes();
-
-        // route order determines route match order
-        // - static routes go first because we match those first
-        // - dynamic, catch-all, and optional catch all routes are sorted lexicographically, except "[", "]" appear last so that deepest routes are tested first
-        // - catch-all & optional catch-all appear at the end because we want to test those at the end.
-        match (a.kind as u8).cmp(&(b.kind as u8)) {
-            Ordering::Equal => match a.kind {
-                // static + dynamic are sorted alphabetically
-                pattern::Tag::Static | pattern::Tag::Dynamic => sort_by_name_string(a_name, b_name),
-                // catch all and optional catch all must appear below dynamic
-                pattern::Tag::CatchAll | pattern::Tag::OptionalCatchAll => {
-                    match a.param_count.cmp(&b.param_count) {
-                        Ordering::Equal => sort_by_name_string(a_name, b_name),
-                        Ordering::Less => false,
-                        Ordering::Greater => true,
-                    }
-                }
-            },
-            Ordering::Less => true,
-            Ordering::Greater => false,
-        }
-    }
-
-    /// Adapter for slice::sort_by which expects an Ordering.
-    pub(crate) fn sort_by_name_cmp(a: &Route, b: &Route) -> Ordering {
-        if sort_by_name(a, b) {
-            Ordering::Less
-        } else if sort_by_name(b, a) {
-            Ordering::Greater
-        } else {
-            Ordering::Equal
-        }
+        (a.kind != Tag::Static)
+            .cmp(&(b.kind != Tag::Static))
+            .then_with(|| {
+                strings::tokenize(a_name, b"/")
+                    .map(segment_key)
+                    .cmp(strings::tokenize(b_name, b"/").map(segment_key))
+            })
+            // Only differing parameter names remain (`[a]/x` vs `[b]/x`); keep
+            // the winner deterministic instead of up to directory order.
+            .then_with(|| a_name.cmp(b_name))
     }
 }
 

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -980,10 +980,8 @@ pub(crate) mod sorter {
         }
     }
 
-    /// Match order: `Routes::match_dynamic` takes the first hit. Fully static routes
-    /// lead because `load_all` splits the list there; the rest follow Next.js's
-    /// `getSortedRoutes`: per segment, static before `[x]` before `[...x]` before
-    /// `[[...x]]`, and a route that ends first comes first.
+    /// Next.js's `getSortedRoutes` order, which is also the match order, except that
+    /// fully static routes lead as a group because `load_all` splits the list there.
     pub(crate) fn compare(a: &Route, b: &Route) -> Ordering {
         let a_name = a.match_name.as_bytes();
         let b_name = b.match_name.as_bytes();

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -311,6 +311,9 @@ impl Routes {
             if Pattern::match_::<true>(path, &case_sensitive_name[1..], name, params) {
                 return Some(&raw const **route);
             }
+            // A rejected candidate may have recorded the segments it did match
+            // (https://github.com/oven-sh/bun/issues/12206); the next one starts clean.
+            params.clear();
         }
 
         None

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -383,6 +383,78 @@ it("lists routes in match order", () => {
   ]);
 });
 
+// With static segments winning, a deeper route is often tried (and rejected) before
+// the shallower route that wins. The rejected candidate has already recorded the
+// params of the segments it did match; if they survived, the winner would report
+// them too (`team: ["acme", "acme"]`), or crash in `.params` when the leaked name is
+// not one of its own (https://github.com/oven-sh/bun/issues/12206). The crash takes
+// the process down, so the routers run in a subprocess.
+it("a candidate rejected before the winner leaves no params behind", async () => {
+  const trees = {
+    "catch-all stops on an empty remainder, winner shares the param name": {
+      files: ["[team]/docs/[...topic].tsx", "[team]/[page].tsx"],
+      pathname: "/acme/docs",
+      expected: { name: "/[team]/[page]", params: { team: "acme", page: "docs" } },
+    },
+    "catch-all stops on an empty remainder, winner has other param names": {
+      files: ["[a]/docs/[...topic].tsx", "[z]/[...rest].tsx"],
+      pathname: "/bob/docs",
+      expected: { name: "/[z]/[...rest]", params: { z: "bob", rest: "docs" } },
+    },
+    "pattern ends with URL left over, winner shares the param name": {
+      files: ["[team]/settings.tsx", "[team]/[section]/[item].tsx"],
+      pathname: "/acme/settings/profile",
+      expected: { name: "/[team]/[section]/[item]", params: { team: "acme", section: "settings", item: "profile" } },
+    },
+    "pattern ends with URL left over, winner has other param names": {
+      files: ["[a]/settings.tsx", "[z]/[b]/[c].tsx"],
+      pathname: "/bob/settings/profile",
+      expected: { name: "/[z]/[b]/[c]", params: { z: "bob", b: "settings", c: "profile" } },
+    },
+  };
+
+  const fixture: Record<string, string> = {};
+  const cases: Record<string, { tree: string; pathname: string }> = {};
+  Object.entries(trees).forEach(([label, { files, pathname }], i) => {
+    for (const file of files) fixture[`tree-${i}/${file}`] = "export default 1;";
+    cases[label] = { tree: `tree-${i}`, pathname };
+  });
+  using dir = tempDir("fsr-rejected-candidate", fixture);
+
+  const code = /* ts */ `
+    import path from "path";
+    const out = {};
+    for (const [label, { tree, pathname }] of Object.entries(${JSON.stringify(cases)})) {
+      const router = new Bun.FileSystemRouter({
+        dir: path.join(${JSON.stringify(String(dir))}, tree),
+        style: "nextjs",
+      });
+      const match = router.match(pathname);
+      // .query is built from the same param list as .params, so it must agree with it.
+      out[label] = match && { name: match.name, params: match.params, query: match.query };
+    }
+    console.log(JSON.stringify(out));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual(
+    Object.fromEntries(
+      Object.entries(trees).map(([label, { expected }]) => [
+        label,
+        { name: expected.name, params: expected.params, query: expected.params },
+      ]),
+    ),
+  );
+  expect(exitCode).toBe(0);
+});
+
 it("should support index routes", () => {
   // set up the test
   const { dir } = make(["index.tsx", "posts/[id].tsx", "posts.tsx", "posts/hey.tsx"]);

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -222,13 +222,165 @@ it("should support catch-all routes", () => {
     expect(match?.name).not.toBe("/posts/[...id]");
   }
 
-  for (let fixture of ["/posts/hey/there", "/posts/hey/there/you", "/posts/zorp/123", "/posts/wow/hey/there"]) {
+  for (let fixture of ["/posts/hey/there", "/posts/hey/there/you", "/posts/zorp/123"]) {
     const { name, params, filePath } = router.match(fixture)!;
 
     expect(name).toBe("/posts/[...id]");
     expect(filePath).toBe(`${dir}/posts/[...id].tsx`);
     expect(params.id).toBe(fixture.split("/").slice(2).join("/"));
   }
+
+  // The static "wow" segment beats "[...id]" at the same depth, as in Next.js;
+  // otherwise posts/wow/[[...id]] could never match anything.
+  for (const [fixture, params] of [
+    ["/posts/wow", {}],
+    ["/posts/wow/hey/there", { id: "hey/there" }],
+  ] as const) {
+    const match = router.match(fixture)!;
+    expect({ fixture, name: match.name, filePath: match.filePath, params: match.params }).toEqual({
+      fixture,
+      name: "/posts/wow/[[...id]]",
+      filePath: `${dir}/posts/wow/[[...id]].tsx`,
+      params,
+    });
+  }
+});
+
+// Route precedence follows Next.js (getSortedRoutes): routes are compared one
+// segment at a time and at the first depth where they differ a static segment
+// beats [param], which beats [...rest], which beats [[...rest]]. In particular a
+// route's precedence is not decided by its most dynamic segment.
+it.each([
+  {
+    label: "a static directory holding an optional catch-all beats a root dynamic route",
+    files: ["[slug].tsx", "opt/[[...rest]].tsx"],
+    matches: [
+      ["/opt", { name: "/opt/[[...rest]]", params: {} }],
+      ["/opt/", { name: "/opt/[[...rest]]", params: {} }],
+      ["/opt/x/y", { name: "/opt/[[...rest]]", params: { rest: "x/y" } }],
+      ["/other", { name: "/[slug]", params: { slug: "other" } }],
+    ],
+  },
+  {
+    label: "a static directory holding a catch-all beats a root dynamic route",
+    files: ["[slug]/[id].tsx", "opt/[...rest].tsx"],
+    matches: [
+      ["/opt/x", { name: "/opt/[...rest]", params: { rest: "x" } }],
+      ["/opt/x/y", { name: "/opt/[...rest]", params: { rest: "x/y" } }],
+      ["/a/b", { name: "/[slug]/[id]", params: { slug: "a", id: "b" } }],
+      // A catch-all still needs at least one segment; nothing else is two segments deep.
+      ["/opt", null],
+    ],
+  },
+  {
+    label: "a static first segment beats a dynamic one even when its route ends in an optional catch-all",
+    files: ["[team]/[...rest].tsx", "docs/[[...rest]].tsx"],
+    matches: [
+      ["/docs", { name: "/docs/[[...rest]]", params: {} }],
+      ["/docs/intro", { name: "/docs/[[...rest]]", params: { rest: "intro" } }],
+      ["/acme/intro", { name: "/[team]/[...rest]", params: { team: "acme", rest: "intro" } }],
+    ],
+  },
+  {
+    label: "a static segment below a dynamic one beats the sibling catch-all",
+    files: ["[team]/[...rest].tsx", "[team]/docs/[[...path]].tsx"],
+    matches: [
+      ["/acme/docs", { name: "/[team]/docs/[[...path]]", params: { team: "acme" } }],
+      ["/acme/docs/intro", { name: "/[team]/docs/[[...path]]", params: { team: "acme", path: "intro" } }],
+      ["/acme/billing", { name: "/[team]/[...rest]", params: { team: "acme", rest: "billing" } }],
+    ],
+  },
+  {
+    label: "a static second segment beats a dynamic one regardless of the parameter names",
+    files: ["[a]/settings.tsx", "[ab]/[page].tsx"],
+    matches: [
+      ["/acme/settings", { name: "/[a]/settings", params: { a: "acme" } }],
+      ["/acme/billing", { name: "/[ab]/[page]", params: { ab: "acme", page: "billing" } }],
+    ],
+  },
+  {
+    label: "a static second segment beats a dynamic one regardless of the parameter names (swapped)",
+    files: ["[abc]/settings.tsx", "[a]/[page].tsx"],
+    matches: [
+      ["/acme/settings", { name: "/[abc]/settings", params: { abc: "acme" } }],
+      ["/acme/billing", { name: "/[a]/[page]", params: { a: "acme", page: "billing" } }],
+    ],
+  },
+  {
+    label: "at one depth, [param] beats [...rest] beats [[...rest]]",
+    files: ["docs/[page].tsx", "docs/[...rest].tsx", "docs/[[...optional]].tsx"],
+    matches: [
+      ["/docs/intro", { name: "/docs/[page]", params: { page: "intro" } }],
+      ["/docs/a/b", { name: "/docs/[...rest]", params: { rest: "a/b" } }],
+    ],
+  },
+  {
+    label: "at one depth, [...rest] beats [[...rest]] but still needs a segment",
+    files: ["docs/[...rest].tsx", "docs/[[...optional]].tsx"],
+    matches: [
+      ["/docs/intro", { name: "/docs/[...rest]", params: { rest: "intro" } }],
+      ["/docs", { name: "/docs/[[...optional]]", params: {} }],
+    ],
+  },
+  {
+    label: "a dynamic segment beats a catch-all at the same depth however deep the dynamic route goes on",
+    files: ["[...all].tsx", "[a]/[b].tsx", "[a]/[b]/[c].tsx", "[a]/[...rest].tsx"],
+    matches: [
+      ["/x", { name: "/[...all]", params: { all: "x" } }],
+      ["/x/y", { name: "/[a]/[b]", params: { a: "x", b: "y" } }],
+      ["/x/y/z", { name: "/[a]/[b]/[c]", params: { a: "x", b: "y", c: "z" } }],
+      ["/x/y/z/w", { name: "/[a]/[...rest]", params: { a: "x", rest: "y/z/w" } }],
+    ],
+  },
+  {
+    label: "fully static routes still beat every dynamic route",
+    files: ["index.tsx", "[[...all]].tsx", "[slug].tsx", "docs.tsx", "docs/[[...rest]].tsx"],
+    matches: [
+      ["/", { name: "/", params: {} }],
+      ["/docs", { name: "/docs", params: {} }],
+      ["/docs/intro", { name: "/docs/[[...rest]]", params: { rest: "intro" } }],
+      ["/about", { name: "/[slug]", params: { slug: "about" } }],
+      ["/a/b", { name: "/[[...all]]", params: { all: "a/b" } }],
+    ],
+  },
+] as const)("route precedence: $label", ({ files, matches }) => {
+  const { dir } = make([...files]);
+  const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+  for (const [pathname, expected] of matches) {
+    const match = router.match(pathname);
+    expect({ pathname, match: match && { name: match.name, params: match.params } }).toEqual({
+      pathname,
+      match: expected,
+    });
+  }
+});
+
+it("lists routes in match order", () => {
+  const { dir } = make([
+    "index.tsx",
+    "blog.tsx",
+    "blog/[slug].tsx",
+    "blog/archive/[[...date]].tsx",
+    "blog/[...rest].tsx",
+    "[user].tsx",
+    "[user]/[repo].tsx",
+    "[user]/settings.tsx",
+    "[[...fallback]].tsx",
+  ]);
+  const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+  // Static routes come first (they are looked up by name); the dynamic routes
+  // follow in the order match() tries them, which is Next.js's sorted order.
+  expect(Object.keys(router.routes).filter(name => name.includes("["))).toEqual([
+    "/blog/archive/[[...date]]",
+    "/blog/[slug]",
+    "/blog/[...rest]",
+    "/[user]",
+    "/[user]/settings",
+    "/[user]/[repo]",
+    "/[[...fallback]]",
+  ]);
 });
 
 it("should support index routes", () => {
@@ -504,7 +656,7 @@ it("origin should be validated", async () => {
 });
 
 // POSIX allows arbitrary bytes (except '/' and NUL) in filenames, including 0xFF.
-// The route sorter's lookup table must cover the full u8 range.
+// The route sorter must handle the full u8 range (https://github.com/oven-sh/bun/pull/29973).
 // Windows and macOS (APFS/HFS+) require filenames to be valid Unicode, so skip there.
 it.skipIf(isWindows || isMacOS)("handles filenames containing byte 0xFF", () => {
   using dir = tempDir("fsr-byte-ff", {});


### PR DESCRIPTION
### Problem

- `Bun.FileSystemRouter({ style: "nextjs" })` picks the wrong route whenever a catch-all route competes with a shallower plain dynamic route. With `pages/[slug].js` and `pages/opt/[[...rest]].js`, `match("/opt")` returns `/[slug]` (`{ slug: "opt" }`) while `match("/opt/x")` returns `/opt/[[...rest]]`, so the same directory serves different routes depending on whether a trailing segment is present. Next.js serves both from `opt/[[...rest]]`.
- Same cause, other shapes: `posts/[...id]` shadows `posts/wow/[[...id]]` completely (that file can never match), `[team]/[...rest]` beats `[team]/docs/[[...path]]` for `/acme/docs`, and `[ab]/[page]` beats `[a]/settings` for `/acme/settings` while `[a]/[page]` loses to `[abc]/settings`: the parameter name length decided precedence.
- Cause: `sorter::sort_by_name` (`src/router/lib.rs`) ordered the dynamic list primarily by `Route::kind`, the most dynamic segment anywhere in the route (dynamic < catch-all < optional catch-all), and within a kind by a byte table that weighted `]` above every letter. `Routes::match_dynamic` returns the first route in that list that matches, so a route's position was decided by its deepest segment rather than by the first segment where two routes differ.
- Second problem, exposed by fixing the first: two failure exits of `Pattern::match_` (a `[...rest]` that finds nothing left to consume, and a pattern that ends while URL segments remain) return without dropping the params the candidate pushed before giving up. The next candidate inherits them, so the winner reports a duplicated value (`team: ["acme", "acme"]`) or, when the leaked name is not one of its own parameters, `.params` crashes (`Segmentation fault at address 0x0` on the released binary; issue #12206). Today this needs the losing route to sort before the winner by accident of kind or parameter name; with per-segment precedence a deeper static-prefixed route is tried before the shallower winner as a matter of course (`[team]/docs/[...topic]` before `[team]/[page]`), so trees that work on the released binary would start hitting it.

### Fix

- `sorter::compare` replaces the kind ordering and the byte table. Routes are compared one `/`-segment at a time; at the first depth where they differ, static beats `[x]` beats `[...x]` beats `[[...x]]` (static segments compare by name among themselves), and a route that ends first comes first. Ties (only possible for routes that differ in parameter names alone, like `[a]/x` vs `[b]/x`) fall back to the name so the winner does not depend on directory read order.
- Fully static routes still sort first as one group: `load_all` splits the list at the first non-static route and matches static routes through the hash map, so only the dynamic suffix's order matters for matching.
- Why this is the right order: it is what Next.js's `getSortedRoutes` (`packages/next/src/shared/lib/router/utils/sorted-routes.ts`) produces, which is the contract `style: "nextjs"` advertises. At each tree node it emits the node's own route, then static children, then `[slug]`, then `[...rest]`, then `[[...rest]]`, depth first. The old order already agreed with this for static-vs-dynamic shapes (that is what the byte table approximated); the per-segment comparison keeps those results and fixes the catch-all and parameter-name cases.
- `Routes::match_dynamic` clears `params` after every rejected candidate, so each candidate starts from an empty list whatever exit `Pattern::match_` took. This is the loop that reuses the list across candidates, and the hunk is independent of #36680, which makes `Pattern::match_` itself truncate on every failure (and also fixes the shapes that leak under the current order); the two merge cleanly in either order and each is correct on its own.
- `load_all` loses the `index_id` bookkeeping. The index route has `kind == Static` and has always sorted into the static group, so the "index route can be the last route" branch never ran; its comment described the ordering this PR replaces.
- Behavior change to note in release notes: where a catch-all or optional catch-all route shares a static prefix with a shallower dynamic route, the prefixed route now wins, as in Next.js. The existing "should support catch-all routes" test asserted the old result for `/posts/wow/hey/there`; it now asserts the Next.js result. `router.routes` keys also come out in the new order (static routes first, then match order).
- Verified with `test/js/bun/util/filesystem_router.test.ts`. On the released binary: the five new-behavior "route precedence" cases, the updated catch-all test and "lists routes in match order" fail with the old winner, and "a candidate rejected before the winner leaves no params behind" fails with the segfault above (two of its four trees leak under the old order too; the other two only under the new order, and all four fail on a build with the reorder but without the `params.clear()`, with `panic: assertion failed: name_slice.length > 0`). All 45 tests in the file pass with this build; the other precedence cases pass on both builds and pin what must not move. `cargo clippy -p bun_router`, `cargo fmt --check` and `test/regression/issue/18242.test.ts` (the other FileSystemRouter consumer) are clean.

### Background

- `Route::kind` is the highest `pattern::Tag` among a route's segments (`Static < Dynamic < CatchAll < OptionalCatchAll`), computed by `Pattern::validate` when the route is loaded. `param_count` is the number of non-static segments and is what `append_route` uses to send fully static routes to the hash map.
- `Routes::match_` looks the path up in the static hash map first and only then walks the dynamic list in order with one `params` list shared by every candidate, so for dynamic routes list order is precedence, and a candidate that pushes params and then fails must not leave them behind.
- `.params` and `.query` are built later by scanning the winning route's name for the recorded parameter names; a name that is not in the winner's route name produces an empty key, which is the crash.
- `match_name` is the route name without its leading slash and lowercased; `[[...x]]`, `[...x]` and `[x]` are the three prefixes `Pattern::init` dispatches on, and every name in the list has already passed `Pattern::validate`, so classifying a segment by prefix in the sorter agrees with how the matcher consumes it. Walking `Pattern::init` in the comparator instead would tie the sorter to the `len`/`is_end` encoding that #36680 is changing, for no difference in result.
- Separate bugs found while testing, each handed off on its own rather than folded in here: a root-level `[[...slug]]` never matches `/` without an index route and a trailing `[param]` accepts an empty segment (#39290 has both); bake's dev-server `FrameworkRouter` matches its dynamic routes in directory scan order and needs the same precedence rule. #36680 also fixes single-character trailing static segments (`[a]/x`); the tests here use multi-character segments so they do not depend on it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/filesystem_router.test.ts

<!-- robobun:evidence:end -->