### PR TITLE
Drop the DOMWrapperWorld wrapper HashMap

### DIFF
--- a/src/jsc/JSRef.rs
+++ b/src/jsc/JSRef.rs
@@ -125,7 +125,7 @@ impl JsRef {
     pub fn try_get(&self) -> Option<JSValue> {
         match self {
             JsRef::Weak(weak) => {
-                if weak.is_empty_or_undefined_or_null() {
+                if weak.is_empty_or_undefined_or_null() || !weak.is_live_cell() {
                     None
                 } else {
                     Some(*weak)

--- a/src/jsc/JSRef.rs
+++ b/src/jsc/JSRef.rs
@@ -173,6 +173,9 @@ impl JsRef {
             JsRef::Weak(weak) => {
                 debug_assert!(!weak.is_empty_or_undefined_or_null());
                 let weak = *weak;
+                if !weak.is_live_cell() {
+                    return;
+                }
                 *self = JsRef::Strong(Strong::create(weak, global));
             }
             JsRef::Strong(_) => {}

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -227,6 +227,14 @@ impl JSValue {
         const NOT_CELL_MASK: usize = 0xfffe_0000_0000_0002;
         !self.is_empty() && (self.0 & NOT_CELL_MASK) == 0
     }
+    /// False for a cell the last completed GC found dead but the sweeper has not destroyed yet.
+    #[inline]
+    pub fn is_live_cell(self) -> bool {
+        unsafe extern "C" {
+            safe fn JSC__JSValue__isLiveCell(this: JSValue) -> bool;
+        }
+        JSC__JSValue__isLiveCell(self)
+    }
     #[inline]
     pub fn is_int32(self) -> bool {
         const NUMBER_TAG: usize = 0xfffe_0000_0000_0000;

--- a/src/jsc/bindings/DOMStructureSlot.h
+++ b/src/jsc/bindings/DOMStructureSlot.h
@@ -5,68 +5,68 @@
 namespace WebCore {
 
 // Every wrapper class whose Structure is cached on the global object gets one fixed slot here.
-#define FOR_EACH_DOM_STRUCTURE_SLOT(macro) \
-    macro(JSAbortController)               \
-    macro(JSAbortSignal)                   \
-    macro(JSBroadcastChannel)              \
-    macro(JSByteLengthQueuingStrategy)     \
-    macro(JSCloseEvent)                    \
-    macro(JSCompressionStream)             \
-    macro(JSCookie)                        \
-    macro(JSCookieMap)                     \
-    macro(JSCountQueuingStrategy)          \
-    macro(JSCryptoKey)                     \
-    macro(JSCustomEvent)                   \
-    macro(JSDOMException)                  \
-    macro(JSDOMFormData)                   \
-    macro(JSDOMURL)                        \
-    macro(JSDecompressionStream)           \
-    macro(JSErrorEvent)                    \
-    macro(JSEvent)                         \
-    macro(JSEventEmitter)                  \
-    macro(JSEventTarget)                   \
-    macro(JSFetchHeaders)                  \
-    macro(JSMessageChannel)                \
-    macro(JSMessageEvent)                  \
-    macro(JSMessagePort)                   \
-    macro(JSPerformance)                   \
-    macro(JSPerformanceEntry)              \
-    macro(JSPerformanceMark)               \
-    macro(JSPerformanceMeasure)            \
-    macro(JSPerformanceObserver)           \
-    macro(JSPerformanceObserverEntryList)  \
-    macro(JSPerformanceResourceTiming)     \
-    macro(JSPerformanceServerTiming)       \
-    macro(JSPerformanceTiming)             \
-    macro(JSReadableArrayBufferSinkController) \
-    macro(JSReadableFetchRequestBodySinkController) \
-    macro(JSReadableFileSinkController)    \
-    macro(JSReadableH3ResponseSinkController) \
-    macro(JSReadableHTMLRewriterSinkController) \
-    macro(JSReadableHTTPResponseSinkController) \
-    macro(JSReadableHTTPSResponseSinkController) \
-    macro(JSReadableNetworkSinkController) \
-    macro(JSReadableByteStreamController)  \
-    macro(JSReadableStream)                \
-    macro(JSReadableStreamAsyncIterator)   \
-    macro(JSReadableStreamBYOBReader)      \
-    macro(JSReadableStreamBYOBRequest)     \
-    macro(JSReadableStreamDefaultController) \
-    macro(JSReadableStreamDefaultReader)   \
-    macro(JSSubtleCrypto)                  \
-    macro(JSTextDecoderStream)             \
-    macro(JSTextEncoder)                   \
-    macro(JSTextEncoderStream)             \
-    macro(JSTransformStream)               \
-    macro(JSTransformStreamDefaultController) \
-    macro(JSURLPattern)                    \
-    macro(JSURLSearchParams)               \
-    macro(JSWasmStreamingCompiler)         \
-    macro(JSWebSocket)                     \
-    macro(JSWorker)                        \
-    macro(JSWritableStream)                \
-    macro(JSWritableStreamDefaultController) \
-    macro(JSWritableStreamDefaultWriter)
+#define FOR_EACH_DOM_STRUCTURE_SLOT(macro)                                                                                                                                                                                                                                               \
+    macro(JSAbortController)                                                                                                                                                                                                                                                             \
+        macro(JSAbortSignal)                                                                                                                                                                                                                                                             \
+            macro(JSBroadcastChannel)                                                                                                                                                                                                                                                    \
+                macro(JSByteLengthQueuingStrategy)                                                                                                                                                                                                                                       \
+                    macro(JSCloseEvent)                                                                                                                                                                                                                                                  \
+                        macro(JSCompressionStream)                                                                                                                                                                                                                                       \
+                            macro(JSCookie)                                                                                                                                                                                                                                              \
+                                macro(JSCookieMap)                                                                                                                                                                                                                                       \
+                                    macro(JSCountQueuingStrategy)                                                                                                                                                                                                                        \
+                                        macro(JSCryptoKey)                                                                                                                                                                                                                               \
+                                            macro(JSCustomEvent)                                                                                                                                                                                                                         \
+                                                macro(JSDOMException)                                                                                                                                                                                                                    \
+                                                    macro(JSDOMFormData)                                                                                                                                                                                                                 \
+                                                        macro(JSDOMURL)                                                                                                                                                                                                                  \
+                                                            macro(JSDecompressionStream)                                                                                                                                                                                                 \
+                                                                macro(JSErrorEvent)                                                                                                                                                                                                      \
+                                                                    macro(JSEvent)                                                                                                                                                                                                       \
+                                                                        macro(JSEventEmitter)                                                                                                                                                                                            \
+                                                                            macro(JSEventTarget)                                                                                                                                                                                         \
+                                                                                macro(JSFetchHeaders)                                                                                                                                                                                    \
+                                                                                    macro(JSMessageChannel)                                                                                                                                                                              \
+                                                                                        macro(JSMessageEvent)                                                                                                                                                                            \
+                                                                                            macro(JSMessagePort)                                                                                                                                                                         \
+                                                                                                macro(JSPerformance)                                                                                                                                                                     \
+                                                                                                    macro(JSPerformanceEntry)                                                                                                                                                            \
+                                                                                                        macro(JSPerformanceMark)                                                                                                                                                         \
+                                                                                                            macro(JSPerformanceMeasure)                                                                                                                                                  \
+                                                                                                                macro(JSPerformanceObserver)                                                                                                                                             \
+                                                                                                                    macro(JSPerformanceObserverEntryList)                                                                                                                                \
+                                                                                                                        macro(JSPerformanceResourceTiming)                                                                                                                               \
+                                                                                                                            macro(JSPerformanceServerTiming)                                                                                                                             \
+                                                                                                                                macro(JSPerformanceTiming)                                                                                                                               \
+                                                                                                                                    macro(JSReadableArrayBufferSinkController)                                                                                                           \
+                                                                                                                                        macro(JSReadableFetchRequestBodySinkController)                                                                                                  \
+                                                                                                                                            macro(JSReadableFileSinkController)                                                                                                          \
+                                                                                                                                                macro(JSReadableH3ResponseSinkController)                                                                                                \
+                                                                                                                                                    macro(JSReadableHTMLRewriterSinkController)                                                                                          \
+                                                                                                                                                        macro(JSReadableHTTPResponseSinkController)                                                                                      \
+                                                                                                                                                            macro(JSReadableHTTPSResponseSinkController)                                                                                 \
+                                                                                                                                                                macro(JSReadableNetworkSinkController)                                                                                   \
+                                                                                                                                                                    macro(JSReadableByteStreamController)                                                                                \
+                                                                                                                                                                        macro(JSReadableStream)                                                                                          \
+                                                                                                                                                                            macro(JSReadableStreamAsyncIterator)                                                                         \
+                                                                                                                                                                                macro(JSReadableStreamBYOBReader)                                                                        \
+                                                                                                                                                                                    macro(JSReadableStreamBYOBRequest)                                                                   \
+                                                                                                                                                                                        macro(JSReadableStreamDefaultController)                                                         \
+                                                                                                                                                                                            macro(JSReadableStreamDefaultReader)                                                         \
+                                                                                                                                                                                                macro(JSSubtleCrypto)                                                                    \
+                                                                                                                                                                                                    macro(JSTextDecoderStream)                                                           \
+                                                                                                                                                                                                        macro(JSTextEncoder)                                                             \
+                                                                                                                                                                                                            macro(JSTextEncoderStream)                                                   \
+                                                                                                                                                                                                                macro(JSTransformStream)                                                 \
+                                                                                                                                                                                                                    macro(JSTransformStreamDefaultController)                            \
+                                                                                                                                                                                                                        macro(JSURLPattern)                                              \
+                                                                                                                                                                                                                            macro(JSURLSearchParams)                                     \
+                                                                                                                                                                                                                                macro(JSWasmStreamingCompiler)                           \
+                                                                                                                                                                                                                                    macro(JSWebSocket)                                   \
+                                                                                                                                                                                                                                        macro(JSWorker)                                  \
+                                                                                                                                                                                                                                            macro(JSWritableStream)                      \
+                                                                                                                                                                                                                                                macro(JSWritableStreamDefaultController) \
+                                                                                                                                                                                                                                                    macro(JSWritableStreamDefaultWriter)
 
 #define DOM_STRUCTURE_SLOT_FORWARD_DECLARE(name) class name;
 FOR_EACH_DOM_STRUCTURE_SLOT(DOM_STRUCTURE_SLOT_FORWARD_DECLARE)
@@ -86,8 +86,10 @@ enum class DOMStructureSlot : uint8_t {
 
 template<typename WrapperClass> struct DOMStructureSlotOf;
 
-#define DOM_STRUCTURE_SLOT_SPECIALIZE(name) \
-    template<> struct DOMStructureSlotOf<name> { static constexpr DOMStructureSlot value = DOMStructureSlot::name; };
+#define DOM_STRUCTURE_SLOT_SPECIALIZE(name)                               \
+    template<> struct DOMStructureSlotOf<name> {                          \
+        static constexpr DOMStructureSlot value = DOMStructureSlot::name; \
+    };
 FOR_EACH_DOM_STRUCTURE_SLOT(DOM_STRUCTURE_SLOT_SPECIALIZE)
 #undef DOM_STRUCTURE_SLOT_SPECIALIZE
 

--- a/src/jsc/bindings/DOMStructureSlot.h
+++ b/src/jsc/bindings/DOMStructureSlot.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstdint>
+
+namespace WebCore {
+
+// Every wrapper class whose Structure is cached on the global object gets one fixed slot here.
+#define FOR_EACH_DOM_STRUCTURE_SLOT(macro) \
+    macro(JSAbortController)               \
+    macro(JSAbortSignal)                   \
+    macro(JSBroadcastChannel)              \
+    macro(JSByteLengthQueuingStrategy)     \
+    macro(JSCloseEvent)                    \
+    macro(JSCompressionStream)             \
+    macro(JSCookie)                        \
+    macro(JSCookieMap)                     \
+    macro(JSCountQueuingStrategy)          \
+    macro(JSCryptoKey)                     \
+    macro(JSCustomEvent)                   \
+    macro(JSDOMException)                  \
+    macro(JSDOMFormData)                   \
+    macro(JSDOMURL)                        \
+    macro(JSDecompressionStream)           \
+    macro(JSErrorEvent)                    \
+    macro(JSEvent)                         \
+    macro(JSEventEmitter)                  \
+    macro(JSEventTarget)                   \
+    macro(JSFetchHeaders)                  \
+    macro(JSMessageChannel)                \
+    macro(JSMessageEvent)                  \
+    macro(JSMessagePort)                   \
+    macro(JSPerformance)                   \
+    macro(JSPerformanceEntry)              \
+    macro(JSPerformanceMark)               \
+    macro(JSPerformanceMeasure)            \
+    macro(JSPerformanceObserver)           \
+    macro(JSPerformanceObserverEntryList)  \
+    macro(JSPerformanceResourceTiming)     \
+    macro(JSPerformanceServerTiming)       \
+    macro(JSPerformanceTiming)             \
+    macro(JSReadableArrayBufferSinkController) \
+    macro(JSReadableFetchRequestBodySinkController) \
+    macro(JSReadableFileSinkController)    \
+    macro(JSReadableH3ResponseSinkController) \
+    macro(JSReadableHTMLRewriterSinkController) \
+    macro(JSReadableHTTPResponseSinkController) \
+    macro(JSReadableHTTPSResponseSinkController) \
+    macro(JSReadableNetworkSinkController) \
+    macro(JSReadableByteStreamController)  \
+    macro(JSReadableStream)                \
+    macro(JSReadableStreamAsyncIterator)   \
+    macro(JSReadableStreamBYOBReader)      \
+    macro(JSReadableStreamBYOBRequest)     \
+    macro(JSReadableStreamDefaultController) \
+    macro(JSReadableStreamDefaultReader)   \
+    macro(JSSubtleCrypto)                  \
+    macro(JSTextDecoderStream)             \
+    macro(JSTextEncoder)                   \
+    macro(JSTextEncoderStream)             \
+    macro(JSTransformStream)               \
+    macro(JSTransformStreamDefaultController) \
+    macro(JSURLPattern)                    \
+    macro(JSURLSearchParams)               \
+    macro(JSWasmStreamingCompiler)         \
+    macro(JSWebSocket)                     \
+    macro(JSWorker)                        \
+    macro(JSWritableStream)                \
+    macro(JSWritableStreamDefaultController) \
+    macro(JSWritableStreamDefaultWriter)
+
+#define DOM_STRUCTURE_SLOT_FORWARD_DECLARE(name) class name;
+FOR_EACH_DOM_STRUCTURE_SLOT(DOM_STRUCTURE_SLOT_FORWARD_DECLARE)
+#undef DOM_STRUCTURE_SLOT_FORWARD_DECLARE
+
+enum class DOMStructureSlot : uint8_t {
+#define DOM_STRUCTURE_SLOT_ENUMERATE(name) name,
+    FOR_EACH_DOM_STRUCTURE_SLOT(DOM_STRUCTURE_SLOT_ENUMERATE)
+#undef DOM_STRUCTURE_SLOT_ENUMERATE
+    // TU-local JSDOMIterator subclasses; each specializes DOMStructureSlotOf next to its definition.
+    CookieMapIterator,
+    DOMFormDataIterator,
+    FetchHeadersIterator,
+    URLSearchParamsIterator,
+    Count,
+};
+
+template<typename WrapperClass> struct DOMStructureSlotOf;
+
+#define DOM_STRUCTURE_SLOT_SPECIALIZE(name) \
+    template<> struct DOMStructureSlotOf<name> { static constexpr DOMStructureSlot value = DOMStructureSlot::name; };
+FOR_EACH_DOM_STRUCTURE_SLOT(DOM_STRUCTURE_SLOT_SPECIALIZE)
+#undef DOM_STRUCTURE_SLOT_SPECIALIZE
+
+} // namespace WebCore

--- a/src/jsc/bindings/DOMWrapperWorld-class.h
+++ b/src/jsc/bindings/DOMWrapperWorld-class.h
@@ -6,8 +6,6 @@
 
 namespace WebCore {
 
-typedef HashMap<void*, JSC::Weak<JSC::JSObject>> DOMObjectWrapperMap;
-
 class DOMWrapperWorld : public RefCounted<DOMWrapperWorld> {
 public:
     enum class Type {
@@ -22,8 +20,6 @@ public:
     }
     WEBCORE_EXPORT ~DOMWrapperWorld();
 
-    DOMObjectWrapperMap& wrappers() { return m_wrappers; }
-
     Type type() const { return m_type; }
     bool isNormal() const { return m_type == Type::Normal; }
 
@@ -36,7 +32,6 @@ protected:
 
 private:
     JSC::VM& m_vm;
-    DOMObjectWrapperMap m_wrappers;
 
     String m_name;
     Type m_type { Type::Internal };

--- a/src/jsc/bindings/JSCTestingHelpers.cpp
+++ b/src/jsc/bindings/JSCTestingHelpers.cpp
@@ -6,10 +6,13 @@
 #include <JavaScriptCore/JSString.h>
 #include "ZigGlobalObject.h"
 
+#include <JavaScriptCore/JSBigInt.h>
+#include <JavaScriptCore/JSBigIntInlines.h>
 #if OS(WINDOWS)
 #include <JavaScriptCore/ExecutableAllocator.h>
-#include <JavaScriptCore/JSBigInt.h>
 #endif
+
+extern "C" bool JSC__JSValue__isLiveCell(JSC::EncodedJSValue);
 
 namespace Bun {
 using namespace JSC;
@@ -64,6 +67,26 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStartOfFixedExecutableMemoryPool,
 }
 #endif
 
+// Test-only stand-in for JsRef::Weak; the address is only meaningful until that cell is swept.
+JSC_DEFINE_HOST_FUNCTION(jsFunctionRawCellAddress, (JSGlobalObject * globalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue value = callframe->argument(0);
+    if (!value.isCell())
+        return JSValue::encode(jsUndefined());
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSBigInt::makeHeapBigIntOrBigInt32(globalObject, static_cast<uint64_t>(JSValue::encode(value)))));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionIsLiveCellAtRawAddress, (JSGlobalObject * globalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    uint64_t bits = JSBigInt::toBigUInt64(callframe->argument(0));
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSValue::encode(jsBoolean(JSC__JSValue__isLiveCell(static_cast<JSC::EncodedJSValue>(bits))));
+}
+
 JSC::JSValue createJSCTestingHelpers(Zig::GlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -78,6 +101,16 @@ JSC::JSValue createJSCTestingHelpers(Zig::GlobalObject* globalObject)
     object->putDirectNativeFunction(
         vm, globalObject, JSC::Identifier::fromString(vm, "isLatin1String"_s), 1,
         jsFunctionIsLatin1String, ImplementationVisibility::Public, NoIntrinsic,
+        JSC::PropertyAttribute::DontDelete | 0);
+
+    object->putDirectNativeFunction(
+        vm, globalObject, JSC::Identifier::fromString(vm, "rawCellAddress"_s), 1,
+        jsFunctionRawCellAddress, ImplementationVisibility::Public, NoIntrinsic,
+        JSC::PropertyAttribute::DontDelete | 0);
+
+    object->putDirectNativeFunction(
+        vm, globalObject, JSC::Identifier::fromString(vm, "isLiveCellAtRawAddress"_s), 1,
+        jsFunctionIsLiveCellAtRawAddress, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);
 
 #if OS(WINDOWS)

--- a/src/jsc/bindings/JSCTestingHelpers.cpp
+++ b/src/jsc/bindings/JSCTestingHelpers.cpp
@@ -87,6 +87,12 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsLiveCellAtRawAddress, (JSGlobalObject * glo
     return JSValue::encode(jsBoolean(JSC__JSValue__isLiveCell(static_cast<JSC::EncodedJSValue>(bits))));
 }
 
+JSC_DEFINE_HOST_FUNCTION(jsFunctionCollectSyncWithoutSweep, (JSGlobalObject * globalObject, CallFrame*))
+{
+    JSC::getVM(globalObject).heap.collectSync(JSC::CollectionScope::Full);
+    return JSValue::encode(jsUndefined());
+}
+
 JSC::JSValue createJSCTestingHelpers(Zig::GlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
@@ -106,6 +112,11 @@ JSC::JSValue createJSCTestingHelpers(Zig::GlobalObject* globalObject)
     object->putDirectNativeFunction(
         vm, globalObject, JSC::Identifier::fromString(vm, "rawCellAddress"_s), 1,
         jsFunctionRawCellAddress, ImplementationVisibility::Public, NoIntrinsic,
+        JSC::PropertyAttribute::DontDelete | 0);
+
+    object->putDirectNativeFunction(
+        vm, globalObject, JSC::Identifier::fromString(vm, "collectSyncWithoutSweep"_s), 0,
+        jsFunctionCollectSyncWithoutSweep, ImplementationVisibility::Public, NoIntrinsic,
         JSC::PropertyAttribute::DontDelete | 0);
 
     object->putDirectNativeFunction(

--- a/src/jsc/bindings/JSDOMWrapperCache.cpp
+++ b/src/jsc/bindings/JSDOMWrapperCache.cpp
@@ -24,24 +24,4 @@
 #include "JSDOMWrapperCache.h"
 
 namespace WebCore {
-using namespace JSC;
-
-Structure* getCachedDOMStructure(const JSDOMGlobalObject& globalObject, const ClassInfo* classInfo)
-{
-    return globalObject.structures().get(classInfo).get();
-}
-
-Structure* cacheDOMStructure(JSDOMGlobalObject& globalObject, Structure* structure, const ClassInfo* classInfo)
-{
-    auto addToStructures = [](JSDOMStructureMap& structures, JSDOMGlobalObject& globalObject, Structure* structure, const ClassInfo* classInfo) {
-        ASSERT(!structures.contains(classInfo));
-        return structures.set(classInfo, JSC::WriteBarrier<Structure>(globalObject.vm(), &globalObject, structure)).iterator->value.get();
-    };
-    if (globalObject.vm().heap.mutatorShouldBeFenced()) {
-        Locker locker { globalObject.gcLock() };
-        return addToStructures(globalObject.structures(), globalObject, structure, classInfo);
-    }
-    return addToStructures(globalObject.structures(NoLockingNecessary), globalObject, structure, classInfo);
-}
-
 } // namespace WebCore

--- a/src/jsc/bindings/JSDOMWrapperCache.h
+++ b/src/jsc/bindings/JSDOMWrapperCache.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "DOMStructureSlot.h"
 #include "DOMWrapperWorld.h"
 #include "JSDOMGlobalObject.h"
 #include "JSDOMWrapper.h"
@@ -36,8 +37,6 @@
 
 namespace WebCore {
 
-WEBCORE_EXPORT JSC::Structure* getCachedDOMStructure(const JSDOMGlobalObject&, const JSC::ClassInfo*);
-WEBCORE_EXPORT JSC::Structure* cacheDOMStructure(JSDOMGlobalObject&, JSC::Structure*, const JSC::ClassInfo*);
 
 template<typename WrapperClass> JSC::Structure* getDOMStructure(JSC::VM&, JSDOMGlobalObject&);
 template<typename WrapperClass> JSC::JSObject* getDOMPrototype(JSC::VM&, JSDOMGlobalObject&);
@@ -76,9 +75,10 @@ inline JSDOMGlobalObject* deprecatedGlobalObjectForPrototype(JSC::JSGlobalObject
 
 template<typename WrapperClass> inline JSC::Structure* getDOMStructure(JSC::VM& vm, JSDOMGlobalObject& globalObject)
 {
-    if (JSC::Structure* structure = getCachedDOMStructure(globalObject, WrapperClass::info()))
+    constexpr auto slot = DOMStructureSlotOf<WrapperClass>::value;
+    if (JSC::Structure* structure = globalObject.domStructure(slot))
         return structure;
-    return cacheDOMStructure(globalObject, WrapperClass::createStructure(vm, &globalObject, WrapperClass::createPrototype(vm, globalObject)), WrapperClass::info());
+    return globalObject.setDOMStructure(slot, WrapperClass::createStructure(vm, &globalObject, WrapperClass::createPrototype(vm, globalObject)));
 }
 
 template<typename WrapperClass> inline JSC::JSObject* getDOMPrototype(JSC::VM& vm, JSDOMGlobalObject& globalObject)

--- a/src/jsc/bindings/JSDOMWrapperCache.h
+++ b/src/jsc/bindings/JSDOMWrapperCache.h
@@ -43,19 +43,17 @@ template<typename WrapperClass> JSC::Structure* getDOMStructure(JSC::VM&, JSDOMG
 template<typename WrapperClass> JSC::JSObject* getDOMPrototype(JSC::VM&, JSDOMGlobalObject&);
 
 JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, JSC::ArrayBuffer*);
-void* wrapperKey(JSC::ArrayBuffer*);
 
-std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld&, void*);
-std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*);
-std::optional<JSC::JSArrayBuffer*> getInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*);
+template<typename DOMClass> inline constexpr bool hasInlineWrapperCache = std::is_base_of_v<ScriptWrappable, DOMClass> || std::is_same_v<DOMClass, JSC::ArrayBuffer>;
 
-bool setInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*, JSC::WeakHandleOwner*);
-bool setInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*, JSDOMObject* wrapper, JSC::WeakHandleOwner* wrapperOwner);
-bool setInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*, JSC::JSArrayBuffer* wrapper, JSC::WeakHandleOwner* wrapperOwner);
+JSDOMObject* getInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*);
+JSC::JSArrayBuffer* getInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*);
 
-bool clearInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*);
-bool clearInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*, JSDOMObject* wrapper);
-bool clearInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*, JSC::JSArrayBuffer* wrapper);
+void setInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*, JSDOMObject* wrapper, JSC::WeakHandleOwner* wrapperOwner);
+void setInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*, JSC::JSArrayBuffer* wrapper, JSC::WeakHandleOwner* wrapperOwner);
+
+void clearInlineCachedWrapper(DOMWrapperWorld&, ScriptWrappable*, JSDOMObject* wrapper);
+void clearInlineCachedWrapper(DOMWrapperWorld&, JSC::ArrayBuffer*, JSC::JSArrayBuffer* wrapper);
 
 template<typename DOMClass> JSC::JSObject* getCachedWrapper(DOMWrapperWorld&, DOMClass&);
 template<typename DOMClass> inline JSC::JSObject* getCachedWrapper(DOMWrapperWorld& world, Ref<DOMClass>& object) { return getCachedWrapper(world, object.get()); }
@@ -93,81 +91,66 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld& world, JSC::ArrayBuff
     return static_cast<WebCoreTypedArrayController*>(world.vm().m_typedArrayController.get())->wrapperOwner();
 }
 
-inline void* wrapperKey(JSC::ArrayBuffer* domObject)
-{
-    return domObject;
-}
-
-inline std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld&, void*) { return std::nullopt; }
-inline bool setInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*, JSC::WeakHandleOwner*) { return false; }
-inline bool clearInlineCachedWrapper(DOMWrapperWorld&, void*, JSDOMObject*) { return false; }
-
-inline std::optional<JSDOMObject*> getInlineCachedWrapper(DOMWrapperWorld& world, ScriptWrappable* domObject)
+inline JSDOMObject* getInlineCachedWrapper(DOMWrapperWorld& world, ScriptWrappable* domObject)
 {
     if (!world.isNormal())
-        return std::nullopt;
+        return nullptr;
     return domObject->wrapper();
 }
 
-inline std::optional<JSC::JSArrayBuffer*> getInlineCachedWrapper(DOMWrapperWorld& world, JSC::ArrayBuffer* buffer)
+inline JSC::JSArrayBuffer* getInlineCachedWrapper(DOMWrapperWorld& world, JSC::ArrayBuffer* buffer)
 {
     if (!world.isNormal())
-        return std::nullopt;
+        return nullptr;
     return buffer->m_wrapper.get();
 }
 
-inline bool setInlineCachedWrapper(DOMWrapperWorld& world, ScriptWrappable* domObject, JSDOMObject* wrapper, JSC::WeakHandleOwner* wrapperOwner)
+inline void setInlineCachedWrapper(DOMWrapperWorld& world, ScriptWrappable* domObject, JSDOMObject* wrapper, JSC::WeakHandleOwner* wrapperOwner)
 {
     if (!world.isNormal())
-        return false;
+        return;
     domObject->setWrapper(wrapper, wrapperOwner, &world);
-    return true;
 }
 
-inline bool setInlineCachedWrapper(DOMWrapperWorld& world, JSC::ArrayBuffer* domObject, JSC::JSArrayBuffer* wrapper, JSC::WeakHandleOwner* wrapperOwner)
+inline void setInlineCachedWrapper(DOMWrapperWorld& world, JSC::ArrayBuffer* domObject, JSC::JSArrayBuffer* wrapper, JSC::WeakHandleOwner* wrapperOwner)
 {
     if (!world.isNormal())
-        return false;
+        return;
     domObject->m_wrapper = JSC::Weak<JSC::JSArrayBuffer>(wrapper, wrapperOwner, &world);
-    return true;
 }
 
-inline bool clearInlineCachedWrapper(DOMWrapperWorld& world, ScriptWrappable* domObject, JSDOMObject* wrapper)
+inline void clearInlineCachedWrapper(DOMWrapperWorld& world, ScriptWrappable* domObject, JSDOMObject* wrapper)
 {
     if (!world.isNormal())
-        return false;
+        return;
     domObject->clearWrapper(wrapper);
-    return true;
 }
 
-inline bool clearInlineCachedWrapper(DOMWrapperWorld& world, JSC::ArrayBuffer* domObject, JSC::JSArrayBuffer* wrapper)
+inline void clearInlineCachedWrapper(DOMWrapperWorld& world, JSC::ArrayBuffer* domObject, JSC::JSArrayBuffer* wrapper)
 {
     if (!world.isNormal())
-        return false;
+        return;
     weakClear(domObject->m_wrapper, wrapper);
-    return true;
 }
 
 template<typename DOMClass> inline JSC::JSObject* getCachedWrapper(DOMWrapperWorld& world, DOMClass& domObject)
 {
-    if (auto wrapper = getInlineCachedWrapper(world, &domObject))
-        return *wrapper;
-    return world.wrappers().get(wrapperKey(&domObject));
+    if constexpr (hasInlineWrapperCache<DOMClass>)
+        return getInlineCachedWrapper(world, &domObject);
+    else
+        return nullptr;
 }
 
 template<typename DOMClass, typename WrapperClass> inline void cacheWrapper(DOMWrapperWorld& world, DOMClass* domObject, WrapperClass* wrapper)
 {
-    JSC::WeakHandleOwner* owner = wrapperOwner(world, domObject);
-    if (setInlineCachedWrapper(world, domObject, wrapper, owner))
-        return;
-    weakAdd(world.wrappers(), wrapperKey(domObject), JSC::Weak<JSC::JSObject>(wrapper, owner, &world));
+    if constexpr (hasInlineWrapperCache<DOMClass>)
+        setInlineCachedWrapper(world, domObject, wrapper, wrapperOwner(world, domObject));
 }
 
 template<typename DOMClass, typename WrapperClass> inline void uncacheWrapper(DOMWrapperWorld& world, DOMClass* domObject, WrapperClass* wrapper)
 {
-    if (clearInlineCachedWrapper(world, domObject, wrapper))
-        return;
-    weakRemove(world.wrappers(), wrapperKey(domObject), wrapper);
+    if constexpr (hasInlineWrapperCache<DOMClass>)
+        clearInlineCachedWrapper(world, domObject, wrapper);
 }
 
 template<typename DOMClass, typename T> inline auto createWrapper(JSDOMGlobalObject* globalObject, Ref<T>&& domObject) -> typename std::enable_if<std::is_same<DOMClass, T>::value, typename JSDOMWrapperConverterTraits<DOMClass>::WrapperClass*>::type

--- a/src/jsc/bindings/JSDOMWrapperCache.h
+++ b/src/jsc/bindings/JSDOMWrapperCache.h
@@ -37,7 +37,6 @@
 
 namespace WebCore {
 
-
 template<typename WrapperClass> JSC::Structure* getDOMStructure(JSC::VM&, JSDOMGlobalObject&);
 template<typename WrapperClass> JSC::JSObject* getDOMPrototype(JSC::VM&, JSDOMGlobalObject&);
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3386,12 +3386,12 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
+    for (auto& structure : thisObject->m_domStructures)
+        visitor.append(structure);
+
     {
         // The GC thread has to grab the GC lock even though it is not mutating the containers.
         Locker locker { thisObject->m_gcLock };
-
-        for (auto& structure : thisObject->m_structures.values())
-            visitor.append(structure);
 
         for (auto& guarded : thisObject->m_guardedObjects)
             guarded->visitAggregate(visitor);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -58,6 +58,7 @@ struct node_module;
 #include <JavaScriptCore/JSTypeInfo.h>
 #include <JavaScriptCore/Structure.h>
 #include "DOMConstructors.h"
+#include "DOMStructureSlot.h"
 #include "BunPlugin.h"
 #include "JSMockFunction.h"
 #include "InternalModuleRegistry.h"
@@ -100,7 +101,6 @@ namespace Zig {
 
 class JSCStackTrace;
 
-using JSDOMStructureMap = UncheckedKeyHashMap<const JSC::ClassInfo*, JSC::WriteBarrier<JSC::Structure>>;
 using DOMGuardedObjectSet = UncheckedKeyHashSet<WebCore::DOMGuardedObject*>;
 
 #define ZIG_GLOBAL_OBJECT_DEFINED
@@ -160,10 +160,16 @@ public:
     static GlobalObject* create(JSC::VM& vm, JSC::Structure* structure, const JSC::GlobalObjectMethodTable* methodTable);
     static GlobalObject* create(JSC::VM& vm, JSC::Structure* structure, uint32_t scriptExecutionContextId, const JSC::GlobalObjectMethodTable* methodTable);
 
-    const JSDOMStructureMap& structures() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS
+    JSC::Structure* domStructure(WebCore::DOMStructureSlot slot) const
     {
         ASSERT(!Thread::mayBeGCThread());
-        return m_structures;
+        return m_domStructures[static_cast<size_t>(slot)].get();
+    }
+    JSC::Structure* setDOMStructure(WebCore::DOMStructureSlot slot, JSC::Structure* structure)
+    {
+        ASSERT(!m_domStructures[static_cast<size_t>(slot)]);
+        m_domStructures[static_cast<size_t>(slot)].set(vm(), this, structure);
+        return structure;
     }
     const WebCore::DOMConstructors& constructors() const
     {
@@ -182,12 +188,6 @@ public:
 
     WebCore::ScriptExecutionContext* scriptExecutionContext() const;
 
-    JSDOMStructureMap& structures() WTF_REQUIRES_LOCK(m_gcLock) { return m_structures; }
-    JSDOMStructureMap& structures(NoLockingNecessaryTag) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
-    {
-        ASSERT(!vm().heap.mutatorShouldBeFenced());
-        return m_structures;
-    }
 
     WebCore::DOMConstructors& constructors() { return *m_constructors; }
 
@@ -810,7 +810,7 @@ private:
 
     friend class WebCore::JSBuiltinInternalFunctions;
     uint8_t m_worldIsNormal;
-    JSDOMStructureMap m_structures WTF_GUARDED_BY_LOCK(m_gcLock);
+    JSC::WriteBarrier<JSC::Structure> m_domStructures[static_cast<size_t>(WebCore::DOMStructureSlot::Count)];
     Lock m_gcLock;
     Ref<WebCore::DOMWrapperWorld> m_world;
     RefPtr<WebCore::Performance> m_performance { nullptr };

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -188,7 +188,6 @@ public:
 
     WebCore::ScriptExecutionContext* scriptExecutionContext() const;
 
-
     WebCore::DOMConstructors& constructors() { return *m_constructors; }
 
     Lock& gcLock() WTF_RETURNS_LOCK(m_gcLock) { return m_gcLock; }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4190,6 +4190,14 @@ bool JSC__JSValue__isException(JSC::EncodedJSValue JSValue0, JSC::VM* arg1)
     return JSC::JSValue::decode(JSValue0).isBigInt32();
 }
 
+[[ZIG_EXPORT(nothrow)]] bool JSC__JSValue__isLiveCell(JSC::EncodedJSValue JSValue0)
+{
+    JSC::JSValue value = JSC::JSValue::decode(JSValue0);
+    if (!value.isCell())
+        return false;
+    return !value.asCell()->isPendingDestruction();
+}
+
 void JSC__JSValue__put(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, const ZigString* arg2, JSC::EncodedJSValue JSValue3)
 {
     JSC::JSObject* object = JSC::JSValue::decode(JSValue0).asCell()->getObject();

--- a/src/jsc/bindings/webcore/JSAbortController.h
+++ b/src/jsc/bindings/webcore/JSAbortController.h
@@ -81,11 +81,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, AbortController*)
     return &owner.get();
 }
 
-inline void* wrapperKey(AbortController* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, AbortController&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, AbortController* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<AbortController>&&);

--- a/src/jsc/bindings/webcore/JSAbortSignal.h
+++ b/src/jsc/bindings/webcore/JSAbortSignal.h
@@ -89,11 +89,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, AbortSignal*)
     return &owner.get();
 }
 
-inline void* wrapperKey(AbortSignal* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, AbortSignal&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, AbortSignal* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<AbortSignal>&&);

--- a/src/jsc/bindings/webcore/JSBroadcastChannel.h
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.h
@@ -81,11 +81,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, BroadcastChannel*)
     return &owner.get();
 }
 
