### PR TITLE
node:fs: accept the stat family's bigint/throwIfNoEntry values node accepts

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2965,6 +2965,26 @@ pub mod args {
 
     pub(crate) type LCHmod = Chmod;
 
+    /// Consumes the stat family's optional options object.
+    fn eat_stat_options(arguments: &mut ArgumentsSlice) -> Option<JSValue> {
+        let options = arguments.next()?;
+        if !options.is_object() || options.is_callable() {
+            return None;
+        }
+        arguments.eat();
+        Some(options)
+    }
+
+    /// Node does not validate the stat family's `bigint`: the binding reads it with
+    /// `IsTrue()`, so only exactly `true` selects BigInt stats.
+    /// https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L1140
+    fn stat_big_int_option(ctx: &JSGlobalObject, options: Option<JSValue>) -> JsResult<bool> {
+        match options {
+            Some(options) => Ok(options.get(ctx, "bigint")? == Some(JSValue::TRUE)),
+            None => Ok(false),
+        }
+    }
+
     pub struct StatFS {
         pub path: PathLike,
         pub(crate) big_int: bool,
@@ -2972,23 +2992,9 @@ pub mod args {
     fs_args_path_forwarders!(StatFS; path);
     impl StatFS {
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<StatFS> {
-            // `Drop for PathLike` covers the
-            // `get_boolean_strict` throw below.
+            // `Drop for PathLike` covers the option getter throw below.
             let path = PathLike::from_js_required(ctx, arguments, "path")?;
-            let big_int = 'brk: {
-                if let Some(next_val) = arguments.next() {
-                    if next_val.is_object() {
-                        if next_val.is_callable() {
-                            break 'brk false;
-                        }
-                        arguments.eat();
-                        if let Some(b) = next_val.get_boolean_strict(ctx, "bigint")? {
-                            break 'brk b;
-                        }
-                    }
-                }
-                false
-            };
+            let big_int = stat_big_int_option(ctx, eat_stat_options(arguments))?;
             Ok(StatFS { path, big_int })
         }
     }
@@ -3012,23 +3018,14 @@ pub mod args {
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Stat> {
             // `Drop for PathLike` covers the error returns below.
             let path = PathLike::from_js_required(ctx, arguments, "path")?;
-            let mut throw_if_no_entry = true;
-            let big_int = 'brk: {
-                if let Some(next_val) = arguments.next() {
-                    if next_val.is_object() {
-                        if next_val.is_callable() {
-                            break 'brk false;
-                        }
-                        arguments.eat();
-                        if let Some(v) = next_val.get_boolean_strict(ctx, "throwIfNoEntry")? {
-                            throw_if_no_entry = v;
-                        }
-                        if let Some(b) = next_val.get_boolean_strict(ctx, "bigint")? {
-                            break 'brk b;
-                        }
-                    }
-                }
-                false
+            let options = eat_stat_options(arguments);
+            let big_int = stat_big_int_option(ctx, options)?;
+            // Not validated by node either: the binding reads it with `IsFalse()`,
+            // so only exactly `false` keeps a missing path from throwing.
+            // https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L1143
+            let throw_if_no_entry = match options {
+                Some(options) => options.get(ctx, "throwIfNoEntry")? != Some(JSValue::FALSE),
+                None => true,
             };
             Ok(Stat {
                 path,
@@ -3046,20 +3043,7 @@ pub mod args {
         pub(crate) fn to_thread_safe(&mut self) {}
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Fstat> {
             let fd = FD::from_js_required(ctx, arguments)?;
-            let big_int = 'brk: {
-                if let Some(next_val) = arguments.next() {
-                    if next_val.is_object() {
-                        if next_val.is_callable() {
-                            break 'brk false;
-                        }
-                        arguments.eat();
-                        if let Some(b) = next_val.get_boolean_strict(ctx, "bigint")? {
-                            break 'brk b;
-                        }
-                    }
-                }
-                false
-            };
+            let big_int = stat_big_int_option(ctx, eat_stat_options(arguments))?;
             Ok(Fstat { fd, big_int })
         }
     }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1481,6 +1481,94 @@ it("statSync throwIfNoEntry: true", () => {
   expect(() => lstatSync(path)).toThrow("no such file or directory");
 });
 
+// Node never validates the stat family's options: its binding reads `bigint`
+// with IsTrue() and `throwIfNoEntry` with IsFalse(), so anything other than
+// exactly `true` / exactly `false` is the default.
+// https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L1140-L1143
+describe("stat family accepts the bigint/throwIfNoEntry values node accepts", () => {
+  const statCallback = promisify(fs.stat) as (path: string, options: any) => Promise<any>;
+  const lstatCallback = promisify(fs.lstat) as (path: string, options: any) => Promise<any>;
+  const fstatCallback = promisify(fs.fstat) as (fd: number, options: any) => Promise<any>;
+  const statfsCallback = promisify(fs.statfs) as (path: string, options: any) => Promise<any>;
+
+  // `typeof` of a stats field from every entry point that shares the native
+  // option parsers: "number" for plain Stats/StatFs, "bigint" for the BigInt forms.
+  async function fieldTypes(options: any) {
+    using dir = tempDir("stat-option-values", { "file.txt": "x" });
+    const file = join(String(dir), "file.txt");
+    const fd = openSync(file, "r");
+    const handle = await promises.open(file, "r");
+    try {
+      return {
+        statSync: typeof statSync(file, options)!.size,
+        lstatSync: typeof lstatSync(file, options)!.size,
+        fstatSync: typeof fstatSync(fd, options).size,
+        statfsSync: typeof statfsSync(file, options).bsize,
+        stat: typeof (await statCallback(file, options)).size,
+        lstat: typeof (await lstatCallback(file, options)).size,
+        fstat: typeof (await fstatCallback(fd, options)).size,
+        statfs: typeof (await statfsCallback(file, options)).bsize,
+        "promises.stat": typeof (await promises.stat(file, options)).size,
+        "promises.lstat": typeof (await promises.lstat(file, options)).size,
+        "promises.statfs": typeof (await promises.statfs(file, options)).bsize,
+        "FileHandle.stat": typeof (await handle.stat(options)).size,
+      };
+    } finally {
+      await handle.close();
+      closeSync(fd);
+    }
+  }
+
+  function allEntryPoints(type: "number" | "bigint") {
+    return {
+      statSync: type,
+      lstatSync: type,
+      fstatSync: type,
+      statfsSync: type,
+      stat: type,
+      lstat: type,
+      fstat: type,
+      statfs: type,
+      "promises.stat": type,
+      "promises.lstat": type,
+      "promises.statfs": type,
+      "FileHandle.stat": type,
+    };
+  }
+
+  it.each([null, 0, 1, "", "x", {}, 0n, 1n])("{ bigint: %p } returns number stats", async bigint => {
+    expect(await fieldTypes({ bigint })).toEqual(allEntryPoints("number"));
+  });
+
+  it("{ bigint: true } returns BigInt stats", async () => {
+    expect(await fieldTypes({ bigint: true })).toEqual(allEntryPoints("bigint"));
+  });
+
+  it.each([null, 0, 1, "x", {}])(
+    "an existing path with { throwIfNoEntry: %p } returns its stats",
+    async throwIfNoEntry => {
+      expect(await fieldTypes({ throwIfNoEntry })).toEqual(allEntryPoints("number"));
+    },
+  );
+
+  // `throwIfNoEntry: false` itself is covered by "statSync throwIfNoEntry" above.
+  it.each([null, 0, 1, "", "x", {}])(
+    "a missing path with { throwIfNoEntry: %p } still fails with ENOENT",
+    async throwIfNoEntry => {
+      using dir = tempDir("stat-option-values", {});
+      const missing = join(String(dir), "missing");
+      const options: any = { throwIfNoEntry };
+      const enoent = expect.objectContaining({ code: "ENOENT" });
+      expect(() => statSync(missing, options)).toThrow(enoent);
+      expect(() => lstatSync(missing, options)).toThrow(enoent);
+      await expect(statCallback(missing, options)).rejects.toThrow(enoent);
+      await expect(lstatCallback(missing, options)).rejects.toThrow(enoent);
+      await expect(promises.stat(missing, options)).rejects.toThrow(enoent);
+      await expect(promises.lstat(missing, options)).rejects.toThrow(enoent);
+    },
+  );
+});
+
 it("stat == statSync", async () => {
   const sync = statSync(import.meta.path);
   const async = await promises.stat(import.meta.path);

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1496,27 +1496,21 @@ describe("stat family accepts the bigint/throwIfNoEntry values node accepts", ()
   async function fieldTypes(options: any) {
     using dir = tempDir("stat-option-values", { "file.txt": "x" });
     const file = join(String(dir), "file.txt");
-    const fd = openSync(file, "r");
-    const handle = await promises.open(file, "r");
-    try {
-      return {
-        statSync: typeof statSync(file, options)!.size,
-        lstatSync: typeof lstatSync(file, options)!.size,
-        fstatSync: typeof fstatSync(fd, options).size,
-        statfsSync: typeof statfsSync(file, options).bsize,
-        stat: typeof (await statCallback(file, options)).size,
-        lstat: typeof (await lstatCallback(file, options)).size,
-        fstat: typeof (await fstatCallback(fd, options)).size,
-        statfs: typeof (await statfsCallback(file, options)).bsize,
-        "promises.stat": typeof (await promises.stat(file, options)).size,
-        "promises.lstat": typeof (await promises.lstat(file, options)).size,
-        "promises.statfs": typeof (await promises.statfs(file, options)).bsize,
-        "FileHandle.stat": typeof (await handle.stat(options)).size,
-      };
-    } finally {
-      await handle.close();
-      closeSync(fd);
-    }
+    await using handle = await promises.open(file, "r");
+    return {
+      statSync: typeof statSync(file, options)!.size,
+      lstatSync: typeof lstatSync(file, options)!.size,
+      fstatSync: typeof fstatSync(handle.fd, options).size,
+      statfsSync: typeof statfsSync(file, options).bsize,
+      stat: typeof (await statCallback(file, options)).size,
+      lstat: typeof (await lstatCallback(file, options)).size,
+      fstat: typeof (await fstatCallback(handle.fd, options)).size,
+      statfs: typeof (await statfsCallback(file, options)).bsize,
+      "promises.stat": typeof (await promises.stat(file, options)).size,
+      "promises.lstat": typeof (await promises.lstat(file, options)).size,
+      "promises.statfs": typeof (await promises.statfs(file, options)).bsize,
+      "FileHandle.stat": typeof (await handle.stat(options)).size,
+    };
   }
 
   function allEntryPoints(type: "number" | "bigint") {


### PR DESCRIPTION
### Problem

- `fs.statSync(file, { bigint: 1 })` throws `TypeError: The "bigint" property must be of type boolean, got number` (`ERR_INVALID_ARG_TYPE`). Any present non-boolean value does (`null`, `0`, `"x"`, `{}`, `1n`, ...), and so does `fs.statSync(missing, { throwIfNoEntry: 0 })`, which should fail with ENOENT.
- Every entry point is affected because they share the native parsers: `statSync`/`lstatSync`/`fstatSync`/`statfsSync`, the callback forms of `stat`/`lstat`/`fstat`/`statfs`, `fs.promises.stat`/`lstat`/`statfs` and `FileHandle.stat`.
- Node v26.3.0 does not validate either option. `lib/fs.js` hands `options.bigint` and `options.throwIfNoEntry` to the binding as-is ([`statSync`](https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1717-L1723), [`fstatSync`](https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1670-L1671), [`statfsSync`](https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L1730-L1731), [promises `stat`](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1685-L1690)), and the binding reads `bigint` with [`IsTrue()`](https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L1140) and `throwIfNoEntry` with [`IsFalse()`](https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L1143): only exactly `true` selects BigInt stats, only exactly `false` suppresses ENOENT, every other value is the default. `{ bigint: 1 }` returns number stats and `{ throwIfNoEntry: 0 }` still throws ENOENT, so this is not truthiness either.
- Cause: `args::StatFS::from_js`, `args::Stat::from_js` (stat and lstat) and `args::Fstat::from_js` in `src/runtime/node/node_fs.rs` read both options through `JSValue::get_boolean_strict`, which throws for any non-boolean. The Zig implementation did the same, so this is not a regression.

### Fix

- `node_fs.rs`: the three copies of the options loop become `eat_stat_options` plus `stat_big_int_option`; `bigint` is now `options.bigint === true` and `throwIfNoEntry` is `options.throwIfNoEntry !== false`, the binding's `IsTrue()` / `IsFalse()`. `get_boolean_strict` itself is unchanged; it is still right where node calls `validateBoolean` (mkdir's `recursive`, for example).
- The properties are still read, so getters still run in the same situation as before (the existing "keeps a Uint8Array path's ArrayBuffer attached while reading options" test still exercises that path), `undefined` still means omitted, and `bigint` is now read before `throwIfNoEntry`, which is the order node's argument list evaluates them in.
- Verified with the new `describe("stat family accepts the bigint/throwIfNoEntry values node accepts")` in `test/js/node/fs/fs.test.ts`: it checks the stats field type from all 12 entry points for eight non-`true` `bigint` values and for `bigint: true`, an existing path with non-boolean `throwIfNoEntry`, and a missing path with six non-`false` `throwIfNoEntry` values across the sync, callback and promise forms. 19 of its 20 cases fail on bun 1.4.0 and all pass with this change.
- Whole `fs.test.ts` (532 pass) and the vendored `test-fs-stat.js`, `test-fs-stat-bigint.js`, `test-fs-statfs.js` and `test-fs-promises.js` pass with this build. The probe script below prints identical output under node 26.3.0 and this build; under bun 1.4.0, 42 of its 53 lines are `ERR_INVALID_ARG_TYPE`.
- Not changed here: `fs.watchFile` has the same strictness for its `bigint`/`persistent` options in `node_fs_stat_watcher.rs` (node treats `persistent` by truthiness there, a different rule), and node's `stat` with `throwIfNoEntry: false` also swallows ENOTDIR while bun only swallows ENOENT. Both are separate fixes.

### Background

- `JSValue::get_boolean_strict` (`src/jsc/JSValue.rs`) reads a property and returns `None` for missing/`undefined`, `Some(bool)` for a boolean, and throws `ERR_INVALID_ARG_TYPE` for anything else. `JSValue::get` returns the raw value (`None` for missing/`undefined`), and comparing it with `JSValue::TRUE` / `JSValue::FALSE` is a JS `===` against the boolean, which is what V8's `IsTrue()` / `IsFalse()` are.
- All `node:fs` stat entry points, sync and async, parse their JS arguments through these `args::*::from_js` functions (wired up in `node_fs_binding.rs`); `fs.promises.*` and `FileHandle.stat` are thin wrappers over the same native functions, so the parser change covers every form.

<details>
<summary>Probe script and output (node 26.3.0 output is identical to this build's)</summary>

The probe calls each entry point on an existing file (`f`), an open fd and a missing path and prints `typeof stats.size` (`bsize` for statfs) or the error code. Abridged:

```js
fs.statSync(f, { bigint: v })                 // v in null, 0, 1, "x", "", {}, [], 0n, 1n, true
fs.lstatSync(f, { bigint: v }); fs.fstatSync(fd, { bigint: v }); fs.statfsSync(f, { bigint: v })
fs.statSync(missing, { throwIfNoEntry: v })   // v in 0, null, "x", {}, "", 1, true, false
fs.lstatSync(missing, { throwIfNoEntry: v })
fs.statSync(f, { throwIfNoEntry: 0 })
await fs.promises.stat(f, { bigint: {} }); await fs.promises.lstat(f, { bigint: null })
await handle.stat({ bigint: 1 }); await fs.promises.statfs(f, { bigint: null })
fs.stat(f, { bigint: 1 }, cb); fs.lstat(f, { bigint: "x" }, cb); fs.fstat(fd, { bigint: 1 }, cb); fs.statfs(f, { bigint: 1 }, cb)
fs.stat(missing, { throwIfNoEntry: 0 }, cb)
```

node 26.3.0 and this build:

```
== bigint ==
statSync({bigint: null})                                     -> number
statSync({bigint: 0})                                        -> number
statSync({bigint: 1})                                        -> number
statSync({bigint: "x"})                                      -> number
statSync({bigint: ""})                                       -> number
statSync({bigint: {}})                                       -> number
statSync({bigint: []})                                       -> number
statSync({bigint: 0n})                                       -> number
statSync({bigint: 1n})                                       -> number
statSync({bigint: true})                                     -> bigint
lstatSync({bigint: null})                                    -> number
fstatSync({bigint: null})                                    -> number
lstatSync({bigint: 1})                                       -> number
fstatSync({bigint: 1})                                       -> number
lstatSync({bigint: "x"})                                     -> number
fstatSync({bigint: "x"})                                     -> number
fstatSync({bigint: true})                                    -> bigint
statfsSync({bigint: null})                                   -> number
statfsSync({bigint: 1})                                      -> number
statfsSync({bigint: "x"})                                    -> number
statfsSync({bigint: true})                                   -> bigint
== throwIfNoEntry ==
statSync(missing, {throwIfNoEntry: 0})                       -> throws ENOENT
lstatSync(missing, {throwIfNoEntry: 0})                      -> throws ENOENT
statSync(missing, {throwIfNoEntry: null})                    -> throws ENOENT
lstatSync(missing, {throwIfNoEntry: null})                   -> throws ENOENT
statSync(missing, {throwIfNoEntry: "x"})                     -> throws ENOENT
lstatSync(missing, {throwIfNoEntry: "x"})                    -> throws ENOENT
statSync(missing, {throwIfNoEntry: {}})                      -> throws ENOENT
lstatSync(missing, {throwIfNoEntry: {}})                     -> throws ENOENT
statSync(missing, {throwIfNoEntry: ""})                      -> throws ENOENT
lstatSync(missing, {throwIfNoEntry: ""})                     -> throws ENOENT
statSync(missing, {throwIfNoEntry: 1})                       -> throws ENOENT
lstatSync(missing, {throwIfNoEntry: 1})                      -> throws ENOENT
statSync(missing, {throwIfNoEntry: true})                    -> throws ENOENT
lstatSync(missing, {throwIfNoEntry: true})                   -> throws ENOENT
statSync(missing, {throwIfNoEntry: false})                   -> undefined
lstatSync(missing, {throwIfNoEntry: false})                  -> undefined
statSync(f, {throwIfNoEntry: 0})                             -> number
== promises ==
promises.stat({bigint: {}})                                  -> number
promises.stat({bigint: 1})                                   -> number
promises.lstat({bigint: null})                               -> number
promises.stat({bigint: true})                                -> bigint
filehandle.stat({bigint: 1})                                 -> number
filehandle.stat({bigint: true})                              -> bigint
promises.statfs({bigint: null})                              -> number
== callbacks ==
stat cb ({bigint: 1})                                        -> number
stat cb ({bigint: null})                                     -> number
lstat cb ({bigint: "x"})                                     -> number
fstat cb ({bigint: 1})                                       -> number
stat cb ({bigint: true})                                     -> bigint
statfs cb ({bigint: 1})                                      -> number
stat cb (missing, {throwIfNoEntry: 0})                       -> cb err ENOENT
stat cb (missing, {throwIfNoEntry: false})                   -> undefined
```

bun 1.4.0 prints `-> throws ERR_INVALID_ARG_TYPE` for every line above whose option value is not a boolean.

</details>
