### PR TITLE
fs: writeFile with flag "a+" overwrites from offset 0 on Windows

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6979,12 +6979,16 @@ fn openat_windows_impl(dir: Fd, norm: &bun_core::WStr, flags: i32, perm: Mode) -
     let mut access_mask: u32 = w::READ_CONTROL | w::SYNCHRONIZE;
     if (flags & O::RDWR) != 0 {
         access_mask |= w::GENERIC_READ | w::GENERIC_WRITE;
-    } else if (flags & O::APPEND) != 0 {
-        access_mask |= w::GENERIC_WRITE | w::FILE_APPEND_DATA;
     } else if (flags & O::WRONLY) != 0 {
         access_mask |= w::GENERIC_WRITE;
     } else {
         access_mask |= w::GENERIC_READ;
+    }
+    // O_APPEND is orthogonal to the access mode, so it cannot be another arm of
+    // the chain above: `a+` is O_RDWR|O_APPEND and would otherwise never get
+    // FILE_APPEND_DATA, which is what the post-open seek to FILE_END keys off.
+    if (flags & O::APPEND) != 0 {
+        access_mask |= w::GENERIC_WRITE | w::FILE_APPEND_DATA;
     }
 
     // Create disposition is derived from O_CREAT/O_EXCL/O_TRUNC alone; the

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -552,6 +552,48 @@ it("writeFileSync in append should not truncate the file", () => {
   expect(readFileSync(path, "utf8")).toBe(str);
 });
 
+describe("append with flag a+ writes at end of file", () => {
+  const seed = "0123456789";
+  const expected = "0123456789AB";
+
+  it("writeFileSync", () => {
+    const path = join(tmpdirSync(), "a-plus.txt");
+    writeFileSync(path, seed);
+    writeFileSync(path, "AB", { flag: "a+" });
+    expect(readFileSync(path, "utf8")).toBe(expected);
+  });
+
+  it("promises.writeFile", async () => {
+    const path = join(tmpdirSync(), "a-plus.txt");
+    writeFileSync(path, seed);
+    await promises.writeFile(path, "AB", { flag: "a+" });
+    expect(readFileSync(path, "utf8")).toBe(expected);
+  });
+
+  it("appendFileSync", () => {
+    const path = join(tmpdirSync(), "a-plus.txt");
+    writeFileSync(path, seed);
+    fs.appendFileSync(path, "AB", { flag: "a+" });
+    expect(readFileSync(path, "utf8")).toBe(expected);
+  });
+
+  it("openSync + writeSync", () => {
+    const path = join(tmpdirSync(), "a-plus.txt");
+    writeFileSync(path, seed);
+    const fd = openSync(path, "a+");
+    try {
+      writeSync(fd, "AB");
+      // a+ (unlike a) also grants read access.
+      const buf = Buffer.alloc(expected.length);
+      expect(readSync(fd, buf, 0, buf.length, 0)).toBe(expected.length);
+      expect(buf.toString()).toBe(expected);
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(path, "utf8")).toBe(expected);
+  });
+});
+
 it.concurrent("await readdir #3931", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), join(import.meta.dir, "./repro-3931.js")],


### PR DESCRIPTION
### What does this PR do?

Fixes #39356.

On Windows, `fs.writeFileSync(path, data, { flag: "a+" })` and `fs.promises.writeFile(path, data, { flag: "a+" })` write at offset 0 instead of appending, silently clobbering the start of the file:

```js
fs.writeFileSync("t.txt", "0123456789");
fs.writeFileSync("t.txt", "AB", { flag: "a+" });
fs.readFileSync("t.txt", "utf8"); // node: "0123456789AB"   bun (Windows): "AB23456789"
```

Plain `a`, `appendFileSync` with `a+`, and `openSync(p, "a+")` + `writeSync` are unaffected. POSIX is unaffected.

Root cause is in the POSIX-flag → `NtCreateFile` translation (`openat_windows_impl` in `src/sys/lib.rs`): the desired-access mask is built with an if/else chain where `O_RDWR` is checked before `O_APPEND`. `a+` is `O_RDWR|O_CREAT|O_APPEND`, so it takes the RDWR arm and never receives `FILE_APPEND_DATA` — and that bit is what the post-open `SetFilePointerEx(FILE_END)` keys off. Plain `a` is `O_WRONLY|O_APPEND` and does reach the append arm, which is why only `a+` breaks.

Fix (the only source hunk, in `openat_windows_impl`): compute the access mask from the RDONLY/WRONLY/RDWR mode only, then apply `O_APPEND` as an orthogonal adjustment that ORs in `GENERIC_WRITE | FILE_APPEND_DATA` — mirroring libuv's `fs__open`. Masks are bit-identical for every previously-working combination; the one extra delta is `O_RDONLY|O_APPEND` (raw numeric flags only, unreachable from Node flag strings) now also gets `GENERIC_READ`, matching libuv.

Out of scope, pre-existing: Bun's Windows `O_APPEND` seeks to end once at open rather than on every write like POSIX `O_APPEND`; not reachable through `node:fs`.

### How did you verify your code works?

New cases in `test/js/node/fs/fs.test.ts` next to the existing plain-`a` append test: `writeFileSync`, `promises.writeFile`, `appendFileSync`, and `openSync("a+")`+`writeSync`, each seeding `"0123456789"`, writing `"AB"`, expecting `"0123456789AB"`. The first commit on this branch (3d9465c) adds only the tests so Windows CI shows them failing on the unfixed build; the second commit (b8f45e1) is the fix.

- macOS: `bun test test/js/node/fs/fs.test.ts -t "append with flag a\+"` — 4 pass (POSIX not affected).
- `cargo check -p bun_sys` for `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` — clean.
- Windows: relying on CI for the red → green demonstration; I do not have a Windows machine at hand.

Note: running the whole `fs.test.ts` without a `-t` filter currently aborts in the `fs.readv/writev with a non-number position` block (`integer does not fit in destination type`); that reproduces on unmodified `main` and is unrelated to this change.