### PR TITLE
test: re-enable the LeakSanitizer exit check for the bake dev tests that no longer leak

### DIFF
--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -37,7 +37,6 @@ test/cli/install/bun-pack.test.ts
 test/cli/install/bun-pm-pkg.test.ts
 test/cli/install/bun-pm-version.test.ts
 test/cli/install/bun-pm.test.ts
-test/cli/install/bun-repl.test.ts
 test/cli/run/filter-workspace.test.ts
 test/js/bun/repl/repl.test.ts
 test/cli/install/bun-update.test.ts
@@ -352,24 +351,16 @@ test/regression/issue/10139.test.ts
 test/js/bun/udp/udp_socket.test.ts
 test/cli/init/init.test.ts
 
-# There are some leaks related to the dev server closing on process exit, the fix is to
-# tick the event loop on globalExit but this breaks like 50 tests. Since the
-# leak is when process exits it should be fine for now but it should be fixed at
-# some point.
-test/bake/dev/react-response.test.ts
-test/bake/dev/react-cookies.test.ts
-test/bake/dev/server-sourcemap.test.ts
-
-# Watcher Thread
-test/bake/dev-and-prod.test.ts
+# Dev server processes that still leak at exit; remove each entry once the fix
+# for its leak lands.
+# bundle.test.ts, "removing 'use client' from a component with a pending
+#   resolution failure": the ServerComponentParseTask boxed in
+#   BundleV2::enqueue_server_component_generated_file (336 bytes), fix in #38004.
+# css.test.ts, "changing html file with link tag works" and "css import before
+#   create": the path copied by Watcher::add_directory for a DirectoryWatchStore
+#   entry is lost when the entry is evicted (30 bytes), fix in #39197.
 test/bake/dev/bundle.test.ts
 test/bake/dev/css.test.ts
-test/bake/dev/esm.test.ts
-test/bake/dev/hot.test.ts
-test/bake/dev/react-spa.test.ts
-test/bake/dev/sourcemap.test.ts
-test/bake/dev/ssg-pages-router.test.ts
-test/bake/dev/deinitialization.test.ts
 
 # Need to terminate HTTP thread.
 test/js/bun/test/parallel/test-http-should-not-accept-untrusted-certificates.ts


### PR DESCRIPTION
### Problem
- `test/no-validate-leaksan.txt` switches off the ASAN lane's exit-time leak check for the files it lists. Its two bake blocks listed ten dev server test files: the "Watcher Thread" block (entries excluded since the check was wired into CI in #21142, grouped under that heading in a09dc2f450) and the "leaks related to the dev server closing on process exit" block (#22138). Those files have never run under the check.
- Eight of the ten no longer leak. Run on current main under exactly the environment the runner sets for checked files (`scripts/runner.node.mjs`: `BUN_DESTRUCT_VM_ON_EXIT=1`, `ASAN_OPTIONS=...detect_leaks=1...`, `LSAN_OPTIONS=...suppressions=test/leaksan.supp`), `dev-and-prod`, `dev/esm`, `dev/hot`, `dev/react-spa`, `dev/sourcemap`, `dev/ssg-pages-router`, `dev/react-response` and `dev/server-sourcemap` exit 0 with no LeakSanitizer output, 4 of 4 runs each (table below).
- The other two still fail the check, each for one known leak that has a fix in flight, and the old comments did not say so:
  - `dev/bundle.test.ts`, "removing 'use client' from a component with a pending resolution failure": `Direct leak of 336 byte(s)` from `BundleV2::enqueue_server_component_generated_file` (`src/bundler/bundle_v2.rs:3752`), the `ServerComponentParseTask` #38004 frees. The other 20 cases in the file are clean.
  - `dev/css.test.ts`, "changing html file with link tag works" and "css import before create": `Direct leak of 30 byte(s)` from `Watcher::add_directory` via `DirectoryWatchStore::insert` (`src/runtime/bake/dev_server/mod.rs:1447`), the evicted watch entry path #39197 frees. The other 13 cases are clean.
- Three entries name files that do not exist, so they have never excluded anything: `test/bake/dev/deinitialization.test.ts` (the file is `test/bake/deinitialization.test.ts`; no file ever existed at the listed path), `test/bake/dev/react-cookies.test.ts` (added in the same commit as `request-cookies.test.ts`, which is the file that exists), and `test/cli/install/bun-repl.test.ts` (deleted in fa3a30f075). The two real files have been running under the check in CI all along; #34035 is a CI failure of `request-cookies.test.ts` under `BUN_DESTRUCT_VM_ON_EXIT`.

