### PR TITLE
pm licenses: escape control characters in text output (adds bun_core::fmt::escape_control_chars)

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -3339,6 +3339,63 @@ fn escape_powershell_impl(str: &[u8], writer: &mut impl fmt::Write) -> fmt::Resu
     write_bytes(writer, remain)
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// escapeControlChars
+// ───────────────────────────────────────────────────────────────────────────
+
+/// `Display` adapter that spells out C0 controls, DEL and C1 controls
+/// (`\n`, `\x1b`, `\x7f`, `\u009b`, ...) so text authored by a dependency
+/// cannot erase, repaint or forge lines of terminal output when printed.
+pub struct EscapeControlChars<T>(pub T);
+
+/// [`EscapeControlChars`] over raw bytes; invalid UTF-8 renders as U+FFFD.
+pub fn escape_control_chars(text: &[u8]) -> EscapeControlChars<&bstr::BStr> {
+    EscapeControlChars(bstr::BStr::new(text))
+}
+
+impl<T: Display> Display for EscapeControlChars<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut writer = EscapeControlCharsWriter(f);
+        write!(writer, "{}", self.0)
+    }
+}
+
+struct EscapeControlCharsWriter<'a, 'f>(&'a mut Formatter<'f>);
+
+impl fmt::Write for EscapeControlCharsWriter<'_, '_> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let bytes = s.as_bytes();
+        let mut start = 0;
+        let mut cursor = 0;
+        // `\` doubles as the quote char so the scan stops at nothing else extra.
+        while let Some(offset) =
+            strings::index_of_needs_escape_for_java_script_string(&bytes[cursor..], b'\\')
+        {
+            let i = cursor + offset as usize;
+            let (code_point, len) = match bytes[i] {
+                byte @ (0x00..=0x1F | 0x7F) => (byte as u32, 1),
+                0xC2 if matches!(bytes.get(i + 1), Some(0x80..=0x9F)) => (bytes[i + 1] as u32, 2),
+                byte => {
+                    let char_len = strings::wtf8_byte_sequence_length(byte) as usize;
+                    cursor = (i + char_len).min(bytes.len());
+                    continue;
+                }
+            };
+            self.0.write_str(&s[start..i])?;
+            match code_point {
+                0x0A => self.0.write_str("\\n")?,
+                0x0D => self.0.write_str("\\r")?,
+                0x09 => self.0.write_str("\\t")?,
+                0x00..=0x7F => write!(self.0, "\\x{:02x}", code_point)?,
+                _ => write!(self.0, "\\u{:04x}", code_point)?,
+            }
+            start = i + len;
+            cursor = start;
+        }
+        self.0.write_str(&s[start..])
+    }
+}
+
 // js_bindings (fmtString for highlighter.test.ts) lives in src/jsc/fmt_jsc.rs
 // alongside fmt_jsc.bind.ts; bun_core/ stays JSC-free.
 

--- a/src/runtime/cli/pm_licenses_command.rs
+++ b/src/runtime/cli/pm_licenses_command.rs
@@ -1,11 +1,10 @@
-use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::io::Write as _;
 
 use bstr::BStr;
 use bun_ast::{Expr, Log, Source};
 use bun_collections::{DynamicBitSet, StringHashMap, index_sort};
-use bun_core::fmt::PathSep;
+use bun_core::fmt::{PathSep, escape_control_chars};
 use bun_core::{FileKind, Global, Output, strings};
 use bun_install::isolated_install::store::entry::fmt_store_key;
 use bun_install::lockfile::{Lockfile, package::PackageColumns as _, reachable, tree};
@@ -347,19 +346,6 @@ fn license_order(a: &[u8], b: &[u8]) -> Ordering {
                 .cmp(b_key.iter().map(u8::to_ascii_lowercase))
         })
         .then_with(|| a.cmp(b))
