### PR TITLE
wasi: number WASI_SIG* constants in wasi_snapshot_preview1 order

### DIFF
--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -114,31 +114,37 @@ var require_constants = __commonJS({
     exports.WASI_ETXTBSY = 74;
     exports.WASI_EXDEV = 75;
     exports.WASI_ENOTCAPABLE = 76;
-    exports.WASI_SIGABRT = 0;
-    exports.WASI_SIGALRM = 1;
-    exports.WASI_SIGBUS = 2;
-    exports.WASI_SIGCHLD = 3;
-    exports.WASI_SIGCONT = 4;
-    exports.WASI_SIGFPE = 5;
-    exports.WASI_SIGHUP = 6;
-    exports.WASI_SIGILL = 7;
-    exports.WASI_SIGINT = 8;
+    // wasi_snapshot_preview1 `signal` enum order (0 is SIGNONE).
+    exports.WASI_SIGHUP = 1;
+    exports.WASI_SIGINT = 2;
+    exports.WASI_SIGQUIT = 3;
+    exports.WASI_SIGILL = 4;
+    exports.WASI_SIGTRAP = 5;
+    exports.WASI_SIGABRT = 6;
+    exports.WASI_SIGBUS = 7;
+    exports.WASI_SIGFPE = 8;
     exports.WASI_SIGKILL = 9;
-    exports.WASI_SIGPIPE = 10;
-    exports.WASI_SIGQUIT = 11;
-    exports.WASI_SIGSEGV = 12;
-    exports.WASI_SIGSTOP = 13;
-    exports.WASI_SIGTERM = 14;
-    exports.WASI_SIGTRAP = 15;
-    exports.WASI_SIGTSTP = 16;
-    exports.WASI_SIGTTIN = 17;
-    exports.WASI_SIGTTOU = 18;
-    exports.WASI_SIGURG = 19;
-    exports.WASI_SIGUSR1 = 20;
-    exports.WASI_SIGUSR2 = 21;
-    exports.WASI_SIGVTALRM = 22;
+    exports.WASI_SIGUSR1 = 10;
+    exports.WASI_SIGSEGV = 11;
+    exports.WASI_SIGUSR2 = 12;
+    exports.WASI_SIGPIPE = 13;
+    exports.WASI_SIGALRM = 14;
+    exports.WASI_SIGTERM = 15;
+    exports.WASI_SIGCHLD = 16;
+    exports.WASI_SIGCONT = 17;
+    exports.WASI_SIGSTOP = 18;
+    exports.WASI_SIGTSTP = 19;
+    exports.WASI_SIGTTIN = 20;
+    exports.WASI_SIGTTOU = 21;
+    exports.WASI_SIGURG = 22;
     exports.WASI_SIGXCPU = 23;
     exports.WASI_SIGXFSZ = 24;
+    exports.WASI_SIGVTALRM = 25;
+    exports.WASI_SIGPROF = 26;
+    exports.WASI_SIGWINCH = 27;
+    exports.WASI_SIGPOLL = 28;
+    exports.WASI_SIGPWR = 29;
+    exports.WASI_SIGSYS = 30;
     exports.WASI_FILETYPE_UNKNOWN = 0;
     exports.WASI_FILETYPE_BLOCK_DEVICE = 1;
     exports.WASI_FILETYPE_CHARACTER_DEVICE = 2;
@@ -394,6 +400,11 @@ var require_constants = __commonJS({
       [exports.WASI_SIGXCPU]: "SIGXCPU",
       [exports.WASI_SIGXFSZ]: "SIGXFSZ",
       [exports.WASI_SIGVTALRM]: "SIGVTALRM",
+      [exports.WASI_SIGPROF]: "SIGPROF",
+      [exports.WASI_SIGWINCH]: "SIGWINCH",
+      [exports.WASI_SIGPOLL]: "SIGPOLL",
+      [exports.WASI_SIGPWR]: "SIGPWR",
+      [exports.WASI_SIGSYS]: "SIGSYS",
     };
   },
 });
