### PR TITLE
spawn: attach the command path to uv_spawn errors on Windows

### DIFF
--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -2112,7 +2112,12 @@ mod spawn_process_body {
                 (*process).close();
                 Process::deref(process);
             }
-            return Ok(Err(err));
+            // Blame argv[0], as `posix_spawn::spawn_z` does on Linux and as
+            // Node's `err.path` does, rather than the resolved `file`.
+            // SAFETY: argv[0] is non-null (read above for `file`) and the
+            // caller keeps argv alive for the duration of this call.
+            let arg0 = unsafe { bun_core::ffi::cstr(*argv) }.to_bytes();
+            return Ok(Err(err.with_path(arg0)));
         }
         // The process handle is open on this thread's loop until `close()`; a
         // thread teardown closes it through us (the child keeps running, as with

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1394,6 +1394,24 @@ it.if(isWindows)("handles duplicated for Bun.file(fd).stream() are not inherited
   }
 });
 
+// posix_spawn failures name the command in err.path and in the message. On
+// Windows, uv_spawn failures (anything CreateProcess refuses, here a file
+// that is not a valid executable) used to carry neither.
+it.if(isWindows)("uv_spawn failure names the command in err.path", () => {
+  using dir = tempDir("spawn-uv-spawn-path", { "bad.exe": Buffer.from("\x00\x01\x02garbage\n", "latin1") });
+  const exe = join(String(dir), "bad.exe");
+  for (const start of [() => spawnSync({ cmd: [exe] }), () => spawn({ cmd: [exe] })]) {
+    let thrown: any;
+    try {
+      start();
+    } catch (e) {
+      thrown = e;
+    }
+    expect({ syscall: thrown?.syscall, path: thrown?.path }).toEqual({ syscall: "uv_spawn", path: exe });
+    expect(thrown.message).toEndWith(`uv_spawn '${exe}'`);
+  }
+});
+
 it.if(isWindows)("throws a spawn error for a cwd longer than the maximum path length", async () => {
   const fixture = `
     try {
@@ -1617,6 +1635,20 @@ describe("uid/gid", () => {
       thrown = e;
     }
     expect(thrown?.code).toBe("EPERM");
+  });
+
+  // libuv rejects uid/gid on Windows. The error names the command as it was
+  // given (not the resolved cmd.exe path), like a posix_spawn failure does.
+  it.if(isWindows)("throws ENOTSUP naming the command for uid/gid on Windows", () => {
+    for (const ids of [{ uid: 0 }, { gid: 0 }]) {
+      let thrown: any;
+      try {
+        spawnSync({ cmd: ["cmd.exe", "/c", "exit 0"], ...ids });
+      } catch (e) {
+        thrown = e;
+      }
+      expect({ code: thrown?.code, path: thrown?.path }).toEqual({ code: "ENOTSUP", path: "cmd.exe" });
+    }
   });
 });
 

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -830,6 +830,16 @@ it("spawnSync(does-not-exist)", () => {
   expect(x.stderr).toEqual(null);
 });
 
+// Node sets error.path to the file for every spawnSync failure. A file that
+// exists but CreateProcess refuses to run fails inside uv_spawn, which used to
+// produce an error without a path on Windows.
+it.if(isWindows)("spawnSync(file CreateProcess refuses) reports error.path", () => {
+  using dir = tempDir("spawnsync-bad-exe", { "bad.exe": Buffer.from("\x00\x01\x02garbage\n", "latin1") });
+  const exe = path.join(String(dir), "bad.exe");
+  const r = spawnSync(exe);
+  expect({ path: r.error?.path, syscall: r.error?.syscall }).toEqual({ path: exe, syscall: `spawnSync ${exe}` });
+});
+
 // https://github.com/oven-sh/bun/issues/32067
 // Darwin's posix_spawn file actions reject any fd number >= OPEN_MAX (10240)
 // with EBADF at registration time, before checking whether the fd is open.
@@ -1102,8 +1112,9 @@ console.log(JSON.stringify({ uid: process.getuid(), threwCode: thrown?.code, thr
     }
     expect(thrown?.code).toBe("ENOTSUP");
 
+    // Like node, error.path is the file as given, not the resolved cmd.exe.
     const r = spawnSync("cmd.exe", ["/c", "exit 0"], { gid: 0 });
-    expect(r.error?.code).toBe("ENOTSUP");
+    expect({ code: r.error?.code, path: r.error?.path }).toEqual({ code: "ENOTSUP", path: "cmd.exe" });
   });
 });
 


### PR DESCRIPTION
### Problem
- On Windows, a spawn that fails inside `uv_spawn` throws an error with no `path` property and a message that does not name the command: `Bun.spawnSync({ cmd: ["C:/tmp/bad.exe"] })` (a file CreateProcess refuses to run) throws `err.path === undefined`, message `EUNKNOWN: unknown error, uv_spawn`; `child_process.spawnSync("C:/tmp/bad.exe").error.path` is `undefined` too, and so is it for the uid/gid `ENOTSUP` case.
- Node reports `error.path === "C:/tmp/bad.exe"` (`spawnSync` sets `error.path = options.file` for every failure) and `"cmd.exe"` for the uid/gid case. On Linux, Bun already reports the path: `posix_spawn::spawn_z` builds the error with `path: argv[0]` (src/spawn_sys/posix_spawn.rs), so `Bun.spawnSync({ cmd: ["/tmp/bad.bin"] })` throws `ENOEXEC: ..., posix_spawn '/tmp/bad.bin'` with `err.path` set.
- Cause: `spawn_process_windows` (src/spawn/process.rs:2103) turns the `uv_spawn` return code into a `bun_sys::Error` with `to_error(Tag::uv_spawn)` and returns it as is, without a path. The JS binding (src/runtime/api/bun/js_bun_spawn_bindings.rs:1262) only patches a path onto the `ENOENT`/`EACCES`/`EPERM`/`EISDIR`/`ENOTDIR` errnos, so every other `uv_spawn` failure reaches JS without one.
- The shell prints these errors through the same `Error`, so a refused command printed `bun: unknown error: ` with nothing after the colon.

### Fix
- In `spawn_process_windows`, attach `argv[0]` to the `uv_spawn` error with `Error::with_path` before returning it. `with_path` keeps `errno` and `syscall`, so `err.code`, `err.errno` (`-4094`, `-4049`) and `err.syscall` are unchanged; only `err.path` and the message's `'path'` suffix are added.
- `argv[0]` (the command as the caller wrote it) rather than `uv_process_options.file` (the resolved executable): this is what the Linux `posix_spawn` path attaches, what the JS binding attaches for the `ENOENT` class on every platform, and what Node puts in `error.path` (`"cmd.exe"`, not `C:\Windows\system32\cmd.exe`). (The macOS system-posix_spawn arm attaches the resolved file instead; not touched here.)
- Fixing it in `spawn_process_windows` rather than the JS binding makes the Windows error carry the same information as the POSIX one for every caller, so the shell (`bun: unknown error: C:/tmp/bad.exe`) and the CLI call sites that print the error get the command name too. Nothing on main asserts on the old path-less `uv_spawn` message; the other callers either print the error's name only or drop it to an errno.
- After the fix (debug build, Windows x64):
  - `Bun.spawnSync` of a refused file: `path: "C:/workspace/bad.exe"`, message `EUNKNOWN: unknown error, uv_spawn 'C:/workspace/bad.exe'`
  - `Bun.spawnSync` with `uid`: `path: "cmd.exe"`, code `ENOTSUP`
  - `child_process.spawnSync(exe).error.path === exe`, matching node v26.3.0 on the same machine
- Tests (all `it.if(isWindows)`; fail on the current canary, pass with this change on Windows x64; the whole of both files passes there):
  - test/js/bun/spawn/spawn.test.ts: `uv_spawn failure names the command in err.path` (`spawn` and `spawnSync`, `err.path` and the message), `uid/gid > throws ENOTSUP naming the command for uid/gid on Windows` (deterministic `uv_spawn` failure, asserts the unresolved `"cmd.exe"`)
  - test/js/node/child_process/child_process.test.ts: `spawnSync(file CreateProcess refuses) reports error.path`, and the existing uid/gid `ENOTSUP` test now asserts `error.path` as well
  - The tests do not assert the error code name, so they are unaffected by #39340 (`EUNKNOWN` to `UNKNOWN`). That PR's new spawn.test.ts case pins the exact path-less message `UNKNOWN: unknown error, uv_spawn`, which this change extends with `'<exe>'`; whichever lands second needs that one assertion loosened (noted there).
- Also ran test/js/node/test/parallel/test-child-process-{uid-gid,spawnsync,spawn-error}.js on Windows: pass.

### Background
- Bun spawns children through `bun_spawn::spawn_process`, which is `spawn_process_posix` (posix_spawn) on POSIX and `spawn_process_windows` (libuv's `uv_spawn` over CreateProcessW) on Windows. Both return a `bun_sys::Error` on failure: an errno plus a syscall tag plus an optional `path`, which `to_system_error()` turns into the Node-shaped `CODE: label, syscall 'path'` message and the `err.path` property, and which the shell formats as `bun: label: path`.
- `spawn_process` receives two names for the command: `argv[0]`, the command as the caller wrote it (the child's `argv[0]`), and `options.argv0`, the executable Bun resolved from `PATH` (libuv's `file`). Node's `error.path` is the former.
- libuv fails `uv_spawn` with `UV_ENOTSUP` whenever `uid`/`gid` is set on Windows, before touching the executable, which is why the tests use it as a deterministic `uv_spawn` failure; a file CreateProcess refuses is the case from the report.
