### PR TITLE
FileSystemRouter: throw when a relative dir does not fit in the path buffer instead of aborting

### DIFF
--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -161,17 +161,15 @@ impl FileSystemRouter {
                 if path::Platform::AUTO.is_absolute(path_) {
                     root_dir_path = root_dir_path_;
                 } else {
-                    // Same limit as `Resolver::read_dir_info`, so a path it would reject by
-                    // length is reported as too long rather than as a missing directory.
                     let Some(joined) =
                         path::resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
                             Fs::FileSystem::instance().top_level_dir,
-                            &mut dir_buf[..MAX_PATH_BYTES - 1],
+                            &mut dir_buf[..],
                             &[path_],
                         )
                     else {
                         return Err(global_this.throw_invalid_arguments(format_args!(
-                            "Expected dir to resolve to a path shorter than {} bytes",
+                            "Expected dir to resolve to a path of at most {} bytes",
                             MAX_PATH_BYTES
                         )));
                     };

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -135,7 +135,8 @@ impl FileSystemRouter {
         let mut origin_str: ZigStringSlice = ZigStringSlice::default();
         let mut asset_prefix_slice: ZigStringSlice = ZigStringSlice::default();
 
-        let mut out_buf = [0u8; MAX_PATH_BYTES * 2];
+        // Backs `root_dir_path` when `dir` is relative; read until `root_dir_info` is looked up.
+        let mut dir_buf = path::path_buffer_pool::get();
         if let Some(style_val) = argument.get(global_this, "style")? {
             if !(style_val.get_zig_string(global_this)?).eql_comptime("nextjs") {
                 return Err(global_this.throw_invalid_arguments(format_args!(
@@ -160,14 +161,21 @@ impl FileSystemRouter {
                 if path::Platform::AUTO.is_absolute(path_) {
                     root_dir_path = root_dir_path_;
                 } else {
-                    let parts: [&[u8]; 1] = [path_];
-                    root_dir_path = ZigStringSlice::from_utf8_never_free(
-                        path::resolve_path::join_abs_string_buf::<path::platform::Auto>(
+                    // Same limit as `Resolver::read_dir_info`, so a path it would reject by
+                    // length is reported as too long rather than as a missing directory.
+                    let Some(joined) =
+                        path::resolve_path::join_abs_string_buf_checked::<path::platform::Auto>(
                             Fs::FileSystem::instance().top_level_dir,
-                            &mut out_buf,
-                            &parts,
-                        ),
-                    );
+                            &mut dir_buf[..MAX_PATH_BYTES - 1],
+                            &[path_],
+                        )
+                    else {
+                        return Err(global_this.throw_invalid_arguments(format_args!(
+                            "Expected dir to resolve to a path shorter than {} bytes",
+                            MAX_PATH_BYTES
+                        )));
+                    };
+                    root_dir_path = ZigStringSlice::from_utf8_never_free(joined);
                 }
             }
         } else {

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -490,6 +490,68 @@ it("dir should be validated", async () => {
   }).toThrow("Expected dir to be a string");
 });
 
+it("throws instead of aborting when a relative dir no longer fits in a path buffer once joined with the cwd", async () => {
+  // A relative `dir` is joined onto the cwd inside a MAX_PATH_BYTES buffer
+  // (src/bun_core/util.rs). The constructor used to write past the end of that
+  // buffer and abort the process, so run the cases in a subprocess. An absolute
+  // `dir` never touches the buffer and is reported as a missing directory.
+  const maxPathBytes = isWindows ? 32767 * 3 + 1 : isMacOS ? 1024 : 4096;
+  const tooLong = `TypeError: Expected dir to resolve to a path shorter than ${maxPathBytes} bytes`;
+  using dir = tempDir("fsr-long-relative-dir", {
+    "pages/index.tsx": "export default 1;\n",
+  });
+
+  const code = /* ts */ `
+    import path from "path";
+    function construct(dir: string) {
+      try {
+        const router = new Bun.FileSystemRouter({ dir, style: "nextjs", fileExtensions: [".tsx"] });
+        return Object.keys(router.routes);
+      } catch (e: any) {
+        return e.name + ": " + e.message.replace(dir, "<dir>").replace(process.cwd(), "<cwd>");
+      }
+    }
+    // The joined path is cwd + separator + dir.
+    const resolvingTo = (bytes: number) => Buffer.alloc(bytes - Buffer.byteLength(process.cwd()) - 1, "a").toString();
+    // Longer than MAX_PATH_BYTES on every platform.
+    const longDir = Buffer.alloc(100_000, "a").toString();
+    console.log(JSON.stringify({
+      relative: construct(longDir),
+      absolute: construct(path.parse(process.cwd()).root + longDir),
+      oneByteBelowLimit: construct(resolvingTo(${maxPathBytes} - 1)),
+      atLimit: construct(resolvingTo(${maxPathBytes})),
+      afterwards: construct("pages"),
+    }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // An aborted subprocess prints nothing to stdout; keep it as-is so the panic in stderr is what the diff shows.
+  expect({
+    stdout: stdout === "" ? stdout : JSON.parse(stdout),
+    stderr,
+    exitCode,
+    signalCode: proc.signalCode,
+  }).toEqual({
+    stdout: {
+      relative: tooLong,
+      absolute: "Error: Unable to find directory: <dir>",
+      oneByteBelowLimit: `Error: Unable to find directory: <cwd>${path.sep}<dir>`,
+      atLimit: tooLong,
+      afterwards: ["/"],
+    },
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
 it("origin should be validated", async () => {
   const { dir } = make(["posts.tsx"]);
 

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -496,7 +496,7 @@ it("throws instead of aborting when a relative dir no longer fits in a path buff
   // buffer and abort the process, so run the cases in a subprocess. An absolute
   // `dir` never touches the buffer and is reported as a missing directory.
   const maxPathBytes = isWindows ? 32767 * 3 + 1 : isMacOS ? 1024 : 4096;
-  const tooLong = `TypeError: Expected dir to resolve to a path shorter than ${maxPathBytes} bytes`;
+  const tooLong = `TypeError: Expected dir to resolve to a path of at most ${maxPathBytes} bytes`;
   using dir = tempDir("fsr-long-relative-dir", {
     "pages/index.tsx": "export default 1;\n",
   });
@@ -519,8 +519,8 @@ it("throws instead of aborting when a relative dir no longer fits in a path buff
     console.log(JSON.stringify({
       relative: construct(longDir),
       absolute: construct(path.parse(process.cwd()).root + longDir),
-      oneByteBelowLimit: construct(resolvingTo(${maxPathBytes} - 1)),
       atLimit: construct(resolvingTo(${maxPathBytes})),
+      oneByteOverLimit: construct(resolvingTo(${maxPathBytes} + 1)),
       afterwards: construct("pages"),
     }));
   `;
@@ -543,8 +543,8 @@ it("throws instead of aborting when a relative dir no longer fits in a path buff
     stdout: {
       relative: tooLong,
       absolute: "Error: Unable to find directory: <dir>",
-      oneByteBelowLimit: `Error: Unable to find directory: <cwd>${path.sep}<dir>`,
-      atLimit: tooLong,
+      atLimit: `Error: Unable to find directory: <cwd>${path.sep}<dir>`,
+      oneByteOverLimit: tooLong,
       afterwards: ["/"],
     },
     stderr: "",

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -513,8 +513,9 @@ it("throws instead of aborting when a relative dir no longer fits in a path buff
     }
     // The joined path is cwd + separator + dir.
     const resolvingTo = (bytes: number) => Buffer.alloc(bytes - Buffer.byteLength(process.cwd()) - 1, "a").toString();
-    // Longer than MAX_PATH_BYTES on every platform.
-    const longDir = Buffer.alloc(100_000, "a").toString();
+    // Longer than MAX_PATH_BYTES on every platform, and than the 2 * MAX_PATH_BYTES
+    // buffer the constructor used to overflow (196604 bytes on Windows).
+    const longDir = Buffer.alloc(250_000, "a").toString();
     console.log(JSON.stringify({
       relative: construct(longDir),
       absolute: construct(path.parse(process.cwd()).root + longDir),


### PR DESCRIPTION
### Problem

- `new Bun.FileSystemRouter({ dir, style: "nextjs" })` aborts the process when `dir` is relative and `cwd + dir` is longer than the join buffer:

  ```
  panic: range end index 10004 out of range for slice of length 8191
  ```

  Reproduces on 1.4.0 with `dir: Buffer.alloc(10000, "a").toString()` (exit 134, SIGABRT). Found while fixing the same pattern in bake (#39196); there is no user report. The joined path has to be longer than `2 * MAX_PATH_BYTES` (8192 bytes on Linux, 2048 on macOS, 196604 on Windows, where the panic reads `range end index 200017 out of range for slice of length 196604`), so only a `dir` that could never name a directory reaches the abort. It is still an abort on a documented constructor's string option rather than a thrown error.
- Cause: the constructor (`src/runtime/api/filesystem_router.rs`, `FileSystemRouter::constructor`) resolves a relative `dir` with `join_abs_string_buf` into a fixed `[u8; MAX_PATH_BYTES * 2]` stack array. That join normalizes straight into the buffer and indexes past its end when the result does not fit; nothing checks the length first.
- The absolute form of the same input does not crash: it skips the join, `Resolver::read_dir_info` refuses any path of `MAX_PATH_BYTES` or more, and the constructor throws `Unable to find directory: ...`. Relative dirs that joined to between `MAX_PATH_BYTES` and `2 * MAX_PATH_BYTES` bytes got the same `Unable to find directory` error.

### Fix

- Join with `join_abs_string_buf_checked` into a pooled `PathBuffer` (`path_buffer_pool::get()`), and throw `TypeError: Expected dir to resolve to a path of at most <MAX_PATH_BYTES> bytes` when the joined path does not fit in it.
- The limit is the buffer itself, nothing else: a joined path of exactly `MAX_PATH_BYTES` bytes still fits and takes the existing route (`read_dir_info` refuses it, `Unable to find directory`), one byte more throws the new error. The message names the option and the limit rather than echoing the path, which can be arbitrarily long.
- Behavior change besides the abort: a relative `dir` joining to more than `MAX_PATH_BYTES` bytes now gets this `TypeError` instead of `Error: Unable to find directory`. No such path can name a directory, so nothing that constructed successfully before changes.
- This is the same shape as the other JS entry points that join user input onto the cwd (`Bun.mmap` in `BunObject.rs`, `fs.watch` in `node_fs_watcher.rs`), and the same per-site granularity as the merged fixes of this class in `Bun.Glob` (#33145), the resolver (#37526) and `bun install` (#37531). Dropping the stack array also removes ~196 KB of stack usage per construction on Windows, where `MAX_PATH_BYTES` is 98302.
- The pooled buffer stays checked out for the whole constructor because `root_dir_path` is a borrowed slice into it that is read up to the `Unable to find directory` error.
- The absolute branch is intentionally unchanged: it never touches the buffer, and it keeps throwing `Unable to find directory`.
- Test: `test/js/bun/util/filesystem_router.test.ts`, "throws instead of aborting when a relative dir no longer fits in a path buffer once joined with the cwd". One spawned fixture constructs with a 250 KB relative dir (the abort on every platform), the same dir made absolute (still `Unable to find directory`), relative dirs resolving to exactly `MAX_PATH_BYTES` and `MAX_PATH_BYTES + 1` bytes (missing directory vs. the new error), and finally a real relative `pages` dir, which still resolves against the cwd (no existing test in the file used a relative `dir`).
- Verified: the test aborts with the panic above on a build without the `src/` change and passes with it, on Linux and on Windows x64; the rest of `filesystem_router.test.ts` passes; the fixture also passes under `BUN_JSC_validateExceptionChecks=1`.

### Background

- `MAX_PATH_BYTES` (`src/bun_core/util.rs`) is Bun's fixed path buffer size: 4096 on Linux, 1024 on macOS, 98302 on Windows (the UTF-8 worst case of a 32767-unit wide path). `PathBuffer` is a `[u8; MAX_PATH_BYTES]`, and `bun_paths::path_buffer_pool` hands out heap-allocated ones so large path buffers do not live on the stack.
- `join_abs_string_buf(cwd, buf, parts)` resolves `parts` against `cwd` and normalizes the result into `buf`; it assumes the result fits. `join_abs_string_buf_checked` is the variant for user-controlled input: it returns `None` when the normalized result is longer than `buf`.
- `Resolver::read_dir_info(path)` is what the constructor uses next to load the directory; it returns "not found" for any path of `MAX_PATH_BYTES` bytes or more, which is how the absolute form (and the exactly-`MAX_PATH_BYTES` relative form) end up as `Unable to find directory`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/filesystem_router.test.ts

<!-- robobun:evidence:end -->