### PR TITLE
bun test --reporter=junit: sum nested suites and sub-millisecond tests into a describe's time

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -281,7 +281,8 @@ pub struct Metrics {
     pub(crate) assertions: u32,
     pub(crate) failures: u32,
     pub(crate) skipped: u32,
-    pub(crate) elapsed_time: u64,
+    /// Sum of the `<testcase>` durations in this suite, including nested suites.
+    pub(crate) elapsed_ns: u64,
 }
 
 impl Metrics {
@@ -290,6 +291,7 @@ impl Metrics {
         self.assertions += other.assertions;
         self.failures += other.failures;
         self.skipped += other.skipped;
+        self.elapsed_ns = self.elapsed_ns.saturating_add(other.elapsed_ns);
     }
 }
 
@@ -610,7 +612,7 @@ impl JunitReporter {
             };
             end_ns.saturating_sub(suite_info.started_ns) as f64 / bun::time::NS_PER_S as f64
         } else {
-            suite_info.metrics.elapsed_time as f64 / bun::time::MS_PER_S as f64
+            suite_info.metrics.elapsed_ns as f64 / bun::time::NS_PER_S as f64
         };
 
         // Reshaped for borrowck — get hostname first
@@ -667,10 +669,8 @@ impl JunitReporter {
         if !self.suite_stack.is_empty() {
             let last = self.suite_stack.len() - 1;
             let current_suite = &mut self.suite_stack[last];
-            current_suite.metrics.elapsed_time = current_suite
-                .metrics
-                .elapsed_time
-                .saturating_add(elapsed_ms as u64);
+            current_suite.metrics.elapsed_ns =
+                current_suite.metrics.elapsed_ns.saturating_add(elapsed_ns);
             current_suite.metrics.test_cases += 1;
             current_suite.metrics.assertions += assertions;
         }

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -150,6 +150,76 @@ describe("junit reporter", () => {
     }
   });
 
