### PR TITLE
test(cron): do not let leftover crontab entries fail the Linux suites

### DIFF
--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -67,7 +67,10 @@ function readCrontab(): string {
     stdout: "pipe",
     stderr: "pipe",
   });
-  return result.exitCode === 0 ? result.stdout.toString() : "";
+  if (result.exitCode === 0) return result.stdout.toString();
+  // Exit code 1 is "no crontab for <user>"; Bun.cron reads it the same way.
+  if (result.exitCode === 1) return "";
+  throw new Error(`crontab -l exited with ${result.exitCode}: ${result.stderr.toString()}`);
 }
 
 function writeCrontab(content: string) {
@@ -112,15 +115,15 @@ function entryLines(crontab: string, title: string): string[] {
 }
 
 function removeStaleTestEntries() {
+  const marker = `# bun-cron: ${TEST_TITLE_PREFIX}`;
   const lines = readCrontab().split("\n");
-  const kept: string[] = [];
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].startsWith(`# bun-cron: ${TEST_TITLE_PREFIX}`)) {
-      i++; // skip the command line that belongs to the marker
-    } else {
-      kept.push(lines[i]);
-    }
-  }
+  const kept = lines.filter((line, i) => {
+    if (line.startsWith(marker)) return false;
+    // A command line goes only together with the test marker right above it.
+    const previous = i > 0 ? lines[i - 1] : "";
+    if (!previous.startsWith(marker)) return true;
+    return !line.includes(` --cron-title=${previous.slice("# bun-cron: ".length)} `);
+  });
   if (kept.length !== lines.length) writeCrontab(kept.join("\n"));
 }
 
