### PR TITLE
node:fs: report mkdir/readdir/rm boolean option type errors like node

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -541,6 +541,7 @@ impl JSGlobalObject {
     }
 
     /// "The {argname} argument must be of type {typename}. Received {value}"
+    /// (a dotted `argname` is a "property", see `InvalidArgTypeName`).
     ///
     /// Accepts `&str`, `&[u8]`, or `b"..."` for `argname`/`typename`.
     pub fn throw_invalid_argument_type_value(
@@ -556,8 +557,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be of type {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be of type {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -565,6 +566,8 @@ impl JSGlobalObject {
         .throw()
     }
 
+    /// Like [`Self::throw_invalid_argument_type_value`], but `typename` is the whole
+    /// phrase after "must be" (e.g. `"an instance of Array"`).
     pub fn throw_invalid_argument_type_value2(
         &self,
         argname: impl AsRef<[u8]>,
@@ -578,8 +581,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -627,8 +630,8 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be one of type {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
+                "The {} must be one of type {}. Received {}",
+                InvalidArgTypeName(argname.as_ref()),
                 bstr::BStr::new(typename.as_ref()),
                 actual_string_value
             ),
@@ -1378,6 +1381,26 @@ pub struct SysErrOptions {
     pub code: NodeErrorCode,
     pub errno: Option<i32>,
     pub name: Option<&'static [u8]>,
+}
+
+/// The subject of Node's `ERR_INVALID_ARG_TYPE` message: `"name" argument`,
+/// `"options.name" property` for a dotted name, or the name verbatim when it
+/// already ends in ` argument` ("first argument"). Same rule as
+/// `Bun::Message::addParameter` in ErrorCode.cpp.
+/// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1407-L1414
+struct InvalidArgTypeName<'a>(&'a [u8]);
+
+impl core::fmt::Display for InvalidArgTypeName<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let name = bstr::BStr::new(self.0);
+        if self.0.ends_with(b" argument") {
+            write!(f, "{name}")
+        } else if strings::contains_char(self.0, b'.') {
+            write!(f, "\"{name}\" property")
+        } else {
+            write!(f, "\"{name}\" argument")
+        }
+    }
 }
 
 // Unified with the crate-root definitions (lib.rs) — re-exported here so

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3220,6 +3220,17 @@ pub mod args {
         Ok(encoding)
     }
 
+    /// Node's `validateBoolean(value, name)`, where `name` is the dotted path
+    /// node reports (`"options.recursive"`). `validators::validate_boolean` is
+    /// not used here because it still renders Bun's older `..., got <typeof>`
+    /// wording and node:fs errors have to match node's text.
+    fn validate_boolean_option(ctx: &JSGlobalObject, value: JSValue, name: &str) -> JsResult<bool> {
+        if value.is_boolean() {
+            return Ok(value.as_boolean());
+        }
+        Err(ctx.throw_invalid_argument_type_value(name, "boolean", value))
+    }
+
     pub struct Unlink {
         pub path: PathLike,
     }
@@ -3304,23 +3315,13 @@ pub mod args {
                             val.get(ctx, name)
                         }
                     };
