### PR TITLE
node:path: stringify String-object arguments before borrowing any argument

### DIFF
--- a/src/jsc/bindings/Path.cpp
+++ b/src/jsc/bindings/Path.cpp
@@ -41,7 +41,7 @@ static inline JSC::EncodedJSValue createZigFunction(JSGlobalObject* globalObject
         // A String object can run user JS (Symbol.toPrimitive / toString) when
         // stringified; do it here so the resulting JSString is rooted in `args`
         // before the native side borrows characters from any argument.
-        if (Function != Bun__Path__format) {
+        if (Function != Bun__Path__format && Function != Bun__Path__toNamespacedPath) {
             if (arg.isCell()) {
                 const JSC::JSType type = arg.asCell()->type();
                 if (type == JSC::StringObjectType || type == JSC::DerivedStringObjectType) {

--- a/src/jsc/bindings/Path.cpp
+++ b/src/jsc/bindings/Path.cpp
@@ -37,7 +37,20 @@ static inline JSC::EncodedJSValue createZigFunction(JSGlobalObject* globalObject
     auto scope = DECLARE_THROW_SCOPE(vm);
     MarkedArgumentBufferWithSize<8> args = MarkedArgumentBufferWithSize<8>();
     for (unsigned i = 0, size = callFrame->argumentCount(); i < size; ++i) {
-        args.append(callFrame->argument(i));
+        JSValue arg = callFrame->argument(i);
+        // A String object can run user JS (Symbol.toPrimitive / toString) when
+        // stringified; do it here so the resulting JSString is rooted in `args`
+        // before the native side borrows characters from any argument.
+        if (Function != Bun__Path__format) {
+            if (arg.isCell()) {
+                const JSType type = arg.asCell()->type();
+                if (type == StringObjectType || type == DerivedStringObjectType) {
+                    arg = arg.toString(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
+            }
+        }
+        args.append(arg);
     }
     const auto result = Function(globalObject, isWindows, args.data(), args.size());
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/Path.cpp
+++ b/src/jsc/bindings/Path.cpp
@@ -43,8 +43,8 @@ static inline JSC::EncodedJSValue createZigFunction(JSGlobalObject* globalObject
         // before the native side borrows characters from any argument.
         if (Function != Bun__Path__format) {
             if (arg.isCell()) {
-                const JSType type = arg.asCell()->type();
-                if (type == StringObjectType || type == DerivedStringObjectType) {
+                const JSC::JSType type = arg.asCell()->type();
+                if (type == JSC::StringObjectType || type == JSC::DerivedStringObjectType) {
                     arg = arg.toString(globalObject);
                     RETURN_IF_EXCEPTION(scope, {});
                 }

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -68,7 +68,7 @@ test("String-object arguments whose toPrimitive triggers GC do not corrupt earli
       bunExe(),
       "-e",
       `const path = require("node:path");
-const long = "/dir/" + "seg_".repeat(4000);
+const long = "/dir/" + Buffer.alloc(16000, "seg_").toString();
 const first = () => Object.assign(new String("x"), {
   [Symbol.toPrimitive]() { return long.slice(1).padStart(long.length, "/"); },
 });
@@ -76,7 +76,7 @@ const second = value => Object.assign(new String("y"), {
   [Symbol.toPrimitive]() {
     Bun.gc(true);
     const keep = [];
-    for (let i = 0; i < 200; i++) keep.push("Q".repeat(50000 + i));
+    for (let i = 0; i < 200; i++) keep.push(Buffer.alloc(50000 + i, "Q").toString());
     globalThis.keep = keep;
     Bun.gc(true);
     return value;
@@ -100,7 +100,8 @@ for (const ns of ["posix", "win32"]) {
 }
 console.log(results.join("\\n"));`,
     ],
-    env: { ...bunEnv, Malloc: "1" },
+    // Malloc=1 lets ASan builds see the freed JSC string; bmalloc has no SystemHeap on Windows.
+    env: isWindows ? bunEnv : { ...bunEnv, Malloc: "1", ASAN_OPTIONS: "detect_leaks=0" },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/js/node/path/path.test.js
+++ b/test/js/node/path/path.test.js
@@ -1,4 +1,4 @@
-import { describe, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows } from "harness";
 import assert from "node:assert";
 import path from "node:path";
@@ -58,6 +58,60 @@ describe("path", () => {
     if (isWindows) assert.strictEqual(path, path.win32);
     else assert.strictEqual(path, path.posix);
   });
+});
+
+test("String-object arguments whose toPrimitive triggers GC do not corrupt earlier arguments", async () => {
+  // Converting argument N+1 runs user JS that GCs; the string produced for
+  // argument N must still be intact when the native side reads it.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const path = require("node:path");
+const long = "/dir/" + "seg_".repeat(4000);
+const first = () => Object.assign(new String("x"), {
+  [Symbol.toPrimitive]() { return long.slice(1).padStart(long.length, "/"); },
+});
+const second = value => Object.assign(new String("y"), {
+  [Symbol.toPrimitive]() {
+    Bun.gc(true);
+    const keep = [];
+    for (let i = 0; i < 200; i++) keep.push("Q".repeat(50000 + i));
+    globalThis.keep = keep;
+    Bun.gc(true);
+    return value;
+  },
+});
+const results = [];
+for (const ns of ["posix", "win32"]) {
+  const p = path[ns];
+  const cases = {
+    join: () => [p.join(first(), second("tail")), p.join(long, "tail")],
+    resolve: () => [p.resolve(first(), second("tail")), p.resolve(long, "tail")],
+    relative: () => [p.relative(first(), second(long + "/x")), p.relative(long, long + "/x")],
+    basename: () => [p.basename(first(), second("_")), p.basename(long, "_")],
+  };
+  for (const [name, fn] of Object.entries(cases)) {
+    for (let r = 0; r < 3; r++) {
+      const [got, want] = fn();
+      results.push(ns + "." + name + "[" + r + "]=" + (got === want ? "OK" : "MISMATCH"));
+    }
+  }
+}
+console.log(results.join("\\n"));`,
+    ],
+    env: { ...bunEnv, Malloc: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const expected = [];
+  for (const ns of ["posix", "win32"])
+    for (const name of ["join", "resolve", "relative", "basename"])
+      for (let r = 0; r < 3; r++) expected.push(`${ns}.${name}[${r}]=OK`);
+  expect({ lines: stdout.trim().split("\n"), stderr }).toEqual({ lines: expected, stderr: "" });
+  expect(exitCode).toBe(0);
 });
 
 test.if(isWindows)("Bun.which skips PATH segments longer than the Windows wide-path buffer", async () => {


### PR DESCRIPTION
### What
`node:path` functions (`join`, `resolve`, `relative`, `basename(path, suffix)`, … posix and win32) accept String *objects*. The native side borrowed each argument's characters in order, so a later argument's `Symbol.toPrimitive` / `toString` could GC the temporary JSString an earlier String-object argument had produced, leaving a dangling view (ASan `heap-use-after-free READ` with `Malloc=1`; without ASan, foreign heap bytes end up in the returned path).

The single C++ trampoline used by every `path.posix/win32` function now stringifies String-object arguments up front and roots the resulting `JSString`s in the existing `MarkedArgumentBuffer`, so all user JS runs before Rust borrows any characters. Primitive strings and non-strings are untouched (validation errors unchanged); `path.format` is excluded (object argument, already copied).

### Repro (before)
```js
import path from "node:path";
const a0 = Object.assign(new String("x"), { [Symbol.toPrimitive]: () => "seg0_".repeat(3000).slice(0) + "" });
const a1 = Object.assign(new String("y"), { [Symbol.toPrimitive]() { Bun.gc(true); globalThis.k = Array.from({length: 400}, (_, i) => "Q".repeat(50000 + i)); Bun.gc(true); return "tail"; } });
console.log(path.join(a0, a1) === path.join("seg0_".repeat(3000), "tail")); // false / ASan UAF READ
```
Same for `path.basename(p, suffix)`.

### Tests
`test/js/node/path/path.test.js` — "String-object arguments whose toPrimitive triggers GC do not corrupt earlier arguments" (join/resolve/relative/basename × posix/win32, `Malloc=1`). Fails on the ASan canary and debug main; passes here.