@@ -582,7 +585,7 @@ describe.skipIf(!hasCrontab)("cron registration (Linux)", () => {
     const [marker, command] = entryLines(readCrontab(), "test-register");
     expect(marker).toBe("# bun-cron: test-register");
     expect(command).toStartWith("30 2 * * 1 ");
-    expect(command).toContain(scriptPath);
+    expect(command).toEndWith(` '${scriptPath}'`);
   });
 
   test("crontab entry contains correct format", async () => {
@@ -755,6 +758,9 @@ describe.skipIf(!hasCrontab)("cron removal (Linux)", () => {
         "30 2 * * 1 /usr/bin/some-other-job",
         "# bun-cron: not-a-test-job",
         "* * * * * /usr/bin/not-a-test-job",
+        // A marker whose command line went missing: only the marker goes.
+        "# bun-cron: test-orphaned-marker",
+        "0 0 * * * /usr/bin/unrelated-line",
         "",
       ].join("\n"),
     );
@@ -766,6 +772,7 @@ describe.skipIf(!hasCrontab)("cron removal (Linux)", () => {
         "30 2 * * 1 /usr/bin/some-other-job",
         "# bun-cron: not-a-test-job",
         "* * * * * /usr/bin/not-a-test-job",
+        "0 0 * * * /usr/bin/unrelated-line",
         "",
       ].join("\n"),
     );

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -614,11 +614,15 @@ describe.skipIf(!hasCrontab)("cron registration (Linux)", () => {
       "job.ts": `export default { scheduled() {} };`,
     });
 
+    // A foreign line shares the schedule that gets replaced.
+    writeCrontab("0 * * * * /usr/bin/some-other-job\n");
     await Bun.cron(`${dir}/job.ts`, "0 * * * *", "test-replace");
     await Bun.cron(`${dir}/job.ts`, "30 2 * * 1", "test-replace");
 
+    const crontab = readCrontab();
+    expect(crontab).toContain("0 * * * * /usr/bin/some-other-job\n");
     // One marker and one command line: the first entry's pair is gone.
-    expect(entryLines(readCrontab(), "test-replace")).toEqual([
+    expect(entryLines(crontab, "test-replace")).toEqual([
       "# bun-cron: test-replace",
       expect.stringMatching(/^30 2 \* \* 1 /),
     ]);
@@ -753,8 +757,11 @@ describe.skipIf(!hasCrontab)("cron removal (Linux)", () => {
     using _restore = saveCrontabState();
     writeCrontab(
       [
+        // Two runs died in different tests, leaving adjacent blocks.
         "# bun-cron: test-stale",
         "30 2 * * 1 '/old/bun' run --cron-title=test-stale --cron-period='30 2 * * 1' '/gone/job.ts'",
+        "# bun-cron: test-rm-keep",
+        "0 * * * * '/old/bun' run --cron-title=test-rm-keep --cron-period='0 * * * *' '/gone/a.ts'",
         "30 2 * * 1 /usr/bin/some-other-job",
         "# bun-cron: not-a-test-job",
         "* * * * * /usr/bin/not-a-test-job",

--- a/test/js/bun/cron/cron.test.ts
+++ b/test/js/bun/cron/cron.test.ts
@@ -74,7 +74,10 @@ function writeCrontab(content: string) {
   const tmpFile = `/tmp/bun-cron-${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`;
   writeFileSync(tmpFile, content);
   try {
-    Bun.spawnSync({ cmd: [crontabPath!, tmpFile] });
+    const result = Bun.spawnSync({ cmd: [crontabPath!, tmpFile], stdout: "pipe", stderr: "pipe" });
+    if (result.exitCode !== 0) {
+      throw new Error(`crontab exited with ${result.exitCode}: ${result.stderr.toString()}`);
+    }
   } finally {
     try {
       unlinkSync(tmpFile);
@@ -90,6 +93,38 @@ function saveCrontabState(): Disposable {
     },
   };
 }
+
+// Every title this file registers starts with this prefix, so entries left
+// behind by a run that was killed mid-test (nothing restores the crontab then)
+// can be removed without touching the user's own jobs.
+const TEST_TITLE_PREFIX = "test-";
+
+/**
+ * The lines Bun.cron installs for `title`: its `# bun-cron: <title>` marker and
+ * the command line after it. Assertions go through this rather than searching
+ * the whole crontab, which also holds whatever the user (or an earlier, killed
+ * run of this file) has installed.
+ */
+function entryLines(crontab: string, title: string): string[] {
+  return crontab
+    .split("\n")
+    .filter(line => line === `# bun-cron: ${title}` || line.includes(` --cron-title=${title} `));
+}
+
+function removeStaleTestEntries() {
+  const lines = readCrontab().split("\n");
+  const kept: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith(`# bun-cron: ${TEST_TITLE_PREFIX}`)) {
+      i++; // skip the command line that belongs to the marker
+    } else {
+      kept.push(lines[i]);
+    }
+  }
+  if (kept.length !== lines.length) writeCrontab(kept.join("\n"));
+}
+
+if (hasCrontab) beforeAll(removeStaleTestEntries);
 
 // ==========================================================================
 // API shape
@@ -544,10 +579,10 @@ describe.skipIf(!hasCrontab)("cron registration (Linux)", () => {
     const scriptPath = `${dir}/job.ts`;
     await Bun.cron(scriptPath, "30 2 * * 1", "test-register");
 
-    const crontab = readCrontab();
-    expect(crontab).toContain("# bun-cron: test-register");
-    expect(crontab).toContain("30 2 * * 1");
-    expect(crontab).toContain(scriptPath);
+    const [marker, command] = entryLines(readCrontab(), "test-register");
+    expect(marker).toBe("# bun-cron: test-register");
+    expect(command).toStartWith("30 2 * * 1 ");
+    expect(command).toContain(scriptPath);
   });
 
   test("crontab entry contains correct format", async () => {
@@ -579,11 +614,11 @@ describe.skipIf(!hasCrontab)("cron registration (Linux)", () => {
     await Bun.cron(`${dir}/job.ts`, "0 * * * *", "test-replace");
     await Bun.cron(`${dir}/job.ts`, "30 2 * * 1", "test-replace");
 
-    const crontab = readCrontab();
-    const count = (crontab.match(/# bun-cron: test-replace/g) || []).length;
-    expect(count).toBe(1);
-    expect(crontab).toContain("30 2 * * 1");
-    expect(crontab).not.toContain("0 * * * *");
+    // One marker and one command line: the first entry's pair is gone.
+    expect(entryLines(readCrontab(), "test-replace")).toEqual([
+      "# bun-cron: test-replace",
+      expect.stringMatching(/^30 2 \* \* 1 /),
+    ]);
   });
 
   test("registers multiple different cron jobs", async () => {
@@ -593,14 +628,18 @@ describe.skipIf(!hasCrontab)("cron registration (Linux)", () => {
       "b.ts": `export default { scheduled() {} };`,
     });
 
-    await Bun.cron(`${dir}/a.ts`, "0 * * * *", "multi-a");
-    await Bun.cron(`${dir}/b.ts`, "30 12 * * 5", "multi-b");
+    await Bun.cron(`${dir}/a.ts`, "0 * * * *", "test-multi-a");
+    await Bun.cron(`${dir}/b.ts`, "30 12 * * 5", "test-multi-b");
 
     const crontab = readCrontab();
-    expect(crontab).toContain("# bun-cron: multi-a");
-    expect(crontab).toContain("# bun-cron: multi-b");
-    expect(crontab).toContain("0 * * * *");
-    expect(crontab).toContain("30 12 * * 5");
+    expect(entryLines(crontab, "test-multi-a")).toEqual([
+      "# bun-cron: test-multi-a",
+      expect.stringMatching(/^0 \* \* \* \* /),
+    ]);
+    expect(entryLines(crontab, "test-multi-b")).toEqual([
+      "# bun-cron: test-multi-b",
+      expect.stringMatching(/^30 12 \* \* 5 /),
+    ]);
   });
 
   test("preserves existing non-bun crontab entries", async () => {
@@ -646,21 +685,22 @@ describe.skipIf(!hasCrontab)("cron removal (Linux)", () => {
       "job.ts": `export default { scheduled() {} };`,
     });
 
-    await Bun.cron(`${dir}/job.ts`, "30 2 * * 1", "rm-target");
+    await Bun.cron(`${dir}/job.ts`, "30 2 * * 1", "test-rm-target");
 
-    let crontab = readCrontab();
-    expect(crontab).toContain("# bun-cron: rm-target");
+    expect(entryLines(readCrontab(), "test-rm-target")).toEqual([
+      "# bun-cron: test-rm-target",
+      expect.stringMatching(/^30 2 \* \* 1 /),
+    ]);
 
-    await Bun.cron.remove("rm-target");
+    await Bun.cron.remove("test-rm-target");
 
-    crontab = readCrontab();
-    expect(crontab).not.toContain("# bun-cron: rm-target");
-    expect(crontab).not.toContain("30 2 * * 1");
+    // Both the marker and its command line are removed.
+    expect(entryLines(readCrontab(), "test-rm-target")).toEqual([]);
   });
 
   test("removing non-existent entry resolves without error", async () => {
     using _restore = saveCrontabState();
-    const result = await Bun.cron.remove("rm-nonexistent");
+    const result = await Bun.cron.remove("test-rm-nonexistent");
     expect(result).toBeUndefined();
   });
 
@@ -671,14 +711,20 @@ describe.skipIf(!hasCrontab)("cron removal (Linux)", () => {
       "b.ts": `export default { scheduled() {} };`,
     });
 
-    await Bun.cron(`${dir}/a.ts`, "0 * * * *", "rm-keep");
-    await Bun.cron(`${dir}/b.ts`, "30 2 * * 1", "rm-delete");
+    // A foreign line and another entry share the removed entry's schedule.
+    writeCrontab("30 2 * * 1 /usr/bin/some-other-job\n");
+    await Bun.cron(`${dir}/a.ts`, "30 2 * * 1", "test-rm-keep");
+    await Bun.cron(`${dir}/b.ts`, "30 2 * * 1", "test-rm-delete");
 
-    await Bun.cron.remove("rm-delete");
+    await Bun.cron.remove("test-rm-delete");
 
     const crontab = readCrontab();
-    expect(crontab).toContain("# bun-cron: rm-keep");
-    expect(crontab).not.toContain("# bun-cron: rm-delete");
+    expect(crontab).toContain("30 2 * * 1 /usr/bin/some-other-job\n");
+    expect(entryLines(crontab, "test-rm-keep")).toEqual([
+      "# bun-cron: test-rm-keep",
+      expect.stringMatching(/^30 2 \* \* 1 /),
+    ]);
+    expect(entryLines(crontab, "test-rm-delete")).toEqual([]);
   });
 
   test("register after remove works", async () => {
@@ -687,17 +733,42 @@ describe.skipIf(!hasCrontab)("cron removal (Linux)", () => {
       "job.ts": `export default { scheduled() {} };`,
     });
 
-    await Bun.cron(`${dir}/job.ts`, "0 * * * *", "rm-reregister");
-    await Bun.cron.remove("rm-reregister");
+    await Bun.cron(`${dir}/job.ts`, "0 * * * *", "test-rm-reregister");
+    await Bun.cron.remove("test-rm-reregister");
 
-    let crontab = readCrontab();
-    expect(crontab).not.toContain("# bun-cron: rm-reregister");
+    expect(entryLines(readCrontab(), "test-rm-reregister")).toEqual([]);
 
-    await Bun.cron(`${dir}/job.ts`, "30 6 * * *", "rm-reregister");
+    await Bun.cron(`${dir}/job.ts`, "30 6 * * *", "test-rm-reregister");
 
-    crontab = readCrontab();
-    expect(crontab).toContain("# bun-cron: rm-reregister");
-    expect(crontab).toContain("30 6 * * *");
+    expect(entryLines(readCrontab(), "test-rm-reregister")).toEqual([
+      "# bun-cron: test-rm-reregister",
+      expect.stringMatching(/^30 6 \* \* \* /),
+    ]);
+  });
+
+  test("entries left behind by a killed run are removed, everything else is kept", () => {
+    using _restore = saveCrontabState();
+    writeCrontab(
+      [
+        "# bun-cron: test-stale",
+        "30 2 * * 1 '/old/bun' run --cron-title=test-stale --cron-period='30 2 * * 1' '/gone/job.ts'",
+        "30 2 * * 1 /usr/bin/some-other-job",
+        "# bun-cron: not-a-test-job",
+        "* * * * * /usr/bin/not-a-test-job",
+        "",
+      ].join("\n"),
+    );
+
+    removeStaleTestEntries();
+
+    expect(readCrontab()).toBe(
+      [
+        "30 2 * * 1 /usr/bin/some-other-job",
+        "# bun-cron: not-a-test-job",
+        "* * * * * /usr/bin/not-a-test-job",
+        "",
+      ].join("\n"),
+    );
   });
 });
 


### PR DESCRIPTION
### Problem
- `test/js/bun/cron/cron.test.ts` is red on the Ubuntu 25.04 lanes (builds 99065, 99199, 99243, 99284, 99330): `cron removal (Linux) > removes an existing cron entry` fails at `expect(crontab).not.toContain("30 2 * * 1")` (cron.test.ts:658), and in 99284 `replaces existing entry with same title` fails the same way at `:586` on `"0 * * * *"`. The line it finds belongs to a different test of the same file (`# bun-cron: test-replace`, `test-register`, `rm-keep`, ...), and all four retries of the file fail identically.
- Sequence in every failing job: the file was interrupted in the `bun test --parallel` batch (`Interrupted while still running: test/js/bun/cron/cron.test.ts (258s)`), which killed it between a `Bun.cron()` call and that test's crontab restore, so the entry stayed in the agent's real crontab. `saveCrontabState()` then snapshots and restores that entry on every later test, and the `not.toContain(<schedule>)` assertions scan the whole crontab, so the leftover fails each solo retry. The same assertions also fail on any machine whose crontab already has an hourly job or a Monday 02:30 job.
- Exposed by #39236, which moved the file into the parallel batch. The Linux suites only run on lanes that have `crontab` (Ubuntu 25.04, and Alpine through busybox), and all 19 interruptions of this file in builds 98637 to 99358 were on the Ubuntu lanes. The interruption itself is the open spawnSync private-loop keep-alive bug (#34069, fix in #37754): in the same window it interrupted `env.test.ts`, `process-on.test.ts`, `nodemailer.test.ts` and other sync-spawn files on every Linux lane; cron.test.ts is the one victim that turns into a hard failure because the kill leaves state behind. A failed `crontab <file>` in `writeCrontab()` was also silently ignored.

### Fix
- Assert through `entryLines(crontab, title)`, which returns the two lines Bun.cron installs for a title (the `# bun-cron: <title>` marker and the command line carrying `--cron-title=<title>`). Removal now asserts both lines are gone (what `:657`/`:658` were checking), replace asserts exactly one marker and one command line with the new schedule (what the count and the two `toContain`s were checking), and the other schedule assertions check the title's own command line. Unrelated lines, whether a user's jobs or a leftover from a killed run, cannot satisfy or trip them.
- `beforeAll` removes entries whose marker starts with `# bun-cron: test-`, the prefix every title registered by this file uses (the `multi-*` and `rm-*` titles are renamed to get there), so a killed run cannot fail later runs or leave `* * * * *` test jobs on the machine. The command line under a marker is only removed when it carries that marker's title; other `# bun-cron:` blocks and plain lines are kept, so the one thing the sweep would remove that it did not create is a user's own Bun.cron job titled `test-...` on a machine where someone runs this file. A new test covers the sweep: two adjacent stale blocks, a foreign block, plain lines, and a marker whose next line is unrelated.
- `removes only the targeted entry` and `replaces existing entry with same title` now seed a foreign line with the schedule being removed or replaced (the shapes from builds 99199 and 99284) and check it survives. `writeCrontab()` throws when `crontab` exits non-zero instead of leaving the failure to surface tests later, and `readCrontab()` only maps exit 1 (no crontab, the same reading Bun.cron's backend uses) to empty and throws on anything else.
- This is the right layer: Bun's crontab backend is behaving correctly in every failing log (the leftover blocks are intact and `remove` only touches its own title), the test was asserting on state it does not own.
- Verified with the debug build and a stand-in `crontab` script in `PATH` (keeps the spool in a file), since this container has no cron: the unmodified file fails `:658` with a leftover `test-replace` block planted, matching CI, and fails `:586` and `:658` with a plain `0 * * * *` / `30 2 * * 1` user crontab; this file passes all three setups (83 pass, 35 skip) and leaves the user's lines, including a foreign `# bun-cron:` block, in place while the planted stale blocks are removed. Without `crontab` in `PATH` the Linux suites skip as before (54 pass, 64 skip). Against the real binaries in this PR's build, the suites pass on Ubuntu 25.04 x64 and aarch64 (Debian cron) and Alpine x64 (busybox) with 83 pass, 35 skip, and skip on Debian 13 as before.

<details>
<summary>Self-review notes</summary>

- Considered fixing only the hang (#37754) or taking the file back out of the batch instead: neither fixes the assertions, which also fail on any crontab that already has an hourly or a Monday 02:30 job, and a kill of the file for any other reason (runner timeout, ^C) poisons the next run the same way. The allowlist regen will drop the file from the batch on its own from the flaky annotations it has now.
- `entryLines` cannot confuse `test-rm` with `test-rm-keep`: the marker is compared whole and the command match includes the space after the title. Titles are `[A-Za-z0-9_-]` so nothing needs escaping.
- `removeStaleTestEntries` probed directly with: a marker as the last line, content without a trailing newline, adjacent stale blocks, a foreign `# bun-cron:` block and plain user lines (only the stale lines go); it never writes unless it dropped something, so a `crontab -l` that reports no crontab leaves everything untouched.
- `readCrontab` maps exit 1 to empty because that is what every crontab here returns for "no crontab" (Debian cron and busybox both exercised by this PR's build); the message differs between implementations so it is not used.
- The only titles renamed are the seven `multi-*`/`rm-*` ones; nothing outside this file refers to them. macOS and Windows sections are untouched.
</details>

### Background
- Bun.cron on Linux installs a two-line block per job into the user's crontab: a `# bun-cron: <title>` marker line, then `<schedule> '<bun>' run --cron-title=<title> --cron-period='<schedule>' '<script>'`. `Bun.cron.remove(title)` and re-registration drop the marker line plus the line after it (`filter_crontab` in `src/runtime/api/cron.rs`), so a correct removal leaves neither line.
- These suites run against the real crontab of whoever runs them; `saveCrontabState()` restores the previous contents at the end of each test, which only happens if the process survives the test.
- The CI runner executes most files in one `bun test --parallel` process per shard and kills it after four minutes of silence; files still in flight are re-run alone, so a file that is interrupted normally shows up as flaky rather than failed.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->