-inline void* wrapperKey(BroadcastChannel* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, BroadcastChannel&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, BroadcastChannel* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<BroadcastChannel>&&);

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -902,14 +902,6 @@ void JSCookie::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSCookieOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
 DEFINE_VISIT_CHILDREN(JSCookie);
 
 template<typename Visitor>
@@ -920,13 +912,6 @@ void JSCookie::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(thisObject, visitor);
 
     visitor.append(thisObject->m_expires);
-}
-
-void JSCookieOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsCookie = static_cast<JSCookie*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsCookie->wrapped(), jsCookie);
 }
 
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<Cookie>&& impl)

--- a/src/jsc/bindings/webcore/JSCookie.h
+++ b/src/jsc/bindings/webcore/JSCookie.h
@@ -48,18 +48,6 @@ protected:
     void finishCreation(JSC::VM&);
 };
 
-class JSCookieOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, Cookie*)
-{
-    static NeverDestroyed<JSCookieOwner> owner;
-    return &owner.get();
-}
-
 inline void* wrapperKey(Cookie* wrappableObject)
 {
     return wrappableObject;

--- a/src/jsc/bindings/webcore/JSCookie.h
+++ b/src/jsc/bindings/webcore/JSCookie.h
@@ -2,7 +2,6 @@
 
 #include "JSDOMWrapper.h"
 #include "Cookie.h"
-#include <wtf/NeverDestroyed.h>
 #include <JavaScriptCore/DateInstance.h>
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSCookie.h
+++ b/src/jsc/bindings/webcore/JSCookie.h
@@ -48,10 +48,6 @@ protected:
     void finishCreation(JSC::VM&);
 };
 
