### PR TITLE
Bun.serve: accept in-memory Blobs (embedded files, Bun.embeddedFiles) as route values

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -930,12 +930,11 @@ import "./public/styles.css" with { type: "file" };
 import { embeddedFiles, serve } from "bun";
 
 // Build static routes from all embedded files
-const staticRoutes: Record<string, Response> = {};
+const staticRoutes: Record<string, Blob> = {};
 for (const blob of embeddedFiles) {
   // Remove hash from filename: "icon-a1b2c3d4.png" -> "icon.png"
   const name = blob.name.replace(/-[a-z0-9]+\./, ".");
-  // embeddedFiles are plain Blobs, which routes does not accept directly
-  staticRoutes[`/${name}`] = new Response(blob);
+  staticRoutes[`/${name}`] = blob;
 }
 
 serve({

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -620,7 +620,16 @@ declare module "bun" {
       statCache?: boolean;
     }
 
-    type BaseRouteValue = Response | false | HTMLBundle | BunFile | DirectoryRouteOptions;
+    /**
+     * Route values other than handler functions.
+     *
+     * A `Blob` backed by a file on disk (`Bun.file(path)`) is read from disk on
+     * each request. Any other `Blob` (`new Blob()`, `Bun.file()` of a file
+     * embedded in a compiled executable, a {@link Bun.embeddedFiles} entry) is
+     * served from memory, like `new Response(blob)`, with its `type` as the
+     * `Content-Type`. An {@link S3File} is rejected.
+     */
+    type BaseRouteValue = Response | false | HTMLBundle | Blob | DirectoryRouteOptions;
 
     type Routes<WebSocketData, R extends string> = {
       [Path in R]:

--- a/src/runtime/server/StaticRoute.rs
+++ b/src/runtime/server/StaticRoute.rs
@@ -1,5 +1,5 @@
 //! StaticRoute stores and serves a static blob. This can be created out of a JS
-//! Response object, or from globally allocated bytes.
+//! Response object, an in-memory JS Blob, or from globally allocated bytes.
 
 use core::cell::Cell;
 use core::mem::size_of;
@@ -18,7 +18,7 @@ use crate::server::jsc::{JSGlobalObject, JSValue, JsResult};
 use crate::server::{AnyServer, HTTPStatusText, write_status};
 use crate::webcore::body::Value as BodyValue;
 use crate::webcore::headers_ref::any_blob_content_type;
-use crate::webcore::{AnyBlob, FetchHeaders, InternalBlob, Response};
+use crate::webcore::{AnyBlob, Blob, FetchHeaders, InternalBlob, Response};
 
 // bun.ptr.RefCount(@This(), "ref_count", deinit, .{}) — single-thread refcount.
 // `*StaticRoute` is also passed as uws onAborted/
@@ -257,6 +257,25 @@ impl StaticRoute {
                 server: Cell::new(None),
                 status_code: response.status_code(),
             }))));
