### PR TITLE
bun test --reporter=junit: write testcase classname outermost describe first

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1338,23 +1338,17 @@ impl CommandLineReporter {
                 describe_suite_index += 1;
             }
 
+            // Outermost-first (`scopes` is innermost-first), matching the console
+            // reporter's "outer > inner > name" line and the <testsuite> nesting above.
             let mut concatenated_describe_scopes: Vec<u8> = Vec::new();
-
-            {
-                let initial_length = concatenated_describe_scopes.len();
-                for &scope in scopes {
-                    // SAFETY: scope alive for test run
-                    if let Some(name) = unsafe { (*scope).base.name.as_deref() } {
-                        if !name.is_empty() {
-                            if initial_length != concatenated_describe_scopes.len() {
-                                concatenated_describe_scopes.extend_from_slice(b" > ");
-                            }
-
-                            // write_test_case escapes class_name once; do not pre-escape here.
-                            concatenated_describe_scopes.extend_from_slice(name);
-                        }
-                    }
+            for (i, &scope) in needed_suites.iter().enumerate() {
+                if i > 0 {
+                    concatenated_describe_scopes.extend_from_slice(b" > ");
                 }
+                // SAFETY: scope alive for test run
+                let name = unsafe { (*scope).base.name.as_deref() }.unwrap_or(b"");
+                // write_test_case escapes class_name once; do not pre-escape here.
+                concatenated_describe_scopes.extend_from_slice(name);
             }
 
             junit

--- a/test/js/junit-reporter/__snapshots__/junit.test.js.snap
+++ b/test/js/junit-reporter/__snapshots__/junit.test.js.snap
@@ -6,16 +6,16 @@ exports[`junit reporter more scenarios 1`] = `
   <testsuite name="comprehensive.test.js" file="comprehensive.test.js" tests="22" assertions="16" failures="1" skipped="6">
     <testsuite name="comprehensive test suite" file="comprehensive.test.js" line="4" tests="22" assertions="16" failures="1" skipped="6">
       <testsuite name="division suite 10 / 5" file="comprehensive.test.js" line="8" tests="1" assertions="1" failures="0" skipped="0">
-        <testcase name="should divide correctly" classname="division suite 10 / 5 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="1" />
+        <testcase name="should divide correctly" classname="comprehensive test suite &gt; division suite 10 / 5" file="comprehensive.test.js" line="9" assertions="1" />
       </testsuite>
       <testsuite name="division suite 20 / 10" file="comprehensive.test.js" line="8" tests="1" assertions="1" failures="0" skipped="0">
-        <testcase name="should divide correctly" classname="division suite 20 / 10 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="1" />
+        <testcase name="should divide correctly" classname="comprehensive test suite &gt; division suite 20 / 10" file="comprehensive.test.js" line="9" assertions="1" />
       </testsuite>
       <testsuite name="conditional describe that runs" file="comprehensive.test.js" line="14" tests="1" assertions="1" failures="0" skipped="0">
-        <testcase name="nested test in conditional describe" classname="conditional describe that runs &gt; comprehensive test suite" file="comprehensive.test.js" line="15" assertions="1" />
+        <testcase name="nested test in conditional describe" classname="comprehensive test suite &gt; conditional describe that runs" file="comprehensive.test.js" line="15" assertions="1" />
       </testsuite>
       <testsuite name="conditional describe that skips" file="comprehensive.test.js" line="20" tests="1" assertions="0" failures="0" skipped="1">
-        <testcase name="nested test that gets skipped" classname="conditional describe that skips &gt; comprehensive test suite" file="comprehensive.test.js" line="21" assertions="0">
+        <testcase name="nested test that gets skipped" classname="comprehensive test suite &gt; conditional describe that skips" file="comprehensive.test.js" line="21" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
@@ -61,22 +61,22 @@ exports[`junit reporter more scenarios 2`] = `
   <testsuite name="comprehensive.test.js" file="comprehensive.test.js" tests="22" assertions="1" failures="0" skipped="21">
     <testsuite name="comprehensive test suite" file="comprehensive.test.js" line="4" tests="22" assertions="1" failures="0" skipped="21">
       <testsuite name="division suite 10 / 5" file="comprehensive.test.js" line="8" tests="1" assertions="0" failures="0" skipped="1">
-        <testcase name="should divide correctly" classname="division suite 10 / 5 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="0">
+        <testcase name="should divide correctly" classname="comprehensive test suite &gt; division suite 10 / 5" file="comprehensive.test.js" line="9" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
       <testsuite name="division suite 20 / 10" file="comprehensive.test.js" line="8" tests="1" assertions="0" failures="0" skipped="1">
-        <testcase name="should divide correctly" classname="division suite 20 / 10 &gt; comprehensive test suite" file="comprehensive.test.js" line="9" assertions="0">
+        <testcase name="should divide correctly" classname="comprehensive test suite &gt; division suite 20 / 10" file="comprehensive.test.js" line="9" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
       <testsuite name="conditional describe that runs" file="comprehensive.test.js" line="14" tests="1" assertions="0" failures="0" skipped="1">
-        <testcase name="nested test in conditional describe" classname="conditional describe that runs &gt; comprehensive test suite" file="comprehensive.test.js" line="15" assertions="0">
+        <testcase name="nested test in conditional describe" classname="comprehensive test suite &gt; conditional describe that runs" file="comprehensive.test.js" line="15" assertions="0">
           <skipped />
         </testcase>
       </testsuite>
       <testsuite name="conditional describe that skips" file="comprehensive.test.js" line="20" tests="1" assertions="0" failures="0" skipped="1">
-        <testcase name="nested test that gets skipped" classname="conditional describe that skips &gt; comprehensive test suite" file="comprehensive.test.js" line="21" assertions="0">
+        <testcase name="nested test that gets skipped" classname="comprehensive test suite &gt; conditional describe that skips" file="comprehensive.test.js" line="21" assertions="0">
           <skipped />
         </testcase>
       </testsuite>

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -467,9 +467,97 @@ describe("junit reporter", () => {
     const tc = inner.testcase[0];
     // The classname should decode back to the original describe names joined by " > ".
     expect(outer.$.name).toBe('suite <a> & "b"');
-    expect(tc.$.classname).toBe('inner > stuff > suite <a> & "b"');
+    expect(tc.$.classname).toBe('suite <a> & "b" > inner > stuff');
     expect(exitCode).toBe(0);
   });
+
+  // With --parallel each worker writes its files' part of the report and the coordinator
+  // stitches the parts together, so the classname is checked in both modes.
+  it.each([
+    ["serial", []],
+    ["--parallel=2", ["--parallel=2"]],
+  ])(
+    "lists describe scopes in classname outermost-first, like the console line and the <testsuite> nesting (%s)",
+    async (_mode, extraArgs) => {
+      await using tmpDir = tempDir("junit-classname-order", {
+        "package.json": "{}",
+        "nested.test.js": `
+          import { describe, test } from "bun:test";
+          test("top level", () => {});
+          describe("outer", () => {
+            test("in outer", () => {});
+            describe("middle", () => {
+              describe("inner", () => {
+                test("nested", () => {});
+              });
+            });
+            describe("", () => {
+              describe("below anonymous", () => {
+                test("skips the unnamed describe", () => {});
+              });
+            });
+          });
+        `,
+        "other.test.js": `
+          import { describe, test } from "bun:test";
+          describe("first", () => {
+            describe("second", () => {
+              test("deep", () => {});
+            });
+          });
+        `,
+      });
+
+      const junitPath = join(tmpDir, "junit.xml");
+      await using proc = spawn([bunExe(), "test", ...extraArgs, "--reporter=junit", "--reporter-outfile", junitPath], {
+        cwd: tmpDir,
+        env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      const xmlContent = await file(junitPath).text();
+      const result = await new Promise((resolve, reject) => {
+        xml2js.parseString(xmlContent, { strict: true }, (err, r) => (err ? reject(err) : resolve(r)));
+      });
+
+      // Every <testcase> in a file's suite, paired with the names of the describe
+      // <testsuite> elements it is nested in.
+      const collect = (suite, path, out) => {
+        for (const tc of suite.testcase ?? []) {
+          out.push({ name: tc.$.name, classname: tc.$.classname, suites: path });
+        }
+        for (const child of suite.testsuite ?? []) {
+          collect(child, [...path, child.$.name], out);
+        }
+        return out;
+      };
+      const byFile = Object.fromEntries(
+        result.testsuites.testsuite.map(suite => [suite.$.name, collect(suite, [], [])]),
+      );
+
+      expect(byFile).toEqual({
+        "nested.test.js": [
+          { name: "top level", classname: "", suites: [] },
+          { name: "in outer", classname: "outer", suites: ["outer"] },
+          { name: "nested", classname: "outer > middle > inner", suites: ["outer", "middle", "inner"] },
+          {
+            name: "skips the unnamed describe",
+            classname: "outer > below anonymous",
+            suites: ["outer", "below anonymous"],
+          },
+        ],
+        "other.test.js": [{ name: "deep", classname: "first > second", suites: ["first", "second"] }],
+      });
+
+      // The console reporter prints the same path in front of each test name.
+      expect(stderr).toContain("(pass) outer > middle > inner > nested");
+      expect(stderr).toContain("(pass) outer > below anonymous > skips the unnamed describe");
+      expect(stderr).toContain("(pass) first > second > deep");
+      expect(exitCode).toBe(0);
+    },
+  );
 
   it("keeps the test body's error in <failure> when afterEach also throws", async () => {
     await using tmpDir = tempDir("junit-aftereach", {


### PR DESCRIPTION
### Problem

- `bun test --reporter=junit` writes the describe path of a `<testcase>` innermost first. For `describe("outer") > describe("middle") > describe("inner") > test("nested")` the report contains `<testcase name="nested" classname="inner &gt; middle &gt; outer">`.
- The console reporter prints the same test as `outer > middle > inner > nested`, and the `<testsuite>` elements wrapping that `<testcase>` in the same report are nested `outer` > `middle` > `inner`, so the classname reads backwards relative to both.
- Cause: `maybe_print_junit_line` in `src/runtime/cli/test_command.rs` collects `scopes` by walking `parent` pointers from the test upwards, so the slice is innermost first. The console reporter (`print_test_line`) and the `needed_suites` list that drives the nested `<testsuite>` elements both index it from the end; the classname loop iterated it from the start. The loop has been this way since the reporter was added, so this is not a regression, just a long-standing inconsistency.

### Fix

- Build the classname from `needed_suites`, the outermost-first list of named describe scopes that the nested `<testsuite>` elements are already opened from. The classname is now, by construction, the same path as the `<testsuite>` nesting and the console line; unnamed describes stay omitted as before.
- Outer-to-inner is what a JUnit classname means everywhere else: it came from Java's fully qualified class name (package, outer class, inner class), pytest writes `module.Class`, jest-junit joins ancestor titles outermost first. Consumers that group by classname (Jenkins, GitLab, Buildkite test analytics) now show the same grouping the terminal shows.
- Separator (`" > "`) and the empty classname for a test outside any describe are unchanged; only the order changes, and only for tests under two or more named describes.
- `--parallel` workers emit their `<testcase>` elements through the same function, so both modes are fixed.
- Verified: `test/js/junit-reporter/junit.test.js`
  - new case `lists describe scopes in classname outermost-first ...`, run serially and with `--parallel=2`, walks the parsed report and checks each testcase's classname against the `<testsuite>` path it sits in and against the `(pass) ...` console line. With the release binary both variants fail with `"inner > middle > outer"`; with this change all 10 tests in the file pass.
  - `escapes the classname attribute exactly once` and the two `more scenarios` snapshots pinned the reversed order and are updated (snapshot diff is the 8 two-level classnames, flipped).

### Background

- JUnit XML: `<testsuites>` > `<testsuite>` > `<testcase name classname>`. Bun writes one `<testsuite>` per file, a nested `<testsuite>` per named describe, and a `<testcase>` per test. `classname` is free-form; CI systems use it to group test cases, which is why it is expected to read as a path from the outer grouping to the inner one.
- Under `--parallel`, each worker process runs the normal reporter with `elements_only` set, ships its `<testsuite>` fragments to the coordinator over IPC, and the coordinator concatenates them inside a single `<testsuites>` element.
