### PR TITLE
server.publish()/ws.publish(): convert topic and message before reading server state

### DIFF
--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -875,6 +875,10 @@ impl ServerWebSocket {
 
         {
             let js_string = message_value.to_js_string(global_this)?;
+            // `to_js_string` can run user JS that stops the server.
+            let Some(ctx) = self.publish_ctx() else {
+                return Ok(JSValue::js_number(0.0));
+            };
             let view = js_string.view(global_this);
             let slice = view.to_slice();
 
@@ -903,10 +907,10 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("publish requires at least 1 argument")));
         }
 
-        let Some(ctx) = self.publish_ctx() else {
+        if self.publish_ctx().is_none() {
             bun_output::scoped_log!(WebSocketServer, "publish() closed");
             return Ok(JSValue::js_number(0.0));
-        };
+        }
 
         if topic_value.is_empty_or_undefined_or_null() || !topic_value.is_string() {
             bun_output::scoped_log!(WebSocketServer, "publish() topic invalid");
@@ -927,6 +931,9 @@ impl ServerWebSocket {
         }
 
         let js_string = message_value.to_js_string(global_this)?;
+        let Some(ctx) = self.publish_ctx() else {
+            return Ok(JSValue::js_number(0.0));
+        };
         let view = js_string.view(global_this);
         let slice = view.to_slice();
 

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -836,17 +836,16 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("publish requires at least 1 argument")));
         }
 
-        let Some(ctx) = self.publish_ctx() else {
-            bun_output::scoped_log!(WebSocketServer, "publish() closed");
-            return Ok(JSValue::js_number(0.0));
-        };
-
         if topic_value.is_empty_or_undefined_or_null() || !topic_value.is_string() {
             bun_output::scoped_log!(WebSocketServer, "publish() topic invalid");
             return Err(global_this.throw(format_args!("publish requires a topic string")));
         }
 
-        let topic_slice = topic_value.to_slice(global_this)?;
+        // ToString on either argument can run user JS that stops the server or
+        // triggers GC, so both are converted (and their JSStrings held) before
+        // the handler state is read.
+        let topic_string = topic_value.to_js_string(global_this)?;
+        let topic_slice = topic_string.view(global_this).to_slice();
         if topic_slice.slice().is_empty() {
             return Err(global_this.throw(format_args!("publish requires a non-empty topic")));
         }
@@ -862,36 +861,32 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("publish requires a non-empty message")));
         }
 
-        if let Some(array_buffer) = message_value.as_array_buffer(global_this) {
-            let buffer = array_buffer.slice();
-            return Ok(self.do_publish(ctx, topic_slice.slice(), buffer, Opcode::Binary, compress));
-        }
+        let array_buffer = message_value.as_array_buffer(global_this);
+        let mut message_string = None;
+        let message_slice;
+        let (buffer, opcode): (&[u8], Opcode) = if let Some(array_buffer) = &array_buffer {
+            (array_buffer.slice(), Opcode::Binary)
+        } else if let Some(slice) = blob_payload(global_this, "publish", message_value)? {
+            (slice, Opcode::Binary)
+        } else {
+            let string = message_value.to_js_string(global_this)?;
+            message_slice = string.view(global_this).to_slice();
+            message_string = Some(string);
+            (message_slice.slice(), Opcode::Text)
+        };
 
-        if let Some(slice) = blob_payload(global_this, "publish", message_value)? {
-            let ret = self.do_publish(ctx, topic_slice.slice(), slice, Opcode::Binary, compress);
-            message_value.ensure_still_alive();
-            return Ok(ret);
-        }
+        let Some(ctx) = self.publish_ctx() else {
+            bun_output::scoped_log!(WebSocketServer, "publish() closed");
+            return Ok(JSValue::js_number(0.0));
+        };
 
