### PR TITLE
url: give blob: URLs a null origin when the inner host has invalid punycode

### DIFF
--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -47,7 +47,7 @@ String URLDecomposition::origin() const
     if (fullURL.protocolIsBlob()) {
         const String& path = fullURL.path().toString();
         const URL subUrl { URL {}, path };
-        if (subUrl.isValid()) {
+        if (subUrl.isValid() && hasAcceptableHost(subUrl)) {
             if (subUrl.protocolIsInHTTPFamily() or subUrl.protocolIsInFTPFamily() or subUrl.protocolIs("ws"_s) or subUrl.protocolIs("wss"_s) or subUrl.protocolIsFile())
                 return subUrl.protocolHostAndPort();
         }

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -250,6 +250,40 @@ describe("url", () => {
     expect(v.href).toBe("http://example.com/");
   });
 
+  it("blob: origin is null when the inner URL has an invalid punycode label (like Node)", () => {
+    // The origin of a blob: URL is the origin of its re-parsed path, so an
+    // inner URL the constructor rejects must not produce a tuple origin.
+    for (const inner of [
+      "http://xn--a.com/",
+      "https://XN--A.com/x",
+      "http://xn--a/",
+      "http://x%6E--a.com/",
+      "http://xn--nxasmq6b.xn--a.com/",
+      "ws://xn--a-.com/",
+      "wss://xn---.com/",
+      "ftp://xn--a.com/",
+      "file://xn--a/x",
+    ]) {
+      expect(() => new URL(inner)).toThrow(TypeError);
+      expect(new URL("blob:" + inner).origin).toBe("null");
+    }
+    expect(
+      [
+        "http://xn--ls8h.la/",
+        "https://xn--ls8h.la:8443/x",
+        "http://m\u00FCnchen.de/x",
+        "http://xn--ls8h.la/xn--a",
+        "http://ok.example/?xn--a",
+      ].map(inner => new URL("blob:" + inner).origin),
+    ).toEqual([
+      "http://xn--ls8h.la",
+      "https://xn--ls8h.la:8443",
+      "http://xn--mnchen-3ya.de",
+      "http://xn--ls8h.la",
+      "http://ok.example",
+    ]);
+  });
+
   it("prints", () => {
     // URL.prototype carries [Symbol.for("nodejs.util.inspect.custom")], so
     // Bun.inspect matches node's util.inspect output.


### PR DESCRIPTION
### Problem
- `new URL("blob:http://xn--a.com/").origin` returns `"http://xn--a.com"` on main, while `new URL("http://xn--a.com/")` throws `Invalid URL` on the same build. Bun 1.3.14 and Node 26.3 return `"null"` for the blob origin.
- `URLDecomposition::origin()` (src/jsc/bindings/URLDecomposition.cpp:49) derives a blob: URL's origin by re-parsing its path with a bare `WTF::URL` and only checks `isValid()`.
- Since the WebKit bump in #32414 the WTF parser no longer runs ICU over ASCII `xn--` labels, so that inner parse accepts invalid punycode. #34660 restored the rejection (`hasValidPunycodeHost`) for the constructor, `URL.parse`, `URL.canParse`, `href`, and the `host`/`hostname` setters, but not for this path, which is where the two answers diverged. In 1.3.14 the parser itself rejected the host, so both agreed.

### Fix
- The blob: branch of `origin()` now also requires `hasAcceptableHost(subUrl)`, the helper the `host`/`hostname` setters in the same file already use. An inner URL with an invalid punycode label is treated as unparsed, so the origin is `"null"`.
- Correct because it applies the same rule the constructor applies to the same input: a tuple origin is only produced for an inner URL that `new URL(inner)` would accept. Hosts without `xn--` return from the check without touching ICU; parser-produced punycode (from a Unicode inner host) still validates, which the test covers.
- Test: `test/js/web/url/url.test.ts`, "blob: origin is null when the inner URL has an invalid punycode label (like Node)". Fails on the released 1.4 build (`Received: "http://xn--a.com"`), passes with this change.
- `bun bd test test/js/web/url` (1306 pass, includes the WPT url-constructor origin expectations) and `test/js/node/url` pass; the one failure there is `url-canParse-whatwg.test.js` timing out a 1e5-iteration loop under the debug ASAN build on a loaded box, which does not go through `origin()`.
- The 15 inner URLs in the details block below now print the same as Node 26.3 byte for byte.

### Direction (maintainer call)
- The URL Standard changed on 2026-06-25 (whatwg/url a8d5ca3716): domain-to-ASCII now falls back to the lowercased input for all-ASCII domains, so invalid literal `xn--` labels parse. WPT b63305b743 flipped the matching cases and Node 26.7 follows it (ada 3.4.4 to 4.0.0). Node 26.3, Bun 1.3.14 and the WPT fixtures vendored in this repo all still reject.
- Main today implements the reject behavior at every entry point except `origin()` (#34660, with a fast path added in #39468), and its vendored fixtures pin it. This PR completes that state with one line.
- The other consistent state is to follow the new spec: delete `hasValidPunycodeHost` and its callers, `ASCIIHostPunycodeCheck.h`, and re-vendor the fixtures. That removes the line this PR adds along with everything around it, so it would be its own PR. Which state Bun wants is the decision to make here; as long as main rejects in the constructor, `.origin` should not accept the same host.

### Background
- Punycode / `xn--` label: the ASCII encoding of a Unicode domain label (`xn--ls8h` is the pile of poo emoji). UTS #46 (IDNA) defines which `xn--` labels are valid; `xn--a` does not decode to anything, so ada 3.x (Node up to 26.6) fails to parse hosts containing it.
- `hasValidPunycodeHost` (src/jsc/bindings/NodeURL.cpp): Bun's port of that check, run on top of WebKit's parser, which only lowercases all-ASCII hosts. `hasAcceptableHost` in URLDecomposition.cpp wraps it and skips non-special schemes, whose hosts are opaque and never go through IDNA.
- blob: origin (https://url.spec.whatwg.org/#concept-url-origin): a blob: URL's origin is the origin of the URL obtained by parsing its path; if that parse fails the origin is opaque, serialized as `"null"`.

<details>
<summary>Before / after for the inner URLs checked (after column equals Node 26.3)</summary>

```
inner URL                       new URL(inner)   blob origin before     blob origin after (= node 26.3)
http://xn--a.com/               throws           http://xn--a.com       null
https://XN--A.com/x             throws           https://xn--a.com      null
http://xn--a/                   throws           http://xn--a           null
http://x%6E--a.com/             throws           http://xn--a.com       null
ftp://xn--nxasmq6b.xn--a.com/   throws           ftp://xn--nxasmq6b...  null
ws://xn--a-.com/                throws           ws://xn--a-.com        null
wss://xn---.com/                throws           wss://xn---.com        null
file://xn--a/x                  throws           file://xn--a           null
http://xn--ls8h.la/             ok               http://xn--ls8h.la     http://xn--ls8h.la
https://xn--ls8h.la:8443/x      ok               https://xn--ls8h.la:8443  https://xn--ls8h.la:8443
http://münchen.de/x             ok               http://xn--mnchen-3ya.de  http://xn--mnchen-3ya.de
http://xn--ls8h.la/xn--a        ok               http://xn--ls8h.la     http://xn--ls8h.la
http://ok.example/?xn--a        ok               http://ok.example      http://ok.example
foo://xn--a/                    ok               null                   null
http://example.com:8080/x       ok               http://example.com:8080  http://example.com:8080
```

Where the rejection went: the WTF `URLParser` at the WebKit pin used by Bun 1.3.14 still had `subdomainStartsWithXNDashDash`, which sent ASCII `xn--` hosts through ICU; the pin from #32414 onward does not. Bun's own check (#34660) covers `DOMURL::create`, `parse`, `canParse`, `setHref`, `setHost` and `setHostname`; `origin()` was the remaining path that parses user input into a host.
</details>