-inline void* wrapperKey(Cookie* wrappableObject)
-{
-    return wrappableObject;
-}
 JSC::JSValue getInternalProperties(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSCookie* castedThis);
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, Cookie&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Cookie* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -577,7 +577,9 @@ private:
     {
     }
 };
-template<> struct DOMStructureSlotOf<CookieMapIterator> { static constexpr DOMStructureSlot value = DOMStructureSlot::CookieMapIterator; };
+template<> struct DOMStructureSlotOf<CookieMapIterator> {
+    static constexpr DOMStructureSlot value = DOMStructureSlot::CookieMapIterator;
+};
 
 using CookieMapIteratorPrototype = JSDOMIteratorPrototype<JSCookieMap, CookieMapIteratorTraits>;
 JSC_ANNOTATE_HOST_FUNCTION(CookieMapIteratorPrototypeNext, CookieMapIteratorPrototype::next);

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -577,6 +577,7 @@ private:
     {
     }
 };
+template<> struct DOMStructureSlotOf<CookieMapIterator> { static constexpr DOMStructureSlot value = DOMStructureSlot::CookieMapIterator; };
 
 using CookieMapIteratorPrototype = JSDOMIteratorPrototype<JSCookieMap, CookieMapIteratorTraits>;
 JSC_ANNOTATE_HOST_FUNCTION(CookieMapIteratorPrototypeNext, CookieMapIteratorPrototype::next);

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -645,21 +645,6 @@ void JSCookieMap::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSCookieMapOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
-void JSCookieMapOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsCookieMap = static_cast<JSCookieMap*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsCookieMap->wrapped(), jsCookieMap);
-}
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<CookieMap>&& impl)
 {
     return createWrapper<CookieMap>(globalObject, WTF::move(impl));

--- a/src/jsc/bindings/webcore/JSCookieMap.h
+++ b/src/jsc/bindings/webcore/JSCookieMap.h
@@ -2,7 +2,6 @@
 
 #include "JSDOMWrapper.h"
 #include "CookieMap.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSCookieMap.h
+++ b/src/jsc/bindings/webcore/JSCookieMap.h
@@ -45,23 +45,6 @@ protected:
     void finishCreation(JSC::VM&);
 };
 JSC::JSValue getInternalProperties(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSCookieMap* castedThis);
