### PR TITLE
bake: return bun build --app failures instead of exiting; name the output directory it cannot open

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1275,7 +1275,7 @@ mod draft {
             super::out_of_memory();
         } else if matches!(
             name,
-            b"InvalidArgument" | b"Invalid Bunfig" | b"InstallFailed"
+            b"InvalidArgument" | b"Invalid Bunfig" | b"InstallFailed" | b"BakeBuildFailed"
         ) {
             if !show_trace {
                 Global::exit(1);

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -646,7 +646,17 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     Output::flush();
 
     // mkdir -p + open.
-    let root_dir = bun_sys::Dir::cwd().make_open_path(b"dist", Default::default())?;
+    let root_dir = match bun_sys::Dir::cwd().make_open_path(b"dist", Default::default()) {
+        Ok(dir) => dir,
+        Err(err) => {
+            Output::err(
+                err,
+                "could not open output directory {}",
+                (bun_core::fmt::quote(&root_dir_path),),
+            );
+            Global::crash();
+        }
+    };
 
     let mut maybe_runtime_file_index: Option<u32> = None;
 

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -116,7 +116,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     // Note: pass `vm_ptr` by value into the guard so the drop closure does
     // not borrow the local (`defer!` would capture `&vm_ptr`, which under
     // edition-2024 disjoint-capture rules collides with the `&mut *vm_ptr`
-    // re-borrows on the JSError path).
+    // re-borrows below).
     let _vm_guard = scopeguard::guard(vm_ptr, |p| {
         // SAFETY: p is the unique live VM on this thread; its loop is alive, so
         // queued work is released here rather than by a thread teardown.
@@ -211,28 +211,25 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     // LIFO order — under the API lock, before the VM is destroyed.
     let mut pt = PerThread::placeholder(vm_ptr);
 
-    match build_with_vm(ctx, &cwd, &mut pt) {
-        Ok(()) => {}
+    let result = build_with_vm(ctx, &cwd, &mut pt);
+    // SAFETY: `build_with_vm` has returned, so its reborrows through `pt.vm` are
+    // dead; the VM is live until `global_exit` (or `_vm_guard`) destroys it.
+    let vm = unsafe { &mut *vm_ptr };
+    match result {
+        Ok(()) => return Ok(()),
         Err(crate::Error::JSError) => {
-            // SAFETY: vm.global is live for VM lifetime.
-            let global = unsafe { &*(*vm_ptr).global };
-            let err_value = global.take_exception(jsc::JsError::Thrown);
-            // SAFETY: see above.
-            unsafe {
-                (*vm_ptr)
-                    .print_error_like_object_to_console(err_value.to_error().unwrap_or(err_value))
-            };
-            // SAFETY: see above.
-            let vm = unsafe { &mut *vm_ptr };
-            if vm.exit_handler.exit_code == 0 {
-                vm.exit_handler.exit_code = 1;
-            }
-            vm.on_exit();
-            vm.global_exit();
+            let err_value = vm.global().take_exception(jsc::JsError::Thrown);
+            vm.print_error_like_object_to_console(err_value.to_error().unwrap_or(err_value));
         }
+        // Already reported by `build_with_vm`.
+        Err(crate::Error::BakeBuildFailed) => {}
         Err(e) => return Err(e),
     }
-    Ok(())
+    if vm.exit_handler.exit_code == 0 {
+        vm.exit_handler.exit_code = 1;
+    }
+    vm.on_exit();
+    vm.global_exit()
 }
 
 /// Ported inline from `bun.bun_js.failWithBuildError` to avoid the
@@ -654,7 +651,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 "could not open output directory {}",
                 (bun_core::fmt::quote(&root_dir_path),),
             );
-            Global::crash();
+            return Err(crate::Error::BakeBuildFailed);
         }
     };
 

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -20,8 +20,8 @@ use bun_bundler::options::{self as bundler_options, OutputFile, SourceMapOption}
 use bun_bundler::output_file::Index as OutputFileIndex;
 
 use bun_collections::{AutoBitSet, StringArrayHashMap};
+use bun_core::Output;
 use bun_core::String as BunString;
-use bun_core::{Global, Output};
 use bun_dotenv as dotenv;
 use bun_jsc::js_promise::{UnwrapMode, Unwrapped};
 use bun_jsc::virtual_machine::VirtualMachine;
@@ -75,12 +75,12 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
 
     if ctx.args.entry_points.len() > 1 {
         bun_core::err_generic!("bun build --app only accepts one entrypoint");
-        Global::crash();
+        return Err(crate::Error::BakeBuildFailed);
     }
 
     if ctx.debug.hot_reload != HotReload::None {
         bun_core::err_generic!("Instead of using --watch, use 'bun run'");
-        Global::crash();
+        return Err(crate::Error::BakeBuildFailed);
     }
 
     let mut cwd_buf = PathBuffer::uninit();
@@ -88,7 +88,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
         Ok(cwd) => cwd.as_bytes(),
         Err(err) => {
             Output::err(err, "Could not query current working directory", ());
-            Global::crash();
+            return Err(crate::Error::BakeBuildFailed);
         }
     };
     // Note: reshaped for borrowck — clone the cwd slice so the PathBuffer
