### PR TITLE
Make a failed util.inspect load throw from custom inspect functions instead of aborting

### DIFF
--- a/src/jsc/bindings/UtilInspect.cpp
+++ b/src/jsc/bindings/UtilInspect.cpp
@@ -55,7 +55,7 @@ extern "C" JSC::EncodedJSValue JSC__JSValue__callCustomInspectFunction(
     JSObject* options = Bun::createInspectOptionsObject(vm, globalObject, max_depth, colors);
     RETURN_IF_EXCEPTION(scope, {});
 
-    JSFunction* inspectFn = globalObject->utilInspectFunction();
+    JSObject* inspectFn = globalObject->utilInspectFunction();
     RETURN_IF_EXCEPTION(scope, {});
     auto callData = JSC::getCallData(functionToCall);
     MarkedArgumentBuffer arguments;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2777,23 +2777,23 @@ EncodedJSValue GlobalObject::assignToStream(JSValue stream, JSValue controller)
     return JSC::JSValue::encode(result);
 }
 
-JSC::JSFunction* GlobalObject::utilInspectFunction()
+JSC::JSObject* GlobalObject::utilInspectFunction()
 {
     if (auto* inspect = m_utilInspectFunction.get())
         return inspect;
 
     auto& vm = this->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue nodeUtil = internalModuleRegistry()->requireId(this, vm, Bun::InternalModuleRegistry::Field::NodeUtil);
+    JSValue inspectModule = internalModuleRegistry()->requireId(this, vm, Bun::InternalModuleRegistry::Field::InternalUtilInspect);
     RETURN_IF_EXCEPTION(scope, nullptr);
-    RELEASE_ASSERT(nodeUtil.isObject());
-    JSValue inspectValue = asObject(nodeUtil)->get(this, Identifier::fromString(vm, "inspect"_s));
+    RELEASE_ASSERT(inspectModule.isObject());
+    JSValue inspectValue = asObject(inspectModule)->get(this, Identifier::fromString(vm, "inspect"_s));
     RETURN_IF_EXCEPTION(scope, nullptr);
-    auto* inspect = dynamicDowncast<JSFunction>(inspectValue);
-    if (!inspect) [[unlikely]] {
+    if (!inspectValue.isCallable()) [[unlikely]] {
         throwTypeError(this, scope, "util.inspect is not a function"_s);
         return nullptr;
     }
+    JSObject* inspect = asObject(inspectValue);
     m_utilInspectFunction.set(vm, this, inspect);
     return inspect;
 }
@@ -2805,7 +2805,7 @@ JSC::JSFunction* GlobalObject::utilInspectStylizeColorFunction()
 
     auto& vm = this->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSFunction* inspect = utilInspectFunction();
+    JSObject* inspect = utilInspectFunction();
     RETURN_IF_EXCEPTION(scope, nullptr);
 
     JSC::MarkedArgumentBuffer args;

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2514,37 +2514,6 @@ void GlobalObject::finishCreation(VM& vm)
         { OBJECT_OFFSETOF(GlobalObject, m_errorConstructorPrepareStackTraceInternalValue), [](const LazyProperty<JSGlobalObject, JSFunction>::Initializer& init) {
              init.set(JSFunction::create(init.vm, init.owner, 2, "ErrorPrepareStackTrace"_s, jsFunctionDefaultErrorPrepareStackTrace, ImplementationVisibility::Public));
          } },
-
-        { OBJECT_OFFSETOF(GlobalObject, m_utilInspectFunction), [](const LazyProperty<JSGlobalObject, JSFunction>::Initializer& init) {
-             auto scope = DECLARE_THROW_SCOPE(init.vm);
-             JSValue nodeUtilValue = uncheckedDowncast<Zig::GlobalObject>(init.owner)->internalModuleRegistry()->requireId(init.owner, init.vm, Bun::InternalModuleRegistry::Field::NodeUtil);
-             RETURN_IF_EXCEPTION(scope, );
-             RELEASE_ASSERT(nodeUtilValue.isObject());
-             auto prop = nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s));
-             RETURN_IF_EXCEPTION(scope, );
-             ASSERT(prop);
-             init.set(uncheckedDowncast<JSFunction>(prop));
-         } },
-        { OBJECT_OFFSETOF(GlobalObject, m_utilInspectStylizeColorFunction), [](const LazyProperty<JSGlobalObject, JSFunction>::Initializer& init) {
-             auto scope = DECLARE_THROW_SCOPE(init.vm);
-             JSC::MarkedArgumentBuffer args;
-             args.append(uncheckedDowncast<Zig::GlobalObject>(init.owner)->utilInspectFunction());
-             RETURN_IF_EXCEPTION(scope, );
-
-             JSC::JSFunction* getStylize = JSC::JSFunction::create(init.vm, init.owner, utilInspectGetStylizeWithColorCodeGenerator(init.vm), init.owner);
-             RETURN_IF_EXCEPTION(scope, );
-
-             JSC::CallData callData = JSC::getCallData(getStylize);
-             NakedPtr<JSC::Exception> returnedException = nullptr;
-             auto result = JSC::profiledCall(init.owner, ProfilingReason::API, getStylize, callData, jsNull(), args, returnedException);
-             RETURN_IF_EXCEPTION(scope, );
-
-             if (returnedException) {
-                 throwException(init.owner, scope, returnedException.get());
-             }
-             RETURN_IF_EXCEPTION(scope, );
-             init.set(uncheckedDowncast<JSFunction>(result));
-         } },
         { OBJECT_OFFSETOF(GlobalObject, m_utilInspectStylizeNoColorFunction), [](const LazyProperty<JSGlobalObject, JSFunction>::Initializer& init) {
              init.set(JSC::JSFunction::create(init.vm, init.owner, utilInspectStylizeWithNoColorCodeGenerator(init.vm), init.owner));
          } },
