### PR TITLE
standalone: release embedded module pages after startup and from the idle GC timer

### DIFF
--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -1,4 +1,4 @@
-//! Idle GC timer: JSC's own `GCActivityCallback` (via `WTFTimer`) paces eden/full against allocation rate; this only adds a 1 s / 30 s idle `collect_async()` so a process that stops allocating still releases memory. Knobs: `BUN_GC_TIMER_INTERVAL` (ms), `BUN_GC_TIMER_DISABLE`. One per JS thread, not thread-safe.
+//! Idle GC timer: JSC's own `GCActivityCallback` (via `WTFTimer`) paces eden/full against allocation rate; this only adds a 1 s / 30 s idle `collect_async()` so a process that stops allocating still releases memory (and, in a compiled binary, drops the embedded module pages JSC has decoded since the last tick). Knobs: `BUN_GC_TIMER_INTERVAL` (ms), `BUN_GC_TIMER_DISABLE`. One per JS thread, not thread-safe.
 
 use core::cell::Cell;
 use core::ffi::c_int;
@@ -145,6 +145,13 @@ impl GarbageCollectionController {
         }
         let prev_heap_size = this.gc_last_heap_size.get();
         this.perform_gc();
+        // SAFETY: per fn contract.
+        let vm_ref = unsafe { &*vm };
+        if vm_ref.is_main_thread && !vm_ref.is_watcher_enabled() {
+            if let Some(graph) = vm_ref.standalone_module_graph {
+                graph.release_module_pages();
+            }
+        }
         if prev_heap_size == this.gc_last_heap_size.get() {
             let ticks = this
                 .heap_size_didnt_change_for_repeating_timer_ticks_count

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -145,13 +145,6 @@ impl GarbageCollectionController {
         }
         let prev_heap_size = this.gc_last_heap_size.get();
         this.perform_gc();
-        // SAFETY: per fn contract.
-        let vm_ref = unsafe { &*vm };
-        if vm_ref.is_main_thread && !vm_ref.is_watcher_enabled() {
-            if let Some(graph) = vm_ref.standalone_module_graph {
-                graph.release_module_pages();
-            }
-        }
         if prev_heap_size == this.gc_last_heap_size.get() {
             let ticks = this
                 .heap_size_didnt_change_for_repeating_timer_ticks_count
@@ -166,6 +159,11 @@ impl GarbageCollectionController {
             this.heap_size_didnt_change_for_repeating_timer_ticks_count
                 .set(0);
             this.gc_repeating_timer_fast.set(true);
+            // Decoding a lazily-called function allocates, so a heap that
+            // moved is the cheap signal that embedded pages may have been
+            // faulted back in.
+            // SAFETY: per fn contract.
+            unsafe { &*vm }.release_standalone_module_pages();
         }
         let interval = this.repeat_interval();
         Self::arm(

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1488,6 +1488,18 @@ impl VirtualMachine {
         !self.bun_watcher.is_null()
     }
 
+    /// Drop the resident pages of a compiled binary's embedded modules (see
+    /// `bun_standalone_graph::Graph::release_module_pages`). Main-thread only,
+    /// and skipped under `--hot`/`--watch`, which re-read the source on reload.
+    pub fn release_standalone_module_pages(&self) {
+        if !self.is_main_thread || self.is_watcher_enabled() {
+            return;
+        }
+        if let Some(graph) = self.standalone_module_graph {
+            graph.release_module_pages();
+        }
+    }
+
     /// Thin setter so callers don't need `.with` plumbing on the thread-local.
     #[inline]
     pub fn set_is_main_thread_vm(value: bool) {

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -1106,12 +1106,6 @@ extern "C" uint64_t* Bun__getStandaloneModuleGraphMachoLength()
     return &BUN_COMPILED.size;
 }
 
-// Replaces page-aligned ranges of the __BUN segment with fresh private
-// mappings of the same bytes of the executable, which is the only way to drop
-// the resident pages on XNU (madvise/msync only reprioritize file-backed
-// pages). Refuses unless the segment is currently backed by the file open on
-// `exeFd`, so a binary that was replaced on disk after exec is never mapped in.
-// `ranges` is `count` pairs of (start, len); returns the bytes remapped.
 static const segment_command_64* findBunSegment()
 {
     const uint8_t* command = reinterpret_cast<const uint8_t*>(&_mh_execute_header) + sizeof(mach_header_64);
@@ -1127,35 +1121,58 @@ static const segment_command_64* findBunSegment()
     return nullptr;
 }
 
-extern "C" size_t Bun__StandaloneModuleGraph__remapRanges(int exeFd, const size_t* ranges, size_t count)
+// Replaces page-aligned ranges of the __BUN segment with fresh private
+// mappings of the same bytes of the executable, which is the only way to drop
+// the resident pages on XNU (madvise/msync only reprioritize file-backed
+// pages). The file offset comes from the kernel's own record of the segment
+// mapping (`pri_offset`), so it is right even for a slice of a fat binary.
+// Refuses (returns -1) unless the segment is backed by the file open on
+// `exeFd` and that file still looks like it did the first time: a binary
+// replaced or rewritten on disk after exec is never mapped in.
+// `ranges` is `count` pairs of (start, len); returns the bytes remapped.
+extern "C" ssize_t Bun__StandaloneModuleGraph__remapRanges(int exeFd, const size_t* ranges, size_t count)
 {
     const segment_command_64* segment = findBunSegment();
-    if (!segment || count == 0)
-        return 0;
+    if (!segment)
+        return -1;
     uintptr_t segmentStart = segment->vmaddr + _dyld_get_image_vmaddr_slide(0);
 
+    // The first page of the segment holds the blob header and is never
+    // remapped, so this is always the loader's original mapping.
     struct proc_regionwithpathinfo region;
     if (proc_pidinfo(getpid(), PROC_PIDREGIONPATHINFO, segmentStart, &region, sizeof(region)) != sizeof(region))
-        return 0;
+        return -1;
+    const auto& info = region.prp_prinfo;
+    if (info.pri_address > segmentStart)
+        return -1;
     struct stat st;
     if (fstat(exeFd, &st) != 0)
-        return 0;
+        return -1;
     const auto& backing = region.prp_vip.vip_vi.vi_stat;
     if (backing.vst_ino == 0 || backing.vst_ino != st.st_ino || backing.vst_dev != static_cast<uint32_t>(st.st_dev))
-        return 0;
+        return -1;
+    static struct stat firstSeen;
+    static bool firstSeenSet = false;
+    if (!firstSeenSet) {
+        firstSeen = st;
+        firstSeenSet = true;
+    } else if (st.st_size != firstSeen.st_size || st.st_mtimespec.tv_sec != firstSeen.st_mtimespec.tv_sec || st.st_mtimespec.tv_nsec != firstSeen.st_mtimespec.tv_nsec) {
+        return -1;
+    }
 
+    off_t segmentFileOffset = info.pri_offset + (segmentStart - info.pri_address);
     size_t remapped = 0;
     for (size_t i = 0; i < count; i++) {
         uintptr_t start = ranges[2 * i];
         size_t len = ranges[2 * i + 1];
         if (start < segmentStart || len > segment->filesize || start - segmentStart > segment->filesize - len)
             continue;
-        off_t fileOffset = segment->fileoff + (start - segmentStart);
+        off_t fileOffset = segmentFileOffset + (start - segmentStart);
         void* addr = reinterpret_cast<void*>(start);
         if (mmap(addr, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED, exeFd, fileOffset) == addr)
             remapped += len;
     }
-    return remapped;
+    return static_cast<ssize_t>(remapped);
 }
 
 #else // __linux__ / __FreeBSD__ — both ELF, same .bun section approach

--- a/src/jsc/bindings/c-bindings.cpp
+++ b/src/jsc/bindings/c-bindings.cpp
@@ -1092,11 +1092,70 @@ struct BlobHeader {
 
 #if OS(DARWIN)
 
+#include <libproc.h>
+#include <mach-o/dyld.h>
+#include <mach-o/ldsyms.h>
+#include <mach-o/loader.h>
+#include <sys/mman.h>
+#include <sys/proc_info.h>
+
 extern "C" BlobHeader __attribute__((section("__BUN,__bun"))) BUN_COMPILED = { 0, 0 };
 
 extern "C" uint64_t* Bun__getStandaloneModuleGraphMachoLength()
 {
     return &BUN_COMPILED.size;
+}
+
+// Replaces page-aligned ranges of the __BUN segment with fresh private
+// mappings of the same bytes of the executable, which is the only way to drop
+// the resident pages on XNU (madvise/msync only reprioritize file-backed
+// pages). Refuses unless the segment is currently backed by the file open on
+// `exeFd`, so a binary that was replaced on disk after exec is never mapped in.
+// `ranges` is `count` pairs of (start, len); returns the bytes remapped.
+static const segment_command_64* findBunSegment()
+{
+    const uint8_t* command = reinterpret_cast<const uint8_t*>(&_mh_execute_header) + sizeof(mach_header_64);
+    for (uint32_t i = 0; i < _mh_execute_header.ncmds; i++) {
+        const auto* header = reinterpret_cast<const load_command*>(command);
+        if (header->cmd == LC_SEGMENT_64) {
+            const auto* segment = reinterpret_cast<const segment_command_64*>(header);
+            if (strncmp(segment->segname, "__BUN", sizeof(segment->segname)) == 0)
+                return segment;
+        }
+        command += header->cmdsize;
+    }
+    return nullptr;
+}
+
+extern "C" size_t Bun__StandaloneModuleGraph__remapRanges(int exeFd, const size_t* ranges, size_t count)
+{
+    const segment_command_64* segment = findBunSegment();
+    if (!segment || count == 0)
+        return 0;
+    uintptr_t segmentStart = segment->vmaddr + _dyld_get_image_vmaddr_slide(0);
+
+    struct proc_regionwithpathinfo region;
+    if (proc_pidinfo(getpid(), PROC_PIDREGIONPATHINFO, segmentStart, &region, sizeof(region)) != sizeof(region))
+        return 0;
+    struct stat st;
+    if (fstat(exeFd, &st) != 0)
+        return 0;
+    const auto& backing = region.prp_vip.vip_vi.vi_stat;
+    if (backing.vst_ino == 0 || backing.vst_ino != st.st_ino || backing.vst_dev != static_cast<uint32_t>(st.st_dev))
+        return 0;
+
+    size_t remapped = 0;
+    for (size_t i = 0; i < count; i++) {
+        uintptr_t start = ranges[2 * i];
+        size_t len = ranges[2 * i + 1];
+        if (start < segmentStart || len > segment->filesize || start - segmentStart > segment->filesize - len)
+            continue;
+        off_t fileOffset = segment->fileoff + (start - segmentStart);
+        void* addr = reinterpret_cast<void*>(start);
+        if (mmap(addr, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_FIXED, exeFd, fileOffset) == addr)
+            remapped += len;
+    }
+    return remapped;
 }
 
 #else // __linux__ / __FreeBSD__ — both ELF, same .bun section approach

--- a/src/resolver/standalone_module_graph.rs
+++ b/src/resolver/standalone_module_graph.rs
@@ -27,4 +27,8 @@ pub trait StandaloneModuleGraph: Send + Sync {
     /// so `process.execArgv` (lower-tier `bun_jsc` callers holding only the
     /// trait object) can read it without downcasting to the concrete graph.
     fn compile_exec_argv(&self) -> &[u8];
+    /// Drop the resident pages of the embedded modules' source and bytecode;
+    /// they fault back in from the executable if needed again. Exposed via the
+    /// trait so the idle GC timer in `bun_jsc` can call it.
+    fn release_module_pages(&self);
 }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1466,10 +1466,12 @@ impl Run<'_> {
 
         // Initial synchronous evaluation of the entrypoint is done (TLA may
         // still be pending and will resolve in the loop below); the embedded
-        // source pages are off the hot path now. Skip under --watch/--hot
+        // module pages are off the hot path now. Skip under --watch/--hot
         // since those re-read source on every reload.
         if !vm.is_watcher_enabled() {
-            bun_standalone_graph::Graph::hint_source_pages_dont_need();
+            if let Some(graph) = vm.standalone_module_graph {
+                graph.release_module_pages();
+            }
         }
 
         // ── core run-loop ──────────────────────────────────────────────────

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1466,13 +1466,8 @@ impl Run<'_> {
 
         // Initial synchronous evaluation of the entrypoint is done (TLA may
         // still be pending and will resolve in the loop below); the embedded
-        // module pages are off the hot path now. Skip under --watch/--hot
-        // since those re-read source on every reload.
-        if !vm.is_watcher_enabled() {
-            if let Some(graph) = vm.standalone_module_graph {
-                graph.release_module_pages();
-            }
-        }
+        // module pages are off the hot path now.
+        vm.release_standalone_module_pages();
 
         // ── core run-loop ──────────────────────────────────────────────────
         if vm.is_watcher_enabled() {

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -35,9 +35,10 @@ bun_opaque::opaque_ffi! {
 pub struct StandaloneModuleGraph {
     /// Raw view over the serialized graph (`[0, offsets.byte_count)`). Stored as a
     /// raw fat pointer — NOT `&'static [u8]` — because `byte_count` covers the
-    /// bytecode/module_info subranges that JSC mutates in place via
+    /// bytecode/module_info subranges handed to JSC as a mutable span via
     /// `File.bytecode`. Holding a `&'static [u8]` over those bytes would freeze
-    /// them under Stacked/Tree Borrows and make the later foreign write UB.
+    /// them under Stacked/Tree Borrows and make a foreign write UB. (In practice
+    /// nothing writes: `release_module_pages` relies on the pages staying clean.)
     pub bytes: *const [u8],
     pub files: StringArrayHashMap<File>,
     /// Directory prefixes derived from `files` keys (no trailing `/`, always posix-separated).
@@ -316,6 +317,10 @@ impl bun_resolver::StandaloneModuleGraph for StandaloneModuleGraph {
     fn compile_exec_argv(&self) -> &[u8] {
         self.compile_exec_argv
     }
+
+    fn release_module_pages(&self) {
+        StandaloneModuleGraph::release_module_pages(self)
+    }
 }
 
 #[repr(C)]
@@ -368,6 +373,12 @@ mod macho {
     // the symbol's only consumer.
     unsafe extern "C" {
         pub(super) fn Bun__getStandaloneModuleGraphMachoLength() -> *mut u64; // possibly unaligned
+        /// `ranges` is `count` pairs of `(start, len)`; returns the bytes remapped.
+        pub(super) fn Bun__StandaloneModuleGraph__remapRanges(
+            exe_fd: bun_core::FdNative,
+            ranges: *const usize,
+            count: usize,
+        ) -> usize;
     }
 
     /// Returns `(base, len)` for the embedded `__BUN` section data. Kept as a
@@ -448,8 +459,8 @@ mod elf {
         // `dlpi_addr` of the object containing BUN_COMPILED itself; for
         // non-PIE it is 0.
         // Format at target: [u64 payload_len][payload bytes]
-        // Synthesize a `*mut u8` directly so the provenance carries write
-        // permission for the in-place bytecode mutation done by JSC.
+        // Synthesize a `*mut u8` directly so the provenance carries the write
+        // permission of the mutable span the bytecode is handed to JSC as.
         let load_bias =
             bun_sys::elf::find_loaded_module(vaddr_ptr as usize).map_or(0, |m| m.base_address);
         let target = (vaddr as usize).wrapping_add(load_bias) as *mut u8;
@@ -472,7 +483,8 @@ pub struct File {
     pub cached_blob: Option<NonNull<Blob>>,
     pub encoding: Encoding,
     pub wtf_string: BunString,
-    // BACKREF into the embedded section; JSC mutates the bytecode buffer in place.
+    // BACKREF into the embedded section; handed to JSC as a mutable span, but
+    // only ever read (`release_module_pages` remaps it out from under JSC).
     pub bytecode: *mut [u8],
     pub module_info: *mut [u8],
     /// The file path used when generating bytecode (e.g., "B:/~BUN/root/app.js").
@@ -647,8 +659,8 @@ impl StandaloneModuleGraph {
         }
 
         // This function hands out read-only subslices
-        // (name/contents/sourcemap) AND writable subslices (bytecode/module_info, which JSC
-        // mutates in place) into the same allocation. We must not derive the writable
+        // (name/contents/sourcemap) AND writable subslices (bytecode/module_info, handed to
+        // JSC as mutable spans) into the same allocation. We must not derive the writable
         // ones from a `&[u8]` reborrow (writing through const-derived provenance is UB), and we
         // must not hold a long-lived `&[u8]` that *spans* a writable subrange (a foreign write
         // would invalidate it under Stacked/Tree Borrows). Keep `(raw_ptr, raw_len)` raw and
@@ -710,8 +722,8 @@ impl StandaloneModuleGraph {
                         LazySourceMap::None
                     },
                     bytecode: if module.bytecode.length > 0 {
-                        // SAFETY: section bytes are a writable 'static allocation; JSC mutates
-                        // bytecode in place. Subrange is in-bounds (serialized by to_bytes) and
+                        // SAFETY: section bytes are a writable 'static allocation handed to JSC
+                        // as a mutable span. Subrange is in-bounds (serialized by to_bytes) and
                         // disjoint from every read-only subslice handed out above — no
                         // `&[u8]` is ever formed over this range.
                         unsafe { slice_to_mut(raw_ptr, raw_len, module.bytecode) }
@@ -773,7 +785,7 @@ impl StandaloneModuleGraph {
 
 /// Read-only subslice helper. Builds a `&'static [u8]` over the *subrange only* so no
 /// shared reference ever spans the writable bytecode/module_info regions of the same
-/// allocation (which would be invalidated by JSC's in-place writes).
+/// allocation (which a write through their mutable spans would invalidate).
 ///
 /// SAFETY: caller guarantees `base[..len]` is a live 'static allocation and
 /// `[ptr.offset, ptr.offset + ptr.length)` is in-bounds and never written through a
@@ -2235,81 +2247,108 @@ impl StandaloneModuleGraph {
         }
     }
 
-    /// Hint to the kernel that the embedded `__BUN`/`.bun` source pages are
-    /// unlikely to be accessed again after the entrypoint has been parsed.
-    /// The pages are clean file-backed COW, so any later read (lazy require,
-    /// stack-trace source lookup) faults back in transparently from the
-    /// executable on disk. Only applies when running as a compiled
-    /// standalone binary; `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1`
-    /// skips the hint.
-    pub fn hint_source_pages_dont_need() {
-        #[cfg(windows)]
+    /// Drops the resident pages of the embedded section, except those holding
+    /// files that are exposed as plain files (assets, client-side chunks): those
+    /// may be read repeatedly, whereas JSC copies what it decodes out of a
+    /// module's source/bytecode, so once a module has been evaluated its pages
+    /// are dead weight until a lazily-called function is decoded (or a stack
+    /// trace reads the source), and those fault back in from the executable.
+    ///
+    /// Called after the entrypoint has been evaluated and again from the idle
+    /// GC timer, since each newly decoded function drags its whole page back in.
+    /// `BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1` disables it.
+    pub fn release_module_pages(&self) {
+        #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
         {
-            return;
-        }
-
-        #[cfg(not(windows))]
-        {
-            let (base, len): (*mut u8, usize) = {
-                #[cfg(target_os = "macos")]
-                {
-                    match macho::get_data() {
-                        Some(b) => b,
-                        None => return,
-                    }
-                }
-                #[cfg(any(target_os = "linux", target_os = "android"))]
-                {
-                    match elf::get_data() {
-                        Some(b) => b,
-                        None => return,
-                    }
-                }
-                #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "android")))]
-                {
-                    return;
-                }
+            if self.files.is_empty()
+                || bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE
+                    .get()
+                    .unwrap_or(false)
+            {
+                return;
+            }
+            #[cfg(target_os = "macos")]
+            let Some((base, len)) = macho::get_data() else {
+                return;
+            };
+            #[cfg(not(target_os = "macos"))]
+            let Some((base, len)) = elf::get_data() else {
+                return;
             };
 
-            #[cfg(any(target_os = "macos", target_os = "linux", target_os = "android"))]
-            {
-                if len == 0
-                    || bun_core::env_var::feature_flag::BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE
-                        .get()
-                        .unwrap_or(false)
-                {
-                    return;
-                }
+            let page: usize = bun_alloc::page_size();
+            let round_up = |addr: usize| (addr + page - 1) & !(page - 1);
+            let round_down = |addr: usize| addr & !(page - 1);
 
-                let page: usize = bun_alloc::page_size();
-                let start = (base as usize) & !(page - 1);
-                let end_unaligned = base as usize + len;
-                let end = (end_unaligned + page - 1) & !(page - 1);
-
-                // This is a best-effort hint, so call libc madvise directly and
-                // just log on failure rather than treating errors as fatal.
-                // SAFETY: start..end covers a mapped range of the executable image.
-                let rc = unsafe {
-                    libc::madvise(
-                        start as *mut core::ffi::c_void,
-                        end - start,
-                        libc::MADV_DONTNEED,
-                    )
-                };
-                if rc != 0 {
-                    bun_core::scoped_log!(
-                        StandaloneModuleGraph,
-                        "hintSourcePagesDontNeed: madvise failed errno={}",
-                        bun_sys::last_errno()
-                    );
-                    return;
+            // Byte ranges that must stay mapped as-is; everything between them
+            // is released in maximal page-aligned runs.
+            let mut keep: Vec<(usize, usize)> = self
+                .files
+                .values()
+                .iter()
+                .filter(|file| file.appears_in_embedded_files_array())
+                .map(|file| {
+                    let start = file.contents.as_bytes().as_ptr() as usize;
+                    (start, start + file.contents.len())
+                })
+                .collect();
+            keep.sort_unstable();
+            let mut runs: Vec<[usize; 2]> = Vec::with_capacity(keep.len() + 1);
+            let section_end = base as usize + len;
+            let mut cursor = round_up(base as usize);
+            for (start, end) in keep.into_iter().chain([(section_end, section_end)]) {
+                let run_end = round_down(start);
+                if run_end > cursor {
+                    runs.push([cursor, run_end - cursor]);
                 }
-                bun_core::scoped_log!(
-                    StandaloneModuleGraph,
-                    "hintSourcePagesDontNeed: MADV_DONTNEED {} bytes",
-                    end - start
-                );
+                cursor = cursor.max(round_up(end));
             }
+            #[cfg(target_os = "macos")]
+            let released = if runs.is_empty() {
+                0
+            } else {
+                // On XNU, madvise(DONTNEED/FREE/FREE_REUSABLE) and msync are only
+                // paging hints for file-backed memory; the pages stay resident.
+                // Re-mapping the same bytes of the executable over the range is
+                // the one thing that actually drops them.
+                let Ok(path) = bun_core::self_exe_path() else {
+                    return;
+                };
+                let Ok(exe) =
+                    bun_sys::File::open(path, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)
+                else {
+                    return;
+                };
+                // SAFETY: every run lies inside the mapped `__BUN` segment.
+                unsafe {
+                    macho::Bun__StandaloneModuleGraph__remapRanges(
+                        exe.handle().native(),
+                        runs.as_ptr().cast(),
+                        runs.len(),
+                    )
+                }
+            };
+            #[cfg(not(target_os = "macos"))]
+            let released = {
+                let mut released = 0usize;
+                for &[start, run_len] in &runs {
+                    // SAFETY: every run lies inside the mapped `.bun` segment.
+                    let rc = unsafe {
+                        libc::madvise(start as *mut core::ffi::c_void, run_len, libc::MADV_DONTNEED)
+                    };
+                    if rc == 0 {
+                        released += run_len;
+                    }
+                }
+                released
+            };
+            bun_core::scoped_log!(
+                StandaloneModuleGraph,
+                "releaseModulePages: released {} of {} bytes in {} ranges",
+                released,
+                len,
+                runs.len()
+            );
         }
     }
 }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2324,8 +2324,11 @@ impl StandaloneModuleGraph {
                 .filter(|&&[start, run_len]| {
                     // SAFETY: every run lies inside the mapped `.bun` segment.
                     unsafe {
-                        libc::madvise(start as *mut core::ffi::c_void, run_len, libc::MADV_DONTNEED)
-                            == 0
+                        libc::madvise(
+                            start as *mut core::ffi::c_void,
+                            run_len,
+                            libc::MADV_DONTNEED,
+                        ) == 0
                     }
                 })
                 .map(|&[_, run_len]| run_len)
@@ -2393,7 +2396,10 @@ mod page_runs_tests {
         // Keep bytes [3.5P, 5.5P): pages 3 and 5 are shared, so runs stop at 3P and resume at 6P.
         let base = 0;
         let keep = [(3 * P + P / 2, 5 * P + P / 2)];
-        assert_eq!(page_runs(base, 10 * P, P, &keep), vec![[0, 3 * P], [6 * P, 4 * P]]);
+        assert_eq!(
+            page_runs(base, 10 * P, P, &keep),
+            vec![[0, 3 * P], [6 * P, 4 * P]]
+        );
     }
 
     #[test]

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -37,8 +37,8 @@ pub struct StandaloneModuleGraph {
     /// raw fat pointer — NOT `&'static [u8]` — because `byte_count` covers the
     /// bytecode/module_info subranges handed to JSC as a mutable span via
     /// `File.bytecode`. Holding a `&'static [u8]` over those bytes would freeze
-    /// them under Stacked/Tree Borrows and make a foreign write UB. (In practice
-    /// nothing writes: `release_module_pages` relies on the pages staying clean.)
+    /// them under Stacked/Tree Borrows and make a foreign write UB. Nothing
+    /// actually writes today, which `release_module_pages` relies on.
     pub bytes: *const [u8],
     pub files: StringArrayHashMap<File>,
     /// Directory prefixes derived from `files` keys (no trailing `/`, always posix-separated).
@@ -373,12 +373,13 @@ mod macho {
     // the symbol's only consumer.
     unsafe extern "C" {
         pub(super) fn Bun__getStandaloneModuleGraphMachoLength() -> *mut u64; // possibly unaligned
-        /// `ranges` is `count` pairs of `(start, len)`; returns the bytes remapped.
+        /// `ranges` is `count` pairs of `(start, len)`; returns the bytes
+        /// remapped, or -1 if the executable no longer matches the mapping.
         pub(super) fn Bun__StandaloneModuleGraph__remapRanges(
             exe_fd: bun_core::FdNative,
             ranges: *const usize,
             count: usize,
-        ) -> usize;
+        ) -> isize;
     }
 
     /// Returns `(base, len)` for the embedded `__BUN` section data. Kept as a
@@ -483,8 +484,7 @@ pub struct File {
     pub cached_blob: Option<NonNull<Blob>>,
     pub encoding: Encoding,
     pub wtf_string: BunString,
-    // BACKREF into the embedded section; handed to JSC as a mutable span, but
-    // only ever read (`release_module_pages` remaps it out from under JSC).
+    // BACKREF into the embedded section; handed to JSC as a mutable span (see `bytes`).
     pub bytecode: *mut [u8],
     pub module_info: *mut [u8],
     /// The file path used when generating bytecode (e.g., "B:/~BUN/root/app.js").
@@ -2248,11 +2248,12 @@ impl StandaloneModuleGraph {
     }
 
     /// Drops the resident pages of the embedded section, except those holding
-    /// files that are exposed as plain files (assets, client-side chunks): those
-    /// may be read repeatedly, whereas JSC copies what it decodes out of a
-    /// module's source/bytecode, so once a module has been evaluated its pages
-    /// are dead weight until a lazily-called function is decoded (or a stack
-    /// trace reads the source), and those fault back in from the executable.
+    /// files that are exposed as plain files (assets, client-side chunks), which
+    /// may be read repeatedly. Everything else is read by JSC only once per
+    /// module (source hashing, top-level bytecode decode) plus once per lazily
+    /// decoded function or stack-trace source lookup, so after startup most of
+    /// those pages are never touched again; the ones that are fault back in
+    /// from the executable with identical bytes, which is what keeps this safe.
     ///
     /// Called after the entrypoint has been evaluated and again from the idle
     /// GC timer, since each newly decoded function drags its whole page back in.
@@ -2267,21 +2268,8 @@ impl StandaloneModuleGraph {
             {
                 return;
             }
-            #[cfg(target_os = "macos")]
-            let Some((base, len)) = macho::get_data() else {
-                return;
-            };
-            #[cfg(not(target_os = "macos"))]
-            let Some((base, len)) = elf::get_data() else {
-                return;
-            };
-
-            let page: usize = bun_alloc::page_size();
-            let round_up = |addr: usize| (addr + page - 1) & !(page - 1);
-            let round_down = |addr: usize| addr & !(page - 1);
-
-            // Byte ranges that must stay mapped as-is; everything between them
-            // is released in maximal page-aligned runs.
+            let base = self.bytes.cast::<u8>() as usize;
+            let len = self.bytes.len();
             let mut keep: Vec<(usize, usize)> = self
                 .files
                 .values()
@@ -2293,63 +2281,136 @@ impl StandaloneModuleGraph {
                 })
                 .collect();
             keep.sort_unstable();
-            let mut runs: Vec<[usize; 2]> = Vec::with_capacity(keep.len() + 1);
-            let section_end = base as usize + len;
-            let mut cursor = round_up(base as usize);
-            for (start, end) in keep.into_iter().chain([(section_end, section_end)]) {
-                let run_end = round_down(start);
-                if run_end > cursor {
-                    runs.push([cursor, run_end - cursor]);
-                }
-                cursor = cursor.max(round_up(end));
-            }
+            let runs = page_runs(base, len, bun_alloc::page_size(), &keep);
+
             #[cfg(target_os = "macos")]
-            let released = if runs.is_empty() {
-                0
-            } else {
-                // On XNU, madvise(DONTNEED/FREE/FREE_REUSABLE) and msync are only
-                // paging hints for file-backed memory; the pages stay resident.
-                // Re-mapping the same bytes of the executable over the range is
-                // the one thing that actually drops them.
-                let Ok(path) = bun_core::self_exe_path() else {
-                    return;
-                };
-                let Ok(exe) =
-                    bun_sys::File::open(path, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0)
-                else {
-                    return;
-                };
+            // On XNU, madvise(DONTNEED/FREE/FREE_REUSABLE) and msync are only
+            // paging hints for file-backed memory; the pages stay resident.
+            // Re-mapping the same bytes of the executable over the range is
+            // the one thing that actually drops them.
+            let released = match bun_core::self_exe_path().ok().and_then(|path| {
+                bun_sys::File::open(path, bun_sys::O::RDONLY | bun_sys::O::CLOEXEC, 0).ok()
+            }) {
                 // SAFETY: every run lies inside the mapped `__BUN` segment.
-                unsafe {
+                Some(exe) if !runs.is_empty() => match unsafe {
                     macho::Bun__StandaloneModuleGraph__remapRanges(
                         exe.handle().native(),
                         runs.as_ptr().cast(),
                         runs.len(),
                     )
+                } {
+                    -1 => {
+                        bun_core::scoped_log!(
+                            StandaloneModuleGraph,
+                            "releaseModulePages: executable no longer matches the mapping, skipping"
+                        );
+                        return;
+                    }
+                    n => n as usize,
+                },
+                Some(_) => 0,
+                None => {
+                    bun_core::scoped_log!(
+                        StandaloneModuleGraph,
+                        "releaseModulePages: cannot open executable errno={}",
+                        bun_sys::last_errno()
+                    );
+                    return;
                 }
             };
             #[cfg(not(target_os = "macos"))]
-            let released = {
-                let mut released = 0usize;
-                for &[start, run_len] in &runs {
+            let released = runs
+                .iter()
+                .filter(|&&[start, run_len]| {
                     // SAFETY: every run lies inside the mapped `.bun` segment.
-                    let rc = unsafe {
+                    unsafe {
                         libc::madvise(start as *mut core::ffi::c_void, run_len, libc::MADV_DONTNEED)
-                    };
-                    if rc == 0 {
-                        released += run_len;
+                            == 0
                     }
-                }
-                released
-            };
-            bun_core::scoped_log!(
-                StandaloneModuleGraph,
-                "releaseModulePages: released {} of {} bytes in {} ranges",
-                released,
-                len,
-                runs.len()
-            );
+                })
+                .map(|&[_, run_len]| run_len)
+                .sum::<usize>();
+            let requested: usize = runs.iter().map(|&[_, run_len]| run_len).sum();
+            if released < requested {
+                bun_core::scoped_log!(
+                    StandaloneModuleGraph,
+                    "releaseModulePages: released {} of {} requested bytes, last errno={}",
+                    released,
+                    requested,
+                    bun_sys::last_errno()
+                );
+            } else {
+                bun_core::scoped_log!(
+                    StandaloneModuleGraph,
+                    "releaseModulePages: released {} of {} bytes in {} ranges",
+                    released,
+                    len,
+                    runs.len()
+                );
+            }
         }
+    }
+}
+
+/// Page-aligned `[start, len]` runs of `[base, base + len)` that avoid the
+/// sorted `keep` byte ranges: each run is rounded inwards so a page shared with
+/// a kept range stays mapped. Keep ranges outside the section are ignored.
+#[cfg(any(target_os = "macos", target_os = "linux", target_os = "android", test))]
+fn page_runs(base: usize, len: usize, page: usize, keep: &[(usize, usize)]) -> Vec<[usize; 2]> {
+    let section_end = base + len;
+    let mut runs = Vec::with_capacity(keep.len() + 1);
+    let mut cursor = base.next_multiple_of(page);
+    let mut cut = |runs: &mut Vec<[usize; 2]>, start: usize, end: usize| {
+        let run_end = start & !(page - 1);
+        if run_end > cursor {
+            runs.push([cursor, run_end - cursor]);
+        }
+        cursor = cursor.max(end.next_multiple_of(page));
+    };
+    for &(start, end) in keep {
+        if end > base && start < section_end {
+            cut(&mut runs, start.max(base), end.min(section_end));
+        }
+    }
+    cut(&mut runs, section_end, section_end);
+    runs
+}
+
+#[cfg(test)]
+mod page_runs_tests {
+    use super::page_runs;
+
+    const P: usize = 4096;
+
+    #[test]
+    fn whole_section_when_nothing_kept() {
+        // Section covers [P+8, 11P+8): only the full pages 2..11 are released.
+        assert_eq!(page_runs(P + 8, 10 * P, P, &[]), vec![[2 * P, 9 * P]]);
+    }
+
+    #[test]
+    fn kept_range_splits_and_rounds_inwards() {
+        // Keep bytes [3.5P, 5.5P): pages 3 and 5 are shared, so runs stop at 3P and resume at 6P.
+        let base = 0;
+        let keep = [(3 * P + P / 2, 5 * P + P / 2)];
+        assert_eq!(page_runs(base, 10 * P, P, &keep), vec![[0, 3 * P], [6 * P, 4 * P]]);
+    }
+
+    #[test]
+    fn overlapping_and_adjacent_keeps_merge() {
+        let keep = [(P, 2 * P), (2 * P - 10, 3 * P), (2 * P + 5, 2 * P + 6)];
+        assert_eq!(page_runs(0, 10 * P, P, &keep), vec![[0, P], [3 * P, 7 * P]]);
+    }
+
+    #[test]
+    fn keeps_outside_the_section_are_ignored() {
+        let keep = [(0, 16), (100 * P, 101 * P)];
+        assert_eq!(page_runs(10 * P, 4 * P, P, &keep), vec![[10 * P, 4 * P]]);
+    }
+
+    #[test]
+    fn keep_covering_everything_yields_no_runs() {
+        assert!(page_runs(P, 4 * P, P, &[(0, 10 * P)]).is_empty());
     }
 }
 

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -5,7 +5,6 @@
 // runtime, disables both.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir } from "harness";
-import { statSync } from "node:fs";
 import path from "node:path";
 
 // Debug ASAN builds embed an @executable_path rpath for asan-dyld-shim.dylib;
@@ -18,9 +17,9 @@ async function compile(dir: string, entry: string, ...flags: string[]): Promise<
     cmd: [bunExe(), "build", "--compile", ...flags, path.join(dir, entry), "--outfile", out],
     env: bunEnv,
     stderr: "pipe",
-    stdout: "pipe",
+    stdout: "ignore",
   });
-  const [stderr, exitCode] = await Promise.all([build.stderr.text(), build.exited, build.stdout.text()]);
+  const [stderr, exitCode] = await Promise.all([build.stderr.text(), build.exited]);
   expect(stderr).not.toContain("error:");
   expect(exitCode).toBe(0);
   return out;
@@ -123,12 +122,12 @@ test.concurrent.skipIf(isWindows)(
   `;
     using dir = tempDir("standalone-release-pages", { "entry.js": source });
     const out = await compile(String(dir), "entry.js", "--bytecode");
-    const section = statSync(out).size - statSync(bunExe()).size;
-    expect(section).toBeGreaterThan(1024 * 1024);
-    // Without the release both drops come out around zero. With it they are
-    // roughly the section size (startup) and the bytecode size (timer), less
-    // whatever the heap grows by between samples, which ASAN inflates.
-    const expected = Math.floor(section * (isASAN ? 0.2 : 0.4));
+    // The embedded bytecode is several times the source; the startup release
+    // drops source + bytecode and the timer release re-drops the bytecode
+    // pages that calling every function faulted back in. Compare against the
+    // flag-off run so heap movement between samples cancels out, and keep the
+    // bar at a couple of source lengths since debug/ASAN heaps move more.
+    const expected = source.length * (isASAN || isDebug ? 1.5 : 2);
 
     async function run(env: Record<string, string | undefined>) {
       await using proc = Bun.spawn({
@@ -145,10 +144,10 @@ test.concurrent.skipIf(isWindows)(
 
     const [released, disabled] = await Promise.all([
       run({ CHECK_TIMER: String(expected) }),
-      run({ BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE: "1" }),
+      run({ CHECK_TIMER: String(expected), BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE: "1" }),
     ]);
     expect(released.startupDrop - disabled.startupDrop).toBeGreaterThanOrEqual(expected);
-    expect(released.timerDrop).toBeGreaterThanOrEqual(expected);
+    expect(released.timerDrop - disabled.timerDrop).toBeGreaterThanOrEqual(expected);
   },
   60_000,
 );

--- a/test/js/bun/compile/standalone-madvise-tla.test.ts
+++ b/test/js/bun/compile/standalone-madvise-tla.test.ts
@@ -1,18 +1,38 @@
-// PR #29320: hintSourcePagesDontNeed() must be reached even when the
-// entrypoint has top-level await. loadEntryPoint() returns a promise without
-// blocking, so the call site at bun.js.zig:466 is hit synchronously before the
-// main event loop spins — TLA resolution happens later in that loop.
+// A compiled binary drops the resident pages of its embedded modules
+// (source + bytecode) once the entrypoint has been evaluated, and again from
+// the idle GC timer as lazily-decoded functions page them back in.
 // BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE, read by the compiled binary at
-// runtime, skips the hint.
+// runtime, disables both.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir } from "harness";
+import { statSync } from "node:fs";
 import path from "node:path";
+
+// Debug ASAN builds embed an @executable_path rpath for asan-dyld-shim.dylib;
+// the compiled exe lives elsewhere, so point dyld back at the build dir.
+const runEnv = { ...bunEnv, DYLD_FALLBACK_LIBRARY_PATH: path.dirname(bunExe()) };
+
+async function compile(dir: string, entry: string, ...flags: string[]): Promise<string> {
+  const out = path.join(dir, "compiled");
+  await using build = Bun.spawn({
+    cmd: [bunExe(), "build", "--compile", ...flags, path.join(dir, entry), "--outfile", out],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([build.stderr.text(), build.exited, build.stdout.text()]);
+  expect(stderr).not.toContain("error:");
+  expect(exitCode).toBe(0);
+  return out;
+}
 
 // Relies on the StandaloneModuleGraph scoped logger which is compiled out in
 // release builds.
-test.skipIf(isWindows || !isDebug)(
-  "standalone madvise hint fires with top-level await entrypoint",
+test.concurrent.skipIf(isWindows || !isDebug)(
+  "release fires with a top-level await entrypoint",
   async () => {
+    // PR #29320: loadEntryPoint() returns without blocking on TLA, so the
+    // release must still happen synchronously before the event loop spins.
     using dir = tempDir("standalone-madvise-tla", {
       "entry.ts": `
       console.log("before-await");
@@ -20,22 +40,9 @@ test.skipIf(isWindows || !isDebug)(
       console.log("after-await");
     `,
     });
+    const out = await compile(String(dir), "entry.ts");
 
-    const out = path.join(String(dir), "compiled");
-    const build = Bun.spawnSync({
-      cmd: [bunExe(), "build", "--compile", path.join(String(dir), "entry.ts"), "--outfile", out],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    expect(build.stderr.toString()).not.toContain("error:");
-    expect(build.exitCode).toBe(0);
-
-    // BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE is read by the compiled
-    // executable at runtime (the binary above was built without it); a falsy
-    // value leaves the hint enabled. With the flag set, the function returns
-    // before logging anything, so the only evidence is the missing line.
-    for (const [flag, hinted] of [
+    for (const [flag, released] of [
       [undefined, true],
       ["0", true],
       ["1", false],
@@ -43,7 +50,7 @@ test.skipIf(isWindows || !isDebug)(
       await using proc = Bun.spawn({
         cmd: [out],
         env: {
-          ...bunEnv,
+          ...runEnv,
           BUN_DEBUG_StandaloneModuleGraph: "1",
           BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE: flag,
         },
@@ -55,11 +62,10 @@ test.skipIf(isWindows || !isDebug)(
       expect(stdout).toContain("before-await");
       expect(stdout).toContain("after-await");
       // Scoped loggers write to the debug-writer stream (stdout by default).
-      // Either the success or failure variant proves the call site is reached.
-      if (hinted) {
-        expect(stdout).toContain("hintSourcePagesDontNeed:");
+      if (released) {
+        expect(stdout).toContain("releaseModulePages:");
       } else {
-        expect(stdout).not.toContain("hintSourcePagesDontNeed:");
+        expect(stdout).not.toContain("releaseModulePages:");
       }
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
@@ -67,21 +73,82 @@ test.skipIf(isWindows || !isDebug)(
 
     // The scope is declared hidden, so without opting in the log must not
     // appear even when BUN_DEBUG_QUIET_LOGS is unset.
-    {
+    await using proc = Bun.spawn({
+      cmd: [out],
+      env: { ...runEnv, BUN_DEBUG_QUIET_LOGS: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).not.toContain("releaseModulePages:");
+    expect(stdout).toContain("before-await");
+    expect(stdout).toContain("after-await");
+    expect(stderr).not.toContain("releaseModulePages:");
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);
+
+test.concurrent.skipIf(isWindows)(
+  "embedded module pages are released after startup and again from the GC timer",
+  async () => {
+    // Enough small functions that decoding the top-level module's function
+    // list touches every page of the bytecode blob, so the whole section is
+    // resident when the entrypoint finishes evaluating.
+    const count = 6000;
+    let source = "";
+    for (let i = 0; i < count; i++) {
+      source += `function f${i}(a, b) { const o = { x: a, y: b, name: "fn${i}" }; return o.x + o.y + o.name.length + ${i}; }\n`;
+    }
+    source += `const table = [${Array.from({ length: count }, (_, i) => `f${i}`).join(",")}];\n`;
+    source += `
+    const rss = () => process.memoryUsage().rss;
+    const evaluated = rss();
+    setImmediate(async () => {
+      const afterStartup = rss();
+      const result = { startupDrop: evaluated - afterStartup, timerDrop: 0 };
+      if (process.env.CHECK_TIMER) {
+        let sum = 0;
+        for (const f of table) sum += f(1, 2);
+        const afterDecode = rss();
+        const deadline = Date.now() + 20_000;
+        while (Date.now() < deadline) {
+          result.timerDrop = Math.max(result.timerDrop, afterDecode - rss());
+          if (result.timerDrop >= Number(process.env.CHECK_TIMER)) break;
+          await new Promise(r => setTimeout(r, 5));
+        }
+      }
+      console.log(JSON.stringify(result));
+    });
+  `;
+    using dir = tempDir("standalone-release-pages", { "entry.js": source });
+    const out = await compile(String(dir), "entry.js", "--bytecode");
+    const section = statSync(out).size - statSync(bunExe()).size;
+    expect(section).toBeGreaterThan(1024 * 1024);
+    // Without the release both drops come out around zero. With it they are
+    // roughly the section size (startup) and the bytecode size (timer), less
+    // whatever the heap grows by between samples, which ASAN inflates.
+    const expected = Math.floor(section * (isASAN ? 0.2 : 0.4));
+
+    async function run(env: Record<string, string | undefined>) {
       await using proc = Bun.spawn({
         cmd: [out],
-        env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: undefined },
+        env: { ...runEnv, BUN_GC_TIMER_INTERVAL: "10", ...env },
         stdout: "pipe",
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stdout).not.toContain("hintSourcePagesDontNeed:");
-      expect(stdout).toContain("before-await");
-      expect(stdout).toContain("after-await");
-      expect(stderr).not.toContain("hintSourcePagesDontNeed:");
+      expect(stderr).toBe("");
       expect(exitCode).toBe(0);
+      return JSON.parse(stdout) as { startupDrop: number; timerDrop: number };
     }
+
+    const [released, disabled] = await Promise.all([
+      run({ CHECK_TIMER: String(expected) }),
+      run({ BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE: "1" }),
+    ]);
+    expect(released.startupDrop - disabled.startupDrop).toBeGreaterThanOrEqual(expected);
+    expect(released.timerDrop).toBeGreaterThanOrEqual(expected);
   },
-  30_000,
+  60_000,
 );


### PR DESCRIPTION
### What does this PR do?

A `bun build --compile` executable maps its embedded modules (source, and with `--bytecode` the bytecode cache) straight from its own `__BUN` / `.bun` segment. JSC reads those bytes once per module (source hashing, top-level bytecode decode) plus once per lazily called function, and copies what it decodes onto its heap — but the pages it touched stay resident for the life of the process. For a large compiled CLI (~330 MB embedded section, ~870 modules, `--bytecode`) that was ~135 MB of RSS that never went away.

Two things kept the existing `MADV_DONTNEED` hint from helping:

1. On macOS, `madvise(MADV_DONTNEED)` / `MADV_FREE` / `MADV_FREE_REUSABLE` / `msync(MS_INVALIDATE)` are only paging hints for file-backed private mappings; resident pages do not drop (measured, table below). Only re-mapping the same bytes of the executable over the range with `mmap(MAP_FIXED | MAP_PRIVATE)` does.
2. It ran once, right after the entrypoint's synchronous evaluation. Because JSC's bytecode cache interleaves each function's header with its body, decoding one lazily called function faults its whole 16 KB page back in — calling 10% of the functions brought back 67% of the pages, and nothing ever released them again.

This PR replaces `hint_source_pages_dont_need` with `StandaloneModuleGraph::release_module_pages`, which:

- releases everything in the embedded section except the byte ranges of files exposed as plain files (assets, client-side chunks), computed as page-aligned runs rounded inwards (`page_runs`, unit-tested);
- on macOS re-maps each run from the executable (`Bun__StandaloneModuleGraph__remapRanges` in `c-bindings.cpp`) after checking that the segment is still backed by the file being opened (dev/ino via `proc_pidinfo(PROC_PIDREGIONPATHINFO)` vs `fstat`) and that the file's size/mtime haven't changed since the first release, taking the file offset from the kernel's own record of the mapping (`pri_offset`, correct for fat binaries too). On Linux it stays `MADV_DONTNEED`, now per run;
- is called from the same place as before (`run_command.rs`, after entrypoint evaluation) and additionally from the idle GC timer, on ticks where the heap moved (lazy decode allocates, so that is the cheap signal that pages may have come back). Both call sites go through `VirtualMachine::release_standalone_module_pages` (main thread only, skipped under `--hot`/`--watch`).

`BUN_FEATURE_FLAG_DISABLE_STANDALONE_MADVISE=1` disables both, as before. The flag name predates the macOS mechanism; kept for compatibility.

Nothing writes to the mapping (JSC's `Decoder` only reads; Bun's `SourceProvider` implements no bytecode write-back; measured 0 dirty pages), and every byte the remap brings back is identical, so lazily decoded functions, `Function.prototype.toString` and stack-trace source lookups keep working — they just fault their pages back in.

### Measurements (macOS arm64, release build)

Which macOS calls actually drop resident file-backed pages (100 MB touched range):

| call | resident after |
|---|---|
| `madvise(MADV_DONTNEED)` (previous implementation) | 100.0 M (unchanged) |
| `MADV_FREE`, `MADV_FREE_REUSABLE`, `msync(MS_INVALIDATE)`, `mach_vm_behavior_set(FREE/REUSABLE)` | 100.0 M (unchanged) |
| `mmap(MAP_FIXED\|MAP_PRIVATE)` of the same file range | 0 K |

Large compiled CLI, same binary, flag on vs off (`hyperfine`, 25 runs, exit after first render):

```
patched   373.1 ms ± 6.0 ms   [User: 430.6 ms, System: 88.3 ms]
disabled  372.0 ms ± 4.9 ms   [User: 432.5 ms, System: 85.8 ms]
```

Idle after startup, sampled every 0.5 s for 30 s:

```
patched   rss ≈ 299 MB   __BUN resident 0.2 M / 327 M
disabled  rss ≈ 436 MB   __BUN resident 135.6 M / 327 M
```

Synthetic app (40 000 functions, 106 MB section, `--bytecode`), flag on vs off:

```
startup, no calls              34.0 ms ± 2.2  vs  43.1 ms ± 1.5
startup + call 10% of fns      55.9 ms ± 1.6  vs  53.5 ms ± 1.6   (refault cost)
startup + call 30% of fns      89.8 ms ± 2.2  vs  85.5 ms ± 1.7
after calling 10%: resident 71.0 M → next GC-timer tick → 0.0 M
```

An earlier version of this change remapped per file and re-ran the identity check per file; with ~870 modules that cost +73 ms of startup (`proc_pidinfo` is ~64 µs a call), which is why the identity check runs once per release and runs are merged.

### Notes / trade-offs

- On macOS this lowers RSS (`process.memoryUsage().rss`, `ps`); clean file-backed pages were already excluded from `phys_footprint` (Activity Monitor). Under memory pressure the effect is the same either way — the pages become reclaimable page cache.
- A process that keeps allocating will re-release on every idle tick where the heap moved; pages that JSC actually re-reads (source for stack traces, functions decoded since the last tick) fault back in from page cache at a few µs per page.
- Linux: the startup release already worked there; the new part is the periodic release and skipping asset ranges. The Linux path was checked with `cargo check --target x86_64-unknown-linux-gnu`; I have not run it on a Linux machine.

### Tests

- `test/js/bun/compile/standalone-madvise-tla.test.ts` (rewritten): compiles a `--bytecode` app with 6000 functions and checks, against a flag-off run of the same binary, that RSS drops after the entrypoint and again after the GC timer once every function has been called; plus the existing debug-only check that the release log fires with a top-level-await entrypoint. Fails on a build without this change (`startupDrop - disabled.startupDrop` comes out ≈ 0).
- `page_runs` unit tests in `StandaloneModuleGraph.rs` (rounding inwards, overlapping/adjacent keeps, keeps outside the section, fully covered section).
