### PR TITLE
ServerWebSocket: convert string arguments before the closed check

### DIFF
--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -351,6 +351,11 @@ impl ServerWebSocket {
             );
         }
 
+        // `to_slice` can run user `toString()`, which may close the socket.
+        if self.is_closed() {
+            return Ok(JSValue::FALSE);
+        }
+
         Ok(JSValue::from(op(self.websocket(), topic.slice())))
     }
 
@@ -1100,6 +1105,9 @@ impl ServerWebSocket {
 
         {
             let js_string = message_value.to_js_string(global_this)?;
+            if self.is_closed() {
+                return Ok(JSValue::js_number(0.0));
+            }
             let view = js_string.view(global_this);
             let slice = view.to_slice();
 
@@ -1145,6 +1153,9 @@ impl ServerWebSocket {
         }
 
         let js_string = message_value.to_js_string(global_this)?;
+        if self.is_closed() {
+            return Ok(JSValue::js_number(0.0));
+        }
         let view = js_string.view(global_this);
         let slice = view.to_slice();
 
@@ -1270,6 +1281,9 @@ impl ServerWebSocket {
                     let buffer = string_value.slice();
                     if buffer.len() > MAX_CONTROL_FRAME_PAYLOAD {
                         return Err(throw_control_frame_too_large(global_this, buffer.len()));
+                    }
+                    if self.is_closed() {
+                        return Ok(JSValue::js_number(0.0));
                     }
                     return Ok(send_status_to_js(
                         self.websocket().send(buffer, opcode, false, true),

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -335,15 +335,14 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("{fn_name} requires at least 1 argument")));
         }
 
-        if self.is_closed() {
-            return Ok(JSValue::FALSE);
-        }
-
         if !args[0].is_string() {
             return Err(global_this.throw_invalid_argument_type_value(b"topic", b"string", args[0]));
         }
 
-        let topic = args[0].to_slice(global_this)?;
+        // ToString can run user JS (a String object's toString/toPrimitive), so
+        // it happens before the closed check; the JSString roots the bytes.
+        let topic_string = args[0].to_js_string(global_this)?;
+        let topic = topic_string.view(global_this).to_slice();
 
         if topic.slice().is_empty() {
             return Err(
@@ -351,12 +350,13 @@ impl ServerWebSocket {
             );
         }
 
-        // `to_slice` can run user `toString()`, which may close the socket.
         if self.is_closed() {
             return Ok(JSValue::FALSE);
         }
 
-        Ok(JSValue::from(op(self.websocket(), topic.slice())))
+        let result = op(self.websocket(), topic.slice());
+        topic_string.ensure_still_alive();
+        Ok(JSValue::from(result))
     }
 
     // pub const js = jsc.Codegen.JSServerWebSocket; — provided by #[bun_jsc::JsClass]
@@ -1066,11 +1066,6 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("send requires at least 1 argument")));
         }
 
-        if self.is_closed() {
-            bun_output::scoped_log!(WebSocketServer, "send() closed");
-            return Ok(JSValue::js_number(0.0));
-        }
-
         let compress = Self::parse_compress_arg(
             global_this,
             "send",
@@ -1082,45 +1077,38 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("send requires a non-empty message")));
         }
 
-        if let Some(buffer) = message_value.as_array_buffer(global_this) {
-            let slice = buffer.slice();
-            return Ok(send_status_to_js(
-                self.websocket().send(slice, Opcode::Binary, compress, true),
-                slice.len(),
-                "send",
-                "bytes",
-            ));
+        let array_buffer = message_value.as_array_buffer(global_this);
+        let mut js_string = None;
+        let string_slice;
+        let (buffer, opcode, unit): (&[u8], Opcode, &'static str) =
+            if let Some(buffer) = &array_buffer {
+                (buffer.slice(), Opcode::Binary, "bytes")
+            } else if let Some(slice) = blob_payload(global_this, "send", message_value)? {
+                (slice, Opcode::Binary, "bytes")
+            } else {
+                // ToString can run user JS that closes the socket; do it before the closed check.
+                let string = message_value.to_js_string(global_this)?;
+                string_slice = string.view(global_this).to_slice();
+                js_string = Some(string);
+                (string_slice.slice(), Opcode::Text, "bytes string")
+            };
+
+        if self.is_closed() {
+            bun_output::scoped_log!(WebSocketServer, "send() closed");
+            return Ok(JSValue::js_number(0.0));
         }
 
-        if let Some(slice) = blob_payload(global_this, "send", message_value)? {
-            let ret = send_status_to_js(
-                self.websocket().send(slice, Opcode::Binary, compress, true),
-                slice.len(),
-                "send",
-                "bytes",
-            );
-            message_value.ensure_still_alive();
-            return Ok(ret);
-        }
-
-        {
-            let js_string = message_value.to_js_string(global_this)?;
-            if self.is_closed() {
-                return Ok(JSValue::js_number(0.0));
-            }
-            let view = js_string.view(global_this);
-            let slice = view.to_slice();
-
-            let buffer = slice.slice();
-            let ret = send_status_to_js(
-                self.websocket().send(buffer, Opcode::Text, compress, true),
-                buffer.len(),
-                "send",
-                "bytes string",
-            );
+        let ret = send_status_to_js(
+            self.websocket().send(buffer, opcode, compress, true),
+            buffer.len(),
+            "send",
+            unit,
+        );
+        message_value.ensure_still_alive();
+        if let Some(js_string) = js_string {
             js_string.ensure_still_alive();
-            Ok(ret)
         }
+        Ok(ret)
     }
 
     #[bun_jsc::host_fn(method)]
@@ -1136,11 +1124,6 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("sendText requires at least 1 argument")));
         }
 