+  it("sums nested suites and sub-millisecond testcases into a describe's <testsuite time>", async () => {
+    await using tmpDir = tempDir("junit-suite-time", {
+      "package.json": "{}",
+      "suite-time.test.js": `
+        import { describe, test } from "bun:test";
+
+        function spin(ms) {
+          const end = Bun.nanoseconds() + ms * 1e6;
+          while (Bun.nanoseconds() < end) {}
+        }
+
+        describe("outer", () => {
+          describe("middle", () => {
+            test("direct", () => spin(5));
+            describe("inner", () => {
+              test("nested", () => spin(20));
+            });
+          });
+        });
+
+        describe("fast", () => {
+          for (let i = 0; i < 10; i++) {
+            test("t" + i, () => spin(0.5));
+          }
+        });
+      `,
+    });
+
+    const junitPath = join(tmpDir, "junit.xml");
+    await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
+      cwd: tmpDir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const xmlContent = await file(junitPath).text();
+    const result = await new Promise((resolve, reject) => {
+      xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+    });
+    const fileSuite = result.testsuites.testsuite[0];
+    const [outer, fast] = fileSuite.testsuite;
+    const middle = outer.testsuite[0];
+    const inner = middle.testsuite[0];
+    expect([outer.$.name, middle.$.name, inner.$.name, fast.$.name]).toEqual(["outer", "middle", "inner", "fast"]);
+
+    const seconds = element => Number.parseFloat(element.$.time);
+    // <testcase time> is rounded to the microsecond; <testsuite time> is not.
+    const testcaseRounding = 1e-6;
+
+    // "middle" holds the "direct" testcase plus the nested "inner" suite;
+    // "outer" holds nothing but "middle".
+    expect(seconds(inner)).toBeGreaterThanOrEqual(0.02);
+    expect(seconds(middle)).toBeGreaterThanOrEqual(seconds(inner) + seconds(middle.testcase[0]) - testcaseRounding);
+    expect(outer.$.time).toBe(middle.$.time);
+
+    // Ten testcases of at least 0.5ms each: summing them truncated to whole
+    // milliseconds would lose most (in a release build, all) of the suite's time.
+    expect(fast.testcase).toHaveLength(10);
+    const fastTestcasesTotal = fast.testcase.reduce((total, testcase) => total + seconds(testcase), 0);
+    expect(fastTestcasesTotal).toBeGreaterThanOrEqual(0.005);
+    expect(seconds(fast)).toBeGreaterThanOrEqual(fastTestcasesTotal - fast.testcase.length * testcaseRounding);
+
+    // The file's <testsuite time> is wall-clock and encloses every describe.
+    expect(seconds(outer)).toBeLessThanOrEqual(seconds(fileSuite));
+    expect(seconds(fast)).toBeLessThanOrEqual(seconds(fileSuite));
+    expect(exitCode).toBe(0);
+  });
+
   it("more scenarios", async () => {
     await using tmpDir = tempDir("junit-comprehensive", {
       "package.json": "{}",


### PR DESCRIPTION
### Problem
- `bun test --reporter=junit` writes a wrong `time="..."` on describe-level `<testsuite>` elements, in two independent ways.
- A describe whose tests live in nested describes reports `time="0"`: `Metrics::add` (src/runtime/cli/test_command.rs) folds a finished child suite's `tests`/`assertions`/`failures`/`skipped` into the parent but not its elapsed time. Counts propagate (`tests="1"` on the parent), the time does not.
- A describe of sub-millisecond tests reports `time="0"` no matter how many tests it has: `write_test_case` added each test as `elapsed_ms as u64`, truncating every test to whole milliseconds before summing, and `end_test_suite` printed that millisecond count.
- Observed with bun 1.4.0 on the fixture below: `outer` reports `time="0"`, `middle` reports `time="0.005"` while containing a 5 ms test plus `inner` at `time="0.02"`, and `fast` (ten tests of ~0.5 ms each) reports `time="0"`.

### Fix
- `Metrics` keeps the suite total in nanoseconds (`elapsed_ns`), `write_test_case` adds the test's `elapsed_ns` to it unrounded, and `Metrics::add` sums it along with the counts, so closing a nested describe carries its time into the parent.
- `end_test_suite` prints it as `elapsed_ns / NS_PER_S`, the same expression the file-level branch next to it already uses, so every `<testsuite time>` in the report is seconds with the same precision.
- Correct because a describe's `<testsuite>` has no wall clock of its own (it is opened lazily when its first test result arrives, see `begin_test_suite_with_line`), so the sum of the `<testcase time>` values it contains, direct and nested, is its duration; that is also what the `tests`/`failures`/`skipped` attributes on the same element already are (sums over the subtree).
- The file-level `<testsuite time>` and `<testsuites time>` are measured from timestamps and are unchanged; `<testcase time>` is unchanged. The `--parallel` merge only reads `tests`/`failures`/`skipped` from worker chunks, so it picks up the corrected describe times as-is.
- Test: `test/js/junit-reporter/junit.test.js` ("sums nested suites and sub-millisecond testcases into a describe's `<testsuite time>`"). A describe with only a nested describe must print the identical time as that child, a describe with a direct test and a nested describe must cover both, and a describe of ten 0.5 ms tests must cover the sum of its testcases (to within the microsecond rounding of `<testcase time>`). Fails on `USE_SYSTEM_BUN=1 bun test` (`middle` prints `0.005`, expected at least `0.02505`); passes with `bun bd test`, 6/6 repeated runs.
- Also ran the whole `junit.test.js` file with `bun bd test` (9 pass, snapshots unchanged: they strip `time=`) and checked the fixture under `--parallel`.

### Background
- The JUnit reporter writes each `<testsuite ...` opening tag with its summary attributes missing, pushes a `SuiteInfo` (holding a `Metrics`) onto `suite_stack`, accumulates into the top entry as `<testcase>`s are written, and splices the `tests=... time=...` attributes into the saved offset when the suite closes (`end_test_suite`). On close, the suite's `Metrics` is `add`ed into the new top of the stack, which is how a parent describe learns about everything inside its children.
- The file-level suite is the one case with real timestamps (`file_start_ns`/`file_end_ns`, taken around loading and running the file), which is why `end_test_suite` has two branches: wall clock for the file, accumulated metrics for describes.
- `write_test_case` receives the test's duration as `elapsed_ns` from the test runner; the millisecond value it derived was only needed for the `<testcase time>` attribute.

<details>
<summary>Fixture and output before/after</summary>

```js
import { describe, test } from "bun:test";
function spin(ms) { const end = Bun.nanoseconds() + ms * 1e6; while (Bun.nanoseconds() < end) {} }
describe("outer", () => {
  describe("middle", () => {
    test("direct", () => spin(5));
    describe("inner", () => { test("nested", () => spin(20)); });
  });
});
describe("fast", () => { for (let i = 0; i < 10; i++) test("t" + i, () => spin(0.5)); });
```

Before (bun 1.4.0, attributes other than name/time elided):

```xml
<testsuite name="outer" time="0">
  <testsuite name="middle" time="0.005">
    <testcase name="direct" time="0.005071" />
    <testsuite name="inner" time="0.02">
      <testcase name="nested" time="0.020023" />
<testsuite name="fast" time="0">
  <testcase name="t0" time="0.000558" /> ... ten testcases of ~0.0005 each
```

After (debug build of this branch):

```xml
<testsuite name="outer" time="0.028480502">
  <testsuite name="middle" time="0.028480502">
    <testcase name="direct" time="0.007752" />
    <testsuite name="inner" time="0.020728574">
      <testcase name="nested" time="0.020729" />
<testsuite name="fast" time="0.007561199">
  <testcase name="t0" time="0.0017" /> ...
```
</details>