-class JSCookieMapOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, CookieMap*)
-{
-    static NeverDestroyed<JSCookieMapOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(CookieMap* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, CookieMap&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, CookieMap* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<CookieMap>&&);

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -333,21 +333,6 @@ void JSDOMException::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSDOMExceptionOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
-void JSDOMExceptionOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsDOMException = static_cast<JSDOMException*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsDOMException->wrapped(), jsDOMException);
-}
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<DOMException>&& impl)
 {
     return createWrapper<DOMException>(globalObject, WTF::move(impl));
@@ -363,12 +348,6 @@ DOMException* JSDOMException::toWrapped(JSC::VM& vm, JSC::JSValue value)
     if (auto* wrapper = dynamicDowncast<JSDOMException>(value))
         return &wrapper->wrapped();
     return nullptr;
-}
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, DOMException*)
-{
-    static NeverDestroyed<JSDOMExceptionOwner> owner;
-    return &owner.get();
 }
 
 }

--- a/src/jsc/bindings/webcore/JSDOMException.h
+++ b/src/jsc/bindings/webcore/JSDOMException.h
@@ -67,7 +67,6 @@ protected:
     void finishCreation(JSC::VM&);
 };
 
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, DOMException&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, DOMException* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<DOMException>&&);

--- a/src/jsc/bindings/webcore/JSDOMException.h
+++ b/src/jsc/bindings/webcore/JSDOMException.h
@@ -25,7 +25,6 @@
 #include "DOMException.h"
 #include "JSDOMWrapper.h"
 #include <JavaScriptCore/ErrorPrototype.h>
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSDOMException.h
+++ b/src/jsc/bindings/webcore/JSDOMException.h
@@ -67,18 +67,6 @@ protected:
     void finishCreation(JSC::VM&);
 };
 
