### PR TITLE
bake: match dynamic framework routes by precedence instead of scan order

### DIFF
--- a/src/runtime/bake/FrameworkRouter.rs
+++ b/src/runtime/bake/FrameworkRouter.rs
@@ -49,7 +49,9 @@ pub struct FrameworkRouter {
     ///
     /// Root files are not caught using this technique, since every route tree has a
     /// root. This check is special cased.
-    // TODO: no code to sort this data structure
+    ///
+    /// `match_slow` returns the first pattern in here that matches, so `scan`
+    /// sorts this by `EncodedPattern::precedence_key` after inserting the files.
     pub(crate) dynamic_routes: DynamicRouteMap,
 
     /// Arena allocator for pattern strings.
@@ -311,6 +313,25 @@ impl EncodedPattern {
             }
         }
         bun_wyhash::hash(&stack_space[..pos]) as usize
+    }
+
+    /// Of two patterns matching the same URL, the one whose key compares lower
+    /// (`Iterator::cmp`) should serve it. This is the order of Next.js'
+    /// `getSortedRoutes`: at the first part where the patterns differ, text
+    /// beats a param, which beats a catch-all, which beats an optional
+    /// catch-all, and a pattern that ends first comes first.
+    ///
+    /// Like `matches`, this ignores groups and param names. The ranks are not
+    /// `PartTag`, whose values are the serialization format and put the
+    /// optional catch-all before the required one.
+    fn precedence_key(&self) -> impl Iterator<Item = (u8, &[u8])> {
+        self.iterate().filter_map(|part| match part {
+            Part::Text(text) => Some((0, text)),
+            Part::Param(_) => Some((1, b"".as_slice())),
+            Part::CatchAll(_) => Some((2, b"".as_slice())),
+            Part::CatchAllOptional(_) => Some((3, b"".as_slice())),
+            Part::Group(_) => None,
+        })
     }
 
     fn matches(&self, path: &[u8], params: &mut MatchedParams) -> bool {
@@ -1485,7 +1506,14 @@ impl FrameworkRouter {
             return Ok(());
         };
         let mut arena_state = Arena::new();
-        self.scan_inner(ty, r, &root_info, &mut arena_state, ctx)
+        self.scan_inner(ty, r, &root_info, &mut arena_state, ctx)?;
+        self.dynamic_routes.sort(|patterns, _, a, b| {
+            patterns[a]
+                .precedence_key()
+                .cmp(patterns[b].precedence_key())
+                .is_lt()
+        });
+        Ok(())
     }
 
     fn scan_inner(

--- a/test/bake/dev/route-matching.test.ts
+++ b/test/bake/dev/route-matching.test.ts
@@ -1,0 +1,24 @@
+// Which framework route the dev server serves a URL with.
+import { devTest, minimalFramework } from "../bake-harness";
+
+const page = (name: string) => `export default () => new Response(${JSON.stringify(name)});`;
+
+devTest("the most specific dynamic route serves the request", {
+  framework: minimalFramework,
+  files: {
+    "routes/[...all].ts": page("[...all]"),
+    "routes/[slug].ts": page("[slug]"),
+    "routes/[slug]/[id].ts": page("[slug]/[id]"),
+    "routes/[team]/docs/[[...path]].ts": page("[team]/docs/[[...path]]"),
+    "routes/opt/[[...rest]].ts": page("opt/[[...rest]]"),
+  },
+  async test(dev) {
+    await dev.fetch("/a").equals("[slug]");
+    await dev.fetch("/a/b").equals("[slug]/[id]");
+    await dev.fetch("/a/b/c").equals("[...all]");
+    await dev.fetch("/acme/docs").equals("[team]/docs/[[...path]]");
+    await dev.fetch("/acme/docs/intro").equals("[team]/docs/[[...path]]");
+    await dev.fetch("/opt").equals("opt/[[...rest]]");
+    await dev.fetch("/opt/a").equals("opt/[[...rest]]");
+  },
+});

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -133,3 +133,97 @@ test("discovers from filesystem paths", () => {
     ],
   });
 });
