### PR TITLE
bun-types: accept the { name, cause } options object in the DOMException constructor

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -943,35 +943,43 @@ interface DOMException extends Error {
   readonly INVALID_NODE_TYPE_ERR: 24;
   readonly DATA_CLONE_ERR: 25;
 }
-declare var DOMException: {
-  prototype: DOMException;
-  new (message?: string, name?: string): DOMException;
-  readonly INDEX_SIZE_ERR: 1;
-  readonly DOMSTRING_SIZE_ERR: 2;
-  readonly HIERARCHY_REQUEST_ERR: 3;
-  readonly WRONG_DOCUMENT_ERR: 4;
-  readonly INVALID_CHARACTER_ERR: 5;
-  readonly NO_DATA_ALLOWED_ERR: 6;
-  readonly NO_MODIFICATION_ALLOWED_ERR: 7;
-  readonly NOT_FOUND_ERR: 8;
-  readonly NOT_SUPPORTED_ERR: 9;
-  readonly INUSE_ATTRIBUTE_ERR: 10;
-  readonly INVALID_STATE_ERR: 11;
-  readonly SYNTAX_ERR: 12;
-  readonly INVALID_MODIFICATION_ERR: 13;
-  readonly NAMESPACE_ERR: 14;
-  readonly INVALID_ACCESS_ERR: 15;
-  readonly VALIDATION_ERR: 16;
-  readonly TYPE_MISMATCH_ERR: 17;
-  readonly SECURITY_ERR: 18;
-  readonly NETWORK_ERR: 19;
-  readonly ABORT_ERR: 20;
-  readonly URL_MISMATCH_ERR: 21;
-  readonly QUOTA_EXCEEDED_ERR: 22;
-  readonly TIMEOUT_ERR: 23;
-  readonly INVALID_NODE_TYPE_ERR: 24;
-  readonly DATA_CLONE_ERR: 25;
-};
+declare var DOMException: Bun.__internal.UseLibDomIfAvailable<
+  "DOMException",
+  {
+    prototype: DOMException;
+    new (message?: string, name?: string): DOMException;
+    /**
+     * `options.name` defaults to `"Error"`. `options.cause`, when present, is
+     * stored as the exception's `cause`, like `new Error(message, { cause })`.
+     */
+    new (message?: string, options?: { name?: string | undefined; cause?: unknown }): DOMException;
+    readonly INDEX_SIZE_ERR: 1;
+    readonly DOMSTRING_SIZE_ERR: 2;
+    readonly HIERARCHY_REQUEST_ERR: 3;
+    readonly WRONG_DOCUMENT_ERR: 4;
+    readonly INVALID_CHARACTER_ERR: 5;
+    readonly NO_DATA_ALLOWED_ERR: 6;
+    readonly NO_MODIFICATION_ALLOWED_ERR: 7;
+    readonly NOT_FOUND_ERR: 8;
+    readonly NOT_SUPPORTED_ERR: 9;
+    readonly INUSE_ATTRIBUTE_ERR: 10;
+    readonly INVALID_STATE_ERR: 11;
+    readonly SYNTAX_ERR: 12;
+    readonly INVALID_MODIFICATION_ERR: 13;
+    readonly NAMESPACE_ERR: 14;
+    readonly INVALID_ACCESS_ERR: 15;
+    readonly VALIDATION_ERR: 16;
+    readonly TYPE_MISMATCH_ERR: 17;
+    readonly SECURITY_ERR: 18;
+    readonly NETWORK_ERR: 19;
+    readonly ABORT_ERR: 20;
+    readonly URL_MISMATCH_ERR: 21;
+    readonly QUOTA_EXCEEDED_ERR: 22;
+    readonly TIMEOUT_ERR: 23;
+    readonly INVALID_NODE_TYPE_ERR: 24;
+    readonly DATA_CLONE_ERR: 25;
+  }
+>;
 
 declare function alert(message?: string): void;
 declare function confirm(message?: string): boolean;

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -368,20 +368,23 @@ describe("@types/bun integration test", () => {
   });
 
   // Runs on debug builds too: spawning tsc over a single file is cheap,
