### PR TITLE
node:url: strip tab and newline before the bracket and port checks in domainToASCII/domainToUnicode

### DIFF
--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -112,8 +112,12 @@ bool hasValidPunycodeHost(WTF::StringView host)
 // Mirrors Node's url.domainToASCII/domainToUnicode, which run the input
 // through a WHATWG URL host parse (ada's url.set_hostname on a "ws://x"
 // base). Returns a null String when host parsing fails.
-static String parseDomainAsHost(const String& domain)
+static String parseDomainAsHost(const String& input)
 {
+    // The basic URL parser strips ASCII tab and newline before anything else.
+    // WTF::URL does that too, but the bracket and ':' checks below run first.
+    String domain = input.removeCharacters([](char16_t c) { return c == '\t' || c == '\n' || c == '\r'; });
+
     // The hostname setter's basic-URL parse stops at the first path, query,
     // fragment, or backslash (special scheme) terminator.
     StringView view { domain };

--- a/src/jsc/bindings/NodeURL.cpp
+++ b/src/jsc/bindings/NodeURL.cpp
@@ -114,8 +114,7 @@ bool hasValidPunycodeHost(WTF::StringView host)
 // base). Returns a null String when host parsing fails.
 static String parseDomainAsHost(const String& input)
 {
-    // The basic URL parser strips ASCII tab and newline before anything else.
-    // WTF::URL does that too, but the bracket and ':' checks below run first.
+    // The basic URL parser removes ASCII tab and newline from its input first.
     String domain = input.removeCharacters([](char16_t c) { return c == '\t' || c == '\n' || c == '\r'; });
 
     // The hostname setter's basic-URL parse stops at the first path, query,

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -102,24 +102,10 @@ describe("url.domainToUnicode", () => {
 });
 
 // Node implements both functions as a WHATWG host parse of the input (the hostname setter on a "ws://x" URL)
-// and returns "" when that parse fails, so punycode validation, percent-decoding, IPv4/IPv6 canonicalization
-// and the authority terminators all apply. Rows are [input, domainToASCII(input), domainToUnicode(input)]
-// as produced by Node 26.
+// and returns "" when that parse fails, so percent-decoding, IPv4/IPv6 canonicalization, tab and newline
+// stripping and the authority terminators all apply. Rows are [input, domainToASCII(input),
+// domainToUnicode(input)]; the expected values are Node's.
 const hostParserParity = [
-  // Punycode labels are decoded and validated; one invalid label fails the whole host.
-  ["xn--a-ecp.example", "", ""],
-  ["sub.xn--a-ecp.example", "", ""],
-  ["XN--A-ECP.example", "", ""],
-  ["xn--a-ecp.xn--fiqs8s", "", ""],
-  ["xn--pokxncvks", "", ""],
-  ["xn--a", "", ""],
-  ["xn--a.example", "", ""],
-  ["xn--a.xn--nxa", "", ""],
-  ["xn--zn7c.com", "", ""],
-  ["xn--", "", ""],
-  ["xn--.example", "", ""],
-  ["a.xn--", "", ""],
-  ["xn--1ug.example", "", ""],
   // Valid punycode is kept (lowercased); a label that merely contains "xn--" is not punycode.
   ["xn--bcher-kva.de", "xn--bcher-kva.de", "b\u00fccher.de"],
   ["XN--BCHER-KVA.DE", "xn--bcher-kva.de", "b\u00fccher.de"],
@@ -157,12 +143,20 @@ const hostParserParity = [
   ["[", "", ""],
   ["[:", "", ""],
   ["[::1]:80", "", ""],
-  // Tabs and newlines are removed before IDNA runs, so they never end up inside a punycode label.
+  // Tabs and newlines are removed before anything else: before IDNA runs, so they never end up inside a
+  // punycode label, and before the IPv6 brackets and the port check are looked at.
   ["ex\tample.com", "example.com", "example.com"],
   ["a\r\nb", "ab", "ab"],
   ["b\t\u00fccher.de", "xn--bcher-kva.de", "b\u00fccher.de"],
   ["\u00df\nxn", "xn--xn-fia", "\u00dfxn"],
   ["\u03c2a\nxn--bcher-kva", "xn--axn--bcher-kva-phk", "\u03c2axn--bcher-kva"],
+  ["\t[::1]", "[::1]", "[::1]"],
+  ["[::1]\n", "[::1]", "[::1]"],
+  ["\t[::1]\r\n", "[::1]", "[::1]"],
+  ["[::\n1]", "[::1]", "[::1]"],
+  ["\t[::1]:80", "", ""],
+  ["a\t:80", "", ""],
+  ["\t", "", ""],
   // The host ends at the first path, query, fragment or backslash; a port or userinfo fails.
   ["a/b", "a", "a"],
   ["a?b", "a", "a"],
@@ -183,16 +177,14 @@ const hostParserParity = [
   ["-a.example", "-a.example", "-a.example"],
   ["ab--c.example", "ab--c.example", "ab--c.example"],
   ["r4---sn-a5mlrn7s.gevideo.com", "r4---sn-a5mlrn7s.gevideo.com", "r4---sn-a5mlrn7s.gevideo.com"],
-  // UTS #46 mapping, deviation characters (nontransitional) and CONTEXTJ.
+  // UTS #46 mapping, deviation characters (nontransitional) and CONTEXTJ. A non-ASCII host still goes through
+  // the full UTS #46 processing, so an xn-- label with a non-ASCII character in it fails.
   ["x\u200bn--a.example", "", ""],
   ["xn--te\u0161la", "", ""],
-  ["\ufffd.example", "", ""],
   ["fa\u00df.de", "xn--fa-hia.de", "fa\u00df.de"],
   ["\u0130.com", "xn--i-9bb.com", "i\u0307.com"],
   ["\u03c2.com", "xn--3xa.com", "\u03c2.com"],
-  ["\u0dc1\u0dca\u200d\u0dbb\u0dd3", "xn--10cl1a0b660p", "\u0dc1\u0dca\u200d\u0dbb\u0dd3"],
   ["\u30c6\u30b9\u30c8.example", "xn--zckzah.example", "\u30c6\u30b9\u30c8.example"],
-  ["\u200d.example", "", ""],
   ["look\u200cout.net", "", ""],
   ["", "", ""],
 ];
@@ -206,25 +198,6 @@ describe("WHATWG host parser parity", () => {
       }).toEqual({ ascii, unicode });
     });
   }
-
-  test("a host longer than the IDNA conversion's initial buffer", () => {
-    // The conversion runs with a 256 code unit buffer first and is retried with a larger one; the retry has to
-    // produce both the converted host and, for an invalid label, the failure.
-    const filler = Buffer.alloc(1000, "a").toString();
-    const valid = `xn--bcher-kva.${filler}.de`;
-    const invalid = `xn--a-ecp.${filler}.de`;
-    expect({
-      validASCII: url.domainToASCII(valid),
-      validUnicode: url.domainToUnicode(valid),
-      invalidASCII: url.domainToASCII(invalid),
-      invalidUnicode: url.domainToUnicode(invalid),
-    }).toEqual({
-      validASCII: valid,
-      validUnicode: `b\u00fccher.${filler}.de`,
-      invalidASCII: "",
-      invalidUnicode: "",
-    });
-  });
 });
 
 // Unicode 16 moved these code points from disallowed to mapped or ignored. ICU 76 is the first release with that

