### PR TITLE
bun-types: drop undefined from the Null* subprocess aliases where the default is "pipe"

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8157,19 +8157,27 @@ declare module "bun" {
   type WritableSubprocess = Subprocess<"pipe", any, any>;
   /** Utility type for any process from {@link Bun.spawn()} with stdin, stdout, stderr all set to `"pipe"`. A combination of {@link ReadableSubprocess} and {@link WritableSubprocess} */
   type PipedSubprocess = Subprocess<"pipe", "pipe", "pipe">;
-  /** Utility type for any process from {@link Bun.spawn()} with stdin, stdout, stderr all set to `null` or similar. */
+  /**
+   * Utility type for any process from {@link Bun.spawn()} with stdin, stdout, stderr all set to `"ignore"`, `"inherit"`
+   * or `null`, so none of them is exposed on the process.
+   *
+   * An `undefined` option means the slot's default. That qualifies for stdin (`"ignore"`) and stderr (`"inherit"`),
+   * but not for stdout, whose default is `"pipe"`.
+   */
   type NullSubprocess = Subprocess<
     "ignore" | "inherit" | null | undefined,
-    "ignore" | "inherit" | null | undefined,
+    "ignore" | "inherit" | null,
     "ignore" | "inherit" | null | undefined
   >;
   /** Utility type for any process from {@link Bun.spawnSync()} with both stdout and stderr set to `"pipe"` */
   type ReadableSyncSubprocess = SyncSubprocess<"pipe", "pipe">;
-  /** Utility type for any process from {@link Bun.spawnSync()} with both stdout and stderr set to `null` or similar */
-  type NullSyncSubprocess = SyncSubprocess<
-    "ignore" | "inherit" | null | undefined,
-    "ignore" | "inherit" | null | undefined
-  >;
+  /**
+   * Utility type for any process from {@link Bun.spawnSync()} with both stdout and stderr set to `"ignore"`, `"inherit"`
+   * or `null`, so neither is captured.
+   *
+   * An `undefined` option does not qualify: {@link Bun.spawnSync()} defaults both slots to `"pipe"`.
+   */
+  type NullSyncSubprocess = SyncSubprocess<"ignore" | "inherit" | null, "ignore" | "inherit" | null>;
 
   /**
    * Options for creating a pseudo-terminal (PTY).

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,6 +400,35 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Also runs on debug builds, where the in-process typeTest cases (which cover the whole
+  // fixture directory) are skipped: checks fixture/spawn.ts alone against the packed bun-types.
+  describe("Bun.spawn", () => {
+    test("fixture/spawn.ts type-checks", async () => {
+      const checkDir = join(TEMP_DIR, "spawn-fixture-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.files = [join(BASE_FIXTURE_DIR, "spawn.ts")];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -185,6 +185,23 @@ tsd.expectAssignable<WritableSubprocess>(Bun.spawn([], { stdio: ["pipe", "pipe",
 tsd.expectAssignable<WritableSubprocess>(Bun.spawn([], { stdio: ["pipe", "ignore", "inherit"] }));
 tsd.expectAssignable<NullSubprocess>(Bun.spawn([], { stdio: ["ignore", "inherit", "ignore"] }));
 tsd.expectAssignable<NullSubprocess>(Bun.spawn([], { stdio: [null, null, null] }));
+// A Null* process exposes none of its stdio slots. An undefined option means the slot's default: "ignore"
+// for Bun.spawn's stdin and "inherit" for its stderr, but "pipe" for Bun.spawn's stdout and for both
+// Bun.spawnSync slots. So the aliases accept undefined in Bun.spawn's stdin and stderr slots only.
+tsd.expectType<NullSubprocess["stdin"]>().is<undefined>();
+tsd.expectType<NullSubprocess["stdout"]>().is<undefined>();
+tsd.expectType<Bun.NullSyncSubprocess["stdout"]>().is<undefined>();
+tsd.expectType<Bun.NullSyncSubprocess["stderr"]>().is<undefined>();
+tsd.expectAssignable<NullSubprocess>(Bun.spawn([], { stdio: [undefined, "ignore", undefined] }));
+tsd.expectAssignable<NullSubprocess>(Bun.spawn([], { stdout: "ignore" }));
+// @ts-expect-error stdout: undefined means "pipe", so this process has a stdout stream
+tsd.expectAssignable<NullSubprocess>(Bun.spawn([], { stdio: ["ignore", undefined, "ignore"] }));
+tsd.expectAssignable<Bun.NullSyncSubprocess>(Bun.spawnSync([], { stdio: ["ignore", "ignore", "inherit"] }));
+tsd.expectAssignable<Bun.NullSyncSubprocess>(Bun.spawnSync([], { stdio: [null, null, null] }));
+// @ts-expect-error stdout: undefined means "pipe", so this process has a stdout Buffer
+tsd.expectAssignable<Bun.NullSyncSubprocess>(Bun.spawnSync([], { stdio: ["ignore", undefined, "ignore"] }));
+// @ts-expect-error stderr: undefined means "pipe" in spawnSync, so this process has a stderr Buffer
+tsd.expectAssignable<Bun.NullSyncSubprocess>(Bun.spawnSync([], { stdio: ["ignore", "ignore", undefined] }));
 
 tsd.expectAssignable<SyncSubprocess<Bun.SpawnOptions.Readable, Bun.SpawnOptions.Readable>>(Bun.spawnSync([], {}));
 


### PR DESCRIPTION
### Problem
- `NullSubprocess` and `NullSyncSubprocess` (packages/bun-types/bun.d.ts:8161 and :8169 on main) list `undefined` in every stdio type argument, so `NullSubprocess["stdout"]` is `ReadableStream<Uint8Array<ArrayBuffer>> | undefined` and `NullSyncSubprocess["stdout"]` / `["stderr"]` are `Buffer | undefined`, not `undefined`.
- `undefined` in a stdio option means the slot's default, and the default is `"pipe"` for `Bun.spawn`'s stdout and for both `Bun.spawnSync` slots, so `Bun.spawn(cmd, { stdio: ["ignore", undefined, "ignore"] })` has a live `ReadableStream` on `.stdout` and `Bun.spawnSync(cmd, { stdio: ["ignore", undefined, undefined] })` has two `Buffer`s, yet both are accepted as `NullSubprocess` / `NullSyncSubprocess`.
- The other slots are fine: `Bun.spawn` defaults stdin to `"ignore"` and stderr to `"inherit"`, so `undefined` there leaves nothing on the process.

### Fix
- Removes `undefined` from the three type arguments whose slot defaults to `"pipe"`: `NullSubprocess`'s stdout, and both of `NullSyncSubprocess`'s. The stdin and stderr arguments of `NullSubprocess` still accept `undefined`. The JSDoc of both aliases now says which options qualify and why `undefined` only counts in some slots.
- Correct because the aliases now list exactly the options for which the runtime exposes nothing on the process (checked with bun 1.4.0, output in the details below), and because the mapping types `ReadableToIO` / `ReadableToSyncIO` already turn an `undefined` option in these slots into a stream / `Buffer`: with the change, all three properties become exactly `undefined`, and a `Subprocess` / `SyncSubprocess` with a `"pipe"`-by-default slot no longer satisfies the alias.
- The only code that stops compiling is code assigning a process with an explicitly `undefined` stdout (or `spawnSync` stderr) to a `Null*` alias, which is the case the alias mistyped. Nothing in this repo uses the aliases outside the fixture, and the docs do not mention them.
- Verified by test/integration/bun-types/fixture/spawn.ts (new assertions after the existing `NullSubprocess` ones): the three properties are `undefined`, `undefined` is still accepted in `Bun.spawn`'s stdin and stderr slots, and the three `"pipe"`-by-default cases are rejected via `@ts-expect-error`. Against the unfixed bun.d.ts the new lines produce 6 diagnostics (3 wrong property types, 3 unused `@ts-expect-error`); with the fix, zero.
- `bun bd test test/integration/bun-types/bun-types.test.ts`: the new `Bun.spawn > fixture/spawn.ts type-checks` case fails with those 6 diagnostics when packages/ is stashed and passes with the fix.
- `USE_SYSTEM_BUN=1 bun test test/integration/bun-types/bun-types.test.ts`: 16 pass, including the lib.dom run, whose pinned spawn.ts:62 / :107 diagnostics are unchanged (the new lines are below them).
- The added test case in bun-types.test.ts is byte-identical to the one in #39279, #39283 and #39297, so whichever lands first, the rest merge cleanly; `git merge-tree` of this branch with each of those (and with #39270) reports no conflicts, and fixture/spawn.ts still type-checks in each merged tree. #39297's `NullSubprocess["stderr"]` assertion relies on stderr keeping `undefined`, which this PR preserves.

### Background
- `Bun.spawn` returns `Subprocess<In, Out, Err>` and `Bun.spawnSync` returns `SyncSubprocess<Out, Err>`, where the type arguments are the literal types of the stdio options passed. `proc.stdout` is typed as `ReadableToIO<Out>` (a `ReadableStream` for `"pipe"`, a `number` for an fd, otherwise `undefined`), and `SyncSubprocess.stdout` as `ReadableToSyncIO<Out>` (`Buffer` for `"pipe"`, otherwise `undefined`). Both map an `undefined` option like `"pipe"`.
- `NullSubprocess`, `PipedSubprocess`, `NullSyncSubprocess` and friends are aliases that instantiate those interfaces with a union of options, for holding processes whose exact configuration is not known statically. Because the mapping types distribute over the union, each property of the alias is the union of what every listed option produces, and a process is assignable to the alias when its own options (or what they produce) fit in those unions.
- An option that is `undefined` (explicitly, or through a union such as a `stdio` tuple with a conditional entry) leaves the runtime default for that slot: `["ignore", "pipe", "inherit"]` for `Bun.spawn` and `["ignore", "pipe", "pipe"]` for `Bun.spawnSync` (`src/runtime/api/bun/js_bun_spawn_bindings.rs`, the `@default` lines on `stdio` / `stdout` / `stderr` in bun.d.ts). Omitting the option altogether does not produce an `undefined` type argument: the spawn signatures default the type parameters to those same values.

<details>
<summary>Runtime check of the defaults (bun 1.4.0)</summary>

```
spawn  [ignore, undefined, ignore]    -> stdin undefined, stdout ReadableStream, stderr undefined
spawn  [undefined, ignore, undefined] -> stdin undefined, stdout undefined,      stderr undefined
spawn  [undefined, undefined, undefined] -> stdin undefined, stdout ReadableStream, stderr undefined
spawnSync [ignore, undefined, undefined] -> stdout Buffer,    stderr Buffer
spawnSync [ignore, undefined, ignore]    -> stdout Buffer,    stderr undefined
spawnSync [ignore, ignore, undefined]    -> stdout undefined, stderr Buffer
spawnSync [ignore, ignore, inherit]      -> stdout undefined, stderr undefined
spawnSync [null, null, null]             -> stdout undefined, stderr undefined
```

</details>

<details>
<summary>tsc 6.0.2 over fixture/spawn.ts against the unfixed bun.d.ts</summary>

```
spawn.ts(192,44): error TS2554: Expected 2 arguments, but got 0.      // NullSubprocess["stdout"] is not undefined
spawn.ts(193,52): error TS2554: Expected 2 arguments, but got 0.      // NullSyncSubprocess["stdout"]
spawn.ts(194,52): error TS2554: Expected 2 arguments, but got 0.      // NullSyncSubprocess["stderr"]
spawn.ts(197,1): error TS2578: Unused '@ts-expect-error' directive.   // spawn stdio ["ignore", undefined, "ignore"] accepted as NullSubprocess
spawn.ts(201,1): error TS2578: Unused '@ts-expect-error' directive.   // spawnSync stdio ["ignore", undefined, "ignore"] accepted as NullSyncSubprocess
spawn.ts(203,1): error TS2578: Unused '@ts-expect-error' directive.   // spawnSync stdio ["ignore", "ignore", undefined] accepted as NullSyncSubprocess
```

</details>