+        }
+
+        // `FileRoute::from_js` runs first and takes the blobs backed by a file
+        // on disk. The ones left are held in memory (`new Blob()`, a
+        // `Bun.file()` of a file embedded in a compiled executable, a
+        // `Bun.embeddedFiles` entry, a `BuildArtifact`), so they are served the
+        // same way as the body of `new Response(blob)`. An S3 blob has no bytes
+        // to snapshot either, so it stays rejected.
+        if let Some(blob) = argument.as_class_ref::<Blob>() {
+            if blob.needs_to_read_file() || blob.is_s3() {
+                return Ok(None);
+            }
+            let blob = blob.dupe();
+            blob.global_this
+                .set(std::ptr::from_ref::<JSGlobalObject>(global_this));
+            return Ok(Some(Self::init_from_any_blob(
+                AnyBlob::Blob(blob),
+                InitFromBytesOptions::default(),
+            )));
         }
 
         Ok(None)

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -148,7 +148,8 @@ pub(crate) fn write_status<const SSL: bool>(resp: *mut uws_sys::NewAppResponse<S
 // a second header and break the round-trip). Hold them as raw intrusive
 // pointers.
 pub enum AnyRoute {
-    /// Serve a static file — `"/robots.txt": new Response(...)`
+    /// Serve a static file — `"/robots.txt": new Response(...)`, or any `Blob`
+    /// whose bytes are already in memory
     Static(core::ptr::NonNull<StaticRoute>),
     /// Serve a file from disk
     File(core::ptr::NonNull<FileRoute>),

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -403,6 +403,48 @@ describe("bundler", () => {
     outfile: "dist/out",
     run: { stdout: "Hello, world!" },
   });
+  // Inside the executable, file() of an embedded path is an in-memory Blob
+  // rather than a file on disk. It and the Bun.embeddedFiles entries have to
+  // be accepted as route values just like file() of a file on disk is.
+  itBundled("compile/EmbeddedFileServeRoute", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import { embeddedFiles, file, serve } from "bun";
+        import asset from "./asset.txt" with { type: "file" };
+        import "./icon.ico" with { type: "file" };
+
+        const routes: Record<string, Blob> = { "/asset.txt": file(asset) };
+        for (const blob of embeddedFiles) {
+          // "icon-a1b2c3d4.ico" -> "/embedded/icon.ico"
+          routes["/embedded/" + blob.name.replace(/-[a-z0-9]+\\./, ".")] = blob;
+        }
+
+        using server = serve({
+          port: 0,
+          routes,
+          fetch: () => new Response("fallback", { status: 404 }),
+        });
+        console.log("standalone:", Bun.isStandaloneExecutable);
+        for (const path of ["/asset.txt", "/embedded/asset.txt", "/embedded/icon.ico", "/missing"]) {
+          const res = await fetch(new URL(path, server.url));
+          console.log(path, res.status, res.headers.get("Content-Type"), JSON.stringify(await res.text()));
+        }
+      `,
+      "/asset.txt": "embedded text",
+      "/icon.ico": "not really an icon",
+    },
+    outfile: "dist/out",
+    run: {
+      stdout: `
+        standalone: true
+        /asset.txt 200 text/plain;charset=utf-8 "embedded text"
+        /embedded/asset.txt 200 text/plain;charset=utf-8 "embedded text"
+        /embedded/icon.ico 200 image/x-icon "not really an icon"
+        /missing 404 text/plain;charset=utf-8 "fallback"
+      `,
+    },
+  });
   itBundled("compile/WorkerRelativePathNoExtension", {
     backend: "cli",
     compile: true,

--- a/test/integration/bun-types/fixture/serve.ts
+++ b/test/integration/bun-types/fixture/serve.ts
@@ -84,3 +84,18 @@ const s4 = Bun.serve({
     },
   },
 });
+
+// In-memory Blobs and the Blobs of a compiled executable's embedded files are
+// route values, like Bun.file() of a file on disk.
+Bun.serve({
+  routes: {
+    "/on-disk.txt": Bun.file("on-disk.txt"),
+    "/in-memory.txt": new Blob(["in memory"], { type: "text/plain" }),
+  },
+});
+
+const embeddedRoutes: Record<string, Blob> = {};
+Bun.embeddedFiles.forEach((blob, i) => {
+  embeddedRoutes[`/embedded/${i}`] = blob;
+});
+Bun.serve({ routes: embeddedRoutes });

--- a/test/js/bun/http/bun-serve-static.test.ts
+++ b/test/js/bun/http/bun-serve-static.test.ts
@@ -1,3 +1,4 @@
+import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, it, mock, test } from "bun:test";
 import { isBroken, isMacOS, tempDir } from "harness";
 import { routes, static_responses } from "./bun-serve-static-helpers";
@@ -343,5 +344,187 @@ describe("static route preconditions (RFC 9110 §13.2.2)", () => {
     it("If-Match pass then If-None-Match match → 304", async () => {
       expect((await get("/s", { "If-Match": '"s1"', "If-None-Match": '"s1"' }, method)).status).toBe(304);
     });
+  });
+});
+
+// A Blob whose bytes are already in memory (new Blob(), Bun.file() of a file
+// embedded in a compiled executable, a Bun.embeddedFiles entry) is a static
+// route, served the way `new Response(blob)` would be. Bun.file() of a file on
+// disk keeps going through the file route.
+describe("Blob route values", () => {
+  const notFound = () => new Response("fallback", { status: 404 });
+
+  async function request(server: Server<undefined>, path: string, init?: RequestInit) {
+    const res = await fetch(new URL(path, server.url), init);
+    return {
+      status: res.status,
+      contentType: res.headers.get("content-type"),
+      contentLength: res.headers.get("content-length"),
+      etag: res.headers.get("etag"),
+      body: await res.text(),
+    };
+  }
+
+  test("serves the bytes and the type of the Blob", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/typed": new Blob(["<h1>hi</h1>"], { type: "text/html" }),
+        "/untyped": new Blob(["no type"]),
+        "/empty": new Blob([]),
+        "/named": new File(["named"], "named.bin", { type: "application/x-named" }),
+        "/slice": new Blob(["0123456789"], { type: "text/plain" }).slice(2, 6, "text/x-slice"),
+      },
+      fetch: notFound,
+    });
+
+    const etag = expect.stringMatching(/^"[0-9a-f]+"$/);
+    expect({
+      typed: await request(server, "/typed"),
+      untyped: await request(server, "/untyped"),
+      empty: await request(server, "/empty"),
+      named: await request(server, "/named"),
+      slice: await request(server, "/slice"),
+    }).toEqual({
+      typed: { status: 200, contentType: "text/html;charset=utf-8", contentLength: "11", etag, body: "<h1>hi</h1>" },
+      untyped: { status: 200, contentType: null, contentLength: "7", etag, body: "no type" },
+      empty: { status: 200, contentType: null, contentLength: "0", etag: null, body: "" },
+      named: { status: 200, contentType: "application/x-named", contentLength: "5", etag, body: "named" },
+      slice: { status: 200, contentType: "text/x-slice", contentLength: "4", etag, body: "2345" },
+    });
+  });
+
+  test("responds exactly like the same Blob wrapped in new Response()", async () => {
+    const typed = new Blob(["same bytes"], { type: "application/x-parity" });
+    const untyped = new Blob(["same bytes"]);
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/typed": typed,
+        "/typed/wrapped": new Response(typed),
+        "/untyped": untyped,
+        "/untyped/wrapped": new Response(untyped),
+      },
+      fetch: notFound,
+    });
+
+    for (const path of ["/typed", "/untyped"]) {
+      for (const method of ["GET", "HEAD"]) {
+        const bare = await request(server, path, { method });
+        expect(bare.status).toBe(200);
+        expect(bare).toEqual(await request(server, `${path}/wrapped`, { method }));
+      }
+    }
+  });
+
+  test("gets the static route cache headers", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: { "/b": new Blob(["cacheable"], { type: "text/plain" }) },
+      fetch: notFound,
+    });
+
+    const { etag } = await request(server, "/b");
+    expect(etag).toMatch(/^"[0-9a-f]+"$/);
+    expect(await request(server, "/b", { method: "HEAD" })).toEqual({
+      status: 200,
+      contentType: "text/plain;charset=utf-8",
+      contentLength: "9",
+      etag,
+      body: "",
+    });
+    expect(await request(server, "/b", { headers: { "If-None-Match": etag! } })).toMatchObject({
+      status: 304,
+      body: "",
+    });
+  });
+
+  test("is accepted under a method", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      routes: { "/m": { GET: new Blob(["GET only"], { type: "text/plain" }) } },
+      fetch: notFound,
+    });
+
+    expect({
+      get: (await request(server, "/m")).body,
+      post: await request(server, "/m", { method: "POST" }).then(r => [r.status, r.body]),
+    }).toEqual({ get: "GET only", post: [404, "fallback"] });
+  });
+
+  test("is accepted under the static option", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      static: { "/s": new Blob(["static option"], { type: "text/plain" }) },
+      fetch: notFound,
+    });
+
+    expect((await request(server, "/s")).body).toBe("static option");
+  });
+
+  test("does not consume the Blob, so it can be registered twice and again on reload()", async () => {
+    const blob = new Blob(["shared"], { type: "text/plain" });
+    await using server = Bun.serve({ port: 0, routes: { "/a": blob, "/b": blob }, fetch: notFound });
+    expect([(await request(server, "/a")).body, (await request(server, "/b")).body]).toEqual(["shared", "shared"]);
+
+    server.reload({ routes: { "/c": blob }, fetch: notFound });
+    expect((await request(server, "/c")).body).toBe("shared");
+    expect(await blob.text()).toBe("shared");
+  });
+
+  test("keeps the bytes alive after the Blob itself is garbage collected", async () => {
+    // The options literal is the only reference to the Blob.
+    await using server = Bun.serve({
+      port: 0,
+      routes: { "/gc": new Blob([Buffer.alloc(64 * 1024, "g")], { type: "text/plain" }) },
+      fetch: notFound,
+    });
+    Bun.gc(true);
+
+    const { status, contentLength, body } = await request(server, "/gc");
+    expect({ status, contentLength, body: body.length, allG: !/[^g]/.test(body) }).toEqual({
+      status: 200,
+      contentLength: String(64 * 1024),
+      body: 64 * 1024,
+      allG: true,
+    });
+  });
+
+  test("a BuildArtifact responds like new Response(artifact)", async () => {
+    using dir = tempDir("blob-route-artifact", { "entry.ts": "export const answer = 42;" });
+    const {
+      outputs: [artifact],
+    } = await Bun.build({ entrypoints: [`${dir}/entry.ts`] });
+    await using server = Bun.serve({
+      port: 0,
+      routes: { "/bare.js": artifact, "/wrapped.js": new Response(artifact) },
+      fetch: notFound,
+    });
+
+    const bare = await request(server, "/bare.js");
+    expect(bare.status).toBe(200);
+    expect(bare.body).toBe(await artifact.text());
+    expect(bare).toEqual(await request(server, "/wrapped.js"));
+  });
+
+  test("Bun.file() of a file on disk is still read on every request", async () => {
+    using dir = tempDir("blob-route-disk", { "a.txt": "before" });
+    await using server = Bun.serve({ port: 0, routes: { "/a.txt": Bun.file(`${dir}/a.txt`) }, fetch: notFound });
+
+    expect((await request(server, "/a.txt")).body).toBe("before");
+    await Bun.write(`${dir}/a.txt`, "after!");
+    expect((await request(server, "/a.txt")).body).toBe("after!");
+  });
+
+  test("an S3 file is still rejected", () => {
+    const s3 = Bun.s3.file("key", {
+      bucket: "bucket",
+      accessKeyId: "id",
+      secretAccessKey: "secret",
+      endpoint: "http://127.0.0.1:1",
+    });
+    expect(() => {
+      using _server = Bun.serve({ port: 0, routes: { "/s3": s3 }, fetch: notFound });
+    }).toThrow("'routes' expects a Record<string,");
   });
 });


### PR DESCRIPTION
### Problem
- `Bun.serve({ routes: { "/favicon.ico": file(favicon) } })`, with `favicon` imported `with { type: "file" }`, serves the file under `bun server.ts` but throws at startup inside a `bun build --compile` binary: `TypeError: 'routes' expects a Record<string, Response | HTMLBundle | {[method: string]: ...}>` (`ERR_INVALID_ARG_TYPE`). This is the example in `docs/bundler/executables.mdx`, and `packages/bun-types/serve.d.ts` types `BunFile` as a route value, so the same typed, documented code works uncompiled and fails compiled.
- Inside the executable, `Bun.file()` of an embedded path returns a Blob whose bytes live in memory (`src/runtime/webcore/Blob.rs` `find_or_create_file_from_path`, via `src/runtime/api/standalone_graph_jsc.rs` `file_blob`), not a Blob backed by a file on disk. `AnyRoute::from_js` (`src/runtime/server/server_body.rs`) only builds a route from a bare Blob in `FileRoute::from_js` (`src/runtime/server/FileRoute.rs:194`), which requires `needs_to_read_file()`, i.e. a disk-backed store; `StaticRoute::from_js` only took a `Response`. Every other Blob (embedded file, `Bun.embeddedFiles` entry, `new Blob()`) fell through to the error. The same value wrapped in `new Response(blob)` was accepted, and a `{ GET: blob }` method object silently registered nothing.

### Fix
- `StaticRoute::from_js` (`src/runtime/server/StaticRoute.rs`) now accepts a Blob that is not backed by a file or by S3 and builds a static route from a `dupe()` of it with `init_from_any_blob`. This is the fixing hunk; the rest of the diff is types, docs and tests.
- Why this is right: `init_from_any_blob` is what the `Response` branch of the same function ends up with after snapshotting the response body (`AnyBlob::Blob`, Content-Type from the blob's type, generated ETag, status 200), and it is also how bundled HTML manifests already serve embedded assets (`AnyRoute::from_options` in `server_body.rs`). So a bare Blob route is exactly `new Response(blob)` as a route, which is the form the docs had to fall back to. `dupe()` takes its own ref on the store, so the route does not consume the Blob (it can be registered twice and again on `reload()`) and keeps the bytes alive after the JS Blob is collected. Disk-backed blobs are unaffected because `FileRoute::from_js` still runs first; S3 blobs have no bytes to snapshot and keep producing the existing error (`new Response(s3file)` is a presigned redirect, a different thing, and still works as before).
- `BaseRouteValue` in `serve.d.ts` goes from `BunFile` to `Blob` (`BunFile` extends `Blob`), with JSDoc saying which blobs are read from disk and which are served from memory. The per-method record type is left as is; #36319 widens it to `BaseRouteValue`, which composes with this.
- `docs/bundler/executables.mdx`: the `Bun.embeddedFiles` example no longer wraps each blob in a `Response`. The static-assets example a few sections up already uses bare `file(...)` and becomes correct with this change (#39013 currently proposes wrapping it because of this bug; that hunk becomes unnecessary once this lands).
- Verified:
  - `test/js/bun/http/bun-serve-static.test.ts` "Blob route values": bytes, type, Content-Length and ETag of typed, untyped, empty, `File` and `slice()`d blobs; GET and HEAD byte-for-byte parity with the same blob wrapped in `new Response()`; 304 on `If-None-Match`; `{ GET: blob }` and the `static` option; reuse across two routes and `reload()`; bytes survive `Bun.gc(true)`; a `BuildArtifact` matches `new Response(artifact)`; `Bun.file()` of a disk file is still re-read per request; an S3 file is still rejected. 8 of the 10 cases fail on the unfixed build (the last two are regression guards).
  - `test/bundler/bundler_compile.test.ts` `compile/EmbeddedFileServeRoute`: compiles a server that routes `file(asset)` and every `Bun.embeddedFiles` entry, runs the binary and checks status, Content-Type and body. Fails on the unfixed build with the `ERR_INVALID_ARG_TYPE` above.
  - `test/integration/bun-types/fixture/serve.ts`: `new Blob()` and a `Record<string, Blob>` of embedded files as routes; `bun test test/integration/bun-types/bun-types.test.ts` fails on these lines with the old declarations and passes with the new ones (15/15).
  - The updated docs example, compiled with `--compile` and run: `/favicon.ico` `image/x-icon`, `/logo.png` `image/png`, `/styles.css` `text/css;charset=utf-8`, all 200.
  - `bun-serve-routes.test.ts`, `bun-serve-file.test.ts`, `serve-directory-routes.test.ts`, `bun-serve-html-manifest.test.ts`, `html-import-manifest.test.ts` pass on the debug build.
- Found while doing this and handed off separately: a static route built from `new Response(buildArtifact)` (and therefore a bare artifact too) sends no Content-Type although the same Response from `fetch()` does; the parity test here compares the two registrations so it stays valid whichever way that is fixed. Also, a per-method value that is neither a handler nor a route value (`{ GET: 42 }`) is still silently dropped; this PR only makes Blobs valid there.

### Background
- Route values: besides handler functions, `routes` accepts values that are turned into native routes once at startup in `AnyRoute::from_js`: a `StaticRoute` holds bytes in memory and writes them with a precomputed header block and ETag; a `FileRoute` holds a `Bun.file()` and reads the file on each request; HTML bundles and `{ dir }` directory routes are the other kinds.
- `Blob` stores: a Blob's bytes come from one of three store kinds: `Bytes` (in memory), `File` (a path or fd on disk; `needs_to_read_file()` is true) or `S3`. `Bun.file(path)` normally creates a `File` store; in a compiled executable, a path under the embedded-files root is answered from the standalone module graph with a `Bytes` store instead, with the Content-Type taken from the extension.
- `AnyBlob` is the server's body enum (`Blob`, an internal byte buffer, or a WTF string); `StaticRoute::init_from_any_blob` builds the route from any of them.
- `dupe()` creates a new Blob view onto the same store and takes a reference on it, so the route's copy is independent of the JS wrapper's lifetime.
