### PR TITLE
deepEquals: compare DOMException name, message and cause

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -117,6 +117,7 @@
 #include "FetchHeaders.h"
 #include "DOMURL.h"
 #include "JSDOMURL.h"
+#include "JSDOMException.h"
 
 #include <string_view>
 #include <bun-uws/src/App.h>
@@ -736,6 +737,31 @@ static bool nonIndexOwnPropertiesEqual(JSC::JSGlobalObject* globalObject, Marked
     return true;
 }
 
+// `.cause` is a non-enumerable own property on Error and DOMException instances,
+// so the enumerable-property walks never see it and it has to be compared
+// explicitly. In strict mode a missing cause differs from `cause: undefined`.
+template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
+static bool errorCausesEqual(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* left, JSC::JSObject* right)
+{
+    const PropertyName cause(globalObject->vm().propertyNames->cause);
+    if constexpr (isStrict) {
+        bool leftHasCause = left->hasProperty(globalObject, cause);
+        RETURN_IF_EXCEPTION(scope, false);
+        bool rightHasCause = right->hasProperty(globalObject, cause);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (leftHasCause != rightHasCause) {
+            return false;
+        }
+    }
+    JSValue leftCause = left->get(globalObject, cause);
+    RETURN_IF_EXCEPTION(scope, false);
+    JSValue rightCause = right->get(globalObject, cause);
+    RETURN_IF_EXCEPTION(scope, false);
+    bool causesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, leftCause, rightCause, gcBuffer, stack, scope, true);
+    RETURN_IF_EXCEPTION(scope, false);
+    return causesEqual;
+}
+
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
 bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, bool addToStack)
 {
@@ -1242,6 +1268,38 @@ static std::optional<bool> temporalObjectsDequal(JSC::JSObject* o1, JSC::JSObjec
     return std::nullopt;
 }
 
+// A DOMException keeps its name and message in the wrapped WebCore::DOMException
+// and exposes them through prototype getters (`code` is derived from the name),
+// so as far as the own-property walk is concerned every DOMException is an empty
+// object. Compare that state and the own non-enumerable `cause` the way the
+// ErrorInstanceType case does for errors. Returns false on a mismatch, or when
+// only `o1` is a DOMException (the caller's swapped second call covers a
+// DOMException on the right); otherwise std::nullopt so the own-property walk
+// still compares properties added to the instances.
+template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
+static std::optional<bool> domExceptionsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2)
+{
+    auto* left = dynamicDowncast<WebCore::JSDOMException>(o1);
+    if (!left)
+        return std::nullopt;
+    auto* right = dynamicDowncast<WebCore::JSDOMException>(o2);
+    if (!right)
+        return false;
+
+    // Both getters hand a null and an empty string to JS as "", so the comparison
+    // has to treat them alike too.
+    const auto& leftException = left->wrapped();
+    const auto& rightException = right->wrapped();
+    if (!equalIgnoringNullity(leftException.name(), rightException.name()) || !equalIgnoringNullity(leftException.message(), rightException.message()))
+        return false;
+
+    bool causesEqual = errorCausesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, left, right);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!causesEqual)
+        return false;
+    return std::nullopt;
+}
+
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
 std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSCell* _Nonnull c1, JSCell* _Nonnull c2)
 {
@@ -1514,30 +1572,13 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
                 }
             }
 
-            VM& vm = JSC::getVM(globalObject);
-
-            // `.cause` is non-enumerable, so it must be checked explicitly.
-            // note that an undefined cause is different than a missing cause in
-            // strict mode.
-            const PropertyName cause(vm.propertyNames->cause);
-            if constexpr (isStrict) {
-                bool leftHasCause = left->hasProperty(globalObject, cause);
-                RETURN_IF_EXCEPTION(scope, {});
-                bool rightHasCause = right->hasProperty(globalObject, cause);
-                RETURN_IF_EXCEPTION(scope, {});
-                if (leftHasCause != rightHasCause) {
-                    return false;
-                }
-            }
-            auto leftCause = left->get(globalObject, cause);
-            RETURN_IF_EXCEPTION(scope, {});
-            auto rightCause = right->get(globalObject, cause);
-            RETURN_IF_EXCEPTION(scope, {});
-            bool causesEqual = Bun__deepEquals<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, leftCause, rightCause, gcBuffer, stack, scope, true);
+            bool causesEqual = errorCausesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, left, right);
             RETURN_IF_EXCEPTION(scope, {});
             if (!causesEqual) {
                 return false;
             }
+
+            VM& vm = JSC::getVM(globalObject);
 
             // check arbitrary enumerable properties. `.stack` is not checked.
             left->materializeErrorInfoIfNeeded(vm);
@@ -1896,18 +1937,25 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
         }
     }
 