-class JSDOMExceptionOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, DOMException*);
-
-inline void* wrapperKey(DOMException* wrappableObject)
-{
-    return wrappableObject;
-}
 
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, DOMException&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, DOMException* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -560,7 +560,9 @@ private:
     {
     }
 };
-template<> struct DOMStructureSlotOf<DOMFormDataIterator> { static constexpr DOMStructureSlot value = DOMStructureSlot::DOMFormDataIterator; };
+template<> struct DOMStructureSlotOf<DOMFormDataIterator> {
+    static constexpr DOMStructureSlot value = DOMStructureSlot::DOMFormDataIterator;
+};
 
 using DOMFormDataIteratorPrototype = JSDOMIteratorPrototype<JSDOMFormData, DOMFormDataIteratorTraits>;
 JSC_ANNOTATE_HOST_FUNCTION(DOMFormDataIteratorPrototypeNext, DOMFormDataIteratorPrototype::next);

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -560,6 +560,7 @@ private:
     {
     }
 };
+template<> struct DOMStructureSlotOf<DOMFormDataIterator> { static constexpr DOMStructureSlot value = DOMStructureSlot::DOMFormDataIterator; };
 
 using DOMFormDataIteratorPrototype = JSDOMIteratorPrototype<JSDOMFormData, DOMFormDataIteratorTraits>;
 JSC_ANNOTATE_HOST_FUNCTION(DOMFormDataIteratorPrototypeNext, DOMFormDataIteratorPrototype::next);

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -713,21 +713,6 @@ void JSDOMFormData::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSDOMFormDataOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
-void JSDOMFormDataOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsDOMFormData = static_cast<JSDOMFormData*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsDOMFormData->wrapped(), jsDOMFormData);
-}
-
 #if ENABLE(BINDING_INTEGRITY)
 #if PLATFORM(WIN)
 #pragma warning(disable : 4483)

--- a/src/jsc/bindings/webcore/JSDOMFormData.h
+++ b/src/jsc/bindings/webcore/JSDOMFormData.h
@@ -22,7 +22,6 @@
 
 #include "DOMFormData.h"
 #include "JSDOMWrapper.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSDOMFormData.h
+++ b/src/jsc/bindings/webcore/JSDOMFormData.h
@@ -67,23 +67,6 @@ protected:
 
 JSC::JSValue getInternalProperties(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSDOMFormData* castedThis);
 
-class JSDOMFormDataOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, DOMFormData*)
-{
-    static NeverDestroyed<JSDOMFormDataOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(DOMFormData* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, DOMFormData&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, DOMFormData* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<DOMFormData>&&);

--- a/src/jsc/bindings/webcore/JSDOMURL.cpp
+++ b/src/jsc/bindings/webcore/JSDOMURL.cpp
@@ -894,25 +894,6 @@ void JSDOMURL::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-JSDOMURLOwner::~JSDOMURLOwner()
-{
-}
-
-bool JSDOMURLOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
-void JSDOMURLOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsDOMURL = static_cast<JSDOMURL*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsDOMURL->wrapped(), jsDOMURL);
-}
-
 #if ENABLE(BINDING_INTEGRITY)
 #if PLATFORM(WIN)
 #pragma warning(disable : 4483)

--- a/src/jsc/bindings/webcore/JSDOMURL.h
+++ b/src/jsc/bindings/webcore/JSDOMURL.h
@@ -22,7 +22,6 @@
 
 #include "DOMURL.h"
 #include "JSDOMWrapper.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSDOMURL.h
+++ b/src/jsc/bindings/webcore/JSDOMURL.h
@@ -69,24 +69,6 @@ protected:
     void finishCreation(JSC::VM&);
 };
 
-class JSDOMURLOwner final : public JSC::WeakHandleOwner {
-public:
-    ~JSDOMURLOwner() final;
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, DOMURL*)
-{
-    static NeverDestroyed<JSDOMURLOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(DOMURL* wrappableObject)
-{
-    return wrappableObject;
-}
-
 WEBCORE_EXPORT JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, DOMURL&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, DOMURL* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<DOMURL>&&);

--- a/src/jsc/bindings/webcore/JSEvent.h
+++ b/src/jsc/bindings/webcore/JSEvent.h
@@ -79,11 +79,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, Event*)
     return &owner.get();
 }
 
-inline void* wrapperKey(Event* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, Event&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Event* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<Event>&&);

--- a/src/jsc/bindings/webcore/JSEventEmitter.h
+++ b/src/jsc/bindings/webcore/JSEventEmitter.h
@@ -64,11 +64,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, EventEmitter*)
     return &owner.get();
 }
 
-inline void* wrapperKey(EventEmitter* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, EventEmitter&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, EventEmitter* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<EventEmitter>&&);

--- a/src/jsc/bindings/webcore/JSEventTarget.h
+++ b/src/jsc/bindings/webcore/JSEventTarget.h
@@ -85,11 +85,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, EventTarget*)
     return &owner.get();
 }
 
-inline void* wrapperKey(EventTarget* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, EventTarget&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, EventTarget* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<EventTarget>&&);

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -552,7 +552,9 @@ private:
     {
     }
 };
-template<> struct DOMStructureSlotOf<FetchHeadersIterator> { static constexpr DOMStructureSlot value = DOMStructureSlot::FetchHeadersIterator; };
+template<> struct DOMStructureSlotOf<FetchHeadersIterator> {
+    static constexpr DOMStructureSlot value = DOMStructureSlot::FetchHeadersIterator;
+};
 
 using FetchHeadersIteratorPrototype = JSDOMIteratorPrototype<JSFetchHeaders, FetchHeadersIteratorTraits>;
 JSC_ANNOTATE_HOST_FUNCTION(FetchHeadersIteratorPrototypeNext, FetchHeadersIteratorPrototype::next);

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -710,14 +710,6 @@ JSC::JSValue getInternalProperties(JSC::VM& vm, JSGlobalObject* lexicalGlobalObj
     RELEASE_AND_RETURN(throwScope, obj);
 }
 
-bool JSFetchHeadersOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
 template<typename Visitor>
 void JSFetchHeaders::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
@@ -728,13 +720,6 @@ void JSFetchHeaders::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 }
 
 DEFINE_VISIT_CHILDREN(JSFetchHeaders);
-
-void JSFetchHeadersOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsFetchHeaders = static_cast<JSFetchHeaders*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsFetchHeaders->wrapped(), jsFetchHeaders);
-}
 
 #if ENABLE(BINDING_INTEGRITY)
 #if PLATFORM(WIN)

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -552,6 +552,7 @@ private:
     {
     }
 };
+template<> struct DOMStructureSlotOf<FetchHeadersIterator> { static constexpr DOMStructureSlot value = DOMStructureSlot::FetchHeadersIterator; };
 
 using FetchHeadersIteratorPrototype = JSDOMIteratorPrototype<JSFetchHeaders, FetchHeadersIteratorTraits>;
 JSC_ANNOTATE_HOST_FUNCTION(FetchHeadersIteratorPrototypeNext, FetchHeadersIteratorPrototype::next);

--- a/src/jsc/bindings/webcore/JSFetchHeaders.h
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.h
@@ -22,7 +22,6 @@
 
 #include "FetchHeaders.h"
 #include "JSDOMWrapper.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSFetchHeaders.h
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.h
@@ -71,23 +71,6 @@ protected:
 
 JSC::JSValue getInternalProperties(JSC::VM& vm, JSC::JSGlobalObject* lexicalGlobalObject, JSFetchHeaders* castedThis);
 
-class JSFetchHeadersOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, FetchHeaders*)
-{
-    static NeverDestroyed<JSFetchHeadersOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(FetchHeaders* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, FetchHeaders&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, FetchHeaders* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<FetchHeaders>&&);

--- a/src/jsc/bindings/webcore/JSMessageChannel.cpp
+++ b/src/jsc/bindings/webcore/JSMessageChannel.cpp
@@ -253,21 +253,6 @@ void JSMessageChannel::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSMessageChannelOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
-void JSMessageChannelOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsMessageChannel = static_cast<JSMessageChannel*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsMessageChannel->wrapped(), jsMessageChannel);
-}
-
 #if ENABLE(BINDING_INTEGRITY)
 #if PLATFORM(WIN)
 #pragma warning(disable : 4483)

--- a/src/jsc/bindings/webcore/JSMessageChannel.h
+++ b/src/jsc/bindings/webcore/JSMessageChannel.h
@@ -22,7 +22,6 @@
 
 #include "JSDOMWrapper.h"
 #include "MessageChannel.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSMessageChannel.h