--- a/test/js/node/url/url-domain-ascii-unicode.test.js
+++ b/test/js/node/url/url-domain-ascii-unicode.test.js
@@ -96,7 +96,150 @@ describe("url.domainToUnicode", () => {
   }
   for (const [input, expected] of invalids) {
     test(`-> '${input}' is '${expected}'`, () => {
-      expect(url.domainToASCII(input)).toEqual(expected);
+      expect(url.domainToUnicode(input)).toEqual(expected);
     });
   }
+});
+
+// Node implements both functions as a WHATWG host parse of the input (the hostname setter on a "ws://x" URL)
+// and returns "" when that parse fails, so punycode validation, percent-decoding, IPv4/IPv6 canonicalization
+// and the authority terminators all apply. Rows are [input, domainToASCII(input), domainToUnicode(input)]
+// as produced by Node 26.
+const hostParserParity = [
+  // Punycode labels are decoded and validated; one invalid label fails the whole host.
+  ["xn--a-ecp.example", "", ""],
+  ["sub.xn--a-ecp.example", "", ""],
+  ["XN--A-ECP.example", "", ""],
+  ["xn--a-ecp.xn--fiqs8s", "", ""],
+  ["xn--pokxncvks", "", ""],
+  ["xn--a", "", ""],
+  ["xn--a.example", "", ""],
+  ["xn--a.xn--nxa", "", ""],
+  ["xn--zn7c.com", "", ""],
+  ["xn--", "", ""],
+  ["xn--.example", "", ""],
+  ["a.xn--", "", ""],
+  ["xn--1ug.example", "", ""],
+  // Valid punycode is kept (lowercased); a label that merely contains "xn--" is not punycode.
+  ["xn--bcher-kva.de", "xn--bcher-kva.de", "b\u00fccher.de"],
+  ["XN--BCHER-KVA.DE", "xn--bcher-kva.de", "b\u00fccher.de"],
+  ["xn--fiqs8s", "xn--fiqs8s", "\u4e2d\u56fd"],
+  ["xn--ls8h.example", "xn--ls8h.example", "\u{1f4a9}.example"],
+  ["xn--6qqa088eba", "xn--6qqa088eba", "\u4f60\u597d\u4f60\u597d"],
+  ["axn--a-ecp.example", "axn--a-ecp.example", "axn--a-ecp.example"],
+  // Forbidden host code points: %, C0 controls, DEL, space.
+  ["a%b", "", ""],
+  ["%", "", ""],
+  ["%ZZ", "", ""],
+  ["a\x01b", "", ""],
+  ["a\x0cb", "", ""],
+  ["a\x7fb", "", ""],
+  ["a b", "", ""],
+  [" a ", "", ""],
+  // Percent-decoding happens before IDNA.
+  ["%41", "a", "a"],
+  ["ex%61mple.com", "example.com", "example.com"],
+  ["%e4%bd%a0%e5%a5%bd", "xn--6qq79v", "\u4f60\u597d"],
+  ["%zz%66%a", "", ""],
+  // ASCII lowercasing.
+  ["EXAMPLE.COM", "example.com", "example.com"],
+  // IPv4 canonicalization and rejection.
+  ["0x7f.1", "127.0.0.1", "127.0.0.1"],
+  ["0x7f.0x0.0x0.0x1", "127.0.0.1", "127.0.0.1"],
+  ["192.168.1.1", "192.168.1.1", "192.168.1.1"],
+  ["999.999.999.999", "", ""],
+  ["1.2.3.4.5", "", ""],
+  ["09.1", "", ""],
+  // IPv6.
+  ["[::1]", "[::1]", "[::1]"],
+  ["[0:0:0:0:0:0:0:1]", "[::1]", "[::1]"],
+  ["[::ffff:127.0.0.1]", "[::ffff:7f00:1]", "[::ffff:7f00:1]"],
+  ["[", "", ""],
+  ["[:", "", ""],
+  ["[::1]:80", "", ""],
+  // Tabs and newlines are removed before IDNA runs, so they never end up inside a punycode label.
+  ["ex\tample.com", "example.com", "example.com"],
+  ["a\r\nb", "ab", "ab"],
+  ["b\t\u00fccher.de", "xn--bcher-kva.de", "b\u00fccher.de"],
+  ["\u00df\nxn", "xn--xn-fia", "\u00dfxn"],
+  ["\u03c2a\nxn--bcher-kva", "xn--axn--bcher-kva-phk", "\u03c2axn--bcher-kva"],
+  // The host ends at the first path, query, fragment or backslash; a port or userinfo fails.
+  ["a/b", "a", "a"],
+  ["a?b", "a", "a"],
+  ["a#b", "a", "a"],
+  ["a\\b", "a", "a"],
+  ["a:80", "", ""],
+  ["a@b", "", ""],
+  // Valid domains are preserved (CheckHyphens and VerifyDnsLength are off).
+  ["example.com", "example.com", "example.com"],
+  ["b\u00fccher.de", "xn--bcher-kva.de", "b\u00fccher.de"],
+  ["\u00e7.com", "xn--7ca.com", "\u00e7.com"],
+  ["a..b", "a..b", "a..b"],
+  [".", ".", "."],
+  ["..", "..", ".."],
+  ["example.com.", "example.com.", "example.com."],
+  ["a_b.example", "a_b.example", "a_b.example"],
+  ["a-.example", "a-.example", "a-.example"],
+  ["-a.example", "-a.example", "-a.example"],
+  ["ab--c.example", "ab--c.example", "ab--c.example"],
+  ["r4---sn-a5mlrn7s.gevideo.com", "r4---sn-a5mlrn7s.gevideo.com", "r4---sn-a5mlrn7s.gevideo.com"],
+  // UTS #46 mapping, deviation characters (nontransitional) and CONTEXTJ.
+  ["x\u200bn--a.example", "", ""],
+  ["xn--te\u0161la", "", ""],
+  ["\ufffd.example", "", ""],
+  ["fa\u00df.de", "xn--fa-hia.de", "fa\u00df.de"],
+  ["\u0130.com", "xn--i-9bb.com", "i\u0307.com"],
+  ["\u03c2.com", "xn--3xa.com", "\u03c2.com"],
+  ["\u0dc1\u0dca\u200d\u0dbb\u0dd3", "xn--10cl1a0b660p", "\u0dc1\u0dca\u200d\u0dbb\u0dd3"],
+  ["\u30c6\u30b9\u30c8.example", "xn--zckzah.example", "\u30c6\u30b9\u30c8.example"],
+  ["\u200d.example", "", ""],
+  ["look\u200cout.net", "", ""],
+  ["", "", ""],
+];
+
+describe("WHATWG host parser parity", () => {
+  for (const [input, ascii, unicode] of hostParserParity) {
+    test(JSON.stringify(input), () => {
+      expect({
+        ascii: url.domainToASCII(input),
+        unicode: url.domainToUnicode(input),
+      }).toEqual({ ascii, unicode });
+    });
+  }
+
+  test("a host longer than the IDNA conversion's initial buffer", () => {
+    // The conversion runs with a 256 code unit buffer first and is retried with a larger one; the retry has to
+    // produce both the converted host and, for an invalid label, the failure.
+    const filler = Buffer.alloc(1000, "a").toString();
+    const valid = `xn--bcher-kva.${filler}.de`;
+    const invalid = `xn--a-ecp.${filler}.de`;
+    expect({
+      validASCII: url.domainToASCII(valid),
+      validUnicode: url.domainToUnicode(valid),
+      invalidASCII: url.domainToASCII(invalid),
+      invalidUnicode: url.domainToUnicode(invalid),
+    }).toEqual({
+      validASCII: valid,
+      validUnicode: `b\u00fccher.${filler}.de`,
+      invalidASCII: "",
+      invalidUnicode: "",
+    });
+  });
+});
+
+// Unicode 16 moved these code points from disallowed to mapped or ignored. ICU 76 is the first release with that
+// table; macOS links the system ICU, which can be older.
+describe.skipIf(parseInt(process.versions.icu) < 76)("Unicode 16 UTS #46 table", () => {
+  test("domainToASCII maps the reclassified code points", () => {
+    expect(
+      [
+        "\u04C0", // CYRILLIC LETTER PALOCHKA
+        "\u10AC", // GEORGIAN CAPITAL LETTER NAR
+        "\u2132", // TURNED CAPITAL F
+        "\u2183", // ROMAN NUMERAL REVERSED ONE HUNDRED
+        "a\u180Eb", // MONGOLIAN VOWEL SEPARATOR, now ignored
+        "a\u3164b", // HANGUL FILLER, now ignored
+      ].map(domain => url.domainToASCII(domain)),
+    ).toEqual(["xn--s5a", "xn--3kj", "xn--73g", "xn--r5g", "ab", "ab"]);
+  });
 });

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -154,34 +154,6 @@ describe("url", () => {
     ).toEqual(["xn--3kj", "xn--a-hws", "xn--73g", "xn--r5g", "xn--fc9a.xn----qmg097k469k", "ab", "ab"]);
   });
 
