### PR TITLE
http_parser: reject execute()/finish() on an uninitialised HTTPParser

### DIFF
--- a/src/jsc/bindings/node/http/NodeHTTPParser.cpp
+++ b/src/jsc/bindings/node/http/NodeHTTPParser.cpp
@@ -1,5 +1,6 @@
 #include "NodeHTTPParser.h"
 #include "BunBuiltinNames.h"
+#include "ErrorCode.h"
 #include "helpers.h"
 #include "JSConnectionsList.h"
 #include "JSHTTPParser.h"
@@ -116,6 +117,11 @@ JSValue HTTPParser::execute(JSGlobalObject* globalObject, const char* data, size
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto& builtinNames = WebCore::builtinNames(vm);
+
+    if (!isInitialized()) {
+        Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_STATE, "HTTPParser is not initialized"_s);
+        return {};
+    }
 
     // Forbid re-entrant execution of a new buffer while a previous execute()
     // is still on the stack: llhttp keeps span pointers into the in-progress

--- a/src/jsc/bindings/node/http/NodeHTTPParser.h
+++ b/src/jsc/bindings/node/http/NodeHTTPParser.h
@@ -178,14 +178,17 @@ public:
     JSC::JSGlobalObject* m_globalObject;
     JSHTTPParser* m_thisParser = nullptr;
 
-    llhttp_t m_parserData;
+    // Zeroed until initialize(); `m_parserData.settings == nullptr` means uninitialised.
+    llhttp_t m_parserData {};
     StringPtr m_fields[kMaxHeaderFieldsCount];
     StringPtr m_values[kMaxHeaderFieldsCount];
     StringPtr m_url;
     StringPtr m_statusMessage;
-    size_t m_numFields;
-    size_t m_numValues;
-    bool m_haveFlushed;
+    size_t m_numFields = 0;
+    size_t m_numValues = 0;
+    bool m_haveFlushed = false;
+
+    inline bool isInitialized() const { return m_parserData.settings != nullptr; }
 
     // We don't use m_gotException. Instead, we use RETURN_IF_EXCEPTION
     // bool m_gotException;

--- a/test/js/node/http/node-http-parser.test.ts
+++ b/test/js/node/http/node-http-parser.test.ts
@@ -51,6 +51,40 @@ describe("HTTPParser.prototype.close", () => {
   });
 });
 
+describe("HTTPParser before initialize()", () => {
+  test("execute() and finish() throw instead of running over uninitialised state", () => {
+    // Churn the parser heap first so a fresh cell is likely to land on reused memory.
+    let junk = [];
+    for (let i = 0; i < 500; i++) {
+      const q = new HTTPParser();
+      q.initialize(HTTPParser.REQUEST, {});
+      q.execute(Buffer.from(`GET /${"a".repeat(i % 50)} HTTP/1.1\r\nHost: a\r\nX: b\r\n\r\n`));
+      junk.push(q);
+    }
+    junk = null;
+    Bun.gc(true);
+
+    for (let i = 0; i < 50; i++) {
+      const parser = new HTTPParser();
+      expect(() => parser.execute(Buffer.from("GET / HTTP/1.1\r\nHost: a\r\n\r\n"))).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_STATE" }),
+      );
+      expect(() => parser.finish()).toThrow(expect.objectContaining({ code: "ERR_INVALID_STATE" }));
+      expect(parser.pause()).toBeUndefined();
+      expect(parser.resume()).toBeUndefined();
+      expect(parser.getCurrentBuffer()).toEqual(Buffer.alloc(0));
+      expect(parser.headersCompleted()).toBe(false);
+    }
+
+    // and the parser is still usable once initialised
+    const parser = new HTTPParser();
+    expect(() => parser.finish()).toThrow(expect.objectContaining({ code: "ERR_INVALID_STATE" }));
+    parser.initialize(HTTPParser.REQUEST, {});
+    const input = Buffer.from("GET / HTTP/1.1\r\nHost: a\r\n\r\n");
+    expect(parser.execute(input)).toBe(input.length);
+  });
+});
+
 describe("HTTPParser.prototype.finish", () => {
   test("reports bytesParsed of 0 when finish() fails after a paused parse", () => {
     const parser = new HTTPParser();


### PR DESCRIPTION
### What
`process.binding("http_parser").HTTPParser` left `llhttp_t`, `m_numFields`, `m_numValues` and `m_haveFlushed` uninitialised until `initialize()` was called, so `execute()` on a fresh parser ran llhttp and `save()` over whatever the GC cell previously held (UBSan `index 33 out of bounds for type 'StringPtr[32]'`; stock SEGV at 0x21). Node has the same uninitialised members and dies with `std::bad_alloc` here, so there is no behaviour to match; this zero-initialises the members and throws `ERR_INVALID_STATE` from `execute()`/`finish()` before `initialize()`.

### Repro (before)
```js
const { HTTPParser } = process.binding("http_parser");
new HTTPParser().execute(Buffer.from("GET / HTTP/1.1\r\nHost: a\r\n\r\n")); // SEGV
```

### Tests
`test/js/node/http/node-http-parser.test.ts` — "HTTPParser before initialize() › execute() and finish() throw instead of running over uninitialised state". Crashes the runner on the ASan canary and debug main; passes here.
