### PR TITLE
bake: fail bun build --app when an output file cannot be written

### DIFF
--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -259,8 +259,6 @@ fn write_sourcemap_to_disk(
     Ok(())
 }
 
-/// The output directory. A failed write is reported and counted instead of returned, so one build
-/// lists every output it could not write before it fails.
 struct OutputDir {
     dir: bun_sys::Dir,
     failed_writes: usize,

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -259,6 +259,27 @@ fn write_sourcemap_to_disk(
     Ok(())
 }
 
+/// The output directory. A failed write is reported and counted instead of returned, so one build
+/// lists every output it could not write before it fails.
+struct OutputDir {
+    dir: bun_sys::Dir,
+    failed_writes: usize,
+}
+
+impl OutputDir {
+    fn write(&mut self, file: &OutputFile) {
+        if let Err(err) = file.write_to_disk(self.dir.fd(), b".") {
+            bun_core::handle_error_return_trace(err);
+            Output::err(
+                err,
+                "Failed to write {} to output directory",
+                (bun_core::fmt::quote(&file.dest_path),),
+            );
+            self.failed_writes += 1;
+        }
+    }
+}
+
 fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<()> {
     // `pt.vm` is the live per-thread VM's BackRef set in `build_command`;
     // `as_ptr()` is `Copy` and does not borrow `pt`.
@@ -641,6 +662,10 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             return Err(crate::Error::BakeBuildFailed);
         }
     };
+    let mut output_dir = OutputDir {
+        dir: root_dir,
+        failed_writes: 0,
+    };
 
     let mut maybe_runtime_file_index: Option<u32> = None;
 
@@ -697,25 +722,11 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             match side {
                 bun_bundler::options::Side::Client => {
                     // Client-side resources will be written to disk for usage on the client side
-                    if let Err(err) = file.write_to_disk(root_dir.fd(), b".") {
-                        bun_core::handle_error_return_trace(err);
-                        Output::err(
-                            err,
-                            "Failed to write {} to output directory",
-                            (bun_core::fmt::quote(&file.dest_path),),
-                        );
-                    }
+                    output_dir.write(file);
                 }
                 bun_bundler::options::Side::Server => {
                     if ctx.bundler_options.bake_debug_dump_server {
-                        if let Err(err) = file.write_to_disk(root_dir.fd(), b".") {
-                            bun_core::handle_error_return_trace(err);
-                            Output::err(
-                                err,
-                                "Failed to write {} to output directory",
-                                (bun_core::fmt::quote(&file.dest_path),),
-                            );
-                        }
+                        output_dir.write(file);
                     }
 
                     // If the file has a sourcemap, store it so we can put it on
@@ -787,16 +798,12 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 && file.src_path.text != b"bun-framework-react/client.tsx"
         });
         if any_client_chunks {
-            let runtime_file: &OutputFile = &bundled_outputs_list[runtime_file_index as usize];
-            if let Err(err) = runtime_file.write_to_disk(root_dir.fd(), b".") {
-                bun_core::handle_error_return_trace(err);
-                Output::err(
-                    err,
-                    "Failed to write {} to output directory",
-                    (bun_core::fmt::quote(&runtime_file.dest_path),),
-                );
-            }
+            output_dir.write(&bundled_outputs_list[runtime_file_index as usize]);
         }
