### PR TITLE
Clear exceptions left by failed property lookups while formatting objects

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5643,10 +5643,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5718,7 +5719,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototype) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,75 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe.concurrent("property lookup throws while formatting", () => {
+  async function run(fixture) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("skips a lazy property whose initializer throws and keeps walking", async () => {
+    // Bun.$ and Bun.sql are built lazily on first access by running JS that
+    // uses Symbol, so clobbering it makes those initializers throw. The rest
+    // of the properties must still be printed.
+    const fixture = `
+      const keys = s => s.split("\\n").filter(l => /^  [^ ]+: /.test(l)).map(l => l.slice(2, l.indexOf(":")));
+      const RealSymbol = Symbol;
+      globalThis.Symbol = NaN;
+      const broken = keys(Bun.inspect(Bun));
+      let sqlError;
+      try { Bun.sql; } catch (e) { sqlError = e; }
+      globalThis.Symbol = RealSymbol;
+      const healthy = keys(Bun.inspect(Bun));
+      console.log("dropped $:", healthy.includes("$") && !broken.includes("$"));
+      console.log("kept Archive:", broken.includes("Archive"));
+      console.log("sql getter threw:", sqlError instanceof TypeError);
+    `;
+    expect(await run(fixture)).toEqual({
+      stdout: "dropped $: true\nkept Archive: true\nsql getter threw: true\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("skips an inherited property whose Proxy get trap throws", async () => {
+    const fixture = `
+      const proto = new Proxy({ a: 1, b: 2 }, {
+        get(target, key, receiver) {
+          if (key === "a") throw new Error("get trap");
+          return Reflect.get(target, key, receiver);
+        },
+      });
+      const obj = Object.create(proto);
+      obj.own = 1;
+      console.log(Bun.inspect(obj));
+    `;
+    expect(await run(fixture)).toEqual({
+      stdout: "{\n  own: 1,\n  b: 2,\n}\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("stops walking the prototype chain when a Proxy getPrototypeOf trap throws", async () => {
+    const fixture = `
+      const proto = new Proxy({ a: 1 }, {
+        getPrototypeOf() { throw new Error("getPrototypeOf trap"); },
+      });
+      const obj = Object.create(proto);
+      obj.own = 1;
+      console.log(Bun.inspect(obj));
+    `;
+    expect(await run(fixture)).toEqual({
+      stdout: "{\n  own: 1,\n  a: 1,\n}\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -947,6 +947,10 @@ describe.concurrent("property lookup throws while formatting", () => {
     // of the properties must still be printed.
     const fixture = `
       const keys = s => s.split("\\n").filter(l => /^  [^ ]+: /.test(l)).map(l => l.slice(2, l.indexOf(":")));
+      // The formatter loads node:util the first time it runs an inspect.custom
+      // hook, and process.env has one on Windows. Load it while Symbol is intact
+      // so the walk below only hits the throwing static property initializers.
+      Bun.inspect({ [Bun.inspect.custom]() { return 1; } });
       const RealSymbol = Symbol;
       globalThis.Symbol = NaN;
       const broken = keys(Bun.inspect(Bun));


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found assertion failure in debug builds (`Unexpected exception observed ... Symbol is not a function. (In 'Symbol("cwd")' ...)`), plus a null dereference reachable from the same loop in release builds.

The fuzzer clobbered the global `Symbol` and then hit `new DecompressionStream(globalThis)`. The `ERR_INVALID_ARG_VALUE` message inspects the argument, so the formatter walks `globalThis`, then `Bun`. `Bun.$` is a static `PropertyCallback` property whose initializer runs `shell.ts`, which calls `Symbol("cwd")` and throws. WebKit already handles that case by returning "not found" from `getOwnPropertySlot` and leaving the exception pending for the caller to deal with.

The caller here is `JSC__JSValue__forEachPropertyImpl` in `bindings.cpp`. When `getPropertySlot` returned false it did `continue` without clearing the exception; the `CLEAR_IF_EXCEPTION` was only reached when the property was found. So the lookup for the next property (`Bun.Archive`) ran with the `$` exception still pending. In debug builds the Rust lazy property wrapper asserts that a returned value and a pending exception never coexist, which is the reported crash. In release builds every following static property lookup bails out on the stale exception, so `Bun.inspect(Bun)` silently drops most of the object.

Changes, all in the slow path of that loop and in the two `Bun.sql` getters:

- `bindings.cpp`: clear the exception before checking whether the property was found. This is the fix for the reported crash.
- `bindings.cpp`: when walking to the prototype, `getPrototype()` returns an empty `JSValue` if it threw (a Proxy `getPrototypeOf` trap, or a stale exception like the one above) and the old code called `.getObject()` on it unconditionally, which is a null dereference. The release build segfaults on `Bun.inspect(Object.create(new Proxy({}, { getPrototypeOf() { throw 1 } })))`. Clear and stop walking instead. This is the same crash class in the same loop, so it is fixed here rather than separately.
- `BunObject.cpp`: remove the debug-only `reportUncaughtExceptionAtEventLoop` calls from the `Bun.sql` / `Bun.SQL` lazy getters. They ran the uncaught exception path (which does `process.get("_fatalException")`) while the module load exception was still pending, which trips a `Structure::storedPrototype` assertion in debug builds as soon as `Bun.sql` fails to load (`Symbol = NaN; Bun.sql` is enough), and it is what the first fix uncovered next when walking `Bun`. The exception is propagated to the caller by the `RETURN_IF_EXCEPTION` right after it, in both debug and release, so nothing is lost.

### How did you verify your code works?

Added three tests to `test/js/bun/util/inspect.test.js` (`property lookup throws while formatting`). Each spawns a child so a crash is observed as an exit code:

- lazy property initializer throws while inspecting `Bun`: on the unfixed debug build this aborts with the exact assertion from the report; on the unfixed release build it prints `kept Archive: false` because the rest of the object is dropped.
- inherited property whose Proxy `get` trap throws: exit 139 on the unfixed release build, UBSan null member call on the unfixed debug build.
- Proxy `getPrototypeOf` trap throws: same failure modes as above.

All three pass with `bun bd test`, and the rest of `inspect.test.js` still passes. The original fuzzer script (run through indirect eval like the REPRL harness does, with `Symbol` clobbered beforehand) no longer crashes on the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->