-  // unlike the in-process LanguageService runs above.
-  describe("Bun.mmap", () => {
-    test("MMapOptions accepts offset and size", async () => {
-      const checkDir = join(TEMP_DIR, "mmap-options-check");
+  // unlike the in-process LanguageService runs above. The fixture/ files carry
+  // the full assertions for these declarations; this is the check of them that
+  // a debug build still runs.
+  describe("tsc over a single file", () => {
+    test("Bun.mmap offset/size and the DOMException options object are accepted", async () => {
+      const checkDir = join(TEMP_DIR, "single-file-check");
       const tsconfig = structuredClone(sourceTsconfig);
-      tsconfig.include = ["mmap-options.ts"];
+      tsconfig.include = ["check.ts"];
       tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
       await mkdir(checkDir, { recursive: true });
       await makeTree(checkDir, {
         "tsconfig.json": JSON.stringify(tsconfig, null, 2),
-        "mmap-options.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
+        "check.ts": `const view = Bun.mmap("./data.bin", { shared: true, sync: false, offset: 4096, size: 1024 });
            view satisfies Uint8Array<ArrayBuffer>;
            Bun.mmap("./data.bin", { offset: 4096 }) satisfies Uint8Array<ArrayBuffer>;
-           Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;`,
+           Bun.mmap("./data.bin", { size: 1024 }) satisfies Uint8Array<ArrayBuffer>;
+           new DOMException("boom", { name: "AbortError", cause: new Error("inner") }) satisfies DOMException;`,
       });
 
       await using proc = Bun.spawn({
@@ -684,6 +687,22 @@ describe("@types/bun integration test", () => {
           code: 2353,
           line: "globals.ts:307:5",
           message: "Object literal may only specify known properties, and 'headers' does not exist in type 'string[]'.",
+        },
+        {
+          code: 2345,
+          line: "globals.ts:340:37",
+          message:
+            "Argument of type '{ name: string; cause: Error; }' is not assignable to parameter of type 'string'.",
+        },
+        {
+          code: 2345,
+          line: "globals.ts:341:37",
+          message: "Argument of type '{ name: string; }' is not assignable to parameter of type 'string'.",
+        },
+        {
+          code: 2345,
+          line: "globals.ts:342:37",
+          message: "Argument of type '{ cause: string; }' is not assignable to parameter of type 'string'.",
         },
         {
           code: 2345,

--- a/test/integration/bun-types/fixture/globals.ts
+++ b/test/integration/bun-types/fixture/globals.ts
@@ -336,6 +336,14 @@ new Error("asdf", {
   cause: new Error("asdf"),
 });
 
+expectType(new DOMException("asdf", "AbortError")).is<DOMException>();
+expectType(new DOMException("asdf", { name: "AbortError", cause: err })).is<DOMException>();
+expectType(new DOMException("asdf", { name: "AbortError" })).is<DOMException>();
+expectType(new DOMException("asdf", { cause: "asdf" })).is<DOMException>();
+expectType(new DOMException().cause).is<unknown>();
+// @ts-expect-error the second argument is a name or an options object
+new DOMException("asdf", 20);
+
 // @ts-expect-error this interface is defined top level in globals.d.ts so we
 // are making sure that .d.ts is a module and that anything top level doesn't
 // leak to userland


### PR DESCRIPTION
### Problem
- Against `bun-types`, `new DOMException("boom", { name: "AbortError", cause: err })` fails to compile: `error TS2345: Argument of type '{ name: string; cause: Error; }' is not assignable to parameter of type 'string'.` The `{ name }` and `{ cause }` forms fail the same way.
- The runtime accepts all of them: `JSDOMExceptionDOMConstructor::construct` (src/jsc/bindings/webcore/JSDOMException.cpp:136-153) reads `name` and `cause` from an object second argument and falls back to treating the argument as the name string. Node accepts the same form (its `test/parallel/test-domexception-cause.js` runs in Bun's suite), and `@types/node` declares it (`web-globals/domexception.d.ts`).
- packages/bun-types/globals.d.ts:948 declared only `new (message?: string, name?: string)`.

### Fix
- Adds the overload `new (message?: string, options?: { name?: string | undefined; cause?: unknown }): DOMException` to the `DOMException` declaration. This is the fixing line; the rest of that hunk is re-indentation.
- Declares the variable through `Bun.__internal.UseLibDomIfAvailable<"DOMException", ...>`, like the other web globals in the file. lib.dom.d.ts also declares `var DOMException`, and TypeScript requires repeated `var` declarations to have identical types, which the old declaration met by being a copy of lib.dom's. With the wrapper, lib.dom's declaration is used when lib.dom is loaded, so in that configuration the options form stays rejected exactly as before (the three new entries in the "checks with lib.dom.d.ts" list record that), and the overload applies everywhere else.
- Why this shape: it mirrors what `construct()` accepts. `name` is optional and an explicit `undefined` is treated as absent (hence `string | undefined`, which also matters under `exactOptionalPropertyTypes`); `cause` is stored as given, whatever its type, so it is `unknown`, matching `ErrorOptions.cause`. The two overloads are the same two `@types/node` declares. `@types/node` itself is not affected: its `var DOMException` is conditional on `onmessage` existing on `globalThis`, which `bun-types` declares (index.d.ts:32), so it takes whatever `bun-types` declares.
- Verified:
  - test/integration/bun-types/fixture/globals.ts gains the string form, the three options forms, the `cause` type and a rejected second argument. Without the `.d.ts` change the `checks without lib.dom.d.ts` and tsgo cases fail with the three `TS2345` errors above; with it the whole file passes (`bun test test/integration/bun-types/bun-types.test.ts`, 15 pass).
  - The existing single-file tsc case, the only fixture check that also runs under a debug build, gets one `{ name, cause }` line and is renamed accordingly. `bun bd test` on the file: fails without the `.d.ts` change, 3 pass / 12 skip with it. If #39270 lands first, that block goes away and the fixture lines are the coverage.
  - `tsc -p packages/bun-types` is clean.
  - Runtime probe of every form under bun 1.4.0 and node 26.3.0 below.

### Background
- `bun-types` and lib.dom.d.ts both declare the web globals. Interfaces merge, but a `var` declared twice must have the identical type, so `bun-types` declares such variables as `UseLibDomIfAvailable<Name, T>` (bun.d.ts:58): when lib.dom is loaded (detected by `onabort` existing on `globalThis`) it resolves to lib.dom's type for `Name`, otherwise to `T`. The cost is that Bun-only surface is unavailable when lib.dom is loaded; the "checks with lib.dom.d.ts" list in bun-types.test.ts is the record of that surface.
- `@types/node` declares its web globals as `typeof globalThis extends { onmessage: any; X: infer T } ? T : { ... }`, deferring to a DOM-like environment when one is present. `bun-types` declares `onmessage` so that `@types/node` defers to it, which is why the declaration users see for `DOMException` is the one in globals.d.ts and not `@types/node`'s.
- test/integration/bun-types packs `packages/bun-types`, installs it into a copy of `fixture/` and type-checks the fixture with and without lib.dom. Most of those cases drive TypeScript in-process and are skipped on debug builds; the single-file tsc case is the one that runs under either build.

<details>
<summary>Runtime probe</summary>

```ts
const inner = new Error("inner");
for (const [label, e] of [
  ["string name", new DOMException("boom", "AbortError")],
  ["{name, cause}", new DOMException("boom", { name: "AbortError", cause: inner })],
  ["{name}", new DOMException("boom", { name: "NotFoundError" })],
  ["{cause}", new DOMException("boom", { cause: 42 })],
  ["{}", new DOMException("boom", {})],
  ["{cause: undefined}", new DOMException("boom", { cause: undefined })],
]) console.log(label, { name: e.name, code: e.code, hasCause: "cause" in e, cause: e.cause });
```

bun 1.4.0:

```
string name          {"name":"AbortError","code":20,"hasCause":false}
{name, cause}        {"name":"AbortError","code":20,"hasCause":true,"cause":"Error(inner)"}
{name}               {"name":"NotFoundError","code":8,"hasCause":false}
{cause}              {"name":"Error","code":0,"hasCause":true,"cause":42}
{}                   {"name":"Error","code":0,"hasCause":false}
{cause: undefined}   {"name":"Error","code":0,"hasCause":true}
```

node 26.3.0 accepts the same inputs; the only difference is that it reports `name` as `"undefined"` when the options object has no `name`, which does not affect the declaration (`name` is optional either way).

</details>