### Fix
- Remove the eight clean files and the three dead entries; CI's ASAN lane now applies the exit-time check to the eight files (this PR's own ASAN run is the first one that does).
- Keep `bundle.test.ts` and `css.test.ts`, under a comment that names the leaking case in each, the allocation site and size, and the PR that fixes it, so each entry can be removed with its fix. #39197 already removes the `css.test.ts` line on its branch; whichever lands second needs a one-line rebase of this block. #38004 does not touch this file, so `bundle.test.ts` should be removed when it lands.
- Removing an entry is correct when the file passes under the runner's environment: that environment is the only thing the list controls. The removed files were verified on a debug ASAN build, which checks the same allocations as the release ASAN build CI uses. The positive control is the same harness and environment reporting the `css.test.ts` and `bundle.test.ts` leaks above from inside the dev server child processes, so a clean run means the check ran and found nothing, not that it was skipped.
- Not touched: `dev/production.test.ts` (`bun build --app` still leaks its transpilers, #38233; #38241 documents that entry) and the bake files listed in the generic blocks near the top of the file (`ecosystem`, `html`, `plugins`, `stress`, `vfile`, `import-meta-inline`, `incremental-graph-edge-deletion`), which were not audited here.
- Verified: every file in the diff was run with `./build/debug/bun-debug test <file>` under the three variables above, on main at f0f6b2cbb6. Results are in the table below. Every non-`vendor/` entry remaining in the file exists on disk.

### Background
- LeakSanitizer (LSan) is part of the ASAN build. At process exit it reports heap blocks nothing points to any more; with `abort_on_error=1` a report aborts the process. Bun disables it by default; `scripts/runner.node.mjs` turns it back on for every test file not in `test/no-validate-leaksan.txt` and also sets `BUN_DESTRUCT_VM_ON_EXIT=1`, which tears the JSC VM down before exit so memory still owned by live JS objects is freed rather than reported.
- The bake tests spawn one dev server process per test case (`test/bake/bake-harness.ts`). The test process's environment is inherited, so the check runs in each dev server process: at the end of a case the harness stops the server, waits until `DevServer` has been dropped, and calls `process.exit(0)`; a leak report there makes the server exit by SIGABRT and the case fails with `DevServer exited with signal SIGABRT`. This is how the two remaining entries fail, and the leak coverage the removed entries were withholding.
- The list also decides which files the runner may batch into its parallel bucket on the ASAN lane (`isBucketCandidate` requires the file to be leak-checked); `sourcemap`, `react-response` and `server-sourcemap` become eligible there, as they already are on the other lanes.

<details>
<summary>Probe results (debug ASAN build of main at f0f6b2cbb6, runner environment)</summary>

| file | runs | result |
|---|---|---|
| test/bake/dev-and-prod.test.ts | 4 | 12 pass, exit 0, no LSan output, every run |
| test/bake/dev/esm.test.ts | 4 | 17 pass, exit 0, no LSan output, every run |
| test/bake/dev/hot.test.ts | 4 | 11 pass, exit 0, no LSan output, every run |
| test/bake/dev/react-spa.test.ts | 4 | 6 pass, exit 0, no LSan output, every run |
| test/bake/dev/sourcemap.test.ts | 4 | 2 pass, exit 0, no LSan output, every run |
| test/bake/dev/ssg-pages-router.test.ts | 4 | 9 pass, exit 0, no LSan output, every run |
| test/bake/dev/react-response.test.ts | 4 | 11 pass, exit 0, no LSan output, every run |
| test/bake/dev/server-sourcemap.test.ts | 4 | 5 pass, exit 0, no LSan output, every run |
| test/bake/deinitialization.test.ts (never actually excluded) | 1 | pass, exit 0, no LSan output |
| test/bake/dev/request-cookies.test.ts (never actually excluded) | 1 | 2 pass, exit 0, no LSan output |
| test/bake/dev/bundle.test.ts (kept) | 1 | 20 pass, 1 fail: the 336 byte ServerComponentParseTask report |
| test/bake/dev/css.test.ts (kept) | 1 | 13 pass, 2 fail: one 30 byte Watcher::add_directory report each |

Cost of the check on the debug build: `sourcemap.test.ts` 11s without the environment, 18s with it; `dev-and-prod.test.ts` (12 dev server processes) 37s and 79s. The existing checked bake files show the release ASAN equivalent in `test/expected-durations.json` (`deinitialization.test.ts`: 2.2s default, 8.0s asan).

Leak report from bundle.test.ts, bun frames only:

```
Direct leak of 336 byte(s) in 1 object(s) allocated from:
    <alloc::boxed::Box<bun_bundler::ServerComponentParseTask::ServerComponentParseTask>>::new
    <bun_bundler::bundle_v2::BundleV2>::enqueue_server_component_generated_file src/bundler/bundle_v2.rs:3752
    <bun_bundler::bundle_v2::BundleV2>::on_parse_task_complete src/bundler/bundle_v2.rs:7219
    bun_bundler::parse_task::parse_worker::on_complete src/bundler/ParseTask.rs:2935
SUMMARY: AddressSanitizer: 336 byte(s) leaked in 1 allocation(s).
```

Leak report from css.test.ts (css-13; css-14 is identical), bun frames only:

```
Direct leak of 30 byte(s) in 1 object(s) allocated from:
    <bun_watcher::watcher_impl::Watcher>::append_directory_assume_capacity::<true> src/watcher/Watcher.rs:616
    <bun_watcher::watcher_impl::Watcher>::add_directory::<true> src/watcher/Watcher.rs:802
    <bun_runtime::bake::dev_server::DirectoryWatchStore>::insert src/runtime/bake/dev_server/mod.rs:1447
    <bun_runtime::bake::dev_server::DirectoryWatchStore>::track_resolution_failure src/runtime/bake/dev_server/mod.rs:1313
    <bun_bundler::bundle_v2::BundleV2>::resolve_import_records src/bundler/bundle_v2.rs:6259
SUMMARY: AddressSanitizer: 30 byte(s) leaked in 1 allocation(s).
```
</details>
