### PR TITLE
node compile cache: unmap an accepted entry's stored source, keep only the bytecode mapped

### DIFF
--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -71,13 +71,15 @@ struct AlignedBlob {
 
 enum Backing {
     Heap,
-    /// `PROT_READ`/`MAP_PRIVATE` mapping of the cache file's tail: the file is
-    /// mapped whole to validate it, then the pages in front of the one holding
-    /// [`blob_file_offset`] (header + stored code, never read again once
-    /// compared) are unmapped, so `base` is the last page boundary at or before
-    /// the blob. `ptr` stays 128-aligned because page boundaries are. Safe
-    /// against entry rewrites: writers go through tmpfile + rename, so a
-    /// replaced file's old inode stays live under the mapping.
+    /// What is still mapped (`PROT_READ`/`MAP_PRIVATE`) of the cache file. The
+    /// file is mapped whole to validate it, then the pages in front of the one
+    /// holding [`blob_file_offset`] (header + stored code, never read again
+    /// once compared) are unmapped, leaving the tail from the last page
+    /// boundary at or before the blob; when the blob begins in the first page
+    /// or that partial unmap fails, this is still the whole file. `ptr` stays
+    /// 128-aligned because page boundaries are. Safe against entry rewrites:
+    /// writers go through tmpfile + rename, so a replaced file's old inode
+    /// stays live under the mapping.
     Map {
         base: core::ptr::NonNull<u8>,
         map_len: usize,

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -71,15 +71,12 @@ struct AlignedBlob {
 
 enum Backing {
     Heap,
-    /// What is still mapped (`PROT_READ`/`MAP_PRIVATE`) of the cache file. The
-    /// file is mapped whole to validate it, then the pages in front of the one
-    /// holding [`blob_file_offset`] (header + stored code, never read again
-    /// once compared) are unmapped, leaving the tail from the last page
-    /// boundary at or before the blob; when the blob begins in the first page
-    /// or that partial unmap fails, this is still the whole file. `ptr` stays
-    /// 128-aligned because page boundaries are. Safe against entry rewrites:
-    /// writers go through tmpfile + rename, so a replaced file's old inode
-    /// stays live under the mapping.
+    /// `PROT_READ`/`MAP_PRIVATE` mapping of the cache file from the page the
+    /// blob starts on (so `ptr` stays 128-aligned) to its end; the header and
+    /// stored code before that page are unmapped once validated, or still
+    /// included here if that unmap failed. Safe against entry rewrites: writers
+    /// go through tmpfile + rename, so a replaced file's old inode stays live
+    /// under the mapping.
     Map {
         base: core::ptr::NonNull<u8>,
         map_len: usize,
@@ -115,11 +112,8 @@ impl AlignedBlob {
         unsafe { core::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
     }
 
-    /// Takes ownership of a validated whole-file mapping, keeping only the
-    /// pages from the blob onwards mapped (see [`Backing::Map`]). The stored
-    /// code in the unmapped prefix was paged in by the byte compare and would
-    /// otherwise stay resident next to the live source string for the rest of
-    /// the process.
+    /// Takes over a validated whole-file mapping, unmapping everything before
+    /// the blob's page (see [`Backing::Map`]).
     ///
     /// # Safety
     /// `(base, map_len)` must be a live mapping nothing else reads any more,
@@ -136,9 +130,6 @@ impl AlignedBlob {
         let (base, map_len) = if prefix_len != 0 && sys::munmap(base.as_ptr(), prefix_len).is_ok() {
             (tail, map_len - prefix_len)
         } else {
-            // The blob starts in the first page, or the kernel refused the
-            // partial unmap: keep owning the whole mapping and release it at
-            // once on drop.
             (base, map_len)
         };
         Self {

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -62,7 +62,7 @@ struct Entry {
 /// 128-byte-aligned blob. JSC's bytecode decoder reads the blob in place and
 /// requires the same alignment the standalone graph provides (see
 /// StandaloneModuleGraph.rs "Bytecode alignment" note). Either a heap buffer
-/// or a span inside a whole-file mapping.
+/// or a span inside a mapping of the cache file.
 struct AlignedBlob {
     ptr: core::ptr::NonNull<u8>,
     len: usize,
@@ -71,11 +71,13 @@ struct AlignedBlob {
 
 enum Backing {
     Heap,
-    /// `PROT_READ`/`MAP_PRIVATE` mapping of the whole cache file; `ptr` points
-    /// at [`blob_file_offset`] inside it, 128-aligned because the mapping base
-    /// is page-aligned. Safe against entry rewrites: writers go through
-    /// tmpfile + rename, so a replaced file's old inode stays live under the
-    /// mapping.
+    /// `PROT_READ`/`MAP_PRIVATE` mapping of the cache file's tail: the file is
+    /// mapped whole to validate it, then the pages in front of the one holding
+    /// [`blob_file_offset`] (header + stored code, never read again once
+    /// compared) are unmapped, so `base` is the last page boundary at or before
+    /// the blob. `ptr` stays 128-aligned because page boundaries are. Safe
+    /// against entry rewrites: writers go through tmpfile + rename, so a
+    /// replaced file's old inode stays live under the mapping.
     Map {
         base: core::ptr::NonNull<u8>,
         map_len: usize,
@@ -109,6 +111,39 @@ impl AlignedBlob {
     fn as_mut_slice(&mut self) -> &mut [u8] {
         // SAFETY: `ptr` is valid for `len` bytes for the lifetime of `self`.
         unsafe { core::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
+    }
+
+    /// Takes ownership of a validated whole-file mapping, keeping only the
+    /// pages from the blob onwards mapped (see [`Backing::Map`]). The stored
+    /// code in the unmapped prefix was paged in by the byte compare and would
+    /// otherwise stay resident next to the live source string for the rest of
+    /// the process.
+    ///
+    /// # Safety
+    /// `(base, map_len)` must be a live mapping nothing else reads any more,
+    /// with `blob_off + blob_len <= map_len` and `base + blob_off` 128-aligned.
+    unsafe fn from_mapping(
+        base: core::ptr::NonNull<u8>,
+        map_len: usize,
+        blob_off: usize,
+        blob_len: usize,
+    ) -> Self {
+        let prefix_len = blob_off - blob_off % bun_alloc::page_size();
+        // SAFETY: `prefix_len <= blob_off <= map_len` per the contract.
+        let (ptr, tail) = unsafe { (base.add(blob_off), base.add(prefix_len)) };
+        let (base, map_len) = if prefix_len != 0 && sys::munmap(base.as_ptr(), prefix_len).is_ok() {
+            (tail, map_len - prefix_len)
+        } else {
+            // The blob starts in the first page, or the kernel refused the
+            // partial unmap: keep owning the whole mapping and release it at
+            // once on drop.
+            (base, map_len)
+        };
+        Self {
+            ptr,
+            len: blob_len,
+            backing: Backing::Map { base, map_len },
+        }
     }
 }
 
@@ -831,14 +866,11 @@ fn read_cache_file(state: &CacheState, key: u64, entry: &mut Entry, code: Option
     });
     let blob = if map_is_aligned {
         let (base, map_len) = map_guard.take().expect("checked above");
-        // SAFETY: `blob_off + cache_size == map_len` was just validated.
-        let ptr =
-            unsafe { core::ptr::NonNull::new_unchecked(base.as_ptr().add(blob_off as usize)) };
-        AlignedBlob {
-            ptr,
-            len: cache_size as usize,
-            backing: Backing::Map { base, map_len },
-        }
+        // SAFETY: `blob_off + cache_size == map_len` and the blob's alignment
+        // were just validated, and `bytes`/`blob_bytes` (views of the whole
+        // mapping, part of which is unmapped here) are not used past this
+        // point.
+        unsafe { AlignedBlob::from_mapping(base, map_len, blob_off as usize, cache_size as usize) }
     } else {
         // No mapping, or the blob would be misaligned in it: copy to an
         // aligned heap buffer instead (map_guard unmaps on return).

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -254,23 +254,39 @@ console.log("survived", require("./late.js"));`,
     // Misses populate the cache and leave nothing mapped.
     expect(await run(cacheDir)).toEqual({ length: sourceSize, mapped: [] });
 
-    // big.js has the large entry: header, stored source, then the bytecode.
+    // big.js has the large entry. Its layout (NodeCompileCache.rs) is a 108-byte
+    // header whose second u32 is the stored source's size, the stored source,
+    // then the bytecode at the next multiple of 128.
     const entries = [...new Bun.Glob("**/*").scanSync({ cwd: cacheDir, onlyFiles: true })]
-      .map(f => ({ basename: path.basename(f), size: fs.statSync(path.join(cacheDir, f)).size }))
-      .sort((a, b) => b.size - a.size);
+      .map(f => path.join(cacheDir, f))
+      .sort((a, b) => fs.statSync(b).size - fs.statSync(a).size);
     expect(entries).toHaveLength(2);
-    const { basename, size } = entries[0];
-    expect(size).toBeGreaterThan(sourceSize);
+    const entry = fs.readFileSync(entries[0]);
+    const codeSize = entry.readUInt32LE(4);
+    expect(codeSize).toBeGreaterThanOrEqual(sourceSize);
+    const bytecodeOffset = Math.ceil((108 + codeSize) / 128) * 128;
 
-    const { length, mapped } = await run(basename);
-    expect(length).toBe(sourceSize);
-    expect(mapped).toHaveLength(1);
-    const [{ offset, length: mappedLength }] = mapped;
-    // The mapping starts at the page the bytecode begins on, not at the start of the file...
-    expect(offset).toBeGreaterThan(0);
-    expect(mappedLength).toBeLessThan(size);
-    // ...and still covers the bytecode through the end of the file.
-    expect(offset + mappedLength).toBeGreaterThanOrEqual(size);
+    // /proc/self/auxv is a list of (type, value) u64 pairs; AT_PAGESZ is type 6.
+    const auxv = fs.readFileSync("/proc/self/auxv");
+    let pageSize = 0;
+    for (let i = 0; i + 16 <= auxv.length; i += 16) {
+      if (auxv.readBigUInt64LE(i) === 6n) pageSize = Number(auxv.readBigUInt64LE(i + 8));
+    }
+    expect(pageSize).toBeGreaterThan(0);
+    const roundDown = n => n - (n % pageSize);
+    const roundUp = n => roundDown(n + pageSize - 1);
+
+    // Only the pages from the one the bytecode starts on through the end of
+    // the file stay mapped.
+    expect(await run(path.basename(entries[0]))).toEqual({
+      length: sourceSize,
+      mapped: [
+        {
+          offset: roundDown(bytecodeOffset),
+          length: roundUp(entry.length) - roundDown(bytecodeOffset),
+        },
+      ],
+    });
   });
 
   const compileCacheEnv = { ...bunEnv };

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -254,17 +254,17 @@ console.log("survived", require("./late.js"));`,
     // Misses populate the cache and leave nothing mapped.
     expect(await run(cacheDir)).toEqual({ length: sourceSize, mapped: [] });
 
-    // big.js has the large entry. Its layout (NodeCompileCache.rs) is a 108-byte
-    // header whose second u32 is the stored source's size, the stored source,
-    // then the bytecode at the next multiple of 128.
+    // big.js has the large entry. An entry (NodeCompileCache.rs) starts with
+    // `magic u32 | stored source size u32 | bytecode size u32`, holds the stored
+    // source after the header, and ends with the bytecode.
     const entries = [...new Bun.Glob("**/*").scanSync({ cwd: cacheDir, onlyFiles: true })]
       .map(f => path.join(cacheDir, f))
       .sort((a, b) => fs.statSync(b).size - fs.statSync(a).size);
     expect(entries).toHaveLength(2);
     const entry = fs.readFileSync(entries[0]);
-    const codeSize = entry.readUInt32LE(4);
-    expect(codeSize).toBeGreaterThanOrEqual(sourceSize);
-    const bytecodeOffset = Math.ceil((108 + codeSize) / 128) * 128;
+    const bytecodeOffset = entry.length - entry.readUInt32LE(8);
+    expect(entry.readUInt32LE(4)).toBeGreaterThanOrEqual(sourceSize);
+    expect(bytecodeOffset).toBeGreaterThan(sourceSize);
 
     // /proc/self/auxv is a list of (type, value) u64 pairs; AT_PAGESZ is type 6.
     const auxv = fs.readFileSync("/proc/self/auxv");

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isWindows, ospath, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, ospath, tempDir } from "harness";
 import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
 import path from "path";
 
@@ -214,6 +214,63 @@ console.log("survived", require("./late.js"));`,
     const modes = files.map(f => (fs.statSync(path.join(cacheDir, f)).mode & 0o777).toString(8));
     expect(modes).toEqual(["600", "600"]);
     expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!isLinux)("compile cache keeps only the bytecode pages of an accepted entry mapped", async () => {
+    // An accepted entry file is mmapped so JSC reads the bytecode in place. The
+    // stored source in front of the bytecode is only read by the byte compare
+    // (the module's live source holds the same text), so its pages are unmapped
+    // afterwards instead of staying resident for the rest of the process.
+    const sourceSize = 256 * 1024;
+    using dir = tempDir("compile-cache-unmap", {
+      // Spans several pages even with 64 KiB pages.
+      "big.js": `module.exports = "${Buffer.alloc(sourceSize, "x").toString()}";`,
+      // Prints the mappings (file offset + mapped length) of every file whose
+      // path contains argv[2].
+      "main.js": `
+        const length = require("./big.js").length;
+        const mapped = require("fs")
+          .readFileSync("/proc/self/maps", "utf8")
+          .split("\\n")
+          .filter(line => line.includes(process.argv[2]))
+          .map(line => {
+            const [range, , offset] = line.split(/\\s+/);
+            const [start, end] = range.split("-");
+            return { offset: parseInt(offset, 16), length: parseInt(end, 16) - parseInt(start, 16) };
+          });
+        console.log(JSON.stringify({ length, mapped }));
+      `,
+    });
+    const cacheDir = path.join(String(dir), "cc");
+    const env = { ...bunEnv, NODE_COMPILE_CACHE: cacheDir };
+    async function run(filter) {
+      await using proc = Bun.spawn({ cmd: [bunExe(), "main.js", filter], env, cwd: String(dir), stderr: "pipe" });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout);
+    }
+
+    // Misses populate the cache and leave nothing mapped.
+    expect(await run(cacheDir)).toEqual({ length: sourceSize, mapped: [] });
+
+    // big.js has the large entry: header, stored source, then the bytecode.
+    const entries = [...new Bun.Glob("**/*").scanSync({ cwd: cacheDir, onlyFiles: true })]
+      .map(f => ({ basename: path.basename(f), size: fs.statSync(path.join(cacheDir, f)).size }))
+      .sort((a, b) => b.size - a.size);
+    expect(entries).toHaveLength(2);
+    const { basename, size } = entries[0];
+    expect(size).toBeGreaterThan(sourceSize);
+
+    const { length, mapped } = await run(basename);
+    expect(length).toBe(sourceSize);
+    expect(mapped).toHaveLength(1);
+    const [{ offset, length: mappedLength }] = mapped;
+    // The mapping starts at the page the bytecode begins on, not at the start of the file...
+    expect(offset).toBeGreaterThan(0);
+    expect(mappedLength).toBeLessThan(size);
+    // ...and still covers the bytecode through the end of the file.
+    expect(offset + mappedLength).toBeGreaterThanOrEqual(size);
   });
 
   const compileCacheEnv = { ...bunEnv };


### PR DESCRIPTION
### Problem
- On a `NODE_COMPILE_CACHE` hit, `read_cache_file` maps the whole entry file, byte-compares the stored source against the current post-transpile source, and then keeps the entire mapping alive for the process because the bytecode blob at the end of the file is handed to JSC in place (`src/jsc/NodeCompileCache.rs`, `Backing::Map`).
- The header and stored source in front of the blob are never read again after that compare, but the memcmp paged them in, so every accepted module keeps a second resident copy of its source (the mapping) next to the live source string for the rest of the process. For the 256 KiB test module, 0x40000 bytes of the entry's mapping are source that is never read again; across a dependency tree this adds up to roughly the app's total transpiled size, held twice.

### Fix
- After validation, `AlignedBlob::from_mapping` unmaps the page-aligned prefix in front of `blob_file_offset` and records only the remaining tail (`base` = last page boundary at or before the blob) in `Backing::Map`; `Drop` releases that tail.
- Alignment is preserved: the blob offset is a multiple of 128 by construction and the retained base is a page boundary, so the decoder's 128-byte alignment check is unaffected. The blob pointer itself does not move.
- Entries whose blob starts inside the first page have nothing to unmap and keep the whole mapping as before; if `munmap` of the prefix fails, the whole mapping is likewise kept and released at once on drop, so nothing leaks.
- The miss path (the `Box` copy of the source kept until persist) is unchanged; that is a separate, larger change.
- Verified:
  - `test/js/node/module/node-module-module.test.js` ("compile cache keeps only the bytecode pages of an accepted entry mapped"): loads a 256 KiB module twice and reads the child's `/proc/self/maps`. It takes the blob offset from the entry itself (file size minus the blob size stored in the header), the page size from `AT_PAGESZ`, and asserts the entry's single mapping is exactly `{ offset: pageFloor(blobOffset), length: pageCeil(fileSize) - pageFloor(blobOffset) }`. Before: offset 0 / length 528384 (whole file). After: offset 262144 / length 266240. Linux-only because the layout is read from `/proc/self/maps`; the unmap itself is plain POSIX and runs on macOS too.
  - The rest of that file and the 14 `test/js/node/test/parallel/test-compile-cache-*.js` tests pass with the debug build.
  - A 460 KB ESM module with 6000 functions loaded on a hit with `BUN_JSC_verboseDiskCache=1` reports `[Disk Cache] Cache hit` and evaluates to the same result, so JSC decodes the blob from the truncated mapping.

### Background
- Entry file layout: 76-byte header (`HEADER_SIZE`: three u32s for magic, code size and blob size, plus two sha256s), the module's post-transpile source, zero padding up to the next multiple of 128, then the JSC bytecode blob (`blob_file_offset`), which runs to the end of the file.
- The blob must stay alive and 128-byte aligned for the process because JSC's bytecode decoder reads it in place rather than copying it; this is why the file is mmapped and the mapping is owned by the entry (`AlignedBlob`) instead of being read into a temporary buffer.
- `munmap` works on any page-aligned sub-range of a mapping, so unmapping the leading pages simply shrinks the mapping; the kernel keeps the file's old inode alive under the remaining range, which is what makes entry rewrites (tmpfile + rename) safe, as before.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->