### PR TITLE
fix(module): cut dirname at the last separator of either kind (#33325)

### DIFF
--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -91,6 +91,29 @@ using namespace JSC;
 JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireCommonJS);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionRequireNativeModule);
 
+// A module id (or the path a require function was bound to) may contain
+// forward slashes even on Windows — e.g. when the user calls require() with an
+// absolute forward-slash path and the resolver preserves the user's
+// separators. The dirname is then the substring up to the last separator of
+// either kind, matching how path.dirname treats both '/' and '\\' as
+// separators there. Finding only PLATFORM_SEP ('\\' on Windows) cuts the path
+// at the wrong position for such ids.
+// https://github.com/oven-sh/bun/issues/33325
+static size_t reverseFindPathSeparator(const WTF::String& path, size_t length)
+{
+#if OS(WINDOWS)
+    auto backslash = path.reverseFind(WINDOWS_PATH_SEP, length);
+    auto slash = path.reverseFind(POSIX_PATH_SEP, length);
+    if (backslash == WTF::notFound)
+        return slash;
+    if (slash == WTF::notFound)
+        return backslash;
+    return backslash > slash ? backslash : slash;
+#else
+    return path.reverseFind(POSIX_PATH_SEP, length);
+#endif
+}
+
 static bool canPerformFastEnumeration(Structure* s)
 {
     if (s->typeInfo().overridesGetOwnPropertySlot())
@@ -905,7 +928,7 @@ JSCommonJSModule* JSCommonJSModule::create(
 {
     auto& vm = JSC::getVM(globalObject);
     auto key = requireMapKey->value(globalObject);
-    auto index = key->reverseFind(PLATFORM_SEP, key->length());
+    auto index = reverseFindPathSeparator(key, key->length());
 
     JSString* dirname;
     if (index != WTF::notFound) {
@@ -1515,7 +1538,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     }
 
     if (!moduleObject) {
-        size_t index = sourceURL.reverseFind(PLATFORM_SEP, sourceURL.length());
+        size_t index = reverseFindPathSeparator(sourceURL, sourceURL.length());
         JSString* dirname;
         JSString* filename = requireMapKey;
         if (index != WTF::notFound) {
@@ -1634,7 +1657,7 @@ std::optional<JSC::SourceCode> createCommonJSModule(
     }
 
     if (!moduleObject) {
-        size_t index = sourceURL.reverseFind(PLATFORM_SEP, sourceURL.length());
+        size_t index = reverseFindPathSeparator(sourceURL, sourceURL.length());
         JSString* dirname;
         JSString* filename = requireMapKey;
         if (index != WTF::notFound) {
@@ -1674,7 +1697,7 @@ JSObject* JSCommonJSModule::createBoundRequireFunction(VM& vm, JSGlobalObject* l
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSString* filename = JSC::jsStringWithCache(vm, pathString);
-    auto index = pathString.reverseFind(PLATFORM_SEP, pathString.length());
+    auto index = reverseFindPathSeparator(pathString, pathString.length());
     JSString* dirname;
     if (index != WTF::notFound) {
         dirname = JSC::jsSubstring(globalObject, filename, 0, index);

--- a/test/js/node/module/require-dirname-separators.test.js
+++ b/test/js/node/module/require-dirname-separators.test.js
@@ -1,0 +1,54 @@
+// Use bun:test in Bun, or node:test in Node.js
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { createRequire } from "module";
+import { tmpdir } from "os";
+import { dirname, join } from "path";
+
+const require = createRequire(import.meta.url);
+
+// Detect runtime and import appropriate test framework
+const isBun = typeof Bun !== "undefined";
+let test, expect;
+
+if (isBun) {
+  ({ test, expect } = await import("bun:test"));
+} else {
+  const nodeTest = await import("node:test");
+  const assert = await import("node:assert/strict");
+  test = nodeTest.test;
+  expect = value => ({
+    toBe: expected => assert.strictEqual(value, expected),
+  });
+}
+
+// Create a fixture module that reports its own __dirname.
+function makeFixture() {
+  const root = mkdtempSync(join(tmpdir(), "bun-require-dirname-"));
+  const child = join(root, "child.js");
+  writeFileSync(child, "module.exports = __dirname;");
+  return { root, child };
+}
+
+test("__dirname is correct when requiring an absolute path with forward slashes", () => {
+  const { root } = makeFixture();
+  try {
+    // Build the id with string concatenation so the forward slashes are
+    // preserved (path.join would normalize them away on Windows).
+    const forward = root.replaceAll("\\", "/");
+    for (const id of [forward + "/child", forward + "/child.js"]) {
+      expect(require(id)).toBe(dirname(require.resolve(id)));
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("__dirname is correct when requiring an absolute path with native separators", () => {
+  const { root } = makeFixture();
+  try {
+    const id = join(root, "child.js");
+    expect(require(id)).toBe(dirname(require.resolve(id)));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #33325 — on Windows, requiring a module via an absolute path containing forward slashes (with or without an extension) produced a wrong or empty `__dirname` in the child module.

**Root cause**: the CommonJS module's `dirname` is computed by cutting the module id at the last `PLATFORM_SEP` (`\` on Windows). But a module id resolved from a user-supplied forward-slash path keeps the forward slashes (e.g. `C:\Users\me\app\utils/a.js`), so the cut lands at the last backslash — or doesn't land at all for all-forward-slash paths — yielding a wrong or empty `__dirname`.

`path.dirname` (and Node's win32 dirname) treat both `/` and `\` as separators; this makes the module dirname computation do the same on Windows.

### Changes

- New `reverseFindPathSeparator()` helper in `JSCommonJSModule.cpp`: finds the last separator of *either* kind on Windows; unchanged behavior on POSIX.
- Applied at all 4 dirname-from-path sites:
  - `JSCommonJSModule::create` (main require() path)
  - `createCommonJSModule` (both overloads)
  - `JSCommonJSModule::createBoundRequireFunction` (`createRequire`-style bound requires)

### How did you verify your code works?

- New test `test/js/node/module/require-dirname-separators.test.js` asserts `__dirname === dirname(require.resolve(id))` for forward-slash absolute ids (with and without extension) plus a native-separator control case. Runs under both Bun and Node (`node:test` fallback).
- On Windows with unfixed Bun: forward-slash cases fail (empty `__dirname`), native-separator case passes. Both pass under Node, and the C++ change makes the forward-slash cases cut at the correct separator (verified by tracing the new cut position for the mixed-separator ids).