-    // Symbol and BigInt wrapper objects are plain ObjectType in JSC, so they are not
-    // reachable from the switch above. Like Number and Boolean wrappers, they must be
-    // the same kind of wrapper and hold the same internal value. Everything else --
-    // object literals, arrays -- has its own JSType and skips this.
+    // DOMExceptions, Temporal objects, and Symbol and BigInt wrapper objects are plain
+    // ObjectType in JSC, so they are not reachable from the switch above, and each keeps
+    // the state that tells two instances apart outside of its own properties. Everything
+    // else -- object literals, arrays -- has its own JSType and skips this.
     if (c1Type == ObjectType) {
         JSObject* obj1 = c1->getObject();
         JSObject* obj2 = c2->getObject();
         if (obj1 && obj2) {
+            std::optional<bool> domExceptionEqual = domExceptionsDequal<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, obj1, obj2);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (domExceptionEqual.has_value())
+                return domExceptionEqual;
+
             std::optional<bool> temporalEqual = temporalObjectsDequal(obj1, obj2);
             if (temporalEqual.has_value())
                 return temporalEqual;
 
+            // Like Number and Boolean wrappers, Symbol and BigInt wrappers must be the
+            // same kind of wrapper and hold the same internal value.
             const bool isSymbol1 = obj1->inherits<SymbolObject>();
             const bool isBigInt1 = obj1->inherits<BigIntObject>();
             if (isSymbol1 || isBigInt1) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -737,9 +737,8 @@ static bool nonIndexOwnPropertiesEqual(JSC::JSGlobalObject* globalObject, Marked
     return true;
 }
 
-// `.cause` is a non-enumerable own property on Error and DOMException instances,
-// so the enumerable-property walks never see it and it has to be compared
-// explicitly. In strict mode a missing cause differs from `cause: undefined`.
+// `.cause` is non-enumerable, so the property walks skip it. Strict mode also
+// distinguishes a missing cause from `cause: undefined`.
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
 static bool errorCausesEqual(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* left, JSC::JSObject* right)
 {
@@ -1268,14 +1267,10 @@ static std::optional<bool> temporalObjectsDequal(JSC::JSObject* o1, JSC::JSObjec
     return std::nullopt;
 }
 
-// A DOMException keeps its name and message in the wrapped WebCore::DOMException
-// and exposes them through prototype getters (`code` is derived from the name),
-// so as far as the own-property walk is concerned every DOMException is an empty
-// object. Compare that state and the own non-enumerable `cause` the way the
-// ErrorInstanceType case does for errors. Returns false on a mismatch, or when
-// only `o1` is a DOMException (the caller's swapped second call covers a
-// DOMException on the right); otherwise std::nullopt so the own-property walk
-// still compares properties added to the instances.
+// A DOMException's name and message live in the wrapped object (`code` is derived
+// from the name), so the own-property walk alone sees two empty objects. Returns
+// std::nullopt once the wrapped state and `cause` match so that walk still runs;
+// the caller's swapped second call handles a DOMException on the right only.
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
 static std::optional<bool> domExceptionsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2)
 {
@@ -1286,8 +1281,7 @@ static std::optional<bool> domExceptionsDequal(JSC::JSGlobalObject* globalObject
     if (!right)
         return false;
 
-    // Both getters hand a null and an empty string to JS as "", so the comparison
-    // has to treat them alike too.
+    // The getters expose a null and an empty string identically.
     const auto& leftException = left->wrapped();
     const auto& rightException = right->wrapped();
     if (!equalIgnoringNullity(leftException.name(), rightException.name()) || !equalIgnoringNullity(leftException.message(), rightException.message()))
@@ -1937,10 +1931,10 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
         }
     }
 
-    // DOMExceptions, Temporal objects, and Symbol and BigInt wrapper objects are plain
-    // ObjectType in JSC, so they are not reachable from the switch above, and each keeps
-    // the state that tells two instances apart outside of its own properties. Everything
-    // else -- object literals, arrays -- has its own JSType and skips this.
+    // Symbol and BigInt wrapper objects are plain ObjectType in JSC, so they are not
+    // reachable from the switch above. Like Number and Boolean wrappers, they must be
+    // the same kind of wrapper and hold the same internal value. Everything else --
+    // object literals, arrays -- has its own JSType and skips this.
     if (c1Type == ObjectType) {
         JSObject* obj1 = c1->getObject();
         JSObject* obj2 = c2->getObject();
@@ -1954,8 +1948,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
             if (temporalEqual.has_value())
                 return temporalEqual;
 
-            // Like Number and Boolean wrappers, Symbol and BigInt wrappers must be the
-            // same kind of wrapper and hold the same internal value.
             const bool isSymbol1 = obj1->inherits<SymbolObject>();
             const bool isBigInt1 = obj1->inherits<BigIntObject>();
             if (isSymbol1 || isBigInt1) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -737,8 +737,7 @@ static bool nonIndexOwnPropertiesEqual(JSC::JSGlobalObject* globalObject, Marked
     return true;
 }
 
-// `.cause` is non-enumerable, so the property walks skip it. Strict mode also
-// distinguishes a missing cause from `cause: undefined`.
+// `.cause` is non-enumerable, so the enumerable-property walks never see it.
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
 static bool errorCausesEqual(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* left, JSC::JSObject* right)
 {
@@ -1267,21 +1266,18 @@ static std::optional<bool> temporalObjectsDequal(JSC::JSObject* o1, JSC::JSObjec
     return std::nullopt;
 }
 
-// A DOMException's name and message live in the wrapped object (`code` is derived
-// from the name), so the own-property walk alone sees two empty objects. Returns
-// std::nullopt once the wrapped state and `cause` match so that walk still runs;
-// the caller's swapped second call handles a DOMException on the right only.
+// name and message live in the wrapped DOMException (code derives from name), not in own properties.
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
 static std::optional<bool> domExceptionsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2)
 {
     auto* left = dynamicDowncast<WebCore::JSDOMException>(o1);
-    if (!left)
-        return std::nullopt;
     auto* right = dynamicDowncast<WebCore::JSDOMException>(o2);
-    if (!right)
+    if (!left && !right)
+        return std::nullopt;
+    if (!left || !right)
         return false;
 
-    // The getters expose a null and an empty string identically.
+    // JS reads a null and an empty WTF::String from the getters as the same "".
     const auto& leftException = left->wrapped();
     const auto& rightException = right->wrapped();
     if (!equalIgnoringNullity(leftException.name(), rightException.name()) || !equalIgnoringNullity(leftException.message(), rightException.message()))
@@ -1291,6 +1287,7 @@ static std::optional<bool> domExceptionsDequal(JSC::JSGlobalObject* globalObject
     RETURN_IF_EXCEPTION(scope, {});
     if (!causesEqual)
         return false;
+    // nullopt so the caller still walks any properties assigned onto the instances.
     return std::nullopt;
 }
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -760,6 +760,34 @@ static bool errorCausesEqual(JSC::JSGlobalObject* globalObject, MarkedArgumentBu
     return causesEqual;
 }
 
+// name and message live in the wrapped DOMException (code derives from name), not in own properties.
+template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
+static std::optional<bool> domExceptionsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2)
+{
+    // JSDOMException's JSType; ordinary objects are FinalObjectType and skip the class walks below.
+    if (o1->type() != ObjectType && o2->type() != ObjectType)
+        return std::nullopt;
+    auto* left = dynamicDowncast<WebCore::JSDOMException>(o1);
+    auto* right = dynamicDowncast<WebCore::JSDOMException>(o2);
+    if (!left && !right)
+        return std::nullopt;
+    if (!left || !right)
+        return false;
+
+    // JS reads a null and an empty WTF::String from the getters as the same "".
+    const auto& leftException = left->wrapped();
+    const auto& rightException = right->wrapped();
+    if (!equalIgnoringNullity(leftException.name(), rightException.name()) || !equalIgnoringNullity(leftException.message(), rightException.message()))
+        return false;
+
+    bool causesEqual = errorCausesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, left, right);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!causesEqual)
+        return false;
+    // nullopt so the caller still walks any properties assigned onto the instances.
+    return std::nullopt;
+}
+
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
 bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, bool addToStack)
 {
@@ -865,6 +893,11 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     if (isSpecialEqual.has_value()) return WTF::move(*isSpecialEqual);
     JSObject* o1 = v1.getObject();
     JSObject* o2 = v2.getObject();
+
+    // Not part of specialObjectsDequal, which runs twice per pair: this recurses into `cause`.
+    std::optional<bool> isDOMExceptionEqual = domExceptionsDequal<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, o1, o2);
+    RETURN_IF_EXCEPTION(scope, false);
+    if (isDOMExceptionEqual.has_value()) return *isDOMExceptionEqual;
 
     bool v1Array = isArray(globalObject, v1);
     RETURN_IF_EXCEPTION(scope, false);
