### PR TITLE
Read sink.start() options before resolving the native sink

### DIFF
--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -562,13 +562,8 @@ impl<T: JsSinkType> JSSink<T> {
         use bun_sys_jsc::ErrorJsc;
         bun_core::mark_binding!();
 
-        // SAFETY: get_this returns a live ThisSink* on Ok.
-        let this = Self::get_this(global, frame)?;
-
-        if let Some(err) = this.sink.get_pending_error() {
-            return Err(global.throw_value(err));
-        }
-
+        // Option getters can run user JS that closes the sink, so read them
+        // before resolving `this`.
         let config = if frame.arguments_count() > 0 {
             match T::START_TAG {
                 Some(tag) => {
@@ -579,6 +574,12 @@ impl<T: JsSinkType> JSSink<T> {
         } else {
             streams::Start::Empty
         };
+
+        let this = Self::get_this(global, frame)?;
+
+        if let Some(err) = this.sink.get_pending_error() {
+            return Err(global.throw_value(err));
+        }
 
         match this.sink.start(config) {
             sys::Result::Ok(()) => Ok(JSValue::UNDEFINED),

--- a/test/js/bun/util/arraybuffersink.test.ts
+++ b/test/js/bun/util/arraybuffersink.test.ts
@@ -155,4 +155,32 @@ describe("ArrayBufferSink", () => {
     expect(() => s.end()).toThrow(/already been closed/);
     expect(s.close()).toBeUndefined();
   });
+
+  it("start() with an option getter that closes the sink throws instead of crashing", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        for (const key of ["highWaterMark", "asUint8Array", "stream"]) {
+          const s = new Bun.ArrayBufferSink();
+          s.write("hello");
+          let err;
+          try {
+            s.start({ get [key]() { s.close(); return key === "highWaterMark" ? 1024 : true; } });
+          } catch (e) { err = e; }
+          console.log(key, /already been closed/.test(err?.message));
+          try { s.write("x"); console.log("write ok"); } catch (e) { console.log("write", /already been closed/.test(e.message)); }
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("highWaterMark true\nwrite true\nasUint8Array true\nwrite true\nstream true\nwrite true\n");
+    if (exitCode !== 0) expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -566,6 +566,38 @@ it("start() without path/fd on an already-open writer does not crash", async () 
   expect(await Bun.file(path).text()).toBe("hello");
 });
 
+it("start() with a path/fd getter that closes the writer throws instead of crashing", async () => {
+  const dir = tmpdirSync();
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { join } = require("node:path");
+      for (const key of ["path", "fd"]) {
+        const p = join(process.argv[1], "start-reentrant-" + key + ".txt");
+        const w = Bun.file(p).writer();
+        w.write("hello");
+        let err;
+        try {
+          w.start({ get [key]() { w.close(); return key === "path" ? p : 1; } });
+        } catch (e) { err = e; }
+        console.log(key, /already been closed/.test(err?.message));
+        try { w.write("x"); console.log("write ok"); } catch (e) { console.log("write", /already been closed/.test(e.message)); }
+      }
+      `,
+      dir,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("path true\nwrite true\nfd true\nwrite true\n");
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
 it.skipIf(!isPosix)("writing after end() fails during flush does not crash", async () => {
   const dir = tmpdirSync();
   const target = join(dir, "ro.txt");


### PR DESCRIPTION
### What
`sink.start(options)` on `Bun.ArrayBufferSink` / `FileSink` resolved the native sink from `this` first and *then* read the options (`highWaterMark` / `asUint8Array` / `stream` / `path` / `fd`) via property gets. A getter that calls the sink's own `close()` frees the payload and `start()` continued on freed memory (ASan: heap-use-after-free WRITE in `ArrayBufferSink::start`, READ in `FileSink::setup`).

`js_start` now parses the `Start` config before resolving `this`.

### Repro (before)
```js
const sink = new Bun.ArrayBufferSink(); sink.write("hello");
sink.start({ get highWaterMark() { sink.close(); return 1024; } }); // ASan: heap-use-after-free WRITE of size 8
```

### Tests
`test/js/bun/util/arraybuffersink.test.ts` and `test/js/bun/util/filesink.test.ts` — "start() with an option getter that closes the sink/writer throws instead of crashing". Fail on the current ASan canary and debug main; pass with this change.
