### PR TITLE
Embed the source hash next to bytecode so compiled modules load without reading their source

### DIFF
--- a/src/bundler/OutputFile.rs
+++ b/src/bundler/OutputFile.rs
@@ -24,6 +24,10 @@ pub struct OutputFile {
     pub source_map_index: u32,
     pub bytecode_index: u32,
     pub module_info_index: u32,
+    /// Only set on `OutputKind::Bytecode` files: the JSC source hash the
+    /// bytecode was keyed with (`dispatch::GeneratedBytecode::source_hash`),
+    /// embedded next to the bytecode by `bun build --compile`. 0 otherwise.
+    pub bytecode_source_hash: u32,
     pub output_kind: OutputKind,
     /// Relative
     pub dest_path: Box<[u8]>,
@@ -52,6 +56,7 @@ impl OutputFile {
             source_map_index: u32::MAX,
             bytecode_index: u32::MAX,
             module_info_index: u32::MAX,
+            bytecode_source_hash: 0,
             output_kind: OutputKind::Chunk,
             dest_path: Box::default(),
             side: None,
@@ -91,6 +96,7 @@ impl Clone for OutputFile {
             source_map_index: self.source_map_index,
             bytecode_index: self.bytecode_index,
             module_info_index: self.module_info_index,
+            bytecode_source_hash: self.bytecode_source_hash,
             output_kind: self.output_kind,
             dest_path: self.dest_path.clone(),
             side: self.side,
@@ -198,6 +204,7 @@ pub struct Options {
     pub(crate) source_map_index: Option<u32>,
     pub(crate) bytecode_index: Option<u32>,
     pub(crate) module_info_index: Option<u32>,
+    pub(crate) bytecode_source_hash: u32,
     pub(crate) output_path: Box<[u8]>,
     pub(crate) source_index: IndexOptional,
     pub(crate) size: Option<usize>,
@@ -235,6 +242,7 @@ impl OutputFile {
             output_kind: options.output_kind,
             bytecode_index: options.bytecode_index.unwrap_or(u32::MAX),
             module_info_index: options.module_info_index.unwrap_or(u32::MAX),
+            bytecode_source_hash: options.bytecode_source_hash,
             source_map_index: options.source_map_index.unwrap_or(u32::MAX),
             is_executable: options.is_executable,
             value: match options.data {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1365,6 +1365,16 @@ pub mod bv2_impl {
             }
         }
 
+        /// A chunk's generated JSC bytecode cache.
+        pub struct GeneratedBytecode {
+            pub bytes: Box<[u8]>,
+            /// `JSC::SourceProvider::hash()` of the source the bytecode was
+            /// generated from; part of the cache key JSC checks before using
+            /// `bytes`. Recording it lets the runtime build the key without
+            /// reading the source text. Never 0.
+            pub source_hash: u32,
+        }
+
         unsafe extern "Rust" {
             /// Defined `#[no_mangle]` in `bun_jsc::cached_bytecode`. Generic
             /// "generate JSC bytecode off the main JS thread" helper — marks the
@@ -1376,7 +1386,7 @@ pub mod bv2_impl {
                 format: crate::options_impl::Format,
                 source: &[u8],
                 source_provider_url: &mut bun_core::String,
-            ) -> Option<Box<[u8]>>;
+            ) -> Option<GeneratedBytecode>;
         }
 
         unsafe extern "Rust" {
@@ -1414,7 +1424,7 @@ pub mod bv2_impl {
             format: crate::options_impl::Format,
             source: &[u8],
             source_provider_url: &mut bun_core::String,
-        ) -> Option<Box<[u8]>> {
+        ) -> Option<GeneratedBytecode> {
             __bun_jsc_generate_cached_bytecode(format, source, source_provider_url)
         }
 

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -382,6 +382,7 @@ impl Default for output_file::Options {
             source_map_index: None,
             bytecode_index: None,
             module_info_index: None,
+            bytecode_source_hash: 0,
             output_path: Box::default(),
             source_index: output_file::IndexOptional::NONE,
             size: None,

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1070,7 +1070,10 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         let mut source_provider_url =
                             bun_core::OwnedString::new(source_provider_url);
 
-                        if let Some(bytecode) = crate::bundle_v2::dispatch::generate_cached_bytecode(
+                        if let Some(crate::bundle_v2::dispatch::GeneratedBytecode {
+                            bytes: bytecode,
+                            source_hash,
+                        }) = crate::bundle_v2::dispatch::generate_cached_bytecode(
                             c.options.output_format,
                             &code_result.buffer,
                             &mut source_provider_url,
@@ -1105,6 +1108,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                     None
                                 },
                                 output_kind: options::OutputKind::Bytecode,
+                                bytecode_source_hash: source_hash,
                                 loader: Loader::File,
                                 size: Some(bytecode.len()),
                                 display_size: bytecode.len() as u32,

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -160,6 +160,7 @@ pub(crate) fn write_output_files_to_disk(
                             source_map_index: None,
                             bytecode_index: None,
                             module_info_index: None,
+                            bytecode_source_hash: 0,
                             display_size: 0,
                             referenced_css_chunks: Box::default(),
                             source_index: IndexOptional::NONE,
@@ -184,6 +185,7 @@ pub(crate) fn write_output_files_to_disk(
                 source_map_index,
                 bytecode_index: None,
                 module_info_index: None,
+                bytecode_source_hash: 0,
                 side: Some(options::Side::Client),
                 entry_point_index: None,
                 referenced_css_chunks: Box::default(),
@@ -356,6 +358,7 @@ pub(crate) fn write_output_files_to_disk(
                     source_map_index: None,
                     bytecode_index: None,
                     module_info_index: None,
+                    bytecode_source_hash: 0,
                     display_size: 0,
                     referenced_css_chunks: Box::default(),
                     source_index: IndexOptional::NONE,
@@ -408,7 +411,10 @@ pub(crate) fn write_output_files_to_disk(
                     // `defer source_provider_url.deref()` handled by Drop on OwnedString.
                     let mut source_provider_url = bun_core::OwnedString::new(source_provider_url);
 
-                    if let Some(bytecode) = crate::bundle_v2::dispatch::generate_cached_bytecode(
+                    if let Some(crate::bundle_v2::dispatch::GeneratedBytecode {
+                        bytes: bytecode,
+                        source_hash,
+                    }) = crate::bundle_v2::dispatch::generate_cached_bytecode(
                         c.options.output_format,
                         &code_result.buffer,
                         &mut source_provider_url,
@@ -478,6 +484,7 @@ pub(crate) fn write_output_files_to_disk(
                                 None
                             },
                             output_kind: options::OutputKind::Bytecode,
+                            bytecode_source_hash: source_hash,
                             loader: Loader::File,
                             size: Some(bytecode.len()),
                             display_size: bytecode.len() as u32,
@@ -560,6 +567,7 @@ pub(crate) fn write_output_files_to_disk(
             source_map_index,
             bytecode_index,
             module_info_index: None,
+            bytecode_source_hash: 0,
             size: Some(code_result.buffer.len()),
             display_size: display_size as u32,
             is_executable: chunk.flags.contains(ChunkFlags::IS_EXECUTABLE),

--- a/src/jsc/CachedBytecode.rs
+++ b/src/jsc/CachedBytecode.rs
@@ -1,5 +1,6 @@
 use core::ptr::NonNull;
 
+use bun_bundler::dispatch::GeneratedBytecode;
 use bun_core::String as BunString;
 use bun_options_types::Format;
 
@@ -15,6 +16,7 @@ unsafe extern "C" {
         input_source_code_size: usize,
         output_byte_code: *mut Option<NonNull<u8>>,
         output_byte_code_size: *mut usize,
+        output_source_hash: *mut u32,
         cached_bytecode: *mut Option<NonNull<CachedBytecode>>,
     ) -> bool;
 
@@ -24,6 +26,7 @@ unsafe extern "C" {
         input_source_code_size: usize,
         output_byte_code: *mut Option<NonNull<u8>>,
         output_byte_code_size: *mut usize,
+        output_source_hash: *mut u32,
         cached_bytecode: *mut Option<NonNull<CachedBytecode>>,
     ) -> bool;
 
@@ -33,18 +36,28 @@ unsafe extern "C" {
     safe fn CachedBytecode__deref(this: &mut CachedBytecode);
 }
 
+/// Output of [`CachedBytecode::generate`].
+///
+/// SAFETY CONTRACT: `bytes` actually borrows from `handle` and is invalidated
+/// when `CachedBytecode__deref` is called on it. Callers own the handle and
+/// must deref it to free.
+pub(crate) struct Generated {
+    pub bytes: &'static [u8],
+    /// See [`GeneratedBytecode::source_hash`].
+    pub source_hash: u32,
+    pub handle: NonNull<CachedBytecode>,
+}
+
 impl CachedBytecode {
-    // SAFETY CONTRACT: the returned `&'static [u8]` actually borrows from the
-    // `CachedBytecode` handle and is invalidated when `deref()` is called. Callers own
-    // the handle and must call `deref()` (or drop via `allocator()`) to free.
     pub(crate) fn generate_for_esm(
         source_provider_url: &mut BunString,
         input: &[u8],
-    ) -> Option<(&'static [u8], NonNull<CachedBytecode>)> {
+    ) -> Option<Generated> {
         let mut this: Option<NonNull<CachedBytecode>> = None;
 
         let mut input_code_size: usize = 0;
         let mut input_code_ptr: Option<NonNull<u8>> = None;
+        let mut source_hash: u32 = 0;
         // SAFETY: out-params are valid for write; input slice valid for read.
         let ok = unsafe {
             generateCachedModuleByteCodeFromSourceCode(
@@ -53,6 +66,7 @@ impl CachedBytecode {
                 input.len(),
                 &raw mut input_code_ptr,
                 &raw mut input_code_size,
+                &raw mut source_hash,
                 &raw mut this,
             )
         };
@@ -61,7 +75,11 @@ impl CachedBytecode {
             // and the slice is valid for `input_code_size` bytes until deref().
             let slice =
                 unsafe { bun_core::ffi::slice(input_code_ptr.unwrap().as_ptr(), input_code_size) };
-            return Some((slice, this.unwrap()));
+            return Some(Generated {
+                bytes: slice,
+                source_hash,
+                handle: this.unwrap(),
+            });
         }
 
         None
@@ -70,10 +88,11 @@ impl CachedBytecode {
     pub(crate) fn generate_for_cjs(
         source_provider_url: &mut BunString,
         input: &[u8],
-    ) -> Option<(&'static [u8], NonNull<CachedBytecode>)> {
+    ) -> Option<Generated> {
         let mut this: Option<NonNull<CachedBytecode>> = None;
         let mut input_code_size: usize = 0;
         let mut input_code_ptr: Option<NonNull<u8>> = None;
+        let mut source_hash: u32 = 0;
         // SAFETY: out-params are valid for write; input slice valid for read.
         let ok = unsafe {
             generateCachedCommonJSProgramByteCodeFromSourceCode(
@@ -82,6 +101,7 @@ impl CachedBytecode {
                 input.len(),
                 &raw mut input_code_ptr,
                 &raw mut input_code_size,
+                &raw mut source_hash,
                 &raw mut this,
             )
         };
@@ -90,7 +110,11 @@ impl CachedBytecode {
             // and the slice is valid for `input_code_size` bytes until deref().
             let slice =
                 unsafe { bun_core::ffi::slice(input_code_ptr.unwrap().as_ptr(), input_code_size) };
-            return Some((slice, this.unwrap()));
+            return Some(Generated {
+                bytes: slice,
+                source_hash,
+                handle: this.unwrap(),
+            });
         }
 
         None
@@ -100,7 +124,7 @@ impl CachedBytecode {
         format: Format,
         input: &[u8],
         source_provider_url: &mut BunString,
-    ) -> Option<(&'static [u8], NonNull<CachedBytecode>)> {
+    ) -> Option<Generated> {
         match format {
             Format::Esm => Self::generate_for_esm(source_provider_url, input),
             Format::Cjs => Self::generate_for_cjs(source_provider_url, input),
@@ -133,14 +157,21 @@ pub(crate) fn __bun_jsc_generate_cached_bytecode(
     format: Format,
     source: &[u8],
     source_provider_url: &mut BunString,
-) -> Option<Box<[u8]>> {
+) -> Option<GeneratedBytecode> {
     crate::virtual_machine::IS_BUNDLER_THREAD_FOR_BYTECODE_CACHE.set(true);
     crate::initialize(false);
-    let (bytes, handle) = CachedBytecode::generate(format, source, source_provider_url)?;
+    let Generated {
+        bytes,
+        source_hash,
+        handle,
+    } = CachedBytecode::generate(format, source, source_provider_url)?;
     let owned = Box::<[u8]>::from(bytes);
     // `handle` was just produced by C++ and is valid until deref;
     // `CachedBytecode` is an opaque ZST handle so `opaque_mut` is the
     // centralised zero-byte deref proof.
     CachedBytecode__deref(CachedBytecode::opaque_mut(handle.as_ptr()));
-    Some(owned)
+    Some(GeneratedBytecode {
+        bytes: owned,
+        source_hash,
+    })
 }

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -887,7 +887,7 @@ fn generate_bytecode(format: Format, code: &[u8], url: &[u8]) -> Option<Box<[u8]
                             job.format, &job.code, &mut url,
                         );
                         url.deref();
-                        let _ = job.resp.send(result);
+                        let _ = job.resp.send(result.map(|generated| generated.bytes));
                     }
                 });
             match spawned {

--- a/src/jsc/ResolvedSource.rs
+++ b/src/jsc/ResolvedSource.rs
@@ -51,6 +51,13 @@ pub struct ResolvedSource {
     /// was used at build time. If empty, the origin is derived from source_url.
     /// This is converted to a file:// URL on the C++ side.
     pub bytecode_origin_path: BunString,
+    /// `JSC::SourceProvider::hash()` of `source_code`, recorded when
+    /// `bytecode_cache` was generated. The C++ side installs it on the
+    /// `SourceProvider` so building the bytecode cache key does not have to
+    /// read `source_code` (for a compiled executable that would fault in every
+    /// page of the embedded source). 0 when unknown; WTF string hashes are
+    /// never 0, so 0 unambiguously means "compute it from the source".
+    pub bytecode_source_hash: u32,
 }
 
 impl Default for ResolvedSource {
@@ -70,6 +77,7 @@ impl Default for ResolvedSource {
             bytecode_cache_size: 0,
             module_info: core::ptr::null_mut(),
             bytecode_origin_path: BunString::empty(),
+            bytecode_source_hash: 0,
         }
     }
 }

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -1419,6 +1419,8 @@ void JSCommonJSModule::evaluate(
                 string.substring(trimStart, string.length() - trimStart - 4),
                 wrapperEnd));
             source.needsDeref = true;
+            // The source no longer matches what the bytecode was built from.
+            source.bytecode_source_hash = 0;
         }
     }
 
@@ -1539,6 +1541,8 @@ std::optional<JSC::SourceCode> createCommonJSModule(
                 globalObject->m_moduleWrapperEnd);
             source.source_code.deref();
             source.source_code = Bun::toStringRef(concat);
+            // The source no longer matches what the bytecode was built from.
+            source.bytecode_source_hash = 0;
         }
 
         auto sourceProvider = Zig::SourceProvider::create(globalObject, source, JSC::SourceProviderSourceType::Program, isBuiltIn);

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -126,6 +126,7 @@ Ref<SourceProvider> SourceProvider::create(
                 sourceURLString.impl(), TextPosition(),
                 sourceType));
             provider->m_cachedBytecode = WTF::move(bytecode);
+            provider->m_hash = resolvedSource.bytecode_source_hash;
             return provider;
         }
 
@@ -196,7 +197,7 @@ static JSC::VM& getVMForBytecodeCache()
     return *vmForBytecodeCache;
 }
 
-extern "C" bool generateCachedModuleByteCodeFromSourceCode(BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr)
+extern "C" bool generateCachedModuleByteCodeFromSourceCode(BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, unsigned* outputSourceHash, JSC::CachedBytecode** cachedBytecodePtr)
 {
     std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
     JSC::SourceCode sourceCode = JSC::makeSource(WTF::String(sourceCodeSpan), toSourceOrigin(sourceProviderURL->toWTFString(), false), JSC::SourceTaintedOrigin::Untainted);
@@ -227,11 +228,12 @@ extern "C" bool generateCachedModuleByteCodeFromSourceCode(BunString* sourceProv
     *cachedBytecodePtr = cachedBytecode.get();
     *outputByteCode = cachedBytecode->span().data();
     *outputByteCodeSize = cachedBytecode->span().size();
+    *outputSourceHash = sourceCode.provider()->hash();
 
     return true;
 }
 
-extern "C" bool generateCachedCommonJSProgramByteCodeFromSourceCode(BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, JSC::CachedBytecode** cachedBytecodePtr)
+extern "C" bool generateCachedCommonJSProgramByteCodeFromSourceCode(BunString* sourceProviderURL, const Latin1Character* inputSourceCode, size_t inputSourceCodeSize, const uint8_t** outputByteCode, size_t* outputByteCodeSize, unsigned* outputSourceHash, JSC::CachedBytecode** cachedBytecodePtr)
 {
     std::span<const Latin1Character> sourceCodeSpan(inputSourceCode, inputSourceCodeSize);
 
@@ -262,12 +264,17 @@ extern "C" bool generateCachedCommonJSProgramByteCodeFromSourceCode(BunString* s
     *cachedBytecodePtr = cachedBytecode.get();
     *outputByteCode = cachedBytecode->span().data();
     *outputByteCodeSize = cachedBytecode->span().size();
+    *outputSourceHash = sourceCode.provider()->hash();
 
     return true;
 }
 
 unsigned SourceProvider::hash() const
 {
+    // m_hash is only set when the bytecode cache carried the hash computed at
+    // build time. Falling through to StringImpl::hash() walks the entire source,
+    // which for a compiled executable faults in every page of the embedded
+    // source even though the bytecode cache means it is never parsed.
     if (m_hash) {
         return m_hash;
     }

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -134,6 +134,10 @@ typedef struct ResolvedSource {
     // File path used as source origin for bytecode cache validation.
     // Converted to file:// URL. If empty, origin is derived from source_url.
     BunString bytecode_origin_path;
+    // JSC::SourceProvider::hash() of source_code, recorded when bytecode_cache
+    // was generated, so the cache key can be built without reading source_code.
+    // 0 when unknown (StringImpl hashes are never 0).
+    uint32_t bytecode_source_hash;
 } ResolvedSource;
 inline constexpr uint32_t ResolvedSourceTagPackageJSONTypeModule = 1;
 typedef union ErrorableResolvedSourceResult {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4032,6 +4032,7 @@ export default db;
                         core::ptr::null_mut()
                     },
                     bytecode_cache_size: bytecode_len,
+                    bytecode_source_hash: file.bytecode_source_hash,
                     module_info: if module_info_len > 0 {
                         bun_bundler::analyze_transpiled_module::ModuleInfoDeserialized
                             ::create_from_cached_record(&*file.module_info)

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -329,6 +329,11 @@ pub(crate) struct CompiledModuleGraphFile {
     /// The file path used when generating bytecode (e.g., "B:/~BUN/root/app.js").
     /// Must match exactly at runtime for bytecode cache hits.
     pub bytecode_origin_path: StringPointer,
+    /// JSC's hash of `contents`, recorded when `bytecode` was generated, so the
+    /// runtime can build the bytecode cache key without reading `contents`
+    /// (which would fault in every page of the embedded source). 0 when not
+    /// recorded; JSC string hashes are never 0.
+    pub bytecode_source_hash: u32,
     pub encoding: Encoding,
     pub loader: Loader,
     pub module_format: ModuleFormat,
@@ -478,6 +483,10 @@ pub struct File {
     /// The file path used when generating bytecode (e.g., "B:/~BUN/root/app.js").
     /// Must match exactly at runtime for bytecode cache hits.
     pub bytecode_origin_path: &'static [u8],
+    /// See `CompiledModuleGraphFile::bytecode_source_hash`. Only ever non-zero
+    /// when `encoding` is `Latin1`, i.e. when `to_wtf_string()` hands JSC the
+    /// exact bytes this hash was computed over.
+    pub bytecode_source_hash: u32,
     pub module_format: ModuleFormat,
     pub side: FileSide,
 }
@@ -729,6 +738,7 @@ impl StandaloneModuleGraph {
                     } else {
                         b""
                     },
+                    bytecode_source_hash: module.bytecode_source_hash,
                     module_format: module.module_format,
                     side: module.side,
                     cached_blob: None,
@@ -1017,14 +1027,36 @@ pub(crate) fn to_bytes(
             }
         }
 
+        // Latin1 lets the runtime wrap the mmapped section bytes in a
+        // zero-copy ExternalStringImpl. The printer escapes non-ASCII for
+        // server-side JS, but `--banner`/`--footer`/hashbang and
+        // client-side (target=browser) chunks are concatenated verbatim
+        // as UTF-8, so verify the final bytes before committing to Latin1.
+        let encoding = match output_file.loader {
+            Loader::Js | Loader::Jsx | Loader::Ts | Loader::Tsx
+                if strings::first_non_ascii(buf_bytes).is_none() =>
+            {
+                Encoding::Latin1
+            }
+            _ => Encoding::Binary,
+        };
+
         // When there's bytecode, store the bytecode output file's path as bytecode_origin_path.
         // This path was used to generate the bytecode cache and must match at runtime.
-        let bytecode_origin_path: StringPointer = if output_file.bytecode_index != u32::MAX {
-            string_builder
-                .append_count_z(&output_files[output_file.bytecode_index as usize].dest_path)
-        } else {
-            StringPointer::default()
-        };
+        let mut bytecode_origin_path = StringPointer::default();
+        let mut bytecode_source_hash: u32 = 0;
+        if output_file.bytecode_index != u32::MAX {
+            let bytecode_file = &output_files[output_file.bytecode_index as usize];
+            bytecode_origin_path = string_builder.append_count_z(&bytecode_file.dest_path);
+            // The bytecode was keyed on `buf_bytes` read as Latin1, which is
+            // exactly the string the runtime builds for `Encoding::Latin1`. A
+            // `Binary` module is decoded as UTF-8 into a different string, so
+            // the recorded hash would not describe it; leave it 0 and let the
+            // runtime hash whatever it ends up with.
+            if encoding == Encoding::Latin1 {
+                bytecode_source_hash = bytecode_file.bytecode_source_hash;
+            }
+        }
 
         let mut module = CompiledModuleGraphFile {
             name: string_builder.fmt_append_count_z(format_args!(
@@ -1034,19 +1066,7 @@ pub(crate) fn to_bytes(
             )),
             loader: output_file.loader,
             contents: string_builder.append_count_z(buf_bytes),
-            // Latin1 lets the runtime wrap the mmapped section bytes in a
-            // zero-copy ExternalStringImpl. The printer escapes non-ASCII for
-            // server-side JS, but `--banner`/`--footer`/hashbang and
-            // client-side (target=browser) chunks are concatenated verbatim
-            // as UTF-8, so verify the final bytes before committing to Latin1.
-            encoding: match output_file.loader {
-                Loader::Js | Loader::Jsx | Loader::Ts | Loader::Tsx
-                    if strings::first_non_ascii(buf_bytes).is_none() =>
-                {
-                    Encoding::Latin1
-                }
-                _ => Encoding::Binary,
-            },
+            encoding,
             module_format: if output_file.loader.is_javascript_like() {
                 match output_format {
                     Format::Cjs => ModuleFormat::Cjs,
@@ -1059,6 +1079,7 @@ pub(crate) fn to_bytes(
             bytecode,
             module_info,
             bytecode_origin_path,
+            bytecode_source_hash,
             side: match output_file.side.unwrap_or(options::Side::Server) {
                 options::Side::Server => FileSide::Server,
                 options::Side::Client => FileSide::Client,

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { rmSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { join } from "path";
 import { BundlerTestInput, itBundled as itBundledBase } from "./expectBundled";
 
@@ -1156,6 +1156,106 @@ const server = serve({
     expect(exeStderr).toMatch(/\[Disk Cache\].*Cache hit/i);
     expect(exeExitCode).toBe(0);
   }, 30_000);
+
+  // The executable embeds JSC's hash of each module's source next to its
+  // bytecode, so loading a module from the bytecode cache never has to read the
+  // source text. Otherwise building the cache key hashes the whole source
+  // string, which faults every page of the embedded source into memory for a
+  // module that is never parsed.
+  //
+  // Linux only: the embedded module graph is part of the executable's writable
+  // PT_LOAD segment, so the Rss of the executable's writable mappings in
+  // /proc/self/smaps measures how much of it has been touched. CommonJS because
+  // debug builds re-parse ESM modules to cross-check the embedded module info,
+  // which reads the source regardless of the cache key.
+  test.skipIf(!isLinux)(
+    "bytecode modules are loaded without reading their embedded source",
+    async () => {
+      const sourceSize = 8 * 1024 * 1024;
+      using dir = tempDir("compile-bytecode-source-hash", {
+        "entry.js": /* js */ `
+          const { readFileSync } = require("fs");
+
+          function executableDataRssKB() {
+            let total = 0;
+            let counting = false;
+            for (const line of readFileSync("/proc/self/smaps", "utf8").split("\\n")) {
+              // Mapping header: "start-end perms offset dev inode pathname"; the
+              // lines that follow it describe that mapping. Only writable
+              // mappings: read-only ones hold code, and require() itself runs
+              // code for the first time.
+              if (/^[0-9a-f]+-[0-9a-f]+ /.test(line)) {
+                const fields = line.split(/\\s+/);
+                counting = fields[1].startsWith("rw") && fields.slice(5).join(" ") === process.execPath;
+              } else if (counting && line.startsWith("Rss:")) {
+                total += parseInt(line.slice(4), 10);
+              }
+            }
+            return total;
+          }
+
+          // Computed specifier so big.js is loaded from the embedded module
+          // graph at runtime instead of being bundled into this entry point.
+          const specifier = "./big" + ".js";
+          const before = executableDataRssKB();
+          const big = require(specifier);
+          const after = executableDataRssKB();
+          console.log(JSON.stringify({ before, after, loaded: typeof big }));
+        `,
+        // Never called, so nothing reads the string through either the source
+        // text or the bytecode (JSC decodes a function's bytecode on first call).
+        "big.js": `module.exports = function unused() { return "${Buffer.alloc(sourceSize, "x").toString()}"; };\n`,
+      });
+
+      await using build = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "build",
+          "--compile",
+          "--bytecode",
+          "--format=cjs",
+          "./entry.js",
+          "./big.js",
+          "--outfile",
+          "app",
+        ],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, buildStderr, buildExitCode] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      expect(buildStderr).toBe("");
+      expect(buildExitCode).toBe(0);
+
+      await using exe = Bun.spawn({
+        cmd: [join(String(dir), "app")],
+        env: { ...bunEnv, BUN_JSC_verboseDiskCache: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [exeStdout, exeStderr, exeExitCode] = await Promise.all([exe.stdout.text(), exe.stderr.text(), exe.exited]);
+
+      const { before, after, loaded } = JSON.parse(exeStdout);
+      expect(loaded).toBe("function");
+      // The mapping was found at all (bun's own data lives there too).
+      expect(before).toBeGreaterThan(0);
+      // Loading big.js touched at most a few pages of the module graph, not the
+      // 8 MiB of source. Without the embedded hash this is >= sourceSize.
+      expect(after - before).toBeLessThan(sourceSize / 1024 / 2);
+      // entry.js and big.js both loaded from bytecode, which also proves the
+      // embedded hash matches the key JSC stored in the bytecode.
+      expect(exeStderr.split("\n").filter(line => line.includes("[Disk Cache] Cache hit for sourceCode"))).toHaveLength(
+        2,
+      );
+      expect(exeExitCode).toBe(0);
+    },
+    30_000,
+  );
 
   // When compiling with 8+ entry points, the main entry point should still run correctly.
   test("compile with 8+ entry points runs main entry correctly", async () => {


### PR DESCRIPTION
### Problem
- Loading a module from a `bun build --compile --bytecode` executable faults the module's entire embedded source into memory even though the bytecode cache means the source is never parsed. Measured on a CommonJS module with 8 MiB of source: `require()` grows the Rss of the executable's data mapping by 8128 KB (the whole source).
- Cause: `Zig::SourceProvider::m_hash` (src/jsc/bindings/ZigSourceProvider.h:64) is declared but never assigned, so `SourceProvider::hash()` (ZigSourceProvider.cpp:269) falls through to `StringImpl::hash()`, which walks the whole source string. JSC calls it from the `SourceCodeKey` constructor (SourceCodeKey.h:85) before it consults the bytecode cache. When `module_info` is present this is the only thing on the load path that reads the source at all, so on the bytecode path it is also pure CPU cost (and on signed macOS binaries each first-touched page additionally pays signature verification).

### Fix
- The build step already constructs the same key when it generates the bytecode, so `generateCachedModuleByteCodeFromSourceCode` / `generateCachedCommonJSProgramByteCodeFromSourceCode` return `sourceCode.provider()->hash()` through a new out parameter. That is exactly the value the runtime provider has to return for the stored key to match.
- The hash travels: `bun_jsc::cached_bytecode` -> `dispatch::GeneratedBytecode` -> the bytecode `OutputFile` (`bytecode_source_hash`) -> `CompiledModuleGraphFile::bytecode_source_hash` (a `u32`; the graph format is only read by the binary that wrote it, same as every other field) -> `File` -> `ResolvedSource::bytecode_source_hash` -> `provider->m_hash` in `SourceProvider::create`, set only on the branch that attaches a bytecode cache.
- The hash is only recorded for modules embedded with `Encoding::Latin1`, because that is the only case where the string the runtime hands JSC is byte-for-byte what the bytecode was keyed on. `Binary` modules (any non-ASCII byte in the chunk) are decoded as UTF-8 into a different string; they stay at 0 and keep hashing at runtime, which is their existing behaviour (their bytecode already misses today; that is a separate pre-existing issue, handed off).
- The two `hasOverriddenModuleWrapper` paths in JSCommonJSModule.cpp replace `source_code`, so they zero the hash; a wrong hash can only ever produce a cache miss (JSC compares hash and length against what is stored in the bytecode), never the wrong bytecode for a source that was built correctly.
- 0 is a safe "not recorded" value: WTF string hashes are never 0, which is also what the pre-existing `if (m_hash)` in `hash()` relies on.
- Verified: test/bundler/bundler_compile.test.ts, "bytecode modules are loaded without reading their embedded source". It compiles an entry plus an 8 MiB CommonJS module, `require()`s the second one at runtime, and checks the Rss delta of the executable's writable mappings in `/proc/self/smaps`, plus that both modules still report `[Disk Cache] Cache hit` (which proves the embedded hash matches the key stored in the bytecode). Debug build: delta 64 to 128 KB, passes. Release 1.4.0 without the fix: delta 8128 KB, fails. Linux only because it reads `/proc/self/smaps`; CommonJS because debug builds re-parse ESM modules to cross-check `module_info`, which reads the source regardless.
- Also ran: the rest of bundler_compile.test.ts (70 pass; `compile/HelloWorldWithProcessVersionsBun` fails on main too in debug builds, unrelated, handed off), test/regression/issue/26298.test.ts, bundler_bun, bundler_banner, the standalone madvise test, and the node compile-cache scripts that go through the changed `__bun_jsc_generate_cached_bytecode` helper. Checked manually with `BUN_JSC_verboseDiskCache=1` that ESM `--compile` builds, non-compile `--bytecode` output and non-ASCII (`Binary`) modules behave exactly as before.

### Background
- Bytecode cache: `bun build --bytecode` runs JSC's parser and bytecode generator at build time and serializes the result (`CachedBytecode`). At runtime Bun hands that blob to JSC through `SourceProvider::cachedBytecode()`, and JSC's `CodeCache` decodes it instead of parsing, provided the `SourceCodeKey` stored inside the blob matches the one computed for the runtime source.
- `SourceCodeKey`: JSC's cache key for a piece of source. It is built from `provider->hash()` (xor'd with a few parse-mode flags) and compared by hash, length, flags, name and origin host. `provider->hash()` is normally `StringImpl::hash()`, a lazily computed, cached hash of every character in the string; this PR makes Bun's provider return the value computed at build time instead of computing it again.
- `Zig::SourceProvider`: Bun's `JSC::SourceProvider` subclass. It wraps the `ResolvedSource` that Rust fills in for a module (source string, optional bytecode, optional `module_info`, origin path used for the bytecode key).
- Standalone module graph: the blob `bun build --compile` appends to the bun executable. Per module it stores name, contents, optional bytecode, `module_info` and the origin path in a `#[repr(C)]` record (`CompiledModuleGraphFile`); at runtime the OS maps it straight from the executable and `File::to_wtf_string()` wraps the Latin1 contents zero-copy, so whatever touches the string decides which pages get faulted in. `hint_source_pages_dont_need()` (the madvise after entry evaluation) is left as is; with this change there is much less for it to drop.
- `module_info`: the module's import/export table, precomputed at build time so JSC can skip the analysis parse of ESM modules too. Debug builds still run that parse to cross-check it, which is why the test uses CommonJS.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->