-                    if let Some(boolean) = get_option("recursive")? {
-                        if boolean.is_boolean() {
-                            recursive = boolean.to_boolean();
-                        } else {
-                            return Err(ctx.throw_invalid_arguments(format_args!(
-                                "The \"options.recursive\" property must be of type boolean."
-                            )));
-                        }
+                    // Validated in the order node's `validateRmOptions` uses, so an
+                    // options bag with several bad values reports the same one.
+                    if let Some(force_) = get_option("force")? {
+                        force = validate_boolean_option(ctx, force_, "options.force")?;
                     }
-                    if let Some(boolean) = get_option("force")? {
-                        if boolean.is_boolean() {
-                            force = boolean.to_boolean();
-                        } else {
-                            return Err(ctx.throw_invalid_arguments(format_args!(
-                                "The \"options.force\" property must be of type boolean."
-                            )));
-                        }
+                    if let Some(recursive_) = get_option("recursive")? {
+                        recursive = validate_boolean_option(ctx, recursive_, "options.recursive")?;
                     }
                     if let Some(delay) = get_option("retryDelay")? {
                         retry_delay = c_uint::try_from(validators::validate_integer(
@@ -3343,9 +3344,7 @@ pub mod args {
                         .expect("infallible: validated range");
                     }
                 } else if !val.is_undefined() {
-                    return Err(ctx.throw_invalid_arguments(format_args!(
-                        "The \"options\" argument must be of type object."
-                    )));
+                    return Err(ctx.throw_invalid_argument_type_value(b"options", b"object", val));
                 }
             }
             Ok(RmDir {
@@ -3392,8 +3391,8 @@ pub mod args {
             if let Some(val) = arguments.next() {
                 arguments.eat();
                 if val.is_object() {
-                    if let Some(b) = val.get_boolean_strict(ctx, "recursive")? {
-                        recursive = b;
+                    if let Some(recursive_) = val.get(ctx, "recursive")? {
+                        recursive = validate_boolean_option(ctx, recursive_, "options.recursive")?;
                     }
                     if let Some(mode_) = val.get(ctx, "mode")? {
                         mode = node::mode_from_js(ctx, mode_)?.unwrap_or(mode);
@@ -3485,11 +3484,16 @@ pub mod args {
                     _ => {
                         if val.is_object() {
                             encoding = get_encoding(val, ctx, encoding)?;
-                            if let Some(r) = val.get_boolean_strict(ctx, "recursive")? {
-                                recursive = r;
+                            if let Some(recursive_) = val.get(ctx, "recursive")? {
+                                recursive =
+                                    validate_boolean_option(ctx, recursive_, "options.recursive")?;
                             }
-                            if let Some(w) = val.get_boolean_strict(ctx, "withFileTypes")? {
-                                with_file_types = w;
+                            if let Some(with_file_types_) = val.get(ctx, "withFileTypes")? {
+                                with_file_types = validate_boolean_option(
+                                    ctx,
+                                    with_file_types_,
+                                    "options.withFileTypes",
+                                )?;
                             }
                         }
                     }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1034,7 +1034,179 @@ describe("mkdirSync", () => {
         // @ts-expect-error
         { recursive: "lalala" },
       ),
-    ).toThrow('The "recursive" property must be of type boolean, got string');
+    ).toThrow(`The "options.recursive" property must be of type boolean. Received type string ('lalala')`);
+  });
+});
+
+// Node validates these option-bag booleans with `validateBoolean(value, 'options.<name>')`,
+// so the message names the option as a property and ends with node's description of
+// the value that was received. Every message below is node v26.3.0's text.
+describe("fs boolean options report ERR_INVALID_ARG_TYPE like node", () => {
+  type Thrown = { name: string; code: string; message: string };
+  const pick = (e: any): Thrown => ({ name: e.name, code: e.code, message: e.message });
+  const invalidArgType = (message: string): Thrown => ({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE", message });
+  const recursiveMessage = (received: string) =>
+    `The "options.recursive" property must be of type boolean. Received ${received}`;
+
+  function thrownBy(fn: () => unknown): Thrown {
+    try {
+      fn();
+    } catch (e) {
+      return pick(e);
+    }
+    throw new Error("expected the call to throw");
+  }
+  async function rejectedBy(promise: Promise<unknown>): Promise<Thrown> {
+    return promise.then(
+      () => {
+        throw new Error("expected the promise to reject");
+      },
+      e => pick(e),
+    );
+  }
+  // The callback APIs hand the error to the callback or, like node for these
+  // options, throw it synchronously; either way it is the native parser's error.
+  function failedCallback(call: (callback: (err: any) => void) => void): Promise<Thrown> {
+    const { promise, resolve, reject } = Promise.withResolvers<Thrown>();
+    try {
+      call(err => (err ? resolve(pick(err)) : reject(new Error("expected the callback to receive an error"))));
+    } catch (e) {
+      resolve(pick(e));
+    }
+    return promise;
+  }
+
+  describe("mkdir options.recursive", () => {
+    const cases: [value: unknown, received: string][] = [
+      ["x", "type string ('x')"],
+      [1, "type number (1)"],
+      [null, "null"],
+      [[], "an instance of Array"],
+    ];
+
+    it.each(cases)("mkdirSync(path, { recursive: %p })", (recursive, received) => {
+      using dir = tempDir("fs-mkdir-recursive-option", {});
+      const target = join(String(dir), "a", "b");
+      expect(thrownBy(() => mkdirSync(target, { recursive } as any))).toEqual(
+        invalidArgType(recursiveMessage(received)),
+      );
+      expect(existsSync(target)).toBe(false);
+    });
+
+    it("mkdir (callback) and promises.mkdir use the same message", async () => {
+      using dir = tempDir("fs-mkdir-recursive-option-async", {});
+      const target = join(String(dir), "a", "b");
+      expect(await failedCallback(cb => fs.mkdir(target, { recursive: "x" } as any, cb))).toEqual(
+        invalidArgType(recursiveMessage("type string ('x')")),
+      );
+      expect(await rejectedBy(promises.mkdir(target, { recursive: 1 } as any))).toEqual(
+        invalidArgType(recursiveMessage("type number (1)")),
+      );
+      expect(existsSync(target)).toBe(false);
+    });
+  });
+
+  describe("readdir options.recursive / options.withFileTypes", () => {
+    const withFileTypesMessage = (received: string) =>
+      `The "options.withFileTypes" property must be of type boolean. Received ${received}`;
+
+    it("readdirSync", () => {
+      using dir = tempDir("fs-readdir-boolean-options", { "file.txt": "" });
+      const d = String(dir);
+      expect(thrownBy(() => readdirSync(d, { recursive: "x" } as any))).toEqual(
+        invalidArgType(recursiveMessage("type string ('x')")),
+      );
+      expect(thrownBy(() => readdirSync(d, { recursive: {} } as any))).toEqual(
+        invalidArgType(recursiveMessage("an instance of Object")),
+      );
+      // node does not validate withFileTypes (it coerces it); Bun keeps rejecting
+      // a non-boolean here, using the same wording it would have in node.
+      expect(thrownBy(() => readdirSync(d, { withFileTypes: "x" } as any))).toEqual(
+        invalidArgType(withFileTypesMessage("type string ('x')")),
+      );
+      // recursive is validated first, as in node.
+      expect(thrownBy(() => readdirSync(d, { recursive: "x", withFileTypes: "y" } as any))).toEqual(
+        invalidArgType(recursiveMessage("type string ('x')")),
+      );
+      // Valid values still work through the same parser.
+      expect(readdirSync(d, { recursive: false, withFileTypes: false })).toEqual(["file.txt"]);
+    });
+
+    it("readdir (callback) and promises.readdir use the same message", async () => {
+      using dir = tempDir("fs-readdir-boolean-options-async", { "file.txt": "" });
+      const d = String(dir);
+      expect(await failedCallback(cb => fs.readdir(d, { recursive: "x" } as any, cb))).toEqual(
+        invalidArgType(recursiveMessage("type string ('x')")),
+      );
+      expect(await failedCallback(cb => fs.readdir(d, { withFileTypes: 1 } as any, cb))).toEqual(
+        invalidArgType(withFileTypesMessage("type number (1)")),
+      );
+      expect(await rejectedBy(promises.readdir(d, { recursive: "x" } as any))).toEqual(
+        invalidArgType(recursiveMessage("type string ('x')")),
+      );
+      expect(await rejectedBy(promises.readdir(d, { withFileTypes: null } as any))).toEqual(
+        invalidArgType(withFileTypesMessage("null")),
+      );
+    });
+  });
+
+  describe("rm options", () => {
+    const forceMessage = (received: string) =>
+      `The "options.force" property must be of type boolean. Received ${received}`;
+    const optionsMessage = (received: string) => `The "options" argument must be of type object. Received ${received}`;
+
+    it("rmSync", () => {
+      using dir = tempDir("fs-rm-boolean-options", { "file.txt": "" });
+      const file = join(String(dir), "file.txt");
+      expect(thrownBy(() => rmSync(file, { recursive: "x" } as any))).toEqual(
+        invalidArgType(recursiveMessage("type string ('x')")),
+      );
+      // node spreads the caller's options over its defaults, so an own key holding
+      // undefined is validated (and rejected) too.
+      expect(thrownBy(() => rmSync(file, { recursive: undefined }))).toEqual(
+        invalidArgType(recursiveMessage("undefined")),
+      );
+      expect(thrownBy(() => rmSync(file, { force: "x" } as any))).toEqual(
+        invalidArgType(forceMessage("type string ('x')")),
+      );
+      expect(thrownBy(() => rmSync(file, { force: null } as any))).toEqual(invalidArgType(forceMessage("null")));
+      // node's validateRmOptions checks force before recursive.
+      expect(thrownBy(() => rmSync(file, { recursive: "x", force: "y" } as any))).toEqual(
+        invalidArgType(forceMessage("type string ('y')")),
+      );
+      expect(thrownBy(() => rmSync(file, "x" as any))).toEqual(invalidArgType(optionsMessage("type string ('x')")));
+      expect(thrownBy(() => rmSync(file, null as any))).toEqual(invalidArgType(optionsMessage("null")));
+      // Validation fails before anything is removed.
+      expect(existsSync(file)).toBe(true);
+    });
+
+    it("rm (callback) and promises.rm use the same messages", async () => {
+      using dir = tempDir("fs-rm-boolean-options-async", { "file.txt": "" });
+      const file = join(String(dir), "file.txt");
+      expect(await failedCallback(cb => fs.rm(file, { recursive: "x" } as any, cb))).toEqual(
+        invalidArgType(recursiveMessage("type string ('x')")),
+      );
+      expect(await failedCallback(cb => fs.rm(file, { force: 1 } as any, cb))).toEqual(
+        invalidArgType(forceMessage("type number (1)")),
+      );
+      expect(await rejectedBy(promises.rm(file, { recursive: "x", force: "y" } as any))).toEqual(
+        invalidArgType(forceMessage("type string ('y')")),
+      );
+      expect(await rejectedBy(promises.rm(file, { recursive: [] } as any))).toEqual(
+        invalidArgType(recursiveMessage("an instance of Array")),
+      );
+      expect(await rejectedBy(promises.rm(file, "x" as any))).toEqual(
+        invalidArgType(optionsMessage("type string ('x')")),
+      );
+      expect(existsSync(file)).toBe(true);
+    });
+
+    it("rmdirSync shares the options argument check", () => {
+      using dir = tempDir("fs-rmdir-options-argument", { "sub": {} });
+      const sub = join(String(dir), "sub");
+      expect(thrownBy(() => rmdirSync(sub, "x" as any))).toEqual(invalidArgType(optionsMessage("type string ('x')")));
+      expect(existsSync(sub)).toBe(true);
+    });
   });
 });
 

--- a/test/js/node/test/parallel/test-fs-mkdir.js
+++ b/test/js/node/test/parallel/test-fs-mkdir.js
@@ -248,8 +248,8 @@ if (common.isMainThread && (common.isLinux || common.isMacOS)) {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: typeof Bun === 'undefined' ? 'The "options.recursive" property must be of type boolean.' +
-          received : 'The "recursive" property must be of type boolean, got ' +typeof recursive,
+        message: 'The "options.recursive" property must be of type boolean.' +
+          received
       }
     );
     assert.throws(
@@ -257,8 +257,8 @@ if (common.isMainThread && (common.isLinux || common.isMacOS)) {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: typeof Bun === 'undefined' ? 'The "options.recursive" property must be of type boolean.' +
-          received : 'The "recursive" property must be of type boolean, got ' +typeof recursive,
+        message: 'The "options.recursive" property must be of type boolean.' +
+          received
       }
     );
   });


### PR DESCRIPTION
### Problem

- `fs.mkdirSync(p, { recursive: "x" })` throws `ERR_INVALID_ARG_TYPE` with `The "recursive" property must be of type boolean, got string`. Node v26.3.0 throws the same code with `The "options.recursive" property must be of type boolean. Received type string ('x')`. `fs.mkdir` and `fs.promises.mkdir` share the parser, as do `fs.readdir`/`readdirSync`/`promises.readdir` for `recursive` and `withFileTypes`.
- `fs.rmSync(p, { recursive: "x" })` and `{ force: "x" }` (also `fs.rm`, `fs.promises.rm`) say `The "options.recursive" property must be of type boolean.` with no `Received ...` half; `fs.rmSync(p, "x")` and `fs.rmdirSync(d, "x")` say `The "options" argument must be of type object.` without it either. `rmSync(p, { recursive: "x", force: "y" })` reports `recursive`; node reports `force`.
- Causes, all in `src/runtime/node/node_fs.rs`: `Mkdir::from_js` (:3395) and `Readdir::from_js` (:3488, :3491) read the option through `JSValue::get_boolean_strict`, whose error is Bun's `..., got <typeof>` template with the bare key; `RmDir::from_js_impl` (:3307-3323, :3346) formats its messages by hand. Node validates every one of these with `validateBoolean(value, 'options.<name>')` (and `validateObject(options, 'options')`).
- The shared Rust renderer these sites need, `JSGlobalObject::throw_invalid_argument_type_value` (`src/jsc/JSGlobalObject.rs:559`), hardcodes `"<name>" argument`, so it could not produce `"options.recursive" property` either.
- The codes were already right, which is why the vendored tests did not catch it: `test-fs-mkdir.js` carried a `typeof Bun` branch with the old wording and `test-fs-rm.js` matches the message with a prefix regex.

### Fix

- `node_fs.rs`: a small `validate_boolean_option` (node's `validateBoolean`) throws through `throw_invalid_argument_type_value` with the dotted name; `mkdir`'s and `readdir`'s `recursive`, `readdir`'s `withFileTypes`, and `rm`/`rmdir`'s `force` and `recursive` use it. `rm`'s non-object `options` error goes through the same renderer. `force` is checked before `recursive`, the order of node's `validateRmOptions`.
- `JSGlobalObject.rs`: the three `throw_invalid_argument_type_value*` renderers format the name through `InvalidArgTypeName`, node's subject rule (`"x" argument`, `"a.b" property`, a name ending in ` argument` verbatim), which is the rule `Bun::Message::addParameter` in `ErrorCode.cpp` already applies to every C++ caller. This hunk is byte-identical to the one carried by the open #38663, #39266 and #39274, so these PRs merge in any order; whichever lands first carries it and the others reduce to their call sites.
- Why this is right: for `node:fs` errors node's text is the contract, and the `Received ...` half already comes from the same `determineSpecificType` the JS builtins use, so the result is node's exact text. A 160-case matrix (mkdir, readdir, rm, rmdir; sync, callback and promise entry points; 8 non-boolean values each) against a local node v26.3.0 changes 122 lines with this PR, and every line where both runtimes throw now carries identical text; the lines still differing are pre-existing behavioral differences (which values `readdir` and `rmdir` accept, callback-form `rm` delivering the error through the callback where node throws synchronously, the `stat` family validating options node ignores), listed below and not touched here.
- Which values are accepted does not change: the sites keep the same `get`/`get_own` lookups and the same `is_boolean` test, so `rm`'s own-key `recursive: undefined` is still rejected (node's spread-over-defaults semantics) and `mkdir`'s missing or `undefined` `recursive` is still the default. Only the text and the `force`/`recursive` order change.
- Renderer blast radius: only names containing a `.` render differently. The ones passed today are `options.retryDelay`/`options.maxRetries` (`fs.rm`), `options.address`/`options.flowlabel` (`net.SocketAddress`), `options.silent`/`endStream`/`exclusive`/`parent`/`weight`/`signal` (http2 request options), `handle.fd` (cluster), and Bun's own `compress.encoding` (fetch) and `rule.syscall`/`rule.action` (socket fault injection). Node renders all of its own as `property`; no test in the repo pinned `argument` for any of them. Plain names render exactly as before.
- Deliberately left alone: `get_boolean_strict` itself and its `stat`/`fstat`/`statfs`/`watchFile` callers (`bigint`, `throwIfNoEntry`, `persistent`), which node does not validate at all, so there is no node text to match; `validators::validate_boolean` (that is #38663's change); the behavioral deltas the matrix surfaced, which are tracked separately: `readdir` rejects `recursive: null`, non-boolean `withFileTypes`, and non-boolean `recursive` in `promises.readdir` where node coerces; `rmdir` still validates `force`/`retryDelay`/`maxRetries`, which node v26 ignores; and the JS `rm` wrappers report `ERR_FS_EISDIR` before the options are validated when the target is a directory. The draft #35423 carries a broader variant of the `mkdir`/`readdir` `recursive` part (it renames `throw_invalid_property_type` for all callers); it does not cover `withFileTypes`, `rm`, or the `options` argument, and the two overlapping hunks rebase trivially in either order.
- Verified:
  - `test/js/node/fs/fs.test.ts`: new `fs boolean options report ERR_INVALID_ARG_TYPE like node` block (mkdir, readdir and rm through sync, callback and promise entry points, the `Received` shapes, the `force`-before-`recursive` order, the `options` argument for rm and rmdir, and that the file is still there afterwards) plus the updated `mkdirSync > throws for invalid options`: 11 tests, all fail on the released build, all pass with this change. The whole file: 521 pass; the one remaining failure is noted below.
  - `test/js/node/test/parallel/test-fs-mkdir.js` now asserts upstream's text; it fails on the released build and passes here. `test-fs-rm.js`, `test-fs-promises.js`, `test-fs-readdir.js`, `test-fs-readdir-recursive.js`, `test-fs-readdir-types.js`, `test-fs-rmdir-type-check.js` pass.
  - Other callers of the changed renderers: `test/js/web/fetch/wasm-streaming.test.ts`, `test/js/node/child_process/child_process-node.test.js`, `test/js/node/net/socketaddress.spec.ts`, `test/js/web/fetch/fetch-compress.test.ts`, `test-crypto-random.js`, `test-socketaddress.js`, `test-http2-client-request-options-errors.js` pass (one unrelated timeout below).
  - `cargo clippy -p bun_runtime -p bun_jsc` is clean.

### Background

- Node's `ERR_INVALID_ARG_TYPE(name, expected, actual)` (`lib/internal/errors.js`) renders `The <subject> must be of type <expected>. Received <description of actual>`. The subject is `"name" argument`, unless the name contains a `.`, in which case it is an option path such as `options.recursive` and renders as `"name" property`; a name that already ends in ` argument` is used verbatim. The description of the actual value (`type string ('x')`, `null`, `an instance of Array`) is `determineSpecificType`.
- Bun renders this error in two places: C++ (`ErrorCode.cpp`, behind `$ERR_INVALID_ARG_TYPE` in the JS builtins and the C++ bindings) and the Rust helpers on `JSGlobalObject` used by natively implemented modules such as `node:fs`. The Rust helpers already call the C++ `determineSpecificType` for the `Received` half; only the subject rule was missing.
- `fs.rm` validates its options the way node's `validateRmOptions` does: the caller's own keys are spread over the defaults, then `force`, `recursive`, `retryDelay`, `maxRetries` are validated in that order. That is why an own `recursive: undefined` is an error for `rm` but not for `mkdir`, and why `force` is reported first when both booleans are bad.

<details>
<summary>Unrelated failures seen while running the suites in this (debug, ASAN) container</summary>

- `fs.test.ts > fs/promises > readdirSync(path, {recursive: true} should work x 100` exceeds its 10 s budget here (12 s). Timing the body: the four recursive `readdirSync` calls take 0.4 s; sorting the four 6660-entry arrays takes 7.5 s under the debug build. No code on that path is touched by this PR.
- `socketaddress.spec.ts > does not leak memory` exceeds its 5 s budget here (6.8 s); it constructs 101k valid addresses and never reaches an error renderer.

</details>

<details>
<summary>Before / after (right column is also node v26.3.0's output)</summary>

| call | before | after |
| --- | --- | --- |
| `mkdirSync(p, { recursive: "x" })` | `The "recursive" property must be of type boolean, got string` | `The "options.recursive" property must be of type boolean. Received type string ('x')` |
| `promises.mkdir(p, { recursive: null })` | `The "recursive" property must be of type boolean, got object` | `The "options.recursive" property must be of type boolean. Received null` |
| `readdirSync(d, { recursive: [] })` | `The "recursive" property must be of type boolean, got array` | `The "options.recursive" property must be of type boolean. Received an instance of Array` |
| `readdirSync(d, { withFileTypes: 1 })` | `The "withFileTypes" property must be of type boolean, got number` | `The "options.withFileTypes" property must be of type boolean. Received type number (1)` (node coerces this one; Bun keeps rejecting it) |
| `rmSync(f, { force: "x" })` | `The "options.force" property must be of type boolean.` | `The "options.force" property must be of type boolean. Received type string ('x')` |
| `rmSync(f, { recursive: undefined })` | `The "options.recursive" property must be of type boolean.` | `The "options.recursive" property must be of type boolean. Received undefined` |
| `rmSync(f, { recursive: "x", force: "y" })` | `The "options.recursive" property must be of type boolean.` | `The "options.force" property must be of type boolean. Received type string ('y')` |
| `rmSync(f, "x")` | `The "options" argument must be of type object.` | `The "options" argument must be of type object. Received type string ('x')` |
| `rmSync(f, { maxRetries: "x" })` (renderer only) | `The "options.maxRetries" argument must be of type number. Received type string ('x')` | `The "options.maxRetries" property must be of type number. Received type string ('x')` |

</details>
