### PR TITLE
assert.partialDeepStrictEqual: compare DOMExceptions by name, message and cause

### DIFF
--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -560,7 +560,7 @@ static bool setSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuff
     return true;
 }
 
-// Errors compare name/message/errors leniently: `undefined` (or an empty
+// Errors compare message/name/cause/errors leniently: `undefined` (or an empty
 // expected message) on the expected side is ignored. An own `cause` on the
 // expected error (even undefined) must exist on the actual error as well.
 static bool errorSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBuffer& gcBuffer, CycleState& cycles, JSC::ThrowScope& scope, JSValue actual, JSValue expected)
@@ -569,9 +569,10 @@ static bool errorSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBu
     JSC::JSObject* actualObject = actual.getObject();
     JSC::JSObject* expectedObject = expected.getObject();
 
-    const JSC::Identifier keys[3] = {
+    const JSC::Identifier keys[4] = {
         vm.propertyNames->message,
         vm.propertyNames->name,
+        vm.propertyNames->cause,
         JSC::Identifier::fromString(vm, "errors"_s),
     };
     for (const auto& key : keys) {
@@ -592,23 +593,14 @@ static bool errorSubset(JSC::JSGlobalObject* globalObject, JSC::MarkedArgumentBu
             return false;
     }
 
-    const JSC::Identifier causeIdentifier = JSC::Identifier::fromString(vm, "cause"_s);
     JSC::PropertySlot expectedCauseSlot(expectedObject, JSC::PropertySlot::InternalMethodType::GetOwnProperty);
-    bool expectedHasCause = expectedObject->methodTable()->getOwnPropertySlot(expectedObject, globalObject, causeIdentifier, expectedCauseSlot);
+    bool expectedHasCause = expectedObject->methodTable()->getOwnPropertySlot(expectedObject, globalObject, vm.propertyNames->cause, expectedCauseSlot);
     RETURN_IF_EXCEPTION(scope, false);
     if (expectedHasCause) {
         JSC::PropertySlot actualCauseSlot(actualObject, JSC::PropertySlot::InternalMethodType::GetOwnProperty);
-        bool actualHasCause = actualObject->methodTable()->getOwnPropertySlot(actualObject, globalObject, causeIdentifier, actualCauseSlot);
+        bool actualHasCause = actualObject->methodTable()->getOwnPropertySlot(actualObject, globalObject, vm.propertyNames->cause, actualCauseSlot);
         RETURN_IF_EXCEPTION(scope, false);
         if (!actualHasCause)
-            return false;
-        JSValue actualCause = actualObject->get(globalObject, causeIdentifier);
-        RETURN_IF_EXCEPTION(scope, false);
-        JSValue expectedCause = expectedObject->get(globalObject, causeIdentifier);
-        RETURN_IF_EXCEPTION(scope, false);
-        bool equal = compareBranch(globalObject, gcBuffer, cycles, scope, actualCause, expectedCause);
-        RETURN_IF_EXCEPTION(scope, false);
-        if (!equal)
             return false;
     }
     return objectSubset(globalObject, gcBuffer, cycles, scope, actual, expected);

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -750,10 +750,8 @@ static bool compareBranch(JSC::JSGlobalObject* globalObject, JSC::MarkedArgument
         return withCycleGuard(globalObject, gcBuffer, cycles, scope, actual, expected, objectSubset);
     }
 
-    // DOMException is `instanceof Error`, so node compares it like an Error, but it is a DOM
-    // wrapper whose name/message are prototype accessors: the own-property walk at the bottom
-    // sees nothing to compare. Must stay ahead of the ErrorInstance arm and separate from it:
-    // node rejects DOMException vs Error on the Object.prototype.toString tag.
+    // Not an ErrorInstance (name/message are prototype accessors, so the own-property walk sees
+    // nothing), and kept ahead of and apart from the Error arm: node rejects DOMException vs Error.
     const bool actualIsDOMException = actual.isCell() && actual.asCell()->inherits<WebCore::JSDOMException>();
     const bool expectedIsDOMException = expected.isCell() && expected.asCell()->inherits<WebCore::JSDOMException>();
     if (actualIsDOMException || expectedIsDOMException) {

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -750,8 +750,7 @@ static bool compareBranch(JSC::JSGlobalObject* globalObject, JSC::MarkedArgument
         return withCycleGuard(globalObject, gcBuffer, cycles, scope, actual, expected, objectSubset);
     }
 
-    // Not an ErrorInstance (name/message are prototype accessors, so the own-property walk sees
-    // nothing), and kept ahead of and apart from the Error arm: node rejects DOMException vs Error.
+    // Not an ErrorInstance; kept ahead of and apart from the Error arm (node rejects DOMException vs Error).
     const bool actualIsDOMException = actual.isCell() && actual.asCell()->inherits<WebCore::JSDOMException>();
     const bool expectedIsDOMException = expected.isCell() && expected.asCell()->inherits<WebCore::JSDOMException>();
     if (actualIsDOMException || expectedIsDOMException) {

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -1,4 +1,5 @@
 #include "BunClientData.h"
+#include "JSDOMException.h"
 #include "JSDOMURL.h"
 #include "JSDOMWrapper.h"
 #include "node/crypto/JSKeyObject.h"
@@ -755,6 +756,18 @@ static bool compareBranch(JSC::JSGlobalObject* globalObject, JSC::MarkedArgument
         if (actualURL.href() != expectedURL.href())
             return false;
         return withCycleGuard(globalObject, gcBuffer, cycles, scope, actual, expected, objectSubset);
+    }
+
+    // DOMException is `instanceof Error`, so node compares it like an Error, but it is a DOM
+    // wrapper whose name/message are prototype accessors: the own-property walk at the bottom
+    // sees nothing to compare. Must stay ahead of the ErrorInstance arm and separate from it:
+    // node rejects DOMException vs Error on the Object.prototype.toString tag.
+    const bool actualIsDOMException = actual.isCell() && actual.asCell()->inherits<WebCore::JSDOMException>();
+    const bool expectedIsDOMException = expected.isCell() && expected.asCell()->inherits<WebCore::JSDOMException>();
+    if (actualIsDOMException || expectedIsDOMException) {
+        if (!actualIsDOMException || !expectedIsDOMException)
+            return false;
+        return withCycleGuard(globalObject, gcBuffer, cycles, scope, actual, expected, errorSubset);
     }
 
     const bool actualIsError = actual.isCell() && actual.asCell()->inherits<JSC::ErrorInstance>();

--- a/test/js/node/assert/assert.test.cjs
+++ b/test/js/node/assert/assert.test.cjs
@@ -91,4 +91,198 @@ describe("assert.partialDeepStrictEqual", () => {
     const arr = [[]];
     assert.partialDeepStrictEqual([arr], arr);
   });
+
+  // DOMException is `instanceof Error` but has no own enumerable properties (name and message
+  // are prototype accessors), so node compares it like an Error: name, message and cause.
+  // Expectations below were checked against Node v26.
+  describe("DOMException", () => {
+    class SubException extends DOMException {}
+    const abortMessage = AbortSignal.abort().reason.message;
+
+    const rejected = [
+      [
+        "different name and message",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("other", "NotFoundError"),
+      ],
+      [
+        "same name, different message",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("other", "AbortError"),
+      ],
+      [
+        "same message, different name",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("boom", "NotFoundError"),
+      ],
+      ["default name vs explicit name", () => new DOMException("boom", "AbortError"), () => new DOMException("boom")],
+      [
+        "empty actual message vs non-empty expected message",
+        () => new DOMException("", "AbortError"),
+        () => new DOMException("boom", "AbortError"),
+      ],
+      [
+        "different cause",
+        () => new DOMException("boom", { name: "AbortError", cause: 1 }),
+        () => new DOMException("boom", { name: "AbortError", cause: 2 }),
+      ],
+      [
+        "expected cause has a property the actual cause lacks",
+        () => new DOMException("boom", { name: "AbortError", cause: { x: 1 } }),
+        () => new DOMException("boom", { name: "AbortError", cause: { x: 1, y: 2 } }),
+      ],
+      [
+        "own cause on expected only",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("boom", { name: "AbortError", cause: 1 }),
+      ],
+      [
+        "own undefined cause on expected only",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("boom", { name: "AbortError", cause: undefined }),
+      ],
+      [
+        "own enumerable property on expected only",
+        () => new DOMException("boom", "AbortError"),
+        () => Object.assign(new DOMException("boom", "AbortError"), { extra: 1 }),
+      ],
+      [
+        "subclass instances with different messages",
+        () => new SubException("boom", "SyntaxError"),
+        () => new SubException("other", "SyntaxError"),
+      ],
+      [
+        "AbortSignal reason vs a different DOMException",
+        () => AbortSignal.abort().reason,
+        () => new DOMException("boom", "TimeoutError"),
+      ],
+      [
+        "AbortSignal reason vs the same message under a different name",
+        () => AbortSignal.abort().reason,
+        () => new DOMException(abortMessage, "TimeoutError"),
+      ],
+      ["DOMException vs a plain object", () => new DOMException("boom", "AbortError"), () => ({})],
+      ["plain object vs DOMException", () => ({}), () => new DOMException("boom", "AbortError")],
+      [
+        "DOMException vs an object with the same name and message",
+        () => new DOMException("boom", "AbortError"),
+        () => ({ name: "AbortError", message: "boom" }),
+      ],
+      [
+        "DOMException vs an Error with the same name and message",
+        () => new DOMException("boom"),
+        () => new Error("boom"),
+      ],
+      [
+        "Error vs a DOMException with the same name and message",
+        () => new Error("boom"),
+        () => new DOMException("boom"),
+      ],
+      [
+        "nested in an object",
+        () => ({ error: new DOMException("boom", "AbortError") }),
+        () => ({ error: new DOMException("other", "NotFoundError") }),
+      ],
+      [
+        "no array element matches",
+        () => [new DOMException("a", "AbortError"), new DOMException("b", "TimeoutError")],
+        () => [new DOMException("c", "TimeoutError")],
+      ],
+    ];
+
+    const accepted = [
+      [
+        "same name and message",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("boom", "AbortError"),
+      ],
+      ["both default name", () => new DOMException("boom"), () => new DOMException("boom")],
+      [
+        "empty expected message",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("", "AbortError"),
+      ],
+      [
+        "same cause",
+        () => new DOMException("boom", { name: "AbortError", cause: 1 }),
+        () => new DOMException("boom", { name: "AbortError", cause: 1 }),
+      ],
+      [
+        "expected cause is a subset of the actual cause",
+        () => new DOMException("boom", { name: "AbortError", cause: { x: 1, y: 2 } }),
+        () => new DOMException("boom", { name: "AbortError", cause: { x: 1 } }),
+      ],
+      [
+        "own cause on actual only",
+        () => new DOMException("boom", { name: "AbortError", cause: 1 }),
+        () => new DOMException("boom", "AbortError"),
+      ],
+      [
+        "own undefined cause on both",
+        () => new DOMException("boom", { name: "AbortError", cause: undefined }),
+        () => new DOMException("boom", { name: "AbortError", cause: undefined }),
+      ],
+      [
+        "own enumerable property on actual only",
+        () => Object.assign(new DOMException("boom", "AbortError"), { extra: 1 }),
+        () => new DOMException("boom", "AbortError"),
+      ],
+      [
+        "same own enumerable property on both",
+        () => Object.assign(new DOMException("boom", "AbortError"), { extra: 1 }),
+        () => Object.assign(new DOMException("boom", "AbortError"), { extra: 1 }),
+      ],
+      [
+        "subclass instances with the same name and message",
+        () => new SubException("boom", "SyntaxError"),
+        () => new SubException("boom", "SyntaxError"),
+      ],
+      [
+        "subclass instance vs base instance",
+        () => new SubException("boom", "SyntaxError"),
+        () => new DOMException("boom", "SyntaxError"),
+      ],
+      [
+        "AbortSignal reason vs an equal DOMException",
+        () => AbortSignal.abort().reason,
+        () => new DOMException(abortMessage, "AbortError"),
+      ],
+      [
+        "nested in an object",
+        () => ({ error: new DOMException("boom", "AbortError"), z: 1 }),
+        () => ({ error: new DOMException("boom", "AbortError") }),
+      ],
+      [
+        "a later array element matches",
+        () => [new DOMException("a", "AbortError"), new DOMException("b", "TimeoutError")],
+        () => [new DOMException("b", "TimeoutError")],
+      ],
+      [
+        "self-referencing causes on both sides",
+        () => {
+          const cause = {};
+          cause.self = cause;
+          return new DOMException("boom", { name: "AbortError", cause });
+        },
+        () => {
+          const cause = {};
+          cause.self = cause;
+          return new DOMException("boom", { name: "AbortError", cause });
+        },
+      ],
+    ];
+
+    test.each(rejected)("rejects %s", (_name, actual, expected) => {
+      expect(() => assert.partialDeepStrictEqual(actual(), expected())).toThrow(assert.AssertionError);
+    });
+
+    test.each(accepted)("accepts %s", (_name, actual, expected) => {
+      assert.partialDeepStrictEqual(actual(), expected());
+    });
+
+    test("the same instance on both sides is accepted", () => {
+      const error = new DOMException("boom", "AbortError");
+      assert.partialDeepStrictEqual(error, error);
+    });
+  });
 });

--- a/test/js/node/assert/assert.test.cjs
+++ b/test/js/node/assert/assert.test.cjs
@@ -92,6 +92,70 @@ describe("assert.partialDeepStrictEqual", () => {
     assert.partialDeepStrictEqual([arr], arr);
   });
 
+  // Node reads `cause` like message/name/errors (an undefined expected value is not compared)
+  // and additionally requires an own `cause` on expected to exist on actual.
+  // Expectations below were checked against Node v26.
+  describe("error cause", () => {
+    class InheritedCauseError extends Error {
+      get cause() {
+        return 1;
+      }
+    }
+
+    const rejected = [
+      [
+        "no actual cause vs own undefined expected cause",
+        () => new Error("x"),
+        () => new Error("x", { cause: undefined }),
+      ],
+      [
+        "own undefined actual cause vs defined expected cause",
+        () => new Error("x", { cause: undefined }),
+        () => new Error("x", { cause: 1 }),
+      ],
+      ["different causes", () => new Error("x", { cause: 1 }), () => new Error("x", { cause: 2 })],
+      [
+        "actual cause differs from an inherited expected cause",
+        () => new Error("x", { cause: 2 }),
+        () => new InheritedCauseError("x"),
+      ],
+      ["no actual cause vs an inherited expected cause", () => new Error("x"), () => new InheritedCauseError("x")],
+      [
+        "inherited actual cause vs an own expected cause with the same value",
+        () => new InheritedCauseError("x"),
+        () => new Error("x", { cause: 1 }),
+      ],
+    ];
+
+    const accepted = [
+      [
+        "defined actual cause vs own undefined expected cause",
+        () => new Error("x", { cause: 1 }),
+        () => new Error("x", { cause: undefined }),
+      ],
+      ["same causes", () => new Error("x", { cause: 1 }), () => new Error("x", { cause: 1 })],
+      [
+        "expected cause is a subset of the actual cause",
+        () => new Error("x", { cause: { a: 1, b: 2 } }),
+        () => new Error("x", { cause: { a: 1 } }),
+      ],
+      ["actual cause vs no expected cause", () => new Error("x", { cause: 1 }), () => new Error("x")],
+      [
+        "own actual cause vs an inherited expected cause with the same value",
+        () => new Error("x", { cause: 1 }),
+        () => new InheritedCauseError("x"),
+      ],
+    ];
+
+    test.each(rejected)("rejects %s", (_name, actual, expected) => {
+      expect(() => assert.partialDeepStrictEqual(actual(), expected())).toThrow(assert.AssertionError);
+    });
+
+    test.each(accepted)("accepts %s", (_name, actual, expected) => {
+      assert.partialDeepStrictEqual(actual(), expected());
+    });
+  });
+
   // DOMException is `instanceof Error` but has no own enumerable properties (name and message
   // are prototype accessors), so node compares it like an Error: name, message and cause.
   // Expectations below were checked against Node v26.
@@ -220,6 +284,11 @@ describe("assert.partialDeepStrictEqual", () => {
       [
         "own undefined cause on both",
         () => new DOMException("boom", { name: "AbortError", cause: undefined }),
+        () => new DOMException("boom", { name: "AbortError", cause: undefined }),
+      ],
+      [
+        "defined cause on actual, own undefined cause on expected",
+        () => new DOMException("boom", { name: "AbortError", cause: 1 }),
         () => new DOMException("boom", { name: "AbortError", cause: undefined }),
       ],
       [


### PR DESCRIPTION
### Problem
- `assert.partialDeepStrictEqual(new DOMException("boom", "AbortError"), new DOMException("other", "NotFoundError"))` passes. Node v26 throws `ERR_ASSERTION`. Same for two DOMExceptions that differ only in message, only in name, or only in `cause`, and for an expected DOMException that has a `cause` when the actual one has none. The same holds when the DOMExceptions are nested in objects or arrays, and for `AbortSignal` reasons compared against a DOMException with a different name or message.
- `assert.partialDeepStrictEqual` is native (`PartialDeepEqual::compareBranch`, `src/jsc/modules/NodeUtilTypesModule.cpp`). Its error arm keys on `inherits<JSC::ErrorInstance>()`. A DOMException is a `WebCore::JSDOMException` wrapper, not an `ErrorInstance`, so the pair falls through to the generic tail of `compareBranch`: the `Object.prototype.toString` tags match (`[object DOMException]` on both sides) and `objectSubset` walks expected's own enumerable properties, of which a DOMException has none (`name` and `message` are accessors on `DOMException.prototype`, `cause` is an own non-enumerable property). Nothing is compared, so every pair is reported as equal.
- Smaller, in the error comparison itself (`errorSubset`, shared by the Error arm and the new DOMException arm): `cause` was only looked at when expected had it as an own property, and was then always compared. So `partialDeepStrictEqual(new Error("x", { cause: 1 }), new Error("x", { cause: undefined }))` threw (node passes) and an expected error whose `cause` comes from a prototype getter was never compared (node compares it).

### Fix
- Add a DOMException arm to `compareBranch`, next to the URL and KeyObject arms: if either side is a `JSDOMException`, both must be, and the pair goes through the existing `errorSubset`.
- `errorSubset` is the right comparison because it reads the error properties with an ordinary `[[Get]]`, which runs the DOMException prototype accessors, and applies node's own-`cause` rule. That is what node's error arm does: node treats anything `instanceof Error` as an error there and reads the same properties, with the same partial-mode leniency (an `undefined` expected value or an empty expected message is ignored). DOMException's prototype chain goes through `Error.prototype`, so node takes that arm for it.
- The arm is a separate arm, ahead of the `ErrorInstance` one, rather than a widening of the `ErrorInstance` check: node rejects a DOMException against a plain Error with the same name and message (its tag check runs before its error arm), and `errorSubset` alone would accept that pair. Requiring both sides to be DOMExceptions keeps that rejection, and the ordering keeps it even if `JSDOMException` later becomes an `ErrorInstance` (#32898).
- In `errorSubset`, move `cause` into the loop that reads `message`, `name` and `errors`, and leave only the presence check in the own-property block. That is node's structure exactly: `isEnumerableOrIdentical` for each of the four properties, then the separate own-`cause` presence rule (`comparisons.js`). It fixes the two `cause` divergences above for plain Errors as well as DOMExceptions.
- Not changed here: `assert.deepStrictEqual` / `util.isDeepStrictEqual` have the same DOMException blind spot in `Bun__deepEquals` (`bindings.cpp`), a different implementation that also backs `Bun.deepEquals` and the `expect()` matchers. That is fixed separately in #39308; the two changes do not overlap.
- Verified with `test/js/node/assert/assert.test.cjs`, two new blocks in the `partialDeepStrictEqual` describe. `DOMException`: 14 of its cases fail on the unfixed binary (`USE_SYSTEM_BUN=1`, every "rejects" case whose operands are both DOMExceptions); the accepted cases and the mixed pairs (DOMException vs `{}`, vs a same-shaped plain object, vs an Error in both directions, expected with an extra own property) pin the behavior that was already correct. `error cause`: 3 of its cases fail on the unfixed binary (undefined expected cause, and the two inherited-cause cases); the rest pin the existing cause rules. All 58 tests in the file pass with the fix. Every expectation was checked against Node v26.3.0.
- Also run with the fix: `test/js/node/assert/` plus the vendored `test-assert.js`, `test-assert-class.js` and `test-assert-deep-with-error.js` (486 pass), `test-assert-typedarray-deepequal.js` and `test-util-isDeepStrictEqual.js`, and the test file under `BUN_JSC_validateExceptionChecks=1`.

### Background
- `assert.partialDeepStrictEqual(actual, expected)` is node's "partial" deep equality: `expected` has to be recursively contained in `actual` (own enumerable properties of expected must exist and match on actual, arrays are matched as an in-order subsequence, and so on). Bun implements it natively in `compareBranch`, which is a chain of arms, one per kind of value (Map, typed array, KeyObject, URL, Error, Date, ...), each of which first checks that both sides are of that kind and then compares the kind's internal state before falling back to the own-property subset walk. A pair that matches no arm ends in the `Object.prototype.toString` tag check plus that walk.
- `errorSubset` is the body of the Error arm. Node's rules for errors in partial mode, which it implements: `message`, `name`, `cause` and `errors` are read with `[[Get]]` on both sides and compared unless the expected value is `undefined` (or, for `message`, empty); an own `cause` on expected, even one set to `undefined`, requires an own `cause` on actual; then the normal own-property subset walk runs.
- `JSDOMException` is the JS wrapper for WebCore's `DOMException`. Its prototype's prototype is `Error.prototype`, so `instanceof Error` is true, but the object itself is a plain DOM wrapper: `name`/`message`/`code` are prototype getters over the wrapped C++ object, and the constructor stores an options `cause` as an own non-enumerable property, the same shape node's DOMException has.

<details>
<summary>Comparison table, fixed debug build vs Node v26.3.0</summary>

Each line is `assert.partialDeepStrictEqual(actual, expected)`. The first ten lines pass on the unfixed binary; everything else was already correct.

```
diff name+msg (should throw)                                           THROWS
same name diff msg (should throw)                                      THROWS
same msg diff name (should throw)                                      THROWS
diff cause (should throw)                                              THROWS
expected has cause, actual not (should throw)                          THROWS
actual empty msg, expected msg (should throw)                          THROWS
nested in object diff (should throw)                                   THROWS
subclass diff msg (should throw)                                       THROWS
AbortSignal.abort().reason vs different DOMException (should throw)    THROWS
in array subsequence: no match (should throw)                          THROWS
actual has cause, expected not (should pass)                           passes
identical (should pass)                                                passes
expected cause subset of actual cause (should pass)                    passes
expected empty msg (should pass)                                       passes
actual extra own prop (should pass)                                    passes
nested in object same (should pass)                                    passes
subclass vs base same name/msg (should pass)                           passes
AbortSignal.abort().reason vs equal DOMException (should pass)         passes
DOMException vs {} (should throw)                                      THROWS
{} vs DOMException (should throw)                                      THROWS
DOMException vs {name, message} object (should throw)                  THROWS
DOMException vs Error same msg (should throw)                          THROWS
Error vs DOMException same msg (should throw)                          THROWS
expected extra own prop (should throw)                                 THROWS
```

Bun with the fix and node agree on every line.
</details>
