### PR TITLE
Fix `bun init`, `bun info`, `bun upgrade` and `bun pm trust` when runtime flags or BUN_OPTIONS precede the subcommand

### DIFF
--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -503,6 +503,13 @@ pub use bun_install::PRETEND_TO_BE_NODE;
 /// This is set `true` during `Command.which()` if argv0 is "bunx"
 static IS_BUNX_EXE: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
 
+/// argv index of the subcommand keyword as located by `Command::which()`.
+/// `bun init …` → 1; `bun --smol init …` → 2, as does `bun init …` with
+/// `BUN_OPTIONS=--smol`, whose tokens are spliced in after argv[0]. Commands
+/// that read their arguments straight out of argv start after this index.
+static SUBCOMMAND_ARGV_INDEX: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(1);
+
 bun_core::declare_scope!(CLI, hidden);
 
 pub(crate) type LoaderColonList =
@@ -797,6 +804,12 @@ pub mod command {
         (0..a.len()).map(|i| a.get(i).unwrap()).collect()
     }
 
+    /// See [`SUBCOMMAND_ARGV_INDEX`](super::SUBCOMMAND_ARGV_INDEX).
+    #[inline]
+    pub(crate) fn subcommand_argv_index() -> usize {
+        super::SUBCOMMAND_ARGV_INDEX.load(core::sync::atomic::Ordering::Relaxed)
+    }
+
     pub use bun_options_types::command_tag::Tag;
     pub use bun_options_types::command_tag::{LOADS_CONFIG, USES_GLOBAL_OPTIONS};
     pub use bun_options_types::context::{Context, ContextData, HotReload, TestOptions};
@@ -942,6 +955,7 @@ pub mod command {
             return Tag::RunAsNodeCommand;
         }
 
+        let mut idx: usize = 1;
         let Some(mut first_arg_name) = iter.next() else {
             return Tag::AutoCommand;
         };
@@ -953,10 +967,14 @@ pub mod command {
             // routes to RunCommand::exec_node_repl. An early ReplCommand return here would bypass
             // that and boot the legacy `bun repl` implementation instead.
             match iter.next() {
-                Some(n) => first_arg_name = n,
+                Some(n) => {
+                    idx += 1;
+                    first_arg_name = n;
+                }
                 None => return Tag::AutoCommand,
             }
         }
+        SUBCOMMAND_ARGV_INDEX.store(idx, core::sync::atomic::Ordering::Relaxed);
 
         type RootCommandMatcher = strings::ExactSizeMatcher<12>;
         let x = RootCommandMatcher::r#match(first_arg_name);
@@ -1504,7 +1522,8 @@ pub mod command {
     fn exec_init() -> CmdResult {
         // InitCommand parses its own argv (no Context).
         let argv = argv_zslice();
-        super::init_command::InitCommand::exec(&argv[2.min(argv.len())..])
+        let start = (subcommand_argv_index() + 1).min(argv.len());
+        super::init_command::InitCommand::exec(&argv[start..])
     }
 
     #[cold]
@@ -1936,29 +1955,15 @@ To create a project with the official Next.js scaffolding tool, run\n\
         // Parse arguments manually since the standard flow doesn't work for standalone commands
         let cli = CommandLineArguments::parse(PmSubcommand::Info)?;
         let json_output = cli.json_output;
+        // `positionals[0]` is the `info` keyword itself.
+        let positionals = match cli.positionals {
+            [b"info", rest @ ..] => rest,
+            rest => rest,
+        };
+        let package_name: &[u8] = positionals.first().copied().unwrap_or(b"");
+        let property_path: Option<&[u8]> = positionals.get(1).copied();
         let ctx = init(Tag::InfoCommand, log)?;
         let (pm, _) = PackageManager::init(ctx, cli, Subcommand::Info)?;
-
-        // Handle arguments correctly for standalone info command
-        let mut package_name: &[u8] = b"";
-        let mut property_path: Option<&[u8]> = None;
-
-        // Find non-flag arguments starting from argv[2] (after "bun info").
-        let mut found_package = false;
-        let argv = bun::argv();
-        for arg in argv.iter().skip(2) {
-            // Skip flags
-            if !arg.is_empty() && arg[0] == b'-' {
-                continue;
-            }
-            if !found_package {
-                package_name = arg;
-                found_package = true;
-            } else {
-                property_path = Some(arg);
-                break;
-            }
-        }
 
         super::pm_view_command::view(pm, package_name, property_path, json_output)
     }

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -249,7 +249,14 @@ impl TrustCommand {
         );
         Output::flush();
 
