### PR TITLE
node:fs: stat with throwIfNoEntry: false returns undefined on ENOTDIR like node

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7845,6 +7845,8 @@ impl NodeFS {
                 ))));
             }
         }
+        // With `throwIfNoEntry: false`, node's stat() reports both ENOENT and
+        // ENOTDIR as "no entry"; its lstat() only does so for ENOENT.
         #[cfg(any(target_os = "linux", target_os = "android"))]
         if sys::SUPPORTS_STATX_ON_LINUX.load(Ordering::Relaxed) {
             return match sys::statx(path, sys::STATX_MASK_FOR_STATS) {
@@ -7853,7 +7855,8 @@ impl NodeFS {
                     args.big_int,
                 )))),
                 Err(err) => {
-                    if !args.throw_if_no_entry && err.get_errno() == E::ENOENT {
+                    if !args.throw_if_no_entry && matches!(err.get_errno(), E::ENOENT | E::ENOTDIR)
+                    {
                         return Ok(StatOrNotFound::NotFound);
                     }
                     Err(err.with_path(args.path.slice()))
@@ -7866,7 +7869,7 @@ impl NodeFS {
                 args.big_int,
             )))),
             Err(err) => {
-                if !args.throw_if_no_entry && err.get_errno() == E::ENOENT {
+                if !args.throw_if_no_entry && matches!(err.get_errno(), E::ENOENT | E::ENOTDIR) {
                     return Ok(StatOrNotFound::NotFound);
                 }
                 Err(err.with_path(args.path.slice()))

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7845,8 +7845,7 @@ impl NodeFS {
                 ))));
             }
         }
