### PR TITLE
node:buffer: treat a detached view as empty in compare, equals, swapNN and as a fill value

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -715,11 +715,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_allocBody(JSC::JSGlobalOb
                 return Bun::ERR::INVALID_ARG_VALUE(scope, lexicalGlobalObject, "value"_s, value);
             }
         } else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
-            if (view->isDetached()) [[unlikely]] {
-                throwVMTypeError(lexicalGlobalObject, scope, "Uint8Array is detached"_s);
-                return {};
-            }
-
+            // A detached view has byteLength() 0 and is rejected as an empty fill value, like in Node.
             size_t length = view->byteLength();
             if (length == 0) [[unlikely]] {
                 return Bun::ERR::INVALID_ARG_VALUE(scope, lexicalGlobalObject, "value"_s, value);
@@ -840,21 +836,15 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_compareBody(JSC::JSGlobal
     if (!castedThis) [[unlikely]] {
         return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "buf1"_s, "Buffer or Uint8Array"_s, castedThisValue);
     }
-    if (castedThis->isDetached()) [[unlikely]] {
-        throwVMTypeError(lexicalGlobalObject, throwScope, "Uint8Array (first argument) is detached"_s);
-        return {};
-    }
 
     auto buffer = callFrame->argument(1);
     JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
     if (!view) [[unlikely]] {
         return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "buf2"_s, "Buffer or Uint8Array"_s, buffer);
     }
-    if (view->isDetached()) [[unlikely]] {
-        throwVMTypeError(lexicalGlobalObject, throwScope, "Uint8Array (second argument) is detached"_s);
-        return {};
-    }
 
+    // A detached view has byteLength() 0 and compares as empty, like in Node. Its
+    // vector() is null, but the memcmp below is skipped for a zero length.
     size_t targetStart = 0;
     size_t targetEndInit = view->byteLength();
     size_t targetEnd = targetEndInit;
@@ -1112,11 +1102,9 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
         return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "target"_s, "Buffer or Uint8Array"_s, arg0);
     }
 
-    if (view->isDetached()) [[unlikely]] {
-        throwVMTypeError(lexicalGlobalObject, throwScope, "Uint8Array is detached"_s);
-        return {};
-    }
-
+    // Either side may be detached: it then has byteLength() 0, so the explicit
+    // targetEnd/sourceEnd are validated against 0 and the empty-range returns
+    // below fire before either vector is read, like in Node.
     size_t targetStart = 0;
     size_t targetEndInit = view->byteLength();
     size_t targetEnd = targetEndInit;
@@ -1321,11 +1309,9 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_equalsBody(JSC::JSGlobalObj
         return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "otherBuffer"_s, "Buffer or Uint8Array"_s, buffer);
     }
 
-    if (view->isDetached()) [[unlikely]] {
-        throwVMTypeError(lexicalGlobalObject, throwScope, "Uint8Array is detached"_s);
-        return {};
-    }
-
+    // Either side may be detached: it then has byteLength() 0 and a null vector,
+    // and only equals another empty view, like in Node. The memcmp below is
+    // skipped for a zero length, so the null vector is never read.
     size_t a_length = castedThis->byteLength();
     size_t b_length = view->byteLength();
     auto sourceStartPtr = castedThis->typedVector();