-}
-
-fn printable(s: &[u8]) -> Cow<'_, [u8]> {
-    if s.iter().any(u8::is_ascii_control) {
-        Cow::Owned(
-            s.iter()
-                .copied()
-                .filter(|b| !b.is_ascii_control())
-                .collect(),
-        )
-    } else {
-        Cow::Borrowed(s)
-    }
 }
 
 fn tree_locations(lockfile: &Lockfile) -> Vec<Option<Box<[u8]>>> {
@@ -732,7 +718,7 @@ fn print_text(entries: &[Entry], long: bool, checked: usize, summary: bool) {
         licenses += 1;
         bun_core::prettyln!(
             "<b>{}<r> <d>({})<r>",
-            BStr::new(&printable(license)),
+            escape_control_chars(license),
             end - start
         );
         for (i, entry) in entries[start..end].iter().enumerate() {
@@ -740,8 +726,8 @@ fn print_text(entries: &[Entry], long: bool, checked: usize, summary: bool) {
             bun_core::pretty!(
                 "<d>{}<r> {}<d>@{}<r>",
                 if last { "└──" } else { "├──" },
-                BStr::new(&entry.name),
-                BStr::new(&entry.version)
+                escape_control_chars(&entry.name),
+                escape_control_chars(&entry.version)
             );
             if entry.dev_only {
                 bun_core::pretty!(" <d>(dev)<r>");
@@ -753,9 +739,9 @@ fn print_text(entries: &[Entry], long: bool, checked: usize, summary: bool) {
                     .flatten()
                 {
                     if last {
-                        bun_core::prettyln!("    <d>{}<r>", BStr::new(&printable(field)));
+                        bun_core::prettyln!("    <d>{}<r>", escape_control_chars(field));
                     } else {
-                        bun_core::prettyln!("<d>│   {}<r>", BStr::new(&printable(field)));
+                        bun_core::prettyln!("<d>│   {}<r>", escape_control_chars(field));
                     }
                 }
             }

--- a/test/cli/install/bun-pm-licenses.test.ts
+++ b/test/cli/install/bun-pm-licenses.test.ts
@@ -71,6 +71,9 @@ function expectEmptyText(stdout: string, checked: number) {
 
 const MISSING_NOTE = "note: run 'bun install' first";
 
+// Text output is printable text and newlines; any other C0 byte, DEL or C1 character came through from a package.json unescaped.
+const RAW_CONTROL = /[\x00-\x09\x0b-\x1f\x7f\x80-\x9f]/;
+
 const fixturePackageJson = JSON.stringify({
   name: "licenses-fixture",
   version: "1.0.0",
@@ -770,7 +773,7 @@ describe("bun pm licenses", () => {
 
     const second = await licensesText(dir, "--long");
     expect(second).toContain(
-      "├── no-deps@1.0.0\n│   only a description\n├── no-deps@1.0.1\n│   newest winsline two\n│   https://example.com/new\n└── one-dep@1.0.0\n",
+      "├── no-deps@1.0.0\n│   only a description\n├── no-deps@1.0.1\n│   newest wins\\nline two\n│   https://example.com/new\n└── one-dep@1.0.0\n",
     );
     expect(second.split("\n").some(line => line.startsWith("line two"))).toBeFalse();
     const parsed = await licensesJson(dir);
@@ -838,7 +841,7 @@ describe("bun pm licenses", () => {
   });
 
   test.concurrent(
-    "control characters from package.json are stripped in text output but preserved in --json",
+    "control characters from package.json are escaped in text output but preserved in --json",
     async () => {
       const dir = await setup();
       const evilLicense = "MIT\u001b[31m\nEVIL";
@@ -849,17 +852,15 @@ describe("bun pm licenses", () => {
       // --no-summary drops the "bun pm licenses v<version> (<short sha>)" banner. A short sha can be all
       // digits, and the banner would then pass the group-header filter below.
       const stdout = await licensesText(dir, "--long", "--no-summary");
-      expect(stdout).not.toContain("\u001b");
-      expect(stdout).not.toContain("\r");
-      expect(stdout).not.toContain("\t");
-      expect(stdout).toContain("MIT[31mEVIL (1)\n└── a-dep@1.0.1 (dev)\n    tabhere\n");
-      expect(stdout).toContain("ISCGPL-3.0 (1)\n└── one-dep@1.0.0\n");
-      expect(stdout).toContain("BSD2 (1)\n└── no-deps@1.0.0\n");
+      expect(stdout).not.toMatch(RAW_CONTROL);
+      expect(stdout).toContain("MIT\\x1b[31m\\nEVIL (1)\n└── a-dep@1.0.1 (dev)\n    tab\\there\\r\\n\n");
+      expect(stdout).toContain("ISC\\nGPL-3.0 (1)\n└── one-dep@1.0.0\n");
+      expect(stdout).toContain("BSD\\t2 (1)\n└── no-deps@1.0.0\n");
       expect(stdout.split("\n").filter(line => / \(\d+\)$/.test(line))).toStrictEqual([
-        "BSD2 (1)",
-        "ISCGPL-3.0 (1)",
+        "BSD\\t2 (1)",
+        "ISC\\nGPL-3.0 (1)",
         "MIT (2)",
-        "MIT[31mEVIL (1)",
+        "MIT\\x1b[31m\\nEVIL (1)",
         "Unknown (1)",
       ]);
       expect(stdout.split("\n").some(line => line.startsWith("GPL-3.0") || line.startsWith("EVIL"))).toBeFalse();
@@ -875,7 +876,7 @@ describe("bun pm licenses", () => {
     },
   );
 
-  test.concurrent("--long strips control characters from author, description and homepage", async () => {
+  test.concurrent("--long escapes control characters in author, description and homepage", async () => {
     const dir = await setup();
     const author = "Eve\u001b]8;;https://evil.example\u0007click\u001b]8;;\u0007";
     const description = "first\r\nsecond";
@@ -883,11 +884,13 @@ describe("bun pm licenses", () => {
     patchInstalledManifest(dir, "a-dep", { author, description, homepage });
 
     const stdout = await licensesText(dir, "--long");
-    expect(stdout).not.toContain("\u001b");
-    expect(stdout).not.toContain("\u0007");
-    expect(stdout).not.toContain("\r");
+    expect(stdout).not.toMatch(RAW_CONTROL);
     expect(stdout).toContain(
-      "├── a-dep@1.0.1 (dev)\n│   Eve]8;;https://evil.exampleclick]8;;\n│   firstsecond\n│   https://example.com/[2Jx\n├── no-deps@1.0.0\n",
+      "├── a-dep@1.0.1 (dev)\n" +
+        "│   Eve\\x1b]8;;https://evil.example\\x07click\\x1b]8;;\\x07\n" +
+        "│   first\\r\\nsecond\n" +
+        "│   https://example.com/\\x1b[2Jx\n" +
+        "├── no-deps@1.0.0\n",
     );
     expect(stdout.split("\n").some(line => line.startsWith("second"))).toBeFalse();
 
@@ -896,6 +899,39 @@ describe("bun pm licenses", () => {
       author,
       description,
       homepage,
+    });
+  });
+
+  // U+009B is the one-character form of ESC [ and, unlike the ASCII controls above, is accepted in a file name, so a
+  // tarball specifier carries it into the version column. A backslash and U+00A9 (encoded with the same lead byte as
+  // U+009B) must come through unchanged.
+  test.concurrent("C1 controls and DEL are escaped in the license, the version column and --long fields", async () => {
+    const C1 = "\u009b";
+    const tarball = `path-parse-${C1}.tgz`;
+    const { packageDir: dir } = await registry.createTestDir({
+      bunfigOpts: { linker: "hoisted" },
+      files: { "package.json": pkg({ dependencies: { pp: `file:./${tarball}` } }) },
+    });
+    copyFileSync(join(registry.packagesPath, "path-parse", "path-parse-1.0.6.tgz"), join(dir, tarball));
+    await install(dir, "hoisted");
+    const license = `MIT${C1}31m`;
+    const author = `Eve${C1}2J \\ \u007f \u00a9`;
+    const description = `one${C1}two`;
+    const homepage = `https://example.com/${C1}x`;
+    patchInstalledManifest(dir, "pp", { license, author, description, homepage });
+
+    const stdout = await licensesText(dir, "--long");
+    expect(stdout).not.toMatch(RAW_CONTROL);
+    expect(stdout).toContain(
+      "MIT\\u009b31m (1)\n" +
+        "└── path-parse@./path-parse-\\u009b.tgz\n" +
+        "    Eve\\u009b2J \\ \\x7f \u00a9\n" +
+        "    one\\u009btwo\n" +
+        "    https://example.com/\\u009bx\n",
+    );
+
+    expect(await licensesJson(dir)).toStrictEqual({
+      [license]: [{ name: "path-parse", versions: [`./${tarball}`], license, author, description, homepage }],
     });
   });
 

--- a/test/cli/install/bun-pm-licenses.test.ts
+++ b/test/cli/install/bun-pm-licenses.test.ts
@@ -902,38 +902,46 @@ describe("bun pm licenses", () => {
     });
   });
 
-  // U+009B is the one-character form of ESC [ and, unlike the ASCII controls above, is accepted in a file name, so a
-  // tarball specifier carries it into the version column. A backslash and U+00A9 (encoded with the same lead byte as
-  // U+009B) must come through unchanged.
-  test.concurrent("C1 controls and DEL are escaped in the license, the version column and --long fields", async () => {
-    const C1 = "\u009b";
-    const tarball = `path-parse-${C1}.tgz`;
-    const { packageDir: dir } = await registry.createTestDir({
-      bunfigOpts: { linker: "hoisted" },
-      files: { "package.json": pkg({ dependencies: { pp: `file:./${tarball}` } }) },
-    });
-    copyFileSync(join(registry.packagesPath, "path-parse", "path-parse-1.0.6.tgz"), join(dir, tarball));
-    await install(dir, "hoisted");
-    const license = `MIT${C1}31m`;
-    const author = `Eve${C1}2J \\ \u007f \u00a9`;
-    const description = `one${C1}two`;
-    const homepage = `https://example.com/${C1}x`;
-    patchInstalledManifest(dir, "pp", { license, author, description, homepage });
+  // U+009B is the one-character form of ESC [ and, unlike the ASCII controls above, is accepted in a file name and a
+  // package name, so a tarball carries it into both halves of the name@version column. A backslash and U+00A9 (encoded
+  // with the same lead byte as U+009B) must come through unchanged.
+  test.concurrent(
+    "C1 controls and DEL are escaped in the license, the name@version column and --long fields",
+    async () => {
+      const C1 = "\u009b";
+      const manifest = {
+        name: `dep-${C1}`,
+        version: "1.0.0",
+        license: `MIT${C1}31m`,
+        author: `Eve${C1}2J \\ \u007f \u00a9`,
+        description: `one${C1}two`,
+        homepage: `https://example.com/${C1}x`,
+      };
+      const tarball = `dep-${C1}.tgz`;
+      const { packageDir: dir } = await registry.createTestDir({
+        bunfigOpts: { linker: "hoisted" },
+        files: { "package.json": pkg({ dependencies: { dep: `file:./${tarball}` } }) },
+      });
+      const archive = new Bun.Archive({ "package/package.json": JSON.stringify(manifest) }, { compress: "gzip" });
+      writeFileSync(join(dir, tarball), await archive.bytes());
+      await install(dir, "hoisted");
 
-    const stdout = await licensesText(dir, "--long");
-    expect(stdout).not.toMatch(RAW_CONTROL);
-    expect(stdout).toContain(
-      "MIT\\u009b31m (1)\n" +
-        "└── path-parse@./path-parse-\\u009b.tgz\n" +
-        "    Eve\\u009b2J \\ \\x7f \u00a9\n" +
-        "    one\\u009btwo\n" +
-        "    https://example.com/\\u009bx\n",
-    );
+      const stdout = await licensesText(dir, "--long");
+      expect(stdout).not.toMatch(RAW_CONTROL);
+      expect(stdout).toContain(
+        "MIT\\u009b31m (1)\n" +
+          "└── dep-\\u009b@./dep-\\u009b.tgz\n" +
+          "    Eve\\u009b2J \\ \\x7f \u00a9\n" +
+          "    one\\u009btwo\n" +
+          "    https://example.com/\\u009bx\n",
+      );
 
-    expect(await licensesJson(dir)).toStrictEqual({
-      [license]: [{ name: "path-parse", versions: [`./${tarball}`], license, author, description, homepage }],
-    });
-  });
+      const { name, license, author, description, homepage } = manifest;
+      expect(await licensesJson(dir)).toStrictEqual({
+        [license]: [{ name, versions: [`./${tarball}`], license, author, description, homepage }],
+      });
+    },
+  );
 
   test.concurrent("isolated linker matches hoisted: marker, --dev and --long", async () => {
     const dir = await setup("isolated");


### PR DESCRIPTION
### Problem
- `bun pm licenses` (new in #38333, not in any release yet) prints text it did not write: the `license`, `author`, `description` and `homepage` fields of every installed package.json, and each package's name and resolution.
- Its sanitizer, `printable()` in `src/runtime/cli/pm_licenses_command.rs`, only dropped bytes matching `u8::is_ascii_control`. C1 controls (U+0080..U+009F; U+009B is the one-character form of `ESC [`, and xterm-style terminals execute it) went through raw in the license header and in the `--long` lines.
- The `name@version` line was not passed through `printable()` at all. The version column is the resolution rendered to text (`resolution.fmt(...)` at the top of `exec`): for a tarball, folder or git dependency that is a path or URL taken from some package.json in the tree, and the name of such a package is whatever its own package.json says. A tarball named `dep-<U+009B>.tgz` whose manifest is named `dep-<U+009B>` installs today and was printed as-is on both sides of the `@`.
- Dropping the bytes also misrepresented the data: a license of `MIT<ESC>[31m<LF>EVIL` was printed as `MIT[31mEVIL`.
- Found while reviewing the command's output; there is no user report. Since the command is unreleased, changing what it prints for these fields costs nothing now.

### Fix
- Adds `bun_core::fmt::escape_control_chars` / `EscapeControlChars<T: Display>`: a `Display` adapter that writes C0 controls, DEL and C1 controls as `\n`, `\r`, `\t`, `\xNN` (other C0 and DEL) and `\uNNNN` (C1). Everything else passes through unchanged, backslashes included: the output is for reading, `--json` is the machine-readable form.
- `pm licenses` prints the license header, the name, the version and the `--long` fields through it; `printable()` is deleted.
- Escaping at the print site is the right layer: the raw strings are still what groups and sorts entries, what is compared with the installed version, and what `--json` emits. `--json` is unchanged; its string escaping already makes the output parse back to the original bytes, which the tests check.
- The helper is the one several open package manager PRs need, and this PR is meant to be the one that lands it; the others rebase onto it and drop their copy (they cannot all auto-merge against each other, because the copies are not all the same):
  - #38631 carries this exact hunk (it is where the SIMD scan below was reviewed), so its copy disappears on rebase.
  - #38525, #38615, #38673 and #38536 carry an earlier `char_indices` body with the same output (#38536 also adds a multi-line variant). They take this copy; #38536 rebuilds its variant on it.
  - #38557 carries a byte-slice variant that spells ESC as `\^[`; it switches to this one and respells its assertions.
  - #38977 wraps the same version column in `redacted(..)`; with this helper generic over `Display` that becomes `EscapeControlChars(redacted(..))`.
- The escape spelling is pinned by `test/cli/install/bun-pm-licenses.test.ts` rather than by a Rust unit test: `cargo test -p bun_core` does not link (the crate's SIMD entry points such as `highway_memmem` live in the C++ build), and CI runs no unit tests for it.
- Verified with `test/cli/install/bun-pm-licenses.test.ts`: three existing control-character assertions move from the dropped to the escaped spelling, and a new case installs a tarball with U+009B in its file name and in its package name, and U+009B, DEL, a backslash and U+00A9 (same UTF-8 lead byte as the C1 range) in the manifest fields, then checks every line of the text output and the `--json` round trip. Against a build of main these four tests fail (raw U+009B in the output, `MIT[31mEVIL` instead of `MIT\x1b[31m\nEVIL`); with the fix all 81 tests in the file pass.
- `test/internal/source-lints` passes; `cargo clippy -p bun_core` is clean.

### Background
- C0 controls are bytes 0x00..0x1F (ESC, BEL, CR, ...), DEL is 0x7F. C1 controls are the code points U+0080..U+009F, encoded in UTF-8 as `C2 80`..`C2 9F`; terminals treat several of them as one-byte equivalents of ESC sequences (U+009B = CSI, U+009D = OSC), so a byte-level `is_ascii_control` filter does not cover them.
- The version column is the lockfile `Resolution` formatted as text: the version number for registry packages, otherwise the tarball path or URL, the git URL plus commit, or the folder path. The name column is the lockfile package name, which for tarball, folder and git packages is copied from the package's own package.json (#38615 and #38633 are about rejecting such names at install time; this PR escapes whatever reaches the printer, and if they land the new test's package name moves to its tarball file name only).
- `escape_control_chars` finds candidates with `strings::index_of_needs_escape_for_java_script_string`, a SIMD scan whose stop set is everything outside 0x20..0x7E plus the quote character (`\` is passed as the quote so nothing extra is added), and only inspects those positions, stepping over ordinary multi-byte characters with `wtf8_byte_sequence_length`.

<details><summary>Notes</summary>

Rebased onto main after #38952 (banner and summary line for `bun pm licenses`) and #40074 landed. One conflict, in the test "control characters from package.json are escaped in text output but preserved in --json": #40074 runs it with `--no-summary` so the banner cannot match the group-header filter, and this PR changes the expected spelling from dropped to escaped. The resolution keeps both (`--no-summary` plus the escaped assertions). The five print sites in `print_text` merged without conflict.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pm-licenses.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-pm-licenses.test.ts:
(pass) bun pm licenses > text output groups packages by license, Unknown last, dev-only packages marked [155.64ms]
(pass) bun pm licenses > --json shape [178.14ms]
(pass) bun pm licenses > legacy license shapes [388.27ms]
(pass) bun pm licenses > `license` array and legacy `name` key [394.00ms]
(pass) bun pm licenses > empty `license` falls through to `licenses`; `license` wins when both are present [329.96ms]
(pass) bun pm licenses > non-string license shapes are Unknown; entries with non-string type are skipped [349.89ms]
(pass) bun pm licenses > groups are ordered case-insensitively, ignoring a leading parenthesis, Unknown last [520.69ms]
(pass) bun pm licenses > repeated legacy entries are not deduplicated [366.27ms]
(pass) bun pm licenses > --json `license` follows each version's group; an empty description is omitted [374.08ms]
(pass) bun pm licenses > one package with two versions: per-license grouping, metadata from t
... (truncated)

release without fix: 26 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/cli/install/bun-pm-licenses.test.ts:
271 |     [hoistedDir, monoDir] = await Promise.all([setup(), setup("hoisted", monorepoFiles)]);
272 |   });
273 | 
274 |   test.concurrent("text output groups packages by license, Unknown last, dev-only packages marked", async () => {
275 |     const [stdout, stderr, exitCode] = await licenses(hoistedDir);
276 |     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
                                               ^
error: expect(received).toMatchInlineSnapshot(expected)

  
- "bun pm licenses <version> (<revision>)
- 
- MIT (2)
+ "MIT (2)
  ├── path-parse@1.0.6
  └── resolve@1.9.0
  
  Unknown (4)
  ├── a-dep@1.0.1 (dev)
  ├── no-deps@1.0.0
  ├── no-deps@1.0.1
- └── one-dep@1.0.0
- 
- 6 packages across 2 licenses (checked 6 packages in bun.lock)"
- 
+ └── one-dep@1.0.0"
+ 

- Expected  - 7
+ Received  + 3

      at <anonymous> (/workspace/bun/test/cli/install/bun-pm-licenses.test.ts:276:42)
(fail) bun pm licenses > text output groups packages by license, Unknown last, dev-only packages marked [14.33ms]
(pass) bun pm licenses > --json sh
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pm-licenses.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bun-pm-licenses.test.ts:
(pass) bun pm licenses > text output groups packages by license, Unknown last, dev-only packages marked [189.34ms]
(pass) bun pm licenses > --json shape [192.76ms]
(pass) bun pm licenses > legacy license shapes [428.93ms]
(pass) bun pm licenses > `license` array and legacy `name` key [419.79ms]
(pass) bun pm licenses > empty `license` falls through to `licenses`; `license` wins when both are present [369.27ms]
(pass) bun pm licenses > non-string license shapes are Unknown; entries with non-string type are skipped [345.02ms]
(pass) bun pm licenses > groups are ordered case-insensitively, ignoring a leading parenthesis, Unknown last [566.77ms]
(pass) bun pm licenses > repeated legacy entries are not deduplicated [370.18ms]
(pass) bun pm licenses > --json `license` follows each version's group; an empty description is omitted [381.22ms]
(pass) bun pm licenses > one package with two versions: per-license grouping, metadata from t
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     496a637b60
  features     baseline

23 deps, 129 codegen, 1172 objects in 716ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [7.00ms]
[2/1244] gen bindgenv2
[3/1244] fetch zlib
[zlib] up to date
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1244] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1216] install /workspace/bun/src/node-fal
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/fmt.rs                      | 57 ++++++++++++++++++++++++
 src/runtime/cli/pm_licenses_command.rs   | 26 +++--------
 test/cli/install/bun-pm-licenses.test.ts | 76 +++++++++++++++++++++++++-------
 3 files changed, 123 insertions(+), 36 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/bun_core/fmt.rs                           0      0      0
src/runtime/cli/pm_licenses_command.rs        4      8      0
test/cli/install/bun-pm-licenses.test.ts      9      9      0
```

</details>

<!-- robobun:evidence:end -->
