### PR TITLE
URL: WebKit parser follow-ups + reuse input string for href, cache the last base URL

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "0cbb4a194653231955187f9d8a2990d4b4a55266";
+export const WEBKIT_VERSION = "c6cfe90c6064bd80a1916b844c2f092735cfc720";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
### What does this PR do?

**WebKit bump → `c6cfe90c6064`** (oven-sh/WebKit#454): table-lookup (`pshufb`/`tbl`) SIMD classification in the URL scanners; `host:port` and dotted-quad IPv4 hosts stay on the parser's fast path. (oven-sh/WebKit#463 — SIMD scan for percent-encoded/Unicode hosts — is up separately and can be folded in once merged.)

**Bun-side, things a standalone URL library can't do:**
- `new URL(s).href` / `toString()` / `toJSON()`: when nothing needed rewriting, WebKit's parser result *is* the input `StringImpl`, so return the constructor's own `JSString` instead of allocating another; the last `JSString` produced for `href` is cached on the wrapper either way (also makes `new URL(rel, urlObject)` cheaper, since the base is stringified through it).
- `new URL(input, base)` / `URL.parse` / `URL.canParse` with a string base re-parsed and re-validated the base every call; it is nearly always the same string (configured origin, request URL), so the last valid base is remembered per thread.
- `hasValidParsedHost`'s "does the host contain `xn--`" check ran a generic substring search on every URL; look for `--` instead.
- `bench/snippets/url-kinds.mjs`: `new URL()` / `canParse` / `parse` over realistic URL shapes.

Same-machine, both non-LTO, ns per call (previous = the #452-era build):

| | previous | this PR |
|---|---|---|
| `new URL("http://localhost:3000/api/users/42")` | 191 | **123** |
| `new URL("http://192.168.1.10:8080/metrics")` | 244 | **135** |
| `new URL("http://[2001:db8::…]:8080/status")` | 429 | **289** |
| `new URL(longCdnPath)` / 2 KB query | 169 / 340 | **127 / 225** |
| `new URL("../assets/logo.svg", pageUrlString)` | 401 | **263** |
| `new URL("?page=3", listUrlString)` | 327 | **229** |
| `new URL("../assets/logo.svg", urlObject)` | 562 | **371** |
| `new URL(u).href` / `.toString()` | 185 / 184 | **147 / 147** |
| `URL.canParse(pathQueryHash)` | 116 | **87** |
| IDN host | 1256 | **1078** |

### How did you verify your code works?

`test/js/web/url` (new cases for repeated/alternating/invalid string bases incl. error `.input`/`.base`, and href/toString/toJSON consistency across mutation), `test/js/node/url`, node `test-whatwg-url-*` / `test-url-*` pass on a release build against WebKit `c6cfe90c` + #463.