### PR TITLE
undici: implement EventSource

### DIFF
--- a/docs/guides/http/sse.mdx
+++ b/docs/guides/http/sse.mdx
@@ -89,3 +89,26 @@ Bun.serve({
   },
 });
 ```
+
+## Consuming a stream from Bun
+
+Bun has no `EventSource` global. To consume an SSE stream from a Bun script, add the `undici` package with `bun add undici` and import `EventSource` from it. The package provides the TypeScript types; at runtime, Bun resolves `undici` to its built-in implementation.
+
+```ts client.ts icon="/icons/typescript.svg"
+import { EventSource } from "undici";
+
+const events = new EventSource("http://localhost:3000/events");
+
+events.onmessage = event => {
+  console.log(event.data);
+};
+
+events.onerror = () => {
+  // Bun reconnects on its own after the server closes the stream.
+  // readyState is EventSource.CLOSED when the server answered with a
+  // status other than 200 or a Content-Type other than text/event-stream.
+  console.log("readyState:", events.readyState);
+};
+```
+
+Bun sends the `Last-Event-ID` header when it reconnects, and honors the `retry:` field. Call `events.close()` to stop the stream.

--- a/src/js/thirdparty/undici.js
+++ b/src/js/thirdparty/undici.js
@@ -1,5 +1,6 @@
 const EventEmitter = require("node:events");
 const { _ReadableFromWeb: ReadableFromWeb } = require("internal/webstreams_adapters");
+const { validateNumber } = require("internal/validators");
 
 const ObjectCreate = Object.create;
 const kEmptyObject = ObjectCreate(null);
@@ -18,6 +19,7 @@ const WebSocket = bindings[8];
 const CloseEvent = bindings[9];
 const ErrorEvent = bindings[10];
 const MessageEvent = bindings[11];
+const { AbortController, DOMException, Event, TextDecoder, clearTimeout, decodeURIComponent, setTimeout } = globalThis;
 
 class FileReader extends EventTarget {
   constructor() {
@@ -364,15 +366,388 @@ const util = {
   },
 };
 
-class EventSource extends EventTarget {
-  static CONNECTING = 0;
-  static OPEN = 1;
-  static CLOSED = 2;
+const kConnecting = 0;
+const kOpen = 1;
+const kClosed = 2;
+// Same default as undici and Chromium.
+const kDefaultReconnectionTime = 3000;
+// setTimeout() treats anything wider than an i32 as 1ms, which would turn a huge `retry:` into a busy loop.
+const kMaxReconnectionTime = 2 ** 31 - 1;
 
-  constructor() {
-    super();
+function isASCIIDigits(value) {
+  if (value.length === 0) return false;
+  for (let i = 0; i < value.length; i++) {
+    const c = value.charCodeAt(i);
+    if (c < 0x30 || c > 0x39) return false;
+  }
+  return true;
+}
+
+function isEventStreamContentType(contentType) {
+  if (contentType === null) return false;
+  const semicolon = contentType.indexOf(";");
+  const essence = semicolon === -1 ? contentType : contentType.slice(0, semicolon);
+  // Only HTTP whitespace may surround the type; String#trim would also strip characters the MIME parser rejects.
+  return essence.replace(/^[\t\n\r ]+|[\t\n\r ]+$/g, "").toLowerCase() === "text/event-stream";
+}
+
+function percentDecode(component) {
+  try {
+    return decodeURIComponent(component);
+  } catch {
+    return component;
   }
 }
+
+// https://fetch.spec.whatwg.org/#concept-url-converted-to-authorization-value
+function basicAuthorizationFor(url) {
+  if (url.username === "" && url.password === "") return null;
+  return "Basic " + Buffer.from(`${percentDecode(url.username)}:${percentDecode(url.password)}`).toString("base64");
+}
+
+// Header values are byte strings (one byte per code unit); this spells out a string's UTF-8 bytes as one.
+function utf8ByteString(string) {
+  return Buffer.from(string).toString("latin1");
+}
+
+// https://html.spec.whatwg.org/multipage/server-sent-events.html
+class EventSource extends EventTarget {
+  #url;
+  // Only reflected: fetch() in Bun has no ambient credentials (cookies) for this to include or omit, same as in undici.
+  #withCredentials = false;
+  #readyState = kConnecting;
+  #lastEventId = "";
+  #reconnectionTime = kDefaultReconnectionTime;
+  // Credentials from the URL as an Authorization value, sent once a 401 has asked for them (#challenged).
+  #authorization = null;
+  #challenged = false;
+
+  // The current connection. Async continuations compare against it, so a closed or superseded connection is inert.
+  #controller = null;
+  #reconnectTimer = null;
+
+  // Per-connection state, reset in #readBody().
+  #origin = "";
+  #decoder = null;
+  #partialLine = "";
+  #skipLF = false;
+  #dataBuffer = "";
+  #eventTypeBuffer = "";
+  #lastEventIdBuffer = "";
+
+  // on{open,message,error} handler values, plus the listener registered on behalf of each non-null one.
+  #handlers = { __proto__: null, open: null, message: null, error: null };
+  #handlerListeners = { __proto__: null, open: null, message: null, error: null };
+
+  constructor(url, init) {
+    super();
+    if (arguments.length === 0) {
+      throw new TypeError("EventSource constructor: 1 argument required, but only 0 present.");
+    }
+
+    let parsed;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new DOMException(`Cannot open an EventSource to '${url}'. The URL is invalid.`, "SyntaxError");
+    }
+    this.#url = parsed.href;
+    this.#authorization = basicAuthorizationFor(parsed);
+
+    if (init !== undefined && init !== null) {
+      if (!$isObject(init)) {
+        throw new TypeError("EventSource constructor: the second argument must be a dictionary.");
+      }
+      this.#withCredentials = !!init.withCredentials;
+      // undici extension: `{ node: { reconnectionTime } }` overrides the delay used until the server sends `retry:`.
+      const reconnectionTime = init.node?.reconnectionTime;
+      if (reconnectionTime !== undefined) {
+        validateNumber(reconnectionTime, "init.node.reconnectionTime", 0, kMaxReconnectionTime);
+        this.#reconnectionTime = reconnectionTime;
+      }
+    }
+
+    this.#connect();
+  }
+
+  get url() {
+    return this.#url;
+  }
+
+  get withCredentials() {
+    return this.#withCredentials;
+  }
+
+  get readyState() {
+    return this.#readyState;
+  }
+
+  close() {
+    if (this.#readyState === kClosed) return;
+    this.#readyState = kClosed;
+    if (this.#reconnectTimer !== null) {
+      clearTimeout(this.#reconnectTimer);
+      this.#reconnectTimer = null;
+    }
+    this.#abort();
+  }
+
+  get onopen() {
+    return this.#handlers.open;
+  }
+  set onopen(value) {
+    this.#setHandler("open", value);
+  }
+
+  get onmessage() {
+    return this.#handlers.message;
+  }
+  set onmessage(value) {
+    this.#setHandler("message", value);
+  }
+
+  get onerror() {
+    return this.#handlers.error;
+  }
+  set onerror(value) {
+    this.#setHandler("error", value);
+  }
+
+  #setHandler(type, value) {
+    // EventHandler IDL attributes keep any object (even a non-callable one) and turn everything else into null.
+    if (!$isObject(value)) value = null;
+    this.#handlers[type] = value;
+
+    if (value !== null) {
+      if (this.#handlerListeners[type] !== null) return;
+      const listener = event => {
+        const handler = this.#handlers[type];
+        if ($isCallable(handler)) handler.$call(this, event);
+      };
+      this.#handlerListeners[type] = listener;
+      super.addEventListener(type, listener);
+    } else if (this.#handlerListeners[type] !== null) {
+      super.removeEventListener(type, this.#handlerListeners[type]);
+      this.#handlerListeners[type] = null;
+    }
+  }
+
+  #abort() {
+    const controller = this.#controller;
+    if (controller === null) return;
+    this.#controller = null;
+    controller.abort();
+  }
+
+  #connect() {
+    const controller = new AbortController();
+    this.#controller = controller;
+
+    const headers = new Headers({ "accept": "text/event-stream", "cache-control": "no-cache" });
+    if (this.#challenged) headers.set("authorization", this.#authorization);
+    if (this.#lastEventId !== "") headers.set("last-event-id", utf8ByteString(this.#lastEventId));
+
+    fetch(this.#url, { headers, signal: controller.signal }).then(
+      response => {
+        if (this.#controller !== controller) return;
+        this.#onResponse(controller, response);
+      },
+      () => {
+        if (this.#controller !== controller) return;
+        this.#reestablish();
+      },
+    );
+  }
+
+  #onResponse(controller, response) {
+    if (response.status === 401 && this.#authorization !== null && !this.#challenged) {
+      this.#challenged = true;
+      this.#abort();
+      this.#connect();
+      return;
+    }
+    if (response.status !== 200 || !isEventStreamContentType(response.headers.get("content-type"))) {
+      this.#fail();
+      return;
+    }
+
+    this.#readyState = kOpen;
+    super.dispatchEvent(new Event("open"));
+    // The open handler may have called close().
+    if (this.#controller !== controller) return;
+
+    this.#readBody(controller, response);
+  }
+
+  async #readBody(controller, response) {
+    // Events carry the origin of the URL that actually served the stream, which may differ from #url after redirects.
+    this.#origin = new URL(response.url || this.#url).origin;
+    this.#decoder = new TextDecoder();
+    this.#partialLine = "";
+    this.#skipLF = false;
+    this.#dataBuffer = "";
+    this.#eventTypeBuffer = "";
+    this.#lastEventIdBuffer = this.#lastEventId;
+
+    const reader = response.body.getReader();
+    while (true) {
+      let result;
+      try {
+        result = await reader.read();
+      } catch {
+        // A connection that drops mid-stream is treated like one the server closed.
+        result = { done: true };
+      }
+      if (this.#controller !== controller) return;
+      if (result.done) break;
+      try {
+        this.#feed(result.value);
+      } catch (error) {
+        // Typically a line too long to fit in a string; reported as an ErrorEvent rather than leaving the stream OPEN unread.
+        if (this.#controller === controller) this.#fail(error);
+        return;
+      }
+      if (this.#controller !== controller) return;
+    }
+
+    this.#reestablish();
+  }
+
+  #feed(chunk) {
+    const text = this.#decoder.decode(chunk, { stream: true });
+    const length = text.length;
+    if (length === 0) return;
+    let start = 0;
+
+    if (this.#skipLF) {
+      this.#skipLF = false;
+      if (text.charCodeAt(0) === 0x0a) start = 1;
+    }
+
+    while (start < length) {
+      let end = start;
+      while (end < length) {
+        const c = text.charCodeAt(end);
+        if (c === 0x0a || c === 0x0d) break;
+        end++;
+      }
+      if (end === length) {
+        this.#partialLine += text.slice(start);
+        return;
+      }
+
+      const line = this.#partialLine + text.slice(start, end);
+      this.#partialLine = "";
+      start = end + 1;
+      if (text.charCodeAt(end) === 0x0d) {
+        // A CR LF pair is a single line ending, even when the LF only arrives with the next chunk.
+        if (start < length) {
+          if (text.charCodeAt(start) === 0x0a) start++;
+        } else {
+          this.#skipLF = true;
+        }
+      }
+
+      this.#processLine(line);
+      // A listener may have called close(); the rest of the chunk must not be dispatched.
+      if (this.#readyState === kClosed) return;
+    }
+  }
+
+  #processLine(line) {
+    if (line === "") {
+      this.#dispatchBufferedEvent();
+      return;
+    }
+
+    const colon = line.indexOf(":");
+    if (colon === 0) return; // comment
+
+    let field, value;
+    if (colon === -1) {
+      field = line;
+      value = "";
+    } else {
+      field = line.slice(0, colon);
+      value = line.slice(line.charCodeAt(colon + 1) === 0x20 ? colon + 2 : colon + 1);
+    }
+
+    switch (field) {
+      case "data":
+        this.#dataBuffer += value + "\n";
+        break;
+      case "event":
+        this.#eventTypeBuffer = value;
+        break;
+      case "id":
+        if (!value.includes("\0")) this.#lastEventIdBuffer = value;
+        break;
+      case "retry":
+        if (isASCIIDigits(value)) this.#reconnectionTime = Math.min(Number(value), kMaxReconnectionTime);
+        break;
+    }
+  }
+
+  #dispatchBufferedEvent() {
+    // An empty line commits the id even when there is no data to dispatch.
+    this.#lastEventId = this.#lastEventIdBuffer;
+
+    const data = this.#dataBuffer;
+    const type = this.#eventTypeBuffer;
+    this.#dataBuffer = "";
+    this.#eventTypeBuffer = "";
+    if (data === "") return;
+
+    super.dispatchEvent(
+      new MessageEvent(type === "" ? "message" : type, {
+        // Every `data:` line appended a LF; the last one is not part of the payload.
+        data: data.slice(0, -1),
+        origin: this.#origin,
+        lastEventId: this.#lastEventId,
+      }),
+    );
+  }
+
+  // https://html.spec.whatwg.org/multipage/server-sent-events.html#fail-the-connection
+  #fail(error) {
+    this.#readyState = kClosed;
+    this.#abort();
+    super.dispatchEvent(
+      error === undefined
+        ? new Event("error")
+        : new ErrorEvent("error", { error, message: `${error?.message ?? error}` }),
+    );
+  }
+
+  // https://html.spec.whatwg.org/multipage/server-sent-events.html#reestablish-the-connection
+  #reestablish() {
+    this.#controller = null;
+    this.#readyState = kConnecting;
+    super.dispatchEvent(new Event("error"));
+    // The error handler may have called close().
+    if (this.#readyState !== kConnecting) return;
+
+    // Like undici, waiting to reconnect does not by itself keep the process alive; an in-flight connection does.
+    this.#reconnectTimer = setTimeout(() => {
+      this.#reconnectTimer = null;
+      this.#connect();
+    }, this.#reconnectionTime).unref();
+  }
+}
+
+for (const [name, value] of [
+  ["CONNECTING", kConnecting],
+  ["OPEN", kOpen],
+  ["CLOSED", kClosed],
+]) {
+  // WebIDL constants live on both the interface and its prototype and are read-only.
+  Object.defineProperty(EventSource, name, { enumerable: true, value });
+  Object.defineProperty(EventSource.prototype, name, { enumerable: true, value });
+}
+for (const name of ["url", "withCredentials", "readyState", "close", "onopen", "onmessage", "onerror"]) {
+  Object.defineProperty(EventSource.prototype, name, { enumerable: true });
+}
+Object.defineProperty(EventSource.prototype, Symbol.toStringTag, { configurable: true, value: "EventSource" });
 
 // Add missing cookie functions
 function deleteCookie() {

--- a/test/js/first_party/undici/undici.test.ts
+++ b/test/js/first_party/undici/undici.test.ts
@@ -1,6 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { Readable } from "node:stream";
-import { request, fetch as undiciFetch } from "undici";
+// @ts-expect-error the undici@5 types in test/node_modules predate EventSource
+import { EventSource, request, fetch as undiciFetch } from "undici";
 
 import { createServer } from "../../../http-test-server";
 
@@ -265,5 +267,626 @@ describe("undici.request maxRedirections", () => {
     } finally {
       server.stop(true);
     }
+  });
+});
+
+describe.concurrent("undici.EventSource", () => {
+  function sse(body: BodyInit | null, init: ResponseInit = {}) {
+    return new Response(body, { ...init, headers: { "content-type": "text/event-stream", ...init.headers } });
+  }
+
+  // Records events in dispatch order, along with the readyState each listener observed, until `until` matches one.
+  function record(es: EventSource, until: (event: Event) => boolean, types = ["open", "message", "error"]) {
+    const seen: Record<string, unknown>[] = [];
+    const { promise: done, resolve } = Promise.withResolvers<void>();
+    const listener = (event: Event) => {
+      const entry: Record<string, unknown> = { type: event.type, readyState: es.readyState };
+      if (event instanceof MessageEvent) {
+        entry.data = event.data;
+        entry.lastEventId = event.lastEventId;
+      }
+      seen.push(entry);
+      if (until(event)) resolve();
+    };
+    for (const type of types) es.addEventListener(type, listener);
+    return { seen, done };
+  }
+
+  const isError = (event: Event) => event.type === "error";
+  function nthError(n: number) {
+    let errors = 0;
+    return (event: Event) => isError(event) && ++errors === n;
+  }
+
+  it("has the WebIDL shape and validates its arguments", () => {
+    const readOnly = (value: number) => ({ value, writable: false, enumerable: true, configurable: false });
+    expect(Object.getOwnPropertyDescriptors(EventSource)).toMatchObject({
+      CONNECTING: readOnly(0),
+      OPEN: readOnly(1),
+      CLOSED: readOnly(2),
+    });
+    expect(Object.getOwnPropertyDescriptors(EventSource.prototype)).toMatchObject({
+      CONNECTING: readOnly(0),
+      OPEN: readOnly(1),
+      CLOSED: readOnly(2),
+    });
+    expect(Object.keys(EventSource.prototype).sort()).toEqual([
+      "CLOSED",
+      "CONNECTING",
+      "OPEN",
+      "close",
+      "onerror",
+      "onmessage",
+      "onopen",
+      "readyState",
+      "url",
+      "withCredentials",
+    ]);
+
+    // @ts-expect-error the url argument is required
+    expect(() => new EventSource()).toThrow(TypeError);
+    expect(() => new EventSource("not a url")).toThrow(expect.objectContaining({ name: "SyntaxError" }));
+    expect(() => new EventSource("/relative")).toThrow(expect.objectContaining({ name: "SyntaxError" }));
+    expect(() => new EventSource("http://localhost/", { node: { reconnectionTime: -1 } })).toThrow(
+      expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+    );
+    expect(() => new EventSource("http://localhost/", { node: { reconnectionTime: "5" } })).toThrow(
+      expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+    );
+    expect(() => new EventSource("http://localhost/", "with-credentials" as any)).toThrow(TypeError);
+    // A dictionary argument accepts null and undefined as "no options".
+    for (const init of [null, undefined]) {
+      const es = new EventSource("http://127.0.0.1:1/", init as any);
+      es.close();
+      expect(es.readyState).toBe(EventSource.CLOSED);
+    }
+  });
+
+  it("connects and dispatches MessageEvents", async () => {
+    const requestHeaders: Record<string, string | null> = {};
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        for (const name of ["accept", "cache-control", "last-event-id"]) requestHeaders[name] = req.headers.get(name);
+        return sse('id: 1\ndata: hello\n\nevent: ping\ndata: {"n":2}\n\n');
+      },
+    });
+
+    const es = new EventSource(new URL("/stream?x=1", server.url), { withCredentials: true });
+    try {
+      const { seen, done } = record(es, isError, ["open", "message", "ping", "error"]);
+      const { promise: firstMessage, resolve, reject } = Promise.withResolvers<MessageEvent>();
+      es.onmessage = resolve;
+      es.onerror = reject;
+      expect(es.readyState).toBe(EventSource.CONNECTING);
+      expect(es.url).toBe(`${server.url.origin}/stream?x=1`);
+      expect(es.withCredentials).toBe(true);
+      expect(String(es)).toBe("[object EventSource]");
+
+      const message = await firstMessage;
+      expect(message).toBeInstanceOf(MessageEvent);
+      expect(message.origin).toBe(server.url.origin);
+
+      // The server ended the stream after the second event, which reports an error and schedules a reconnect.
+      await done;
+      expect(seen).toEqual([
+        { type: "open", readyState: 1 },
+        { type: "message", readyState: 1, data: "hello", lastEventId: "1" },
+        { type: "ping", readyState: 1, data: '{"n":2}', lastEventId: "1" },
+        { type: "error", readyState: 0 },
+      ]);
+      expect(requestHeaders).toEqual({
+        "accept": "text/event-stream",
+        "cache-control": "no-cache",
+        "last-event-id": null,
+      });
+    } finally {
+      es.close();
+    }
+    expect(es.readyState).toBe(EventSource.CLOSED);
+  });
+
+  it("interprets the event stream format", async () => {
+    const stream = [
+      "\uFEFF: a leading BOM and comment lines are ignored\n",
+      "data: first line\ndata: second line\n\n",
+      "data:no space after the colon\n\n",
+      "data:  only one leading space is stripped\n\n",
+      "event: custom\ndata: typed\n\n",
+      "event: dropped\n\n", // no data: nothing is dispatched and the type buffer is reset
+      "data: back to message\n\n",
+      "data\n\n", // a field without a colon has an empty value
+      "id: 42\n\n", // the blank line commits the id even without data
+      "id: bad\0id\ndata: keeps 42\n\n",
+      "id\ndata: empty id\n\n",
+      "unknown: field\ndata: unknown fields are ignored\n\n",
+      "data: never dispatched, the stream ends before the blank line",
+    ].join("");
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => sse(stream, { headers: { "content-type": "TEXT/Event-Stream; charset=utf-8" } }),
+    });
+
+    const es = new EventSource(server.url);
+    try {
+      const { seen, done } = record(es, isError, ["message", "custom", "dropped", "error"]);
+      await done;
+      expect(seen).toEqual([
+        { type: "message", readyState: 1, data: "first line\nsecond line", lastEventId: "" },
+        { type: "message", readyState: 1, data: "no space after the colon", lastEventId: "" },
+        { type: "message", readyState: 1, data: " only one leading space is stripped", lastEventId: "" },
+        { type: "custom", readyState: 1, data: "typed", lastEventId: "" },
+        { type: "message", readyState: 1, data: "back to message", lastEventId: "" },
+        { type: "message", readyState: 1, data: "", lastEventId: "" },
+        { type: "message", readyState: 1, data: "keeps 42", lastEventId: "42" },
+        { type: "message", readyState: 1, data: "empty id", lastEventId: "" },
+        { type: "message", readyState: 1, data: "unknown fields are ignored", lastEventId: "" },
+        { type: "error", readyState: 0 },
+      ]);
+    } finally {
+      es.close();
+    }
+  });
+
+  it("handles line endings and UTF-8 sequences that are split across chunks", async () => {
+    let push!: (bytes: Uint8Array) => void;
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return sse(
+          new ReadableStream({
+            start(controller) {
+              push = bytes => controller.enqueue(bytes);
+              push(Buffer.from("data: 1\r\n\r\ndata: a\rdata: b\r"));
+            },
+          }),
+        );
+      },
+    });
+
+    const es = new EventSource(server.url);
+    try {
+      const data: string[] = [];
+      let waiter = Promise.withResolvers<void>();
+      es.onmessage = event => {
+        data.push(event.data);
+        waiter.resolve();
+      };
+      es.onerror = () => waiter.reject(new Error(`unexpected error event, readyState ${es.readyState}`));
+      const nextMessage = () => (waiter = Promise.withResolvers<void>()).promise;
+
+      // Each chunk below is only sent once the client has dispatched the previous chunk's last event, so every
+      // boundary is really observed by the parser.
+      await nextMessage();
+      expect(data).toEqual(["1"]);
+
+      // The LF completes the CR that ended the previous chunk; it is not an empty line.
+      let received = nextMessage();
+      push(Buffer.from("\ndata: c\r\r"));
+      await received;
+      expect(data).toEqual(["1", "a\nb\nc"]);
+
+      // The previous chunk ended in a CR that is not followed by a LF, and this one ends mid-character.
+      received = nextMessage();
+      push(new Uint8Array([...Buffer.from("data: d\n\ndata: "), 0xe2, 0x82]));
+      await received;
+      expect(data).toEqual(["1", "a\nb\nc", "d"]);
+
+      received = nextMessage();
+      push(new Uint8Array([0xac, 0x0a, 0x0a]));
+      await received;
+      expect(data).toEqual(["1", "a\nb\nc", "d", "\u20ac"]);
+    } finally {
+      es.close();
+    }
+  });
+
+  it("reconnects after the server ends the stream, sending Last-Event-ID and honoring retry:", async () => {
+    // One character inside Latin-1 and one outside it: the header has to carry the id's UTF-8 bytes.
+    const id = "\u00e9v\u00e9nement \u2026 7";
+    const lastEventIdHeaders: (string | null)[] = [];
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        // Header values arrive one character per byte; decode them as UTF-8 like an SSE server would.
+        const header = req.headers.get("last-event-id");
+        lastEventIdHeaders.push(header === null ? null : Buffer.from(header, "latin1").toString());
+        if (lastEventIdHeaders.length === 1) {
+          // `id: 8` is never followed by a blank line, so it must not become the last event id.
+          return sse(`retry: 10\n\nid: ${id}\ndata: first\n\nid: 8\ndata: incomplete`);
+        }
+        return sse("data: second\n\n");
+      },
+    });
+
+    const es = new EventSource(server.url);
+    try {
+      const { seen, done } = record(es, nthError(2));
+      await done;
+      expect(seen).toEqual([
+        { type: "open", readyState: 1 },
+        { type: "message", readyState: 1, data: "first", lastEventId: id },
+        { type: "error", readyState: 0 },
+        { type: "open", readyState: 1 },
+        { type: "message", readyState: 1, data: "second", lastEventId: id },
+        { type: "error", readyState: 0 },
+      ]);
+      expect(lastEventIdHeaders).toEqual([null, id]);
+    } finally {
+      es.close();
+    }
+  });
+
+  it("reconnects after the connection drops mid-stream", async () => {
+    const firstEventDelivered = Promise.withResolvers<void>();
+    const head = "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ntransfer-encoding: chunked\r\n\r\n";
+    const chunk = (body: string) => `${body.length.toString(16)}\r\n${body}\r\n`;
+    let connections = 0;
+    using listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        async open(socket) {
+          if (++connections > 1) {
+            socket.end(head + chunk("data: after the drop\n\n") + "0\r\n\r\n");
+            return;
+          }
+          socket.write(head + chunk("retry: 10\ndata: before the drop\n\n"));
+          await firstEventDelivered.promise;
+          // Hanging up before the terminating chunk is what a dropped connection looks like to the client.
+          socket.end();
+        },
+        data() {},
+      },
+    });
+
+    const es = new EventSource(`http://127.0.0.1:${listener.port}/`);
+    try {
+      const { seen, done } = record(es, nthError(2));
+      es.addEventListener("message", () => firstEventDelivered.resolve(), { once: true });
+      await done;
+      expect(seen).toEqual([
+        { type: "open", readyState: 1 },
+        { type: "message", readyState: 1, data: "before the drop", lastEventId: "" },
+        { type: "error", readyState: 0 },
+        { type: "open", readyState: 1 },
+        { type: "message", readyState: 1, data: "after the drop", lastEventId: "" },
+        { type: "error", readyState: 0 },
+      ]);
+      expect(connections).toBe(2);
+    } finally {
+      es.close();
+    }
+  });
+
+  it("uses node.reconnectionTime until the server sends retry:", async () => {
+    let connections = 0;
+    using server = Bun.serve({ port: 0, fetch: () => sse(`data: ${++connections}\n\n`) });
+
+    const es = new EventSource(server.url, { node: { reconnectionTime: 5 } });
+    try {
+      const { seen, done } = record(es, nthError(2));
+      await done;
+      expect(seen).toEqual([
+        { type: "open", readyState: 1 },
+        { type: "message", readyState: 1, data: "1", lastEventId: "" },
+        { type: "error", readyState: 0 },
+        { type: "open", readyState: 1 },
+        { type: "message", readyState: 1, data: "2", lastEventId: "" },
+        { type: "error", readyState: 0 },
+      ]);
+    } finally {
+      es.close();
+    }
+  });
+
+  it.each([
+    ["a 204", () => new Response(null, { status: 204 })],
+    ["a non-200 event stream", () => sse("data: x\n\n", { status: 500 })],
+    [
+      "a 200 with another content type",
+      () => new Response("data: x\n\n", { headers: { "content-type": "text/plain" } }),
+    ],
+    ["a 401 when the URL carries no credentials", () => new Response(null, { status: 401 })],
+  ])("fails the connection without reconnecting on %s", async (_, respond) => {
+    using server = Bun.serve({ port: 0, fetch: respond });
+
+    const es = new EventSource(server.url);
+    try {
+      const { seen, done } = record(es, isError);
+      await done;
+      expect(seen).toEqual([{ type: "error", readyState: 2 }]);
+      expect(es.readyState).toBe(EventSource.CLOSED);
+    } finally {
+      es.close();
+    }
+  });
+
+  it("reports the origin of the URL that served the stream after a redirect", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname === "/redirect") {
+          return Response.redirect(`http://127.0.0.1:${server.port}/target`, 302);
+        }
+        return sse("data: redirected\n\n");
+      },
+    });
+
+    const url = `http://localhost:${server.port}/redirect`;
+    const es = new EventSource(url);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+      es.onmessage = resolve;
+      es.onerror = reject;
+      const event = await promise;
+      expect({ url: es.url, data: event.data, origin: event.origin }).toEqual({
+        url,
+        data: "redirected",
+        origin: `http://127.0.0.1:${server.port}`,
+      });
+    } finally {
+      es.close();
+    }
+  });
+
+  it("close() while connecting fires no events and hangs up the request", async () => {
+    const requestArrived = Promise.withResolvers<void>();
+    const requestAborted = Promise.withResolvers<void>();
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        requestArrived.resolve();
+        req.signal.addEventListener("abort", () => requestAborted.resolve());
+        // Never respond; the client is expected to hang up.
+        return new Promise<Response>(() => {});
+      },
+    });
+
+    const es = new EventSource(server.url);
+    const { seen } = record(es, () => false);
+    await requestArrived.promise;
+    expect(es.readyState).toBe(EventSource.CONNECTING);
+
+    es.close();
+    expect(es.readyState).toBe(EventSource.CLOSED);
+    await requestAborted.promise;
+    expect(seen).toEqual([]);
+  });
+
+  it("close() inside a listener drops the rest of the chunk and releases the connection", async () => {
+    const streamCancelled = Promise.withResolvers<void>();
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        return sse(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(Buffer.from("data: 1\n\ndata: 2\n\ndata: 3\n\n"));
+            },
+            cancel() {
+              streamCancelled.resolve();
+            },
+          }),
+        );
+      },
+    });
+
+    const es = new EventSource(server.url);
+    es.onmessage = () => es.close();
+    const { seen, done } = record(es, event => event instanceof MessageEvent);
+    await done;
+    await streamCancelled.promise;
+    expect(seen).toEqual([
+      { type: "open", readyState: 1 },
+      { type: "message", readyState: 2, data: "1", lastEventId: "" },
+    ]);
+  });
+
+  it("close() inside the error listener cancels the reconnect", async () => {
+    let streamRequests = 0;
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname !== "/stream") return new Response();
+        streamRequests++;
+        return sse("retry: 1\ndata: only\n\n");
+      },
+    });
+
+    const es = new EventSource(new URL("/stream", server.url));
+    const { seen, done } = record(es, isError);
+    es.onerror = () => es.close();
+    await done;
+    expect(seen).toEqual([
+      { type: "open", readyState: 1 },
+      { type: "message", readyState: 1, data: "only", lastEventId: "" },
+      { type: "error", readyState: 0 },
+    ]);
+    expect(es.readyState).toBe(EventSource.CLOSED);
+
+    // A reconnect was due after 1ms; a full round trip to the server later, none has happened.
+    await fetch(new URL("/probe", server.url));
+    expect(streamRequests).toBe(1);
+  });
+
+  it("implements onopen/onmessage/onerror as event handler attributes", async () => {
+    using server = Bun.serve({ port: 0, fetch: () => sse("data: x\n\n") });
+
+    const es = new EventSource(server.url);
+    try {
+      const calls: string[] = [];
+      const handler = function (this: unknown, event: MessageEvent) {
+        calls.push(`handler:${event.data}:${this === es}`);
+      };
+
+      expect([es.onopen, es.onmessage, es.onerror]).toEqual([null, null, null]);
+      es.onmessage = handler;
+      expect(es.onmessage).toBe(handler);
+      // The attribute is a listener of its own, so the same function can also be registered explicitly.
+      es.addEventListener("message", handler);
+      es.onopen = "not a handler" as any;
+      expect(es.onopen).toBeNull();
+      const notCallable = {};
+      es.onopen = notCallable as any;
+      expect(es.onopen).toBe(notCallable);
+      es.onerror = () => calls.push("replaced");
+      es.onerror = () => calls.push("error");
+
+      const { done } = record(es, isError, ["error"]);
+      await done;
+      expect(calls).toEqual(["handler:x:true", "handler:x:true", "error"]);
+
+      es.onmessage = null;
+      expect(es.onmessage).toBeNull();
+    } finally {
+      es.close();
+    }
+  });
+
+  it("does not route its own events and handler registration through subclass overrides", async () => {
+    using server = Bun.serve({ port: 0, fetch: () => sse("data: x\n\n") });
+    const overrideCalls: string[] = [];
+    class Logged extends EventSource {
+      addEventListener(type: string, listener: any, options?: any) {
+        overrideCalls.push(`addEventListener:${type}`);
+        super.addEventListener(type, listener, options);
+      }
+      dispatchEvent(event: Event) {
+        overrideCalls.push(`dispatchEvent:${event.type}`);
+        return super.dispatchEvent(event);
+      }
+    }
+
+    const es = new Logged(server.url);
+    try {
+      const { seen, done } = record(es, isError);
+      es.onmessage = () => {};
+      es.dispatchEvent(new Event("custom"));
+      await done;
+      expect(seen).toEqual([
+        { type: "open", readyState: 1 },
+        { type: "message", readyState: 1, data: "x", lastEventId: "" },
+        { type: "error", readyState: 0 },
+      ]);
+      // Only the explicit calls made by the test went through the overrides, as with a native EventTarget subclass.
+      expect(overrideCalls).toEqual([
+        "addEventListener:open",
+        "addEventListener:message",
+        "addEventListener:error",
+        "dispatchEvent:custom",
+      ]);
+    } finally {
+      es.close();
+    }
+  });
+
+  it("answers a 401 challenge with the credentials embedded in the URL, and keeps sending them when reconnecting", async () => {
+    const authorizations: (string | null)[] = [];
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const authorization = req.headers.get("authorization");
+        authorizations.push(authorization);
+        if (authorization === null) {
+          return new Response(null, { status: 401, headers: { "www-authenticate": 'Basic realm="events"' } });
+        }
+        return sse(`retry: 10\ndata: stream ${authorizations.length}\n\n`);
+      },
+    });
+
+    const url = `http://user:p%40ss@127.0.0.1:${server.port}/events`;
+    const es = new EventSource(url);
+    try {
+      const { seen, done } = record(es, nthError(2));
+      await done;
+      expect(es.url).toBe(url);
+      // The challenge round trip is invisible: the first observable event is the open of the authenticated request.
+      expect(seen).toEqual([
+        { type: "open", readyState: 1 },
+        { type: "message", readyState: 1, data: "stream 2", lastEventId: "" },
+        { type: "error", readyState: 0 },
+        { type: "open", readyState: 1 },
+        { type: "message", readyState: 1, data: "stream 3", lastEventId: "" },
+        { type: "error", readyState: 0 },
+      ]);
+      const basic = `Basic ${btoa("user:p@ss")}`;
+      expect(authorizations).toEqual([null, basic, basic]);
+    } finally {
+      es.close();
+    }
+  });
+
+  it("fails the connection with an ErrorEvent when the stream cannot be parsed", async () => {
+    // Parsing only throws on resource exhaustion (a line too long to hold in a string), which is too expensive to
+    // provoke in a test, so the decoder is made to throw instead. The client runs in a subprocess to contain the
+    // patched prototype; the subprocess has nothing else keeping it alive, so it exits as soon as the connection is gone.
+    const streamCancelled = Promise.withResolvers<void>();
+    using server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        sse(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(Buffer.from("data: x\n\n"));
+            },
+            cancel() {
+              streamCancelled.resolve();
+            },
+          }),
+        ),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { EventSource } = require("undici");
+         TextDecoder.prototype.decode = () => { throw new RangeError("decoder boom"); };
+         const es = new EventSource(process.env.SSE_URL);
+         es.onmessage = () => console.log("unexpected message");
+         es.onerror = event => {
+           console.log(JSON.stringify({
+             event: event.constructor.name,
+             message: event.message,
+             error: event.error instanceof RangeError,
+             readyState: es.readyState,
+           }));
+         };`,
+      ],
+      env: { ...bunEnv, SSE_URL: server.url.href },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(
+      JSON.stringify({ event: "ErrorEvent", message: "decoder boom", error: true, readyState: 2 }) + "\n",
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    await streamCancelled.promise;
+  });
+
+  it("a refused connection reports an error without keeping the process alive for the reconnect", async () => {
+    // Nothing listens on port 1 (tcpmux); the same address the shape test above uses.
+    const url = "http://127.0.0.1:1/";
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { EventSource } = require("undici");
+         const es = new EventSource(${JSON.stringify(url)});
+         es.onopen = () => console.log("unexpected open");
+         es.onerror = () => console.log(JSON.stringify({ readyState: es.readyState, url: es.url, close: typeof es.close }));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(JSON.stringify({ readyState: 0, url, close: "function" }) + "\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `import { EventSource } from "undici"` resolves to Bun's built-in `undici` shim even when the npm package is installed, and the shim's `EventSource` was a 9 line empty `EventTarget` subclass (`src/js/thirdparty/undici.js:375` on main).
- Constructing it succeeds, opens no connection and never fires `open`, `message` or `error`; `url` and `readyState` are `undefined` and `close` is not a function. Nothing warns, so SSE clients silently hang.
- Bun has no `EventSource` global either (Node 26 has none by default), so the undici import is the way to consume SSE in Bun today. Related: #8474.

### Fix
- Replaces the stub with an SSE client built on `Bun.fetch`, the same way undici implements its own (`undici/lib/web/eventsource`). No native code changes; the only new dependency inside the shim is `validateNumber`.
- Processing model follows https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model:
  - 200 + `text/event-stream` (essence compared case-insensitively, parameters ignored): `readyState` becomes `OPEN`, `open` fires, the body is parsed incrementally.
  - any other status or content type, including 204: `readyState` becomes `CLOSED`, one `error` fires, no reconnect (`#fail`).
  - fetch rejection, server ending the stream, or the connection dropping mid-body: `readyState` becomes `CONNECTING`, `error` fires, a new fetch of the constructor URL is made after the reconnection time (`#reestablish`); like the spec's reconnect step and undici, a redirect, permanent or not, is followed per connection and never changes the URL that is reconnected to. The reconnect timer is unref'd, as in undici, so a dead server does not keep a process alive.
  - `Last-Event-ID` is sent as the id's UTF-8 bytes (`utf8ByteString`): header values are byte strings, so passing the id itself would send Latin-1 and could not carry ids outside it at all. This is what WPT `format-field-id*.any.js` checks.
  - a URL with credentials (`http://user:pass@host/events`) answers a 401 with `Authorization: Basic`, invisibly to the caller, and keeps sending it on later requests, as browsers and undici do (`basicAuthorizationFor`, `#challenged`). Bun's fetch already drops the header on cross-origin redirects.
  - `close()` aborts the in-flight fetch (which releases the socket) or cancels the pending reconnect. Every async continuation checks that its `AbortController` is still the current one (`#controller`), so a closed or superseded connection cannot fire events or change state.
  - an exception while parsing a chunk (in practice: a line too long to fit in a string) fails the connection with an `ErrorEvent` carrying it, the way Bun's WebSocket reports errors, instead of leaving the object `OPEN` with nobody reading the stream.
