### PR TITLE
test: make websocket-server.test.ts fast on debug builds (echo fixture without ws, smaller send() benchmark)

### DIFF
--- a/test/js/bun/websocket/websocket-client-echo.mjs
+++ b/test/js/bun/websocket/websocket-client-echo.mjs
@@ -1,6 +1,6 @@
-// Echoes every message, ping and pong back to the server. This deliberately uses the built-in
-// WebSocket and not "ws": requiring "ws" loads node:http, which on a debug build makes each of
-// the ~90 clients websocket-server.test.ts spawns take ~2s to start instead of ~0.3s.
+// Echoes every message, ping and pong back to the server. websocket-server.test.ts spawns ~90 of
+// these per run, so start-up has to stay minimal: it deliberately uses the built-in WebSocket and
+// no module on top of it ("ws" and the modules it pulls in cost ~1.6s per client on a debug build).
 let url;
 try {
   url = new URL(process.argv[2]);

--- a/test/js/bun/websocket/websocket-client-echo.mjs
+++ b/test/js/bun/websocket/websocket-client-echo.mjs
@@ -1,5 +1,6 @@
-import { WebSocket } from "ws";
-
+// Echoes every message, ping and pong back to the server. This deliberately uses the built-in
+// WebSocket and not "ws": requiring "ws" loads node:http, which on a debug build makes each of
+// the ~90 clients websocket-server.test.ts spawns take ~2s to start instead of ~0.3s.
 let url;
 try {
   url = new URL(process.argv[2]);
@@ -10,67 +11,37 @@ try {
 const ws = new WebSocket(url, {
   perMessageDeflate: false,
 });
+ws.binaryType = "nodebuffer";
 
-ws.on("open", () => {
+ws.addEventListener("open", () => {
   if (process.send) {
     process.send("connected");
   }
-  console.log(`[${process.versions.bun ? "bun" : "node"}]`, "Connected", ws.url); // read by test script
-  console.error(`[${process.versions.bun ? "bun" : "node"}]`, "Connected", ws.url);
 });
+
 const logMessages = process.env.LOG_MESSAGES === "1";
-ws.on("message", (data, isBinary) => {
+ws.addEventListener("message", ({ data }) => {
   if (logMessages) {
-    if (isBinary) {
-      console.error("Received binary message:", data);
-    } else {
-      console.error("Received text message:", data);
-      data = data.toString();
-    }
+    console.error(typeof data === "string" ? "Received text message:" : "Received binary message:", data);
   }
-  ws.send(data, { binary: !!isBinary });
-
-  if (data === "ping") {
-    console.error("Sending ping");
-    ws.ping();
-  } else if (data === "pong") {
-    console.error("Sending pong");
-    ws.pong();
-  } else if (data === "close") {
-    console.error("Sending close");
-    ws.close();
-  } else if (data === "terminate") {
-    console.error("Sending terminate");
-    ws.terminate();
-  }
+  // data is a string for text frames and a Buffer for binary frames, so send() echoes the same frame type.
+  ws.send(data);
 });
 
-ws.on("ping", data => {
+ws.addEventListener("ping", ({ data }) => {
   console.error("Received ping:", data);
   ws.ping(data);
 });
 
-ws.on("pong", data => {
+ws.addEventListener("pong", ({ data }) => {
   console.error("Received pong:", data);
   ws.pong(data);
 });
 
-ws.on("error", error => {
-  console.error("Received error:", error);
+ws.addEventListener("error", ({ error, message }) => {
+  console.error("Received error:", error ?? message);
 });
 
-ws.on("close", (code, reason, wasClean) => {
-  if (wasClean === true) {
-    console.error("Received abrupt close:", code, reason);
-  } else {
-    console.error("Received close:", code, reason);
-  }
-});
-
-ws.on("redirect", url => {
-  console.error("Received redirect:", url);
-});
-
-ws.on("unexpected-response", (_, response) => {
-  console.error("Received unexpected response:", response.statusCode, { ...response.headers });
+ws.addEventListener("close", ({ code, reason, wasClean }) => {
+  console.error(wasClean ? "Received close:" : "Received abrupt close:", code, reason);
 });

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -756,16 +756,13 @@ describe("ServerWebSocket", () => {
     test(
       "(benchmark)",
       (done, connect) => {
-        // On debug/ASAN builds each echo client takes ~2s to start and every round trip is
-        // ~50x slower than release: 10 clients x 10_000 messages runs right up to the 30s timeout.
-        const maxClients = isDebug || isASAN ? 4 : 10;
+        const maxClients = 10;
+        // A round trip takes ~75us on a debug+ASAN build (vs <1us on release), so 10_000 runs for ~25s there.
         const maxMessages = isDebug || isASAN ? 1_000 : 10_000;
         let count = 0;
         return {
           open(ws) {
-            // test() spawned the first client; each client spawns the next one until maxClients
-            // are connected. Spawning them all at once would trip the pid limit of small containers:
-            // this file's concurrent tests already keep ~20 echo clients (14 threads each) alive.
+            // test() spawned the first client; each client spawns the next until maxClients are connected.
             if (ws.data.id < maxClients - 1) {
               connect();
             }

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1,7 +1,7 @@
 import type { Server, ServerWebSocket, Subprocess, WebSocketHandler } from "bun";
 import { serve, spawn } from "bun";
 import { afterEach, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, forceGuardMalloc, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, forceGuardMalloc, isASAN, isDebug, isWindows, tempDir } from "harness";
 import net, { isIP } from "node:net";
 import path from "node:path";
 
@@ -756,12 +756,17 @@ describe("ServerWebSocket", () => {
     test(
       "(benchmark)",
       (done, connect) => {
-        const maxClients = 10;
-        const maxMessages = 10_000;
+        // On debug/ASAN builds each echo client takes ~2s to start and every round trip is
+        // ~50x slower than release: 10 clients x 10_000 messages runs right up to the 30s timeout.
+        const maxClients = isDebug || isASAN ? 4 : 10;
+        const maxMessages = isDebug || isASAN ? 1_000 : 10_000;
         let count = 0;
         return {
           open(ws) {
-            if (ws.data.id < maxClients) {
+            // test() spawned the first client; each client spawns the next one until maxClients
+            // are connected. Spawning them all at once would trip the pid limit of small containers:
+            // this file's concurrent tests already keep ~20 echo clients (14 threads each) alive.
+            if (ws.data.id < maxClients - 1) {
               connect();
             }
             for (let i = 0; i < maxMessages; i++) {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -354,6 +354,64 @@ it("isBinary", async () => {
   await promise;
 });
 
+// send(data, { binary }) overrides the frame type that would otherwise be picked from the type of data.
+describe("send() with { binary }", () => {
+  const sends = [
+    { data: Buffer.from("sent as text"), opts: { binary: false } },
+    { data: "sent as binary", opts: { binary: true } },
+  ] as const;
+  const expected = [
+    { data: Buffer.from("sent as text"), isBinary: false },
+    { data: Buffer.from("sent as binary"), isBinary: true },
+  ];
+
+  function receiveAll(ws: WebSocket) {
+    const { promise, resolve, reject } = Promise.withResolvers<{ data: unknown; isBinary: boolean }[]>();
+    const received: { data: unknown; isBinary: boolean }[] = [];
+    ws.on("message", (data, isBinary) => {
+      received.push({ data, isBinary });
+      if (received.length === sends.length) resolve(received);
+    });
+    ws.on("error", reject);
+    return promise;
+  }
+
+  async function connectPair() {
+    const wss = new WebSocketServer({ port: 0 });
+    const connection = once(wss, "connection");
+    const client = new WebSocket("ws://localhost:" + wss.address().port);
+    clients.push(client);
+    const opened = once(client, "open");
+    const [serverSide] = (await connection) as [WebSocket];
+    await opened;
+    return { wss, client, serverSide };
+  }
+
+  it("from the client", async () => {
+    const { wss, client, serverSide } = await connectPair();
+    try {
+      const received = receiveAll(serverSide);
+      for (const { data, opts } of sends) client.send(data, opts);
+      expect(await received).toEqual(expected);
+    } finally {
+      serverSide.terminate();
+      wss.close();
+    }
+  });
+
+  it("from the server", async () => {
+    const { wss, client, serverSide } = await connectPair();
+    try {
+      const received = receiveAll(client);
+      for (const { data, opts } of sends) serverSide.send(data, opts);
+      expect(await received).toEqual(expected);
+    } finally {
+      serverSide.terminate();
+      wss.close();
+    }
+  });
+});
+
 it("onmessage", done => {
   const wss = new WebSocketServer({ port: 0 });
   wss.on("connection", ws => {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -373,42 +373,33 @@ describe("send() with { binary }", () => {
       if (received.length === sends.length) resolve(received);
     });
     ws.on("error", reject);
+    ws.on("close", () => reject(new Error(`closed after ${received.length} of ${sends.length} messages`)));
     return promise;
   }
 
-  async function connectPair() {
+  // Connects a client to a new server, sends `sends` from one side and returns what the other side received.
+  async function exchange(from: "client" | "server") {
     const wss = new WebSocketServer({ port: 0 });
-    const connection = once(wss, "connection");
-    const client = new WebSocket("ws://localhost:" + wss.address().port);
-    clients.push(client);
-    const opened = once(client, "open");
-    const [serverSide] = (await connection) as [WebSocket];
-    await opened;
-    return { wss, client, serverSide };
+    try {
+      const connection = once(wss, "connection");
+      const client = new WebSocket("ws://localhost:" + wss.address().port);
+      clients.push(client);
+      const [[serverSide]] = (await Promise.all([connection, once(client, "open")])) as [[WebSocket], unknown[]];
+      const [sender, receiver] = from === "client" ? [client, serverSide] : [serverSide, client];
+      const received = receiveAll(receiver);
+      for (const { data, opts } of sends) sender.send(data, opts);
+      return await received;
+    } finally {
+      wss.close();
+    }
   }
 
   it("from the client", async () => {
-    const { wss, client, serverSide } = await connectPair();
-    try {
-      const received = receiveAll(serverSide);
-      for (const { data, opts } of sends) client.send(data, opts);
-      expect(await received).toEqual(expected);
-    } finally {
-      serverSide.terminate();
-      wss.close();
-    }
+    expect(await exchange("client")).toEqual(expected);
   });
 
   it("from the server", async () => {
-    const { wss, client, serverSide } = await connectPair();
-    try {
-      const received = receiveAll(client);
-      for (const { data, opts } of sends) serverSide.send(data, opts);
-      expect(await received).toEqual(expected);
-    } finally {
-      serverSide.terminate();
-      wss.close();
-    }
+    expect(await exchange("server")).toEqual(expected);
   });
 });
 


### PR DESCRIPTION
### Problem
- `test/js/bun/websocket/websocket-server.test.ts` > `ServerWebSocket > send() > (benchmark)` fails with `this test timed out after 30000ms` on debug+ASAN builds: 29.7s to 30.6s in isolation (2 of 3 runs failed), 30.0s to 30.2s inside the file, 31.4s in the report that prompted this when the file ran batched with other files. The whole file takes ~59s there.
- Two costs add up to that, and both were sized for release builds (where the test takes ~0.5s):
  - Every test in the file spawns `websocket-client-echo.mjs`, which imported `ws`. The `ws` shim loads `node:http` at module scope (`src/js/thirdparty/ws.js:12`), so on a debug build each client takes ~1.9s to connect (`bun-debug -e "require('ws')"`: 1.87s, `-e 1`: 0.26s). The benchmark spawns its 10 clients one after another, so its spawn chain alone is ~19.5s regardless of message count; the file spawns ~90 such clients in total.
  - The benchmark then does 300k round trips, which cost ~75us each on debug+ASAN (vs <1us on release): ~25s of server CPU on top of the chain.

### Fix
- `websocket-client-echo.mjs` now uses the built-in `WebSocket` instead of `ws`. The shim is itself a wrapper over the built-in client, so the fixture keeps the same behaviour: `perMessageDeflate: false` on the handshake, `binaryType = "nodebuffer"` so a text frame echoes as text and a binary frame as binary, ping and pong frames reflected with their payload (the `ping()`/`pong()` tests check those payloads byte for byte), and the IPC `connected` message `connect()` waits for. A client now connects in ~0.3s on a debug build and has 11 threads instead of 14. It stays a separate process: only the transport inside the fixture changes, so the ~100 tests built on it keep a peer that reads on its own event loop (the `drain`/`backpressureLimit` tests depend on that) and the same kill-based teardown.
- Removed from the fixture because they did nothing in any test run: the `"ping"`/`"pong"`/`"close"`/`"terminate"` message commands (under the `ws` shim message data was a `Buffer`, so the string comparisons never matched, and no test sends those strings), the `redirect`/`unexpected-response` listeners (`ws`-only; `redirect` just printed a "not implemented" warning per client) and the two "Connected" log lines (the stdout one claimed to be read by the test, but `connect()` uses IPC and inherits stdio). `LOG_MESSAGES=1` still logs every message.
- The fixture's `ws.send(data, { binary: !!isBinary })` was the only place in the suite that exercised the `{ binary }` option of the `ws` shim's `send()` (`normalizeData` in `src/js/thirdparty/ws.js`): under the shim every text frame it echoed went through the Buffer + `binary: false` branch, and the tests expecting a string back checked it. That coverage now lives in `test/js/first_party/ws/ws.test.ts` as two explicit cases (`Buffer` + `binary: false` -> text frame, string + `binary: true` -> binary frame), sent from the client and from the server-side connection object; both fail if `normalizeData` stops reading the option (checked by temporarily making it ignore `opts`).
- The benchmark keeps 10 clients on every build and uses `isDebug || isASAN ? 1_000 : 10_000` messages. Release coverage is unchanged; with the fast fixture 10 x 10,000 still takes ~25.6s on debug+ASAN and 10 x 1,000 takes ~3.4s, so the message count is the one knob that still needs to be build-dependent. Nothing is lost at 1,000: the burst never engages backpressure at either size (`ws.getBufferedAmount()` is 0 right after the loop at 1,000 and at 10,000), so the test is a "many frames, all of them arrive" check in both configurations; the backpressure behaviour has its own tests.
- The benchmark spawns exactly `maxClients` clients instead of `maxClients + 1` (`ws.data.id < maxClients - 1`), so `done()` now requires every frame sent to be echoed back; before, the extra client's echoes padded the count (300k of 330k), which would have hidden a dropped frame.
- The clients are still spawned one after another on purpose. The file's concurrent tests keep ~35 echo clients alive at a time (20 concurrent tests plus kill/reap lag), which on a 512 pid cgroup is ~450 to 500 pids in release on main and on this branch alike (0 limit hits in every run). Spawning the benchmark's 9 extra clients at once on top of that failed 5 to 14 unrelated `publish()` tests per run in such a container (`posix_spawn` `EAGAIN` from their `connect()`), as did a binary fan-out, so that variant was dropped. The explicit 30s timeout is left as it was.
- Verified with `bun bd test test/js/bun/websocket/websocket-server.test.ts` (debug+ASAN): 115 pass / 3 todo in 3 of 3 full-file runs, benchmark 3.46s to 3.58s, file 13.5s (was ~59s, with the benchmark failing).
- `USE_SYSTEM_BUN=1 bun test test/js/bun/websocket/websocket-server.test.ts` (release build of the same main commit): 115 pass in 4 of 4 runs, benchmark ~0.3s (was ~0.53s, the spawn chain is faster too), file ~0.55s (was ~0.8s); `bun test test/js/bun/websocket` 137 pass. The fixture's only consumer is `connect()` in this file.
- `bun bd test test/js/first_party/ws/ws.test.ts`: 49 pass (47 before); same with the release build.
- The eager `node:http` load in the shim itself is a separate, product-side cost (~27ms of the ~28ms a release `require("ws")` takes); tracked in #39434 rather than changed here.

### Background
- `websocket-client-echo.mjs` is the client fixture behind every `test(...)` in this file: a separate bun process that connects to the test's server, echoes every message back and reports `connected` over IPC. The `test()` helper at the bottom of the file spawns one per test and hands the handler a `connect()` function to spawn more; the benchmark and the two-client `publish()` tests use it.
- Bun's `ws` module is a built-in shim (`src/js/thirdparty/ws.js`) that wraps the global `WebSocket` in the `ws` event-emitter API; the global client already provides `ping()`, `pong()`, `terminate()`, `binaryType = "nodebuffer"`, `ping`/`pong` events and the `perMessageDeflate` constructor option the fixture needs. The shim's own tests live in `test/js/first_party/ws/`, which is where the `{ binary }` cases above were added.
- `isDebug` / `isASAN` from `test/harness.ts` are the usual way sizes are branched on build type in this repo (for example `test/js/bun/http/serve-body-leak.test.ts`). `isASAN` is also true on the release ASAN CI lane, which is the slowest lane running this file (6.4s for the file per `test/expected-durations.json`, vs 1.7s on the default lane); the benchmark exercises the same path at either size, so it is included.
- A cgroup `pids.max` limit counts threads, not processes, which is why ~35 concurrently alive bun processes come close to a 512 limit and why the spawn pattern of this one test mattered.

<details>
<summary>Measurements (linux-x64, 12 CPU container; debug+ASAN `bun bd` build and release build of the same commit)</summary>

Benchmark test duration:

| variant | debug+ASAN | release |
|---|---|---|
| main (ws fixture, 10 x 10,000, serial spawn) | 29.7s / 30.0s (timeout) / 30.6s (timeout) isolated; 30.0s / 30.2s (timeout) in file | 0.51s to 0.54s |
| ws fixture, 10 x 1,000 | 19.4s, 19.5s | n/a |
| ws fixture, 10 x 500 | 19.0s | n/a |
| ws fixture, 10 x 10,000, all clients spawned at once | 27.2s | 0.23s, but 5 to 14 other tests fail per run (pid limit) |
| ws fixture, 10 x 1,000, binary fan-out | 8.7s | 8 to 13 other tests fail per run (pid limit) |
| ws fixture, 4 x 1,000, serial (first revision of this PR) | 8.3s to 8.5s | 0.57s to 0.61s |
| built-in fixture, 10 x 10,000, serial | 25.5s, 25.7s | 0.28s to 0.33s (this PR's release configuration) |
| built-in fixture, 10 x 2,500, serial | 6.5s | n/a |
| built-in fixture, 10 x 1,000, serial (this PR's debug/ASAN configuration) | 3.35s to 3.40s isolated, 3.46s to 3.58s in file | n/a |

Whole file (`Ran 118 tests`): debug+ASAN 59.4s to 59.7s on main -> 13.5s here; release ~0.8s -> ~0.55s.

Per-client start-up on the debug build, measured from spawn to the server's `open()`: ~1.9s with `ws`, 296ms with the built-in client. Module load cost behind it (`bun-debug -e "require(...)"`): `-e 1` 0.26s, `node:events` 0.43s, `node:net` 0.82s, `node:http` 1.76s, `ws` 1.87s. Threads per client process (`/proc/<pid>/task`): 14 -> 11 release, 15 -> 13 debug.

cgroup `pids.events` "max" delta per full-file release run: 0 on main (7 runs) and on this branch (10 runs across both revisions); 8 to 28 for the spawn-at-once and fan-out variants (7 runs). Peak echo clients alive at once during a release run, sampled every 3ms: 33 to 34 on main, 34 to 40 here; `pids.current` peaks at ~440 to 500 in both.

Backpressure check: a standalone script sending the benchmark's burst to one echo client and reading `ws.getBufferedAmount()` right after the loop reports 0 bytes for 250, 500, 1,000, 2,500 and 10,000 messages on both builds.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->