### PR TITLE
Clear exceptions from failed property lookups while formatting objects

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5643,10 +5643,12 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers;
+                // either one reports the property as missing.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5718,7 +5720,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototype)
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,82 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// A lookup that threw used to leave its exception pending for the rest of the
+// property walk, and a throwing getPrototypeOf trap was read as an object.
+// Both took the process down, so each case runs in a subprocess.
+describe.concurrent("property lookups that throw while formatting", () => {
+  async function runFixture(fixture) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: normalizeBunSnapshot(stdout), exitCode };
+  }
+
+  it("skips a prototype Proxy property whose get trap throws", async () => {
+    const { stdout, exitCode } = await runFixture(`
+      const proto = new Proxy({}, {
+        ownKeys: () => ["a", "b", "c"],
+        getOwnPropertyDescriptor: () => ({ value: 0, configurable: true, enumerable: true, writable: true }),
+        get(target, key) {
+          if (key === "b") throw new Error("no b");
+          return key === "a" || key === "c" ? key : undefined;
+        },
+      });
+      console.log(Bun.inspect(Object.create(proto)));
+    `);
+    expect(stdout).toMatchInlineSnapshot(`
+      "{
+        a: "a",
+        c: "c",
+      }"
+    `);
+    expect(exitCode).toBe(0);
+  });
+
+  it("stops at a prototype Proxy whose getPrototypeOf trap throws", async () => {
+    const { stdout, exitCode } = await runFixture(`
+      const proto = new Proxy({}, {
+        ownKeys: () => ["a"],
+        getOwnPropertyDescriptor: () => ({ value: 0, configurable: true, enumerable: true, writable: true }),
+        get: (target, key) => (key === "a" ? 1 : undefined),
+        getPrototypeOf() { throw new Error("no prototype"); },
+      });
+      console.log(Bun.inspect(Object.create(proto)));
+    `);
+    expect(stdout).toMatchInlineSnapshot(`
+      "{
+        a: 1,
+      }"
+    `);
+    expect(exitCode).toBe(0);
+  });
+
+  it("keeps going after a lazy property fails to initialize near the stack limit", async () => {
+    // Bun.$ is the first entry in Bun's property table and runs JS to build
+    // itself, so looking it up right after a stack overflow throws. The
+    // entries after it must still be formatted, and it must still work later.
+    const { stdout, exitCode } = await runFixture(`
+      let deep;
+      function recurse() {
+        try {
+          recurse();
+        } catch (e) {
+          if (deep === undefined) deep = Bun.inspect(Bun);
+        }
+      }
+      recurse();
+      console.log(deep.includes("Archive:"), deep.includes("version:"));
+      console.log(typeof Bun.$, Bun.inspect(Bun).includes("$:"));
+    `);
+    expect(stdout).toMatchInlineSnapshot(`
+      "true true
+      function true"
+    `);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Found by the fuzzer. Formatting an object (`Bun.inspect`, `console.log`, the "received" value in a failing `expect()` message) walks its properties in `JSC__JSValue__forEachPropertyImpl` in `bindings.cpp`. In the slow path, when `getPropertySlot` returned false the loop did `continue` before reaching `CLEAR_IF_EXCEPTION`. If the lookup returned false *because it threw*, the exception stayed pending for the rest of the walk. Two ways to get there:

- a static-table lazy property whose initializer runs JS. `Bun.$` is the first entry in the Bun object's table and builds itself by calling a builtin, so formatting `Bun` right after a stack overflow makes that lookup throw `Maximum call stack size exceeded` (the fuzzer got there via `expect(Bun).toHaveBeenCalledTimes()` inside the catch of a runaway recursion).
- a Proxy on the prototype chain whose `get` trap throws for one key.

With the exception left pending, JSC's `setUpStaticFunctionSlot` reports every later static-table entry as missing (so in release builds most of the Bun object silently disappeared from the output), the next lazy property callback runs with an exception already set (the `releaseAssertNoException` failure in the fuzzer report), and a Proxy further up the chain returns an empty value from `getPrototype`, which the loop then called `.getObject()` on (segfault at address 0x5 in release builds).

Changes, all in the slow path of `forEachPropertyImpl`:

- the fix: `CLEAR_IF_EXCEPTION(scope)` now runs after `getPropertySlot` whether or not the property was found, same as `forEachPropertyOrdered` already did.
- the prototype step checks the value returned by `getPrototype` before calling `getObject()` on it and stops walking if it is empty. This is the line that segfaulted in release builds with a stale exception, and it also segfaulted on its own for a prototype Proxy whose `getPrototypeOf` trap throws.

`BunObject.cpp`: once the walk gets past `Bun.$`, the same script reached the `Bun.sql` / `Bun.SQL` getters, which in debug builds passed a failed module load to `reportUncaughtExceptionAtEventLoop` while that exception was still pending, and the uncaught exception handler then tripped a `Structure::storedPrototype` assertion looking up `process._fatalException`. The debug-only block is removed; the exception is propagated to the caller through the `RETURN_IF_EXCEPTION` right below it, which is what release builds already did.

### How did you verify your code works?

Tests added to `test/js/bun/util/inspect.test.js` ("property lookups that throw while formatting"), each running in a subprocess because the old behavior takes the process down:

- prototype Proxy with a throwing `get` trap: segfault before, prints the other keys after
- prototype Proxy with a throwing `getPrototypeOf` trap: segfault before, prints the own-chain keys after
- `Bun.inspect(Bun)` in the catch of a stack overflow: before, the output lost `Archive`, `version` and everything else that follows a throwing entry (and debug builds hit the assertion); after, those are present and `Bun.$` still initializes afterwards

All three fail with `USE_SYSTEM_BUN=1 bun test` and pass with `bun bd test`. The fuzzer script (with the expect call limited to the deepest few hundred frames, since every frame formats the whole Bun object) aborts on the prebuilt debug binary and exits 0 on the fixed one, also with `BUN_JSC_validateExceptionChecks=1`. The rest of `inspect.test.js`, `bun-inspect.test.ts`, `custom-inspect.test.js`, the node `util-inspect-proxy` tests and `BunObject.test.ts` pass with the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->