+    }
+    if output_dir.failed_writes > 0 {
+        // Every failed write has been reported; the pages would only reference the missing files.
+        return Err(crate::Error::BakeBuildFailed);
     }
 
     *pt = PerThread::init(

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync, symlinkSync } from "fs";
+import { existsSync, mkdirSync, readdirSync, rmSync, symlinkSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps, WAIT_MULTIPLIER } from "../bake-harness";
@@ -741,5 +741,122 @@ export default function IndexPage() {
 
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
+  });
+
+  describe.concurrent("output files that cannot be written", () => {
+    const app = {
+      "src/index.tsx": `
+        process.on("exit", code => console.log("exit event: " + code));
+        export default { app: { framework: "react" } };
+      `,
+      "pages/index.tsx": `import Client from "../components/Client";
+
+export default function IndexPage() {
+  return <Client />;
+}`,
+      "components/Client.tsx": `"use client";
+
+export default function Client() {
+  return "client";
+}`,
+    };
+
+    // With --debug-no-minify the files are named after their sources. A build of `app` writes the
+    // client entry point, the client component and the runtime chunk both of them import into
+    // dist/_bun; the server files only with --debug-dump-server-files. The page becomes dist/index.html.
+    const clientEntry = expect.stringMatching(/^bun-framework-react\/client\.\w+\.js$/);
+    const runtimeChunk = expect.stringMatching(/^bun-framework-react\/server\.\w+\.chunk\.js$/);
+    const clientComponent = expect.stringMatching(/^components\/Client\.\w+\.js$/);
+    const serverPage = expect.stringMatching(/^pages\/index\.\w+\.js$/);
+
+    async function build(dir: string, ...flags: string[]) {
+      const { exitCode, stdout, stderr } =
+        await Bun.$`${bunExe()} build --app ./src/index.tsx --debug-no-minify ${flags}`
+          .cwd(dir)
+          .env({ ...bunEnv, BUN_DESTRUCT_VM_ON_EXIT: "1" })
+          .quiet()
+          .throws(false);
+      return {
+        exitCode,
+        stdout: stdout.toString(),
+        // Paths relative to dist/_bun, sorted.
+        failedWrites: Array.from(
+          normalizePath(stderr.toString()).matchAll(/Failed to write "_bun\/([^"]+)" to output directory/g),
+          match => match[1],
+        ).sort(),
+        prerendered: existsSync(path.join(dir, "dist", "index.html")),
+        stderr: stderr.toString(),
+      };
+    }
+
+    // The failure is returned to build_command, which exits through the build VM: the config's
+    // 'exit' handler runs, and nothing is prerendered.
+    const failed = { exitCode: 1, stdout: "exit event: 1\n", prerendered: false };
+
+    // Every test bundles a react app once or twice; see "failures reported by the build" above.
+    const timeout = 30_000 * WAIT_MULTIPLIER;
+
+    test(
+      "every failed write is reported",
+      async () => {
+        // Files in the way of both directories the outputs go into. (Not a single file at dist/_bun:
+        // on Windows, creating a directory underneath a file currently never returns.)
+        const dir = await tempDirWithBakeDeps("bake-production-unwritable-output-dirs", {
+          ...app,
+          "dist/_bun/bun-framework-react": "a file in the way of the directory",
+          "dist/_bun/components": "a file in the way of the directory",
+        });
+
+        expect(await build(dir)).toMatchObject({
+          ...failed,
+          failedWrites: [clientEntry, runtimeChunk, clientComponent],
+        });
+      },
+      timeout,
+    );
+
+    test(
+      "a client chunk that cannot be written fails the build",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-unwritable-client-chunk", {
+          ...app,
+          "dist/_bun/components": "a file in the way of the directory",
+        });
+
+        expect(await build(dir)).toMatchObject({ ...failed, failedWrites: [clientComponent] });
+      },
+      timeout,
+    );
+
+    test(
+      "a runtime chunk that cannot be written fails the build",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-unwritable-runtime-chunk", app);
+        expect(await build(dir)).toMatchObject({ exitCode: 0, failedWrites: [], prerendered: true });
+
+        // The hash in the chunk's name is only known from a build that wrote it.
+        const frameworkDir = path.join(dir, "dist", "_bun", "bun-framework-react");
+        const chunks = readdirSync(frameworkDir).filter(name => name.endsWith(".chunk.js"));
+        expect(chunks).toHaveLength(1);
+        rmSync(path.join(dir, "dist"), { recursive: true });
+        mkdirSync(path.join(frameworkDir, chunks[0]), { recursive: true });
+
+        expect(await build(dir)).toMatchObject({ ...failed, failedWrites: [`bun-framework-react/${chunks[0]}`] });
+      },
+      2 * timeout,
+    );
+
+    test(
+      "a dumped server file that cannot be written fails the build",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-unwritable-server-file", {
+          ...app,
+          "dist/_bun/pages": "a file in the way of the directory",
+        });
+
+        expect(await build(dir, "--debug-dump-server-files")).toMatchObject({ ...failed, failedWrites: [serverPage] });
+      },
+      timeout,
+    );
   });
 });


### PR DESCRIPTION
Stacked on #39302 (the PR base is its branch, so the diff here is only this change); it uses the `BakeBuildFailed` return that PR introduces.

