### PR TITLE
node:fs: accept non-boolean bigint and persistent options in watchFile

### DIFF
--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -1100,10 +1100,8 @@ impl Arguments {
         if let Some(options_or_callable) = arguments.next_eat() {
             // options
             if options_or_callable.is_object() {
-                // Node spreads the caller's own options over `{ persistent: true }`
-                // and never validates these two: `persistent` is tested for
-                // truthiness (so an own `persistent: undefined` unrefs the watcher)
-                // and `bigint` only counts when it is exactly `true`.
+                // Node spreads the caller's own options over its defaults and never
+                // validates these two, so an own property of any type counts here.
                 persistent = options_or_callable
                     .get_own(global, &bun_core::String::static_("persistent"))?
                     .is_none_or(JSValue::to_boolean);

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -1100,15 +1100,17 @@ impl Arguments {
         if let Some(options_or_callable) = arguments.next_eat() {
             // options
             if options_or_callable.is_object() {
-                // default true
+                // Node spreads the caller's own options over `{ persistent: true }`
+                // and never validates these two: `persistent` is tested for
+                // truthiness (so an own `persistent: undefined` unrefs the watcher)
+                // and `bigint` only counts when it is exactly `true`.
                 persistent = options_or_callable
-                    .get_boolean_strict(global, "persistent")?
-                    .unwrap_or(true);
+                    .get_own(global, &bun_core::String::static_("persistent"))?
+                    .is_none_or(JSValue::to_boolean);
 
-                // default false
                 bigint = options_or_callable
-                    .get_boolean_strict(global, "bigint")?
-                    .unwrap_or(false);
+                    .get_own(global, &bun_core::String::static_("bigint"))?
+                    == Some(JSValue::TRUE);
 
                 if let Some(interval_) = options_or_callable.get(global, "interval")? {
                     if !interval_.is_number() && !interval_.is_any_int() {

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -1100,8 +1100,7 @@ impl Arguments {
         if let Some(options_or_callable) = arguments.next_eat() {
             // options
             if options_or_callable.is_object() {
-                // Node spreads the caller's own options over its defaults and never
-                // validates these two, so an own property of any type counts here.
+                // Like node, which spreads the options (own keys) and never validates these.
                 persistent = options_or_callable
                     .get_own(global, &bun_core::String::static_("persistent"))?
                     .is_none_or(JSValue::to_boolean);

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -1100,7 +1100,7 @@ impl Arguments {
         if let Some(options_or_callable) = arguments.next_eat() {
             // options
             if options_or_callable.is_object() {
-                // Like node, which spreads the options (own keys) and never validates these.
+                // Like node, which spreads the options object and never validates these two.
                 persistent = options_or_callable
                     .get_own(global, &bun_core::String::static_("persistent"))?
                     .is_none_or(JSValue::to_boolean);

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -178,59 +178,89 @@ describe("fs.watchFile", () => {
   // So any value is accepted, truthiness decides whether the watcher keeps the
   // process alive, an own `persistent: undefined` replaces the default, and an
   // inherited property is not seen at all.
-  test("options.persistent accepts any value and is read for truthiness", async () => {
-    const cases: Array<[options: string, keepsProcessAlive: boolean]> = [
-      ["{ persistent: true }", true],
-      ["{ persistent: 1 }", true],
-      ['{ persistent: "x" }', true],
-      ["Object.create({ persistent: false })", true],
-      ["{ persistent: false }", false],
-      ["{ persistent: 0 }", false],
-      ['{ persistent: "" }', false],
-      ["{ persistent: null }", false],
-      ["{ persistent: undefined }", false],
-    ];
+  //
+  // Whether a watcher keeps the process alive is observed per process: the
+  // fixtures watch files that an unref'd interval keeps appending to, so a
+  // watcher that holds the process alive gets to report a change, and one that
+  // does not lets the process exit first. `cases` holds the option expressions
+  // as source text; each fixture evaluates them next to their labels.
+  describe("options.persistent accepts any value and is read for truthiness", () => {
+    const casesSource = (cases: string[]) => `[${cases.map(c => `[${JSON.stringify(c)}, ${c}]`).join(", ")}]`;
 
-    const results = Object.fromEntries(
-      await Promise.all(
-        cases.map(async ([options], i) => {
-          const file = path.join(testDir, `persistent-option-${i}.txt`);
-          fs.writeFileSync(file, "a");
-          // The interval touching the file is unref'd, so only the watcher can
-          // keep the process alive. A watcher that does sees a change and prints
-          // it; one that does not lets the process exit without printing anything.
-          const fixture = /* js */ `
-            const fs = require("fs");
-            const file = ${JSON.stringify(file)};
-            const options = ${options};
-            options.interval = 20;
-            fs.watchFile(file, options, () => {
-              console.log("change");
-              fs.unwatchFile(file);
-              clearInterval(touch);
-            });
-            const touch = setInterval(() => fs.appendFileSync(file, "b"), 10).unref();
-          `;
-          await using proc = Bun.spawn({
-            cmd: [bunExe(), "-e", fixture],
-            env: bunEnv,
-            stdout: "pipe",
-            stderr: "pipe",
+    async function runFixture(fixture: string) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    test.concurrent("truthy values keep the process alive", async () => {
+      const cases = [
+        "{ persistent: true }",
+        "{ persistent: 1 }",
+        '{ persistent: "x" }',
+        "Object.create({ persistent: false })",
+      ];
+      using dir = tempDir("watchfile-persistent-truthy", { "file.txt": "a" });
+      // The values are tried one at a time, each one being the only watcher in
+      // the process, so every line printed is one value that kept the process
+      // alive on its own; the process exits after the first value that does not.
+      const fixture = /* js */ `
+        const fs = require("fs");
+        const file = ${JSON.stringify(path.join(String(dir), "file.txt"))};
+        const cases = ${casesSource(cases)};
+        const touch = setInterval(() => fs.appendFileSync(file, "b"), 10).unref();
+        function watchNext() {
+          if (cases.length === 0) return clearInterval(touch);
+          const [label, options] = cases.shift();
+          options.interval = 20;
+          fs.watchFile(file, options, () => {
+            console.log(label);
+            fs.unwatchFile(file);
+            watchNext();
           });
-          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-          return [options, { stdout, stderr, exitCode }];
-        }),
-      ),
-    );
+        }
+        watchNext();
+      `;
 
-    expect(results).toEqual(
-      Object.fromEntries(
-        cases.map(([options, keepsProcessAlive]) => [
-          options,
-          { stdout: keepsProcessAlive ? "change\n" : "", stderr: "", exitCode: 0 },
-        ]),
-      ),
-    );
+      expect(await runFixture(fixture)).toEqual({ stdout: cases.join("\n") + "\n", stderr: "", exitCode: 0 });
+    });
+
+    test.concurrent("falsy values do not keep the process alive", async () => {
+      const cases = [
+        "{ persistent: false }",
+        "{ persistent: 0 }",
+        '{ persistent: "" }',
+        "{ persistent: null }",
+        "{ persistent: undefined }",
+      ];
+      using dir = tempDir("watchfile-persistent-falsy", Object.fromEntries(cases.map((_, i) => [`${i}.txt`, "a"])));
+      // All values are watched at once (a separate file each, since watchFile
+      // shares one watcher per path). Nothing else holds the process, so it must
+      // exit without printing; any value that wrongly holds it prints its label.
+      const fixture = /* js */ `
+        const fs = require("fs");
+        const path = require("path");
+        const dir = ${JSON.stringify(String(dir))};
+        const cases = ${casesSource(cases)};
+        const files = cases.map((_, i) => path.join(dir, i + ".txt"));
+        const touch = setInterval(() => files.forEach(file => fs.appendFileSync(file, "b")), 10).unref();
+        cases.forEach(([label, options], i) => {
+          options.interval = 20;
+          fs.watchFile(files[i], options, () => {
+            console.log(label);
+            files.forEach(file => fs.unwatchFile(file));
+            clearInterval(touch);
+          });
+        });
+      `;
+
+      expect(await runFixture(fixture)).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    });
   });
 
   test.if(isWindows)("does not fire on atime-only update", async () => {

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -125,6 +125,113 @@ describe("fs.watchFile", () => {
     expect(typeof entries[0][0].mtimeMs === "bigint").toBe(true);
   });
 
+  // Node does not validate `bigint`: it spreads the caller's own options over
+  // its defaults and hands `options.bigint` to the native StatWatcher, which
+  // checks it with IsTrue(). So every value is accepted and only exactly
+  // `true` switches to BigIntStats.
+  test("options.bigint accepts any value and enables BigIntStats only for true", async () => {
+    const cases: Record<string, any> = {
+      "true": { bigint: true },
+      "false": { bigint: false },
+      "1": { bigint: 1 },
+      '"true"': { bigint: "true" },
+      "null": { bigint: null },
+      "undefined": { bigint: undefined },
+      "{}": { bigint: {} },
+      "new Boolean(true)": { bigint: new Boolean(true) },
+      "inherited true": Object.create({ bigint: true }),
+    };
+
+    const results = Object.fromEntries(
+      await Promise.all(
+        Object.entries(cases).map(async ([label, options], i) => {
+          // The path does not exist, so the listener fires right away with zeroed stats.
+          const file = path.join(testDir, `bigint-option-${i}`);
+          const { promise, resolve } = Promise.withResolvers<string>();
+          try {
+            fs.watchFile(file, options, (curr, prev) => resolve(`${curr.constructor.name}/${prev.constructor.name}`));
+            return [label, await promise];
+          } catch (e: any) {
+            return [label, `throws ${e.code}`];
+          } finally {
+            fs.unwatchFile(file);
+          }
+        }),
+      ),
+    );
+
+    expect(results).toEqual({
+      "true": "BigIntStats/BigIntStats",
+      "false": "Stats/Stats",
+      "1": "Stats/Stats",
+      '"true"': "Stats/Stats",
+      "null": "Stats/Stats",
+      "undefined": "Stats/Stats",
+      "{}": "Stats/Stats",
+      "new Boolean(true)": "Stats/Stats",
+      "inherited true": "Stats/Stats",
+    });
+  });
+
+  // Node does not validate `persistent` either: after spreading the caller's
+  // own options over `{ persistent: true }` it only does `if (!persistent) unref()`.
+  // So any value is accepted, truthiness decides whether the watcher keeps the
+  // process alive, an own `persistent: undefined` replaces the default, and an
+  // inherited property is not seen at all.
+  test("options.persistent accepts any value and is read for truthiness", async () => {
+    const cases: Array<[options: string, keepsProcessAlive: boolean]> = [
+      ["{ persistent: true }", true],
+      ["{ persistent: 1 }", true],
+      ['{ persistent: "x" }', true],
+      ["Object.create({ persistent: false })", true],
+      ["{ persistent: false }", false],
+      ["{ persistent: 0 }", false],
+      ["{ persistent: null }", false],
+      ["{ persistent: undefined }", false],
+    ];
+
+    const results = Object.fromEntries(
+      await Promise.all(
+        cases.map(async ([options], i) => {
+          const file = path.join(testDir, `persistent-option-${i}.txt`);
+          fs.writeFileSync(file, "a");
+          // The interval touching the file is unref'd, so only the watcher can
+          // keep the process alive. A watcher that does sees a change and prints
+          // it; one that does not lets the process exit without printing anything.
+          const fixture = /* js */ `
+            const fs = require("fs");
+            const file = ${JSON.stringify(file)};
+            const options = ${options};
+            options.interval = 20;
+            fs.watchFile(file, options, () => {
+              console.log("change");
+              fs.unwatchFile(file);
+              clearInterval(touch);
+            });
+            const touch = setInterval(() => fs.appendFileSync(file, "b"), 10).unref();
+          `;
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), "-e", fixture],
+            env: bunEnv,
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          return [options, { stdout, stderr, exitCode }];
+        }),
+      ),
+    );
+
+    expect(results).toEqual(
+      Object.fromEntries(
+        cases.map(([options, keepsProcessAlive]) => [
+          options,
+          { stdout: keepsProcessAlive ? "change\n" : "", stderr: "", exitCode: 0 },
+        ]),
+      ),
+    );
+  });
+
   test.if(isWindows)("does not fire on atime-only update", async () => {
     let called = false;
     const file = path.join(testDir, "watch.txt");

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -186,6 +186,7 @@ describe("fs.watchFile", () => {
       ["Object.create({ persistent: false })", true],
       ["{ persistent: false }", false],
       ["{ persistent: 0 }", false],
+      ['{ persistent: "" }', false],
       ["{ persistent: null }", false],
       ["{ persistent: undefined }", false],
     ];


### PR DESCRIPTION
### Problem

- `fs.watchFile(file, { bigint: 1 }, listener)` and `fs.watchFile(file, { persistent: 0 }, listener)` throw `TypeError [ERR_INVALID_ARG_TYPE]: The "bigint" property must be of type boolean, got number` (same for `persistent`). Node v26.3.0 accepts any value for both options; the same calls work there (number stats in the first case, an unref'd watcher in the second).
- Cause: `Arguments::from_js` in `src/runtime/node/node_fs_stat_watcher.rs:1104-1111` reads both options with `JSValue::get_boolean_strict`, which throws for every present non-boolean value.
- Two smaller deltas from the same lines: bun applied `bigint`/`persistent` found on the options object's prototype chain (node does not), and treated an own `persistent: undefined` as the default `true` (node unrefs the watcher).

### Fix

- Read both options as own properties: `persistent` is missing or truthy, `bigint` is `=== true`.
- Why this is right: it is what node does. `lib/fs.js` `watchFile` does `options = { interval: 5007, persistent: true, ...options }` and validates only the listener (and `interval`, via `validateUint32`); `lib/internal/fs/watchers.js` then only does `if (!persistent) this.unref()`, and `src/node_stat_watcher.cc` `StatWatcher::New` reads `bigint` with `args[0]->IsTrue()`. The spread is why only own properties count and why an own `persistent: undefined` overrides the default; the truthiness test and `IsTrue()` are the two value rules. Every row of the probe below now matches node (it was run against a local node v26.3.0).
- One approximation, shared with `fs.rm`'s parser: `get_own` also sees a non-enumerable own property, which a spread skips. Reaching it takes `Object.defineProperty` on the options object; the previous code saw those too, so nothing changes there.
- `interval` is not touched; its validation is a separate matter (#34988). The same `get_boolean_strict` pattern in the `stat` family (`node_fs.rs`) is #39335; the two PRs touch different files.
- Verified:
  - `test/js/node/watch/fs.watchFile.test.ts`: three new tests. `options.bigint ...` watches a missing path per value (the listener fires at once with zeroed stats) and checks which values produce `BigIntStats`. `options.persistent ...` spawns two fixtures: one tries the truthy values one at a time and prints each value that kept the process alive, the other watches all the falsy values at once and must exit without printing. All three fail on the released build (the non-boolean rows throw; the inherited and own-`undefined` rows come out the other way) and pass with this change. The whole file also passes with the leak checker and `BUN_DESTRUCT_VM_ON_EXIT` that CI's ASAN lanes turn on, which reach the fixtures through the environment.
  - Upstream `test-fs-watchfile.js`, `test-fs-watchfile-bigint.js`, `test-fs-watchfile-ref-unref.js` and `test-fs-watch-file-enoent-after-deletion.js` still pass.

### Background

- `fs.watchFile` polls a path with `stat` and calls the listener with `(current, previous)` stats objects. `bigint: true` makes those `BigIntStats` instead of `Stats`; `persistent: false` makes the watcher not keep the process alive (the same thing as calling `unref()` on it). Bun implements the option parsing natively in `node_fs_stat_watcher.rs`; `src/js/internal/fs/watchfile.ts` only dedupes watchers per path and passes the options object through.
- `JSValue::get_own` is the own-property lookup (`getOwnPropertySlot`, so it still runs getters); it returns `Some` for an own property whose value is `undefined`. `JSValue::get`, used for most options in `node:fs`, walks the prototype chain and folds `undefined` into "absent", which is the right shape when node itself reads `options.x`, but not when node copies the options with a spread. `fs.rm`'s parser in `node_fs.rs` uses `get_own` for the same reason.

<details>
<summary>Probe: node v26.3.0 vs bun 1.4.0 vs this branch</summary>

`bigint`, watching a missing path (listener fires immediately with zeroed stats); value shown is the class of the stats objects:

| options | node | bun 1.4.0 | this branch |
| --- | --- | --- | --- |
| `{ bigint: true }` | BigIntStats | BigIntStats | BigIntStats |
| `{ bigint: false }` | Stats | Stats | Stats |
| `{ bigint: 1 }` | Stats | throws ERR_INVALID_ARG_TYPE | Stats |
| `{ bigint: "true" }` | Stats | throws ERR_INVALID_ARG_TYPE | Stats |
| `{ bigint: null }` | Stats | throws ERR_INVALID_ARG_TYPE | Stats |
| `{ bigint: undefined }` | Stats | Stats | Stats |
| `{ bigint: {} }` | Stats | throws ERR_INVALID_ARG_TYPE | Stats |
| `{ bigint: new Boolean(true) }` | Stats | throws ERR_INVALID_ARG_TYPE | Stats |
| `Object.create({ bigint: true })` | Stats | BigIntStats | Stats |

`persistent`, watching an existing file that an unref'd interval keeps appending to; "change" means the watcher kept the process alive long enough to report it, "exit" means the process exited right away:

| options | node | bun 1.4.0 | this branch |
| --- | --- | --- | --- |
| `{}` | change | change | change |
| `{ persistent: true }` | change | change | change |
| `{ persistent: 1 }` | change | throws ERR_INVALID_ARG_TYPE | change |
| `{ persistent: "x" }` | change | throws ERR_INVALID_ARG_TYPE | change |
| `{ persistent: {} }` | change | throws ERR_INVALID_ARG_TYPE | change |
| `Object.create({ persistent: false })` | change | exit | change |
| `{ persistent: false }` | exit | exit | exit |
| `{ persistent: 0 }` | exit | throws ERR_INVALID_ARG_TYPE | exit |
| `{ persistent: "" }` | exit | throws ERR_INVALID_ARG_TYPE | exit |
| `{ persistent: null }` | exit | throws ERR_INVALID_ARG_TYPE | exit |
| `{ persistent: undefined }` | exit | change | exit |

</details>