@@ -1263,31 +1296,6 @@ static std::optional<bool> temporalObjectsDequal(JSC::JSObject* o1, JSC::JSObjec
     // (and must not reach the own-property walk).
     if (isTemporalObject(o2))
         return false;
-    return std::nullopt;
-}
-
-// name and message live in the wrapped DOMException (code derives from name), not in own properties.
-template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity>
-static std::optional<bool> domExceptionsDequal(JSC::JSGlobalObject* globalObject, MarkedArgumentBuffer& gcBuffer, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>& stack, ThrowScope& scope, JSC::JSObject* o1, JSC::JSObject* o2)
-{
-    auto* left = dynamicDowncast<WebCore::JSDOMException>(o1);
-    auto* right = dynamicDowncast<WebCore::JSDOMException>(o2);
-    if (!left && !right)
-        return std::nullopt;
-    if (!left || !right)
-        return false;
-
-    // JS reads a null and an empty WTF::String from the getters as the same "".
-    const auto& leftException = left->wrapped();
-    const auto& rightException = right->wrapped();
-    if (!equalIgnoringNullity(leftException.name(), rightException.name()) || !equalIgnoringNullity(leftException.message(), rightException.message()))
-        return false;
-
-    bool causesEqual = errorCausesEqual<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, left, right);
-    RETURN_IF_EXCEPTION(scope, {});
-    if (!causesEqual)
-        return false;
-    // nullopt so the caller still walks any properties assigned onto the instances.
     return std::nullopt;
 }
 
@@ -1936,11 +1944,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
         JSObject* obj1 = c1->getObject();
         JSObject* obj2 = c2->getObject();
         if (obj1 && obj2) {
-            std::optional<bool> domExceptionEqual = domExceptionsDequal<isStrict, enableAsymmetricMatchers, checkPrototypes, skipPrototypeIdentity>(globalObject, gcBuffer, stack, scope, obj1, obj2);
-            RETURN_IF_EXCEPTION(scope, {});
-            if (domExceptionEqual.has_value())
-                return domExceptionEqual;
-
             std::optional<bool> temporalEqual = temporalObjectsDequal(obj1, obj2);
             if (temporalEqual.has_value())
                 return temporalEqual;

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -77,6 +77,152 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
       expect(areEqual).toBe(false);
     });
   });