### Problem
- `bun build --app` exits 0 when a client chunk or the runtime chunk cannot be written to `dist/`. It prints `ENOTDIR: Failed to write "_bun/<hash>.js" to output directory` for each file, prerenders the routes anyway, and `dist/index.html` ends up referencing chunks that do not exist, so a CI build publishes a broken site. Same for the server files written by `--debug-dump-server-files`.
- Reproduced on the 1.4.0 canary (eabb96de7) with the built-in react framework, a `"use client"` component and a regular file where the output directory goes: three `Failed to write` lines, `dist/index.html` written, exit 0.
- Cause: the three `write_to_disk` call sites in `build_with_vm` (`src/runtime/bake/production.rs`: client chunks, server files under `--debug-dump-server-files`, and the runtime chunk after the loop) each call `Output::err` and continue. Nothing records that a write failed, so the function goes on to `BakeRenderRoutesForProdStatic` and returns `Ok(())`.

### Fix
- The three call sites go through `OutputDir::write`, which reports the failure as before and counts it. After the runtime chunk, the last write, `build_with_vm` returns `Error::BakeBuildFailed` if anything failed, before `PerThread::init` and prerendering; `build_command` (from #39302) then exits 1 through the build VM, the same way as the failures the build already reports.
- Why count instead of returning at the first failure: the loop already reported every unwritable output before this change, and keeping that is what lets one run list all of them; the first test below pins it.
- Why return before prerendering: the HTML and RSC payloads reference the chunks by name, so with a chunk missing the pages can only be broken; writing them would be the current behavior with a different exit code.
- Verified with `test/bake/dev/production.test.ts`, new `output files that cannot be written` describe, one test per call site plus the all-fail case. Every test puts a file or directory where an output goes, runs with `BUN_DESTRUCT_VM_ON_EXIT=1` like the #39302 tests, and asserts the exact list of reported files, exit 1, `exit event: 1` from an `exit` handler in the config (the build returned instead of exiting in place), and no `dist/index.html`:
  - files at `dist/_bun/bun-framework-react` and `dist/_bun/components`: the client entry, the runtime chunk and the client component are all reported
  - a file at `dist/_bun/components`: only the client component chunk (loop call site)
  - a directory where the runtime chunk goes, located with a prior successful build: only the runtime chunk (call site after the loop)
  - a file at `dist/_bun/pages` with `--debug-dump-server-files`: only the server page module (server call site)
  - All four fail on the unfixed build (exit 0, `index.html` written) on Linux and on Windows x64, and pass with `bun bd`; the whole file (including the #39302 tests) passes with `bun bd`; `cargo clippy -p bun_runtime` is clean.
  - The tests pass `--debug-no-minify` so the output files are named after their sources instead of by hash. Like `--app` itself, the two debug flags exist on canary and debug builds, which is what CI runs. They carry the same explicit timeout as the #39302 tests in this file because each one bundles a react app (the runtime chunk test twice), which takes several seconds on the debug ASAN build.
  - The all-fail test does not use a single file at `dist/_bun`: with a file in place of an ancestor directory, bun's recursive mkdir on Windows alternates between ENOENT for the child and EEXIST for the file forever (`make_path_with` in `src/paths/component_iterator.rs` with the Windows step in `src/sys/lib.rs`), which is how the first version of the test hung on the Windows lanes. That is a separate, pre-existing `bun_sys` bug, reported separately; on POSIX `mkdir` returns ENOTDIR and both shapes behave the same.

### Background
- `bun build --app` (bake's static build, `production.rs`) bundles the app, writes the client-side output files to `dist/_bun/`, keeps the server-side output files in memory, and then prerenders every route to `dist/<route>/index.html` from JS (`BakeRenderRoutesForProdStatic`). Server files are only written to disk with the debug flag `--debug-dump-server-files`.
- The runtime chunk holds the bundler helpers (`__esm`, `__commonJS`, ...). It comes out of the server bundle, but the client chunks import it, so it is also written to `dist/_bun`, after the loop over the other outputs; that is why it is a separate call site.
- `Error::BakeBuildFailed` (#39302) means "the build already printed why it failed". `build_command` catches it after `build_with_vm` returns and exits through the VM (`on_exit`, which runs `process`'s `exit` handlers, then `global_exit` with exit code 1), instead of the build code calling `exit` itself.

<details>
<summary>Earlier version</summary>

The first version (b3c6274 to 9b5175b) was based on main and ended the build with `Global::crash()` at the check, matching the other failure sites in the file at the time, and described that as the same report-all-then-exit shape as `bun build`. Review of #39302 asked that bake's code return its failures instead of exiting, and that PR converts the existing sites, so this one was rebased onto it and returns `BakeBuildFailed` instead. The `bun build` comparison was also dropped: bundled `bun build --outdir` stops at the first write it cannot do (`writeOutputFilesToDisk`); only `--no-bundle` reports every file.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/production.test.ts

<!-- robobun:evidence:end -->