@@ -1450,14 +1436,11 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_fillBody(JSC::JSGlobalObjec
     } else if (auto* view = dynamicDowncast<JSC::JSArrayBufferView>(value)) {
         branch = ViewBranch;
         viewValue = view;
-        if (viewValue->isDetached()) [[unlikely]] {
-            throwVMTypeError(lexicalGlobalObject, scope, "Uint8Array is detached"_s);
-            return {};
-        }
         // Single read of viewValue->byteLength() — used both for the
         // empty check here and for the repeat length in the write loop.
         // No further side effects can run before the write, so the value
-        // is stable.
+        // is stable. A detached view reads as 0 and is rejected as an
+        // empty fill value, like in Node.
         viewValueLength = viewValue->byteLength();
         if (viewValueLength == 0) [[unlikely]] {
             scope.throwException(lexicalGlobalObject, createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_ARG_VALUE, "Buffer cannot be empty"_s));
@@ -1956,15 +1939,12 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_swap16Body(JSC::JSGlobalObj
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // A detached buffer has byteLength() 0: nothing below touches its null vector
+    // and it is returned unchanged, like in Node.
     constexpr size_t elemSize = 2;
     size_t length = castedThis->byteLength();
     if (length % elemSize != 0) {
         return Bun::throwError(lexicalGlobalObject, scope, Bun::ErrorCode::ERR_INVALID_BUFFER_SIZE, "Buffer size must be a multiple of 16-bits"_s);
-    }
-
-    if (castedThis->isDetached()) [[unlikely]] {
-        throwVMTypeError(lexicalGlobalObject, scope, "Buffer is detached"_s);
-        return {};
     }
 
     uint8_t* data = castedThis->typedVector();
@@ -1985,15 +1965,12 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_swap32Body(JSC::JSGlobalObj
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // A detached buffer has byteLength() 0: nothing below touches its null vector
+    // and it is returned unchanged, like in Node.
     constexpr int elemSize = 4;
     int64_t length = static_cast<int64_t>(castedThis->byteLength());
     if (length % elemSize != 0) {
         return Bun::throwError(lexicalGlobalObject, scope, Bun::ErrorCode::ERR_INVALID_BUFFER_SIZE, "Buffer size must be a multiple of 32-bits"_s);
-    }
-
-    if (castedThis->isDetached()) [[unlikely]] {
-        throwVMTypeError(lexicalGlobalObject, scope, "Buffer is detached"_s);
-        return {};
     }
 
     uint8_t* typedVector = castedThis->typedVector();
@@ -2019,15 +1996,12 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_swap64Body(JSC::JSGlobalObj
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    // A detached buffer has byteLength() 0: nothing below touches its null vector
+    // and it is returned unchanged, like in Node.
     constexpr size_t elemSize = 8;
     size_t length = castedThis->byteLength();
     if (length % elemSize != 0) {
         return Bun::throwError(lexicalGlobalObject, scope, Bun::ErrorCode::ERR_INVALID_BUFFER_SIZE, "Buffer size must be a multiple of 64-bits"_s);
-    }
-
-    if (castedThis->isDetached()) [[unlikely]] {
-        throwVMTypeError(lexicalGlobalObject, scope, "Buffer is detached"_s);
-        return {};
     }
 
     uint8_t* data = castedThis->typedVector();

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4561,6 +4561,106 @@ describe("raw <enc>Slice / <enc>Write bindings match Node", () => {
   });
 });
 
+// Node reads a detached view's length (0) like any other buffer's: it sorts before any
+// non-empty buffer, equals any other empty one, swapNN() has nothing to swap, and as a fill
+// value it is rejected the way an empty one is. The expected values below are Node v26's.
+describe("detached buffers in compare, equals, swapNN and as a fill value", () => {
+  const detached = (size = 16) => {
+    const buf = Buffer.alloc(size);
+    buf.buffer.transfer();
+    return buf;
+  };
+  // A length-tracking view on a resizable ArrayBuffer computes its byteLength through a
+  // different path in JSC than a fixed-length one; both must read as 0 once detached.
+  const detachedLengthTracking = () => {
+    const rab = new ArrayBuffer(16, { maxByteLength: 32 });
+    const view = new Uint8Array(rab);
+    rab.transfer();
+    return view;
+  };
+  const abc = () => Buffer.from("abc");
+  const empty = () => Buffer.alloc(0);
+  const OUT_OF_RANGE = expect.objectContaining({ code: "ERR_OUT_OF_RANGE" });
+
+  it("Buffer.compare() treats a detached argument in either position as empty", () => {
+    const same = detached();
+    expect([
+      Buffer.compare(detached(), detached()),
+      Buffer.compare(same, same),
+      Buffer.compare(detached(), abc()),
+      Buffer.compare(abc(), detached()),
+      Buffer.compare(detached(), empty()),
+      Buffer.compare(empty(), detached()),
+      Buffer.compare(detachedLengthTracking(), abc()),
+      Buffer.compare(abc(), detachedLengthTracking()),
+      Buffer.compare(detachedLengthTracking(), detachedLengthTracking()),
+    ]).toEqual([0, 0, -1, 1, 0, 0, -1, 1, 0]);
+  });
+
+  it("buf.compare() treats a detached target or source as empty", () => {
+    const same = detached();
+    expect([
+      abc().compare(detached()),
+      empty().compare(detached()),
+      detached().compare(detached()),
+      same.compare(same),
+      detached().compare(abc()),
+      abc().compare(detachedLengthTracking()),
+      // With explicit offsets the detached side is an empty range whatever its start is.
+      abc().compare(detached(), 0),
+      abc().compare(detached(), 5),
+      detached().compare(detached(), 5),
+      empty().compare(detached(), 0, 0, 0, 0),
+    ]).toEqual([1, 0, 0, 0, -1, 1, 1, 1, 0, 0]);
+  });
+
+  it("buf.compare() range-checks an explicit end against the detached side's length of 0", () => {
+    expect(() => abc().compare(detached(), 0, 1)).toThrow(OUT_OF_RANGE);
+    expect(() => detached().compare(abc(), 0, 3, 0, 1)).toThrow(OUT_OF_RANGE);
+  });
+
+  it("buf.equals() treats a detached buffer on either side as empty", () => {
+    const same = detached();
+    expect([
+      abc().equals(detached()),
+      empty().equals(detached()),
+      detached().equals(detached()),
+      same.equals(same),
+      detached().equals(abc()),
+      detached().equals(empty()),
+      abc().equals(detachedLengthTracking()),
+      empty().equals(detachedLengthTracking()),
+    ]).toEqual([false, true, true, true, false, true, false, true]);
+  });
+
+  it.each(["swap16", "swap32", "swap64"])("%s() returns a detached buffer unchanged", method => {
+    const buf = detached();
+    expect(buf[method]()).toBe(buf);
+    expect(buf.length).toBe(0);
+
+    // The size check sees the detached length of 0, not the 3 bytes it was created with.
+    const odd = detached(3);
+    expect(odd[method]()).toBe(odd);
+
+    const view = detachedLengthTracking();
+    expect(Buffer.prototype[method].call(view)).toBe(view);
+  });
+
+  it("Buffer.alloc() and buf.fill() reject a detached fill value like an empty one", () => {
+    const INVALID_ARG_VALUE = expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" });
+    expect(() => Buffer.alloc(4, detached())).toThrow(INVALID_ARG_VALUE);
+    expect(() => Buffer.alloc(4, detachedLengthTracking())).toThrow(INVALID_ARG_VALUE);
+    expect(() => abc().fill(detached())).toThrow(INVALID_ARG_VALUE);
+    expect(() => abc().fill(detachedLengthTracking())).toThrow(INVALID_ARG_VALUE);
+
+    // Nothing to fill, so the value is never looked at (in Node either).
+    expect(Buffer.alloc(0, detached()).length).toBe(0);
+    const buf = abc();
+    expect(buf.fill(detached(), 1, 1)).toBe(buf);
+    expect(buf.toString()).toBe("abc");
+  });
+});
+
 describe("Buffer.copyBytesFrom", () => {
   it("copies the correct bytes from a Uint8Array view with a non-zero byteOffset", () => {
     const ab = new ArrayBuffer(10);


### PR DESCRIPTION
### Problem
- A Buffer (or Uint8Array) whose ArrayBuffer has been detached is rejected with a bare `TypeError` by `Buffer.compare()` (`Uint8Array (first argument) is detached`), `buf.compare()` and `buf.equals()` (`Uint8Array is detached`), `buf.swap16()`/`swap32()`/`swap64()` (`Buffer is detached`), and as the fill value of `Buffer.alloc(n, view)` / `buf.fill(view)` (`Uint8Array is detached`).
- Node has no detached special case in any of these. A detached view has length 0 there, so it compares as empty (`Buffer.compare(detached, detached)` is `0`, `Buffer.from("abc").compare(detached)` is `1`), `equals()` is true only against another empty view, `swapNN()` returns the buffer unchanged, and a detached fill value gets the same `ERR_INVALID_ARG_VALUE` an empty one gets.
- Cause: explicit `isDetached()` guards in `src/jsc/bindings/JSBuffer.cpp` (on main at lines 718, 843, 853, 1115, 1324, 1453, 1965, 1994 and 2028). Pre-existing, reproduces on 1.3.14 and the current canary; not a regression.

### Fix
- Removes those nine guards. Nothing else changes.
- Correct because JSC, like V8, gives a detached view `byteLength()` 0 (`JSArrayBufferView::detachFromArrayBuffer` sets the length to 0 and clears the data pointer), and each body already handles a zero-length view exactly as Node does: both `compare` bodies and `equals` skip the `memcmp` when the shorter length is 0 and order on lengths alone, the `swapNN` loops run zero iterations and return `this`, and `alloc`/`fill` hit their existing `length == 0` branch, which throws `ERR_INVALID_ARG_VALUE`. The guards were the only source of the divergence.
- The detached view's null data pointer is never dereferenced: every memory access in these bodies is behind a non-zero length, and no user JS can run between the length read and the access (`compare`'s offsets go through `validateInteger`, which rejects anything that is not already a number; `fill` reads the value's length after all argument coercion). A length-tracking view on a resizable buffer takes JSC's other `byteLength()` path and also reads 0 once detached; the tests cover it.
- Verified with the new `describe("detached buffers in compare, equals, swapNN and as a fill value")` block in `test/js/node/buffer.test.js`: all 8 tests fail on the released build with the TypeErrors above and pass with this change on a debug (ASAN + UBSan) build. Expected values were taken from Node v26.3.0 running the same calls.
- Also passing: the rest of `buffer.test.js` (640 tests), `buffer-copy-fill-detach.test.ts`, `buffer-indexOf-detach.test.ts`, and upstream `test-buffer-compare.js`, `test-buffer-compare-offset.js`, `test-buffer-equals.js`, `test-buffer-swap.js`, `test-buffer-fill.js`, `test-buffer-alloc.js`.
- Not changed: the `isDetached()` checks that remain in the file are places where Node throws too (`Buffer.concat`, `slice`/`subarray`, `Buffer.from(detachedArrayBuffer)`), the `indexOf` check that returns -1, and the `write()` re-checks that #30138 replaces. `detached.fill(1)` returning the buffer where Node throws, and the wording of `ERR_OUT_OF_RANGE` / fill's `ERR_INVALID_ARG_VALUE` messages, are pre-existing and unrelated to the detached guards.

### Background
- Detaching: `ArrayBuffer.prototype.transfer()` and `structuredClone(ab, { transfer })` move an ArrayBuffer's memory out from under its views. The engine then reports every view on it as length 0 with no data pointer; the views themselves stay usable objects.
- In Node, `Buffer.compare`, `buf.compare`, `buf.equals` and `swapNN` are JS wrappers over `this.length`/`byteLength` plus a native `compare` that uses V8's view length, and `fill` passes the value view's length to native code. None of them look at the detached state, which is why a detached view simply behaves as an empty one there.
- The Bun functions here are C++ bindings over the same JSC view object (`JSUint8Array`). `byteLength()` is the length JSC reports (0 once detached); `vector()`/`typedVector()` is the data pointer (null once detached).

<details>
<summary>Node v26.3.0 vs Bun, before and after (`det` = 16-byte Buffer whose ArrayBuffer was transferred, `abc` = Buffer.from("abc"), `empty` = Buffer.alloc(0))</summary>

```
                                node                      bun before                                        bun after
Buffer.compare(det, det)        0                         TypeError: Uint8Array (first argument) is detached   0
Buffer.compare(det, abc)        -1                        TypeError (first argument)                        -1
Buffer.compare(abc, det)        1                         TypeError (second argument)                       1
Buffer.compare(empty, det)      0                         TypeError (second argument)                       0
abc.compare(det)                1                         TypeError: Uint8Array is detached                 1
empty.compare(det)              0                         TypeError                                         0
abc.compare(det, 5)             1                         TypeError                                         1
abc.compare(det, 0, 1)          ERR_OUT_OF_RANGE          TypeError                                         ERR_OUT_OF_RANGE
det.compare(abc)                -1                        -1 (no guard on this side)                        -1
abc.equals(det)                 false                     TypeError: Uint8Array is detached                 false
empty.equals(det)               true                      TypeError                                         true
det.equals(det)                 true                      TypeError                                         true
det.equals(abc)                 false                     false (no guard on this side)                     false
det.swap16/32/64()              returns det (length 0)    TypeError: Buffer is detached                     returns det
det(3 bytes).swap16()           returns det               TypeError                                         returns det
Buffer.alloc(4, det)            ERR_INVALID_ARG_VALUE     TypeError: Uint8Array is detached                 ERR_INVALID_ARG_VALUE
abc.fill(det)                   ERR_INVALID_ARG_VALUE     TypeError: Uint8Array is detached                 ERR_INVALID_ARG_VALUE
Buffer.alloc(0, det)            empty Buffer              empty Buffer                                      empty Buffer
abc.fill(det, 1, 1)             returns abc               returns abc                                       returns abc
```

Unchanged, and the same kind of error in Node: `Buffer.concat([det])`, `det.slice()`, `det.subarray()` and `Buffer.from(detachedArrayBuffer)` all throw a TypeError in both.
</details>