-        {
-            let js_string = message_value.to_js_string(global_this)?;
-            // `to_js_string` can run user JS that stops the server.
-            let Some(ctx) = self.publish_ctx() else {
-                return Ok(JSValue::js_number(0.0));
-            };
-            let view = js_string.view(global_this);
-            let slice = view.to_slice();
-
-            let ret = self.do_publish(
-                ctx,
-                topic_slice.slice(),
-                slice.slice(),
-                Opcode::Text,
-                compress,
-            );
-            js_string.ensure_still_alive();
-            Ok(ret)
+        let ret = self.do_publish(ctx, topic_slice.slice(), buffer, opcode, compress);
+        topic_string.ensure_still_alive();
+        message_value.ensure_still_alive();
+        if let Some(message_string) = message_string {
+            message_string.ensure_still_alive();
         }
+        Ok(ret)
     }
 
     #[bun_jsc::host_fn(method)]
@@ -907,17 +902,13 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("publish requires at least 1 argument")));
         }
 
-        if self.publish_ctx().is_none() {
-            bun_output::scoped_log!(WebSocketServer, "publish() closed");
-            return Ok(JSValue::js_number(0.0));
-        }
-
         if topic_value.is_empty_or_undefined_or_null() || !topic_value.is_string() {
             bun_output::scoped_log!(WebSocketServer, "publish() topic invalid");
             return Err(global_this.throw(format_args!("publishText requires a topic string")));
         }
 
-        let topic_slice = topic_value.to_slice(global_this)?;
+        let topic_string = topic_value.to_js_string(global_this)?;
+        let topic_slice = topic_string.view(global_this).to_slice();
 
         let compress = Self::parse_compress_arg(
             global_this,
@@ -930,21 +921,23 @@ impl ServerWebSocket {
             return Err(global_this.throw(format_args!("publishText requires a non-empty message")));
         }
 
-        let js_string = message_value.to_js_string(global_this)?;
+        let message_string = message_value.to_js_string(global_this)?;
+        let message_slice = message_string.view(global_this).to_slice();
+
         let Some(ctx) = self.publish_ctx() else {
+            bun_output::scoped_log!(WebSocketServer, "publish() closed");
             return Ok(JSValue::js_number(0.0));
         };
-        let view = js_string.view(global_this);
-        let slice = view.to_slice();
 
         let ret = self.do_publish(
             ctx,
             topic_slice.slice(),
-            slice.slice(),
+            message_slice.slice(),
             Opcode::Text,
             compress,
         );
-        js_string.ensure_still_alive();
+        topic_string.ensure_still_alive();
+        message_string.ensure_still_alive();
         Ok(ret)
     }
 
@@ -963,17 +956,13 @@ impl ServerWebSocket {
             );
         }
 
-        let Some(ctx) = self.publish_ctx() else {
-            bun_output::scoped_log!(WebSocketServer, "publish() closed");
-            return Ok(JSValue::js_number(0.0));
-        };
-
         if topic_value.is_empty_or_undefined_or_null() || !topic_value.is_string() {
             bun_output::scoped_log!(WebSocketServer, "publishBinary() topic invalid");
             return Err(global_this.throw(format_args!("publishBinary requires a topic string")));
         }
 
-        let topic_slice = topic_value.to_slice(global_this)?;
+        let topic_string = topic_value.to_js_string(global_this)?;
+        let topic_slice = topic_string.view(global_this).to_slice();
         if topic_slice.slice().is_empty() {
             return Err(global_this.throw(format_args!("publishBinary requires a non-empty topic")));
         }
@@ -991,23 +980,26 @@ impl ServerWebSocket {
             );
         }
 
-        if let Some(array_buffer) = message_value.as_array_buffer(global_this) {
-            return Ok(self.do_publish(
-                ctx,
-                topic_slice.slice(),
-                array_buffer.slice(),
-                Opcode::Binary,
-                compress,
-            ));
-        }
+        let array_buffer = message_value.as_array_buffer(global_this);
+        let buffer: &[u8] = if let Some(array_buffer) = &array_buffer {
+            array_buffer.slice()
+        } else if let Some(slice) = blob_payload(global_this, "publishBinary", message_value)? {
+            slice
+        } else {
+            return Err(
+                global_this.throw(format_args!("publishBinary expects a Blob or BufferSource"))
+            );
+        };
 
