### PR TITLE
inspect: handle exceptions thrown by property lookups while formatting an object

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5643,10 +5643,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5718,7 +5719,11 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Empty when a Proxy "getPrototypeOf" trap threw; the exception is cleared below.
+            if (!prototype) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,88 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe.concurrent("property lookup throws while formatting", () => {
+  async function inspectInChild(code) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: normalizeBunSnapshot(stdout), stderr, exitCode };
+  }
+
+  it("skips an inherited property whose Proxy get trap throws and keeps formatting", async () => {
+    const { stdout, stderr, exitCode } = await inspectInChild(`
+      const proto = new Proxy(
+        { a: 1, b: 2, c: 3 },
+        {
+          get(target, key) {
+            if (key === "a") throw new Error("a");
+            return target[key];
+          },
+        },
+      );
+      const obj = Object.create(proto);
+      obj.x = 1;
+      console.log(Bun.inspect(obj));
+    `);
+    expect(stdout).toMatchInlineSnapshot(`
+      "{
+        x: 1,
+        b: 2,
+        c: 3,
+      }"
+    `);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it("stops walking the prototype chain when a Proxy getPrototypeOf trap throws", async () => {
+    const { stdout, stderr, exitCode } = await inspectInChild(`
+      const proto = new Proxy(
+        { a: 1 },
+        {
+          getPrototypeOf() {
+            throw new Error("getPrototypeOf");
+          },
+        },
+      );
+      const obj = Object.create(proto);
+      obj.x = 1;
+      console.log(Bun.inspect(obj));
+    `);
+    expect(stdout).toMatchInlineSnapshot(`
+      "{
+        x: 1,
+        a: 1,
+      }"
+    `);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it("keeps formatting after a lazy property initializer throws", async () => {
+    // Bun.$ is the first property of the Bun object and is created on first
+    // access by the shell builtin, which calls Symbol("cwd"). Making that call
+    // throw leaves an exception behind while the remaining lazy properties
+    // (Archive is the next one) are still being initialized.
+    const { stdout, stderr, exitCode } = await inspectInChild(`
+      const OriginalSymbol = Symbol;
+      globalThis.Symbol = new Proxy(OriginalSymbol, {
+        apply(target, thisValue, args) {
+          if (args[0] === "cwd") throw new Error("cwd");
+          return Reflect.apply(target, thisValue, args);
+        },
+      });
+      const out = Bun.inspect(Bun);
+      globalThis.Symbol = OriginalSymbol;
+      console.log(out.includes("Archive:"));
+    `);
+    expect(stdout).toBe("true");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes two exception handling bugs in `JSC__JSValue__forEachPropertyImpl` (`src/jsc/bindings/bindings.cpp`), the property walk behind `Bun.inspect` / `console.log` for objects that take the slow path (objects with non-reified static tables such as `Bun`, objects with a Proxy in their prototype chain, etc).

1. When `getPropertySlot` returned `false` the loop did `continue` before reaching `CLEAR_IF_EXCEPTION(scope)`, so an exception thrown during the lookup (a Proxy `get` trap, or a lazy static property whose initializer throws; `setUpStaticFunctionSlot` reports those as "not found" with the exception left pending) stayed pending while the remaining properties were visited. The fix is to run `CLEAR_IF_EXCEPTION` before the `continue`, the same thing `JSC__JSValue__forEachPropertyOrdered` already does.

   Consequences of the stale exception before this change:
   - Debug/ASAN builds: the next lazy property callback on the object (for `Bun`, `Archive` right after `$`) trips `releaseAssertNoException` in the Rust host call wrapper. This is the Fuzzilli crash that prompted the change. The fuzzer hit it through `Bun.readableStreamToFormData(Bun)` formatting the `Bun` object into its error message after earlier iterations in the same process had tampered with `Symbol` and `Object.prototype.constructor`.
   - Release builds: every static property looked up after the failing one is also reported as missing until something clears the exception, so they silently disappear from the output. With a Proxy in the prototype chain it is worse, see below.

2. At the end of the loop, `iterating->getPrototype(globalObject).getObject()` ran on the empty `JSValue` that `getPrototype` returns when a Proxy `getPrototypeOf` trap throws (or when an exception was already pending because of bug 1). `JSValue::getObject()` on the empty value calls into a null cell, which is a segfault at address 0x5 in release builds:

   ```js
   const proto = new Proxy({ a: 1 }, { getPrototypeOf() { throw new Error("x"); } });
   const obj = Object.create(proto);
   obj.x = 1;
   console.log(obj); // Bun 1.4: "panic(main thread): Segmentation fault at address 0x5"
   ```

   Same crash with a `get` trap that throws for one of the keys (via bug 1). The fix checks the returned value and stops walking the chain; the pending exception is cleared by the existing block after the loop.

Other sites: `JSC__JSValue__forEachPropertyOrdered` already clears after `getPropertySlot` and does not walk prototypes. The only other `getPrototype(...).getObject()` in the tree is the `napi_key_include_prototypes` loop in `napi_get_all_property_names` (`src/jsc/bindings/napi.cpp`), which has the same two problems but is only reachable from a native addon and needs an N-API addon test; it is intentionally left out of this PR and is being fixed separately.

### How did you verify your code works?

Added three tests to `test/js/bun/util/inspect.test.js` ("property lookup throws while formatting"), each running the scenario in a child `bun -e`:

- inherited property whose Proxy `get` trap throws: segfaults the child on the unfixed build, now prints the other properties
- Proxy `getPrototypeOf` trap throws: segfaults the child on the unfixed build
- lazy property initializer throws (`Bun.$`, by making `Symbol("cwd")` throw, then `Bun.inspect(Bun)`): assertion failure in unfixed debug builds, and `Archive` is missing from the output in unfixed release builds

All three fail with `USE_SYSTEM_BUN=1 bun test` and pass with `bun bd test`. The rest of `inspect.test.js`, `inspect-error.test.js`, `bun-inspect.test.ts`, `custom-inspect.test.js`, the console table tests, `test/js/web/console/*` and `util.test.js` pass with the debug build (the two "Error inside minified file" tests in `inspect-error.test.js` fail identically on a debug build without this change). The original fuzzer script's trigger line reproduces the `releaseAssertNoException` failure on the unfixed debug build and throws a normal `TypeError` with this change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->
