### PR TITLE
bake: give each DevServer module its own renamer scope

### DIFF
--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -11,7 +11,8 @@ use crate::bun_renamer as renamer;
 use crate::bun_renamer::{ChunkRenamer, MinifyRenamer, NumberRenamer, StableSymbolCount};
 use crate::chunk::Content;
 use crate::js_meta;
-use crate::{Chunk, LinkerContext, StableRef, WrapKind};
+use crate::options::Format;
+use crate::{Chunk, Index, LinkerContext, StableRef, WrapKind};
 
 /// TODO: investigate if we need to parallelize this function
 /// esbuild does parallelize it.
@@ -279,11 +280,40 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
     }
 
     let mut sorted: Vec<u32> = Vec::new();
+    let is_dev_server = c.options.output_format == Format::InternalBakeDev;
 
     for &source_index in files_in_order {
         let wrap = all_flags[source_index as usize].wrap;
         // Need `&mut [Part]` for `add_top_level_declared_symbols`.
         let parts: &mut [Part] = all_parts[source_index as usize].as_mut_slice();
+
+        // DevServer gives every module its own closure, so its top level is not the chunk's.
+        if is_dev_server && !Index::source(source_index).is_runtime() {
+            let module_scope = &all_module_scopes[source_index as usize];
+            let file_scope = r.push_scope_under_root(module_scope.members.count());
+            let parts_live = &c.graph.parts_live[source_index as usize];
+            for (part_index, part) in parts.iter_mut().enumerate() {
+                if !parts_live.is_set(part_index) {
+                    continue;
+                }
+
+                // SAFETY: `file_scope` is live until the `put_scope` below.
+                unsafe { r.add_declared_symbols_to_scope(file_scope, &mut part.declared_symbols) };
+                for scope in part.scopes.iter() {
+                    // SAFETY: each `*mut Scope` is a valid arena-allocated scope.
+                    r.assign_names_recursive_with_number_scope(
+                        file_scope,
+                        unsafe { &**scope },
+                        source_index,
+                        &mut sorted,
+                    );
+                }
+            }
+            // SAFETY: `file_scope` came from `push_scope_under_root` above and
+            // every scope opened under it is already back in the pool.
+            unsafe { r.put_scope(file_scope) };
+            continue;
+        }
 
         match wrap {
             // Modules wrapped in a CommonJS closure look like this:

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -721,6 +721,43 @@ impl NumberRenamer {
         });
     }
 
