### PR TITLE
Fix crash when a property lookup throws while formatting an object

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5643,10 +5643,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5718,7 +5719,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from "getPrototypeOf" proxy traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototype)
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -937,7 +937,7 @@ describe("property lookup throws while formatting", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { stdout, exitCode };
   }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,62 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("property lookup throws while formatting", () => {
+  async function run(fixture) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    return { stdout, exitCode };
+  }
+
+  it.concurrent("get trap on a prototype Proxy throws", async () => {
+    const { stdout, exitCode } = await run(`
+      const proto = new Proxy(
+        { a: 1, b: 2 },
+        {
+          get(target, key) {
+            if (key === "a" || key === "b") throw new Error("boom");
+            return Reflect.get(target, key);
+          },
+        },
+      );
+      console.log(Bun.inspect(Object.create(proto)));
+    `);
+    expect(stdout).toBe("{}\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("getPrototypeOf trap on a prototype Proxy throws", async () => {
+    const { stdout, exitCode } = await run(`
+      const proto = new Proxy(
+        { a: 1 },
+        {
+          getPrototypeOf() {
+            throw new Error("boom");
+          },
+        },
+      );
+      console.log(Bun.inspect(Object.create(proto)));
+    `);
+    expect(stdout).toBe("{\n  a: 1,\n}\n");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("lazy property initializer throws", async () => {
+    // Bun.$ is the first lazy property on the Bun object and its initializer
+    // calls Symbol(), so it throws here. The properties after it must still be
+    // printed.
+    const { stdout, exitCode } = await run(`
+      globalThis.Symbol = {};
+      const text = Bun.inspect(Bun);
+      console.log(text.includes("Archive:"), text.includes("inspect:"));
+    `);
+    expect(stdout).toBe("true true\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -977,8 +977,11 @@ describe("property lookup throws while formatting", () => {
   it.concurrent("lazy property initializer throws", async () => {
     // Bun.$ is the first lazy property on the Bun object and its initializer
     // calls Symbol(), so it throws here. The properties after it must still be
-    // printed.
+    // printed. node:util is loaded up front because formatting a value with a
+    // custom inspect function (Bun.env on Windows) needs util.inspect, which
+    // can no longer be loaded once Symbol is gone.
     const { stdout, exitCode } = await run(`
+      require("node:util");
       globalThis.Symbol = {};
       const text = Bun.inspect(Bun);
       console.log(text.includes("Archive:"), text.includes("inspect:"));


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in the object formatter used by `Bun.inspect` / `console.log` when looking up a property throws.

`JSC__JSValue__forEachPropertyImpl` (bindings.cpp) walks the property names it collected and calls `getPropertySlot` for each one. When that lookup throws (a Proxy `get` trap in the prototype chain, or a lazy property on a static table whose initializer throws), `getPropertySlot` returns `false` with the exception still pending, and the loop hit `continue` before reaching the `CLEAR_IF_EXCEPTION` on the next line. The next property was then looked up with a stale exception on the VM:

- In debug builds the next lazy property getter (`Bun.Archive` in the fuzzer case, right after `Bun.$` whose initializer fails) trips `to_js_host_call`'s "no exception" assertion, since it returned a value while an exception was pending. This is the Fuzzilli crash.
- In release builds JSC's static table reification sees the stale exception and reports every following property as missing, so `Bun.inspect(Bun)` silently drops most of the object.

The fix is to clear the exception before checking the return value, which is what `JSC__JSValue__forEachPropertyOrdered` already does a few lines further down.

The end of the same loop did `iterating->getPrototype(globalObject).getObject()`. A Proxy in the chain whose `getPrototypeOf` trap throws returns an empty `JSValue` there, and `getObject()` on the empty value reads through a null cell pointer. This segfaults a release build today (`Segmentation fault at address 0x5`):

```js
const proto = new Proxy({ a: 1 }, { getPrototypeOf() { throw new Error("boom"); } });
console.log(Object.create(proto));
```

The stale-exception variant of the `get` trap case reaches the same line and segfaults the same way, so both hunks are needed for the Proxy repros. The walk now clears the exception and stops at that point, like the fast path already does for prototype traps.

With the loop fixed, the original repro (`globalThis.Symbol = {}; Bun.inspect(Bun)`) got further and hit a second assertion: `defaultBunSQLObject` / `constructBunSQLObject` had a debug-only block that called `reportUncaughtExceptionAtEventLoop` while the exception from loading the `sql` module was still pending. That runs `process._fatalException` lookups and listeners on top of a pending exception, which trips `Structure::storedPrototype` inside `getPropertySlot` in debug builds. The block is removed; the error is already thrown to whoever accesses `Bun.sql`, and no other lazy `Bun.*` property reports its load failure this way.

Two related things this PR does not change, both being handled separately: the same `getPrototype(...).getObject()` pattern in `napi_get_all_property_names` (needs a native addon to reach), and the `m_utilInspectFunction` lazy initializer in ZigGlobalObject.cpp, which returns without setting anything when `node:util` fails to load, so `LazyProperty` aborts (`RELEASE_ASSERT`) the first time a value with a custom inspect function is formatted. The first CI run hit that second one on Windows, where `Bun.env` has a custom inspect function: with the walk fixed, `Bun.inspect(Bun)` now reaches `Bun.env`, and `node:util` can no longer be loaded once `Symbol` is gone. It reproduces on main on every platform with `const c = Symbol.for("nodejs.util.inspect.custom"); globalThis.Symbol = {}; Bun.inspect({ [c]() { return "x"; } })`.

### How did you verify your code works?

Three new tests in `test/js/bun/util/inspect.test.js` ("property lookup throws while formatting"). Each spawns a child so a crash shows up as a failed assertion rather than taking the runner down:

- `get` trap on a prototype Proxy throws: unfixed build segfaults (empty stdout), fixed build prints `{}`.
- `getPrototypeOf` trap on a prototype Proxy throws: unfixed build segfaults, fixed build prints `a: 1` and stops walking the chain there.
- lazy property initializer throws (`globalThis.Symbol = {}` then `Bun.inspect(Bun)`): unfixed release build prints `false true` because `Archive` is dropped, unfixed debug build asserts, fixed build prints `true true`. The fixture loads `node:util` before clobbering `Symbol` so it stays clear of the unrelated util.inspect abort described above; it still prints `false true` on the unfixed build with that line in place (checked on Linux and Windows).

All three fail with `USE_SYSTEM_BUN=1 bun test` and pass with `bun bd test`, on Linux and on a Windows x64 debug build. The fuzzer script, the minimized repros above, and the existing inspect / console / util.inspect tests pass on the debug build, also with `BUN_JSC_validateExceptionChecks=1`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->
