### PR TITLE
Keep require() of node builtins as written on both runtime transpile paths

### DIFF
--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -3,7 +3,7 @@
 use std::io::Write as _;
 
 use bun_ast::Log;
-use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags, ImportRecordTag};
+use bun_ast::{ImportKind, ImportRecord, ImportRecordFlags};
 use bun_collections::HashMap;
 use bun_paths::{self, SEP};
 // two `fs` shapes are in play here. `bun_resolver::fs` (`Fs`) holds
@@ -13,6 +13,7 @@ use bun_paths::{self, SEP};
 // `import_record.path` via `PFs::Path` so the field assignment unifies.
 use bun_core::strings;
 use bun_paths::fs as PFs;
+use bun_resolve_builtins::{Alias as HardcodedAlias, Cfg as HardcodedAliasCfg};
 use bun_resolver::fs as Fs;
 use bun_resolver::{self as resolver, Resolver};
 use bun_sys::Fd;
@@ -81,37 +82,6 @@ static RELATIVE_PATHS_LIST: std::sync::LazyLock<ImportPathsListPtr> =
 #[inline]
 fn relative_paths_list_ptr() -> *mut ImportPathsList {
     RELATIVE_PATHS_LIST.0.as_ptr()
-}
-
-// ── HardcodedModule alias lookup ────────────────────────────────────────
-// Thin adapter over `bun_resolve_builtins::Alias::get` so the call site keeps
-// `&'static [u8]` for `import_record.path.text` (the table stores `&'static
-// ZStr`). `BundleTarget` and `bun_resolve_builtins::Target` are the same
-// `bun_ast::Target`; ditto `ImportRecordTag` /
-// `import_record::Tag`, so no bridge is needed.
-mod hardcoded_module {
-    use super::*;
-    #[derive(Default, Clone, Copy)]
-    pub(super) struct AliasOptions {
-        pub rewrite_jest_for_tests: bool,
-    }
-    pub(super) struct Alias {
-        pub path: &'static [u8],
-        pub tag: ImportRecordTag,
-    }
-    pub(super) fn get(name: &[u8], target: BundleTarget, opts: AliasOptions) -> Option<Alias> {
-        bun_resolve_builtins::Alias::get(
-            name,
-            target,
-            bun_resolve_builtins::Cfg {
-                rewrite_jest_for_tests: opts.rewrite_jest_for_tests,
-            },
-        )
-        .map(|a| Alias {
-            path: a.path.as_bytes(),
-            tag: a.tag,
-        })
-    }
 }
 
 /// Intern a byte buffer into the process-lifetime `relative_paths_list`
