### PR TITLE
Bun.serve: don't finalize the request again when error() upgraded or ended it

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3497,6 +3497,11 @@ where
                     )
                     .unwrap_or_else(|err| server.global_this().take_exception(err));
                 let _keep = jsc::EnsureStillAlive(result);
+                // error() may have ended the request or called server.upgrade(req),
+                // either of which already released this context's ref.
+                if self.is_aborted_or_ended() || self.did_upgrade_web_socket() {
+                    return;
+                }
                 if !result.is_empty_or_undefined_or_null() {
                     if let Some(err) = result.to_error() {
                         self.finish_running_error_handler(err, status);
@@ -3558,14 +3563,6 @@ where
                 ); // TODO: properly propagate exception upwards
             }
             jsc::PromiseResult::Fulfilled(fulfilled_value) => {
-                // if you return a Response object or a Promise<Response>
-                // but you upgraded the connection to a WebSocket
-                // just ignore the Response object. It doesn't do anything.
-                // it's better to do that than to throw an error
-                if ctx.did_upgrade_web_socket() {
-                    return;
-                }
-
                 // `fulfilled_value` is rooted via ensure_still_alive() below for
                 // as long as `response` is used.
                 let Some(response) = as_response(fulfilled_value) else {

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1452,6 +1452,42 @@ it("you can call server.subscriberCount() when its not a websocket server", asyn
   expect(server.subscriberCount("boop")).toBe(0);
 });
 
+it.concurrent("server.upgrade() from the error() handler after fetch() threw completes the handshake", async () => {
+  await using proc = spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const server = Bun.serve({
+         port: 0,
+         development: true,
+         fetch(req) { throw Object.assign(new Error("boom"), { req }); },
+         error(err) {
+           if (err.req && server.upgrade(err.req, { data: { from: "error" } })) return;
+           return new Response("err", { status: 500 });
+         },
+         websocket: {
+           open(ws) { ws.send("opened:" + ws.data.from); },
+           message(ws, m) { ws.send("echo:" + m); },
+         },
+       });
+       const ws = new WebSocket(server.url.href.replace(/^http/, "ws"));
+       ws.onerror = () => { console.log("ws error"); process.exit(1); };
+       ws.onmessage = e => {
+         console.log(e.data);
+         if (e.data === "echo:hi") ws.close();
+         else ws.send("hi");
+       };
+       ws.onclose = e => { console.log("closed", e.code); server.stop(true); };`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("opened:error\necho:hi\nclosed 1000\n");
+  expect(exitCode).toBe(0);
+});
+
 it("server.upgrade() does not blank the Request's url/headers read afterwards", async () => {
   // req.url and req.headers are lifted lazily from the uws request. upgrade()
   // detaches that context, so fields not touched before the call must be


### PR DESCRIPTION
### What
`server.upgrade(req)` called from inside `Bun.serve`'s `error(err)` handler (after `fetch` threw for a WebSocket-upgrade request) completed the upgrade — which releases the `RequestContext`'s base ref and detaches `resp` — and then the synchronous error-handler path fell through into `finish_running_error_handler` → (dev mode) `render_default_error`, whose `resp == None` arm finalizes and derefs *again*: `assertion failed: ref_count > 0` on debug/assert builds, a refcount underflow on release. The async error-handler path already returned early on `did_upgrade_web_socket()`; only the sync path was missing it.

After calling `on_error`, `run_error_handler_with_status_code_dont_check_responded` now returns if `is_aborted_or_ended() || did_upgrade_web_socket()` — the same guard every sibling site uses after re-entering user JS (`handle_resolve`, `on_response`, `on_upgrade`) — which also covers `error()` handlers that end the request another way (e.g. `server.stop(true)`). The now-redundant check in `process_on_error_promise`'s `Fulfilled` arm is removed. Semantics: upgrading from `error()` works (101 + `open` fires), matching what the async path already did.

### Repro (before)
```js
let server = Bun.serve({ port: 0, development: true,
  fetch(req) { throw Object.assign(new Error("boom"), { req }); },
  error(err) { if (err.req && server.upgrade(err.req, { data: {} })) return; return new Response("err", { status: 500 }); },
  websocket: { open(ws) { ws.send("opened"); }, message(ws, m) { ws.send(m); } } });
const ws = new WebSocket(`ws://127.0.0.1:${server.port}/`); ws.onmessage = e => console.log(e.data);
// debug/ASan+assert: panic: assertion failed: ref_count > 0 (RequestContext.rs deref ← render_default_error)
```

### Tests
`test/js/bun/websocket/websocket-server.test.ts` — "server.upgrade() from the error() handler after fetch() threw completes the handshake". Fails on the ASan canary and debug main; passes here.