@@ -2806,6 +2775,47 @@ EncodedJSValue GlobalObject::assignToStream(JSValue stream, JSValue controller)
         return JSC::JSValue::encode(exception);
     }
     return JSC::JSValue::encode(result);
+}
+
+JSC::JSFunction* GlobalObject::utilInspectFunction()
+{
+    if (auto* inspect = m_utilInspectFunction.get())
+        return inspect;
+
+    auto& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue nodeUtil = internalModuleRegistry()->requireId(this, vm, Bun::InternalModuleRegistry::Field::NodeUtil);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    RELEASE_ASSERT(nodeUtil.isObject());
+    JSValue inspectValue = asObject(nodeUtil)->get(this, Identifier::fromString(vm, "inspect"_s));
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    auto* inspect = dynamicDowncast<JSFunction>(inspectValue);
+    if (!inspect) [[unlikely]] {
+        throwTypeError(this, scope, "util.inspect is not a function"_s);
+        return nullptr;
+    }
+    m_utilInspectFunction.set(vm, this, inspect);
+    return inspect;
+}
+
+JSC::JSFunction* GlobalObject::utilInspectStylizeColorFunction()
+{
+    if (auto* stylize = m_utilInspectStylizeColorFunction.get())
+        return stylize;
+
+    auto& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSFunction* inspect = utilInspectFunction();
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    JSC::MarkedArgumentBuffer args;
+    args.append(inspect);
+    JSFunction* getStylize = JSFunction::create(vm, this, utilInspectGetStylizeWithColorCodeGenerator(vm), this);
+    JSValue result = JSC::profiledCall(this, ProfilingReason::API, getStylize, JSC::getCallData(getStylize), jsNull(), args);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    auto* stylize = uncheckedDowncast<JSFunction>(result);
+    m_utilInspectStylizeColorFunction.set(vm, this, stylize);
+    return stylize;
 }
 
 JSC::GCClient::IsoSubspace* GlobalObject::subspaceForImpl(JSC::VM& vm)

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -266,8 +266,8 @@ public:
     JSC::Structure* callSiteStructure() const { return m_callSiteStructure.getInitializedOnMainThread(this); }
 
     JSC::Structure* utilInspectOptionsStructure() const { return m_utilInspectOptionsStructure.getInitializedOnMainThread(this); }