+
+describe("dynamic route precedence", () => {
+  /** Scans a router made of `files` and returns, for each url, the page file (relative to the root) that serves it. */
+  function servedBy(files: string[], urls: string[]): Record<string, string | null> {
+    using dir = tempDir("fsr-precedence", Object.fromEntries(files.map(file => [file, "1"])));
+    const router = new FrameworkRouter({ root: String(dir), style: "nextjs-pages" });
+    return Object.fromEntries(
+      urls.map(url => {
+        const match = router.match(url);
+        return [url, match === null ? null : path.relative(String(dir), match.route.page).replaceAll("\\", "/")];
+      }),
+    );
+  }
+
+  // Routes are inserted in the order the directory scan visits them, which is
+  // derived from the file names. The names in each case below are chosen so
+  // that the scan visits the losing route first, so every case depends on the
+  // router sorting the routes rather than matching them in scan order.
+  test.each([
+    [
+      "a static segment beats a param",
+      ["blog/[slug].tsx", "[section]/[slug].tsx"],
+      { "/blog/hello": "blog/[slug].tsx", "/news/hello": "[section]/[slug].tsx" },
+    ],
+    [
+      "a static segment beats a param after a shared param",
+      ["[user]/posts/[id].tsx", "[user]/[section]/[id].tsx"],
+      { "/joe/posts/1": "[user]/posts/[id].tsx", "/joe/likes/1": "[user]/[section]/[id].tsx" },
+    ],
+    [
+      "a static segment beats a catch-all after a shared param",
+      ["[team]/docs/[[...path]].tsx", "[team]/[...path].tsx"],
+      {
+        "/acme/docs": "[team]/docs/[[...path]].tsx",
+        "/acme/docs/a/b": "[team]/docs/[[...path]].tsx",
+        "/acme/billing": "[team]/[...path].tsx",
+      },
+    ],
+    [
+      "a static segment followed by an optional catch-all beats a param",
+      ["[id].tsx", "opt/[[...rest]].tsx"],
+      { "/opt": "opt/[[...rest]].tsx", "/opt/a": "opt/[[...rest]].tsx", "/other": "[id].tsx" },
+    ],
+    ["a param beats a catch-all", ["[slug].tsx", "[...rest].tsx"], { "/a": "[slug].tsx", "/a/b": "[...rest].tsx" }],
+    [
+      "a param beats an optional catch-all",
+      ["[slug].tsx", "[[...rest]].tsx"],
+      { "/a": "[slug].tsx", "/a/b": "[[...rest]].tsx" },
+    ],
+    [
+      "a catch-all beats an optional catch-all",
+      ["[...slug].tsx", "[[...slug]].tsx"],
+      { "/a": "[...slug].tsx", "/a/b": "[...slug].tsx" },
+    ],
+    [
+      "two params beat a catch-all",
+      ["[slug]/[id].tsx", "[...rest].tsx"],
+      { "/a/b": "[slug]/[id].tsx", "/a/b/c": "[...rest].tsx" },
+    ],
+    [
+      "the route that ends first beats one that continues with an optional catch-all",
+      ["[slug].tsx", "[slug]/[[...rest]].tsx"],
+      { "/a": "[slug].tsx", "/a/b": "[slug]/[[...rest]].tsx" },
+    ],
+  ])("%s", (_, files, expected) => {
+    expect(servedBy(files, Object.keys(expected))).toEqual(expected);
+  });
+
+  test("precedence is decided at the first segment that differs", () => {
+    const files = [
+      "[...all].tsx",
+      "[[...opt]].tsx",
+      "[slug].tsx",
+      "[slug]/[id].tsx",
+      "[slug]/[...rest].tsx",
+      "[team]/docs/[[...path]].tsx",
+      "docs/[page]/[[...rest]].tsx",
+      "docs/[...rest].tsx",
+      "opt/[[...rest]].tsx",
+    ];
+    const expected = {
+      "/a": "[slug].tsx",
+      "/a/b": "[slug]/[id].tsx",
+      "/a/b/c": "[slug]/[...rest].tsx",
+      "/acme/docs": "[team]/docs/[[...path]].tsx",
+      "/acme/docs/intro": "[team]/docs/[[...path]].tsx",
+      "/docs/intro": "docs/[page]/[[...rest]].tsx",
+      "/docs/intro/b": "docs/[page]/[[...rest]].tsx",
+      "/opt": "opt/[[...rest]].tsx",
+      "/opt/a": "opt/[[...rest]].tsx",
+    };
+    expect(servedBy(files, Object.keys(expected))).toEqual(expected);
+  });
+});


### PR DESCRIPTION
### Problem

