### PR TITLE
HTMLRewriter: decode content-op string arguments into owned slices

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -28,6 +28,7 @@ use crate::webcore::streams::{
 };
 use crate::webcore::{self, ByteStream, DrainResult, ReadableStream, Response, SinkHandle};
 use bun_core::String as BunString;
+use bun_core::ZigStringSlice;
 // `ZigString` re-exports `bun_core::ZigString`; JSC-side methods
 // (`to_js`, `with_encoding`, …) come from the `ZigStringJsc` extension trait.
 use bun_jsc::ZigStringJsc as _;
@@ -65,20 +66,22 @@ fn system_error(code: &'static str, message: &'static str) -> SystemError {
 //
 // Note: a `#[bun_jsc::host_fn(method)]` proc-macro form of typed argument
 // decoding hasn't landed, so the per-type decode arms used by HTMLRewriter
-// (`ZigString`, `?ContentOptions`, `JSValue`) are open-coded here as small
+// (string, `?ContentOptions`, `JSValue`) are open-coded here as small
 // helpers.
 
-/// Decode arm for `ZigString` — eat next arg, throw
-/// "Missing argument" if absent, "Expected string" if undefined/null,
-/// otherwise `get_zig_string`.
-fn eat_zig_string(iter: &mut ArgumentsSlice<'_>, global: &JSGlobalObject) -> JsResult<ZigString> {
+/// Decode arm for a string — eat next arg, throw "Missing argument" if
+/// absent, "Expected string" if undefined/null, otherwise ToString it into a
+/// slice that owns (or holds a ref on) its bytes. A borrowed view of the
+/// temporary `JSString` would not survive the user JS (a later argument's
+/// `toString`/getter) that runs before lol-html copies the bytes.
+fn eat_string(iter: &mut ArgumentsSlice<'_>, global: &JSGlobalObject) -> JsResult<ZigStringSlice> {
     let Some(value) = iter.next_eat() else {
         return Err(global.throw_invalid_arguments(format_args!("Missing argument")));
     };
     if value.is_undefined_or_null() {
         return Err(global.throw_invalid_arguments(format_args!("Expected string")));
     }
-    value.get_zig_string(global)
+    value.to_slice(global)
 }
 
 /// Decode arm for `JSValue` (required) — eat next arg or
@@ -105,15 +108,15 @@ fn eat_content_options(
     }
 }
 
-/// Common `(content: ZigString, contentOptions: ?ContentOptions)` pair —
+/// Common `(content: string, contentOptions: ?ContentOptions)` pair —
 /// every `before/after/replace/append/prepend/setInnerContent` wrapper
 /// decodes exactly this shape.
 fn eat_content_args(
     global: &JSGlobalObject,
     call_frame: &CallFrame,
-) -> JsResult<(ZigString, Option<ContentOptions>)> {
+) -> JsResult<(ZigStringSlice, Option<ContentOptions>)> {
     let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
-    let content = eat_zig_string(&mut iter, global)?;
+    let content = eat_string(&mut iter, global)?;
     let opts = eat_content_options(&mut iter, global)?;
     Ok((content, opts))
 }
@@ -152,15 +155,14 @@ macro_rules! lol_content_ops {
             callback: fn(&mut $Raw, &str, lol_html::html_content::ContentType),
             this_object: JSValue,
             global_object: &JSGlobalObject,
-            content: ZigString,
+            content: ZigStringSlice,
             content_options: Option<ContentOptions>,
         ) -> JsResult<JSValue> {
             let Some(raw) = self.$field.get_mut() else {
                 return Ok($null_ret);
             };
-            let content_slice = content.to_slice();
             // lol-html content ops are infallible, so the UTF-8 check is the only throw path.
-            let content_str = utf8_or_throw(global_object, content_slice.slice())?;
+            let content_str = utf8_or_throw(global_object, content.slice())?;
             callback(raw, content_str, content_type(content_options));
             Ok(this_object)
         }
@@ -171,7 +173,7 @@ macro_rules! lol_content_ops {
                 &self,
                 call_frame: &CallFrame,
                 global_object: &JSGlobalObject,
-                content: ZigString,
+                content: ZigStringSlice,
                 content_options: Option<ContentOptions>,
             ) -> JsResult<JSValue> {
                 self.content_handler(
@@ -183,7 +185,7 @@ macro_rules! lol_content_ops {
                 )
             }
 
-            // Decode `(content: ZigString, contentOptions: ?ContentOptions)`
+            // Decode `(content: string, contentOptions: ?ContentOptions)`
             // then forward.
             $(#[$attr])*
             pub fn $name(
@@ -363,11 +365,11 @@ impl HTMLRewriter {
     pub(crate) fn on_(
         &self,
         global: &JSGlobalObject,
-        selector_name: ZigString,
+        selector_name: ZigStringSlice,
         call_frame: &CallFrame,
         listener: JSValue,
     ) -> JsResult<JSValue> {
-        let selector_source = selector_name.to_string();
+        let selector_source = String::from_utf8_lossy(selector_name.slice());
         let selector = match selector_source.parse::<lol_html::Selector>() {
             Ok(s) => s,
             Err(e) => return Err(global.throw_value(create_lolhtml_error(global, &e))),
@@ -524,7 +526,7 @@ impl HTMLRewriter {
 
     pub(crate) fn on(&self, global: &JSGlobalObject, call_frame: &CallFrame) -> JsResult<JSValue> {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
-        let selector_name = eat_zig_string(&mut iter, global)?;
+        let selector_name = eat_string(&mut iter, global)?;
         let listener = eat_js_value(&mut iter, global)?;
         self.on_(global, selector_name, call_frame, listener)
     }
@@ -3016,15 +3018,14 @@ impl Element {
     pub(crate) fn get_attribute_(
         &self,
         global_object: &JSGlobalObject,
-        name: ZigString,
+        name: ZigStringSlice,
     ) -> JsResult<JSValue> {
         let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::NULL);
         };
-        let slice = name.to_slice();
         // A non-UTF-8 name came back from the C API as a null-data `Str`,
         // which JS saw as `null` — not a throw. Keep that distinction.
-        let Ok(name) = core::str::from_utf8(slice.slice()) else {
+        let Ok(name) = core::str::from_utf8(name.slice()) else {
             return Ok(JSValue::NULL);
         };
         opt_string_to_js_or_null(el.get_attribute(name), global_object)
@@ -3034,13 +3035,12 @@ impl Element {
     pub(crate) fn has_attribute_(
         &self,
         global: &JSGlobalObject,
-        name: ZigString,
+        name: ZigStringSlice,
     ) -> JsResult<JSValue> {
         let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::FALSE);
         };
-        let slice = name.to_slice();
-        let name = utf8_or_throw(global, slice.slice())?;
+        let name = utf8_or_throw(global, name.slice())?;
         Ok(JSValue::from(el.has_attribute(name)))
     }
 
@@ -3049,8 +3049,8 @@ impl Element {
         &self,
         call_frame: &CallFrame,
         global_object: &JSGlobalObject,
-        name_: ZigString,
-        value_: ZigString,
+        name: ZigStringSlice,
+        value: ZigStringSlice,
     ) -> JsResult<JSValue> {
         let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::UNDEFINED);
@@ -3060,10 +3060,8 @@ impl Element {
         // to, so end their iteration rather than let them repeat or skip one.
         self.detach_attribute_iterators();
 
-        let name_slice = name_.to_slice();
-        let value_slice = value_.to_slice();
-        let name = utf8_or_throw(global_object, name_slice.slice())?;
-        let value = utf8_or_throw(global_object, value_slice.slice())?;
+        let name = utf8_or_throw(global_object, name.slice())?;
+        let value = utf8_or_throw(global_object, value.slice())?;
         if let Err(e) = el.set_attribute(name, value) {
             let err = create_lolhtml_error(global_object, &e);
             return Err(global_object.throw_value(err));
@@ -3076,7 +3074,7 @@ impl Element {
         &self,
         call_frame: &CallFrame,
         global_object: &JSGlobalObject,
-        name: ZigString,
+        name: ZigStringSlice,
     ) -> JsResult<JSValue> {
         let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::UNDEFINED);
@@ -3086,8 +3084,7 @@ impl Element {
         // AttributeIterator's index would skip the one that took this slot.
         self.detach_attribute_iterators();
 
-        let name_slice = name.to_slice();
-        let name = utf8_or_throw(global_object, name_slice.slice())?;
+        let name = utf8_or_throw(global_object, name.slice())?;
         el.remove_attribute(name);
         Ok(call_frame.this())
     }
@@ -3110,7 +3107,7 @@ impl Element {
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
-        let name = eat_zig_string(&mut iter, global)?;
+        let name = eat_string(&mut iter, global)?;
         self.get_attribute_(global, name)
     }
 
@@ -3120,7 +3117,7 @@ impl Element {
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
-        let name = eat_zig_string(&mut iter, global)?;
+        let name = eat_string(&mut iter, global)?;
         self.has_attribute_(global, name)
     }
 
@@ -3130,8 +3127,8 @@ impl Element {
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
-        let name = eat_zig_string(&mut iter, global)?;
-        let value = eat_zig_string(&mut iter, global)?;
+        let name = eat_string(&mut iter, global)?;
+        let value = eat_string(&mut iter, global)?;
         self.set_attribute_(call_frame, global, name, value)
     }
 
@@ -3141,7 +3138,7 @@ impl Element {
         call_frame: &CallFrame,
     ) -> JsResult<JSValue> {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
-        let name = eat_zig_string(&mut iter, global)?;
+        let name = eat_string(&mut iter, global)?;
         self.remove_attribute_(call_frame, global, name)
     }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -155,7 +155,7 @@ macro_rules! lol_content_ops {
             callback: fn(&mut $Raw, &str, lol_html::html_content::ContentType),
             this_object: JSValue,
             global_object: &JSGlobalObject,
-            content: ZigStringSlice,
+            content: &ZigStringSlice,
             content_options: Option<ContentOptions>,
         ) -> JsResult<JSValue> {
             let Some(raw) = self.$field.get_mut() else {
@@ -173,7 +173,7 @@ macro_rules! lol_content_ops {
                 &self,
                 call_frame: &CallFrame,
                 global_object: &JSGlobalObject,
-                content: ZigStringSlice,
+                content: &ZigStringSlice,
                 content_options: Option<ContentOptions>,
             ) -> JsResult<JSValue> {
                 self.content_handler(
@@ -194,7 +194,7 @@ macro_rules! lol_content_ops {
                 call_frame: &CallFrame,
             ) -> JsResult<JSValue> {
                 let (content, opts) = eat_content_args(global, call_frame)?;
-                self.$name_(call_frame, global, content, opts)
+                self.$name_(call_frame, global, &content, opts)
             }
         )*
     };
@@ -365,11 +365,11 @@ impl HTMLRewriter {
     pub(crate) fn on_(
         &self,
         global: &JSGlobalObject,
-        selector_name: ZigStringSlice,
+        selector_name: &ZigStringSlice,
         call_frame: &CallFrame,
         listener: JSValue,
     ) -> JsResult<JSValue> {
-        let selector_source = String::from_utf8_lossy(selector_name.slice());
+        let selector_source = utf8_or_throw(global, selector_name.slice())?;
         let selector = match selector_source.parse::<lol_html::Selector>() {
             Ok(s) => s,
             Err(e) => return Err(global.throw_value(create_lolhtml_error(global, &e))),
@@ -528,7 +528,7 @@ impl HTMLRewriter {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
         let selector_name = eat_string(&mut iter, global)?;
         let listener = eat_js_value(&mut iter, global)?;
-        self.on_(global, selector_name, call_frame, listener)
+        self.on_(global, &selector_name, call_frame, listener)
     }
 
     pub(crate) fn on_document(
@@ -3018,7 +3018,7 @@ impl Element {
     pub(crate) fn get_attribute_(
         &self,
         global_object: &JSGlobalObject,
-        name: ZigStringSlice,
+        name: &ZigStringSlice,
     ) -> JsResult<JSValue> {
         let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::NULL);
@@ -3035,7 +3035,7 @@ impl Element {
     pub(crate) fn has_attribute_(
         &self,
         global: &JSGlobalObject,
-        name: ZigStringSlice,
+        name: &ZigStringSlice,
     ) -> JsResult<JSValue> {
         let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::FALSE);
@@ -3049,8 +3049,8 @@ impl Element {
         &self,
         call_frame: &CallFrame,
         global_object: &JSGlobalObject,
-        name: ZigStringSlice,
-        value: ZigStringSlice,
+        name: &ZigStringSlice,
+        value: &ZigStringSlice,
     ) -> JsResult<JSValue> {
         let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::UNDEFINED);
@@ -3074,7 +3074,7 @@ impl Element {
         &self,
         call_frame: &CallFrame,
         global_object: &JSGlobalObject,
-        name: ZigStringSlice,
+        name: &ZigStringSlice,
     ) -> JsResult<JSValue> {
         let Some(el) = self.element.get_mut() else {
             return Ok(JSValue::UNDEFINED);
@@ -3108,7 +3108,7 @@ impl Element {
     ) -> JsResult<JSValue> {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
         let name = eat_string(&mut iter, global)?;
-        self.get_attribute_(global, name)
+        self.get_attribute_(global, &name)
     }
 
     pub(crate) fn has_attribute(
@@ -3118,7 +3118,7 @@ impl Element {
     ) -> JsResult<JSValue> {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
         let name = eat_string(&mut iter, global)?;
-        self.has_attribute_(global, name)
+        self.has_attribute_(global, &name)
     }
 
     pub(crate) fn set_attribute(
@@ -3129,7 +3129,7 @@ impl Element {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
         let name = eat_string(&mut iter, global)?;
         let value = eat_string(&mut iter, global)?;
-        self.set_attribute_(call_frame, global, name, value)
+        self.set_attribute_(call_frame, global, &name, &value)
     }
 
     pub(crate) fn remove_attribute(
@@ -3139,7 +3139,7 @@ impl Element {
     ) -> JsResult<JSValue> {
         let mut iter = ArgumentsSlice::init(global.bun_vm_ref(), call_frame.arguments());
         let name = eat_string(&mut iter, global)?;
-        self.remove_attribute_(call_frame, global, name)
+        self.remove_attribute_(call_frame, global, &name)
     }
 
     lol_content_ops! { RawElement, element, JSValue::UNDEFINED;

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2853,8 +2853,9 @@ describe("GC pressure mid-rewrite", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      // Malloc=1 routes JSC string allocations through the system allocator so ASan builds see the free.
-      env: { ...bunEnv, Malloc: "1" },
+      // Malloc=1 routes JSC string allocations through the system allocator so ASan builds see the free
+      // (bmalloc's SystemHeap is unavailable on Windows).
+      env: isWindows ? bunEnv : { ...bunEnv, Malloc: "1", ASAN_OPTIONS: "detect_leaks=0" },
       stdout: "pipe",
       stderr: "inherit",
     });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2793,7 +2793,11 @@ describe("GC pressure mid-rewrite", () => {
   it("content op string arguments survive a GC triggered while coercing a later argument", async () => {
     const fixture = /* js */ `
       const N = 20000;
-      const mk = (ch, n) => Array.from({ length: n }, () => ch).join("");
+      // A fresh, non-atom string each call (slice+concat resolves to a new StringImpl on toString()).
+      const mk = (ch, n) => {
+        const s = ch.repeat(n);
+        return s.slice(0, 1) + s.slice(1);
+      };
       const churn = () => {
         Bun.gc(true);
         for (let i = 0; i < 50; i++) mk("SECRET", 20000);
@@ -2849,7 +2853,8 @@ describe("GC pressure mid-rewrite", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      // Malloc=1 routes JSC string allocations through the system allocator so ASan builds see the free.
+      env: { ...bunEnv, Malloc: "1" },
       stdout: "pipe",
       stderr: "inherit",
     });

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2785,4 +2785,85 @@ describe("GC pressure mid-rewrite", () => {
     const start = () => rw2.transform(rw1.transform(new Response("<p>x</p>"))).text();
     expect(await start()).toBe('<p one="" two="">x</p>');
   });
+
+  // Content ops coerce their first argument to a string, then coerce the
+  // second (the `{ html }` options getter / the attribute value), which runs
+  // user JS. A GC in that window must not free the first argument's bytes
+  // before lol-html copies them into the output.
+  it("content op string arguments survive a GC triggered while coercing a later argument", async () => {
+    const fixture = /* js */ `
+      const N = 20000;
+      const mk = (ch, n) => Array.from({ length: n }, () => ch).join("");
+      const churn = () => {
+        Bun.gc(true);
+        for (let i = 0; i < 50; i++) mk("SECRET", 20000);
+        Bun.gc(true);
+      };
+      // toString() hands back a temporary string nothing else references.
+      const content = ch => ({ toString: () => mk(ch, N) + "END" });
+      const opts = {
+        get html() {
+          churn();
+          return false;
+        },
+      };
+      const out = new HTMLRewriter()
+        .on("p", {
+          element(el) {
+            el.setInnerContent(content("I"), opts);
+            el.before(content("B"), opts);
+            el.setAttribute({ toString: () => mk("n", N) }, { toString: () => (churn(), "v") });
+            el.onEndTag(end => {
+              end.after(content("E"), opts);
+            });
+          },
+        })
+        .onDocument({
+          comments(c) {
+            c.replace(content("C"), opts);
+          },
+          text(t) {
+            if (t.text === "txt") t.after(content("T"), opts);
+          },
+          end(end) {
+            end.append(content("D"), opts);
+          },
+        })
+        .transform("<p>x</p><div>txt</div><!-- c -->");
+      const fragments = {
+        "element.before": mk("B", N) + "END<p ",
+        "element.setAttribute": "<p " + mk("n", N) + '="v">',
+        "element.setInnerContent": '="v">' + mk("I", N) + "END</p>",
+        "endTag.after": "</p>" + mk("E", N) + "END<div>",
+        "text.after": "<div>txt" + mk("T", N) + "END</div>",
+        "comment.replace": "</div>" + mk("C", N) + "END",
+        "documentEnd.append": "END" + mk("D", N) + "END",
+      };
+      const result = {};
+      for (const [op, fragment] of Object.entries(fragments)) result[op] = out.includes(fragment);
+      result.exact =
+        out ===
+        mk("B", N) + "END<p " + mk("n", N) + '="v">' + mk("I", N) + "END</p>" + mk("E", N) + "END" +
+        "<div>txt" + mk("T", N) + "END</div>" + mk("C", N) + "END" + mk("D", N) + "END";
+      console.log(JSON.stringify(result));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(JSON.parse(stdout.trim() || "{}")).toEqual({
+      "element.before": true,
+      "element.setAttribute": true,
+      "element.setInnerContent": true,
+      "endTag.after": true,
+      "text.after": true,
+      "comment.replace": true,
+      "documentEnd.append": true,
+      exact: true,
+    });
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### What
HTMLRewriter content ops (`before/after/replace/append/prepend/setInnerContent`, `setAttribute`, `Comment.replace`, `EndTag.*`, `Document.end append`) decoded their first argument as a *borrowed* view of the temporary JSString that `toString()` produced, then coerced the next argument (the `{ html }` options getter or the attribute value), which runs user JS. A GC in that window swept the temporary and lol-html copied freed heap bytes into the HTML output (info disclosure; ASan `heap-use-after-free READ` in `ZigString::to_slice ← Element::content_handler` with `Malloc=1`).

Content-op string arguments are now decoded via `JSValue::to_slice`, which refs the `StringImpl` (or owns the transcoded bytes) independent of the temporary JSString. All conversions still happen before the native handle is dereferenced.

### Repro (before)
```js
const mk = (ch, n) => Array.from({ length: n }, () => ch).join("");
const churn = () => { Bun.gc(true); for (let i = 0; i < 50; i++) mk("SECRET", 20000); Bun.gc(true); };
const out = new HTMLRewriter().on("p", { element(el) {
  el.setInnerContent({ toString: () => mk("C", 100000) + "END" }, { get html() { churn(); return false; } });
  el.setAttribute({ toString: () => mk("n", 40000) }, { toString: () => (churn(), "v") });
} }).transform("<p>x</p>");
console.log(/C{100000}END/.test(out), / n{40000}="v"/.test(out)); // false false / foreign bytes in output
```

### Tests
`test/js/workerd/html-rewriter.test.js` — "content op string arguments survive a GC triggered while coercing a later argument" (runs with `Malloc=1` so ASan lanes see the free). Fails on the ASan canary and debug main; passes here.