-        if let Some(slice) = blob_payload(global_this, "publishBinary", message_value)? {
-            let ret = self.do_publish(ctx, topic_slice.slice(), slice, Opcode::Binary, compress);
-            message_value.ensure_still_alive();
-            return Ok(ret);
-        }
+        let Some(ctx) = self.publish_ctx() else {
+            bun_output::scoped_log!(WebSocketServer, "publish() closed");
+            return Ok(JSValue::js_number(0.0));
+        };
 
-        Err(global_this.throw(format_args!("publishBinary expects a Blob or BufferSource")))
+        let ret = self.do_publish(ctx, topic_slice.slice(), buffer, Opcode::Binary, compress);
+        topic_string.ensure_still_alive();
+        message_value.ensure_still_alive();
+        Ok(ret)
     }
 
     // `passThis: true` in server.classes.ts — wrapper is emitted by

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1540,16 +1540,19 @@ where
         if topic_value.is_undefined_or_null() {
             return Err(global.throw_invalid_arguments(format_args!("Expected string")));
         }
-        // Owning slice: converting `message_value` below can run user JS / GC,
-        // which must not free the topic bytes.
-        let topic = topic_value.to_slice(global)?;
+        // Converting `message_value` can run user JS / GC; the JSString keeps the
+        // topic bytes alive across it.
+        let topic_string = topic_value.to_js_string(global)?;
+        let topic = topic_string.view(global).to_slice();
         // jsc.JSValue
         let message_value = iter
             .next_eat()
             .ok_or_else(|| global.throw_invalid_arguments(format_args!("Missing argument")))?;
         // ?jsc.JSValue
         let compress_value = iter.next_eat();
-        self.publish(global, topic.slice(), message_value, compress_value)
+        let result = self.publish(global, topic.slice(), message_value, compress_value);
+        topic_string.ensure_still_alive();
+        result
     }
 
     /// `pub const doRequestIP = host_fn.wrapInstanceMethod(ThisServer, "requestIP", false)`

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1540,14 +1540,16 @@ where
         if topic_value.is_undefined_or_null() {
             return Err(global.throw_invalid_arguments(format_args!("Expected string")));
         }
-        let topic = topic_value.get_zig_string(global)?;
+        // Owning slice: converting `message_value` below can run user JS / GC,
+        // which must not free the topic bytes.
+        let topic = topic_value.to_slice(global)?;
         // jsc.JSValue
         let message_value = iter
             .next_eat()
             .ok_or_else(|| global.throw_invalid_arguments(format_args!("Missing argument")))?;
         // ?jsc.JSValue
         let compress_value = iter.next_eat();
-        self.publish(global, topic, message_value, compress_value)
+        self.publish(global, topic.slice(), message_value, compress_value)
     }
 
     /// `pub const doRequestIP = host_fn.wrapInstanceMethod(ThisServer, "requestIP", false)`
@@ -1656,7 +1658,7 @@ where
     pub(crate) fn publish(
         &mut self,
         global: &JSGlobalObject,
-        topic: ZigString,
+        topic: &[u8],
         message_value: JSValue,
         compress_value: Option<JSValue>,
     ) -> JsResult<JSValue> {
@@ -1664,87 +1666,53 @@ where
             return Ok(JSValue::js_number(0.0));
         }
 
