### PR TITLE
DOMException: make line/column/sourceURL on internally created exceptions non-enumerable

### DIFF
--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -28,9 +28,11 @@
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMPromiseDeferred.h"
 
+#include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/ErrorHandlingScope.h>
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/ExceptionHelpers.h>
+#include <JavaScriptCore/Interpreter.h>
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>
 #include "headers.h"
@@ -115,6 +117,32 @@ String retrieveErrorMessage(JSGlobalObject& lexicalGlobalObject, VM& vm, JSValue
     return errorMessage;
 }
 
+// JSC::addErrorInfo(), except every property is DontEnum: JSDOMException is not an
+// ErrorInstance, so addErrorInfo() would make line/column/sourceURL enumerable.
+// The error printer (ZigException.cpp) reads them back to locate uncaught DOMExceptions.
+static void addDOMExceptionErrorInfo(JSGlobalObject* lexicalGlobalObject, JSObject* exception)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto stackTrace = getStackTrace(vm, exception, /* useCurrentFrame */ true);
+    if (!stackTrace)
+        return;
+
+    constexpr unsigned attributes = JSC::PropertyAttribute::DontEnum | 0;
+    if (stackTrace->isEmpty()) {
+        exception->putDirect(vm, vm.propertyNames->stack, vm.smallStrings.emptyString(), attributes);
+        return;
+    }
+
+    LineColumn lineColumn;
+    String sourceURL;
+    getLineColumnAndSource(vm, stackTrace.get(), lineColumn, sourceURL);
+    exception->putDirect(vm, vm.propertyNames->line, jsNumber(lineColumn.line), attributes);
+    exception->putDirect(vm, vm.propertyNames->column, jsNumber(lineColumn.column), attributes);
+    if (!sourceURL.isEmpty())
+        exception->putDirect(vm, vm.propertyNames->sourceURL, jsString(vm, WTF::move(sourceURL)), attributes);
+    exception->putDirect(vm, vm.propertyNames->stack, jsString(vm, Interpreter::stackTraceAsString(vm, *stackTrace)), attributes);
+}
+
 JSValue createDOMException(JSGlobalObject* lexicalGlobalObject, ExceptionCode ec, const String& message, const String& extra)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
@@ -184,7 +212,7 @@ JSValue createDOMException(JSGlobalObject* lexicalGlobalObject, ExceptionCode ec
         JSValue errorObject = toJS(lexicalGlobalObject, globalObject, DOMException::create(ec, message));
 
         ASSERT(errorObject);
-        addErrorInfo(lexicalGlobalObject, asObject(errorObject), true);
+        addDOMExceptionErrorInfo(lexicalGlobalObject, asObject(errorObject));
         return errorObject;
     }
     }

--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -117,9 +117,7 @@ String retrieveErrorMessage(JSGlobalObject& lexicalGlobalObject, VM& vm, JSValue
     return errorMessage;
 }
 
