### PR TITLE
Fix exception handling in the console.log / Bun.inspect property walk, napi_get_all_property_names and util.isError

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5643,10 +5643,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5718,7 +5719,11 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Empty when a Proxy "getPrototypeOf" trap threw; the exception is cleared below.
+            if (!prototype) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2077,7 +2077,10 @@ extern "C" napi_status napi_get_all_property_names(
             if (key_mode == napi_key_include_prototypes) {
                 // Climb up the prototype chain to find inherited properties
                 while (!owner->getOwnPropertyDescriptor(globalObject, propKey, desc)) {
-                    JSObject* proto = owner->getPrototype(globalObject).getObject();
+                    NAPI_RETURN_IF_EXCEPTION(env);
+                    JSValue prototype = owner->getPrototype(globalObject);
+                    NAPI_RETURN_IF_EXCEPTION(env);
+                    JSObject* proto = prototype.getObject();
                     if (!proto) {
                         break;
                     }
@@ -2085,6 +2088,7 @@ extern "C" napi_status napi_get_all_property_names(
                 }
             } else {
                 owner->getOwnPropertyDescriptor(globalObject, propKey, desc);
+                NAPI_RETURN_IF_EXCEPTION(env);
             }
 
             // V8 never applies ONLY_WRITABLE/ONLY_CONFIGURABLE to Proxy keys

--- a/src/jsc/modules/NodeUtilTypesModule.cpp
+++ b/src/jsc/modules/NodeUtilTypesModule.cpp
@@ -901,6 +901,8 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsError,
         PropertySlot slot(object, PropertySlot::InternalMethodType::VMInquiry, &vm);
         bool has = object->getPropertySlot(globalObject, vm.propertyNames->toStringTagSymbol, slot);
         scope.assertNoException();
+        // A VMInquiry slot forbids entering the VM while it is alive, and getPrototype() below may run a Proxy trap.
+        slot.disallowVMEntry.reset();
         if (has) {
             if (slot.isValue()) {
                 JSValue value = slot.getValue(globalObject, vm.propertyNames->toStringTagSymbol);
@@ -914,6 +916,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsError,
         }
 
         JSValue proto = object->getPrototype(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
         if (proto.isCell() && (proto.inherits<JSC::ErrorInstance>() || proto.asCell()->type() == ErrorInstanceType || proto.inherits<JSC::ErrorPrototype>()))
             return JSValue::encode(jsBoolean(true));
     }

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -947,11 +947,31 @@ describe.concurrent("exceptions thrown while walking properties", () => {
     // properties were visited, so they were dropped from the output (and debug
     // builds asserted when the next initializer ran).
     const { stdout, stderr, exitCode } = await run(`
+      // Formatting a value with a custom inspect function (process.env on Windows)
+      // loads node:util's inspect helpers, which read process.env. Load them
+      // before breaking process.env so only the Bun.$ initializer throws.
+      Bun.inspect({ [Bun.inspect.custom]() { return ""; } });
       Object.defineProperty(process, "env", { get() { throw new Error("boom"); } });
       const s = Bun.inspect(Bun);
       console.log(/^  \\$:/m.test(s), /^  Archive:/m.test(s), /^  version:/m.test(s));
     `);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "false true true\n", stderr: "", exitCode: 0 });
+  });
+
+  it("a get trap that throws for one inherited property only hides that property", async () => {
+    // Same leak through a Proxy: the pending exception made the remaining
+    // properties look missing and then the prototype step dereferenced the
+    // empty value returned by the proxy's getPrototype.
+    const { stdout, stderr, exitCode } = await run(`
+      const proto = new Proxy({ a: 1, b: 2, c: 3 }, {
+        get(target, key, receiver) {
+          if (key === "a") throw new Error("trap");
+          return Reflect.get(target, key, receiver);
+        },
+      });
+      console.log(Bun.inspect(Object.create(proto)));
+    `);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "{\n  b: 2,\n  c: 3,\n}\n", stderr: "", exitCode: 0 });
   });
 
   it("a throwing getPrototypeOf trap in the prototype chain stops the walk", async () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,42 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe.concurrent("exceptions thrown while walking properties", () => {
+  async function run(fixture) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("a lazy property initializer that throws only hides that property", async () => {
+    // Bun.$ is initialized on first access and reads process.env while doing so.
+    // The exception it throws here used to stay pending while the following
+    // properties were visited, so they were dropped from the output (and debug
+    // builds asserted when the next initializer ran).
+    const { stdout, stderr, exitCode } = await run(`
+      Object.defineProperty(process, "env", { get() { throw new Error("boom"); } });
+      const s = Bun.inspect(Bun);
+      console.log(/^  \\$:/m.test(s), /^  Archive:/m.test(s), /^  version:/m.test(s));
+    `);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "false true true\n", stderr: "", exitCode: 0 });
+  });
+
+  it("a throwing getPrototypeOf trap in the prototype chain stops the walk", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const proto = new Proxy({ inherited: 1 }, { getPrototypeOf() { throw new Error("trap"); } });
+      console.log(Bun.inspect(Object.create(proto)));
+      console.log(Object.create(proto));
+    `);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "{\n  inherited: 1,\n}\n{\n  inherited: 1,\n}\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -23,7 +23,7 @@
 
 import assert from "assert";
 import { describe, expect, it } from "bun:test";
-import "harness";
+import { bunEnv, bunExe } from "harness";
 import util from "util";
 // const context = require('vm').runInNewContext; // TODO: Use a vm polyfill
 
@@ -153,16 +153,25 @@ describe("util", () => {
       strictEqual(util.isError(err8), true);
     });
 
-    it("propagates an exception from a getPrototypeOf trap", () => {
-      const proxy = new Proxy(
-        {},
-        {
-          getPrototypeOf() {
-            throw new Error("getPrototypeOf trap");
-          },
-        },
-      );
-      expect(() => util.isError(proxy)).toThrow("getPrototypeOf trap");
+    it("propagates an exception from a getPrototypeOf trap", async () => {
+      // Used to crash the process, so the call runs in a child.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const proxy = new Proxy({}, { getPrototypeOf() { throw new Error("getPrototypeOf trap"); } });
+           try {
+             console.log("returned", require("util").isError(proxy));
+           } catch (e) {
+             console.log("threw", e.message);
+           }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "threw getPrototypeOf trap\n", stderr: "", exitCode: 0 });
     });
   });
 

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -152,6 +152,18 @@ describe("util", () => {
       let err8 = new Error3();
       strictEqual(util.isError(err8), true);
     });
+
+    it("propagates an exception from a getPrototypeOf trap", () => {
+      const proxy = new Proxy(
+        {},
+        {
+          getPrototypeOf() {
+            throw new Error("getPrototypeOf trap");
+          },
+        },
+      );
+      expect(() => util.isError(proxy)).toThrow("getPrototypeOf trap");
+    });
   });
 
   describe("isObject", () => {

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -321,6 +321,40 @@ nativeTests.test_get_all_property_names_proxy_and_string_wrapper = () => {
   show("frozen writable:", apn(Object.freeze({ a: 1, b: 2 }), napi_key_writable));
 };
 
+nativeTests.test_get_all_property_names_throwing_trap = () => {
+  const napi_key_include_prototypes = 0;
+  const napi_key_own_only = 1;
+  const napi_key_enumerable = 1 << 1;
+  const napi_key_keep_numbers = 0;
+
+  // The enumerable filter makes both engines ask the proxy for descriptors.
+  const makeProxy = () =>
+    new Proxy(
+      { k: 1 },
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error("descriptor trap");
+        },
+      },
+    );
+  for (const [label, obj, mode] of [
+    ["own_only", makeProxy(), napi_key_own_only],
+    ["include_prototypes", Object.create(makeProxy()), napi_key_include_prototypes],
+  ]) {
+    try {
+      const { status, keys } = nativeTests.get_all_property_names(
+        obj,
+        mode,
+        napi_key_enumerable,
+        napi_key_keep_numbers,
+      );
+      console.log(`${label}: returned status=${status} keys=${JSON.stringify(keys)}`);
+    } catch (e) {
+      console.log(`${label}: threw ${e.message}`);
+    }
+  }
+};
+
 nativeTests.test_set_property = () => {
   const objects = [
     {},

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -880,6 +880,11 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(output).toContain(`plain writable: status=0 keys=["w","nc"]`);
       expect(output).toContain(`frozen writable: status=0 keys=[]`);
     });
+    it("propagates an exception thrown by a Proxy trap while filtering", async () => {
+      const output = await checkSameOutput("test_get_all_property_names_throwing_trap", []);
+      expect(output).toContain("own_only: threw descriptor trap");
+      expect(output).toContain("include_prototypes: threw descriptor trap");
+    });
   });
 
   describe("napi_value <=> integer conversion", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes two exception handling bugs in `JSC__JSValue__forEachPropertyImpl` (`src/jsc/bindings/bindings.cpp`), the property walk behind `console.log` / `Bun.inspect` for objects that take the slow path (objects with a static property table such as `Bun`, objects with a Proxy in their prototype chain, ...), plus the one other place with the same prototype step (`napi_get_all_property_names`).

1. When `getPropertySlot` returned false, the loop did `continue` before the `CLEAR_IF_EXCEPTION` that follows it. `getPropertySlot` returns false with an exception pending when a lazy static property initializer or a Proxy trap throws, so that exception stayed pending for the rest of the walk. Every later lookup then fails as well (`setUpStaticFunctionSlot` and the Proxy trap code both bail out on a pending exception), so the remaining properties were silently dropped from the output: on a release build, `Bun.inspect(Bun)` with a throwing `Bun.$` initializer loses everything from `Archive` through `inflateSync`, and an inherited Proxy property whose `get` trap throws hides every property after it. On debug builds the next initializer that is implemented in Rust trips `assert_exception_presence_matches`, which is the crash this was found through:

   ```
   ASSERTION FAILED: Unexpected exception observed ...
   Error Exception: Symbol is not a function. (In 'Symbol("cwd")', 'Symbol' is NaN)
   ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
   ```

   (`Symbol("cwd")` is the first line of the `Bun.$` initializer in `src/js/builtins/shell.ts`; the fuzzer had replaced `Symbol` earlier and then formatted the `Bun` object.)

   The fix is to clear the exception before the `continue`, the same order `JSC__JSValue__forEachPropertyOrdered` already uses.

2. At the end of each prototype step the loop did `iterating->getPrototype(globalObject).getObject()`. When `iterating` is a Proxy and `getPrototype` throws (its `getPrototypeOf` trap throws, or an exception leaked by bug 1 is still pending), it returns the empty value, and `getObject()` on it dereferences null:

   ```js
   console.log(Object.create(new Proxy({}, { getPrototypeOf() { throw new Error("x"); } })));
   // panic(main thread): Segmentation fault at address 0x5   (Linux release build)
   ```

   The walk now stops there; the exception is cleared on the way out like the other ignored getter exceptions in this function (and like the fast path already does for the same trap).

3. `napi_get_all_property_names` (`src/jsc/bindings/napi.cpp`) has the same `getPrototype(...).getObject()` step in its descriptor filter loop (pointed out in review). With `napi_key_include_prototypes` and an enumerable/writable/configurable filter, a Proxy in the prototype chain whose `getOwnPropertyDescriptor` trap throws leaves the exception pending, the following `getPrototype` returns empty and `getObject()` dereferences null; with `napi_key_own_only` the pending exception instead reached `NAPI_RETURN_SUCCESS` (an assertion on debug builds). Both lookups are now followed by `NAPI_RETURN_IF_EXCEPTION`, so the call returns `napi_pending_exception` and the trap's exception propagates to the caller, which is what Node does.

4. `util.isError` (`jsFunctionIsError` in `src/jsc/modules/NodeUtilTypesModule.cpp`, also pointed out in review) reads `getPrototype()` of its argument and dereferences the result without checking it. `util.isError(new Proxy({}, { getPrototypeOf() { throw ... } }))` segfaults on the release canary. There were two things wrong: the `VMInquiry` slot used for the `Symbol.toStringTag` lookup a few lines earlier was still alive, so the Proxy trap was not allowed to be entered at all (debug builds crash right there with "VM entry disallowed"; release builds get a TypeError instead of running the trap), and the empty value returned on that exception was then dereferenced. The slot's restriction is now released once the lookup is done (`slot.disallowVMEntry.reset()`, the usual JSC idiom) and `getPrototype()` is followed by `RETURN_IF_EXCEPTION`, so the trap runs and whatever it throws propagates to the caller, which is also what the old Node implementation (`instanceof`-based) did.

I went through the other `getPrototype` call sites in `src/` (C++ and the Rust `get_prototype` callers) after that. The rest either already check for the exception (`WebStreamsInspectCustom.cpp`, `ObjectBindings.cpp`, the deepEquals prototype comparison), or can only be reached with ordinary objects whose `[[GetPrototypeOf]]` cannot throw (`JSBuffer__isBuffer` on a `JSUint8Array`, `isAsyncFunction` / `isGeneratorFunction` on a `JSFunction`, the sqlite constructor setup, the test runner's scope functions, and the console / test-runner formatters, which never format a Proxy itself, only its target). The one remaining site with a real difference is `napi_get_prototype` (`src/runtime/napi/napi_body.rs`), which returns `napi_ok` plus a handle to the empty value instead of `napi_pending_exception` when the trap throws; it does not dereference anything, so it is left out of this PR and tracked separately.

Two more pre-existing problems that these tests brushed against are tracked separately and not touched here: the `Bun.sql` / `Bun.SQL` initializers report a module load failure while the exception is still pending (debug builds only, so `globalThis.Symbol = NaN; console.log(Bun)` still asserts on a debug build after this change, now in `Structure::storedPrototype` when the walk reaches `sql`), and formatting a value with a custom inspect function aborts if loading `node:util`'s inspect helpers throws (which is what happens to `process.env` on Windows once `process.env` has been made to throw; the first test below loads the helpers first to stay clear of it).

### How did you verify your code works?

Three tests added to `test/js/bun/util/inspect.test.js` (`exceptions thrown while walking properties`), each running its snippet in a child `bun -e`:

- `a lazy property initializer that throws only hides that property`: makes `process.env` throw (the `Bun.$` initializer reads it), then checks that `Bun.inspect(Bun)` still lists `Archive` and `version`. Before the fix it fails with the `releaseAssertNoException` abort above on a debug build and prints `false false true` (Archive missing) on release builds, on Linux and Windows.
- `a get trap that throws for one inherited property only hides that property`: before the fix, on the Linux release build, the leaked exception hides the other properties and the walk then segfaults in the prototype step.
- `a throwing getPrototypeOf trap in the prototype chain stops the walk`: before the fix this segfaults on the Linux release build and is a UBSan null member call on the debug build.

One test added to `test/napi/napi.test.ts` (`propagates an exception thrown by a Proxy trap while filtering`, fixture `test_get_all_property_names_throwing_trap` in `napi-app/module.js`), which compares Bun's output with Node's for both key modes. Before the napi change the own_only case aborts in `NAPI_RETURN_SUCCESS` on the debug build and the include_prototypes case is the same UBSan null member call in `JSValue::getObject`.

One test added to the `isError` block of `test/js/node/util/util.test.js` (`propagates an exception from a getPrototypeOf trap`), which runs the call in a child `bun -e`. Before the change the child aborts on the debug build and segfaults with the release canary (exit 139), so only this test fails.

All of these pass with `bun bd test test/js/bun/util/inspect.test.js`, `bun bd test test/napi/napi.test.ts` and `bun bd test test/js/node/util/util.test.js`, as do the rest of those files; the three repro scripts are also clean under `BUN_JSC_validateExceptionChecks=1`. The fixed debug build runs the original fuzzer script cleanly.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js test/napi/napi.test.ts

<!-- robobun:evidence:end -->