### PR TITLE
Add an embed API and a libbun shared library target (macOS)

### DIFF
--- a/packages/bun-embed/bun_embed.h
+++ b/packages/bun-embed/bun_embed.h
@@ -1,0 +1,62 @@
+#ifndef BUN_EMBED_H
+#define BUN_EMBED_H
+
+/*
+ * Host Bun inside another program.
+ *
+ * Link against (or dlopen with RTLD_GLOBAL) the `libbun` shared library
+ * built with `bun run build --target=libbun`; the RTLD_GLOBAL matters because
+ * native addons resolve `napi_*` against the process's global symbol table.
+ *
+ * Bun keeps a good deal of process-global state, so one process gets one run:
+ * bun_embed_run() may be called exactly once, from any thread with a large
+ * stack (the standalone executable reserves 18 MB; 8 MB is enough for most
+ * scripts). Starting Bun installs its crash-reporting signal handlers, ignores
+ * SIGPIPE/SIGXFSZ, puts stdio into unbuffered mode and, on a TTY, restores the
+ * terminal state on exit; it reads the process environment (`envp` overrides
+ * it before start).
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Run Bun on the calling thread with the given command line, exactly as the
+ * `bun` executable would run it (`argv[0]` is the program name, e.g.
+ * `{"bun", "run", "script.ts"}`).
+ *
+ * `envp` (`KEY=VALUE` strings, NULL-terminated) is applied to the process
+ * environment before Bun starts; pass NULL to keep it as is.
+ *
+ * Returns Bun's exit code once the script's event loop drains or the script
+ * calls `process.exit()` (or the host calls bun_embed_request_exit()); the
+ * runtime is torn down first, so servers and sockets it opened are closed by
+ * the time this returns. `on_exit`, if non-NULL, is called with the exit code
+ * right before returning; it also fires when Bun ends its run from a place
+ * that cannot return to the caller — a subcommand that exits without running
+ * a script (`bun --version`), an early command-line error, a crash report —
+ * in which case this function never returns and the calling thread parks.
+ *
+ * Returns -1 (without running anything) when called a second time.
+ */
+int bun_embed_run(int argc, const char *const *argv, const char *const *envp,
+                  void (*on_exit)(int code, void *user), void *user);
+
+/**
+ * Ask the running script to exit as if it had called `process.exit(code)`:
+ * `process.on('exit')` listeners run, then bun_embed_run() returns `code`.
+ * Thread-safe; takes effect the next time the event loop turns (a request
+ * that arrives before the event loop starts is applied once it does; one that
+ * arrives after the run finished is dropped).
+ */
+void bun_embed_request_exit(int code);
+
+/** Bun's version string, e.g. "1.3.14". Static; do not free. */
+const char *bun_embed_version(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BUN_EMBED_H */

--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -193,6 +193,7 @@ Split CI modes: `rust-only` (lolhtml+codegen+cargo → libbun_rust.a), `cpp-only
 | `cargo-config.ts`              | Generates the git-ignored `.cargo/config.toml` (per-target `linker` from `cfg.hostCxx`)                                 |
 | `bun.ts`                       | `emitBun()` — assembles deps+codegen+rust+compile+link                                                                  |
 | `shims.ts`                     | Platform/toolchain workaround dylibs, `emitShims()`                                                                     |
+| `shared-lib.ts`                | `libbun` — the embeddable shared library (`--target=libbun`, macOS), `emitSharedLib()`                                  |
 | `workarounds.ts`               | Self-obsoleting workaround registry, `checkWorkarounds()`                                                               |
 | `macos-sdk.ts`                 | macOS SDK resolution/download for darwin cross-compiles — `resolveMacosSdkPath()`, `ensureMacosSdk()`                   |
 | `features-json.ts`             | Host-side `features.json` for cross lanes — `parsePackedFeaturesList()`, `crossFeaturesJson()`                          |

--- a/scripts/build/bun.ts
+++ b/scripts/build/bun.ts
@@ -40,6 +40,7 @@ import { bunIncludes, computeFlags, extraFlagsFor, linkDepends } from "./flags.t
 import { writeIfChanged } from "./fs.ts";
 import type { BuildNode, Ninja } from "./ninja.ts";
 import { emitRust, linkerMapPath, rustLibPath, rustLtoLinkInputs } from "./rust.ts";
+import { canBuildSharedLib, emitSharedLib } from "./shared-lib.ts";
 import { quote, slash } from "./shell.ts";
 import { emitShims, machoPostlinkCommand, machoPostlinkImplicitInputs } from "./shims.ts";
 import { computeDepLibs, resolveDep, type ResolvedDep } from "./source.ts";
@@ -510,6 +511,11 @@ export function emitBun(n: Ninja, cfg: Config, sources: Sources): BunOutput {
 
   // ─── Step 7: post-link (strip, dsymutil, smoke test) ───
   const { strippedExe, dsym } = emitPostLink(n, cfg, exe, exeName, flags.stripflags);
+
+  // ─── libbun (opt-in: `--target=libbun`) — same objects, linked as a dylib ───
+  if (canBuildSharedLib(cfg)) {
+    emitSharedLib(n, cfg, linkObjects, depLibs, systemLibs(cfg), shims);
+  }
 
   return { exe, strippedExe, dsym, deps, codegen, rustObjects, objects: allObjects, uploadStamps };
 }

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -119,6 +119,14 @@ export interface Config {
   debug: boolean;
   release: boolean;
   mode: BuildMode;
+  /**
+   * The link being described produces `libbun` (the embeddable shared
+   * library, `scripts/build/shared-lib.ts`) instead of the executable.
+   * Always false in the resolved config; `emitSharedLib` evaluates the link
+   * flag table against `{...cfg, sharedLib: true}` so the executable-only
+   * flags (stack size, order file, exported-symbol list) drop out.
+   */
+  sharedLib: boolean;
 
   // ─── Features (all explicit booleans) ───
   lto: boolean;
@@ -1196,6 +1204,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     debug,
     release,
     mode: partial.mode ?? "full",
+    sharedLib: false,
     lto,
     crossLangLto,
     pgoGenerate,

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -1008,9 +1008,21 @@ export const linkerFlags: Flag[] = [
 
   // ─── macOS ───
   {
-    flag: ["-Wl,-no_compact_unwind", `-Wl,-stack_size,${DARWIN_STACK_SIZE}`, "-fno-keep-static-consts"],
+    // The stack size is an executable's: libbun runs on the host's threads.
+    flag: c => [
+      "-Wl,-no_compact_unwind",
+      ...(c.sharedLib ? [] : [`-Wl,-stack_size,${DARWIN_STACK_SIZE}`]),
+      "-fno-keep-static-consts",
+    ],
     when: c => c.darwin,
     desc: "18MB stack, skip compact unwind",
+  },
+  {
+    // @loader_path: the shim dylibs (shims.ts) sit next to libbun, not next
+    // to the host executable.
+    flag: ["-dynamiclib", "-install_name", "@rpath/libbun.dylib", "-Wl,-rpath,@loader_path"],
+    when: c => c.darwin && c.sharedLib,
+    desc: "libbun: link as a shared library, located via @rpath",
   },
   {
     // Force the linker to reserve + emit LC_CODE_SIGNATURE on arm64 cross
@@ -1103,7 +1115,11 @@ export const linkerFlags: Flag[] = [
     desc: "Suppress all linker warnings (workaround: no selective suppress for alignment warnings as of 2025-07)",
   },
   {
-    flag: c => ["-dead_strip", "-dead_strip_dylibs", `-Wl,-map,${c.buildDir}/${bunExeName(c)}.linker-map`],
+    flag: c => [
+      "-dead_strip",
+      "-dead_strip_dylibs",
+      ...(c.sharedLib ? [] : [`-Wl,-map,${c.buildDir}/${bunExeName(c)}.linker-map`]),
+    ],
     when: c => c.darwin && c.release,
     desc: "Dead-code strip + emit linker map",
   },
@@ -1114,7 +1130,7 @@ export const linkerFlags: Flag[] = [
     // linker deletes after the link, which would leave the debug map dangling
     // and the dSYM empty. -object_path_lto persists the LTO-codegen'd object
     // at a stable path inside the build dir and points the debug map at it.
-    flag: c => `-Wl,-object_path_lto,${c.buildDir}/${bunExeName(c)}.lto.o`,
+    flag: c => `-Wl,-object_path_lto,${c.buildDir}/${c.sharedLib ? "libbun" : bunExeName(c)}.lto.o`,
     when: c => c.darwin && c.lto,
     desc: "Persist the LTO-generated object so dsymutil can extract its DWARF into the dSYM",
   },
@@ -1128,7 +1144,7 @@ export const linkerFlags: Flag[] = [
     // nothing else. Unknown names are silently skipped, so a stale file only
     // costs part of the win.
     flag: c => `-Wl,-order_file,${orderFilePath(c)}`,
-    when: c => c.darwin && usesOrderFile(c),
+    when: c => c.darwin && !c.sharedLib && usesOrderFile(c),
     desc: "Sort startup-hot functions to the front of __text (cuts resident binary pages)",
   },
 
@@ -1343,8 +1359,15 @@ export const linkerFlags: Flag[] = [
   },
   {
     flag: c => ["-exported_symbols_list", `${c.cwd}/src/symbols.txt`],
-    when: c => c.darwin,
+    when: c => c.darwin && !c.sharedLib,
     desc: "Exported symbol list",
+  },
+  {
+    // Generated at configure time from src/symbols.txt + src/symbols.embed.txt
+    // (see shared-lib.ts).
+    flag: c => ["-exported_symbols_list", sharedLibExportsPath(c)],
+    when: c => c.darwin && c.sharedLib,
+    desc: "libbun: exported symbol list (napi/v8 surface + the embed API)",
   },
   {
     flag: c => [
@@ -1451,6 +1474,11 @@ export function orderFilePath(cfg: Pick<Config, "buildDir">): string {
   return join(cfg.buildDir, "linker.order");
 }
 
+/** libbun's exported-symbol list — written by `emitSharedLib` (shared-lib.ts). */
+export function sharedLibExportsPath(cfg: Pick<Config, "buildDir">): string {
+  return join(cfg.buildDir, "libbun.exports");
+}
+
 /**
  * Files the linker reads via flags above. Return as implicit inputs so
  * ninja relinks when exported symbols / version script change.
@@ -1462,6 +1490,7 @@ export function linkDepends(cfg: Config): string[] {
   // The release symbol ordering file: listing it here is what makes
   // regenerating it relink, and only relink.
   if (cfg.darwin) {
+    if (cfg.sharedLib) return [sharedLibExportsPath(cfg)];
     const darwin = [join(cfg.cwd, "src/symbols.txt")];
     if (usesOrderFile(cfg)) darwin.push(orderFilePath(cfg));
     return darwin;

--- a/scripts/build/shared-lib.ts
+++ b/scripts/build/shared-lib.ts
@@ -1,0 +1,74 @@
+/**
+ * `libbun` — Bun linked as a shared library so another program can host it
+ * in-process through the C API in `packages/bun-embed/bun_embed.h`
+ * (`bun_embed_run`, `bun_embed_request_exit`, `bun_embed_version`; the
+ * Rust side is `src/bun_bin/embed.rs`).
+ *
+ * The library is linked from the very same object set as the executable —
+ * only the link differs: `-dynamiclib`, no executable-only flags (stack size,
+ * order file, linker map), and an exported-symbol list of `src/symbols.txt`
+ * (the napi/v8 surface addons resolve against) minus `__mh_execute_header`,
+ * plus `src/symbols.embed.txt`. `main` is deliberately not exported.
+ *
+ * It is a separate ninja target (`bun run build --target=libbun`), never a
+ * default one, so the executable build is untouched. macOS only for now:
+ * Linux would need the whole object set built position-independent
+ * (`-fno-pic` / `-no-pie` / Rust `relocation-model=static` are the current
+ * defaults), and Windows would need an import library story.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { link } from "./compile.ts";
+import type { Config } from "./config.ts";
+import { computeFlags, linkDepends, sharedLibExportsPath } from "./flags.ts";
+import { writeIfChanged } from "./fs.ts";
+import type { Ninja } from "./ninja.ts";
+import { needsMachoPostlink, type ShimLinkOpts } from "./shims.ts";
+
+export const SHARED_LIB_NAME = "libbun.dylib";
+
+/** Whether this configuration can produce libbun. */
+export function canBuildSharedLib(cfg: Config): boolean {
+  // The darwin cross-link appends the Mach-O post-link fixup (stack size,
+  // re-sign) to the link command; both are executable-only.
+  return cfg.darwin && !needsMachoPostlink(cfg);
+}
+
+/**
+ * Write libbun's exported-symbol list (a configure-time constant manifest,
+ * like `build_options.rs`) and emit the `libbun.dylib` link edge plus a
+ * `libbun` phony. Returns the library path.
+ */
+export function emitSharedLib(
+  n: Ninja,
+  cfg: Config,
+  linkObjects: string[],
+  depLibs: string[],
+  systemLibs: string[],
+  shims: ShimLinkOpts,
+): string {
+  const libCfg: Config = { ...cfg, sharedLib: true };
+
+  const exeSymbols = readFileSync(join(cfg.cwd, "src/symbols.txt"), "utf8")
+    .split("\n")
+    .filter(s => s.length > 0 && s !== "__mh_execute_header");
+  const embedSymbols = readFileSync(join(cfg.cwd, "src/symbols.embed.txt"), "utf8")
+    .split("\n")
+    .filter(s => s.length > 0 && !s.startsWith("#"));
+  writeIfChanged(sharedLibExportsPath(cfg), [...exeSymbols, ...embedSymbols].join("\n") + "\n");
+
+  const flags = computeFlags(libCfg);
+  const lib = link(n, libCfg, SHARED_LIB_NAME, linkObjects, {
+    libs: depLibs,
+    flags: [...flags.ldflags, ...systemLibs, ...shims.ldflags],
+    implicitInputs: [
+      ...linkDepends(libCfg),
+      join(cfg.cwd, "src/symbols.txt"),
+      join(cfg.cwd, "src/symbols.embed.txt"),
+      ...shims.implicitInputs,
+    ],
+  });
+  n.phony("libbun", [lib]);
+  return lib;
+}

--- a/src/bun_bin/embed.rs
+++ b/src/bun_bin/embed.rs
@@ -1,0 +1,111 @@
+//! The C API for hosting Bun inside another program —
+//! `packages/bun-embed/bun_embed.h`. Exported by `libbun`, the shared
+//! library `scripts/build/shared-lib.ts` links from the executable's objects
+//! (`bun run build --target=libbun`).
+//!
+//! `bun_embed_run` is [`main`](crate::main) on the caller's thread: the same
+//! init sequence, the same CLI. What differs is the end of the run. The
+//! process is the host's, so `Global::exit` must not end it; instead the
+//! main VM's `Run::start` returns to the host once the script is done
+//! (`VirtualMachine::global_exit_embedded`), and a `process.exit()` under it
+//! becomes a termination request the loop observes
+//! (`VirtualMachine::request_embedded_exit`). Whatever still reaches
+//! `Global::exit` — a subcommand with no event loop, an early CLI error —
+//! reports its code through the host's `on_exit` callback and parks the
+//! thread (`Global::embedded_park`), because those stacks have no way back.
+//!
+//! One run per process: argv, the CLI arena and log, the main-thread VM
+//! slot and JSC's own process state are all written once, on the assumption
+//! that the process ends with the run.
+
+use core::ffi::{CStr, c_char, c_int, c_void};
+use core::sync::atomic::{AtomicU8, Ordering};
+use std::ffi::CString;
+
+use bun_core::Global;
+
+const IDLE: u8 = 0;
+const STARTED: u8 = 1;
+static STATE: AtomicU8 = AtomicU8::new(IDLE);
+
+/// # Safety
+/// `argv` points to `argc` NUL-terminated strings and `envp`, when non-null,
+/// to a NUL-terminated array of them; all only need to live for the call.
+#[unsafe(no_mangle)]
+pub(crate) unsafe extern "C" fn bun_embed_run(
+    argc: c_int,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
+    on_exit: Option<Global::EmbedExitFn>,
+    user: *mut c_void,
+) -> c_int {
+    if STATE
+        .compare_exchange(IDLE, STARTED, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return -1;
+    }
+
+    // Bun keeps borrowing argv for the rest of the process (`bun_core::argv`,
+    // `process.argv`); the caller's array is only good for the call.
+    let argc = usize::try_from(argc).unwrap_or(0);
+    let owned: Vec<CString> = (0..argc)
+        // SAFETY: fn contract.
+        .map(|i| unsafe { CStr::from_ptr(*argv.add(i)) }.to_owned())
+        .collect();
+    let mut ptrs: Vec<*const c_char> = owned.iter().map(|s| s.as_ptr()).collect();
+    ptrs.push(core::ptr::null());
+    let ptrs = Box::leak(ptrs.into_boxed_slice());
+    Box::leak(owned.into_boxed_slice());
+
+    if !envp.is_null() {
+        let mut p = envp;
+        // SAFETY: fn contract — NUL-terminated array of C strings.
+        while let Some(entry) = unsafe { (*p).as_ref() } {
+            // SAFETY: as above.
+            let bytes = unsafe { CStr::from_ptr(entry) }.to_bytes();
+            if let Some(eq) = bytes.iter().position(|&b| b == b'=') {
+                set_env(&bytes[..eq], &bytes[eq + 1..]);
+            }
+            // SAFETY: as above.
+            p = unsafe { p.add(1) };
+        }
+    }
+
+    Global::enter_embedded_mode(on_exit, user);
+    // SAFETY: `ptrs` is a leaked NUL-terminated argv of process lifetime.
+    unsafe { crate::start(argc as c_int, ptrs.as_ptr()) };
+    // The command returned on its own (a run that ended through
+    // `Global::exit` reported itself and never gets here).
+    Global::finish_embedded_run(0);
+    Global::embedded_exit_code()
+}
+
+fn set_env(key: &[u8], value: &[u8]) {
+    #[cfg(unix)]
+    let (key, value) = {
+        use std::os::unix::ffi::OsStrExt;
+        (
+            std::ffi::OsStr::from_bytes(key),
+            std::ffi::OsStr::from_bytes(value),
+        )
+    };
+    #[cfg(not(unix))]
+    let (key, value) = (String::from_utf8_lossy(key), String::from_utf8_lossy(value));
+    if key.is_empty() {
+        return;
+    }
+    // SAFETY: before Bun starts, on the only thread that has entered it.
+    unsafe { std::env::set_var(key, value) };
+}
+
+/// Thread-safe; see `bun_runtime::node::process::request_exit_from_host`.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn bun_embed_request_exit(code: c_int) {
+    bun_runtime::node::process::request_exit_from_host(code);
+}
+
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn bun_embed_version() -> *const c_char {
+    Global::package_json_version_z.as_ptr()
+}

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -36,6 +36,7 @@
 use core::ffi::{c_char, c_int};
 
 mod c_abi_exports;
+mod embed;
 
 // Force-link `bun_platform` so its `#[no_mangle]` C exports
 // (`sys_epoll_pwait2`, …) reach the linker.
@@ -151,6 +152,20 @@ pub(crate) extern "C" fn __lsan_default_suppressions() -> *const core::ffi::c_ch
 /// the entire process — guaranteed by the C runtime that calls this symbol.
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) -> c_int {
+    // SAFETY: per the fn contract.
+    unsafe { start(argc, argv) };
+    // `Global::exit` is `-> !`; it coerces to the `c_int` return type.
+    Global::exit(0)
+}
+
+/// Process init + CLI dispatch — the body of [`main`], also what
+/// `bun_embed_run` runs on an embedding host's thread. Returns only when the
+/// command returns (a run that ended through `Global::exit` never does).
+///
+/// # Safety
+/// As [`main`]: `argv` points to `argc` NUL-terminated strings that live for
+/// the rest of the process.
+pub(crate) unsafe fn start(argc: c_int, argv: *const *const c_char) {
     // 0. Capture argv FIRST — before the crash handler, whose panic path
     //    dumps the command line via `bun_core::argv()`.
     //    SAFETY: `argc`/`argv` come from the C runtime; the argv block lives
@@ -206,6 +221,4 @@ pub(crate) unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) ->
 
     // 7. CLI dispatch.
     bun_runtime::cli::Cli::start();