@@ -427,23 +397,13 @@ impl Linker {
                     }
 
                     if IS_BUN {
-                        if let Some(replacement) = hardcoded_module::get(
-                            import_record.path.text,
+                        if HardcodedAlias::rewrite_import_record(
+                            import_record,
                             target,
-                            hardcoded_module::AliasOptions {
+                            HardcodedAliasCfg {
                                 rewrite_jest_for_tests,
                             },
                         ) {
-                            if replacement.tag == ImportRecordTag::Builtin
-                                && import_record.kind.is_common_js()
-                            {
-                                continue;
-                            }
-                            import_record.path.text = replacement.path;
-                            import_record.tag = replacement.tag;
-                            import_record
-                                .flags
-                                .insert(ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
                             continue;
                         }
                         if strings::starts_with(import_record.path.text, b"node:") {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,9 +51,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: `require()` / `require.resolve()` of a builtin keeps the written
-/// specifier on the concurrent transpiler too. Entries it wrote (and the
-/// JS-thread path then replayed) carry the rewritten specifier, e.g. `node:fs`.
+/// Version 26: `require()` of a builtin keeps the written specifier on the
+/// concurrent transpiler too; older entries carry the rewritten one (`node:fs`).
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,9 +51,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: `require()` / `require.resolve()` of a node builtin keeps the
-/// written specifier on the concurrent transpiler too. Entries it wrote (and
-/// the JS-thread path then replayed) carry the rewritten `"node:"` specifier.
+/// Version 26: `require()` / `require.resolve()` of a builtin keeps the written
+/// specifier on the concurrent transpiler too. Entries it wrote (and the
+/// JS-thread path then replayed) carry the rewritten specifier, e.g. `node:fs`.
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: `require()` / `require.resolve()` of a node builtin keeps the
+/// written specifier on the concurrent transpiler too. Entries it wrote (and
+/// the JS-thread path then replayed) carry the rewritten `"node:"` specifier.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -7,9 +7,9 @@ use core::ptr::{self, NonNull};
 use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use bun_alloc::Arena;
+use bun_ast::ImportRecordFlags;
 use bun_ast::Loader;
 use bun_ast::{ASTMemoryAllocator, ExportsKind};
-use bun_ast::{ImportRecord, ImportRecordFlags};
 use bun_bundler::analyze_transpiled_module;
 use bun_bundler::options::ModuleType;
 use bun_bundler::transpiler::{self as transpiler, AlreadyBundled, ParseOptions, Transpiler};
@@ -1066,20 +1066,13 @@ impl TranspilerJob {
         }
 
         for import_record in parse_result.ast.import_records.as_mut_slice() {
-            let import_record: &mut ImportRecord = import_record;
-
-            if let Some(replacement) = HardcodedAlias::get(
-                import_record.path.text,
+            if HardcodedAlias::rewrite_import_record(
+                import_record,
                 transpiler.options.target,
                 HardcodedAliasCfg {
                     rewrite_jest_for_tests: transpiler.options.rewrite_jest_for_tests,
                 },
             ) {
-                import_record.path.text = replacement.path.as_bytes();
-                import_record.tag = replacement.tag;
-                import_record
-                    .flags
-                    .insert(ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
                 continue;
             }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4316,10 +4316,8 @@ impl VirtualMachine {
         slice
     }
 
-    /// Builtin alias table configuration for specifiers resolved at runtime.
-    /// A `require()` of a builtin reaches the resolver with the specifier as
-    /// written (`Alias::rewrite_import_record`), so under `bun test` the
-    /// `@jest/globals` / `vitest` entries have to apply here too.
+    /// `require()` of a builtin reaches the resolver with the specifier as
+    /// written (`Alias::rewrite_import_record`), so the jest aliases apply here too.
     fn builtin_alias_cfg(&self) -> ModuleLoader::HardcodedModule::Cfg {
         ModuleLoader::HardcodedModule::Cfg {
             rewrite_jest_for_tests: self.transpiler.options.rewrite_jest_for_tests,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4316,6 +4316,16 @@ impl VirtualMachine {
         slice
     }
 
+    /// Builtin alias table configuration for specifiers resolved at runtime.
+    /// A `require()` of a builtin reaches the resolver with the specifier as
+    /// written (`Alias::rewrite_import_record`), so under `bun test` the
+    /// `@jest/globals` / `vitest` entries have to apply here too.
+    fn builtin_alias_cfg(&self) -> ModuleLoader::HardcodedModule::Cfg {
+        ModuleLoader::HardcodedModule::Cfg {
+            rewrite_jest_for_tests: self.transpiler.options.rewrite_jest_for_tests,
+        }
+    }
+
     /// Note: `is_a_file_path` is a runtime
     /// arg to avoid duplicating the body for both monomorphizations.
     pub(crate) fn _resolve(
@@ -4359,7 +4369,7 @@ impl VirtualMachine {
         if let Some(result) = ModuleLoader::HardcodedModule::Alias::get(
             specifier,
             bun_ast::Target::Bun,
-            Default::default(),
+            self.builtin_alias_cfg(),
         ) {
             ret.result = None;
             ret.path = result.path.as_bytes();
@@ -4593,7 +4603,7 @@ impl VirtualMachine {
         if let Some(hardcoded) = ModuleLoader::HardcodedModule::Alias::get(
             specifier_utf8.slice(),
             bun_ast::Target::Bun,
-            Default::default(),
+            jsc_vm.builtin_alias_cfg(),
         ) {
             *res = ErrorableString::ok(
                 if mode == ResolveMode::RequireResolve && hardcoded.node_builtin {

--- a/src/resolve_builtins/HardcodedModule.rs
+++ b/src/resolve_builtins/HardcodedModule.rs
@@ -951,23 +951,15 @@ impl Alias {
         None
     }
 
-    /// Pre-pass the runtime module loader runs over each import record before
-    /// printing a file. Shared by the JS-thread linker and the concurrent
-    /// transpiler so a file prints the same way on both (they also share the
-    /// on-disk transpiler cache). Returns whether the record names a hardcoded
-    /// module; the runtime resolve hook serves those, so callers are done with
-    /// the record either way.
+    /// The module loader's pre-pass over one import record, shared by the
+    /// JS-thread linker and the concurrent transpiler so both print a file the
+    /// same way. Returns whether the record names a hardcoded module.
     ///
-    /// A `require()` / `require.resolve()` of a builtin keeps the specifier as
-    /// written; the runtime resolve hook maps it to the module when the call
-    /// runs. The hook takes the names in this table, not every `path` in it
-    /// (`internal/cluster/round_robin_handle` resolves, its path
-    /// `internal:cluster/RoundRobinHandle` does not), and for node builtins it
-    /// implements node's behavior, which depends on the written form:
-    /// `require.resolve("fs")` returns `"fs"`, `require("fs")` honors
-    /// `require.cache["fs"]`, a `Module._resolveFilename` override sees `"fs"`.
-    /// `"bun"` (`Tag::Bun`) is the exception: the printer turns it into
-    /// `globalThis.Bun`.
+    /// `require()` / `require.resolve()` of a builtin stays as written: the
+    /// runtime resolves table names, not paths (`internal:cluster/RoundRobinHandle`
+    /// does not resolve), and node's `require.resolve("fs") === "fs"` and
+    /// `require.cache["fs"]` semantics need the written name. Only `"bun"`
+    /// (`Tag::Bun`) is rewritten, since the printer inlines it as `globalThis.Bun`.
     pub fn rewrite_import_record(record: &mut ImportRecord, target: Target, cfg: Cfg) -> bool {
         let Some(alias) = Self::get(record.path.text, target, cfg) else {
             return false;

--- a/src/resolve_builtins/HardcodedModule.rs
+++ b/src/resolve_builtins/HardcodedModule.rs
@@ -1,5 +1,5 @@
-use bun_ast::Target;
 use bun_ast::import_record;
+use bun_ast::{ImportRecord, ImportRecordFlags, Target};
 use bun_core::ZStr;
 use bun_core::zstr;
 
@@ -949,5 +949,32 @@ impl Alias {
             return lookup(&NODE_ALIAS_MAP, name);
         }
         None
+    }
+
+    /// Pre-pass the runtime module loader runs over each import record before
+    /// printing a file. Shared by the JS-thread linker and the concurrent
+    /// transpiler so a file prints the same way on both (they also share the
+    /// on-disk transpiler cache). Returns whether the record names a hardcoded
+    /// module; the runtime resolve hook serves those, so callers are done with
+    /// the record either way.
+    ///
+    /// A `require()` / `require.resolve()` of a node builtin keeps the
+    /// specifier as written instead of the canonical `node:` path: like node,
+    /// the runtime resolves it when the call runs, so `require.resolve("fs")`
+    /// returns `"fs"`, `require("fs")` honors `require.cache["fs"]`, and a
+    /// `Module._resolveFilename` override sees `"fs"`.
+    pub fn rewrite_import_record(record: &mut ImportRecord, target: Target, cfg: Cfg) -> bool {
+        let Some(alias) = Self::get(record.path.text, target, cfg) else {
+            return false;
+        };
+        if alias.node_builtin && record.kind.is_common_js() {
+            return true;
+        }
+        record.path.text = alias.path.as_bytes();
+        record.tag = alias.tag;
+        record
+            .flags
+            .insert(ImportRecordFlags::IS_EXTERNAL_WITHOUT_SIDE_EFFECTS);
+        true
     }
 }

--- a/src/resolve_builtins/HardcodedModule.rs
+++ b/src/resolve_builtins/HardcodedModule.rs
@@ -958,16 +958,21 @@ impl Alias {
     /// module; the runtime resolve hook serves those, so callers are done with
     /// the record either way.
     ///
-    /// A `require()` / `require.resolve()` of a node builtin keeps the
-    /// specifier as written instead of the canonical `node:` path: like node,
-    /// the runtime resolves it when the call runs, so `require.resolve("fs")`
-    /// returns `"fs"`, `require("fs")` honors `require.cache["fs"]`, and a
-    /// `Module._resolveFilename` override sees `"fs"`.
+    /// A `require()` / `require.resolve()` of a builtin keeps the specifier as
+    /// written; the runtime resolve hook maps it to the module when the call
+    /// runs. The hook takes the names in this table, not every `path` in it
+    /// (`internal/cluster/round_robin_handle` resolves, its path
+    /// `internal:cluster/RoundRobinHandle` does not), and for node builtins it
+    /// implements node's behavior, which depends on the written form:
+    /// `require.resolve("fs")` returns `"fs"`, `require("fs")` honors
+    /// `require.cache["fs"]`, a `Module._resolveFilename` override sees `"fs"`.
+    /// `"bun"` (`Tag::Bun`) is the exception: the printer turns it into
+    /// `globalThis.Bun`.
     pub fn rewrite_import_record(record: &mut ImportRecord, target: Target, cfg: Cfg) -> bool {
         let Some(alias) = Self::get(record.path.text, target, cfg) else {
             return false;
         };
-        if alias.node_builtin && record.kind.is_common_js() {
+        if alias.tag == import_record::Tag::Builtin && record.kind.is_common_js() {
             return true;
         }
         record.path.text = alias.path.as_bytes();

--- a/test/js/bun/resolve/require.test.ts
+++ b/test/js/bun/resolve/require.test.ts
@@ -1,4 +1,4 @@
-import { bunRun, tempDirWithFiles } from "harness";
+import { bunRun, tempDir, tempDirWithFiles } from "harness";
 import fs from "node:fs";
 import path from "node:path";
 const fixture = (...segs: string[]): string => path.join(import.meta.dirname, "fixtures", "require", ...segs);
@@ -43,6 +43,35 @@ describe("require(specifier)", () => {
     it.todo("require('*.html') synchronously produces a string");
     it.todo("require('*.wasm') produces a WebAssembly.Module");
     it.todo("require('*.db') wraps a sqlite file in a Database object and exports it");
+  });
+
+  describe("when specifier is a builtin alias", () => {
+    // main.js is transpiled on the JS thread, the file it imports by the
+    // concurrent transpiler. Both must print the require() as written: the
+    // runtime resolves an alias by its name, not by the path it maps to
+    // (internal/cluster/round_robin_handle maps to internal:cluster/RoundRobinHandle,
+    // which is not itself resolvable).
+    it("require() resolves the alias on both transpile paths", async () => {
+      const probe = /* js */ `
+        module.exports = {
+          roundRobinHandle: typeof require("internal/cluster/round_robin_handle"),
+          ffi: require("ffi") === require("bun:ffi"),
+        };
+      `;
+      using dir = tempDir("require-builtin-alias", {
+        "via-require.cjs": probe,
+        "via-import.cjs": probe,
+        "main.js": /* js */ `
+          const viaRequire = require("./via-require.cjs");
+          const { default: viaImport } = await import("./via-import.cjs");
+          console.log(JSON.stringify({ viaRequire, viaImport }));
+        `,
+      });
+      const expected = { roundRobinHandle: "function", ffi: true };
+      expect(await bunRun(["--expose-internals", path.join(String(dir), "main.js")])).toSpawn(
+        JSON.stringify({ viaRequire: expected, viaImport: expected }),
+      );
+    });
   });
 
   describe("require.main", () => {

--- a/test/js/bun/test/bun_test.test.ts
+++ b/test/js/bun/test/bun_test.test.ts
@@ -308,6 +308,48 @@ test.concurrent("hooks may be registered during preload, test/describe may not",
   expect(exitCode).toBe(0);
 });
 
+// The test file and files it require()s are transpiled on the JS thread; files
+// it imports are transpiled by the concurrent transpiler. `bun test` rewrites
+// @jest/globals and vitest to bun:test on both, for require() as well as for
+// import.
+test.concurrent("require() of @jest/globals and vitest resolves to bun:test on every transpile path", async () => {
+  // Evaluates to the same shape as `expected` below; a failing require()
+  // reports its error code in place of the value.
+  const probe = /* js */ `(() => {
+    const bunTest = require("bun:test");
+    const attempt = fn => { try { return fn(); } catch (e) { return e.code; } };
+    return {
+      jestGlobals: attempt(() => require("@jest/globals") === bunTest),
+      vitest: attempt(() => require("vitest") === bunTest),
+      resolved: attempt(() => require.resolve("@jest/globals")),
+    };
+  })()`;
+  using dir = tempDir("bun-test-require-jest-aliases", {
+    "via-require.cjs": `module.exports = ${probe};`,
+    "via-import.cjs": `module.exports = ${probe};`,
+    "aliases.test.js": /* js */ `
+      const direct = ${probe};
+      const viaRequire = require("./via-require.cjs");
+      const { default: viaImport } = await import("./via-import.cjs");
+      console.log(JSON.stringify({ direct, viaRequire, viaImport }));
+      require("bun:test").test("aliases", () => {});
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./aliases.test.js"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("1 pass");
+  const expected = { jestGlobals: true, vitest: true, resolved: "bun:test" };
+  const report = stdout.split("\n").find(line => line.startsWith("{"));
+  expect(JSON.parse(report!)).toEqual({ direct: expected, viaRequire: expected, viaImport: expected });
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("test/describe and hooks throw outside of the test runner", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -564,6 +564,77 @@ console.log("survived", require("./late.js"));`,
       delete require.cache["util/types"];
     }
   });
+  // The two tests above run in a file transpiled on the JS thread. Files
+  // loaded with import (statically or with import()) are transpiled by the
+  // concurrent transpiler instead. Both must print a require()/require.resolve()
+  // of a node builtin with the specifier the user wrote: like node, the
+  // runtime resolves that specifier when the call runs, so rewriting it to the
+  // canonical "node:" form at transpile time changes what require.resolve()
+  // returns, skips the require.cache entry, and changes what a
+  // Module._resolveFilename override sees.
+  test.each([
+    ["concurrent transpiler", {}],
+    ["concurrent transpiler disabled", { BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1" }],
+  ])("require() of node builtins keeps the written specifier on every transpile path (%s)", async (_, env) => {
+    const probe = /* js */ `
+      const Module = require("module");
+      const seenByResolveFilename = [];
+      const originalResolveFilename = Module._resolveFilename;
+      Module._resolveFilename = function (request, ...rest) {
+        seenByResolveFilename.push(request);
+        return originalResolveFilename.call(this, request, ...rest);
+      };
+      try {
+        require("os");
+        require.resolve("os");
+      } finally {
+        Module._resolveFilename = originalResolveFilename;
+      }
+
+      const fakeFs = { fake: true };
+      require.cache["fs"] = { exports: fakeFs };
+      let cacheOverrideApplies;
+      try {
+        cacheOverrideApplies = [require("fs") === fakeFs, require("node:fs") === fakeFs];
+      } finally {
+        delete require.cache["fs"];
+      }
+
+      module.exports = {
+        resolve: [require.resolve("fs"), require.resolve("node:fs"), require.resolve("sys")],
+        cacheOverrideApplies,
+        seenByResolveFilename,
+      };
+    `;
+    using dir = tempDir("require-builtin-specifier", {
+      "via-require.cjs": probe,
+      "via-static-import.cjs": probe,
+      "via-import.cjs": probe,
+      "main.js": /* js */ `
+        import viaStaticImport from "./via-static-import.cjs";
+        const viaRequire = require("./via-require.cjs");
+        const { default: viaImport } = await import("./via-import.cjs");
+        console.log(JSON.stringify({ viaRequire, viaStaticImport, viaImport }));
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      cwd: String(dir),
+      env: { ...bunEnv, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // What node prints for each of these files.
+    const expected = {
+      resolve: ["fs", "node:fs", "sys"],
+      cacheOverrideApplies: [true, false],
+      seenByResolveFilename: ["os", "os"],
+    };
+    expect(JSON.parse(stdout)).toEqual({ viaRequire: expected, viaStaticImport: expected, viaImport: expected });
+    expect(exitCode).toBe(0);
+  });
   test("require a cjs file uses the 'module.exports' export", () => {
     expect(require("./esm_to_cjs_interop.mjs")).toEqual(Symbol.for("meow"));
   });


### PR DESCRIPTION
### Problem
- `require.resolve("fs")` returns `"node:fs"` in a file loaded with `import` / `import()`, and `"fs"` in the same file loaded with `require()`. Node returns `"fs"` (and `"node:fs"` only for `require.resolve("node:fs")`).
- Same rewrite, more symptoms in files loaded with `import`: `require("fs")` ignores a `require.cache["fs"]` entry (node and bun's `require()` path honor it), a `Module._resolveFilename` override sees `"node:fs"` instead of `"fs"`, and `require("internal/cluster/round_robin_handle")` (vendored node tests, `--expose-internals`) throws `Cannot find module 'internal:cluster/RoundRobinHandle'`.
- For files of 4 KiB or more the result also depends on history: both paths share the on-disk transpiler cache, so after a run that loaded such a file with `import`, a later run that `require()`s it replays the rewritten output and returns `"node:fs"` too (probe in the details below).
- Cause: the runtime has two copies of the import-record pre-pass that maps specifiers through the builtin alias table, and they disagree.
  - The JS-thread copy (`Linker::link`, `src/bundler/linker.rs`, skip added in #18266, bun 1.2.6) leaves `require()` / `require.resolve()` records of builtins as written. The runtime resolver (`VirtualMachine::resolve_maybe_needs_trailing_slash`, `src/jsc/VirtualMachine.rs`) then maps the written name to the module, returns the written name itself for `require.resolve` of a node builtin, and `overridableRequire` (`src/js/builtins/CommonJS.ts`) looks up `require.cache` under the written name.
  - The concurrent transpiler's copy (`TranspilerJob::run`, `src/jsc/RuntimeTranspilerStore.rs`) never got that skip. It prints the table's path in place of the name, which defeats all of the above, and for `internal/cluster/round_robin_handle` prints a path (`internal:cluster/RoundRobinHandle`) the resolver does not accept at all.
- The JS-thread copy has a defect of its own: since #22888 (bun 1.3.1) moved the `@jest/globals` / `vitest` aliases into the same table, its skip leaves `require("@jest/globals")` as written too, and the runtime resolver looked the name up without the test-mode entries. Under `bun test` that `require()` fails with `Cannot find module '@jest/globals'` in the test file itself and in any `require()`d file (#4466 again); it only worked in files loaded with `import`, where the store rewrote it.

### Fix
- One shared function, `Alias::rewrite_import_record` (`src/resolve_builtins/HardcodedModule.rs`), replaces both loop bodies; the linker's private adapter module over `Alias::get` is deleted. The rule is the linker's existing one: a `require()` / `require.resolve()` record of any `Tag::Builtin` entry stays as written, everything else (`import`, `import()`, and `"bun"` itself, which the printer inlines as `globalThis.Bun`) is rewritten as before.
  - Correct because the resolver accepts the names in the table and not necessarily the paths, and because node's `require.resolve` / `require.cache` / `_resolveFilename` behavior is defined in terms of the written name. Leaving the record alone hands the resolver exactly what it handles; this is the output every entry point and every `require()`d file has had since 1.2.6.
  - Both paths now print a given file identically, which the shared transpiler cache requires anyway.
- `VirtualMachine::_resolve` and `resolve_maybe_needs_trailing_slash` look the name up with the VM's `rewrite_jest_for_tests` (`builtin_alias_cfg()`), so under `bun test` a `require()` of `@jest/globals` / `vitest` resolves to `bun:test` on both paths, the same way `import` of them already did. Outside `bun test` the flag is false and nothing changes.
- Runtime transpiler cache version 25 -> 26, so entries the concurrent transpiler wrote with rewritten specifiers are not replayed (same reason as version 17, the previous change to this rewrite).
- Verified:
  - `test/js/node/module/node-module-module.test.js`, new `require() of node builtins keeps the written specifier on every transpile path`: one probe file loaded three ways (`require()`, static `import`, `import()`) reports `require.resolve` of `fs` / `node:fs` / `sys`, whether `require.cache["fs"]` is honored for `fs` and not for `node:fs`, and what a `_resolveFilename` override sees; expected values are what node prints for the same file. Run with the concurrent transpiler on and off. Fails on the released binary for the two `import` loads.
  - `test/js/bun/resolve/require.test.ts`, new `require() resolves the alias on both transpile paths`: `internal/cluster/round_robin_handle` (the entry whose path is not a resolvable name) and `ffi` required from a `require()`d and an `import()`ed file. Fails on the released binary for the `import()`ed file; also the case that rejects skipping only node builtins, which a first version of this change did and `test/js/node/test/parallel/test-cluster-accept-fail.js` caught in CI (that test passes again).
  - `test/js/bun/test/bun_test.test.ts`, new `require() of @jest/globals and vitest resolves to bun:test on every transpile path`: the test file, a `require()`d helper and an `import()`ed helper each `require()` both aliases and `require.resolve` one. Fails on the released binary for the first two (`MODULE_NOT_FOUND`); the `import()` case pins the behavior that already worked.
  - Still passing locally: the rest of those files, `test/js/node/module/*`, `test/js/bun/resolve/{import-meta,import-meta-resolve,resolve,resolve-error,builtin-esm-lazy-exports}`, `test/js/node/missing-module.test.js`, `test/cli/run/{transpiler-cache,require-and-import-trailing}.test.ts`, `test/regression/issue/{25707,09739}.test.ts`, `test/js/first_party/undici/undici-primordials.test.ts`, `test/js/node/test_runner/node-test.test.ts`, `test/js/bun/test/{fake-timers,test-auto-import-jest-globals,jest-extended,expect-extend,mock/mock-module}`, `test/js/node/test/parallel/{test-require-node-prefix,test-stream-iter-disabled,test-cluster-accept-fail}.js`, and the `test/internal/source-lints` dead-export / byte-search lints. The RSS leak tests in `test/cli/run/require-cache.test.ts` exceed their time and memory budgets on the local debug ASAN build; the files they reload in a loop contain no import records, so this pass never runs in them.
- #36102 edits the two old loop bodies separately (it predates transpiler cache version 24); after a rebase its change is one condition inside `rewrite_import_record`.

### Background
- Runtime transpile paths: the entry point, every file reached through `require()`, and everything when a plugin is registered are transpiled on the JS thread (`transpile_source_code` -> `Linker::link`). Files reached through `import` statements or `import()` are transpiled on a thread pool by `RuntimeTranspilerStore` (`BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER=1` turns that off, which is how the tests run a case on both paths). Each path runs its own pre-pass over the file's import records before printing.
- Import record: the parser's entry for each `import`, `import()`, `require()` or `require.resolve()` in a file; `kind` says which (`is_common_js()` is `require` or `require.resolve`) and the printer emits `path.text` as the specifier, so rewriting it here changes the string the runtime later receives.
- Builtin alias table (`src/resolve_builtins/HardcodedModule.rs`): maps names to built-in module paths, e.g. `fs` -> `node:fs`, `sys` -> `node:util`, `ffi` -> `bun:ffi`, `internal/cluster/round_robin_handle` -> `internal:cluster/RoundRobinHandle`, and, only when `Cfg::rewrite_jest_for_tests` is set (`bun test`), `@jest/globals` / `vitest` -> `bun:test`. Resolution (`Alias::get`) is keyed by name; the fetch step that serves the module is keyed by path.
- Runtime transpiler cache: on-disk cache of printed output for source files of 4 KiB or more, keyed by source hash plus parser options, written and read by both transpile paths; `EXPECTED_VERSION` is bumped whenever the output for unchanged input changes.
- `src/runtime/jsc_hooks.rs` also contains a `resolve_hook` with the same alias lookup; it is installed in `LoaderHooks` but nothing dispatches that field, so it is left alone here.

<details>
<summary>Shared-cache probe on the released binary (1.4.0)</summary>

`big.cjs` is `module.exports = require.resolve("fs");` padded past 4 KiB; `BUN_RUNTIME_TRANSPILER_CACHE_PATH` points at an empty directory.

```
$ bun via-import.js     # await import("./big.cjs")
import(): node:fs
$ bun via-require.js    # require("./big.cjs"), cache hit
require(): node:fs

# fresh cache directory, reversed order
$ bun via-require.js
require(): fs
$ bun via-import.js
import(): fs
```
</details>

<details>
<summary>Superseded first version</summary>

The first commit skipped the rewrite only for entries with `node_builtin` set and rewrote the remaining `require()` records on both paths, on the theory that the resolver maps every other entry's path back to the same module. That holds for every entry except `internal/cluster/round_robin_handle`, whose path is not a name the resolver accepts, so it broke `test-cluster-accept-fail.js` on the JS-thread path. The current version keeps the linker's `Tag::Builtin` rule instead and fixes the jest aliases in the resolver, which is also where a `require()` of them has to be handled for files the store transpiles.
</details>
