### PR TITLE
Fix bun install through subst drives, cross-drive junctions, and symlinked package.json

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1699,13 +1699,22 @@ pub fn init(
                     let json_stat_size = json_file.get_end_pos()?;
                     let mut json_buf = vec![0u8; (json_stat_size + 64) as usize];
                     let json_len = json_file.pread_all(&mut json_buf, 0)?;
+                    // Keep the package.json path in cwd space (the path it was
+                    // opened at) instead of realpath'ing the fd: realpath can
+                    // land on a different drive letter (subst / cross-drive
+                    // junction on Windows) or outside the project (symlinked
+                    // package.json), and no relative path exists across drives
+                    // (#39357). Copied out of `parent_path_buf` because that
+                    // buffer is reused below while `json_source` is live.
+                    let json_path_len =
+                        parent_without_trailing_slash.len() + b"/package.json".len();
                     // SAFETY: ROOT_PACKAGE_JSON_PATH_BUF is a process-global only touched on main
                     // thread; `&raw mut` + explicit reborrow avoids the 2024 `static_mut_refs` deny.
-                    let json_path = unsafe {
-                        bun_sys::get_fd_path(
-                            json_file.handle,
-                            &mut *ROOT_PACKAGE_JSON_PATH_BUF.get(),
-                        )?
+                    let json_path: &[u8] = unsafe {
+                        let root_buf = &mut *ROOT_PACKAGE_JSON_PATH_BUF.get();
+                        root_buf[..json_path_len]
+                            .copy_from_slice(&parent_path_buf[..json_path_len]);
+                        &root_buf[..json_path_len]
                     };
                     let json_source =
                         bun_ast::Source::init_path_string(&*json_path, &json_buf[..json_len]);
@@ -1855,17 +1864,17 @@ pub fn init(
         // until now). The slice excludes the NUL — `top_level_dir` is `[]u8`.
         // PathBuffer is repr(transparent) over [u8; N], so the raw cast is sound.
         fs.set_top_level_dir(bun_core::ffi::slice(CWD_BUF.get().cast::<u8>(), tld.len()));
-        // bun_sys exposes the non-Z `get_fd_path`;
-        // append the NUL ourselves so the static `&ZStr` invariant holds.
+        // Derive the root package.json path from `top_level_dir` rather than
+        // realpath'ing the fd: the realpath can sit on a different drive
+        // letter than the cwd (subst / cross-drive junction on Windows), and
+        // every later relative-path computation against `top_level_dir` must
+        // stay on the same alias (#39357).
         let root_buf = &mut *ROOT_PACKAGE_JSON_PATH_BUF.get();
-        let plen = if no_project {
-            // Where the file would be; nothing reads it in this mode.
-            let p = original_package_json_path.as_bytes();
-            root_buf[..p.len()].copy_from_slice(p);
-            p.len()
-        } else {
-            bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?.len()
-        };
+        // In `no_project` mode this is where the file would be; nothing reads it.
+        let tld_no_slash = strings::without_trailing_slash(tld);
+        let plen = tld_no_slash.len() + SEP_PACKAGE_JSON.len();
+        root_buf[..tld_no_slash.len()].copy_from_slice(tld_no_slash);
+        root_buf[tld_no_slash.len()..plen].copy_from_slice(SEP_PACKAGE_JSON);
         root_buf[plen] = 0;
         ROOT_PACKAGE_JSON_PATH.write(ZStr::from_raw(root_buf.as_ptr(), plen));
     }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1699,13 +1699,11 @@ pub fn init(
                     let json_stat_size = json_file.get_end_pos()?;
                     let mut json_buf = vec![0u8; (json_stat_size + 64) as usize];
                     let json_len = json_file.pread_all(&mut json_buf, 0)?;
-                    // Keep the package.json path in cwd space (the path it was
-                    // opened at) instead of realpath'ing the fd: realpath can
-                    // land on a different drive letter (subst / cross-drive
-                    // junction on Windows) or outside the project (symlinked
-                    // package.json), and no relative path exists across drives
-                    // (#39357). Copied out of `parent_path_buf` because that
-                    // buffer is reused below while `json_source` is live.
+                    // Use the cwd-space path the file was opened at, not the fd's
+                    // realpath: the realpath can sit on another drive letter
+                    // (subst / junction) or outside the project (symlink), and
+                    // relative paths cannot cross drives (#39357). Copied because
+                    // `parent_path_buf` is reused while `json_source` is live.
                     let json_path_len =
                         parent_without_trailing_slash.len() + b"/package.json".len();
                     // SAFETY: ROOT_PACKAGE_JSON_PATH_BUF is a process-global only touched on main
@@ -1864,11 +1862,9 @@ pub fn init(
         // until now). The slice excludes the NUL — `top_level_dir` is `[]u8`.
         // PathBuffer is repr(transparent) over [u8; N], so the raw cast is sound.
         fs.set_top_level_dir(bun_core::ffi::slice(CWD_BUF.get().cast::<u8>(), tld.len()));
-        // Derive the root package.json path from `top_level_dir` rather than
-        // realpath'ing the fd: the realpath can sit on a different drive
-        // letter than the cwd (subst / cross-drive junction on Windows), and
-        // every later relative-path computation against `top_level_dir` must
-        // stay on the same alias (#39357).
+        // Build the root package.json path from `top_level_dir` instead of
+        // realpath'ing the fd, so later relative-path computations against
+        // `top_level_dir` never cross onto a different drive letter (#39357).
         let root_buf = &mut *ROOT_PACKAGE_JSON_PATH_BUF.get();
         // In `no_project` mode this is where the file would be; nothing reads it.
         let tld_no_slash = strings::without_trailing_slash(tld);
@@ -2177,8 +2173,7 @@ pub fn init(
         // make sure folder packages can find the root package without creating a new one
         // Posix-normalize the
         // separators before hashing; `FolderResolution.hash` is always fed `/`-separated
-        // bytes by every resolver-side caller. On Windows `ROOT_PACKAGE_JSON_PATH`
-        // (built from `top_level_dir` + `SEP_PACKAGE_JSON` above) contains `\`, so
+        // bytes by every resolver-side caller. On Windows this path contains `\`, so
         // hashing the raw bytes would seed a key the resolver never looks up — copy into
         // a stack buffer and convert separators in place.
         // SAFETY: ROOT_PACKAGE_JSON_PATH set above on the main thread.

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2177,7 +2177,8 @@ pub fn init(
         // make sure folder packages can find the root package without creating a new one
         // Posix-normalize the
         // separators before hashing; `FolderResolution.hash` is always fed `/`-separated
-        // bytes by every resolver-side caller. On Windows `get_fd_path` yields `\`, so
+        // bytes by every resolver-side caller. On Windows `ROOT_PACKAGE_JSON_PATH`
+        // (built from `top_level_dir` + `SEP_PACKAGE_JSON` above) contains `\`, so
         // hashing the raw bytes would seed a key the resolver never looks up — copy into
         // a stack buffer and convert separators in place.
         // SAFETY: ROOT_PACKAGE_JSON_PATH set above on the main thread.

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -208,9 +208,8 @@ pub fn make_path_with<'a, T: PathChar, E>(
         return Ok(());
     };
     // A component that reports `NotFound` twice with no `Created` in between
-    // can never succeed (a dangling symlink in the path, or Windows
-    // STATUS_OBJECT_NAME_INVALID surfacing as ENOENT while the parent
-    // EEXISTs); return its error instead of ping-ponging forever (#39357).
+    // can never succeed (dangling symlink, or Windows OBJECT_NAME_INVALID
+    // surfacing as ENOENT); abort instead of ping-ponging forever (#39357).
     let mut last_not_found: Option<usize> = None;
     loop {
         match mkdir(comp.path)? {
@@ -382,8 +381,7 @@ mod tests {
 
     #[test]
     fn make_path_terminates_on_uncreatable_component() {
-        // `x` always reports NotFound while its parent `dangling` EEXISTs
-        // (dangling symlink, or invalid name on Windows). The walk must
+        // `x` always reports NotFound while its parent EEXISTs; the walk must
         // return the error instead of ping-ponging Exists<->NotFound forever.
         let it = ComponentIterator::init(&b"/t/dangling/x"[..], PathFormat::Posix).unwrap();
         let mut calls = 0usize;

--- a/src/paths/component_iterator.rs
+++ b/src/paths/component_iterator.rs
@@ -207,15 +207,31 @@ pub fn make_path_with<'a, T: PathChar, E>(
     let Some(mut comp) = it.last() else {
         return Ok(());
     };
+    // A component that reports `NotFound` twice with no `Created` in between
+    // can never succeed (a dangling symlink in the path, or Windows
+    // STATUS_OBJECT_NAME_INVALID surfacing as ENOENT while the parent
+    // EEXISTs); return its error instead of ping-ponging forever (#39357).
+    let mut last_not_found: Option<usize> = None;
     loop {
         match mkdir(comp.path)? {
-            MakePathStep::Created | MakePathStep::Exists => {
+            MakePathStep::Created => {
+                last_not_found = None;
+                comp = match it.next() {
+                    Some(c) => c,
+                    None => return Ok(()),
+                };
+            }
+            MakePathStep::Exists => {
                 comp = match it.next() {
                     Some(c) => c,
                     None => return Ok(()),
                 };
             }
             MakePathStep::NotFound(e) => {
+                if last_not_found == Some(comp.path.len()) {
+                    return Err(e);
+                }
+                last_not_found = Some(comp.path.len());
                 comp = match it.previous() {
                     Some(c) => c,
                     None => return Err(e),
@@ -362,6 +378,46 @@ mod tests {
         assert!(ComponentIterator::<u8>::init(b"\\\\?\\C:\\", PathFormat::Windows).is_err());
         assert!(ComponentIterator::<u8>::init(b"\\??\\C:\\", PathFormat::Windows).is_err());
         assert!(ComponentIterator::<u8>::init(b"\\\\\\x", PathFormat::Windows).is_err());
+    }
+
+    #[test]
+    fn make_path_terminates_on_uncreatable_component() {
+        // `x` always reports NotFound while its parent `dangling` EEXISTs
+        // (dangling symlink, or invalid name on Windows). The walk must
+        // return the error instead of ping-ponging Exists<->NotFound forever.
+        let it = ComponentIterator::init(&b"/t/dangling/x"[..], PathFormat::Posix).unwrap();
+        let mut calls = 0usize;
+        let result = make_path_with(it, |p| {
+            calls += 1;
+            assert!(calls < 100, "make_path_with did not terminate");
+            match p {
+                b"/t" | b"/t/dangling" => Ok(MakePathStep::Exists),
+                b"/t/dangling/x" => Ok(MakePathStep::NotFound("enoent")),
+                _ => panic!("unexpected prefix"),
+            }
+        });
+        assert_eq!(result, Err("enoent"));
+
+        // A NotFound that resolves after the parent is created still succeeds.
+        let it = ComponentIterator::init(&b"/t/a/b"[..], PathFormat::Posix).unwrap();
+        let mut created = std::collections::HashSet::new();
+        let result: Result<(), &str> = make_path_with(it, |p| {
+            if p == b"/t" {
+                return Ok(MakePathStep::Exists);
+            }
+            if created.contains(p) {
+                return Ok(MakePathStep::Exists);
+            }
+            let parent_ok = p == b"/t/a" || created.contains(b"/t/a".as_slice());
+            if parent_ok {
+                created.insert(p);
+                Ok(MakePathStep::Created)
+            } else {
+                Ok(MakePathStep::NotFound("enoent"))
+            }
+        });
+        assert_eq!(result, Ok(()));
+        assert!(created.contains(b"/t/a/b".as_slice()));
     }
 
     #[test]

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1,12 +1,13 @@
 import { file, spawn, write } from "bun";
 import { install_test_helpers } from "bun:internal-for-testing";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
 import { cp, exists, mkdir, rm } from "fs/promises";
 import {
   assertManifestsPopulated,
   bunEnv as baseEnv,
   bunExe,
+  isWindows,
   readdirSorted,
   runBunInstall,
   toMatchNodeModulesAt,
@@ -2668,5 +2669,113 @@ describe("packages whose version label is longer than 512 bytes", () => {
     expect(await file(join(packageDir, "node_modules", "baz", "index.js")).text()).toBe(
       '#! /usr/bin/env node\n\nconsole.log("patched baz");\n',
     );
+  });
+});
+
+// #39357: `bun install` must identify the project root by the path it was
+// invoked through. It used to realpath the root package.json fd, so workspace
+// discovery and lockfile keys were computed against a different root than
+// `top_level_dir` (the cwd). On Windows a subst drive or cross-drive junction
+// put the two roots on different drive letters, where no relative path exists:
+// the hoisted linker wrote machine-absolute workspace keys into bun.lock and
+// the isolated linker looped forever. On POSIX a symlinked root package.json
+// made workspace discovery run in the symlink target's directory.
+describe("aliased project root", () => {
+  test.concurrent.skipIf(isWindows)("workspaces install when the root package.json is a symlink", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "real", "package.json"),
+        JSON.stringify({
+          name: "ws-root",
+          private: true,
+          workspaces: ["packages/*"],
+          devDependencies: { "pkg-a": "workspace:*" },
+        }),
+      ),
+      write(
+        join(packageDir, "ws", "packages", "a", "package.json"),
+        JSON.stringify({ name: "pkg-a", version: "1.0.0" }),
+      ),
+    ]);
+    symlinkSync(join("..", "real", "package.json"), join(packageDir, "ws", "package.json"));
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: join(packageDir, "ws"),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+    expect(stdout).not.toContain("No packages!");
+    expect(exitCode).toBe(0);
+
+    const lockfile = await file(join(packageDir, "ws", "bun.lock")).text();
+    expect(lockfile).toContain('"packages/a"');
+    expect(lockfile).not.toContain("real/packages");
+    expect(await exists(join(packageDir, "ws", "node_modules", "pkg-a", "package.json"))).toBe(true);
+  });
+
+  test.skipIf(!isWindows)("workspaces install when cwd is a subst drive for the project's real path", async () => {
+    using ctx = await setupTest();
+    const { packageDir, env } = ctx;
+    await Promise.all([
+      write(
+        join(packageDir, "ws", "package.json"),
+        JSON.stringify({
+          name: "ws-root",
+          private: true,
+          workspaces: ["packages/*"],
+          devDependencies: { "pkg-a": "workspace:*" },
+        }),
+      ),
+      write(
+        join(packageDir, "ws", "packages", "a", "package.json"),
+        JSON.stringify({ name: "pkg-a", version: "1.0.0" }),
+      ),
+    ]);
+
+    // Map a free drive letter onto packageDir so the cwd's drive letter
+    // differs from the files' physical drive.
+    let drive: string | undefined;
+    for (const letter of "ZYXWVUTSRQONMLKJIHGFE") {
+      const { exitCode } = Bun.spawnSync({ cmd: ["cmd", "/c", "subst", `${letter}:`, packageDir], env });
+      if (exitCode === 0) {
+        drive = letter;
+        break;
+      }
+    }
+    if (!drive) throw new Error("no free drive letter available for subst");
+
+    try {
+      for (const linker of ["hoisted", "isolated"]) {
+        rmSync(join(packageDir, "ws", "node_modules"), { recursive: true, force: true });
+        rmSync(join(packageDir, "ws", "bun.lock"), { force: true });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "install", `--linker=${linker}`],
+          cwd: `${drive}:\\ws`,
+          env,
+          stdout: "pipe",
+          stderr: "pipe",
+          // the unfixed isolated linker spins forever; kill instead of hanging the runner
+          timeout: 120_000,
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ linker, stderr }).toEqual({ linker, stderr: expect.not.stringContaining("error:") });
+        expect({ linker, exitCode }).toEqual({ linker, exitCode: 0 });
+
+        const lockfile = await file(join(packageDir, "ws", "bun.lock")).text();
+        // workspace keys must stay relative, never the machine-absolute realpath
+        expect(lockfile).toContain('"packages/a"');
+        expect(lockfile).not.toContain(packageDir.replaceAll("\\", "/"));
+        expect(await exists(join(packageDir, "ws", "node_modules", "pkg-a", "package.json"))).toBe(true);
+      }
+    } finally {
+      Bun.spawnSync({ cmd: ["cmd", "/c", "subst", `${drive}:`, "/d"], env });
+    }
   });
 });


### PR DESCRIPTION
Fixes #39357

### Problem

- On Windows, `bun install` run through a path alias whose drive letter differs from the real path (`subst P: D:\Projects`, or a cross-drive junction) either hangs forever (isolated linker, ~100% CPU, alternating `STATUS_OBJECT_NAME_COLLISION` / `STATUS_OBJECT_NAME_INVALID` on a bogus `<root>\D:` path) or silently rewrites every workspace key in `bun.lock` from `"packages/a"` to a machine-absolute `"D:/Projects/ws/packages/a"` (hoisted linker).
- Cause: `PackageManager::init` resolves `ROOT_PACKAGE_JSON_PATH` with `get_fd_path` (`GetFinalPathNameByHandle`) while `top_level_dir` stays the cwd (`src/install/PackageManager.rs:1852` and `:1695`). When the two sit on different drive letters, no relative path exists between them, so `resolve_path::relative` returns the absolute `to` path (matching `path.win32.relative`), which `Package::parse_dependency` stores as a workspace key (`src/install/lockfile/Package.rs:1965`) and the isolated linker then appends onto `top_level_dir`, producing `P:\ws\C:\...`.
- The hang itself: `make_path_with` (`src/paths/component_iterator.rs`) steps back on ENOENT and forward on EEXIST with no progress guard. The bogus mid-path `C:` component fails `NtCreateFile` with `STATUS_OBJECT_NAME_INVALID`, which translates to ENOENT (libuv's `ERROR_INVALID_NAME` mapping), so the walk ping-pongs between the existing parent and the invalid child forever.
- Same root cause on POSIX in a milder form: a symlinked root `package.json` made workspace discovery run in the symlink target's directory, so `bun install` reported "No packages!" and deleted the lockfile.

### Fix

- Derive `ROOT_PACKAGE_JSON_PATH` (and the package.json path used during the workspace-root walk) from the cwd-space path the file was opened at, instead of realpath'ing the fd. The project root, `top_level_dir`, and every workspace path now stay on the same alias, so relative-path computations never cross drives. This matches how `bun add` already builds the path (`updatePackageJSONAndInstall.rs`).
- Make `make_path_with` return the carried error when the same component reports NotFound twice with no successful create in between, so recursive mkdir can never loop forever regardless of how an errno maps.
- Verified:
  - `test/cli/install/bun-workspaces.test.ts`: new "aliased project root" tests. POSIX: symlinked root package.json installs workspaces with relative lockfile keys (fails on current main). Windows: installs via a `subst` drive with both linkers, asserting relative keys and no machine-absolute paths (fails on current main: both linkers write absolute keys).
  - Rust unit test for the `make_path_with` termination guard.
  - Windows end-to-end, exact issue repro (`subst` + real deps): unfixed canary 8326d1bd3 hangs >45s; fixed build completes in 263ms with `"packages/a"` keys.
  - Full `bun-workspaces.test.ts` (74 tests) green on Linux and Windows; `bun-add`, `bun-lock`, `bun-pm`, `isolated-install`, `isolated-relink`, `bad-workspace`, `frozen-lockfile-missing-workspace` green on Linux.

### Background

- `top_level_dir` is the project root bun chdirs into; it is seeded from `getcwd` and is the base every install path (node_modules, store, lockfile keys) is joined onto or made relative to. `getcwd` preserves path aliases (a subst drive, a junction), while `GetFinalPathNameByHandle` resolves them to the physical path.
- Windows has no relative path between two drive letters, so `path.relative` across drives returns the absolute destination; any code that treats that result as relative builds paths like `P:\ws\C:\repro\...` with a drive designator as a middle component, which NT rejects as `STATUS_OBJECT_NAME_INVALID`.
- `make_path_with` is bun's shared recursive-mkdir walk: try the full path, step back one component on "parent missing", step forward on "exists/created". `ERROR_INVALID_NAME` maps to ENOENT (libuv/Node convention), which the walk read as "parent missing", hence the infinite back-and-forth.

<details>
<summary>Unfixed vs fixed behavior through a subst drive</summary>

```
# unfixed (1.4.0-canary.1+8326d1bd3), cwd P:\ws -> real C:\repro3\ws
bun install                 # hangs forever, killed after 45s
bun install --linker=hoisted  # exit 0, bun.lock:
    "C:/repro3/ws/packages/a": {
    "pkg-a": ["pkg-a@workspace:C:/repro3/ws/packages/a"],

# fixed, same setup
bun install                 # exit 0, 263ms, bun.lock:
    "packages/a": {
    "pkg-a": ["pkg-a@workspace:packages/a"],
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-workspaces.test.ts

<!-- robobun:evidence:end -->

---

Rebase note: main's `bun pm diff` (#39229) added a `no_project` mode that special-cased `ROOT_PACKAGE_JSON_PATH` because `get_fd_path` cannot run on that mode's invalid fd. The `top_level_dir`-based construction here does not touch the fd and produces the same "where the file would be" path in that mode, so the special case is subsumed (verified: `bun-pm-diff.test.ts` 46 pass, `bun-workspaces.test.ts` 76 pass after rebase).
