### PR TITLE
Fix crash when a property lookup throws while formatting an object

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5643,10 +5643,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5718,7 +5719,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue proto = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!proto) [[unlikely]]
+                break;
+            iterating = proto.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,65 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("property lookup throws while an object is being formatted", () => {
+  it("skips the property and keeps formatting", async () => {
+    // A Proxy is unwrapped when it is the value being formatted, but it is
+    // walked normally when it is on the prototype chain.
+    const fixture = `
+      const throwingGet = new Proxy({ a: 1, b: 2, c: 3 }, {
+        get(target, key, receiver) {
+          if (key === "b") throw new Error("get trap");
+          return Reflect.get(target, key, receiver);
+        },
+      });
+      console.log(Bun.inspect(Object.create(throwingGet)));
+      const withOwn = Object.create(throwingGet);
+      withOwn.own = 0;
+      console.log(Bun.inspect(withOwn));
+
+      const throwingGetPrototypeOf = new Proxy({ a: 1 }, {
+        getPrototypeOf() { throw new Error("getPrototypeOf trap"); },
+      });
+      console.log(Bun.inspect(Object.create(throwingGetPrototypeOf)));
+
+      // Lazily initialized properties of native objects can throw from their
+      // initializer too. Bun.$ is built by JS that calls Symbol(), so breaking
+      // the global makes it throw; the properties after it must still show up.
+      const RealSymbol = Symbol;
+      globalThis.Symbol = 1;
+      const bun = Bun.inspect(Bun);
+      globalThis.Symbol = RealSymbol;
+      console.log("Bun:", bun.includes("Archive:"), bun.includes("version:"));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe(
+      [
+        "{",
+        "  a: 1,",
+        "  c: 3,",
+        "}",
+        "{",
+        "  own: 0,",
+        "  a: 1,",
+        "  c: 3,",
+        "}",
+        "{",
+        "  a: 1,",
+        "}",
+        "Bun: true true",
+        "",
+      ].join("\n"),
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -953,6 +953,9 @@ describe("property lookup throws while an object is being formatted", () => {
       // Lazily initialized properties of native objects can throw from their
       // initializer too. Bun.$ is built by JS that calls Symbol(), so breaking
       // the global makes it throw; the properties after it must still show up.
+      // On Windows, Bun.env has an inspect.custom hook, and calling one loads
+      // node:util, which needs a working Symbol: load it before breaking the global.
+      Bun.inspect({ [Bun.inspect.custom]() { return 0; } });
       const RealSymbol = Symbol;
       globalThis.Symbol = 1;
       const bun = Bun.inspect(Bun);


### PR DESCRIPTION
### What does this PR do?

Fixes a crash in the object formatter behind `Bun.inspect` / `console.log` when a property lookup throws while the object's properties are being walked.

`JSC__JSValue__forEachPropertyImpl` (bindings.cpp) does this for every property name in the slow path:

```cpp
if (!object->getPropertySlot(globalObject, property, slot))
    continue;
CLEAR_IF_EXCEPTION(scope);
```

`getPropertySlot()` returns false when the lookup threw, so the `continue` skipped the clear and the exception stayed pending on the VM. That happens when a Proxy on the prototype chain has a throwing `get` trap, or when a lazily initialized static property of a native object throws from its initializer. Two things then go wrong:

- The next property lookup runs with the exception still set. When that property is a lazy native property (this is what the fuzzer hit: `Bun.inspect(Bun)` after `Symbol` had been reassigned, so the `Bun.$` initializer threw and the `Bun.Archive` initializer ran next), the host function wrapper sees a pending exception on a successful return and asserts in debug builds. In release builds every property after the throwing one reads as missing, so the output is mostly empty.
- At the end of the walk `iterating->getPrototype(globalObject).getObject()` is called. With an exception pending (or with a `getPrototypeOf` trap that throws on its own), `getPrototype()` returns an empty `JSValue`, and `getObject()` on an empty value goes through a null `JSCell*`. This is a plain segfault in release builds:

  ```js
  const proto = new Proxy({ a: 1 }, { getPrototypeOf() { throw new Error("x"); } });
  console.log(Object.create(proto)); // panic: Segmentation fault at address 0x5
  ```

The fix is the two hunks in bindings.cpp: clear the exception before deciding whether to skip the property (same shape as `JSC__JSValue__forEachPropertyOrdered` already uses), and keep the `getPrototype()` result in a `JSValue`, clear the exception, and stop walking if it came back empty.

BunObject.cpp: `defaultBunSQLObject` / `constructBunSQLObject` had a debug-only `reportUncaughtExceptionAtEventLoop()` call made while the exception was still pending. With the walk no longer dying on the first property, `Bun.inspect(Bun)` in the repro reached `Bun.sql`, and that call failed a stale-structure assertion inside `process._fatalException` lookup (a static property gets reified during the lookup, then the pending exception makes the lookup report "not found"). Every other caller of `reportUncaughtExceptionAtEventLoop()` clears the exception first; these two propagate it anyway on the next line, so the extra report is dropped rather than reworked.

The crash was found by fuzzing and reported as flaky: the REPRL loop reuses one global object across programs, so the `Symbol` reassignment came from an earlier program and is not in the crashing one. Adding `globalThis.Symbol = "a"` to the script reproduces it deterministically.

### How did you verify your code works?

Added a test to `test/js/bun/util/inspect.test.js` that formats an object whose prototype is a Proxy with a throwing `get` trap (with and without own properties), one whose prototype Proxy throws from `getPrototypeOf`, and `Bun` with a throwing lazy property initializer.

- `USE_SYSTEM_BUN=1 bun test test/js/bun/util/inspect.test.js -t "property lookup throws"`: fails on the current release build (the child segfaults, stdout is empty). The `Bun.inspect(Bun)` part on its own prints `Bun: false false` there, and the prebuilt unfixed debug binary hits the `releaseAssertNoException` assertion from the fuzzer report on it.
- `bun bd test test/js/bun/util/inspect.test.js`: all 75 tests pass. Also ran the console tests under `test/js/web/console` and `test/js/bun/console`, `test/js/bun/util/BunObject.test.ts`, and the repros with `BUN_JSC_validateExceptionChecks=1`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->