### PR TITLE
test: size inspect-error-leak for the build that runs it

### DIFF
--- a/test/js/bun/util/inspect-error-leak.test.js
+++ b/test/js/bun/util/inspect-error-leak.test.js
@@ -1,14 +1,15 @@
 import { expect, test } from "bun:test";
 import { isASAN, isDebug, rss } from "harness";
 
-// The leak this guards against (the error printer not releasing its
-// ZigException holder) is ~1 KB per printed error, so 30k prints grow a release
-// build by ~30 MB against the 10 MB bound below. ASAN and debug builds print an
-// error 4-50x slower and the bound has no teeth under ASAN's quarantine anyway
-// (the ASAN lane runs LeakSanitizer), so they only get enough iterations to
-// exercise the path.
-const perBatch = isASAN || isDebug ? 250 : 1000;
-const repeat = isASAN || isDebug ? 4 : 30;
+// Release builds are the detector. The leaks this file has caught (#12831's six
+// source-line StringImpls, the per-print path buffer noted in jsc_hooks.rs) are
+// one to two hundred bytes per printed error, so it takes ~100k prints to push
+// them past the 10 MB bound below; a clean run drifts a few MB regardless of the
+// count. ASAN and debug builds print an error 4-50x slower, and the 400 MB ASAN
+// bound is quarantine headroom rather than a leak detector, so they only need
+// enough prints to exercise the path.
+const perBatch = isASAN || isDebug ? 250 : 2000;
+const repeat = isASAN || isDebug ? 4 : 50;
 
 test("Printing errors does not leak", () => {
   function batch() {

--- a/test/js/bun/util/inspect-error-leak.test.js
+++ b/test/js/bun/util/inspect-error-leak.test.js
@@ -1,8 +1,15 @@
 import { expect, test } from "bun:test";
-import { isASAN, rss } from "../../../harness";
+import { isASAN, isDebug, rss } from "harness";
 
-const perBatch = 2000;
-const repeat = 50;
+// The leak this guards against (the error printer not releasing its
+// ZigException holder) is ~1 KB per printed error, so 30k prints grow a release
+// build by ~30 MB against the 10 MB bound below. ASAN and debug builds print an
+// error 4-50x slower and the bound has no teeth under ASAN's quarantine anyway
+// (the ASAN lane runs LeakSanitizer), so they only get enough iterations to
+// exercise the path.
+const perBatch = isASAN || isDebug ? 250 : 1000;
+const repeat = isASAN || isDebug ? 4 : 30;
+
 test("Printing errors does not leak", () => {
   function batch() {
     for (let i = 0; i < perBatch; i++) {
@@ -23,4 +30,4 @@ test("Printing errors does not leak", () => {
   // ASAN's free quarantine (default 256 MB) plus redzones and glibc page
   // retention inflate RSS even when nothing is leaking.
   expect(diff, `RSS grew by ${diff} MB after ${perBatch * repeat} iterations`).toBeLessThan(isASAN ? 400 : 10);
-}, 10_000);
+});


### PR DESCRIPTION
### Problem
- `test/js/bun/util/inspect-error-leak.test.js` ("Printing errors does not leak") times out in CI on the slow lanes and then passes when re-run alone, so it shows up as flaky on most builds: main build 98850, and PR builds 99746 (debian 13 x64-asan) and 99764 (windows 11 aarch64) for #36602. Build 88574 had it hard red on x64-asan (`this test timed out after 10000ms`).
- The test prints 102k errors (`Bun.inspect(new Error())` 2000 x 51, with a full GC per batch) on every build, under a 10 s timeout it passes as the third argument to `test()`. That argument overrides the per-test budget the CI runner passes (`scripts/runner.node.mjs:1969`: 90 s, 270 s on asan).
- Cost of the loop per lane, CI's own numbers (`test/expected-durations.json:5009`): 1.6 s linux release, 1.75 s musl, 6.3 s windows x64, 6.8 s asan. In build 99764 the windows aarch64 lane hit 10035 ms in the batch and then passed alone in 7.12 s. So the asan and windows lanes had about 1.5x headroom against the self-imposed 10 s and any load on the runner pushed them over. On a debug ASAN build (`bun bd test`) the loop takes 80 s and the test has been failing on its own timeout every time.
- On ASAN builds the loop is not measuring anything: a clean run grows RSS by ~345 MB of ASAN quarantine against the 400 MB bound, leak or no leak.

### Fix
- Drop the explicit timeout. The release lanes keep their 2000 x 50 loop and now run it against the runner's 90 s budget (worst lane ~7 s) instead of 10 s; locally the loop is 1.8-2.4 s on release builds against the 5 s default.
- ASAN and debug builds (`isASAN || isDebug`, the shape `serve-body-leak.test.ts` and `load-file-loader-a-lot.test.ts` use) print 250 x 4 errors instead. Their bound is not the leak detector (see Problem), so they only need to exercise the path; the asan lane drops from 6.8 s to well under a second and `bun bd test` from 80 s (failing) to 1.2-1.3 s (passing).
- The release count is left alone on purpose: the leaks this file has actually caught are small per print (#12831 leaked six header-only `StringImpl`s per printed error, ~150-200 B; the per-print path buffer described at `src/runtime/jsc_hooks.rs:2648-2657` is ~60-200 B), and with whole-MB truncation a leak needs 10 MB to fail the test, i.e. ~105 B/print at 100k prints. Fewer prints would raise that floor above those classes (an earlier revision of this PR used 30k, which puts it at ~350 B/print). The benign drift is 0-6 MB across the release lanes and does not shrink with the count, so the 10 MB bound itself cannot usefully be tightened either.
- Thresholds (10 MB, 400 MB under ASAN) are unchanged. The header comment now records the per-print sizing so the count does not get trimmed again without seeing what it costs.
- Verified:
  - `bun bd test test/js/bun/util/inspect-error-leak.test.js`: on main, `timed out after 10000ms` after 80.3 s (RSS +341 MB); with this branch, passes in 1.1-1.3 s (RSS +2-5 MB), 7 runs (the last one after rebasing onto 1dd66afde2).
  - `USE_SYSTEM_BUN=1 bun test ...` (release, linux x64): passes in 1.8-2.0 s, RSS +0-3 MB, 4 runs (the loop is unchanged on release, main measures the same).
  - Build 99825 (the 30k revision) was green on every lane; the release lanes all reported 0 MB growth, asan +5 MB at 1000 prints. The debug/asan arm is unchanged since; the release arm is main's loop.

### Background
- The test takes RSS after one warm-up batch, prints errors in batches with a `Bun.gc(true)` after each so JS garbage is collected, truncates the growth to whole MB and asserts it is below the bound. What is left after the GCs is native memory the error printer allocated and did not free.
- Printing an Error (`Bun.inspect`, `console.log`, uncaught error output) fills a native `ZigException` holder with the error's name, message, stack frames and up to six source lines, remaps it through the source map of the file (`src/jsc/VirtualMachine.rs`, `remap_zig_exception`), and releases everything when the print finishes. Every allocation on that path is a candidate for a per-print leak, and the two noted above were found by this test.
- ASAN quarantine: ASAN builds park freed blocks in a 256 MB quarantine instead of reusing them, so RSS grows with the number of frees (~5 KB per printed error here) until the quarantine is full. That is what the 400 MB bound accommodates, and why growth under ASAN says nothing about leaks of the size this test is after. (`test/leaksan.supp` also suppresses `fromErrorInstance`, so LeakSanitizer on the asan lane does not cover this path either; only the release lanes do.)
- `isASAN` is true on the CI asan lane ("Release with ASAN" in `.buildkite/ci.mjs`) and for `bun bd` builds; `isDebug` is true for `bun bd` builds. Every other CI test lane is a release build and keeps the full loop.
- Since #39373 this file is also kept out of the `bun test --parallel` batch (`test/parallel-denylist.txt`); that removes the interference from neighbouring files, this PR removes the budget problem the test has on its own.

<details>
<summary>Earlier revision</summary>

The first push also cut the release loop to 1000 x 30 on the theory that the leak class being guarded was ~1 KB/print (the wording of the comment at `VirtualMachine.rs:5948`). Sizing the leaks this test has actually caught (above) showed that 30k prints would miss both of them, and the release lanes were never the ones timing out once the 10 s override is gone, so the release count was restored. Build 99825 ran the 30k revision.

</details>