+
+  // A DOMException has no own properties: name, message and code are getters on
+  // the prototype backed by native state, and cause is a non-enumerable own
+  // property. It compares like an Error: name, message, cause, then any own
+  // enumerable properties.
+  describe("DOMException", () => {
+    class SubException extends DOMException {}
+
+    it.each([
+      [
+        "the same name and message",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("boom", "AbortError"),
+      ],
+      ["no arguments", () => new DOMException(), () => new DOMException()],
+      ["an omitted and an empty message", () => new DOMException(), () => new DOMException("", "Error")],
+      [
+        "a name given as a string and as an option",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("boom", { name: "AbortError" }),
+      ],
+      [
+        "equal object causes",
+        () => new DOMException("boom", { name: "AbortError", cause: { code: 1 } }),
+        () => new DOMException("boom", { name: "AbortError", cause: { code: 1 } }),
+      ],
+      [
+        "the same extra own property",
+        () => Object.assign(new DOMException("boom", "AbortError"), { extra: 1 }),
+        () => Object.assign(new DOMException("boom", "AbortError"), { extra: 1 }),
+      ],
+      [
+        "a structured clone",
+        () => new DOMException("boom", "DataCloneError"),
+        () => structuredClone(new DOMException("boom", "DataCloneError")),
+      ],
+      [
+        "subclass instances with the same state",
+        () => new SubException("boom", "AbortError"),
+        () => new SubException("boom", "AbortError"),
+      ],
+    ])("DOMExceptions with %s are equal", (_label, makeA, makeB) => {
+      expect(deepEquals(makeA(), makeB())).toBe(true);
+      expect(deepEquals(makeB(), makeA())).toBe(true);
+    });
+
+    it.each([
+      [
+        "different names",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("boom", "NotFoundError"),
+      ],
+      [
+        "different messages",
+        () => new DOMException("boom", "AbortError"),
+        () => new DOMException("other", "AbortError"),
+      ],
+      ["a default and an explicit name", () => new DOMException("boom"), () => new DOMException("boom", "AbortError")],
+      [
+        "different causes",
+        () => new DOMException("boom", { name: "AbortError", cause: 1 }),
+        () => new DOMException("boom", { name: "AbortError", cause: 2 }),
+      ],
+      [
+        "different object causes",
+        () => new DOMException("boom", { name: "AbortError", cause: { code: 1 } }),
+        () => new DOMException("boom", { name: "AbortError", cause: { code: 2 } }),
+      ],
+      [
+        "a cause on one side only",
+        () => new DOMException("boom", { name: "AbortError", cause: 1 }),
+        () => new DOMException("boom", "AbortError"),
+      ],
+      [
+        "different extra own properties",
+        () => Object.assign(new DOMException("boom", "AbortError"), { extra: 1 }),
+        () => Object.assign(new DOMException("boom", "AbortError"), { extra: 2 }),
+      ],
+      [
+        "an extra own property on one side only",
+        () => Object.assign(new DOMException("boom", "AbortError"), { extra: 1 }),
+        () => new DOMException("boom", "AbortError"),
+      ],
+      [
+        "subclass instances with different messages",
+        () => new SubException("boom", "AbortError"),
+        () => new SubException("other", "AbortError"),
+      ],
+    ])("DOMExceptions with %s are not equal", (_label, makeA, makeB) => {
+      expect(deepEquals(makeA(), makeB())).toBe(false);
+      expect(deepEquals(makeB(), makeA())).toBe(false);
+    });
+
+    it.each([
+      ["an empty object", () => ({})],
+      ["an object with the same name and message as own properties", () => ({ name: "Error", message: "boom" })],
+      ["an Error with the same message", () => new Error("boom")],
+      ["an Error with the same name and message", () => Object.assign(new Error("boom"), { name: "AbortError" })],
+    ])("a DOMException is never equal to %s", (_label, makeOther) => {
+      expect(deepEquals(new DOMException("boom"), makeOther())).toBe(false);
+      expect(deepEquals(makeOther(), new DOMException("boom"))).toBe(false);
+    });
+
+    it("an undefined cause and a missing cause differ only in strict mode, as for Error", () => {
+      const domExceptions = [
+        new DOMException("boom", { name: "AbortError", cause: undefined }),
+        new DOMException("boom", "AbortError"),
+      ] as const;
+      const errors = [new Error("boom", { cause: undefined }), new Error("boom")] as const;
+      expect(deepEquals(...domExceptions)).toBe(!strict);
+      expect(deepEquals(...errors)).toBe(!strict);
+    });
+
+    it("a subclass instance and a base instance with the same state are equal only when not strict", () => {
+      expect(deepEquals(new SubException("boom", "AbortError"), new DOMException("boom", "AbortError"))).toBe(!strict);
+      expect(deepEquals(new SubException("boom", "AbortError"), new DOMException("other", "AbortError"))).toBe(false);
+    });
+
+    it("compares DOMExceptions nested in other values", () => {
+      const make = (name: string) => ({
+        reasons: [new DOMException("boom", name)],
+        byKey: new Map([["k", new DOMException("boom", name)]]),
+      });
+      expect(deepEquals(make("AbortError"), make("AbortError"))).toBe(true);
+      expect(deepEquals(make("AbortError"), make("TimeoutError"))).toBe(false);
+    });
+
+    it("compares a DOMException used as a cause", () => {
+      const make = (name: string) => new Error("outer", { cause: new DOMException("inner", name) });
+      expect(deepEquals(make("AbortError"), make("AbortError"))).toBe(true);
+      expect(deepEquals(make("AbortError"), make("TimeoutError"))).toBe(false);
+    });
+
+    it("a getter on the cause that throws propagates", () => {
+      const throwing = () =>
+        new DOMException("boom", {
+          name: "AbortError",
+          cause: {
+            get value() {
+              throw new RangeError("from cause");
+            },
+          },
+        });
+      expect(() => deepEquals(throwing(), throwing())).toThrow(RangeError);
+    });
+  });
 });
 
 // The cases documented at https://bun.sh/docs/api/utils#bun-deepequals as the

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -224,6 +224,47 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
         });
       expect(() => deepEquals(throwing(), throwing())).toThrow(RangeError);
     });
