### PR TITLE
DOMException: record source-mapped positions and a Bun-format stack on internally created exceptions

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -393,6 +393,28 @@ WTF::String formatStackTrace(
     return sb.toString();
 }
 
+void addErrorInfoWithSourceMap(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSObject* object, const WTF::String& name, const WTF::String& message)
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    std::unique_ptr<Vector<StackFrame>> stackTrace = JSC::getStackTrace(vm, object, /* useCurrentFrame */ true);
+    if (!stackTrace)
+        return;
+
+    OrdinalNumber line = OrdinalNumber::beforeFirst();
+    OrdinalNumber column = OrdinalNumber::beforeFirst();
+    WTF::String sourceURL;
+    WTF::String stack = formatStackTrace(vm, defaultGlobalObject(lexicalGlobalObject), lexicalGlobalObject, name, message, line, column, sourceURL, *stackTrace, object);
+
+    constexpr unsigned attributes = JSC::PropertyAttribute::DontEnum | 0;
+    if (line != OrdinalNumber::beforeFirst()) {
+        object->putDirect(vm, vm.propertyNames->line, jsNumber(line.oneBasedInt()), attributes);
+        object->putDirect(vm, vm.propertyNames->column, jsNumber(column.oneBasedInt()), attributes);
+    }
+    if (!sourceURL.isEmpty())
+        object->putDirect(vm, vm.propertyNames->sourceURL, jsString(vm, WTF::move(sourceURL)), attributes);
+    object->putDirect(vm, vm.propertyNames->stack, jsString(vm, WTF::move(stack)), attributes);
+}
+
 // error.stack calls this function
 static String computeErrorInfoWithoutPrepareStackTrace(
     JSC::VM& vm,

--- a/src/jsc/bindings/FormatStackTraceForJS.h
+++ b/src/jsc/bindings/FormatStackTraceForJS.h
@@ -70,9 +70,7 @@ WTF::String formatStackTrace(
     WTF::Vector<JSC::StackFrame>& stackTrace,
     JSC::JSObject* errorInstance);
 
-// JSC::addErrorInfo() for objects that are not ErrorInstances (DOMException): puts the properties
-// an ErrorInstance materializes, i.e. source-mapped line/column/sourceURL, a Bun-format stack,
-// and originalLine/originalColumn (which tell the error printer the position is already mapped).
+// JSC::addErrorInfo() for objects that are not ErrorInstances (DOMException), putting what an ErrorInstance materializes: source-mapped positions and a Bun-format stack.
 void addErrorInfoWithSourceMap(JSC::JSGlobalObject*, JSC::JSObject*, const WTF::String& name, const WTF::String& message);
 
 // JSC Host Functions - Error constructor methods

--- a/src/jsc/bindings/FormatStackTraceForJS.h
+++ b/src/jsc/bindings/FormatStackTraceForJS.h
@@ -70,11 +70,9 @@ WTF::String formatStackTrace(
     WTF::Vector<JSC::StackFrame>& stackTrace,
     JSC::JSObject* errorInstance);
 
-// Replacement for JSC::addErrorInfo() for objects that are not ErrorInstances (DOMException).
-// Captures the current stack and puts the same DontEnum line/column/sourceURL/stack
-// properties an ErrorInstance materializes: positions are run through the source maps
-// and `stack` uses Bun's format, with originalLine/originalColumn recording the
-// unmapped position so the error printer does not remap them a second time.
+// JSC::addErrorInfo() for objects that are not ErrorInstances (DOMException): puts the properties
+// an ErrorInstance materializes, i.e. source-mapped line/column/sourceURL, a Bun-format stack,
+// and originalLine/originalColumn (which tell the error printer the position is already mapped).
 void addErrorInfoWithSourceMap(JSC::JSGlobalObject*, JSC::JSObject*, const WTF::String& name, const WTF::String& message);
 
 // JSC Host Functions - Error constructor methods

--- a/src/jsc/bindings/FormatStackTraceForJS.h
+++ b/src/jsc/bindings/FormatStackTraceForJS.h
@@ -70,6 +70,13 @@ WTF::String formatStackTrace(
     WTF::Vector<JSC::StackFrame>& stackTrace,
     JSC::JSObject* errorInstance);
 
+// Replacement for JSC::addErrorInfo() for objects that are not ErrorInstances (DOMException).
+// Captures the current stack and puts the same DontEnum line/column/sourceURL/stack
+// properties an ErrorInstance materializes: positions are run through the source maps
+// and `stack` uses Bun's format, with originalLine/originalColumn recording the
+// unmapped position so the error printer does not remap them a second time.
+void addErrorInfoWithSourceMap(JSC::JSGlobalObject*, JSC::JSObject*, const WTF::String& name, const WTF::String& message);
+
 // JSC Host Functions - Error constructor methods
 JSC_DECLARE_HOST_FUNCTION(errorConstructorFuncCaptureStackTrace);
 JSC_DECLARE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace);

