### PR TITLE
bundler: frame .jsc bytecode sidecars and verify them before decoding

### DIFF
--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -27,6 +27,46 @@ pub mod bun_css {
 
 pub use crate::HTMLScanner as html_scanner;
 
+/// Framing for the `<chunk>.jsc` bytecode sidecar written by `bun build --bytecode`.
+/// JSC decodes cached bytecode in place with no bounds or integrity checks, so the
+/// payload is followed by `payload_len: u64 le | wyhash(payload): u64 le | MAGIC`
+/// and anything that does not verify is ignored (the module is parsed from source).
+/// Bytecode embedded in `--compile` executables is not framed.
+pub mod bytecode_sidecar {
+    pub const EXTENSION: &str = ".jsc";
+    const MAGIC: [u8; 8] = *b"\0bun.jsc";
+    pub const FOOTER_LEN: usize = 8 + 8 + 8;
+
+    fn footer(payload: &[u8]) -> [u8; FOOTER_LEN] {
+        let mut out = [0u8; FOOTER_LEN];
+        out[0..8].copy_from_slice(&(payload.len() as u64).to_le_bytes());
+        out[8..16].copy_from_slice(&bun_wyhash::hash(payload).to_le_bytes());
+        out[16..].copy_from_slice(&MAGIC);
+        out
+    }
+
+    pub fn frame(payload: Box<[u8]>) -> Box<[u8]> {
+        let footer = footer(&payload);
+        let mut bytes = Vec::from(payload);
+        bytes.reserve_exact(FOOTER_LEN);
+        bytes.extend_from_slice(&footer);
+        bytes.into_boxed_slice()
+    }
+
+    /// Length of the verified JSC payload at the start of `file`.
+    pub fn payload_len(file: &[u8]) -> Option<usize> {
+        let (payload, tail) = file.split_at(file.len().checked_sub(FOOTER_LEN)?);
+        if payload.is_empty()
+            || tail[16..] != MAGIC
+            || tail[0..8] != (payload.len() as u64).to_le_bytes()
+            || tail[8..16] != bun_wyhash::hash(payload).to_le_bytes()
+        {
+            return None;
+        }
+        Some(payload.len())
+    }
+}
+
 pub(crate) mod index {
     pub(crate) use bun_ast::IndexInt as Int;
 }

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1075,6 +1075,12 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                             &code_result.buffer,
                             &mut source_provider_url,
                         ) {
+                            // Executables embed the raw payload (aligned by the module graph).
+                            let bytecode = if c.options.compile_mode.is_executable() {
+                                bytecode
+                            } else {
+                                crate::bytecode_sidecar::frame(bytecode)
+                            };
                             let source_provider_url_str = source_provider_url.to_utf8();
                             debug!(
                                 "Bytecode cache generated {}: {}",

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -34,8 +34,7 @@ use crate::linker_context::static_route_visitor::StaticRouteVisitor;
 use crate::linker_context::write_output_files_to_disk::write_output_files_to_disk;
 use crate::linker_context_mod::{GenerateChunkCtx, PendingPartRange};
 
-/// Bytecode output file extension (also defined in `writeOutputFilesToDisk.rs`).
-const BYTECODE_EXTENSION: &str = ".jsc";
+use crate::bytecode_sidecar::EXTENSION as BYTECODE_EXTENSION;
 
 // `Chunk.final_rel_path` / `metafile_chunk_json` are owned
 // `Box<[u8]>`; assignments

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -413,6 +413,7 @@ pub(crate) fn write_output_files_to_disk(
                         &code_result.buffer,
                         &mut source_provider_url,
                     ) {
+                        let bytecode = crate::bytecode_sidecar::frame(bytecode);
                         let source_provider_url_str = source_provider_url.to_utf8();
                         debug!(
                             "Bytecode cache generated {}: {}",

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -25,8 +25,7 @@ use bun_sys::{
     write_file_with_path_buffer,
 };
 
-/// Bytecode output file extension (also defined in `generateChunksInParallel.rs`).
-const BYTECODE_EXTENSION: &str = ".jsc";
+use crate::bytecode_sidecar::EXTENSION as BYTECODE_EXTENSION;
 
 pub(crate) fn write_output_files_to_disk(
     c: &mut LinkerContext,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1712,9 +1712,9 @@ impl<'a> Transpiler<'a> {
                             | js_ast::AlreadyBundled::Bytecode => 'brk: {
                                 // When the parser
                                 // saw `// @bun @bytecode`, attempt to load the
-                                // sidecar `<path>.jsc` cached bytecode. Only
-                                // fall back to re-parsing source on read
-                                // failure / empty file.
+                                // sidecar `<path>.jsc` cached bytecode. Fall
+                                // back to re-parsing source on read failure or
+                                // when the sidecar does not verify.
                                 let is_cjs =
                                     matches!(already_bundled, js_ast::AlreadyBundled::BytecodeCjs);
                                 let default_value = if is_cjs {
@@ -1725,9 +1725,8 @@ impl<'a> Transpiler<'a> {
                                 if this_parse.virtual_source.is_none()
                                     && this_parse.allow_bytecode_cache
                                 {
-                                    // No shared const for the bytecode extension
-                                    // in `bun_core` yet, so inline the literal.
-                                    const BYTECODE_EXT: &[u8] = b".jsc";
+                                    const BYTECODE_EXT: &[u8] =
+                                        crate::bytecode_sidecar::EXTENSION.as_bytes();
                                     let mut path_buf2 = bun_paths::PathBuffer::uninit();
                                     let n = path.text.len();
                                     let total = n + BYTECODE_EXT.len();
@@ -1749,7 +1748,13 @@ impl<'a> Transpiler<'a> {
                                     // `read_from` directly.
                                     let dir = dirname_fd.unwrap_valid().unwrap_or_else(FD::cwd);
                                     match bun_sys::File::read_from(dir, zpath) {
-                                        Ok(contents) if !contents.is_empty() => {
+                                        Ok(mut contents) => {
+                                            let Some(payload_len) =
+                                                crate::bytecode_sidecar::payload_len(&contents)
+                                            else {
+                                                break 'brk default_value;
+                                            };
+                                            contents.truncate(payload_len);
                                             break 'brk if is_cjs {
                                                 AlreadyBundled::BytecodeCjs(
                                                     contents.into_boxed_slice(),
@@ -1760,7 +1765,7 @@ impl<'a> Transpiler<'a> {
                                                 )
                                             };
                                         }
-                                        _ => {}
+                                        Err(_) => {}
                                     }
                                 }
                                 default_value

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -92,19 +92,20 @@ describe("Bun.build", () => {
     const pristine = readFileSync(jsc);
     expect(pristine.length).toBeGreaterThan(256);
 
-    const run = () => {
-      const { stdout, stderr, exitCode } = Bun.spawnSync({
+    const run = async () => {
+      await using proc = Bun.spawn({
         cmd: [bunExe(), js],
         env: { ...bunEnv, BUN_JSC_verboseDiskCache: "1" },
         stdout: "pipe",
         stderr: "pipe",
       });
-      return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
     };
     const expected = "PROG 83 62 249-72 84,85,86\n";
 
     // sanity: the untouched sidecar is actually used
-    let result = run();
+    let result = await run();
     expect(result.stdout).toBe(expected);
     expect(result.stderr).toContain("[Disk Cache] Cache hit");
     expect(result.exitCode).toBe(0);
@@ -132,7 +133,7 @@ describe("Bun.build", () => {
     ];
     for (const [name, bytes] of variants) {
       writeFileSync(jsc, bytes);
-      result = run();
+      result = await run();
       expect({ name, stdout: result.stdout }).toEqual({ name, stdout: expected });
       expect(result.stderr).not.toContain("[Disk Cache] Cache hit");
       expect(result.exitCode).toBe(0);

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -71,6 +71,74 @@ describe("Bun.build", () => {
     expect(await bunRun(build.outputs[0].path)).toSpawn("world");
   });
 
+  test("a corrupted or truncated .jsc sidecar is ignored instead of decoded", async () => {
+    using dir = tempDir("bun-build-api-bytecode-corrupt", {
+      "app.ts": `
+        const K: number = 83;
+        function f(x: number) { let s = 0; for (let j = 0; j < x; j++) s += (j * K) % 7; return s; }
+        class C { v = K; m() { return this.v * 3 + "-72"; } }
+        console.log("PROG", K, f(20), new C().m(), [1, 2, 3].map(n => n + K).join(","));
+      `,
+    });
+    const build = await Bun.build({
+      entrypoints: [join(dir, "app.ts")],
+      outdir: join(dir, "out"),
+      target: "bun",
+      bytecode: true,
+    });
+    expect(build.success).toBe(true);
+    const js = join(dir, "out", "app.js");
+    const jsc = js + ".jsc";
+    const pristine = readFileSync(jsc);
+    expect(pristine.length).toBeGreaterThan(256);
+
+    const run = () => {
+      const { stdout, stderr, exitCode } = Bun.spawnSync({
+        cmd: [bunExe(), js],
+        env: { ...bunEnv, BUN_JSC_verboseDiskCache: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
+    };
+    const expected = "PROG 83 62 249-72 84,85,86\n";
+
+    // sanity: the untouched sidecar is actually used
+    let result = run();
+    expect(result.stdout).toBe(expected);
+    expect(result.stderr).toContain("[Disk Cache] Cache hit");
+    expect(result.exitCode).toBe(0);
+
+    const variants: Array<[string, Buffer]> = [
+      ["truncated to 32 bytes", pristine.subarray(0, 32)],
+      ["truncated by one byte", pristine.subarray(0, pristine.length - 1)],
+      [
+        "one flipped byte",
+        (() => {
+          const b = Buffer.from(pristine);
+          b[pristine.length >> 1] ^= 0xff;
+          return b;
+        })(),
+      ],
+      [
+        "header smashed",
+        (() => {
+          const b = Buffer.from(pristine);
+          b.fill(0xff, 48, 160);
+          return b;
+        })(),
+      ],
+      ["trailing garbage", Buffer.concat([pristine, Buffer.from("garbage")])],
+    ];
+    for (const [name, bytes] of variants) {
+      writeFileSync(jsc, bytes);
+      result = run();
+      expect({ name, stdout: result.stdout }).toEqual({ name, stdout: expected });
+      expect(result.stderr).not.toContain("[Disk Cache] Cache hit");
+      expect(result.exitCode).toBe(0);
+    }
+  });
+
   test("passing undefined doesnt segfault", () => {
     try {
       // @ts-ignore


### PR DESCRIPTION
### What
`bun build --bytecode --target=bun --outdir` writes `<chunk>.js` + `<chunk>.js.jsc`. At load time the sidecar was handed straight to JSC's cached-bytecode decoder, which decodes in place and trusts the buffer completely (only the JSC cache version / boot UUID / `SourceCodeKey` are checked — no length or checksum, by design, since JSC assumes it wrote the file). A truncated or single-byte-corrupted `.jsc` therefore gave a heap-buffer-overflow READ in the decoder and a heap WRITE in `CodeBlock::finishCreation` (ASan), SEGV/abort on release.

The sidecar now ends with a 24-byte footer — `payload_len u64 LE | wyhash(payload) u64 LE | "\0bun.jsc"` — written by both output paths (`writeOutputFilesToDisk` and the in-memory/`Bun.build` path in `generateChunksInParallel`), and the single sidecar reader in `bundler/transpiler.rs` verifies it before truncating to the payload and handing it to JSC; on any mismatch the sidecar is ignored and the source is parsed. A footer rather than a header keeps the payload at offset 0 (JSC needs the allocation's alignment; no copy on load). Bytecode embedded in `--compile` executables and the `NODE_COMPILE_CACHE` blobs are unchanged (the former is aligned inside the StandaloneModuleGraph, the latter already has its own sha256 header). Unframed `.jsc` files from older builds are ignored (source is parsed), which is the safe outcome and what a JSC version bump does anyway.

### Repro (before)
```sh
bun build --bytecode --target=bun app.ts --outdir out && bun out/app.js     # ok, [Disk Cache] hit
cp -r out t1 && python3 -c "b=bytearray(open('t1/app.js.jsc','rb').read()); b[1152]^=0xFF; open('t1/app.js.jsc','wb').write(b)" && bun t1/app.js   # SEGV / ASan heap-buffer-overflow WRITE
cp -r out t2 && truncate -s 32 t2/app.js.jsc && bun t2/app.js               # abort / ASan heap-buffer-overflow READ
```

### Tests
`test/bundler/bun-build-api.test.ts` — "a corrupted or truncated .jsc sidecar is ignored instead of decoded" (pristine → cache hit; truncated-to-32, truncated-by-1, one flipped byte, header smashed, trailing garbage → correct output, no cache hit, exit 0). Fails on the ASan canary and debug main; passes here. Existing `--bytecode` tests in `bun-build-api`, `bundler_bun`, `bundler_compile` exercise the framed and raw paths.