-        // With `throwIfNoEntry: false`, node's stat() reports both ENOENT and
-        // ENOTDIR as "no entry"; its lstat() only does so for ENOENT.
+        // node swallows ENOTDIR as well as ENOENT here, but only ENOENT in lstat().
         #[cfg(any(target_os = "linux", target_os = "android"))]
         if sys::SUPPORTS_STATX_ON_LINUX.load(Ordering::Relaxed) {
             return match sys::statx(path, sys::STATX_MASK_FOR_STATS) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1467,6 +1467,69 @@ it("promises.readdir on a large folder withFileTypes", async () => {
   rmSync(huge, { force: true, recursive: true });
 });
 
+// A path that goes through a regular file fails with ENOTDIR on POSIX (Windows reports ENOENT for it,
+// which the ENOENT tests below cover). Node's stat() treats ENOTDIR like ENOENT for throwIfNoEntry: false;
+// its lstat() does not.
+describe.skipIf(isWindows)("throwIfNoEntry: false with ENOTDIR", () => {
+  const enotdir = expect.objectContaining({ code: "ENOTDIR" });
+  const callback = (fn: (...args: any[]) => void, ...args: unknown[]) => {
+    const { promise, resolve } = Promise.withResolvers<[unknown, unknown]>();
+    fn(...args, (err: unknown, stats: unknown) => resolve([err, stats]));
+    return promise;
+  };
+
+  it("stat reports a file in the middle of the path as no entry", async () => {
+    using dir = tempDir("fs-stat-enotdir", { "file.txt": "not a directory" });
+    const under = join(String(dir), "file.txt", "child");
+    const options = { throwIfNoEntry: false };
+
+    expect(statSync(under, options)).toBeUndefined();
+    expect(statSync(under, { ...options, bigint: true })).toBeUndefined();
+    expect(await promises.stat(under, options)).toBeUndefined();
+    expect(await promises.stat(under, { ...options, bigint: true })).toBeUndefined();
+    expect(await callback(fs.stat, under, options)).toEqual([null, undefined]);
+
+    expect(() => statSync(under)).toThrow(expect.objectContaining({ code: "ENOTDIR", syscall: "stat", path: under }));
+    expect(() => statSync(under, { throwIfNoEntry: true })).toThrow(enotdir);
+    await expect(promises.stat(under)).rejects.toMatchObject({ code: "ENOTDIR", syscall: "stat", path: under });
+    expect(await callback(fs.stat, under)).toEqual([enotdir, undefined]);
+  });
+
+  it("stat reports a file with a trailing slash as no entry", async () => {
+    using dir = tempDir("fs-stat-enotdir", { "file.txt": "not a directory" });
+    const trailingSlash = join(String(dir), "file.txt") + "/";
+
+    expect(statSync(trailingSlash, { throwIfNoEntry: false })).toBeUndefined();
+    expect(await promises.stat(trailingSlash, { throwIfNoEntry: false })).toBeUndefined();
+    expect(() => statSync(trailingSlash)).toThrow(enotdir);
+  });
+
+  it("lstat still throws ENOTDIR", async () => {
+    using dir = tempDir("fs-lstat-enotdir", { "file.txt": "not a directory" });
+    const under = join(String(dir), "file.txt", "child");
+    const trailingSlash = join(String(dir), "file.txt") + "/";
+    const options = { throwIfNoEntry: false };
+
+    expect(() => lstatSync(under, options)).toThrow(
+      expect.objectContaining({ code: "ENOTDIR", syscall: "lstat", path: under }),
+    );
+    expect(() => lstatSync(trailingSlash, options)).toThrow(enotdir);
+    await expect(promises.lstat(under, options)).rejects.toMatchObject({ code: "ENOTDIR", syscall: "lstat" });
+    expect(await callback(fs.lstat, under, options)).toEqual([enotdir, undefined]);
+  });
+
+  it("stat still throws errors other than ENOENT and ENOTDIR", async () => {
+    using dir = tempDir("fs-stat-eloop", {});
+    const loop = join(String(dir), "loop");
+    symlinkSync("loop", loop);
+    const options = { throwIfNoEntry: false };
+
+    expect(() => statSync(loop, options)).toThrow(expect.objectContaining({ code: "ELOOP" }));
+    await expect(promises.stat(loop, options)).rejects.toMatchObject({ code: "ELOOP" });
+    expect(await callback(fs.stat, loop, options)).toEqual([expect.objectContaining({ code: "ELOOP" }), undefined]);
+  });
+});
+
 it("statSync throwIfNoEntry", () => {
   const path = join(tmpdirSync(), "does", "not", "exist");
   expect(statSync(path, { throwIfNoEntry: false })).toBeUndefined();


### PR DESCRIPTION
### Problem

- `fs.statSync(p, { throwIfNoEntry: false })` throws `ENOTDIR: not a directory, stat '.../file.txt/child'` when a component of `p` is a regular file (`file.txt/child`, or `file.txt/` with a trailing slash). `fs.promises.stat` rejects and the callback form of `fs.stat` reports the same error. Node v26.3.0 returns `undefined` from all three.
- Cause: `NodeFS::stat` in `src/runtime/node/node_fs.rs` (main: [L7856](https://github.com/oven-sh/bun/blob/aec33f581d9158191d6e0c5fcdd73a69411d249d/src/runtime/node/node_fs.rs#L7856) for the statx path and [L7869](https://github.com/oven-sh/bun/blob/aec33f581d9158191d6e0c5fcdd73a69411d249d/src/runtime/node/node_fs.rs#L7869) for `stat(2)`) only maps ENOENT to `StatOrNotFound::NotFound`. Every other errno, ENOTDIR included, is thrown even when the caller passed `throwIfNoEntry: false`.
- Node's binding swallows both: the sync path uses [`is_uv_error_except_no_entry_dir`](https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L1124-L1126) (ENOENT or ENOTDIR) at [node_file.cc#L1180](https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L1180), and the callback and promise paths resolve `undefined` for either errno in [`AfterStatNoThrowIfNoEntry`](https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L824-L837). `fs.stat`, `fs.statSync` and `fsPromises.stat` all forward `options.throwIfNoEntry` to it (`node -p "fs.promises.stat.toString()"` shows the binding call and the comment "Binding will resolve undefined if UV_ENOENT or UV_ENOTDIR").
- `lstat` is different on purpose: node's sync `LStat` uses [`is_uv_error_except_no_entry`](https://github.com/nodejs/node/blob/v26.3.0/src/node_file.cc#L1232-L1233) (ENOENT only), so `lstatSync(file.txt/child, { throwIfNoEntry: false })` throws ENOTDIR in node. Bun's `NodeFS::lstat` already does exactly that and is not touched.
- The Zig implementation had the same ENOENT-only check, so this is not a regression. Callers that rely on the node contract exist: `import-meta-resolve`'s `fileExists()` calls `statSync(url, { throwIfNoEntry: false })` with no try/catch, so a resolution candidate that passes through a file throws out of the resolver on bun and is `false` on node.

### Fix

- The two error branches in `NodeFS::stat` return `NotFound` for `ENOENT | ENOTDIR` when `throw_if_no_entry` is false ([node_fs.rs#L7848-L7875](https://github.com/oven-sh/bun/blob/farm/83b35e00/stat-throwifnoentry-enotdir/src/runtime/node/node_fs.rs#L7848-L7875)). `NotFound` already becomes `undefined` (sync return value, promise resolution, callback's second argument), so the three JS entry points are covered by the one change; they all run through this function.
- Correct because it is node's rule for `stat` (links above), and only for `stat`: `lstat` keeps the ENOENT-only check, every other errno (ELOOP, EACCES, ENAMETOOLONG, ...) still throws, and `throwIfNoEntry` defaults to `true` so nothing changes for callers that do not pass `false`. The only in-tree caller that builds `args::Stat` itself (`Bun.file().stat()` in `Blob.rs`) passes `throw_if_no_entry: true`.
- Not changed: bun's callback `fs.lstat` and `fsPromises.lstat` honor `throwIfNoEntry: false` for ENOENT, while node's async `LStat` ignores the option (it is documented for `lstatSync` only). That is pre-existing and separate from this ENOTDIR delta; the new tests only assert what node and bun agree on for lstat.
- Verified with the new `describe("throwIfNoEntry: false with ENOTDIR")` in `test/js/node/fs/fs.test.ts` (skipped on Windows, where libuv reports these paths as ENOENT and the existing ENOENT tests apply): `statSync` (number and bigint), `fs.promises.stat` and callback `fs.stat` return `undefined` for `file.txt/child` and `file.txt/`; the same calls without the option or with `throwIfNoEntry: true` still throw ENOTDIR with `syscall: "stat"`; `lstatSync`, `fsPromises.lstat` and callback `fs.lstat` still throw ENOTDIR with `throwIfNoEntry: false`; and a symlink loop still throws ELOOP with `throwIfNoEntry: false` from all three stat forms. The two stat tests fail on bun 1.4.0, all four pass with this build.
- Whole `fs.test.ts` (516 pass, 6 skip) and the vendored `test-fs-stat.js`, `test-fs-stat-bigint.js` and `test-fs-promises.js` pass with this build. The probe below prints identical output for node 26.3.0 and this build on every stat line.
- #39335 changes how `args::Stat` parses these options and explicitly leaves this errno rule alone; the two branches merge cleanly in either order (`git merge-tree` checked).

### Background

- `throwIfNoEntry` is a `fs.statSync`/`fs.lstatSync` option (node 14.17+): when `false`, a missing entry returns `undefined` instead of throwing. Node's `fs.stat` callback form and `fsPromises.stat` also forward it to the binding; `fs.lstat`/`fsPromises.lstat` do not.
- ENOTDIR is what POSIX `stat(2)` returns when a non-final path component exists but is not a directory (`file.txt/child`), or when the final component is a non-directory named with a trailing slash (`file.txt/`). For "does this path exist" callers it means the same thing as ENOENT, which is why node folds both into `undefined` for `stat`. Windows (libuv) reports these paths as ENOENT instead, hence the platform skip on the new tests.
- `NodeFS::stat` / `NodeFS::lstat` are the single native implementations behind the sync, callback and promise entry points (`node_fs_binding.rs` wires the sync forms; `async_::Stat`/`async_::Lstat` run the same functions on the thread pool). They return `Maybe<StatOrNotFound>`; `StatOrNotFound::NotFound` is converted to `undefined` on the way back to JS. On Linux with a recent kernel the `statx` branch runs, otherwise the `stat(2)` branch, which is why the same check appears twice.

<details>
<summary>Probe (node 26.3.0 vs this build); <code>f</code> is a regular file</summary>

```
statSync(f/child, {throwIfNoEntry:false})          node: undefined        bun 1.4.0: throws ENOTDIR   this PR: undefined
statSync(f/child, {throwIfNoEntry:false,bigint})   node: undefined        bun 1.4.0: throws ENOTDIR   this PR: undefined
statSync(f/, {throwIfNoEntry:false})               node: undefined        bun 1.4.0: throws ENOTDIR   this PR: undefined
promises.stat(f/child, {throwIfNoEntry:false})     node: undefined        bun 1.4.0: rejects ENOTDIR  this PR: undefined
stat(f/child, {throwIfNoEntry:false}, cb)          node: cb(null, undef)  bun 1.4.0: cb(ENOTDIR)      this PR: cb(null, undef)
statSync(f/child)                                  node: throws ENOTDIR   bun 1.4.0: throws ENOTDIR   this PR: throws ENOTDIR
statSync(loop, {throwIfNoEntry:false})             node: throws ELOOP     bun 1.4.0: throws ELOOP     this PR: throws ELOOP
statSync(<300 chars>, {throwIfNoEntry:false})      node: ENAMETOOLONG     bun 1.4.0: ENAMETOOLONG     this PR: ENAMETOOLONG
lstatSync(f/child, {throwIfNoEntry:false})         node: throws ENOTDIR   bun 1.4.0: throws ENOTDIR   this PR: throws ENOTDIR
lstatSync(f/, {throwIfNoEntry:false})              node: throws ENOTDIR   bun 1.4.0: throws ENOTDIR   this PR: throws ENOTDIR
promises.lstat(f/child, {throwIfNoEntry:false})    node: rejects ENOTDIR  bun 1.4.0: rejects ENOTDIR  this PR: rejects ENOTDIR
statSync(missing, {throwIfNoEntry:false})          node: undefined        bun 1.4.0: undefined        this PR: undefined
lstatSync(missing, {throwIfNoEntry:false})         node: undefined        bun 1.4.0: undefined        this PR: undefined
```

</details>
