### PR TITLE
Report unmapped Windows syscall errors with code "UNKNOWN" instead of "EUNKNOWN"

### DIFF
--- a/src/errno/windows_errno.rs
+++ b/src/errno/windows_errno.rs
@@ -550,7 +550,10 @@ pub enum SystemErrno {
     ENOTRECOVERABLE = 131,
     ERFKILL = 132,
     EHWPOISON = 133,
-    // made up erropr
+    /// `UV_UNKNOWN`, and the fallback for Win32/uv codes the tables do not map.
+    /// The strum name becomes the JS-visible `err.code`; libuv and node spell
+    /// this one `UNKNOWN` (`uv_err_name(UV_UNKNOWN)`), as does `uv_e::ENTRIES`.
+    #[strum(serialize = "UNKNOWN")]
     EUNKNOWN = 134,
     ECHARSET = 135,
     EOF = 136,

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -270,9 +270,10 @@ impl Listener {
                         // does (EADDRINUSE vs EACCES need different caller
                         // handling) rather than an invalid-arguments TypeError.
                         if let ListenPipeError::Sys(sys_err, uv_errno) = &e {
-                            // get_error_code_tag_name does not reject EUNKNOWN /
-                            // UV_EAI_* (>=3000); neither is a node-style code, so
-                            // route those through the generic error below.
+                            // get_error_code_tag_name does not reject EUNKNOWN (the
+                            // fallback for every unmapped code, so it does not identify
+                            // the failure) or UV_EAI_* (>=3000, whose tag names are not
+                            // node's codes); route both through the generic error below.
                             if let Some((name, se)) = sys_err.get_error_code_tag_name() {
                                 if se != bun_sys::SystemErrno::EUNKNOWN && (se as u16) < 3000 {
                                     let err = jsc::SystemError {
@@ -298,7 +299,7 @@ impl Listener {
                         }
                         let detail = match &e {
                             ListenPipeError::Other(err) => err.name(),
-                            // Sys whose errno has no node-style code (EUNKNOWN / UV_EAI_*).
+                            // Sys skipped above: the EUNKNOWN fallback or UV_EAI_*.
                             ListenPipeError::Sys(..) => "UNKNOWN",
                         };
                         return Err(global.throw_invalid_arguments(format_args!(

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1280,7 +1280,7 @@ pub(crate) fn inject<'a>(
                 // Map the Win32 code through the errno table so users see a
                 // name, not a raw integer.
                 bun_core::pretty_errorln!(
-                    "<r><red>error<r><d>:<r> failed to copy bun executable into temporary file: {:?}",
+                    "<r><red>error<r><d>:<r> failed to copy bun executable into temporary file: {}",
                     e.to_system_errno()
                         .unwrap_or(bun_sys::SystemErrno::EUNKNOWN)
                 );

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1413,6 +1413,25 @@ it.if(isWindows)("throws a spawn error for a cwd longer than the maximum path le
   expect(exitCode).toBe(0);
 });
 
+// CreateProcess rejects a file that is not a PE image with a Win32 error libuv has
+// no errno for, so uv_spawn fails with UV_UNKNOWN (-4094), which libuv, node and
+// util.getSystemErrorName all name "UNKNOWN".
+it.if(isWindows)("spawn errors libuv reports as UV_UNKNOWN use node's UNKNOWN code", () => {
+  using dir = tempDir("spawn-unknown-error", { "bad.exe": "\x00\x01\x02garbage\n" });
+  const exe = join(String(dir), "bad.exe");
+  function thrownBy(fn: () => unknown) {
+    try {
+      fn();
+    } catch (e: any) {
+      return { code: e.code, errno: e.errno, message: e.message };
+    }
+    return "did not throw";
+  }
+  const expected = { code: "UNKNOWN", errno: -4094, message: "UNKNOWN: unknown error, uv_spawn" };
+  expect(thrownBy(() => spawnSync({ cmd: [exe] }))).toEqual(expected);
+  expect(thrownBy(() => spawn({ cmd: [exe] }))).toEqual(expected);
+});
+
 describe("onDisconnect", () => {
   it.todoIf(isWindows)("ipc delivers message", async () => {
     const msg = Promise.withResolvers<void>();

--- a/test/js/bun/sys/error-name-from-libuv.test.ts
+++ b/test/js/bun/sys/error-name-from-libuv.test.ts
@@ -9,6 +9,7 @@
 import { sysErrorNameFromLibuv } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
 import { isWindows } from "harness";
+import { getSystemErrorName } from "node:util";
 
 test.skipIf(!isWindows)("Error.name() with from_libuv=true does not overflow", () => {
   // errno values as stored by node_fs.zig: @intCast(-rc) where rc is the
@@ -16,7 +17,15 @@ test.skipIf(!isWindows)("Error.name() with from_libuv=true does not overflow", (
   expect(sysErrorNameFromLibuv(4058)).toBe("ENOENT"); // -UV_ENOENT
   expect(sysErrorNameFromLibuv(4083)).toBe("EBADF"); // -UV_EBADF
   expect(sysErrorNameFromLibuv(4092)).toBe("EACCES"); // -UV_EACCES
-  expect(sysErrorNameFromLibuv(4094)).toBe("EUNKNOWN"); // -UV_UNKNOWN
+  expect(sysErrorNameFromLibuv(4094)).toBe("UNKNOWN"); // -UV_UNKNOWN
+});
+
+// This name becomes err.code. libuv's uv_err_name(UV_UNKNOWN) is "UNKNOWN", and
+// so is Bun's own util.getSystemErrorName(-4094); the Rust variant is EUNKNOWN.
+test.skipIf(!isWindows)("Error.name() spells the unknown-errno fallback like node", () => {
+  expect(sysErrorNameFromLibuv(4094)).toBe(getSystemErrorName(-4094)); // -UV_UNKNOWN
+  // A code with no UV_E* constant folds to the same fallback.
+  expect(sysErrorNameFromLibuv(4000)).toBe("UNKNOWN");
 });
 
 test.skipIf(isWindows)("sysErrorNameFromLibuv is a no-op off Windows", () => {

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1107,6 +1107,34 @@ console.log(JSON.stringify({ uid: process.getuid(), threwCode: thrown?.code, thr
   });
 });
 
+// A file that is not a PE image makes CreateProcess fail with a Win32 error libuv
+// has no errno for, so the spawn fails with UV_UNKNOWN. The expected values are
+// what node v26 reports for the same file.
+it.if(isWindows)("spawn errors libuv cannot map report code UNKNOWN like node", () => {
+  using dir = tempDir("spawn-unknown-error", { "bad.exe": "\x00\x01\x02garbage\n" });
+  const exe = path.join(String(dir), "bad.exe");
+
+  // Node throws codes outside its deferred set (ENOENT, EACCES, ...) synchronously.
+  let thrown: any;
+  try {
+    spawn(exe);
+  } catch (e) {
+    thrown = e;
+  }
+  expect({ code: thrown?.code, errno: thrown?.errno, syscall: thrown?.syscall }).toEqual({
+    code: "UNKNOWN",
+    errno: -4094,
+    syscall: "spawn",
+  });
+
+  const { error } = spawnSync(exe);
+  expect({ code: error?.code, errno: error?.errno, syscall: error?.syscall }).toEqual({
+    code: "UNKNOWN",
+    errno: -4094,
+    syscall: `spawnSync ${exe}`,
+  });
+});
+
 // Regression: Bun registered the stdout/stderr poll immediately, so the native
 // reader drained the child's output into an unbounded in-memory buffer before
 // any JS consumer attached. The child never blocked on a full pipe, and once


### PR DESCRIPTION
### Problem
- On Windows, any syscall failure that resolves to the unknown-errno fallback reaches JS as `err.code === "EUNKNOWN"` with a message starting `EUNKNOWN: unknown error, ...`. Example: spawning a file CreateProcess refuses (libuv reports `UV_UNKNOWN`, -4094) through `Bun.spawn`, `Bun.spawnSync`, `child_process.spawn` or `child_process.spawnSync`.
- node reports `code: "UNKNOWN"` for the same file (output below), because libuv's name for `UV_UNKNOWN` is `UNKNOWN` (`uv_err_name`, `src/uv-common.c`); `EUNKNOWN` exists nowhere in libuv or node. Bun's own `util.getSystemErrorName(-4094)` (`src/errno/lib.rs:52`) and `process.binding("uv").errname(-4094)` (`src/jsc/bindings/ProcessBindingUV.cpp:94`) also say `UNKNOWN`, so bun disagreed with itself.
- Cause: `bun_sys::Error::get_error_code_tag_name` (`src/sys/Error.rs:329`) uses the strum name of the resolved `SystemErrno` variant as the code, and `to_system_error` puts the same string into the message. The Windows enum names that variant `EUNKNOWN` (`src/errno/windows_errno.rs:554`). Every other variant's Rust name is already the node spelling (`ENOENT`, `ECHARSET`, `EOF`, `EFTYPE`, ...); this one is the only mismatch. It is reached by `UV_UNKNOWN` itself, by `translate_uv_error_to_e`'s fallback for uv codes with no `E` row, and by the `unwrap_or(EUNKNOWN)` fallbacks in `src/sys/windows/mod.rs` and `src/sys/lib.rs`.

### Fix
- `#[strum(serialize = "UNKNOWN")]` on `SystemErrno::EUNKNOWN` (the fixing line). The Rust identifier stays, so the existing `SystemErrno::EUNKNOWN` / `E::EUNKNOWN` uses are unchanged; only the rendered name changes, and it changes in one place for every path that renders it: `err.code`, the message prefix, `Error::name()`, `Display for SystemErrno`, and the per-crate `Error::name()` impls.
- Correct because the rendered name is defined by libuv/node, not by the Rust identifier; the same file already does this for `E::_2BIG` (`serialize = "2BIG"`). Nothing parses a `SystemErrno` from a string (no `from_str`/`parse` users of the `EnumString` derive), so the serialize attribute has no other effect. `Error::name()` already returned the literal `"UNKNOWN"` when the errno cannot be resolved at all, so the two fallbacks now agree too. POSIX is unaffected: its `SystemErrno` has no such variant.
- `StandaloneModuleGraph.rs` formatted this errno with `{:?}`, which prints the Rust identifier and would have kept saying `EUNKNOWN`; it now uses `{}`, which goes through the same strum name as everything else.
- `Listener.rs` intentionally keeps routing `EUNKNOWN` through its generic "Failed to listen" error (that variant is also the fallback for unmapped codes, so it does not identify the failure); only its comments changed, since they justified the exclusion by the old spelling.
- `src/js/node/child_process.ts:1168` (`#handleOnExit`, `exitCode < 0` branch) is intentionally left alone: that literal is a JS-side `err.errno` value (its `code` is `ERR_CHILD_PROCESS_UNKNOWN_ERROR`), not a rendering of this variant, and the native side never passes a negative exit code (`Subprocess::get_exit_code` returns the `u8` or `null`; a `Status::Err` arrives as the `err` argument), so the branch is not reachable today. Reshaping it to node's `errnoException` form is a separate change.
- `src/js/internal/fs/cp.ts` and `cp-sync.ts` already special-case `err.code === "UNKNOWN"` (ported from node's Windows readlink workaround); that branch becomes reachable on bun now.
- Verification (all Windows-only tests, `it.if(isWindows)` / `test.skipIf(!isWindows)`; they fail on the unfixed build and pass with it, checked on windows-x64 with `USE_SYSTEM_BUN=1` vs `bun bd`):
  - `test/js/bun/sys/error-name-from-libuv.test.ts`: the existing `4094` assertion updated from `"EUNKNOWN"` to `"UNKNOWN"`, plus a test that `Error.name()` agrees with `util.getSystemErrorName(-4094)` and that a uv code with no constant (4000) folds to the same name.
  - `test/js/bun/spawn/spawn.test.ts`: `Bun.spawnSync` and `Bun.spawn` on a non-PE `bad.exe` throw `{ code: "UNKNOWN", errno: -4094, message: "UNKNOWN: unknown error, uv_spawn" }`.
  - `test/js/node/child_process/child_process.test.ts`: `spawn` throws and `spawnSync` returns `{ code: "UNKNOWN", errno: -4094 }` with node's `syscall` values; the expected values are node v26.3.0's output for the same file.
  - The garbage `bad.exe` yields `-4094` on both windows-x64 and windows-aarch64 (checked with the released bun on both), so the precondition holds on both Windows CI lanes.
  - Also green with the fix on windows-x64: the full `spawn.test.ts` and `child_process.test.ts` files, `test/js/node/fs/translate-uv-error-windows.test.ts`, `rm-windows-ntstatus.test.ts`, `test/js/bun/net/named-pipe-listen-error.test.ts`, `test/js/node/util/util.test.js`.
- The same repro also shows that Windows spawn errors carry no `path` (POSIX ones and node do); that is a separate defect in `spawn_process_windows` and is tracked separately, not changed here.

### Background
- `bun_sys::Error` stores an errno as an `E` discriminant. On Windows there is no host errno, so bun keeps two parallel `#[repr(u16)]` enums with identical discriminants: `E` (bare names, `UNKNOWN = 134`) for matching in Rust code, and `SystemErrno` (E-prefixed names, `EUNKNOWN = 134`) whose variant names double as the node-style error codes shown to users. Win32 and libuv error codes are folded into these tables; anything without a row lands on discriminant 134.
- strum's `IntoStaticStr` derive turns a variant into its name as a `&'static str`; `#[strum(serialize = "...")]` overrides that string for one variant without renaming it.
- `UV_UNKNOWN` (-4094) is libuv's own "no errno for this" code. node's `err.errno` is the libuv code and `err.code` is `uv_err_name()` of it, which is where `UNKNOWN` comes from; bun already reports `errno: -4094` here, only the name was off.

<details>
<summary>Repro output (windows-x64)</summary>

Fixture: 11 bytes that are not a PE image, written to `C:/tmp/bad.exe`.

node v26.3.0:

```
child_process.spawnSync -> { code: "UNKNOWN", errno: -4094, syscall: "spawnSync C:/tmp/bad.exe", path: "C:/tmp/bad.exe" }
child_process.spawn     -> throws { code: "UNKNOWN", errno: -4094, syscall: "spawn" }
util.getSystemErrorName(-4094) -> "UNKNOWN"
```

bun 1.4.0 canary (before):

```
Bun.spawnSync           -> { code: "EUNKNOWN", errno: -4094, syscall: "uv_spawn", message: "EUNKNOWN: unknown error, uv_spawn" }
Bun.spawn               -> same
child_process.spawnSync -> { code: "EUNKNOWN", errno: -4094, syscall: "spawnSync C:/tmp/bad.exe" }
child_process.spawn     -> throws { code: "EUNKNOWN", errno: -4094, syscall: "spawn" }
util.getSystemErrorName(-4094) -> "UNKNOWN"
```

this branch (`bun bd`):

```
Bun.spawnSync           -> { code: "UNKNOWN", errno: -4094, syscall: "uv_spawn", message: "UNKNOWN: unknown error, uv_spawn" }
Bun.spawn               -> same
child_process.spawnSync -> { code: "UNKNOWN", errno: -4094, syscall: "spawnSync C:/tmp/bad.exe" }
child_process.spawn     -> throws { code: "UNKNOWN", errno: -4094, syscall: "spawn" }
```

</details>