-    // nullptr with an exception pending if loading node:util throws.
-    JSC::JSFunction* utilInspectFunction();
+    // The callable `inspect` export of internal/util/inspect, or nullptr with an exception pending.
+    JSC::JSObject* utilInspectFunction();
     JSC::JSFunction* utilInspectStylizeColorFunction();
     JSC::JSFunction* utilInspectStylizeNoColorFunction() const { return m_utilInspectStylizeNoColorFunction.getInitializedOnMainThread(this); }
 
@@ -605,7 +605,7 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_pendingVirtualModuleResultStructure)                 \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSocketHandlersStructure)                           \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_nativeMicrotaskTrampoline)                          \
-    V(private, WriteBarrier<JSFunction>, m_utilInspectFunction)                                              \
+    V(private, WriteBarrier<JSObject>, m_utilInspectFunction)                                                \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_utilInspectOptionsStructure)                         \
     V(private, WriteBarrier<JSFunction>, m_utilInspectStylizeColorFunction)                                  \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectStylizeNoColorFunction)                  \

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -266,8 +266,9 @@ public:
     JSC::Structure* callSiteStructure() const { return m_callSiteStructure.getInitializedOnMainThread(this); }
 
     JSC::Structure* utilInspectOptionsStructure() const { return m_utilInspectOptionsStructure.getInitializedOnMainThread(this); }
-    JSC::JSFunction* utilInspectFunction() const { return m_utilInspectFunction.getInitializedOnMainThread(this); }
-    JSC::JSFunction* utilInspectStylizeColorFunction() const { return m_utilInspectStylizeColorFunction.getInitializedOnMainThread(this); }
+    // nullptr with an exception pending if loading node:util throws.
+    JSC::JSFunction* utilInspectFunction();
+    JSC::JSFunction* utilInspectStylizeColorFunction();
     JSC::JSFunction* utilInspectStylizeNoColorFunction() const { return m_utilInspectStylizeNoColorFunction.getInitializedOnMainThread(this); }
 
     JSC::JSFunction* wasmStreamingConsumeStreamFunction() const { return m_wasmStreamingConsumeStreamFunction.getInitializedOnMainThread(this); }