- Parser follows the event stream interpretation rules: CR, LF and CRLF line endings (a CRLF split across chunks counts once), one leading BOM (via `TextDecoder`), comments, `data` lines joined with LF, `event`, `id` (ignored when it contains NUL, committed by the blank line even without data, persisted across reconnects), `retry` (digits only, applied when read, clamped to the i32 range `setTimeout` supports). An event without a blank line at end of stream is discarded. Dispatch stops as soon as a listener calls `close()`.
- Surface matches the IDL: `url`, `withCredentials`, `readyState`, `close()`, `onopen`/`onmessage`/`onerror` as event handler attributes, `CONNECTING`/`OPEN`/`CLOSED` as read-only constants on the constructor and the prototype, missing url throws `TypeError`, invalid url throws a `SyntaxError` `DOMException`, a non-object init throws `TypeError` like any dictionary. Events are fired and handler listeners registered through `EventTarget.prototype`, not through methods a subclass may override, as with native EventTargets. undici's documented `{ node: { reconnectionTime } }` init option is accepted; its `dispatcher` options are ignored like the rest of the shim's dispatchers (#35145 would make forwarding them a two line change).
- Deliberate differences from undici 7.29, all in favor of the spec and browsers: no `error` event when `close()` is called while connecting, no further events from a chunk after a listener calls `close()`, `retry:` takes effect when the line is read rather than at the next blank line, and `Object.prototype.toString` reports `[object EventSource]`.
- Verification:
  - `test/js/first_party/undici/undici.test.ts`: 20 new test cases under `undici.EventSource` (shape and argument validation, request headers, MessageEvent fields, stream format fixtures, split chunks, reconnect with a non-Latin-1 `Last-Event-ID` and `retry:`, mid-stream drop, `node.reconnectionTime`, the fail cases, redirect origin, URL credentials, `close()` while connecting / inside a message listener / inside the error listener, handler attributes, subclass overrides, the parse failure path, and a spawned process reproducing the original report). Waits in the tests reject on an unexpected `error` event instead of running into the timeout. All 20 fail against a released bun with the stub (1.3.14 and 1.4.0), 31/31 in the directory pass with `bun bd test`.
  - The vendored WPT `eventsource/` files that do not need a Window or a second origin (38 files, 62 subtests), run locally through `test/js/third_party/wpt-testharness-shim` against a small server standing in for the `resources/*.py` handlers: 59 pass. The 3 others are `eventsource-onmessage-trusted` (`isTrusted` is false for events dispatched from JS; undici has the same result) and the two `request-cache-control` subtests that need `www2.localhost` to resolve, which it does not in the container. Not checked in; it can be a follow-up in the shape of `test/js/third_party/wpt-h2/`.
  - `undici-primordials.test.ts`, `test-eventsource-disabled.js` and `fuzzy-wuzzy.test.ts` still pass. A differential script against Node 26.3.0 + undici 7.29.0 matches except for the differences listed above (transcript below).
  - The snippet added to `docs/guides/http/sse.mdx` was run against the guide's server example, and type-checked with undici installed, which is what the text now recommends.
- Not in this PR: a global `EventSource` (Node 26 still has none without a flag, the vendored `test-eventsource-disabled.js` asserts it is undefined, and `packages/bun-types/globals.d.ts` already declares one; the class is self-contained, so exposing it would be a small follow-up if wanted), and whether the shim should keep shadowing an installed undici (#17799, #30561, #36102). Under any of those outcomes this change stays useful or becomes a plain deletion.

### Background
- Server-Sent Events: the server keeps a `text/event-stream` response open and writes blocks of `field: value` lines separated by blank lines; each blank line dispatches the block as a `MessageEvent` whose type defaults to `message`. `id:` lets the client resume after a reconnect by sending the last id back as the `Last-Event-ID` request header, and `retry:` lets the server set the reconnect delay in milliseconds. The only standard way to authenticate an EventSource is credentials in the URL, which the client uses when the server answers 401.
- The `undici` shim: `src/js/thirdparty/undici.js` is a built-in module that Bun resolves for the specifier `undici` (and `next/dist/compiled/undici`) ahead of `node_modules`, re-exporting Bun's native fetch classes plus stubs for the rest of undici's API. `Headers`, `URL`, `MessageEvent` and `ErrorEvent` used here are the native constructors captured through `Undici.cpp`, and the remaining globals the class needs (`AbortController`, `Event`, `TextDecoder`, `DOMException`, the timer functions, `decodeURIComponent`) are captured when the module loads, so user code replacing globals afterwards does not affect the shim; `Buffer` is rewritten to an intrinsic by the builtin preprocessor.
- Event handler attributes (`onmessage = fn`) are defined by the HTML spec as one internal listener per attribute whose position in the listener list is fixed when the attribute first becomes non-null; non-object values set it to null. The implementation registers one wrapper listener per attribute and calls the current value through it, which is why `onmessage = fn` plus `addEventListener("message", fn)` invokes `fn` twice, as in browsers.

<details>
<summary>Differential script output, Node 26.3.0 + undici 7.29.0 vs this branch</summary>

Only the three lines below differ; the remaining output (request headers, parse fixtures, fail cases, redirect origin, handler attribute semantics, socket release on close) is identical.

```
node: /reconnect: [open, message, message, error rs=0, open, message, after close rs=2]
bun:  same sequence; bun's events are also instances of the global MessageEvent, so the
      script additionally printed data="one" id="1", data="two" id="2", data="three" id="2"
      and the server saw last-event-id="2" on the second connection in both runtimes

node: /close-in-handler: ["1","2","3"] rs=2
bun:  /close-in-handler: ["1"] rs=2

node: /close-while-connecting: ["error"] rs=2
bun:  /close-while-connecting: [] rs=2
```

Original report, `bun -e` with no server listening on the port, now prints the same as Node:

```
onerror fired (expected)
{ readyState: 0, url: "http://127.0.0.1:1/", close: "function" }
```

Rebased onto main twice, after #39778 (null bodies for 204/205/304/HEAD) and #39917 (streamed request bodies) landed; both times the only conflict was the import block of the undici test file. The review rounds were squashed into one commit. `#readBody` only runs for a 200, so the null body that a 204 now has does not reach it; the 204 case in the fail table passes on the rebased build.

Earlier revision of this PR: the first push documented "ids outside Latin-1 reconnect without Last-Event-ID" as a limitation and ignored URL credentials, routed events through `this.dispatchEvent`, and let a parse exception escape as an unhandled rejection; the second push fixed all four.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 20 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/undici/undici.test.ts
bun test v1.4.0 (6e906e468)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [70.54ms]
(pass) undici > request > should error when body has already been consumed [17.21ms]
(pass) undici > request > should make a POST request when provided a body and POST method [11.18ms]
(pass) undici > request > should stream a node:stream Readable body [253.89ms]
(pass) undici > request > should accept a URL class object [10.56ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [11.81ms]
(pass) undici > request > a 204 has no body [53.93ms]
(pass) undici > request > the response to a HEAD request has no body [20.43ms]
(pass) undici > request > should allow a query string to be passed [21.76ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [18.70ms]
(pass) undici > request > should allow us to abort the request with a signal [530.87ms]
(pass) undici > req
... (truncated)

release without fix: 23 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [3.58ms]
(pass) undici > request > should error when body has already been consumed [0.48ms]
(pass) undici > request > should make a POST request when provided a body and POST method [0.23ms]
83 |   }
84 |   if (method = method && typeof method === "string" ? method.toUpperCase() : null, inputBody && (method === "GET" || method === "HEAD"))
85 |     throw Error("Body not allowed for GET or HEAD requests");
86 |   if (inputBody && inputBody.read && inputBody instanceof Readable) {
87 |     let data = "";
88 |     for await (let chunk of stream)
                              ^
TypeError: iterable should have an iterator symbol
      at request (undici:88:26)
      at <anonymous> (/workspace/bun/test/js/first_party/undici/undici.test.ts:82:42)
(fail) undici > request > should stream a node:stream Readable body [1.15ms]
(pass) undici > request > should accept a URL class object [0.24ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [0.15ms]
134 |     it.each([
135 |      
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/undici/undici.test.ts
bun test v1.4.0 (6e906e468)

test/js/first_party/undici/undici.test.ts:
(pass) undici > request > should make a GET request when passed a URL string [70.99ms]
(pass) undici > request > should error when body has already been consumed [17.85ms]
(pass) undici > request > should make a POST request when provided a body and POST method [10.43ms]
(pass) undici > request > should stream a node:stream Readable body [245.96ms]
(pass) undici > request > should accept a URL class object [10.77ms]
(pass) undici > request > should prevent body from being attached to GET or HEAD requests [11.75ms]
(pass) undici > request > a 204 has no body [51.31ms]
(pass) undici > request > the response to a HEAD request has no body [19.95ms]
(pass) undici > request > should allow a query string to be passed [19.43ms]
(pass) undici > request > should throw on HTTP 4xx or 5xx error when throwOnError is true [17.19ms]
(pass) undici > request > should allow us to abort the request with a signal [529.43ms]
(pass) undici > req
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     12ad2015a5
  features     baseline

23 deps, 129 codegen, 1172 objects in 703ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [12.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [9.00ms]
[5/1244] fetch zlib
[zlib] up to date
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] gen .bind.ts → GeneratedBindings.cpp
[8/1217] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [9.00ms]
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/guides/http/sse.mdx                  |  23 ++
 src/js/thirdparty/undici.js               | 385 +++++++++++++++++-
 test/js/first_party/undici/undici.test.ts | 625 +++++++++++++++++++++++++++++-
 3 files changed, 1027 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
docs/guides/http/sse.mdx                       2      2      0
src/js/thirdparty/undici.js                   10     25      0
test/js/first_party/undici/undici.test.ts     13     24      0
```

</details>

<!-- robobun:evidence:end -->