-        if self.is_closed() {
-            bun_output::scoped_log!(WebSocketServer, "sendText() closed");
-            return Ok(JSValue::js_number(0.0));
-        }
-
         let compress = Self::parse_compress_arg(
             global_this,
             "sendText",
@@ -1152,14 +1135,16 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("sendText expects a string")));
         }
 
+        // ToString can run user JS that closes the socket; do it before the closed check.
         let js_string = message_value.to_js_string(global_this)?;
+        let slice = js_string.view(global_this).to_slice();
+        let buffer = slice.slice();
+
         if self.is_closed() {
+            bun_output::scoped_log!(WebSocketServer, "sendText() closed");
             return Ok(JSValue::js_number(0.0));
         }
-        let view = js_string.view(global_this);
-        let slice = view.to_slice();
 
-        let buffer = slice.slice();
         let ret = send_status_to_js(
             self.websocket().send(buffer, Opcode::Text, compress, true),
             buffer.len(),
@@ -1245,67 +1230,52 @@ impl ServerWebSocket {
         name: &'static str,
         opcode: Opcode,
     ) -> JsResult<JSValue> {
+        let value = callframe.argument(0);
+        let array_buffer = if value.is_empty_or_undefined_or_null() {
+            None
+        } else {
+            value.as_array_buffer(global_this)
+        };
+        let string_slice;
+        let mut js_string = None;
+        let buffer: &[u8] = if value.is_empty_or_undefined_or_null() {
+            &[]
+        } else if let Some(data) = &array_buffer {
+            data.slice()
+        } else if let Some(buffer) = blob_payload(global_this, name, value)? {
+            buffer
+        } else if value.is_string() {
+            // ToString can run user JS that closes the socket; do it before the closed check.
+            let string = value.to_js_string(global_this)?;
+            string_slice = string.view(global_this).to_slice();
+            js_string = Some(string);
+            string_slice.slice()
+        } else {
+            return Err(global_this.throw(format_args!(
+                "{} requires a string, Blob, or BufferSource",
+                name
+            )));
+        };
+
+        if buffer.len() > MAX_CONTROL_FRAME_PAYLOAD {
+            return Err(throw_control_frame_too_large(global_this, buffer.len()));
+        }
+
         if self.is_closed() {
             return Ok(JSValue::js_number(0.0));
         }
 
-        if callframe.arguments_count() > 0 {
-            let value = callframe.argument(0);
-            if !value.is_empty_or_undefined_or_null() {
-                if let Some(data) = value.as_array_buffer(global_this) {
-                    let buffer = data.slice();
-                    if buffer.len() > MAX_CONTROL_FRAME_PAYLOAD {
-                        return Err(throw_control_frame_too_large(global_this, buffer.len()));
-                    }
-                    return Ok(send_status_to_js(
-                        self.websocket().send(buffer, opcode, false, true),
-                        buffer.len(),
-                        name,
-                        "bytes",
-                    ));
-                } else if let Some(buffer) = blob_payload(global_this, name, value)? {
-                    if buffer.len() > MAX_CONTROL_FRAME_PAYLOAD {
-                        return Err(throw_control_frame_too_large(global_this, buffer.len()));
-                    }
-                    let ret = send_status_to_js(
-                        self.websocket().send(buffer, opcode, false, true),
-                        buffer.len(),
-                        name,
-                        "bytes",
-                    );
-                    value.ensure_still_alive();
-                    return Ok(ret);
-                } else if value.is_string() {
-                    // SAFETY: to_js_string returns a non-null *mut JSString on the Ok path.
-                    let string_value = value.to_js_string(global_this)?.to_slice(global_this);
-                    let buffer = string_value.slice();
-                    if buffer.len() > MAX_CONTROL_FRAME_PAYLOAD {
-                        return Err(throw_control_frame_too_large(global_this, buffer.len()));
-                    }
-                    if self.is_closed() {
-                        return Ok(JSValue::js_number(0.0));
-                    }
-                    return Ok(send_status_to_js(
-                        self.websocket().send(buffer, opcode, false, true),
-                        buffer.len(),
-                        name,
-                        "bytes",
-                    ));
-                } else {
-                    return Err(global_this.throw(format_args!(
-                        "{} requires a string, Blob, or BufferSource",
-                        name
-                    )));
-                }
-            }
-        }
-
-        Ok(send_status_to_js(
-            self.websocket().send(&[], opcode, false, true),
-            0,
+        let ret = send_status_to_js(
+            self.websocket().send(buffer, opcode, false, true),
+            buffer.len(),
             name,
             "bytes",
-        ))
+        );
+        value.ensure_still_alive();
+        if let Some(js_string) = js_string {
+            js_string.ensure_still_alive();
+        }
+        Ok(ret)
     }
 
     #[bun_jsc::host_fn(getter)]

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1501,6 +1501,70 @@ it("server.upgrade() does not blank the Request's url/headers read afterwards", 
   expect(captured!.headerCount).toBeGreaterThan(0);
 });
 
