### PR TITLE
bun test --parallel: keep line= attributes in the merged JUnit report

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -122,6 +122,11 @@ platform_specific_new!(pub LIBRARY_PATH: string, posix = "LIBRARY_PATH", windows
 // `process.on('exit')` checks (e.g. common.mustCall) see completed async work.
 // Opt-in for the vendored node:test suite and run() children.
 new!(pub BUN_TEST_DRAIN_EVENT_LOOP: boolean, "BUN_TEST_DRAIN_EVENT_LOOP", { default: false });
+// Set by the `bun test --parallel` coordinator in its workers' environment when
+// it was given `--reporter=junit`. The workers build the JUnit elements that the
+// coordinator merges; the flag itself is not forwarded because it requires
+// `--reporter-outfile`, which only the coordinator writes.
+new!(pub BUN_TEST_WORKER_JUNIT: boolean, "BUN_TEST_WORKER_JUNIT", { default: false });
 new!(pub BUN_TMPDIR: string, "BUN_TMPDIR", {});
 new!(pub BUN_WATCHER_TRACE: string, "BUN_WATCHER_TRACE", {});
 new!(pub CI: boolean, "CI", {});

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -67,7 +67,10 @@ pub(crate) fn run_as_coordinator(
         // Coordinator's own JunitReporter would otherwise produce an empty
         // document and overwrite the merged one in writeJUnitReportIfNeeded.
         if let Some(jr) = reporter.reporters.junit.take() {
-            let _ = env.map.put(b"BUN_TEST_WORKER_JUNIT", b"1");
+            let _ = env.map.put(
+                bun_core::env_var::BUN_TEST_WORKER_JUNIT.key().as_bytes(),
+                b"1",
+            );
             drop(jr);
         }
     }
@@ -646,13 +649,10 @@ pub(crate) fn run_as_worker(
     vm_ref.arena = Some(NonNull::from(&mut arena));
     // vm.allocator = arena.arena(); — allocator params dropped in Rust
 
-    let env = vm_ref.env_loader();
+    // Created by TestCommand::exec, from bunfig or BUN_TEST_WORKER_JUNIT; the
+    // coordinator wraps the merged elements in the document.
     if let Some(junit) = reporter.reporters.junit.as_mut() {
         junit.elements_only = true;
-    } else if env.get(b"BUN_TEST_WORKER_JUNIT").is_some() {
-        let mut junit = test_command::JunitReporter::init();
-        junit.elements_only = true;
-        reporter.reporters.junit = Some(junit);
     }
 
     let mut wloop = WorkerLoop {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2182,6 +2182,15 @@ impl TestCommand {
             .map(|b| unsafe { bun_ptr::detach_lifetime::<u8>(b) })
             .collect();
 
+        // A --parallel worker learns about --reporter=junit from the coordinator
+        // through the environment. It has to land in `test_options` before
+        // `TestRunner` takes its reference below: `capture_test_line_number`
+        // reads the flag from there to decide whether test()/describe() record
+        // the line= attribute.
+        if ctx.test_options.test_worker && env_var::BUN_TEST_WORKER_JUNIT.get().unwrap_or(false) {
+            ctx.test_options.reporters.junit = true;
+        }
+
         // Keep an owned `Box` local — `exec()` never returns before process
         // exit, so the heap allocation outlives all raw-pointer observers
         // (e.g. `Jest::RUNNER` below).

--- a/test/cli/test/parallel.test.ts
+++ b/test/cli/test/parallel.test.ts
@@ -508,6 +508,57 @@ test("--parallel --reporter=junit produces a merged report covering all files", 
   expect(exitCode).toBe(1);
 });
 
+test("--parallel --reporter=junit reports the same line numbers as a serial run", async () => {
+  // b.test.js is a.test.js shifted down one line, so every line= below is
+  // specific to the file that produced it.
+  const body = [
+    `import { describe, test } from "bun:test";`,
+    `describe("outer", () => {`,
+    `  test("nested", () => {});`,
+    `});`,
+    `test("top", () => {});`,
+    ``,
+  ].join("\n");
+  using dir = tempDir("parallel-junit-lines", {
+    "a.test.js": body,
+    "b.test.js": "\n" + body,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--parallel=2", "--reporter=junit", "--reporter-outfile=out.xml"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toContain("PARALLEL");
+  expect(stderr).toContain("4 pass");
+
+  const xml = await Bun.file(String(dir) + "/out.xml").text();
+  const elements = [...xml.matchAll(/<(testsuite|testcase)\b([^>]*)>/g)].map(([, tag, attrs]) => ({
+    tag,
+    name: /\bname="([^"]*)"/.exec(attrs)?.[1],
+    file: /\bfile="([^"]*)"/.exec(attrs)?.[1],
+    line: /\bline="([^"]*)"/.exec(attrs)?.[1],
+  }));
+  // Files finish in either order, so compare per file; within a file the
+  // elements are in document order.
+  expect(elements.filter(e => e.file === "a.test.js")).toEqual([
+    { tag: "testsuite", name: "a.test.js", file: "a.test.js", line: undefined },
+    { tag: "testsuite", name: "outer", file: "a.test.js", line: "2" },
+    { tag: "testcase", name: "nested", file: "a.test.js", line: "3" },
+    { tag: "testcase", name: "top", file: "a.test.js", line: "5" },
+  ]);
+  expect(elements.filter(e => e.file === "b.test.js")).toEqual([
+    { tag: "testsuite", name: "b.test.js", file: "b.test.js", line: undefined },
+    { tag: "testsuite", name: "outer", file: "b.test.js", line: "3" },
+    { tag: "testcase", name: "nested", file: "b.test.js", line: "4" },
+    { tag: "testcase", name: "top", file: "b.test.js", line: "6" },
+  ]);
+  expect(elements).toHaveLength(8);
+  expect(exitCode).toBe(0);
+});
+
 test("--parallel --reporter=junit keeps the suites of files a worker finished before it crashed", async () => {
   using dir = tempDir("parallel-junit-crash", {
     "aslow.test.js": `import {test,expect} from "bun:test"; test("slow", async () => { await Bun.sleep(400); expect(1).toBe(1); });`,


### PR DESCRIPTION
### Problem
- `bun test --parallel=N --reporter=junit` writes a report with no `line="..."` attribute on any describe-level `<testsuite>` or `<testcase>`. A serial `bun test --reporter=junit` run of the same files has them (`grep -c 'line="'`: 6 in the serial report, 0 in the parallel one for the two-file repro below).
- `capture_test_line_number` (`src/runtime/test_runner/jest.rs:834`) only reads the call site's line when `test_options.reporters.junit` is set. In a worker that flag was never set: the coordinator passes JUnit mode through the `BUN_TEST_WORKER_JUNIT` environment variable (`--reporter` is not forwarded, see `build_worker_argv`), and `run_as_worker` (`src/runtime/cli/test/parallel/runner.rs`) answered it by creating a `JunitReporter` directly, after `TestRunner` had already been built. So every `test()`/`describe()` in a worker recorded `line_no = 0`, and `write_test_case`/`begin_test_suite_with_line` omit the attribute for 0.
- JUnit configured through bunfig (`[test] reporter = { junit = "..." }`) was not affected: workers read bunfig themselves, so the flag was set the normal way. Only the `--reporter=junit` flag path lost the attribute.

### Fix
- `TestCommand::exec` now applies `BUN_TEST_WORKER_JUNIT` to `ctx.test_options.reporters.junit` when running as a `--test-worker`, before `TestRunner` takes its reference to `test_options` and before the `JunitReporter` is created. `run_as_worker` only switches the reporter it was handed to elements-only output; its own late creation path is gone.
- This is the right place because it makes the env var equivalent to the bunfig path the worker already supports: one flag drives both the reporter's creation and the line capture, so the two cannot disagree again. Setting the flag in `run_as_worker` instead would mutate `test_options` behind the `&'static` reference `TestRunner` already holds.
- The variable is declared in `bun_core::env_var` and the coordinator writes it through the declaration's key, so the two sides share one definition.
- Verified with the new case in `test/cli/test/parallel.test.ts` ("--parallel --reporter=junit reports the same line numbers as a serial run"): two files whose contents are offset by one line, asserting the exact `line=` of each describe suite and test case per file. Fails on the unfixed binary (every `line` is `undefined`), passes with this change.
- The rest of `test/cli/test/parallel.test.ts` and `test/js/junit-reporter/junit.test.js` pass with the debug build. The one exception is the pre-existing timing case "--parallel lazily scales workers based on file duration", which fails in my environment with and without this change (a debug+ASAN single-file run takes ~300ms there, above the test's 250ms scale-up threshold); #39059 reworks that test.
- The repro's serial and parallel reports are now byte-identical apart from `time=` attributes.

### Background
- `bun test --parallel` runs a coordinator process that spawns `bun test --test-worker` processes. Workers run the test files and stream results back over a pipe; for JUnit they send the XML elements for each file, and the coordinator wraps the merged elements into the final document and writes `--reporter-outfile`. Workers never write the file, which is why `--reporter=junit` (which insists on an outfile) is not forwarded and an environment variable is used instead.
- `TestOptions` lives in the CLI context; `TestRunner` (what `Jest::runner()` returns) holds a reference to it for the life of the process, which is why option fixups in `exec` happen before the runner is constructed (the `--randomize` seed is persisted there the same way).
- `line=` on `<testcase>` and on describe `<testsuite>` comes from the JS call frame of the `test()`/`describe()` call. Capturing it costs a stack walk per registration, so it is gated on a JUnit reporter being requested.

<details>
<summary>Repro</summary>

```sh
mkdir t && cd t && echo '{}' > package.json
printf 'import { describe, test } from "bun:test";\ndescribe("outer", () => {\n  test("nested", () => {});\n});\ntest("top", () => {});\n' > a.test.js
cp a.test.js b.test.js
bun test --reporter=junit --reporter-outfile=serial.xml a.test.js b.test.js
bun test --parallel=2 --reporter=junit --reporter-outfile=par.xml a.test.js b.test.js
grep -c 'line="' serial.xml par.xml
```

Before (1.4.0-canary.1 and main): `serial.xml:6`, `par.xml:0`. After: both 6, and `diff` of the two reports with `time=` stripped is empty.
</details>
