### PR TITLE
build rust std without the backtrace symbolizer

### DIFF
--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -426,6 +426,14 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
     //          `-Zsanitizer=address` so OOB/UAF inside Vec/String/HashMap are
     //          visible instead of stopping at the std boundary.
     args.push(cargoBuildStdArg);
+    if (cfg.release && !cfg.asan) {
+      // Cargo's default build-std feature set is `panic-unwind,backtrace,default`.
+      // `backtrace` links std's symbolizer (gimli, addr2line, miniz_oxide,
+      // rustc-demangle, ~200 KB on linux-x64) for `std::backtrace` and the
+      // default panic hook; bun installs its own panic hook and symbolizes
+      // crash traces out of process, so nothing reads it.
+      args.push("-Zbuild-std-features=panic-unwind,default");
+    }
   }
 
   // ─── rustflags ───


### PR DESCRIPTION
Release builds already compile std from source (`-Zbuild-std`). Cargo's default build-std feature set is `panic-unwind,backtrace,default`; std's `backtrace` feature is what pulls in the symbolizer (`addr2line`, `object`, `miniz_oxide`, and through them `gimli` and `rustc-demangle`). On the current linux-x64 canary those symbols add up to about 275 KB of text and rodata.

Nothing reads it: bun installs its own panic hook at startup and its crash reports carry an address trace string that is symbolized out of process, and no crate in the workspace (or any dependency that ends up in the binary; `anyhow` is only reached through wit-bindgen's proc-macro side) calls `std::backtrace`. Without the feature std's `get_backtrace_style()` is a constant `None`, so the default hook's backtrace printing and `Backtrace::capture()` (now `Unsupported`) are dead and get dropped at link time. `RUST_BACKTRACE` stops doing anything, which it effectively already did under bun's hook.

This passes `-Zbuild-std-features=panic-unwind,default` on release (non-asan) builds. Checked: `cargo check` with these build-std flags on x86_64-linux-gnu, x86_64-linux-musl, aarch64-android, x86_64-windows-msvc and aarch64-freebsd; a local macOS release build still produces the normal crash report on a Rust panic (`fixture-crash.js panic`) and its `bun-profile` contains no gimli/addr2line/miniz_oxide symbols.

Size delta: see the CI binary size annotation.