### PR TITLE
bake: report a bundling failure of bun build --app instead of an internal error

### DIFF
--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -116,7 +116,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     // Note: pass `vm_ptr` by value into the guard so the drop closure does
     // not borrow the local (`defer!` would capture `&vm_ptr`, which under
     // edition-2024 disjoint-capture rules collides with the `&mut *vm_ptr`
-    // re-borrows on the JSError path).
+    // re-borrow after `build_with_vm`).
     let _vm_guard = scopeguard::guard(vm_ptr, |p| {
         // SAFETY: p is the unique live VM on this thread; its loop is alive, so
         // queued work is released here rather than by a thread teardown.
@@ -211,28 +211,39 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     // LIFO order — under the API lock, before the VM is destroyed.
     let mut pt = PerThread::placeholder(vm_ptr);
 
-    match build_with_vm(ctx, &cwd, &mut pt) {
-        Ok(()) => {}
+    let result = build_with_vm(ctx, &cwd, &mut pt);
+    // SAFETY: `build_with_vm` has returned, so its reborrows through `pt.vm` are
+    // dead; the VM is live until `global_exit` (or `_vm_guard`) destroys it.
+    let vm = unsafe { &mut *vm_ptr };
+    match result {
+        Ok(()) => return Ok(()),
         Err(crate::Error::JSError) => {
-            // SAFETY: vm.global is live for VM lifetime.
-            let global = unsafe { &*(*vm_ptr).global };
-            let err_value = global.take_exception(jsc::JsError::Thrown);
-            // SAFETY: see above.
-            unsafe {
-                (*vm_ptr)
-                    .print_error_like_object_to_console(err_value.to_error().unwrap_or(err_value))
-            };
-            // SAFETY: see above.
-            let vm = unsafe { &mut *vm_ptr };
-            if vm.exit_handler.exit_code == 0 {
-                vm.exit_handler.exit_code = 1;
-            }
-            vm.on_exit();
-            vm.global_exit();
+            let err_value = vm.global().take_exception(jsc::JsError::Thrown);
+            vm.print_error_like_object_to_console(err_value.to_error().unwrap_or(err_value));
+        }
+        // The bundler reports what failed (parse, resolve and link errors)
+        // through the log; `BuildFailed` only says that it did. Without
+        // logged errors it is the internal error the caller reports it as.
+        Err(crate::Error::Bundler(bun_bundler::Error::BuildFailed))
+            if vm.log_ref().is_some_and(bun_ast::Log::has_errors) =>
+        {
+            print_build_log(vm);
         }
         Err(e) => return Err(e),
     }
-    Ok(())
+    if vm.exit_handler.exit_code == 0 {
+        vm.exit_handler.exit_code = 1;
+    }
+    vm.on_exit();
+    vm.global_exit()
+}
+
+fn print_build_log(vm: &VirtualMachine) {
+    // `vm.log` is the process-lifetime ctx.log set in build_command;
+    // `log_ref()` is the safe accessor encapsulating the NonNull deref.
+    if let Some(log) = vm.log_ref() {
+        let _ = log.print(std::ptr::from_mut(Output::error_writer()));
+    }
 }
 
 /// Ported inline from `bun.bun_js.failWithBuildError` to avoid the
@@ -241,11 +252,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
 #[cold]
 #[inline(never)]
 fn fail_with_build_error(vm: &mut VirtualMachine) -> ! {
-    // `vm.log` is the process-lifetime ctx.log set in build_command;
-    // `log_ref()` is the safe accessor encapsulating the NonNull deref.
-    if let Some(log) = vm.log_ref() {
-        let _ = log.print(std::ptr::from_mut(Output::error_writer()));
-    }
+    print_build_log(vm);
     Global::exit(1);
 }
 
@@ -618,10 +625,7 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
         // Lives in this block's stack frame, outliving the bundle call.
         let mut any_loop = bun_event_loop::AnyEventLoop::js(vm.event_loop().cast());
 
-        // Propagate via `?`. Do NOT
-        // catch-and-exit here: the bake path expects this call to succeed for
-        // valid inputs, and any `BuildFailed` indicates a bug upstream
-        // (in the bundler), not a user-facing diagnostic to swallow.
+        // `BuildFailed` (the errors are in the log) is reported by `build_command`.
         BundleV2::generate_from_bake_production_cli(
             &entry_points,
             // SAFETY: see `server_ptr` comment above.

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -570,11 +570,9 @@ pub mod cli {
         // SAFETY: just initialized above; single-threaded for the lifetime of `log`.
         let log = unsafe { (*LOG_.get()).assume_init_mut() };
         if let Err(err) = Command::start(log) {
-            // Print accumulated diagnostics BEFORE the
-            // generic `handle_root_error` "An internal error occurred (..)"
-            // message. The bake production path returns `error.BuildFailed`
-            // with the actual parse/link errors sitting in `ctx.log` (== this
-            // `log`); without this print, users see only the opaque error name.
+            // Print the diagnostics a command accumulated in `ctx.log` (== this
+            // `log`) before the generic `handle_root_error` "An internal error
+            // occurred (..)" message names the error.
             let _ = log.print(std::ptr::from_mut::<bun_core::io::Writer>(
                 bun_core::Output::error_writer(),
             ));

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
 import path from "path";
-import { tempDirWithBakeDeps } from "../bake-harness";
+import { tempDirWithBakeDeps, WAIT_MULTIPLIER } from "../bake-harness";
 
 const normalizePath = (path: string) => (process.platform === "win32" ? path.replaceAll("\\", "/") : path);
 const platformPath = (path: string) => (process.platform === "win32" ? path.replaceAll("/", "\\") : path);
@@ -365,6 +365,76 @@ export default function Docs() {
       .env(bunEnv)
       .throws(false);
     expect(stderr.toString()).toContain("Multiple pages matching the same route pattern is ambiguous");
+  });
+
+  // The bundler's diagnostics are the whole report for a build it rejects. The build then exits 1
+  // through the build VM (so the config's 'exit' handler runs), like a build whose page throws
+  // while rendering. Before, the diagnostics were followed by
+  // "error: An internal error occurred (BuildFailed)" and the 'exit' handler did not run.
+  describe.concurrent("a build the bundler rejects", () => {
+    const config = `
+      process.on("exit", code => console.log("exit event: " + code));
+      export default { app: { framework: "react" } };
+    `;
+
+    async function build(dir: string) {
+      const { exitCode, stdout, stderr } = await Bun.$`${bunExe()} build --app ./src/index.tsx`
+        .cwd(dir)
+        .env(bunEnv)
+        .quiet()
+        .throws(false);
+      // Everything printed after the bundler started.
+      const report = stderr.toString().split("Bundling routes\n").at(-1)!;
+      return { exitCode, stdout: stdout.toString(), report: normalizeBunSnapshot(report, dir) };
+    }
+
+    // Each case still bundles the framework on a debug (and ASAN) build before it fails; this is
+    // the budget the bake harness gives a production build.
+    const timeout = 30_000 * WAIT_MULTIPLIER;
+
+    test(
+      "a page that does not parse",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-parse-error", {
+          "src/index.tsx": config,
+          "pages/index.tsx": `export default function IndexPage() { return <p>index</p>; `,
+        });
+
+        const { exitCode, stdout, report } = await build(dir);
+        expect(report).toMatchInlineSnapshot(`
+          "1 | export default function IndexPage() { return <p>index</p>;
+                                                                        ^
+          error: Unexpected end of file
+              at <dir>/pages/index.tsx:1:59"
+        `);
+        expect(stdout).toBe("exit event: 1\n");
+        expect(exitCode).toBe(1);
+      },
+      timeout,
+    );
+
+    test(
+      "a page with an import that does not resolve",
+      async () => {
+        const dir = await tempDirWithBakeDeps("bake-production-resolve-error", {
+          "src/index.tsx": config,
+          "pages/index.tsx": `import { title } from "../lib/title";
+export default function IndexPage() { return <p>{title}</p>; }
+`,
+        });
+
+        const { exitCode, stdout, report } = await build(dir);
+        expect(report).toMatchInlineSnapshot(`
+          "1 | import { title } from "../lib/title";
+                                    ^
+          error: Could not resolve: "../lib/title"
+              at <dir>/pages/index.tsx:1:23"
+        `);
+        expect(stdout).toBe("exit event: 1\n");
+        expect(exitCode).toBe(1);
+      },
+      timeout,
+    );
   });
 
   test("handles build with no pages directory without crashing", async () => {


### PR DESCRIPTION
### Problem
- When the bundler rejects a `bun build --app` app (a page with a syntax error, an import that does not resolve, a link error), the real diagnostics are printed and then followed by `error: An internal error occurred (BuildFailed)` (`error: 'main' returned error.BuildFailed` on a debug build). The exit code is already 1.
- The config's `process.on("exit")` handlers do not run on that path either, while they do run when a page throws during prerendering.
- Reproduced on the 1.4.0 canary (eabb96de7) and on main with a react app whose `pages/index.tsx` is missing its closing brace, and again with a page importing a file that does not exist.
- Cause: `BundleV2::generate_from_bake_production_cli` returns `BuildFailed` after putting the errors in the log (`src/bundler/bundle_v2.rs`, the `has_errors()` checks, and `LinkerContext::link`). `build_with_vm` propagates it with `?` (`src/runtime/bake/production.rs:625`; the comment there claimed a `BuildFailed` from this call is a bundler bug), `build_command` only handles `JSError` (`production.rs:214`) and returns it, and `Cli::start` (`src/runtime/cli/mod.rs:572`) prints the log and then hands the error to `handle_root_error` (`src/crash_handler/lib.rs`), which has no entry for `BuildFailed` and prints the generic line. The same bug was in the Zig version, which also used `try` here.

### Fix
- `build_command` handles `Error::Bundler(BuildFailed)` next to its `JSError` arm: it prints the log (`ctx.log`, the log the build's transpilers and the bundler write to), and both arms then leave through the existing `exit_code = 1` (unless the build set one) + `vm.on_exit()` + `vm.global_exit()` sequence. The success path and the `Err(e)` return for anything else are unchanged.
- Why this is the right place: `BuildFailed` is the bundler's signal that the diagnostics it logged are the complete report, which is how `bun build` treats it in `build_command.rs` (print the log, exit 1). The bundler is called after the config module has been evaluated in the build VM, so the exit has to go through the VM's exit sequence to run the config's `exit` handlers, as the `JSError` path (a page that throws, or the `catch-all routes are not supported` error) already does.
- The arm is guarded on the log actually holding errors. A `BuildFailed` with nothing logged would be a bundler bug, and it keeps going to `Cli::start`, which prints it as the internal error it is. With the guard, the log print in `Cli::start` is no longer what makes the bake path readable; its comment said it was, so it is reworded.
- `fail_with_build_error` (the `configure_defines` failure, before any user code runs) now shares the log printing helper; its behavior is unchanged.
- Verified with `a build the bundler rejects` in `test/bake/dev/production.test.ts`: a page that does not parse and a page whose import does not resolve. Each snapshots everything printed after `Bundling routes` (the diagnostic alone), and asserts `exit event: 1` from the config's `exit` handler on stdout and exit code 1. On the unfixed debug build both fail with the extra `error: 'main' returned error.BuildFailed` line in the snapshot (and an empty stdout); with the fix they pass, 8/8 runs on the debug ASAN build, about 1.5 s each.
- A link-phase failure (`No matching export`) goes through the same arm and was checked by hand, but is not in the test: on the debug build the bundler's teardown after a failed link still races its source-map tasks (an ASAN report or SEGV before the diagnostic is printed), which #37480 fixes independently of this change.
- The rest of `production.test.ts` passes on the debug build with a CI-sized timeout (the throwing-page tests exercise the restructured `JSError` arm); two of its existing tests take just over the 5 s local default on this machine with and without the change. The new cases get the timeout the bake harness gives a production build. rustfmt is clean.
- #39302 and #38241 (both open) restructure the same `match` in `build_command` in the same shape for other exits; this adds one arm to it, so whichever lands later has a one-arm rebase.

### Background
- `bun build --app` is bake's static production build (`src/runtime/bake/production.rs`). `build_command` creates a dedicated JS VM and calls `build_with_vm`, which evaluates the user's config module in it, bundles the app with `BundleV2::generate_from_bake_production_cli`, and then prerenders the routes in the same VM.
- The bundler never prints: parse, resolve and link errors are appended to a `bun_ast::Log` (here `ctx.log`, shared by the CLI, the build VM and the build's transpilers), and a build with errors in it returns the payload-less `bun_bundler::Error::BuildFailed`. `Log::print` renders the messages with their source excerpts.
- `VirtualMachine::on_exit` emits `process`'s `exit` event and runs the cleanup hooks; `global_exit` exits the process with `exit_handler.exit_code` (the value behind `process.exitCode`) and, under `BUN_DESTRUCT_VM_ON_EXIT`, tears the VM down first.
- `Cli::start` is the fallback for any error a command returns: it prints the accumulated log and calls `handle_root_error`, which exits 1 quietly for a few error names it knows are already reported and otherwise prints `An internal error occurred (<name>)`.
