### PR TITLE
node:fs: treat any non-object watchFile options argument as the listener

### DIFF
--- a/src/js/internal/fs/watchfile.ts
+++ b/src/js/internal/fs/watchfile.ts
@@ -58,7 +58,9 @@ const statWatchers = new Map();
 function watchFile(filename, options, listener) {
   filename = getValidatedPath(filename);
 
-  if (typeof options === "function") {
+  // Like node, any non-object second argument is the listener (so a third
+  // argument is ignored), and a non-function one fails the listener check below.
+  if (options === null || typeof options !== "object") {
     listener = options;
     options = {};
   }

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -32,6 +32,64 @@ beforeEach(() => {
 });
 
 describe("fs.watchFile", () => {
+  // Like node, a second argument that is not an object is the listener: a
+  // listener passed third is ignored, and a non-function one is a TypeError.
+  describe("non-object options argument is the listener", () => {
+    const cases: [label: string, options: unknown, received: string][] = [
+      ["null", null, "null"],
+      ["undefined", undefined, "undefined"],
+      ["a string", "x", "type string ('x')"],
+      ["a number", 5, "type number (5)"],
+      ["a boolean", true, "type boolean (true)"],
+      ["a symbol", Symbol("s"), "type symbol (Symbol(s))"],
+      ["a bigint", 10n, "type bigint (10n)"],
+    ];
+
+    for (const [label, options, received] of cases) {
+      test(`${label} throws ERR_INVALID_ARG_TYPE even when a listener is passed third`, () => {
+        const file = path.join(testDir, "watch.txt");
+        const expected = expect.objectContaining({
+          name: "TypeError",
+          code: "ERR_INVALID_ARG_TYPE",
+          message: `The "listener" argument must be of type function. Received ${received}`,
+        });
+        try {
+          expect(() => fs.watchFile(file, options as any, () => {})).toThrow(expected);
+          expect(() => fs.watchFile(file, options as any)).toThrow(expected);
+
+          // the rejected calls did not register anything for the file
+          expect(fs.watchFile(file, () => {}).listenerCount("change")).toBe(1);
+        } finally {
+          fs.unwatchFile(file);
+        }
+      });
+    }
+
+    test("an object, an array or a null-prototype object is the options and the third argument is the listener", () => {
+      const file = path.join(testDir, "watch.txt");
+      const listener = () => {};
+      try {
+        for (const options of [{}, [], Object.create(null)]) {
+          expect(fs.watchFile(file, options, listener).listeners("change")).toEqual([listener]);
+          fs.unwatchFile(file);
+        }
+      } finally {
+        fs.unwatchFile(file);
+      }
+    });
+
+    test("a function is the listener and the third argument is ignored", () => {
+      const file = path.join(testDir, "watch.txt");
+      const second = () => {};
+      const third = () => {};
+      try {
+        expect(fs.watchFile(file, second, third).listeners("change")).toEqual([second]);
+      } finally {
+        fs.unwatchFile(file);
+      }
+    });
+  });
+
   test("zeroed stats if does not exist", async () => {
     let entries: any = [];
     let { promise, resolve } = Promise.withResolvers<void>();


### PR DESCRIPTION
### Problem

- `fs.watchFile(file, null, listener)` starts watching in Bun. So does any other non-object second argument: `undefined`, `"x"`, `5`, `true`, a symbol, a bigint. Node v26.3.0 throws on every one of them:
  `TypeError [ERR_INVALID_ARG_TYPE]: The "listener" argument must be of type function. Received null`
- The two-argument form `fs.watchFile(file, null)` throws in both, but Bun's message says `Received undefined` where node's says `Received null` (the value that was actually passed).
- Cause: `src/js/internal/fs/watchfile.ts:61` only shifted the arguments when the second one was a function. Every other non-object value was passed through as `options` to the native binding, which ignores a non-object options value (`node_fs_stat_watcher.rs`, `Arguments::from_js` checks `is_object()`), so the third argument was used as the listener.
- Node's `watchFile` ([lib/fs.js L2581-L2584](https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L2581-L2584)) shifts on `options === null || typeof options !== 'object'` and then runs `validateFunction(listener)` ([L2595](https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L2595)): a non-object second argument is the listener, whatever comes third.

### Fix

- `watchFile` in `watchfile.ts` shifts on node's condition instead of `typeof options === "function"`. The existing listener check then throws node's error for the shifted value; the function case behaves exactly as before.
- Matches node. Objects keep working as options: `typeof` is `"object"` for arrays, null-prototype objects and proxies, so those still take the third argument as the listener, and the native side still reads the options from them unchanged.
- Nothing is registered for the path when the call throws, since the check runs before the `statWatchers` lookup.
- Verified with `test/js/node/watch/fs.watchFile.test.ts` (new `non-object options argument is the listener` block): 7 cases fail on the released build and pass with the fix; the two guard tests (object/array/null-prototype options, function second argument with an ignored third) pass on both.
- The whole file passes with the debug build, as do the upstream `test-fs-watchfile.js`, `test-fs-watchfile-ref-unref.js`, `test-fs-watchfile-bigint.js`, `test-fs-options-immutable.js`, `test-fs-watch-stop-{sync,async}.js`, `test-fs-null-bytes.js` and `test-fs-watch-file-enoent-after-deletion.js`.
- A probe of 21 call shapes (every second-argument type above with and without a third argument, the one-argument form, object options with bad listeners, two functions) produces output identical to node v26.3.0 with the fix.

### Background

- `fs.watchFile(filename[, options], listener)` polls a file with `stat` and calls `listener(curr, prev)` when it changes. In Bun the argument handling and the per-path listener table live in `src/js/internal/fs/watchfile.ts`; the polling itself is native (`src/runtime/node/node_fs_stat_watcher.rs`), and the JS layer hands it the options object once per path.
- `ERR_INVALID_ARG_TYPE` is node's error for an argument of the wrong type. Its message names the value it received (`Received null`, `Received type string ('x')`), which is why the tests can tell that it is the second argument, and not the third, that node and Bun report as the listener.
