### PR TITLE
JSSink: install the pump controller before the pump runs (HTMLRewriter segfault when a handler throws inside transform())

### DIFF
--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -959,15 +959,14 @@ extern "C" void* ${name}__fromJS(JSC::EncodedJSValue value)
     return (void*)1;
 }
 
-extern "C" JSC::EncodedJSValue ${name}__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue stream, void* sinkPtr, void **controllerValue)
+// JSSink::assign_to_stream (Sink.rs): records the controller as the sink's source, then pumps via JSSinkController__assignToStream.
+extern "C" JSC::EncodedJSValue ${name}__createController(JSC::JSGlobalObject* arg0, void* sinkPtr)
 {
     auto& vm = arg0->vm();
     Zig::GlobalObject* globalObject = reinterpret_cast<Zig::GlobalObject*>(arg0);
 
     JSC::Structure* structure = WebCore::getDOMStructure<WebCore::${controller}>(vm, *globalObject);
-    WebCore::${controller} *controller = WebCore::${controller}::create(vm, globalObject, structure, sinkPtr, 0);
-    *controllerValue = reinterpret_cast<void*>(JSC::JSValue::encode(controller));
-    return globalObject->assignToStream(JSC::JSValue::decode(stream), controller);
+    return JSC::JSValue::encode(WebCore::${controller}::create(vm, globalObject, structure, sinkPtr, 0));
 }
 
 `;
@@ -1018,6 +1017,12 @@ extern "C" void JSSinkController__onClose(JSC::EncodedJSValue controllerValue, J
     arguments.append(JSC::JSValue::decode(reason));
     AsyncContextFrame::call(globalObject, function, JSC::jsUndefined(), arguments);
     RELEASE_AND_RETURN(scope, void());
+}
+
+extern "C" JSC::EncodedJSValue JSSinkController__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue stream, JSC::EncodedJSValue controllerValue)
+{
+    Zig::GlobalObject* globalObject = reinterpret_cast<Zig::GlobalObject*>(arg0);
+    return globalObject->assignToStream(JSC::JSValue::decode(stream), JSC::JSValue::decode(controllerValue));
 }
 
 extern "C" void JSSinkController__detachPtr(JSC::EncodedJSValue controllerValue)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3062,8 +3062,9 @@ EncodedJSValue GlobalObject::assignToStream(JSValue stream, JSValue controller)
     auto* readableStream = dynamicDowncast<WebCore::JSReadableStream>(stream);
     if (!readableStream) [[unlikely]]
         return JSC::JSValue::encode(JSC::Exception::create(vm, createTypeError(this, "Expected a ReadableStream"_s)));
-    // The generated `${Sink}__assignToStream` caller expects any failure returned as the
-    // encoded Exception cell, never left pending on the VM.
+    // The native caller (JSSink::assign_to_stream, via the generated
+    // JSSinkController__assignToStream) expects any failure returned as the encoded
+    // Exception cell, never left pending on the VM.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue result = Bun::WebStreams::assignToStream(this, readableStream, controller);
     if (auto* exception = scope.exception()) [[unlikely]] {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3062,9 +3062,8 @@ EncodedJSValue GlobalObject::assignToStream(JSValue stream, JSValue controller)
     auto* readableStream = dynamicDowncast<WebCore::JSReadableStream>(stream);
     if (!readableStream) [[unlikely]]
         return JSC::JSValue::encode(JSC::Exception::create(vm, createTypeError(this, "Expected a ReadableStream"_s)));
-    // The native caller (JSSink::assign_to_stream, via the generated
-    // JSSinkController__assignToStream) expects any failure returned as the encoded
-    // Exception cell, never left pending on the VM.
+    // The native caller (JSSinkController__assignToStream) expects any failure returned as the
+    // encoded Exception cell, never left pending on the VM.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue result = Bun::WebStreams::assignToStream(this, readableStream, controller);
     if (auto* exception = scope.exception()) [[unlikely]] {

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -458,7 +458,6 @@ extern "C" JSC::EncodedJSValue SYSV_ABI Bun__Path__toNamespacedPath(JSC::JSGloba
 
 #endif
 
-CPP_DECL JSC::EncodedJSValue ArrayBufferSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
 CPP_DECL JSC::EncodedJSValue ArrayBufferSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
 
 #ifdef __cplusplus
@@ -474,7 +473,6 @@ ZIG_DECL void ArrayBufferSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(ArrayBufferSink__write);
 
 #endif
-CPP_DECL JSC::EncodedJSValue HTTPSResponseSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
 CPP_DECL JSC::EncodedJSValue HTTPSResponseSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
 
 #ifdef __cplusplus
@@ -490,7 +488,6 @@ ZIG_DECL void HTTPSResponseSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(HTTPSResponseSink__write);
 
 #endif
-CPP_DECL JSC::EncodedJSValue HTTPResponseSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
 CPP_DECL JSC::EncodedJSValue HTTPResponseSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
 
 #ifdef __cplusplus
@@ -506,7 +503,6 @@ ZIG_DECL void HTTPResponseSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(HTTPResponseSink__write);
 
 #endif
-CPP_DECL JSC::EncodedJSValue FileSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
 CPP_DECL JSC::EncodedJSValue FileSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
 
 #ifdef __cplusplus
@@ -523,7 +519,6 @@ BUN_DECLARE_HOST_FUNCTION(FileSink__write);
 
 #endif
 
-CPP_DECL JSC::EncodedJSValue FileSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
 CPP_DECL JSC::EncodedJSValue FileSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
 
 #ifdef __cplusplus
@@ -539,7 +534,6 @@ ZIG_DECL void FileSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(FileSink__write);
 
 #endif
-CPP_DECL JSC::EncodedJSValue NetworkSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
 CPP_DECL JSC::EncodedJSValue NetworkSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
 CPP_DECL void* NetworkSink__fromJS(JSC::EncodedJSValue JSValue1);
 
@@ -556,7 +550,6 @@ ZIG_DECL void NetworkSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(NetworkSink__write);
 #endif
 
-CPP_DECL JSC::EncodedJSValue H3ResponseSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
 CPP_DECL JSC::EncodedJSValue H3ResponseSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
 CPP_DECL void* H3ResponseSink__fromJS(JSC::EncodedJSValue JSValue1);
 
@@ -573,7 +566,6 @@ ZIG_DECL void H3ResponseSink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(H3ResponseSink__write);
 #endif
 
-CPP_DECL JSC::EncodedJSValue FetchRequestBodySink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
 CPP_DECL JSC::EncodedJSValue FetchRequestBodySink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
 CPP_DECL void* FetchRequestBodySink__fromJS(JSC::EncodedJSValue JSValue1);
 
@@ -590,7 +582,6 @@ ZIG_DECL void FetchRequestBodySink__updateRef(void* arg0, bool arg1);
 BUN_DECLARE_HOST_FUNCTION(FetchRequestBodySink__write);
 #endif
 
-CPP_DECL JSC::EncodedJSValue HTMLRewriterSink__assignToStream(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue1, void* arg2, void** arg3);
 CPP_DECL JSC::EncodedJSValue HTMLRewriterSink__createObject(JSC::JSGlobalObject* arg0, void* arg1, uintptr_t destructor);
 CPP_DECL void* HTMLRewriterSink__fromJS(JSC::EncodedJSValue JSValue1);
 

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -245,11 +245,9 @@ impl<T: JsSinkAbi> JSSink<T> {
         // Setup threw (e.g. a direct stream's `pull` getter): nothing will ever
         // end()/close() the controller, and its destructor would otherwise run
         // `${name}__finalize` on the sink after the caller has freed it. Detach
-        // it while `ptr` is live (a no-op if it already detached in the call).
+        // it while `ptr` is live; that reaches `js_controller_detached`, which
+        // drops it from `source()` (a no-op if it already detached in the call).
         if result.to_error().is_some() {
-            if let Some(src) = ptr.source() {
-                src.clear();
-            }
             let _ = ::bun_jsc::call_check_slow(global, || {
                 streams::controller_abi::detach_ptr(controller)
             });

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -227,6 +227,19 @@ impl<T: JsSinkAbi> JSSink<T> {
         }
     }
 
+    /// Pump `stream` into the sink through a `JSReadable*SinkController`
+    /// (`${abi}__assignToStream`), leaving that controller in the sink's
+    /// `source()` so the sink can `ready()`/`close()`/[`detach`](Self::detach)
+    /// it.
+    ///
+    /// The extern stores the controller through its out-pointer before it
+    /// starts the pump, and the pump may drain the whole stream, user code
+    /// included, before returning. A sink that fails during that drain
+    /// detaches whatever its `source()` holds at the time, so the out-pointer
+    /// is aimed straight at the `JSController` payload instead of at a local
+    /// that would only be copied into the slot afterwards. Until the store
+    /// lands the payload is `JSValue::ZERO`, which `SourceHandle::close`/
+    /// `ready` and [`Self::detach`] treat as "no controller yet".
     pub fn assign_to_stream(
         global: &crate::webcore::jsc::JSGlobalObject,
         stream: crate::webcore::jsc::JSValue,
@@ -237,45 +250,35 @@ impl<T: JsSinkAbi> JSSink<T> {
     {
         use crate::webcore::jsc::JSValue;
         // SAFETY: `ptr` is a live sink owned by the caller for this synchronous
-        // call; the pointer is only stashed in C++ `m_sinkPtr` and `source()` is
-        // read here synchronously.
+        // call; the pointer is only stashed in C++ `m_sinkPtr`, and the slot
+        // handed to the extern below lives inside it (or in this frame).
         let ptr = unsafe { ptr.as_mut() };
-        // Pre-seed JSController(ZERO) so a sync drain's __controllerDetached can match-and-clear;
-        // only install the real controller value if the placeholder survived.
-        if let Some(src) = ptr.source() {
+        let mut unsourced = streams::SourceHandle::None;
+        // `JSValue` is `repr(transparent)` over the encoded bits the extern
+        // stores.
+        let controller_slot: *mut JSValue = {
+            let src = ptr.source().unwrap_or(&mut unsourced);
             *src = streams::SourceHandle::JSController(JSValue::ZERO);
-        }
-        let mut bits: usize = 0;
+            match src {
+                streams::SourceHandle::JSController(slot) => slot,
+                _ => unreachable!(),
+            }
+        };
         let result = T::assign_to_stream_extern(
             global,
             stream,
             std::ptr::from_mut::<T>(ptr).cast::<c_void>(),
-            (&raw mut bits).cast::<*mut c_void>(),
+            controller_slot.cast::<*mut c_void>(),
         );
-        // `${name}__assignToStream` creates the JSReadable*SinkController with
-        // m_sinkPtr=ptr before calling into the stream pump. If the pump setup
-        // throws (e.g. a direct stream's `pull` getter), nothing ever calls
-        // end()/close() on the controller, so its destructor would run
-        // `${name}__finalize(m_sinkPtr)` after the caller has freed the sink.
-        // Detach it now while `ptr` is still live; the controller's later GC
-        // then sees m_sinkPtr==null and skips the native finalize.
-        if bits != 0 && result.to_error().is_some() {
-            if let Some(src) = ptr.source() {
-                *src = streams::SourceHandle::None;
-            }
-            let _ = ::bun_jsc::call_check_slow(global, || {
-                streams::controller_abi::detach_ptr(JSValue::from_encoded(bits))
-            });
-            return result;
-        }
-        if let Some(src) = ptr.source() {
-            if matches!(*src, streams::SourceHandle::JSController(_)) {
-                *src = if bits != 0 {
-                    streams::SourceHandle::JSController(JSValue::from_encoded(bits))
-                } else {
-                    streams::SourceHandle::None
-                };
-            }
+        // The controller was created with m_sinkPtr=ptr before the pump
+        // started. If the pump setup throws (e.g. a direct stream's `pull`
+        // getter), nothing ever calls end()/close() on it, so its destructor
+        // would run `${name}__finalize(m_sinkPtr)` after the caller has freed
+        // the sink. Detach it now while `ptr` is still live; a controller that
+        // detached inside the call already cleared the slot
+        // (`js_controller_detached`), and this is then a no-op.
+        if result.to_error().is_some() {
+            Self::detach(ptr.source().unwrap_or(&mut unsourced), global);
         }
         result
     }
@@ -285,6 +288,10 @@ impl<T: JsSinkAbi> JSSink<T> {
         match *source {
             SourceHandle::JSController(value) => {
                 source.clear();
+                // `assign_to_stream` has not received the controller yet.
+                if value == JSValue::ZERO {
+                    return;
+                }
                 value.unprotect();
                 // detachPtr leaves m_needExceptionCheck set; wrap to satisfy the verifier.
                 let _ = ::bun_jsc::call_check_slow(_global, || {
@@ -641,13 +648,9 @@ impl<T: JsSinkType> JSSink<T> {
     /// but only when it still holds this controller's bits — a sink
     /// re-assigned to a new stream holds the newer controller's bits.
     pub(crate) fn js_controller_detached(this: &mut T, controller: crate::webcore::jsc::JSValue) {
-        use crate::webcore::jsc::JSValue;
         if let Some(src) = this.source() {
-            if let SourceHandle::JSController(held) = *src {
-                // ZERO = assign_to_stream placeholder; clear it too.
-                if held == controller || held == JSValue::ZERO {
-                    src.clear();
-                }
+            if matches!(*src, SourceHandle::JSController(held) if held == controller) {
+                src.clear();
             }
         }
         this.controller_detached();

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -66,12 +66,10 @@ macro_rules! decl_js_sink_externs {
                 ) -> ::bun_jsc::JSValue;
                 #[link_name = concat!($abi, "__setDestroyCallback")]
                 pub(crate) safe fn set_destroy_callback(v: ::bun_jsc::JSValue, cb: usize);
-                #[link_name = concat!($abi, "__assignToStream")]
-                pub(crate) safe fn assign_to_stream(
+                #[link_name = concat!($abi, "__createController")]
+                pub(crate) safe fn create_controller(
                     g: &::bun_jsc::JSGlobalObject,
-                    s: ::bun_jsc::JSValue,
                     p: *mut ::core::ffi::c_void,
-                    jp: *mut *mut ::core::ffi::c_void,
                 ) -> ::bun_jsc::JSValue;
             }
         }
@@ -100,13 +98,11 @@ macro_rules! impl_js_sink_abi {
                 fn set_destroy_callback_extern(value: ::bun_jsc::JSValue, callback: usize) {
                     __abi::set_destroy_callback(value, callback)
                 }
-                fn assign_to_stream_extern(
+                fn create_controller_extern(
                     global: &::bun_jsc::JSGlobalObject,
-                    stream: ::bun_jsc::JSValue,
                     ptr: *mut ::core::ffi::c_void,
-                    jsvalue_ptr: *mut *mut ::core::ffi::c_void,
                 ) -> ::bun_jsc::JSValue {
-                    __abi::assign_to_stream(global, stream, ptr, jsvalue_ptr)
+                    __abi::create_controller(global, ptr)
                 }
             }
         };
@@ -180,14 +176,12 @@ pub trait JsSinkAbi {
     ) -> crate::webcore::jsc::JSValue;
     /// `${abi_name}__setDestroyCallback`.
     fn set_destroy_callback_extern(value: crate::webcore::jsc::JSValue, callback: usize);
-    /// `${abi_name}__assignToStream`. Safe wrapper: takes `&JSGlobalObject` and
-    /// performs the `as_ptr()` projection internally so the FFI call is the
-    /// impl body's sole guarded operation.
-    fn assign_to_stream_extern(
+    /// `${abi_name}__createController`: a `JSReadable*SinkController` cell
+    /// holding `ptr` as its `m_sinkPtr`, for [`JSSink::assign_to_stream`] to
+    /// hand to the stream pump.
+    fn create_controller_extern(
         global: &crate::webcore::jsc::JSGlobalObject,
-        stream: crate::webcore::jsc::JSValue,
         ptr: *mut c_void,
-        jsvalue_ptr: *mut *mut c_void,
     ) -> crate::webcore::jsc::JSValue;
 }
 
@@ -227,19 +221,14 @@ impl<T: JsSinkAbi> JSSink<T> {
         }
     }
 
-    /// Pump `stream` into the sink through a `JSReadable*SinkController`
-    /// (`${abi}__assignToStream`), leaving that controller in the sink's
-    /// `source()` so the sink can `ready()`/`close()`/[`detach`](Self::detach)
-    /// it.
+    /// Pump `stream` into the sink through a new `JSReadable*SinkController`,
+    /// which the sink keeps as its `source()` to `ready()`/`close()`/
+    /// [`detach`](Self::detach) the pump.
     ///
-    /// The extern stores the controller through its out-pointer before it
-    /// starts the pump, and the pump may drain the whole stream, user code
-    /// included, before returning. A sink that fails during that drain
-    /// detaches whatever its `source()` holds at the time, so the out-pointer
-    /// is aimed straight at the `JSController` payload instead of at a local
-    /// that would only be copied into the slot afterwards. Until the store
-    /// lands the payload is `JSValue::ZERO`, which `SourceHandle::close`/
-    /// `ready` and [`Self::detach`] treat as "no controller yet".
+    /// The controller is installed before the pump starts: the pump writes
+    /// everything the stream has already queued (running user code on the
+    /// way) before `JSSinkController__assignToStream` returns, and a sink that
+    /// fails during that drain detaches whatever its `source()` holds.
     pub fn assign_to_stream(
         global: &crate::webcore::jsc::JSGlobalObject,
         stream: crate::webcore::jsc::JSValue,
@@ -248,37 +237,29 @@ impl<T: JsSinkAbi> JSSink<T> {
     where
         T: JsSinkType,
     {
-        use crate::webcore::jsc::JSValue;
         // SAFETY: `ptr` is a live sink owned by the caller for this synchronous
-        // call; the pointer is only stashed in C++ `m_sinkPtr`, and the slot
-        // handed to the extern below lives inside it (or in this frame).
+        // call; the pointer is only stashed in C++ `m_sinkPtr`.
         let ptr = unsafe { ptr.as_mut() };
-        let mut unsourced = streams::SourceHandle::None;
-        // `JSValue` is `repr(transparent)` over the encoded bits the extern
-        // stores.
-        let controller_slot: *mut JSValue = {
-            let src = ptr.source().unwrap_or(&mut unsourced);
-            *src = streams::SourceHandle::JSController(JSValue::ZERO);
-            match src {
-                streams::SourceHandle::JSController(slot) => slot,
-                _ => unreachable!(),
-            }
-        };
-        let result = T::assign_to_stream_extern(
-            global,
-            stream,
-            std::ptr::from_mut::<T>(ptr).cast::<c_void>(),
-            controller_slot.cast::<*mut c_void>(),
-        );
-        // The controller was created with m_sinkPtr=ptr before the pump
-        // started. If the pump setup throws (e.g. a direct stream's `pull`
-        // getter), nothing ever calls end()/close() on it, so its destructor
+        let controller =
+            T::create_controller_extern(global, std::ptr::from_mut::<T>(ptr).cast::<c_void>());
+        if let Some(src) = ptr.source() {
+            *src = streams::SourceHandle::JSController(controller);
+        }
+        let result = streams::controller_abi::assign_to_stream(global, stream, controller);
+        // If the pump setup throws (e.g. a direct stream's `pull` getter),
+        // nothing ever calls end()/close() on the controller, so its destructor
         // would run `${name}__finalize(m_sinkPtr)` after the caller has freed
-        // the sink. Detach it now while `ptr` is still live; a controller that
-        // detached inside the call already cleared the slot
-        // (`js_controller_detached`), and this is then a no-op.
+        // the sink. Detach it now while `ptr` is still live; the controller's
+        // later GC then sees m_sinkPtr==null and skips the native finalize.
+        // (detachPtr is a no-op for a controller that already detached inside
+        // the call.)
         if result.to_error().is_some() {
-            Self::detach(ptr.source().unwrap_or(&mut unsourced), global);
+            if let Some(src) = ptr.source() {
+                src.clear();
+            }
+            let _ = ::bun_jsc::call_check_slow(global, || {
+                streams::controller_abi::detach_ptr(controller)
+            });
         }
         result
     }
@@ -288,10 +269,6 @@ impl<T: JsSinkAbi> JSSink<T> {
         match *source {
             SourceHandle::JSController(value) => {
                 source.clear();
-                // `assign_to_stream` has not received the controller yet.
-                if value == JSValue::ZERO {
-                    return;
-                }
                 value.unprotect();
                 // detachPtr leaves m_needExceptionCheck set; wrap to satisfy the verifier.
                 let _ = ::bun_jsc::call_check_slow(_global, || {
@@ -641,11 +618,11 @@ impl<T: JsSinkType> JSSink<T> {
     /// controller stops being attached to this sink.
     ///
     /// `SourceHandle::JSController` stores the controller's encoded JSValue
-    /// bits (written by `__assignToStream`) without rooting the cell, so the
-    /// controller can be collected while the native sink still has a flush in
-    /// flight. Once the controller detaches or dies the source must never
-    /// fire again: `onClose`/`onReady` would decode a dead cell. Clear it,
-    /// but only when it still holds this controller's bits — a sink
+    /// bits (installed by [`JSSink::assign_to_stream`]) without rooting the
+    /// cell, so the controller can be collected while the native sink still
+    /// has a flush in flight. Once the controller detaches or dies the source
+    /// must never fire again: `onClose`/`onReady` would decode a dead cell.
+    /// Clear it, but only when it still holds this controller's bits — a sink
     /// re-assigned to a new stream holds the newer controller's bits.
     pub(crate) fn js_controller_detached(this: &mut T, controller: crate::webcore::jsc::JSValue) {
         if let Some(src) = this.source() {

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -176,9 +176,8 @@ pub trait JsSinkAbi {
     ) -> crate::webcore::jsc::JSValue;
     /// `${abi_name}__setDestroyCallback`.
     fn set_destroy_callback_extern(value: crate::webcore::jsc::JSValue, callback: usize);
-    /// `${abi_name}__createController`: a `JSReadable*SinkController` cell
-    /// holding `ptr` as its `m_sinkPtr`, for [`JSSink::assign_to_stream`] to
-    /// hand to the stream pump.
+    /// `${abi_name}__createController`: a `JSReadable*SinkController` with
+    /// `m_sinkPtr = ptr`.
     fn create_controller_extern(
         global: &crate::webcore::jsc::JSGlobalObject,
         ptr: *mut c_void,
@@ -222,13 +221,10 @@ impl<T: JsSinkAbi> JSSink<T> {
     }
 
     /// Pump `stream` into the sink through a new `JSReadable*SinkController`,
-    /// which the sink keeps as its `source()` to `ready()`/`close()`/
-    /// [`detach`](Self::detach) the pump.
-    ///
-    /// The controller is installed before the pump starts: the pump writes
-    /// everything the stream has already queued (running user code on the
-    /// way) before `JSSinkController__assignToStream` returns, and a sink that
-    /// fails during that drain detaches whatever its `source()` holds.
+    /// kept as the sink's `source()`. It is installed before the pump starts
+    /// because the pump drains whatever the stream already holds (user code
+    /// included) before returning, and a sink failing in there detaches its
+    /// `source()`.
     pub fn assign_to_stream(
         global: &crate::webcore::jsc::JSGlobalObject,
         stream: crate::webcore::jsc::JSValue,
@@ -246,13 +242,10 @@ impl<T: JsSinkAbi> JSSink<T> {
             *src = streams::SourceHandle::JSController(controller);
         }
         let result = streams::controller_abi::assign_to_stream(global, stream, controller);
-        // If the pump setup throws (e.g. a direct stream's `pull` getter),
-        // nothing ever calls end()/close() on the controller, so its destructor
-        // would run `${name}__finalize(m_sinkPtr)` after the caller has freed
-        // the sink. Detach it now while `ptr` is still live; the controller's
-        // later GC then sees m_sinkPtr==null and skips the native finalize.
-        // (detachPtr is a no-op for a controller that already detached inside
-        // the call.)
+        // Setup threw (e.g. a direct stream's `pull` getter): nothing will ever
+        // end()/close() the controller, and its destructor would otherwise run
+        // `${name}__finalize` on the sink after the caller has freed it. Detach
+        // it while `ptr` is live (a no-op if it already detached in the call).
         if result.to_error().is_some() {
             if let Some(src) = ptr.source() {
                 src.clear();
@@ -618,11 +611,11 @@ impl<T: JsSinkType> JSSink<T> {
     /// controller stops being attached to this sink.
     ///
     /// `SourceHandle::JSController` stores the controller's encoded JSValue
-    /// bits (installed by [`JSSink::assign_to_stream`]) without rooting the
-    /// cell, so the controller can be collected while the native sink still
-    /// has a flush in flight. Once the controller detaches or dies the source
-    /// must never fire again: `onClose`/`onReady` would decode a dead cell.
-    /// Clear it, but only when it still holds this controller's bits — a sink
+    /// bits (set by `assign_to_stream`) without rooting the cell, so the
+    /// controller can be collected while the native sink still has a flush in
+    /// flight. Once the controller detaches or dies the source must never
+    /// fire again: `onClose`/`onReady` would decode a dead cell. Clear it,
+    /// but only when it still holds this controller's bits — a sink
     /// re-assigned to a new stream holds the newer controller's bits.
     pub(crate) fn js_controller_detached(this: &mut T, controller: crate::webcore::jsc::JSValue) {
         if let Some(src) = this.source() {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -814,7 +814,8 @@ impl StreamResult {
 
 /// Generic controller externs (defined in the generated `JSSink.cpp`). Every
 /// `JSReadable*SinkController` shares the `JSReadableSinkControllerBase`
-/// layout, so one symbol per signal suffices for all sink kinds.
+/// layout, so one symbol per operation suffices for all sink kinds; only
+/// creating a controller (`${abi}__createController`) is per sink.
 pub(crate) mod controller_abi {
     unsafe extern "C" {
         #[link_name = "JSSinkController__onReady"]
@@ -827,6 +828,15 @@ pub(crate) mod controller_abi {
         pub(crate) safe fn on_close(c: ::bun_jsc::JSValue, reason: ::bun_jsc::JSValue);
         #[link_name = "JSSinkController__detachPtr"]
         pub(crate) safe fn detach_ptr(c: ::bun_jsc::JSValue);
+        /// Start pumping `stream` into the controller's sink. Returns
+        /// undefined (drained inline), the pump promise, or the Exception
+        /// cell if setup threw.
+        #[link_name = "JSSinkController__assignToStream"]
+        pub(crate) safe fn assign_to_stream(
+            g: &::bun_jsc::JSGlobalObject,
+            stream: ::bun_jsc::JSValue,
+            c: ::bun_jsc::JSValue,
+        ) -> ::bun_jsc::JSValue;
     }
 }
 
@@ -901,9 +911,8 @@ pub enum SourceHandle {
     /// No source attached.
     #[default]
     None,
-    /// Encoded `JSValue` of the C++ controller cell, stored straight into this
-    /// payload by `${abi}__assignToStream` (see `JSSink::assign_to_stream`).
-    /// `JSValue::ZERO` only while that store is still pending.
+    /// Encoded `JSValue` of the C++ controller cell pumping a JS
+    /// `ReadableStream` into the sink (`JSSink::assign_to_stream`).
     JSController(JSValue),
     ByteStream(BackRef<crate::webcore::ByteStream>),
     FileReader(BackRef<crate::webcore::FileReader>),
@@ -935,12 +944,7 @@ impl SourceHandle {
     pub fn close(&mut self, err: Option<SysError>) {
         match *self {
             SourceHandle::None => {}
-            // `JSController(ZERO)`: `assign_to_stream` has not received the
-            // controller yet, so there is no cell to notify.
             SourceHandle::JSController(cpp) => {
-                if cpp == JSValue::ZERO {
-                    return;
-                }
                 let global = VirtualMachine::get().global();
                 // A frame above is unwinding with its exception: not ours to run
                 // over. Otherwise the controller's close is settled here like a
@@ -971,9 +975,6 @@ impl SourceHandle {
         match *self {
             SourceHandle::None => {}
             SourceHandle::JSController(cpp) => {
-                if cpp == JSValue::ZERO {
-                    return;
-                }
                 let global = VirtualMachine::get().global();
                 if global.has_exception() {
                     return;
@@ -1188,13 +1189,8 @@ impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkAbi
     fn set_destroy_callback_extern(value: JSValue, callback: usize) {
         http_sink_dispatch!(set_destroy_callback(value, callback))
     }
-    fn assign_to_stream_extern(
-        global: &JSGlobalObject,
-        stream: JSValue,
-        ptr: *mut c_void,
-        jsvalue_ptr: *mut *mut c_void,
-    ) -> JSValue {
-        http_sink_dispatch!(assign_to_stream(global, stream, ptr, jsvalue_ptr))
+    fn create_controller_extern(global: &JSGlobalObject, ptr: *mut c_void) -> JSValue {
+        http_sink_dispatch!(create_controller(global, ptr))
     }
 }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -814,8 +814,7 @@ impl StreamResult {
 
 /// Generic controller externs (defined in the generated `JSSink.cpp`). Every
 /// `JSReadable*SinkController` shares the `JSReadableSinkControllerBase`
-/// layout, so one symbol per operation suffices for all sink kinds; only
-/// creating a controller (`${abi}__createController`) is per sink.
+/// layout, so one symbol per operation suffices for all sink kinds.
 pub(crate) mod controller_abi {
     unsafe extern "C" {
         #[link_name = "JSSinkController__onReady"]
@@ -828,9 +827,7 @@ pub(crate) mod controller_abi {
         pub(crate) safe fn on_close(c: ::bun_jsc::JSValue, reason: ::bun_jsc::JSValue);
         #[link_name = "JSSinkController__detachPtr"]
         pub(crate) safe fn detach_ptr(c: ::bun_jsc::JSValue);
-        /// Start pumping `stream` into the controller's sink. Returns
-        /// undefined (drained inline), the pump promise, or the Exception
-        /// cell if setup threw.
+        /// Returns undefined (drained inline), the pump promise, or the thrown Exception cell.
         #[link_name = "JSSinkController__assignToStream"]
         pub(crate) safe fn assign_to_stream(
             g: &::bun_jsc::JSGlobalObject,
@@ -911,8 +908,7 @@ pub enum SourceHandle {
     /// No source attached.
     #[default]
     None,
-    /// Encoded `JSValue` of the C++ controller cell pumping a JS
-    /// `ReadableStream` into the sink (`JSSink::assign_to_stream`).
+    /// The C++ controller cell of a JS-stream pump (`JSSink::assign_to_stream`).
     JSController(JSValue),
     ByteStream(BackRef<crate::webcore::ByteStream>),
     FileReader(BackRef<crate::webcore::FileReader>),

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -901,8 +901,9 @@ pub enum SourceHandle {
     /// No source attached.
     #[default]
     None,
-    /// Encoded `JSValue` of the C++ controller cell written by
-    /// `${abi}__assignToStream`. `JSValue::ZERO` is the pre-seed sentinel.
+    /// Encoded `JSValue` of the C++ controller cell, stored straight into this
+    /// payload by `${abi}__assignToStream` (see `JSSink::assign_to_stream`).
+    /// `JSValue::ZERO` only while that store is still pending.
     JSController(JSValue),
     ByteStream(BackRef<crate::webcore::ByteStream>),
     FileReader(BackRef<crate::webcore::FileReader>),
@@ -934,9 +935,8 @@ impl SourceHandle {
     pub fn close(&mut self, err: Option<SysError>) {
         match *self {
             SourceHandle::None => {}
-            // `JSController(ZERO)` is the `assign_to_stream` pre-seed
-            // placeholder; the real controller value hasn't been installed yet,
-            // so there is no cell to notify.
+            // `JSController(ZERO)`: `assign_to_stream` has not received the
+            // controller yet, so there is no cell to notify.
             SourceHandle::JSController(cpp) => {
                 if cpp == JSValue::ZERO {
                     return;

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -101,6 +101,85 @@ describe("HTMLRewriter", () => {
     await expect(res.text()).rejects.toThrow("test");
   });
 
+  // Inputs that go through the JS stream pump with data already queued are
+  // drained synchronously inside `transform()`, so the handler throws (and the
+  // pipe fails, detaching its input) while `assign_to_stream` is still on the
+  // stack. The pump controller must already be installed as the pipe's input
+  // source at that point: previously the pipe detached an empty placeholder
+  // and the process segfaulted. Detaching the real controller is also what
+  // cancels the input, as it does when the throwing chunk arrives later.
+  // Spawned so a regression shows up as a failed assertion instead of taking
+  // the test runner down.
+  it("error inside element handler rejects the body when the input is drained inside transform()", async () => {
+    const fixture = /* js */ `
+      const html = "<a href=/x>abc</a>";
+      const bytes = () => new TextEncoder().encode(html);
+      let upstreamCancels = 0;
+      const inputs = {
+        "Response(string) whose .body was read": () => {
+          const res = new Response(html);
+          void res.body;
+          return res;
+        },
+        "Response(Blob) whose .body was read": () => {
+          const res = new Response(new Blob([html]));
+          void res.body;
+          return res;
+        },
+        "ReadableStream with a string queued in start()": () =>
+          new Response(new ReadableStream({ start(c) { c.enqueue(html); c.close(); } })),
+        "ReadableStream with bytes queued in start()": () =>
+          new Response(new ReadableStream({ start(c) { c.enqueue(bytes()); c.close(); } })),
+        "bytes ReadableStream with a chunk queued in start()": () =>
+          new Response(new ReadableStream({ type: "bytes", start(c) { c.enqueue(bytes()); c.close(); } })),
+        "direct ReadableStream writing synchronously from pull()": () =>
+          new Response(new ReadableStream({ type: "direct", pull(c) { c.write(html); c.close(); } })),
+        "still-open ReadableStream with a chunk queued in start()": () =>
+          new Response(new ReadableStream({ start(c) { c.enqueue(html); }, cancel() { upstreamCancels++; } })),
+      };
+      for (const [name, input] of Object.entries(inputs)) {
+        const out = new HTMLRewriter()
+          .on("a", {
+            element() {
+              throw new Error("handler threw");
+            },
+          })
+          .transform(input());
+        const outcome = await out.text().then(
+          text => "resolved with " + JSON.stringify(text),
+          err => "rejected with " + err.message,
+        );
+        // Sweep the pump controller too: it must have been detached from the
+        // failed pipe rather than left pointing at it.
+        Bun.gc(true);
+        console.log(name + ": " + outcome);
+      }
+      console.log("still-open input cancelled " + upstreamCancels + " time(s)");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(
+      [
+        "Response(string) whose .body was read: rejected with handler threw",
+        "Response(Blob) whose .body was read: rejected with handler threw",
+        "ReadableStream with a string queued in start(): rejected with handler threw",
+        "ReadableStream with bytes queued in start(): rejected with handler threw",
+        "bytes ReadableStream with a chunk queued in start(): rejected with handler threw",
+        "direct ReadableStream writing synchronously from pull(): rejected with handler threw",
+        "still-open ReadableStream with a chunk queued in start(): rejected with handler threw",
+        "still-open input cancelled 1 time(s)",
+        "",
+      ].join("\n"),
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   it("HTMLRewriter: async replacement", async () => {
     await gcTick();
     const res = new HTMLRewriter()


### PR DESCRIPTION
### Problem

- `HTMLRewriter.transform(response)` kills the process with `panic(main thread): Segmentation fault at address 0x0` when an element handler throws and the input was drained inside `transform()`. Under ASan: `member call on null pointer of type 'JSC::JSCell'` in `JSSinkController__detachPtr`, reached from `RewriterPipe::fail -> detach_input_source -> JSSink<RewriterPipe>::detach`, with `JSSink::assign_to_stream` still on the stack.
- Inputs that drain inside `transform()`: a `Response` whose `.body` getter was touched first (in-memory, `Blob`, or a fully received `fetch()` response), a `ReadableStream` with a chunk already queued in `start()` (default or `type: "bytes"`), and a `type: "direct"` stream whose `pull()` writes synchronously. The same handler throwing on a chunk that arrives later rejects the output body as expected.
- Regression from f68e504ae4 (1.4 canaries; 1.3.14 is fine). Cause in `src/runtime/webcore/Sink.rs`, `JSSink::assign_to_stream`: the generated `${Sink}__assignToStream` created the controller, wrote it to a `void**` out-param, and started the pump in the same call; Rust pre-seeded the sink's source with `JSController(JSValue::ZERO)` and copied the out-param into it only after the call returned. The pump drains already queued data before returning, so the pipe's `fail()` ran while the source still held the placeholder. `SourceHandle::close`/`ready` special-cased `ZERO`; `JSSink::detach` did not and handed the empty value to `detachPtr`, which downcasts it as a cell.
- Before f68e504ae4 the C++ side wrote the controller straight into the sink's signal slot before starting the pump, which is why 1.3 does not crash.

### Fix

- Split the generated entry point so the ordering is fixed by construction: `${Sink}__createController(sinkPtr)` returns the controller cell, and one shared `JSSinkController__assignToStream(stream, controller)` starts the pump (`src/codegen/generate-jssink.ts`). `JSSink::assign_to_stream` creates the controller, stores `JSController(controller)` as the sink's source, and then starts the pump, so the source holds the real controller whenever the pump can run sink or user code. The six callers are unchanged.
- A failure mid-drain therefore detaches the real controller, which runs the pump's `onClose` and cancels the input, exactly what already happened when the failing chunk arrived later.
- `JSController(ZERO)` no longer exists, so its special cases in `SourceHandle::close`/`ready` are deleted; `js_controller_detached` clears the slot only for the controller it holds. The setup-throws path (#36783: a direct stream's `pull` getter throwing leaves the controller attached to a sink the caller is about to free) detaches the controller returned by create; the detach reaches `js_controller_detached`, which is what clears the slot, so there is a single clearing path and it is identity-checked. The stale `${Sink}__assignToStream` prototypes in `headers.h` are removed.
- This is the shared `JSSink` path, so a mid-drain `close()`/`detach()` from `HTTPResponseSink`, `FetchRequestBodySink`, `FileSink` or `NetworkSink` now reaches the pump too (the 1.3 behaviour) instead of being dropped until the stream drains to EOF. I did not find a way to trigger a mid-drain failure for those sinks deterministically from JS (`Bun.write("/dev/full", stream)` rejects through `FileSink`'s own path without touching the source), so the regression test uses HTMLRewriter; the code it exercises is the shared function.
- Verified with `test/js/workerd/html-rewriter.test.js` ("error inside element handler rejects the body when the input is drained inside transform()"): seven input shapes in one spawned fixture, each must reject with the handler error and survive a full GC, and the still-open input must have its `cancel()` called once. Without the fix the fixture segfaults on the first shape (`USE_SYSTEM_BUN=1`); with it every line prints and stderr is empty.
- Also run against the debug+ASan build of this version: the four HTMLRewriter test files and the spawn stdin `ReadableStream` suites including the #36783 `stdin stream setup fails` tests (252 pass), streams/ArrayBufferSink/FileSink (264 pass), `bun-write.test.js` (49 pass; the one failure is a 256 MB file copy that times out in this container on any build), the Bun.serve streaming suites plus `serve.test.ts` (430 pass; the 4 failures reproduce with the unmodified binary: IPv6 `localhost`, running as root), and the fetch body stream suites (9134 pass; 4 h3 backpressure tests time out under load and pass when run alone).

### Background

- A `JSSink` is a native byte consumer (`RewriterPipe` for HTMLRewriter input, the HTTP response sink, the fetch request body sink, `FileSink`, the S3 `NetworkSink`) exposed to the stream machinery through a small JS cell, the `JSReadable*SinkController`, whose `m_sinkPtr` points at the native sink.
- `assign_to_stream` is how a sink consumes a JS `ReadableStream` that has no native fast path: the pump (`readStreamIntoSink`, or `readDirectStream` for `type: "direct"`) reads the stream and calls the sink's `write()` through the controller. Anything already queued is written before the pump call returns; the rest arrives later and the call returns a promise.
- `SourceHandle` is the sink's handle to whatever feeds it. For the pump it is `JSController(cell)`; the sink calls `ready()` on it to resume the pump after backpressure, and `detach()` (`detachPtr`) to cut it off, which nulls `m_sinkPtr` and runs the pump's `onClose` so the pump cancels the upstream stream. The pump ignores the sink's `write()` return value on failure, so `detach()` is the only way a failing sink stops it.
- `js_controller_detached` is the reverse edge: the controller tells the sink it is going away (`close()`/`end()` or its GC destructor) and the sink drops its handle, so a dead cell is never decoded.

<details>
<summary>Probe results on the unfixed canary (1.4.0-canary.1, 8326d1bd3) and the fixed debug build</summary>

Unfixed, handler throws on `<a>`:

```
no-touch (new Response(html))                  rejected: handler-throw
body-touch (void res.body first)               Segmentation fault at address 0x0
blob-body-touch                                Segmentation fault at address 0x0
fetch + body touch after the body arrived      Segmentation fault at address 0x0
ReadableStream, string enqueued in start()     Segmentation fault at address 0x0
ReadableStream, bytes enqueued in start()      Segmentation fault at address 0x0
type: "bytes", chunk enqueued in start()       Segmentation fault at address 0x0
type: "direct", pull() writes synchronously    Segmentation fault at address 0x0
same shapes with the chunk delivered later     rejected: handler-throw
```

Fixed (debug + ASan): every shape above prints `rejected: handler-throw`, exit 0, nothing from the sanitizer. For a stream left open with one chunk queued, the upstream `cancel()` is invoked once, both when the handler throws during `transform()` and when it throws on a later chunk; the unfixed build already did this for the later chunk.

</details>

<details>
<summary>First version of this PR (52ddca2)</summary>

The first revision kept the `void**` protocol and aimed the out-pointer at the `JSController` payload inside the sink's own source slot (`JSValue` is `repr(transparent)` over the encoded bits), with `JSController(ZERO)` remaining as the state between the pre-seed and the C++ store and a matching `ZERO` check added to `JSSink::detach`. It fixed the crash and CI was green (build 99906), but it kept the sentinel alive at three sites and relied on a pointer into an enum payload crossing the FFI boundary. The current revision removes the sentinel instead; the test is unchanged.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/workerd/html-rewriter.test.js

<!-- robobun:evidence:end -->