### PR TITLE
vs-shell: pass -products * to vswhere so Build Tools installs are found

### DIFF
--- a/scripts/vs-shell.ps1
+++ b/scripts/vs-shell.ps1
@@ -29,7 +29,11 @@ if($env:VSINSTALLDIR -eq $null) {
     )
     foreach ($searchPath in $searchPaths) {
       if (Test-Path $searchPath) {
-        $vsDir = (Get-ChildItem -Path $searchPath -Directory | Select-Object -First 1).FullName
+        # Only accept an install that actually ships the C++ toolset (vswhere
+        # isn't usable here, so check for the toolset directory instead).
+        $vsDir = (Get-ChildItem -Path $searchPath -Directory |
+          Where-Object { Test-Path (Join-Path $_.FullName "VC\Tools\MSVC") } |
+          Select-Object -First 1).FullName
         if ($vsDir -ne $null) { break }
       }
     }

--- a/scripts/vs-shell.ps1
+++ b/scripts/vs-shell.ps1
@@ -15,7 +15,10 @@ if($env:VSINSTALLDIR -eq $null) {
     throw "Command not found: vswhere (did you install Visual Studio?)"
   }
 
-  $vsDir = (& $vswhere -prerelease -latest -property installationPath)
+  # -products * is required to also match Build Tools installs, which vswhere
+  # skips by default (a machine with only Build Tools would fall through to the
+  # hardcoded 2022 paths and miss newer toolsets entirely).
+  $vsDir = (& $vswhere -products * -prerelease -latest -property installationPath)
   if ($vsDir -eq $null) {
     # Check common VS installation paths
     $searchPaths = @(

--- a/scripts/vs-shell.ps1
+++ b/scripts/vs-shell.ps1
@@ -17,8 +17,10 @@ if($env:VSINSTALLDIR -eq $null) {
 
   # -products * is required to also match Build Tools installs, which vswhere
   # skips by default (a machine with only Build Tools would fall through to the
-  # hardcoded 2022 paths and miss newer toolsets entirely).
-  $vsDir = (& $vswhere -products * -prerelease -latest -property installationPath)
+  # hardcoded 2022 paths and miss newer toolsets entirely). Require the C++
+  # toolset for the target arch so an install without it can't be selected.
+  $vcTools = if ($script:IsARM64) { "Microsoft.VisualStudio.Component.VC.Tools.ARM64" } else { "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" }
+  $vsDir = (& $vswhere -products * -requires $vcTools -prerelease -latest -property installationPath)
   if ($vsDir -eq $null) {
     # Check common VS installation paths
     $searchPaths = @(


### PR DESCRIPTION
### What does this PR do?

`scripts/vs-shell.ps1` calls `vswhere -prerelease -latest` without `-products *`, and vswhere skips Build Tools products by default. On a machine whose newest MSVC ships with a Build Tools install, the script silently selects an older IDE install (or falls through to the hardcoded 2022 paths). Adds `-products *` so the newest toolset wins regardless of product type.

Hit in practice while building current `main` for #39383: the machine has VS 2022 Community 17.7 and Build Tools 18.4; the script picked 17.7, whose STL predates `__std_minmax_8i` / `__std_find_first_of_trivial_pos_1`, so linking against the prebuilt JavaScriptCore/ICU failed at the final `bun-debug.exe` link.

### How did you verify your code works?

A/B on the selection line (Windows 11, both installs present):

```
OLD (no -products *): C:\Program Files\Microsoft Visual Studio\2022\Community
NEW (-products *):    C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools
```

Full script run after the change loads "Visual Studio 2026 Developer PowerShell v18.0" (`VSINSTALLDIR` = Build Tools 18, `cl` = MSVC 14.50.35717) — the environment that successfully linked `bun-debug.exe` for #39383.