- When two framework routes both match a URL, bake's dev server serves whichever one the directory scan happened to insert first. With `pages/blog/[slug].tsx` and `pages/[section]/[slug].tsx`, `/blog/hello` is served by `[section]/[slug]`; with `pages/[slug]/[id].tsx` and `pages/[...rest].tsx`, `/a/b` is served by `[...rest]`; with `pages/[team]/docs/[[...path]].tsx` and `pages/[team]/[...path].tsx`, `/acme/docs` is served by `[team]/[...path]`. Renaming a parameter can flip any of these, because the scan order is derived from a hash of the file names.
- Cause: `FrameworkRouter::match_slow` (`src/runtime/bake/FrameworkRouter.rs:1259` on main) returns the first entry of `dynamic_routes` that matches, and nothing orders that map after `scan_inner` fills it in directory-walk order (the field carried `TODO: no code to sort this data structure`, line 52).
- Same bug as #39291 fixes for `Bun.FileSystemRouter`; that PR leaves bake's separate router alone, and this one covers it.

### Fix

- `scan` sorts `dynamic_routes` once the walk is done. Patterns are compared through `EncodedPattern::precedence_key`, which yields one `(rank, text)` pair per part, compared lexicographically: a text segment ranks before a param, which ranks before a catch-all, which ranks before an optional catch-all; two text segments compare by value; a pattern that runs out of parts first comes first. Groups are left out, as `matches` leaves them out.
- Why this order: it is the order Next.js's `getSortedRoutes` produces for the pages router (at each level: the level's own route, static children, `[slug]`, `[...rest]`, `[[...rest]]`, depth first), which is the convention the `nextjs-pages` style implements, and it is the rule #39291 gives `Bun.FileSystemRouter`, so the two routers agree.
- Why sorting in `scan` is enough: `scan` is the only code path that inserts routes, and the dev server, `bun build --app` and the test binding each run it once at startup. `scan_all` calls it once per router type, so the final call sorts the combined map; the sort is stable, so routes that compare equal keep the router-type order. Two entries can only compare equal when they have the same effective URL, which `dynamic_routes` already rejects as a collision, so the resulting order does not depend on the scan at all.
- Not affected: `static_routes` is still consulted first, the route tree (`toJSON`, layouts) is built the same way, and production builds prerender every route without calling `match_slow`.
- Left to #37120: `EncodedPattern::matches` still lets `[x]` match an empty segment and `[...x]` match zero segments (on main, `pages/[slug].tsx` on its own serves `/` with `slug: ""`). #37120 fixes that in `matches`, which this PR does not touch. Until it lands, a URL that leaves such a route zero segments (`/` with `[slug].tsx` or `[...all].tsx` next to `[[...rest]].tsx`, `/docs` with `docs/[...rest].tsx` next to `docs/[[...opt]].tsx`) is always served by the required route, where main serves it by whichever route the scan visited first; with both changes the optional catch-all serves it, which is what #37120's tests assert. Landing #37120 first or together avoids that window. Its "failed candidate's captures don't leak" test also states scan order as its premise, which whichever PR lands second has to revisit.
- Verified with `test/bake/framework-router.test.ts` ("dynamic route precedence", 10 cases) and `test/bake/dev/route-matching.test.ts` (the dev server end to end). On the current release all 11 fail, each naming the scan-order winner; the file names in the unit cases were picked so that the scan visits the losing route first. With this build they pass.
- `test/bake/dev/import-meta-inline.test.ts`, `ssg-pages-router.test.ts` and `react-response.test.ts` still pass; `cargo clippy -p bun_runtime` and `cargo fmt --check` are clean.

### Background

- A bake framework declares file system router types (for example a `pages/` directory in the `nextjs-pages` style). `FrameworkRouter` scans them once at startup and records every page in one of two maps: `static_routes`, keyed by the full URL, for routes without parameters, and `dynamic_routes`, an insertion-ordered array hash map keyed by pattern, for the rest. `match_slow` is the only URL matcher (the dev server calls it for every request); it looks the URL up in `static_routes` and then tries `dynamic_routes` in array order, so that order is the precedence.
- An `EncodedPattern` is a route pattern serialized as a list of `Part`s: `Text` (a literal segment), `Param` (`[x]`, one segment), `CatchAll` (`[...x]`, all remaining segments), `CatchAllOptional` (`[[...x]]`, all remaining segments or none) and `Group` (`(name)`, app-router directories that do not appear in the URL). `PartTag` is the tag stored in that serialization; its numbering puts the optional catch-all before the required one, which is why the sort uses ranks of its own.
- The scan visits directory entries in the iteration order of a hash map keyed by entry name. That order is deterministic for a given set of names, which is why the examples above reproduce everywhere, but it has nothing to do with the shape of the routes.
