### PR TITLE
docs: fix Statement.all/get examples to show retained bound params

### DIFF
--- a/packages/bun-types/sqlite.d.ts
+++ b/packages/bun-types/sqlite.d.ts
@@ -628,7 +628,7 @@ declare module "bun:sqlite" {
      * // => [{bar: "baz"}]
      *
      * stmt.all();
-     * // => []
+     * // => [{bar: "baz"}]
      *
      * stmt.all("foo");
      * // => [{bar: "foo"}]
@@ -651,7 +651,7 @@ declare module "bun:sqlite" {
      * // => {bar: "baz"}
      *
      * stmt.get();
-     * // => null
+     * // => {bar: "baz"}
      *
      * stmt.get("foo");
      * // => {bar: "foo"}


### PR DESCRIPTION
Fixes #26622

When `params` are omitted, the statement is run with the **last bound values** (as the `@param` docs already state, and as the `values()`/`raw()` examples already show). The `all()` and `get()` examples incorrectly claimed that calling with no args after `stmt.all("baz")` / `stmt.get("baz")` returns `[]` / `null`.

Fixed examples now show the retained binding behavior, consistent with the `values()` example:

```ts
const stmt = db.prepare("SELECT * FROM foo WHERE bar = ?");

stmt.get("baz");
// => {bar: "baz"}

stmt.get();
// => {bar: "baz"}

stmt.get("foo");
// => {bar: "foo"}
```