### PR TITLE
node:fs: validate rm options before the ERR_FS_EISDIR check

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -9,6 +9,8 @@ const {
   validateObject,
   validateAbortSignal,
   validateEncoding,
+  validateInt32,
+  validateUint32,
 } = require("internal/validators");
 
 const constants = $processBindingConstants.fs;
@@ -207,6 +209,70 @@ async function opendir(dir: string, options) {
   return promise;
 }
 
+// fs.rm, fs.rmSync and fs.promises.rm all go through node's validateRmOptions
+// (https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/utils.js#L905-L1006):
+// the options are checked first, then the path is lstat'ed and a directory is
+// refused with ERR_FS_EISDIR unless `recursive` is set. Keeping that order is
+// what makes a bad option win over ERR_FS_EISDIR when both apply. The option
+// half is shared here; the lstat half differs per flavor (sync below, async in
+// rmValidated). Any lstat failure is left for the native rm to report, since it
+// already implements node's `force`/ENOENT handling.
+const defaultRmOptions = {
+  recursive: false,
+  force: false,
+  retryDelay: 100,
+  maxRetries: 0,
+};
+
+function validateRmOptions(options) {
+  if (options === undefined) return { ...defaultRmOptions };
+  validateObject(options, "options");
+  // Like node, the spread copies own enumerable keys only, so an own
+  // `recursive: undefined` overrides the default and is rejected below.
+  options = { ...defaultRmOptions, ...options };
+  validateBoolean(options.force, "options.force");
+  validateBoolean(options.recursive, "options.recursive");
+  validateInt32(options.retryDelay, "options.retryDelay", 0);
+  validateUint32(options.maxRetries, "options.maxRetries");
+  return options;
+}
+
+function rmEisdirError(path) {
+  return require("internal/fs/cp-sync").fsEisdirError({
+    code: "EISDIR",
+    message: "is a directory",
+    path,
+    syscall: "rm",
+    errno: $processBindingConstants.os.errno.EISDIR,
+  });
+}
+
+function validateRmOptionsSync(path, options) {
+  options = validateRmOptions(options);
+  if (!options.recursive) {
+    let stats;
+    try {
+      stats = fs.lstatSync(path);
+    } catch {}
+    if (stats?.isDirectory()) throw rmEisdirError(path);
+  }
+  return options;
+}
+
+// `options` must already have been through validateRmOptions. fs.rm runs that
+// itself before calling this so that, as in node, invalid options throw
+// synchronously instead of reaching the callback.
+async function rmValidated(path, options) {
+  if (!options.recursive) {
+    let stats;
+    try {
+      stats = await fs.lstat(path);
+    } catch {}
+    if (stats?.isDirectory()) throw rmEisdirError(path);
+  }
+  return fs.rm(path, options);
+}
+
 // Node.js closes a FileHandle's fd in its native finalizer and raises
 // ERR_INVALID_STATE (DEP0137 end-of-life) when collected without close().
 // Mirror that with a FinalizationRegistry so dropped handles don't leak fds.
@@ -235,6 +301,10 @@ const private_symbols = {
   kTransferList,
   kDeserialize,
   FileHandle: null as any,
+  // shared with node:fs, whose rm/rmSync are the callback and sync flavors of rm below
+  validateRmOptions,
+  validateRmOptionsSync,
+  rmValidated,
 };
 
 const _readFile = fs.readFile.bind(fs);