-// JSC::addErrorInfo(), except every property is DontEnum: JSDOMException is not an
-// ErrorInstance, so addErrorInfo() would make line/column/sourceURL enumerable.
-// The error printer (ZigException.cpp) reads them back to locate uncaught DOMExceptions.
+// JSC::addErrorInfo() would make these enumerable (JSDOMException is not an ErrorInstance); ZigException.cpp reads them back.
 static void addDOMExceptionErrorInfo(JSGlobalObject* lexicalGlobalObject, JSObject* exception)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { join } from "node:path";
 import { isDeepStrictEqual } from "node:util";
 
 describe("DOMException in Node.js environment", () => {
@@ -161,13 +162,17 @@ describe("DOMException own properties", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const locations = normalizeBunSnapshot(stderr, String(dir))
+    // The location comes from the sourceURL JSC recorded, which spells the
+    // drive letter in lowercase on Windows.
+    const normalizeCase = line => (isWindows ? line.toLowerCase() : line);
+    const locations = stderr
       .split("\n")
       .map(line => line.trim())
-      .filter(line => line.startsWith("at "));
+      .filter(line => line.startsWith("at "))
+      .map(normalizeCase);
     expect({ stdout, locations, exitCode }).toEqual({
       stdout: "",
-      locations: ["at <dir>/reject.js:1"],
+      locations: [normalizeCase(`at ${join(String(dir), "reject.js")}:1`)],
       exitCode: 1,
     });
   });

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { isDeepStrictEqual } from "node:util";
 
 describe("DOMException in Node.js environment", () => {
   it("exists globally", () => {
@@ -70,5 +72,103 @@ describe("DOMException in Node.js environment", () => {
     // Create an exception with known code
     const abortError = new DOMException("Aborted", "AbortError");
     expect(abortError.code).toBe(20); // ABORT_ERR
+  });
+});
+
+function thrownBy(fn) {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected the callback to throw");
+}
+
+async function rejectionOf(promise) {
+  try {
+    await promise;
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected the promise to reject");
+}
+
+async function timeoutReason() {
+  const signal = AbortSignal.timeout(0);
+  const { promise, resolve } = Promise.withResolvers();
+  signal.addEventListener("abort", resolve, { once: true });
+  await promise;
+  return signal.reason;
+}
+
+// As in Node, no DOMException has own enumerable properties. The creation site Bun
+// records on internally created ones (line/column/sourceURL/stack) is non-enumerable.
+describe("DOMException own properties", () => {
+  it.each([
+    ["new DOMException()", "AbortError", () => new DOMException("The operation was aborted.", "AbortError")],
+    ["structuredClone(domException)", "AbortError", () => structuredClone(new DOMException("cloned", "AbortError"))],
+    ["AbortSignal.abort().reason", "AbortError", () => AbortSignal.abort().reason],
+    [
+      "AbortController#abort() reason",
+      "AbortError",
+      () => {
+        const controller = new AbortController();
+        controller.abort();
+        return controller.signal.reason;
+      },
+    ],
+    ["AbortSignal.timeout() reason", "TimeoutError", timeoutReason],
+    ["structuredClone() DataCloneError", "DataCloneError", () => thrownBy(() => structuredClone(() => {}))],
+    ["atob() InvalidCharacterError", "InvalidCharacterError", () => thrownBy(() => atob("!"))],
+    [
+      "crypto.subtle rejection",
+      "DataError",
+      () => rejectionOf(crypto.subtle.importKey("raw", new Uint8Array(3), { name: "AES-GCM" }, false, ["encrypt"])),
+    ],
+  ])("%s has no own enumerable properties", async (_, name, create) => {
+    const exception = await create();
+    expect(exception).toBeInstanceOf(DOMException);
+    expect(exception.name).toBe(name);
+
+    expect({
+      keys: Object.keys(exception),
+      json: JSON.stringify(exception),
+      spread: { ...exception },
+    }).toEqual({ keys: [], json: "{}", spread: {} });
+  });
+
+  it("internally created DOMExceptions from different call sites are deep equal", () => {
+    const first = AbortSignal.abort().reason;
+    const second = AbortSignal.abort().reason;
+    const constructed = new DOMException(first.message, first.name);
+
+    expect(isDeepStrictEqual(first, second)).toBe(true);
+    expect(isDeepStrictEqual(first, constructed)).toBe(true);
+    expect(first).toEqual(second);
+    expect(first).toEqual(constructed);
+  });
+
+  it("the uncaught error printer still reports where an internally created DOMException came from", async () => {
+    using dir = tempDir("domexception-uncaught", {
+      "reject.js": "Promise.reject(AbortSignal.abort().reason);\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "reject.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const locations = normalizeBunSnapshot(stderr, String(dir))
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("at "));
+    expect({ stdout, locations, exitCode }).toEqual({
+      stdout: "",
+      locations: ["at <dir>/reject.js:1"],
+      exitCode: 1,
+    });
   });
 });

--- a/test/js/web/abort/abort.test.ts
+++ b/test/js/web/abort/abort.test.ts
@@ -103,7 +103,6 @@ describe("AbortSignal", () => {
   function fmt(value: any) {
     const res = {};
     for (const key in value) {
-      if (key === "column" || key === "line" || key === "sourceURL") continue;
       res[key] = value[key];
     }
     return res;


### PR DESCRIPTION
### Problem
- Every DOMException that Bun creates internally has own enumerable `line`, `column` and `sourceURL` properties: `Object.keys(AbortSignal.abort().reason)` is `["line", "column", "sourceURL"]` (Node: `[]`), and the same holds for `AbortController#abort()` reasons, `structuredClone()` DataCloneErrors, `atob()` InvalidCharacterErrors, `WebSocket#close()` InvalidAccessErrors and WebCrypto rejections. `JSON.stringify(reason)` is `{"line":1,"column":32,"sourceURL":"/app/index.js"}` and `{ ...reason }` copies the three properties.
- `util.isDeepStrictEqual`, `assert.deepStrictEqual` and `expect().toEqual()` compare those properties as ordinary own enumerable properties, so two abort reasons created on different lines (or against a `new DOMException(...)` with the same name and message) are not deep equal. They are in Node. `test/js/web/abort/abort.test.ts` was stripping these keys before comparing a reason with a constructed DOMException.
- Cause: `createDOMException()` (`src/jsc/bindings/JSDOMExceptionHandling.cpp`, default arm) records the creation site on the new wrapper with `JSC::addErrorInfo()`. `JSDOMException` is a plain DOM wrapper, not a `JSC::ErrorInstance`, so `addErrorInfo()` stores `line`, `column` and `sourceURL` with `putDirect()` and default (enumerable) attributes (`vendor/WebKit/Source/JavaScriptCore/runtime/Error.cpp`, `addErrorInfo(VM&, Vector<StackFrame>*, JSObject*)`); only `stack` is stored `DontEnum` there. User-constructed and structured-cloned DOMExceptions do not go through this arm and have no own properties at all.

### Fix
- Replace the `addErrorInfo()` call with a local `addDOMExceptionErrorInfo()` that stores the same four properties (`line`, `column`, `sourceURL`, `stack`; just `stack: ""` when no JS frame is on the stack, as for `AbortSignal.timeout()`) with `DontEnum`. Values, `stack` contents and the empty-trace case are unchanged; only the attribute differs.
- Why non-enumerable rather than dropping the properties: the uncaught error / unhandled rejection printer reads `sourceURL` and `line` back off the object to print the `at file:line` location of an internally created DOMException (`ZigException.cpp`, `exceptionFromString()`), since a rejection reason was never thrown and has no `JSC::Exception` stack. Keeping them `DontEnum` keeps that output and `reason.line` reads working while removing them from everything enumeration-based. This is also how Bun's own `Error` objects already carry `line`/`column`/`sourceURL` (own, non-enumerable), and it gives the shape Node and WebIDL define for a DOMException: no own enumerable properties.
- `console.log(reason)` output is unchanged (Bun.inspect lists a DOM wrapper's own properties regardless of enumerability, and it already listed the non-enumerable `stack`).
- `abort.test.ts`: removed the line that skipped `column`/`line`/`sourceURL` in its `fmt()` helper. The two tests using it now fail without this change and pass with it.
- Verified with:
  - `test/js/node/domexception-node.test.js`: new `DOMException own properties` block. An `it.each` over constructed, structured-cloned, `AbortSignal.abort()`, `AbortController#abort()`, `AbortSignal.timeout()`, `structuredClone()` DataCloneError, `atob()` and a WebCrypto rejection asserts `Object.keys` / `JSON.stringify` / spread are empty; a deep-equality test covers `util.isDeepStrictEqual` and `toEqual()` across call sites and against a constructed DOMException; a spawned fixture asserts the printer still prints `at <fixture path>:1` for an unhandled abort reason (compared case-insensitively on Windows, where the sourceURL JSC records spells the drive letter in lowercase; that is pre-existing and unchanged here). On the released binary (`USE_SYSTEM_BUN=1`, checked on Linux and Windows x64) the five internally created paths and the deep-equality test fail; everything passes with the fix. Every assertion in the block also holds under Node v26.3.0 (output below).
  - `test/js/web/abort/abort.test.ts` (16 pass; `.signal.reason should be a DOMException` fails on the released binary), plus `globals.test.js`, `web-globals.test.js`, `abort-controller-gc-reason.test.ts`, `websocket-close-code.test.ts`, `structured-clone.test.ts`, `timers.promises.test.ts`, the deno `encoding.test.ts`, and the upstream `test-global-domexception.js`, `test-domexception-cause.js`, `test-structuredClone-domexception.js`.
  - The new tests pass under `BUN_JSC_validateExceptionChecks=1` (the helper makes the same non-throwing calls `addErrorInfo()` made).
- Related: #39308 and #39306 make the deep-equality helpers compare DOMException name/message/cause and list this enumerable-property issue as the remaining difference; the tests here hold with or without them. #32898 re-parents `JSDOMException` onto `JSC::ErrorInstance` and deletes this call altogether; this change is the small fix for the shape problem independent of that refactor.

### Background
- `DOMException` in Bun is a WebCore DOM wrapper (`JSDOMException`): `name`, `message` and `code` are getters on the prototype that read the wrapped C++ object, so an instance normally has no own properties. `JSC::ErrorInstance` is the class behind `new Error()`; it stores line/column/sourceURL/stack in internal fields and materializes them as non-enumerable own properties, which is why the same data is invisible to `Object.keys` on a regular Error.
- `JSC::addErrorInfo(globalObject, object, useCurrentFrame)` captures the current JS stack and writes `line`, `column`, `sourceURL` and `stack` onto an arbitrary object. Upstream WebCore calls it from `createDOMException()`; `createDOMException()` is the single place all of Bun's internally created DOMExceptions come from (abort reasons via `toJS(CommonAbortReason)`, `throwDataCloneError()`, `propagateException()` for WebIDL `ExceptionCode`s, and `DeferredPromise` rejections).
- `DontEnum` is JSC's name for `enumerable: false`. `Object.keys`, `JSON.stringify`, spread, `for...in` and Bun's and Node's deep-equality walks only look at enumerable own properties; `[[Get]]`-based reads such as the error printer's still see a `DontEnum` property.

<details>
<summary>Node v26.3.0 on the same scenarios</summary>

```
$ node nodecheck.mjs
new DOMException()                 DOMException AbortError {"keys":[],"json":"{}","spread":{}}
structuredClone(domException)      DOMException AbortError {"keys":[],"json":"{}","spread":{}}
AbortSignal.abort().reason         DOMException AbortError {"keys":[],"json":"{}","spread":{}}
AbortController#abort()            DOMException AbortError {"keys":[],"json":"{}","spread":{}}
structuredClone() DataCloneError   DOMException DataCloneError {"keys":[],"json":"{}","spread":{}}
atob()                             DOMException InvalidCharacterError {"keys":[],"json":"{}","spread":{}}
subtle rejection                   DOMException DataError {"keys":[],"json":"{}","spread":{}}
isDeepStrictEqual(first, second): true
isDeepStrictEqual(first, new DOMException(first.message, first.name)): true
```

Bun 1.4.0 on the same script reports `"keys":["line","column","sourceURL"]` for the last five creation paths and `false` for both deep-equality lines; this branch matches the Node output above (Node's own property set differs only in the non-enumerable `stack` / creation-site properties, which none of these operations observe).

</details>

<details>
<summary>Before / after for the printer and for util.inspect</summary>

```
$ cat reject.js
Promise.reject(AbortSignal.abort().reason);

$ bun reject.js            # identical before and after: the `at` line comes from the retained line/sourceURL properties
AbortError: The operation was aborted.
DOMException { ... }
      at /tmp/x/reject.js:1

$ bun -e 'console.log(require("util").inspect(AbortSignal.abort().reason))'
# before (1.4.0)
[global code@/tmp/x/[eval]:1:56] {
  line: 1,
  column: 56,
  sourceURL: '/tmp/x/[eval]'
}
# after
[global code@/tmp/x/[eval]:1:56]
```

The missing `AbortError: ...` header in that `util.inspect` output comes from the JSC-format `stack` string, which this change does not touch; #32898 replaces it with a Bun-formatted stack.

</details>
