### PR TITLE
Print a module's build or resolve error every time it is reported, not only the first time

### DIFF
--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -834,9 +834,7 @@ impl<'a> Run<'a> {
                 }
 
                 let promise = value.as_any_promise().expect("Unexpected promise type");
-                // A rejection is reported below. Without this the rejection
-                // tracker reports it as well: while waiting, or from a later
-                // event loop tick when the promise is already rejected.
+                // A rejection is reported below, not by the rejection tracker.
                 promise.set_handled(self.global.vm());
 
                 let _ = self.macro_.vm();

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -834,6 +834,10 @@ impl<'a> Run<'a> {
                 }
 
                 let promise = value.as_any_promise().expect("Unexpected promise type");
+                // A rejection is reported below. Without this the rejection
+                // tracker reports it as well: while waiting, or from a later
+                // event loop tick when the promise is already rejected.
+                promise.set_handled(self.global.vm());
 
                 let _ = self.macro_.vm();
                 let vm = VirtualMachine::get();

--- a/src/jsc/BuildMessage.rs
+++ b/src/jsc/BuildMessage.rs
@@ -7,9 +7,6 @@ use crate::{
 
 #[crate::JsClass] // codegen: JSBuildMessage (toJS / fromJS / fromJSDirect wired by derive)
 #[derive(Default)]
-// R-2 (`sharedThis`): every JS-facing host-fn takes `&self`, and nothing is
-// mutated after construction, so re-entrant JS cannot stack two `&mut` to the
-// same `m_ctx`.
 pub struct BuildMessage {
     pub msg: bun_ast::Msg,
     // resolve_result: Resolver.Result,

--- a/src/jsc/BuildMessage.rs
+++ b/src/jsc/BuildMessage.rs
@@ -1,4 +1,3 @@
-use core::cell::Cell;
 use std::io::Write as _;
 
 use crate::zig_string::ZigString;
@@ -7,22 +6,13 @@ use crate::{
 };
 
 #[crate::JsClass] // codegen: JSBuildMessage (toJS / fromJS / fromJSDirect wired by derive)
-// R-2 (`sharedThis`): every JS-facing host-fn takes `&self`; the only field
-// mutated post-construction (`logged`, flipped by `VirtualMachine::print_error_*`)
-// is `Cell<bool>` so re-entrant JS cannot stack two `&mut` to the same `m_ctx`.
+#[derive(Default)]
+// R-2 (`sharedThis`): every JS-facing host-fn takes `&self`, and nothing is
+// mutated after construction, so re-entrant JS cannot stack two `&mut` to the
+// same `m_ctx`.
 pub struct BuildMessage {
     pub msg: bun_ast::Msg,
     // resolve_result: Resolver.Result,
-    pub(crate) logged: Cell<bool>,
-}
-
-impl Default for BuildMessage {
-    fn default() -> Self {
-        Self {
-            msg: bun_ast::Msg::default(),
-            logged: Cell::new(false),
-        }
-    }
 }
 
 impl BuildMessage {
@@ -89,7 +79,6 @@ impl BuildMessage {
         let build_error = BuildMessage {
             msg,
             // resolve_result: resolve_result.*,
-            logged: Cell::new(false),
         };
 
         Ok(build_error.to_js(global))

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -1,4 +1,3 @@
-use std::cell::Cell;
 use std::io::Write as _;
 
 use bun_ast::ImportKind;
@@ -9,11 +8,10 @@ use crate::{
     CallFrame, JSGlobalObject, JSValue, JsClass, JsResult, StringJsc as _, ZigStringJsc as _,
 };
 
-// R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`. `msg` and
-// `referrer` are read-only after construction; only `logged` is mutated
-// post-wrap (by `VirtualMachine::print_error_like_object` via the JSCell ptr),
-// so it gets `Cell<bool>`.
+// R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`, and both
+// fields are read-only after construction.
 #[crate::JsClass]
+#[derive(Default)]
 pub struct ResolveMessage {
     pub msg: bun_ast::Msg,
     // Note: fields own their allocations and free on Drop / finalize.
@@ -22,17 +20,6 @@ pub struct ResolveMessage {
     // store the duped text directly so we don't pull in `bun_paths::fs::Path`
     // (which is lifetime-parameterised over its backing buffer).
     pub(crate) referrer: Option<Box<[u8]>>,
-    pub(crate) logged: Cell<bool>,
-}
-
-impl Default for ResolveMessage {
-    fn default() -> Self {
-        Self {
-            msg: bun_ast::Msg::default(),
-            referrer: None,
-            logged: Cell::new(false),
-        }
-    }
 }
 
 /// `ImportKind.label()` — the canonical table lives in
@@ -334,7 +321,6 @@ impl ResolveMessage {
         let resolve_error = ResolveMessage {
             msg: msg.clone(),
             referrer: Some(Box::<[u8]>::from(referrer)),
-            logged: Cell::new(false),
         };
         Ok(resolve_error.to_js(global))
     }

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -8,8 +8,6 @@ use crate::{
     CallFrame, JSGlobalObject, JSValue, JsClass, JsResult, StringJsc as _, ZigStringJsc as _,
 };
 
-// R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`, and both
-// fields are read-only after construction.
 #[crate::JsClass]
 #[derive(Default)]
 pub struct ResolveMessage {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5268,8 +5268,6 @@ impl VirtualMachine {
         allow_side_effects: bool,
     ) -> bool {
         if value.js_type() == jsc::JSType::DOMWrapper {
-            // The loader settles every later load of a failed module with this
-            // same object, and each of those loads is its own failure: always print.
             let msg: Option<&bun_ast::Msg> =
                 if let Some(build_error) = value.as_class_ref::<crate::BuildMessage>() {
                     Some(&build_error.msg)

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5268,10 +5268,8 @@ impl VirtualMachine {
         allow_side_effects: bool,
     ) -> bool {
         if value.js_type() == jsc::JSType::DOMWrapper {
-            // A failed module's BuildMessage/ResolveMessage (or the
-            // AggregateError holding them) is the same object for every later
-            // load of that module, so it is reported once per test file, test
-            // or request that hits the failure: print it every time.
+            // The loader settles every later load of a failed module with this
+            // same object, and each of those loads is its own failure: always print.
             let msg: Option<&bun_ast::Msg> =
                 if let Some(build_error) = value.as_class_ref::<crate::BuildMessage>() {
                     Some(&build_error.msg)

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5267,53 +5267,35 @@ impl VirtualMachine {
         allow_ansi_color: bool,
         allow_side_effects: bool,
     ) -> bool {
-        macro_rules! write_msg {
-            ($msg:expr, $w:expr, $color:expr) => {
-                if $color {
-                    let _ = $msg.write_format::<true>(&mut bun_io::AsFmt::new($w));
-                } else {
-                    let _ = $msg.write_format::<false>(&mut bun_io::AsFmt::new($w));
-                }
-            };
-        }
-
         if value.js_type() == jsc::JSType::DOMWrapper {
-            // `as_class_ref` is the audited `as_::<T>() → &T` backref-deref;
-            // R-2: shared borrow — `logged` is `Cell<bool>`.
-            if let Some(build_error) = value.as_class_ref::<crate::BuildMessage>() {
-                if !build_error.logged.get() {
-                    if self.had_errors {
-                        let _ = writer.write_all(b"\n");
-                    }
-                    write_msg!(build_error.msg, writer, allow_ansi_color);
-                    build_error.logged.set(true);
+            // A failed module's BuildMessage/ResolveMessage (or the
+            // AggregateError holding them) is the same object for every later
+            // load of that module, so it is reported once per test file, test
+            // or request that hits the failure: print it every time.
+            let msg: Option<&bun_ast::Msg> =
+                if let Some(build_error) = value.as_class_ref::<crate::BuildMessage>() {
+                    Some(&build_error.msg)
+                } else if let Some(resolve_error) = value.as_class_ref::<crate::ResolveMessage>() {
+                    Some(&resolve_error.msg)
+                } else {
+                    None
+                };
+            if let Some(msg) = msg {
+                if self.had_errors {
                     let _ = writer.write_all(b"\n");
                 }
-                self.had_errors = self.had_errors || build_error.msg.kind == bun_ast::Kind::Err;
+                if allow_ansi_color {
+                    let _ = msg.write_format::<true>(&mut bun_io::AsFmt::new(writer));
+                } else {
+                    let _ = msg.write_format::<false>(&mut bun_io::AsFmt::new(writer));
+                }
+                let _ = writer.write_all(b"\n");
+                self.had_errors = self.had_errors || msg.kind == bun_ast::Kind::Err;
                 if exception_list.is_some() {
                     // `log_mut()` is the centralized set-once `Option<NonNull>`
                     // accessor — single audited deref lives there.
                     if let Some(log) = self.log_mut() {
-                        let _ = log.add_msg(build_error.msg.clone());
-                    }
-                }
-                bun_core::Output::flush();
-                return true;
-            } else if let Some(resolve_error) = value.as_class_ref::<crate::ResolveMessage>() {
-                if !resolve_error.logged.get() {
-                    if self.had_errors {
-                        let _ = writer.write_all(b"\n");
-                    }
-                    write_msg!(resolve_error.msg, writer, allow_ansi_color);
-                    resolve_error.logged.set(true);
-                    let _ = writer.write_all(b"\n");
-                }
-                self.had_errors = self.had_errors || resolve_error.msg.kind == bun_ast::Kind::Err;
-                if exception_list.is_some() {
-                    // `log_mut()` is the centralized set-once `Option<NonNull>`
-                    // accessor — single audited deref lives there.
-                    if let Some(log) = self.log_mut() {
-                        let _ = log.add_msg(resolve_error.msg.clone());
+                        let _ = log.add_msg(msg.clone());
                     }
                 }
                 bun_core::Output::flush();

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -200,12 +200,17 @@ describe.concurrent("a macro that fails is reported once per failure", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    return { stderr, exitCode };
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Debug builds trace every macro call to stdout; nothing else is expected there.
+    const output = stdout
+      .split(/\r?\n/)
+      .filter(line => line !== "" && !line.startsWith("[macro] call "))
+      .join("\n");
+    return { stdout: output, stderr, exitCode };
   }
 
   test("a promise that rejects with an Error", async () => {
-    const { stderr, exitCode } = await run(
+    const { stdout, stderr, exitCode } = await run(
       {
         "macro.ts": `export async function m() {\n  await Promise.resolve();\n  throw new Error("macro rejected");\n}\n`,
         "entry.ts": `import { m } from "./macro.ts" with { type: "macro" };\nconsole.log(m());\n`,
@@ -216,14 +221,15 @@ describe.concurrent("a macro that fails is reported once per failure", () => {
     expect({
       rejections: countLines(stderr, "error: macro rejected"),
       failedCalls: countLines(stderr, "error: macro threw exception"),
+      stdout,
       exitCode,
-    }).toEqual({ rejections: 1, failedCalls: 1, exitCode: 1 });
+    }).toEqual({ rejections: 1, failedCalls: 1, stdout: "", exitCode: 1 });
   });
 
   // Every call of the macro is rejected with the one BuildMessage the module
   // registry keeps for bad.js, so three calls print it three times.
   test("a promise that rejects with the build error of an imported module, once per call", async () => {
-    const { stderr, exitCode } = await run(
+    const { stdout, stderr, exitCode } = await run(
       {
         "bad.js": "function bad( {",
         "macro.ts": `export async function m() {\n  await import("./bad.js");\n}\n`,
@@ -241,12 +247,13 @@ describe.concurrent("a macro that fails is reported once per failure", () => {
     expect({
       buildErrors: countLines(stderr, "error: Expected identifier but found end of file"),
       failedCalls: countLines(stderr, "error: macro threw exception"),
+      stdout,
       exitCode,
-    }).toEqual({ buildErrors: 3, failedCalls: 3, exitCode: 1 });
+    }).toEqual({ buildErrors: 3, failedCalls: 3, stdout: "", exitCode: 1 });
   });
 
   test("a macro module that fails to load", async () => {
-    const { stderr, exitCode } = await run(
+    const { stdout, stderr, exitCode } = await run(
       {
         "bad.js": "function bad( {",
         "macro.ts": `import "./bad.js";\nexport function m() {\n  return 1;\n}\n`,
@@ -258,8 +265,9 @@ describe.concurrent("a macro that fails is reported once per failure", () => {
     expect({
       buildErrors: countLines(stderr, "error: Expected identifier but found end of file"),
       loadErrors: countLines(stderr, 'error: "MacroLoadError" error in macro'),
+      stdout,
       exitCode,
-    }).toEqual({ buildErrors: 1, loadErrors: 1, exitCode: 1 });
+    }).toEqual({ buildErrors: 1, loadErrors: 1, stdout: "", exitCode: 1 });
   });
 });
 

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -182,6 +182,87 @@ test("object destructuring of a macro result keeps every bound property regardle
   expect(exitCode).toBe(0);
 });
 
+// A macro's rejected promise is reported by the macro runner itself (Macro.rs).
+// The promise also used to reach the unhandled rejection tracker, which
+// reported it a second time: while the runner waited for it, or, when it was
+// already rejected, from a later tick of the event loop.
+describe.concurrent("a macro that fails is reported once per failure", () => {
+  function countLines(output: string, line: string) {
+    return output.split(/\r?\n/).filter(l => l === line).length;
+  }
+
+  async function run(files: Record<string, string>, ...args: string[]) {
+    using dir = tempDir("macro-failure-report", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stderr, exitCode };
+  }
+
+  test("a promise that rejects with an Error", async () => {
+    const { stderr, exitCode } = await run(
+      {
+        "macro.ts": `export async function m() {\n  await Promise.resolve();\n  throw new Error("macro rejected");\n}\n`,
+        "entry.ts": `import { m } from "./macro.ts" with { type: "macro" };\nconsole.log(m());\n`,
+      },
+      "build",
+      "./entry.ts",
+    );
+    expect({
+      rejections: countLines(stderr, "error: macro rejected"),
+      failedCalls: countLines(stderr, "error: macro threw exception"),
+      exitCode,
+    }).toEqual({ rejections: 1, failedCalls: 1, exitCode: 1 });
+  });
+
+  // Every call of the macro is rejected with the one BuildMessage the module
+  // registry keeps for bad.js, so three calls print it three times.
+  test("a promise that rejects with the build error of an imported module, once per call", async () => {
+    const { stderr, exitCode } = await run(
+      {
+        "bad.js": "function bad( {",
+        "macro.ts": `export async function m() {\n  await import("./bad.js");\n}\n`,
+        "entry.ts": [
+          `import { m } from "./macro.ts" with { type: "macro" };`,
+          `console.log(m());`,
+          `console.log(m());`,
+          `console.log(m());`,
+          ``,
+        ].join("\n"),
+      },
+      "build",
+      "./entry.ts",
+    );
+    expect({
+      buildErrors: countLines(stderr, "error: Expected identifier but found end of file"),
+      failedCalls: countLines(stderr, "error: macro threw exception"),
+      exitCode,
+    }).toEqual({ buildErrors: 3, failedCalls: 3, exitCode: 1 });
+  });
+
+  test("a macro module that fails to load", async () => {
+    const { stderr, exitCode } = await run(
+      {
+        "bad.js": "function bad( {",
+        "macro.ts": `import "./bad.js";\nexport function m() {\n  return 1;\n}\n`,
+        "entry.ts": `import { m } from "./macro.ts" with { type: "macro" };\nconsole.log(m());\n`,
+      },
+      "run",
+      "./entry.ts",
+    );
+    expect({
+      buildErrors: countLines(stderr, "error: Expected identifier but found end of file"),
+      loadErrors: countLines(stderr, 'error: "MacroLoadError" error in macro'),
+      exitCode,
+    }).toEqual({ buildErrors: 1, loadErrors: 1, exitCode: 1 });
+  });
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -1,4 +1,5 @@
-import { bunEnv, bunExe, tempDir } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "node:path";
 
 test("BuildError is modifiable", async () => {
@@ -87,4 +88,199 @@ test("BuildMessage finalize frees with the same allocator it was created with", 
     }
     Bun.gc(true);
   }
+});
+
+// The module loader settles every later load of a module that failed to load
+// with the error object the first load produced, so the same BuildMessage or
+// ResolveMessage is reported once per failure it causes. The error printer
+// used to print such an object only the first time it saw it, so every report
+// after the first (another test file importing the module, another test in
+// the same file, the error being reported again by the program) was empty.
+describe.concurrent("an error from a module that failed to load is printed every time it is reported", () => {
+  async function run(files: Record<string, string>, ...args: string[]) {
+    using dir = tempDir("replayed-load-error", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return {
+      stdout: normalizeBunSnapshot(stdout, String(dir)),
+      stderr: normalizeBunSnapshot(stderr, String(dir)),
+      exitCode,
+    };
+  }
+
+  test("a build error, by each test file that imports the module", async () => {
+    const { stderr, exitCode } = await run(
+      {
+        "bad.js": "function bad( {",
+        "a.test.js": `import "./bad.js";`,
+        "b.test.js": `import "./bad.js";`,
+      },
+      "test",
+      "./a.test.js",
+      "./b.test.js",
+    );
+    expect(stderr).toMatchInlineSnapshot(`
+      "a.test.js:
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | function bad( {
+                        ^
+      error: Expected identifier but found end of file
+          at <dir>/bad.js:1:15
+      -------------------------------
+
+
+      b.test.js:
+
+      # Unhandled error between tests
+      -------------------------------
+      1 | function bad( {
+                        ^
+      error: Expected identifier but found end of file
+          at <dir>/bad.js:1:15
+      -------------------------------
+
+
+       0 pass
+       2 fail
+       2 errors
+      Ran 2 tests across 2 files."
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test("a resolve error, by each test file that imports the module", async () => {
+    const { stderr, exitCode } = await run(
+      {
+        "lib.js": `import "./missing.js";`,
+        "a.test.js": `import "./lib.js";`,
+        "b.test.js": `import "./lib.js";`,
+      },
+      "test",
+      "./a.test.js",
+      "./b.test.js",
+    );
+    expect(stderr).toMatchInlineSnapshot(`
+      "a.test.js:
+
+      # Unhandled error between tests
+      -------------------------------
+      error: Cannot find module './missing.js' from '<dir>/lib.js'
+      -------------------------------
+
+
+      b.test.js:
+
+      # Unhandled error between tests
+      -------------------------------
+      error: Cannot find module './missing.js' from '<dir>/lib.js'
+      -------------------------------
+
+
+       0 pass
+       2 fail
+       2 errors
+      Ran 2 tests across 2 files."
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test("a build error, by each test that imports the module", async () => {
+    const { stderr, exitCode } = await run(
+      {
+        "bad.js": "function bad( {",
+        "c.test.js": /* js */ `
+          import { test } from "bun:test";
+          test("first", () => import("./bad.js"));
+          test("second", () => import("./bad.js"));
+        `,
+      },
+      "test",
+      "./c.test.js",
+    );
+    expect(stderr).toMatchInlineSnapshot(`
+      "c.test.js:
+      1 | function bad( {
+                        ^
+      error: Expected identifier but found end of file
+          at <dir>/bad.js:1:15
+      (fail) first
+      1 | function bad( {
+                        ^
+      error: Expected identifier but found end of file
+          at <dir>/bad.js:1:15
+      (fail) second
+
+       0 pass
+       2 fail
+      Ran 2 tests across 1 file."
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  test("a build error reported twice by the program", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "bad.js": "function bad( {",
+        "entry.js": /* js */ `
+          for (let i = 1; i <= 2; i++) {
+            const error = await import("./bad.js").then(() => null, e => e);
+            console.log("report " + i + ": " + error.constructor.name);
+            reportError(error);
+          }
+        `,
+      },
+      "entry.js",
+    );
+    expect(stdout).toMatchInlineSnapshot(`
+      "report 1: BuildMessage
+      report 2: BuildMessage"
+    `);
+    expect(stderr).toMatchInlineSnapshot(`
+      "1 | function bad( {
+                        ^
+      error: Expected identifier but found end of file
+          at <dir>/bad.js:1:15
+      1 | function bad( {
+                        ^
+      error: Expected identifier but found end of file
+          at <dir>/bad.js:1:15
+
+      Bun v<bun-version>"
+    `);
+    expect(exitCode).toBe(1);
+  });
+
+  // Two or more build errors reject the load with one AggregateError holding a
+  // BuildMessage per error, and printing it prints those members.
+  test("the build errors of an AggregateError printed twice", async () => {
+    const { stdout, exitCode } = await run(
+      {
+        "bad.js": "const dup = 1; const dup = 2; const dup = 3;",
+        "entry.js": /* js */ `
+          const error = await import("./bad.js").then(() => null, e => e);
+          console.log(error.constructor.name);
+          console.log(error);
+          console.log(error.constructor.name);
+          console.log(error);
+        `,
+      },
+      "entry.js",
+    );
+    const errorLocations = (report: string) =>
+      Array.from(report.matchAll(/^error: "dup" has already been declared\n\s+at (\S+)$/gm), match => match[1]);
+    const [, firstReport, secondReport] = stdout.split(/^AggregateError$/m);
+    expect([firstReport, secondReport].map(errorLocations)).toEqual([
+      ["<dir>/bad.js:1:22", "<dir>/bad.js:1:37"],
+      ["<dir>/bad.js:1:22", "<dir>/bad.js:1:37"],
+    ]);
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- `bun test ./a.test.js ./b.test.js` where both files import a module that fails to build prints the build error under `a.test.js:` and, under `b.test.js:`, an empty block:
  ```
  # Unhandled error between tests
  -------------------------------
  -------------------------------
  ```
  followed by `0 pass, 2 fail, 2 errors`; nothing says why `b.test.js` failed. Reproduces on bun 1.4.0.
- The same happens to every later report of the same failure: a module whose own import does not resolve (a `ResolveMessage`) imported by two test files, two tests in one file that `import()` the broken module (the second `(fail)` has no error above it), a program calling `reportError()` on the error twice, and `console.log()` of the `AggregateError` of a module with two or more build errors printed twice (the second print is blank). Once #39204 lands, the two-test-file case with two or more build errors (#36963) prints the same empty block instead of crashing.
- Cause: the module loader settles every later load of a module that failed to load with the error object the first load produced, and `print_error_from_maybe_private_data` (`src/jsc/VirtualMachine.rs`) printed a `BuildMessage`/`ResolveMessage` only while its `logged` flag was unset, setting it on the first print. Every report after the first printed nothing.
- The flag dates from the 2021 dev server, which handed one failure to the printer twice (once to print it, once more to collect it for the error page). Today's equivalent (`finish_running_error_handler` in `src/runtime/server/RequestContext.rs`) prints and collects in one call. One double hand-off is left, in macros: `Runner::coerce` (`src/js_parser_jsc/Macro.rs`) waits for a macro's promise and then reports its rejection itself, but never marks the promise handled, so the rejection tracker reports it too (during the wait, or from a later event loop tick when the promise was already rejected). Today that prints a rejected `Error` twice per call; with the flag removed alone it would also print a replayed `BuildMessage` twice per call (one call site went from 1 to 2 prints, three call sites from 1 to 6).

### Fix
- Removes the `logged` flag from `BuildMessage` and `ResolveMessage`; the printer prints the message on every report, and its two identical branches become one.
- `Runner::coerce` marks the macro's promise handled before waiting for it, the way `expect().resolves` (`expect.rs`) and `Bun.build`'s plugin setup (`JSBundler.rs`) already do before waiting, so its own report is the only one: one print per failing call for a rejected `Error` (was two) and for a replayed `BuildMessage` (was one in total, would have been two per call). The macro load failure path (`Macro::init`) reports once already and is unchanged.
- Why this is right: each remaining report is a separate failure the user is looking at. The non-isolated `bun test` output now matches what `--isolate` and `--parallel` already print (they re-transpile the module per file, so they always printed it per file), and matches how an `Error` thrown by a module's evaluation, which the loader replays the same way, is already printed for every file.
- Output within one report is unchanged: the blank line between consecutive messages comes from `had_errors`, which `run_error_handler` saves and resets per report. The development error page still receives the message through `vm.log`, as before.
- Other reporting paths audited for a second hand-off of one object: `bun test` file load and test failures (`bun_test.rs`, `jest.rs`), the `bun run` entry point (`run_command.rs`), `Bun.serve` development mode (`RequestContext.rs`) and `Macro::init` each report once per failure; `--hot` has its own per-reload guard (`pending_internal_promise_reported_at`); `console.log(buildMessage)` goes through the console formatter, which never used the flag.
- Tests, printer: `test/js/bun/resolve/build-error.test.ts`, `describe("an error from a module that failed to load is printed every time it is reported")`: two test files sharing a module with a build error, two test files sharing a module with a resolve error, two tests in one file, `reportError()` twice, the members of an `AggregateError` printed twice. All five fail on the unfixed binary with exactly the second report missing.
- Tests, macros: `test/bundler/transpiler/macro-test.test.ts`, `describe("a macro that fails is reported once per failure")`: a macro rejecting with an `Error` prints it once under `bun build` (2 on main); a macro awaiting an import of a broken module, called three times, prints the build error exactly three times (1 on main, 6 with the printer change alone); a macro module that fails to load prints its build error once (passes on main too, pinning that path). The load case runs under `bun run` because the `bun build` form trips a pre-existing debug-build API lock assertion in `Macro::init`, reported separately.
- Also run with the fix: `test/js/bun/test/`, `test/js/bun/resolve/`, `test/cli/test/bun-test.test.ts` plus the regression tests that print build or resolve errors, the macro, transpiler and plugin tests, `test/internal/source-lints/`, `cargo clippy` on `bun_jsc` and `bun_js_parser_jsc`, `cargo fmt --check`. The only failures are unrelated and independent of this change: debug-build snapshot differences (colors, a seconds-level timing, private frames in `inspect-error.test.js`), the `load the same empty JS file 2000 times` debug timeout, and `pretty-format-overflow.test.ts` overflowing the stack under ASAN.
- Related: #39204 makes the loader replay a multi-error `AggregateError` intact; with both changes its `bun test` test can assert that the second file's block contains the errors.

### Background
- `BuildMessage` / `ResolveMessage`: the objects a module load is rejected with when transpiling the file fails (a syntax error) or one of its imports does not resolve. Each wraps one `bun_ast::Msg` (text, location, notes); `process_fetch_log` in `VirtualMachine.rs` turns two or more messages into an `AggregateError` holding one of these per message.
- Module registry replay: JSC's module loader keeps the registry entry of a module whose load failed and settles every later load of that specifier from the entry, without calling back into Bun, so every importer receives the same error object. `bun test` without `--isolate` runs all files in one registry; `--isolate` (and `--parallel`) give each file a fresh one. A macro that imports the broken module gets the same object on every call for the same reason.
- Error printer: `VirtualMachine::run_error_handler` -> `print_errorlike_object` -> `print_error_from_maybe_private_data` is the path behind uncaught exceptions, unhandled rejections, `bun test`'s `(fail)` and "Unhandled error" blocks, `Bun.serve`'s development-mode error output and the macro runner's reports. `console.log` formats values with the console formatter instead, which prints these two classes directly; it only reaches the printer above for the members of an `AggregateError`.
- Rejection tracker: JSC tells Bun about a promise that rejects with no handler attached; Bun reports those promises at the end of each event loop tick (`handleRejectedPromises`), skipping any that were marked handled in the meantime. Native code that waits for a promise and deals with the rejection itself marks the promise handled first so it is not reported twice.

<details>
<summary>Repro output before and after</summary>

```
bad.js:     function bad( {
a.test.js:  import "./bad.js";
b.test.js:  import "./bad.js";
bun test ./a.test.js ./b.test.js
```

Before (bun 1.4.0), the `b.test.js` section:

```
b.test.js:

# Unhandled error between tests
-------------------------------
-------------------------------
```

After, the `b.test.js` section is the same as the `a.test.js` one (and as `bun test --isolate` prints today):

```
b.test.js:

# Unhandled error between tests
-------------------------------
1 | function bad( {
                   ^
error: Expected identifier but found end of file
    at /tmp/repro/bad.js:1:16
-------------------------------
```

Macro counts (`bun build entry.js`, macro `m()` does `await import("./bad.js")`, three call sites), build error excerpts printed: 1.4.0 prints 1; the printer change alone prints 6; this PR prints 3, one per failing call, each followed by its `macro threw exception`.

The `AggregateError` test checks the member locations of each print rather than the exact text, because #36602 changes the layout around the members (header line, `[errors]:` label). Printing the same aggregate a second time through `console.log` starts with a blank line both before and after this change: `had_errors` is only reset by `run_error_handler`, and the console path does not go through it; that is independent of the flag removed here.

</details>

<details>
<summary>First version of this PR</summary>

The first push only removed the flag. Review of it found the macro double report described above, which the flag had been masking for `BuildMessage`/`ResolveMessage`; the `Macro.rs` change and its tests were added in response, and the description's earlier claim that macros reported once per failure was wrong for the promise path.

</details>