+++ b/src/jsc/bindings/webcore/JSMessageChannel.h
@@ -68,23 +68,6 @@ protected:
     DECLARE_DEFAULT_FINISH_CREATION;
 };
 
-class JSMessageChannelOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, MessageChannel*)
-{
-    static NeverDestroyed<JSMessageChannelOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(MessageChannel* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, MessageChannel&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, MessageChannel* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<MessageChannel>&&);

--- a/src/jsc/bindings/webcore/JSMessagePort.h
+++ b/src/jsc/bindings/webcore/JSMessagePort.h
@@ -85,11 +85,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, MessagePort*)
     return &owner.get();
 }
 
-inline void* wrapperKey(MessagePort* wrappableObject)
-{
-    return wrappableObject;
-}
-
 WEBCORE_EXPORT JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, MessagePort&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, MessagePort* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<MessagePort>&&);

--- a/src/jsc/bindings/webcore/JSPerformance.h
+++ b/src/jsc/bindings/webcore/JSPerformance.h
@@ -85,11 +85,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, Performance*)
     return &owner.get();
 }
 
-inline void* wrapperKey(Performance* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, Performance&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Performance* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<Performance>&&);

--- a/src/jsc/bindings/webcore/JSPerformanceEntry.h
+++ b/src/jsc/bindings/webcore/JSPerformanceEntry.h
@@ -76,11 +76,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, PerformanceEntry*)
     return &owner.get();
 }
 
-inline void* wrapperKey(PerformanceEntry* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, PerformanceEntry&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, PerformanceEntry* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<PerformanceEntry>&&);

--- a/src/jsc/bindings/webcore/JSPerformanceObserver.h
+++ b/src/jsc/bindings/webcore/JSPerformanceObserver.h
@@ -81,11 +81,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, PerformanceObserver*
     return &owner.get();
 }
 
-inline void* wrapperKey(PerformanceObserver* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, PerformanceObserver&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, PerformanceObserver* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<PerformanceObserver>&&);

--- a/src/jsc/bindings/webcore/JSPerformanceObserverEntryList.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceObserverEntryList.cpp
@@ -248,21 +248,6 @@ void JSPerformanceObserverEntryList::analyzeHeap(JSCell* cell, HeapAnalyzer& ana
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSPerformanceObserverEntryListOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
-void JSPerformanceObserverEntryListOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsPerformanceObserverEntryList = static_cast<JSPerformanceObserverEntryList*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsPerformanceObserverEntryList->wrapped(), jsPerformanceObserverEntryList);
-}
-
 #if ENABLE(BINDING_INTEGRITY)
 #if PLATFORM(WIN)
 #pragma warning(disable : 4483)

--- a/src/jsc/bindings/webcore/JSPerformanceObserverEntryList.h
+++ b/src/jsc/bindings/webcore/JSPerformanceObserverEntryList.h
@@ -64,23 +64,6 @@ protected:
     DECLARE_DEFAULT_FINISH_CREATION;
 };
 
-class JSPerformanceObserverEntryListOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, PerformanceObserverEntryList*)
-{
-    static NeverDestroyed<JSPerformanceObserverEntryListOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(PerformanceObserverEntryList* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, PerformanceObserverEntryList&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, PerformanceObserverEntryList* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<PerformanceObserverEntryList>&&);

--- a/src/jsc/bindings/webcore/JSPerformanceObserverEntryList.h
+++ b/src/jsc/bindings/webcore/JSPerformanceObserverEntryList.h
@@ -22,7 +22,6 @@
 
 #include "JSDOMWrapper.h"
 #include "PerformanceObserverEntryList.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSPerformanceServerTiming.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceServerTiming.cpp
@@ -248,21 +248,6 @@ void JSPerformanceServerTiming::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSPerformanceServerTimingOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
-void JSPerformanceServerTimingOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsPerformanceServerTiming = static_cast<JSPerformanceServerTiming*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, jsPerformanceServerTiming->protectedWrapped().ptr(), jsPerformanceServerTiming);
-}
-
 #if ENABLE(BINDING_INTEGRITY)
 #if PLATFORM(WIN)
 #pragma warning(disable : 4483)

--- a/src/jsc/bindings/webcore/JSPerformanceServerTiming.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceServerTiming.cpp
@@ -248,6 +248,21 @@ void JSPerformanceServerTiming::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer
     Base::analyzeHeap(cell, analyzer);
 }
 
+bool JSPerformanceServerTimingOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
+{
+    UNUSED_PARAM(handle);
+    UNUSED_PARAM(visitor);
+    UNUSED_PARAM(reason);
+    return false;
+}
+
+void JSPerformanceServerTimingOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
+{
+    auto* jsPerformanceServerTiming = static_cast<JSPerformanceServerTiming*>(handle.slot()->asCell());
+    auto& world = *static_cast<DOMWrapperWorld*>(context);
+    uncacheWrapper(world, jsPerformanceServerTiming->protectedWrapped().ptr(), jsPerformanceServerTiming);
+}
+
 #if ENABLE(BINDING_INTEGRITY)
 #if PLATFORM(WIN)
 #pragma warning(disable : 4483)

--- a/src/jsc/bindings/webcore/JSPerformanceServerTiming.h
+++ b/src/jsc/bindings/webcore/JSPerformanceServerTiming.h
@@ -65,6 +65,18 @@ protected:
     DECLARE_DEFAULT_FINISH_CREATION;
 };
 
+class JSPerformanceServerTimingOwner final : public JSC::WeakHandleOwner {
+public:
+    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
+    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
+};
+
+inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, PerformanceServerTiming*)
+{
+    static NeverDestroyed<JSPerformanceServerTimingOwner> owner;
+    return &owner.get();
+}
+
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, PerformanceServerTiming&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, PerformanceServerTiming* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<PerformanceServerTiming>&&);

--- a/src/jsc/bindings/webcore/JSPerformanceServerTiming.h
+++ b/src/jsc/bindings/webcore/JSPerformanceServerTiming.h
@@ -65,23 +65,6 @@ protected:
     DECLARE_DEFAULT_FINISH_CREATION;
 };
 
-class JSPerformanceServerTimingOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, PerformanceServerTiming*)
-{
-    static NeverDestroyed<JSPerformanceServerTimingOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(PerformanceServerTiming* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, PerformanceServerTiming&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, PerformanceServerTiming* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<PerformanceServerTiming>&&);

--- a/src/jsc/bindings/webcore/JSPerformanceTiming.h
+++ b/src/jsc/bindings/webcore/JSPerformanceTiming.h
@@ -76,11 +76,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, PerformanceTiming*)
     return &owner.get();
 }
 
-inline void* wrapperKey(PerformanceTiming* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, PerformanceTiming&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, PerformanceTiming* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<PerformanceTiming>&&);

--- a/src/jsc/bindings/webcore/JSTextEncoder.cpp
+++ b/src/jsc/bindings/webcore/JSTextEncoder.cpp
@@ -330,21 +330,6 @@ void JSTextEncoder::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSTextEncoderOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
-void JSTextEncoderOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsTextEncoder = static_cast<JSTextEncoder*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsTextEncoder->wrapped(), jsTextEncoder);
-}
-
 #if ENABLE(BINDING_INTEGRITY)
 #if PLATFORM(WIN)
 #pragma warning(disable : 4483)

--- a/src/jsc/bindings/webcore/JSTextEncoder.h
+++ b/src/jsc/bindings/webcore/JSTextEncoder.h
@@ -67,23 +67,6 @@ protected:
     void finishCreation(JSC::VM&);
 };
 
-class JSTextEncoderOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, TextEncoder*)
-{
-    static NeverDestroyed<JSTextEncoderOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(TextEncoder* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, TextEncoder&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, TextEncoder* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<TextEncoder>&&);

--- a/src/jsc/bindings/webcore/JSTextEncoder.h
+++ b/src/jsc/bindings/webcore/JSTextEncoder.h
@@ -25,7 +25,6 @@
 #include "JSDOMConvertDictionary.h"
 #include "JSDOMWrapper.h"
 #include "TextEncoder.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSURLPattern.cpp
+++ b/src/jsc/bindings/webcore/JSURLPattern.cpp
@@ -473,21 +473,6 @@ void JSURLPattern::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSURLPatternOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
-void JSURLPatternOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    SUPPRESS_MEMORY_UNSAFE_CAST auto* jsURLPattern = static_cast<JSURLPattern*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, jsURLPattern->protectedWrapped().ptr(), jsURLPattern);
-}
-
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #if ENABLE(BINDING_INTEGRITY)
 #if PLATFORM(WIN)

--- a/src/jsc/bindings/webcore/JSURLPattern.h
+++ b/src/jsc/bindings/webcore/JSURLPattern.h
@@ -22,7 +22,6 @@
 
 #include "URLPattern.h"
 #include "JSDOMWrapper.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSURLPattern.h
+++ b/src/jsc/bindings/webcore/JSURLPattern.h
@@ -65,23 +65,6 @@ protected:
     DECLARE_DEFAULT_FINISH_CREATION;
 };
 
-class JSURLPatternOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, URLPattern*)
-{
-    static NeverDestroyed<JSURLPatternOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(URLPattern* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, URLPattern&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, URLPattern* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<URLPattern>&&);

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -774,21 +774,6 @@ void JSURLSearchParams::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSURLSearchParamsOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    UNUSED_PARAM(handle);
-    UNUSED_PARAM(visitor);
-    UNUSED_PARAM(reason);
-    return false;
-}
-
-void JSURLSearchParamsOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsURLSearchParams = static_cast<JSURLSearchParams*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsURLSearchParams->wrapped(), jsURLSearchParams);
-}
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<URLSearchParams>&& impl)
 {
     return createWrapper<URLSearchParams>(globalObject, WTF::move(impl));

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -704,7 +704,9 @@ private:
     {
     }
 };
-template<> struct DOMStructureSlotOf<URLSearchParamsIterator> { static constexpr DOMStructureSlot value = DOMStructureSlot::URLSearchParamsIterator; };
+template<> struct DOMStructureSlotOf<URLSearchParamsIterator> {
+    static constexpr DOMStructureSlot value = DOMStructureSlot::URLSearchParamsIterator;
+};
 
 using URLSearchParamsIteratorPrototype = JSDOMIteratorPrototype<JSURLSearchParams, URLSearchParamsIteratorTraits>;
 JSC_ANNOTATE_HOST_FUNCTION(URLSearchParamsIteratorPrototypeNext, URLSearchParamsIteratorPrototype::next);

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -704,6 +704,7 @@ private:
     {
     }
 };