@@ -1606,7 +1617,12 @@ var require_wasi = __commonJS({
             if (!(sig in constants_1.SIGNAL_MAP)) {
               return constants_1.WASI_EINVAL;
             }
-            bindings.kill(constants_1.SIGNAL_MAP[sig]);
+            try {
+              bindings.kill(constants_1.SIGNAL_MAP[sig]);
+            } catch {
+              // e.g. SIGPOLL/SIGPWR do not exist on every host.
+              return constants_1.WASI_ENOTSUP;
+            }
             return constants_1.WASI_ESUCCESS;
           },
           random_get: (bufPtr, bufLen) => {

--- a/src/js/node/wasi.ts
+++ b/src/js/node/wasi.ts
@@ -1619,9 +1619,10 @@ var require_wasi = __commonJS({
             }
             try {
               bindings.kill(constants_1.SIGNAL_MAP[sig]);
-            } catch {
+            } catch (err) {
               // e.g. SIGPOLL/SIGPWR do not exist on every host.
-              return constants_1.WASI_ENOTSUP;
+              if (err?.code === "ERR_UNKNOWN_SIGNAL") return constants_1.WASI_ENOTSUP;
+              throw err;
             }
             return constants_1.WASI_ESUCCESS;
           },

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -72,6 +72,96 @@ it("random_get fills only the requested window", () => {
   expect(after.subarray(bufPtr, bufPtr + bufLen).some(b => b !== 0)).toBe(true);
 });
 
+it("proc_raise uses wasi_snapshot_preview1 signal numbering", () => {
+  const raised = [];
+  const wasi = new WASI({
+    bindings: {
+      hrtime: () => process.hrtime.bigint(),
+      exit: () => {},
+      kill: signal => raised.push(signal),
+      randomFillSync: array => crypto.getRandomValues(array),
+      isTTY: () => false,
+      fs,
+      path,
+    },
+  });
+  wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+
+  const WASI_ESUCCESS = 0;
+  const WASI_EINVAL = 28;
+  // https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-signal-variant
+  const preview1 = [
+    "SIGHUP",
+    "SIGINT",
+    "SIGQUIT",
+    "SIGILL",
+    "SIGTRAP",
+    "SIGABRT",
+    "SIGBUS",
+    "SIGFPE",
+    "SIGKILL",
+    "SIGUSR1",
+    "SIGSEGV",
+    "SIGUSR2",
+    "SIGPIPE",
+    "SIGALRM",
+    "SIGTERM",
+    "SIGCHLD",
+    "SIGCONT",
+    "SIGSTOP",
+    "SIGTSTP",
+    "SIGTTIN",
+    "SIGTTOU",
+    "SIGURG",
+    "SIGXCPU",
+    "SIGXFSZ",
+    "SIGVTALRM",
+    "SIGPROF",
+    "SIGWINCH",
+    "SIGPOLL",
+    "SIGPWR",
+    "SIGSYS",
+  ];
+  const errnos = preview1.map((_, i) => wasi.wasiImport.proc_raise(i + 1));
+  expect(raised).toEqual(preview1);
+  expect(errnos).toEqual(preview1.map(() => WASI_ESUCCESS));
+  expect(wasi.wasiImport.proc_raise(0)).toBe(WASI_EINVAL);
+  expect(wasi.wasiImport.proc_raise(31)).toBe(WASI_EINVAL);
+  expect(raised.length).toBe(preview1.length);
+});
+
+it.skipIf(isWindows)("bun prog.wasm: proc_raise(SIGTERM) delivers SIGTERM to the host process", () => {
+  // (module
+  //   (import "wasi_snapshot_preview1" "proc_raise" (func (param i32) (result i32)))
+  //   (import "wasi_snapshot_preview1" "proc_exit" (func (param i32)))
+  //   (memory (export "memory") 1)
+  //   (func (export "_start") (drop (call 0 (i32.const 15))) (call 1 (i32.const 77))))
+  const s = t => [t.length, ...Buffer.from(t)];
+  const sec = (id, b) => [id, b.length, ...b];
+  const W = "wasi_snapshot_preview1";
+  const body = [0, 0x41, 15, 0x10, 0, 0x1a, 0x41, 77, 0x10, 1, 0x0b];
+  const mod = Buffer.from([
+    ...[0, 97, 115, 109, 1, 0, 0, 0],
+    ...sec(1, [3, 0x60, 1, 0x7f, 1, 0x7f, 0x60, 1, 0x7f, 0, 0x60, 0, 0]),
+    ...sec(2, [2, ...s(W), ...s("proc_raise"), 0, 0, ...s(W), ...s("proc_exit"), 0, 1]),
+    ...sec(3, [1, 2]),
+    ...sec(5, [1, 0, 1]),
+    ...sec(7, [2, ...s("memory"), 2, 0, ...s("_start"), 0, 2]),
+    ...sec(10, [1, body.length, ...body]),
+  ]);
+  using dir = tempDir("wasi-proc-raise", { "raise.wasm": mod });
+
+  const { stdout, exitCode, signalCode } = spawnSync({
+    cmd: [bunExe(), path.join(String(dir), "raise.wasm")],
+    stdout: "pipe",
+    stderr: "inherit",
+    env: bunEnv,
+  });
+  expect(stdout.toString()).toBe("");
+  expect(signalCode).toBe("SIGTERM");
+  expect(exitCode).not.toBe(77);
+});
+
 it("path_open reports the host errno to the guest when the open fails", () => {
   using dir = tempDir("wasi-path-open-errno", {
     "exists.txt": "x",

--- a/test/js/bun/wasm/wasi.test.js
+++ b/test/js/bun/wasm/wasi.test.js
@@ -130,16 +130,46 @@ it("proc_raise uses wasi_snapshot_preview1 signal numbering", () => {
   expect(raised.length).toBe(preview1.length);
 });
 
+it("proc_raise reports ENOTSUP for a signal the host does not have and rethrows anything else", () => {
+  const WASI_ENOTSUP = 58;
+  const makeWasi = kill => {
+    const wasi = new WASI({
+      bindings: {
+        hrtime: () => process.hrtime.bigint(),
+        exit: () => {},
+        kill,
+        randomFillSync: array => crypto.getRandomValues(array),
+        isTTY: () => false,
+        fs,
+        path,
+      },
+    });
+    wasi.setMemory(new WebAssembly.Memory({ initial: 1 }));
+    return wasi;
+  };
+
+  const unknownSignal = makeWasi(signal => {
+    throw Object.assign(new TypeError("Unknown signal: " + signal), { code: "ERR_UNKNOWN_SIGNAL" });
+  });
+  // 28 is SIGPOLL in preview1 numbering.
+  expect(unknownSignal.wasiImport.proc_raise(28)).toBe(WASI_ENOTSUP);
+
+  const broken = makeWasi(() => {
+    throw new Error("kill binding bug");
+  });
+  expect(() => broken.wasiImport.proc_raise(28)).toThrow("kill binding bug");
+});
+
 it.skipIf(isWindows)("bun prog.wasm: proc_raise(SIGTERM) delivers SIGTERM to the host process", () => {
   // (module
   //   (import "wasi_snapshot_preview1" "proc_raise" (func (param i32) (result i32)))
   //   (import "wasi_snapshot_preview1" "proc_exit" (func (param i32)))
   //   (memory (export "memory") 1)
-  //   (func (export "_start") (drop (call 0 (i32.const 15))) (call 1 (i32.const 77))))
+  //   (func (export "_start") (drop (call 0 (i32.const 15))) (call 1 (i32.const 42))))
   const s = t => [t.length, ...Buffer.from(t)];
   const sec = (id, b) => [id, b.length, ...b];
   const W = "wasi_snapshot_preview1";
-  const body = [0, 0x41, 15, 0x10, 0, 0x1a, 0x41, 77, 0x10, 1, 0x0b];
+  const body = [0, 0x41, 15, 0x10, 0, 0x1a, 0x41, 42, 0x10, 1, 0x0b];
   const mod = Buffer.from([
     ...[0, 97, 115, 109, 1, 0, 0, 0],
     ...sec(1, [3, 0x60, 1, 0x7f, 1, 0x7f, 0x60, 1, 0x7f, 0, 0x60, 0, 0]),
@@ -159,7 +189,7 @@ it.skipIf(isWindows)("bun prog.wasm: proc_raise(SIGTERM) delivers SIGTERM to the
   });
   expect(stdout.toString()).toBe("");
   expect(signalCode).toBe("SIGTERM");
-  expect(exitCode).not.toBe(77);
+  expect(exitCode).not.toBe(42);
 });
 
 it("path_open reports the host errno to the guest when the open fails", () => {


### PR DESCRIPTION
### What
`bun prog.wasm`: WASI `proc_raise(sig)` looked the guest signal up in a table whose `WASI_SIG*` constants were numbered alphabetically (the pre-preview1 `wasi_unstable` order) instead of the `wasi_snapshot_preview1` `signal` enum, so e.g. guest `SIGTERM` (15) was delivered to the host as `SIGTRAP` — which also printed the "Bun has crashed" banner. Renumbered to preview1 order (`SIGHUP=1 … SIGSYS=30`, matching wasi-libc `__WASI_SIGNAL_*`), added the five signals missing from `SIGNAL_MAP`, and `proc_raise` returns `ENOTSUP` when the host has no such signal (e.g. `SIGPOLL`/`SIGPWR` on macOS) instead of throwing out of the import.

### Repro (before)
A hand-assembled wasm module that calls `wasi_snapshot_preview1.proc_raise(15)`: `bun raise.wasm` → `signal=SIGTRAP` + crash banner (expected `SIGTERM`). `proc_raise(6)` → `SIGHUP`, `proc_raise(1)` → `SIGALRM`.

### Tests
`test/js/bun/wasm/wasi.test.js` — "proc_raise uses wasi_snapshot_preview1 signal numbering" (all 30 + out-of-range → EINVAL, mocked kill) and "bun prog.wasm: proc_raise(SIGTERM) delivers SIGTERM to the host process". Fail on the current canary; pass here.