--- a/src/jsc/bindings/JSDOMExceptionHandling.cpp
+++ b/src/jsc/bindings/JSDOMExceptionHandling.cpp
@@ -24,6 +24,7 @@
 #include "ErrorCode.h"
 
 #include "DOMException.h"
+#include "FormatStackTraceForJS.h"
 #include "JSDOMException.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMPromiseDeferred.h"
@@ -181,10 +182,11 @@ JSValue createDOMException(JSGlobalObject* lexicalGlobalObject, ExceptionCode ec
         // frames[0].document.createElement(null, null); // throws an exception which should have the subframe's prototypes.
         // https://bugs.webkit.org/show_bug.cgi?id=222229
         JSDOMGlobalObject* globalObject = deprecatedGlobalObjectForPrototype(lexicalGlobalObject);
-        JSValue errorObject = toJS(lexicalGlobalObject, globalObject, DOMException::create(ec, message));
+        auto domException = DOMException::create(ec, message);
+        JSValue errorObject = toJS(lexicalGlobalObject, globalObject, domException.get());
 
         ASSERT(errorObject);
-        addErrorInfo(lexicalGlobalObject, asObject(errorObject), true);
+        Bun::addErrorInfoWithSourceMap(lexicalGlobalObject, asObject(errorObject), domException->name(), domException->message());
         return errorObject;
     }
     }

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -770,19 +770,28 @@ void exceptionFromString(ZigException& except, JSC::JSValue value, JSC::JSGlobal
             }
             if (line) {
                 if (line.isNumber()) {
-                    except.stack.frames_ptr[0].position.line_zero_based = OrdinalNumber::fromOneBasedInt(line.toInt32(global)).zeroBasedInt();
+                    ZigStackFrame& frame = except.stack.frames_ptr[0];
+                    frame.position.line_zero_based = OrdinalNumber::fromOneBasedInt(line.toInt32(global)).zeroBasedInt();
+                    except.stack.frames_len = 1;
 
-                    // TODO: don't sourcemap it twice
+                    auto column = obj->getIfPropertyExists(global, vm.propertyNames->column);
+                    if (scope.exception()) [[unlikely]] {
+                        scope.clearExceptionExceptTermination();
+                    }
+                    if (column) {
+                        if (column.isNumber()) {
+                            frame.position.column_zero_based = OrdinalNumber::fromOneBasedInt(column.toInt32(global)).zeroBasedInt();
+                        }
+                    }
+
+                    // Bun::addErrorInfoWithSourceMap() puts originalLine next to a line/column
+                    // that already went through the source map, so the printer must not remap
+                    // them again. Same as the ErrorInstance path in fromErrorInstance().
                     auto originalLine = obj->getIfPropertyExists(global, builtinNames(vm).originalLinePublicName());
                     if (scope.exception()) [[unlikely]] {
                         scope.clearExceptionExceptTermination();
                     }
-                    if (originalLine) {
-                        if (originalLine.isNumber()) {
-                            except.stack.frames_ptr[0].position.line_zero_based = OrdinalNumber::fromOneBasedInt(originalLine.toInt32(global)).zeroBasedInt();
-                        }
-                    }
-                    except.stack.frames_len = 1;
+                    frame.remapped = !!originalLine;
                 }
             }
         }

