### PR TITLE
BufferedReader: enforce the blob slice window at the read instead of after it

### DIFF
--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -75,7 +75,6 @@ pub mod task_tag {
         FetchTasklet,
         FetchTaskletDeinit,
         FetchTaskletPromiseSettle,
-        FileResponseStreamEof,
         FSWatchTask,
         GetAddrInfoLibuvComplete,
         HotReloadTask,

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -148,8 +148,7 @@ impl Drop for ParentKeepAlive {
     }
 }
 
-/// Bytes the reader may still take out of its source (a blob slice window); `None` reads to EOF.
-/// Every read is cut to it before the syscall, and using it up (or starting used up) is reported as EOF.
+/// Bytes the reader may still take out of its source (a blob slice window; `None` reads to EOF): reads are cut to it and using it up is reported as EOF.
 #[derive(Clone, Copy)]
 struct ReadLimit(Option<usize>);
 

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -148,6 +148,46 @@ impl Drop for ParentKeepAlive {
     }
 }
 
+/// Bytes the reader may still take out of its source (a blob slice window), or `None` to read to EOF.
+///
+/// Enforced at the read itself: every read is cut to what is left, so the bytes after the window stay
+/// in a pipe or socket for the next reader, and using the window up is reported exactly like EOF
+/// (`Stop::Eof` / `ReadState::Eof` followed by `on_reader_done`), which is what ends the parent's stream.
+/// A window that is already used up is reported on the parent's first read request without touching
+/// the source, so an empty slice of a pipe ends without waiting for bytes it would not deliver anyway.
+#[derive(Clone, Copy)]
+struct ReadLimit(Option<usize>);
+
+impl ReadLimit {
+    const NONE: ReadLimit = ReadLimit(None);
+
+    fn reached(self) -> bool {
+        self.0 == Some(0)
+    }
+
+    fn clamp_len(self, len: usize) -> usize {
+        self.0.map_or(len, |remaining| len.min(remaining))
+    }
+
+    fn clamp(self, buf: &mut [u8]) -> &mut [u8] {
+        let len = self.clamp_len(buf.len());
+        &mut buf[..len]
+    }
+
+    /// Charges `n` bytes read from the source; `true` once the window is used up.
+    fn charge(&mut self, n: usize) -> bool {
+        let Some(remaining) = &mut self.0 else {
+            return false;
+        };
+        debug_assert!(
+            n <= *remaining,
+            "read past the limit: the read was not clamped"
+        );
+        *remaining = remaining.saturating_sub(n);
+        *remaining == 0
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // PosixBufferedReader
 // ──────────────────────────────────────────────────────────────────────────
@@ -156,6 +196,7 @@ pub struct PosixBufferedReader {
     pub handle: PollOrFd,
     pub _buffer: Vec<u8>,
     pub(crate) _offset: usize,
+    limit: ReadLimit,
     pub(crate) vtable: BufferedReaderVTable,
     pub flags: PosixFlags,
     // MaxBuf uses hand-rolled dual-ownership (Subprocess + reader) via
@@ -192,6 +233,7 @@ impl PosixBufferedReader {
             handle: PollOrFd::Closed,
             _buffer: Vec::new(),
             _offset: 0,
+            limit: ReadLimit::NONE,
             vtable: BufferedReaderVTable::init::<T>(),
             flags: PosixFlags::new(),
             maxbuf: None,
@@ -225,12 +267,14 @@ impl PosixBufferedReader {
             handle: mem::replace(&mut other.handle, PollOrFd::Closed),
             _buffer: mem::take(other.buffer()),
             _offset: other._offset,
+            limit: other.limit,
             flags: other.flags,
             vtable: BufferedReaderVTable { kind, parent },
             maxbuf: None,
         };
         other.flags.insert(PosixFlags::IS_DONE);
         other._offset = 0;
+        other.limit = ReadLimit::NONE;
         MaxBuf::transfer_to_pipereader(&mut other.maxbuf, &mut self.maxbuf);
         // Capture *mut Self before borrowing `handle` so the owner pointer
         // doesn't conflict with the field borrow.
@@ -517,7 +561,8 @@ impl PosixBufferedReader {
         if self.get_fd() != fd {
             self.handle = PollOrFd::Fd(fd);
         }
-        if !self.flags.contains(PosixFlags::IS_PAUSED) {
+        // With nothing left to read the fd is never waited on: like a non-pollable source, the parent's first read request ends the reader.
+        if !self.flags.contains(PosixFlags::IS_PAUSED) && !self.limit.reached() {
             // SAFETY: `self` is live. Note: this `&mut self` receiver still carries
             // a protector across the (maybe-freeing) error dispatch — pre-existing
             // on the parent chain, tracked with the raw-dispatch follow-up.
@@ -531,6 +576,11 @@ impl PosixBufferedReader {
         self._offset = offset;
         self.flags.insert(PosixFlags::USE_PREAD);
         self.start(fd, poll)
+    }
+
+    /// Ends the reader after the next `len` bytes of the source as if they were followed by EOF (`ReadLimit`); `None` reads to EOF. Set before starting.
+    pub fn set_limit(&mut self, len: Option<usize>) {
+        self.limit = ReadLimit(len);
     }
 
     // Exists for consistently with Windows.
@@ -575,7 +625,9 @@ impl PosixBufferedReader {
         // afterwards, so the parent (which embeds this reader) must outlive it.
         let _parent = vtable.ref_parent();
         let mut received_hup = false;
-        if file_type == FileType::Pipe {
+        // A used-up limit is reported without reading, so there is nothing to wait for.
+        // SAFETY: caller contract; borrow ends at `;`.
+        if file_type == FileType::Pipe && !unsafe { (*this).limit.reached() } {
             match bun_core::is_readable(fd) {
                 bun_core::Pollable::Ready => {}
                 bun_core::Pollable::Hup => received_hup = true,
@@ -631,15 +683,21 @@ impl PosixBufferedReader {
         }
     }
 
-    /// One syscall into `buf`; charges the byte budget and advances the offset.
+    /// One syscall into `buf`, cut to the limit and the byte budget; charges both and advances the offset. A limit that is (or gets) used up is this reader's EOF.
     fn read_once(&mut self, file_type: FileType, fd: Fd, buf: &mut [u8]) -> ReadOnce {
-        let buf = MaxBuf::clamp_read_buf(self.maxbuf, buf);
+        if self.limit.reached() {
+            return ReadOnce::Stop(Stop::Eof);
+        }
+        let buf = MaxBuf::clamp_read_buf(self.maxbuf, self.limit.clamp(buf));
         match self.sys_read(file_type, fd, buf) {
             sys::Result::Ok(0) => ReadOnce::Stop(Stop::Eof),
             sys::Result::Ok(n) => {
                 self._offset += n;
+                let limit_reached = self.limit.charge(n);
                 if self.charge_max_buffer(n) {
                     ReadOnce::Read(n, Some(Stop::OverBudget))
+                } else if limit_reached {
+                    ReadOnce::Read(n, Some(Stop::Eof))
                 } else {
                     ReadOnce::Read(n, None)
                 }
@@ -865,7 +923,9 @@ impl PosixBufferedReader {
             return (0, ReadState::Progress);
         }
         let _parent = vtable.ref_parent();
-        if file_type == FileType::Pipe {
+        // As in `read`: a used-up limit is reported without reading.
+        // SAFETY: caller contract; borrow ends at `;`.
+        if file_type == FileType::Pipe && !unsafe { (*this).limit.reached() } {
             match bun_core::is_readable(fd) {
                 bun_core::Pollable::Ready | bun_core::Pollable::Hup => {}
                 bun_core::Pollable::NotReady => {
@@ -937,6 +997,7 @@ pub struct WindowsBufferedReader {
     /// It cannot change because we don't know what libuv will do with it.
     pub source: Option<Source>,
     pub(crate) _offset: usize,
+    limit: ReadLimit,
     pub _buffer: Vec<u8>,
     // for compatibility with Linux
     pub flags: WindowsFlags,
@@ -980,6 +1041,7 @@ impl WindowsBufferedReader {
         WindowsBufferedReader {
             source: None,
             _offset: 0,
+            limit: ReadLimit::NONE,
             _buffer: Vec::new(),
             flags: WindowsFlags::new(),
             maxbuf: None,
@@ -1002,6 +1064,7 @@ impl WindowsBufferedReader {
         self.flags = other.flags;
         self._buffer = mem::take(other.buffer());
         self._offset = other._offset;
+        self.limit = other.limit;
         // Ownership of the handle (or listed file) moves with the source;
         // `set_parent` below re-records this reader as the one a VM teardown
         // stops it through.
@@ -1009,6 +1072,7 @@ impl WindowsBufferedReader {
 
         other.flags.insert(WindowsFlags::IS_DONE);
         other._offset = 0;
+        other.limit = ReadLimit::NONE;
         // other._buffer / other.source already cleared by mem::take above.
         // The field-by-field assigns above leave `self.maxbuf` untouched, so
         // drop any prior owner-count first to avoid leaking a MaxBuf ref when
@@ -1166,12 +1230,15 @@ impl WindowsBufferedReader {
     fn get_read_buffer_with_stable_memory_address(&mut self, suggested_size: usize) -> &mut [u8] {
         self.flags.insert(WindowsFlags::HAS_INFLIGHT_READ);
         // Spare capacity grows well past `suggested_size`, so an unclamped read
-        // overshoots `maxBuffer` by however much the buffer had room for.
+        // overshoots the limit or `maxBuffer` by however much the buffer had room for.
         let maxbuf = self.maxbuf;
-        self._buffer.reserve(suggested_size);
+        let limit = self.limit;
+        // Never empty: reads are only issued while the limit has not been reached (`start_reading`, `on_read`), and libuv treats an empty buffer as an error.
+        debug_assert!(!limit.reached());
+        self._buffer.reserve(limit.clamp_len(suggested_size));
         // SAFETY: returning spare capacity for libuv to write into; len updated in on_read.
         let buf = unsafe { bun_core::vec::spare_bytes_mut(&mut self._buffer) };
-        MaxBuf::clamp_read_buf(maxbuf, buf)
+        MaxBuf::clamp_read_buf(maxbuf, limit.clamp(buf))
     }
 
     pub fn start_with_current_pipe(&mut self) -> sys::Result<()> {
@@ -1247,6 +1314,11 @@ impl WindowsBufferedReader {
         self._offset = offset;
         self.flags.insert(WindowsFlags::USE_PREAD);
         self.start(fd, poll)
+    }
+
+    /// See `PosixBufferedReader::set_limit`.
+    pub fn set_limit(&mut self, len: Option<usize>) {
+        self.limit = ReadLimit(len);
     }
 
     pub fn set_raw_mode(&mut self, value: bool) -> sys::Result<()> {
@@ -1502,8 +1574,10 @@ impl WindowsBufferedReader {
 
     #[cfg(windows)]
     fn start_reading(&mut self) -> sys::Result<()> {
+        // A used-up limit stays paused: `start` has nothing to read and `unpause` reports it as EOF instead.
         if self.flags.contains(WindowsFlags::IS_DONE)
             || !self.flags.contains(WindowsFlags::IS_PAUSED)
+            || self.limit.reached()
         {
             return sys::Result::Ok(());
         }
@@ -1777,8 +1851,10 @@ impl WindowsBufferedReader {
         // SAFETY: slice is inside _buffer's spare capacity; libuv wrote `amount_result` bytes.
         unsafe { bun_core::vec::commit_spare(&mut self._buffer, amount_result) };
 
+        // Using the limit up is this reader's EOF (`ReadLimit`); so is exhausting `maxBuffer`.
+        let limit_reached = self.limit.charge(amount_result);
         let over_budget = self.charge_max_buffer(amount_result);
-        let has_more = if over_budget {
+        let has_more = if limit_reached || over_budget {
             ReadState::Eof
         } else {
             has_more
@@ -1786,7 +1862,7 @@ impl WindowsBufferedReader {
         // Parents that want the reader paused call `reader().pause()` themselves; stopping here could free a parent whose caller still holds `this` (FileResponseStream on abort).
         let _ = self.on_read_chunk(has_more);
 
-        if has_more == ReadState::Eof || over_budget {
+        if has_more == ReadState::Eof {
             self.close();
         }
     }
@@ -1796,6 +1872,11 @@ impl WindowsBufferedReader {
     }
 
     pub fn unpause(&mut self) {
+        if self.limit.reached() && !self.is_done() {
+            // Nothing left to read: report EOF the way a completed read does instead of issuing one.
+            self.on_read(sys::Result::Ok(0), &mut [], ReadState::Eof);
+            return;
+        }
         let _ = self.start_reading();
     }
 

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -148,13 +148,8 @@ impl Drop for ParentKeepAlive {
     }
 }
 
-/// Bytes the reader may still take out of its source (a blob slice window), or `None` to read to EOF.
-///
-/// Enforced at the read itself: every read is cut to what is left, so the bytes after the window stay
-/// in a pipe or socket for the next reader, and using the window up is reported exactly like EOF
-/// (`Stop::Eof` / `ReadState::Eof` followed by `on_reader_done`), which is what ends the parent's stream.
-/// A window that is already used up is reported on the parent's first read request without touching
-/// the source, so an empty slice of a pipe ends without waiting for bytes it would not deliver anyway.
+/// Bytes the reader may still take out of its source (a blob slice window); `None` reads to EOF.
+/// Every read is cut to it before the syscall, and using it up (or starting used up) is reported as EOF.
 #[derive(Clone, Copy)]
 struct ReadLimit(Option<usize>);
 

--- a/src/io/pipes.rs
+++ b/src/io/pipes.rs
@@ -140,7 +140,7 @@ pub enum ReadState {
     /// Neither EOF nor EAGAIN
     Progress,
 
-    /// Received a 0-byte read
+    /// Received a 0-byte read, or the reader's limit or byte budget is used up: nothing more will be read
     Eof,
 
     /// Received an EAGAIN
@@ -153,7 +153,7 @@ pub enum Chunk<'a> {
     Scratch(&'a [u8]),
     /// The reader's own buffer, which it clears and reuses after the call. Copy what you keep, or `take()` it when moving beats copying.
     Buffer(&'a mut Vec<u8>),
-    /// The reader is finished with these bytes (EOF, error, budget): yours to move.
+    /// The reader is finished with these bytes (EOF, limit, error, budget): yours to move.
     Owned(Vec<u8>),
 }
 
@@ -169,14 +169,6 @@ impl Chunk<'_> {
 
     pub fn is_owned(&self) -> bool {
         matches!(self, Chunk::Owned(_))
-    }
-
-    pub fn truncate(&mut self, len: usize) {
-        match self {
-            Chunk::Scratch(bytes) => *bytes = &bytes[..len.min(bytes.len())],
-            Chunk::Buffer(buffer) => buffer.truncate(len),
-            Chunk::Owned(buffer) => buffer.truncate(len),
-        }
     }
 }
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -253,15 +253,6 @@ pub(crate) fn run_task(
             };
             holder.run()?;
         }
-        task_tag::FileResponseStreamEof => {
-            let stream = cast_ptr!(crate::server::FileResponseStream);
-            // SAFETY: tag identifies pointee; `on_read_chunk` took a ref for
-            // this task at enqueue time which this guard adopts.
-            let _pin =
-                unsafe { bun_ptr::ScopedRef::<crate::server::FileResponseStream>::adopt(stream) };
-            // SAFETY: `stream` is live for this call (pinned above).
-            unsafe { (*stream).on_reader_done() };
-        }
         task_tag::DuplexUpgradeContext => {
             // SAFETY: tag identifies pointee; `run_event` may free the context,
             // so it takes the raw pointer (no `&mut` at this boundary).
@@ -600,7 +591,7 @@ fn run_task_cold(task: Task) {
 /// `release_task_unrun` track `bun_event_loop::task_tag::COUNT`. Bump when
 /// adding a variant — and give it an arm in both.
 const _: () = assert!(
-    task_tag::COUNT == 62,
+    task_tag::COUNT == 61,
     "dispatch::run_task / release_task_unrun arm count out of sync with bun_event_loop::task_tag",
 );
 
@@ -1250,7 +1241,6 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
         task_tag::FetchTaskletPromiseSettle => {
             release!(crate::webcore::fetch::fetch_tasklet::FetchTaskletPromiseSettle)
         }
-        task_tag::FileResponseStreamEof => release!(crate::server::FileResponseStream),
         task_tag::FSWatchTask => release!(FSWatchTask),
         task_tag::HotReloadTask => release!(hot_reloader::HotReloadTask),
         task_tag::WatchReloadTask => release!(hot_reloader::WatchReloadTask),

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -504,11 +504,8 @@ impl FileResponseStream {
     }
 
     /// Clear all uWS callbacks pointing at us. Must run while `resp` is still
-    /// live (i.e., before `resp.end()` / `end_send_file()` / `force_close()` give
-    /// the socket back to uWS, which may free it on the next loop tick). After
-    /// this runs, `finish()` — which the reader still reaches through
-    /// `on_reader_done` after the chunk that ended the response — will not
-    /// touch `resp` again.
+    /// live, i.e. before `resp.end()` / `end_send_file()` / `force_close()` give
+    /// the socket back to uWS; the stream does not touch `resp` after that.
     fn detach_resp(&self) {
         if self.state.get().contains(State::RESP_DETACHED) {
             return;
@@ -575,11 +572,9 @@ impl FileResponseStream {
 // BufferedReader vtable parent.
 // `loop_` delegates to the inherent `r#loop()` which already does the
 // cfg(windows) `.uv_loop` projection. The read/done/error arms take a ref for
-// the duration of the handler since it can end in `finish()`. `ref_`/`deref`
-// pin the stream for the whole of a read dispatch: the chunk that uses the
-// body length up is followed by `on_reader_done` (which releases the owning
-// ref) while the reader's read loop or libuv completion still has the reader
-// embedded here on its stack.
+// the duration of the handler since it can end in `finish()`; `ref_`/`deref`
+// keep the stream alive for the reader's whole dispatch, which uses the reader
+// embedded here after `on_reader_done` has released the owning ref.
 bun_io::impl_buffered_reader_parent! {
     FileResponseStream for FileResponseStream;
     has_on_read_chunk = true;

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -503,9 +503,7 @@ impl FileResponseStream {
         self.finish();
     }
 
-    /// Clear all uWS callbacks pointing at us. Must run while `resp` is still
-    /// live, i.e. before `resp.end()` / `end_send_file()` / `force_close()` give
-    /// the socket back to uWS; the stream does not touch `resp` after that.
+    /// Clears the uWS callbacks pointing at us; runs before `resp.end()` / `end_send_file()` / `force_close()` hand the socket back to uWS, after which nothing here touches `resp`.
     fn detach_resp(&self) {
         if self.state.get().contains(State::RESP_DETACHED) {
             return;
@@ -572,9 +570,7 @@ impl FileResponseStream {
 // BufferedReader vtable parent.
 // `loop_` delegates to the inherent `r#loop()` which already does the
 // cfg(windows) `.uv_loop` projection. The read/done/error arms take a ref for
-// the duration of the handler since it can end in `finish()`; `ref_`/`deref`
-// keep the stream alive for the reader's whole dispatch, which uses the reader
-// embedded here after `on_reader_done` has released the owning ref.
+// the duration of the handler since it can end in `finish()`.
 bun_io::impl_buffered_reader_parent! {
     FileResponseStream for FileResponseStream;
     has_on_read_chunk = true;
@@ -592,6 +588,7 @@ bun_io::impl_buffered_reader_parent! {
     };
     loop_           = |this| (*this).r#loop();
     event_loop      = |this| (*this).event_loop_handle.get().as_event_loop_ctx();
+    // The reader still uses itself (embedded here) after dispatching the `on_reader_done` that releases the owning ref.
     ref_            = |this| (*this).ref_();
     deref           = |this| Self::deref(this);
 }

--- a/src/runtime/server/FileResponseStream.rs
+++ b/src/runtime/server/FileResponseStream.rs
@@ -21,7 +21,7 @@ use bun_jsc::JsCell;
 use bun_sys::{self as sys, Fd};
 use bun_uws::{AnyResponse, WriteResult};
 
-use crate::server::jsc::{EventLoopHandle, Task, VirtualMachine};
+use crate::server::jsc::{EventLoopHandle, VirtualMachine};
 
 bun_output::declare_scope!(FileResponseStream, hidden);
 
@@ -46,7 +46,6 @@ pub(crate) struct FileResponseStream {
 
     mode: Cell<Mode>,
     reader: JsCell<BufferedReader>,
-    max_size: Cell<Option<u64>>,
     sendfile: JsCell<Sendfile>,
 
     state: Cell<State>,
@@ -146,7 +145,6 @@ impl FileResponseStream {
                     Mode::Reader
                 }),
                 reader: JsCell::new(BufferedReader::init::<FileResponseStream>()),
-                max_size: Cell::new(None),
                 sendfile: JsCell::new(Sendfile::default()),
                 state: Cell::new(State::default()),
             }));
@@ -192,7 +190,6 @@ impl FileResponseStream {
         }
 
         // BufferedReader path
-        this_ref.max_size.set(opts.length);
         this_ref.reader.with_mut(|reader| {
             reader.flags.remove(ReaderFlags::CLOSE_HANDLE); // we own fd via auto_close
             reader.flags.set(ReaderFlags::POLLABLE, opts.pollable);
@@ -203,6 +200,8 @@ impl FileResponseStream {
             if opts.file_type == FileType::Socket {
                 reader.flags.insert(ReaderFlags::SOCKET);
             }
+            // The reader reports the end of the body as EOF, so `on_read_chunk` ends the response there like at a real EOF.
+            reader.set_limit(opts.length.map(|len| len as usize));
             reader.set_parent(this.cast::<c_void>());
         });
 
@@ -268,34 +267,10 @@ impl FileResponseStream {
         unsafe { &mut *self.reader.as_ptr() }
     }
 
-    fn on_read_chunk(&self, chunk_: &[u8], state_: ReadState) -> bool {
+    fn on_read_chunk(&self, chunk: &[u8], state: ReadState) -> bool {
         if self.state.get().contains(State::RESPONSE_DONE) {
             return false;
         }
-
-        let (chunk, state) = 'brk: {
-            if let Some(max) = self.max_size.get() {
-                let c = &chunk_[..chunk_.len().min(usize::try_from(max).unwrap_or(usize::MAX))];
-                let remaining = max.saturating_sub(c.len() as u64);
-                self.max_size.set(Some(remaining));
-                if state_ != ReadState::Eof && remaining == 0 {
-                    #[cfg(not(unix))]
-                    // SAFETY: reader entry point; `pause()` does not call back
-                    // into this object.
-                    self.reader_mut().pause();
-                    // Ref for the queued task; adopted in the
-                    // `FileResponseStreamEof` dispatch/shutdown arms.
-                    self.ref_();
-                    // SAFETY: `vm.event_loop()` returns the live JS loop.
-                    unsafe {
-                        (*self.vm.get().event_loop()).enqueue_task(Task::init(self.as_ptr()));
-                    }
-                    break 'brk (c, ReadState::Eof);
-                }
-                break 'brk (c, state_);
-            }
-            (chunk_, state_)
-        };
 
         let resp = self.resp.get();
         resp.timeout(self.idle_timeout.get());
@@ -531,8 +506,9 @@ impl FileResponseStream {
     /// Clear all uWS callbacks pointing at us. Must run while `resp` is still
     /// live (i.e., before `resp.end()` / `end_send_file()` / `force_close()` give
     /// the socket back to uWS, which may free it on the next loop tick). After
-    /// this runs, `finish()` — which can be reached from the deferred `eof_task`
-    /// — will not touch `resp` again.
+    /// this runs, `finish()` — which the reader still reaches through
+    /// `on_reader_done` after the chunk that ended the response — will not
+    /// touch `resp` again.
     fn detach_resp(&self) {
         if self.state.get().contains(State::RESP_DETACHED) {
             return;
@@ -599,7 +575,11 @@ impl FileResponseStream {
 // BufferedReader vtable parent.
 // `loop_` delegates to the inherent `r#loop()` which already does the
 // cfg(windows) `.uv_loop` projection. The read/done/error arms take a ref for
-// the duration of the handler since it can end in `finish()`.
+// the duration of the handler since it can end in `finish()`. `ref_`/`deref`
+// pin the stream for the whole of a read dispatch: the chunk that uses the
+// body length up is followed by `on_reader_done` (which releases the owning
+// ref) while the reader's read loop or libuv completion still has the reader
+// embedded here on its stack.
 bun_io::impl_buffered_reader_parent! {
     FileResponseStream for FileResponseStream;
     has_on_read_chunk = true;
@@ -617,6 +597,8 @@ bun_io::impl_buffered_reader_parent! {
     };
     loop_           = |this| (*this).r#loop();
     event_loop      = |this| (*this).event_loop_handle.get().as_event_loop_ctx();
+    ref_            = |this| (*this).ref_();
+    deref           = |this| Self::deref(this);
 }
 
 impl Drop for FileResponseStream {
@@ -656,14 +638,5 @@ fn can_sendfile(resp: AnyResponse, file_type: FileType, length: Option<u64>) -> 
         let Some(len) = length else { return false };
         // Below ~1MB the syscall + dual-readiness overhead doesn't pay off.
         len >= (1 << 20)
-    }
-}
-
-impl bun_event_loop::Taskable for FileResponseStream {
-    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::FileResponseStreamEof;
-    /// `on_read_chunk` took a ref for the queued EOF hop; drop it.
-    unsafe fn release_unrun(this: *mut Self) {
-        // SAFETY: fn contract; adopts the ref the enqueue took.
-        drop(unsafe { bun_ptr::ScopedRef::<FileResponseStream>::adopt(this) });
     }
 }

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -49,10 +49,8 @@ pub struct FileReader {
     pub(crate) fd: Cell<Fd>,
     /// Read-only after construction (set via struct literal in `from_blob_*`).
     pub(crate) start_offset: Option<usize>,
-    /// Length of the slice window at `start_offset`; the stream ends there. Read-only after init.
+    /// Length of the slice window at `start_offset`; the reader is limited to it when it is started and ends the stream there. Read-only after init.
     pub(crate) max_size: Option<usize>,
-    /// Bytes delivered so far; never exceeds `max_size`.
-    pub(crate) total_readed: Cell<usize>,
     pub(crate) started: Cell<bool>,
     pub(crate) waiting_for_on_reader_done: Cell<bool>,
     pub(crate) event_loop: Cell<EventLoopHandle>,
@@ -79,7 +77,6 @@ impl Default for FileReader {
             fd: Cell::new(Fd::INVALID),
             start_offset: None,
             max_size: None,
-            total_readed: Cell::new(0),
             started: Cell::new(false),
             waiting_for_on_reader_done: Cell::new(false),
             // Sentinel only; never dispatched (callers must overwrite before use).
@@ -400,6 +397,7 @@ impl FileReader {
                 unsafe { (*self.parent()).increment_count() };
                 self.waiting_for_on_reader_done.set(true);
             }
+            self.reader().set_limit(self.max_size);
             let start_result = if let Some(offset) = self.start_offset {
                 self.reader()
                     .start_file_offset(self.fd.get(), pollable, offset)
@@ -621,7 +619,7 @@ impl FileReader {
         true
     }
 
-    pub(crate) fn on_read_chunk(&self, mut chunk: Chunk<'_>, state: ReadState) -> bool {
+    pub(crate) fn on_read_chunk(&self, chunk: Chunk<'_>, state: ReadState) -> bool {
         bun_core::scoped_log!(
             FileReader,
             "onReadChunk() = {} ({})",
@@ -633,17 +631,10 @@ impl FileReader {
             self.reader().close();
             return false;
         }
-        let window_exhausted = match self.window_remaining() {
-            Some(remaining) => {
-                chunk.truncate(remaining);
-                self.consume_window(chunk.len())
-            }
-            None => false,
-        };
-        let has_more = state != ReadState::Eof && !window_exhausted;
+        let has_more = state != ReadState::Eof;
 
         let sink = *self.sink.get();
-        let keep_going = if sink.is_some() {
+        if sink.is_some() {
             self.write_chunk_to_sink(sink, &chunk, has_more)
         } else if self.pending.get().state == streams::PendingState::Pending {
             // Pipes may return 0-byte reads short of EOF; keep reading.
@@ -667,35 +658,6 @@ impl FileReader {
                 self.reader().pause();
             }
             keep_going
-        };
-        if window_exhausted {
-            // Closed only now: closing first would settle a parked read with `Done` ahead of this chunk.
-            self.end_at_window();
-            return false;
-        }
-        keep_going
-    }
-
-    /// Bytes the blob's slice window still allows; `None` when the source is unbounded.
-    fn window_remaining(&self) -> Option<usize> {
-        Some(self.max_size? - self.total_readed.get())
-    }
-
-    /// Charges `len` bytes to the window; `true` once it is used up, which is this stream's EOF.
-    fn consume_window(&self, len: usize) -> bool {
-        let Some(max_size) = self.max_size else {
-            return false;
-        };
-        let total_readed = self.total_readed.get() + len;
-        debug_assert!(total_readed <= max_size);
-        self.total_readed.set(total_readed);
-        total_readed == max_size
-    }
-
-    /// Ends the stream the way EOF does; `on_reader_done` settles whatever is waiting.
-    fn end_at_window(&self) {
-        if !self.reader().is_done() {
-            self.reader().close();
         }
     }
 
@@ -847,17 +809,9 @@ impl FileReader {
         }
 
         if !self.reader().has_pending_read() && self.flowing.get() {
-            // `read_into` does not go through `on_read_chunk`, so the slice window is applied here: the read is cut to what is left of it (an empty destination reads nothing).
-            let len = self
-                .window_remaining()
-                .map_or(buffer.len(), |remaining| remaining.min(buffer.len()));
             // SAFETY: the reader cell is live for `self`'s lifetime; `read_into` is the raw re-entrancy-safe entry (EOF/error dispatch runs user JS).
-            let (amount_read, state) =
-                unsafe { IOReader::read_into(self.reader.get(), &mut buffer[..len]) };
-            bun_core::scoped_log!(FileReader, "onPull({}) = {}", len, amount_read);
-            if self.consume_window(amount_read) {
-                self.end_at_window();
-            }
+            let (amount_read, state) = unsafe { IOReader::read_into(self.reader.get(), buffer) };
+            bun_core::scoped_log!(FileReader, "onPull({}) = {}", buffer.len(), amount_read);
             let done = state == ReadState::Eof || self.reader().is_done();
             if amount_read > 0 {
                 let into = streams::IntoArray {

--- a/test/js/bun/http/serve-file-slice-read-error.test.ts
+++ b/test/js/bun/http/serve-file-slice-read-error.test.ts
@@ -1,14 +1,15 @@
-// Bun.serve returning `Bun.file(path).slice(0, n)` where a read() on the file
-// fails after the first read has already returned more than `n` bytes. Before
-// the fix, FileResponseStream::on_read_chunk enqueued a deferred eof task
-// without holding a ref on the stream, and the read-error path
-// (on_reader_error) consumed the in-flight read ref and finished the stream,
-// so the stream was freed before the queued task ran (heap-use-after-free
-// under ASAN).
+// Bun.serve returning `Bun.file(path).slice(0, n)` of a larger file: the
+// response's reader asks the kernel for exactly `n` bytes and ends there, so
+// each request costs one read() of the served file and an error from the file
+// can only fail the response it belongs to. (The reader used to pull in the
+// whole read buffer and cut the chunk down afterwards, so every request took
+// two read()s, a 4 KiB one and the EOF probe, and the response had to end
+// itself from a queued task. That task was once freed out from under the
+// read-error path: heap-use-after-free under ASAN.)
 //
-// A small ptrace supervisor injects EIO on the second read() of the served
-// file. Bun issues read() as a raw syscall on Linux (rustix linux_raw
-// backend), so LD_PRELOAD cannot intercept it.
+// A small ptrace supervisor counts the read() calls on the served file and
+// injects EIO into the second one. Bun issues read() as a raw syscall on Linux
+// (rustix linux_raw backend), so LD_PRELOAD cannot intercept it.
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { join } from "node:path";
@@ -184,8 +185,9 @@ int main(int argc, char **argv) {
 `;
 
 // The file is 4 KiB; slicing to 2 KiB keeps us on the BufferedReader path
-// (below the 1 MiB sendfile threshold) and makes read #1 (4096 bytes) exceed
-// max_size=2048 so on_read_chunk enqueues the eof task with state==Progress.
+// (below the 1 MiB sendfile threshold) while leaving bytes past the slice that
+// a read sized by the buffer instead of the slice would pick up. The slice
+// starts at 0 so the reader uses read(), which is what the supervisor counts.
 const FIXTURE_JS = /* js */ `
 const path = process.argv[2];
 const server = Bun.serve({
@@ -196,7 +198,10 @@ const server = Bun.serve({
 let okBodies = 0;
 for (let i = 0; i < 3; i++) {
   try {
-    const r = await fetch(\`http://127.0.0.1:\${server.port}/\`);
+    // A fresh connection per request: a request that fails on a reused
+    // keep-alive connection before any response bytes would be retried
+    // (and then succeed) instead of being reported.
+    const r = await fetch(\`http://127.0.0.1:\${server.port}/\`, { headers: { connection: "close" } });
     const b = await r.arrayBuffer();
     if (b.byteLength === 2048) okBodies++;
   } catch {}
@@ -236,7 +241,7 @@ afterAll(() => {
 });
 
 test.skipIf(!isLinux || !cc)(
-  "Bun.serve Bun.file().slice() survives a read() error after the slice is satisfied",
+  "Bun.serve Bun.file().slice() reads the file once per response, so a read() error fails only its own response",
   async () => {
     expect(supervisorBin).toBeDefined();
 
@@ -253,16 +258,14 @@ test.skipIf(!isLinux || !cc)(
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // Three requests; one injected EIO on request #1's second read. The slice
-    // was already satisfied by read #1, so all three responses carry the full
-    // 2048 bytes.
-    expect({ stdout: stdout.trim(), stderr }).toEqual({
-      stdout: "DONE 3",
-      stderr: expect.stringContaining("matched read() calls on target:"),
-    });
-    // Injection sanity: each request does two read()s on the served file.
-    const m = stderr.match(/matched read\(\) calls on target:\s*(\d+)/);
-    expect(Number(m?.[1])).toBeGreaterThanOrEqual(2);
+    // Three requests, one read() each, so the injected EIO lands on request
+    // #2's only read: that response fails and the other two carry their 2048
+    // bytes. A reader that over-reads takes two read()s per request (6 in
+    // total) and the EIO lands on request #1's EOF probe, after the slice has
+    // already been satisfied, so all three responses succeed.
+    expect(stderr).toContain("matched read() calls on target:");
+    const reads = Number(stderr.match(/matched read\(\) calls on target:\s*(\d+)/)![1]);
+    expect({ stdout: stdout.trim(), reads }).toEqual({ stdout: "DONE 2", reads: 3 });
     expect(exitCode).toBe(0);
   },
 );

--- a/test/js/bun/util/bun-stdin-slice.test.ts
+++ b/test/js/bun/util/bun-stdin-slice.test.ts
@@ -95,3 +95,104 @@ describe("Bun.stdin.slice(0, N).stream() over a pipe that stays open", () => {
     },
   );
 });
+
+// The bytes after the window have to stay in the pipe for whoever reads stdin
+// next. The slice is consumed by a grandchild that shares the child's stdin
+// and prints the window as <chunk>...; once it has exited the child prints "|"
+// followed by whatever is still in the pipe. A reader that asks the kernel for
+// more than the window leaves nothing for the child. The stdin Bun.spawn hands
+// out is a socketpair on POSIX and a named pipe on Windows; the window is
+// enforced the same way on both, so unlike the tests above these run everywhere.
+describe("Bun.stdin.slice(0, N) over a pipe that stays open leaves the bytes after the window in the pipe", () => {
+  const consumers = {
+    // One <...> per chunk, so an empty window prints nothing.
+    "stream()": {
+      script: (n: number) =>
+        `for await (const chunk of Bun.stdin.slice(0, ${n}).stream()) process.stdout.write("<" + Buffer.from(chunk) + ">");`,
+      emptyWindow: "",
+    },
+    // A native sink reading the file stream (HTMLRewriter) instead of JS pulls; prints the whole window once it has ended.
+    "HTMLRewriter.transform(new Response(slice))": {
+      script: (n: number) =>
+        `process.stdout.write("<" + (await new HTMLRewriter().transform(new Response(Bun.stdin.slice(0, ${n}))).text()) + ">");`,
+      emptyWindow: "<>",
+    },
+  };
+
+  function spawnWindowThenRest(consumer: keyof typeof consumers, n: number) {
+    const readWindow = consumers[consumer].script(n);
+    const proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const window = Bun.spawn({ cmd: [process.execPath, "-e", ${JSON.stringify(readWindow)}], stdin: "inherit", stdout: "inherit", stderr: "inherit" });
+         process.exitCode = await window.exited;
+         process.stdout.write("|");
+         process.stdout.write(await Bun.stdin.text());`,
+      ],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let stdout = "";
+    return {
+      proc,
+      async stdoutUntil(marker: string) {
+        for (let r; !stdout.includes(marker) && !(r = await reader.read()).done; ) {
+          stdout += decoder.decode(r.value, { stream: true });
+        }
+        return stdout;
+      },
+      async finish() {
+        await proc.stdin.end();
+        for (let r; !(r = await reader.read()).done; ) stdout += decoder.decode(r.value, { stream: true });
+        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+        return { stdout, stderr, exitCode };
+      },
+    };
+  }
+
+  for (const consumer of Object.keys(consumers) as (keyof typeof consumers)[]) {
+    describe(consumer, () => {
+      test.concurrent("a write larger than the window", async () => {
+        const child = spawnWindowThenRest(consumer, 3);
+        await using proc = child.proc;
+        proc.stdin.write("0123456789");
+        await proc.stdin.flush();
+        // "|" means the window reader exited while stdin was still open.
+        expect(await child.stdoutUntil("|")).toBe("<012>|");
+
+        expect(await child.finish()).toEqual({ stdout: "<012>|3456789", stderr: "", exitCode: 0 });
+      });
+
+      test.concurrent("an empty window ends without waiting for any input", async () => {
+        const { emptyWindow } = consumers[consumer];
+        const child = spawnWindowThenRest(consumer, 0);
+        await using proc = child.proc;
+        // Nothing has been written: only the window itself can end the grandchild's stream.
+        expect(await child.stdoutUntil("|")).toBe(`${emptyWindow}|`);
+
+        proc.stdin.write("xyz");
+        expect(await child.finish()).toEqual({ stdout: `${emptyWindow}|xyz`, stderr: "", exitCode: 0 });
+      });
+    });
+  }
+
+  test.concurrent("stream(): the write that fills the window is larger than what is left of it", async () => {
+    const child = spawnWindowThenRest("stream()", 4);
+    await using proc = child.proc;
+    proc.stdin.write("01");
+    await proc.stdin.flush();
+    // Wait for the first chunk to come back out so the second write is a separate read in the grandchild.
+    expect(await child.stdoutUntil("<01>")).toBe("<01>");
+
+    proc.stdin.write("23456");
+    await proc.stdin.flush();
+    expect(await child.stdoutUntil("|")).toBe("<01><23>|");
+
+    expect(await child.finish()).toEqual({ stdout: "<01><23>|456", stderr: "", exitCode: 0 });
+  });
+});

--- a/test/js/bun/util/bun-stdin-slice.test.ts
+++ b/test/js/bun/util/bun-stdin-slice.test.ts
@@ -138,6 +138,8 @@ describe("Bun.stdin.slice(0, N) over a pipe that stays open leaves the bytes aft
     const reader = proc.stdout.getReader();
     const decoder = new TextDecoder();
     let stdout = "";
+    // Drained from the start so a failing child can never block on a full stderr pipe while stdout is being waited on.
+    const stderr = proc.stderr.text();
     return {
       proc,
       async stdoutUntil(marker: string) {
@@ -149,8 +151,7 @@ describe("Bun.stdin.slice(0, N) over a pipe that stays open leaves the bytes aft
       async finish() {
         await proc.stdin.end();
         for (let r; !(r = await reader.read()).done; ) stdout += decoder.decode(r.value, { stream: true });
-        const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-        return { stdout, stderr, exitCode };
+        return { stdout, stderr: await stderr, exitCode: await proc.exited };
       },
     };
   }


### PR DESCRIPTION
Follow-up to #39201, where moving the slice window into the reader was agreed as a separate PR.

### Problem
- Streaming a slice of a pipe, socket or stdin consumes bytes past the slice. With `0123456789` written to a child's stdin, `for await (const c of Bun.stdin.slice(0, 3).stream())` delivers `012` and whoever reads stdin next gets nothing: the other 7 bytes were read and dropped. Same through a native sink (`HTMLRewriter.transform(new Response(Bun.stdin.slice(0, 3)))`). With 60000 bytes written, the stream leaves 0 of them in the pipe. Same on Windows.
- `Bun.stdin.slice(0, 0).stream()` (any empty slice of a pollable source) never ends while the pipe stays open and silent; it ends only when a byte arrives, which it drops, or at EOF. Same through a native sink.
- `Bun.serve` responding with `Bun.file(p).slice(0, 2048)` of a 4 KiB file issues two `read()`s per response (a 256 KiB request that returns the whole file, then an EOF probe) and ends the response from a queued task. Harmless for regular files, but it is the same after-the-fact window as above, implemented a second time.
- Cause: the window is applied by the reader's parents after the bytes have been read. `FileReader::on_read_chunk` cuts the delivered chunk down (`src/runtime/webcore/FileReader.rs:636`); the only place that cut the read itself was `on_pull`'s `read_into` branch (`FileReader.rs:849`), which is skipped whenever a poll is registered, i.e. for every pollable fd, and `read_into` is a stub on Windows. The read loop in `src/io/PipeReader.rs` reads up to its 256 KiB scratch buffer (`fill_scratch`, line 653) and the Windows reader hands libuv its whole spare capacity (`get_read_buffer_with_stable_memory_address`, line 1166); neither knows about the window. The empty-window hang is the same gap: the check lived on the `read_into` branch, and a pollable source parks on its poll before reaching it. `FileResponseStream` keeps a third copy of the window (`src/runtime/server/FileResponseStream.rs:277`) and needs the `FileResponseStreamEof` task to end itself.

### Fix
- `PosixBufferedReader` and `WindowsBufferedReader` get a `ReadLimit` next to the pread offset, set with `set_limit` before starting. `read_once` (every POSIX read: loop, buffer and `read_into`) and the libuv buffer on Windows cut each read to what is left of it, and charging it down to zero is reported the way EOF already is (`Stop::Eof` / `ReadState::Eof`, then `close` and `on_reader_done`). A limit that starts at zero makes `start` register no poll and issue no read; the parent's first read request (`read`, `read_into`, Windows `unpause`) reports EOF without touching the fd.
- `FileReader` passes the blob's size to the reader at start and `FileResponseStream` passes the body length; both now treat the end of the window exactly like EOF, because that is what the reader reports. Deleted: `FileReader`'s `total_readed` / `window_remaining` / `consume_window` / `end_at_window`, `FileResponseStream`'s `max_size` and the `FileResponseStreamEof` task (tag, dispatch arm, `Taskable` impl), and `Chunk::truncate`, which only existed for this.
- `FileResponseStream` implements the reader's `ref_` / `deref` (as `FileReader` does). The chunk that fills the window is now followed by `on_reader_done`, which releases the stream's owning ref, while the reader's read loop (POSIX) or libuv completion (Windows, which re-checks the reader's flags after delivering a data read) is still on the stack with the reader embedded in the stream; the pin keeps the stream alive until those frames return. This is the job the queued task used to do.
- Why this is the right place: the window is a bound on how many bytes may be taken out of the source, and on anything that is not seekable the bytes a read returns are gone, so the bound has to be applied to the read, and only the reader knows whether a read is needed at all. Reporting it as EOF is correct because for this reader the source does end there, and every consumer already handles EOF (real EOF and `maxBuffer` exhaustion end streams through the same path), which is what lets the two parent implementations (three code paths, two of which #39201 had to bring back into agreement) go away. For regular files the delivered bytes are unchanged; only the reads get shorter.
- Verified with `bun bd test test/js/bun/util/bun-stdin-slice.test.ts test/js/bun/http/serve-file-slice-read-error.test.ts`. The five new `bun-stdin-slice` cases run the slice in a grandchild sharing the child's stdin and then read what is left: a write larger than the window and an empty window with nothing written, each via `stream()` and via HTMLRewriter, plus a window filled by a write larger than its remainder. With `src/` stashed, the three over-read cases get `""` instead of `3456789` / `456` back and the two empty-window cases time out; with the fix all pass on Linux and on a Windows x64 debug build (the block is not Windows-skipped; the same protocol reproduces the over-read with the current Windows canary). `serve-file-slice-read-error.test.ts` kept its ptrace read counter: 3 responses now take 3 `read()`s and the EIO injected into the second one fails that response alone (`DONE 2`); without the fix it is 6 reads and `DONE 3`.
- Also run with the fix: `blob.test.ts` (the #39201 window cases: `read_into`, sink, Windows `on_read_chunk`, empty window on a regular file), `bun-serve-file`, `bun-serve-static`, `serve-directory-routes` (empty files give `FileResponseStream` a zero length), `bun-file*`, `spawn.test.ts`, `spawn-maxbuf` (the budget shares `read_once` / `on_read`), `spawn-streaming-stdout`, `spawn-stream-serve`, `spawn-stdout-filereader-gc-uaf`, `streams.test.js`, `html-rewriter*`, `body*.test.ts`, `process-stdin`, `bun-write`; on Windows additionally `blob`, `bun-serve-file`, `bun-serve-static`, `spawn-maxbuf`, `bun-file*`. `cargo fmt` clean.

### Background
- `BufferedReader` (`src/io/PipeReader.rs`, one POSIX and one libuv implementation behind a cfg alias) reads an fd on behalf of a parent embedded around it and reports through a vtable: `on_read_chunk` per read, then `on_reader_done` at EOF or `on_reader_error`. `FileReader` is the parent behind a file-backed `ReadableStream` (`Bun.file().stream()`, `new Response(file).body`, the stream a native sink such as HTMLRewriter or a fetch body pulls from); `FileResponseStream` is the parent that writes a `Bun.serve` file body to the socket.
- A file blob carries an offset and a size; for a slice these describe the window. `ReadableStream::from_blob_copy_ref` copies them into `FileReader` as `start_offset` / `max_size`; `Bun.serve` computes the body's offset and length from the blob (or a Range header) and passes them to `FileResponseStream`. The offset was already the reader's job (`start_file_offset`); this PR gives it the length as well.
- On POSIX a pollable fd (pipe, socket, tty) is read when its poll fires, from the reader's own loop; a regular file is read synchronously when the parent asks (`read`, or `read_into` straight into the JS pull buffer). `FileReader::on_pull` only uses `read_into` when no poll is registered, which is why a window applied there never affected pollable sources. On Windows every read completes through libuv into a buffer the reader allocates up front, so that allocation is where a read's size is decided.
- `ref_` / `deref` on the parent vtable are taken by the reader around a read dispatch (`ParentKeepAlive`) because the reader touches its own fields after calling into the parent; a parent whose `on_reader_done` can free it needs them so that free happens after the dispatch returns. `maxBuffer` (`MaxBuf`) is the reader's other byte bound; the limit is charged and reported alongside it.

<details>
<summary>Related open PRs</summary>

- #39257 (alii) fixes the empty-window hang inside `FileReader` with the helpers this PR deletes; if it lands first this PR will be rebased to drop those two guards (the reader covers them) and keep its tests, which pass here as well. The over-read is not covered there.
- #31680 and #33510 are about the buffered (`.text()` / `.arrayBuffer()`) path in `blob/read_file.rs`, which does not use `BufferedReader`; #31680's `FileReader.rs` hunk was made unnecessary by #39201.
- #34185 wanted `FileResponseStream`'s remaining count to tell a short file from a complete one; with this PR that is the bytes it has written versus the length it was given.
</details>
