### PR TITLE
FileSystemRouter: do not match a dynamic segment against an empty URL segment

### DIFF
--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -1188,6 +1188,13 @@ pub mod pattern {
                         }
                     }
                     Value::Dynamic(dynamic) => {
+                        // A dynamic segment needs a non-empty URL segment: `docs/[page]` does
+                        // not match "/docs", and `a/[x]/[y]` does not match "/a//b".
+                        if path_.is_empty() || path_[0] == b'/' {
+                            params.clear(); // shrinkRetainingCapacity(0)
+                            return false;
+                        }
+
                         if let Some(i) = strings::index_of_char_usize(path_, b'/') {
                             params.push(Param {
                                 name: dynamic.str(name),
@@ -1696,6 +1703,14 @@ mod tests {
             (b"404/[[...slug]]", b"404", &[]),
             (b"404a/[[...slug]]", b"404a", &[]),
             (
+                b"docs/[page]/[[...rest]]",
+                b"docs/intro",
+                &[Entry {
+                    name: b"page",
+                    value: b"intro",
+                }],
+            ),
+            (
                 b"[teamSlug]/lemon/[project]/[[...slug]]",
                 b"team/lemon/lemon/slugggg",
                 &[
@@ -1775,6 +1790,36 @@ mod tests {
 
         assert!(run(regular_list) == 0);
         assert!(run(optional_catch_all) == 0);
+    }
+
+    #[test]
+    fn pattern_rejects_empty_dynamic_segment() {
+        let no_match: &[(&[u8], &[u8])] = &[
+            // the URL ends where the dynamic segment starts
+            (b"docs/[page]", b"docs"),
+            (b"docs/[page]/[[...rest]]", b"docs"),
+            (b"[org]/settings/[id]", b"acme/settings"),
+            // the URL has an empty segment where the dynamic segment is
+            (b"blog/[slug]/[id]", b"blog//42"),
+            (b"blog/[slug]/[[...rest]]", b"blog//42"),
+        ];
+        for (route, url) in no_match {
+            let mut params = route_param::List::default();
+            let matched = Pattern::match_::<true>(url, route, route, &mut params);
+            assert!(
+                !matched,
+                "route {:?} should not match {:?}",
+                bstr::BStr::new(route),
+                bstr::BStr::new(url),
+            );
+            assert!(
+                params.is_empty(),
+                "route {:?} left {} param(s) behind after rejecting {:?}",
+                bstr::BStr::new(route),
+                params.len(),
+                bstr::BStr::new(url),
+            );
+        }
     }
 
     // The route-loader integration tests ("Github

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -986,6 +986,105 @@ it("match() returns null when the URL has fewer segments than a dynamic route re
   }
 });
 
+// A [param] segment needs a non-empty URL segment, as in Next.js. The matcher
+// used to accept an empty one, both when the URL ended right before the
+// dynamic segment (params: { page: "" }) and when the URL had an empty segment
+// in its place ("/blog//42").
+it("match() does not give a dynamic segment an empty value", () => {
+  const cases: {
+    files: string[];
+    expected: Record<string, { name: string; params: Record<string, string> } | null>;
+  }[] = [
+    {
+      files: ["docs/[page].tsx"],
+      expected: {
+        "/docs/intro": { name: "/docs/[page]", params: { page: "intro" } },
+        "/docs": null,
+        "/docs/": null,
+        "/docs//": null,
+        "/docs?page=intro": null,
+      },
+    },
+    {
+      files: ["docs/[page]/[[...rest]].tsx"],
+      expected: {
+        "/docs/intro": { name: "/docs/[page]/[[...rest]]", params: { page: "intro" } },
+        "/docs/intro/a/b": { name: "/docs/[page]/[[...rest]]", params: { page: "intro", rest: "a/b" } },
+        "/docs": null,
+        "/docs/": null,
+      },
+    },
+    {
+      files: ["[org]/settings/[id].tsx"],
+      expected: {
+        "/acme/settings/7": { name: "/[org]/settings/[id]", params: { org: "acme", id: "7" } },
+        "/acme/settings": null,
+        "/acme/settings/": null,
+      },
+    },
+    {
+      files: ["blog/[slug]/[id].tsx"],
+      expected: {
+        "/blog/hello/42": { name: "/blog/[slug]/[id]", params: { slug: "hello", id: "42" } },
+        "/blog//42": null,
+        "/blog/hello": null,
+      },
+    },
+    {
+      files: ["blog/[slug]/[[...rest]].tsx"],
+      expected: {
+        "/blog/hello": { name: "/blog/[slug]/[[...rest]]", params: { slug: "hello" } },
+        "/blog//42": null,
+      },
+    },
+  ];
+
+  for (const { files, expected } of cases) {
+    const { dir } = make(files);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+    const actual: typeof expected = {};
+    for (const input of Object.keys(expected)) {
+      const match = router.match(input);
+      actual[input] = match && { name: match.name, params: match.params };
+    }
+    expect({ files, ...actual }).toEqual({ files, ...expected });
+  }
+});
+
+it("a URL that is one segment short of a dynamic route falls through to the routes after it", () => {
+  const pick = (match: ReturnType<FileSystemRouter["match"]>) => match && { name: match.name, params: match.params };
+
+  {
+    const { dir } = make(["docs/[page].tsx", "docs/[[...rest]].tsx"]);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+    // docs/[page] is tried first; it must reject "/docs" so that the optional
+    // catch-all, which does match an empty remainder, gets to see it.
+    expect(pick(router.match("/docs"))).toEqual({ name: "/docs/[[...rest]]", params: {} });
+    expect(pick(router.match("/docs/"))).toEqual({ name: "/docs/[[...rest]]", params: {} });
+    expect(pick(router.match("/docs/intro"))).toEqual({ name: "/docs/[page]", params: { page: "intro" } });
+    expect(pick(router.match("/docs/a/b"))).toEqual({ name: "/docs/[[...rest]]", params: { rest: "a/b" } });
+  }
+
+  {
+    const { dir } = make(["[org]/settings/[id].tsx", "[org]/[...rest].tsx"]);
+    const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+
+    // [org]/settings/[id] records org before it rejects "/acme/settings". That
+    // param must not survive into the catch-all's match, or org would come back
+    // as ["acme", "acme"].
+    expect(pick(router.match("/acme/settings"))).toEqual({
+      name: "/[org]/[...rest]",
+      params: { org: "acme", rest: "settings" },
+    });
+    expect(pick(router.match("/acme/settings/7"))).toEqual({
+      name: "/[org]/settings/[id]",
+      params: { org: "acme", id: "7" },
+    });
+  }
+});
+
 it.skipIf(isWindows || isMacOS)(
   "src is computed for a route whose path is longer than the fast-path buffer",
   async () => {


### PR DESCRIPTION
### Problem

- `Bun.FileSystemRouter({ style: "nextjs" })` matches a route whose next segment is a `[param]` against a URL that has nothing in that position. With `pages/docs/[page].js`, `match("/docs")` (and `"/docs/"`) returns `/docs/[page]` with `params: { page: "" }`; Next.js does not match `pages/docs/[page].js` for `/docs` at all.
- Same defect, other shapes: `docs/[page]/[[...rest]]` also matches `/docs` with `page: ""`, and `blog/[slug]/[id]` matches `/blog//42` with `slug: ""`.
- Because `Routes::match_dynamic` returns the first candidate that matches, the bogus match also shadows routes that should own the URL: with `docs/[page].js` and `docs/[[...rest]].js` both present, `/docs` is served by `docs/[page]` with an empty param instead of the optional catch-all.
- Cause: the `Value::Dynamic` arm of `Pattern::match_` (`src/router/lib.rs`, around line 1190) never checks that the URL segment it is about to consume is non-empty. When the URL is already exhausted, the `pattern.is_end()` branch pushes `path_` (empty) as the value and returns `true`, and the optional catch-all lookahead branch does the same; when the URL has an empty segment (`//`), the `index_of_char(b'/') == Some(0)` branch pushes an empty slice. #36165 fixed the case where more pattern follows the dynamic segment; these paths were left as is. The `CatchAll` arm already requires `!path_.is_empty()`.

### Fix

- At the top of the `Value::Dynamic` arm, reject the candidate when `path_` is empty or starts with `/`, i.e. when there is no non-empty URL segment for the parameter to take. The rejection clears `params`, like the arm's other failure paths, so a param recorded by an earlier segment of the losing route (`org` in `[org]/settings/[id]` vs `/acme/settings`) does not leak into the route that is tried next.
- Correct because a `[param]` segment stands for exactly one non-empty path segment (Next.js compiles it to `([^/]+?)`), so a URL with no segment there cannot be a match for the route; returning `false` lets `match_dynamic` continue to the next candidate, which is how `/docs` reaches `docs/[[...rest]]`. Static segments are unaffected (they already compare against the exact segment), and catch-all segments keep their existing checks.
- Verified with `test/js/bun/util/filesystem_router.test.ts`: two new tests, one table of trees (`docs/[page]`, `docs/[page]/[[...rest]]`, `[org]/settings/[id]`, `blog/[slug]/[id]`, `blog/[slug]/[[...rest]]`) asserting the exact `{ name, params }` or `null` for the short, trailing-slash, `//`, and control URLs, and one asserting that the short URL falls through to `docs/[[...rest]]` (`params: {}`) and to `[org]/[...rest]` (`params: { org, rest }`, which also fails if the new rejection did not clear `org`). Both fail on the released `bun` 1.4.0 with the `page: ""` result shown above and pass with this change; the whole file (35 tests) passes.
- `src/router/lib.rs` gains `pattern_rejects_empty_dynamic_segment` (the five patterns above at the `Pattern::match_` level, also asserting `params` ends up empty) and a positive `docs/[page]/[[...rest]]` vs `docs/intro` row in `pattern_match`. Run with `bun run rust:miri -p bun_router --lib -- pattern` (the crate's test binary does not link outside Miri because `bun_core::strings` calls into the C++ Highway helpers): all three pass, and the new one fails with the guard disabled.

Related open PRs, each a different defect in the same file: #39291 (dynamic route ordering, which found this one), #39290 (root-level `[[...slug]]` vs `/`), #36680 (param leak on other failure paths and single-character trailing segments; it removes the per-path `params.clear()` calls in favour of one truncate in a wrapper, so whichever lands second drops or keeps one `clear()` line).

### Background

- `FileSystemRouter.match()` looks the path up in a hash map of fully static routes first, then walks the sorted list of dynamic routes and returns the first one for which `Pattern::match_` returns `true`, so for dynamic routes list order is precedence and a false positive from one route hides every route after it.
- `Pattern::match_` walks the route name one pattern at a time (`Pattern::init` yields the next static segment, `[param]`, `[...param]` or `[[...param]]`) while consuming the URL (`path_`, already lowercased and without its leading slash, with trailing slashes and `/index` suffixes stripped by the caller) segment by segment. `pattern.is_end()` reports that the pattern just consumed was the last one in the route name.
- Every candidate route in one `match()` call shares a single `params` scratch list; a route that pushed a param and then failed has to clear it, otherwise the winning route reports that name twice (the symptom from #12206).

<details>
<summary>Released bun 1.4.0 vs this branch on the repro trees</summary>

```
routes: /docs/[page]  /opt/[page]/[[...rest]]  /blog/[slug]/[id]  /both/[page]  /both/[[...rest]]

                 bun 1.4.0                                   this branch
"/docs"      =>  /docs/[page] {"page":""}                    null
"/docs/"     =>  /docs/[page] {"page":""}                    null
"/docs/x"    =>  /docs/[page] {"page":"x"}                   /docs/[page] {"page":"x"}
"/opt"       =>  /opt/[page]/[[...rest]] {"page":""}         null
"/opt/x"     =>  /opt/[page]/[[...rest]] {"page":"x"}        /opt/[page]/[[...rest]] {"page":"x"}
"/blog//b"   =>  /blog/[slug]/[id] {"slug":"","id":"b"}      null
"/blog/a/b"  =>  /blog/[slug]/[id] {"slug":"a","id":"b"}     /blog/[slug]/[id] {"slug":"a","id":"b"}
"/both"      =>  /both/[page] {"page":""}                    /both/[[...rest]] {}
"/both/x"    =>  /both/[page] {"page":"x"}                   /both/[page] {"page":"x"}
"/both/x/y"  =>  /both/[[...rest]] {"rest":"x/y"}            /both/[[...rest]] {"rest":"x/y"}
```

</details>