+
+    it("reads each cause once per side, as for Error", () => {
+      let reads = 0;
+      const cause = () => ({
+        get value() {
+          reads++;
+          return 1;
+        },
+      });
+      deepEquals(
+        new DOMException("boom", { name: "AbortError", cause: cause() }),
+        new DOMException("boom", { name: "AbortError", cause: cause() }),
+      );
+      expect(reads).toBe(2);
+      reads = 0;
+      deepEquals(new Error("boom", { cause: cause() }), new Error("boom", { cause: cause() }));
+      expect(reads).toBe(2);
+    });
+
+    // Each level used to be compared twice, once per argument order, so a chain
+    // of n causes took 2^n comparisons.
+    it("compares a long chain of causes in linear time", () => {
+      const chain = (depth: number, leafMessage: string) => {
+        let exception = new DOMException(leafMessage, "AbortError");
+        for (let i = 0; i < depth; i++) {
+          exception = new DOMException(`level ${i}`, { name: "AbortError", cause: exception });
+        }
+        return exception;
+      };
+      expect(deepEquals(chain(64, "leaf"), chain(64, "leaf"))).toBe(true);
+      expect(deepEquals(chain(64, "leaf"), chain(64, "other leaf"))).toBe(false);
+    });
+
+    it("terminates on a cause cycle", () => {
+      const cyclic = () => {
+        const exception = new DOMException("boom", { name: "AbortError", cause: null });
+        exception.cause = exception;
+        return exception;
+      };
+      expect(deepEquals(cyclic(), cyclic())).toBe(true);
+    });
   });
 });
 

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -170,11 +170,13 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
       expect(deepEquals(makeB(), makeA())).toBe(false);
     });
 
