### PR TITLE
webcrypto: store the cause of ML-DSA/ML-KEM rejections as a non-enumerable property

### DIFF
--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -689,7 +689,7 @@ static void rejectWithCause(Ref<DeferredPromise>&& promise, ExceptionCode ec, co
         JSC::JSValue cause = makeCause(globalObject);
         auto exception = createDOMException(&globalObject, ec, message);
         if (auto* exceptionObject = exception.getObject(); exceptionObject && cause)
-            exceptionObject->putDirect(vm, vm.propertyNames->cause, cause);
+            exceptionObject->putDirect(vm, vm.propertyNames->cause, cause, JSC::PropertyAttribute::DontEnum | 0);
         return exception;
     });
 }

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -830,6 +830,91 @@ describe("ChaCha20-Poly1305 and AKP review fixes", () => {
   });
 });
 
+describe("ML-DSA and ML-KEM rejections that carry a cause", () => {
+  // Node builds these rejections with `new DOMException(message, { name, cause })`,
+  // which stores `cause` as a non-enumerable own property (verified on v26.3.0),
+  // the same way Bun's own DOMException constructor does. One case per call
+  // site that attaches a cause: importKey for both AKP families, the inner
+  // import of unwrapKey, and the ML-DSA context length check in sign and verify.
+  const garbage = new Uint8Array(64).fill(1);
+  const iv = new Uint8Array(12);
+  const tooLongContext = { name: "ML-DSA-44", context: new Uint8Array(256) };
+  const cases: [string, string, RegExp, () => Promise<unknown>][] = [
+    [
+      "importKey pkcs8 ML-DSA-44",
+      "DataError",
+      /^ERR_OSSL_/,
+      () => crypto.subtle.importKey("pkcs8", garbage, "ML-DSA-44", false, ["sign"]),
+    ],
+    [
+      "importKey spki ML-KEM-768",
+      "DataError",
+      /^ERR_OSSL_/,
+      () => crypto.subtle.importKey("spki", garbage, "ML-KEM-768", false, ["encapsulateBits"]),
+    ],
+    [
+      "unwrapKey pkcs8 ML-DSA-44",
+      "DataError",
+      /^ERR_OSSL_/,
+      async () => {
+        const kek = await crypto.subtle.importKey("raw", new Uint8Array(16), "AES-GCM", false, [
+          "encrypt",
+          "unwrapKey",
+        ]);
+        const wrapped = await crypto.subtle.encrypt({ name: "AES-GCM", iv }, kek, garbage);
+        return crypto.subtle.unwrapKey("pkcs8", wrapped, kek, { name: "AES-GCM", iv }, "ML-DSA-44", false, ["sign"]);
+      },
+    ],
+    [
+      "sign with a context longer than 255 bytes",
+      "OperationError",
+      /^ERR_OUT_OF_RANGE$/,
+      async () => {
+        const { privateKey } = (await crypto.subtle.generateKey("ML-DSA-44", false, [
+          "sign",
+          "verify",
+        ])) as CryptoKeyPair;
+        return crypto.subtle.sign(tooLongContext, privateKey, garbage);
+      },
+    ],
+    [
+      "verify with a context longer than 255 bytes",
+      "OperationError",
+      /^ERR_OUT_OF_RANGE$/,
+      async () => {
+        const { publicKey } = (await crypto.subtle.generateKey("ML-DSA-44", false, [
+          "sign",
+          "verify",
+        ])) as CryptoKeyPair;
+        return crypto.subtle.verify(tooLongContext, publicKey, garbage, garbage);
+      },
+    ],
+  ];
+
+  it.each(cases)("%s stores the cause like the DOMException constructor does", async (_, name, code, run) => {
+    const err = await run().then(
+      () => null,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(DOMException);
+    expect(err.name).toBe(name);
+    expect(err.cause.code).toMatch(code);
+
+    const constructed = new DOMException(err.message, { name, cause: err.cause });
+    expect(Object.getOwnPropertyDescriptor(err, "cause")).toEqual(
+      Object.getOwnPropertyDescriptor(constructed, "cause"),
+    );
+    expect(Object.getOwnPropertyDescriptor(err, "cause")).toMatchObject({
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+    expect(Object.keys(err)).not.toContain("cause");
+    expect(JSON.parse(JSON.stringify(err))).not.toHaveProperty("cause");
+    expect({ ...err }).not.toHaveProperty("cause");
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/32613
 describe("AES-KW wrapKey/unwrapKey with jwk format", () => {
   // The serialized JWK is rarely a multiple of 8 bytes, which AES-KW (RFC 3394)


### PR DESCRIPTION
### Problem
- The `cause` that WebCrypto attaches to its ML-DSA / ML-KEM rejections is an enumerable own property of the DOMException: `Object.keys(err)` contains `"cause"`, `JSON.stringify(err)` and `{ ...err }` include it, and `util.isDeepStrictEqual` / `toEqual` against a `new DOMException(msg, { name, cause })` fails. Affected rejections: the `DataError` from `importKey` and from `unwrapKey`'s inner import of ML-DSA / ML-KEM key data (cause: the BoringSSL error), and the `OperationError` from ML-DSA `sign` / `verify` with a context longer than 255 bytes (cause: `ERR_OUT_OF_RANGE`).
- `new DOMException(msg, { name, cause })` stores `cause` with `enumerable: false` (`src/jsc/bindings/webcore/JSDOMException.cpp:165`), as does `JSC::ErrorInstance` for `new Error(msg, { cause })`, and Node builds these same rejections with `new DOMException(msg, { name, cause })`, so on Node v26.3.0 all of these have `{ writable: true, enumerable: false, configurable: true }` and `Object.keys(err)` is `[]`.
- Cause: `rejectWithCause()` in `src/jsc/bindings/webcrypto/SubtleCrypto.cpp:692` calls `putDirect(vm, vm.propertyNames->cause, cause)` with the default (enumerable) attributes. Every rejection above goes through this one helper.

### Fix
- Pass `JSC::PropertyAttribute::DontEnum | 0` to that `putDirect`, the same attributes `JSDOMException.cpp` uses for the constructor's `cause`. The value, `err.cause` reads, writability and configurability are unchanged; only enumerability differs.
- Matches Node and the DOMException constructor (descriptors above), so constructed, rejected and Node-produced exceptions now have the same shape. `console.log(err)` and the unhandled rejection printer still show the cause (they list a DOM wrapper's own properties regardless of enumerability); `util.inspect(err)` now renders it as `[cause]:` exactly as Node does.
- Verified with `test/js/web/crypto/web-crypto.test.ts`, new block "ML-DSA and ML-KEM rejections that carry a cause": one case per call site (importKey ML-DSA pkcs8, importKey ML-KEM spki, unwrapKey inner ML-DSA import, sign and verify with a 256 byte context), each asserting the `cause` descriptor equals the one the DOMException constructor produces and is `{ writable, !enumerable, configurable }`, and that keys / JSON / spread do not contain it. All 5 fail on the released binary (`enumerable: true`) and pass with the fix; the whole file passes (99 tests).
- Also run with the fix: `test/js/node/test/parallel/test-webcrypto-export-import-ml-dsa.js`, `-ml-kem.js`, `test-webcrypto-sign-verify-ml-dsa.js` (these read `err.cause.code` through `[[Get]]`, still pass), `test-domexception-cause.js`, `test/js/node/domexception-node.test.js`, `test/js/node/crypto/crypto-pqc.test.ts`.
- Related, not overlapping: #39311 makes the `line` / `column` / `sourceURL` that `createDOMException()` adds non-enumerable too (its WebCrypto case uses a rejection without a cause); #39320 adds an exception check to this same lambda but keeps the `putDirect` as is; #35374 adds a third caller of `rejectWithCause()` (RSA-PSS saltLength), which this change covers as well.

### Background
- `rejectWithCause()` is the WebCrypto helper that rejects a promise with a DOMException and then attaches a `cause` to it, because Node's ML-DSA / ML-KEM code paths expose the underlying error that way. Bun's `DOMException` is a DOM wrapper, not a `JSC::ErrorInstance`, so the helper has to install the property itself instead of going through the Error constructor's options handling.
- `putDirect(vm, name, value)` defines an own property with default attributes, which in JSC means writable, enumerable and configurable. `DontEnum` is JSC's name for `enumerable: false`; `Object.keys`, `JSON.stringify`, spread, `for...in` and the deep equality helpers only look at enumerable own properties, while `err.cause` and `Object.getOwnPropertyDescriptor` see a `DontEnum` property as before.
- ECMAScript's `InstallErrorCause` (used by `new Error(msg, { cause })`) defines `cause` as a non-enumerable own data property; Node's DOMException constructor and JSC's `ErrorInstance` both follow that, which is why a non-enumerable `cause` is the shape everything else produces.

<details>
<summary>Probe output: Node v26.3.0 vs Bun 1.4.0 vs this branch</summary>

One line per rejection path; `attrs` is the own `cause` descriptor, `keysHasCause` is `Object.keys(err).includes("cause")`.

```
# node v26.3.0
importKey pkcs8 ML-DSA-44    name=DataError        causeCode=ERR_OSSL_ASN1_WRONG_TAG    attrs={writable,!enumerable,configurable} keysHasCause=false json={}
importKey spki ML-KEM-768    name=DataError        causeCode=ERR_OSSL_ASN1_WRONG_TAG    attrs={writable,!enumerable,configurable} keysHasCause=false json={}
unwrapKey pkcs8 ML-DSA-44    name=DataError        causeCode=ERR_OSSL_ASN1_WRONG_TAG    attrs={writable,!enumerable,configurable} keysHasCause=false json={}
sign ctx>255                 name=OperationError   causeCode=ERR_OUT_OF_RANGE           attrs={writable,!enumerable,configurable} keysHasCause=false json={}
verify ctx>255               name=OperationError   causeCode=ERR_OUT_OF_RANGE           attrs={writable,!enumerable,configurable} keysHasCause=false json={}
new DOMException(x, {name, cause})                                                      attrs={writable,!enumerable,configurable} keysHasCause=false json={}

# bun 1.4.0
importKey pkcs8 ML-DSA-44    name=DataError        causeCode=ERR_OSSL_EVP_DECODE_ERROR  attrs={writable,enumerable,configurable}  keysHasCause=true  json={"line":..,"column":..,"sourceURL":..,"cause":{...}}
importKey spki ML-KEM-768    (same)
unwrapKey pkcs8 ML-DSA-44    name=DataError        causeCode=ERR_OSSL_EVP_DECODE_ERROR  attrs={writable,enumerable,configurable}  keysHasCause=true  json={"cause":{...}}
sign ctx>255                 name=OperationError   causeCode=ERR_OUT_OF_RANGE           attrs={writable,enumerable,configurable}  keysHasCause=true  json={"line":..,"column":..,"sourceURL":..,"cause":{}}
verify ctx>255               (same)
new DOMException(x, {name, cause})                                                      attrs={writable,!enumerable,configurable} keysHasCause=false json={}

# this branch
all five paths              attrs={writable,!enumerable,configurable} keysHasCause=false
unwrapKey                   json={}
the other four              json={"line":..,"column":..,"sourceURL":..}   (those three keys are what #39311 removes)
```

The differing `causeCode` values between Node (OpenSSL) and Bun (BoringSSL) are pre-existing and not touched here; the new test only requires an `ERR_OSSL_` code on the import paths.

</details>
