### PR TITLE
docs: Windows builds require the C++ ATL component

### DIFF
--- a/docs/project/building-windows.mdx
+++ b/docs/project/building-windows.mdx
@@ -23,12 +23,12 @@ Bun v1.1 or later. The build uses Bun to run its own code generators.
 irm bun.sh/install.ps1 | iex
 ```
 
-[Visual Studio](https://visualstudio.microsoft.com) with the "Desktop Development with C++" workload. While installing, also install Git if Git for Windows is not already installed.
+[Visual Studio](https://visualstudio.microsoft.com) with the "Desktop Development with C++" workload, plus the "C++ ATL for latest build tools" component — `src/jsc/bindings/windows/rescle.cpp` needs `atlstr.h` to compile and `atls.lib` to link, and neither ships with the bare workload. While installing, also install Git if Git for Windows is not already installed.
 
 Install Visual Studio with the graphical wizard or through WinGet:
 
 ```ps1
-winget install "Visual Studio Community 2022" --override "--add Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.Git " -s msstore
+winget install "Visual Studio Community 2022" --override "--add Microsoft.VisualStudio.Workload.NativeDesktop Microsoft.VisualStudio.Component.VC.ATL Microsoft.VisualStudio.Component.Git " -s msstore
 ```
 
 After Visual Studio, you need the following:


### PR DESCRIPTION
### What does this PR do?

Documents a missing Windows build prerequisite: the "C++ ATL for latest build tools" VS component. `src/jsc/bindings/windows/rescle.cpp` includes `atlstr.h` (line 35) and links `atls.lib`; neither ships with the bare "Desktop Development with C++" workload. Also adds `Microsoft.VisualStudio.Component.VC.ATL` to the WinGet install line so a fresh setup gets it from the start.

### How did you verify your code works?

Fresh Windows build of current `main` (`c3995e43d5`) following the existing doc verbatim fails twice: at object 1207/1240 (`fatal error: 'atlstr.h' file not found`) and, with headers borrowed from another toolset, again at link (`lld-link: error: could not open 'atls.lib'`). Installing `Microsoft.VisualStudio.Component.VC.ATL` via the VS installer fixed both and the build completed (`bun-debug.exe`, used to verify #39383).
