### PR TITLE
node:fs: accept the readdir recursive/withFileTypes values node accepts

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -304,7 +304,18 @@ const exports = {
   },
   read: asyncWrap(fs.read, "read"),
   write: asyncWrap(fs.write, "write"),
-  readdir: asyncWrap(fs.readdir, "readdir"),
+  readdir: async function readdir(path, options) {
+    // Unlike fs.readdir, node's promise form only tests `options.recursive` for
+    // truthiness, while the shared native parser implements fs.readdir's check.
+    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1601
+    if (typeof options === "object" && options !== null) {
+      const { recursive } = options;
+      if (recursive != null && typeof recursive !== "boolean") {
+        options = { ...options, recursive: !!recursive };
+      }
+    }
+    return fs.readdir(path, options);
+  },
   readFile: async function (fileHandleOrFdOrPath, ...args) {
     fileHandleOrFdOrPath = fileHandleOrFdOrPath?.[kFd] ?? fileHandleOrFdOrPath;
     return _readFile(fileHandleOrFdOrPath, ...args);

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -305,14 +305,10 @@ const exports = {
   read: asyncWrap(fs.read, "read"),
   write: asyncWrap(fs.write, "write"),
   readdir: async function readdir(path, options) {
-    // Unlike fs.readdir, node's promise form only tests `options.recursive` for
-    // truthiness, while the shared native parser implements fs.readdir's check.
-    // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1601
+    // The promise form skips fs.readdir's recursive check, which the native parser applies: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1601
     if (typeof options === "object" && options !== null) {
       const { recursive } = options;
       if (recursive != null && typeof recursive !== "boolean") {
-        // The native parser reads the other options through the prototype chain,
-        // so it sees exactly what it would have seen on the caller's object.
         options = { __proto__: options, recursive: !!recursive };
       }
     }

--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -311,7 +311,9 @@ const exports = {
     if (typeof options === "object" && options !== null) {
       const { recursive } = options;
       if (recursive != null && typeof recursive !== "boolean") {
-        options = { ...options, recursive: !!recursive };
+        // The native parser reads the other options through the prototype chain,
+        // so it sees exactly what it would have seen on the caller's object.
+        options = { __proto__: options, recursive: !!recursive };
       }
     }
     return fs.readdir(path, options);

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3485,10 +3485,18 @@ pub mod args {
                     _ => {
                         if val.is_object() {
                             encoding = get_encoding(val, ctx, encoding)?;
-                            if let Some(r) = val.get_boolean_strict(ctx, "recursive")? {
-                                recursive = r;
+                            // readdir/readdirSync skip the boolean check for a nullish
+                            // `recursive` (fs.promises.readdir coerces it in fs.promises.ts):
+                            // https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1546-L1548
+                            if let Some(r) = val.get(ctx, "recursive")? {
+                                if !r.is_null() {
+                                    recursive = validators::validate_boolean(ctx, r, "recursive")?;
+                                }
                             }
-                            if let Some(w) = val.get_boolean_strict(ctx, "withFileTypes")? {
+                            // Node never validates `withFileTypes`; every entry point
+                            // passes `!!options.withFileTypes`:
+                            // https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1557
+                            if let Some(w) = val.get_boolean_loose(ctx, "withFileTypes")? {
                                 with_file_types = w;
                             }
                         }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3485,17 +3485,13 @@ pub mod args {
                     _ => {
                         if val.is_object() {
                             encoding = get_encoding(val, ctx, encoding)?;
-                            // readdir/readdirSync skip the boolean check for a nullish
-                            // `recursive` (fs.promises.readdir coerces it in fs.promises.ts):
-                            // https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1546-L1548
+                            // Only a non-nullish `recursive` is validated: https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1546-L1548
                             if let Some(r) = val.get(ctx, "recursive")? {
                                 if !r.is_null() {
                                     recursive = validators::validate_boolean(ctx, r, "recursive")?;
                                 }
                             }
-                            // Node never validates `withFileTypes`; every entry point
-                            // passes `!!options.withFileTypes`:
-                            // https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1557
+                            // `!!options.withFileTypes`, never validated: https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1557
                             if let Some(w) = val.get_boolean_loose(ctx, "withFileTypes")? {
                                 with_file_types = w;
                             }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1792,6 +1792,15 @@ describe("readdir accepts the recursive/withFileTypes values node accepts", () =
     expect(summarize(await promises.readdir(String(dir), options as any))).toEqual(deep);
     expect(options).toEqual({ recursive: 1, withFileTypes: 0 });
   });
+
+  it("promises.readdir still sees inherited options when it coerces recursive", async () => {
+    using dir = tempDir("readdir-option-values", tree);
+    const options = Object.create({ withFileTypes: true });
+    options.recursive = 1;
+    expect(summarize(await promises.readdir(String(dir), options))).toEqual(deepDirents);
+    options.recursive = true;
+    expect(summarize(await promises.readdir(String(dir), options))).toEqual(deepDirents);
+  });
 });
 
 // The error cleanup path previously called MarkedArrayBuffer.destroy() on

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { beforeAll, describe, expect, it, jest, spyOn } from "bun:test";
 import {
   bunEnv,
   bunExe,
@@ -1703,6 +1703,95 @@ it("readdir with { encoding: 'buffer' } returns Buffer entries", async () => {
   expect(
     summarize((await promisify(fs.readdir)(String(dir), { encoding: "buffer" } as const)) as unknown as Buffer[]),
   ).toEqual(expected);
+});
+
+// readdir/readdirSync validate `options.recursive` only when it is not nullish
+// and never validate `withFileTypes` (they pass `!!options.withFileTypes`);
+// fs.promises.readdir only tests `recursive` for truthiness.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1546-L1557
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1601-L1608
+describe("readdir accepts the recursive/withFileTypes values node accepts", () => {
+  const tree = { "a.txt": "", "sub/b.txt": "" };
+  const flat = { names: ["a.txt", "sub"], dirents: false };
+  const flatDirents = { names: ["a.txt", "sub"], dirents: true };
+  const deep = { names: ["a.txt", "b.txt", "sub"], dirents: false };
+  const deepDirents = { names: ["a.txt", "b.txt", "sub"], dirents: true };
+
+  // Entry names only (the basename of a recursive path entry), so the summary
+  // is the same for string and Dirent results on every platform.
+  function summarize(entries: (string | Dirent)[]) {
+    const dirents = entries.every(entry => entry instanceof Dirent);
+    const names = entries.map(entry => (typeof entry === "string" ? entry.split(/[\\/]/).pop()! : entry.name)).sort();
+    return { names, dirents };
+  }
+
+  const readdirCallback = promisify(fs.readdir) as (path: string, options: any) => Promise<(string | Dirent)[]>;
+
+  const acceptedEverywhere: [options: Record<string, unknown>, expected: typeof flat][] = [
+    [{ recursive: undefined }, flat],
+    [{ recursive: null }, flat],
+    [{ recursive: true }, deep],
+    [{ withFileTypes: undefined }, flat],
+    [{ withFileTypes: null }, flat],
+    [{ withFileTypes: 0 }, flat],
+    [{ withFileTypes: "" }, flat],
+    [{ withFileTypes: 1 }, flatDirents],
+    [{ withFileTypes: "x" }, flatDirents],
+    [{ withFileTypes: {} }, flatDirents],
+    [{ withFileTypes: 1, recursive: true }, deepDirents],
+    [{ withFileTypes: null, recursive: null }, flat],
+  ];
+
+  it.each(acceptedEverywhere.map(([options, expected]) => [inspect(options), options, expected] as const))(
+    "readdirSync, readdir and promises.readdir accept %s",
+    async (_name, options, expected) => {
+      using dir = tempDir("readdir-option-values", tree);
+      expect(summarize(readdirSync(String(dir), options as any))).toEqual(expected);
+      expect(summarize(await readdirCallback(String(dir), options))).toEqual(expected);
+      expect(summarize(await promises.readdir(String(dir), options as any))).toEqual(expected);
+    },
+  );
+
+  // Non-nullish, non-boolean `recursive`: a type error in the sync and callback
+  // forms (thrown synchronously, before the callback is ever called), plain
+  // truthiness in the promise form.
+  const nonBooleanRecursive: [recursive: unknown, expected: typeof flat][] = [
+    [0, flat],
+    [1, deep],
+    ["", flat],
+    ["x", deep],
+    [{}, deep],
+    [[], deep],
+    [0n, flat],
+  ];
+
+  it.each(nonBooleanRecursive)("readdirSync and readdir reject { recursive: %p }", (recursive, _expected) => {
+    using dir = tempDir("readdir-option-values", tree);
+    const invalidArgType = expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" });
+    expect(() => readdirSync(String(dir), { recursive } as any)).toThrow(invalidArgType);
+    const callback = jest.fn();
+    expect(() => fs.readdir(String(dir), { recursive } as any, callback)).toThrow(invalidArgType);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it.each(nonBooleanRecursive)(
+    "promises.readdir treats { recursive: %p } as its truthiness",
+    async (recursive, expected) => {
+      using dir = tempDir("readdir-option-values", tree);
+      expect(summarize(await promises.readdir(String(dir), { recursive } as any))).toEqual(expected);
+      expect(summarize(await promises.readdir(String(dir), { recursive, withFileTypes: 1 } as any))).toEqual({
+        ...expected,
+        dirents: true,
+      });
+    },
+  );
+
+  it("promises.readdir does not mutate the caller's options", async () => {
+    using dir = tempDir("readdir-option-values", tree);
+    const options = { recursive: 1, withFileTypes: 0 };
+    expect(summarize(await promises.readdir(String(dir), options as any))).toEqual(deep);
+    expect(options).toEqual({ recursive: 1, withFileTypes: 0 });
+  });
 });
 
 // The error cleanup path previously called MarkedArrayBuffer.destroy() on


### PR DESCRIPTION
### Problem
- `fs.readdirSync(dir, { recursive: null })` throws `ERR_INVALID_ARG_TYPE` (`The "recursive" property must be of type boolean, got object`); node returns the flat listing. Same for `fs.readdir` (callback) and `fs.promises.readdir`.
- `{ withFileTypes: 1 }`, `{ withFileTypes: "x" }`, `{ withFileTypes: null }`, `{ withFileTypes: 0 }` throw the same way in all three forms; node returns Dirents for the truthy values and names for the falsy ones.
- `fs.promises.readdir(dir, { recursive: "x" })` / `{ recursive: 1 }` reject; node returns the recursive listing (`{ recursive: 0 }` the flat one).
- Cause: `args::Readdir::from_js` (src/runtime/node/node_fs.rs:3488-3493) reads both options with `get_boolean_strict`, which rejects anything present that is not `undefined` or a boolean. It is the one parser behind `readdirSync`, `readdir` and `promises.readdir`.
- Node (v26.3.0): `readdir`/`readdirSync` run `validateBoolean` only when `options.recursive != null` ([lib/fs.js#L1546-L1548](https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1546-L1548)); no entry point validates `withFileTypes`, they all pass `!!options.withFileTypes` ([lib/fs.js#L1557](https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1557)); `fs.promises.readdir` never validates `recursive` and just branches on it ([lib/internal/fs/promises.js#L1601](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1601)).
- Until #14900 replaced the old `getOptional(..., bool)` with `getBooleanStrict`, the parser treated `null` as absent and accepted numbers, so `{ recursive: null }` and `{ withFileTypes: 1 }` used to work in Bun too.

### Fix
- `Readdir::from_js`: a `null` `recursive` is skipped (stays `false`); any other non-boolean still goes through `validators::validate_boolean`, so `readdirSync`/`readdir` keep throwing `ERR_INVALID_ARG_TYPE` for `0`, `"x"`, `{}`, ... with the message unchanged. `withFileTypes` is read with `get_boolean_loose`, i.e. JS truthiness, like `!!options.withFileTypes`.
- `fs.promises.readdir` (src/js/node/fs.promises.ts) gets a small wrapper in place of `asyncWrap`: when `recursive` is present, non-nullish and not a boolean, it passes the native binding `{ __proto__: options, recursive: !!recursive }`, so the parser still reads `encoding`/`withFileTypes` off the caller's object (own or inherited, exactly as on the pass-through path) and the caller's object is never mutated. Booleans, `null` and `undefined` go through untouched, so the common case does no extra work. This is the only form whose node behavior differs from the shared parser, and the same file already adapts `rm`/`rmdir` this way. (Side effect: `promises.readdir.length` is now 2, as in node; it was 3.)
- Why this is right: node's observed behavior is the contract for `node:*`, and every loosened value here is one node accepts; the values node rejects (non-nullish, non-boolean `recursive` in the sync and callback forms) are still rejected, and `mkdir`'s `recursive`, which node validates strictly, is untouched.
- The error text for the remaining rejection is deliberately left as is; #39328 changes that wording. Both PRs touch these lines: whichever lands second keeps this PR's acceptance rules with #39328's message, and #39328's readdir assertions that `withFileTypes: "x"` / `withFileTypes: 1` / `withFileTypes: null` throw and that `promises.readdir({ recursive: "x" })` rejects no longer hold once this lands.
- Tests: `test/js/node/fs/fs.test.ts`, `describe("readdir accepts the recursive/withFileTypes values node accepts")`. 12 accepted option bags checked through all three forms, 7 non-boolean `recursive` values checked to still throw synchronously in the sync and callback forms (callback never called) and to act as truthiness in the promise form, plus a no-mutation check and an inherited-`withFileTypes` check for the coercion path. 18 of the 28 cases fail on the unfixed build (`USE_SYSTEM_BUN=1`), all pass with the fix; the rest pin what must keep rejecting.
- Also run with the fix: the whole of `fs.test.ts` (539 pass), `promises.test.js`, `dir.test.ts`, and the ported `test-fs-readdir*.js` / `test-fs-promises.js`.

### Background
- `node:fs` in Bun has one native argument parser per operation (`args::*::from_js` in `node_fs.rs`). The sync binding and the async binding both call it, and `fs.readdir` (callback) and `fs.promises.readdir` both call the same async binding, so a rule that only applies to the promise form has to live in `fs.promises.ts`.
- `JSValue::get` returns `None` for a missing or `undefined` property, so `{ recursive: undefined }` was already treated as absent; `null` is the value that reaches the check. `get_boolean_loose` is the existing helper for "missing means default, otherwise JS truthiness"; `get_boolean_strict` is the one for "must be a boolean".
- `validators::validate_boolean` is the Rust port of node's `validateBoolean`; it throws the same `ERR_INVALID_ARG_TYPE` `get_boolean_strict` threw before, so only the accepted set changes in this PR.

<details>
<summary>node 26.3.0 vs bun 1.4.0 vs this branch</summary>

Each option was probed through `readdirSync`, `readdir` (callback) and `promises.readdir` on a directory containing `a.txt` and `sub/b.txt`.

```
                      node 26.3.0 (sync / cb / promises)     bun 1.4.0 (all three)    this branch
recursive: null       names x2 / names x2 / names x2         ERR_INVALID_ARG_TYPE     same as node
recursive: 0          THROW / THROW / names x2               ERR_INVALID_ARG_TYPE     same as node
recursive: 1          THROW / THROW / names x3               ERR_INVALID_ARG_TYPE     same as node
recursive: "x"        THROW / THROW / names x3               ERR_INVALID_ARG_TYPE     same as node
recursive: {}         THROW / THROW / names x3               ERR_INVALID_ARG_TYPE     same as node
recursive: 0n         THROW / THROW / names x2               ERR_INVALID_ARG_TYPE     same as node
withFileTypes: null   names x2 in all three                  ERR_INVALID_ARG_TYPE     same as node
withFileTypes: 0      names x2 in all three                  ERR_INVALID_ARG_TYPE     same as node
withFileTypes: ""     names x2 in all three                  ERR_INVALID_ARG_TYPE     same as node
withFileTypes: 1      dirents x2 in all three                ERR_INVALID_ARG_TYPE     same as node
withFileTypes: "x"    dirents x2 in all three                ERR_INVALID_ARG_TYPE     same as node
withFileTypes: {}     dirents x2 in all three                ERR_INVALID_ARG_TYPE     same as node
```

`THROW` is node's `ERR_INVALID_ARG_TYPE`, thrown synchronously in the callback form as well (the callback is not invoked); this branch does the same. `undefined`, `true` and `false` behave identically in all three runtimes.
</details>
