### PR TITLE
css: convert color-mix() operands into hsl and hwb without gamut mapping them

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5773,8 +5773,12 @@ pub mod color {
 
     /// <https://drafts.csswg.org/css-color/#hsl-color> except with h
     /// pre-multiplied by 3, to avoid some rounding errors.
+    ///
+    /// `m2`/`m1` are the largest and smallest channel, `lightness ± saturation * min(l, 1 - l)`
+    /// as in the spec, so a saturation above 1 or a lightness outside 0..1 (an hsl value of a
+    /// color outside the sRGB gamut) gives the out-of-gamut channels back.
     pub(crate) fn hsl_to_rgb(hue: f32, saturation: f32, lightness: f32) -> (f32, f32, f32) {
-        debug_assert!(saturation >= 0.0 && saturation <= 1.0);
+        debug_assert!(saturation >= 0.0);
         fn hue_to_rgb(m1: f32, m2: f32, mut h3: f32) -> f32 {
             if h3 < 0.0 {
                 h3 += 3.0;

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1069,6 +1069,8 @@ pub trait Colorspace: Copy + Sized + FromAnyColorspace {
 
 /// Gamut behavior — in-gamut check and clipping per color space.
 pub trait ColorGamut: Sized + Copy {
+    /// Whether the space can only hold colors inside its gamut (the lab family and XYZ hold any).
+    const BOUNDED: bool;
     fn in_gamut(&self) -> bool;
     fn clip(&self) -> Self;
 }
@@ -1574,12 +1576,14 @@ macro_rules! define_colorspace {
     // Gamut variants
     (@gamut unbounded $name:ident { $a:ident, $b:ident, $c:ident }) => {
         impl ColorGamut for $name {
+            const BOUNDED: bool = false;
             fn in_gamut(&self) -> bool { true }
             fn clip(&self) -> Self { *self }
         }
     };
     (@gamut bounded $name:ident { $a:ident, $b:ident, $c:ident }) => {
         impl ColorGamut for $name {
+            const BOUNDED: bool = true;
             fn in_gamut(&self) -> bool {
                 self.$a >= 0.0 && self.$a <= 1.0
                     && self.$b >= 0.0 && self.$b <= 1.0
@@ -1597,6 +1601,7 @@ macro_rules! define_colorspace {
     };
     (@gamut hsl_hwb $name:ident { $h:ident, $a:ident, $b:ident }) => {
         impl ColorGamut for $name {
+            const BOUNDED: bool = true;
             fn in_gamut(&self) -> bool {
                 self.$a >= 0.0 && self.$a <= 1.0 && self.$b >= 0.0 && self.$b <= 1.0
             }
@@ -1752,6 +1757,14 @@ impl SRGB {
     pub fn into_rgba(&self) -> RGBA {
         let rgb = self.resolve();
         RGBA::from_floats(rgb.r, rgb.g, rgb.b, rgb.alpha)
+    }
+
+    /// `in_gamut()` with room for the ~1e-6 of noise a boundary color picks up converting from another space.
+    fn is_nearly_in_gamut(&self) -> bool {
+        // 0.03 of an 8-bit step.
+        const TOLERANCE: f32 = 1e-4;
+        let nearly = |v: f32| (-TOLERANCE..=1.0 + TOLERANCE).contains(&v);
+        nearly(self.r) && nearly(self.g) && nearly(self.b)
     }
 }
 
@@ -1933,6 +1946,15 @@ impl ComponentParser {
             input.reset(&state);
             let dark = self.parse_from::<T, C, F>(*dark, input, func)?;
             return Ok(C::light_dark_owned(light, dark));
+        }
+
+        // Browsers keep these unclamped and clip when painting (w3c/csswg-drafts#8444); `resolve()` would not match.
+        if T::BOUNDED
+            // In sRGB rather than `T`: the HSL and HWB conversions gamut map on the way in.
+            && !SRGB::try_from_css_color(&from)
+                .is_some_and(|srgb| srgb.resolve_missing().is_nearly_in_gamut())
+        {
+            return Err(input.new_custom_error(css::ParserError::invalid_value));
         }
 
         let new_from = match T::try_from_css_color(&from) {

--- a/src/css/values/color.rs
+++ b/src/css/values/color.rs
@@ -1491,10 +1491,6 @@ pub(crate) fn parse_number_or_percentage(
 }
 
 impl LABColor {
-    pub fn into_hsl(&self) -> HSL {
-        HSL::from_lab_color(self)
-    }
-
     pub fn into_lab(&self) -> LAB {
         LAB::from_lab_color(self)
     }
@@ -1770,6 +1766,8 @@ impl SRGB {
 
 define_colorspace! {
     /// A color in the [`hsl`](https://www.w3.org/TR/css-color-4/#the-hsl-notation) color space.
+    /// `s` and `l` are fractions (100% is 1.0); a color outside the sRGB gamut has `s` above 1
+    /// or `l` outside 0..1 (see `From<SRGB>`).
     HSL { h, s, l }
     types = (CT_ANG, CT_PCT, CT_PCT);
     gamut = hsl_hwb;
@@ -1780,6 +1778,8 @@ define_colorspace! {
 
 define_colorspace! {
     /// A color in the [`hwb`](https://www.w3.org/TR/css-color-4/#the-hwb-notation) color space.
+    /// `w` and `b` are fractions (100% is 1.0); a color outside the sRGB gamut has a negative
+    /// `w` or `b` (see `From<SRGB>`).
     HWB { h, w, b }
     types = (CT_ANG, CT_PCT, CT_PCT);
     gamut = hsl_hwb;
@@ -1950,7 +1950,7 @@ impl ComponentParser {
 
         // Browsers keep these unclamped and clip when painting (w3c/csswg-drafts#8444); `resolve()` would not match.
         if T::BOUNDED
-            // In sRGB rather than `T`: the HSL and HWB conversions gamut map on the way in.
+            // In sRGB for all three targets: hsl and hwb have the sRGB gamut, so one tolerance serves.
             && !SRGB::try_from_css_color(&from)
                 .is_some_and(|srgb| srgb.resolve_missing().is_nearly_in_gamut())
         {
@@ -2861,36 +2861,48 @@ impl From<SRGB> for SRGBLinear {
         }
     }
 }
+
+/// Hue in degrees, `[0, 360)`, or NaN when achromatic; `d` is max - min. Channels outside 0..1
+/// are fine, only the proportions between them matter.
+fn srgb_hue(rgb: &SRGB, max: f32, d: f32) -> f32 {
+    if d == 0.0 {
+        return f32::NAN;
+    }
+    let h = if max == rgb.r {
+        (rgb.g - rgb.b) / d + (if rgb.g < rgb.b { 6.0 } else { 0.0 })
+    } else if max == rgb.g {
+        (rgb.b - rgb.r) / d + 2.0
+    } else {
+        (rgb.r - rgb.g) / d + 4.0
+    };
+    // `(g - b) / d + 6` rounds up to exactly 6 when g is a hair below b.
+    (h * 60.0).rem_euclid(360.0)
+}
+
+// Neither conversion gamut maps (`resolve()`): a color outside the sRGB gamut converts to an
+// hsl/hwb value outside 0..1 that converts back to the same sRGB channels, which is what
+// `color-mix()` needs (css-color-4 interpolates out-of-gamut operands as they are). A caller
+// that needs a value hsl() can express gamut maps the sRGB color before converting it.
 impl From<SRGB> for HSL {
     fn from(rgb_: SRGB) -> HSL {
         // https://drafts.csswg.org/css-color/#rgb-to-hsl
-        let rgb = rgb_.resolve();
-        let r = rgb.r;
-        let g = rgb.g;
-        let b = rgb.b;
-        let max = r.max(g).max(b);
-        let min = r.min(g).min(b);
-        let mut h = f32::NAN;
-        let mut s: f32 = 0.0;
+        let rgb = rgb_.resolve_missing();
+        let max = rgb.r.max(rgb.g).max(rgb.b);
+        let min = rgb.r.min(rgb.g).min(rgb.b);
         let l = (min + max) / 2.0;
         let d = max - min;
+        let mut h = srgb_hue(&rgb, max, d);
+        let mut s: f32 = 0.0;
 
-        if d != 0.0 {
-            s = if l == 0.0 || l == 1.0 {
-                0.0
-            } else {
-                (max - l) / l.min(1.0 - l)
-            };
+        if d != 0.0 && l != 0.0 && l != 1.0 {
+            s = (max - l) / l.min(1.0 - l);
+        }
 
-            if max == r {
-                h = (g - b) / d + (if g < b { 6.0 } else { 0.0 });
-            } else if max == g {
-                h = (b - r) / d + 2.0;
-            } else if max == b {
-                h = (r - g) / d + 4.0;
-            }
-
-            h *= 60.0;
+        // Negative when the lightness is outside 0..1 (a color outside the gamut). The same
+        // color is the opposite hue with a positive saturation (w3c/csswg-drafts#9222).
+        if s < 0.0 {
+            h = (h + 180.0).rem_euclid(360.0);
+            s = -s;
         }
 
         HSL {
@@ -2903,17 +2915,16 @@ impl From<SRGB> for HSL {
 }
 impl From<SRGB> for HWB {
     fn from(rgb_: SRGB) -> HWB {
-        let rgb = rgb_.resolve();
-        let hsl: HSL = rgb.into();
-        let r = rgb.r;
-        let g = rgb.g;
-        let b_ = rgb.b;
-        let w = r.min(g).min(b_);
-        let b = 1.0 - r.max(g).max(b_);
+        // https://drafts.csswg.org/css-color/#rgb-to-hwb
+        let rgb = rgb_.resolve_missing();
+        let max = rgb.r.max(rgb.g).max(rgb.b);
+        let min = rgb.r.min(rgb.g).min(rgb.b);
         HWB {
-            h: hsl.h,
-            w,
-            b,
+            // Not the hsl hue: `From<HWB> for SRGB` scales the pure hue by max - min, which is
+            // positive for every color, so the unflipped hue is the one that converts back.
+            h: srgb_hue(&rgb, max, max - min),
+            w: min,
+            b: 1.0 - max,
             alpha: rgb.alpha,
         }
     }

--- a/src/css_jsc/color_js.rs
+++ b/src/css_jsc/color_js.rs
@@ -214,7 +214,7 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
     use bun_core::ZigStringSlice;
     use bun_css as css;
     use bun_css::CssColor;
-    use bun_css::values::color::{HSL, LAB, RGBA, SRGB};
+    use bun_css::values::color::{Colorspace as _, HSL, LAB, RGBA, SRGB};
     use bun_jsc::StringJsc as _;
 
     let args = frame.arguments_as_array::<2>();
@@ -560,7 +560,9 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
                                     other => other.into_hsl(),
                                 },
                                 CssColor::Rgba(rgba) => rgba.into_hsl(),
-                                CssColor::Lab(lab) => lab.into_hsl(),
+                                // Gamut mapped like `into_rgba()` above, so a lab() outside sRGB
+                                // prints the hsl() of the color the rgb formats print.
+                                CssColor::Lab(lab) => HSL::from(lab.into_srgb().resolve()),
                                 _ => break 'formatted,
                             };
 

--- a/test/bundler/css/wpt/relative_color_out_of_gamut.test.ts
+++ b/test/bundler/css/wpt/relative_color_out_of_gamut.test.ts
@@ -1,6 +1,18 @@
 import { describe } from "bun:test";
 import { itBundled } from "../../expectBundled";
 
+// https://github.com/web-platform-tests/wpt/blob/master/css/css-color/parsing/relative-color-out-of-gamut.html
+//
+// The WPT asserts that a relative rgb()/hsl()/hwb() color whose origin is outside the sRGB
+// gamut computes to the unclamped out-of-gamut color (browsers clip it when painting), so the
+// bundler must not resolve these: gamut mapping the origin gives a different color (the
+// display-p3 green below used to come out as #00f942, browsers paint it as #00ff00). The
+// declaration is left for the browser. What the bundler does do is its usual handling of a
+// wide-gamut color literal inside a value it does not resolve: under the default browser
+// targets the origin gets an sRGB fallback plus an `@supports` tier with the color as written.
+//
+// The lab()/lch()/oklab()/oklch() origins below are written with a number lightness, which
+// does not parse yet (#16727), so those declarations are emitted as written for that reason.
 let i = 0;
 const testname = () => `test-${i++}`;
 describe("relative_color_out_of_gamut", () => {
@@ -18,7 +30,13 @@ h1 {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
 /* a.css */
 h1 {
-    color: #00f942;
+  color: rgb(from #00f942 r g b / alpha);
+}
+
+@supports (color: color(display-p3 0 0 0)) {
+  h1 {
+    color: rgb(from color(display-p3 0 1 0) r g b / alpha);
+  }
 }
 `);
     },
@@ -198,7 +216,13 @@ h1 {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
   /* a.css */
   h1 {
-      color: #00f942;
+    color: hsl(from #00f942 h s l / alpha);
+  }
+
+  @supports (color: color(display-p3 0 0 0)) {
+    h1 {
+      color: hsl(from color(display-p3 0 1 0) h s l / alpha);
+    }
   }
   `);
     },
@@ -378,7 +402,13 @@ h1 {
       api.expectFile("/out.css").toEqualIgnoringWhitespace(`
   /* a.css */
   h1 {
-      color: #00f942;
+    color: hwb(from #00f942 h w b / alpha);
+  }
+
+  @supports (color: color(display-p3 0 0 0)) {
+    h1 {
+      color: hwb(from color(display-p3 0 1 0) h w b / alpha);
+    }
   }
   `);
     },

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -774,6 +774,171 @@ describe("color-mix() results outside the sRGB gamut are clipped", () => {
   });
 });
 
+// color-mix(in hsl, ...) and color-mix(in hwb, ...) convert their operands into hsl or hwb first.
+// That conversion used to gamut map an operand outside the sRGB gamut, so the mix was computed
+// from a different color than the one written: display-p3 green went in as #00f942, and the
+// bright lab()/oklch() magentas below went in as plain white (which even came back from the
+// mapping with a stray hue and saturation, see the grey cases). css-color-4 converts the operand
+// as it is: an hsl value with a saturation above 100% or a lightness outside 0%..100%, or an hwb
+// value with a negative whiteness or blackness, which converts back to the same out-of-gamut
+// sRGB channels. The mix is interpolated from those and the result is clipped like any other
+// (the block above). WPT css/css-color/parsing/color-mix-out-of-gamut.html mixes the operands of
+// the first table 100% / 0% with black in both spaces and expects the operand's own unclipped
+// sRGB value back, so the fold is that value clipped to 8 bits: the same color the `in srgb` mixes
+// above fold to. The other expected values are the css-color-4 sample code's results clipped to 8
+// bits; the unclipped result is noted where it is not obvious.
+describe("color-mix() in hsl and hwb mixes out-of-gamut operands as written", () => {
+  const operands: [operand: string, expected: string, before: string][] = [
+    ["color(display-p3 0 1 0)", "#0f0", "#00f942"],
+    ["lab(100% 104.3 -50.9)", "#ff96ff", "#fff"],
+    ["lab(0% 104.3 -50.9)", "#5a004c", "#2a0022"],
+    ["lch(100% 116 334)", "#ff96ff", "#fff"],
+    ["lch(0% 116 334)", "#5a004c", "#2a0022"],
+    ["oklab(100% 0.365 -0.16)", "#ff5cff", "#fff"],
+    ["oklab(0% 0.365 -0.16)", "#130018", "#000"],
+    ["oklch(100% 0.399 336.3)", "#ff5bff", "#fff"],
+    ["oklch(0% 0.399 336.3)", "#140018", "#000"],
+  ];
+  describe.each(["hsl", "hwb"])("in %s, mixed with 0% of black or with itself", space => {
+    test.each(operands)("%s is %s (used to be %s)", (operand, expected) => {
+      expect(color(`color-mix(in ${space}, ${operand} 100%, black 0%)`, "css")).toBe(expected);
+      expect(color(`color-mix(in ${space}, ${operand}, ${operand})`, "css")).toBe(expected);
+    });
+  });
+
+  test.each([
+    // display-p3 green is hsl(127.9 302% 25.3%) and hwb(127.9 -51.2% -1.8%). Mixing with white or
+    // black moves it halfway towards 100% / 0% lightness, or towards 100% whiteness / blackness.
+    ["color-mix(in hsl, color(display-p3 0 1 0), white)", "#10ff36", "#9ddeae"],
+    ["color-mix(in hwb, color(display-p3 0 1 0), white)", "#3eff58", "#80fca0"],
+    ["color-mix(in hsl, color(display-p3 0 1 0), black)", "#005100", "#1f5d30"],
+    ["color-mix(in hwb, color(display-p3 0 1 0), black)", "#008200", "#007c21"],
+    ["color-mix(in hsl, color(display-p3 0 1 0) 25%, white)", "#abf3b5", "#d6e7db"],
+    ["color-mix(in hwb, color(display-p3 0 1 0) 25%, white)", "#9fffab", "#bffdd0"],
+    // The hue is interpolated from the operand's own hue (127.9, not the 135.9 of #00f942), and
+    // the 302% saturation survives the mix: hsl(183.9 201% 37.7%) is color(srgb -0.38 1.03 1.13).
+    ["color-mix(in hsl, color(display-p3 0 1 0), blue)", "#0ff", "#00dafc"],
+    ["color-mix(in hwb, color(display-p3 0 1 0), blue)", "#00ecff", "#00dafc"],
+    ["color-mix(in hsl longer hue, color(display-p3 0 1 0), blue)", "red", "#fc2100"],
+    ["color-mix(in hwb longer hue, color(display-p3 0 1 0), blue)", "red", "#fc2100"],
+    // The alpha is premultiplied into the out-of-range channels like into any other.
+    ["color-mix(in hsl, color(display-p3 0 1 0 / 0.5), black)", "#002b06bf", "#1c3723bf"],
+    ["color-mix(in hwb, color(display-p3 0 1 0 / 0.5), black)", "#005700bf", "#005316bf"],
+    ["color-mix(in hsl, color(display-p3 0 1 0 / 0.5), color(display-p3 0 1 0 / 0.5))", "#00ff0080", "#00f94280"],
+    [
+      "color-mix(in hsl, light-dark(color(display-p3 0 1 0), red), light-dark(color(display-p3 0 1 0), blue))",
+      "light-dark(#0f0, #f0f)",
+      "light-dark(#00f942, #f0f)",
+    ],
+    // lab(100% 104.3 -50.9) is color(srgb 1.59 0.59 1.41): a lightness of 109%, which makes the
+    // rgb-to-hsl saturation negative. The spec (w3c/csswg-drafts#9222) expresses that as the
+    // opposite hue with a positive saturation, hsl(131.2 555% 109%), so in hsl it mixes with red
+    // towards yellow. hwb keeps the hue of the channels themselves, hwb(311.2 58.8% -59.4%), the
+    // only one its whiteness and blackness convert back with, so in hwb it mixes towards magenta.
+    ["color-mix(in hsl, lab(100% 104.3 -50.9), red)", "#ffff20", "#bfef8f"],
+    ["color-mix(in hwb, lab(100% 104.3 -50.9), red)", "#ff4bb3", "#bfff7f"],
+    ["color-mix(in hsl, lab(100% 104.3 -50.9), black)", "#0f0", "#609f9f"],
+    ["color-mix(in hwb, lab(100% 104.3 -50.9), black)", "#cb4bb3", "#7f8080"],
+    ["color-mix(in hwb, lab(100% 104.3 -50.9), lab(0% 104.3 -50.9))", "#f830dc", "#817f94"],
+    // lab(0% 104.3 -50.9) is color(srgb 0.35 -0.21 0.30): hsl(305.5 411% 6.9%), hwb(305.5 -21.4% 64.9%).
+    ["color-mix(in hsl, lab(0% 104.3 -50.9), white)", "#f0f", "#c44fae"],
+    ["color-mix(in hwb, lab(0% 104.3 -50.9), white)", "#ac64a6", "#948090"],
+    ["color-mix(in hsl, oklch(100% 0.399 336.3) 50%, white)", "#ffd5ff", "#fff"],
+    ["color-mix(in hwb, oklch(100% 0.399 336.3) 50%, white)", "#ffadff", "#fff"],
+    // oklch(70% 0.4 145) is color(srgb -0.53 0.82 -0.39), hsl(126.4 466% 14.5%).
+    ["color-mix(in hsl, oklch(70% 0.4 145), oklch(70% 0.4 145))", "#00d200", "#00c30b"],
+    ["color-mix(in hsl, oklch(70% 0.4 145), black)", "#003e00", "#18491b"],
+    ["color-mix(in hwb, oklch(70% 0.4 145), black)", "#006900", "#006105"],
+    ["color-mix(in hsl, color(srgb-linear 0 1.5 0), color(srgb-linear 0 1.5 0))", "#0f0", "#edffea"],
+    ["color-mix(in hwb, color(srgb-linear 0 1.5 0), color(srgb-linear 0 1.5 0))", "#0f0", "#edffea"],
+    // Slightly out of gamut (Tailwind's red-600 is color(srgb 0.91 -0.10 0.04)): the operand is
+    // mixed as written instead of as its gamut mapped #e7000b, which has a different hue.
+    ["color-mix(in hsl, oklch(57.7% 0.245 27.325), white)", "#e28491", "#dc969a"],
+    ["color-mix(in hwb, oklch(57.7% 0.245 27.325), white)", "#f37385", "#f38085"],
+    // Greys outside the gamut: hsl(none 0% 120%) and hwb(none 120% -20%) have no hue to mix, and
+    // hwb lands in the whiteness + blackness >= 100% branch with the out-of-range values. The
+    // gamut mapping used to turn the bright one into a white carrying a noise hue and a 50%
+    // saturation (from the conversion noise of its white), hence the teal hsl mix with black.
+    ["color-mix(in hsl, color(srgb 1.2 1.2 1.2), black)", "#999", "#609f9f"],
+    ["color-mix(in hwb, color(srgb 1.2 1.2 1.2), black)", "#999", "#7f8080"],
+    ["color-mix(in hsl, color(srgb -0.2 -0.2 -0.2), white)", "#666", "gray"],
+    ["color-mix(in hwb, color(srgb -0.2 -0.2 -0.2), white)", "#666", "gray"],
+  ])("%s is %s (used to be %s)", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  test("the typed output formats get the clipped result too", () => {
+    const formats = (mix: string) => ({
+      rgb: color(mix, "{rgb}"),
+      rgba: color(mix, "[rgba]"),
+      hex: color(mix, "hex"),
+      hsl: color(mix, "hsl"),
+    });
+    const expected = {
+      rgb: { r: 0, g: 255, b: 0 },
+      rgba: [0, 255, 0, 255],
+      hex: "#00ff00",
+      hsl: "hsl(120, 100%, 50%)",
+    };
+    expect(formats("color-mix(in hsl, color(display-p3 0 1 0), color(display-p3 0 1 0))")).toEqual(expected);
+    expect(formats("color-mix(in hwb, color(display-p3 0 1 0), color(display-p3 0 1 0))")).toEqual(expected);
+  });
+
+  // Operands inside the gamut convert exactly as before, so every mix of such operands is unchanged.
+  // These also cover what the conversion change comes closest to: a boundary color written as lab()
+  // converts back with channels a few 1e-7 outside the gamut, greys (8-bit, converted from lab(), or
+  // out of gamut) have a missing hue, and an operand that only clips still folds to its clipped color.
+  test.each([
+    ["color-mix(in hsl, red, white)", "#df9f9f"],
+    ["color-mix(in hsl, red, blue)", "#f0f"],
+    ["color-mix(in hwb, red, blue)", "#f0f"],
+    ["color-mix(in hsl, red 25%, blue)", "#8000ff"],
+    ["color-mix(in hwb, red 25%, blue)", "#8000ff"],
+    ["color-mix(in hsl, #808080, red)", "#bf4040"],
+    ["color-mix(in hwb, #808080, red)", "#c04040"],
+    ["color-mix(in hsl, lab(54.2905% 80.8049 69.891), lab(54.2905% 80.8049 69.891))", "red"],
+    ["color-mix(in hwb, lab(54.2905% 80.8049 69.891), lab(54.2905% 80.8049 69.891))", "red"],
+    ["color-mix(in hsl, lab(50% 0 0), lab(50% 0 0))", "#777"],
+    ["color-mix(in hwb, lab(50% 0 0), lab(50% 0 0))", "#777"],
+    // color(display-p3 0 0 1) is color(srgb 0 0 1.04); it clipped to #00f under the mapping too.
+    ["color-mix(in hsl, color(display-p3 0 0 1), color(display-p3 0 0 1))", "#00f"],
+    ["color-mix(in hwb, color(display-p3 0 0 1), color(display-p3 0 0 1))", "#00f"],
+    ["color-mix(in hsl, color(srgb 1.2 1.2 1.2), color(srgb 1.2 1.2 1.2))", "#fff"],
+    ["color-mix(in hwb, color(srgb -0.2 -0.2 -0.2), color(srgb -0.2 -0.2 -0.2))", "#000"],
+  ])("%s is still %s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+});
+
+// The "hsl" output format converts the same way. It gamut maps first, like the rgb formats do,
+// so a color outside the sRGB gamut still prints an hsl() inside 0%..100% that describes the
+// same color as its "hex" output, rather than the unclipped hsl(305.5, 411%, 6.9%) of the first one.
+describe('color(wide gamut input, "hsl") is the hsl of the gamut mapped color', () => {
+  test.each([
+    "lab(0% 104.3 -50.9)",
+    "lch(0% 116 334)",
+    "oklch(70% 0.4 145)",
+    "oklab(60% -0.3 0.2)",
+    "lab(100% 104.3 -50.9)",
+  ])("%s", input => {
+    const hsl = color(input, "hsl") as string;
+    const [h, s, l] = hsl.match(/-?[\d.]+(?:e[+-]?\d+)?/g)!.map(Number);
+    expect(hsl).toStartWith("hsl(");
+    expect(h).toBeWithin(0, 360);
+    expect(s).toBeWithin(0, 100.0001);
+    expect(l).toBeWithin(0, 100.0001);
+    expect(color(hsl, "hex")).toBe(color(input, "hex")!);
+  });
+
+  test("a color inside the gamut is converted without quantizing it to 8 bits first", () => {
+    // #777777 is 46.67% lightness; the lab() grey itself is 46.63%.
+    const [, s, l] = (color("lab(50% 0 0)", "hsl") as string).match(/-?[\d.]+(?:e[+-]?\d+)?/g)!.map(Number);
+    expect(s).toBeCloseTo(0, 3);
+    expect(l).toBeCloseTo(46.63, 1);
+    expect(color("lab(50% 0 0)", "hex")).toBe("#777777");
+  });
+});
+
 describe("conversions between color spaces", () => {
   // Each case converts a color whose channels all differ, so a channel landing
   // in another channel's place shows up in the output. Mixing a color with

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -857,3 +857,60 @@ describe("conversions between color spaces", () => {
     );
   });
 });
+
+// rgb(), hsl() and hwb() cannot hold an origin outside the sRGB gamut. Browsers compute the
+// unclamped color and clip it when painting (w3c/csswg-drafts#8444): the display-p3 green
+// below paints as #00ff00, the lab() one as #ff96ff. These used to be resolved by gamut
+// mapping the origin, to #00f942 and #ffffff, so now they are not resolved at all.
+describe("relative colors with an origin outside the sRGB gamut", () => {
+  test.each([
+    "rgb(from lab(100% 104.3 -50.9) r g b)",
+    "hsl(from color(display-p3 0 1 0) h s l)",
+    "hwb(from oklch(100% 0.399 336.3) h w b)",
+    "rgb(from light-dark(red, color(display-p3 0 1 0)) r g b)",
+    "color-mix(in srgb, rgb(from lab(100% 104.3 -50.9) r g b), red)",
+  ])("%s is not resolved", input => {
+    expect([color(input, "css"), color(input, "hex")]).toEqual([null, null]);
+  });
+
+  test.each([
+    // In-gamut origins resolve as before.
+    ["rgb(from lab(50% 40 -50) r g b)", "#965dcd"],
+    ["hsl(from oklch(50% 0.1 120) h s l)", "#5c6b21"],
+    ["hwb(from color(display-p3 0.4 0.4 0.4) h w b)", "#666"],
+    // The unbounded functions hold any origin, so they still resolve out-of-gamut ones.
+    ["lab(from oklch(100% 0.399 336.3) l a b)", "lab(94.0205% 119.644 -57.6823)"],
+    ["color(from lab(100% 104.3 -50.9) srgb r g b)", "color(srgb 1.5935 .587758 1.40555)"],
+  ])("%s is %s", (input, expected) => {
+    expect(color(input, "css")).toBe(expected);
+  });
+
+  // A boundary color written in another space converts back a few 1e-7 outside the gamut.
+  // That is conversion noise, not an out-of-gamut origin: every color on the faces of the
+  // sRGB cube, written as the lab() Bun.color prints for it, still resolves to itself.
+  test("boundary colors written as lab() still resolve", () => {
+    withoutAggressiveGC(() => {
+      const steps = [0, 51, 102, 153, 204, 255];
+      for (const face of [0, 255]) {
+        for (let axis = 0; axis < 3; axis++) {
+          for (const x of steps) {
+            for (const y of steps) {
+              const rgb = [0, 0, 0];
+              rgb[axis] = face;
+              rgb[(axis + 1) % 3] = x;
+              rgb[(axis + 2) % 3] = y;
+              const hex = color({ r: rgb[0], g: rgb[1], b: rgb[2] }, "hex");
+              const lab = color(hex!, "lab");
+              for (const relative of [`rgb(from ${lab} r g b)`, `hsl(from ${lab} h s l)`, `hwb(from ${lab} h w b)`]) {
+                const resolved = color(relative, "hex");
+                if (resolved !== hex) {
+                  throw new Error(`${relative} resolved to ${resolved}, expected ${hex}`);
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  });
+});

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7772,6 +7772,110 @@ describe("css tests", () => {
     });
   });
 
+  // color-mix(in hsl, ...) and color-mix(in hwb, ...) convert their operands into hsl or hwb first.
+  // That conversion used to gamut map an operand outside the sRGB gamut, so the mix was computed
+  // from a different color than the one written (display-p3 green went in as #00f942, the bright
+  // lab()/oklch() magentas as plain white). css-color-4 converts the operand as it is, to an hsl
+  // value with a saturation above 100% or a lightness outside 0%..100%, or an hwb value with a
+  // negative whiteness or blackness, which converts back to the same out-of-gamut sRGB channels;
+  // the result of the mix is then clipped like the ones above. WPT
+  // css/css-color/parsing/color-mix-out-of-gamut.html mixes the operands of the first list 100% / 0%
+  // with black in both spaces and expects the operand's own unclipped sRGB value back, so each folds
+  // to the same color as the `in srgb` mixes above. The other expected values are the css-color-4
+  // sample code's results clipped to 8 bits; test/js/bun/css/color.test.ts has the same cases with
+  // the hsl/hwb values involved and the colors they used to fold to.
+  describe("color-mix() in hsl and hwb mixes out-of-gamut operands as written", () => {
+    const operands: [operand: string, expected: string][] = [
+      ["color(display-p3 0 1 0)", "#0f0"],
+      ["lab(100% 104.3 -50.9)", "#ff96ff"],
+      ["lab(0% 104.3 -50.9)", "#5a004c"],
+      ["lch(100% 116 334)", "#ff96ff"],
+      ["lch(0% 116 334)", "#5a004c"],
+      ["oklab(100% 0.365 -0.16)", "#ff5cff"],
+      ["oklab(0% 0.365 -0.16)", "#130018"],
+      ["oklch(100% 0.399 336.3)", "#ff5bff"],
+      ["oklch(0% 0.399 336.3)", "#140018"],
+    ];
+    for (const space of ["hsl", "hwb"]) {
+      for (const [operand, expected] of operands) {
+        minify_test(
+          `.foo { color: color-mix(in ${space}, ${operand} 100%, rgb(0 0 0) 0%) }`,
+          `.foo{color:${expected}}`,
+        );
+      }
+    }
+
+    minify_test(".foo { color: color-mix(in hsl, color(display-p3 0 1 0), white) }", ".foo{color:#10ff36}");
+    minify_test(".foo { color: color-mix(in hwb, color(display-p3 0 1 0), white) }", ".foo{color:#3eff58}");
+    minify_test(".foo { color: color-mix(in hsl, color(display-p3 0 1 0), black) }", ".foo{color:#005100}");
+    minify_test(".foo { color: color-mix(in hwb, color(display-p3 0 1 0), black) }", ".foo{color:#008200}");
+    minify_test(".foo { color: color-mix(in hsl, color(display-p3 0 1 0), blue) }", ".foo{color:#0ff}");
+    minify_test(".foo { color: color-mix(in hwb, color(display-p3 0 1 0), blue) }", ".foo{color:#00ecff}");
+    minify_test(".foo { color: color-mix(in hsl longer hue, color(display-p3 0 1 0), blue) }", ".foo{color:red}");
+    minify_test(".foo { color: color-mix(in hsl, color(display-p3 0 1 0 / 0.5), black) }", ".foo{color:#002b06bf}");
+    minify_test(".foo { color: color-mix(in hwb, color(display-p3 0 1 0 / 0.5), black) }", ".foo{color:#005700bf}");
+    // lab(100% 104.3 -50.9) has a lightness of 109%. In hsl that is the opposite hue with a positive
+    // saturation (w3c/csswg-drafts#9222), which mixes with red towards yellow; hwb keeps the hue of
+    // the channels themselves and mixes towards magenta.
+    minify_test(".foo { color: color-mix(in hsl, lab(100% 104.3 -50.9), red) }", ".foo{color:#ffff20}");
+    minify_test(".foo { color: color-mix(in hwb, lab(100% 104.3 -50.9), red) }", ".foo{color:#ff4bb3}");
+    minify_test(".foo { color: color-mix(in hsl, lab(100% 104.3 -50.9), black) }", ".foo{color:#0f0}");
+    minify_test(".foo { color: color-mix(in hwb, lab(100% 104.3 -50.9), black) }", ".foo{color:#cb4bb3}");
+    minify_test(".foo { color: color-mix(in hsl, lab(0% 104.3 -50.9), white) }", ".foo{color:#f0f}");
+    minify_test(".foo { color: color-mix(in hwb, lab(0% 104.3 -50.9), white) }", ".foo{color:#ac64a6}");
+    minify_test(".foo { color: color-mix(in hsl, oklch(100% 0.399 336.3) 50%, white) }", ".foo{color:#ffd5ff}");
+    minify_test(".foo { color: color-mix(in hwb, oklch(100% 0.399 336.3) 50%, white) }", ".foo{color:#ffadff}");
+    minify_test(".foo { color: color-mix(in hsl, oklch(70% 0.4 145), black) }", ".foo{color:#003e00}");
+    minify_test(".foo { color: color-mix(in hwb, oklch(70% 0.4 145), black) }", ".foo{color:#006900}");
+    minify_test(
+      ".foo { color: color-mix(in hsl, color(srgb-linear 0 1.5 0), color(srgb-linear 0 1.5 0)) }",
+      ".foo{color:#0f0}",
+    );
+    // Greys outside the gamut have no hue. The white the gamut mapping produced for them came with
+    // a noise hue and saturation, which used to make the first of these teal (#609f9f).
+    minify_test(".foo { color: color-mix(in hsl, color(srgb 1.2 1.2 1.2), black) }", ".foo{color:#999}");
+    minify_test(".foo { color: color-mix(in hwb, color(srgb 1.2 1.2 1.2), black) }", ".foo{color:#999}");
+    minify_test(".foo { color: color-mix(in hsl, color(srgb -0.2 -0.2 -0.2), white) }", ".foo{color:#666}");
+    minify_test(
+      ".foo { color: color-mix(in hwb, light-dark(color(display-p3 0 1 0), red), light-dark(color(display-p3 0 1 0), blue)) }",
+      ".foo{color:light-dark(#0f0,#f0f)}",
+    );
+    minify_test(
+      ".foo { background: linear-gradient(color-mix(in hsl, color(display-p3 0 1 0), white), color-mix(in hwb, lab(100% 104.3 -50.9), red)) }",
+      ".foo{background:linear-gradient(#10ff36,#ff4bb3)}",
+    );
+    // Still one 8-bit declaration whatever the targets are.
+    prefix_test(
+      ".foo { color: color-mix(in hsl, color(display-p3 0 1 0), white) }",
+      `.foo {
+        color: #10ff36;
+      }
+      `,
+      { chrome: Some(90 << 16) },
+    );
+
+    describe("operands inside the gamut fold to the same color as before", () => {
+      minify_test(".foo { color: color-mix(in hsl, red, white) }", ".foo{color:#df9f9f}");
+      minify_test(".foo { color: color-mix(in hsl, red 25%, blue) }", ".foo{color:#8000ff}");
+      minify_test(".foo { color: color-mix(in hwb, red 25%, blue) }", ".foo{color:#8000ff}");
+      minify_test(".foo { color: color-mix(in hsl, #808080, red) }", ".foo{color:#bf4040}");
+      minify_test(".foo { color: color-mix(in hwb, #808080, red) }", ".foo{color:#c04040}");
+      // A boundary color written as lab() converts back a few 1e-7 outside the gamut.
+      minify_test(
+        ".foo { color: color-mix(in hsl, lab(54.2905% 80.8049 69.891), lab(54.2905% 80.8049 69.891)) }",
+        ".foo{color:red}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in hwb, lab(54.2905% 80.8049 69.891), lab(54.2905% 80.8049 69.891)) }",
+        ".foo{color:red}",
+      );
+      minify_test(
+        ".foo { color: color-mix(in hsl, color(display-p3 0 0 1), color(display-p3 0 0 1)) }",
+        ".foo{color:#00f}",
+      );
+    });
+  });
+
   describe("font-palette-values", () => {
     minify_test(
       "@font-palette-values --x{font-family:Foo;base-palette:2}",

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7805,6 +7805,63 @@ describe("css tests", () => {
     minify_test(".foo{grid-template-areas:none}", ".foo{grid-template-areas:none}");
   });
 
+  // rgb(), hsl() and hwb() cannot hold an origin outside the sRGB gamut. Browsers keep the
+  // out-of-gamut channels and clip them when painting (w3c/csswg-drafts#8444), so resolving
+  // these by gamut mapping the origin, as before (#fff and #00f942 below), painted a
+  // different color than the unbundled stylesheet. They are left for the browser.
+  describe("relative colors with an origin outside the sRGB gamut", () => {
+    minify_test(
+      ".foo { color: rgb(from lab(100% 104.3 -50.9) r g b) }",
+      ".foo{color:rgb(from lab(100% 104.3 -50.9) r g b)}",
+    );
+    minify_test(
+      ".foo { color: hsl(from color(display-p3 0 1 0) h s l) }",
+      ".foo{color:hsl(from color(display-p3 0 1 0) h s l)}",
+    );
+    minify_test(
+      ".foo { color: hwb(from oklch(100% 0.399 336.3) h w b) }",
+      ".foo{color:hwb(from oklch(100% .399 336.3) h w b)}",
+    );
+    minify_test(
+      ".foo { color: rgb(from lab(100% 104.3 -50.9) r g b / var(--a)) }",
+      ".foo{color:rgb(from lab(100% 104.3 -50.9) r g b/var(--a))}",
+    );
+    // Under targets without lab(), the origin literal gets the fallback tiers any unresolved
+    // value containing it gets; the relative color itself is still left alone in each tier.
+    prefix_test(
+      ".foo { color: rgb(from lab(100% 104.3 -50.9) r g b) }",
+      indoc`
+        .foo {
+          color: rgb(from #fff r g b);
+        }
+
+        @supports (color: lab(0% 0 0)) {
+          .foo {
+            color: rgb(from lab(100% 104.3 -50.9) r g b);
+          }
+        }
+      `,
+      {
+        chrome: 95 << 16,
+      },
+    );
+
+    // In-gamut origins resolve as before, and the unbounded functions resolve any origin.
+    minify_test(".foo { color: rgb(from lab(50% 40 -50) r g b) }", ".foo{color:#965dcd}");
+    minify_test(".foo { color: hsl(from color(display-p3 0.4 0.4 0.4) h s l) }", ".foo{color:#666}");
+    minify_test(
+      ".foo { color: color(from lab(100% 104.3 -50.9) srgb r g b) }",
+      ".foo{color:color(srgb 1.5935 .587758 1.40555)}",
+    );
+    // A boundary color converts back a few 1e-7 outside the gamut; that still resolves.
+    minify_test(".foo { color: rgb(from lab(54.2905% 80.8049 69.891) r g b) }", ".foo{color:red}");
+    minify_test(".foo { color: hsl(from lab(54.2905% 80.8049 69.891) h s l) }", ".foo{color:red}");
+    minify_test(
+      ".foo { color: rgb(from lab(54.2905% 80.8049 69.891) r g b / var(--a)) }",
+      ".foo{color:rgb(255 0 0/var(--a))}",
+    );
+  });
+
   describe("edge cases", () => {
     describe("invalid gradient", () => {
       cssTest(


### PR DESCRIPTION
Stacked on #39269 (this PR's base branch). It also carries #39261's commit (716e4287cc, unchanged), because without it this change would alter what `hsl(from <out-of-gamut color> ...)` resolves to; that commit drops out of the diff once #39261 lands. The change of this PR is the last commit (2b29ca8a83): `src/css/values/color.rs`, one assertion in `src/css/css_parser.rs`, one line in `src/css_jsc/color_js.rs`, and the tests. Landing order: #39261 and #39269 in either order, then this.

### Problem
- `color-mix(in hsl, ...)` and `color-mix(in hwb, ...)` are folded to an 8-bit color at build time (CSS bundler, `Bun.build`, `Bun.color()`). When an operand is outside the sRGB gamut, the fold is computed from a different color than the one written: `color-mix(in hsl, color(display-p3 0 1 0), color(display-p3 0 1 0))` folds to `#00f942` (browsers compute `color(srgb -0.51 1.02 -0.31)` and paint `#00ff00`), `color-mix(in hwb, lab(100% 104.3 -50.9) 100%, black 0%)` folds to `#fff` (browsers paint `#ff96ff`), `color-mix(in hsl, color(display-p3 0 1 0), white)` folds to `#9ddeae` (browsers `#10ff36`). Same on the 1.4.0 release, on main, and on #39269 alone, which fixes the result side of the same problem for all three spaces and leaves this operand side out on purpose.
- Cause: `impl From<SRGB> for HSL` and `impl From<SRGB> for HWB` (`src/css/values/color.rs`) start with `rgb_.resolve()`, which gamut maps the color (css-color-4 section 13 chroma reduction, plus its "oklch lightness >= 1 is white" shortcut) before converting it. Every conversion into hsl or hwb goes through these two (`color_generated.rs` routes `X => SRGB => HSL`), so by the time `CssColor::interpolate` mixes the operands the wide-gamut one has been replaced. css-color-4 converts operands as they are and interpolates the out-of-range channels (#interpolation-space; CSSWG resolution w3c/csswg-drafts#8444 that hsl/hwb carry out-of-gamut colors). WPT `css/css-color/parsing/color-mix-out-of-gamut.html` mixes display-p3 green and the lab/lch/oklab/oklch colors in the tests 100% / 0% with black in both spaces and expects each operand's own unclipped sRGB value back.
- The mapped white also came back with a noise hue and a 50% saturation (the conversion noise of the mapping's white), so `color-mix(in hsl, lab(100% 104.3 -50.9), black)` folded to a teal `#609f9f`, and so did `color-mix(in hsl, color(srgb 1.2 1.2 1.2), black)` (browsers: `#00ff00` and `#999999`).

### Fix
- The two conversions call `resolve_missing()` instead of `resolve()`. An out-of-gamut color now converts to an hsl value with a saturation above 1 or a lightness outside 0..1, or an hwb value with a negative whiteness or blackness; `From<HSL> for SRGB` and `From<HWB> for SRGB` are the spec formulas and turn those back into the original channels (this is what makes the WPT's 100% / 0% mixes the identity). The mix result then reaches #39269's `into_css` closures, which clip it, so the fold is the browser's painted color.
- rgb-to-hsl gets the step the spec's sample code added for w3c/csswg-drafts#9222: a lightness outside 0..1 makes the saturation formula negative, and the same color is expressed as the opposite hue with a positive saturation (`hsl(h + 180, -s, l)` and `hsl(h, s, l)` are the same point, because the hue-to-rgb triangle wave is negated by a 180 degree shift). This keeps saturations non-negative everywhere, so the `hsl_to_rgb` assertion only drops its `<= 1` half, and it is what decides how such an operand mixes with a hued one (`color-mix(in hsl, lab(100% 104.3 -50.9), red)` goes towards yellow, as in the reference implementation below).
- rgb-to-hwb uses the hue of the channels themselves (shared `srgb_hue` helper) rather than the hsl hue it used to copy. hwb-to-rgb scales the pure hue by `1 - w - b`, which is `max - min` and positive for every color, so only the unflipped hue converts back; with the flipped one, `color-mix(in hwb, lab(100% 104.3 -50.9) 100%, black 0%)` would fold to `#96ffc6` instead of the operand itself. This is also how @csstools/color-helpers (the csswg sample code packaged; it is in `test/node_modules`) is structured: `XYZ_D50_to_HWB` uses a separate `sRGB_to_Hue`.
- `Bun.color(x, "hsl")` for a `lab()`-family input relied on the conversion's mapping to print an hsl() in range; it now maps explicitly (`into_srgb().resolve()`, the same call the rgb formats make in `into_rgba()`) and its output is byte-identical to before: checked for 5832 8-bit colors and a grid of 539 `lab()` colors (339 of them out of gamut), and pinned by the new `color(wide gamut input, "hsl")` tests. `LABColor::into_hsl` loses its only caller and is removed. #33047 and #38488 both rewrite this arm as `HSL::try_from_css_color(&result)`; whichever of them lands after this PR needs the mapping in that form (convert to `SRGB`, `resolve()`, then into `HSL`), or wide-gamut inputs print an out-of-range hsl().
- What does not change: a color inside the gamut converts to the same values as before (the only new code paths are the negative-saturation branch, which an in-gamut color cannot reach, and the exactly-360 hue wrap the spec code has), so mixes of in-gamut operands are unchanged; on the `lab()` grid above, the 200 in-gamut colors give identical hsl and hwb mixes and relative colors, and all 339 out-of-gamut ones give different mixes. Relative colors are unchanged because #39261 rejects out-of-gamut origins before the conversion runs (its boundary-color sweep through `hsl(from ...)` / `hwb(from ...)` still passes; a comment of its that this PR makes stale is updated). `in srgb` mixes, `to_rgb()` fallbacks and the hsl()/hwb() literal parsing do not go through these conversions. Slightly out-of-gamut operands do change, unlike in #39269, because the mapped operand has a different hue than the written one: `color-mix(in hsl, oklch(57.7% 0.245 27.325), white)` (Tailwind's red-600) goes from `#dc969a` to `#e28491`, the spec value; Tailwind's own generated fallbacks mix `in srgb`/`in oklab` and are not affected.
- Relationship to the other open color-mix PRs: #38508 changes other lines of `interpolate` (which operand gets the powerless treatment); its hsl/hwb tests use in-gamut operands, so its expectations do not change here and vice versa. Mixes of an hsl()/hwb() literal written with `none` and a wide-gamut operand still go through the operand-mapping block #38508 deletes and are not pinned here.
- Verified: `test/js/bun/css/color.test.ts` (mix block: 53 of its 68 cases fail on the unfixed build, the other 15 pin unchanged in-gamut mixes; `"hsl"` output block: 6 cases that pass before and after, and 5 of which fail if the `resolve()` in `color_js.rs` is left out, checked by building that variant) and `test/js/bun/css/css.test.ts` (44 of 52 fail unfixed, 8 pin unchanged mixes). Every expected value was cross-checked against @csstools/css-color-parser 3.0.7 computing the same `color-mix()` and converting the result back by hand (agrees on all of them; its own `serializeRGB` applies an old-spec powerless rule on top, so it was bypassed). Full `color.test.ts`, `css.test.ts`, `test/bundler/css/wpt/`, the css regression tests and `doesnt_crash.test.ts` pass with the debug build; a sweep of 76k hsl/hwb mixes over 39 operands (out-of-gamut, achromatic, `none`, transparent) times weights and hue methods runs without tripping an assertion in the debug build; `cargo fmt` and `cargo clippy -p bun_css` are clean.

### Background
- `color-mix(in X, a, b)` converts both operands into space X (here via `T::try_from_css_color`, which for hsl and hwb ends in the two `From<SRGB>` impls changed here), fills missing channels, premultiplies, interpolates per channel, and converts the result back out through the space's `into_css` closure; for hsl and hwb that closure converts to sRGB and (since #39269) clips.
- Gamut: the colors a space can express. `rgb()`, `hsl()` and `hwb()` are sRGB; `color(display-p3 ...)`, `lab()`, `oklch()` can express colors outside it. Such a color has sRGB channels outside 0..1, and since hsl and hwb are just other coordinates for the same channels, it has an hsl/hwb representation with out-of-range values as well. Gamut mapping (`resolve()` -> `map_gamut`) replaces it with a nearby in-gamut color by reducing chroma; that is right for the `#rrggbb` fallback the bundler writes in front of a wide-gamut value, but not for an intermediate value that is about to be interpolated. Clipping clamps each channel and is what browsers do when painting.
- hsl: `l = (max + min) / 2`, `s = (max - l) / min(l, 1 - l)`. When `l` is outside 0..1 the divisor is negative and so is `s`; hence the hue flip. hwb: `w = min`, `b = 1 - max`, hue as in hsl; converting back takes the pure color of the hue and scales it by `1 - w - b`.

<details>
<summary>Before / after (Bun.color(input, "css"); the bundler emits the same values; the last column is @csstools/css-color-parser's unclipped result)</summary>

```
input                                                                    before     after      reference (unclipped)
color-mix(in hsl, color(display-p3 0 1 0) 100%, black 0%)                #00f942    #0f0       srgb(-0.5116 1.0183 -0.3107)
color-mix(in hwb, color(display-p3 0 1 0) 100%, black 0%)                #00f942    #0f0       same
color-mix(in hsl, lab(100% 104.3 -50.9) 100%, black 0%)                  #fff       #ff96ff    srgb(1.5935 0.5878 1.4055)   hsl(131.2 554.9% 109.1%)
color-mix(in hwb, lab(100% 104.3 -50.9) 100%, black 0%)                  #fff       #ff96ff    same                          hwb(311.2 58.8% -59.4%)
color-mix(in hsl, lab(0% 104.3 -50.9) 100%, black 0%)                    #2a0022    #5a004c    srgb(0.3514 -0.2139 0.2995)
color-mix(in hsl, oklch(100% 0.399 336.3) 100%, black 0%)                #fff       #ff5bff    srgb(1.5933 0.3586 1.3865)
color-mix(in hsl, color(display-p3 0 1 0), white)                        #9ddeae    #10ff36    srgb(0.063 1.1903 0.2111)
color-mix(in hwb, color(display-p3 0 1 0), white)                        #80fca0    #3eff58    srgb(0.2442 1.0091 0.3447)
color-mix(in hwb, color(display-p3 0 1 0), black)                        #007c21    #008200    srgb(-0.2558 0.5091 -0.1553)
color-mix(in hsl, color(display-p3 0 1 0), blue)                         #00dafc    #0ff       srgb(-0.3803 1.0342 1.1337)
color-mix(in hsl, lab(100% 104.3 -50.9), red)                            #bfef8f    #ffff20    srgb(1.3403 1.4655 0.1251)
color-mix(in hwb, lab(100% 104.3 -50.9), red)                            #bfff7f    #ff4bb3    srgb(1.2968 0.2939 0.7016)
color-mix(in hsl, lab(100% 104.3 -50.9), black)                          #609f9f    #0f0       srgb(-0.7161 1.8067 -0.2446)
color-mix(in hsl, color(srgb 1.2 1.2 1.2), black)                        #609f9f    #999       srgb(0.6 0.6 0.6)
color-mix(in hsl, oklch(57.7% 0.245 27.325), white)                      #dc969a    #e28491    srgb(0.8865 0.5187 0.5694)
color-mix(in hsl, red, white)                                            #df9f9f    #df9f9f    srgb(0.875 0.625 0.625)
color-mix(in hsl, color(display-p3 0 0 1), color(display-p3 0 0 1))      #00f       #00f       srgb(0 0 1.042)
Bun.color("lab(0% 104.3 -50.9)", "hsl")                                  hsl(311.38312, 100%, 8.164707%)   unchanged
```
</details>