+it("ws.subscribe()/send() with an argument whose toPrimitive terminates the socket does not touch the dead socket", async () => {
+  await using proc = spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const evil = (ws, value) =>
+          Object.assign(new String(value), { [Symbol.toPrimitive]() { ws.terminate(); return value; } });
+        const results = [];
+        const { promise, resolve } = Promise.withResolvers();
+        let pending = 5;
+        const server = Bun.serve({
+          port: 0,
+          fetch(req, srv) {
+            if (srv.upgrade(req, { data: new URL(req.url).pathname.slice(1) })) return;
+            return new Response("no");
+          },
+          websocket: {
+            open(ws) {
+              const which = ws.data;
+              let rc;
+              if (which === "subscribe") rc = ws.subscribe(evil(ws, "room"));
+              else if (which === "unsubscribe") { ws.subscribe("room"); rc = ws.unsubscribe(evil(ws, "room")); }
+              else if (which === "isSubscribed") { ws.subscribe("room"); rc = ws.isSubscribed(evil(ws, "room")); }
+              else if (which === "send") rc = ws.send(evil(ws, "hello"));
+              else if (which === "sendText") rc = ws.sendText(evil(ws, "hello"));
+              results.push(which + "=" + rc + " subscribed=" + ws.isSubscribed("room"));
+              if (--pending === 0) resolve();
+            },
+            message() {},
+            close() {},
+          },
+        });
+        for (const which of ["subscribe", "unsubscribe", "isSubscribed", "send", "sendText"]) {
+          new WebSocket("ws://127.0.0.1:" + server.port + "/" + which).onerror = () => {};
+        }
+        await promise;
+        results.sort();
+        for (const r of results) console.log(r);
+        console.log("publish=" + server.publish("room", "hello"));
+        server.stop(true);
+        process.exit(0);
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe(
+    [
+      "isSubscribed=false subscribed=false",
+      "send=0 subscribed=false",
+      "sendText=0 subscribed=false",
+      "subscribe=false subscribed=false",
+      "unsubscribe=false subscribed=false",
+      "publish=0",
+      "",
+    ].join("\n"),
+  );
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 // Regression: onUpgrade stored the ZigString returned by FetchHeaders.fastGet()
 // (which borrows directly from the header map entry's WTF::StringImpl) and then
 // called fastRemove(), which frees that StringImpl when the map holds the only

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1550,6 +1550,7 @@ it("ws.subscribe()/send() with an argument whose toPrimitive terminates the sock
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
   expect(stdout).toBe(
     [
       "isSubscribed=false subscribed=false",
@@ -1561,7 +1562,6 @@ it("ws.subscribe()/send() with an argument whose toPrimitive terminates the sock
       "",
     ].join("\n"),
   );
-  if (exitCode !== 0) expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });
 


### PR DESCRIPTION
### What
`ServerWebSocket.subscribe/unsubscribe/isSubscribed/send/sendText/ping/pong` checked `is_closed()` and *then* converted their argument with `toString()`, which can run user JS that terminates/closes the socket. The uWS call then ran against a closed socket; `subscribe` left a dangling subscriber in the `TopicTree`, so the next `server.publish()` was a heap-use-after-free.

Each of these now converts its argument once, up front (holding the `JSString*` for the duration of the send), and performs the single closed check after that, immediately before the uWS call.

### Repro (before)
```js
const server = Bun.serve({ port: 0,
  fetch(req, srv) { if (srv.upgrade(req)) return; return new Response("no"); },
  websocket: { open(ws) {
    const topic = Object.assign(new String("room"), { [Symbol.toPrimitive]() { ws.terminate(); return "room"; } });
    console.log(ws.subscribe(topic));                                  // true (should be false)
    setTimeout(() => { console.log(server.publish("room", "hello")); process.exit(0); }, 100); // UAF / SEGV
  }, message() {} } });
new WebSocket(`ws://127.0.0.1:${server.port}/`);
```

### Tests
`test/js/bun/websocket/websocket-server.test.ts` — "ws.subscribe()/send() with an argument whose toPrimitive terminates the socket does not touch the dead socket". Fails on the ASan canary and debug main; passes here.