-        if args.len() == 2 {
+        // `get_subcommand` left `positionals[0]` as the `trust` keyword; flags
+        // never reach the positionals, so the rest are the package names.
+        let positionals: &[&[u8]] = pm.options.positionals;
+        let packages_to_trust: &[&[u8]] = &positionals[1.min(positionals.len())..];
+        let trust_all =
+            strings::left_has_any_in_right(args, &[b"-a".as_slice(), b"--all".as_slice()]);
+
+        if !trust_all && packages_to_trust.is_empty() {
             Self::error_expected_args();
         }
 
@@ -271,19 +278,6 @@ impl TrustCommand {
             for meta in slice.items_meta_mut() {
                 meta.set_has_install_script(false);
             }
-        }
-
-        let mut packages_to_trust: Vec<&[u8]> = Vec::with_capacity(args[2..].len());
-        for arg in &args[2..] {
-            if !arg.is_empty() && arg[0] != b'-' {
-                packages_to_trust.push(arg);
-            }
-        }
-        let trust_all =
-            strings::left_has_any_in_right(args, &[b"-a".as_slice(), b"--all".as_slice()]);
-
-        if !trust_all && packages_to_trust.is_empty() {
-            Self::error_expected_args();
         }
 
         // SAFETY: `pm_raw` is the singleton; `pm.log` set at init, non-null.
@@ -324,7 +318,7 @@ impl TrustCommand {
         }
 
         if untrusted_dep_ids.count() == 0 {
-            Self::print_error_zero_untrusted_dependencies_found(trust_all, &packages_to_trust);
+            Self::print_error_zero_untrusted_dependencies_found(trust_all, packages_to_trust);
             Global::crash();
         }
 
@@ -397,7 +391,7 @@ impl TrustCommand {
                             break 'brk false;
                         }
 
-                        for package_name_from_cli in &packages_to_trust {
+                        for package_name_from_cli in packages_to_trust {
                             if strings::eql_long(package_name_from_cli, alias, true)
                                 && !lockfile.has_trusted_dependency(
                                     alias,
@@ -435,7 +429,7 @@ impl TrustCommand {
         }
 
         if scripts_at_depth.count() == 0 || package_names_to_add.count() == 0 {
-            Self::print_error_zero_untrusted_dependencies_found(trust_all, &packages_to_trust);
+            Self::print_error_zero_untrusted_dependencies_found(trust_all, packages_to_trust);
             Global::crash();
         }
 

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -509,13 +509,14 @@ impl UpgradeCommand {
     #[cold]
     pub(crate) fn exec(ctx: Command::Context) -> crate::Result<()> {
         let args = bun_core::argv();
-        if args.len() > 2 {
-            for arg in args.iter().skip(2) {
+        let start = Command::subcommand_argv_index() + 1;
+        if args.len() > start {
+            for arg in args.iter().skip(start) {
                 if !strings::contains(arg, b"--") {
                     bun_core::pretty_error!(
                         "<r><red>error<r><d>:<r> This command updates Bun itself, and does not take package names.\n<blue>note<r><d>:<r> Use `bun update"
                     );
-                    for arg_err in args.iter().skip(2) {
+                    for arg_err in args.iter().skip(start) {
                         bun_core::pretty_error!(" {}", bstr::BStr::new(arg_err));
                     }
                     bun_core::pretty_errorln!("` instead.");

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -63,6 +63,32 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
   }, 30_000);
 
+  // A runtime flag ahead of the subcommand, typed (`bun --smol init`) or
+  // spliced into argv by BUN_OPTIONS, moves "init" out of argv[1]. init used to
+  // take its arguments from a fixed offset, so the shifted "init" keyword became
+  // the target folder and the project landed in ./init/ (#20347, #39377).
+  test.each([
+    ["BUN_OPTIONS", [], { BUN_OPTIONS: "--smol" }],
+    ["a flag typed before the subcommand", ["--smol"], {}],
+  ])(
+    "bun init initializes the cwd with %s",
+    async (_, flagsBeforeSubcommand, extraEnv) => {
+      await using temp = tempDir("bun-init-shifted-argv", {});
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), ...flagsBeforeSubcommand, "init", "-y"],
+        cwd: temp,
+        stdio: ["ignore", "ignore", "ignore"],
+        env: { ...initEnv, ...extraEnv },
+      });
+
+      expect(await proc.exited).toBe(0);
+      expect(fs.existsSync(path.join(temp, "init"))).toBe(false);
+      expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
+    },
+    30_000,
+  );
+
   test("bun init falls back to --yes when stdin is not a TTY", async () => {
     await using temp = tempDir("bun-init-no-tty", {});
 

--- a/test/cli/install/bun-info.test.ts
+++ b/test/cli/install/bun-info.test.ts
@@ -44,6 +44,30 @@ describe.concurrent("bun info", () => {
       expect(output).toContain("maintainers:");
     });
 
+    // A runtime flag ahead of the subcommand, typed or spliced into argv by
+    // BUN_OPTIONS, moves "info" out of argv[1]. The package-name scan used to
+    // start at a fixed offset and picked up the shifted "info" keyword as the
+    // package (#20347, #39377).
+    it.each([
+      ["BUN_OPTIONS", [], { BUN_OPTIONS: "--smol" }],
+      ["a flag typed before the subcommand", ["--smol"], {}],
+    ])("should read the package name with %s", async (_, flagsBeforeSubcommand, extraEnv) => {
+      const testDir = await setupTest();
+      await using proc = spawn({
+        cmd: [bunExe(), ...flagsBeforeSubcommand, "info", "is-number"],
+        cwd: testDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: { ...bunEnv, ...extraEnv },
+      });
+      const [output, error, code] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(error).toBe("");
+      expect(output).toContain("is-number@");
+      expect(code).toBe(0);
+    });
+
     it("should display package info for specific version", async () => {
       const testDir = await setupTest();
       const { output, error, code } = await runCommand([bunExe(), "info", "is-number@7.0.0"], testDir);

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -936,3 +936,54 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
 });
+
+// A runtime flag ahead of the subcommand, typed or spliced into argv by
+// BUN_OPTIONS, moves "pm" out of argv[1]. trust used to take its package names
+// from a fixed argv offset, so the shifted "trust" keyword was itself treated as
+// a package name and `bun pm trust` without packages no longer errored (#20347).
+test.each([
+  ["BUN_OPTIONS", [], { BUN_OPTIONS: "--smol" }],
+  ["a flag typed before the subcommand", ["--smol"], {}],
+])("bun pm trust reads its package names with %s", async (_, flagsBeforeSubcommand, extraEnv) => {
+  using dir = tempDir("pm-trust-shifted-argv", {
+    "package.json": JSON.stringify({
+      name: "trust-shifted-argv",
+      version: "1.0.0",
+      dependencies: { dep: "file:./dep" },
+    }),
+    "dep/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }),
+  });
+  const dirStr = String(dir);
+
+  // trust needs a lockfile before it looks at the package names; a file: dependency produces one offline.
+  await using install = Bun.spawn({ cmd: [bunExe(), "install"], cwd: dirStr, stdout: "pipe", stderr: "pipe", env });
+  expect(await install.exited).toBe(0);
+
+  const spawnEnv = { ...env, ...extraEnv };
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...flagsBeforeSubcommand, "pm", "trust"],
+      cwd: dirStr,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: spawnEnv,
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("expected package names(s) or --all");
+    expect(exitCode).toBe(1);
+  }
+  {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...flagsBeforeSubcommand, "pm", "trust", "not-a-dependency"],
+      cwd: dirStr,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: spawnEnv,
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    // The "don't exist" listing names exactly the packages given on the command line.
+    expect(stderr).toContain("- not-a-dependency");
+    expect(stderr).not.toContain("- trust");
+    expect(exitCode).toBe(1);
+  }
+});

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -957,7 +957,9 @@ test.each([
 
   // trust needs a lockfile before it looks at the package names; a file: dependency produces one offline.
   await using install = Bun.spawn({ cmd: [bunExe(), "install"], cwd: dirStr, stdout: "pipe", stderr: "pipe", env });
-  expect(await install.exited).toBe(0);
+  const [installErr, installExit] = await Promise.all([install.stderr.text(), install.exited, install.stdout.text()]);
+  expect(installErr).not.toContain("error:");
+  expect(installExit).toBe(0);
 
   const spawnEnv = { ...env, ...extraEnv };
   {
@@ -968,7 +970,7 @@ test.each([
       stderr: "pipe",
       env: spawnEnv,
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
     expect(stderr).toContain("expected package names(s) or --all");
     expect(exitCode).toBe(1);
   }
@@ -980,7 +982,7 @@ test.each([
       stderr: "pipe",
       env: spawnEnv,
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
     // The "don't exist" listing names exactly the packages given on the command line.
     expect(stderr).toContain("- not-a-dependency");
     expect(stderr).not.toContain("- trust");

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -256,6 +256,41 @@ describe.concurrent(() => {
     expect(err.split(/\r?\n/)).not.toContain("note: Use `bun update --stable --profile` instead.");
     await proc.exited;
   });
+
+  // A runtime flag ahead of the subcommand, typed (`bun --bun upgrade`) or
+  // spliced into argv by BUN_OPTIONS, moves "upgrade" out of argv[1]. The
+  // package-name check used to scan from a fixed offset and rejected the
+  // shifted "upgrade" keyword itself as a package name (#20347, #39377).
+  it.each([
+    ["BUN_OPTIONS", [], { BUN_OPTIONS: "--smol" }],
+    ["a flag typed before the subcommand", ["--smol"], {}],
+  ])("%s, should not display the package-names error", async (_, flagsBeforeSubcommand, extraEnv) => {
+    // `--stable` keeps canary builds on the GITHUB_API_DOMAIN release-server
+    // path, whose garbage archive makes the upgrade fail after validation so
+    // the binary is never actually replaced.
+    using server = startReleaseServer({ tagName: "bun-v9.9.9" });
+    const cwd = tmpdirSync();
+    const execPath = join(cwd, basename(bunExe()));
+    await copyFile(bunExe(), execPath);
+    await using proc = spawn({
+      cmd: [execPath, ...flagsBeforeSubcommand, "upgrade", "--stable"],
+      cwd,
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env: { ...server.env, ...extraEnv },
+    });
+
+    const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(err.split(/\r?\n/)).not.toContain(
+      "error: This command updates Bun itself, and does not take package names.",
+    );
+    // Proves validation was passed: the run reached the release flow (it
+    // reports the mock server's v9.9.9 tag) and failed there on the garbage
+    // archive, not in argument parsing.
+    expect(err).toContain("v9.9.9");
+    expect(exitCode).not.toBe(0);
+  });
 });
 
 it("completes against a locally-served release with the system temp dir held open without FILE_SHARE_DELETE", async () => {


### PR DESCRIPTION
### Problem

- `BUN_OPTIONS=--bun bun upgrade` and `bun --bun upgrade` both abort with `error: This command updates Bun itself, and does not take package names.` / ``note: Use `bun update upgrade` instead.`` (#20347; #21777 was closed as its duplicate).
- Same cause in three more commands, either spelling: `bun init -y` scaffolds into `./init/` instead of the cwd, `bun info <pkg>` looks up a package named `info`, and `bun pm trust <pkg>` also tries to trust a package named `trust` (so `bun pm trust` with no packages no longer reports `expected package names(s) or --all`).
- Cause: `which()` (src/runtime/cli/mod.rs) finds the subcommand keyword by skipping the flags in front of it, but `exec_init` (mod.rs), `UpgradeCommand::exec` (src/runtime/cli/upgrade_command.rs) and `TrustCommand::exec` (src/runtime/cli/pm_trusted_command.rs) then read their arguments from a fixed argv offset that assumes the keyword is argv[1], and `bun_info` (mod.rs) scanned raw argv from that same offset. A flag typed before the keyword, or a token `BUN_OPTIONS` splices in after argv[0], moves the keyword to argv[2+], and the keyword itself becomes the first argument.
- The bunx fork bomb in #39377 is the same argv shift hitting the `BUN_INTERNAL_BUNX_INSTALL` escape hatch in `which()`. That is fixed by #39383 and is not part of this PR (an earlier revision of this PR carried the same one-line change; see the details block).

### Fix

- `which()` records the index of the keyword it dispatched on (`SUBCOMMAND_ARGV_INDEX`, read through `command::subcommand_argv_index()`); `exec_init` and `UpgradeCommand::exec` start one past it instead of at 2.
- `bun_info` and `TrustCommand::exec` stop reading argv at all. Both already run a clap parse that collects the positionals after the keyword with leading flags skipped (`cli.positionals`, and `pm.options.positionals` after `get_subcommand` has advanced it to the `pm` subcommand), which is how `bun pm view` and the other `pm` subcommands already get their arguments.
- Why this is the right fix: `which()`'s skip loop is the one place that decides which leading tokens are not the subcommand, so taking the position from it (or from the clap parse, which skips the same tokens) means the readers cannot disagree with the dispatcher again. Compensating with `bun_options_argc()` alone (the first revision of this PR) would have fixed only the environment variable spelling and left `bun --bun upgrade` from #20347 broken; both spellings are the same shift.
- `bun upgrade`'s note still echoes the user's own arguments verbatim (`bun update bun-types --dev`) because it echoes argv after the keyword, not clap positionals; the existing tests at the top of bun-upgrade.test.ts pin that.
- The escape hatch in `which()` is deliberately not switched to this index: its `add`/`exec` token is placed by bunx's own re-exec, where the only thing that can precede it is the `BUN_OPTIONS` splice, so `1 + bun_options_argc()` (#39383) is the exact position there.
- Scope: flags without a separate value token, typed or injected. `bun --cwd dir init` still does not dispatch at all today (`which()` lands on `dir`); that is #10333, which #36644 fixes by teaching `which()` to step over those values.
- Relation to #36644: it introduces this same `SUBCOMMAND_ARGV_INDEX` and the same `bun_info` rewrite (also carried by #38151) as groundwork for its classifier change. The `mod.rs` and `upgrade_command.rs` hunks here are taken from it verbatim, so after this lands it rebases down to the classifier change.
- Readers left alone (for #36644) already survive the shift: `reserved_command` and `exec_install_completions` scan for their token, `bun create` locates its positionals relatively (the only difference is a bare `bun create` exiting 0 instead of 1), and `bun x` / `bun whoami` fall through to flag-aware parsers. Checked each by hand on the current build.
- Tests: one `each` case per spelling (`BUN_OPTIONS=--smol`, and `--smol` typed before the keyword) in test/cli/init/init.test.ts, test/cli/install/bun-info.test.ts, test/cli/install/bun-upgrade.test.ts and test/cli/install/bun-pm.test.ts. All eight fail on a build without the src change (init creates `./init/`, info requests `/info`, upgrade prints the package-names error, trust lists `- trust`) and pass with it.
- Also run on the fixed build: the existing `pm trust` flows in bun-install-lifecycle-scripts.test.ts and bun-install-registry.test.ts (`-t trust`, 71 tests) since `TrustCommand` changed how it collects package names; and by hand, both #20347 spellings reach the release flow, `BUN_OPTIONS=--smol bun --silent upgrade bun-types --dev` still suggests exactly `bun update bun-types --dev`, and `BUN_OPTIONS=--smol bun --silent init -y sub` still honours the `sub` target folder.

Fixes #20347

### Background

- `BUN_OPTIONS` is an environment variable whose contents are parsed as extra CLI arguments at startup and inserted into argv right after argv[0] (`argv_view_init` in src/bun_core/util.rs), so they sit in front of the subcommand exactly like typed flags would. `bun_options_argc()` is the count of inserted tokens.
- `which()` is the dispatcher: it looks at argv[0] for the `bunx`/`node` shims, otherwise walks argv past leading `-` tokens and maps the first non-flag token to a command `Tag`. Most commands then parse argv with clap, which handles leading flags itself (unknown flags are skipped, not errors) and exposes the non-flag tokens as positionals; the four commands touched here were the ones still indexing raw argv.

<details>
<summary>Earlier revisions of this PR</summary>

The first revision fixed the bunx escape hatch (`argv.get(1 + bun::bun_options_argc())` in `which()`, with a decoy-binary test in bunx.test.ts) and added `+ bun_options_argc()` to the init, info and upgrade offsets. The hatch change is line-identical to #39383 by the issue's reporter, so it was dropped in favour of that PR. The second revision introduced a separate index for the three remaining sites; review turned up #36644, which already defines the same mechanism, and the `pm trust` reader, so this revision adopts #36644's primitive and positionals reads and adds trust. This PR and #39383 touch different hunks of mod.rs and different test files and merge in either order.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/init/init.test.ts test/cli/install/bun-upgrade.test.ts

<!-- robobun:evidence:end -->