-        let app = self.app.unwrap().cast::<c_void>();
-
-        if topic.len == 0 {
+        if topic.is_empty() {
             httplog!("publish() topic invalid");
             return Err(global.throw(format_args!("publish requires a topic string")));
-        }
-
-        let topic_slice = topic.to_slice();
-        if topic_slice.slice().is_empty() {
-            return Err(global.throw(format_args!("publish requires a non-empty topic")));
         }
 
         // compress defaults to true when the argument is omitted.
         let compress_js = compress_value.unwrap_or(JSValue::TRUE);
         let compress = compress_js.to_boolean();
 
-        if let Some(buffer) = message_value.as_array_buffer(global) {
-            let status = AnyWebSocket::publish_with_options(
-                SSL,
-                app,
-                topic_slice.slice(),
-                buffer.slice(),
-                uws_sys::Opcode::Binary,
-                compress,
-            );
-            return Ok(super::server_web_socket::send_status_to_js(
-                status,
-                buffer.slice().len(),
-                "publish",
-                "bytes",
-            ));
-        }
-
-        if let Some(slice) =
+        // Resolve the payload before reading `self.app`: `to_js_string` can run
+        // user JS that stops the server.
+        let array_buffer = message_value.as_array_buffer(global);
+        let mut js_string: Option<&jsc::JSString> = None;
+        let string_slice;
+        let (buffer, opcode): (&[u8], uws_sys::Opcode) = if let Some(buffer) = &array_buffer {
+            (buffer.slice(), uws_sys::Opcode::Binary)
+        } else if let Some(slice) =
             super::server_web_socket::blob_payload(global, "publish", message_value)?
         {
-            let status = AnyWebSocket::publish_with_options(
-                SSL,
-                app,
-                topic_slice.slice(),
-                slice,
-                uws_sys::Opcode::Binary,
-                compress,
-            );
-            let result = super::server_web_socket::send_status_to_js(
-                status,
-                slice.len(),
-                "publish",
-                "bytes",
-            );
-            message_value.ensure_still_alive();
-            return Ok(result);
-        }
+            (slice, uws_sys::Opcode::Binary)
+        } else {
+            let js_str = message_value.to_js_string(global)?;
+            js_string = Some(js_str);
+            string_slice = js_str.view(global).to_slice();
+            (string_slice.slice(), uws_sys::Opcode::Text)
+        };
 
-        {
-            let js_string = message_value.to_js_string(global)?;
-            let view = js_string.view(global);
-            let slice = view.to_slice();
-            // Keep `js_string` alive, not `message_value`:
-            // when the input was not already a JSString, `to_js_string` allocates
-            // a fresh GC cell that is *not* reachable from `message_value`, so a
-            // GC during `publish_with_options` could otherwise reclaim the bytes
-            // `slice` borrows.
-            let buffer = slice.slice();
-            let status = AnyWebSocket::publish_with_options(
-                SSL,
-                app,
-                topic_slice.slice(),
-                buffer,
-                uws_sys::Opcode::Text,
-                compress,
-            );
-            let result = super::server_web_socket::send_status_to_js(
-                status,
-                buffer.len(),
-                "publish",
-                "bytes",
-            );
+        let Some(app) = self.app else {
+            return Ok(JSValue::js_number(0.0));
+        };
+        let status = AnyWebSocket::publish_with_options(
+            SSL,
+            app.cast::<c_void>(),
+            topic,
+            buffer,
+            opcode,
+            compress,
+        );
+        let result =
+            super::server_web_socket::send_status_to_js(status, buffer.len(), "publish", "bytes");
+        // When the input was not already a JSString, `to_js_string` allocates a
+        // fresh GC cell not reachable from `message_value`; keep both alive.
+        message_value.ensure_still_alive();
+        if let Some(js_string) = js_string {
             js_string.ensure_still_alive();
-            return Ok(result);
         }
+        Ok(result)
     }
 
     pub(crate) fn on_upgrade(

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1580,6 +1580,61 @@ it("server.upgrade() with Sec-WebSocket-Protocol in options.headers does not use
   expect(exitCode).toBe(0);
 });
 