+template<> struct DOMStructureSlotOf<URLSearchParamsIterator> { static constexpr DOMStructureSlot value = DOMStructureSlot::URLSearchParamsIterator; };
 
 using URLSearchParamsIteratorPrototype = JSDOMIteratorPrototype<JSURLSearchParams, URLSearchParamsIteratorTraits>;
 JSC_ANNOTATE_HOST_FUNCTION(URLSearchParamsIteratorPrototypeNext, URLSearchParamsIteratorPrototype::next);

--- a/src/jsc/bindings/webcore/JSURLSearchParams.h
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.h
@@ -22,7 +22,6 @@
 
 #include "JSDOMWrapper.h"
 #include "URLSearchParams.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSURLSearchParams.h
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.h
@@ -65,23 +65,6 @@ protected:
     void finishCreation(JSC::VM&);
 };
 
-class JSURLSearchParamsOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, URLSearchParams*)
-{
-    static NeverDestroyed<JSURLSearchParamsOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(URLSearchParams* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, URLSearchParams&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, URLSearchParams* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<URLSearchParams>&&);

--- a/src/jsc/bindings/webcore/JSWasmStreamingCompiler.cpp
+++ b/src/jsc/bindings/webcore/JSWasmStreamingCompiler.cpp
@@ -206,18 +206,6 @@ void JSWasmStreamingCompiler::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSWasmStreamingCompilerOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor&, ASCIILiteral*)
-{
-    return false;
-}
-
-void JSWasmStreamingCompilerOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsWasmStreamingCompiler = static_cast<JSWasmStreamingCompiler*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsWasmStreamingCompiler->wrapped(), jsWasmStreamingCompiler);
-}
-
 JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<Wasm::StreamingCompiler>&& impl)
 {
     return createWrapper<Wasm::StreamingCompiler>(globalObject, WTF::move(impl));

--- a/src/jsc/bindings/webcore/JSWasmStreamingCompiler.h
+++ b/src/jsc/bindings/webcore/JSWasmStreamingCompiler.h
@@ -43,23 +43,6 @@ protected:
 
     void finishCreation(JSC::VM&);
 };
-class JSWasmStreamingCompilerOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, JSC::Wasm::StreamingCompiler*)
-{
-    static NeverDestroyed<JSWasmStreamingCompilerOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(JSC::Wasm::StreamingCompiler* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, JSC::Wasm::StreamingCompiler&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, JSC::Wasm::StreamingCompiler* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<JSC::Wasm::StreamingCompiler>&&);

--- a/src/jsc/bindings/webcore/JSWasmStreamingCompiler.h
+++ b/src/jsc/bindings/webcore/JSWasmStreamingCompiler.h
@@ -2,7 +2,6 @@
 
 #include "JSDOMWrapper.h"
 #include "JavaScriptCore/WasmStreamingCompiler.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcore/JSWebSocket.h
+++ b/src/jsc/bindings/webcore/JSWebSocket.h
@@ -82,11 +82,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, WebSocket*)
     return &owner.get();
 }
 
-inline void* wrapperKey(WebSocket* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, WebSocket&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, WebSocket* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<WebSocket>&&);

--- a/src/jsc/bindings/webcore/JSWorker.h
+++ b/src/jsc/bindings/webcore/JSWorker.h
@@ -81,11 +81,6 @@ inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, Worker*)
     return &owner.get();
 }
 
-inline void* wrapperKey(Worker* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, Worker&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Worker* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<Worker>&&);

--- a/src/jsc/bindings/webcore/PerformanceEntry.h
+++ b/src/jsc/bindings/webcore/PerformanceEntry.h
@@ -32,13 +32,14 @@
 #pragma once
 
 #include "Performance.h"
+#include "ScriptWrappable.h"
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PerformanceEntry);
-class PerformanceEntry : public RefCounted<PerformanceEntry> {
+class PerformanceEntry : public ScriptWrappable, public RefCounted<PerformanceEntry> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(PerformanceEntry, PerformanceEntry);
 
 public:

--- a/src/jsc/bindings/webcore/PerformanceObserver.cpp
+++ b/src/jsc/bindings/webcore/PerformanceObserver.cpp
@@ -31,9 +31,12 @@
 // #include "LocalDOMWindow.h"
 #include "Performance.h"
 #include "PerformanceObserverEntryList.h"
+#include <wtf/TZoneMallocInlines.h>
 // #include "WorkerGlobalScope.h"
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PerformanceObserver);
 
 PerformanceObserver::PerformanceObserver(ScriptExecutionContext& scriptExecutionContext, Ref<PerformanceObserverCallback>&& callback)
     : m_callback(WTF::move(callback))

--- a/src/jsc/bindings/webcore/PerformanceObserver.h
+++ b/src/jsc/bindings/webcore/PerformanceObserver.h
@@ -28,6 +28,7 @@
 #include "ExceptionOr.h"
 #include "PerformanceEntry.h"
 #include "PerformanceObserverCallback.h"