-    // `Global::exit` is `-> !`; it coerces to the `c_int` return type.
-    Global::exit(0)
 }

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -496,6 +496,13 @@ pub const package_json_version: &str = if env::IS_DEBUG {
 /// `print_version_and_exit` is a single `write_all` (one syscall).
 pub const package_json_version_nl: &str = concatcp!(package_json_version, "\n");
 
+/// `package_json_version` as a C string (`bun_embed_version`).
+pub const package_json_version_z: &core::ffi::CStr =
+    match core::ffi::CStr::from_bytes_with_nul(concatcp!(package_json_version, "\0").as_bytes()) {
+        Ok(s) => s,
+        Err(_) => panic!("version string contains a NUL"),
+    };
+
 /// This is used for `bun` without any arguments, it `package_json_version` but with canary if it is a canary build.
 /// like "1.0.0-canary.12"
 pub const package_json_version_with_canary: &str = if env::IS_DEBUG {
@@ -712,6 +719,10 @@ pub fn exit(code: u32) -> ! {
     // Flush output before exiting to ensure all messages are visible
     Output::flush();
 
+    if is_embedded() {
+        embedded_park(code);
+    }
+
     #[cfg(target_os = "macos")]
     {
         libc_exit(code as i32)
@@ -728,6 +739,67 @@ pub fn exit(code: u32) -> ! {
             libc_exit(code as i32);
         }
         quick_exit(code as c_int);
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Embedded mode — a host program runs Bun in-process (`bun_embed_run`)
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Set once by `bun_embed_run` before Bun starts: the process belongs to the
+/// host, so nothing here may end it.
+static EMBEDDED: AtomicBool = AtomicBool::new(false);
+/// `bun_embed_run`'s `on_exit` callback and its user pointer.
+static EMBED_ON_EXIT: crate::Mutex<Option<(EmbedExitFn, usize)>> = crate::Mutex::new(None);
+/// Set by [`finish_embedded_run`], read back by `bun_embed_run` as its result.
+static EMBED_EXIT_CODE: core::sync::atomic::AtomicI32 = core::sync::atomic::AtomicI32::new(0);
+static EMBED_FINISHED: AtomicBool = AtomicBool::new(false);
+
+pub type EmbedExitFn = extern "C" fn(code: c_int, user: *mut core::ffi::c_void);
+
+/// Enter embedded mode. Called once, before any other Bun code runs.
+pub fn enter_embedded_mode(on_exit: Option<EmbedExitFn>, user: *mut core::ffi::c_void) {
+    *EMBED_ON_EXIT.lock() = on_exit.map(|f| (f, user as usize));
+    EMBEDDED.store(true, Ordering::Release);
+}
+
+/// A host program is running Bun in-process via `bun_embed_run`.
+#[inline]
+pub fn is_embedded() -> bool {
+    EMBEDDED.load(Ordering::Relaxed)
+}
+
+/// The exit code the embedded run settled on (0 until [`finish_embedded_run`]).
+pub fn embedded_exit_code() -> c_int {
+    EMBED_EXIT_CODE.load(Ordering::Acquire)
+}
+
+/// Embedded counterpart of the process ending: run the exit callbacks
+/// `Bun__onExit` would run from `atexit`, record `code`, and tell the host.
+/// Idempotent — the first caller decides the code.
+pub fn finish_embedded_run(code: c_int) {
+    if EMBED_FINISHED.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    Bun__onExit();
+    EMBED_EXIT_CODE.store(code, Ordering::Release);
+    let on_exit = *EMBED_ON_EXIT.lock();
+    if let Some((f, user)) = on_exit {
+        f(code, user as *mut core::ffi::c_void);
+    }
+}
+
+/// [`exit`] in embedded mode. Bun asked to end the process from a call
+/// stack that has no way back to the host (JS frames, a CLI subcommand's
+/// error path): tell the host the exit code and park this thread instead.
+/// The paths that can return — `Run::start` draining, `process.exit()`
+/// under it — never get here.
+#[cold]
+#[inline(never)]
+fn embedded_park(code: u32) -> ! {
+    finish_embedded_run(code as c_int);
+    loop {
+        std::thread::park();
     }
 }
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -217,6 +217,14 @@ pub struct VirtualMachine {
     pub(crate) hide_bun_stackframes: bool,
 
     pub is_shutting_down: bool,
+    /// An embedding host (`bun_embed_run`) is running this VM: `Run::start`
+    /// returns to it when the run is over instead of ending the process, so
+    /// `process.exit()` becomes a termination request (see
+    /// [`request_embedded_exit`](Self::request_embedded_exit)).
+    pub embedded_loop_active: bool,
+    /// Set by [`request_embedded_exit`](Self::request_embedded_exit);
+    /// `Run::start` leaves its loop when it sees this.
+    pub exit_requested: bool,
     /// Set once `on_exit()` has finished draining `RareData::cleanup_hooks`.
     /// After this point the cleanup-hook list is never iterated again, so
     /// pushing to it (e.g. from a deferred N-API finalizer scheduled during
@@ -598,7 +606,7 @@ impl ExitHandler {
     /// parent via `container_of` would escape the provenance of `&mut self`
     /// (which only covers the `ExitHandler` field). Callers pass the VM
     /// reference instead; the body re-enters JS so no `&mut` is held.
-    pub(crate) fn dispatch_on_exit(vm: &VirtualMachine) {
+    pub fn dispatch_on_exit(vm: &VirtualMachine) {
         let exit_code = vm.exit_handler.exit_code;
         // `process.on('exit')` handlers are user script (see `on_exit`).
         if vm.script_allowed() && !vm.exit_handler.skip_exit_listeners {
@@ -1738,6 +1746,36 @@ impl VirtualMachine {
             self.close_sqlite_databases_for_exit();
         }
         bun_core::Global::exit(u32::from(self.exit_handler.exit_code))
+    }
+
+    /// [`global_exit`](Self::global_exit) for a VM an embedding host runs:
+    /// the process goes on without Bun, so the VM is always torn down and the
+    /// exit code goes to the host instead of `exit`. Returns to `Run::start`.
+    pub fn global_exit_embedded(&mut self) {
+        debug_assert!(self.is_shutting_down());
+        let code = self.exit_handler.exit_code;
+        // SAFETY: main-thread VM on the thread that runs it; exit handlers have run.
+        unsafe { Self::teardown(core::ptr::from_mut(self), Teardown::MainThreadExit) };
+        bun_core::Global::finish_embedded_run(i32::from(code));
+    }
+
+    /// `process.exit()` while an embedding host runs this VM: stop script at
+    /// the next safepoint (a JSC termination, as a worker's exit) and let
+    /// `Run::start` return the exit code, rather than ending the process.
+    /// `false` when no run loop would return, and the caller exits as usual.
+    pub fn request_embedded_exit(&mut self) -> bool {
+        if !self.embedded_loop_active {
+            return false;
+        }
+        self.exit_requested = true;
+        unsafe extern "C" {
+            safe fn JSGlobalObject__requestTermination(global: &JSGlobalObject);
+        }
+        // Materializes the TerminationException the trap below throws — a
+        // main-thread VM has none until asked (a worker's is created up front).
+        JSGlobalObject__requestTermination(self.global());
+        self.handle.request_termination();
+        true
     }
 
     /// Checkpoint + close the sqlite connections *this* VM opened, while it is

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1102,7 +1102,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             vm,
             entry_path: run_entry,
         }
-        .start()
+        .start();
+        Ok(())
     }
 
     /// Entry point for
@@ -1213,7 +1214,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             vm,
             entry_path: entry,
         }
-        .start()
+        .start();
+        Ok(())
     }
 }
 
@@ -1275,17 +1277,26 @@ impl Run<'_> {
 
     /// `Run.start`: take the JSC API lock, load the entry point, run the event
     /// loop until idle, fire `beforeExit`/`exit`, then `globalExit`. The lock
-    /// guard is never dropped because this never returns.
-    fn start(self) -> ! {
+    /// guard is never dropped: this never returns, except under an embedding
+    /// host (`bun_embed_run`), where [`finish`](Self::finish) tears the VM
+    /// down and returns so the host gets its thread back.
+    fn start(self) {
         let Run {
             ctx,
             vm,
             entry_path: mut entry,
         } = self;
-        let _api_lock = vm.global().vm().get_api_lock();
+        let api_lock = vm.global().vm().get_api_lock();
+        // Released by process exit, or never: the embedded return path
+        // destroys the JSC VM the guard would unlock.
+        ::core::mem::forget(api_lock);
 
         vm.hot_reload = ctx.debug.hot_reload;
         vm.on_unhandled_rejection = Run::on_unhandled_rejection_before_close;
+        vm.embedded_loop_active = Global::is_embedded();
+        if vm.embedded_loop_active {
+            crate::node::process::embedded_loop_started(vm);
+        }
 
         // ── CPU profiler ────────────────────────────────────────────────────
         if ctx.runtime_options.cpu_prof.enabled {
@@ -1414,6 +1425,9 @@ impl Run<'_> {
         }
 
         match vm.load_entry_point(entry) {
+            // A `process.exit()` in the entry point (embedded: a termination
+            // request, not the end of the process) leaves nothing to inspect.
+            _ if vm.exit_requested => {}
             Ok(promise) => {
                 // SAFETY: `promise` is a live GC cell returned by the module loader.
                 let promise = unsafe { &mut *promise };
@@ -1440,7 +1454,7 @@ impl Run<'_> {
                         // uniquely accessed here.
                         vm.event_loop_ref().tick();
                     } else {
-                        exit_with_unhandled_note(vm);
+                        return exit_with_unhandled_note(vm);
                     }
                 }
 
@@ -1452,11 +1466,13 @@ impl Run<'_> {
                     log_clear_msgs(vm);
                 }
             }
-            Err(err) => entry_point_load_failed(vm, &err.into()),
+            Err(err) => return entry_point_load_failed(vm, &err.into()),
         }
 
         // don't run the GC if we don't actually need to
-        if vm.is_event_loop_alive() || vm.event_loop_ref().tick_concurrent_with_count() > 0 {
+        if !vm.exit_requested
+            && (vm.is_event_loop_alive() || vm.event_loop_ref().tick_concurrent_with_count() > 0)
+        {
             vm.global().vm().release_weak_refs();
             // `bun_alloc::Arena` has no per-heap collect to run alongside this
             // GC; it would only be a memory-usage hint, not correctness.
@@ -1473,7 +1489,10 @@ impl Run<'_> {
         }
 
         // ── core run-loop ──────────────────────────────────────────────────
-        if vm.is_watcher_enabled() {
+        if vm.exit_requested {
+            // Embedded: `process.exit()` already ran the exit listeners; go
+            // straight to shutdown.
+        } else if vm.is_watcher_enabled() {
             vm.report_exception_in_hot_reloaded_module_if_needed();
             loop {
                 while vm.is_event_loop_alive() {
@@ -1491,10 +1510,13 @@ impl Run<'_> {
         } else {
             while vm.is_event_loop_alive() {
                 vm.tick();
+                if vm.exit_requested {
+                    break;
+                }
                 vm.auto_tick_active();
             }
 
-            if ctx.runtime_options.eval.eval_and_print {
+            if ctx.runtime_options.eval.eval_and_print && !vm.exit_requested {
                 let to_print: JSValue = 'brk: {
                     let result = vm
                         .entry_point_result
@@ -1516,7 +1538,7 @@ impl Run<'_> {
                                 );
                                 vm.tick();
                                 vm.auto_tick_active();
-                                while vm.is_event_loop_alive() {
+                                while vm.is_event_loop_alive() && !vm.exit_requested {
                                     vm.tick();
                                     vm.auto_tick_active();
                                 }
@@ -1541,7 +1563,9 @@ impl Run<'_> {
                 }
             }
 
-            vm.on_before_exit();
+            if !vm.exit_requested {
+                vm.on_before_exit();
+            }
         }
 
         if log_has_msgs(vm) {
@@ -1567,6 +1591,18 @@ impl Run<'_> {
         crate::napi::fix_dead_code_elimination();
         crate::webcore::bake_response::fix_dead_code_elimination();
         bun_crash_handler::fix_dead_code_elimination();
+        Self::finish(vm);
+    }
+
+    /// The last thing `Run::start` does: end the process with the VM's exit
+    /// code — or, under an embedding host, tear the VM down and return the
+    /// code to it (see `bun_embed_run`).
+    fn finish(vm: &mut VirtualMachine) {
+        if vm.embedded_loop_active {
+            crate::node::process::embedded_loop_finished();
+            vm.global_exit_embedded();
+            return;
+        }
         vm.global_exit();
     }
 }
@@ -1618,14 +1654,14 @@ fn dump_build_error(vm: &mut VirtualMachine) {
     any(target_os = "linux", target_os = "android"),
     unsafe(link_section = ".text.unlikely")
 )]
-fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
+fn exit_with_unhandled_note(vm: &mut VirtualMachine) {
     vm.exit_handler.exit_code = 1;
     vm.on_exit();
     if ANY_UNHANDLED.load(Ordering::Relaxed) {
         bun_sourcemap::SavedSourceMap::MissingSourceMapNoteInfo::print();
         pretty_errorln!("<r>\n<d>{}<r>", Global::unhandled_error_bun_version_string,);
     }
-    vm.global_exit();
+    Run::finish(vm);
 }
 
 /// Cold `Err(err)` arm of `vm.load_entry_point` in `Run::start`.
@@ -1635,7 +1671,7 @@ fn exit_with_unhandled_note(vm: &mut VirtualMachine) -> ! {
     any(target_os = "linux", target_os = "android"),
     unsafe(link_section = ".text.unlikely")
 )]
-fn entry_point_load_failed(vm: &mut VirtualMachine, err: &crate::Error) -> ! {
+fn entry_point_load_failed(vm: &mut VirtualMachine, err: &crate::Error) {
     if log_has_msgs(vm) {
         dump_build_error(vm);
         log_clear_msgs(vm);
@@ -1646,7 +1682,7 @@ fn entry_point_load_failed(vm: &mut VirtualMachine, err: &crate::Error) -> ! {
         );
         Output::flush();
     }
-    exit_with_unhandled_note(vm);
+    exit_with_unhandled_note(vm)
 }
 
 /// Cold tail of `Run::start` when `ANY_UNHANDLED` tripped on an otherwise-clean

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -72,6 +72,9 @@ pub(crate) extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
         // @190n: we may need to use requestTerminate or throwTerminationException
         // instead to terminate the worker sooner
         worker.exit();
+    } else if vm.request_embedded_exit() {
+        // An embedding host's run loop returns the exit code; like the worker
+        // above, script stops at the next safepoint and this call returns.
     } else {
         // A watch-reload kill-signal handler may call process.exit; node restarts the child
         // regardless. `process.exit()` must never return control to JS, so replace the process
@@ -88,6 +91,73 @@ pub(crate) extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
         vm.on_exit();
         vm.global_exit();
     }
+}
+
+// ───────────────────────────── exit requested by an embedding host ────────
+//
+// `bun_embed_request_exit` (src/bun_bin/embed.rs) may be called from any
+// thread; the request is carried to the JS thread as a task that does what
+// `process.exit(code)` does there.
+
+/// The main VM's handle for as long as `Run::start` drives it for an
+/// embedding host.
+static HOST_VM: bun_core::Mutex<Option<bun_jsc::VmHandle>> = bun_core::Mutex::new(None);
+/// A host exit request that arrived before the run loop was up (`-1`: none).
+static PENDING_HOST_EXIT: core::sync::atomic::AtomicI32 = core::sync::atomic::AtomicI32::new(-1);
+
+pub fn embedded_loop_started(vm: &bun_jsc::virtual_machine::VirtualMachine) {
+    let handle = vm.handle();
+    let pending = PENDING_HOST_EXIT.swap(-1, core::sync::atomic::Ordering::AcqRel);
+    if pending >= 0 {
+        post_host_exit(&handle, pending as u8);
+    }
+    *HOST_VM.lock() = Some(handle);
+}
+
+pub fn embedded_loop_finished() {
+    *HOST_VM.lock() = None;
+}
+
+/// `bun_embed_request_exit`: as `process.exit(code)` from a task on the JS
+/// thread. Before the loop is up the request is kept for it; after the run
+/// it is dropped.
+pub fn request_exit_from_host(code: core::ffi::c_int) {
+    // `process.exit()` truncates the same way.
+    let code = code as u8;
+    let vm = HOST_VM.lock();
+    match &*vm {
+        Some(handle) => post_host_exit(handle, code),
+        None => PENDING_HOST_EXIT.store(
+            core::ffi::c_int::from(code),
+            core::sync::atomic::Ordering::Release,
+        ),
+    }
+}
+
+fn post_host_exit(handle: &bun_jsc::VmHandle, code: u8) {
+    let task = bun_jsc::event_loop::ConcurrentTaskItem::create(
+        bun_jsc::event_loop::ManagedTask::ManagedTask::new_owned(
+            bun_core::heap::into_raw(Box::new(code)),
+            host_exit_task,
+        ),
+    );
+    if let bun_jsc::Posted::Refused(task) = handle.post(bun_jsc::LoopKind::Regular, task) {
+        // SAFETY: refused ⇒ the task (and its boxed code) is ours to free.
+        unsafe { bun_jsc::event_loop::ConcurrentTaskItem::release_refused(task) };
+    }
+}
+
+fn host_exit_task(code: *mut u8) -> bun_jsc::JsResult<()> {
+    // SAFETY: the box `post_host_exit` handed over, run exactly once.
+    let code = *unsafe { bun_core::heap::take(code) };
+    let vm = bun_jsc::virtual_machine::VirtualMachine::get().as_mut();
+    vm.exit_handler.exit_code = code;
+    // 'exit' listeners, then the exit itself — `process.exit()`'s two steps.
+    bun_jsc::virtual_machine::ExitHandler::dispatch_on_exit(vm);
+    // A listener may have set `process.exitCode`.
+    let code = vm.exit_handler.exit_code;
+    exit(vm.global(), code);
+    Ok(())
 }
 
 // ───────────────────────────── misc exports ─────────────────────────────

--- a/src/symbols.embed.txt
+++ b/src/symbols.embed.txt
@@ -1,0 +1,5 @@
+# Symbols libbun exports on top of src/symbols.txt: the embed API
+# (packages/bun-embed/bun_embed.h, src/bun_bin/embed.rs).
+_bun_embed_run
+_bun_embed_request_exit
+_bun_embed_version

--- a/test/embed/embed.test.ts
+++ b/test/embed/embed.test.ts
@@ -1,0 +1,115 @@
+// libbun — Bun hosted in another program through the C API in
+// packages/bun-embed/bun_embed.h. The library is a separate build target
+// (`bun run build --target=libbun`, macOS only for now) that lands next to the
+// executable; without it these tests skip.
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isMacOS, tempDir } from "harness";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const libbun = join(dirname(bunExe()), "libbun.dylib");
+const cc = Bun.which("cc") || Bun.which("clang");
+const canRun = isMacOS && existsSync(libbun) && !!cc;
+
+// An ASAN libbun needs the sanitizer runtime (and the dyld shim next to the
+// library) loaded before it is dlopen'd, so the host links them as dependents.
+function asanLinkFlags(): string[] {
+  if (!isASAN) return [];
+  const otool = Bun.spawnSync({ cmd: ["otool", "-L", libbun], stdout: "pipe" }).stdout.toString();
+  const deps = otool
+    .split("\n")
+    .slice(1)
+    .map(l => l.trim().split(" ")[0])
+    .filter(d => d.includes("libclang_rt.asan") || d.includes("asan-dyld-shim"))
+    .map(d => d.replace("@rpath", dirname(libbun)));
+  return [...deps, ...deps.map(d => `-Wl,-rpath,${dirname(d)}`)];
+}
+
+let hostExe: string | undefined;
+function host(): string {
+  if (hostExe) return hostExe;
+  const dir = tempDir("bun-embed-host", {});
+  hostExe = join(String(dir), "host");
+  const build = Bun.spawnSync({
+    cmd: [cc!, join(import.meta.dir, "host.c"), "-o", hostExe, ...asanLinkFlags()],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  if (build.exitCode !== 0) throw new Error(`building host.c failed:\n${build.stderr}`);
+  return hostExe;
+}
+
+async function runHost(mode: string, bunArgs: string[], env: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [host(), libbun, mode, "bun", ...bunArgs],
+    env: { ...bunEnv, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.skipIf(!canRun)("bun_embed_run", () => {
+  test("returns process.exit()'s code and the host keeps running", async () => {
+    const { stdout, exitCode } = await runHost("run", [
+      "-e",
+      `process.on("exit", c => console.log("exit listener", c)); console.log("env", process.env.BUN_EMBED_TEST_VAR); process.exit(3);`,
+    ]);
+    expect(stdout).toBe(
+      `version=${Bun.version}\nenv from-envp\nexit listener 3\non_exit=3 user=u\nexit=3\nhost alive\n`,
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  test("returns 0 when the event loop drains, 1 on an uncaught error", async () => {
+    const drained = await runHost("run", ["-e", `setTimeout(() => console.log("done"), 5)`]);
+    expect(drained.stdout).toBe(`version=${Bun.version}\ndone\non_exit=0 user=u\nexit=0\nhost alive\n`);
+    expect(drained.exitCode).toBe(0);
+
+    const threw = await runHost("run", ["-e", `throw new Error("boom")`]);
+    expect(threw.stderr).toContain("boom");
+    expect(threw.stdout).toBe(`version=${Bun.version}\non_exit=1 user=u\nexit=1\nhost alive\n`);
+    expect(threw.exitCode).toBe(0);
+  });
+
+  test("bun_embed_request_exit stops a server from another thread", async () => {
+    using dir = tempDir("bun-embed-serve", {
+      "serve.ts": `
+        const server = Bun.serve({ port: 0, fetch: () => new Response("hello from embedded bun") });
+        process.on("exit", c => console.log("exit listener", c));
+        await Bun.write(process.env.READY_FILE!, String(server.port));
+      `,
+    });
+    const READY_FILE = join(String(dir), "ready");
+    const STOP_FILE = join(String(dir), "stop");
+    const running = runHost("serve", [join(String(dir), "serve.ts")], { READY_FILE, STOP_FILE });
+
+    // The script writes its port once the server is listening.
+    let port = "";
+    while (!port) {
+      port = existsSync(READY_FILE) ? await Bun.file(READY_FILE).text() : "";
+      if (!port) await Bun.sleep(10);
+    }
+    expect(await (await fetch(`http://127.0.0.1:${port}/`)).text()).toBe("hello from embedded bun");
+
+    await Bun.write(STOP_FILE, "");
+    const { stdout, exitCode } = await running;
+    expect(stdout).toBe(`version=${Bun.version}\nexit listener 7\non_exit=7 user=u\nexit=7\nhost alive\n`);
+    expect(exitCode).toBe(0);
+    // The runtime was torn down: nothing listens any more.
+    expect(fetch(`http://127.0.0.1:${port}/`)).rejects.toThrow();
+  });
+
+  test("a second run in the same process is refused", async () => {
+    const { stdout, exitCode } = await runHost("twice", ["-e", `process.exit(3)`]);
+    expect(stdout).toBe(`version=${Bun.version}\nfirst=3 second=-1\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("a command that exits without an event loop reports through on_exit", async () => {
+    const { stdout, exitCode } = await runHost("park", ["--version"]);
+    expect(stdout).toBe(`version=${Bun.version}\n${Bun.version}\non_exit=0 user=u\nhost alive\n`);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/embed/host.c
+++ b/test/embed/host.c
@@ -1,0 +1,118 @@
+// A small program hosting Bun through libbun's C API
+// (packages/bun-embed/bun_embed.h), driven by embed.test.ts.
+//
+//   host <libbun.dylib> run <bun argv...>     one run; prints on_exit/exit
+//   host <libbun.dylib> twice <bun argv...>   the same run twice (second is refused)
+//   host <libbun.dylib> serve <bun argv...>   run; request exit 7 once $STOP_FILE exists
+//   host <libbun.dylib> park <bun argv...>    a run that cannot return; wait for on_exit
+#include <dlfcn.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "../../packages/bun-embed/bun_embed.h"
+
+typedef int (*run_fn)(int, const char *const *, const char *const *, void (*)(int, void *), void *);
+typedef void (*request_exit_fn)(int);
+typedef const char *(*version_fn)(void);
+
+static run_fn bun_run;
+static request_exit_fn bun_request_exit;
+static version_fn bun_version;
+static volatile int on_exit_code = -1;
+
+static void on_exit_cb(int code, void *user) {
+  on_exit_code = code;
+  printf("on_exit=%d user=%s\n", code, (const char *)user);
+  fflush(stdout);
+}
+
+static void *stop_watcher(void *arg) {
+  const char *stop_file = arg;
+  struct stat st;
+  while (stat(stop_file, &st) != 0) usleep(20 * 1000);
+  bun_request_exit(7);
+  return NULL;
+}
+
+struct run_args { int argc; const char *const *argv; const char *const *envp; };
+
+static void *run_thread(void *p) {
+  struct run_args *a = p;
+  int code = bun_run(a->argc, a->argv, a->envp, on_exit_cb, "u");
+  printf("returned=%d\n", code); // not reached in `park` mode
+  fflush(stdout);
+  return NULL;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 4) {
+    fprintf(stderr, "usage: host <libbun> <mode> <bun argv...>\n");
+    return 2;
+  }
+  // RTLD_GLOBAL: native addons resolve napi_* against the process.
+  void *lib = dlopen(argv[1], RTLD_NOW | RTLD_GLOBAL);
+  if (!lib) {
+    fprintf(stderr, "dlopen: %s\n", dlerror());
+    return 2;
+  }
+  bun_run = (run_fn)dlsym(lib, "bun_embed_run");
+  bun_request_exit = (request_exit_fn)dlsym(lib, "bun_embed_request_exit");
+  bun_version = (version_fn)dlsym(lib, "bun_embed_version");
+  if (!bun_run || !bun_request_exit || !bun_version) {
+    fprintf(stderr, "dlsym: %s\n", dlerror());
+    return 2;
+  }
+  if (dlsym(lib, "main")) {
+    fprintf(stderr, "libbun must not export main\n");
+    return 2;
+  }
+  printf("version=%s\n", bun_version());
+  fflush(stdout);
+
+  const char *mode = argv[2];
+  const char *const *bun_argv = (const char *const *)argv + 3;
+  int bun_argc = argc - 3;
+  const char *envp[] = {"BUN_EMBED_TEST_VAR=from-envp", NULL};
+
+  if (strcmp(mode, "run") == 0) {
+    int code = bun_run(bun_argc, bun_argv, envp, on_exit_cb, "u");
+    printf("exit=%d\n", code);
+    printf("host alive\n");
+    return 0;
+  }
+  if (strcmp(mode, "twice") == 0) {
+    int first = bun_run(bun_argc, bun_argv, NULL, NULL, NULL);
+    int second = bun_run(bun_argc, bun_argv, NULL, NULL, NULL);
+    printf("first=%d second=%d\n", first, second);
+    return 0;
+  }
+  if (strcmp(mode, "serve") == 0) {
+    pthread_t t;
+    pthread_create(&t, NULL, stop_watcher, (void *)getenv("STOP_FILE"));
+    int code = bun_run(bun_argc, bun_argv, NULL, on_exit_cb, "u");
+    pthread_join(t, NULL);
+    printf("exit=%d\n", code);
+    printf("host alive\n");
+    return 0;
+  }
+  if (strcmp(mode, "park") == 0) {
+    // Runs Bun on another thread; that thread never comes back, the
+    // callback is how the host learns the code.
+    struct run_args a = {bun_argc, bun_argv, NULL};
+    pthread_t t;
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setstacksize(&attr, 8 << 20);
+    pthread_create(&t, &attr, run_thread, &a);
+    while (on_exit_code < 0) usleep(10 * 1000);
+    printf("host alive\n");
+    fflush(stdout);
+    _exit(0);
+  }
+  fprintf(stderr, "unknown mode %s\n", mode);
+  return 2;
+}


### PR DESCRIPTION
### What does this PR do?

Lets another program host Bun in-process, the way other runtimes offer an embed API. Two pieces:

**A C embed API** (`packages/bun-embed/bun_embed.h`, `src/bun_bin/embed.rs`):

```c
int  bun_embed_run(int argc, const char *const *argv, const char *const *envp,
                   void (*on_exit)(int code, void *user), void *user);
void bun_embed_request_exit(int code);   // thread-safe, like process.exit(code)
const char *bun_embed_version(void);
```

`bun_embed_run` runs Bun on the calling thread with the same init sequence and CLI dispatch as `main()`, and **returns the exit code** once the script's event loop drains or it calls `process.exit()`. Under an embedding host the main VM's `Run::start` tears the runtime down and returns instead of `exit()`ing; `process.exit()` becomes a termination request (the same JSC trap a worker's exit uses) that the run loop observes. `bun_embed_request_exit` posts the same request from any thread (exit listeners run). Paths that cannot return to the caller — a subcommand with no event loop like `bun --version`, an early CLI error — report through `on_exit` and park the thread; that is documented in the header. One run per process (a second call returns -1): argv, the CLI arena/log, the main-thread VM slot and JSC's process state are all written once.

**A `libbun` shared library target** (`scripts/build/shared-lib.ts`): `bun run build --target=libbun` links `build/<profile>/libbun.dylib` from the same objects as the executable, exporting `src/symbols.txt` (minus `__mh_execute_header`) plus the three `bun_embed_*` symbols, and not `main`. It is opt-in (never a default target); the executable's link line is byte-for-byte unchanged (checked debug and release `build.ninja` against `main`). Hosts should `dlopen` it `RTLD_GLOBAL` (native addons resolve `napi_*` against the process) or link against it.

Startup still installs Bun's signal handlers, ignores SIGPIPE/SIGXFSZ, sets stdio unbuffered and restores the TTY on exit — the header says so.

### What is not in this PR

- Linux/Windows library targets: Linux would need the whole object set built PIC (`-fno-pic`/`-no-pie`/Rust `relocation-model=static` today); Windows an import-library story. macOS first.
- Re-entrancy / a second run in one process.
- `--watch`/`--hot`, `bun test`, the REPL under an embedding host: they still end through `Global::exit`, so the host gets `on_exit` and a parked thread rather than a return.
- CI does not build `libbun` yet, so `test/embed/embed.test.ts` skips when the library is absent.

### How did you verify your code works?

- `bun bd` (debug+ASAN) then `bun bd --target=libbun`; `test/embed/embed.test.ts` compiles a small C host that dlopens the library and checks: `bun -e "process.exit(3)"` returns 3 with the host still running (env from `envp` visible, exit listeners run); a drained loop returns 0 and an uncaught error 1; `bun_embed_request_exit(7)` from another thread stops a `Bun.serve` script (fetch works before, listeners see 7, the port is closed after); a second run returns -1; `bun --version` reports 0 through `on_exit`. All 5 pass locally.
- The standalone binary's exit paths (`process.exit`, drained loop, uncaught error) unchanged; `test/js/web/workers/worker.test.ts`, `test/cli/run/run-eval.test.ts`, `test/js/node/process/process.test.js`, `process-on.test.ts`, `test/js/bun/http/serve.test.ts` pass except failures that reproduce on `main` locally.
- `cargo build -p bun_bin` is warning-clean; `cargo fmt` clean.