--- a/src/jsc/bindings/ZigException.cpp
+++ b/src/jsc/bindings/ZigException.cpp
@@ -784,9 +784,7 @@ void exceptionFromString(ZigException& except, JSC::JSValue value, JSC::JSGlobal
                         }
                     }
 
-                    // Bun::addErrorInfoWithSourceMap() puts originalLine next to a line/column
-                    // that already went through the source map, so the printer must not remap
-                    // them again. Same as the ErrorInstance path in fromErrorInstance().
+                    // originalLine means line/column are already source-mapped, as in fromErrorInstance().
                     auto originalLine = obj->getIfPropertyExists(global, builtinNames(vm).originalLinePublicName());
                     if (scope.exception()) [[unlikely]] {
                         scope.clearExceptionExceptTermination();

--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -686,7 +686,9 @@ static void rejectWithCause(Ref<DeferredPromise>&& promise, ExceptionCode ec, co
 {
     promise->rejectWithCallback([&](JSDOMGlobalObject& globalObject) -> JSC::JSValue {
         auto& vm = globalObject.vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
         JSC::JSValue cause = makeCause(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         auto exception = createDOMException(&globalObject, ec, message);
         if (auto* exceptionObject = exception.getObject(); exceptionObject && cause)
             exceptionObject->putDirect(vm, vm.propertyNames->cause, cause);

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { realpathSync } from "node:fs";
 
 describe("DOMException in Node.js environment", () => {
   it("exists globally", () => {
@@ -70,5 +72,173 @@ describe("DOMException in Node.js environment", () => {
     // Create an exception with known code
     const abortError = new DOMException("Aborted", "AbortError");
     expect(abortError.code).toBe(20); // ABORT_ERR
+  });
+});
+
+// The transpiler drops these comment lines (and reformats what follows), so the positions
+// JSC reports for the code below them are not the positions in the file. Positions Bun
+// records on a DOMException it creates have to go through the source map like an Error's.
+const padded = source => Array.from({ length: 10 }, (_, i) => `// padding ${i + 1}`).join("\n") + "\n" + source + "\n";
+
+// 1-based line of the (unique) line of `source` containing `needle`.
+function lineContaining(source, needle) {
+  const matches = source.split("\n").flatMap((line, i) => (line.includes(needle) ? [i + 1] : []));
+  expect(matches).toHaveLength(1);
+  return matches[0];
+}
+
+async function runFixture(name, source) {
+  using dir = tempDir("domexception-creation-site", { [name]: source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), name],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  let [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  for (const path of new Set([realpathSync.native(String(dir)), String(dir)])) {
+    stderr = stderr.replaceAll(path, "<dir>");
+  }
+  return { stdout, stderr: stderr.replaceAll("\\", "/"), exitCode };
+}
+
+describe.concurrent("DOMExceptions created by Bun record where they were created", () => {
+  it("line, column, sourceURL and stack are positions in the source file, like an Error's", async () => {
+    // The callbacks passed to caught() have block bodies so that the call inside them is
+    // not a tail call, which strict mode code would otherwise drop from the stack.
+    const source = padded(`
+      function caught(fn) { try { fn(); } catch (e) { return e; } }
+      function nested() {
+        const error = new Error("reference"), reason = AbortSignal.abort().reason;
+        return { error, reason };
+      }
+      const controller = new AbortController();
+      controller.abort();
+      const fromNested = nested();
+      const exceptions = {
+        "AbortSignal.abort().reason": AbortSignal.abort().reason,
+        "AbortController#abort() reason": controller.signal.reason,
+        "atob() InvalidCharacterError": caught(() => { atob("!"); }),
+        "structuredClone() DataCloneError": caught(() => { structuredClone(() => {}); }),
+        "created inside a function": fromNested.reason,
+      };
+      const dump = e => ({
+        isDOMException: e instanceof DOMException,
+        name: e.name,
+        message: e.message,
+        line: e.line,
+        column: e.column,
+        sourceURL: e.sourceURL?.replaceAll(import.meta.path, "<file>"),
+        stack: e.stack?.replaceAll(import.meta.path, "<file>"),
+        enumerableKeys: Object.keys(e),
+      });
+      for (const name in exceptions) exceptions[name] = dump(exceptions[name]);
+      console.log(JSON.stringify({ exceptions, reference: dump(fromNested.error) }));
+    `);
+    const { stdout, stderr, exitCode } = await runFixture("creation-site.js", source);
+    expect(stderr).toBe("");
+    const { exceptions, reference } = JSON.parse(stdout);
+
+    // [line, column] of each frame of `stack` that is in the fixture file.
+    const framePositions = stack =>
+      stack
+        .split("\n")
+        .slice(1)
+        .filter(frame => frame.includes("<file>"))
+        .map(frame =>
+          frame
+            .match(/:(\d+):(\d+)\)?$/)
+            .slice(1)
+            .map(Number),
+        );
+    const summarize = ({ stack, line, column, ...rest }) => ({
+      ...rest,
+      header: stack.split("\n")[0],
+      line,
+      topFrameIsAtLineAndColumn: Bun.deepEquals(framePositions(stack)[0], [line, column]),
+      frameLines: framePositions(stack).map(([line]) => line),
+    });
+    const expected = (name, message, frameLines) => ({
+      isDOMException: true,
+      name,
+      message,
+      header: `${name}: ${message}`,
+      line: frameLines[0],
+      sourceURL: "<file>",
+      topFrameIsAtLineAndColumn: true,
+      frameLines,
+      enumerableKeys: [],
+    });
+
+    const nestedLine = lineContaining(source, 'new Error("reference")');
+    const nestedCallLine = lineContaining(source, "= nested()");
+    const caughtLine = lineContaining(source, "function caught");
+    const atobLine = lineContaining(source, 'atob("!")');
+    const structuredCloneLine = lineContaining(source, "structuredClone(");
+    expect(Object.fromEntries(Object.entries(exceptions).map(([name, e]) => [name, summarize(e)]))).toEqual({
+      // AbortSignal.abort() stores the default reason as an enum; the DOMException is
+      // created when .reason is first read, which here is this line.
+      "AbortSignal.abort().reason": expected("AbortError", "The operation was aborted.", [
+        lineContaining(source, '"AbortSignal.abort().reason":'),
+      ]),
+      // AbortController#abort() creates the reason while aborting.
+      "AbortController#abort() reason": expected("AbortError", "The operation was aborted.", [
+        lineContaining(source, "controller.abort();"),
+      ]),
+      "atob() InvalidCharacterError": expected("InvalidCharacterError", "The string contains invalid characters.", [
+        atobLine,
+        caughtLine,
+        atobLine,
+      ]),
+      "structuredClone() DataCloneError": expected("DataCloneError", "The object can not be cloned.", [
+        structuredCloneLine,
+        caughtLine,
+        structuredCloneLine,
+      ]),
+      "created inside a function": expected("AbortError", "The operation was aborted.", [nestedLine, nestedCallLine]),
+    });
+    // The Error created on the same line as the nested DOMException reports the same frames.
+    expect({
+      sourceURL: reference.sourceURL,
+      frameLines: framePositions(reference.stack).map(([line]) => line),
+    }).toEqual({ sourceURL: "<file>", frameLines: [nestedLine, nestedCallLine] });
+    expect(exitCode).toBe(0);
+  });
+
+  it("a DOMException created with no JavaScript on the stack gets a header-only stack", async () => {
+    const signal = AbortSignal.timeout(0);
+    const { promise, resolve } = Promise.withResolvers();
+    signal.addEventListener("abort", resolve, { once: true });
+    await promise;
+
+    const { reason } = signal;
+    expect({ stack: reason.stack, line: reason.line, column: reason.column, sourceURL: reason.sourceURL }).toEqual({
+      stack: "TimeoutError: The operation timed out.",
+      line: undefined,
+      column: undefined,
+      sourceURL: undefined,
+    });
+  });
+
+  it.each([
+    ["unhandled rejection", `Promise.reject(AbortSignal.abort().reason);`, "Promise.reject("],
+    ["uncaught exception", `function fail() {\n  atob("!");\n}\nfail();`, 'atob("!")'],
+  ])("the %s printer reports the source line the DOMException was created on", async (_, body, needle) => {
+    const source = padded(body);
+    const expectedLine = lineContaining(source, needle);
+    const { stdout, stderr, exitCode } = await runFixture("uncaught.js", source);
+
+    const stackLines = stderr
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.startsWith("at "));
+    expect({ stdout, stackLines }).toEqual({
+      stdout: "",
+      stackLines: [expect.stringMatching(new RegExp(`^at <dir>/uncaught\\.js:${expectedLine}:\\d+$`))],
+    });
+    // The code excerpt above the error is taken from the source file at that line.
+    expect(stderr).toContain(`${expectedLine} | ${source.split("\n")[expectedLine - 1]}`);
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/js/node/domexception-node.test.js
+++ b/test/js/node/domexception-node.test.js
@@ -116,11 +116,13 @@ describe.concurrent("DOMExceptions created by Bun record where they were created
       const controller = new AbortController();
       controller.abort();
       const fromNested = nested();
+      const rejectionOf = promise => promise.then(() => { throw new Error("expected a rejection"); }, e => e);
       const exceptions = {
         "AbortSignal.abort().reason": AbortSignal.abort().reason,
         "AbortController#abort() reason": controller.signal.reason,
         "atob() InvalidCharacterError": caught(() => { atob("!"); }),
         "structuredClone() DataCloneError": caught(() => { structuredClone(() => {}); }),
+        "crypto.subtle.importKey() rejection": await rejectionOf(crypto.subtle.importKey("raw", new Uint8Array(3), "AES-GCM", false, ["encrypt"])),
         "created inside a function": fromNested.reason,
       };
       const dump = e => ({
@@ -196,6 +198,12 @@ describe.concurrent("DOMExceptions created by Bun record where they were created
         caughtLine,
         structuredCloneLine,
       ]),
+      // Rejections are created while the API is being called, so they point at the call too.
+      "crypto.subtle.importKey() rejection": expected(
+        "DataError",
+        "Data provided to an operation does not meet requirements",
+        [lineContaining(source, '"crypto.subtle.importKey() rejection":')],
+      ),
       "created inside a function": expected("AbortError", "The operation was aborted.", [nestedLine, nestedCallLine]),
     });
     // The Error created on the same line as the nested DOMException reports the same frames.
@@ -204,6 +212,32 @@ describe.concurrent("DOMExceptions created by Bun record where they were created
       frameLines: framePositions(reference.stack).map(([line]) => line),
     }).toEqual({ sourceURL: "<file>", frameLines: [nestedLine, nestedCallLine] });
     expect(exitCode).toBe(0);
+  });
+
+  // ML key imports reject through SubtleCrypto's rejectWithCause(), which builds the cause
+  // and then the DOMException, while the import call is still on the stack. The reference
+  // Error is created on the same line as the call.
+  it("a rejection that carries a cause is recorded at the call site too", async () => {
+    // prettier-ignore
+    const reference = new Error("reference"), pending = crypto.subtle.importKey("pkcs8", new Uint8Array(64), "ML-DSA-44", false, ["sign"]);
+    const rejection = await pending.then(
+      () => null,
+      e => e,
+    );
+
+    expect({
+      isDOMException: rejection instanceof DOMException,
+      causeIsError: rejection?.cause instanceof Error,
+      header: rejection?.stack.split("\n")[0],
+      line: rejection?.line,
+      sourceURL: rejection?.sourceURL,
+    }).toEqual({
+      isDOMException: true,
+      causeIsError: true,
+      header: "DataError: Invalid keyData",
+      line: reference.line,
+      sourceURL: reference.sourceURL,
+    });
   });
 
   it("a DOMException created with no JavaScript on the stack gets a header-only stack", async () => {


### PR DESCRIPTION
### Problem
- The DOMExceptions Bun creates itself (`AbortSignal.abort().reason`, `AbortController#abort()`, `AbortSignal.timeout()`, `atob()`'s InvalidCharacterError, `structuredClone()`'s DataCloneError, everything else that goes through `WebCore::createDOMException`) carry `line`, `column`, `sourceURL` and `stack` values that point into Bun's transpiled output, not into the user's file. With 10 comment lines above `const r = AbortSignal.abort().reason;`, `r.line` is `1` and `r.stack` is `module code@/x/f.js:1:30`; a `new Error()` on the same line reports line 11.
- The uncaught exception / unhandled rejection printer prints that position as if it were a source position: `at /x/f.js:1`, with the code excerpt to match. This is the wrong-line half of #37419 (the property dump half is not touched here).
- Cause 1: `createDOMException()` (`src/jsc/bindings/JSDOMExceptionHandling.cpp:187`) attaches the properties with JSC's `addErrorInfo()`, which stores the raw JSC position and `Interpreter::stackTraceAsString()`. Errors get theirs from Bun's `computeErrorInfo` hook, which runs them through the source map.
- Cause 2: the printer's fallback for thrown objects that are not `ErrorInstance`s (`exceptionFromString`, `src/jsc/bindings/ZigException.cpp:751`) reads `line` but never `column`, so the printer's own source map lookup (which needs both) never matches, and when an `originalLine` is present it substitutes it for `line` instead of treating the position as already mapped.

### Fix
- `Bun::addErrorInfoWithSourceMap()` (new, `FormatStackTraceForJS.cpp`) captures the frames the same way as before (`JSC::getStackTrace`, so `Error.stackTraceLimit` is honored as before), formats them with `Bun::formatStackTrace()`, and puts the mapped `line`/`column`/`sourceURL` and the Bun-format `stack` on the object as DontEnum properties. `formatStackTrace()` also records the unmapped position as DontEnum `originalLine`/`originalColumn`, as it does for Errors. `createDOMException()` calls it with the DOMException's name and message, so `stack` is `AbortError: The operation was aborted.` followed by frames in the usual format. `util.inspect()` of these now prints `DOMException [AbortError]: ...` plus frames, as node does, instead of `[@/x/f.js:1:30] { line: 1, ... }`.
- `exceptionFromString()` reads `column` as well and marks the frame `remapped` when `originalLine` is present, which is what `fromErrorInstance()` already does for Errors whose stack has been materialized. The printer then shows the recorded position and takes the excerpt from the source file.
- Why this is the right fix: a DOMException now gets exactly what `ErrorInstance::materializeErrorInfoIfNeeded` gives an Error in Bun (the same four properties, attributes and format, and the `line`/`originalLine` convention that `test/js/bun/test/stack.test.ts` pins), and the printer reads both kinds of object the same way. Two details fall out of using the Error path: a DOMException created with no JS frames (`AbortSignal.timeout()` firing from the timer) gets the header line as its `stack` instead of `""` (node's behavior for a frameless error, and what #38074 does for Errors), and with `Error.stackTraceLimit` deleted nothing is attached, as for an Error. `Error.prepareStackTrace` is not consulted, as before; #32898 is the change that would make these stacks lazy.
- Overlap with other open PRs: #39311 changes the same line to make the properties non-enumerable, which this does as well; whichever lands second is a one-line rebase. #32898 (make `JSDOMException` an `ErrorInstance`) would delete this call together with the old one; until it lands this is the fix for the positions. One visible consequence: Bun's `console.log` object dump of these DOMExceptions, which prints non-enumerable own properties, now also lists `originalLine` and `originalColumn`; #35723 and #32898 replace that dump with error-style output.
- `SubtleCrypto.cpp` `rejectWithCause()` (ML-DSA / ML-KEM import failures and the oversized ML-DSA context rejection) called `makeCause()`, whose import variant declares a `ThrowScope`, and then `createDOMException()` without checking for an exception. That was invisible while `createDOMException()` declared no exception scopes of its own; formatting the stack now does, so the exception-check validator (the ASAN CI lane runs every test with `BUN_JSC_validateExceptionChecks=1`) aborted `test-webcrypto-export-import-ml-dsa.js` and `-ml-kem.js`. The lambda now checks after `makeCause()`; that was the only site the validated suite found. `DeferredPromise::reject()`, `propagateException()` and `throwDataCloneError()`, which cover the other callers, already check or open a scope right before the call.
- Verified with `test/js/node/domexception-node.test.js` (new describe): positions and frames of six creation sites (abort reasons, `atob`, `structuredClone`, a `crypto.subtle.importKey()` rejection, one created inside a function) checked against the line numbers of the fixture source and against an Error created on the same line, enumerability, the ML-DSA rejection-with-cause path compared against an Error created on the same line, the header-only case, and the unhandled rejection and uncaught exception printer output (frame line and excerpt). The five new tests fail on the unfixed binary (line 16 instead of 21, JSC-format `stack`, printer `at <dir>/uncaught.js:1`) and pass with the fix, also under `BUN_JSC_validateExceptionChecks=1` (where the rejection-with-cause test aborts without the `SubtleCrypto.cpp` change).
- Also run with the fix: `test/js/web/abort/`, `structured-clone.test.ts`, `stack.test.ts` (pins the user-object fallback, `at http://example.com/test.js:42`, unchanged), `capture-stack-trace.test.js`, `inspect-error.test.js` (its two minified-file failures are the pre-existing debug-only `at require` frame noted in #38296), `timers.promises`, `web-globals`, `globals`, `reportError`, the #23022 regression test, node's `test-domexception-cause`, `test-global-domexception` and `test-structuredClone-domexception`, and the abort-related fetch tests.
- Cost: both the old and the new path format the stack eagerly. `controller.abort()` in a debug build: 551us/op before, 511 to 526us/op after; the `abortsignal-leak-fixture` timings are unchanged.

### Background
- `createDOMException()` is where a WebCore `ExceptionCode` becomes a JS value. For the codes that are DOMExceptions it creates a `JSDOMException`, which is a plain DOM wrapper object and not a `JSC::ErrorInstance`, so none of the Error machinery below applies to it and its error properties have to be put on it explicitly.
- Bun transpiles every module it loads, so the positions JSC reports are positions in the transpiled text. For Errors, Bun installs JSC's `onComputeErrorInfo` hook (`FormatStackTraceForJS.cpp`); when `stack`, `line` or `column` is first read, `formatStackTrace()` runs the frames through the source maps (`Bun__remapStackFramePositions`), the mapped position becomes `line`/`column`, and the unmapped one is kept as DontEnum `originalLine`/`originalColumn`.
- The error printer (uncaught exceptions, unhandled rejections, `console.error(err)`) converts the thrown value into a `ZigException` in `ZigException.cpp`, then `remap_zig_exception` (`src/jsc/VirtualMachine.rs`) maps each frame through the source maps and fetches the source for the excerpt. A frame's `remapped` flag means its position is already a source position, so the mapping step is skipped for it. `fromErrorInstance()` handles `ErrorInstance`s; `exceptionFromString()` is the fallback for every other thrown object, DOMExceptions included, and builds a single frame from the object's `sourceURL`/`line` properties.

<details>
<summary>Repro</summary>

```sh
{ for i in $(seq 10); do echo "// c$i"; done
  echo 'const r = AbortSignal.abort().reason;'
  echo 'console.log(r.line, JSON.stringify(r.stack));'
  echo 'Promise.reject(r);'; } > f.js && bun f.js
```

Before (1.4.0):

```
1 "module code@/x/f.js:1:30"
AbortError: The operation was aborted.
DOMException { line: 1, column: 30, sourceURL: "/x/f.js", stack: "module code@/x/f.js:1:30", ... }
      at /x/f.js:1
```

After:

```
11 "AbortError: The operation was aborted.\n    at /x/f.js:11:29"
 6 | // c6
 ...
11 | const r = AbortSignal.abort().reason;
                                 ^
AbortError: The operation was aborted.
DOMException { originalLine: 1, originalColumn: 30, line: 11, column: 29, sourceURL: "/x/f.js", stack: "AbortError: ...", ... }
      at /x/f.js:11:29
```

Column 29 comes from the same source map lookup Error frames go through (the nearest mapping at or before the JSC position).
</details>

Refs #37419
