### PR TITLE
bun-types: type Subprocess stdio as null and terminal as Terminal when spawned with the terminal option

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -7031,7 +7031,12 @@ declare module "bun" {
      */
     type OptionsObject<In extends Writable, Out extends Readable, Err extends Readable> = BaseOptions<In, Out, Err>;
 
-    interface BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> {
+    interface BaseOptions<
+      In extends Writable,
+      Out extends Readable,
+      Err extends Readable,
+      Term extends Terminal | undefined = undefined,
+    > {
       /**
        * The current working directory of the process
        *
@@ -7196,7 +7201,7 @@ declare module "bun" {
        * ```
        */
       onExit?(
-        subprocess: Subprocess<In, Out, Err>,
+        subprocess: Subprocess<In, Out, Err, Term>,
         exitCode: number | null,
         signalCode: number | null,
         /**
@@ -7262,7 +7267,7 @@ declare module "bun" {
         /**
          * The {@link Subprocess} that received the message
          */
-        subprocess: Subprocess<In, Out, Err>,
+        subprocess: Subprocess<In, Out, Err, Term>,
         handle?: unknown,
       ): void;
 
@@ -7373,8 +7378,21 @@ declare module "bun" {
     interface SpawnSyncOptions<In extends Writable, Out extends Readable, Err extends Readable>
       extends BaseOptions<In, Out, Err> {}
 
-    interface SpawnOptions<In extends Writable, Out extends Readable, Err extends Readable>
-      extends BaseOptions<In, Out, Err> {
+    /**
+     * Options accepted by {@link spawn}.
+     *
+     * `Term` is what {@link Subprocess.terminal} is on the process these options produce, and decides what
+     * the `terminal` option accepts: only `undefined` when `Term` is `undefined` (the default),
+     * `TerminalOptions | Terminal` when it is `Terminal`, and either when it is `Terminal | undefined`. The
+     * {@link Subprocess} passed to `onExit` and `ipc` has the same `Term`. {@link spawn} picks the overload,
+     * and with it `Term`, from whether the options it is called with carry a `terminal`.
+     */
+    interface SpawnOptions<
+      In extends Writable,
+      Out extends Readable,
+      Err extends Readable,
+      Term extends Terminal | undefined = undefined,
+    > extends BaseOptions<In, Out, Err, Term> {
       /**
        * If true, the stdout and stderr pipes don't automatically start reading
        * data. Reading begins only when you access the `stdout` or `stderr`
@@ -7397,14 +7415,23 @@ declare module "bun" {
        */
       lazy?: boolean;
 
+      // `terminal` is typed as a union that contains `Term` itself rather than as one conditional type on
+      // `Term`, so that TypeScript measures this interface as covariant in `Term`. With a bare conditional
+      // it measures it as bivariant, and a `SpawnOptions<.., Terminal | undefined>` value would then satisfy
+      // the `Term = undefined` instantiation that the terminal-less `spawn` overloads take.
       /**
        * Spawn the subprocess with a pseudo-terminal (PTY) attached.
        *
        * When this option is provided:
-       * - `stdin`, `stdout`, and `stderr` are all connected to the terminal
+       * - `stdin`, `stdout`, and `stderr` are all connected to the terminal; the
+       *   `stdin`, `stdout` and `stderr` options are ignored
        * - The subprocess sees itself running in a real terminal (`isTTY = true`)
-       * - Access the terminal via `subprocess.terminal`
-       * - `subprocess.stdin`, `subprocess.stdout`, `subprocess.stderr` return `null`
+       * - Access the terminal via `subprocess.terminal`, which is a {@link Terminal}
+       * - `subprocess.stdin`, `subprocess.stdout` and `subprocess.stderr` are `null`
+       *
+       * {@link spawn} types the returned {@link Subprocess} accordingly: its `terminal` is a `Terminal`
+       * and its `stdin`, `stdout` and `stderr` are `null`. When the option's value may be `undefined`, the
+       * returned process has both shapes in a union (`proc.stdout` is `ReadableStream | null`, and so on).
        *
        * Only available on POSIX systems (Linux, macOS).
        *
@@ -7433,7 +7460,7 @@ declare module "bun" {
        * terminal.close();
        * ```
        */
-      terminal?: TerminalOptions | Terminal;
+      terminal?: Term | (Term extends Terminal ? TerminalOptions : never);
     }
 
     type ReadableToIO<X extends Readable> = X extends "pipe" | undefined
@@ -7533,26 +7560,57 @@ declare module "bun" {
   /**
    * A process created by {@link Bun.spawn}.
    *
-   * The 3 optional type parameters correspond to the `stdio` array from the options object. Instead of specifying them, use one of these utility types:
+   * The first 3 optional type parameters correspond to the `stdio` array from the options object. Instead of specifying them, use one of these utility types:
    * - {@link ReadableSubprocess} (any, pipe, pipe)
    * - {@link WritableSubprocess} (pipe, any, any)
    * - {@link PipedSubprocess} (pipe, pipe, pipe)
    * - {@link NullSubprocess} (ignore, ignore, ignore)
+   *
+   * The 4th is the type of {@link Subprocess.terminal}: `Terminal` for a process spawned with the `terminal`
+   * option, whose `stdin`, `stdout`, `stderr` and `readable` are then `null`; `undefined` for a process
+   * without one, whose stdio properties are derived from the first 3 parameters. {@link Bun.spawn} picks it
+   * from the options it is called with.
+   *
+   * It defaults to `undefined` when the stdio parameters are given (`Subprocess<"ignore", "pipe", "pipe">`,
+   * the utility types above), so those types keep describing exactly the streams they name. When the stdio
+   * parameters are left unspecified as well (`Subprocess`, `Subprocess<any, any, any>`), it defaults to
+   * `Terminal | undefined`, so a plain `Subprocess` accepts every process {@link Bun.spawn} returns; its
+   * stdio properties then include `null`. `Subprocess<any, any, any, Terminal>` accepts exactly the
+   * processes that have a terminal.
    */
   interface Subprocess<
     In extends SpawnOptions.Writable = SpawnOptions.Writable,
     Out extends SpawnOptions.Readable = SpawnOptions.Readable,
     Err extends SpawnOptions.Readable = SpawnOptions.Readable,
+    Term extends Terminal | undefined = [SpawnOptions.Writable, SpawnOptions.Readable, SpawnOptions.Readable] extends [
+      In,
+      Out,
+      Err,
+    ]
+      ? Terminal | undefined
+      : undefined,
   > extends AsyncDisposable {
-    readonly stdin: SpawnOptions.WritableToIO<In>;
-    readonly stdout: SpawnOptions.ReadableToIO<Out>;
-    readonly stderr: SpawnOptions.ReadableToIO<Err>;
+    /**
+     * Derived from the `stdin` option (see {@link SpawnOptions.WritableToIO}), or `null` when the process
+     * was spawned with the `terminal` option: write to {@link Subprocess.terminal} instead.
+     */
+    readonly stdin: Term extends Terminal ? null : SpawnOptions.WritableToIO<In>;
+    /**
+     * Derived from the `stdout` option (see {@link SpawnOptions.ReadableToIO}), or `null` when the process
+     * was spawned with the `terminal` option: the output arrives in the terminal's `data` callback instead.
+     */
+    readonly stdout: Term extends Terminal ? null : SpawnOptions.ReadableToIO<Out>;
+    /**
+     * Derived from the `stderr` option (see {@link SpawnOptions.ReadableToIO}), or `null` when the process
+     * was spawned with the `terminal` option: the output arrives in the terminal's `data` callback instead.
+     */
+    readonly stderr: Term extends Terminal ? null : SpawnOptions.ReadableToIO<Err>;
 
     /**
-     * The terminal attached to this subprocess, if spawned with the `terminal` option.
-     * `undefined` if no terminal was attached.
+     * The terminal attached to this subprocess when it was spawned with the `terminal` option
+     * (the same object if an existing {@link Terminal} was passed), `undefined` otherwise.
      *
-     * When a terminal is attached, `stdin`, `stdout`, and `stderr` return `null`.
+     * When a terminal is attached, `stdin`, `stdout`, and `stderr` are `null`.
      * Use `terminal.write()` and the `data` callback instead.
      *
      * @example
@@ -7561,10 +7619,10 @@ declare module "bun" {
      *   terminal: { data: (term, data) => console.log(data.toString()) },
      * });
      *
-     * proc.terminal?.write("echo hello\n");
+     * proc.terminal.write("echo hello\n");
      * ```
      */
-    readonly terminal: Terminal | undefined;
+    readonly terminal: Term;
 
     /**
      * Extra file descriptors passed to the `stdio` option.
@@ -7583,7 +7641,7 @@ declare module "bun" {
      *
      * Exists for compatibility with {@link ReadableStream.pipeThrough}
      */
-    readonly readable: SpawnOptions.ReadableToIO<Out>;
+    readonly readable: Term extends Terminal ? null : SpawnOptions.ReadableToIO<Out>;
 
     /**
      * The process ID of the child process
@@ -7733,7 +7791,7 @@ declare module "bun" {
        */
       cmd: string[]; // to support dynamically constructed commands
     },
-  ): Subprocess<In, Out, Err>;
+  ): Subprocess<In, Out, Err, undefined>;
 
   /**
    * Spawn a new process
@@ -7767,7 +7825,95 @@ declare module "bun" {
      */
     cmds: string[],
     options?: SpawnOptions.SpawnOptions<In, Out, Err>,
-  ): Subprocess<In, Out, Err>;
+  ): Subprocess<In, Out, Err, undefined>;
+
+  /**
+   * Spawn a new process with a pseudo-terminal attached (the `terminal` option).
+   *
+   * The process's stdio goes through the terminal, so the returned {@link Subprocess} has a
+   * {@link Terminal} as its `terminal` and `null` as its `stdin`, `stdout` and `stderr`.
+   *
+   * ```ts
+   * const proc = Bun.spawn({
+   *   cmd: ["bash"],
+   *   terminal: { data: (term, data) => process.stdout.write(data) },
+   * });
+   * proc.terminal.write("echo hello\n");
+   * ```
+   */
+  function spawn<
+    const In extends SpawnOptions.Writable = "ignore",
+    const Out extends SpawnOptions.Readable = "pipe",
+    const Err extends SpawnOptions.Readable = "inherit",
+  >(
+    options: SpawnOptions.SpawnOptions<In, Out, Err, Terminal> & {
+      /** The command to run, resolved as described on the first overload. */
+      cmd: string[];
+      terminal: TerminalOptions | Terminal;
+    },
+  ): Subprocess<In, Out, Err, Terminal>;
+
+  /**
+   * Spawn a new process with a pseudo-terminal attached (the `terminal` option).
+   *
+   * The process's stdio goes through the terminal, so the returned {@link Subprocess} has a
+   * {@link Terminal} as its `terminal` and `null` as its `stdin`, `stdout` and `stderr`.
+   *
+   * ```ts
+   * const proc = Bun.spawn(["bash"], {
+   *   terminal: { data: (term, data) => process.stdout.write(data) },
+   * });
+   * proc.terminal.write("echo hello\n");
+   * ```
+   */
+  function spawn<
+    const In extends SpawnOptions.Writable = "ignore",
+    const Out extends SpawnOptions.Readable = "pipe",
+    const Err extends SpawnOptions.Readable = "inherit",
+  >(
+    /** The command to run, resolved as described on the first overload. */
+    cmds: string[],
+    options: SpawnOptions.SpawnOptions<In, Out, Err, Terminal> & { terminal: TerminalOptions | Terminal },
+  ): Subprocess<In, Out, Err, Terminal>;
+
+  // The two overloads below accept everything the four above accept, so they have to stay last. The
+  // object form is the very last one: when a one-argument call matches no overload, TypeScript reports
+  // the last overload's error, which should be the object form's, and `ReturnType<typeof Bun.spawn>` is
+  // the last overload's return type, which this way stays equal to a plain `Subprocess`.
+  /**
+   * Spawn a new process whose `terminal` option may or may not be set (for example
+   * `terminal: interactive ? { ... } : undefined`).
+   *
+   * The returned {@link Subprocess} covers both cases: its `terminal` is `Terminal | undefined` and
+   * its `stdin`, `stdout` and `stderr` are `null` when a terminal is attached.
+   */
+  function spawn<
+    const In extends SpawnOptions.Writable = "ignore",
+    const Out extends SpawnOptions.Readable = "pipe",
+    const Err extends SpawnOptions.Readable = "inherit",
+  >(
+    /** The command to run, resolved as described on the first overload. */
+    cmds: string[],
+    options: SpawnOptions.SpawnOptions<In, Out, Err, Terminal | undefined>,
+  ): Subprocess<In, Out, Err, Terminal | undefined>;
+
+  /**
+   * Spawn a new process whose `terminal` option may or may not be set (for example
+   * `terminal: interactive ? { ... } : undefined`).
+   *
+   * The returned {@link Subprocess} covers both cases: its `terminal` is `Terminal | undefined` and
+   * its `stdin`, `stdout` and `stderr` are `null` when a terminal is attached.
+   */
+  function spawn<
+    const In extends SpawnOptions.Writable = "ignore",
+    const Out extends SpawnOptions.Readable = "pipe",
+    const Err extends SpawnOptions.Readable = "inherit",
+  >(
+    options: SpawnOptions.SpawnOptions<In, Out, Err, Terminal | undefined> & {
+      /** The command to run, resolved as described on the first overload. */
+      cmd: string[];
+    },
+  ): Subprocess<In, Out, Err, Terminal | undefined>;
 
   /**
    * Synchronously spawn a new process

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -400,6 +400,35 @@ describe("@types/bun integration test", () => {
     });
   });
 
+  // Also runs on debug builds, where the in-process typeTest cases (which cover the whole
+  // fixture directory) are skipped: checks fixture/spawn.ts alone against the packed bun-types.
+  describe("Bun.spawn", () => {
+    test("fixture/spawn.ts type-checks", async () => {
+      const checkDir = join(TEMP_DIR, "spawn-fixture-check");
+      const tsconfig = structuredClone(sourceTsconfig);
+      tsconfig.files = [join(BASE_FIXTURE_DIR, "spawn.ts")];
+      tsconfig.compilerOptions.typeRoots = [join(BASE_FIXTURE_DIR, "node_modules", "@types")];
+      await mkdir(checkDir, { recursive: true });
+      await makeTree(checkDir, {
+        "tsconfig.json": JSON.stringify(tsconfig, null, 2),
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(BASE_FIXTURE_DIR, "node_modules", "typescript", "bin", "tsc"), "-p", "."],
+        env: bunEnv,
+        cwd: checkDir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr.trim()).toBe("");
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("Test Globals", () => {
     const code = `
       const test_shouldBeAFunction: Function = test;

--- a/test/integration/bun-types/fixture/spawn.ts
+++ b/test/integration/bun-types/fixture/spawn.ts
@@ -226,3 +226,186 @@ tsd.expectAssignable<SyncSubprocess<Bun.SpawnOptions.Readable, Bun.SpawnOptions.
   Bun.spawnSync({ cmd: ["echo", "hello"], stdout: "pipe", stderr: "pipe", lazy: true,
   });
 }
+
+// The terminal option (async only): stdio goes through the PTY, so the stdio properties are null
+// and `terminal` is always set, whatever the stdio options say.
+declare const interactive: boolean;
+{
+  const proc = Bun.spawn(["bash"], {
+    stdin: "pipe",
+    terminal: {
+      cols: 80,
+      rows: 24,
+      data(term, data) {
+        tsd.expectType(term).is<Bun.Terminal>();
+        tsd.expectType(data).is<Uint8Array<ArrayBuffer>>();
+      },
+    },
+    onExit(proc) {
+      tsd.expectType(proc).is<Bun.Subprocess<"pipe", "pipe", "inherit", Bun.Terminal>>();
+      proc.terminal.close();
+    },
+    ipc(message, proc) {
+      tsd.expectType(proc.stdin).is<null>();
+    },
+  });
+  tsd.expectType(proc).is<Bun.Subprocess<"pipe", "pipe", "inherit", Bun.Terminal>>();
+  tsd.expectType(proc.stdin).is<null>();
+  tsd.expectType(proc.stdout).is<null>();
+  tsd.expectType(proc.stderr).is<null>();
+  tsd.expectType(proc.readable).is<null>();
+  tsd.expectType(proc.terminal).is<Bun.Terminal>();
+  tsd.expectType(proc.stdio).is<[null, null, null, ...(number | null)[]]>();
+  proc.terminal.write("echo hello\n");
+  // @ts-expect-error stdin is null when a terminal is attached
+  proc.stdin.write("hello");
+  // @ts-expect-error stdout is null when a terminal is attached
+  proc.stdout.getReader();
+}
+{
+  // an existing Terminal, and the object form
+  const terminal = new Bun.Terminal({ data() {} });
+  tsd.expectType(Bun.spawn(["bash"], { terminal })).is<Bun.Subprocess<"ignore", "pipe", "inherit", Bun.Terminal>>();
+  tsd
+    .expectType(Bun.spawn({ cmd: ["bash"], terminal }))
+    .is<Bun.Subprocess<"ignore", "pipe", "inherit", Bun.Terminal>>();
+  const proc = Bun.spawn({
+    cmd: ["bash"],
+    stdio: ["pipe", "pipe", "pipe"],
+    terminal: { data(term, data) {} },
+    onExit(proc) {
+      tsd.expectType(proc.terminal).is<Bun.Terminal>();
+    },
+  });
+  tsd.expectType(proc).is<Bun.Subprocess<"pipe", "pipe", "pipe", Bun.Terminal>>();
+  tsd.expectType(proc.stdout).is<null>();
+}
+{
+  // a terminal that may be absent gives the union of both shapes
+  const proc = Bun.spawn(["bash"], {
+    terminal: interactive ? { data(term, data) {} } : undefined,
+    onExit(proc) {
+      tsd.expectType(proc.terminal).is<Bun.Terminal | undefined>();
+    },
+  });
+  tsd.expectType(proc).is<Bun.Subprocess<"ignore", "pipe", "inherit", Bun.Terminal | undefined>>();
+  tsd.expectType(proc.stdin).is<undefined | null>();
+  tsd.expectType(proc.stdout).is<ReadableStream<Uint8Array<ArrayBuffer>> | null>();
+  tsd.expectType(proc.readable).is<ReadableStream<Uint8Array<ArrayBuffer>> | null>();
+  tsd.expectType(proc.terminal).is<Bun.Terminal | undefined>();
+  const objectForm = Bun.spawn({ cmd: ["bash"], terminal: interactive ? {} : undefined });
+  tsd.expectType(objectForm).is<Bun.Subprocess<"ignore", "pipe", "inherit", Bun.Terminal | undefined>>();
+}
+{
+  // without the option, terminal is undefined and the stdio types are unchanged
+  const proc = Bun.spawn(["cat"], {
+    stdin: "pipe",
+    onExit(proc) {
+      tsd.expectType(proc).is<Bun.Subprocess<"pipe", "pipe", "inherit", undefined>>();
+      proc.stdin.write("bye");
+    },
+  });
+  tsd.expectType(proc).is<Bun.Subprocess<"pipe", "pipe", "inherit">>();
+  tsd.expectType(proc).is<Bun.Subprocess<"pipe", "pipe", "inherit", undefined>>();
+  tsd.expectType(proc.stdin).is<FileSink>();
+  tsd.expectType(proc.terminal).is<undefined>();
+  tsd.expectType(Bun.spawn(["cat"])).is<Bun.Subprocess<"ignore", "pipe", "inherit", undefined>>();
+  tsd
+    .expectType(Bun.spawn(["cat"], { terminal: undefined }))
+    .is<Bun.Subprocess<"ignore", "pipe", "inherit", undefined>>();
+  tsd.expectType(Bun.spawn({ cmd: ["cat"], stdin: "pipe" })).is<Bun.Subprocess<"pipe", "pipe", "inherit", undefined>>();
+  tsd
+    .expectType(
+      Bun.spawnSync(["cat"], {
+        onExit(proc) {
+          tsd.expectType(proc.terminal).is<undefined>();
+        },
+      }),
+    )
+    .is<SyncSubprocess<"pipe", "pipe">>();
+  // @ts-expect-error spawnSync does not take a terminal
+  Bun.spawnSync(["cat"], { terminal: {} });
+}
+{
+  // annotated options objects: the 4th type argument says whether they carry a terminal
+  const plain: Bun.SpawnOptions.SpawnOptions<"ignore", "pipe", "inherit"> = {
+    onExit(proc) {
+      tsd.expectType(proc.stdout).is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+    },
+  };
+  tsd.expectType(Bun.spawn(["cat"], plain)).is<Bun.Subprocess<"ignore", "pipe", "inherit", undefined>>();
+  // @ts-expect-error a SpawnOptions without the 4th type argument has no terminal
+  const rejected: Bun.SpawnOptions.SpawnOptions<"ignore", "pipe", "inherit"> = { terminal: {} };
+  const withTerminal: Bun.SpawnOptions.SpawnOptions<"ignore", "pipe", "inherit", Bun.Terminal> = {
+    terminal: { data(term, data) {} },
+    onExit(proc) {
+      tsd.expectType(proc.terminal).is<Bun.Terminal>();
+    },
+  };
+  const maybe: Bun.SpawnOptions.SpawnOptions<"ignore", "pipe", "inherit", Bun.Terminal | undefined> = interactive
+    ? { terminal: new Bun.Terminal({}) }
+    : {};
+  tsd.expectType(Bun.spawn(["cat"], maybe)).is<Bun.Subprocess<"ignore", "pipe", "inherit", Bun.Terminal | undefined>>();
+  tsd.expectAssignable<typeof maybe>(plain);
+  tsd.expectAssignable<typeof maybe>(withTerminal);
+  // @ts-expect-error may carry a terminal
+  tsd.expectAssignable<typeof plain>(maybe);
+  // @ts-expect-error may carry a terminal
+  tsd.expectAssignable<typeof withTerminal>(maybe);
+  tsd.expectType<(typeof plain)["terminal"]>().is<undefined>();
+  tsd.expectType<(typeof withTerminal)["terminal"]>().is<Bun.TerminalOptions | Bun.Terminal | undefined>();
+  tsd.expectType<(typeof maybe)["terminal"]>().is<Bun.TerminalOptions | Bun.Terminal | undefined>();
+}
+{
+  // holder types
+  const withTerminal = Bun.spawn(["bash"], { terminal: {} });
+  const without = Bun.spawn(["cat"], { stdin: "pipe" });
+  const either = Bun.spawn(["cat"], { terminal: interactive ? {} : undefined });
+
+  // Subprocess with no type arguments (and ReturnType<typeof Bun.spawn>) holds any of them
+  tsd.expectAssignable<Bun.Subprocess>(withTerminal);
+  tsd.expectAssignable<Bun.Subprocess>(without);
+  tsd.expectAssignable<Bun.Subprocess>(either);
+  tsd.expectAssignable<Bun.Subprocess<any, any, any>>(withTerminal);
+  tsd.expectAssignable<Bun.Subprocess<any, any, any>>(without);
+  tsd.expectType<ReturnType<typeof Bun.spawn>>().is<Bun.Subprocess>();
+  tsd.expectType<Bun.Subprocess["terminal"]>().is<Bun.Terminal | undefined>();
+  tsd.expectAssignable<Bun.Subprocess["stdin"]>(null);
+  tsd.expectAssignable<Bun.Subprocess["stdout"]>(null);
+  tsd.expectAssignable<Bun.Subprocess["stderr"]>(null);
+  tsd.expectAssignable<Bun.Subprocess["readable"]>(null);
+  function cleanUp(proc: Bun.Subprocess) {
+    proc.terminal?.close();
+    proc.kill();
+  }
+  cleanUp(withTerminal);
+  cleanUp(without);
+  cleanUp(either);
+
+  // Subprocess<.., .., .., Terminal> holds exactly the processes that have one
+  tsd.expectAssignable<Bun.Subprocess<any, any, any, Bun.Terminal>>(withTerminal);
+  tsd.expectAssignable<Bun.Subprocess<any, any, any, Bun.Terminal>>(
+    Bun.spawn(["bash"], { terminal: new Bun.Terminal({}) }),
+  );
+  // @ts-expect-error has no terminal
+  tsd.expectAssignable<Bun.Subprocess<any, any, any, Bun.Terminal>>(without);
+  // @ts-expect-error may have no terminal
+  tsd.expectAssignable<Bun.Subprocess<any, any, any, Bun.Terminal>>(either);
+  tsd.expectType<Bun.Subprocess<any, any, any, Bun.Terminal>["stdout"]>().is<null>();
+
+  // giving the stdio type arguments still describes exactly those streams, and excludes terminal processes
+  tsd.expectType<PipedSubprocess["stdin"]>().is<FileSink>();
+  tsd.expectType<PipedSubprocess["terminal"]>().is<undefined>();
+  tsd.expectType<ReadableSubprocess["stdout"]>().is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+  tsd.expectType<WritableSubprocess["stdin"]>().is<FileSink>();
+  tsd.expectType<NullSubprocess["terminal"]>().is<undefined>();
+  tsd.expectType<Bun.Subprocess<any, "pipe", any>["stdout"]>().is<ReadableStream<Uint8Array<ArrayBuffer>>>();
+  tsd.expectAssignable<WritableSubprocess>(without);
+  // @ts-expect-error its stdin is null, not a FileSink
+  tsd.expectAssignable<WritableSubprocess>(withTerminal);
+  // @ts-expect-error its stdout is null, not a stream
+  tsd.expectAssignable<ReadableSubprocess>(Bun.spawn(["bash"], { stdio: ["pipe", "pipe", "pipe"], terminal: {} }));
+  // @ts-expect-error may have a terminal
+  tsd.expectAssignable<Bun.Subprocess<"ignore", "pipe", "inherit">>(either);
+  tsd.expectAssignable<Bun.Subprocess<"ignore", "pipe", "inherit">>(Bun.spawn(["cat"]));
+}


### PR DESCRIPTION
### Problem
- `Bun.spawn(["bash"], { terminal: { data() {} } })` types `proc.stdout` as `ReadableStream`, `proc.stderr` as `undefined` and, with `stdin: "pipe"`, `proc.stdin` as `FileSink`, so `proc.stdin.write(..)` type-checks and throws; at runtime (bun 1.4.0) all three are `null`. `proc.terminal` is typed `Terminal | undefined` although it is always set, so the documented `proc.terminal.write(..)` (docs/runtime/child-process.mdx, and the option's own JSDoc example) does not compile, and bun's own tests write `proc.terminal!`.
- Runtime: `get_stdin` / `get_stdout` / `get_stderr` in src/runtime/api/bun/subprocess.rs:577-606 return `JSValue::NULL` whenever a terminal is attached, `get_terminal` (:617) returns it, and js_bun_spawn_bindings.rs:888-899 overwrites `stdio[0..3]` with the PTY, so the stdio options have no effect. `readable` and `writable` are registered with the same getters (src/runtime/api/BunObject.classes.ts:71-76).
- Declarations: `Subprocess<In, Out, Err>` (packages/bun-types/bun.d.ts:7542 on main) derives `stdin` / `stdout` / `stderr` / `readable` from the three stdio options only, `terminal` is a fixed `Terminal | undefined` (:7567), and the `terminal` option (:7436) is not reflected in `spawn`'s signatures at all.

### Fix
- `Subprocess` gets a fourth type parameter, `Term extends Terminal | undefined`, which is the type of `proc.terminal`; `stdin`, `stdout`, `stderr` and `readable` are `null` when it is `Terminal` and keep their current types when it is `undefined`. `Term = Terminal | undefined` gives the union of both (`stdout: ReadableStream | null`, `terminal: Terminal | undefined`).
- `Bun.spawn` picks `Term` with overloads, three per call form: options with a `terminal` property give `Terminal`; options without one (or with `terminal: undefined`) give `undefined`, as the existing two signatures now state explicitly; options whose `terminal` may be `undefined` (`terminal: interactive ? {..} : undefined`, or a value whose type declares it optional) fall through to a last pair that gives `Terminal | undefined`. Overloads rather than a type parameter inferred from the option because the usual `terminal: { data(term, data) {..} }` literal is context-sensitive: TypeScript fixes such a parameter to its default before it can infer from the literal (verified with a prototype: the literal was rejected and `term` / `data` became implicit `any`), and inference through an optional property also drops `undefined`, so the third case could not be told apart.
- Default of the new parameter: `undefined` when the stdio type arguments are given (`Subprocess<"pipe", "pipe", "pipe">`, `PipedSubprocess`, `Subprocess<any, "pipe", any>`, ...), so every existing annotation keeps exactly its current property types; `Terminal | undefined` when all three are left at their defaults (`Subprocess`, `Subprocess<any, any, any>`, `ReturnType<typeof Bun.spawn>`), so the plain holder still accepts every process `Bun.spawn` returns, which is what docs/runtime/child-process.mdx's reference block has described since the terminal option landed (`stdin: FileSink | number | undefined | null`, `terminal: Terminal | undefined`). The docs need no change.
- `BaseOptions` and `SpawnOptions` carry the same parameter (default `undefined`) so the `Subprocess` passed to `onExit` / `ipc` matches the returned one, and `SpawnOptions<In, Out, Err>` written as an annotation says whether it may carry a `terminal` (4th argument `Terminal` or `Terminal | undefined`; without it the property is rejected, as `stdin: "pipe"` is rejected by `SpawnOptions<"ignore", ..>` today). The option's type is spelled `Term | (Term extends Terminal ? TerminalOptions : never)` rather than as one conditional so that TypeScript measures the interface as covariant in `Term`; with a bare conditional it measures bivariant and a `SpawnOptions<.., Terminal | undefined>` value matched the terminal-less overload (found while prototyping; the fixture pins the assignability both ways). `SpawnSyncOptions` is untouched, so `spawnSync` still rejects `terminal` and its callbacks see `terminal: undefined`.
- Overload order: the two catch-all signatures are last (they accept everything), the object form being the very last one, so that `ReturnType<typeof Bun.spawn>` is still exactly `Subprocess` and a mistyped one-argument call is reported against the object form. Side effect: `Parameters<typeof Bun.spawn>[0]` was the array form's `string[]` and is now the object form's options type; the one in-tree use (test/js/web/fetch/fetch-http2-client.test.ts:162) wanted the latter.
- Blast radius, measured by type-checking `test/` (7203 pre-existing diagnostics), `src/js` and `src` before and after: `src` is identical; `src/js` and most of `test/` only change the wording or anchor line of diagnostics that were already there (`possibly 'undefined'` becomes `possibly 'null' or 'undefined'` on plain `Subprocess` holders; printed types gain the fourth argument; overload errors now name the offending property, e.g. the pre-existing error in src/js/node/child_process.ts:1410 now points at the two real mismatches instead of "'cmd' does not exist in type 'string[]'"). The one new kind of error is test/cli/watch/watch.test.ts:233/274/307, which passes a plain `Subprocess` variable to a `Subprocess<"ignore", "pipe", any>` parameter; that was accepted only because the conditional stdio types measure as bivariant, and is now rejected because the holder may hold a terminal process. Array-form mistakes now list the three two-argument overloads instead of one message (each line still carries the real error and the spelling suggestion); object-form mistakes get the one relevant message, where main listed both forms.
- Verified: test/integration/bun-types/fixture/spawn.ts (appended below the lines the lib.dom case pins) asserts the canonical literal with `data(term, data)` callbacks, an existing `Terminal`, both call forms, `stdio: [...]` being overridden, the conditional case, `onExit` / `ipc` / `spawnSync` callbacks, explicit `terminal: undefined`, annotated `SpawnOptions` objects and their assignability, `@ts-expect-error` on `proc.stdin.write` / `proc.stdout.getReader()`, and the holder types (`Subprocess`, `ReturnType<typeof Bun.spawn>`, `Subprocess<any, any, any, Terminal>`, and that `PipedSubprocess` / `ReadableSubprocess` / `WritableSubprocess` / `NullSubprocess` keep their types and reject terminal processes). Against main's bun.d.ts it produces 52 diagnostics (listed below); `USE_SYSTEM_BUN=1 bun test test/integration/bun-types/bun-types.test.ts` passes all 16 cases with the fix (tsc 6 with and without lib.dom, and the fixture's own TypeScript 7), the pinned spawn.ts:62 / :107 diagnostics unchanged.
- bun-types.test.ts gains the case that runs tsc over fixture/spawn.ts alone so debug builds, which skip the in-process cases, check it too: `bun bd test test/integration/bun-types/bun-types.test.ts` passes with the fix and fails on that case with packages/ stashed. The block is byte-identical to the one in #39283, #39297 and #39303, so whichever lands first the others merge cleanly; all of them become redundant once #39270 lands.
- Related open PRs, not duplicates: #39283 (stdio mapping arms) and #39297 (`ReadableToIO` default for stderr) edit the same `Subprocess` property lines and pin the plain holder unions, which this PR extends with `| null`; #39279 adds `writable`, which needs the same `Term extends Terminal ? null : ...` wrapper as `stdin`; #39303 (`Null*` aliases) is unaffected. Whichever of these lands second has a small, mechanical conflict in those hunks. The stale "Only available on POSIX systems" line in the same JSDoc block predates this change and is tracked separately.

### Background
- `Bun.spawn` infers one type parameter per stdio slot from the literal options it is called with (`stdin: "pipe"` gives `In = "pipe"`), and `Subprocess<In, Out, Err>` turns each into a property type with a conditional type alias (`WritableToIO<"pipe">` is `FileSink`, `ReadableToIO<"inherit">` is `undefined`). With no type arguments the parameters are the full option unions and each property becomes the union of everything it can be; that instantiation is what code stores processes of unknown configuration in.
- The `terminal` option (#25415) attaches a PTY; the child's three descriptors are the PTY's slave side, and the parent talks to it through `Bun.Terminal` (`write()` and the `data` callback), which is why the process exposes no streams for it.
- TypeScript overload resolution tries the signatures in declaration order and takes the first whose parameter types accept the arguments, so a signature requiring `terminal` and one allowing only `terminal?: undefined` split the cases, and a signature that allows both has to come after them. When more than three signatures could apply and none does, TypeScript reports only the last one's error; `ReturnType` and `Parameters` of an overloaded function also use the last signature.
- TypeScript decides whether `Generic<A>` is assignable to `Generic<B>` by first measuring how the type parameter is used (its variance) and comparing `A` with `B` accordingly, falling back to comparing the members only in some cases. A parameter used only inside conditional types and method parameters measures as bivariant (either direction passes); a parameter that also appears directly as a property type measures as covariant.

<details>
<summary>Runtime probe (bun 1.4.0, linux x64)</summary>

```ts
const p = Bun.spawn(["true"], { stdin: "pipe", stdout: "pipe", stderr: "pipe", terminal: { data() {} } });
console.log(p.stdin, p.stdout, p.stderr, p.readable, p.writable, p.terminal?.constructor?.name);
// null null null null null Terminal
const term = new Bun.Terminal({ data() {} });
const q = Bun.spawn(["true"], { terminal: term });
console.log(q.stdin, q.stdout, q.stderr, q.terminal === term); // null null null true
console.log(Bun.spawn(["true"], { stdout: "pipe" }).terminal); // undefined
```
</details>

<details>
<summary>Diagnostic shape for a mistyped option, main vs this PR (tsc 6.0.2)</summary>

```ts
Bun.spawn(["echo"], { stdoutt: "pipe" });
Bun.spawn({ cmd: ["echo"], stdoutt: "pipe" });
```

main:

```
errs.ts(1,23): error TS2561: Object literal may only specify known properties, but 'stdoutt' does not exist in type 'SpawnOptions<"ignore", "pipe", "inherit">'. Did you mean to write 'stdout'?
errs.ts(2,5): error TS2769: No overload matches this call.
  Overload 1 of 2, '(options: SpawnOptions<"ignore", "pipe", "inherit"> & { cmd: string[]; }): Subprocess<"ignore", "pipe", "inherit">', gave the following error.
    Object literal may only specify known properties, but 'stdoutt' does not exist in type 'SpawnOptions<"ignore", "pipe", "inherit"> & { cmd: string[]; }'. Did you mean to write 'stdout'?
  Overload 2 of 2, '(cmds: string[], options?: SpawnOptions<"ignore", "pipe", "inherit"> | undefined): Subprocess<"ignore", "pipe", "inherit">', gave the following error.
    Object literal may only specify known properties, and 'cmd' does not exist in type 'string[]'.
```

this PR:

```
errs.ts(1,23): error TS2769: No overload matches this call.
  Overload 1 of 6, '(cmds: string[], options?: SpawnOptions<"ignore", "pipe", "inherit", undefined> | undefined): Subprocess<"ignore", "pipe", "inherit", undefined>', gave the following error.
    Object literal may only specify known properties, but 'stdoutt' does not exist in type 'SpawnOptions<"ignore", "pipe", "inherit", undefined>'. Did you mean to write 'stdout'?
  Overload 2 of 6, '(cmds: string[], options: SpawnOptions<"ignore", "pipe", "inherit", Terminal> & { terminal: Terminal | TerminalOptions; }): Subprocess<...>', gave the following error.
    Object literal may only specify known properties, but 'stdoutt' does not exist in type 'SpawnOptions<"ignore", "pipe", "inherit", Terminal> & { terminal: Terminal | TerminalOptions; }'. Did you mean to write 'stdout'?
  Overload 3 of 6, '(cmds: string[], options: SpawnOptions<"ignore", "pipe", "inherit", Terminal | undefined>): Subprocess<"ignore", "pipe", "inherit", Terminal | undefined>', gave the following error.
    Object literal may only specify known properties, but 'stdoutt' does not exist in type 'SpawnOptions<"ignore", "pipe", "inherit", Terminal | undefined>'. Did you mean to write 'stdout'?
errs.ts(2,28): error TS2769: No overload matches this call.
  The last overload gave the following error.
    Object literal may only specify known properties, but 'stdoutt' does not exist in type 'SpawnOptions<"ignore", "pipe", "inherit", Terminal | undefined> & { cmd: string[]; }'. Did you mean to write 'stdout'?
```
</details>

<details>
<summary>Diagnostics the new fixture lines produce against main's bun.d.ts (52, selection)</summary>

```
spawn.ts(246,7): error TS18048: 'proc.terminal' is possibly 'undefined'.
spawn.ts(249,37): error TS2344: Type 'null' does not satisfy the constraint 'FileSink'.
spawn.ts(254,34): error TS2344: Type 'null' does not satisfy the constraint 'ReadableStream<Uint8Array<ArrayBuffer>>'.
spawn.ts(255,34): error TS2344: Type 'null' does not satisfy the constraint 'undefined'.
spawn.ts(257,33): error TS2554: Expected 2 arguments, but got 0.            // proc.terminal is not exactly Terminal
spawn.ts(260,3): error TS2578: Unused '@ts-expect-error' directive.         // proc.stdin.write(..) type-checks
spawn.ts(262,3): error TS2578: Unused '@ts-expect-error' directive.         // proc.stdout.getReader() type-checks
spawn.ts(293,34): error TS2344: Type 'ReadableStream<Uint8Array<ArrayBuffer>> | null' does not satisfy the constraint 'ReadableStream<Uint8Array<ArrayBuffer>>'.
spawn.ts(340,22): error TS7006: Parameter 'term' implicitly has an 'any' type.
spawn.ts(373,49): error TS2345: Argument of type 'null' is not assignable to parameter of type 'number | FileSink | undefined'.
spawn.ts(245,31): error TS2707: Generic type 'Subprocess<In, Out, Err>' requires between 0 and 3 type arguments.   // and 16 more of these
```

Totals by code: TS2707 x17, TS2344 x9, TS2554 x8, TS2578 x7, TS2345 x4, TS7006 x3, TS2314 x2, TS18048 x2.
</details>