@@ -604,9 +605,9 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_pendingVirtualModuleResultStructure)                 \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSocketHandlersStructure)                           \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_nativeMicrotaskTrampoline)                          \
-    V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectFunction)                                \
+    V(private, WriteBarrier<JSFunction>, m_utilInspectFunction)                                              \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_utilInspectOptionsStructure)                         \
-    V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectStylizeColorFunction)                    \
+    V(private, WriteBarrier<JSFunction>, m_utilInspectStylizeColorFunction)                                  \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectStylizeNoColorFunction)                  \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_wasmStreamingConsumeStreamFunction)                 \
     V(private, WebCore::JSStreamsRuntime, m_streamsRuntime)                                                  \

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -7142,6 +7142,7 @@ extern "C" JSC::EncodedJSValue Bun__REPL__formatValue(
     // Get the util.inspect function from the global object
     auto* bunGlobal = uncheckedDowncast<Zig::GlobalObject>(globalObject);
     JSC::JSValue inspectFn = bunGlobal->utilInspectFunction();
+    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
 
     if (!inspectFn || !inspectFn.isCallable()) {
         // Fallback to toString if util.inspect is not available

--- a/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
@@ -209,7 +209,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBroadcastChannelPrototype_inspectCustom, (JSC::JSGlob
     inputObj->putDirect(vm, vm.propertyNames->name, jsString(vm, channel->name()), 0);
     inputObj->putDirect(vm, Identifier::fromString(vm, "active"_s), jsBoolean(!channel->isClosed()), 0);
 
-    JSFunction* utilInspect = globalObject->utilInspectFunction();
+    JSObject* utilInspect = globalObject->utilInspectFunction();
     RETURN_IF_EXCEPTION(throwScope, {});
     auto callData = JSC::getCallData(utilInspect);
     MarkedArgumentBuffer arguments;

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -239,7 +239,7 @@ JSC_DEFINE_HOST_FUNCTION(jsURLSearchParamsPrototypeFunction_inspectCustom, (JSGl
     opts->putDirect(vm, Identifier::fromString(vm, "depth"_s), childDepth, 0);
 
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    JSFunction* utilInspect = globalObject->utilInspectFunction();
+    JSObject* utilInspect = globalObject->utilInspectFunction();
     RETURN_IF_EXCEPTION(scope, {});
     auto inspectCallData = JSC::getCallData(utilInspect);
 

--- a/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsInspectCustom.cpp
@@ -54,7 +54,7 @@ EncodedJSValue customInspect(JSGlobalObject* lexicalGlobalObject, CallFrame* cal
     opts->putDirect(vm, Identifier::fromString(vm, "depth"_s), childDepth, 0);
 
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-    JSFunction* utilInspect = globalObject->utilInspectFunction();
+    JSObject* utilInspect = globalObject->utilInspectFunction();
     RETURN_IF_EXCEPTION(scope, {});
     auto callData = JSC::getCallData(utilInspect);
     MarkedArgumentBuffer arguments;

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -494,36 +494,95 @@ it("Bun.inspect.custom exists", () => {
   expect(Bun.inspect.custom).toBe(util.inspect.custom);
 });
 
-it("a custom inspect function throws when node:util cannot be loaded, and works once it can", async () => {
-  // The native formatter loads util.inspect (and, with colors, its stylize helper) the first
-  // time a custom inspect function runs. A load failure used to abort the process; it has to
-  // throw instead, and a later call has to retry the load. Run in a child because the
-  // unfixed binary aborts.
-  const code = `
-    const obj = { [Bun.inspect.custom]() { return "custom"; } };
-    const styled = { [Bun.inspect.custom](depth, options) { return options.stylize("x", "number"); } };
-    const RealSymbol = Symbol;
-    globalThis.Symbol = 0;
-    try {
-      console.log(Bun.inspect(styled, { colors: true }));
-    } catch {
-      console.log("threw");
-    }
-    globalThis.Symbol = RealSymbol;
-    console.log(Bun.inspect(obj));
-    console.log(Bun.inspect(styled, { colors: true }) === "\\u001b[33mx\\u001b[39m");
-    // Both functions are cached on the global object now; they have to survive a full GC.
-    Bun.gc(true);
-    console.log(Bun.inspect(styled, { colors: true }) === "\\u001b[33mx\\u001b[39m");
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", code],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
+// The native formatter loads util.inspect (and, with colors, its stylize helper) the first time a
+// custom inspect function runs. When that load throws (a global that node:util reads while it
+// loads has been replaced, the stack is nearly exhausted, util.inspect has been replaced with a
+// non-function), the error has to reach the caller and the next call has to load again. It used
+// to abort the process. Each case runs in a fresh child so that nothing has loaded util.inspect
+// for the formatter yet.
+describe.concurrent("Bun.inspect when loading util.inspect for a custom inspect function throws", () => {
+  async function inspectInChild(code) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const obj = { [Bun.inspect.custom]() { return "custom"; } };
+          const styled = { [Bun.inspect.custom](depth, options) { return options.stylize("x", "number"); } };
+          ${code}
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("throws while a global that node:util reads is replaced, and works once it is restored", async () => {
+    const result = await inspectInChild(`
+      const RealSymbol = Symbol;
+      globalThis.Symbol = 0;
+      try {
+        console.log(Bun.inspect(styled, { colors: true }));
+      } catch {
+        console.log("threw");
+      }
+      globalThis.Symbol = RealSymbol;
+      console.log(Bun.inspect(obj));
+      console.log(Bun.inspect(styled, { colors: true }) === "\\u001b[33mx\\u001b[39m");
+      // Both functions are cached on the global object now; they have to survive a full GC.
+      Bun.gc(true);
+      console.log(Bun.inspect(styled, { colors: true }) === "\\u001b[33mx\\u001b[39m");
+    `);
+    expect(result).toEqual({ stdout: "threw\ncustom\ntrue\ntrue\n", stderr: "", exitCode: 0 });
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "threw\ncustom\ntrue\ntrue\n", stderr: "", exitCode: 0 });
+
+  it.each([
+    ["without colors", "Bun.inspect(obj)", '"custom"'],
+    ["with colors", "Bun.inspect(styled, { colors: true })", '"\\u001b[33mx\\u001b[39m"'],
+  ])("throws the RangeError when the stack is exhausted, and works afterwards, %s", async (_, call, expected) => {
+    const result = await inspectInChild(`
+      let deep;
+      function recurse() {
+        try {
+          recurse();
+        } catch {
+          // Only the frame whose call overflowed gets here.
+          try {
+            deep = ${call};
+          } catch (e) {
+            deep = e;
+          }
+        }
+      }
+      recurse();
+      console.log(String(deep));
+      console.log(JSON.stringify(${call}));
+    `);
+    expect(result).toEqual({
+      stdout: `RangeError: Maximum call stack size exceeded.\n${expected}\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("throws a TypeError while util.inspect is not a function, and works once it is restored", async () => {
+    const result = await inspectInChild(`
+      const util = require("node:util");
+      const realInspect = util.inspect;
+      util.inspect = 42;
+      try {
+        console.log(Bun.inspect(obj));
+      } catch (e) {
+        console.log(String(e));
+      }
+      util.inspect = realInspect;
+      console.log(Bun.inspect(obj));
+    `);
+    expect(result).toEqual({ stdout: "TypeError: util.inspect is not a function\ncustom\n", stderr: "", exitCode: 0 });
+  });
 });
 
 describe("Functions with names", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -494,6 +494,38 @@ it("Bun.inspect.custom exists", () => {
   expect(Bun.inspect.custom).toBe(util.inspect.custom);
 });
 
+it("a custom inspect function throws when node:util cannot be loaded, and works once it can", async () => {
+  // The native formatter loads util.inspect (and, with colors, its stylize helper) the first
+  // time a custom inspect function runs. A load failure used to abort the process; it has to
+  // throw instead, and a later call has to retry the load. Run in a child because the
+  // unfixed binary aborts.
+  const code = `
+    const obj = { [Bun.inspect.custom]() { return "custom"; } };
+    const styled = { [Bun.inspect.custom](depth, options) { return options.stylize("x", "number"); } };
+    const RealSymbol = Symbol;
+    globalThis.Symbol = 0;
+    try {
+      console.log(Bun.inspect(styled, { colors: true }));
+    } catch {
+      console.log("threw");
+    }
+    globalThis.Symbol = RealSymbol;
+    console.log(Bun.inspect(obj));
+    console.log(Bun.inspect(styled, { colors: true }) === "\\u001b[33mx\\u001b[39m");
+    // Both functions are cached on the global object now; they have to survive a full GC.
+    Bun.gc(true);
+    console.log(Bun.inspect(styled, { colors: true }) === "\\u001b[33mx\\u001b[39m");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "threw\ncustom\ntrue\ntrue\n", stderr: "", exitCode: 0 });
+});
+
 describe("Functions with names", () => {
   const closures = [
     () => function f() {},

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -494,12 +494,12 @@ it("Bun.inspect.custom exists", () => {
   expect(Bun.inspect.custom).toBe(util.inspect.custom);
 });
 
-// The native formatter loads util.inspect (and, with colors, its stylize helper) the first time a
-// custom inspect function runs. When that load throws (a global that node:util reads while it
-// loads has been replaced, the stack is nearly exhausted, util.inspect has been replaced with a
-// non-function), the error has to reach the caller and the next call has to load again. It used
-// to abort the process. Each case runs in a fresh child so that nothing has loaded util.inspect
-// for the formatter yet.
+// The native formatter loads the inspect function of internal/util/inspect (and, with colors, its
+// stylize helper) the first time a custom inspect function runs. When that load throws (a global
+// that the module reads while it loads has been replaced, the stack is nearly exhausted, the export
+// is not callable), the error has to reach the caller and the next call has to load again. It used
+// to abort the process. Each case runs in a fresh child so that nothing has loaded the function for
+// the formatter yet.
 describe.concurrent("Bun.inspect when loading util.inspect for a custom inspect function throws", () => {
   async function inspectInChild(code) {
     await using proc = Bun.spawn({
@@ -520,7 +520,7 @@ describe.concurrent("Bun.inspect when loading util.inspect for a custom inspect 
     return { stdout, stderr, exitCode };
   }
 
-  it("throws while a global that node:util reads is replaced, and works once it is restored", async () => {
+  it("throws while a global that the module reads is replaced, and works once it is restored", async () => {
     const result = await inspectInChild(`
       const RealSymbol = Symbol;
       globalThis.Symbol = 0;
@@ -568,20 +568,36 @@ describe.concurrent("Bun.inspect when loading util.inspect for a custom inspect 
     });
   });
 
-  it("throws a TypeError while util.inspect is not a function, and works once it is restored", async () => {
+  // bunEnv exposes the internal modules to the child. Any callable export is accepted, not only a
+  // plain function, so a wrapper such as a Proxy or a mock works.
+  it("throws a TypeError while the export is not callable, and passes the export once it is", async () => {
+    const result = await inspectInChild(`
+      const exports = require("internal/util/inspect");
+      const realInspect = exports.inspect;
+      const receives = { [Bun.inspect.custom](depth, options, inspect) { return String(inspect === exports.inspect); } };
+      exports.inspect = 42;
+      try {
+        console.log(Bun.inspect(receives));
+      } catch (e) {
+        console.log(String(e));
+      }
+      exports.inspect = new Proxy(realInspect, {});
+      console.log(Bun.inspect(receives));
+    `);
+    expect(result).toEqual({ stdout: "TypeError: util.inspect is not a function\ntrue\n", stderr: "", exitCode: 0 });
+  });
+
+  // Like node, the formatter passes the inspect function of the internal module to custom inspect
+  // functions. Replacing util.inspect does not change it.
+  it("passes the real inspect function while util.inspect is replaced", async () => {
     const result = await inspectInChild(`
       const util = require("node:util");
       const realInspect = util.inspect;
       util.inspect = 42;
-      try {
-        console.log(Bun.inspect(obj));
-      } catch (e) {
-        console.log(String(e));
-      }
-      util.inspect = realInspect;
-      console.log(Bun.inspect(obj));
+      const receives = { [Bun.inspect.custom](depth, options, inspect) { return String(inspect === realInspect); } };
+      console.log(Bun.inspect(receives));
     `);
-    expect(result).toEqual({ stdout: "TypeError: util.inspect is not a function\ncustom\n", stderr: "", exitCode: 0 });
+    expect(result).toEqual({ stdout: "true\n", stderr: "", exitCode: 0 });
   });
 });
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -498,8 +498,8 @@ it("Bun.inspect.custom exists", () => {
 // stylize helper) the first time a custom inspect function runs. When that load throws (a global
 // that the module reads while it loads has been replaced, the stack is nearly exhausted, the export
 // is not callable), the error has to reach the caller and the next call has to load again. It used
-// to abort the process. Each case runs in a fresh child so that nothing has loaded the function for
-// the formatter yet.
+// to abort the process. Each case runs in a fresh child, so it controls what the formatter has
+// loaded before the failing call.
 describe.concurrent("Bun.inspect when loading util.inspect for a custom inspect function throws", () => {
   async function inspectInChild(code) {
     await using proc = Bun.spawn({
@@ -539,11 +539,19 @@ describe.concurrent("Bun.inspect when loading util.inspect for a custom inspect 
     expect(result).toEqual({ stdout: "threw\ncustom\ntrue\ntrue\n", stderr: "", exitCode: 0 });
   });
 
+  // The first row fails while loading the inspect function. The second row loads it up front, so
+  // the failure happens one step later, while the stylize helper is built from it.
   it.each([
-    ["without colors", "Bun.inspect(obj)", '"custom"'],
-    ["with colors", "Bun.inspect(styled, { colors: true })", '"\\u001b[33mx\\u001b[39m"'],
-  ])("throws the RangeError when the stack is exhausted, and works afterwards, %s", async (_, call, expected) => {
+    ["without colors", "", "Bun.inspect(obj)", '"custom"'],
+    [
+      "with colors and the inspect function already loaded",
+      "Bun.inspect(obj);",
+      "Bun.inspect(styled, { colors: true })",
+      '"\\u001b[33mx\\u001b[39m"',
+    ],
+  ])("throws the RangeError at the stack limit, and works afterwards, %s", async (_, setup, call, expected) => {
     const result = await inspectInChild(`
+      ${setup}
       let deep;
       function recurse() {
         try {
@@ -568,8 +576,8 @@ describe.concurrent("Bun.inspect when loading util.inspect for a custom inspect 
     });
   });
 
-  // bunEnv exposes the internal modules to the child. Any callable export is accepted, not only a
-  // plain function, so a wrapper such as a Proxy or a mock works.
+  // Only code with access to the internal modules (bunEnv gives the child that access) can replace
+  // the export the formatter reads. The formatter accepts any callable there, not only a function.
   it("throws a TypeError while the export is not callable, and passes the export once it is", async () => {
     const result = await inspectInChild(`
       const exports = require("internal/util/inspect");

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -770,7 +770,7 @@ describe.concurrent("Bun.inspect when a property lookup throws", () => {
     // Bun.$ is the first property of the Bun object and is built by a builtin that calls
     // Symbol(), as are Bun.sql and Bun.SQL further down, so breaking Symbol makes those
     // initializers throw while Bun is formatted. Custom inspect functions (Bun.env has one on
-    // Windows) load node:util the first time one runs, which also needs Symbol, so load it first.
+    // Windows) load util.inspect the first time one runs, which also needs Symbol, so load it first.
     const result = await inspectInChild(`
       Bun.inspect({ [Bun.inspect.custom]() { return ""; } });
       globalThis.Symbol = 0;


### PR DESCRIPTION
### Problem

- The formatter loads `util.inspect` when it first runs a custom inspect function. If the load throws, the process aborts. Debug builds report `ASSERTION FAILED: !(initializer.property.m_pointer & lazyTag)` in `LazyProperty::callFunc`.
- The load throws when a global that the module reads was replaced, or near the stack limit. `require("util").inspect = 42` aborts as well.
- Cause: `m_utilInspectFunction` and `m_utilInspectStylizeColorFunction` in `ZigGlobalObject.cpp` were `LazyProperty` members whose initializers returned without `init.set()` on an exception. `LazyProperty` asserts on that.

### Fix

- The two members become `WriteBarrier`s that the getters fill in. When the load throws, the getters return `nullptr` with the exception pending and cache nothing. The next call loads again. `InternalModuleRegistry::requireId` has the same contract.
- Correct because the failure is a normal JavaScript exception whose cause (a replaced global, a deep stack) can go away. Every caller already checks for it.
- `utilInspectFunction()` now reads `inspect` from `internal/util/inspect`, as node does. A replaced `util.inspect` (a value, a Proxy, a mock) no longer reaches custom inspect functions. The internal export only has to be callable. One that is not throws a `TypeError` instead of an abort.
- Verified: five child-process cases in `test/js/bun/util/inspect.test.js`. They fail the load of each member and load it again, and they check the export handling. All five abort on the current build.

### Background

- `LazyProperty<Owner, T>` is a JSC member that a callback fills in on first access. The callback must call `init.set(value)`. `callFunc` asserts (`RELEASE_ASSERT`) if it did not. The type has no failed state.
- `WriteBarrier<T>` is the ordinary GC-aware member pointer, marked through `FOR_EACH_GLOBALOBJECT_GC_MEMBER`. It can hold null, so a failed load leaves it empty.
- `InternalModuleRegistry::requireId` evaluates a built-in module on first use. `internal/util/inspect` implements `util.inspect`. `node:util` re-exports it.

<details><summary>Notes</summary>

Triggers seen: `globalThis.Symbol = 0` or a replaced `Reflect` (the fuzzer's samples), and the first custom inspect call from a stack overflow handler. On Windows `Bun.env` has a custom inspect function, so `console.log(Bun)` reaches this. With `colors`, the `stylize` helper is built from the same function and had the same problem. The abort needs a process that has not loaded the module yet, which is why the fuzzer reports it as flaky. The `require("util").inspect = 42` case aborted because the initializer downcast the property without a check (debug: `ASSERTION FAILED: isCell()`). The callers already checked for an exception after the getters, but the assertion fired first.

Node passes the `inspect` of `internal/util/inspect` to custom inspect functions, so a replaced `util.inspect` has no effect there. The same script now prints the same result in node and bun.

Test block: "Bun.inspect when loading util.inspect for a custom inspect function throws". The child processes run with `bunEnv`, which makes `require("internal/util/inspect")` work. Cases: `Symbol` replaced then restored (colors path, then `Bun.gc(true)` to check that the cached functions are marked), the stack exhausted while the inspect function loads (no colors) and, with it already loaded, while the stylize helper is built from it (colors), the internal export set to `42` (TypeError) and then to a Proxy (accepted), and `util.inspect` replaced (the custom function still receives the real one). All five exit with code 134 in the child on the current release and debug builds. Also run with the debug build: the rest of `inspect.test.js`, `test/js/node/util/custom-inspect.test.js`, `test/js/web/url/url.test.ts`, `test/js/web/broadcastchannel/broadcast-channel.test.ts`, `test/js/web/console/console-log.test.ts`.

Since #39770, `finishCreation` installs the lazy initializers from offset tables (`lazyFunctionInits`). The two entries for these members are removed there. A `WriteBarrier` member must not have a table entry, because the table would call `initLater` on it. The branch is rebased past #39732 as well, which deleted the unused `navigatorObject()` next to which the getters were first placed; they now follow `assignToStream`, with no other change. A third rebase followed #39581, which deleted the unused `m_performMicrotaskVariadicFunction` next to the two entries this PR removes; main's deletion is kept and nothing else moved.

The callers of the getter: `UtilInspect.cpp` (custom inspect functions), `JSURLSearchParams.cpp`, `WebStreamsInspectCustom.cpp`, `JSBroadcastChannel.cpp`, and `Bun__REPL__formatValue` in `bindings.cpp`, which gets the exception check it was missing. The first four now hold a `JSObject*`. `getCallData` and `profiledCall` take a cell or a value, so nothing needed a `JSFunction*`. `Bun__REPL__formatValue` has no caller (`repl.rs` declares only `evaluate`, `getCompletions` and `getProperty`). This PR only adds the check it was missing. Deleting it is a separate cleanup.

History: this PR first also fixed the stale exception and `getPrototype` crash in the property walk, the `napi_get_all_property_names` check and the `BunObject.cpp` report. Those landed through #29642. The same abort was addressed with other designs in #29235, #30267, #37160, #37175, #37202 and #37213 (cache a placeholder or null, install a throwing stub, install an identity fallback). They were closed in favour of this one. #39524 was the same change as this PR. Its stack exhaustion tests are folded in here.

A self-review of the folded revision found two things in the getter. It narrowed the export to a `JSFunction`, which rejected a Proxy or a mock that user code had put on `util.inspect`, and it read that user-mutable property at all. Reading the internal module removes both from user reach. The `JSObject` plus `isCallable` shape is then only observable by code that can require the internal module (`--expose-internals`, or the test environment). It is kept because nothing needs a `JSFunction*` and it turns the remaining tampering case into a `TypeError`. A second self-review of the current revision found that no case reached the stylize helper's own failure (the inspect function always failed first). The last commit adds that case.

Other lazily built members whose builder runs JavaScript, for the record. Same failure on main: `m_lazyRequireCacheObject` (#37338, and #39804 handles it with the lazy property kept, `setMayBeNull` on failure and a getter that builds it again on the next access) and `m_processEnvObject` (#38821). Different policy already on main: `m_lazyTestModuleObject` keeps a placeholder object after a failure. The getter shape in this PR has the same behaviour as the #39804 shape (empty on failure, the exception pending, built again on the next access). It uses a plain `WriteBarrier` because both members are created and read in `ZigGlobalObject.cpp`. If the `LazyProperty` plus `setMayBeNull` shape is preferred for consistency with #39804, the conversion is small and I can push it.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->