@@ -187,9 +187,10 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
         }
         MacroOptions::Unspecified => {}
     }
-    if vm.transpiler.configure_defines().is_err() {
-        fail_with_build_error(vm);
-    }
+    // The errors are in `ctx.log`, which `Cli::start` prints.
+    vm.transpiler
+        .configure_defines()
+        .map_err(|_| crate::Error::BakeBuildFailed)?;
     // `vm.log` was set from `ctx.log` above (non-null, process-lifetime);
     // `log_mut()` is the safe accessor encapsulating the NonNull deref.
     bun_http::async_http::load_env(vm.log_mut().unwrap(), vm.env_loader());
@@ -230,20 +231,6 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     }
     vm.on_exit();
     vm.global_exit()
-}
-
-/// Ported inline from `bun.bun_js.failWithBuildError` to avoid the
-/// `bun_runtime → bun (binary)` dep cycle (PORTING.md §Forbidden: dep-cycle
-/// fixes via fn-ptr hooks — move/port the code instead).
-#[cold]
-#[inline(never)]
-fn fail_with_build_error(vm: &mut VirtualMachine) -> ! {
-    // `vm.log` is the process-lifetime ctx.log set in build_command;
-    // `log_ref()` is the safe accessor encapsulating the NonNull deref.
-    if let Some(log) = vm.log_ref() {
-        let _ = log.print(std::ptr::from_mut(Output::error_writer()));
-    }
-    Global::exit(1);
 }
 
 fn write_sourcemap_to_disk(
@@ -316,7 +303,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                          TODO: insert a link to `bun.com/docs`",
                         (),
                     );
-                    Global::crash();
+                    return Err(crate::Error::BakeBuildFailed);
                 }
             }
 
@@ -325,7 +312,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 "could not resolve application config file '{}'",
                 (BStr::new(&unresolved_config_entry_point),),
             );
-            Global::crash();
+            return Err(crate::Error::BakeBuildFailed);
         }
     };
 
@@ -514,7 +501,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             let _ = server_transpiler
                 .log()
                 .print(std::ptr::from_mut(Output::error_writer()));
-            Global::crash();
+            return Err(crate::Error::BakeBuildFailed);
         }
     };
 
@@ -869,7 +856,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                     pt.input_file(server_file).abs_path()
                 ))
             );
-            Global::crash();
+            return Err(crate::Error::BakeBuildFailed);
         };
 
         let server_param_func = if router.dynamic_routes.count() > 0 {
@@ -895,7 +882,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                             pt.input_file(server_file).abs_path()
                         ))
                     );
