### PR TITLE
Resolve static imports of unknown node: names at runtime so mock.module / build.module / plugins apply to require()d files and the entry point

### DIFF
--- a/src/bundler/error.rs
+++ b/src/bundler/error.rs
@@ -36,8 +36,6 @@ pub enum Error {
     EmptyAST,
     #[error("FormatError")]
     FormatError,
-    #[error("ResolveMessage")]
-    ResolveMessage,
     #[error("JSError")]
     Js(bun_core::JsError),
     #[error(transparent)]
@@ -122,7 +120,6 @@ impl Error {
             Self::InvalidNativePlugin => "InvalidNativePlugin",
             Self::EmptyAST => "EmptyAST",
             Self::FormatError => "FormatError",
-            Self::ResolveMessage => "ResolveMessage",
             Self::Js(bun_core::JsError::OutOfMemory) => "OutOfMemory",
             Self::Js(_) => "JSError",
             Self::Sys(e) => <&'static str>::from(e),

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -3,7 +3,7 @@
 use std::io::Write as _;
 
 use bun_ast::Log;
-use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags, ImportRecordTag};
+use bun_ast::{ImportKind, ImportRecordFlags, ImportRecordTag};
 use bun_collections::HashMap;
 use bun_paths::{self, SEP};
 // two `fs` shapes are in play here. `bun_resolver::fs` (`Fs`) holds
@@ -374,7 +374,6 @@ impl Linker {
 
         let source_dir = file_path.source_dir();
         let mut externals: Vec<u32> = Vec::new();
-        let mut had_resolve_errors = false;
 
         let is_deferred = !result.pending_imports.is_empty();
 
@@ -384,10 +383,8 @@ impl Linker {
             | options::Loader::Js
             | options::Loader::Ts
             | options::Loader::Tsx => {
-                // Iterate by index, take field-disjoint
-                // borrows (`&result.source` + `&mut result.ast.*`) where
-                // needed, and hoist `is_pending_import` (which borrows the
-                // whole `result`) before any `ast` mut borrow.
+                // Iterate by index and hoist `is_pending_import` (which
+                // borrows the whole `result`) before the `ast` mut borrow.
                 let len = result.ast.import_records.as_slice().len();
                 for record_i in 0..len {
                     let record_index = u32::try_from(record_i).expect("int cast");
@@ -395,10 +392,7 @@ impl Linker {
                     let skip_deferred =
                         IS_BUN && is_deferred && !result.is_pending_import(record_index);
 
-                    // Field-split borrow: `source` ⟂ `ast`.
-                    let source = &result.source;
-                    let ast = &mut result.ast;
-                    let import_record = &mut ast.import_records.as_mut_slice()[record_i];
+                    let import_record = &mut result.ast.import_records.as_mut_slice()[record_i];
 
                     if import_record.flags.contains(ImportRecordFlags::IS_UNUSED) || skip_deferred {
                         continue;
@@ -444,21 +438,6 @@ impl Linker {
                             import_record
                                 .flags
                                 .insert(ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
-                            continue;
-                        }
-                        if strings::starts_with(import_record.path.text, b"node:") {
-                            // if a module is not found here, it is not found at
-                            // all so we can just disable it
-                            had_resolve_errors = Self::when_module_not_found::<IS_BUN>(
-                                self.log_mut(),
-                                target,
-                                import_record,
-                                source,
-                            )?;
-
-                            if had_resolve_errors {
-                                return Err(crate::Error::ResolveMessage);
-                            }
                             continue;
                         }
 
@@ -519,86 +498,10 @@ impl Linker {
 
             _ => {}
         }
-        if had_resolve_errors {
-            return Err(crate::Error::ResolveMessage);
-        }
         // Vec drop at scope end frees.
         externals.clear();
         let _ = externals;
         Ok(())
-    }
-
-    // Takes the disjoint pieces explicitly rather than `&mut self` plus
-    // overlapping sub-borrows of `result`.
-    fn when_module_not_found<const IS_BUN: bool>(
-        log: &mut Log,
-        target: BundleTarget,
-        import_record: &mut ImportRecord,
-        source: &bun_ast::Source,
-    ) -> crate::Result<bool> {
-        if import_record
-            .flags
-            .contains(ImportRecordFlags::HANDLES_IMPORT_ERRORS)
-        {
-            import_record.path.is_disabled = true;
-            import_record
-                .flags
-                .insert(ImportRecordFlags::WAS_UNRESOLVED);
-            return Ok(false);
-        }
-
-        if IS_BUN {
-            // make these happen at runtime
-            if import_record.kind == ImportKind::Require
-                || import_record.kind == ImportKind::RequireResolve
-                || import_record.kind == ImportKind::Dynamic
-            {
-                return Ok(false);
-            }
-        }
-
-        if !import_record.path.text.is_empty() && resolver::is_package_path(import_record.path.text)
-        {
-            if target == BundleTarget::Browser && options::is_node_builtin(import_record.path.text)
-            {
-                log.add_resolve_error(
-                    Some(source),
-                    import_record.range,
-                    format_args!(
-                        "Could not resolve: \"{}\". Try setting --target=\"node\"",
-                        bstr::BStr::new(import_record.path.text)
-                    ),
-                    import_record.path.text,
-                    import_record.kind,
-                    bun_ast::Error::ModuleNotFound,
-                );
-            } else {
-                log.add_resolve_error(
-                    Some(source),
-                    import_record.range,
-                    format_args!(
-                        "Could not resolve: \"{}\". Maybe you need to \"bun install\"?",
-                        bstr::BStr::new(import_record.path.text)
-                    ),
-                    import_record.path.text,
-                    import_record.kind,
-                    bun_ast::Error::ModuleNotFound,
-                );
-            }
-        } else {
-            log.add_resolve_error(
-                Some(source),
-                import_record.range,
-                format_args!(
-                    "Could not resolve: \"{}\"",
-                    bstr::BStr::new(import_record.path.text)
-                ),
-                import_record.path.text,
-                import_record.kind,
-                bun_ast::Error::ModuleNotFound,
-            );
-        }
-        Ok(true)
     }
 
     pub(crate) fn generate_import_path(

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -803,3 +803,81 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   expect(stdout.trim() || stderr).toBe("entry ran:dep");
   expect(exitCode).toBe(0);
 });
+
+describe("virtual modules and onResolve plugins for node: names that are not builtins", () => {
+  async function runWithPreload(preload: string, env: Record<string, string> = {}) {
+    using dir = tempDir("plugin-node-prefix", {
+      "preload.ts": preload,
+      "target.ts": `export default "target";`,
+      "entry.ts": `
+        import direct from "node:provided_by_plugin";
+        console.log("entry:", direct);
+        console.log("require():", require("./required.ts").default);
+        console.log("import():", (await import("./imported.ts")).default);
+      `,
+      "required.ts": `
+        import value from "node:provided_by_plugin";
+        export default value;
+      `,
+      "imported.ts": `export { default } from "node:provided_by_plugin";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", "./preload.ts", "entry.ts"],
+      env: { ...bunEnv, ...env },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // The entry point and require()d files are transpiled on the JS thread; with the concurrent
+  // transpiler disabled, so is everything import()ed. Their static imports must reach the plugin
+  // registry exactly like the imports of concurrently transpiled files do.
+  it.concurrent.each([
+    ["concurrent transpiler", {}],
+    ["concurrent transpiler disabled", { BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1" }],
+  ])("build.module() is seen by static imports in every kind of file (%s)", async (_, env) => {
+    const result = await runWithPreload(
+      `
+        Bun.plugin({
+          name: "node-prefixed virtual module",
+          setup(build) {
+            build.module("node:provided_by_plugin", () => ({ exports: { default: "virtual" }, loader: "object" }));
+          },
+        });
+      `,
+      env,
+    );
+
+    expect(result).toEqual({
+      stdout: "entry: virtual\nrequire(): virtual\nimport(): virtual\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Registering onResolve moves every file onto the JS thread, so one run covers all three shapes.
+  it.concurrent('onResolve({ namespace: "node" }) is consulted for static imports in every kind of file', async () => {
+    const result = await runWithPreload(`
+      import { join } from "node:path";
+
+      Bun.plugin({
+        name: "node-namespace onResolve",
+        setup(build) {
+          build.onResolve({ filter: /^provided_by_plugin$/, namespace: "node" }, () => ({
+            path: join(import.meta.dir, "target.ts"),
+          }));
+        },
+      });
+    `);
+
+    expect(result).toEqual({
+      stdout: "entry: target\nrequire(): target\nimport(): target\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -170,6 +170,75 @@ describe("ResolveMessage", () => {
   });
 });
 
+describe.concurrent("static import of an unknown node: builtin", () => {
+  const specifier = "node:this_builtin_does_not_exist";
+  const importer = `import "${specifier}";`;
+
+  // require()d files and the entry point are transpiled on the JS thread, import()ed files on the
+  // concurrent transpiler (unless it is disabled). The JS thread used to reject the import while
+  // transpiling, with a different message; every path now leaves it to the runtime resolver.
+  it.each([
+    ["concurrent transpiler", {}],
+    ["concurrent transpiler disabled", { BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1" }],
+  ])("rejects the same way from require() and import() (%s)", async (_, env) => {
+    using dir = tempDir("unknown-node-builtin", {
+      "required.ts": importer,
+      "imported.ts": importer,
+      "main.ts": `
+        const describe = e => ({ name: e.name, code: e.code, specifier: e.specifier, message: e.message });
+        const errors = {};
+        try {
+          require("./required.ts");
+        } catch (e) {
+          errors.required = describe(e);
+        }
+        try {
+          await import("./imported.ts");
+        } catch (e) {
+          errors.imported = describe(e);
+        }
+        console.log(JSON.stringify(errors));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: { ...bunEnv, ...env },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const error = {
+      name: "ResolveMessage",
+      code: "ERR_UNKNOWN_BUILTIN_MODULE",
+      specifier,
+      message: `No such built-in module: ${specifier}`,
+    };
+    expect({ errors: JSON.parse(stdout), stderr, exitCode }).toEqual({
+      errors: { required: error, imported: error },
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("is reported by the entry point with the same message", async () => {
+    using dir = tempDir("unknown-node-builtin-entry", { "entry.ts": importer });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("");
+    expect(stderr).toContain(`error: No such built-in module: ${specifier}`);
+    expect(exitCode).toBe(1);
+  });
+});
+
 // These tests reproduce panics where the module resolver wrote past fixed-size
 // PathBuffers when given very long import specifiers. The bug triggers when
 // `import_path < PATH_MAX` but `baseUrl + import_path > PATH_MAX` (otherwise a

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -7,7 +7,8 @@
 // - Write test for export {foo} from "./foo"
 // - Write test for import {foo} from "./foo"; export {foo}
 
-import { expect, mock, spyOn, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { default as defaultValue, fn, iCallFn, rexported, rexportedAs, variable } from "./mock-module-fixture";
 import * as spyFixture from "./spymodule-fixture";
 
@@ -165,4 +166,53 @@ test("mocking a builtin", async () => {
 
   const { readFile } = await import("node:fs/promises");
   expect(await readFile("hello.txt", "utf8")).toBe("hello world");
+});
+
+describe("mocking a node: name that is not a builtin", () => {
+  test("is seen by a static import in a require()d file", () => {
+    mock.module("node:mocked_by_mock_module_test", () => ({ default: "mocked" }));
+
+    expect(require("./node-prefix-import-fixture.ts").default).toBe("mocked");
+  });
+
+  // The entry point and require()d files are transpiled on the JS thread; with the concurrent
+  // transpiler disabled, so is everything import()ed. All of them must consult the mock registry
+  // exactly like files transpiled concurrently do.
+  test.concurrent.each([
+    ["concurrent transpiler", {}],
+    ["concurrent transpiler disabled", { BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1" }],
+  ])("is seen by static imports in the entry point, a require()d file and an import()ed file (%s)", async (_, env) => {
+    using dir = tempDir("mock-module-node-prefix", {
+      "preload.ts": `
+        import { mock } from "bun:test";
+        mock.module("node:mocked_in_preload", () => ({ default: "mocked", named: 1 }));
+      `,
+      "entry.ts": `
+        import direct, { named } from "node:mocked_in_preload";
+        console.log("entry:", direct, named);
+        console.log("require():", require("./required.ts").default);
+        console.log("import():", (await import("./imported.ts")).default);
+      `,
+      "required.ts": `
+        import value from "node:mocked_in_preload";
+        export default value;
+      `,
+      "imported.ts": `export { default } from "node:mocked_in_preload";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--preload", "./preload.ts", "entry.ts"],
+      env: { ...bunEnv, ...env },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "entry: mocked 1\nrequire(): mocked\nimport(): mocked\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 });

--- a/test/js/bun/test/mock/node-prefix-import-fixture.ts
+++ b/test/js/bun/test/mock/node-prefix-import-fixture.ts
@@ -1,0 +1,5 @@
+// require()d by mock-module.test.ts after it registers this node: name with mock.module().
+// @ts-expect-error not a real builtin
+import value from "node:mocked_by_mock_module_test";
+
+export default value;


### PR DESCRIPTION
### Problem
- A virtual module registered under a `node:` name that is not a builtin (`mock.module("node:x", ...)`, `build.module("node:x", ...)`) is seen by a static `import` in an `import()`ed file, but the same `import` in a `require()`d file or in the entry point fails the whole file with `Could not resolve: "node:x". Maybe you need to "bun install"?`. With `BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER=1` the `import()`ed file fails the same way.
- Same split for a `node:` name that an `onResolve({ namespace: "node" })` plugin or a tsconfig `paths` entry maps. `import("node:x")` and `require("node:x")` of these names work everywhere; only the static form is affected.
- Cause: `Linker::link` (`src/bundler/linker.rs:449` on main), which only runs over files transpiled on the JS thread, fails every static import of a `node:` name missing from the builtin table while the file is still being transpiled (`when_module_not_found`). That is before the runtime resolve, which is where virtual modules, plugins and tsconfig paths are consulted. The concurrent transpiler's own pass over the import records (`src/jsc/RuntimeTranspilerStore.rs:1068`) has no such check, so its files reach the runtime resolve and work.
- Reported by another session while working on #39246.

### Fix
- Delete the `node:` arm. A static import of an unknown-to-the-table `node:` name is now left in the import record like every other specifier and resolved by the runtime resolve when the module is linked, on both transpile paths.
- Why this is right: the linker resolves nothing else at transpile time any more, and the runtime resolve is already what decides these names for `import()`, `require()` and every concurrently transpiled static import. The arm was a transpile-time shortcut from when the linker still resolved all imports (#3913), and #26981 already had to carve `import()` out of it for the same reason.
- A name nothing provides still fails, now from the runtime resolve on every path: a `ResolveMessage` with `code` `ERR_UNKNOWN_BUILTIN_MODULE` (unchanged) and Node's text `No such built-in module: node:x`, which the concurrent path already produced; the JS-thread path used to print the `bun install` text with the import's source position. This makes #39246 (message text only) unnecessary.
- The arm's other effect was inert: for `try { require("node:x") }` it set `path.is_disabled`, which the printer only reads under `inline_require_and_import_errors`, and the runtime printer (`Format::EsmAscii`, `src/bundler/transpiler.rs:2507`) sets that to false. `try { require("node:x") }` threw `ERR_UNKNOWN_BUILTIN_MODULE` at runtime before and still does.
- Removed with it: `when_module_not_found` (this arm was its only caller; `node:` names are always package paths and the runtime target is never the browser, so only its `bun install` branch was reachable) and `bun_bundler::Error::ResolveMessage` (only produced there).
- `bun build`, `bun build --no-bundle` and `Bun.Transpiler` are unaffected: the bundler reports unresolved imports from `bundle_v2.rs`, and the other two never ran `Linker::link` (verified: all three produce byte-identical output before and after for a file importing an unknown `node:` name, `Bun.Transpiler` with each of the three targets).
- Not changed: a direct `require("node:x")` of such a virtual module throws `Failed to fetch builtin module` on every path. That is the CommonJS `node:` fast path (`src/js/builtins/CommonJS.ts` to `jsFunctionRequireNativeModule`), the area #34984 is about.
- Tests, each failing on the 1.4.0 release binary with the `Could not resolve` text and passing with this change:
  - `test/js/bun/test/mock/mock-module.test.ts`: `mock.module()` of a `node:` name, seen by a static import in a `require()`d fixture, and (via `--preload`) by the entry point, a `require()`d file and an `import()`ed `export ... from`, with and without the concurrent transpiler.
  - `test/js/bun/plugin/plugins.test.ts`: the same matrix for `build.module()`, plus an `onResolve({ namespace: "node" })` plugin redirecting the static import in all three files (registering a plugin puts every file on the JS thread, so one run covers them).
  - `test/js/bun/resolve/resolve-error.test.ts`: an unknown `node:` name rejects with the same `name` / `code` / `specifier` / `message` from `require()` and `import()`, with and without the concurrent transpiler, and the entry point reports the same message.
- Also run with the debug build: all of `test/js/bun/resolve/`, `test/js/bun/plugin/`, `test/js/bun/test/mock/`, `test/regression/issue/25707.test.ts`, `test/js/node/missing-module.test.js`, `test/js/node/test/parallel/test-require-node-prefix.js` and `test-stream-iter-disabled.js`. The one failure, `load-same-js-file-a-lot.test.ts`, is its second test hitting the default 5s timeout under the debug build on this machine (the first test of the file takes 17s here against a 20s budget); it imports a file with no import records, which this change does not touch.

### Background
- Runtime transpile paths: a module's source is transpiled either on the JS thread (`transpile_source_code_inner` in `src/runtime/jsc_hooks.rs`, which calls `Linker::link` at line 3131) or by the concurrent transpiler, a thread pool in `RuntimeTranspilerStore`. The JS thread handles the entry point, every `require()`, plugin-provided sources, and everything once an `onLoad`/`onResolve` plugin is registered or `BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER` is set; ordinary `import`s after startup use the pool. Only the JS-thread path runs `Linker::link`.
- `Linker::link` is a pass over a transpiled file's import records. Today it rewrites builtin aliases (`fs` to `node:fs`), strips `bun:` prefixes and offers namespaced specifiers to onResolve plugins; it does not call the resolver.
- Runtime resolve: when JSC links a module's imports it calls `moduleLoaderResolve` (`src/jsc/bindings/ZigGlobalObject.cpp:3650`), which checks the virtual module map and then the Rust resolve (`resolve_maybe_needs_trailing_slash`, `src/jsc/VirtualMachine.rs:4528`): onResolve plugins for namespaced specifiers, the builtin alias table, then the package resolver (where tsconfig `paths` apply). A `node:` name that fails all of these is formatted by `ResolveMessage::fmt` (`src/jsc/ResolveMessage.rs:171`) as `No such built-in module: <specifier>`.
- Virtual module map: the per-global table in `BunPlugin.cpp` that both `mock.module()` and `build.module()` write into; it is only consulted by the runtime resolve and fetch, never by the transpiler.
- `ResolveMessage`: the error object for a failed resolution. Its `.code` and `.specifier` are derived from the specifier, which is why those already matched on both paths and only `.message` differed.