-  // "xn--a-ecp" is well-formed punycode for "a" + U+2488 (DIGIT ONE FULL STOP), which UTS #46 disallows;
-  // "xn--pokxncvks" does not decode at all. Both fail the way Node (ada) fails them.
-  it("rejects invalid xn-- labels, decodable or not, in every special scheme (like Node)", () => {
-    for (const scheme of ["http", "https", "ws", "wss", "ftp", "file"]) {
-      for (const host of ["xn--a-ecp.example", "sub.xn--a-ecp.example", "xn--a-ecp.xn--fiqs8s", "xn--pokxncvks"]) {
-        const input = `${scheme}://${host}/`;
-        expect(() => new URL(input)).toThrow(expect.objectContaining({ code: "ERR_INVALID_URL", input }));
-        expect(URL.canParse(input)).toBe(false);
-        expect(URL.parse(input)).toBeNull();
-      }
-    }
-    // Hosts of non-special schemes are opaque and never go through IDNA.
-    expect(new URL("foo://xn--a-ecp.example/").hostname).toBe("xn--a-ecp.example");
-    expect(new URL("foo://XN--A-ECP.example/").hostname).toBe("XN--A-ECP.example");
-  });
-
-  it("setters: href throws on an invalid xn-- label, host and hostname leave the URL unchanged", () => {
-    const url = new URL("http://ok.example/p?q#f");
-    expect(() => {
-      url.href = "http://xn--a-ecp.example/";
-    }).toThrow(expect.objectContaining({ code: "ERR_INVALID_URL" }));
-    url.host = "xn--a-ecp.example:8080";
-    url.hostname = "xn--a-ecp.example";
-    expect(url.href).toBe("http://ok.example/p?q#f");
-    url.host = "xn--bcher-kva.de:8080";
-    expect(url.href).toBe("http://xn--bcher-kva.de:8080/p?q#f");
-  });
-
   it("keeps valid xn-- labels, and hosts that only contain the letters xn--", () => {
     const accepted = {
       "http://xn--bcher-kva.de/": "xn--bcher-kva.de",
@@ -190,22 +162,14 @@ describe("url", () => {
       "http://xn--e1afmkfd.xn--p1ai/": "xn--e1afmkfd.xn--p1ai",
       // Not a punycode label: "xn--" is not at the start of it.
       "http://axn--a-ecp.example/": "axn--a-ecp.example",
-      // Invalid punycode outside the host does not fail the host.
+      // xn-- outside the host is not looked at. ("xn--a-ecp" is not valid punycode.)
       "http://xn--a-ecp@ok.example/": "ok.example",
       "http://user:pw@xn--bcher-kva.de:8080/xn--a-ecp?xn--a-ecp#xn--a-ecp": "xn--bcher-kva.de",
+      // Hosts of non-special schemes are opaque: no IDNA, not even lowercasing.
+      "foo://xn--a-ecp.example/": "xn--a-ecp.example",
+      "foo://XN--A-ECP.example/": "XN--A-ECP.example",
     };
     expect(Object.fromEntries(Object.keys(accepted).map(input => [input, new URL(input).hostname]))).toEqual(accepted);
-  });
-
-  it("validates xn-- hosts longer than the IDNA conversion's initial buffer", () => {
-    // The punycode check converts the host with a 256 code unit buffer first and retries with a larger one; the
-    // second attempt has to produce both the converted host and, for an invalid label, the error.
-    const filler = Buffer.alloc(1000, "a").toString();
-    const valid = `xn--bcher-kva.${filler}.de`;
-    expect(new URL(`http://${valid}/`).hostname).toBe(valid);
-    const invalid = `xn--a-ecp.${filler}.de`;
-    expect(() => new URL(`http://${invalid}/`)).toThrow(expect.objectContaining({ code: "ERR_INVALID_URL" }));
-    expect(URL.canParse(`http://${invalid}/`)).toBe(false);
   });
 
   it("rejects invalid punycode labels however they are spelled in the input (like Node)", () => {

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -138,6 +138,74 @@ describe("url", () => {
     const hn = new URL("http://x/");
     hn.hostname = "\u04C0.com";
     expect(hn.hostname).toBe("xn--s5a.com");
+
+    // Capitals whose UTS #46 status went from disallowed to mapped, and format
+    // controls that became ignored. Expected values are Node's.
+    expect(
+      [
+        "\u10AC", // GEORGIAN CAPITAL LETTER NAR
+        "a\u10B5", // GEORGIAN CAPITAL LETTER KHAR
+        "\u2132", // TURNED CAPITAL F
+        "\u2183", // ROMAN NUMERAL REVERSED ONE HUNDRED
+        "\uA846\u3002\u2183\u0FB5\uB1AE-", // WPT IdnaTestV2; U+3002 is a label separator
+        "a\u2061b", // FUNCTION APPLICATION
+        "a\u3164b", // HANGUL FILLER
+      ].map(host => new URL(`https://${host}/`).hostname),
+    ).toEqual(["xn--3kj", "xn--a-hws", "xn--73g", "xn--r5g", "xn--fc9a.xn----qmg097k469k", "ab", "ab"]);
+  });
+
+  // "xn--a-ecp" is well-formed punycode for "a" + U+2488 (DIGIT ONE FULL STOP), which UTS #46 disallows;
+  // "xn--pokxncvks" does not decode at all. Both fail the way Node (ada) fails them.
+  it("rejects invalid xn-- labels, decodable or not, in every special scheme (like Node)", () => {
+    for (const scheme of ["http", "https", "ws", "wss", "ftp", "file"]) {
+      for (const host of ["xn--a-ecp.example", "sub.xn--a-ecp.example", "xn--a-ecp.xn--fiqs8s", "xn--pokxncvks"]) {
+        const input = `${scheme}://${host}/`;
+        expect(() => new URL(input)).toThrow(expect.objectContaining({ code: "ERR_INVALID_URL", input }));
+        expect(URL.canParse(input)).toBe(false);
+        expect(URL.parse(input)).toBeNull();
+      }
+    }
+    // Hosts of non-special schemes are opaque and never go through IDNA.
+    expect(new URL("foo://xn--a-ecp.example/").hostname).toBe("xn--a-ecp.example");
+    expect(new URL("foo://XN--A-ECP.example/").hostname).toBe("XN--A-ECP.example");
+  });
+
+  it("setters: href throws on an invalid xn-- label, host and hostname leave the URL unchanged", () => {
+    const url = new URL("http://ok.example/p?q#f");
+    expect(() => {
+      url.href = "http://xn--a-ecp.example/";
+    }).toThrow(expect.objectContaining({ code: "ERR_INVALID_URL" }));
+    url.host = "xn--a-ecp.example:8080";
+    url.hostname = "xn--a-ecp.example";
+    expect(url.href).toBe("http://ok.example/p?q#f");
+    url.host = "xn--bcher-kva.de:8080";
+    expect(url.href).toBe("http://xn--bcher-kva.de:8080/p?q#f");
+  });
+
+  it("keeps valid xn-- labels, and hosts that only contain the letters xn--", () => {
+    const accepted = {
+      "http://xn--bcher-kva.de/": "xn--bcher-kva.de",
+      "http://XN--BCHER-KVA.DE/": "xn--bcher-kva.de",
+      "http://xn--fiqs8s/": "xn--fiqs8s",
+      "http://xn--e1afmkfd.xn--p1ai/": "xn--e1afmkfd.xn--p1ai",
+      // Not a punycode label: "xn--" is not at the start of it.
+      "http://axn--a-ecp.example/": "axn--a-ecp.example",
+      // Invalid punycode outside the host does not fail the host.
+      "http://xn--a-ecp@ok.example/": "ok.example",
+      "http://user:pw@xn--bcher-kva.de:8080/xn--a-ecp?xn--a-ecp#xn--a-ecp": "xn--bcher-kva.de",
+    };
+    expect(Object.fromEntries(Object.keys(accepted).map(input => [input, new URL(input).hostname]))).toEqual(accepted);
+  });
+
+  it("validates xn-- hosts longer than the IDNA conversion's initial buffer", () => {
+    // The punycode check converts the host with a 256 code unit buffer first and retries with a larger one; the
+    // second attempt has to produce both the converted host and, for an invalid label, the error.
+    const filler = Buffer.alloc(1000, "a").toString();
+    const valid = `xn--bcher-kva.${filler}.de`;
+    expect(new URL(`http://${valid}/`).hostname).toBe(valid);
+    const invalid = `xn--a-ecp.${filler}.de`;
+    expect(() => new URL(`http://${invalid}/`)).toThrow(expect.objectContaining({ code: "ERR_INVALID_URL" }));
+    expect(URL.canParse(`http://${invalid}/`)).toBe(false);
   });
 
   it("rejects invalid punycode labels however they are spelled in the input (like Node)", () => {


### PR DESCRIPTION
### Problem
- `url.domainToASCII("\t[::1]")` and `url.domainToUnicode("[::1]\n")` return `""` in Bun; Node returns `"[::1]"` for both (26.3 and 26.7). `"\t[::1]"` as a hostname also parses fine in Bun's own `new URL("ws://\t[::1]/")`, so the two entry points disagree with each other as well.
- Cause: `parseDomainAsHost` (src/jsc/bindings/NodeURL.cpp) looks for the IPv6 brackets and for `:` / `@` in the raw input before handing it to `WTF::URL`. The basic URL parser removes ASCII tab and newline from its input before anything else, and `WTF::URL` does, but these checks ran first, so `"\t[::1]"` failed the `:` check and `"[::1]\n"` failed the closing bracket check. Tab or newline inside the brackets, or in a domain name, already worked because only `WTF::URL` saw them.
- Second part, test coverage: #33201, #34731 and #33206 were closed today because #34660, #38013 and #39273 landed the behaviour they implemented. Their tables contained cases the tests on main do not have, and this PR keeps the ones that are still worth having (details below).

### Fix
- `parseDomainAsHost` strips tab, LF and CR from the input before the terminator scan and the bracket / `:` / `@` checks. That is the order the host parse Node runs (ada's `set_hostname`) uses; for the 24 tab/newline inputs in the details block Bun now prints the same as Node 26.7 byte for byte. Inputs without those characters take `removeCharacters`' no-copy path and are unaffected; the other callers of the two functions (`url.format`, `fileURLToPath`) pass hostnames taken from parsed URLs, which never contain them.
- `test/js/node/url/url-domain-ascii-unicode.test.js`: the new `"\t[::1]"`, `"[::1]\n"` and `"\t[::1]\r\n"` rows fail on main (`""`) and pass with the change. The rest of the `hostParserParity` table pins the host-parse semantics of `domainToASCII`/`domainToUnicode` that nothing on main covered: percent-decoding before IDNA, forbidden code points, IPv4 and IPv6 canonicalization, the `/ ? # \` terminators, port and userinfo failing, direct `domainToUnicode` outputs. The existing `domainToUnicode` invalid-input loop called `domainToASCII`; it now calls `domainToUnicode`. A Unicode 16 test is added under the same `process.versions.icu < 76` skip the other Unicode 16 tests use.
- `test/js/web/url/url.test.ts`: more Unicode 16 code points in the existing test, plus a table of hosts that must keep parsing: valid `xn--` labels, a label that merely contains `xn--`, `xn--` in userinfo / path / query / fragment, and opaque hosts of non-special schemes.
- Scope note: the tables deliberately contain no row asserting that an all-ASCII host with an invalid `xn--` label is rejected. The URL Standard (whatwg/url a8d5ca3716), WPT (b63305b743) and ada 4.0, shipped in Node 26.7, changed in June to August to accept such hosts (`domainToASCII("xn--a")` is `"xn--a"` in Node 26.7, `""` in 26.3). Bun's `hasValidPunycodeHost` from #34660 still rejects them, as do the WPT fixtures vendored from Node 26.3, so adding more tests for the rejection would only make following upstream harder; whether to follow it is a separate decision (it also affects #39404). Every expected value in this PR holds in Node 26.3 and Node 26.7 (checked with both binaries).
- Verified: `bun bd test test/js/node/url/url-domain-ascii-unicode.test.js` (200 pass; 3 fail without the `NodeURL.cpp` change), `bun bd test test/js/web/url/url.test.ts` (25 pass), the vendored `test-url-domain-ascii-unicode.js`, `test-whatwg-url-custom-domainto.js`, `test-whatwg-url-toascii.js`, `test-url-fileurltopath.js` and `test-url-format-whatwg.js` pass. `bun bd test test/js/node/url test/js/web/url` has one failure, the pre-existing `url-canParse-whatwg.test.js` 5s timeout under the debug build, identical without this change.
- Not changed here: `url.hostname = "\t[::1]"` (and `url.host =`) is still a no-op in Bun while Node sets `[::1]`; that one is inside `WTF::URL::setHost`, a different code path, and everything else in that area (`"\texample.com"`, `"[::1]\n"`, `"\t[::1]:81"`) already matches.

### Background
- `url.domainToASCII` / `domainToUnicode` are defined by Node as: take a `ws://x` URL, set its hostname to the input, return the resulting hostname, or `""` if the setter failed. That is why percent-decoding, IP address canonicalization, the authority terminators and tab/newline removal all show up in their results. Bun implements the same thing in `parseDomainAsHost` with a few pre-checks in front of `WTF::URL` (the hostname setter rejects ports, and `a@b` would otherwise parse as userinfo).
- Basic URL parser: the WHATWG algorithm behind `new URL()` and the setters. Its first step removes every ASCII tab, LF and CR from the input; everything after that, including the host parser, never sees them.
- Punycode / `xn--` label: the ASCII form of an internationalized label. UTS #46 defines which ones are valid; a non-ASCII host still goes through full UTS #46 processing everywhere (Bun, Node 26.3, Node 26.7), which is what the table's `xn--te\u0161la` row pins. What changed upstream is only the treatment of hosts that are entirely ASCII.
- Unicode 16 changed the UTS #46 status of some code points from disallowed to mapped or ignored; ICU 76 is the first release with that table. Linux and Windows builds bundle ICU 78, macOS links the system ICU, so those assertions skip when `process.versions.icu` is older.

<details>
<summary>domainToASCII / domainToUnicode with tab and newline, before and after (Node 26.3 and 26.7 agree with the "after" column on every line)</summary>

```
input              before           after
"\t[::1]"          "" / ""          "[::1]" / "[::1]"
"\n[::1]"          "" / ""          "[::1]" / "[::1]"
"\r[::1]"          "" / ""          "[::1]" / "[::1]"
"[::1]\t"          "" / ""          "[::1]" / "[::1]"
"[::1]\n"          "" / ""          "[::1]" / "[::1]"
"[::1]\r\n"        "" / ""          "[::1]" / "[::1]"
"\t[::1]\n"        "" / ""          "[::1]" / "[::1]"
"[\t::1]"          "[::1]"          unchanged
"[::1\t]"          "[::1]"          unchanged
"[::\n1]"          "[::1]"          unchanged
"\t[::1]:80"       ""               unchanged (port still fails)
"[::1]\t:80"       ""               unchanged
"a\t:80"           ""               unchanged
"a\t@b"            ""               unchanged
"\t0x7f.1"         "127.0.0.1"      unchanged
"0x7f.1\n"         "127.0.0.1"      unchanged
"\texample.com"    "example.com"    unchanged
"example.com\n"    "example.com"    unchanged
"\t[", "[\n", "\t[:", "\t", "\n", "\t\n\r"   ""   unchanged
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/url/url-domain-ascii-unicode.test.js test/js/web/url/url.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/web/url/url.test.ts:
(pass) url > URL throws [11.43ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [9.36ms]
(pass) url > should have correct origin and protocol [11.46ms]
(pass) url > blob urls [7.25ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [7.93ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [8.66ms]
(pass) url > keeps valid xn-- labels, and hosts that only contain the letters xn-- [8.51ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [21.00ms]
(pass) url > prints [98.54ms]
(pass) url > URLContext offsets account for the /. pathname guard [45.74ms]
(pass) url > works [12.51ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [1.59ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined) [0.35ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:b) [0.62ms]
(pass) url > URL.canParse > UR
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (5be43fb35)

test/js/web/url/url.test.ts:
(pass) url > URL throws [0.14ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [0.12ms]
(pass) url > should have correct origin and protocol [0.10ms]
(pass) url > blob urls [0.06ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [0.08ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [0.14ms]
(pass) url > keeps valid xn-- labels, and hosts that only contain the letters xn-- [0.11ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [0.21ms]
(pass) url > prints [1.88ms]
(pass) url > URLContext offsets account for the /. pathname guard [0.68ms]
(pass) url > works [0.13ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [0.02ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined)
(pass) url > URL.canParse > URL.canParse(undefined, a:b)
(pass) url > URL.canParse > URL.canParse(a:/b, undefined)
(pass) url > URL.canParse > URL.canParse(undefined, a:/b)
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined)
(pass) url > URL.canParse > URL.canParse(a, https://b/)
(pass) url > 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/url/url-domain-ascii-unicode.test.js test/js/web/url/url.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/web/url/url.test.ts:
(pass) url > URL throws [11.30ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [9.41ms]
(pass) url > should have correct origin and protocol [11.40ms]
(pass) url > blob urls [7.45ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [7.61ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [8.69ms]
(pass) url > keeps valid xn-- labels, and hosts that only contain the letters xn-- [8.35ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [20.93ms]
(pass) url > prints [98.48ms]
(pass) url > URLContext offsets account for the /. pathname guard [45.20ms]
(pass) url > works [12.24ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [1.65ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined) [0.32ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:b) [0.27ms]
(pass) url > URL.canParse > UR
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     15eb75fb92
  features     baseline

22 deps, 120 codegen, 1175 objects in 635ms

ninja: Entering directory `/workspace/bun/build/release'
[1/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[2/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[3/13] cxx obj/src/jsc/bindings/bindings.cpp.o
[4/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[5/13] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[6/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[7/13] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[8/13] gen cpp.rs (cppbind)
[8/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m std v0.0.0 (/root/.rustup/toolchains/nightly-2026-07-20-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std)
[1m[92m   Compiling[0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NodeURL.cpp                      |   5 +-
 test/js/node/url/url-domain-ascii-unicode.test.js | 118 +++++++++++++++++++++-
 test/js/web/url/url.test.ts                       |  32 ++++++
 3 files changed, 153 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/bindings/NodeURL.cpp                           3      4      0
test/js/node/url/url-domain-ascii-unicode.test.js      4      6      0
test/js/web/url/url.test.ts                            4      6      0
```

</details>

<!-- robobun:evidence:end -->