-                    Global::crash();
+                    return Err(crate::Error::BakeBuildFailed);
                 }
             }
         } else {
@@ -1204,8 +1191,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     Ok(())
 }
 
-/// unsafe function, must be run outside of the event loop
-/// quits the process on exception
+/// Must be run outside of the event loop; failures are returned as `JSError`.
 fn load_module(
     vm: *mut VirtualMachine,
     global: &JSGlobalObject,
@@ -1232,9 +1218,10 @@ fn load_module(
     // TODO: Specially draining microtasks here because `waitForPromise` has a
     //       bug which forgets to do it, but I don't want to fix it right now as it
     //       could affect a lot of the codebase. This should be removed.
-    if vm_ref.event_loop_mut().drain_microtasks().is_err() {
-        Global::crash();
-    }
+    vm_ref
+        .event_loop_mut()
+        .drain_microtasks()
+        .map_err(|stopped| js_err(stopped.throw(vm_ref.global())))?;
     let jsc_vm = vm_ref.as_mut().jsc_vm_mut();
     match jsc::JSInternalPromise::opaque_mut(promise).unwrap(jsc_vm, UnwrapMode::MarkHandled) {
         Unwrapped::Pending => unreachable!(),

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -218,6 +218,10 @@ pub enum Error {
     MissingPackageJSON,
     #[error("InstallFailed")]
     InstallFailed,
+    /// `bun build --app` failed and has already printed why; `bake::production::build_command`
+    /// exits 1 through the build VM.
+    #[error("BakeBuildFailed")]
+    BakeBuildFailed,
     #[error("InvalidPackageJSON")]
     InvalidPackageJSON,
     #[error("HTTPForbidden")]
@@ -679,6 +683,7 @@ impl Error {
             Self::FailedToBindPipe => "FailedToBindPipe",
             Self::MissingPackageJSON => "MissingPackageJSON",
             Self::InstallFailed => "InstallFailed",
+            Self::BakeBuildFailed => "BakeBuildFailed",
             Self::InvalidPackageJSON => "InvalidPackageJSON",
             Self::HTTPForbidden => "HTTPForbidden",
             Self::ExampleNotFound => "ExampleNotFound",

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -218,7 +218,7 @@ pub enum Error {
     MissingPackageJSON,
     #[error("InstallFailed")]
     InstallFailed,
-    /// Already reported; `bake::production::build_command` exits 1 through the build VM.
+    /// `bun build --app` already reported the failure; like `InstallFailed`, the handler only exits 1.
     #[error("BakeBuildFailed")]
     BakeBuildFailed,
     #[error("InvalidPackageJSON")]

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -218,8 +218,7 @@ pub enum Error {
     MissingPackageJSON,
     #[error("InstallFailed")]
     InstallFailed,
-    /// `bun build --app` failed and has already printed why; `bake::production::build_command`
-    /// exits 1 through the build VM.
+    /// Already reported; `bake::production::build_command` exits 1 through the build VM.
     #[error("BakeBuildFailed")]
     BakeBuildFailed,
     #[error("InvalidPackageJSON")]

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync, symlinkSync } from "fs";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps, WAIT_MULTIPLIER } from "../bake-harness";
 
@@ -394,20 +394,22 @@ export default function Docs() {
     }
   });
 
-  // The failure is reported with the directory's path and, like a build whose page throws, the
-  // process exits through the build VM: the config's 'exit' handler runs and, with
-  // BUN_DESTRUCT_VM_ON_EXIT set, the VM is torn down before the exit code is returned.
-  describe.concurrent("output directory that cannot be opened", () => {
+  // A failure the build reports itself is returned rather than exited on: once the config has been
+  // loaded, build_command exits through the build VM like it does for a build that throws (the
+  // config's 'exit' handler runs; with BUN_DESTRUCT_VM_ON_EXIT set the VM is torn down first), and
+  // before that the error goes back to the CLI, which must not print it as an internal error.
+  describe.concurrent("failures reported by the build", () => {
+    const config = `
+      process.on("exit", code => console.log("exit event: " + code));
+      export default { app: { framework: "react" } };
+    `;
     const app = {
-      "src/index.tsx": `
-        process.on("exit", code => console.log("exit event: " + code));
-        export default { app: { framework: "react" } };
-      `,
+      "src/index.tsx": config,
       "pages/index.tsx": `export default function IndexPage() { return <p>index</p>; }`,
     };
 
-    async function build(dir: string) {
-      const { exitCode, stdout, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
+    async function build(dir: string, ...entryPoints: string[]) {
+      const { exitCode, stdout, stderr } = await Bun.$`${bunExe()} build --app ${entryPoints}`
         .cwd(dir)
         .env({ ...bunEnv, BUN_DESTRUCT_VM_ON_EXIT: "1" })
         .quiet()
@@ -415,7 +417,7 @@ export default function Docs() {
       return { exitCode, stdout: stdout.toString(), stderr: stderr.toString() };
     }
 
-    // Each case bundles a react app, which on a debug build takes most of the default timeout;
+    // The dist cases bundle a react app, which on a debug build takes most of the default timeout;
     // this is the budget bake-harness gives its production builds.
     const timeout = 30_000 * WAIT_MULTIPLIER;
 
@@ -427,7 +429,7 @@ export default function Docs() {
           "dist": "a file in the way of the output directory",
         });
 
-        const { exitCode, stdout, stderr } = await build(dir);
+        const { exitCode, stdout, stderr } = await build(dir, "./src/index.tsx");
         expect(stderr).toContain(
           `ENOTDIR: Not a directory: could not open output directory "${path.join(dir, "dist")}"`,
         );
@@ -444,7 +446,7 @@ export default function Docs() {
         const dir = await tempDirWithBakeDeps("bake-production-dist-is-a-dangling-symlink", app);
         symlinkSync("does-not-exist", path.join(dir, "dist"));
 
-        const { exitCode, stdout, stderr } = await build(dir);
+        const { exitCode, stdout, stderr } = await build(dir, "./src/index.tsx");
         expect(stderr).toContain(
           `ENOENT: No such file or directory: could not open output directory "${path.join(dir, "dist")}"`,
         );
@@ -453,6 +455,26 @@ export default function Docs() {
       },
       timeout,
     );
+
+    test("framework imports that do not resolve", async () => {
+      // No react packages are installed here.
+      using dir = tempDir("bake-production-framework-unresolved", { "app.ts": config });
+
+      const { exitCode, stdout, stderr } = await build(String(dir), "./app.ts");
+      expect(stderr).toContain("error: Failed to resolve all imports required by the framework");
+      expect(stdout).toBe("exit event: 1\n");
+      expect(exitCode).toBe(1);
+    });
+
+    test("more than one entry point", async () => {
+      using dir = tempDir("bake-production-two-entry-points", { "app.ts": config, "other.ts": config });
+
+      const { exitCode, stdout, stderr } = await build(String(dir), "./app.ts", "./other.ts");
+      expect(stderr).toContain("error: bun build --app only accepts one entrypoint");
+      expect(stderr).not.toContain("BakeBuildFailed");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+    });
   });
 
   test("client-side component with default import should work", async () => {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { existsSync, symlinkSync } from "fs";
+import { bunEnv, bunExe, isWindows } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -392,6 +392,43 @@ export default function Docs() {
       expect(stderr.toString()).not.toContain("reached unreachable code");
       expect(stderr.toString()).not.toContain("assert(this.cap > 0)");
     }
+  });
+
+  describe.concurrent("output directory that cannot be opened", () => {
+    const app = {
+      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "pages/index.tsx": `export default function IndexPage() { return <p>index</p>; }`,
+    };
+
+    async function build(dir: string) {
+      const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
+        .cwd(dir)
+        .env(bunEnv)
+        .throws(false);
+      return { exitCode, stderr: stderr.toString() };
+    }
+
+    test("a file at dist is reported with its path", async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-dist-is-a-file", {
+        ...app,
+        "dist": "a file in the way of the output directory",
+      });
+
+      const { exitCode, stderr } = await build(dir);
+      expect(stderr).toContain(`ENOTDIR: Not a directory: could not open output directory "${path.join(dir, "dist")}"`);
+      expect(stderr).not.toContain("An internal error occurred");
+      expect(exitCode).toBe(1);
+    });
+
+    test.skipIf(isWindows)("a dangling symlink at dist is reported with its path", async () => {
+      const dir = await tempDirWithBakeDeps("bake-production-dist-is-a-dangling-symlink", app);
+      symlinkSync("does-not-exist", path.join(dir, "dist"));
+
+      const { exitCode, stderr } = await build(dir);
+      expect(stderr).toContain(`could not open output directory "${path.join(dir, "dist")}"`);
+      expect(stderr).not.toContain("missing a better error");
+      expect(exitCode).toBe(1);
+    });
   });
 
   test("client-side component with default import should work", async () => {

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { existsSync, symlinkSync } from "fs";
 import { bunEnv, bunExe, isWindows } from "harness";
 import path from "path";
-import { tempDirWithBakeDeps } from "../bake-harness";
+import { tempDirWithBakeDeps, WAIT_MULTIPLIER } from "../bake-harness";
 
 const normalizePath = (path: string) => (process.platform === "win32" ? path.replaceAll("\\", "/") : path);
 const platformPath = (path: string) => (process.platform === "win32" ? path.replaceAll("/", "\\") : path);
@@ -394,41 +394,65 @@ export default function Docs() {
     }
   });
 
+  // The failure is reported with the directory's path and, like a build whose page throws, the
+  // process exits through the build VM: the config's 'exit' handler runs and, with
+  // BUN_DESTRUCT_VM_ON_EXIT set, the VM is torn down before the exit code is returned.
   describe.concurrent("output directory that cannot be opened", () => {
     const app = {
-      "src/index.tsx": `export default { app: { framework: "react" } };`,
+      "src/index.tsx": `
+        process.on("exit", code => console.log("exit event: " + code));
+        export default { app: { framework: "react" } };
+      `,
       "pages/index.tsx": `export default function IndexPage() { return <p>index</p>; }`,
     };
 
     async function build(dir: string) {
-      const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
+      const { exitCode, stdout, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
         .cwd(dir)
-        .env(bunEnv)
+        .env({ ...bunEnv, BUN_DESTRUCT_VM_ON_EXIT: "1" })
+        .quiet()
         .throws(false);
-      return { exitCode, stderr: stderr.toString() };
+      return { exitCode, stdout: stdout.toString(), stderr: stderr.toString() };
     }
 
-    test("a file at dist is reported with its path", async () => {
-      const dir = await tempDirWithBakeDeps("bake-production-dist-is-a-file", {
-        ...app,
-        "dist": "a file in the way of the output directory",
-      });
+    // Each case bundles a react app, which on a debug build takes most of the default timeout;
+    // this is the budget bake-harness gives its production builds.
+    const timeout = 30_000 * WAIT_MULTIPLIER;
 
-      const { exitCode, stderr } = await build(dir);
-      expect(stderr).toContain(`ENOTDIR: Not a directory: could not open output directory "${path.join(dir, "dist")}"`);
-      expect(stderr).not.toContain("An internal error occurred");
-      expect(exitCode).toBe(1);
-    });
+    test(
+      "a file at dist",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-dist-is-a-file", {
+          ...app,
+          "dist": "a file in the way of the output directory",
+        });
 
-    test.skipIf(isWindows)("a dangling symlink at dist is reported with its path", async () => {
-      const dir = await tempDirWithBakeDeps("bake-production-dist-is-a-dangling-symlink", app);
-      symlinkSync("does-not-exist", path.join(dir, "dist"));
+        const { exitCode, stdout, stderr } = await build(dir);
+        expect(stderr).toContain(
+          `ENOTDIR: Not a directory: could not open output directory "${path.join(dir, "dist")}"`,
+        );
+        expect(stderr).not.toContain("An internal error occurred");
+        expect(stdout).toBe("exit event: 1\n");
+        expect(exitCode).toBe(1);
+      },
+      timeout,
+    );
 
-      const { exitCode, stderr } = await build(dir);
-      expect(stderr).toContain(`could not open output directory "${path.join(dir, "dist")}"`);
-      expect(stderr).not.toContain("missing a better error");
-      expect(exitCode).toBe(1);
-    });
+    test.skipIf(isWindows)(
+      "a dangling symlink at dist",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-dist-is-a-dangling-symlink", app);
+        symlinkSync("does-not-exist", path.join(dir, "dist"));
+
+        const { exitCode, stdout, stderr } = await build(dir);
+        expect(stderr).toContain(
+          `ENOENT: No such file or directory: could not open output directory "${path.join(dir, "dist")}"`,
+        );
+        expect(stdout).toBe("exit event: 1\n");
+        expect(exitCode).toBe(1);
+      },
+      timeout,
+    );
   });
 
   test("client-side component with default import should work", async () => {


### PR DESCRIPTION
### Problem
- When `bun build --app` cannot open or create its output directory (a regular file named `dist` in the project, for example), the build ends with `error: An internal error occurred (ENOTDIR)`; when `dist` is a dangling symlink it ends with `ENOENT: Bun could not find a file, and the code that produces this error is missing a better error.` Neither line names the directory. The exit code is already 1.
- Reproduced on the 1.4.0 canary (eabb96de7) and on main with a react app and `dist` pre-created as a file, and again with `dist` as a dangling symlink.
- Cause: `build_with_vm` in `src/runtime/bake/production.rs` opens the directory with `Dir::cwd().make_open_path(b"dist", ..)?`. The `?` converts the `bun_sys::Error` into the crate error, which only keeps the errno, and returns it all the way to `Cli::start`, whose fallback handler prints the lines above.
- Review of the first version (which printed the error and called `Global::crash()` like the other failure sites in the file) asked that bake's code not exit the process at all and leave that to the handler, so the PR also converts the existing sites.

### Fix
- The output directory failure is printed at the site, for example `ENOTDIR: Not a directory: could not open output directory "/home/me/app/dist" (open)`, and returned as a new `Error::BakeBuildFailed`. The wording is the one `bun build` uses for its `--outdir` in `build_command.rs`; the path is `root_dir_path`, the absolute path the prerender step writes into (the user never spelled `dist`, the production build hardcodes it).
- `Error::BakeBuildFailed` means "bake already printed why; just exit 1". Every site in `production.rs` that printed a message and then exited (`Global::crash()` or the local `fail_with_build_error`) now returns it instead: entry point count, `--watch`, getcwd, `configure_defines`, config file not found, framework imports that do not resolve, the output directory, and the missing `prerender` / `getParams` exports. The stopped microtask drain in `load_module` returns `JSError` the way the `wait_for_promise` call above it already does. `production.rs` no longer imports `Global`.
- Two handlers, by who has something to clean up:
  - Raised inside `build_with_vm` (the build VM is up and the config has run): `build_command` handles it next to its `JSError` arm. Both set the exit code to 1 unless the build set one and leave through `vm.on_exit()` + `vm.global_exit()`, so the config's `process.on("exit")` handlers run and, under `BUN_DESTRUCT_VM_ON_EXIT`, the VM is torn down; `Global::crash()` skipped both. The `JSError` arm additionally prints the exception, as before; the success path and the `Err(e)` return for anything else are unchanged.
  - Raised in `build_command` before that (nothing to exit through yet): it returns to the CLI, and `handle_root_error` (`src/crash_handler/lib.rs`) now lists `BakeBuildFailed` with `InstallFailed` and the other already-reported names, so it exits 1 without the internal error line. This is the `bun install` arrangement: the inner function reports, the command returns a marker error, the root exits.
- `fail_with_build_error` is deleted: the `configure_defines` errors are in `ctx.log`, which `Cli::start` prints for any error a command returns, so the site only returns the marker.
- Verified with the new `failures reported by the build` block in `test/bake/dev/production.test.ts`, every case with an `exit` handler in the config and `BUN_DESTRUCT_VM_ON_EXIT=1`:
  - `dist` as a regular file, and on POSIX `dist` as a dangling symlink (open fails with ENOENT, the mkdir is a no-op on the symlink, the reopen fails again): the errno line with the directory's path on stderr, `exit event: 1` on stdout, exit 1. Both fail on the unfixed canary (the two lines quoted above, empty stdout).
  - framework imports that do not resolve (a fixture without the react packages), one of the converted `build_with_vm` sites: the existing message plus `exit event: 1`, exit 1. Fails on the canary (empty stdout), and the fixture needs no packages so it runs in under half a second on the debug build.
  - two entry points, one of the converted `build_command` sites: the existing message, no `BakeBuildFailed` on stderr, empty stdout, exit 1. This one also passes on the canary; it guards the `handle_root_error` entry, without which it would print `An internal error occurred (BakeBuildFailed)`.
  - Also exercised by hand on the debug build: `--watch`, a missing config file with and without an explicit path, and all of the above with and without `BUN_DESTRUCT_VM_ON_EXIT`. The `configure_defines` and `prerender`/`getParams` sites are the same one line change but have no test; a bad `--define` or a `.env` directory did not make `configure_defines` fail, and the export sites need a custom framework.
  - The whole file passes on the debug build with `--timeout 120000` (16/16, including the throwing-page test that goes through the restructured `JSError` arm); the dist cases get the timeout bake-harness gives its production builds (`30_000 * WAIT_MULTIPLIER`) because a react bundling takes 2 to 4 s on the debug ASAN build and six of the file's existing tests already hit the 5 s default there. `production.test.ts` is the only test of `bun build --app`.
  - `cargo clippy -p bun_runtime -p bun_crash_handler` and rustfmt are clean.

### Background
- `bun build --app` is bake's static production build (`production.rs`). `build_command` validates the arguments, creates a dedicated JS VM and calls `build_with_vm`, which evaluates the app config in it, bundles the app, opens `<cwd>/dist`, writes the client output files into it and prerenders every route into it.
- `Output::err(err, fmt, args)` prints an error line prefixed with the error's name; for a `bun_sys::Error` it also adds the strerror text and the syscall that failed. `Global::crash()` is `exit(1)` after flushing the output buffers.
- `VirtualMachine::on_exit` emits `process`'s `exit` event; `global_exit` exits the process with `exit_handler.exit_code` (the field behind `process.exitCode`) and, when `BUN_DESTRUCT_VM_ON_EXIT` is set (CI's ASAN lane sets it for leak checking), destroys the VM first.
- `Cli::start` receives whatever error a command returns, prints the accumulated log (`ctx.log`) and hands the error to `handle_root_error`, which prints `An internal error occurred (<name>)` unless the name is one it knows; the known already-reported names (`InvalidArgument`, `InstallFailed`, ...) just exit 1.

<details>
<summary>Earlier versions</summary>

c08b2d7 printed the message and called `Global::crash()` at the site, matching the other failure sites in `build_with_vm`. 0773af5 replaced that one crash with the `BakeBuildFailed` return and the `build_command` arm. e062717 converted the remaining sites, added the `handle_root_error` entry for the pre-VM ones and the two extra tests.

</details>
