### PR TITLE
Map .jsc bytecode sidecars and their source instead of reading them into the heap

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -858,8 +858,21 @@ pub enum AlreadyBundled {
     None,
     SourceCode,
     SourceCodeCjs,
-    Bytecode(Box<[u8]>),
-    BytecodeCjs(Box<[u8]>),
+    Bytecode(BytecodeFiles),
+    BytecodeCjs(BytecodeFiles),
+}
+
+/// What a `// @bun @bytecode` module is loaded from. JSC decodes the bytecode
+/// lazily and keeps the module text for as long as the module exists, so both
+/// are mapped rather than copied: untouched pages never become resident, and
+/// the page cache is shared between processes running the same build.
+pub struct BytecodeFiles {
+    /// The `<module>.jsc` sidecar; never empty. A heap copy where the file
+    /// could not be mapped (Windows).
+    pub bytecode: bun_sys::MappedFile,
+    /// The module text, `None` where it could not be mapped; the consumer then
+    /// copies `Source.contents` as it would for a module without bytecode.
+    pub source: Option<bun_sys::MappedFile>,
 }
 
 impl AlreadyBundled {
@@ -869,10 +882,12 @@ impl AlreadyBundled {
             AlreadyBundled::SourceCodeCjs | AlreadyBundled::BytecodeCjs(_)
         )
     }
-    pub fn into_bytecode(self) -> Box<[u8]> {
+    pub fn into_bytecode(self) -> Option<BytecodeFiles> {
         match self {
-            AlreadyBundled::Bytecode(bytes) | AlreadyBundled::BytecodeCjs(bytes) => bytes,
-            _ => Box::default(),
+            AlreadyBundled::Bytecode(files) | AlreadyBundled::BytecodeCjs(files) => Some(files),
+            AlreadyBundled::None | AlreadyBundled::SourceCode | AlreadyBundled::SourceCodeCjs => {
+                None
+            }
         }
     }
 }