+#include "ScriptWrappable.h"
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
@@ -38,7 +39,9 @@ namespace WebCore {
 class Performance;
 class ScriptExecutionContext;
 
-class PerformanceObserver : public RefCounted<PerformanceObserver> {
+class PerformanceObserver : public ScriptWrappable, public RefCounted<PerformanceObserver> {
+    WTF_MAKE_TZONE_ALLOCATED(PerformanceObserver);
+
 public:
     struct Init {
         std::optional<Vector<String>> entryTypes;

--- a/src/jsc/bindings/webcore/PerformanceServerTiming.cpp
+++ b/src/jsc/bindings/webcore/PerformanceServerTiming.cpp
@@ -26,8 +26,11 @@
 
 #include "config.h"
 #include "PerformanceServerTiming.h"
+#include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PerformanceServerTiming);
 
 Ref<PerformanceServerTiming> PerformanceServerTiming::create(String&& name, double duration, String&& description)
 {

--- a/src/jsc/bindings/webcore/PerformanceServerTiming.h
+++ b/src/jsc/bindings/webcore/PerformanceServerTiming.h
@@ -26,12 +26,15 @@
 
 #pragma once
 
+#include "ScriptWrappable.h"
 #include <wtf/RefCounted.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-class PerformanceServerTiming : public RefCounted<PerformanceServerTiming> {
+class PerformanceServerTiming : public ScriptWrappable, public RefCounted<PerformanceServerTiming> {
+    WTF_MAKE_TZONE_ALLOCATED(PerformanceServerTiming);
+
 public:
     static Ref<PerformanceServerTiming> create(String&& name, double duration, String&& description);
     ~PerformanceServerTiming();

--- a/src/jsc/bindings/webcore/PerformanceTiming.cpp
+++ b/src/jsc/bindings/webcore/PerformanceTiming.cpp
@@ -30,6 +30,7 @@
 
 #include "config.h"
 #include "PerformanceTiming.h"
+#include <wtf/TZoneMallocInlines.h>
 
 // #include "Document.h"
 // #include "DocumentEventTiming.h"
@@ -42,6 +43,8 @@
 // #include "ResourceResponse.h"
 
 namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(PerformanceTiming);
 
 PerformanceTiming::PerformanceTiming() {}
 

--- a/src/jsc/bindings/webcore/PerformanceTiming.h
+++ b/src/jsc/bindings/webcore/PerformanceTiming.h
@@ -30,13 +30,16 @@
 
 #pragma once
 
+#include "ScriptWrappable.h"
 #include <wtf/MonotonicTime.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {
 
-class PerformanceTiming : public RefCounted<PerformanceTiming> {
+class PerformanceTiming : public ScriptWrappable, public RefCounted<PerformanceTiming> {
+    WTF_MAKE_TZONE_ALLOCATED(PerformanceTiming);
+
 public:
     static Ref<PerformanceTiming> create() { return adoptRef(*new PerformanceTiming()); }
 

--- a/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
+++ b/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
@@ -339,20 +339,6 @@ void JSCryptoKey::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSCryptoKeyOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void* context, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    if (reason) [[unlikely]]
-        *reason = "Reachable from CryptoKey"_s;
-    return visitor.containsOpaqueRoot(context);
-}
-
-void JSCryptoKeyOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsCryptoKey = static_cast<JSCryptoKey*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsCryptoKey->wrapped(), jsCryptoKey);
-}
-
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<CryptoKey>&& impl)
 {
     return createWrapper<CryptoKey>(globalObject, WTF::move(impl));

--- a/src/jsc/bindings/webcrypto/JSCryptoKey.h
+++ b/src/jsc/bindings/webcrypto/JSCryptoKey.h
@@ -71,23 +71,6 @@ protected:
     void finishCreation(JSC::VM&);
 };
 
-class JSCryptoKeyOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, CryptoKey*)
-{
-    static NeverDestroyed<JSCryptoKeyOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(CryptoKey* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, CryptoKey&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, CryptoKey* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<CryptoKey>&&);

--- a/src/jsc/bindings/webcrypto/JSCryptoKey.h
+++ b/src/jsc/bindings/webcrypto/JSCryptoKey.h
@@ -25,7 +25,6 @@
 #include "CryptoKey.h"
 #include "JSDOMConvertEnumeration.h"
 #include "JSDOMWrapper.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
@@ -819,24 +819,6 @@ void JSSubtleCrypto::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
     Base::analyzeHeap(cell, analyzer);
 }
 
-bool JSSubtleCryptoOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void* context, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
-{
-    auto* jsSubtleCrypto = uncheckedDowncast<JSSubtleCrypto>(handle.slot()->asCell());
-    ScriptExecutionContext* owner = WTF::getPtr(jsSubtleCrypto->wrapped().scriptExecutionContext());
-    if (!owner)
-        return false;
-    if (reason) [[unlikely]]
-        *reason = "Reachable from ScriptExecutionContext"_s;
-    return visitor.containsOpaqueRoot(context);
-}
-
-void JSSubtleCryptoOwner::finalize(JSC::Handle<JSC::Unknown> handle, void* context)
-{
-    auto* jsSubtleCrypto = static_cast<JSSubtleCrypto*>(handle.slot()->asCell());
-    auto& world = *static_cast<DOMWrapperWorld*>(context);
-    uncacheWrapper(world, &jsSubtleCrypto->wrapped(), jsSubtleCrypto);
-}
-
 #if ENABLE(BINDING_INTEGRITY)
 #if PLATFORM(WIN)
 #pragma warning(disable : 4483)

--- a/src/jsc/bindings/webcrypto/JSSubtleCrypto.h
+++ b/src/jsc/bindings/webcrypto/JSSubtleCrypto.h
@@ -24,7 +24,6 @@
 
 #include "JSDOMWrapper.h"
 #include "SubtleCrypto.h"
-#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/src/jsc/bindings/webcrypto/JSSubtleCrypto.h
+++ b/src/jsc/bindings/webcrypto/JSSubtleCrypto.h
@@ -65,23 +65,6 @@ protected:
     void finishCreation(JSC::VM&);
 };
 
-class JSSubtleCryptoOwner final : public JSC::WeakHandleOwner {
-public:
-    bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* context, JSC::AbstractSlotVisitor&, ASCIILiteral*) final;
-    void finalize(JSC::Handle<JSC::Unknown>, void* context) final;
-};
-
-inline JSC::WeakHandleOwner* wrapperOwner(DOMWrapperWorld&, SubtleCrypto*)
-{
-    static NeverDestroyed<JSSubtleCryptoOwner> owner;
-    return &owner.get();
-}
-
-inline void* wrapperKey(SubtleCrypto* wrappableObject)
-{
-    return wrappableObject;
-}
-
 JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, SubtleCrypto&);
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, SubtleCrypto* impl) { return impl ? toJS(lexicalGlobalObject, globalObject, *impl) : JSC::jsNull(); }
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject*, Ref<SubtleCrypto>&&);

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -569,21 +569,23 @@ it("deserialize applies the same nesting depth limit to arrays as to objects", a
 });
 
 describe("JsRef::Weak liveness", () => {
-  // Bun.gc(false) is collectSync without a sweep, so dead cells stay allocated until the sweeper reaches them.
+  // collectSyncWithoutSweep leaves dead cells allocated until the incremental sweeper reaches them.
   it("dead-but-unswept cells read as not live, kept cells read as live", () => {
     const { jscInternals } = require("bun:internal-for-testing");
-    function make(n: number) {
-      const out: bigint[] = [];
-      for (let i = 0; i < n; i++) out.push(jscInternals.rawCellAddress({ i, pad: [i] }));
-      return out;
+    let objects: object[] = [];
+    const dropped: bigint[] = [];
+    for (let i = 0; i < 2000; i++) {
+      const o = { i, pad: [i] };
+      objects.push(o);
+      dropped.push(jscInternals.rawCellAddress(o));
     }
-    const dropped = make(2000);
     const kept = { keep: true };
     const keptAddr = jscInternals.rawCellAddress(kept);
     expect(dropped.every(a => jscInternals.isLiveCellAtRawAddress(a))).toBe(true);
     expect(jscInternals.isLiveCellAtRawAddress(keptAddr)).toBe(true);
 
-    Bun.gc(false);
+    objects = [];
+    jscInternals.collectSyncWithoutSweep();
 
     // A few may survive via the conservative stack scan; the bulk must read as dead.
     const stillLive = dropped.filter(a => jscInternals.isLiveCellAtRawAddress(a)).length;

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -567,3 +567,28 @@ it("deserialize applies the same nesting depth limit to arrays as to objects", a
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout, exitCode }).toEqual({ stdout: "rejected\n65\n", exitCode: 0 });
 });
+
+describe("JsRef::Weak liveness", () => {
+  // Bun.gc(false) is collectSync without a sweep, so dead cells stay allocated until the sweeper reaches them.
+  test("dead-but-unswept cells read as not live, kept cells read as live", () => {
+    const { jscInternals } = require("bun:internal-for-testing");
+    function make(n: number) {
+      const out: bigint[] = [];
+      for (let i = 0; i < n; i++) out.push(jscInternals.rawCellAddress({ i, pad: [i] }));
+      return out;
+    }
+    const dropped = make(2000);
+    const kept = { keep: true };
+    const keptAddr = jscInternals.rawCellAddress(kept);
+    expect(dropped.every(a => jscInternals.isLiveCellAtRawAddress(a))).toBe(true);
+    expect(jscInternals.isLiveCellAtRawAddress(keptAddr)).toBe(true);
+
+    Bun.gc(false);
+
+    // A few may survive via the conservative stack scan; the bulk must read as dead.
+    const stillLive = dropped.filter(a => jscInternals.isLiveCellAtRawAddress(a)).length;
+    expect(stillLive).toBeLessThan(dropped.length / 2);
+    expect(jscInternals.isLiveCellAtRawAddress(keptAddr)).toBe(true);
+    expect(kept.keep).toBe(true);
+  });
+});

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -570,7 +570,7 @@ it("deserialize applies the same nesting depth limit to arrays as to objects", a
 
 describe("JsRef::Weak liveness", () => {
   // Bun.gc(false) is collectSync without a sweep, so dead cells stay allocated until the sweeper reaches them.
-  test("dead-but-unswept cells read as not live, kept cells read as live", () => {
+  it("dead-but-unswept cells read as not live, kept cells read as live", () => {
     const { jscInternals } = require("bun:internal-for-testing");
     function make(n: number) {
       const out: bigint[] = [];

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -189,3 +189,19 @@ test("net entries are instanceof PerformanceEntry", async () => {
   expect(entry.constructor.name).toBe("PerformanceNodeEntry");
   expect(entry.entryType).toBe("net");
 });
+
+test("re-wrapped native entries, timing and observer keep JS identity", async () => {
+  const name = "identity-" + Math.random();
+  performance.mark(name);
+  expect(performance.getEntriesByName(name)[0]).toBe(performance.getEntriesByName(name)[0]);
+  expect(performance.timing).toBe(performance.timing);
+
+  const { promise, resolve } = Promise.withResolvers<boolean>();
+  const observer = new PerformanceObserver((list, obs) => {
+    obs.disconnect();
+    resolve(obs === observer && list.getEntries()[0] === list.getEntries()[0]);
+  });
+  observer.observe({ entryTypes: ["mark"] });
+  performance.mark(name + "-2");
+  expect(await promise).toBe(true);
+});


### PR DESCRIPTION
### What does this PR do?

Removes `DOMWrapperWorld::m_wrappers` (`HashMap<void*, JSC::Weak<JSObject>>`), the WebCore wrapper cache Bun inherited for non-`ScriptWrappable` types.

Before, every `new Headers()` / `new URL()` / `new URLSearchParams()` / `new TextEncoder()` / thrown `DOMException` / `CryptoKey` / `FormData` / etc. did a hash insert + `JSC::Weak` allocation on construction, a hash lookup on every `toJS`, and a `WeakHandleOwner::finalize` + hash remove at GC. None of those types are ever re-wrapped from native in Bun (the JS side already caches `url.searchParams`, `response.headers`, `crypto.subtle`, …), so the map only ever cost. Each wrapper holds its own `Ref<T>`, so two wrappers for one native would be safe anyway.

Now:
- Wrapper caching is only the inline slot: `ScriptWrappable` (Weak + owner, unchanged — the EventTarget family keeps its `isReachableFromOpaqueRoots` semantics) and `ArrayBuffer`.
- Types without a slot get a fresh wrapper per `toJS`; the wrapper destructor derefs the native. No `Weak`, no owner, no finalize. Their `JS*Owner` / `wrapperOwner` / `wrapperKey` boilerplate is deleted (15 classes).
- `PerformanceEntry` (+ Mark/Measure/ResourceTiming), `PerformanceObserver` and `PerformanceTiming` *are* re-emitted from native (`getEntries()`, observer callback `this`/arg, `performance.timing`), so they become `ScriptWrappable` to keep JS identity. Test added.

VM teardown is unchanged for the Weak path; for the no-cache path the wrapper is just a destructible cell that derefs on `lastChanceToFinalize`. Verified with repeated `Worker` create/terminate under ASAN.

### How did you verify your code works?

- `bun bd test` on headers, url, urlpattern, text-encoder, perf_hooks, abort, websocket, workers, crypto, cookies, formdata, fetch/body/blob — passing (the two docker-only websocket tests and the pre-existing ASAN-threshold `message-port-context-destroy-leak` failure reproduce identically on main with the same debug build).
- New identity test in `test/js/node/perf_hooks/perf_hooks.test.ts`.

### Also: `JsRef::Weak` liveness

`JsRef::Weak` is a bare `JSValue`. Between a collection ending (reap) and the incremental sweeper destroying a dead wrapper, `try_get()` would return that zombie and native code could pass it into JS. `try_get()` now consults `HeapCell::isPendingDestruction()` (via `JSC__JSValue__isLiveCell`) — the same answer `JSC::Weak::get()` gives — and returns `None` in that window. Test: `jscInternals.rawCellAddress`/`isLiveCellAtRawAddress` + `Bun.gc(false)` (collectSync without sweep) shows ~1936/2000 dropped objects in the dead-unswept state and a kept object still live.

### Benchmarks

Release builds on an M-series Mac, PR (`5fd354930`) vs canary `39fb3c103`; best of 7 runs × 200k iterations, value returned from a function and stored so nothing is dropped:

| | main | PR | |
|---|---:|---:|---|
| `new Headers()` | 57.0 ns | 22.1 ns | −61% |
| `new Headers({a:'1'})` | 134.1 ns | 87.1 ns | −35% |
| `new URL("http://…?c=1")` | 177.2 ns | 115.9 ns | −35% |
| `new URLSearchParams("a=1&b=2")` | 209.4 ns | 138.6 ns | −34% |
| `new TextEncoder()` | 49.1 ns | 8.9 ns | −82% |
| `new DOMException("x","AbortError")` | 94.0 ns | 35.0 ns | −63% |
| `new FormData()` | 89.1 ns | 26.7 ns | −70% |
| `new Response("x").headers` | 140.7 ns | 92.2 ns | −34% |
| `new AbortController()` (EventTarget set, unchanged path) | 68.2 ns | 71.7 ns | within noise |
| `Bun.gc(true)` with 600k live URL+Headers wrappers | 7.03 ms | 3.55 ms | −49% |

### Also: DOM Structure cache

`getDOMStructure<T>()` used to probe a `HashMap<ClassInfo*, WriteBarrier<Structure>>` on the global object, and the global's `visitChildren` took `m_gcLock` and walked that table every GC. Each wrapper class now has a `constexpr DOMStructureSlot` (`DOMStructureSlot.h`); the cache is a fixed `WriteBarrier<Structure>[Count]` array — one load on lookup, lock-free visit. Structures are still created lazily on first use.