### PR TITLE
require(): load mock.module / build.module virtual modules registered under node: names

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -31,33 +31,38 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
       }
     }
 
-    return this.$requireNativeModule(id);
-  } else {
-    const existing = $requireMap.$get(id);
-    if (existing) {
-      // Scenario where this is necessary:
-      //
-      // In an ES Module, we have:
-      //
-      //    import "react-dom/server"
-      //    import "react"
-      //
-      // Synchronously, the "react" import is created first, and then the
-      // "react-dom/server" import is created. Then, at ES Module link time, they
-      // are evaluated. The "react-dom/server" import is evaluated first, and
-      // require("react") was previously created as an ESM module, so we wait
-      // for the ESM module to load
-      //
-      // ...and then when this code is reached, unless
-      // we evaluate it "early", we'll get an empty object instead of the module
-      // exports.
-      //
-      const c = $evaluateCommonJSModule(existing, this);
-      if (c && c.indexOf(existing) === -1) {
-        c.push(existing);
-      }
-      return existing.exports;
+    const builtin = this.$requireNativeModule(id);
+    if (builtin !== undefined) {
+      return builtin;
     }
+    // Otherwise `id` is a virtual module (mock.module(), build.module()) registered under a
+    // "node:" name. It loads like any other module below.
+  }
+
+  const existing = $requireMap.$get(id);
+  if (existing) {
+    // Scenario where this is necessary:
+    //
+    // In an ES Module, we have:
+    //
+    //    import "react-dom/server"
+    //    import "react"
+    //
+    // Synchronously, the "react" import is created first, and then the
+    // "react-dom/server" import is created. Then, at ES Module link time, they
+    // are evaluated. The "react-dom/server" import is evaluated first, and
+    // require("react") was previously created as an ESM module, so we wait
+    // for the ESM module to load
+    //
+    // ...and then when this code is reached, unless
+    // we evaluate it "early", we'll get an empty object instead of the module
+    // exports.
+    //
+    const c = $evaluateCommonJSModule(existing, this);
+    if (c && c.indexOf(existing) === -1) {
+      c.push(existing);
+    }
+    return existing.exports;
   }
 
   // A resolved id may carry a `?query` suffix (part of the module cache key);

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -35,8 +35,7 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
     if (builtin !== undefined) {
       return builtin;
     }
-    // Otherwise `id` is a virtual module (mock.module(), build.module()) registered under a
-    // "node:" name. It loads like any other module below.
+    // undefined: a virtual module is registered under this id. Load it below.
   }
 
   const existing = $requireMap.$get(id);

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -68,10 +68,7 @@ declare interface Error {
 
 interface JSCommonJSModule {
   $require(id: string, mod: any, args_count: number, args: Array): any;
-  /**
-   * Loads the builtin a resolved `node:` id names. Returns `undefined` when the id is a virtual
-   * module (`mock.module()`, `build.module()`) that has to go through the regular require() path.
-   */
+  /** Loads the builtin a resolved `node:` id names, or `undefined` for a virtual module. */
   $requireNativeModule(id: string): any;
   children: JSCommonJSModule[];
   exports: any;

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -68,6 +68,10 @@ declare interface Error {
 
 interface JSCommonJSModule {
   $require(id: string, mod: any, args_count: number, args: Array): any;
+  /**
+   * Loads the builtin a resolved `node:` id names. Returns `undefined` when the id is a virtual
+   * module (`mock.module()`, `build.module()`) that has to go through the regular require() path.
+   */
   $requireNativeModule(id: string): any;
   children: JSCommonJSModule[];
   exports: any;

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -81,6 +81,7 @@ public:
         JSC::EncodedJSValue run(JSC::JSGlobalObject* globalObject, BunString* namespaceString, BunString* path);
 
         bool hasVirtualModules() const { return virtualModules != nullptr; }
+        bool hasVirtualModule(const String& specifier) const { return virtualModules && virtualModules->contains(specifier); }
 
         void addModuleMock(JSC::VM& vm, const String& path, JSC::JSObject* mock);
 

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1361,6 +1361,13 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlo
 }
 #undef REQUIRE_CJS_RETURN_IF_EXCEPTION
 
+// JSCommonJSModule.$requireNativeModule(resolvedId)
+//
+// require()'s fast path for the "node:" ids the resolver hands back. Returns undefined when the
+// id has to take the regular require() path instead: a virtual module (mock.module(),
+// build.module()) registered under a "node:" name resolves to that name unchanged, and only
+// fetchCommonJSModule knows how to run it. It ranks virtual modules against builtins the same way
+// import() does: under `bun test` the virtual module shadows the builtin, otherwise the builtin wins.
 JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireNativeModule, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
@@ -1374,6 +1381,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireNativeModule, (JSGlobalObject * lexica
     JSValue specifierValue = callframe->argument(0);
     WTF::String specifier = specifierValue.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(throwScope, {});
+
+    const bool isVirtualModule = globalObject->onLoadPlugins.hasVirtualModule(specifier);
+    if (isVirtualModule && isBunTest)
+        return JSC::JSValue::encode(JSC::jsUndefined());
+
     ErrorableResolvedSource res;
     res.success = false;
     memset(&res.result, 0, sizeof res.result);
@@ -1384,6 +1396,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireNativeModule, (JSGlobalObject * lexica
         if (res.success)
             return JSC::JSValue::encode(result);
     }
+    if (isVirtualModule)
+        return JSC::JSValue::encode(JSC::jsUndefined());
     throwScope.assertNoExceptionExceptTermination();
     return throwVMError(globalObject, throwScope, "Failed to fetch builtin module"_s);
 }

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1361,13 +1361,9 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireCommonJS, (JSGlobalObject * lexicalGlo
 }
 #undef REQUIRE_CJS_RETURN_IF_EXCEPTION
 
-// JSCommonJSModule.$requireNativeModule(resolvedId)
-//
-// require()'s fast path for the "node:" ids the resolver hands back. Returns undefined when the
-// id has to take the regular require() path instead: a virtual module (mock.module(),
-// build.module()) registered under a "node:" name resolves to that name unchanged, and only
-// fetchCommonJSModule knows how to run it. It ranks virtual modules against builtins the same way
-// import() does: under `bun test` the virtual module shadows the builtin, otherwise the builtin wins.
+// JSCommonJSModule.$requireNativeModule(resolvedId): require()'s builtin fast path.
+// Returns undefined when a virtual module (mock.module(), build.module()) registered under
+// the "node:" id wins over the builtin, with the same priority rule fetchCommonJSModule uses.
 JSC_DEFINE_HOST_FUNCTION(jsFunctionRequireNativeModule, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -302,6 +302,57 @@ describe("module", () => {
       expect(there).toBeUndefined();
     }
   });
+
+  // A virtual module may be registered under a "node:" name that is not a builtin. The resolver
+  // returns that name unchanged, so require() must not treat it as a builtin.
+  it("a module registered under a node: name works with require()", async () => {
+    Bun.plugin({
+      setup(builder) {
+        builder.module("node:plugins-test-virtual", () => ({
+          exports: { default: "virtual", hello: "world" },
+          loader: "object",
+        }));
+        builder.module("node:plugins-test-virtual-__esModule", () => ({
+          exports: { __esModule: true, default: { unwrapped: true } },
+          loader: "object",
+        }));
+        builder.module("node:plugins-test-virtual-code", () => ({
+          contents: `export const hello = "world"; export default "code";`,
+          loader: "js",
+        }));
+      },
+    });
+
+    const required = require("node:plugins-test-virtual");
+    expect({ ...required }).toEqual({ default: "virtual", hello: "world" });
+    expect(require("node:plugins-test-virtual")).toBe(required);
+    // @ts-expect-error
+    expect(await import("node:plugins-test-virtual")).toBe(required);
+    expect(require.resolve("node:plugins-test-virtual")).toBe("node:plugins-test-virtual");
+
+    expect(require("node:plugins-test-virtual-__esModule")).toEqual({ unwrapped: true });
+
+    const requiredCode = require("node:plugins-test-virtual-code");
+    expect({ ...requiredCode }).toEqual({ default: "code", hello: "world" });
+    // @ts-expect-error
+    expect(await import("node:plugins-test-virtual-code")).toBe(requiredCode);
+  });
+
+  it("a module registered under a node: name works with require() after import()", async () => {
+    Bun.plugin({
+      setup(builder) {
+        builder.module("node:plugins-test-virtual-imported-first", () => ({
+          exports: { hello: "world" },
+          loader: "object",
+        }));
+      },
+    });
+
+    // @ts-expect-error
+    const imported = await import("node:plugins-test-virtual-imported-first");
+    expect(imported.hello).toBe("world");
+    expect(require("node:plugins-test-virtual-imported-first")).toBe(imported);
+  });
 });
 
 describe("dynamic import", () => {
@@ -1063,4 +1114,77 @@ it("object loader: an error thrown by a getter on the exports object rejects the
     },
   });
   expect(() => require("object-loader-throwing-esmodule")).toThrow(boom);
+});
+
+// Outside of `bun test`, builtins take priority over virtual modules, so a "node:" name only
+// reaches the virtual module when no builtin has that name.
+it.concurrent("require() of a module registered under a node: name works outside of bun test", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        Bun.plugin({
+          name: "node-prefixed virtual modules",
+          setup(build) {
+            build.module("node:virt-object", () => ({
+              exports: { default: "object", hello: "world" },
+              loader: "object",
+            }));
+            build.module("node:virt-__esModule", () => ({
+              exports: { __esModule: true, default: { unwrapped: true } },
+              loader: "object",
+            }));
+            build.module("node:virt-code", () => ({
+              contents: 'export const hello = "world"; export default "code";',
+              loader: "js",
+            }));
+            build.module("node:virt-imported-first", () => ({
+              exports: { hello: "world" },
+              loader: "object",
+            }));
+          },
+        });
+
+        function attempt(fn) {
+          try {
+            return fn();
+          } catch (error) {
+            return "threw: " + (error.code ?? error.message);
+          }
+        }
+
+        const importedFirst = await import("node:virt-imported-first");
+        const results = {
+          object: attempt(() => ({ ...require("node:virt-object") })),
+          objectIsCached: attempt(() => require("node:virt-object") === require("node:virt-object")),
+          objectIsWhatImportReturns: attempt(() => require("node:virt-object")) === (await import("node:virt-object")),
+          esModule: attempt(() => require("node:virt-__esModule")),
+          code: attempt(() => ({ ...require("node:virt-code") })),
+          codeIsWhatImportReturns: attempt(() => require("node:virt-code")) === (await import("node:virt-code")),
+          importedFirst: attempt(() => require("node:virt-imported-first")) === importedFirst,
+          unregistered: attempt(() => require("node:virt-unregistered")),
+          builtin: attempt(() => typeof require("node:path").join),
+        };
+        console.log(JSON.stringify(results));
+      `,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The script reports its own failures, so empty stdout means it crashed.
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    object: { default: "object", hello: "world" },
+    objectIsCached: true,
+    objectIsWhatImportReturns: true,
+    esModule: { unwrapped: true },
+    code: { default: "code", hello: "world" },
+    codeIsWhatImportReturns: true,
+    importedFirst: true,
+    unregistered: "threw: ERR_UNKNOWN_BUILTIN_MODULE",
+    builtin: "function",
+  });
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -245,6 +245,21 @@ test("mocking a builtin applies to require() like it does to import()", async ()
   expect(require("querystring")).toBe(imported);
 });
 
+test("mocking a builtin by its node: name applies to require() in both spellings", () => {
+  mock.module("node:punycode", () => ({ encode: () => "mocked" }));
+
+  expect(require("node:punycode").encode("x")).toBe("mocked");
+  expect(require("punycode").encode("x")).toBe("mocked");
+});
+
+test("mocking a builtin with __esModule returns the default export from require()", () => {
+  const defaultExport = { start: () => "mocked" };
+  mock.module("node:repl", () => ({ __esModule: true, default: defaultExport }));
+
+  expect(require("node:repl")).toBe(defaultExport);
+  expect(require("repl")).toBe(defaultExport);
+});
+
 test("outside of bun test, a node: mock applies to require() unless a builtin has that name", async () => {
   using dir = tempDir("mock-module-node-prefix", {
     "index.ts": `

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -8,6 +8,7 @@
 // - Write test for import {foo} from "./foo"; export {foo}
 
 import { expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { default as defaultValue, fn, iCallFn, rexported, rexportedAs, variable } from "./mock-module-fixture";
 import * as spyFixture from "./spymodule-fixture";
 
@@ -212,4 +213,80 @@ test("onResolve plugin errors surface from mock.module; an unresolvable specifie
   } finally {
     Bun.plugin.clearAll();
   }
+});
+
+// require() used to hand every "node:" id straight to the builtin table. That threw for a mocked
+// name that is not a builtin and skipped the mock of a name that is, while import() returned the
+// mock in both cases.
+test("mocking a node: name that is not a builtin applies to require()", async () => {
+  mock.module("node:i-am-not-a-builtin", () => ({ default: 42, named: "yes" }));
+
+  const required = require("node:i-am-not-a-builtin");
+  expect({ ...required }).toEqual({ default: 42, named: "yes" });
+  expect(require("node:i-am-not-a-builtin")).toBe(required);
+  // @ts-expect-error
+  expect(await import("node:i-am-not-a-builtin")).toBe(required);
+  expect(require.resolve("node:i-am-not-a-builtin")).toBe("node:i-am-not-a-builtin");
+});
+
+test("mocking a node: name with __esModule returns the default export from require()", () => {
+  const defaultExport = { unwrapped: true };
+  mock.module("node:i-am-not-a-builtin-either", () => ({ __esModule: true, default: defaultExport }));
+
+  expect(require("node:i-am-not-a-builtin-either")).toBe(defaultExport);
+});
+
+test("mocking a builtin applies to require() like it does to import()", async () => {
+  mock.module("querystring", () => ({ stringify: () => "mocked" }));
+
+  const imported = await import("node:querystring");
+  expect(imported.stringify({})).toBe("mocked");
+  expect(require("node:querystring")).toBe(imported);
+  expect(require("querystring")).toBe(imported);
+});
+
+test("outside of bun test, a node: mock applies to require() unless a builtin has that name", async () => {
+  using dir = tempDir("mock-module-node-prefix", {
+    "index.ts": `
+      import { mock } from "bun:test";
+
+      mock.module("node:i-am-not-a-builtin", () => ({ default: 42 }));
+      mock.module("node:querystring", () => ({ stringify: () => "mocked" }));
+
+      function attempt(fn) {
+        try {
+          return fn();
+        } catch (error) {
+          return "threw: " + error.message;
+        }
+      }
+
+      console.log(
+        JSON.stringify({
+          importedMock: (await import("node:i-am-not-a-builtin")).default,
+          requiredMock: attempt(() => require("node:i-am-not-a-builtin").default),
+          importedBuiltin: (await import("node:querystring")).stringify({ a: 1 }),
+          requiredBuiltin: attempt(() => require("node:querystring").stringify({ a: 1 })),
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The script reports its own failures, so empty stdout means it crashed.
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    importedMock: 42,
+    requiredMock: 42,
+    // Builtins cannot be mocked outside of `bun test`; require() agrees with import() on that.
+    importedBuiltin: "a=1",
+    requiredBuiltin: "a=1",
+  });
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- `require()` of a virtual module registered under a `node:` name that is not a builtin throws `Failed to fetch builtin module`, while `import()` of the same name returns the module. Both `mock.module("node:x", ...)` and `Bun.plugin` `build.module("node:x", ...)` are affected, under `bun run` and under `bun test`:
  ```ts
  import { mock } from "bun:test";
  mock.module("node:made_up_mod", () => ({ default: 42 }));
  (await import("node:made_up_mod")).default; // 42
  require("node:made_up_mod").default;        // throws: Failed to fetch builtin module
  ```
- Same routing, second symptom: under `bun test`, `mock.module()` of a real builtin applies to `import()` but `require()` (in either spelling, `"fs"` or `"node:fs"`) still returns the real module.
- Cause: `overridableRequire` (`src/js/builtins/CommonJS.ts:20`) sends every id that resolves to a `node:` name to `$requireNativeModule` (`jsFunctionRequireNativeModule`, `src/jsc/bindings/JSCommonJSModule.cpp`), which only consults the builtin table and throws at the end. `$resolveSync` returns a virtual module's key unchanged (`functionImportMeta__resolveSyncPrivate`, `src/jsc/bindings/ImportMetaObject.cpp:215`), so a virtual `node:` name lands on that path. The regular `require()` path (`Bun::fetchCommonJSModule`, `src/jsc/bindings/ModuleLoader.cpp`) and the `import()` path (`fetchESMSourceCode`) both run virtual modules; the `node:` fast path is the only loader entry that does not.

### Fix
- `jsFunctionRequireNativeModule` returns `undefined` when a virtual module is registered under the id and it is the one that should load: always under `bun test`, otherwise only when the builtin table has nothing for that name. `overridableRequire` then falls through to the regular path, which runs the virtual module, caches it in `require.cache`, and unwraps `default` for `__esModule` results like it does for every other virtual module.
- Correct because the fall-through reuses the priority rule `fetchCommonJSModule` and `fetchESMSourceCode` already implement (virtual modules shadow builtins under `bun test`, builtins win otherwise), so `require()` now returns what `import()` returns for the same name, and `node:` virtual modules behave the way `bun:` and unprefixed ones already do from `require()`. Nothing changes for ids without a registered virtual module: real builtins still take the fast path and stay out of `require.cache`, and the old error is still thrown for a `node:` id nobody serves. Builtins all export objects, so `undefined` cannot collide with a builtin's exports.
- `hasVirtualModules()` is a null check, so a process with no plugins or mocks pays nothing; with some registered, a builtin `require()` costs one hash lookup, which `$resolveSync` already does for the same id.
- Supersedes #34984, which handles only mocks of real builtins under `bun test` by running the mock inside `jsFunctionRequireNativeModule`; this PR covers that case by routing it through the regular path instead (so it also gets `require.cache` and the `__esModule` handling that path has), plus the non-builtin names and `build.module()`. Both test cases from #34984 pass on this branch and are included here. #39314 is the sibling fix for static imports of these names and leaves this `require()` path alone.
- Verified with:
  - `test/js/bun/plugin/plugins.test.ts`: `build.module()` under `node:` names from `require()` (object loader, `__esModule` unwrap, code loader, cache identity, `require()` after `import()`, `require.resolve`) inside the test runner, and the same shapes plus the unregistered-name and real-builtin controls in a `bun -e` subprocess (no test runner).
  - `test/js/bun/test/mock/mock-module.test.ts`: `mock.module()` of a non-builtin `node:` name from `require()` (plain and `__esModule`), a real builtin mocked under `bun test` from `require("node:querystring")`, `require("querystring")` and `import()`, the same with the mock spelled `mock.module("node:punycode")`, a real builtin mocked with `__esModule` (`node:repl`) unwrapped to its `default` from `require()`, and a subprocess without the test runner where the non-builtin mock applies to `require()` and the builtin mock is ignored by both `require()` and `import()`.
  - All 9 new cases fail on the released binary (`Failed to fetch builtin module`, or the real builtin coming back) and pass with the debug build.
  - `test/js/bun/plugin/`, `test/js/bun/test/mock/`, `test/js/node/module/`, `test/js/bun/resolve/`, `test/js/node/missing-module.test.js` and the `test-require-*` node tests pass with the debug build; the new tests also pass under `BUN_JSC_validateExceptionChecks=1`. The only failures seen were the leak and load-many-times stress tests that time out or misdetect ASAN locally (#35081, #36929), unrelated to this change.

### Background
- Virtual modules: `Bun.plugin`'s `build.module(name, factory)` and `bun:test`'s `mock.module(name, factory)` both store their factory in one per-global map keyed by the exact name (`onLoadPlugins.virtualModules`). `build.module()` refuses builtin names; `mock.module()` resolves its argument first, so a mocked builtin is stored under its canonical `node:` name.
- Resolution of a virtual module: every resolver entry point checks that map before the real resolver and returns the key unchanged, which is why a `node:` virtual name reaches the loader looking exactly like a builtin id.
- `require()` in Bun: `overridableRequire` resolves the specifier, then either takes the builtin fast path (`$requireNativeModule`, which reads the builtin table and keeps builtins out of `require.cache`, matching Node) or creates a module object and hands it to `fetchCommonJSModule`, which tries virtual modules and builtins in the order described above and otherwise loads a file.
- `isBunTest` is the process-wide flag set by the `bun test` command; the loaders use it to decide whether virtual modules may shadow builtins.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1233.08ms]
(pass) require > beep:boop returns 42 [10.68ms]
(pass) require > object module works [8.19ms]
(pass) module > throws with require() [12.30ms]
(pass) module > async module works with async import [25.59ms]
(pass) module > sync module module works with require() [4.22ms]
(pass) module > sync module module works with require.resolve() [3.19ms]
(pass) module > sync module module works with import [4.77ms]
(pass) module > modules are overridable [89.18ms]
321 |           loader: "js",
322 |         }));
323 |       },
324 |     });
325 | 
326 |     const required = require("node:plu
... (truncated)

release without fix: 10 failed, 1 skipped
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [20.13ms]
(pass) require > beep:boop returns 42 [0.16ms]
(pass) require > object module works [0.11ms]
(pass) module > throws with require() [0.14ms]
(pass) module > async module works with async import [1.25ms]
(pass) module > sync module module works with require() [0.06ms]
(pass) module > sync module module works with require.resolve() [0.05ms]
(pass) module > sync module module works with import [0.07ms]
(pass) module > modules are overridable [0.20ms]
321 |           loader: "js",
322 |         }));
323 |       },
324 |     });
325 | 
326 |     const required = require("node:plugins-test-virtual");
                ^
error: Failed to fetch builtin module
      at <anonymous> (/workspace/bun/test/js/bun/plugin/plugins.test.ts:326:11)
(fail) module > a module registered under a node: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1245.52ms]
(pass) require > beep:boop returns 42 [10.37ms]
(pass) require > object module works [7.99ms]
(pass) module > throws with require() [12.17ms]
(pass) module > async module works with async import [26.01ms]
(pass) module > sync module module works with require() [4.17ms]
(pass) module > sync module module works with require.resolve() [2.96ms]
(pass) module > sync module module works with import [5.05ms]
(pass) module > modules are overridable [86.83ms]
(pass) module > a module registered under a node: name works with require() [23.15ms]
(pass) module > a module registered under a
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     16023f1002
  features     baseline

23 deps, 129 codegen, 1172 objects in 709ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [7.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [7.00ms]
[3/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[4/1217] gen ErrorCode+*.h
[5/1217] gen bindgenv2
[6/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [5.00ms]
[7/1217] fetch zlib
[zlib] up to date
[8/1217] fetch tinycc
[tinycc] up to date
[9/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/CommonJS.ts               |  56 +++++++-------
 src/js/private.d.ts                       |   1 +
 src/jsc/bindings/BunPlugin.h              |   1 +
 src/jsc/bindings/JSCommonJSModule.cpp     |  10 +++
 test/js/bun/plugin/plugins.test.ts        | 124 ++++++++++++++++++++++++++++++
 test/js/bun/test/mock/mock-module.test.ts |  92 ++++++++++++++++++++++
 6 files changed, 258 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/builtins/CommonJS.ts                    1      1      0
src/js/private.d.ts                            1      1      0
src/jsc/bindings/BunPlugin.h                   0      0      0
src/jsc/bindings/JSCommonJSModule.cpp          1      1      0
test/js/bun/plugin/plugins.test.ts             0      0      0
test/js/bun/test/mock/mock-module.test.ts      0      0      0
```

</details>

**root cause** · written by the author bot

The bug was that require() used a native fast path for resolved "node:" ids that loaded the builtin directly, so virtual modules registered under those ids via mock.module() or Bun.plugin's build.module() were silently bypassed. The fix makes $requireNativeModule check for a registered virtual module first and return undefined in that case, causing the call to fall through to the regular require() path where fetchCommonJSModule can execute the virtual module. The priority between virtual modules and builtins matches what import() already does, with virtual modules shadowing builtins under b…

<!-- robobun:evidence:end -->