@@ -1730,11 +1745,9 @@ impl<'a> Transpiler<'a> {
                             js_ast::AlreadyBundled::BunCjs => AlreadyBundled::SourceCodeCjs,
                             js_ast::AlreadyBundled::BytecodeCjs
                             | js_ast::AlreadyBundled::Bytecode => 'brk: {
-                                // When the parser
-                                // saw `// @bun @bytecode`, attempt to load the
-                                // sidecar `<path>.jsc` cached bytecode. Only
-                                // fall back to re-parsing source on read
-                                // failure / empty file.
+                                // `// @bun @bytecode` promises a `<path>.jsc`
+                                // sidecar; a missing or empty one degrades to
+                                // running the module from source.
                                 let is_cjs =
                                     matches!(already_bundled, js_ast::AlreadyBundled::BytecodeCjs);
                                 let default_value = if is_cjs {
@@ -1745,39 +1758,27 @@ impl<'a> Transpiler<'a> {
                                 if this_parse.virtual_source.is_none()
                                     && this_parse.allow_bytecode_cache
                                 {
-                                    // No shared const for the bytecode extension
-                                    // in `bun_core` yet, so inline the literal.
                                     const BYTECODE_EXT: &[u8] = b".jsc";
-                                    let mut path_buf2 = bun_paths::PathBuffer::uninit();
+                                    let mut sidecar_path = bun_paths::PathBuffer::uninit();
                                     let n = path.text.len();
                                     let total = n + BYTECODE_EXT.len();
-                                    // `ZStr::from_buf` needs `buf[total] == 0`
-                                    // in-bounds; fall back to re-parsing the
-                                    // source instead of panicking on an
-                                    // over-long path.
-                                    if total >= path_buf2.len() {
+                                    if total > sidecar_path.len() {
                                         break 'brk default_value;
                                     }
-                                    path_buf2[..n].copy_from_slice(path.text);
-                                    path_buf2[n..][..BYTECODE_EXT.len()]
-                                        .copy_from_slice(BYTECODE_EXT);
-                                    path_buf2[total] = 0;
-                                    let zpath = bun_core::ZStr::from_buf(&path_buf2[..], total);
-                                    // `bun.sys.File.toSourceAt(...)` is
-                                    // `read_from` + wrap-in-`bun_ast::Source`.
-                                    // We only need `.contents`, so call
-                                    // `read_from` directly.
+                                    sidecar_path[..n].copy_from_slice(path.text);
+                                    sidecar_path[n..total].copy_from_slice(BYTECODE_EXT);
                                     let dir = dirname_fd.unwrap_valid().unwrap_or_else(FD::cwd);
-                                    match bun_sys::File::read_from(dir, zpath) {
-                                        Ok(contents) if !contents.is_empty() => {
+                                    match bun_sys::MappedFile::open(dir, &sidecar_path[..total]) {
+                                        Ok(bytecode) if !bytecode.is_empty() => {
+                                            let files = BytecodeFiles {
+                                                bytecode,
+                                                source: bun_sys::MappedFile::map(dir, path.text)
+                                                    .ok(),
+                                            };
                                             break 'brk if is_cjs {
-                                                AlreadyBundled::BytecodeCjs(
-                                                    contents.into_boxed_slice(),
-                                                )
+                                                AlreadyBundled::BytecodeCjs(files)
                                             } else {
-                                                AlreadyBundled::Bytecode(
-                                                    contents.into_boxed_slice(),
-                                                )
+                                                AlreadyBundled::Bytecode(files)
                                             };
                                         }
                                         _ => {}

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -862,16 +862,12 @@ pub enum AlreadyBundled {
     BytecodeCjs(BytecodeFiles),
 }
 
-/// What a `// @bun @bytecode` module is loaded from. JSC decodes the bytecode
-/// lazily and keeps the module text for as long as the module exists, so both
-/// are mapped rather than copied: untouched pages never become resident, and
-/// the page cache is shared between processes running the same build.
+/// The files behind a `// @bun @bytecode` module. JSC keeps both for the
+/// module's lifetime and decodes the bytecode lazily, so they are mapped.
 pub struct BytecodeFiles {
-    /// The `<module>.jsc` sidecar; never empty. A heap copy where the file
-    /// could not be mapped (Windows).
+    /// The `<module>.jsc` sidecar, never empty.
     pub bytecode: bun_sys::MappedFile,
-    /// The module text, `None` where it could not be mapped; the consumer then
-    /// copies `Source.contents` as it would for a module without bytecode.
+    /// The module text; `None` when it could not be mapped.
     pub source: Option<bun_sys::MappedFile>,
 }
 
@@ -1745,8 +1741,7 @@ impl<'a> Transpiler<'a> {
                             js_ast::AlreadyBundled::BunCjs => AlreadyBundled::SourceCodeCjs,
                             js_ast::AlreadyBundled::BytecodeCjs
                             | js_ast::AlreadyBundled::Bytecode => 'brk: {
-                                // `// @bun @bytecode` promises a `<path>.jsc`
-                                // sidecar; a missing or empty one degrades to
+                                // A missing or empty `<path>.jsc` falls back to
                                 // running the module from source.
                                 let is_cjs =
                                     matches!(already_bundled, js_ast::AlreadyBundled::BytecodeCjs);

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1741,8 +1741,6 @@ impl<'a> Transpiler<'a> {
                             js_ast::AlreadyBundled::BunCjs => AlreadyBundled::SourceCodeCjs,
                             js_ast::AlreadyBundled::BytecodeCjs
                             | js_ast::AlreadyBundled::Bytecode => 'brk: {
-                                // A missing or empty `<path>.jsc` falls back to
-                                // running the module from source.
                                 let is_cjs =
                                     matches!(already_bundled, js_ast::AlreadyBundled::BytecodeCjs);
                                 let default_value = if is_cjs {

--- a/src/jsc/Errorable.rs
+++ b/src/jsc/Errorable.rs
@@ -40,7 +40,7 @@ impl<T> Errorable<T> {
     }
 }
 
-bun_core::assert_ffi_layout!(Errorable<crate::ResolvedSource>, 144, 8);
+bun_core::assert_ffi_layout!(Errorable<crate::ResolvedSource>, 152, 8);
 bun_core::assert_ffi_layout!(Errorable<bun_core::String>, 32, 8);
 
 impl<T> Drop for Errorable<T> {

--- a/src/jsc/ResolvedSource.rs
+++ b/src/jsc/ResolvedSource.rs
@@ -1,6 +1,9 @@
-use bun_bundler::analyze_transpiled_module::ModuleInfoDeserialized;
+use core::ffi::c_void;
 
+use bun_bundler::analyze_transpiled_module::ModuleInfoDeserialized;
+use bun_bundler::transpiler::AlreadyBundled;
 use bun_core::String as BunString;
+use bun_sys::MappedFile;
 
 use crate::JSValue;
 // The tag type lives in `crate::resolved_source_tag` so it can be kept in lock-step with
@@ -44,15 +47,71 @@ pub struct ResolvedSource {
     pub bytecode_origin_path: BunString,
 }
 
-/// `ResolvedSource.bytecode_cache`: C++ sees `{ uint8_t* ptr; size_t len; bool owned; }`.
-/// When `owned`, `ptr` is a `heap::into_raw(Box<[u8]>)` freed on drop (or by
-/// the C++ consumer once it `std::exchange`s the pointer out); otherwise it is
-/// borrowed from the standalone module graph or the compile cache.
+impl ResolvedSource {
+    /// The fields of a `// @bun` module (the caller adds the URL and tag), or
+    /// `None` for an ordinary one. `source_text` is copied unless the module
+    /// text was mapped along with its bytecode.
+    pub fn from_already_bundled(
+        already_bundled: AlreadyBundled,
+        source_text: &[u8],
+    ) -> Option<Self> {
+        if matches!(already_bundled, AlreadyBundled::None) {
+            return None;
+        }
+        let is_commonjs_module = already_bundled.is_common_js();
+        let (source_code, bytecode_cache) = match already_bundled.into_bytecode() {
+            Some(files) => (
+                files
+                    .source
+                    .and_then(mapped_source_text)
+                    .unwrap_or_else(|| BunString::clone_latin1(source_text)),
+                Bytecode::mapped(files.bytecode),
+            ),
+            None => (BunString::clone_latin1(source_text), Bytecode::default()),
+        };
+        Some(Self {
+            source_code,
+            is_commonjs_module,
+            already_bundled: true,
+            bytecode_cache,
+            ..Default::default()
+        })
+    }
+}
+
+/// A WTF string over the mapped text; `None` when it exceeds the WTF length limit.
+fn mapped_source_text(text: MappedFile) -> Option<BunString> {
+    if text.as_slice().len() > BunString::max_length() {
+        return None;
+    }
+    let file = bun_core::heap::into_raw(Box::new(text));
+    // SAFETY: `file` is freed only by the string created below, after this
+    // borrow ends.
+    let bytes = unsafe { &*file }.as_slice();
+    Some(BunString::create_external(
+        bytes,
+        true,
+        file,
+        destroy_mapped_source_text,
+    ))
+}
+
+/// `WTF::ExternalStringImpl` free function for [`mapped_source_text`].
+extern "C" fn destroy_mapped_source_text(file: *mut MappedFile, _bytes: *mut c_void, _len: usize) {
+    // SAFETY: `file` is the `into_raw` pointer `mapped_source_text` registered;
+    // WTF calls this exactly once.
+    unsafe { bun_core::heap::destroy(file) };
+}
+
+/// `ResolvedSource.bytecode_cache`: C++ sees `{ uint8_t* ptr; size_t len; void* file; bool persistent; }`.
+/// `file` is the `Box<MappedFile>` owning `ptr[..len]` (a `.jsc` sidecar), or
+/// null when the bytes are borrowed from the standalone module graph or the
+/// compile cache.
 #[repr(C)]
 pub struct Bytecode {
     ptr: *mut u8,
     len: usize,
-    owned: bool,
+    file: *mut c_void,
     /// The bytes outlive every VM (executable section, retired compile-cache blob), so JSC may alias them instead of copying.
     persistent: bool,
 }
@@ -62,7 +121,7 @@ impl Default for Bytecode {
         Self {
             ptr: core::ptr::null_mut(),
             len: 0,
-            owned: false,
+            file: core::ptr::null_mut(),
             persistent: false,
         }
     }
@@ -76,7 +135,7 @@ impl Bytecode {
         Self {
             ptr: bytes.as_ptr().cast_mut(),
             len: bytes.len(),
-            owned: false,
+            file: core::ptr::null_mut(),
             persistent: false,
         }
     }
@@ -88,15 +147,18 @@ impl Bytecode {
             ..Self::borrowed(bytes)
         }
     }
-    pub fn owned(bytes: Box<[u8]>) -> Self {
-        if bytes.is_empty() {
+    pub fn mapped(file: MappedFile) -> Self {
+        if file.is_empty() {
             return Self::default();
         }
-        let len = bytes.len();
+        let file = bun_core::heap::into_raw(Box::new(file));
+        // SAFETY: `file` is destroyed only through the returned value, after
+        // this borrow ends.
+        let bytes = unsafe { &*file }.as_slice();
         Self {
-            ptr: bun_core::heap::into_raw(bytes).cast::<u8>(),
-            len,
-            owned: true,
+            ptr: bytes.as_ptr().cast_mut(),
+            len: bytes.len(),
+            file: file.cast::<c_void>(),
             persistent: false,
         }
     }
@@ -104,19 +166,22 @@ impl Bytecode {
 
 impl Drop for Bytecode {
     fn drop(&mut self) {
-        if self.owned && !self.ptr.is_null() {
-            ResolvedSource__freeBytecode(self.ptr);
+        if !self.file.is_null() {
+            // SAFETY: this `Bytecode` is the only owner of `file`.
+            unsafe { ResolvedSource__destroyBytecodeFile(self.file) };
         }
     }
 }
 
-/// `~ErrorableResolvedSource` / `JSC::CachedBytecode` destructor for an owned
-/// `Bytecode` (see above).
+/// `~ErrorableResolvedSource` / `JSC::CachedBytecode` destructor for a
+/// [`Bytecode::mapped`] file.
+///
+/// # Safety
+/// `file` is a `Bytecode::file` that nothing else will destroy or read through.
 #[unsafe(no_mangle)]
-extern "C" fn ResolvedSource__freeBytecode(bytecode: *mut u8) {
-    // SAFETY: only called with the `heap::into_raw(Box<[u8]>)` base pointer;
-    // mimalloc recovers the size from the heap.
-    unsafe { bun_alloc::default_alloc::free(bytecode.cast()) };
+unsafe extern "C" fn ResolvedSource__destroyBytecodeFile(file: *mut c_void) {
+    // SAFETY: per the contract above.
+    unsafe { bun_core::heap::destroy(file.cast::<MappedFile>()) };
 }
 
-bun_core::assert_ffi_layout!(ResolvedSource, 136, 8);
+bun_core::assert_ffi_layout!(ResolvedSource, 144, 8);

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -12,7 +12,7 @@ use bun_ast::{ASTMemoryAllocator, ExportsKind};
 use bun_ast::{ImportRecord, ImportRecordFlags};
 use bun_bundler::analyze_transpiled_module;
 use bun_bundler::options::ModuleType;
-use bun_bundler::transpiler::{self as transpiler, AlreadyBundled, ParseOptions, Transpiler};
+use bun_bundler::transpiler::{self as transpiler, ParseOptions, Transpiler};
 use bun_collections::HiveArrayFallback;
 use bun_core::{MutableString, String, strings};
 use bun_event_loop::{TaskTag, Taskable, task_tag};
@@ -976,18 +976,13 @@ impl TranspilerJob {
             return;
         }
 
-        if !matches!(parse_result.already_bundled, AlreadyBundled::None) {
-            let already_bundled = core::mem::take(&mut parse_result.already_bundled);
-            let is_commonjs_module = already_bundled.is_common_js();
-            let bytecode_cache =
-                crate::resolved_source::Bytecode::owned(already_bundled.into_bytecode());
+        if let Some(already_bundled) = ResolvedSource::from_already_bundled(
+            core::mem::take(&mut parse_result.already_bundled),
+            &parse_result.source.contents,
+        ) {
             self.resolved_source = ResolvedSource {
-                source_code: String::clone_latin1(&parse_result.source.contents),
-                already_bundled: true,
-                bytecode_cache,
-                is_commonjs_module,
                 tag: this_tag,
-                ..Default::default()
+                ..already_bundled
             };
             self.resolved_source.source_code.ensure_hash();
             return;

--- a/src/jsc/bindings/ZigSourceProvider.cpp
+++ b/src/jsc/bindings/ZigSourceProvider.cpp
@@ -100,12 +100,15 @@ Ref<SourceProvider> SourceProvider::create(
     const auto getProvider = [&]() -> Ref<SourceProvider> {
         auto origin = getSourceOrigin();
         if (resolvedSource.bytecode_cache != nullptr) {
-            const auto destructorOwned = [](const void* ptr) {
-                ResolvedSource__freeBytecode(static_cast<uint8_t*>(const_cast<void*>(ptr)));
-            };
-            // Borrowed from the standalone module graph / compile cache.
-            const auto destructorNoOp = [](const void*) {};
-            Ref<JSC::CachedBytecode> bytecode = JSC::CachedBytecode::create(std::span<uint8_t>(std::exchange(resolvedSource.bytecode_cache, nullptr), resolvedSource.bytecode_cache_size), resolvedSource.bytecode_cache_owned ? destructorOwned : destructorNoOp, {});
+            std::span<uint8_t> bytes(std::exchange(resolvedSource.bytecode_cache, nullptr), resolvedSource.bytecode_cache_size);
+            // No file means the bytes are borrowed from the standalone module graph / compile cache.
+            JSC::CachePayload::Destructor destructor;
+            if (void* file = std::exchange(resolvedSource.bytecode_cache_file, nullptr)) {
+                destructor = [file](const void*) {
+                    ResolvedSource__destroyBytecodeFile(file);
+                };
+            }
+            Ref<JSC::CachedBytecode> bytecode = JSC::CachedBytecode::create(bytes, WTF::move(destructor), {});
             if (resolvedSource.bytecode_cache_persistent)
                 bytecode->setPayloadIsPersistent();
             auto provider = adoptRef(*new SourceProvider(

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -119,11 +119,11 @@ typedef struct ResolvedSource {
     uint32_t tag;
     bool already_bundled;
     // -- Bytecode cache fields --
-    // Owned (`ResolvedSource__freeBytecode`) iff `bytecode_cache_owned`; otherwise
-    // borrowed from the standalone module graph / compile cache.
+    // Owned by bytecode_cache_file (`ResolvedSource__destroyBytecodeFile`) when it is
+    // non-null; otherwise borrowed from the standalone module graph / compile cache.
     uint8_t* bytecode_cache;
     size_t bytecode_cache_size;
-    bool bytecode_cache_owned;
+    void* bytecode_cache_file;
     // The bytes outlive every VM (executable section / retired compile-cache blob): JSC may alias them.
     bool bytecode_cache_persistent;
     // Owned; Zig::SourceProvider takes it (nulling the field).
@@ -132,14 +132,14 @@ typedef struct ResolvedSource {
     // Converted to file:// URL. If empty, origin is derived from source_url.
     BunString bytecode_origin_path;
 } ResolvedSource;
-static_assert(sizeof(ResolvedSource) == 136, "ResolvedSource layout is mirrored in src/jsc/ResolvedSource.rs");
+static_assert(sizeof(ResolvedSource) == 144, "ResolvedSource layout is mirrored in src/jsc/ResolvedSource.rs");
 inline constexpr uint32_t ResolvedSourceTagPackageJSONTypeModule = 1;
 typedef union ErrorableResolvedSourceResult {
     ResolvedSource value;
     JSC::EncodedJSValue err;
 } ErrorableResolvedSourceResult;
 extern "C" void zig__ModuleInfoDeserialized__deinit(bun_ModuleInfoDeserialized* info);
-extern "C" void ResolvedSource__freeBytecode(uint8_t* bytecode);
+extern "C" void ResolvedSource__destroyBytecodeFile(void* file);
 struct ErrorableResolvedSource {
     WTF_MAKE_NONCOPYABLE(ErrorableResolvedSource);
 
@@ -155,13 +155,13 @@ public:
         result.value.source_code.deref();
         result.value.source_url.deref();
         result.value.bytecode_origin_path.deref();
-        if (result.value.bytecode_cache_owned && result.value.bytecode_cache)
-            ResolvedSource__freeBytecode(result.value.bytecode_cache);
+        if (result.value.bytecode_cache_file)
+            ResolvedSource__destroyBytecodeFile(result.value.bytecode_cache_file);
         if (result.value.module_info)
             zig__ModuleInfoDeserialized__deinit(result.value.module_info);
     }
 };
-static_assert(sizeof(ErrorableResolvedSource) == 144 && alignof(ErrorableResolvedSource) == 8, "ErrorableResolvedSource layout is mirrored in src/jsc/Errorable.rs");
+static_assert(sizeof(ErrorableResolvedSource) == 152 && alignof(ErrorableResolvedSource) == 8, "ErrorableResolvedSource layout is mirrored in src/jsc/Errorable.rs");
 
 typedef struct SystemError {
     int errno_;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2547,7 +2547,7 @@ fn transpile_source_code_inner(
             // ════════════════════════════════════════════════════════════════
             {
                 use bun_ast::RuntimeTranspilerCache;
-                use bun_bundler::transpiler::{AlreadyBundled, ParseOptions, ParseResult};
+                use bun_bundler::transpiler::{ParseOptions, ParseResult};
                 use bun_jsc::resolved_source::Tag as ResolvedSourceTag;
 
                 // Keep the one-shot
@@ -2855,23 +2855,14 @@ fn transpile_source_code_inner(
                     });
                 }
 
-                // already-bundled (bytecode cache hit).
-                if !matches!(parse_result.already_bundled, AlreadyBundled::None) {
-                    // The bytes live
-                    // in `AlreadyBundled::Bytecode(Box<[u8]>)`, which would drop
-                    // when `parse_result` drops on return — UAF on the C++ side.
-                    // Move the variant out and `heap::alloc` so ownership
-                    // transfers to C++ exactly as in the spec.
-                    let already_bundled = core::mem::take(&mut parse_result.already_bundled);
-                    let is_commonjs_module = already_bundled.is_common_js();
-                    let bytecode_cache = Bytecode::owned(already_bundled.into_bytecode());
+                // already-bundled (`// @bun`, possibly with a bytecode sidecar).
+                if let Some(already_bundled) = ResolvedSource::from_already_bundled(
+                    core::mem::take(&mut parse_result.already_bundled),
+                    &source.contents,
+                ) {
                     return Ok(ResolvedSource {
-                        source_code: bun_core::String::clone_latin1(&source.contents),
                         source_url: input_specifier.create_if_different(path.text),
-                        already_bundled: true,
-                        bytecode_cache,
-                        is_commonjs_module,
-                        ..Default::default()
+                        ..already_bundled
                     });
                 }
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -890,6 +890,8 @@ pub mod signal_code;
 pub use signal_code::SignalCode;
 pub mod tmp;
 pub use tmp::Tmpfile;
+pub mod mapped_file;
+pub use mapped_file::MappedFile;
 // `windows/mod.rs` is `#![cfg(windows)]`-gated internally; on POSIX this
 // declares an empty module so `bun_sys::windows::*` paths still resolve under
 // `#[cfg(windows)]` arms in dependents.

--- a/src/sys/mapped_file.rs
+++ b/src/sys/mapped_file.rs
@@ -1,0 +1,91 @@
+use crate::{AsFd, E, Error, File, Maybe, O, Tag};
+
+/// Read-only contents of a whole file.
+///
+/// Mapping keeps the bytes out of the heap: a page becomes resident only once
+/// something reads it, and the pages belong to the page cache, shared with
+/// every other process mapping the same file. Replacing the file on disk is
+/// safe (the mapping keeps the old inode alive); truncating or rewriting it in
+/// place is visible through the mapping.
+pub struct MappedFile(Repr);
+
+enum Repr {
+    /// `PROT_READ` / `MAP_PRIVATE` mapping of the entire file.
+    #[cfg(unix)]
+    Mapped {
+        ptr: *mut u8,
+        len: usize,
+    },
+    Heap(Vec<u8>),
+}
+
+impl MappedFile {
+    /// Maps `path` (resolved against `dir`), reading it into memory instead
+    /// where it cannot be mapped: Windows (see [`MappedFile::map`]),
+    /// filesystems without mmap support, and empty files (`mmap` rejects a
+    /// zero-length mapping).
+    pub fn open(dir: impl AsFd, path: &[u8]) -> Maybe<Self> {
+        let file = File::openat(dir, path, O::RDONLY | O::CLOEXEC, 0)?;
+        if let Ok(mapped) = Self::map_file(&file) {
+            return Ok(mapped);
+        }
+        file.read_to_end().map(|bytes| Self(Repr::Heap(bytes)))
+    }
+
+    /// Like [`MappedFile::open`], but fails instead of copying when `path`
+    /// cannot be mapped.
+    pub fn map(dir: impl AsFd, path: &[u8]) -> Maybe<Self> {
+        if cfg!(not(unix)) {
+            return Err(Error::new(E::ENOTSUP, Tag::mmap));
+        }
+        let file = File::openat(dir, path, O::RDONLY | O::CLOEXEC, 0)?;
+        Self::map_file(&file)
+    }
+
+    #[cfg(unix)]
+    fn map_file(file: &File) -> Maybe<Self> {
+        let len = file.get_end_pos()?;
+        let ptr = crate::mmap(
+            core::ptr::null_mut(),
+            len,
+            libc::PROT_READ,
+            libc::MAP_PRIVATE,
+            file.fd(),
+            0,
+        )?;
+        Ok(Self(Repr::Mapped { ptr, len }))
+    }
+
+    /// `crate::mmap` is a stub on Windows. A Windows file mapping would also
+    /// make rewriting the file fail (ERROR_USER_MAPPED_FILE) for as long as
+    /// some process has it loaded, e.g. `bun build` over its previous output.
+    #[cfg(not(unix))]
+    fn map_file(_file: &File) -> Maybe<Self> {
+        Err(Error::new(E::ENOTSUP, Tag::mmap))
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        match &self.0 {
+            #[cfg(unix)]
+            // SAFETY: `mmap` succeeded in `map_file`, so `ptr` is a non-null
+            // mapping of `len` readable bytes, and only `Drop` unmaps it.
+            Repr::Mapped { ptr, len } => unsafe { core::slice::from_raw_parts(*ptr, *len) },
+            Repr::Heap(bytes) => bytes,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.as_slice().is_empty()
+    }
+}
+
+impl Drop for MappedFile {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Repr::Mapped { ptr, len } = self.0 {
+            // `munmap` only fails for a bogus `(ptr, len)`, and this pair is the
+            // one `mmap` returned.
+            let _ = crate::munmap(ptr, len);
+        }
+    }
+}

--- a/src/sys/mapped_file.rs
+++ b/src/sys/mapped_file.rs
@@ -1,12 +1,8 @@
 use crate::{AsFd, E, Error, File, Maybe, O, Tag};
 
-/// Read-only contents of a whole file.
-///
-/// Mapping keeps the bytes out of the heap: a page becomes resident only once
-/// something reads it, and the pages belong to the page cache, shared with
-/// every other process mapping the same file. Replacing the file on disk is
-/// safe (the mapping keeps the old inode alive); truncating or rewriting it in
-/// place is visible through the mapping.
+/// Read-only contents of a whole file, mapped rather than read where possible.
+/// Rewriting or truncating the file in place shows through the mapping;
+/// replacing it (rename) does not.
 pub struct MappedFile(Repr);
 
 enum Repr {
@@ -20,10 +16,8 @@ enum Repr {
 }
 
 impl MappedFile {
-    /// Maps `path` (resolved against `dir`), reading it into memory instead
-    /// where it cannot be mapped: Windows (see [`MappedFile::map`]),
-    /// filesystems without mmap support, and empty files (`mmap` rejects a
-    /// zero-length mapping).
+    /// Maps `path` (relative to `dir`), falling back to a heap read where mmap
+    /// is unavailable (Windows) or refused (empty files, some filesystems).
     pub fn open(dir: impl AsFd, path: &[u8]) -> Maybe<Self> {
         let file = File::openat(dir, path, O::RDONLY | O::CLOEXEC, 0)?;
         if let Ok(mapped) = Self::map_file(&file) {
@@ -32,8 +26,7 @@ impl MappedFile {
         file.read_to_end().map(|bytes| Self(Repr::Heap(bytes)))
     }
 
-    /// Like [`MappedFile::open`], but fails instead of copying when `path`
-    /// cannot be mapped.
+    /// [`MappedFile::open`] without the heap fallback.
     pub fn map(dir: impl AsFd, path: &[u8]) -> Maybe<Self> {
         if cfg!(not(unix)) {
             return Err(Error::new(E::ENOTSUP, Tag::mmap));
@@ -56,9 +49,8 @@ impl MappedFile {
         Ok(Self(Repr::Mapped { ptr, len }))
     }
 
-    /// `crate::mmap` is a stub on Windows. A Windows file mapping would also
-    /// make rewriting the file fail (ERROR_USER_MAPPED_FILE) for as long as
-    /// some process has it loaded, e.g. `bun build` over its previous output.
+    /// A Windows file mapping would make `bun build` fail to overwrite its
+    /// output (ERROR_USER_MAPPED_FILE) while a process is running it.
     #[cfg(not(unix))]
     fn map_file(_file: &File) -> Maybe<Self> {
         Err(Error::new(E::ENOTSUP, Tag::mmap))
@@ -67,8 +59,8 @@ impl MappedFile {
     pub fn as_slice(&self) -> &[u8] {
         match &self.0 {
             #[cfg(unix)]
-            // SAFETY: `mmap` succeeded in `map_file`, so `ptr` is a non-null
-            // mapping of `len` readable bytes, and only `Drop` unmaps it.
+            // SAFETY: `map_file` mapped `len` readable bytes at `ptr`; only
+            // `Drop` unmaps them.
             Repr::Mapped { ptr, len } => unsafe { core::slice::from_raw_parts(*ptr, *len) },
             Repr::Heap(bytes) => bytes,
         }
@@ -83,8 +75,6 @@ impl Drop for MappedFile {
     fn drop(&mut self) {
         #[cfg(unix)]
         if let Repr::Mapped { ptr, len } = self.0 {
-            // `munmap` only fails for a bogus `(ptr, len)`, and this pair is the
-            // one `mmap` returned.
             let _ = crate::munmap(ptr, len);
         }
     }

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -7,6 +7,7 @@ import {
   bunRun,
   isASAN,
   isDebug,
+  isLinux,
   isWindows,
   tempDir,
   tempDirWithFiles,
@@ -69,6 +70,165 @@ describe("Bun.build", () => {
     expect(build.outputs[0].kind).toBe("entry-point");
     expect(build.outputs[1].kind).toBe("bytecode");
     expect(await bunRun(build.outputs[0].path)).toSpawn("world");
+  });
+
+  // Loading a `// @bun @bytecode` module maps its .jsc sidecar and its source
+  // text from disk instead of reading them into the heap, and unmaps them as
+  // soon as the load turns out not to need them. Every module below is built
+  // once and loaded through a different path:
+  //   entry     require(): transpiled on the JS thread
+  //   dep       import(): transpiled on the RuntimeTranspilerStore thread pool
+  //   lazy      require(), then import() of the same file: the second load reads
+  //             both files again and then reuses the module from require.cache,
+  //             so that second pair must be released right away (exactly one
+  //             mapping of each file stays, owned by the evaluated module)
+  //   compiled  require() with module._compile overridden: the override only
+  //             gets the source text, so nothing may stay mapped at all
+  // /proc/self/maps is how a process can observe its own mappings, so the
+  // mapping counts are checked on Linux; the rest of the output is checked
+  // everywhere (Windows has no mmap and keeps reading the sidecar into memory).
+  test("bytecode output is mapped from disk while it is in use", async () => {
+    const moduleNames = ["entry", "dep", "lazy", "compiled"];
+    const files: Record<string, string> = {
+      "main.js": `
+        const { readFileSync, realpathSync } = require("fs");
+        const { join } = require("path");
+        const out = realpathSync(join(__dirname, "out"));
+        const Module = require("module");
+
+        async function main() {
+          const results = {};
+          results.entry = require(join(out, "entry.js")).value();
+          results.dep = (await import(join(out, "dep.js"))).default.value();
+          results.lazy = require(join(out, "lazy.js")).value();
+          results.lazyAgain = (await import(join(out, "lazy.js"))).default.value();
+
+          const loadJS = Module._extensions[".js"];
+          Module._extensions[".js"] = function (module, filename) {
+            module._compile = function () {
+              this.exports = { value: () => "compiled by the override" };
+            };
+            return loadJS(module, filename);
+          };
+          results.compiled = require(join(out, "compiled.js")).value();
+
+          if (process.platform === "linux") {
+            const maps = readFileSync("/proc/self/maps", "utf8").split("\\n");
+            results.mappings = {};
+            for (const name of ${JSON.stringify(moduleNames)}) {
+              for (const file of [name + ".js", name + ".js.jsc"]) {
+                results.mappings[file] = maps.filter(line => line.endsWith(" " + join(out, file))).length;
+              }
+            }
+          }
+          console.log(JSON.stringify(results));
+        }
+        main();
+      `,
+    };
+    for (const name of moduleNames) {
+      files[`${name}.js`] = `module.exports = { value: () => ${JSON.stringify(name)} };`;
+    }
+    const dir = tempDirWithFiles("bun-build-api-bytecode-mmap", files);
+
+    const build = await Bun.build({
+      entrypoints: moduleNames.map(name => join(dir, `${name}.js`)),
+      outdir: join(dir, "out"),
+      target: "bun",
+      bytecode: true,
+    });
+    expect(build.outputs.filter(output => output.kind === "bytecode")).toHaveLength(moduleNames.length);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(dir, "main.js")],
+      env: { ...bunEnv, BUN_JSC_verboseDiskCache: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const diskCacheLines = stderr.split(/\r?\n/).filter(Boolean);
+    expect(diskCacheLines.filter(line => !line.startsWith("[Disk Cache] Cache "))).toEqual([]);
+    expect(JSON.parse(stdout)).toEqual({
+      entry: "entry",
+      dep: "dep",
+      lazy: "lazy",
+      lazyAgain: "lazy",
+      compiled: "compiled by the override",
+      ...(isLinux
+        ? {
+            mappings: {
+              "entry.js": 1,
+              "entry.js.jsc": 1,
+              "dep.js": 1,
+              "dep.js.jsc": 1,
+              "lazy.js": 1,
+              "lazy.js.jsc": 1,
+              "compiled.js": 0,
+              "compiled.js.jsc": 0,
+            },
+          }
+        : {}),
+    });
+    // One hit per module that was actually evaluated from its sidecar: entry,
+    // dep, and the require() of lazy. The misses are main.js and builtins.
+    expect(diskCacheLines.filter(line => line === "[Disk Cache] Cache hit for sourceCode")).toHaveLength(3);
+    expect(exitCode).toBe(0);
+  });
+
+  // The evaluated module's SourceProvider owns the two mappings; once the
+  // module is dropped from require.cache and collected, both must be gone.
+  test.skipIf(!isLinux)("bytecode output is unmapped once the module is collected", async () => {
+    const RELOADS = 10;
+    const dir = tempDirWithFiles("bun-build-api-bytecode-munmap", {
+      "index.js": `module.exports = { value: () => "index" };`,
+      "main.js": `
+        const { readFileSync, realpathSync } = require("fs");
+        const { join } = require("path");
+        const file = join(realpathSync(join(__dirname, "out")), "index.js");
+        const mappings = () => {
+          const maps = readFileSync("/proc/self/maps", "utf8").split("\\n");
+          return {
+            js: maps.filter(line => line.endsWith(" " + file)).length,
+            jsc: maps.filter(line => line.endsWith(" " + file + ".jsc")).length,
+          };
+        };
+        function release() {
+          delete require.cache[file];
+          module.children.length = 0;
+        }
+        function reload(times) {
+          for (let i = 0; i < times; i++) {
+            require(file);
+            release();
+          }
+        }
+
+        const value = require(file).value();
+        const loaded = mappings();
+        release();
+        reload(${RELOADS} - 1);
+        Bun.gc(true);
+        console.log(JSON.stringify({ value, loaded, released: mappings() }));
+      `,
+    });
+
+    const build = await Bun.build({
+      entrypoints: [join(dir, "index.js")],
+      outdir: join(dir, "out"),
+      target: "bun",
+      bytecode: true,
+    });
+    expect(build.outputs.map(output => output.kind)).toEqual(["entry-point", "bytecode"]);
+
+    const result = await bunRun(join(dir, "main.js"));
+    expect(result).toSpawn();
+    const { value, loaded, released } = JSON.parse(result.stdout);
+    expect({ value, loaded }).toEqual({ value: "index", loaded: { js: 1, jsc: 1 } });
+    // Each leaked load would leave one more mapping of each file, so a leak
+    // reads as RELOADS. A conservative stack scan may still see the last load.
+    expect(released.js).toBeLessThanOrEqual(1);
+    expect(released.jsc).toBeLessThanOrEqual(1);
   });
 
   test("passing undefined doesnt segfault", () => {

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -223,12 +223,12 @@ describe("Bun.build", () => {
 
     const result = await bunRun(join(dir, "main.js"));
     expect(result).toSpawn();
-    const { value, loaded, released } = JSON.parse(result.stdout);
-    expect({ value, loaded }).toEqual({ value: "index", loaded: { js: 1, jsc: 1 } });
-    // Each leaked load would leave one more mapping of each file, so a leak
-    // reads as RELOADS. A conservative stack scan may still see the last load.
-    expect(released.js).toBeLessThanOrEqual(1);
-    expect(released.jsc).toBeLessThanOrEqual(1);
+    // A leaked load leaves one more mapping of each file, so a leak reads as RELOADS.
+    expect(JSON.parse(result.stdout)).toEqual({
+      value: "index",
+      loaded: { js: 1, jsc: 1 },
+      released: { js: 0, jsc: 0 },
+    });
   });
 
   test("passing undefined doesnt segfault", () => {


### PR DESCRIPTION
### Problem
- Loading a module built with `bun build --target=bun --bytecode` read the whole `.jsc` sidecar into a `Box<[u8]>` (`src/bundler/transpiler.rs`, the `@bytecode` arm of `parse_maybe_return_file_only_allow_shared_buffer`). JSC decodes functions lazily, so it holds that buffer for as long as the module exists, and all of it is resident because `read()` touched every page.
- Sidecars are several times the size of the source (3.4 MB for the 316 KB module below), so the bytecode path ended up using more memory than parsing the source would.
- The same branch (`jsc_hooks.rs` and `RuntimeTranspilerStore.rs`) also copied the module text it had just read into a second WTF string with `clone_latin1`.

### Fix
- New `bun_sys::MappedFile` (`src/sys/mapped_file.rs`): the contents of a whole file as a `PROT_READ`/`MAP_PRIVATE` mapping. `open()` falls back to a heap read where mapping is unavailable (Windows, where `bun_sys::mmap` is a stub and a file mapping would block `bun build` from overwriting its output) or refused; `map()` fails instead of copying.
- The transpiler opens the sidecar and maps the module text, and `AlreadyBundled::Bytecode{,Cjs}` carries both (`BytecodeFiles`). `ResolvedSource::from_already_bundled` (`src/jsc/ResolvedSource.rs`) replaces the two copies of the hand-off code: the text becomes an external Latin-1 WTF string whose free function unmaps it (falling back to `clone_latin1` when the text could not be mapped, as before), and the sidecar mapping goes to C++ as `Bytecode::mapped`.
- `Bytecode`'s `owned: bool` becomes `file: *mut c_void`, the `Box<MappedFile>` behind `ptr[..len]` (null for bytes borrowed from a standalone executable or the Node compile cache, which keep getting no destructor). `ResolvedSource` grows from 136 to 144 bytes (and `ErrorableResolvedSource` to 152) because #40201 added the `persistent` bool that used to share a slot with `owned`; the layout asserts on both sides are updated. The release points are the ones main already has since #40238: the `CachedBytecode` destructor installed in `SourceProvider::create` (which exchanges the field out), `~ErrorableResolvedSource` for a fetch that never creates a provider, and `Bytecode`'s `Drop` on the Rust side. `ResolvedSource__freeBytecode(ptr)` is renamed `ResolvedSource__destroyBytecodeFile(file)` because its argument changed.
- Why mapping is safe here: JSC only reads the payload (`CachePayload::span()` is const and the decoder keeps its pointers in a side table), the Node compile cache already hands JSC a `PROT_READ` mapping (`NodeCompileCache.rs`), and compiled executables on Windows already run bytecode out of a read-only section. The mapping base is page aligned, which covers the decoder's alignment requirement.
- Trade-off to be aware of: a mapping follows in-place truncation or rewriting of the `.js`/`.jsc` by a later `bun build` while an older process is still running them (replacing the files via rename is fine). This is the same exposure the compile cache mapping has; writing sidecars through a temporary file plus rename would remove it and is not part of this PR.
- Verified with `test/bundler/bun-build-api.test.ts`:
  - "bytecode output is mapped from disk while it is in use": four modules loaded through `require()` (JS thread), `import()` (RuntimeTranspilerStore, confirmed with `BUN_DEBUG_RuntimeTranspilerStore=1`), `require()` followed by `import()` (`~ErrorableResolvedSource` release), and an overridden `module._compile`; checks the modules ran from their sidecars (`BUN_JSC_verboseDiskCache`) and, on Linux, the per-file mapping counts in `/proc/self/maps` (1, 1, 1 and 0 of each file). Fails on 1.4.0 with every count at 0.
  - "bytecode output is unmapped once the module is collected" (Linux): one live module holds one mapping of each file; after 10 load/`delete require.cache` cycles and `Bun.gc(true)` none are left (12 of 12 runs gave 0; the assertion allows 1 for a conservative stack scan). Fails on 1.4.0 because nothing is mapped.
  - Also ran `bundler_bun`, `bundler_banner`, `bundler_compile -t bytecode` (30 standalone tests), `regression/issue/26298`, `require-extensions`, `require-extensions-override`, `node-module-module` and the `test-compile-cache-*` Node tests on the debug (ASan) build; `cargo check` of the touched crates for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`; `cargo fmt`, clippy and clang-format are clean.
- Measurements (`RssAnon` of a process after loading the module, minus the same with a build of the same module without `--bytecode`; details in the fold-out):
  - 2000 small functions, 316 KB source, 3.4 MB sidecar: bun 1.4.0 +4.2 MB; this branch +0.7 to +1.2 MB (what JSC decodes eagerly). The sidecar and source now show up as file-backed mappings; for this module they are fully resident because the per-function metadata touches every page.
  - 8 functions of 3000 statements, 360 KB source, 1.9 MB sidecar: with this branch 512 KB of the sidecar is resident after loading without calling anything, and calling one function adds about 112 KB.

### Background
- `// @bun @bytecode` is the pragma `bun build --target=bun --bytecode` puts at the top of its output next to a `<file>.jsc` sidecar holding JSC's serialized bytecode for that exact text. At load time the parser stops at the pragma and the loader hands JSC the text plus the sidecar; JSC checks a hash of the text and decodes from the sidecar instead of parsing, one function at a time as they are first called.
- `ResolvedSource` (`ResolvedSource.rs` and the C mirror in `headers-handwritten.h`) is the struct the Rust module loader fills in for C++ for every module. Since #40238 it is owned on both sides: Rust drops it, C++'s `~ErrorableResolvedSource` releases whatever a consumer did not take.
- `Zig::SourceProvider` is Bun's `JSC::SourceProvider` for a module: it owns the text and, when present, a `JSC::CachedBytecode` wrapping the bytecode bytes. `CachedBytecode` takes a destructor callback that runs when its last reference goes away; lazily decoded functions keep references to it, so it is always the last thing holding the bytes.
- Two producers build these values: `transpile_source_code_inner` in `jsc_hooks.rs` on the JS thread (`require()`, entry points) and `TranspilerJob` in `RuntimeTranspilerStore.rs` on the thread pool (`import` and `import()`), which is why both are changed.
- An external WTF string (`bun_core::String::create_external`) is a `WTF::StringImpl` that points at memory it does not own and calls a free function when it is destroyed; this is also how standalone executables expose their embedded module text.
- Related PRs: #38138 fixed the leak that #40238 has since fixed on main. #39396 adds a footer check to the sidecar reader; it composes with this change (the check would read the mapping) at the cost of touching every page at load.

<details><summary>Measurement setup</summary>

Module A: 2000 one-line functions plus an export (`bun build --target=bun --bytecode`, 316 KB `entry.js`, 3.4 MB `entry.js.jsc`). Module B: 8 functions of 3000 statements each, built with `--minify` (360 KB, 1.9 MB sidecar). The probe records `RssAnon` from `/proc/self/status` before and after `require()` of the built file (after `Bun.gc(true)` both times) and prints the `/proc/self/smaps` entries for the output directory.

Module A, bun 1.4.0 (release), three runs: plain build +3.6/3.6/3.7 MB, bytecode build +7.9/7.9/8.0 MB, no mappings of the output files.

Module A, this branch (debug build, so the baseline differs), three runs: plain build +2.8/2.8/2.8 MB, bytecode build +3.5/3.5/4.0 MB, plus:

```
entry.js.jsc: Size: 3428 kB | Rss: 3428 kB
entry.js:     Size:  316 kB | Rss:  316 kB
```

Module B, this branch, no function called: `big.js.jsc: Size: 1896 kB | Rss: 512 kB`; after calling one of the eight functions: `Rss: 624 kB`. The source is always fully resident because JSC hashes the text to validate the cache.

Reload probe (this branch): `require()` plus `delete require.cache[...]` 30 times leaves 30 mappings of each file before `Bun.gc(true)` and 0 after.

Before the rebase onto #40238 this PR also fixed the sidecar never being freed (`SourceProvider::create` cleared `needsDeref` before reading it to choose the `CachedBytecode` destructor) and added release sites in `ResolvedSourceCodeHolder` and the overridden `module._compile` branch; main now covers those through `~ErrorableResolvedSource`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->
