### PR TITLE
node:http: convert write()/end() arguments before reading response state

### DIFF
--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1991,14 +1991,6 @@ impl NodeHTTPResponse {
             return Err(jsc::JsError::Thrown);
         }
 
-        if self.is_requested_completed_or_ended() {
-            return err_throw(
-                global_object,
-                ErrorCode::ERR_STREAM_WRITE_AFTER_END,
-                "Stream already ended",
-            );
-        }
-
         // Loosely mimicking this code:
         //      function _writeRaw(data, encoding, callback, size) {
         //        const conn = this[kSocket];
@@ -2016,7 +2008,7 @@ impl NodeHTTPResponse {
         }
 
         let state = self.raw_response.get().unwrap().state();
-        if !state.is_response_pending() {
+        if self.is_requested_completed_or_ended() || !state.is_response_pending() {
             return err_throw(
                 global_object,
                 ErrorCode::ERR_STREAM_WRITE_AFTER_END,

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -909,27 +909,8 @@ impl NodeHTTPResponse {
         auto_header_bits: u32,
         keep_alive_timeout_secs: u32,
     ) -> JsResult<JSValue> {
-        if self.is_requested_completed_or_ended() {
-            return err_throw(
-                global_object,
-                ErrorCode::ERR_STREAM_ALREADY_FINISHED,
-                "Stream is already ended",
-            );
-        }
-
-        let flags = self.flags.get();
-        let Some(raw_response) = self.raw_response.get() else {
-            // We haven't emitted the "close" event yet.
-            return Ok(JSValue::UNDEFINED);
-        };
-        if flags.contains(Flags::SOCKET_CLOSED) || flags.contains(Flags::UPGRADED) {
-            // We haven't emitted the "close" event yet.
-            return Ok(JSValue::UNDEFINED);
-        }
-
-        let state = raw_response.state();
-        handle_ended_if_necessary(state, global_object)?;
-
+        // Arguments are converted before any response state is read: ToString on
+        // `statusMessage` can run user JS that destroys or ends the response.
         let status_code_value: JSValue = arguments.first().copied().unwrap_or(JSValue::UNDEFINED);
         let status_message_value: JSValue = match arguments.get(1).copied() {
             Some(v) if v != JSValue::NULL => v,
@@ -974,6 +955,27 @@ impl NodeHTTPResponse {
         if global_object.has_exception() {
             return Err(jsc::JsError::Thrown);
         }
+
+        if self.is_requested_completed_or_ended() {
+            return err_throw(
+                global_object,
+                ErrorCode::ERR_STREAM_ALREADY_FINISHED,
+                "Stream is already ended",
+            );
+        }
+
+        let flags = self.flags.get();
+        let Some(raw_response) = self.raw_response.get() else {
+            // We haven't emitted the "close" event yet.
+            return Ok(JSValue::UNDEFINED);
+        };
+        if flags.contains(Flags::SOCKET_CLOSED) || flags.contains(Flags::UPGRADED) {
+            // We haven't emitted the "close" event yet.
+            return Ok(JSValue::UNDEFINED);
+        }
+
+        let state = raw_response.state();
+        handle_ended_if_necessary(state, global_object)?;
 
         if state.is_http_status_called() {
             return err_throw(
@@ -1219,16 +1221,6 @@ impl NodeHTTPResponse {
         global_object: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        if self.is_done() {
-            return Ok(JSValue::UNDEFINED);
-        }
-        {
-            let Some(raw_response) = self.raw_response.get() else {
-                return Ok(JSValue::UNDEFINED);
-            };
-            handle_ended_if_necessary(raw_response.state(), global_object)?;
-        }
-
         let arguments = callframe.arguments();
         let input_value = arguments.first().copied().unwrap_or(JSValue::UNDEFINED);
         if input_value.is_undefined_or_null() {
@@ -1256,10 +1248,15 @@ impl NodeHTTPResponse {
             ));
         }
 
-        // Re-read after the JS-capable coercion above (R-2: re-entry may clear it).
+        // Response state is read only after the JS-capable coercion above
+        // (R-2: re-entry may destroy or end the response).
+        if self.is_done() {
+            return Ok(JSValue::UNDEFINED);
+        }
         let Some(raw_response) = self.raw_response.get() else {
             return Ok(JSValue::UNDEFINED);
         };
+        handle_ended_if_necessary(raw_response.state(), global_object)?;
         raw_response.write_informational(string_or_buffer.slice());
         Ok(JSValue::UNDEFINED)
     }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2027,6 +2027,24 @@ impl NodeHTTPResponse {
             return Err(jsc::JsError::Thrown);
         }
 
+        // Converting `encoding` / `input` can run user JS (toString,
+        // Symbol.toPrimitive) that destroys or ends the response.
+        if self.flags.get().contains(Flags::SOCKET_CLOSED) || self.raw_response.get().is_none() {
+            return Ok(if IS_END {
+                JSValue::UNDEFINED
+            } else {
+                JSValue::js_number_from_int32(0)
+            });
+        }
+        let state = self.raw_response.get().unwrap().state();
+        if self.is_requested_completed_or_ended() || !state.is_response_pending() {
+            return err_throw(
+                global_object,
+                ErrorCode::ERR_STREAM_WRITE_AFTER_END,
+                "Stream already ended",
+            );
+        }
+
         let bytes = string_or_buffer.slice();
 
         if IS_END {

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1910,41 +1910,8 @@ impl NodeHTTPResponse {
         arguments: &[JSValue],
         this_value: JSValue,
     ) -> JsResult<JSValue> {
-        if self.is_requested_completed_or_ended() {
-            return err_throw(
-                global_object,
-                ErrorCode::ERR_STREAM_WRITE_AFTER_END,
-                "Stream already ended",
-            );
-        }
-
-        // Loosely mimicking this code:
-        //      function _writeRaw(data, encoding, callback, size) {
-        //        const conn = this[kSocket];
-        //        if (conn?.destroyed) {
-        //          // The socket was destroyed. If we're still trying to write to it,
-        //          // then we haven't gotten the 'close' event yet.
-        //          return false;
-        //        }
-        if self.flags.get().contains(Flags::SOCKET_CLOSED) || self.raw_response.get().is_none() {
-            return Ok(if IS_END {
-                JSValue::UNDEFINED
-            } else {
-                JSValue::js_number_from_int32(0)
-            });
-        }
-
-        // Re-read raw_response at each use site (R-2: methods that
-        // re-enter may clear it).
-        let state = self.raw_response.get().unwrap().state();
-        if !state.is_response_pending() {
-            return err_throw(
-                global_object,
-                ErrorCode::ERR_STREAM_WRITE_AFTER_END,
-                "Stream already ended",
-            );
-        }
-
+        // Arguments are converted before any response state is read: ToString on
+        // `input` / `encoding` can run user JS that destroys or ends the response.
         let input_value: JSValue = if arguments.len() > 0 {
             arguments[0]
         } else {
@@ -2027,8 +1994,22 @@ impl NodeHTTPResponse {
             return Err(jsc::JsError::Thrown);
         }
 
-        // Converting `encoding` / `input` can run user JS (toString,
-        // Symbol.toPrimitive) that destroys or ends the response.
+        if self.is_requested_completed_or_ended() {
+            return err_throw(
+                global_object,
+                ErrorCode::ERR_STREAM_WRITE_AFTER_END,
+                "Stream already ended",
+            );
+        }
+
+        // Loosely mimicking this code:
+        //      function _writeRaw(data, encoding, callback, size) {
+        //        const conn = this[kSocket];
+        //        if (conn?.destroyed) {
+        //          // The socket was destroyed. If we're still trying to write to it,
+        //          // then we haven't gotten the 'close' event yet.
+        //          return false;
+        //        }
         if self.flags.get().contains(Flags::SOCKET_CLOSED) || self.raw_response.get().is_none() {
             return Ok(if IS_END {
                 JSValue::UNDEFINED
@@ -2036,8 +2017,9 @@ impl NodeHTTPResponse {
                 JSValue::js_number_from_int32(0)
             });
         }
+
         let state = self.raw_response.get().unwrap().state();
-        if self.is_requested_completed_or_ended() || !state.is_response_pending() {
+        if !state.is_response_pending() {
             return err_throw(
                 global_object,
                 ErrorCode::ERR_STREAM_WRITE_AFTER_END,

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2281,6 +2281,42 @@ it("socket handle write keeps buffered data intact when encoding coercion re-ent
   expect(exitCode).toBe(0);
 }, 30_000);
 
+it("ServerResponse.write() with an encoding whose toPrimitive destroys the response does not crash", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const http = require("node:http");
+        const server = http.createServer((req, res) => {
+          const enc = Object.assign(new String("hex"), {
+            [Symbol.toPrimitive]() { res.destroy(); Bun.gc(true); return "hex"; },
+          });
+          let result;
+          try {
+            result = "returned " + typeof res.write("41".repeat(20000), enc);
+            res.end();
+          } catch (e) {
+            result = "threw " + (e.code || e.message);
+          }
+          console.log(result);
+          setImmediate(() => { server.close(); process.exit(0); });
+        });
+        server.listen(0, "127.0.0.1", () => {
+          fetch("http://127.0.0.1:" + server.address().port + "/").then(r => r.text()).catch(() => {});
+        });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("returned boolean\n");
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 it("client request path that does not begin with a slash stays on the configured host", async () => {
   // `options.path` must only ever influence the request target that is written
   // on the wire; it must never change which server the client connects to,

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -2281,21 +2281,27 @@ it("socket handle write keeps buffered data intact when encoding coercion re-ent
   expect(exitCode).toBe(0);
 }, 30_000);
 
-it("ServerResponse.write() with an encoding whose toPrimitive destroys the response does not crash", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
+it.each([
+  ["write", `result = res.write(payload, enc); res.end();`, "returned boolean"],
+  ["end", `res.flushHeaders(); result = res.end(payload, enc);`, "returned object"],
+])(
+  "ServerResponse.%s() with an encoding whose toPrimitive destroys the response does not crash",
+  async (_method, call, expected) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         const http = require("node:http");
         const server = http.createServer((req, res) => {
           const enc = Object.assign(new String("hex"), {
             [Symbol.toPrimitive]() { res.destroy(); Bun.gc(true); return "hex"; },
           });
+          const payload = Buffer.alloc(40000, "41").toString();
           let result;
           try {
-            result = "returned " + typeof res.write("41".repeat(20000), enc);
-            res.end();
+            ${call}
+            result = "returned " + typeof result;
           } catch (e) {
             result = "threw " + (e.code || e.message);
           }
@@ -2306,16 +2312,17 @@ it("ServerResponse.write() with an encoding whose toPrimitive destroys the respo
           fetch("http://127.0.0.1:" + server.address().port + "/").then(r => r.text()).catch(() => {});
         });
       `,
-    ],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("returned boolean\n");
-  if (exitCode !== 0) expect(stderr).toBe("");
-  expect(exitCode).toBe(0);
-});
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(expected + "\n");
+    expect(exitCode).toBe(0);
+  },
+);
 
 it("client request path that does not begin with a slash stays on the configured host", async () => {
   // `options.path` must only ever influence the request target that is written


### PR DESCRIPTION
### What
`node:http` `ServerResponse.write(chunk, encoding)` / `end(...)`: `NodeHTTPResponse::write_or_end` read the response state (ended / socket closed / pending), then converted `encoding` and the chunk (`Encoding::from_js`, `StringOrBuffer`), which can run user JS (`toString` / `Symbol.toPrimitive`) that destroys the response. It then continued into the zero-copy write path with a closed socket and a null `this` value (UBSan: member call on null `JSCell`; stock SEGV at 0x28).

`write_or_end` now converts all arguments first and reads the response state once, after that (this is also Node's order: `write_()` validates the chunk before the write-after-end / destroyed checks).

### Repro (before)
```js
import http from "http";
const server = http.createServer((req, res) => {
  const enc = Object.assign(new String("hex"), { [Symbol.toPrimitive]() { res.destroy(); Bun.gc(true); return "hex"; } });
  res.write("41".repeat(20000), enc);   // crash
  setTimeout(() => process.exit(0), 100);
});
server.listen(0, () => fetch(`http://127.0.0.1:${server.address().port}/`).catch(() => {}));
```

### Tests
`test/js/node/http/node-http.test.ts` — "ServerResponse.write() with an encoding whose toPrimitive destroys the response does not crash". Fails on the ASan canary and debug main; passes here.