### PR TITLE
macros: hold the JSC API lock while reporting a macro module that failed to load

### DIFF
--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -452,6 +452,15 @@ impl Macro {
             unsafe { (*vm).transpiler.configure_defines()? };
         }
 
+        // `load_macro_entry_point` takes the API lock only while it loads the
+        // module, but reporting a rejected load below runs JS as well
+        // (unhandledRejection listeners, error printing). On a pool thread
+        // (bundler, transpiler store, `Bun.Transpiler#transform`) nothing else
+        // holds this VM's lock; on the main thread (`bun run`) it is re-entrant.
+        // SAFETY: `jsc_vm` is the live JSC VM set in `VirtualMachine::init`; the
+        // raw deref yields an unbounded `&VM`, so the guard does not borrow `*vm`.
+        let _api_lock = unsafe { (*(*vm).jsc_vm).get_api_lock() };
+
         // SAFETY: `vm` is the per-thread VM; uniquely accessed here.
         let loaded_result = unsafe {
             (*vm).load_macro_entry_point(input_specifier, function_name, specifier, hash)

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -182,6 +182,96 @@ test("object destructuring of a macro result keeps every bound property regardle
   expect(exitCode).toBe(0);
 });
 
+// A macro module that fails to load is reported by Macro::init on the thread doing the
+// transpiling. `bun run entry.ts` transpiles the entry point on the main thread, which holds
+// its VM's API lock for the whole program. Everything below transpiles on a pool thread with
+// a macro VM of its own, where the report used to run without the lock and debug builds
+// aborted on JSC's currentThreadIsHoldingAPILock assertion instead of printing the error.
+describe.concurrent("a macro module that fails to load is reported", () => {
+  const files = {
+    "bad.js": "function bad( {",
+    "macro.ts": `import "./bad.js";\nexport function m() {\n  return 1;\n}\n`,
+    "entry.ts": `import { m } from "./macro.ts" with { type: "macro" };\nconsole.log(m());\n`,
+  };
+  // The error of the module the macro imports is printed when the macro module is loaded; the
+  // transpiler then logs the failure at the macro's call site.
+  const badJsError = "error: Expected identifier but found end of file";
+  const loadError = 'error: "MacroLoadError" error in macro';
+  const bothErrors = new RegExp(`${badJsError}.*${loadError}`, "s");
+
+  async function run(extraFiles: Record<string, string>, ...args: string[]) {
+    using dir = tempDir("macro-load-failure", { ...files, ...extraFiles });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+  }
+
+  test("by bun build", async () => {
+    expect(await run({}, "build", "./entry.ts")).toEqual({
+      stdout: "",
+      stderr: expect.stringMatching(bothErrors),
+      exitCode: 1,
+      signalCode: null,
+    });
+  });
+
+  test("by Bun.build()", async () => {
+    const result = await run(
+      {
+        "build.ts": [
+          `const result = await Bun.build({ entrypoints: ["./entry.ts"], throw: false });`,
+          `console.log(JSON.stringify({ success: result.success, logs: result.logs.map(log => log.message) }));`,
+          ``,
+        ].join("\n"),
+      },
+      "run",
+      "./build.ts",
+    );
+    expect(result).toEqual({
+      stdout: JSON.stringify({ success: false, logs: ['"MacroLoadError" error in macro'] }) + "\n",
+      stderr: expect.stringContaining(badJsError),
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test("by bun run, for a module imported by the entry point", async () => {
+    expect(await run({ "main.ts": `import "./entry.ts";\n` }, "run", "./main.ts")).toEqual({
+      stdout: "",
+      stderr: expect.stringMatching(bothErrors),
+      exitCode: 1,
+      signalCode: null,
+    });
+  });
+
+  test("by Bun.Transpiler#transform()", async () => {
+    const result = await run(
+      {
+        "transform.ts": [
+          `const code = await Bun.file("./entry.ts").text();`,
+          `const promise = new Bun.Transpiler({ loader: "ts" }).transform(code);`,
+          `console.log(JSON.stringify(await promise.then(() => "resolved", error => String(error))));`,
+          ``,
+        ].join("\n"),
+      },
+      "run",
+      "./transform.ts",
+    );
+    expect(result).toEqual({
+      stdout: JSON.stringify('BuildMessage: "MacroLoadError" error in macro') + "\n",
+      stderr: expect.stringContaining(badJsError),
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `


### PR DESCRIPTION
### Problem
- A debug build aborts instead of reporting a macro whose module fails to load (for example a macro module that imports a file with a syntax error). Right after it prints `Error importing macro`:
  ```
  ASSERTION FAILED: container.vm().currentThreadIsHoldingAPILock()
  JavaScriptCore/WeakSetInlines.h(37) : static WeakImpl *JSC::WeakSet::allocate(JSValue, WeakHandleOwner *, void *)
  ```
- It happens everywhere the transpile runs on a pool thread: `bun build`, `Bun.build()`, a module imported at runtime (transpiled by the runtime transpiler store) and `Bun.Transpiler#transform()`. `bun run entry.ts` with the macro used in the entry point itself is the one case that works, because `run_command.rs` holds the main VM's API lock for the whole program.
- Cause: `Macro::init` (src/js_parser_jsc/Macro.rs:465-480). `VirtualMachine::load_macro_entry_point` takes the API lock only inside its own `run_with_api_lock` (src/jsc/VirtualMachine.rs:1480). After it returns, `Macro::init` unwraps the rejected promise and calls `unhandled_rejection`, which runs JS (`unhandledRejection` listeners, then printing the error) with no lock held. On a pool thread the macro VM was created by `Macro::init` itself and nothing else holds its lock.
- Release builds compile the assertion out, which is why the error has always printed fine there. The macro call path does not have the problem: `MacroContext::call` wraps the whole `Runner::run` in `run_with_api_lock` (Macro.rs:226), including its own `unhandled_rejection`.

### Fix
- `Macro::init` takes the VM's API lock (`VM::get_api_lock`, the RAII guard already used by `bake/production.rs`) before loading the entry point and holds it until it returns, so the rejection report runs under the lock like the call path does.
- Correct because JSC's API lock is re-entrant: the acquisition inside `load_macro_entry_point` and the lock the main thread (or a Worker) already holds just bump the count, so `bun run` is unaffected. The guard is released on every exit of `init` (`?`, the rejected branch, success), and the lock is not held across anything that did not already run under it today except the report itself.
- Tests: `test/bundler/transpiler/macro-test.test.ts`, "a macro module that fails to load is reported", one test per affected entry point (`bun build`, `Bun.build()`, `bun run` of an importing module, `Bun.Transpiler#transform()`). Each asserts the imported module's error and the `MacroLoadError` log line are printed and the process exits normally. Without the fix all four children die with `SIGABRT` on the assertion above; with it the file passes (19 tests).
- Also ran the file under the ASAN lane's leak-check environment (`detect_leaks=1` with `test/leaksan.supp`, `BUN_DESTRUCT_VM_ON_EXIT=1`, `BUN_JSC_validateExceptionChecks=1`): the new tests pass, no leak reports. The other macro users (`test/regression/issue/{03830,22656,26360}.test.ts`, the macro tests in `bundler_edgecase`, `bun-build-api`, `transpiler.test.js`, `process-on.test.ts`) still pass.

### Background
- API lock: JSC's per-VM `JSLock`. A thread must hold it while it runs JS or touches the VM's heap; acquiring it is what points the thread at the VM's atom-string table and records the stack bounds the GC scans, and debug builds assert on it at many heap entry points (here, allocating a Weak handle while reporting the rejection). It is a recursive lock, so nesting acquisitions on one thread is fine. Bun's main thread and Worker threads hold their VM's lock permanently; Rust code that drives a VM from elsewhere takes it per entry (`run_with_api_lock` or the `get_api_lock()` guard).
- Macro VM: macros run in a JS VM owned by whatever thread is transpiling. On the main thread that is the runtime VM; on a bundler, transpiler-store or `Bun.Transpiler` pool thread `Macro::init` creates a VM for that thread the first time a macro is needed, and only the explicit lock sections in the macro code ever lock it.
- Macro entry point: for each macro import Bun generates a small module that `await import()`s the user's macro module and registers the function. Loading it returns a promise; if the user's module fails to load, that promise rejects with the module's error (a `BuildMessage` here), and `Macro::init` reports it through the VM's unhandled-rejection path, which is what prints the error the user sees.

<details>
<summary>Repro</summary>

```
bad.js:    function bad( {
macro.ts:  import "./bad.js";
           export function m() { return 1; }
entry.ts:  import { m } from "./macro.ts" with { type: "macro" };
           console.log(m());
main.ts:   import "./entry.ts";
```

Debug build before the fix: `bun build ./entry.ts`, `bun run ./main.ts`, `Bun.build({ entrypoints: ["./entry.ts"] })` and `new Bun.Transpiler().transform(entrySource)` all abort with the assertion above. `bun run ./main.ts` stops aborting when the transpiler store is disabled (`BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER=1`), confirming it is the pool thread case. After the fix every variant prints, like the release build does:

```
Error importing macro
1 | function bad( {
                   ^
error: Expected identifier but found end of file
    at bad.js:1:16
2 | console.log(m());
                ^
error: "MacroLoadError" error in macro
    at entry.ts:2:13
```
</details>
