### PR TITLE
HTMLRewriter: defer freeing the pipe when a pin holds its last ref

### DIFF
--- a/src/runtime/api/NativePromiseContext.rs
+++ b/src/runtime/api/NativePromiseContext.rs
@@ -58,7 +58,7 @@ pub enum Tag {
     DebugHTTPSServerH3RequestContext,
     HTMLRewriterSuspension,
     /// Task-only tag (never a context cell): drops the last ref of a
-    /// `RewriterPipe` on behalf of `RewriterPipe::release_pump_ref`.
+    /// `RewriterPipe` on behalf of `RewriterPipe::deref_outside_caller`.
     HTMLRewriterPipeFree,
 }
 
@@ -224,7 +224,7 @@ impl DeferredDerefTask {
         // of the type indicated by `tag`, and this task owns one ref on it,
         // released below (for the HTMLRewriter tags: the ref taken in
         // `begin_suspension`, or the last ref handed over by
-        // `release_pump_ref`). We are on the JS thread.
+        // `deref_outside_caller`). We are on the JS thread.
         unsafe {
             match tag {
                 Tag::HTTPServerRequestContext => (*ctx.cast::<HTTPServerRequestContext>()).deref(),

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -803,15 +803,10 @@ impl RewriterPipe {
         bun_ptr::finalize_js_box(this, |pipe| pipe.cell.set(JSValue::ZERO));
     }
 
-    /// The JS-pump controller detached and can never dispatch into the pipe
-    /// again: release its ref. Releasing the last ref is deferred to the
-    /// event loop because the C++ caller keeps using the allocation in the
-    /// same frame (the destructor's trailing `__finalize`, the close/end host
-    /// fns' `__close`/`__endWithSink` on the saved pointer).
-    fn release_pump_ref(&self) {
-        if !self.pump_controller_attached.replace(false) {
-            return;
-        }
+    /// Release one ref, deferring the release of the *last* ref to the event
+    /// loop: the native caller on the stack keeps dispatching into the
+    /// allocation in the same frame after the call that dropped it returns.
+    fn deref_outside_caller(&self) {
         if self.ref_count.get() > 1 {
             Self::deref_nn(NonNull::from(self));
             return;
@@ -820,6 +815,18 @@ impl RewriterPipe {
             core::ptr::from_ref(self).cast_mut().cast(),
             native_promise_context::Tag::HTMLRewriterPipeFree,
         );
+    }
+
+    /// The JS-pump controller detached and can never dispatch into the pipe
+    /// again: release its ref. Deferred if last: the C++ caller keeps using
+    /// the allocation in the same frame (the destructor's trailing
+    /// `__finalize`, the close/end host fns' `__close`/`__endWithSink` on the
+    /// saved pointer).
+    fn release_pump_ref(&self) {
+        if !self.pump_controller_attached.replace(false) {
+            return;
+        }
+        self.deref_outside_caller();
     }
 
     /// Queued by the `NativePromiseContext` destructor (via
@@ -1271,11 +1278,13 @@ impl RewriterPipe {
 
     /// Hold a ref on the pipe across an externally-entered call whose work
     /// (user handlers, body resolution) can drop the last GC path to the
-    /// Transform cell and sweep it, releasing the cell's ref mid-call.
-    fn pin(&self) -> bun_ptr::ScopedRef<Self> {
-        // SAFETY: `self` is live; the guard's own ref keeps the allocation
-        // valid until it drops.
-        unsafe { bun_ptr::ScopedRef::new(core::ptr::from_ref(self).cast_mut()) }
+    /// Transform cell and sweep it, releasing the cell's ref mid-call. If the
+    /// pin ends up holding the last ref, the free is deferred past the
+    /// caller's frame: a source delivering a chunk follows a `Done` answer
+    /// from `write` with `end`, on the same sink snapshot.
+    fn pin(&self) -> PipePin {
+        self.ref_();
+        PipePin(BackRef::new(self))
     }
 
     /// Nothing is draining the output, so nothing will signal `resume()`:
@@ -1778,6 +1787,16 @@ impl RewriterPipe {
             let _ = body_value.to_error_instance(err, &self.global);
         }
         self.release_input_roots(src);
+    }
+}
+
+/// Guard returned by [`RewriterPipe::pin`].
+#[must_use = "dropping immediately releases the ref"]
+struct PipePin(BackRef<RewriterPipe>);
+
+impl Drop for PipePin {
+    fn drop(&mut self) {
+        self.0.deref_outside_caller();
     }
 }
 

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -2759,6 +2759,91 @@ describe("GC pressure mid-rewrite", () => {
     expect(stash.tagName).toBeUndefined();
   });
 
+  // A handler running inside the input ByteStream's write into the pipe
+  // cancels the output reader and drops the last references to the transform.
+  // The ByteStream follows the pipe's `Done` answer with `end()` on the same
+  // sink snapshot, so the pipe must outlive the write call even when a GC in
+  // the handler swept its Transform cell.
+  it("cancelling the output from a handler mid-chunk does not free the pipe under its caller", async () => {
+    const fixture = /* js */ `
+      const CHUNKS = 6;
+      const CANCEL_AT = 4;
+      let gates;
+      // Chunk N+1 is only sent once the handler saw element N, so every element
+      // after the first reaches the rewriter from the fetch body's ByteStream.
+      const server = Bun.serve({
+        port: 0,
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              async start(controller) {
+                try {
+                  for (let i = 0; i < CHUNKS; i++) {
+                    controller.enqueue(new TextEncoder().encode("<p n=" + i + "></p>"));
+                    await gates[i].promise;
+                  }
+                  controller.close();
+                } catch {}
+              },
+            }),
+            { headers: { "Content-Type": "text/html" } },
+          );
+        },
+      });
+      for (let iter = 0; iter < 3; iter++) {
+        gates = Array.from({ length: CHUNKS }, () => Promise.withResolvers());
+        const cancelled = Promise.withResolvers();
+        let seen = 0;
+        let reader;
+        let out = new HTMLRewriter()
+          .on("p", {
+            element(el) {
+              const n = Number(el.getAttribute("n"));
+              seen++;
+              if (n === CANCEL_AT) {
+                reader.cancel("bye").catch(() => {});
+                reader = out = null;
+                globalThis.junk = Array.from({ length: 2000 }, () => "x".repeat(4096));
+                Bun.gc(true);
+                Bun.gc(true);
+                cancelled.resolve();
+              }
+              el.setAttribute("seen", "1");
+              gates[n].resolve();
+            },
+          })
+          .transform(await fetch(server.url));
+        reader = out.body.getReader();
+        out = null;
+        const drain = (async () => {
+          try {
+            while (reader) {
+              const { done } = await reader.read();
+              if (done) break;
+            }
+          } catch {}
+        })();
+        await cancelled.promise;
+        await drain;
+        Bun.gc(true);
+        for (const g of gates) g.resolve();
+        console.log("iteration", iter, "saw", seen);
+      }
+      console.log("done");
+      server.stop(true);
+      process.exit(0);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("iteration 0 saw 5\niteration 1 saw 5\niteration 2 saw 5\ndone\n");
+    expect(exitCode).toBe(0);
+  });
+
   // Chained transform where the intermediate Response is a temporary: while
   // the second pipe's handler is suspended, the first pipe is parked on the
   // shared ByteStream's backpressure with its producer backref installed.


### PR DESCRIPTION
### What
An HTMLRewriter content handler that cancels the *output* stream while the input `ByteStream`'s `write()` into the pipe is still on the stack detaches every GC edge to the Transform cell; a GC in the same handler sweeps the cell and leaves `write()`'s pin (added in #38656) holding the last ref. Dropping the pin freed the `RewriterPipe`, but `ByteStream::on_data` follows a `Done` answer from `write` with `end()` on the same sink snapshot and read freed memory (debug main: `heap-use-after-free` in `RewriterPipe::rc_ref ← end_from_stream ← ByteStream::on_data`; on the Aug-8 canary the UAF is earlier, in lol-html `handle_start_tag`).

`pin()` now returns a guard whose drop releases through the same deferred-free path `release_pump_ref` already uses (`DeferredDerefTask` / `HTMLRewriterPipeFree`) when it holds the last ref, so no externally-entered entry point (`write`, `end_from_stream`, `resume`, `cancel_from_output`, `fail`) frees the pipe inside its native caller's frame. Non-last derefs stay inline.

### Repro (before)
`fetch()` an HTML response delivered in small chunks, `new HTMLRewriter().on("*", { element(e) { if (++n === 7) reader.cancel(); else if (cancelled) Bun.gc(true); e.setAttribute("x","y"); } }).transform(res)`, read via `getReader()` — crashes at iteration 0 (full script in the test).

### Tests
`test/js/workerd/html-rewriter.test.js` — "cancelling the output from a handler mid-chunk does not free the pipe under its caller" (deterministic chunking via per-element gates, no sleeps). Fails on the ASan canary and debug main; passes here.
