### PR TITLE
bake: reject a function as a file system router style instead of panicking

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -970,7 +970,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
                     .iter()
                     .map(|e| Box::<[u8]>::from(e.as_ref()))
                     .collect(),
-                style: fsr.style.clone(),
+                style: fsr.style,
                 allow_layouts: fsr.allow_layouts,
                 server_file: to_opaque_file_id::<{ bake::Side::Server }>(server_file),
                 client_file: if let Some(client) = &fsr.entry_client {

--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -11,9 +11,7 @@ use bun_alloc::{AllocError, Arena, ArenaVec};
 use bun_collections::array_hash_map::ArrayHashContext;
 use bun_collections::{ArrayHashMap, BoundedArray, StringArrayHashMap};
 use bun_core::Output;
-use bun_jsc::{
-    CallFrame, JSGlobalObject, JSValue, JsClass, JsResult, StringJsc, Strong, StrongOptional,
-};
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsResult, StringJsc, StrongOptional};
 use bun_paths::{self as paths, MAX_PATH_BYTES, PathBuffer};
 use bun_resolver::{DirInfo, Resolver};
 
@@ -612,50 +610,32 @@ pub enum ParsedPatternKind {
     Extra,
 }
 
+#[derive(Copy, Clone)]
 pub enum Style {
     NextjsPages,
     NextjsAppUi,
     NextjsAppRoutes,
-    JavascriptDefined(Strong),
-}
-
-// The built-in styles are trivially copyable; the `JavascriptDefined` arm owns
-// a `Strong` (Drop type), so a shallow copy would double-free. That arm is an
-// unimplemented feature (`Style::from_js` never produces it), so cloning it is
-// unreachable today.
-impl Clone for Style {
-    fn clone(&self) -> Self {
-        match self {
-            Style::NextjsPages => Style::NextjsPages,
-            Style::NextjsAppUi => Style::NextjsAppUi,
-            Style::NextjsAppRoutes => Style::NextjsAppRoutes,
-            Style::JavascriptDefined(_) => {
-                panic!("TODO: customizable Style")
-            }
-        }
-    }
 }
 
 bun_core::comptime_string_map! {
-    pub(crate) static STYLE_MAP: fn() -> Style = {
-        b"nextjs-pages" => || Style::NextjsPages,
-        b"nextjs-app-ui" => || Style::NextjsAppUi,
-        b"nextjs-app-routes" => || Style::NextjsAppRoutes,
+    pub(crate) static STYLE_MAP: Style = {
+        b"nextjs-pages" => Style::NextjsPages,
+        b"nextjs-app-ui" => Style::NextjsAppUi,
+        b"nextjs-app-routes" => Style::NextjsAppRoutes,
     };
 }
 
-const STYLE_ERROR_MESSAGE: &str = "'style' must be either \"nextjs-pages\", \"nextjs-app-ui\", \"nextjs-app-routes\", or a function.";
+const STYLE_ERROR_MESSAGE: &str =
+    "'style' must be either \"nextjs-pages\", \"nextjs-app-ui\", or \"nextjs-app-routes\"";
 
 impl Style {
     pub fn from_js(value: JSValue, global: &JSGlobalObject) -> JsResult<Style> {
         if value.is_string() {
             let bun_string = bun_core::OwnedString::new(value.to_bun_string(global)?);
             let utf8 = bun_string.to_utf8();
-            if let Some(style) = STYLE_MAP.get(utf8.slice()) {
-                return Ok(style());
+            if let Some(&style) = STYLE_MAP.get(utf8.slice()) {
+                return Ok(style);
             }
-        } else if value.is_callable() {
-            return Ok(Style::JavascriptDefined(Strong::create(value, global)));
         }
 
         Err(global.throw_invalid_arguments(format_args!("{STYLE_ERROR_MESSAGE}")))
@@ -676,7 +656,7 @@ enum NextRoutingConvention {
 
 impl Style {
     pub(crate) fn parse<'bump>(
-        &self,
+        self,
         file_path: &'bump [u8],
         ext: &[u8],
         log: &mut TinyLog,
@@ -703,11 +683,6 @@ impl Style {
                 allow_layouts,
                 arena,
             ),
-
-            // The strategy for this should be to collect a list of candidates,
-            // then batch-call the javascript handler and collect all results.
-            // This will avoid most of the back-and-forth native<->js overhead.
-            Style::JavascriptDefined(_) => panic!("TODO: customizable Style"),
         }
     }
 
@@ -1794,8 +1769,6 @@ impl JSFrameworkRouter {
             opts.get(global, "style")?.unwrap_or(JSValue::UNDEFINED),
             global,
         )?;
-        // `Style` owns a `Strong` (Drop type), so `?` on any error path below
-        // drops it automatically.
 
         let abs_root: Box<[u8]> = strings::without_trailing_slash(paths::resolve_path::join_abs::<
             paths::platform::Auto,
@@ -1991,7 +1964,6 @@ impl JSFrameworkRouter {
         let [style_js, filepath_js] = frame.arguments_as_array::<2>();
         let filepath = filepath_js.to_slice(global)?;
         let style = Style::from_js(style_js, global)?;
-        // errdefer style.deinit() — Drop handles this
 
         let mut log = TinyLog::empty();
         let parsed = match style.parse(

--- a/src/runtime/bake/bake.d.ts
+++ b/src/runtime/bake/bake.d.ts
@@ -293,7 +293,7 @@ declare module "bun" {
        *
        * Eventually, an API will be added to add custom styles.
        */
-      style: "nextjs-pages" | "nextjs-app-ui" | "nextjs-app-routes" | CustomFileSystemRouterFunction;
+      style: "nextjs-pages" | "nextjs-app-ui" | "nextjs-app-routes"; // | CustomFileSystemRouterFunction;
       /**
        * If true, this will track route layouts and provide them as an array during SSR.
        * @default false
@@ -328,30 +328,30 @@ declare module "bun" {
           prefix: string;
         };
 
-    /**
-     * Bun will call this function for every found file. This
-     * function classifies each file's role in the file system routing.
-     */
-    type CustomFileSystemRouterFunction = (candidatePath: string) => CustomFileSystemRouterResult;
-
-    type CustomFileSystemRouterResult =
-      /** Skip this file */
-      | undefined
-      | null
-      /**
-       * Use this file as a route. Routes may nest, where a framework
-       * can use parent routes to implement layouts.
-       */
-      | {
-          /**
-           * Route pattern can include `:param` for parameters, '*' for
-           * catch-all, and '*?' for optional catch-all. Parameters must take
-           * the full component of a path segment. Parameters cannot have
-           * constraints at this moment.
-           */
-          pattern: string;
-          type: "route" | "layout" | "extra";
-        };
+    // /**
+    //  * Bun will call this function for every found file. This
+    //  * function classifies each file's role in the file system routing.
+    //  */
+    // type CustomFileSystemRouterFunction = (candidatePath: string) => CustomFileSystemRouterResult;
+    //
+    // type CustomFileSystemRouterResult =
+    //   /** Skip this file */
+    //   | undefined
+    //   | null
+    //   /**
+    //    * Use this file as a route. Routes may nest, where a framework
+    //    * can use parent routes to implement layouts.
+    //    */
+    //   | {
+    //       /**
+    //        * Route pattern can include `:param` for parameters, '*' for
+    //        * catch-all, and '*?' for optional catch-all. Parameters must take
+    //        * the full component of a path segment. Parameters cannot have
+    //        * constraints at this moment.
+    //        */
+    //       pattern: string;
+    //       type: "route" | "layout" | "extra";
+    //     };
 
     /**
      * Will be resolved from the point of view of the framework user's project root

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -942,9 +942,6 @@ impl Framework {
 
             let mut it = array.array_iterator(global)?;
             let mut i: usize = 0;
-            // On the error path, dropping the `Vec` drops each `Style`, which
-            // releases the `Strong` held by its `JavascriptDefined` arm (the
-            // only owning variant; the named styles are unit-like).
             while let Some(fsr_opts) = it.next()? {
                 let root = match get_optional_string(fsr_opts, global, b"root", refs)? {
                     Some(r) => r,
@@ -985,7 +982,6 @@ impl Framework {
                     },
                     global,
                 )?;
-                // errdefer style.deinit() — handled by Style's Drop
 
                 let extensions: &'static [&'static [u8]] = if let Some(exts_js) =
                     fsr_opts.get(global, "extensions")?
@@ -1083,8 +1079,6 @@ impl Framework {
 
             break 'brk file_system_router_types;
         };
-        // errdefer for (file_system_router_types) |*fsr| fsr.style.deinit();
-        // — Vec<FileSystemRouterType> drops contents on early return.
 
         let framework = Framework {
             is_built_in_react: false,

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -100,8 +100,6 @@ impl Default for ReactFastRefresh {
 /// `bake.Framework.FileSystemRouterType`. Full body (with `Style` enum and
 /// `from_js`) lives in the gated `bake_body.rs` draft; only the field set
 /// DevServer touches is named here.
-// Deliberately not `Clone` — `framework_router::Style` is the
-// body enum (carries `JavascriptDefined(jsc::Strong)`, not `Clone`).
 pub struct FileSystemRouterType {
     pub(crate) root: Cow<'static, [u8]>,
     pub(crate) prefix: Cow<'static, [u8]>,

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -574,9 +574,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 .iter()
                 .map(|s| Box::<[u8]>::from(*s))
                 .collect(),
-            // `Style` is `Clone` (the `JavascriptDefined` arm panics inside
-            // `clone()`).
-            style: fsr.style.clone(),
+            style: fsr.style,
             allow_layouts: fsr.allow_layouts,
             server_file: OpaqueFileId::init(server_file.get()),
             client_file: client_file.map(|f| OpaqueFileId::init(f.get())),

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -692,7 +692,7 @@ fn get_routes_object(global: &JSGlobalObject, arg: JSValue) -> JsResult<Option<J
 /// slices live as long as `UserOptions.arena`.
 fn convert_file_system_router_type(
     arena: &bun_alloc::Arena,
-    src: crate::bake::FileSystemRouterType,
+    src: &crate::bake::FileSystemRouterType,
 ) -> crate::bake::bake_body::FileSystemRouterType {
     use crate::bake::bake_body as bb;
     // NOTE: `bb::arena_erase` is the single sanctioned `'bump → 'static`
@@ -1079,7 +1079,7 @@ impl ServerConfig {
                     // duplication; remove once the two structs unify.
                     let router_types: Vec<bb::FileSystemRouterType> =
                         core::mem::take(&mut init_ctx.framework_router_list)
-                            .into_iter()
+                            .iter()
                             .map(|t| convert_file_system_router_type(&arena, t))
                             .collect();
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -811,7 +811,6 @@ impl AnyRoute {
 
                 let style: FrameworkRouter::Style =
                     FrameworkRouter::Style::from_js(style_js.unwrap(), global)?;
-                // Style impls Drop; `?` drops it on the error path.
 
                 // trim the /*
                 // NOTE: `FileSystemRouterType` fields are `Cow<'static,[u8]>`.

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -1,6 +1,6 @@
 import { frameworkRouterInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
 
 const { parseRoutePattern, FrameworkRouter } = frameworkRouterInternals;
@@ -76,6 +76,11 @@ describe("pattern parse", () => {
   testApp("/route/(group)/page.tsx", "/route/(group)", "page");
   testApp("/route/[param]/not-found.tsx", "/route/:param", "extra");
   testApp.isNull("/route/_layout.tsx");
+
+  const testAppRoutes = testRoutePattern("nextjs-app-routes");
+  testAppRoutes("/route.ts", "", "page");
+  testAppRoutes("/api/[id]/route.ts", "/api/:id", "page");
+  testAppRoutes.isNull("/api/page.tsx");
 });
 
 test("discovers from filesystem paths", () => {
@@ -131,5 +136,96 @@ test("discovers from filesystem paths", () => {
         children: [],
       },
     ],
+  });
+});
+
+// Custom router styles are not implemented. A function has to be rejected while the options are
+// parsed, like any other value that is not a built-in style name, instead of being accepted and
+// crashing the process once the router is used.
+describe.concurrent("a style that is not a built-in style name", () => {
+  const message = `'style' must be either "nextjs-pages", "nextjs-app-ui", or "nextjs-app-routes"`;
+  const error = expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE", message });
+  const invalidStyles: [description: string, style: any][] = [
+    ["a function", () => null],
+    ["an unknown name", "remix"],
+  ];
+
+  test.each(invalidStyles)("parseRoutePattern rejects %s", (_, style) => {
+    expect(() => parseRoutePattern(style, "/index.tsx")).toThrow(error);
+  });
+
+  test.each(invalidStyles)("new FrameworkRouter() rejects %s", (_, style) => {
+    using dir = tempDir("fsr-style", { "index.tsx": "1" });
+    expect(() => new FrameworkRouter({ root: String(dir), style })).toThrow(error);
+  });
+
+  test.each(invalidStyles)("Bun.serve() rejects %s in a directory route", (_, style) => {
+    using dir = tempDir("fsr-style-dir-route", { "pages/index.tsx": "1" });
+    expect(() =>
+      Bun.serve({
+        port: 0,
+        development: true,
+        routes: { "/*": { dir: path.join(String(dir), "pages"), style } },
+      }),
+    ).toThrow(error);
+  });
+
+  // The `app` option shared by `Bun.serve()` and `bun build --app`; `style` is JS source.
+  const app = (style: string) => `{
+    framework: {
+      fileSystemRouterTypes: [{ root: "pages", style: ${style}, serverEntryPoint: "./server.ts" }],
+    },
+  }`;
+  const appFiles = {
+    "server.ts": "export default {};",
+    "pages/index.tsx": "export default () => null;",
+  };
+
+  async function run(dir: string, args: string[], env = bunEnv) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      cwd: dir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("Bun.serve({ app }) rejects it", async () => {
+    using dir = tempDir("fsr-style-serve", {
+      ...appFiles,
+      "start.ts": `
+        for (const app of [${app("() => null")}, ${app('"remix"')}]) {
+          try {
+            Bun.serve({ port: 0, development: true, app }).stop(true);
+            console.log("started");
+          } catch (e) {
+            console.log("threw: " + e.message);
+          }
+        }
+      `,
+    });
+    expect(await run(String(dir), ["start.ts"])).toEqual({
+      stdout: `threw: ${message}\nthrew: ${message}\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("bun build --app rejects a function", async () => {
+    using dir = tempDir("fsr-style-build", {
+      ...appFiles,
+      "bun.app.ts": `export default { app: ${app("() => null")} };`,
+    });
+    const { stderr, exitCode } = await run(String(dir), ["build", "--app", "./bun.app.ts"], {
+      ...bunEnv,
+      // Every `bun build --app` trips the exception check validator while loading its config (#38949).
+      BUN_JSC_validateExceptionChecks: undefined,
+      BUN_JSC_dumpSimulatedThrows: undefined,
+    });
+    expect(stderr).toContain(`TypeError: ${message}`);
+    expect(exitCode).toBe(1);
   });
 });


### PR DESCRIPTION
### Problem
- A bake framework config whose router `style` is a function (`fileSystemRouterTypes: [{ root: "pages", style: () => null, ... }]`) passes validation and then crashes the process with `panic: TODO: customizable Style`, in both `bun build --app` and the dev server. Reproduced on the 1.4.0 canary (eabb96de7) with no dependencies.
- `Style::from_js` (src/runtime/bake/FrameworkRouter.rs:657) accepts any callable and returns `Style::JavascriptDefined(Strong)`, and its error message even lists "or a function". Nothing implements that variant: `impl Clone for Style` panics on it (FrameworkRouter.rs:632, reached through `fsr.style.clone()` in production.rs:579 and DevServer.rs:973) and `Style::parse` panics on it (FrameworkRouter.rs:710, reached through the `FrameworkRouter` test bindings).
- Every caller of `Style::from_js` is affected: the framework config (`Bun.serve({ app })` and `bun build --app`, bake_body.rs:976), `Bun.serve` directory routes with a `style` (server_body.rs:813), and `parseRoutePattern` / `new FrameworkRouter()` from `bun:internal-for-testing` (FrameworkRouter.rs:1793 and :1993). The directory route form is not behind the bake feature flag: `Bun.serve({ routes: { "/*": { dir, style: () => null } } })` panics the same way (through DevServer.rs:973) once the built-in react framework's packages are installed, and without them it accepts the function and fails later on the missing packages.

### Fix
- Delete the `JavascriptDefined` variant. `Style` becomes a `Copy` enum of the three built-in styles, `STYLE_MAP` stores the variants directly instead of constructor closures (the closures were only there because a `Strong`-carrying enum cannot live in a static), `from_js` rejects everything that is not one of the three names, and the error message stops advertising functions. The two `panic!` arms and the manual `Clone` impl go away with the variant, as do the comments about `Style` owning a `Strong`.
- `convert_file_system_router_type` (ServerConfig.rs) takes its argument by reference: with a `Copy` style nothing in it is moved out any more, and clippy's `needless_pass_by_value` (denied in this workspace) flags the by-value signature. #32078 moves this function into bake_body.rs, still by value; whichever of the two lands second needs the by-reference signature at the function's new home.
- bake.d.ts: the function form of `style` and the two types describing it are commented out, which is how that file marks planned but unimplemented definitions (see its header). The JSDoc on `style` already says custom styles will be added later.
- Why this is the right fix rather than implementing custom styles: a function style has never worked (every consumer of the value panics), so rejecting it removes no working behavior; the option's own validation is where "this config cannot be honored" belongs, and it already throws this exact `ERR_INVALID_ARG_TYPE` error for every other invalid value. Removing the variant instead of merely not constructing it is what makes the two panic arms and the hand-written `Clone` go away. Implementing JS-defined styles is a feature; it can bring the variant back together with an implementation.
- Verified by test/bake/framework-router.test.ts: one `describe` covering each `Style::from_js` caller (`parseRoutePattern`, `new FrameworkRouter()`, `Bun.serve()` directory routes, `Bun.serve({ app })`, `bun build --app`) with a function and with an unknown name, plus `nextjs-app-routes` parse cases, since that map entry had no coverage. On the unfixed build the in-process function cases panic the test process and the two spawned cases exit 134; the unknown-name cases fail on the old message. The `bun build --app` case runs without `BUN_JSC_validateExceptionChecks` because every `bun build --app` currently trips the validator while loading its config (#38949), independent of this change.
- Also run: the whole file under the ASAN lane's environment (exception check validation, `BUN_DESTRUCT_VM_ON_EXIT`, LeakSanitizer), `cargo clippy -p bun_runtime`, `cargo fmt --check`, test/bake/dev/bundle.test.ts (dev server with a string style), test/js/bun/http/serve-directory-routes.test.ts.

### Background
- A bake framework declares one or more file system router types; each one's `style` names the convention used to turn file paths under `root` into route patterns (`"nextjs-pages"`, `"nextjs-app-ui"`, `"nextjs-app-routes"`). `framework_router::Style` is the parsed form of that option and `Style::parse` is the function that applies the convention to one file.
- `bun_jsc::Strong` is an owning handle that keeps a JS value alive. It is a `Drop` type, which is why the old enum needed a hand-written `Clone` and why `bun_core::comptime_string_map!` (a static string-to-value table) held `fn() -> Style` constructors rather than `Style` values.
- The same `Style::from_js` serves four entry points: `Framework::from_js` (the `app.framework` config parsed by both `Bun.serve({ app })` and `bun build --app`), `Bun.serve` routes of the form `"/*": { dir, style }` (which opt a directory into framework routing), and the `FrameworkRouter` bindings exposed through `bun:internal-for-testing`.
- src/runtime/bake/bake.d.ts is the in-repo type sketch for the bake API (referenced by the bake tests, not shipped in bun-types); its header says commented-out definitions are planned but not implemented.

<details>
<summary>Unfixed build, all entry points</summary>

```
$ bun build --app ./src/index.tsx        # style: () => null
panic: TODO: customizable Style
exit 134

$ bun serve.ts                           # Bun.serve({ app: { framework: { fileSystemRouterTypes: [{ style: () => null, ... }] } } })
panic: TODO: customizable Style
exit 134

$ bun internals.ts                       # parseRoutePattern(() => null, "/index.tsx") and new FrameworkRouter({ root, style: () => null })
panic: TODO: customizable Style
exit 134

$ bun dir-route.ts                       # Bun.serve({ routes: { "/*": { dir: "pages", style: () => null } } }), react packages installed
panic: TODO: customizable Style
exit 134

$ bun dir-route.ts                       # same, without the react packages
caught: Framework is missing required files!   # the function was accepted; the failure is the react framework resolution that runs next
```

With this change every one of them throws / prints:

```
TypeError: 'style' must be either "nextjs-pages", "nextjs-app-ui", or "nextjs-app-routes"
 code: "ERR_INVALID_ARG_TYPE"
```

and `bun build --app` exits 1.
</details>
