### PR TITLE
bun:test: setSystemTime also moves Temporal.Now (WebKit bump)

### DIFF
--- a/docs/test/dates-times.mdx
+++ b/docs/test/dates-times.mdx
@@ -10,6 +10,7 @@ This works with any of the following:
 - `Date.now`
 - `new Date()`
 - `new Intl.DateTimeFormat().format()`
+- `Temporal.Now` (`instant()`, `zonedDateTimeISO()`, `plainDateTimeISO()`, `plainDateISO()`, `plainTimeISO()`)
 
 ## setSystemTime
 

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -64,6 +64,7 @@ declare module "bun:test" {
    * - `Date.now()`
    * - `new Date()`
    * - `Intl.DateTimeFormat().format()`
+   * - `Temporal.Now` (`instant()`, `zonedDateTimeISO()`, `plainDateTimeISO()`, `plainDateISO()`, `plainTimeISO()`)
    *
    * @param now The time to set the system time to. If omitted, the system time is reset
    * @returns `this`

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "f0f60fd2324817dae9656d8bf2fcae25ceaccc37";
+export const WEBKIT_VERSION = "autobuild-preview-pr-453-f4b6b77e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -1,3 +1,4 @@
+import { expect, jest, setSystemTime, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import path from "node:path";
 
@@ -75,6 +76,127 @@ test("setSystemTime accepts pre-epoch and epoch times and resets with no argumen
   } finally {
     jest.useRealTimers();
   }
+});
+
+function temporalNowInUTC() {
+  return {
+    instant: Temporal.Now.instant().toString(),
+    zonedDateTime: Temporal.Now.zonedDateTimeISO("UTC").toString(),
+    plainDateTime: Temporal.Now.plainDateTimeISO("UTC").toString(),
+    plainDate: Temporal.Now.plainDateISO("UTC").toString(),
+    plainTime: Temporal.Now.plainTimeISO("UTC").toString(),
+  };
+}
+
+test("setSystemTime moves Temporal.Now along with Date", () => {
+  const realBefore = Date.now();
+  try {
+    setSystemTime(new Date("1995-12-19T00:00:00.123Z"));
+    expect(Date.now()).toBe(819331200123);
+    expect(temporalNowInUTC()).toEqual({
+      instant: "1995-12-19T00:00:00.123Z",
+      zonedDateTime: "1995-12-19T00:00:00.123+00:00[UTC]",
+      plainDateTime: "1995-12-19T00:00:00.123",
+      plainDate: "1995-12-19",
+      plainTime: "00:00:00.123",
+    });
+    expect(Temporal.Now.instant().epochNanoseconds).toBe(819331200123000000n);
+
+    // Without a time zone argument the system zone is used, whatever it is: the result has to
+    // describe the same mocked instant as the explicit system zone and as the mocked Date.
+    const systemZone = Temporal.Now.timeZoneId();
+    const zoned = Temporal.Now.zonedDateTimeISO();
+    expect([zoned.epochMilliseconds, zoned.timeZoneId]).toEqual([819331200123, systemZone]);
+    const mockedDate = new Date();
+    const plainDateTimeOfMockedDate = Temporal.PlainDateTime.from({
+      year: mockedDate.getFullYear(),
+      month: mockedDate.getMonth() + 1,
+      day: mockedDate.getDate(),
+      hour: mockedDate.getHours(),
+      minute: mockedDate.getMinutes(),
+      second: mockedDate.getSeconds(),
+      millisecond: mockedDate.getMilliseconds(),
+    });
+    expect(Temporal.Now.plainDateTimeISO().toString()).toBe(plainDateTimeOfMockedDate.toString());
+    expect(Temporal.Now.plainDateTimeISO().toString()).toBe(Temporal.Now.plainDateTimeISO(systemZone).toString());
+    expect(Temporal.Now.plainDateISO().toString()).toBe(plainDateTimeOfMockedDate.toPlainDate().toString());
+    expect(Temporal.Now.plainTimeISO().toString()).toBe(plainDateTimeOfMockedDate.toPlainTime().toString());
+
+    // Numbers work like Dates do, including before the epoch.
+    setSystemTime(-1);
+    expect(Date.now()).toBe(-1);
+    expect(temporalNowInUTC()).toEqual({
+      instant: "1969-12-31T23:59:59.999Z",
+      zonedDateTime: "1969-12-31T23:59:59.999+00:00[UTC]",
+      plainDateTime: "1969-12-31T23:59:59.999",
+      plainDate: "1969-12-31",
+      plainTime: "23:59:59.999",
+    });
+    expect(Temporal.Now.instant().epochNanoseconds).toBe(-1000000n);
+  } finally {
+    setSystemTime();
+  }
+
+  expect(Temporal.Now.instant().epochMilliseconds).toBeGreaterThanOrEqual(realBefore);
+  expect(Temporal.Now.zonedDateTimeISO("UTC").epochMilliseconds).toBeGreaterThanOrEqual(realBefore);
+  expect(Temporal.Now.instant().epochMilliseconds).toBeLessThanOrEqual(Date.now());
+});
+
+test("Temporal.Now follows jest.setSystemTime and advanceTimersByTime under fake timers", () => {
+  const realBefore = Date.now();
+  jest.useFakeTimers();
+  try {
+    const base = Date.UTC(2026, 0, 1, 12);
+    jest.setSystemTime(base);
+    expect(Temporal.Now.instant().epochMilliseconds).toBe(base);
+
+    jest.advanceTimersByTime(1500);
+    expect(Date.now()).toBe(base + 1500);
+    expect(temporalNowInUTC()).toEqual({
+      instant: "2026-01-01T12:00:01.5Z",
+      zonedDateTime: "2026-01-01T12:00:01.5+00:00[UTC]",
+      plainDateTime: "2026-01-01T12:00:01.5",
+      plainDate: "2026-01-01",
+      plainTime: "12:00:01.5",
+    });
+  } finally {
+    jest.useRealTimers();
+  }
+
+  expect(Temporal.Now.instant().epochMilliseconds).toBeGreaterThanOrEqual(realBefore);
+  expect(Temporal.Now.instant().epochMilliseconds).toBeLessThanOrEqual(Date.now());
+});
+
+test("Temporal.Now gets the mocked time clipped the way new Date() does", () => {
+  try {
+    // Fractional milliseconds are truncated, as by new Date().
+    setSystemTime(819331200000.75);
+    expect(new Date().getTime()).toBe(819331200000);
+    expect(Temporal.Now.instant().epochNanoseconds).toBe(819331200000000000n);
+
+    // The ends of the Date range are the ends of the Temporal range.
+    setSystemTime(8.64e15);
+    expect(Temporal.Now.instant().toString()).toBe("+275760-09-13T00:00:00Z");
+    setSystemTime(-8.64e15);
+    expect(Temporal.Now.plainDateISO("UTC").toString()).toBe("-271821-04-20");
+
+    // A mocked time that makes new Date() an Invalid Date has no Temporal equivalent.
+    for (const outOfRange of [8.64e15 + 1, Infinity]) {
+      setSystemTime(outOfRange);
+      expect(Date.now()).toBe(outOfRange);
+      expect(new Date().getTime()).toBeNaN();
+      expect(() => Temporal.Now.instant()).toThrow(RangeError);
+      expect(() => Temporal.Now.zonedDateTimeISO()).toThrow(RangeError);
+      expect(() => Temporal.Now.plainDateTimeISO()).toThrow(RangeError);
+      expect(() => Temporal.Now.plainDateISO("UTC")).toThrow(RangeError);
+      expect(() => Temporal.Now.plainTimeISO("UTC")).toThrow(RangeError);
+      expect(typeof Temporal.Now.timeZoneId()).toBe("string");
+    }
+  } finally {
+    setSystemTime();
+  }
+
+  expect(() => Temporal.Now.instant()).not.toThrow();
 });
 
 test.each(["'x'", "Symbol()", "1n"])("useFakeTimers does not crash when globalThis.setTimeout is %s", async value => {


### PR DESCRIPTION
Bumps `WEBKIT_VERSION` to pick up oven-sh/WebKit#453 and adds the `bun:test` tests for it.

### Problem

- `setSystemTime()` (and `jest.setSystemTime()`, with or without `useFakeTimers()`) moves `Date.now()`, `new Date()` and `Intl.DateTimeFormat().format()`, but not `Temporal.Now`, which Bun 1.4 exposes by default. Every `Temporal.Now.*` reading keeps returning the real clock, so code that moved from `Date.now()` to `Temporal.Now.instant()` silently escapes the mock:
  ```ts
  import { test, expect, setSystemTime } from "bun:test";
  test("clock mock vs Temporal.Now", () => {
    setSystemTime(new Date("2020-01-01T00:00:00Z"));
    new Date().toISOString();                                           // 2020-01-01T00:00:00.000Z
    Temporal.Now.instant().toString();                                  // 2026-08-16T03:06:49.96Z
    expect(Temporal.Now.instant().epochMilliseconds).toBe(Date.now());  // fails
  });
  ```
- Cause: the mock is the engine field `JSGlobalObject::overridenDateNow`, which `JSMock__jsSetSystemTime` (`src/jsc/bindings/JSMockFunction.cpp`) and the fake-timer clock (`src/runtime/test_runner/timers/FakeTimers.rs`) write. `Date` and Intl read it through `JSGlobalObject::jsDateNow()`; JavaScriptCore's `TemporalNow.cpp` read `ISO8601::ExactTime::now()` (the real clock) directly in `instant()`, in the shared helper behind `plainDateTimeISO()` / `plainDateISO()` / `plainTimeISO()`, and in `zonedDateTimeISO()`. `Temporal.Now.timeZoneId()` does not read the clock and already followed `process.env.TZ`.

### Fix

- oven-sh/WebKit#453: the three clock reads in `TemporalNow.cpp` go through a helper that returns the override when one is set and `ExactTime::now()` (nanosecond resolution) otherwise. The override gets the same `TimeClip` that `new Date()` applies to it, so `Temporal.Now.instant().epochMilliseconds === new Date().getTime()` for every value `setSystemTime` accepts (fractional, pre-epoch, both ends of the range), and the values that make `new Date()` an Invalid Date (`setSystemTime(Infinity)`, `setSystemTime(8.64e15 + 1)`) make the five functions throw a `RangeError`, since there is no invalid `Temporal.Instant`.
- No Bun source change: both `setSystemTime` entry points and `advanceTimersByTime` already write the field the engine now reads, so the fix covers them all and is engine side on purpose; replacing `Temporal.Now`'s functions from Bun would mean re-implementing them against JSC internals.
- Tests, in `test/js/bun/test/test-timers.test.ts` next to the existing `setSystemTime` coverage (the file now imports from `bun:test` instead of using the injected globals, because it needs `setSystemTime`):
  - `setSystemTime` from `bun:test` with no fake timers: the five functions in explicit UTC for a 1995 instant and for `-1`, `epochNanoseconds`, and the no-argument (system zone) results against the explicit system zone and against the fields of the mocked `new Date()`, then the reset.
  - `jest.useFakeTimers()` + `jest.setSystemTime()` + `advanceTimersByTime(1500)`: `Temporal.Now` ticks with `Date.now()`, and `useRealTimers()` releases it.
  - `TimeClip` equivalence (`819331200000.75`, both ends of the range) and the `RangeError` for `8.64e15 + 1` and `Infinity`.
- Results: the three new tests fail on the current pin (`USE_SYSTEM_BUN=1`, 1.4.0-canary: each at its first `Temporal.Now` assertion, e.g. `Expected: 1767268800000, Received: 1786852807367`; the seven existing tests in the file still pass) and the whole file passes with `bun bd test` (debug, ASAN) against the preview build. Against the same build, `test/js/web/temporal/temporal.test.ts`, `test/js/bun/jsc/temporal-global.test.ts`, `test/js/bun/bun-object/deep-equals-temporal.test.ts`, `test/regression/issue/32793.test.ts`, the two `test/js/bun/cron/` files that use `setSystemTime` (145 tests) and `test/js/bun/test/fake-timers/` (same pass/todo counts as the current release) pass, and `test/integration/bun-types/bun-types.test.ts` passes with the JSDoc change. The engine-side stress test from oven-sh/WebKit#453 passes on the preview tarball's `jsc` under `TZ=Etc/UTC`, `America/Los_Angeles` and `Pacific/Kiritimati` (system zone path) with `--validateExceptionChecks=1`.
- Docs: `docs/test/dates-times.mdx` and the `setSystemTime` JSDoc in `packages/bun-types/test.d.ts` list what the mock covers; `Temporal.Now` is added to both lists.

### Background

- `overridenDateNow`: a per-global-object `double` of epoch milliseconds added to JSC for `bun test`; NaN means no override. `setSystemTime(x)` stores `x` as given (a `Date`'s internal number, or the number itself), `setSystemTime()` stores NaN, and under fake timers `advanceTimersByTime` re-stores base + elapsed. Because the value is stored raw, `new Date()` applies `TimeClip` (truncate to whole milliseconds, NaN outside ±8.64e15 ms) when it reads it; the engine change applies the same clip for Temporal.
- `Temporal.Now`: the five functions above plus `timeZoneId()`. The spec reads the clock through one operation, SystemUTCEpochNanoseconds, which is the helper the engine change introduces; `instant()` and `zonedDateTimeISO()` wrap the instant directly, the three `plain*ISO()` functions convert it to the requested (default: system) time zone first.
- The Date range and the Temporal instant range are both ±8.64e15 ms (±10^8 days), so a clipped override is always a valid instant.

### Also in this range

Nothing else: oven-sh/WebKit#453 is directly on top of `f0f60fd232`, the commit this branch replaces.

> [!NOTE]
> `WEBKIT_VERSION` points at the preview tag `autobuild-preview-pr-453-f4b6b77e` while oven-sh/WebKit#453 is open; it needs to be switched to the merged main sha before this lands.
