### PR TITLE
node:http: stop writing Connection: close into a response body on destroy()

### DIFF
--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1405,15 +1405,22 @@ extern "C"
     {
       uWS::HttpResponse<true> *uwsRes = (uWS::HttpResponse<true> *)res;
       auto *data = uwsRes->getHttpResponseData();
+      /* Once write()/flushHeaders() (HTTP_WRITE_CALLED) or an earlier end
+       * (HTTP_END_CALLED) terminated the header section, header bytes written
+       * here would land inside the body (node:http res.destroy() mid-response
+       * ends up here). Setting HTTP_CONNECTION_CLOSE is what makes the close
+       * gates tear the connection down; the header itself is only advisory,
+       * same as in internalEnd(). */
+      bool headers_open = !(data->state & (uWS::HttpResponseData<true>::HTTP_WRITE_CALLED | uWS::HttpResponseData<true>::HTTP_END_CALLED));
       if (close_connection)
       {
-        if (!(data->state & uWS::HttpResponseData<true>::HTTP_CONNECTION_CLOSE))
+        if (headers_open && !(data->state & uWS::HttpResponseData<true>::HTTP_CONNECTION_CLOSE))
         {
           uwsRes->writeHeader("Connection", "close");
         }
         data->state |= uWS::HttpResponseData<true>::HTTP_CONNECTION_CLOSE;
       }
-      if (!(data->state & uWS::HttpResponseData<true>::HTTP_END_CALLED))
+      if (headers_open)
       {
         uwsRes->AsyncSocket<true>::write("\r\n", 2);
       }
@@ -1431,15 +1438,17 @@ extern "C"
     {
       uWS::HttpResponse<false> *uwsRes = (uWS::HttpResponse<false> *)res;
       auto *data = uwsRes->getHttpResponseData();
+      /* See the SSL arm above. */
+      bool headers_open = !(data->state & (uWS::HttpResponseData<false>::HTTP_WRITE_CALLED | uWS::HttpResponseData<false>::HTTP_END_CALLED));
       if (close_connection)
       {
-        if (!(data->state & uWS::HttpResponseData<false>::HTTP_CONNECTION_CLOSE))
+        if (headers_open && !(data->state & uWS::HttpResponseData<false>::HTTP_CONNECTION_CLOSE))
         {
           uwsRes->writeHeader("Connection", "close");
         }
         data->state |= uWS::HttpResponseData<false>::HTTP_CONNECTION_CLOSE;
       }
-      if (!(data->state & uWS::HttpResponseData<false>::HTTP_END_CALLED))
+      if (headers_open)
       {
         // Some HTTP clients require the complete "<header>\r\n\r\n" to be sent.
         // If not, they may throw a ConnectionError.

--- a/test/js/node/http/node-http-transfer-encoding.test.ts
+++ b/test/js/node/http/node-http-transfer-encoding.test.ts
@@ -1,7 +1,10 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { once } from "events";
+import { bunEnv, bunExe, tls as tlsCert } from "harness";
 import { createServer, request } from "http";
+import { createServer as createHttpsServer } from "https";
 import { AddressInfo, connect, Server } from "net";
+import { connect as tlsConnect } from "tls";
 
 const fixture = "node-http-transfer-encoding-fixture.ts";
 test(`should not duplicate transfer-encoding header in request`, async () => {
@@ -578,4 +581,168 @@ test("pipelined chunked request keeps its own trailers when the next one is pars
   const trailers = await done.promise;
   socket.destroy();
   expect(trailers).toEqual({ "x-a": "a" });
+});
+
+// Once the header section is on the wire, tearing a response down (res.destroy(),
+// req.destroy(), a handler throwing) must not write anything else: the header
+// terminator is gone, so header bytes would land inside the body. Node writes
+// nothing and closes the socket; these tests pin the bytes received after the
+// header section to exactly what the handler wrote before the teardown.
+describe("tearing down a response with its headers on the wire adds no bytes", () => {
+  // Sends one raw request, waits until `marker` (the part of the response the
+  // handler wrote) has arrived so the handler's teardown runs with those bytes
+  // already flushed, then returns what arrived after the header section once
+  // the server closed the connection.
+  async function bodyAfterTeardown({
+    handler,
+    marker,
+    request = "GET / HTTP/1.1\r\nHost: x\r\n\r\n",
+    https = false,
+  }: {
+    handler: (req: any, res: any, markerArrived: Promise<void>) => void;
+    marker: string;
+    request?: string;
+    https?: boolean;
+  }) {
+    const markerArrived = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<void>();
+    const listener = (req: any, res: any) => handler(req, res, markerArrived.promise);
+    await using server = https ? createHttpsServer(tlsCert, listener) : createServer(listener);
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const socket = https
+      ? tlsConnect({ port, host: "127.0.0.1", rejectUnauthorized: false }, () => socket.write(request))
+      : connect(port, "127.0.0.1", () => socket.write(request));
+    let raw = "";
+    socket.on("data", (chunk: Buffer) => {
+      raw += chunk.toString("latin1");
+      if (raw.includes(marker)) markerArrived.resolve();
+    });
+    // The teardown may surface as ECONNRESET; what matters is what arrived before 'close'.
+    socket.on("error", () => {});
+    socket.on("close", closed.resolve);
+    await closed.promise;
+
+    const headerEnd = raw.indexOf("\r\n\r\n");
+    expect(raw.slice(0, headerEnd)).toStartWith("HTTP/1.1 200 OK\r\n");
+    return raw.slice(headerEnd + 4);
+  }
+
+  test.concurrent("res.destroy() after res.write() on a chunked response", async () => {
+    const body = await bodyAfterTeardown({
+      marker: "hello",
+      handler(req, res, markerArrived) {
+        res.writeHead(200, { "content-type": "text/event-stream" });
+        res.write("hello");
+        markerArrived.then(() => res.destroy());
+      },
+    });
+    expect(body).toBe("5\r\nhello\r\n");
+  });
+
+  test.concurrent("res.destroy() after res.flushHeaders() on a chunked response", async () => {
+    const body = await bodyAfterTeardown({
+      marker: "\r\n\r\n",
+      handler(req, res, markerArrived) {
+        res.writeHead(200);
+        res.flushHeaders();
+        markerArrived.then(() => res.destroy());
+      },
+    });
+    expect(body).toBe("");
+  });
+
+  test.concurrent("res.destroy() after res.write() on a Content-Length response", async () => {
+    const body = await bodyAfterTeardown({
+      marker: "hello",
+      handler(req, res, markerArrived) {
+        res.writeHead(200, { "content-length": "10" });
+        res.write("hello");
+        markerArrived.then(() => res.destroy());
+      },
+    });
+    expect(body).toBe("hello");
+  });
+
+  test.concurrent("res.destroy() after res.write() on an HTTP/1.0 (close-delimited) response", async () => {
+    const body = await bodyAfterTeardown({
+      marker: "hello",
+      request: "GET / HTTP/1.0\r\nHost: x\r\n\r\n",
+      handler(req, res, markerArrived) {
+        res.writeHead(200);
+        res.write("hello");
+        markerArrived.then(() => res.destroy());
+      },
+    });
+    expect(body).toBe("hello");
+  });
+
+  test.concurrent("req.destroy() after res.write() on a chunked response", async () => {
+    const body = await bodyAfterTeardown({
+      marker: "hello",
+      handler(req, res, markerArrived) {
+        res.writeHead(200);
+        res.write("hello");
+        markerArrived.then(() => req.destroy());
+      },
+    });
+    expect(body).toBe("5\r\nhello\r\n");
+  });
+
+  test.concurrent("res.destroy() after res.write() on a chunked https response", async () => {
+    const body = await bodyAfterTeardown({
+      https: true,
+      marker: "hello",
+      handler(req, res, markerArrived) {
+        res.writeHead(200);
+        res.write("hello");
+        markerArrived.then(() => res.destroy());
+      },
+    });
+    expect(body).toBe("5\r\nhello\r\n");
+  });
+
+  // A synchronous throw out of the request listener is ended natively by the
+  // server dispatch rather than by res.destroy(); same rule applies. Runs in a
+  // child because the throw reaches uncaughtException.
+  test.concurrent("request listener throwing after res.write() on a chunked response", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { createServer } = require("node:http");
+        const { connect } = require("node:net");
+        process.on("uncaughtException", err => {
+          if (err.message !== "boom") throw err;
+        });
+        const server = createServer((req, res) => {
+          res.writeHead(200);
+          res.write("hello");
+          throw new Error("boom");
+        });
+        server.listen(0, "127.0.0.1", () => {
+          const socket = connect(server.address().port, "127.0.0.1", () => {
+            socket.write("GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+          });
+          let raw = "";
+          socket.on("data", chunk => (raw += chunk.toString("latin1")));
+          socket.on("error", () => {});
+          socket.on("close", () => {
+            console.log(JSON.stringify(raw.slice(raw.indexOf("\\r\\n\\r\\n") + 4)));
+            server.close();
+          });
+        });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toBe("5\r\nhello\r\n");
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem

- In a `node:http` server, `res.destroy()` after the response headers (and usually part of the body) are on the wire makes Bun write `Connection: close\r\n\r\n` to the socket before closing it. For a chunked response the client receives `9\r\ndata: x\n\n\r\nConnection: close\r\n\r\n`; Node sends nothing on destroy and just closes (`9\r\ndata: x\n\n\r\n`). Reproduces on 1.4.0 and on main.
- Same bytes land in a `Content-Length` body (`helloConnection: close\r\n\r\n`), after `res.flushHeaders()`, and a stray `\r\n` lands in an HTTP/1.0 close-delimited body. `req.destroy()` and a request listener that throws after `res.write()` take the same native path and corrupt the body the same way.
- Cause: `uws_res_end_without_body` (`src/uws_sys/libuwsockets.cpp`) wrote the `Connection: close` header gated only on `HTTP_CONNECTION_CLOSE`, and the header-terminating `\r\n` gated only on `HTTP_END_CALLED`. Neither check notices `HTTP_WRITE_CALLED`, i.e. that `write()`/`flushHeaders()` already terminated the header section, so the bytes go out as body data. `NodeHTTPResponse::abort` (reached from `ServerResponse#destroy` and `IncomingMessage#_destroy`) and the server's throwing-handler path (`src/runtime/server/mod.rs`) both end the response through this function.
- Clients that do not simply drop the connection mis-parse it: a chunked decoder reads `C` as the size of a next chunk, which is how the extra `data` event in `test-http-server-capture-rejections.js` and an extra `"\r\n"` chunk from Bun's own `fetch()` come about.

### Fix

- `uws_res_end_without_body` now only writes the `Connection: close` header and the terminating `\r\n` while the header section is still open (neither `HTTP_WRITE_CALLED` nor `HTTP_END_CALLED` set). It still sets `HTTP_CONNECTION_CLOSE` and `HTTP_END_CALLED` and marks the response done, so the connection is torn down exactly as before; only the bytes that could not be valid at that point are gone.
- Correct because every place that sets `HTTP_WRITE_CALLED` or `HTTP_END_CALLED` has already written the header terminator, so once either bit is set there is no position in the message where a header field or a second terminator can legally go. This is the rule `internalEnd()` already applies to its own `Connection: close` and `Content-Length` writes (the `Content-Length` half landed in #38701; an earlier attempt at this half, #32036, was closed when that one merged).
- Closing the connection is driven by the `HTTP_CONNECTION_CLOSE` bit, not by the header reaching the peer, so responses that reach this function with the header section still open (`HEAD`, 304, bodiless `node:http` ends) are unchanged. A chunked body torn down this way stays unterminated on purpose: an aborted response must not look complete to the client, which is also what Node's `destroy()` produces.
- Callers audited: every `end_without_body` site in `src/runtime/server` (HEAD/304 rendering, `render_production_error`, the static/file/directory/HTML routes) reaches it with the header section open. The ones that can reach it after body bytes are all teardowns (`node:http` abort, the throwing-handler path, the mid-stream 413 in `RequestContext`) plus `FileResponseStream::finish`, which wants a real end and gets one in #37082; for all of them the bytes removed here were never valid framing.
- Verified:
  - `test/js/node/http/node-http-transfer-encoding.test.ts`, new `describe` block: `res.destroy()` after `write()` on chunked, `Content-Length`, HTTP/1.0 and https responses, after `flushHeaders()`, `req.destroy()` after `write()`, and a request listener throwing after `write()`. All 7 fail on the unfixed build (`+ Connection: close`, `+ "helloConnection: close`) and pass with the fix; the same bytes are what Node 26 produces.
  - The reporter's repro prints `"9\r\ndata: x\n\n\r\n"`, byte-identical to Node.
  - `test-http-server-capture-rejections.js` 5/5, `node-http.test.ts`, `node-http-backpressure.test.ts`, `node-http-pinned-write.test.ts`, `serve.test.ts`, `bun-server.test.ts`, `hspec.test.ts`, `bun-serve-static/file/html-405`, `serve-directory-routes`, `serve-close-delimited-framing`, `serve-direct-readable-stream`, `http-server-chunking`: no new failures (the 8 failures in this container fail identically without the change: IPv6, root, proxy to `localhost`).

### Background

- uWS tracks each HTTP/1 response in a state bitfield (`HttpResponseData.h`). `HTTP_WRITE_CALLED`: `write()`/`flushHeaders()` terminated the header section and body bytes (chunked, raw or none yet) follow. `HTTP_END_CALLED`: an end path that writes its own terminator (`Content-Length` end, sendfile, this function) ran. `HTTP_CONNECTION_CLOSE`: the connection must be shut down once the response is complete and flushed; the close gates (`closeIfDoneAndMarked`, the cork wrapper, the parser's post-parse check) act on this bit.
- `uws_res_end_without_body` is the C shim Bun's Rust server code uses to finish a response without sending a body: `HEAD`/304 replies, and `node:http`'s abort path, which ends the native response and then closes the socket from JS. The `Connection: close` it writes is purely informational for the peer; the close itself comes from the bit.
- Not changed here: `res.destroy()` before anything reached the wire still emits a bare `HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n` (Node sends nothing). That is a different state (header section still open) and a different fix, in `NodeHTTPResponse::abort`; tracked separately.