+    // new DOMException("boom") has the default name "Error", so the plain object
+    // and the Error below match it on name and message; only the kind of object
+    // differs.
     it.each([
       ["an empty object", () => ({})],
-      ["an object with the same name and message as own properties", () => ({ name: "Error", message: "boom" })],
-      ["an Error with the same message", () => new Error("boom")],
-      ["an Error with the same name and message", () => Object.assign(new Error("boom"), { name: "AbortError" })],
+      ["a plain object with name and message properties", () => ({ name: "Error", message: "boom" })],
+      ["an Error", () => new Error("boom")],
     ])("a DOMException is never equal to %s", (_label, makeOther) => {
       expect(deepEquals(new DOMException("boom"), makeOther())).toBe(false);
       expect(deepEquals(makeOther(), new DOMException("boom"))).toBe(false);

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -295,8 +295,9 @@ describe("expect()", () => {
       expect(new Headers({ "a": "1" })).not.toEqual(new Headers({ "a": "1", "b": "2" }));
     });
 
-    // name, message and cause live behind getters rather than in own properties,
-    // so they are compared the same way they are for Error.
+    // name and message are prototype getters and cause is a non-enumerable own
+    // property, so none of them is visible to the own-property walk; they are
+    // compared the same way they are for Error.
     test("DOMException", () => {
       expect(new DOMException("boom", "AbortError")).toEqual(new DOMException("boom", "AbortError"));
       expect(new DOMException("boom", "AbortError")).toStrictEqual(new DOMException("boom", "AbortError"));

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -295,6 +295,65 @@ describe("expect()", () => {
       expect(new Headers({ "a": "1" })).not.toEqual(new Headers({ "a": "1", "b": "2" }));
     });
 
+    // name, message and cause live behind getters rather than in own properties,
+    // so they are compared the same way they are for Error.
+    test("DOMException", () => {
+      expect(new DOMException("boom", "AbortError")).toEqual(new DOMException("boom", "AbortError"));
+      expect(new DOMException("boom", "AbortError")).toStrictEqual(new DOMException("boom", "AbortError"));
+      expect(new DOMException()).toEqual(new DOMException());
+
+      expect(new DOMException("boom", "AbortError")).not.toEqual(new DOMException("boom", "NotFoundError"));
+      expect(new DOMException("boom", "AbortError")).not.toEqual(new DOMException("other", "AbortError"));
+      expect(new DOMException("boom", "AbortError")).not.toStrictEqual(new DOMException("other", "AbortError"));
+
+      expect(new DOMException("boom")).not.toEqual({});
+      expect({}).not.toEqual(new DOMException("boom"));
+      expect(new DOMException("boom")).not.toEqual(new Error("boom"));
+      expect(new Error("boom")).not.toEqual(new DOMException("boom"));
+
+      expect(new DOMException("boom", { name: "AbortError", cause: { code: 1 } })).toEqual(
+        new DOMException("boom", { name: "AbortError", cause: { code: 1 } }),
+      );
+      expect(new DOMException("boom", { name: "AbortError", cause: 1 })).not.toEqual(
+        new DOMException("boom", { name: "AbortError", cause: 2 }),
+      );
+      expect(new DOMException("boom", { name: "AbortError", cause: 1 })).not.toEqual(
+        new DOMException("boom", "AbortError"),
+      );
+
+      expect(Object.assign(new DOMException("boom", "AbortError"), { extra: 1 })).toEqual(
+        Object.assign(new DOMException("boom", "AbortError"), { extra: 1 }),
+      );
+      expect(Object.assign(new DOMException("boom", "AbortError"), { extra: 1 })).not.toEqual(
+        Object.assign(new DOMException("boom", "AbortError"), { extra: 2 }),
+      );
+      expect(Object.assign(new DOMException("boom", "AbortError"), { extra: 1 })).not.toEqual(
+        new DOMException("boom", "AbortError"),
+      );
+
+      expect({ reason: [new DOMException("boom", "AbortError")] }).toEqual({
+        reason: [new DOMException("boom", "AbortError")],
+      });
+      expect({ reason: [new DOMException("boom", "AbortError")] }).not.toEqual({
+        reason: [new DOMException("boom", "TimeoutError")],
+      });
+    });
+
+    test("DOMException inside asymmetric matchers", () => {
+      expect({ reason: new DOMException("boom", "AbortError") }).toEqual(
+        expect.objectContaining({ reason: new DOMException("boom", "AbortError") }),
+      );
+      expect({ reason: new DOMException("boom", "AbortError") }).not.toEqual(
+        expect.objectContaining({ reason: new DOMException("boom", "TimeoutError") }),
+      );
+      expect([new DOMException("boom", "AbortError")]).toEqual(
+        expect.arrayContaining([new DOMException("boom", "AbortError")]),
+      );
+      expect([new DOMException("boom", "AbortError")]).not.toEqual(
+        expect.arrayContaining([new DOMException("boom", "TimeoutError")]),
+      );
+    });
+
     // TODO: FormData
     // It would need to compare Blob, which is tricky.
   });
@@ -324,6 +383,21 @@ describe("expect()", () => {
 
     expect(new RegExp("s", "g")).toEqual(new RegExp("s", "g"));
     expect(new RegExp("s", "g")).not.toEqual(new RegExp("s", "i"));
+  });
+
+  test("deepEquals error causes", () => {
+    expect(new Error("boom", { cause: { code: 1 } })).toEqual(new Error("boom", { cause: { code: 1 } }));
+    expect(new Error("boom", { cause: { code: 1 } })).toStrictEqual(new Error("boom", { cause: { code: 1 } }));
+    expect(new Error("boom", { cause: 1 })).not.toEqual(new Error("boom", { cause: 2 }));
+    expect(new Error("boom", { cause: 1 })).not.toStrictEqual(new Error("boom", { cause: 2 }));
+    expect(new Error("boom", { cause: 1 })).not.toEqual(new Error("boom"));
+    expect(new Error("boom")).not.toEqual(new Error("boom", { cause: 1 }));
+
+    // Only the presence of the property distinguishes these two.
+    expect(new Error("boom", { cause: undefined })).toEqual(new Error("boom"));
+    if (isBun) {
+      expect(new Error("boom", { cause: undefined })).not.toStrictEqual(new Error("boom"));
+    }
   });
 
   test("deepEquals and deleted properties", () => {

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -355,6 +355,25 @@ describe("expect()", () => {
       );
     });
 
+    test("DOMException causes are read once per side", () => {
+      let reads = 0;
+      const make = () =>
+        new DOMException("boom", {
+          name: "AbortError",
+          cause: {
+            get value() {
+              reads++;
+              return 1;
+            },
+          },
+        });
+      expect(make()).toEqual(make());
+      expect(reads).toBe(2);
+      reads = 0;
+      expect(make()).toStrictEqual(make());
+      expect(reads).toBe(2);
+    });
+
     // TODO: FormData
     // It would need to compare Blob, which is tricky.
   });

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -59,6 +59,8 @@ function withExtraProperty<T extends object>(value: T): T {
   return Object.assign(value, { extra: 1 });
 }
 
+class SubDOMException extends DOMException {}
+
 function selfReferencingObject() {
   const object: Record<string, unknown> = {};
   object.self = object;
@@ -386,6 +388,130 @@ const cases: Case[] = [
     name: "errors with different causes",
     a: () => new Error("x", { cause: 1 }),
     b: () => new Error("x", { cause: 2 }),
+    strict: false,
+    loose: false,
+  },
+
+  // DOMException: Error.prototype is in its chain, so node compares it like an
+  // error (name, message, cause, then own enumerable properties), even though
+  // name and message are prototype getters rather than own properties.
+  {
+    name: "two DOMExceptions with the same name and message",
+    a: () => new DOMException("x", "AbortError"),
+    b: () => new DOMException("x", "AbortError"),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "two DOMExceptions constructed without arguments",
+    a: () => new DOMException(),
+    b: () => new DOMException(),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "a DOMException and its structured clone",
+    a: () => new DOMException("x", "DataCloneError"),
+    b: () => structuredClone(new DOMException("x", "DataCloneError")),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "DOMExceptions with different names",
+    a: () => new DOMException("x", "AbortError"),
+    b: () => new DOMException("x", "NotFoundError"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "DOMExceptions with different messages",
+    a: () => new DOMException("x", "AbortError"),
+    b: () => new DOMException("y", "AbortError"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "a DOMException and an empty object",
+    a: () => new DOMException("x"),
+    b: () => ({}),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "an empty object and a DOMException",
+    a: () => ({}),
+    b: () => new DOMException("x"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "a DOMException and an Error with the same message",
+    a: () => new DOMException("x"),
+    b: () => new Error("x"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "DOMExceptions with different causes",
+    a: () => new DOMException("x", { name: "AbortError", cause: 1 }),
+    b: () => new DOMException("x", { name: "AbortError", cause: 2 }),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "DOMExceptions with equal object causes",
+    a: () => new DOMException("x", { name: "AbortError", cause: { code: 1 } }),
+    b: () => new DOMException("x", { name: "AbortError", cause: { code: 1 } }),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "a DOMException with a cause and one without",
+    a: () => new DOMException("x", { name: "AbortError", cause: 1 }),
+    b: () => new DOMException("x", "AbortError"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "a DOMException with an undefined cause and one without a cause",
+    a: () => new DOMException("x", { name: "AbortError", cause: undefined }),
+    b: () => new DOMException("x", "AbortError"),
+    strict: false,
+    loose: false,
+    looseBug: "reports equal, as it does for Error",
+  },
+  {
+    name: "a DOMException with an extra own property",
+    a: () => withExtraProperty(new DOMException("x", "AbortError")),
+    b: () => new DOMException("x", "AbortError"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "DOMExceptions with the same extra own property",
+    a: () => withExtraProperty(new DOMException("x", "AbortError")),
+    b: () => withExtraProperty(new DOMException("x", "AbortError")),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "a DOMException subclass instance and a DOMException with the same state",
+    a: () => new SubDOMException("x", "AbortError"),
+    b: () => new DOMException("x", "AbortError"),
+    strict: false,
+    loose: true,
+  },
+  {
+    name: "DOMException subclass instances with different messages",
+    a: () => new SubDOMException("x", "AbortError"),
+    b: () => new SubDOMException("y", "AbortError"),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "arrays holding DOMExceptions with different names",
+    a: () => [new DOMException("x", "AbortError")],
+    b: () => [new DOMException("x", "TimeoutError")],
     strict: false,
     loose: false,
   },
@@ -736,6 +862,11 @@ describe("util.isDeepStrictEqual", () => {
       ["Map value", () => new Map([["k", new Foo(1)]]), () => new Map([["k", new Bar(1)]])],
       ["Set element", () => new Set([new Foo(1)]), () => new Set([new Bar(1)])],
       ["Error cause", () => new Error("e", { cause: new Foo(1) }), () => new Error("e", { cause: new Bar(1) })],
+      [
+        "DOMException cause",
+        () => new DOMException("e", { name: "AbortError", cause: new Foo(1) }),
+        () => new DOMException("e", { name: "AbortError", cause: new Bar(1) }),
+      ],
     ])("propagates through %s", (_name, makeA, makeB) => {
       expect(util.isDeepStrictEqual(makeA(), makeB())).toBe(false);
       expect(util.isDeepStrictEqual(makeA(), makeB(), true)).toBe(true);

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -834,6 +834,22 @@ describe("util.isDeepStrictEqual", () => {
     expect(calls).toBe(2);
   });
 
+  test("reads a DOMException's cause once per side", () => {
+    let calls = 0;
+    const make = () =>
+      new DOMException("x", {
+        name: "AbortError",
+        cause: {
+          get k() {
+            calls++;
+            return 42;
+          },
+        },
+      });
+    expect(util.isDeepStrictEqual(make(), make())).toBe(true);
+    expect(calls).toBe(2);
+  });
+
   // The third argument was added in Node v26.
   describe("skipPrototype", () => {
     class Foo {


### PR DESCRIPTION
### Problem
- `Bun.deepEquals(new DOMException("boom", "AbortError"), new DOMException("other", "NotFoundError"))` returns `true`. Node's `util.isDeepStrictEqual` returns `false`.
- The same comparison is shared by `expect().toEqual()` / `toStrictEqual()` (also inside `expect.objectContaining` / `arrayContaining`), `assert.deepEqual`, `assert.deepStrictEqual` and `util.isDeepStrictEqual`, so all of them treat any two DOMExceptions as equal, including ones with different `cause` values. `assert.deepEqual(new DOMException("boom"), {})` passes as well.
- Cause: a DOMException is a `WebCore::JSDOMException` wrapper (`src/jsc/bindings/webcore/JSDOMException.h`). Its name and message live in the wrapped `WebCore::DOMException` and are exposed as getters on the prototype, and the constructor stores `cause` as a non-enumerable own property (`JSDOMException.cpp`, `construct()`). The instance therefore has no enumerable own properties. `specialObjectsDequal` in `src/jsc/bindings/bindings.cpp` has no case for it (its `ErrorInstanceType` case only matches real `JSC::ErrorInstance`s, and a DOMException wrapper is a plain `ObjectType`), so the comparison falls through to the generic own-property walk, which finds two empty objects.

### Fix
- `domExceptionsDequal` (new): if exactly one side is a DOMException the values are not equal; if both are, the wrapped names and messages must match and then `cause` is compared. On a match it returns nullopt so the existing own-property walk still compares any properties that were assigned onto the instances, exactly as the URL and Headers cases do.
- It is called once per pair from `Bun__deepEquals`, after the two `specialObjectsDequal` passes and before the own-property walk, rather than from inside `specialObjectsDequal`: that function runs twice per pair (once per argument order), and since this comparison recurses into `cause` and then returns nullopt, placing it there compared every level of a cause chain twice, so a chain of n DOMExceptions cost 2^n comparisons (16 levels took about 6 s on a debug build; a getter inside a cause ran 4 times instead of 2). The helper starts with a `JSType` check, so pairs of ordinary objects (`FinalObjectType`) skip the class-chain walks.
- `errorCausesEqual` (new) is the `cause` block lifted out of the `ErrorInstanceType` case unchanged and now used by both cases, so a DOMException's cause follows the same rules as an Error's (deep-compared in every mode; in strict modes a present `cause: undefined` also differs from an absent one).
- Why this is the right comparison: node compares anything with `Error.prototype` in its chain (which includes DOMException) by name, message and cause, then own enumerable properties; Jest 30 does the same for `instanceof Error` values; Bun already applies these rules to Error via the `ErrorInstanceType` case. `code` is not compared separately because `DOMException.cpp` derives it from the name. Names and messages are compared with `equalIgnoringNullity` because both getters present a null and an empty `WTF::String` to JS as `""`.
- The strings are read from the wrapped object rather than through `[[Get]]`, mirroring the `sanitizedNameString` / `sanitizedMessageString` reads in the Error case: no user code runs for the name and message, and the result is the same for JS subclasses of DOMException, which share the wrapper class.
- Verified with:
  - `test/js/bun/bun-object/deep-equals.test.ts` (new `DOMException` block, run in both `Bun.deepEquals` modes, including a getter-read count, a 64-deep cause chain and a cause cycle), `test/js/bun/test/expect.test.js` (new `DOMException` tests in the DOM types block, a getter-read count for `toEqual` / `toStrictEqual`, plus an Error cause test that pins the behaviour of the lifted block), `test/js/node/assert/deep-equal.test.ts` (DOMException rows in the deepStrictEqual / deepEqual / isDeepStrictEqual matrix, a `skipPrototype` case and a getter-read count, expectations checked against node v26). The DOMException tests fail on the unfixed binary and pass with the fix.
  - Existing `deep-equals-temporal`, `deep-match`, `jest-extended`, `test-test`, `expect-extend`, the `test/js/node/assert` suite and the upstream `test-assert-deep-with-error.js` / `test-util-isDeepStrictEqual.js` still pass.
  - The new tests also pass under `BUN_JSC_validateExceptionChecks=1`.
- Out of scope, left as they were: `assert.partialDeepStrictEqual` has its own comparison in `NodeUtilTypesModule.cpp` with the same blind spot (reported separately); DOMExceptions created internally (for example `AbortSignal.abort().reason`) additionally carry enumerable own `line` / `column` / `sourceURL` properties, so two of those created on different lines still compare unequal, as before. #32898 re-parents `JSDOMException` onto `JSC::ErrorInstance` and changes its `JSType`; once it lands, DOMExceptions will take the `ErrorInstanceType` case instead, and this helper and its `JSType` check should be folded into that case.

### Background
- `Bun__deepEquals` (`bindings.cpp`) is one template behind all of Bun's deep-equality entry points; the template parameters select strict vs loose, Jest asymmetric matchers, and node's prototype check. Before the generic own-property walk it calls `specialObjectsDequal(a, b)` and then `specialObjectsDequal(b, a)`; a case there returns `true` / `false` to decide the comparison or nullopt to let the own-property walk decide.
- A DOM wrapper (`JSDOMWrapper<T>`) is the JS object for a native WebCore object; `wrapped()` returns the native object. WebIDL attributes such as `DOMException.prototype.name` are getters on the prototype that read from it, so wrapper instances normally have no own properties of their own.
- `JSC::ErrorInstance` is the object class JSC uses for values created by the Error constructors; it is what `specialObjectsDequal`'s `ErrorInstanceType` case compares. In Bun today a DOMException is not one, so it needs its own case.
- `JSType` is the one-byte type tag in every JSC cell header. `JSDOMException` structures are created with the plain `ObjectType`; object literals and class instances are `FinalObjectType`, and most built-ins have their own tags, which is what `specialObjectsDequal` switches on.

<details>
<summary>Earlier shape of this PR (superseded)</summary>

The first revision called `domExceptionsDequal` from the `ObjectType` block of `specialObjectsDequal`, next to the Temporal handling. Review pointed out that because `specialObjectsDequal` runs once per argument order and the helper recurses into `cause` before returning nullopt, a chain of n DOMException causes took 2^n comparisons. 219e771 moved the single call into `Bun__deepEquals` and added the getter-count, chain and cycle tests; the comparison itself is unchanged.

</details>

<details>
<summary>Probe used to compare against node (node v26.3.0 vs bun 1.4.0 vs this branch)</summary>

| case | node | bun 1.4.0 | this branch |
| --- | --- | --- | --- |
| different name and message | false | true | false |
| same name, different message | false | true | false |
| same message, different name | false | true | false |
| identical | true | true | true |
| DOMException vs `{}` (loose) | false | true | false |
| DOMException vs `Error` with the same message | false | false | false |
| same name/message, different `cause` | false | true | false |
| same name/message, equal object `cause` | true | true | true |
| `cause` on one side only | false | true | false |
| extra own property on one side | false | false | false |
| same extra own property on both sides | true | true | true |
| nested in an array / object, different names | false | true | false |

Remaining differences from node are pre-existing and not DOMException-specific: loose mode does not distinguish a present `cause: undefined` from an absent cause (same as for Error; recorded as a `looseBug` row in the matrix), and internally created DOMExceptions carry enumerable `line` / `column` own properties.

</details>
