### PR TITLE
bun-plugin-svelte: stop deriving `preserveWhitespace` from the bundler's minify flag

### DIFF
--- a/packages/bun-plugin-svelte/src/options.spec.ts
+++ b/packages/bun-plugin-svelte/src/options.spec.ts
@@ -13,10 +13,17 @@ describe("getBaseCompileOptions", () => {
       fullDefault = Object.freeze(getBaseCompileOptions(pluginOptions, {}));
     });
 
-    it("when minification is disabled, comments are preserved", () => {
-      expect(getBaseCompileOptions(pluginOptions, { minify: false })).toEqual(
+    it.each([
+      [undefined, true],
+      [false, true],
+      [true, false],
+      // any explicit minify object is truthy, so it counts as minifying
+      [{ whitespace: true }, false],
+      [{ whitespace: false }, false],
+    ] as [BuildConfig["minify"], boolean][])("preserveComments follows minify (%o -> %p)", (minify, expected) => {
+      expect(getBaseCompileOptions(pluginOptions, { minify })).toEqual(
         expect.objectContaining({
-          preserveComments: true,
+          preserveComments: expected,
         }),
       );
     });
@@ -75,6 +82,17 @@ describe("getBaseCompileOptions", () => {
     it("preserveWhitespace overrides the minify-derived default", () => {
       expect(getBaseCompileOptions({ compilerOptions: { preserveWhitespace: true } }, { minify: true })).toEqual(
         expect.objectContaining({ preserveWhitespace: true }),
+      );
+    });
+
+    it.each([
+      [true, true],
+      [false, true],
+      [true, false],
+      [false, false],
+    ])("preserveComments: %p overrides the minify-derived default (minify: %p)", (preserveComments, minify) => {
+      expect(getBaseCompileOptions({ compilerOptions: { preserveComments } }, { minify })).toEqual(
+        expect.objectContaining({ preserveComments }),
       );
     });
   }); // compilerOptions

--- a/packages/bun-plugin-svelte/src/options.spec.ts
+++ b/packages/bun-plugin-svelte/src/options.spec.ts
@@ -13,11 +13,28 @@ describe("getBaseCompileOptions", () => {
       fullDefault = Object.freeze(getBaseCompileOptions(pluginOptions, {}));
     });
 
-    it("when minification is disabled, whitespace and comments are preserved", () => {
+    it("when minification is disabled, comments are preserved", () => {
       expect(getBaseCompileOptions(pluginOptions, { minify: false })).toEqual(
         expect.objectContaining({
-          preserveWhitespace: true,
           preserveComments: true,
+        }),
+      );
+    });
+
+    // `preserveWhitespace` is a semantic compiler option, not a formatting one: it changes
+    // which nodes a component receives. It must not follow the bundler's minify flag.
+    it.each([
+      undefined,
+      false,
+      true,
+      { whitespace: false },
+      { whitespace: true },
+      { syntax: true },
+      { identifiers: true },
+    ] as BuildConfig["minify"][])("preserveWhitespace does not follow minify (%o)", minify => {
+      expect(getBaseCompileOptions(pluginOptions, { minify })).toEqual(
+        expect.objectContaining({
+          preserveWhitespace: false,
         }),
       );
     });
@@ -42,6 +59,26 @@ describe("getBaseCompileOptions", () => {
       );
     },
   );
+  describe("compilerOptions", () => {
+    it.each([true, false])("forwards preserveWhitespace: %p", preserveWhitespace => {
+      expect(getBaseCompileOptions({ compilerOptions: { preserveWhitespace } }, {})).toEqual(
+        expect.objectContaining({ preserveWhitespace }),
+      );
+    });
+
+    it.each([true, false])("forwards preserveComments: %p", preserveComments => {
+      expect(getBaseCompileOptions({ compilerOptions: { preserveComments } }, {})).toEqual(
+        expect.objectContaining({ preserveComments }),
+      );
+    });
+
+    it("preserveWhitespace overrides the minify-derived default", () => {
+      expect(getBaseCompileOptions({ compilerOptions: { preserveWhitespace: true } }, { minify: true })).toEqual(
+        expect.objectContaining({ preserveWhitespace: true }),
+      );
+    });
+  }); // compilerOptions
+
 }); // getBaseCompileOptions
 
 describe("validateOptions(options)", () => {

--- a/packages/bun-plugin-svelte/src/options.ts
+++ b/packages/bun-plugin-svelte/src/options.ts
@@ -2,7 +2,10 @@ import { type BuildConfig } from "bun";
 import { strict as assert } from "node:assert";
 import type { CompileOptions, ModuleCompileOptions } from "svelte/compiler";
 
-type OverrideCompileOptions = Pick<CompileOptions, "customElement" | "runes" | "modernAst" | "namespace">;
+type OverrideCompileOptions = Pick<
+  CompileOptions,
+  "customElement" | "runes" | "modernAst" | "namespace" | "preserveWhitespace" | "preserveComments"
+>;
 export interface SvelteOptions extends Pick<CompileOptions, "runes"> {
   /**
    * Force client-side or server-side generation.
@@ -24,6 +27,9 @@ export interface SvelteOptions extends Pick<CompileOptions, "runes"> {
 
   /**
    * Options to forward to the Svelte compiler.
+   *
+   * `preserveWhitespace` and `preserveComments` default to Svelte's own defaults
+   * (`false`, and `false` when minifying) and can be overridden here.
    */
   compilerOptions?: OverrideCompileOptions;
 }
@@ -61,30 +67,28 @@ export function validateOptions(options: unknown): asserts options is SvelteOpti
 export function getBaseCompileOptions(pluginOptions: SvelteOptions, config: Partial<BuildConfig>): CompileOptions {
   let {
     development = false,
-    compilerOptions: { customElement, runes, modernAst, namespace } = kEmptyObject as OverrideCompileOptions,
+    compilerOptions: {
+      customElement,
+      runes,
+      modernAst,
+      namespace,
+      preserveWhitespace,
+      preserveComments,
+    } = kEmptyObject as OverrideCompileOptions,
   } = pluginOptions;
   const { minify = false } = config;
 
   const shouldMinify = Boolean(minify);
-  const {
-    whitespace: minifyWhitespace,
-    syntax: _minifySyntax,
-    identifiers: _minifyIdentifiers,
-  } = typeof minify === "object"
-    ? minify
-    : {
-        whitespace: shouldMinify,
-        syntax: shouldMinify,
-        identifiers: shouldMinify,
-      };
 
   const generate = generateSide(pluginOptions, config);
 
   return {
     css: "external",
     generate,
-    preserveWhitespace: !minifyWhitespace,
-    preserveComments: !shouldMinify,
+    // `preserveWhitespace` is semantic, not cosmetic: it changes which nodes a component
+    // receives. Deliberately not derived from the bundler's `minify.whitespace`.
+    preserveWhitespace: preserveWhitespace ?? false,
+    preserveComments: preserveComments ?? !shouldMinify,
     dev: development,
     customElement,
     runes,

--- a/packages/bun-plugin-svelte/src/options.ts
+++ b/packages/bun-plugin-svelte/src/options.ts
@@ -28,8 +28,9 @@ export interface SvelteOptions extends Pick<CompileOptions, "runes"> {
   /**
    * Options to forward to the Svelte compiler.
    *
-   * `preserveWhitespace` and `preserveComments` default to Svelte's own defaults
-   * (`false`, and `false` when minifying) and can be overridden here.
+   * `preserveWhitespace` follows Svelte's own default (`false`). `preserveComments`
+   * defaults to `true`, or `false` when the bundler is minifying. Both can be
+   * overridden here.
    */
   compilerOptions?: OverrideCompileOptions;
 }

--- a/packages/bun-plugin-svelte/test/__snapshots__/index.test.ts.snap
+++ b/packages/bun-plugin-svelte/test/__snapshots__/index.test.ts.snap
@@ -2,73 +2,25 @@
 
 exports[`Bun.plugin using { forceSide: 'server' } allows for imported components to be SSR'd: foo.svelte - head 1`] = `""`;
 
-exports[`Bun.plugin using { forceSide: 'server' } allows for imported components to be SSR'd: foo.svelte - body 1`] = `
-"<!--[--><!---->
-
-<main class="app svelte-30r5b3lexyb64">
-  <h1 class="svelte-30r5b3lexyb64">Hello World!</h1>
-</main>
-
-<!--]-->"
-`;
+exports[`Bun.plugin using { forceSide: 'server' } allows for imported components to be SSR'd: foo.svelte - body 1`] = `"<!--[--><main class="app svelte-30r5b3lexyb64"><h1 class="svelte-30r5b3lexyb64">Hello World!</h1></main><!--]-->"`;
 
 exports[`Bun.plugin Generates server-side code: foo.svelte - head 1`] = `""`;
 
-exports[`Bun.plugin Generates server-side code: foo.svelte - body 1`] = `
-"<!--[--><!---->
-
-<main class="app svelte-30r5b3lexyb64">
-  <h1 class="svelte-30r5b3lexyb64">Hello World!</h1>
-</main>
-
-<!--]-->"
-`;
+exports[`Bun.plugin Generates server-side code: foo.svelte - body 1`] = `"<!--[--><main class="app svelte-30r5b3lexyb64"><h1 class="svelte-30r5b3lexyb64">Hello World!</h1></main><!--]-->"`;
 
 exports[`Bun.build Generates server-side code when targeting "node" or "bun": foo.svelte - server-side (node) 1`] = `
 {
-  "body": 
-"<!--[--><!---->
-
-<main class="app svelte-30r5b3lexyb64">
-  <h1 class="svelte-30r5b3lexyb64">Hello World!</h1>
-</main>
-
-<!--]-->"
-,
+  "body": "<!--[--><main class="app svelte-30r5b3lexyb64"><h1 class="svelte-30r5b3lexyb64">Hello World!</h1></main><!--]-->",
   "head": "",
-  "html": 
-"<!--[--><!---->
-
-<main class="app svelte-30r5b3lexyb64">
-  <h1 class="svelte-30r5b3lexyb64">Hello World!</h1>
-</main>
-
-<!--]-->"
-,
+  "html": "<!--[--><main class="app svelte-30r5b3lexyb64"><h1 class="svelte-30r5b3lexyb64">Hello World!</h1></main><!--]-->",
 }
 `;
 
 exports[`Bun.build Generates server-side code when targeting "node" or "bun": foo.svelte - server-side (bun) 1`] = `
 {
-  "body": 
-"<!--[--><!---->
-
-<main class="app svelte-30r5b3lexyb64">
-  <h1 class="svelte-30r5b3lexyb64">Hello World!</h1>
-</main>
-
-<!--]-->"
-,
+  "body": "<!--[--><main class="app svelte-30r5b3lexyb64"><h1 class="svelte-30r5b3lexyb64">Hello World!</h1></main><!--]-->",
   "head": "",
-  "html": 
-"<!--[--><!---->
-
-<main class="app svelte-30r5b3lexyb64">
-  <h1 class="svelte-30r5b3lexyb64">Hello World!</h1>
-</main>
-
-<!--]-->"
-,
+  "html": "<!--[--><main class="app svelte-30r5b3lexyb64"><h1 class="svelte-30r5b3lexyb64">Hello World!</h1></main><!--]-->",
 }
 `;
 


### PR DESCRIPTION
Fixes #39378.

### What

`getBaseCompileOptions` derived the Svelte **compiler** option `preserveWhitespace` from the **bundler's** minify flag. The fixing line is in `src/options.ts`:

```diff
-    preserveWhitespace: !minifyWhitespace,
+    preserveWhitespace: preserveWhitespace ?? false,
```

Everything else in the diff follows from that: the `minify` destructuring becomes dead (`whitespace`, `syntax`, `identifiers` were all unused afterwards), `preserveWhitespace`/`preserveComments` are added to the forwardable `compilerOptions`, and three SSR snapshots change.

### Why

`preserveWhitespace` is semantic, not cosmetic — it changes which nodes a component receives, not just how the output is formatted. A minifier flag shouldn't decide it.

Concretely, it splits dev from prod. Bun's dev server hands plugins a stub bundler config and never sets `minify` — the existing FIXME in `src/index.ts`:

```ts
// FIXME: the dev server does not currently respect bundler configs; it
// just passes a fake one to plugins and then never uses it.
```

So under `bun --hot`, `minify` is unset → `minifyWhitespace` is `false` → `preserveWhitespace: true`. A production `Bun.build` with `minify: true` gets `preserveWhitespace: false`. Same source, two different compilations, and the dev-only one is the unusual setting — Svelte's own default is `false`.

Only `whitespace` mattered, which is what makes it clearly wrong: `minify: { syntax: true }` and `minify: { identifiers: true }` — the flags that could plausibly affect semantics — leave `preserveWhitespace` alone, while the purely cosmetic one flips it.

There was also no way to opt out. `compilerOptions` forwarded only `customElement | runes | modernAst | namespace`, so overriding `preserveWhitespace` meant wrapping or forking the plugin. Both it and `preserveComments` are forwardable now.

`preserveComments` keeps deriving its default from `minify` — that one genuinely is cosmetic — but can now be overridden too.

### How this was found

A `bits-ui` `Popover` rendered nothing under `bun --hot` while working in production builds. That turned out to be a Svelte codegen bug that `preserveWhitespace: true` exposes — under it, whitespace around a `{#snippet}` inside a component tag is serialized as implicit default-slot content, emitting a duplicate `children` key that clobbers an explicit `{#snippet children}`. That half is filed upstream (sveltejs/svelte#18659, PR sveltejs/svelte#18658) and is not this PR's concern; it reproduces under esbuild with no Bun involved.

This PR is the Bun-side half, and stands on its own regardless of what upstream does: nothing in the user's build asked for `preserveWhitespace: true`, and the dev/prod split is this plugin's doing.

Worth noting separately: Bun's bundler emits no duplicate-key warning on the generated code, where esbuild reports `▲ [WARNING] Duplicate key "children" in object literal`. That's why this produced no signal at all under Bun. Not addressed here.

### Testing

`bun test` in `packages/bun-plugin-svelte` — **55 pass, 0 fail**.

`src/options.spec.ts` gains:

- `preserveWhitespace does not follow minify` — parameterised over `undefined`, `false`, `true`, `{ whitespace: false }`, `{ whitespace: true }`, `{ syntax: true }`, `{ identifiers: true }`
- `preserveComments follows minify` — the default matrix, including that any explicit minify *object* is truthy and so counts as minifying (pre-existing behaviour, now pinned)
- `compilerOptions` passthrough for both `preserveWhitespace` and `preserveComments`
- both `preserveWhitespace` and `preserveComments` overriding the minify-derived default

**10 of the 33 tests in that file fail with `src/options.ts` reverted to main** (verified by doing exactly that and re-running).

The existing `when minification is disabled, whitespace and comments are preserved` asserted the old behaviour. It is replaced by the parameterised `preserveComments follows minify` matrix above, which covers its case and more.

The second commit is review follow-up: the suite originally asserted `preserveComments` only for `minify: false`, so a regression that always preserved comments passed it — verified by injecting `preserveComments ?? true`, which passed all 25 tests at the time. It now fails 3. That commit also corrects a JSDoc line of mine that wrongly attributed this plugin'"'"'s `preserveComments` default to Svelte'"'"'s (Svelte defaults it to `false`; this plugin defaults it to `true` unless minifying).

### Snapshots

Three SSR snapshots in `test/__snapshots__/index.test.ts.snap` change:

```diff
-"<!--[--><!---->
-
-<main class="app svelte-30r5b3lexyb64">
-  <h1 class="svelte-30r5b3lexyb64">Hello World!</h1>
-</main>
-
-<!--]-->"
+"<!--[--><main class="app svelte-30r5b3lexyb64"><h1 class="svelte-30r5b3lexyb64">Hello World!</h1></main><!--]-->"
```

This is the intended effect — it's what a production (minified) build already produced before this change.

I updated these by hand rather than with `--update-snapshots`, because that also prunes four obsolete entries belonging to a test that is commented out at `test/index.test.ts:143` and reorders two others. Neither is related to this change, so I left them alone. Worth a separate cleanup if you want it.

### Notes

Per CLAUDE.md I did not use `bun bd test` here: `packages/bun-plugin-svelte` is a standalone TypeScript package whose tests exercise its own source rather than the compiled runtime, so a debug build has nothing to contribute — same reasoning as the documented `bun-types` exception. Tests were run with released Bun 1.3.14, and `tsc --noEmit -p tsconfig.json` is clean.