+    /// Open a scope under [`Self::root`] for symbols that print inside a wrapper
+    /// function instead of at the chunk's top level. Pair with [`Self::put_scope`].
+    pub fn push_scope_under_root(&mut self, capacity: usize) -> *mut NumberScope {
+        let root: *mut NumberScope = &raw mut self.root;
+        self.number_scope_pool
+            .get_init(NumberScope {
+                // SAFETY: `root` points at a field of `self`, so it is non-null
+                // and outlives every scope handed out here.
+                parent: Some(unsafe { bun_ptr::ParentRef::from_raw_mut(root) }),
+                name_counts: NameCountMap::with_capacity_and_hasher(capacity, Default::default()),
+            })
+            .as_ptr()
+    }
+
+    /// # Safety
+    /// `scope` must come from [`Self::push_scope_under_root`], every scope
+    /// opened under it must already be back in the pool, and `scope` must not
+    /// be used afterwards.
+    pub unsafe fn put_scope(&mut self, scope: *mut NumberScope) {
+        // SAFETY: guaranteed by this function's safety contract.
+        unsafe { self.number_scope_pool.put(scope) };
+    }
+
+    /// # Safety
+    /// `scope` must be a live scope from [`Self::push_scope_under_root`].
+    pub unsafe fn add_declared_symbols_to_scope(
+        &mut self,
+        scope: *mut NumberScope,
+        declared_symbols: &mut js_ast::DeclaredSymbolList,
+    ) {
+        js_ast::DeclaredSymbol::for_each_top_level_symbol(declared_symbols, self, |r, ref_| {
+            // SAFETY: `scope` is live for the whole call (fn safety doc), and
+            // `assign_name` does not reach it through `r`.
+            r.assign_name(unsafe { &mut *scope }, ref_)
+        });
+    }
+
     pub fn name_for_symbol(&self, ref_: Ref) -> &[u8] {
         if ref_.is_source_contents_slice() {
             unreachable!("Unexpected unbound symbol!\n{}", ref_);

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -50,6 +50,23 @@ devTest("symbol collision with import identifier", {
     await dev.fetch("/").equals("Hello, 456, 987!");
   },
 });
+devTest("same top-level name in two modules keeps Function.prototype.name (#18017)", {
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": `
+      import { App as Other } from "./other";
+      export function App() {}
+      console.log(App.name + " " + Other.name);
+    `,
+    "other.ts": `
+      export function App() {}
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("App App");
+  },
+});
 devTest('uses "development" condition', {
   framework: minimalFramework,
   files: {

--- a/test/bake/dev/server-sourcemap.test.ts
+++ b/test/bake/dev/server-sourcemap.test.ts
@@ -140,7 +140,7 @@ function helperFunction() {
     const cleanLines = lines.replace(/\x1b\[[0-9;]*m/g, "");
 
     const hasUtilsThrowLine = cleanLines.includes("helperFunction") && cleanLines.includes("5:1");
-    const hasUtilsCallLine = cleanLines.includes("doSomething2") && cleanLines.includes("1:28");
+    const hasUtilsCallLine = cleanLines.includes("doSomething") && cleanLines.includes("1:31");
     const hasPageCallLine = cleanLines.includes("NestedPage") && cleanLines.includes("3:38");
 
     expect(hasUtilsThrowLine).toBe(true);
@@ -194,8 +194,8 @@ devTest("server-side source maps stay correct across repeated reloads", {
       const cleanLines = dev.output.lines.join("\n").replace(/\x1b\[[0-9;]*m/g, "");
       // The throwing function is declared on line 6 + i of round i's version
       // of the source file; frames remap to the declaration position (see the
-      // `helperFunction`/`5:1` expectation above). `\w*` tolerates bundler
-      // symbol renaming (see `doSomething2` above).
+      // `helperFunction`/`5:1` expectation above). `\w*` tolerates any numeric
+      // suffix the bundler's renamer adds.
       expect(cleanLines).toMatch(new RegExp(`at churn${name}\\w* \\(.*pages[/\\\\]churn\\.tsx:${6 + i}:1\\)`));
     }
   },


### PR DESCRIPTION
### What does this PR do?

Fixes #18017. In DevServer, two modules that both declare a top-level `App` ended up with the second one renamed to `App2`, so `App.name` came back as `"App2"`. The same thing happens to `module`, which is why the screenshot on the issue shows a numbered `module`.

DevServer prints every module inside its own closure - `generateCodeForFileInChunkJS.rs:72-174` wraps each file in `(hmr, module, exports) => { ... }` - but `rename_symbols_in_chunk` still pushed every file's top-level symbols into the single chunk-level `NumberScope` through `add_top_level_declared_symbols`. Two files declaring the same name therefore collided at the chunk root, even though neither name is actually at the chunk's top level.

For `Format::InternalBakeDev`, each file now gets its own `NumberScope` parented to the chunk root. Its live parts' top-level symbols and their nested scopes are numbered inside it. Nothing can collide with a name already taken at the chunk root, because `NumberScope` lookup walks the parent chain.

The branch predicate is deliberately the same one the codegen uses (`is_dev_server && !source_index.is_runtime()`). The runtime file stays on the chunk-root path because it prints unwrapped, and it is only in the chunk at all under `bun build --format=internal_bake_dev`. Everything else is untouched: the new code sits behind `output_format == Format::InternalBakeDev`, so production bundling runs exactly the path it ran before.

Two things worth a second look in review:

- The file scope is seeded from `part.declared_symbols`, not from the module scope the way `WrapKind::Cjs` does it. React Fast Refresh temp refs (`var _s = $RefreshSig$()`) are registered on the enclosing *function* scope but print at the file's top level, and `part.declared_symbols` is the only thing that carries them to the renamer. Seeding from the module scope instead drops them and two components in one file both end up as `_s`. `test/bake/dev/react-spa.test.ts` catches that.
- The three new methods on `NumberRenamer` exist because `NumberScope::{parent, name_counts}` and `assign_name` are `pub(crate)` to `bun_js_printer`, so the bundler cannot build a child scope or write into one itself.

One existing test needed updating. `test/bake/dev/server-sourcemap.test.ts` asserted the buggy name, `doSomething2`, and the column that went with it. It now asserts `doSomething`. The frame still resolves to the same file and the same line, only the column moves, 28 to 31, because the identifier is a character shorter so the frame's generated column lands in the neighbouring mapping segment. In `export function doSomething() {`, 28 is the `(` and 31 is the `{`.

This is the `// TODO: instead of running a renamer per chunk, run it per file` at `generateChunksInParallel.rs:61` that the issue points at, scoped to DevServer only.

### How did you verify your code works?

Debug build (`bun bd`) on Linux x64 throughout. Steps 3 and 5 ran with the branch rebased onto `c3995e43d5`; steps 2 and 4 ran two commits earlier at `8326d1bd39`, and the two commits in between are a WebKit bump and a CI allowlist revert that touch neither the bundler nor `test/bake`.

**1. Reproduced it first on the released bun.** Two files that each export `function App`:

```js
// a.js
import { App as Other } from "./other";
export function App() {}
console.log(App.name, Other.name);

// other.js
export function App() {}
```

```console
$ bun --version
1.3.14
$ bun build --format=internal_bake_dev a.js | grep -E 'function App|hmr, module'
  ], [], (hmr, module, exports) => {
    function App() {}
  ], [], (hmr, module2, exports) => {
    function App2() {}
```

Same command on this branch:

```console
$ bun bd build --format=internal_bake_dev a.js | grep -E 'function App|hmr, module'
  ], [], (hmr, module, exports) => {
    function App() {}
  ], [], (hmr, module, exports) => {
    function App() {}
```

**2. The new test fails without the fix.** It runs those two modules through a real DevServer client and asserts `App.name + " " + Other.name === "App App"`. With the test applied but `src/` reverted to main:

```console
$ bun bd test test/bake/dev/bundle.test.ts
  [
-   "App App",
+   "App App2",
  ]
(fail)  DEV:bundle-3: same top-level name in two modules keeps Function.prototype.name (#18017)
 21 pass
 1 fail
```

**3. Targeted runs with the fix applied.**

```console
$ bun bd test test/bake/dev/bundle.test.ts test/bake/dev/server-sourcemap.test.ts \
      test/bake/dev/react-spa.test.ts test/bundler/bundler_loader.test.ts
 91 pass
 0 fail
Ran 91 tests across 4 files. [252.92s]
```

`bundler_loader.test.ts` is in there for its `internal_bake_dev lazy exports` block, and `react-spa.test.ts` for React Fast Refresh. Both are 0 fail on main too (58 pass and 6 pass respectively).

**4. Full `test/bake/` suite, main vs this branch.**

```
main         180 pass, 10 fail, 190 tests
this branch  181 pass, 10 fail, 191 tests
```

The two failure sets are identical, name for name. All 10 are `production > ...` in `dev-and-prod.test.ts`, and every one of them is the 5000 ms default test timeout on a debug build on this machine, not an assertion.

**5. Lints.**

```console
$ cargo fmt --all --check      # clean
$ bun run lint                 # 0 warnings, 0 errors
$ bun test test/internal/source-lints/    # 170 pass, 0 fail
$ prettier --check test/bake/dev/bundle.test.ts test/bake/dev/server-sourcemap.test.ts   # clean
$ bun run rust:clippy          # 0 warnings, 0 errors
```
