### PR TITLE
node errors: give AbortError a real constructor so util.inspect prints its class name

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -200,10 +200,7 @@ static Structure* createErrorStructure(JSC::VM& vm, JSGlobalObject* globalObject
     const auto& data = errors[static_cast<size_t>(code)];
     auto* prototype = createErrorPrototype(vm, globalObject, data.type, data.name, data.code);
 
-    // Node's ERR_* errors are plain Error/TypeError/RangeError instances carrying a `code`, so those
-    // prototypes keep inheriting `constructor` from the base error. AbortError is a real
-    // `class AbortError extends Error` in Node, and util.inspect() / determineSpecificType() print
-    // the name of `err.constructor`, so its shared prototype gets the shape that class would have.
+    // Node's AbortError is a class of its own; its ERR_* errors keep the base error's `constructor`.
     if (code == ErrorCode::ABORT_ERR) {
         auto* constructor = JSC::JSFunction::create(vm, globalObject, 0, "AbortError"_s, jsFunctionMakeAbortError, JSC::ImplementationVisibility::Public, JSC::NoIntrinsic, jsFunctionMakeAbortError);
         constructor->setPrototypeDirect(vm, globalObject->errorConstructor());

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -195,13 +195,32 @@ static Structure* createErrorStructure(JSC::VM& vm, JSGlobalObject* globalObject
     return ErrorInstance::createStructure(vm, globalObject, prototype);
 }
 
+static Structure* createErrorStructure(JSC::VM& vm, JSGlobalObject* globalObject, ErrorCode code)
+{
+    const auto& data = errors[static_cast<size_t>(code)];
+    auto* prototype = createErrorPrototype(vm, globalObject, data.type, data.name, data.code);
+
+    // Node's ERR_* errors are plain Error/TypeError/RangeError instances carrying a `code`, so those
+    // prototypes keep inheriting `constructor` from the base error. AbortError is a real
+    // `class AbortError extends Error` in Node, and util.inspect() / determineSpecificType() print
+    // the name of `err.constructor`, so its shared prototype gets the shape that class would have.
+    if (code == ErrorCode::ABORT_ERR) {
+        auto* constructor = JSC::JSFunction::create(vm, globalObject, 0, "AbortError"_s, jsFunctionMakeAbortError, JSC::ImplementationVisibility::Public, JSC::NoIntrinsic, jsFunctionMakeAbortError);
+        constructor->setPrototypeDirect(vm, globalObject->errorConstructor());
+        constructor->putDirect(vm, vm.propertyNames->prototype, prototype, JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly);
+        prototype->putDirect(vm, vm.propertyNames->constructor, constructor, JSC::PropertyAttribute::DontEnum | 0);
+    }
+
+    return ErrorInstance::createStructure(vm, globalObject, prototype);
+}
+
 JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, ErrorCode code, JSValue message, JSValue options)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* cache = errorCache(globalObject);
     const auto& data = errors[static_cast<size_t>(code)];
     if (!cache->internalField(static_cast<unsigned>(code))) {
-        auto* structure = createErrorStructure(vm, globalObject, data.type, data.name, data.code);
+        auto* structure = createErrorStructure(vm, globalObject, code);
         cache->internalField(static_cast<unsigned>(code)).set(vm, cache, structure);
     }
 
@@ -248,7 +267,7 @@ JSObject* createError(VM& vm, JSC::JSGlobalObject* globalObject, ErrorCode code,
     if (auto* zigGlobalObject = dynamicDowncast<Zig::GlobalObject>(globalObject))
         return createError(vm, zigGlobalObject, code, message, jsUndefined());
 
-    auto* structure = createErrorStructure(vm, globalObject, errors[static_cast<size_t>(code)].type, errors[static_cast<size_t>(code)].name, errors[static_cast<size_t>(code)].code);
+    auto* structure = createErrorStructure(vm, globalObject, code);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     String messageString = message.isUndefined() ? String() : message.toWTFString(globalObject);
     if (scope.exception() && !vm.hasPendingTerminationException())
@@ -1756,7 +1775,7 @@ extern "C" JSC::EncodedJSValue Bun__wrapAbortError(JSC::JSGlobalObject* lexicalG
     return JSC::JSValue::encode(error);
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsFunctionMakeAbortError, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
+JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeAbortError, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callFrame))
 {
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1782,7 +1782,8 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeAbortError, (JSC::JSGlobalObject * l
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto message = callFrame->argument(0);
     auto options = callFrame->argument(1);
-    if (!options.isUndefined() && options.isCell() && !options.asCell()->isObject()) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, options);
+    // Node: `if (options !== undefined && typeof options !== 'object')`
+    if (!options.isUndefined() && !JSC::jsTypeofIsObject(lexicalGlobalObject, options)) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "options"_s, "object"_s, options);
 
     if (message.isUndefined() && options.isUndefined()) {
         return JSValue::encode(Bun::createError(vm, lexicalGlobalObject, Bun::ErrorCode::ABORT_ERR, JSValue(globalObject->commonStrings().OperationWasAbortedString(globalObject))));

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -69,6 +69,8 @@ JSObject* createInvalidThisError(JSGlobalObject* globalObject, JSValue thisValue
 JSObject* createInvalidThisError(JSGlobalObject* globalObject, const String& message);
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionMakeErrorWithCode);
+// `$makeAbortError` for the JS builtins, and the `constructor` of every ABORT_ERR error.
+JSC_DECLARE_HOST_FUNCTION(jsFunctionMakeAbortError);
 
 // Appends Node's `determineSpecificType()` rendering of a value ("type number (5)",
 // "an instance of Foo", ...) — the "Received ..." part of ERR_INVALID_ARG_TYPE messages.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -239,8 +239,6 @@ BUN_DECLARE_HOST_FUNCTION(BUN__HTTP2__getUnpackedSettings);
 BUN_DECLARE_HOST_FUNCTION(BUN__HTTP2_getPackedSettings);
 BUN_DECLARE_HOST_FUNCTION(BUN__HTTP2_assertSettings);
 
-JSC_DECLARE_HOST_FUNCTION(jsFunctionMakeAbortError);
-
 using JSGlobalObject = JSC::JSGlobalObject;
 using Exception = JSC::Exception;
 using JSValue = JSC::JSValue;

--- a/test/js/node/errors/abort-error-constructor.test.ts
+++ b/test/js/node/errors/abort-error-constructor.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter, once } from "node:events";
+import { readFile } from "node:fs/promises";
+import { setTimeout as sleep } from "node:timers/promises";
+import { inspect } from "node:util";
+
+// Node's AbortError is `class AbortError extends Error` (lib/internal/errors.js), so
+// `err.constructor` is a function named AbortError. Bun builds these errors natively
+// (ErrorCode.cpp) from two entry points, `$makeAbortError` in the JS builtins and
+// `Bun__wrapAbortError` for Rust callers; both must produce the same class shape.
+// Except for the bun:test formatting case, every assertion here also holds on Node v26.
+
+async function rejection(promise: Promise<unknown>): Promise<any> {
+  try {
+    await promise;
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected the operation to reject");
+}
+
+function thrown(fn: () => unknown): any {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected the operation to throw");
+}
+
+async function abortErrors() {
+  const signal = AbortSignal.abort();
+  return {
+    // $makeAbortError (JS builtins)
+    "timers/promises": await rejection(sleep(1, undefined, { signal })),
+    "events.once": await rejection(once(new EventEmitter(), "never", { signal })),
+    // Bun__wrapAbortError (Rust callers)
+    "fs.promises.readFile": await rejection(readFile(import.meta.path, { signal })),
+    "Bun.spawn": thrown(() => Bun.spawn({ cmd: ["this-command-is-never-spawned"], signal })),
+  };
+}
+
+describe("node-style AbortError", () => {
+  test("util.inspect prints it under its own class name", async () => {
+    const errors = await abortErrors();
+    const firstLines = Object.fromEntries(
+      Object.entries(errors).map(([producer, err]) => [producer, inspect(err).split("\n")[0]]),
+    );
+    expect(firstLines).toEqual({
+      "timers/promises": "AbortError: The operation was aborted",
+      "events.once": "AbortError: The operation was aborted",
+      "fs.promises.readFile": "AbortError: The operation was aborted",
+      "Bun.spawn": "AbortError: The operation was aborted",
+    });
+  });
+
+  test("every producer shares one AbortError class", async () => {
+    const errors = await abortErrors();
+    const AbortError = errors["timers/promises"].constructor;
+    const prototype = Object.getPrototypeOf(errors["timers/promises"]);
+
+    for (const err of Object.values(errors)) {
+      expect(err.constructor).toBe(AbortError);
+      expect(err).toBeInstanceOf(AbortError);
+      expect(Object.getPrototypeOf(err)).toBe(prototype);
+    }
+
+    expect(AbortError).not.toBe(Error);
+    expect({ name: AbortError.name, length: AbortError.length }).toEqual({ name: "AbortError", length: 0 });
+    expect(AbortError.prototype).toBe(prototype);
+    expect(Object.getPrototypeOf(AbortError)).toBe(Error);
+    expect(Object.getPrototypeOf(prototype)).toBe(Error.prototype);
+
+    // Same attributes `class AbortError extends Error {}` would produce.
+    const { value: constructorValue, ...constructorAttributes } = Object.getOwnPropertyDescriptor(
+      prototype,
+      "constructor",
+    )!;
+    expect(constructorValue).toBe(AbortError);
+    expect(constructorAttributes).toEqual({ writable: true, enumerable: false, configurable: true });
+    const { value: prototypeValue, ...prototypeAttributes } = Object.getOwnPropertyDescriptor(AbortError, "prototype")!;
+    expect(prototypeValue).toBe(prototype);
+    expect(prototypeAttributes).toEqual({ writable: false, enumerable: false, configurable: false });
+  });
+
+  test("err.constructor constructs AbortErrors", async () => {
+    const { "timers/promises": err } = await abortErrors();
+    const AbortError = err.constructor;
+    const cause = new Error("why");
+
+    const custom = new AbortError("custom message", { cause });
+    expect(custom).toBeInstanceOf(AbortError);
+    expect({ name: custom.name, code: custom.code, message: custom.message, cause: custom.cause }).toEqual({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      message: "custom message",
+      cause,
+    });
+    expect(inspect(custom).split("\n")[0]).toBe("AbortError: custom message");
+
+    const defaults = new AbortError();
+    expect(defaults).toBeInstanceOf(AbortError);
+    expect({ name: defaults.name, code: defaults.code, message: defaults.message, cause: defaults.cause }).toEqual({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      message: "The operation was aborted",
+      cause: undefined,
+    });
+
+    const invalid = thrown(() => new AbortError("message", "not an object"));
+    expect({ name: invalid.name, code: invalid.code, message: invalid.message }).toEqual({
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "options" argument must be of type object. Received type string ('not an object')`,
+    });
+  });
+
+  test("ERR_INVALID_ARG_TYPE describes it as an instance of AbortError", async () => {
+    const { "fs.promises.readFile": err } = await abortErrors();
+    const invalid = thrown(() => Buffer.from(err));
+    expect({ code: invalid.code, message: invalid.message }).toEqual({
+      code: "ERR_INVALID_ARG_TYPE",
+      message:
+        "The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of AbortError",
+    });
+  });
+
+  test("bun:test formats it under its class name, like jest does for node's AbortError", async () => {
+    const { "events.once": err } = await abortErrors();
+    expect(err).toMatchInlineSnapshot(`[AbortError: The operation was aborted]`);
+  });
+
+  test("ERR_* errors still report the base constructor, like node", () => {
+    // Node keeps `constructor` pointing at the base class for its ERR_* codes; only
+    // AbortError is a class of its own.
+    const err = thrown(() => Buffer.from(1 as any));
+    expect({ code: err.code, constructor: err.constructor, name: err.name }).toEqual({
+      code: "ERR_INVALID_ARG_TYPE",
+      constructor: TypeError,
+      name: "TypeError",
+    });
+  });
+});

--- a/test/js/node/errors/abort-error-constructor.test.ts
+++ b/test/js/node/errors/abort-error-constructor.test.ts
@@ -107,11 +107,37 @@ describe("node-style AbortError", () => {
       cause: undefined,
     });
 
-    const invalid = thrown(() => new AbortError("message", "not an object"));
-    expect({ name: invalid.name, code: invalid.code, message: invalid.message }).toEqual({
+    const withNull = new AbortError("message", null);
+    expect(withNull).toBeInstanceOf(AbortError);
+    expect({ name: withNull.name, code: withNull.code, message: withNull.message, cause: withNull.cause }).toEqual({
+      name: "AbortError",
+      code: "ABORT_ERR",
+      message: "message",
+      cause: undefined,
+    });
+  });
+
+  test("err.constructor rejects options that are not typeof object", async () => {
+    const { "timers/promises": err } = await abortErrors();
+    const AbortError = err.constructor;
+    const rejected = Object.fromEntries(
+      Object.entries({ number: 42, boolean: true, string: "not an object", function: function named() {} }).map(
+        ([label, options]) => {
+          const invalid = thrown(() => new AbortError("message", options));
+          return [label, { name: invalid.name, code: invalid.code, message: invalid.message }];
+        },
+      ),
+    );
+    const typeError = (received: string) => ({
       name: "TypeError",
       code: "ERR_INVALID_ARG_TYPE",
-      message: `The "options" argument must be of type object. Received type string ('not an object')`,
+      message: `The "options" argument must be of type object. Received ${received}`,
+    });
+    expect(rejected).toEqual({
+      number: typeError("type number (42)"),
+      boolean: typeError("type boolean (true)"),
+      string: typeError("type string ('not an object')"),
+      function: typeError("function named"),
     });
   });
 

--- a/test/js/node/errors/abort-error-constructor.test.ts
+++ b/test/js/node/errors/abort-error-constructor.test.ts
@@ -120,13 +120,19 @@ describe("node-style AbortError", () => {
   test("err.constructor rejects options that are not typeof object", async () => {
     const { "timers/promises": err } = await abortErrors();
     const AbortError = err.constructor;
+    const values = {
+      number: 42,
+      boolean: true,
+      bigint: 0n,
+      string: "not an object",
+      symbol: Symbol("options"),
+      function: function named() {},
+    };
     const rejected = Object.fromEntries(
-      Object.entries({ number: 42, boolean: true, string: "not an object", function: function named() {} }).map(
-        ([label, options]) => {
-          const invalid = thrown(() => new AbortError("message", options));
-          return [label, { name: invalid.name, code: invalid.code, message: invalid.message }];
-        },
-      ),
+      Object.entries(values).map(([label, options]) => {
+        const invalid = thrown(() => new AbortError("message", options));
+        return [label, { name: invalid.name, code: invalid.code, message: invalid.message }];
+      }),
     );
     const typeError = (received: string) => ({
       name: "TypeError",
@@ -136,7 +142,9 @@ describe("node-style AbortError", () => {
     expect(rejected).toEqual({
       number: typeError("type number (42)"),
       boolean: typeError("type boolean (true)"),
+      bigint: typeError("type bigint (0n)"),
       string: typeError("type string ('not an object')"),
+      symbol: typeError("type symbol (Symbol(options))"),
       function: typeError("function named"),
     });
   });


### PR DESCRIPTION
### Problem
- `util.inspect()` of the `AbortError` that `timers/promises`, `events.once`, `fs.promises`, `stream`, `child_process` and `Bun.spawn({ signal })` produce prints `Error [AbortError]: The operation was aborted`; node prints `AbortError: The operation was aborted`. Same for everything built on `util.inspect`: `util.format('%o')`, `new Console(...)`, `node:assert` failure messages, the `node:test` reporter.
- `err.constructor` is `Error` (node: a function named `AbortError`), so `ERR_INVALID_ARG_TYPE` messages that receive one of these errors say `Received an instance of Error` (node: `an instance of AbortError`), via `determineSpecificType()` in src/jsc/bindings/ErrorCode.cpp:505.
- Cause: every `ABORT_ERR` error shares one prototype built by `createErrorPrototype` (src/jsc/bindings/ErrorCode.cpp:104). It carries `name` and `code` but no `constructor`, so the lookup falls through to `Error.prototype.constructor`. `util.inspect`'s `getConstructorName()` then reports `Error`, and `improveStack()` appends ` [AbortError]` because the reported constructor differs from `err.name`. The native `console.log` / `Bun.inspect` path reads `err.name` and was already right.

### Fix
- When the `ABORT_ERR` structure is built (`createErrorStructure`), create a function named `AbortError` and wire it the way `class AbortError extends Error {}` would be: `prototype.constructor` (non-enumerable), `AbortError.prototype` (non-writable, non-configurable), and `Error` as the function's `[[Prototype]]`. The function's construct behavior is the existing `jsFunctionMakeAbortError` host function (the one behind `$makeAbortError`), so `new err.constructor(message, { cause })` builds a regular `ABORT_ERR` error. Calling it without `new` runs the same builtin and returns an error too; node's class throws there, which nothing depends on, so that form is incidental and not tested. `jsFunctionMakeAbortError` moves into the `Bun` namespace and is declared in ErrorCode.h so both files share one declaration.
- Since that function is now reachable as `err.constructor`, its `options` check becomes node's `options !== undefined && typeof options !== 'object'` (`JSC::jsTypeofIsObject`). The old check only looked at heap cells, so a number, boolean or function as `options` was silently ignored; now it throws `ERR_INVALID_ARG_TYPE` with node's wording, and `null` is still accepted. No builtin passes anything other than `undefined` or an object literal.
- Matches node: its `AbortError` is a real class (`lib/internal/errors.js`), so `err.constructor.name === 'AbortError'`, `err instanceof err.constructor`, `Object.getPrototypeOf(err.constructor) === Error`, and one class is shared by every producer. Both of Bun's entry points (`$makeAbortError` from the JS builtins, `Bun__wrapAbortError` from Rust) go through the same cached structure, so one change covers all of the APIs above, and the non-cached fallback used for non-Bun globals takes the same path.
- Scoped to `ABORT_ERR` on purpose: node v26 explicitly sets `constructor` on its `ERR_*` prototypes back to the base class (`TypeError`, `RangeError`, ...), so `err.constructor === TypeError` holds there, which is what Bun's inherited lookup already gives and what vendored node tests (`test-worker-message-port*.js`, `test/js/bun/util/error-code-mirror.test.ts`) assert. The `constructor` property is non-enumerable, so `Bun.deepEquals` / `toEqual` between these errors, `for...in`, and `Object.keys` are unchanged.
- Other output that changes with it: bun:test's pretty-format renders these errors as `[AbortError: ...]` instead of `[Error: ...]` (jest prints node's `AbortError` the same way), and `toThrow()` mismatch messages name the received constructor `AbortError`.
- Test: test/js/node/errors/abort-error-constructor.test.ts creates the error through `timers/promises`, `events.once` (JS entry point), `fs.promises.readFile` and `Bun.spawn` (Rust entry point) and checks the `util.inspect` header, that all four share one class with the attributes a class declaration produces, `new err.constructor(...)` (custom message + cause, defaults, `null` options, and number / boolean / bigint / string / symbol / function options rejected with node's messages), the `ERR_INVALID_ARG_TYPE` wording, the bun:test rendering, and that an `ERR_*` error still reports `TypeError` as its constructor. Every assertion except the bun:test one was also run as a script against node v26.3.0.
  - `bun bd test test/js/node/errors/abort-error-constructor.test.ts`: 7 pass
  - same file without the `src/` change (rebuilt with it stashed, and again with the released 1.4.0 binary after the options test was added): 6 fail, 1 pass (the `ERR_*` control)
  - `bun bd test` on error-code-mirror, timers.promises, event-emitter, fs/promises, spawn-signal and the util-inspect/util-format ports: 144 pass, 1 timeout in util-inspect.test.js unrelated to this change (the machine was at load 40+; the file's CI budget is 1.5s)
  - the vendored node tests mentioning `AbortError` that also introspect the error (`test-stream-finished`, `test-stream-pipeline`, `test-stream-filter`, `test-stream-add-abort-signal`, `test-events-once`, `test-fs-promises-watch`, `test-whatwg-webstreams-adapters-to-writablestream`, `test-diagnostics-channel-http2-client-stream-error`) pass with the debug build

### Background
- `ErrorCodeCache` (ErrorCode.cpp): for each code in src/jsc/bindings/ErrorCode.ts, Bun lazily builds one prototype object (`name`, `code`, `toString`) and one JSC `Structure` whose prototype it is, and caches the structure per global object. Every error with that code is a JSC `ErrorInstance` created from that structure, so anything put on the prototype is shared by all of them, and `instanceof` against a function works as long as the function's `.prototype` is that object.
- `util.inspect` error header: `getConstructorName()` walks the prototype chain for an own `constructor` data property whose function has a non-empty name and which the value is an `instanceof`; `improveStack()` then prints `<constructor> [<name>]` whenever that constructor name differs from `err.name`. So fixing the header means giving the error a real constructor, not patching inspect.js (which is a port of node's code and behaves exactly like node given the same object).
- `JSC::JSFunction::create(..., nativeFunction, ..., nativeConstructor)`: a host function becomes constructible when a native constructor callback is supplied; `new F()` calls it and uses the object it returns, so one host function that always returns a fresh error serves both `F()` and `new F()`. Node's class is not exported, so `err.constructor` is the only way to reach this function; subclassing it is not supported (instances take the `ABORT_ERR` prototype regardless of `new.target`).
- Related open work that does not touch the constructor: #39280 (`toString()` bracket), #35934 (`.stack` header bracket), #35926 (own `code` property).