+it("server.publish() keeps the topic alive while converting the message", async () => {
+  await using proc = spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const TOPIC = "t_".repeat(4000);
+        const server = Bun.serve({
+          port: 0,
+          fetch(req, s) { return s.upgrade(req) ? undefined : new Response("x"); },
+          websocket: { open(ws) { ws.subscribe(TOPIC); }, message() {} },
+        });
+        const client = new WebSocket("ws://127.0.0.1:" + server.port + "/");
+        const got = Promise.withResolvers();
+        client.onmessage = e => got.resolve(e.data);
+        client.onclose = () => got.resolve("closed");
+        await new Promise((resolve, reject) => { client.onopen = resolve; client.onerror = reject; });
+        // A String object so toPrimitive hands back a fresh, otherwise-unreferenced JSString.
+        const topic = Object.assign(new String("z"), { [Symbol.toPrimitive]() { return "t_".repeat(4000).slice(0) + ""; } });
+        const data = Object.assign(new String("z"), {
+          [Symbol.toPrimitive]() {
+            Bun.gc(true);
+            const k = [];
+            for (let i = 0; i < 300; i++) k.push("Q".repeat(40000 + i));
+            globalThis.keep = k;
+            Bun.gc(true);
+            return "payload";
+          },
+        });
+        const rc = server.publish(topic, data);
+        // If the first publish went to a garbage topic, this one arrives first.
+        server.publish(TOPIC, "sentinel");
+        const result = await got.promise;
+        console.log(JSON.stringify({ rc, result }));
+        client.close();
+        server.stop(true);
+      `,
+    ],
+    env: {
+      ...bunEnv,
+      // Route bmalloc through the system heap so ASAN builds observe the freed
+      // StringImpl (see the Sec-WebSocket-Protocol test above).
+      ...(isWindows ? {} : { Malloc: "1" }),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr: stderr.trim() }).toEqual({
+    stdout: JSON.stringify({ rc: 7, result: "payload" }),
+    stderr: "",
+  });
+  expect(exitCode).toBe(0);
+});
+
 // publish() fans out to N subscribers and must report backpressure/drops the
 // same way ws.send() does for a single socket.
 describe.concurrent("publish() return value reflects subscriber backpressure", () => {


### PR DESCRIPTION
### What
`server.publish(topic, data)` borrowed the topic as a `ZigString` view into a JSString and then converted `data` with `to_js_string()`, which can run user JS and GC. When the topic came from `toString()`/`toPrimitive` the backing JSString was otherwise unreferenced and got collected, so uWS `TopicTree::lookupTopic` read a freed buffer (ASan `heap-use-after-free READ of size 8000` with `Malloc=1`; silently mis-delivered otherwise). `ServerWebSocket.publish/publishText/publishBinary` had the same shape via the publish context fetched before the conversions.

Both paths now convert the topic and the message first — `to_js_string()` once each, holding the `JSString*`s (`ensure_still_alive` after the uWS call) and borrowing their views — and read `self.app` / the publish context exactly once, after that.

### Repro (before)
```js
const TOPIC = "t_".repeat(4000);
const srv = Bun.serve({ port: 0, fetch: (req, s) => s.upgrade(req) ? undefined : new Response("x"),
  websocket: { open(ws) { ws.subscribe(TOPIC); }, message() {} } });
const c = new WebSocket(`ws://127.0.0.1:${srv.port}/`); let got = null; c.onmessage = e => { got = e.data; };
await new Promise(r => { c.onopen = r; }); await Bun.sleep(50);
const topic = Object.assign(new String("z"), { [Symbol.toPrimitive]: () => "t_".repeat(4000).slice(0) + "" });
const data = Object.assign(new String("z"), { [Symbol.toPrimitive]() { Bun.gc(true); globalThis.k = Array.from({length: 300}, (_, i) => "Q".repeat(40000 + i)); Bun.gc(true); return "payload"; } });
srv.publish(topic, data);   // Malloc=1 ASan: heap-use-after-free READ of size 8000
```

### Tests
`test/js/bun/websocket/websocket-server.test.ts` — "server.publish() keeps the topic alive while converting the message". Fails on the ASan canary and debug main; passes here.