@@ -333,32 +403,7 @@ const exports = {
   utimes: asyncWrap(fs.utimes, "utimes"),
   lutimes: asyncWrap(fs.lutimes, "lutimes"),
   rm: async function rm(path, options) {
-    if (typeof options === "object" && options !== null) {
-      // Node merges the caller's options over the defaults with a spread, which
-      // copies own enumerable keys only -- including ones holding `undefined`.
-      // Normalize here so the native parser sees exactly that set.
-      options = { ...options };
-    }
-    if (!options?.recursive) {
-      // node validates in JS and reports ERR_FS_EISDIR for directories
-      // (same check as rmSync)
-      let stats;
-      try {
-        stats = await fs.lstat(path);
-      } catch {
-        // let the native call produce the error (respects force/ENOENT)
-      }
-      if (stats?.isDirectory()) {
-        throw require("internal/fs/cp-sync").fsEisdirError({
-          code: "EISDIR",
-          message: "is a directory",
-          path,
-          syscall: "rm",
-          errno: $processBindingConstants.os.errno.EISDIR,
-        });
-      }
-    }
-    return fs.rm(path, options);
+    return rmValidated(path, validateRmOptions(options));
   },
   rmdir: async function rmdir(path, options) {
     // node throws for any defined `recursive`, not just truthy ones
@@ -387,7 +432,7 @@ const exports = {
   opendir,
 
   // "$data" is reuse of private symbol
-  // this is used to export the private symbols to internal/fs/streams and node:http2 without making them public.
+  // this is used to export the private symbols and helpers to node:fs, internal/fs/streams and node:http2 without making them public.
   $data: private_symbols,
 };
 export default exports;

--- a/src/js/node/fs.ts
+++ b/src/js/node/fs.ts
@@ -17,6 +17,9 @@ const isDate = types.isDate;
 // The native `node:fs` binding, shared via `internal/fs/binding`.
 const fs = require("internal/fs/binding");
 
+// rm's option validation and ERR_FS_EISDIR check live next to promises.rm.
+const { validateRmOptions, validateRmOptionsSync, rmValidated } = promises.$data;
+
 const constants = $processBindingConstants.fs;
 var _lazyGlob;
 function lazyGlob() {
@@ -92,8 +95,9 @@ var access = function access(path, mode, callback) {
     }
 
     callback = ensureCallback(callback);
-    // route through promises.rm for the JS-side ERR_FS_EISDIR validation
-    promises.rm(path, options).then(nullcallback(callback), callback);
+    // node's callback form throws synchronously on invalid options
+    options = validateRmOptions(options);
+    rmValidated(path, options).then(nullcallback(callback), callback);
   },
   rmdir = function rmdir(path, options, callback) {
     if ($isCallable(options)) {
@@ -555,31 +559,7 @@ var access = function access(path, mode, callback) {
   utimesSync = fs.utimesSync.bind(fs),
   lutimesSync = fs.lutimesSync.bind(fs),
   rmSync = function rmSync(path, options) {
-    if (typeof options === "object" && options !== null) {
-      // Node merges the caller's options over the defaults with a spread, which
-      // copies own enumerable keys only -- including ones holding `undefined`.
-      // Normalize here so the native parser sees exactly that set.
-      options = { ...options };
-    }
-    if (!options?.recursive) {
-      // node validates in JS and reports ERR_FS_EISDIR for directories
-      let stats;
-      try {
-        stats = fs.lstatSync(path);
-      } catch {
-        // let the native call produce the error (respects force/ENOENT)
-      }
-      if (stats?.isDirectory()) {
-        throw require("internal/fs/cp-sync").fsEisdirError({
-          code: "EISDIR",
-          message: "is a directory",
-          path,
-          syscall: "rm",
-          errno: $processBindingConstants.os.errno.EISDIR,
-        });
-      }
-    }
-    return fs.rmSync(path, options);
+    return fs.rmSync(path, validateRmOptionsSync(path, options));
   },
   rmdirSync = function rmdirSync(path, options) {
     // node throws for any defined `recursive`, not just truthy ones

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -359,6 +359,96 @@ it("rm and promises.rm report ERR_FS_EISDIR for directories like rmSync", async 
   expect(fs.existsSync(target)).toBe(false);
 });
 
+// node validates the options (validateRmOptions in lib/internal/fs/utils.js)
+// before the lstat that produces ERR_FS_EISDIR, so on a directory target an
+// invalid option is what gets reported. Expected codes and messages are node
+// v26.3.0's.
+describe("rm option validation runs before the ERR_FS_EISDIR check", () => {
+  const cases = [
+    [
+      { force: "x" },
+      "ERR_INVALID_ARG_TYPE",
+      `The "options.force" property must be of type boolean. Received type string ('x')`,
+    ],
+    [
+      { recursive: 0 },
+      "ERR_INVALID_ARG_TYPE",
+      `The "options.recursive" property must be of type boolean. Received type number (0)`,
+    ],
+    [
+      { recursive: undefined },
+      "ERR_INVALID_ARG_TYPE",
+      `The "options.recursive" property must be of type boolean. Received undefined`,
+    ],
+    [
+      { maxRetries: "x" },
+      "ERR_INVALID_ARG_TYPE",
+      `The "options.maxRetries" property must be of type number. Received type string ('x')`,
+    ],
+    [
+      { maxRetries: -1 },
+      "ERR_OUT_OF_RANGE",
+      `The value of "options.maxRetries" is out of range. It must be >= 0 && <= 4294967295. Received -1`,
+    ],
+    [
+      { retryDelay: "x" },
+      "ERR_INVALID_ARG_TYPE",
+      `The "options.retryDelay" property must be of type number. Received type string ('x')`,
+    ],
+    [
+      { retryDelay: 2 ** 31 },
+      "ERR_OUT_OF_RANGE",
+      `The value of "options.retryDelay" is out of range. It must be >= 0 && <= 2147483647. Received 2147483648`,
+    ],
+    ["x", "ERR_INVALID_ARG_TYPE", `The "options" argument must be of type object. Received type string ('x')`],
+    [null, "ERR_INVALID_ARG_TYPE", `The "options" argument must be of type object. Received null`],
+    [[], "ERR_INVALID_ARG_TYPE", `The "options" argument must be of type object. Received an instance of Array`],
+    // node checks force first, then recursive, retryDelay, maxRetries
+    [
+      { recursive: "x", force: "x" },
+      "ERR_INVALID_ARG_TYPE",
+      `The "options.force" property must be of type boolean. Received type string ('x')`,
+    ],
+    [
+      { maxRetries: "x", retryDelay: "x" },
+      "ERR_INVALID_ARG_TYPE",
+      `The "options.retryDelay" property must be of type number. Received type string ('x')`,
+    ],
+  ];
+
+  test.each(cases)("options %p", async (options, code, message) => {
+    using dir = tempDir("rm-options-before-eisdir", { "sub/a.txt": "x" });
+    const target = join(String(dir), "sub");
+    const expected = { name: code === "ERR_OUT_OF_RANGE" ? "RangeError" : "TypeError", code, message };
+
+    expect(() => fs.rmSync(target, options)).toThrow(expect.objectContaining(expected));
+    // the callback form reports invalid options by throwing, not through the callback
+    expect(() => fs.rm(target, options, () => expect.unreachable("callback must not run"))).toThrow(
+      expect.objectContaining(expected),
+    );
+    await expect(fsPromises.rm(target, options)).rejects.toMatchObject(expected);
+
+    expect(fs.existsSync(join(target, "a.txt"))).toBe(true);
+  });
+
+  test("valid options still reach the native rm", async () => {
+    using dir = tempDir("rm-options-valid", { "a.txt": "", "b.txt": "", "c.txt": "", "sub/a.txt": "x" });
+    const root = String(dir);
+    fs.rmSync(join(root, "a.txt"), { force: true, maxRetries: 2, retryDelay: 0 });
+    const { promise, resolve } = Promise.withResolvers();
+    fs.rm(join(root, "b.txt"), { recursive: false }, resolve);
+    expect(await promise).toBeNull();
+    await fsPromises.rm(join(root, "c.txt"), {});
+    // a missing target is still an lstat ENOENT unless force is set
+    expect(() => fs.rmSync(join(root, "a.txt"))).toThrow(expect.objectContaining({ code: "ENOENT", syscall: "lstat" }));
+    fs.rmSync(join(root, "a.txt"), { force: true });
+    // and a directory is still refused once the options are fine
+    expect(() => fs.rmSync(join(root, "sub"))).toThrow(expect.objectContaining({ code: "ERR_FS_EISDIR" }));
+    await fsPromises.rm(join(root, "sub"), { recursive: true });
+    expect(fs.readdirSync(root)).toEqual([]);
+  });
+});
+
 it("close() while an operation is in flight actually closes the fd", async () => {
   await using dir = tempDir("deferred-close", { "x.txt": "hello" });
   const fh = await fsPromises.open(join(dir, "x.txt"), "r");


### PR DESCRIPTION
### Problem

- `fs.rmSync(dir, { force: "x" })` throws `ERR_FS_EISDIR` (`Path is a directory: rm returned EISDIR (is a directory) <dir>`). Node v26.3.0 throws `ERR_INVALID_ARG_TYPE` (`The "options.force" property must be of type boolean. Received type string ('x')`). Same for any other invalid option (`recursive: 0`, an own `recursive: undefined`, `maxRetries: "x"`, `retryDelay: -1`, ...) and for a non-object `options` (`rmSync(dir, "x")`), and through all three entry points: `fs.rm` delivers the EISDIR to the callback and `fs.promises.rm` rejects with it.
- Cause: the JS wrappers (`rmSync` in `src/js/node/fs.ts`, `rm` in `src/js/node/fs.promises.ts`, which the callback `fs.rm` also went through) lstat the target and throw `ERR_FS_EISDIR` first, and only then call the native `fs.rm`, which is where the options were validated (`args::Rm::from_js` in `src/runtime/node/node_fs.rs`). Node's `validateRmOptions` validates the options before its lstat, so with a directory target the option error wins there. With a file target the native validation was reached and Bun already reported the type error, so this is purely the wrappers' ordering.
- Smaller consequence of the same structure: node's callback `fs.rm(path, badOptions, cb)` throws synchronously; Bun handed the error to the callback because `fs.rm` was implemented as `promises.rm(...).then(...)`.

### Fix

- `fs.promises.ts`: port node's `validateRmOptions` (`validateObject`, spread over the defaults, then `force`, `recursive`, `retryDelay` as int32 >= 0, `maxRetries` as uint32, in node's order) and run it before the lstat / `ERR_FS_EISDIR` check in all three flavors: `validateRmOptionsSync` (used by `rmSync`) and `rmValidated` (the async lstat + native call, used by `promises.rm` and callback `rm`). The two copies of the EISDIR check in `fs.ts` and `fs.promises.ts` collapse into these; they are shared with `fs.ts` through the module's existing private `$data` export. The fixing change is the order: options first, lstat second.
- `fs.ts`: `rmSync` becomes `fs.rmSync(path, validateRmOptionsSync(path, options))`; callback `rm` calls `validateRmOptions` synchronously (so invalid options throw, as in node) and then `rmValidated`.
- Why this is right: for `node:fs` node's behavior is the contract, and this is node's own structure (options, then lstat, then remove), using the shared validators that already render node's messages. Accepted inputs do not change except in the node direction: the native parser already rejected everything `validateRmOptions` rejects, apart from an array or function as the options bag and `retryDelay` above int32 range, which node rejects too. The normalized object handed to the native binding is the same set of own keys the wrappers passed before (the old `{ ...options }` spread), so the native parser, `fs.rmdir`, and the internal callers that pass literals to the binding are unaffected. The native validation and its `test-fs-rm.js` hook are left in place: the binding still validates its own input, and #39328 is fixing its messages; the native rm also still produces node's `force`/`ENOENT` (`syscall: "lstat"`) behavior, which is why an lstat failure in the wrappers is still left for it to report.
- Verified:
  - `test/js/node/fs/promises.test.js`, new `rm option validation runs before the ERR_FS_EISDIR check` block: 12 option cases (each checked through `rmSync`, callback `rm` throwing synchronously, and `promises.rm`, asserting error class, code and node's message text, and that the directory survives), plus a case that valid options still remove files, still report `ENOENT`/`lstat` and still report `ERR_FS_EISDIR`. The 12 cases fail on the released build, all pass with this change; the whole file passes.
  - A 240-result matrix (20 option values x directory / file / missing / non-string path x 3 entry points) against a local node v26.3.0: 35 results matched node before, 197 after. The 43 still differing are all in the non-string-path column and are not touched here: Bun's native path error has its own text, and in the callback and promise forms node validates the path before the options (`rmSync` matches node: options first). Excerpt below.
  - Vendored `test-fs-rm.js`, `test-fs-rmSync-special-char.js`, `test-fs-rmdir-*.js`, `test-fs-promises.js`, `test-fs-error-messages.js` pass; `test/js/node/fs/fs.test.ts` (512 tests) and the rest of `test/js/node/fs` pass, except `abort-signal-leak-read-write-file.test.ts`, whose 100k-iteration fixture needs about 7 minutes on this debug+ASAN container against a 5 minute budget and does not involve rm.
- Related open PRs: #39328 fixes the native parser's messages (its rm tests accept either delivery channel and assert node's text, so the two land in either order); #33366 rewrites the same callback `rm` wrapper for a different reason (callback dispatch); the overlap is the few lines of that wrapper, and its rm arm would keep the `validateRmOptions` call up front.

### Background

- `ERR_FS_EISDIR` is node's JS-level refusal to `rm` a directory without `recursive: true`. It is not produced by the OS: node's `validateRmOptions` (`lib/internal/fs/utils.js`) lstat's the path and throws it itself, after validating the options; the removal only runs afterwards. Bun's native `rm` does not perform this check, which is why the wrappers do it in JS.
- In node, `{ ...defaults, ...options }` is what makes an own key holding `undefined` an error (`rmSync(p, { recursive: undefined })` is rejected, an absent key is not). Bun's native parser mirrors that with own-property lookups, and the normalized object the wrappers now pass has all four keys as own properties.
- `$data` on the `node:fs/promises` export object is a private-symbol property (invisible to user code) already used to hand `FileHandle` and its symbols to `internal/fs/streams` and `node:http2`; `node:fs` requires `node:fs/promises` at load, so sharing the helpers this way loads nothing extra on the rm path.

<details>
<summary>Matrix excerpt (directory target; node v26.3.0 / before / after)</summary>

```
rmSync(dir, { force: "x" })
  node:   ERR_INVALID_ARG_TYPE: The "options.force" property must be of type boolean. Received type string ('x')
  before: ERR_FS_EISDIR: Path is a directory: rm returned EISDIR (is a directory) <base>/dir
  after:  ERR_INVALID_ARG_TYPE: The "options.force" property must be of type boolean. Received type string ('x')

rmSync(dir, { recursive: 0 })
  node:   ERR_INVALID_ARG_TYPE: The "options.recursive" property must be of type boolean. Received type number (0)
  before: ERR_FS_EISDIR: Path is a directory: rm returned EISDIR (is a directory) <base>/dir
  after:  ERR_INVALID_ARG_TYPE: The "options.recursive" property must be of type boolean. Received type number (0)

rmSync(dir, { maxRetries: "x" })
  node:   ERR_INVALID_ARG_TYPE: The "options.maxRetries" property must be of type number. Received type string ('x')
  before: ERR_FS_EISDIR: Path is a directory: rm returned EISDIR (is a directory) <base>/dir
  after:  ERR_INVALID_ARG_TYPE: The "options.maxRetries" property must be of type number. Received type string ('x')

rmSync(dir, "x")
  node:   ERR_INVALID_ARG_TYPE: The "options" argument must be of type object. Received type string ('x')
  before: ERR_FS_EISDIR: Path is a directory: rm returned EISDIR (is a directory) <base>/dir
  after:  ERR_INVALID_ARG_TYPE: The "options" argument must be of type object. Received type string ('x')

fs.rm(file, { force: "x" }, cb)
  node:   thrown synchronously: ERR_INVALID_ARG_TYPE: The "options.force" property must be of type boolean. Received type string ('x')
  before: passed to cb:         ERR_INVALID_ARG_TYPE: The "options.force" property must be of type boolean.
  after:  thrown synchronously: ERR_INVALID_ARG_TYPE: The "options.force" property must be of type boolean. Received type string ('x')
```

The `fs.rm` callback and `fs.promises.rm` rows for the directory target are the same as the `rmSync` rows above, before and after.

</details>
