### PR TITLE
Fix bunx fork-bombing itself when BUN_OPTIONS is set

### DIFF
--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -913,7 +913,11 @@ pub mod command {
         };
 
         if is_bun_x(argv0) {
-            if let Some(next) = argv.get(1) {
+            // BUN_OPTIONS tokens are spliced in right after argv[0], so the
+            // "add"/"exec" the parent bunx spawned its install child with sits
+            // at `1 + bun_options_argc()` — checking argv[1] made the escape
+            // hatch below miss it and bunx re-spawn itself forever (#39377).
+            if let Some(next) = argv.get(1 + bun::bun_options_argc()) {
                 let next_bytes = next.as_bytes();
                 if next_bytes == b"add"
                     && bun_core::env_var::feature_flag::BUN_INTERNAL_BUNX_INSTALL.get()

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -545,6 +545,7 @@ it.concurrent(
 
     expect(err).not.toContain("error:");
     expect(out.trim()).not.toContain(Bun.version);
+    expect(out.trim()).toMatch(/^\d+\.\d+\.\d+/);
     expect(exited).toBe(0);
   },
   1000 * 60 * 2,

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -587,16 +587,18 @@ it.concurrent("BUN_OPTIONS does not break the internal bunx install escape hatch
 
     {
       await using proc = spawn({ cmd: [bunxPath, "add", "--help"], env: childEnv, stdout: "pipe", stderr: "pipe" });
-      const [out, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      const [out, errOut, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(out).not.toContain("MISDISPATCHED_ADD");
+      expect(errOut).not.toContain("MISDISPATCHED_ADD");
       expect(out).toContain("bun add");
       expect(exitCode).toBe(0);
     }
 
     {
       await using proc = spawn({ cmd: [bunxPath, "exec", "echo hatch-ok"], env: childEnv, stdout: "pipe", stderr: "pipe" });
-      const [out, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      const [out, errOut, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(out).not.toContain("MISDISPATCHED_EXEC");
+      expect(errOut).not.toContain("MISDISPATCHED_EXEC");
       expect(out.trim()).toBe("hatch-ok");
       expect(exitCode).toBe(0);
     }

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "bun";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunEnv, bunExe, isWindows, readdirSorted, tmpdirSync } from "harness";
-import { chmodSync, copyFileSync, readdirSync, symlinkSync } from "node:fs";
+import { chmodSync, copyFileSync, readdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "os";
 import { delimiter, join, resolve } from "path";
 import { dummyAfterAll, dummyBeforeAll, dummyBeforeEach, dummyRegistry, getPort, setHandler } from "./dummy.registry";
@@ -550,6 +550,58 @@ it.concurrent(
   },
   1000 * 60 * 2,
 );
+
+// Companion to the end-to-end test above: exercises the escape hatch directly,
+// so a regression fails as a bounded wrong-output assertion in under a second
+// (no network, no process chain). Covers the exec arm and a two-token
+// BUN_OPTIONS value the e2e path doesn't reach.
+it.concurrent("BUN_OPTIONS does not break the internal bunx install escape hatch", async () => {
+  const { env } = setup();
+  // Dispatch keys off argv[0] ending in "bunx".
+  const bunxDir = tmpdirSync();
+  const bunxPath = join(bunxDir, isWindows ? "bunx.exe" : "bunx");
+  if (isWindows) copyFileSync(bunExe(), bunxPath);
+  else symlinkSync(bunExe(), bunxPath);
+
+  // If the escape hatch misses, BunxCommand resolves "add"/"exec" as the
+  // package to run and finds these on PATH, so the failure is bounded
+  // wrong output instead of an unbounded chain of installs.
+  const decoyDir = tmpdirSync();
+  for (const name of ["add", "exec"]) {
+    if (isWindows) {
+      writeFileSync(join(decoyDir, `${name}.cmd`), `@echo MISDISPATCHED_${name.toUpperCase()}\r\n`);
+    } else {
+      writeFileSync(join(decoyDir, name), `#!/bin/sh\necho MISDISPATCHED_${name.toUpperCase()}\n`, { mode: 0o755 });
+    }
+  }
+
+  // One injected token and two, so skipping a fixed count instead of
+  // bun_options_argc() still fails.
+  for (const bunOptions of ["--smol", "--smol --silent"]) {
+    const childEnv = {
+      ...env,
+      BUN_OPTIONS: bunOptions,
+      BUN_INTERNAL_BUNX_INSTALL: "true",
+      PATH: `${decoyDir}${delimiter}${env.PATH || ""}`,
+    };
+
+    {
+      await using proc = spawn({ cmd: [bunxPath, "add", "--help"], env: childEnv, stdout: "pipe", stderr: "pipe" });
+      const [out, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(out).not.toContain("MISDISPATCHED_ADD");
+      expect(out).toContain("bun add");
+      expect(exitCode).toBe(0);
+    }
+
+    {
+      await using proc = spawn({ cmd: [bunxPath, "exec", "echo hatch-ok"], env: childEnv, stdout: "pipe", stderr: "pipe" });
+      const [out, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(out).not.toContain("MISDISPATCHED_EXEC");
+      expect(out.trim()).toBe("hatch-ok");
+      expect(exitCode).toBe(0);
+    }
+  }
+});
 
 // Pinned to 20: its engines are "^20.19.0 || ^22.12.0 || >=24.0.0", so the node-24
 // requirement this test exercises holds no matter what Node.js version Bun reports.

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -511,6 +511,45 @@ it.concurrent("should handle postinstall scripts correctly with symlinked bunx",
   expect(exited).toBe(0);
 });
 
+// Regression test for #39377: BUN_OPTIONS tokens spliced after argv[0] used to
+// defeat the BUN_INTERNAL_BUNX_INSTALL escape hatch's positional check, so the
+// install child re-entered bunx mode and re-spawned itself forever. Before the
+// fix this test hangs instead of completing.
+it.concurrent(
+  "bunx does not fork-bomb when BUN_OPTIONS is set",
+  async () => {
+    const { x_dir, env } = setup();
+    // The bug only triggers when argv[0] is "bunx": the `bun x` spelling
+    // dispatches through the generic flag-skipping path and is immune.
+    copyFileSync(bunExe(), join(x_dir, isWindows ? "bun.exe" : "bun"));
+    copyFileSync(bunExe(), join(x_dir, isWindows ? "bunx.exe" : "bunx"));
+
+    const subprocess = spawn({
+      cmd: ["bunx", "esbuild@latest", "--version"],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "inherit",
+      stderr: "pipe",
+      env: {
+        ...env,
+        BUN_OPTIONS: "--smol",
+        PATH: `${x_dir}${isWindows ? ";" : ":"}${env.PATH || ""}`,
+      },
+    });
+
+    const [err, out, exited] = await Promise.all([
+      subprocess.stderr.text(),
+      subprocess.stdout.text(),
+      subprocess.exited,
+    ]);
+
+    expect(err).not.toContain("error:");
+    expect(out.trim()).not.toContain(Bun.version);
+    expect(exited).toBe(0);
+  },
+  1000 * 60 * 2,
+);
+
 // Pinned to 20: its engines are "^20.19.0 || ^22.12.0 || >=24.0.0", so the node-24
 // requirement this test exercises holds no matter what Node.js version Bun reports.
 // @latest tracks Angular's engines upward and breaks whenever they outrun us.


### PR DESCRIPTION

### What does this PR do?

Fixes #39377.

With any `BUN_OPTIONS` value set, `bunx <pkg>@latest` forks itself forever instead of installing. Three pieces compose into the loop:

1. `BUN_OPTIONS` tokens are spliced into argv **right after `argv[0]`** at process start (`src/bun_core/util.rs`, `argv_view_init`), shifting every real argument right by `bun_options_argc()`.
2. bunx's install child is spawned as `<self_exe> add <pkg> --no-summary …` with `BUN_INTERNAL_BUNX_INSTALL=true` in its env (`src/runtime/cli/bunx_command.rs`). Since the exe is named `bunx`, the child dispatches through the bunx branch again.
3. The escape hatch that routes that child back to `AddCommand` checks **`argv.get(1)` positionally** (`src/runtime/cli/mod.rs`, `which()`), with no skipping of injected tokens — unlike the generic dispatch below it, which does skip flags.

So the child sees `[bunx, --smol, add, <pkg>, …]`, the hatch misses `"add"`, the child re-enters bunx mode, resolves `add` as *a package to execute*, and re-spawns the install child forever — one blocked `spawnSync` frame and ~44 MB per level (process-growth measurements in #39377).

**The fix is one line** in `which()`:

```rust
if let Some(next) = argv.get(1 + bun::bun_options_argc()) {
```

`bun_options_argc()` is the existing accessor for the injected-token count (already used by the standalone-executable path to compensate for the same splice). The rest of the diff is a comment and a regression test.

Deliberately out of scope (possible follow-up): stripping `BUN_OPTIONS` from the internal install re-exec's env, so injected tokens can never reach internal positional parsing again.

### How did you verify your code works?

New regression test in `test/cli/install/bunx.test.ts` — `"bunx does not fork-bomb when BUN_OPTIONS is set"`, mirroring the existing *symlinked bunx* test (the bug needs `argv[0]` to be `bunx`; the `bun x` spelling dispatches through the flag-skipping generic path and is immune):

- **Unfixed build** (`1.4.0-canary.1+30fa51970`): fails in ~4 s — the misrouted install child dies and the root exits 23 (`expect(exited).toBe(0)` received 23). Outside the harness's isolated TMPDIR the same misroute manifests as the unbounded process chain.
- **Fixed build** (this branch, `1.4.0-debug+c3995e43d`): passes in 4.5 s.

Live repro outside the harness, Windows 11 x64, `BUN_OPTIONS=--smol bunx -y cowsay@latest hello`:

- Unpatched (1.3.14 stable and current canary): recursive chain `bunx add cowsay@latest` → `bunx add add@latest` → … measured 0 → 57 processes in ~4 s (stable) and 0 → 34 in ~3 s (canary); never completes.
- Patched debug build: completes with exit 0, cowsay renders, zero leftover processes.

Full `test/cli/install/bunx.test.ts` suite against the patched Windows debug build: 31 pass / 2 skip / 3 fail — the same 3 fail identically on the unpatched canary in this environment (binary-resolution tests: `--package` with multiple binaries, and the two scoped-package system-binary-collision tests), so they are pre-existing locally and unrelated to this change. `rustfmt` clean with the pinned nightly.
