### PR TITLE
bun-types: type Subprocess.stderr as undefined when the stderr option is undefined

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7119,11 +7119,12 @@ declare module "bun" {
        *
        * For stdout and stderr you may pass:
        *
-       * - `"pipe"`, `undefined`: The process has a {@link ReadableStream} for standard output/error
+       * - `"pipe"`: The process has a {@link ReadableStream} for standard output/error
        * - `"ignore"`, `null`: The process has no standard output/error
        * - `"inherit"`: The process inherits the standard output/error of the current process
        * - `ArrayBufferView`: The process writes to the preallocated buffer. Not implemented.
        * - `number`: The process writes to the file descriptor
+       * - `undefined`: The default for that position, see below
        *
        * At indices >= 3, `"socket-fd"` (POSIX only) is also accepted:
        * creates a socketpair like `"pipe"`, but the parent-end fd exposed
@@ -7152,11 +7153,12 @@ declare module "bun" {
       /**
        * The file descriptor for the standard output. It may be:
        *
-       * - `"pipe"`, `undefined`: The process has a {@link ReadableStream} for standard output/error
+       * - `"pipe"`: The process has a {@link ReadableStream} for standard output/error
        * - `"ignore"`, `null`: The process has no standard output/error
        * - `"inherit"`: The process inherits the standard output/error of the current process
        * - `ArrayBufferView`: The process writes to the preallocated buffer. Not implemented.
        * - `number`: The process writes to the file descriptor
+       * - `undefined`: The default below
        *
        * @default "pipe"
        */
@@ -7164,11 +7166,13 @@ declare module "bun" {
       /**
        * The file descriptor for the standard error. It may be:
        *
-       * - `"pipe"`, `undefined`: The process has a {@link ReadableStream} for standard output/error
+       * - `"pipe"`: The process has a {@link ReadableStream} for standard output/error
        * - `"ignore"`, `null`: The process has no standard output/error
        * - `"inherit"`: The process inherits the standard output/error of the current process
        * - `ArrayBufferView`: The process writes to the preallocated buffer. Not implemented.
        * - `number`: The process writes to the file descriptor
+       * - `undefined`: The default below, so with {@link spawn} the process inherits standard error
+       *   and {@link Subprocess.stderr} is `undefined`
        *
        * @default "inherit" for `spawn`
        * "pipe" for `spawnSync`
@@ -7436,11 +7440,22 @@ declare module "bun" {
       terminal?: TerminalOptions | Terminal;
     }
 
-    type ReadableToIO<X extends Readable> = X extends "pipe" | undefined
-      ? ReadableStream<Uint8Array<ArrayBuffer>>
-      : X extends BunFile | ArrayBufferView | number
-        ? number
-        : undefined;
+    /**
+     * The type of {@link Subprocess.stdout} / {@link Subprocess.stderr} for a `stdout` / `stderr`
+     * option of type `X`.
+     *
+     * An `undefined` option means the slot's default, and {@link spawn} has a different default
+     * for each slot: `"pipe"` for stdout, `"inherit"` for stderr. `Default` is that slot default,
+     * so `ReadableToIO<undefined, "pipe">` (stdout) is a {@link ReadableStream} and
+     * `ReadableToIO<undefined, "inherit">` (stderr) is `undefined`.
+     */
+    type ReadableToIO<X extends Readable, Default extends Exclude<Readable, undefined> = "pipe"> = X extends undefined
+      ? ReadableToIO<Default>
+      : X extends "pipe"
+        ? ReadableStream<Uint8Array<ArrayBuffer>>
+        : X extends BunFile | ArrayBufferView | number
+          ? number
+          : undefined;
 
     type ReadableToSyncIO<X extends Readable> = X extends "pipe" | undefined ? Buffer : undefined;
 
@@ -7545,8 +7560,8 @@ declare module "bun" {
     Err extends SpawnOptions.Readable = SpawnOptions.Readable,
   > extends AsyncDisposable {
     readonly stdin: SpawnOptions.WritableToIO<In>;
-    readonly stdout: SpawnOptions.ReadableToIO<Out>;
-    readonly stderr: SpawnOptions.ReadableToIO<Err>;
+    readonly stdout: SpawnOptions.ReadableToIO<Out, "pipe">;
+    readonly stderr: SpawnOptions.ReadableToIO<Err, "inherit">;
 
     /**
      * The terminal attached to this subprocess, if spawned with the `terminal` option.
@@ -7583,7 +7598,7 @@ declare module "bun" {
      *
      * Exists for compatibility with {@link ReadableStream.pipeThrough}
      */
-    readonly readable: SpawnOptions.ReadableToIO<Out>;
+    readonly readable: SpawnOptions.ReadableToIO<Out, "pipe">;
 
     /**
      * The process ID of the child process

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,6 +400,35 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Also runs on debug builds, where the in-process typeTest cases (which cover the whole
+  // fixture directory) are skipped: checks fixture/spawn.ts alone against the packed bun-types.
+  describe("Bun.spawn", () => {
+    test("fixture/spawn.ts type-checks", async () => {
+      const checkDir = join(TEMP_DIR, "spawn-fixture-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.files = [join(BASE_FIXTURE_DIR, "spawn.ts")];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -188,6 +188,45 @@ tsd.expectAssignable<NullSubprocess>(Bun.spawn([], { stdio: [null, null, null] }
 
 tsd.expectAssignable<SyncSubprocess<Bun.SpawnOptions.Readable, Bun.SpawnOptions.Readable>>(Bun.spawnSync([], {}));
 
+// Lazy option types (async only)
+{
+  // valid: lazy usable with async spawn
+  const p1 = Bun.spawn(["echo", "hello"], {
+    stdout: "pipe",
+    stderr: "pipe",
+    lazy: true,
+  });
+  tsd.expectType(p1.stdout).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+}
+
+{
+  // valid: lazy false is also allowed
+  const p2 = Bun.spawn(["echo", "hello"], {
+    stdout: "pipe",
+    stderr: "pipe",
+    lazy: false,
+  });
+  tsd.expectType(p2.stderr).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+}
+
+{
+  // invalid: lazy is not supported in spawnSync
+  Bun.spawnSync(["echo", "hello"], {
+    stdout: "pipe",
+    stderr: "pipe",
+    // @ts-expect-error lazy applies only to async spawn
+    lazy: true,
+  });
+}
+
+{
+  // invalid: lazy is not supported in spawnSync (object overload)
+  // prettier-ignore
+  // @ts-expect-error lazy applies to async spawn
+  Bun.spawnSync({ cmd: ["echo", "hello"], stdout: "pipe", stderr: "pipe", lazy: true,
+  });
+}
+
 // An undefined stdout/stderr option means that slot's default, which differs between the two slots
 // of Bun.spawn: stdout defaults to "pipe", stderr to "inherit" (so proc.stderr is undefined).
 // Bun.spawnSync defaults both to "pipe".
@@ -262,42 +301,3 @@ tsd.expectType<Bun.Spawn.ReadableToIO<undefined, "inherit">>().is<undefined>();
 tsd
   .expectType<Bun.Spawn.ReadableToIO<"pipe" | undefined, "inherit">>()
   .is<ReadableStream<Uint8Array<ArrayBuffer>> | undefined>();
-
-// Lazy option types (async only)
-{
-  // valid: lazy usable with async spawn
-  const p1 = Bun.spawn(["echo", "hello"], {
-    stdout: "pipe",
-    stderr: "pipe",
-    lazy: true,
-  });
-  tsd.expectType(p1.stdout).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
-}
-
-{
-  // valid: lazy false is also allowed
-  const p2 = Bun.spawn(["echo", "hello"], {
-    stdout: "pipe",
-    stderr: "pipe",
-    lazy: false,
-  });
-  tsd.expectType(p2.stderr).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
-}
-
-{
-  // invalid: lazy is not supported in spawnSync
-  Bun.spawnSync(["echo", "hello"], {
-    stdout: "pipe",
-    stderr: "pipe",
-    // @ts-expect-error lazy applies only to async spawn
-    lazy: true,
-  });
-}
-
-{
-  // invalid: lazy is not supported in spawnSync (object overload)
-  // prettier-ignore
-  // @ts-expect-error lazy applies to async spawn
-  Bun.spawnSync({ cmd: ["echo", "hello"], stdout: "pipe", stderr: "pipe", lazy: true,
-  });
-}

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -188,6 +188,81 @@ tsd.expectAssignable<NullSubprocess>(Bun.spawn([], { stdio: [null, null, null] }
 
 tsd.expectAssignable<SyncSubprocess<Bun.SpawnOptions.Readable, Bun.SpawnOptions.Readable>>(Bun.spawnSync([], {}));
 
+// An undefined stdout/stderr option means that slot's default, which differs between the two slots
+// of Bun.spawn: stdout defaults to "pipe", stderr to "inherit" (so proc.stderr is undefined).
+// Bun.spawnSync defaults both to "pipe".
+//
+// Without exactOptionalPropertyTypes, TypeScript drops undefined from a union passed to the optional
+// `stderr` property (`stderr: cond ? "pipe" : undefined` infers Err = "pipe"), so the union case is
+// asserted through the stdio tuple and through explicit type arguments below.
+declare const pipeWhenCapturing: boolean;
+{
+  const proc = Bun.spawn(["cat"], { stderr: undefined });
+  tsd.expectType(proc).is<Bun.Subprocess<"ignore", "pipe", undefined>>();
+  tsd.expectType(proc.stderr).is<undefined>();
+}
+{
+  const proc = Bun.spawn({ cmd: ["cat"], stderr: undefined });
+  tsd.expectType(proc.stderr).is<undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], { stdout: undefined });
+  tsd.expectType(proc).is<Bun.Subprocess<"ignore", undefined, "inherit">>();
+  tsd.expectType(proc.stdout).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+  tsd.expectType(proc.readable).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+}
+{
+  const proc = Bun.spawn(["cat"], { stdio: [undefined, undefined, undefined] });
+  tsd.expectType(proc.stdin).is<undefined>();
+  tsd.expectType(proc.stdout).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+  tsd.expectType(proc.stderr).is<undefined>();
+}
+{
+  const proc = Bun.spawn(["cat"], {
+    stdio: ["ignore", pipeWhenCapturing ? "pipe" : undefined, pipeWhenCapturing ? "pipe" : undefined],
+  });
+  tsd.expectType(proc).is<Bun.Subprocess<"ignore", "pipe" | undefined, "pipe" | undefined>>();
+  tsd.expectType(proc.stdout).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+  tsd.expectType(proc.stderr).is<ReadableStream<Uint8Array<ArrayBuffer>> | undefined>();
+}
+{
+  Bun.spawn(["cat"], {
+    stderr: undefined,
+    onExit(proc) {
+      tsd.expectType(proc.stderr).is<undefined>();
+    },
+    ipc(message, proc) {
+      tsd.expectType(proc.stderr).is<undefined>();
+    },
+  });
+}
+{
+  const proc = Bun.spawnSync(["cat"], { stdout: undefined, stderr: undefined });
+  tsd.expectType(proc.stdout).is<Buffer>();
+  tsd.expectType(proc.stderr).is<Buffer>();
+}
+{
+  const proc = Bun.spawnSync(["cat"], { stdio: ["ignore", undefined, undefined] });
+  tsd.expectType(proc.stdout).is<Buffer>();
+  tsd.expectType(proc.stderr).is<Buffer>();
+}
+tsd
+  .expectType<Bun.Subprocess<"ignore", "pipe", "pipe" | undefined>["stderr"]>()
+  .is<ReadableStream<Uint8Array<ArrayBuffer>> | undefined>();
+tsd
+  .expectType<Bun.Subprocess<"ignore", "pipe" | undefined, "inherit">["stdout"]>()
+  .is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+tsd.expectType<NullSubprocess["stderr"]>().is<undefined>();
+// Configurations that are not known statically still see every possible value.
+tsd.expectType<Bun.Subprocess["stderr"]>().is<ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined>();
+tsd.expectType<WritableSubprocess["stderr"]>().is<ReadableStream<Uint8Array<ArrayBuffer>> | number | undefined>();
+// The one-parameter form of the alias keeps stdout's default.
+tsd.expectType<Bun.Spawn.ReadableToIO<undefined>>().is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+tsd.expectType<Bun.Spawn.ReadableToIO<undefined, "inherit">>().is<undefined>();
+tsd
+  .expectType<Bun.Spawn.ReadableToIO<"pipe" | undefined, "inherit">>()
+  .is<ReadableStream<Uint8Array<ArrayBuffer>> | undefined>();
+
 // Lazy option types (async only)
 {
   // valid: lazy usable with async spawn


### PR DESCRIPTION
### Problem
- `Bun.spawn(cmd, { stderr: undefined })` types `proc.stderr` as `ReadableStream<Uint8Array<ArrayBuffer>>`; at runtime (bun 1.4.0) it is `undefined`, so `proc.stderr.text()` type-checks and throws. The same happens with `stdio: [.., .., undefined]`, with the `Subprocess` passed to `onExit` / `ipc`, with `Subprocess<In, Out, "pipe" | undefined>["stderr"]` (a plain `ReadableStream`, also what `stderr: cond ? "pipe" : undefined` infers under `exactOptionalPropertyTypes`), and with `NullSubprocess["stderr"]` (`ReadableStream | undefined`).
- Cause: `Spawn.ReadableToIO` (`packages/bun-types/bun.d.ts:7439`) maps the option type `"pipe" | undefined` to `ReadableStream`, and `Subprocess` uses it for both `stdout` and `stderr` (`bun.d.ts:7548-7549`). An `undefined` option means "use this slot's default", and the two slots have different defaults: the runtime starts from `[Ignore, Pipe, Inherit]` for `spawn` (`src/runtime/api/bun/js_bun_spawn_bindings.rs:361-366`), an `undefined` option leaves that default in place (`spawn/stdio.rs:422-424`), and an inherited stream reads back as `undefined` (`subprocess/Readable.rs:266`). The alias dates from when the declarations modelled the stderr default as `"pipe"` (#1501); #2573 and later #19162 changed the omitted-option default to `"inherit"` without touching this arm.
- The JSDoc on the `stdio`, `stdout` and `stderr` options made the same claim (`"pipe"`, `undefined`: the process has a ReadableStream).

### Fix
- `ReadableToIO<X, Default = "pipe">`: an `undefined` `X` resolves to `ReadableToIO<Default>`; the other arms are unchanged. `Subprocess.stdout` and `.readable` pass `"pipe"`, `Subprocess.stderr` passes `"inherit"`. The option JSDoc lists `undefined` as "the default below" instead of grouping it with `"pipe"`.
- Correct because a `Subprocess` only ever comes from `Bun.spawn` (`js_bun_spawn_bindings.rs:1670` is the single construction site; `spawnSync` returns a plain object typed `SyncSubprocess`, the shell uses an internal type), so its stderr slot always defaults to `"inherit"`. `ReadableToSyncIO` is untouched because `spawnSync` defaults both slots to `"pipe"`; `WritableToIO` is untouched because stdin's default (`"ignore"`) already maps to `undefined`.
- Why it is worth having on its own: the declaration is unsound (it accepts code that throws), the correction is the one place in the declarations that can know the slot, and it costs nothing elsewhere. `Default` defaults to `"pipe"`, so `Bun.Spawn.ReadableToIO<X>` in user code keeps its meaning, and the holder unions do not move (`Subprocess["stdout"]` / `["stderr"]` and `WritableSubprocess["stderr"]` stay `ReadableStream | number | undefined`; pinned in the fixture). Type-checking `test/`, `src/js` and `src/` against the changed declarations produces exactly the same diagnostics as before.
- Limit: `stderr: cond ? "pipe" : undefined` as a named option still infers `Err = "pipe"` under default compiler options, because TypeScript drops `undefined` when inferring through an optional property; no declaration shape changes that. It is fixed under `exactOptionalPropertyTypes`, and the same union through the `stdio` tuple or explicit type arguments is fixed under any options (both asserted).
- Verified: `test/integration/bun-types/fixture/spawn.ts` asserts `stderr: undefined` / `stdout: undefined` through both `spawn` overloads, the `stdio` tuple (literal `undefined` and `"pipe" | undefined`), the `onExit` / `ipc` argument, explicit `Subprocess<...>` arguments, `NullSubprocess["stderr"]`, both forms of the alias, and `spawnSync` with `undefined` options (still `Buffer`). Against the unfixed `bun.d.ts` these lines produce 10 diagnostics (below; spawn.ts:241-302); with the fix `bun test test/integration/bun-types/bun-types.test.ts` passes all 16 cases (tsc with and without lib.dom, and tsgo). That file is what `.github/workflows/bun-types.yml` runs, so CI checks the new lines through the existing whole-fixture cases.
- `bun-types.test.ts` also gains a case running tsc over `fixture/spawn.ts` alone, because under a debug build (`bun bd test`) the whole-fixture cases are skipped and nothing else would exercise the fixture; it fails without the `bun.d.ts` change and passes with it. It is byte-identical to the block #39283 carries (one hunk for git), and it is interim: #39270 replaces this per-file pattern with one whole-fixture check that runs on debug builds too, plus a lint holding `bun-types.test.ts` to a single compiler spawn. If #39270 lands first, this block is dropped from here on rebase and the fixture lines are covered by its case; if this lands first, #39270's lint flags the block on its rebase and it goes out with the `Bun.mmap` block #39270 already removes. Either way nothing from it survives.
- Overlap with #39283, which rewrites the other arms of these aliases and explicitly leaves this arm out: `git merge-tree` of the two branches conflicts only in the alias declaration and the `Subprocess.stdout` / `stderr` members (where #39283 adds JSDoc), and the changes compose. Whichever lands second resolves it by adding the `Default` parameter and the `X extends undefined ? ReadableToIO<Default>` arm in front of #39283's arms, passing `"pipe"` / `"inherit"` on the three `Subprocess` members, and merging the two alias doc comments; the option JSDoc and the fixture additions (appended at the end of `spawn.ts`) merge on their own. The branch merges cleanly with #39279 and #39270.
- Adjacent declaration issues found while here and tracked separately, not changed by this PR: `NullSubprocess` / `NullSyncSubprocess` list `undefined` in parameters whose default is `"pipe"` (so `NullSubprocess["stdout"]` stays `ReadableStream | undefined`), and the `terminal` option makes all three stdio properties `null` at runtime, which none of the mapping types model.

### Background
- `Bun.spawn` infers one type parameter per stdio slot (`In`, `Out`, `Err`) from the `stdin` / `stdout` / `stderr` options or the `stdio` tuple. A parameter whose option is omitted takes the declared default (`"ignore"`, `"pipe"`, `"inherit"`); an option that is present but `undefined` makes the parameter `undefined` itself. `Subprocess<In, Out, Err>` then derives each property's type with a conditional type alias, which is therefore the place where an `undefined` parameter has to be turned back into that slot's default.
- These aliases are distributive: applied to a union they map each member and union the results. That is why `"pipe" | undefined` becomes `ReadableStream | undefined` for stderr, and why the unconstrained holder type `Subprocess` (every option at once) still lists every possible value.

<details>
<summary>Diagnostics the new fixture lines produce against the unfixed bun.d.ts</summary>

```
spawn.ts(241,34): error TS2344: Type 'undefined' does not satisfy the constraint 'ReadableStream<Uint8Array<ArrayBuffer>>'.
spawn.ts(245,34): error TS2344: Type 'undefined' does not satisfy the constraint 'ReadableStream<Uint8Array<ArrayBuffer>>'.
spawn.ts(257,34): error TS2344: Type 'undefined' does not satisfy the constraint 'ReadableStream<Uint8Array<ArrayBuffer>>'.
spawn.ts(265,34): error TS2344: Type 'ReadableStream<Uint8Array<ArrayBuffer>> | undefined' does not satisfy the constraint 'ReadableStream<Uint8Array<ArrayBuffer>>'.
  Type 'undefined' is not assignable to type 'ReadableStream<Uint8Array<ArrayBuffer>>'.
spawn.ts(271,38): error TS2344: Type 'undefined' does not satisfy the constraint 'ReadableStream<Uint8Array<ArrayBuffer>>'.
spawn.ts(274,38): error TS2344: Type 'undefined' does not satisfy the constraint 'ReadableStream<Uint8Array<ArrayBuffer>>'.
spawn.ts(290,7): error TS2344: Type 'ReadableStream<Uint8Array<ArrayBuffer>> | undefined' does not satisfy the constraint 'ReadableStream<Uint8Array<ArrayBuffer>>'.
  Type 'undefined' is not assignable to type 'ReadableStream<Uint8Array<ArrayBuffer>>'.
spawn.ts(294,44): error TS2554: Expected 2 arguments, but got 0.
spawn.ts(300,16): error TS2314: Generic type 'ReadableToIO' requires 1 type argument(s).
spawn.ts(302,15): error TS2314: Generic type 'ReadableToIO' requires 1 type argument(s).
```
</details>

<details>
<summary>Runtime probe (bun 1.4.0, linux x64)</summary>

```
spawn     stderr: undefined                 -> undefined
spawn     stdout: undefined                 -> ReadableStream
spawn     stdio: [undefined x3]             -> stdin undefined, stdout ReadableStream, stderr undefined
spawnSync stdout/stderr: undefined          -> Buffer, Buffer
spawnSync stdio: ["ignore", undef, undef]   -> Buffer, Buffer
```
</details>
