### PR TITLE
napi_get_prototype: return null for a Proxy without running its trap, like Node

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -3239,7 +3239,7 @@ pub mod formatter {
         value.get_class_name(global_this, &mut name_str)?;
         if !name_str.eql_comptime(b"Object") {
             return Ok(Some(name_str));
-        } else if value.get_prototype(global_this).eql_value(JSValue::NULL) {
+        } else if value.get_prototype(global_this)?.eql_value(JSValue::NULL) {
             return Ok(Some(ZigString::static_("[Object: null prototype]")));
         }
         Ok(None)
@@ -3969,7 +3969,7 @@ pub mod formatter {
             // (i.e. `class Foo extends Bar`). Built-in and DOM constructors
             // have `Function.prototype` as their prototype, which would
             // render as `[class X extends Function]` and is noise.
-            let proto = value.get_prototype(self.global_this);
+            let proto = value.get_prototype(self.global_this)?;
             let proto_is_class = !proto.is_empty_or_undefined_or_null()
                 && proto.is_cell()
                 && proto.is_class(self.global_this);
@@ -4035,7 +4035,7 @@ pub mod formatter {
             }
             let printable = OwnedString::new(value.get_name(self.global_this)?);
 
-            let proto = value.get_prototype(self.global_this);
+            let proto = value.get_prototype(self.global_this)?;
             // "Function" | "AsyncFunction" | "GeneratorFunction" | "AsyncGeneratorFunction"
             let func_name = OwnedString::new(proto.get_name(self.global_this)?);
 

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2334,9 +2334,10 @@ impl JSValue {
     pub fn unwrap_boxed_primitive(self, global: &JSGlobalObject) -> JsResult<JSValue> {
         host_fn::from_js_host_call(global, || JSC__JSValue__unwrapBoxedPrimitive(global, self))
     }
-    /// `JSValue.getPrototype`.
-    pub fn get_prototype(self, global: &JSGlobalObject) -> JSValue {
-        JSC__JSValue__getPrototype(self, global)
+    /// `JSValue.getPrototype`, i.e. `[[GetPrototypeOf]]`: runs a Proxy's `getPrototypeOf` trap,
+    /// which may throw, and throws a TypeError for null/undefined.
+    pub fn get_prototype(self, global: &JSGlobalObject) -> JsResult<JSValue> {
+        host_fn::from_js_host_call(global, || JSC__JSValue__getPrototype(self, global))
     }
 
     // ── Reflection / naming. ───────────────

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2334,8 +2334,7 @@ impl JSValue {
     pub fn unwrap_boxed_primitive(self, global: &JSGlobalObject) -> JsResult<JSValue> {
         host_fn::from_js_host_call(global, || JSC__JSValue__unwrapBoxedPrimitive(global, self))
     }
-    /// `JSValue.getPrototype`, i.e. `[[GetPrototypeOf]]`: runs a Proxy's `getPrototypeOf` trap,
-    /// which may throw, and throws a TypeError for null/undefined.
+    /// `JSValue.getPrototype`; runs a Proxy's `getPrototypeOf` trap, so it may throw.
     pub fn get_prototype(self, global: &JSGlobalObject) -> JsResult<JSValue> {
         host_fn::from_js_host_call(global, || JSC__JSValue__getPrototype(self, global))
     }

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -976,7 +976,13 @@ extern "C" fn napi_get_prototype(
         return NapiEnv::set_last_error(Some(env), NapiStatus::object_expected);
     }
 
-    result.set(env, object.get_prototype(env.to_js()));
+    // A Proxy's getPrototypeOf trap runs here. If it throws, the exception stays
+    // pending for the addon and *result must be left untouched.
+    let prototype = match object.get_prototype(env.to_js()) {
+        Ok(prototype) => prototype,
+        Err(_) => return env.pending_exception(),
+    };
+    result.set(env, prototype);
     env.ok()
 }
 

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -976,8 +976,13 @@ extern "C" fn napi_get_prototype(
         return NapiEnv::set_last_error(Some(env), NapiStatus::object_expected);
     }
 
-    // A Proxy's getPrototypeOf trap runs here. If it throws, the exception stays
-    // pending for the addon and *result must be left untouched.
+    // Node's v8::Object::GetPrototype cannot run JS: for a Proxy it returns null
+    // without consulting the getPrototypeOf trap. No other object type runs JS
+    // for [[GetPrototypeOf]], so this function never does either.
+    if object.js_type() == jsc::JSType::ProxyObject {
+        result.set(env, JSValue::NULL);
+        return env.ok();
+    }
     let prototype = match object.get_prototype(env.to_js()) {
         Ok(prototype) => prototype,
         Err(_) => return env.pending_exception(),

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -976,9 +976,7 @@ extern "C" fn napi_get_prototype(
         return NapiEnv::set_last_error(Some(env), NapiStatus::object_expected);
     }
 
-    // Node's v8::Object::GetPrototype cannot run JS: for a Proxy it returns null
-    // without consulting the getPrototypeOf trap. No other object type runs JS
-    // for [[GetPrototypeOf]], so this function never does either.
+    // Like V8's Object::GetPrototype: a Proxy yields null and its trap never runs.
     if object.js_type() == jsc::JSType::ProxyObject {
         result.set(env, JSValue::NULL);
         return env.ok();

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -806,7 +806,7 @@ fn bind(value: JSValue, global: &JSGlobalObject, name: BunString) -> JsResult<JS
     // `JSHostFn` shape, not the safe Rust signature.
     let call_fn = bun_jsc::JSFunction::create(global, name.clone(), __jsc_host_call_as_function, 1, Default::default());
     let bound = JSValueTestExt::bind(call_fn, global, value, &name, 1.0, &[])?;
-    set_prototype_direct(bound, value.get_prototype(global), global)?;
+    set_prototype_direct(bound, value.get_prototype(global)?, global)?;
     Ok(bound)
 }
 

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -854,7 +854,7 @@ impl<'a, 'f, W: bun_io::Write, const ENABLE_ANSI_COLORS: bool>
                 writer.print(format_args!("{} ", name_str));
             } else {
                 value
-                    .get_prototype(global_this)
+                    .get_prototype(global_this)?
                     .get_name_property(global_this, &mut name_str)?;
                 if name_str.len > 0 && !name_str.eql_comptime(b"Object") {
                     writer.print(format_args!("{} ", name_str));

--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -362,6 +362,50 @@ static napi_value perform_instanceof(const Napi::CallbackInfo &info) {
   return out;
 }
 
+// perform_get_prototype(object) -> { status, result, pending, exception }
+//
+// `result` is the string "untouched" if napi_get_prototype did not write to
+// *result, the string "null handle" if it wrote a NULL napi_value, and
+// otherwise the prototype it returned.
+static napi_value perform_get_prototype(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value object = info[0];
+
+  napi_value untouched;
+  NODE_API_CALL(env, napi_create_string_utf8(env, "untouched", NAPI_AUTO_LENGTH,
+                                             &untouched));
+  napi_value result = untouched;
+  napi_status status = napi_get_prototype(env, object, &result);
+
+  bool pending = false;
+  NODE_API_CALL(env, napi_is_exception_pending(env, &pending));
+
+  napi_value exception;
+  if (pending) {
+    NODE_API_CALL(env, napi_get_and_clear_last_exception(env, &exception));
+  } else {
+    NODE_API_CALL(env, napi_get_undefined(env, &exception));
+  }
+
+  if (result == nullptr) {
+    NODE_API_CALL(env, napi_create_string_utf8(env, "null handle",
+                                               NAPI_AUTO_LENGTH, &result));
+  }
+
+  napi_value out;
+  NODE_API_CALL(env, napi_create_object(env, &out));
+
+  napi_value status_val, pending_val;
+  NODE_API_CALL(env, napi_create_uint32(env, status, &status_val));
+  NODE_API_CALL(env, napi_get_boolean(env, pending, &pending_val));
+
+  NODE_API_CALL(env, napi_set_named_property(env, out, "status", status_val));
+  NODE_API_CALL(env, napi_set_named_property(env, out, "result", result));
+  NODE_API_CALL(env, napi_set_named_property(env, out, "pending", pending_val));
+  NODE_API_CALL(env, napi_set_named_property(env, out, "exception", exception));
+  return out;
+}
+
 // create_latin1_string(byte_length): returns a JS string created via
 // napi_create_string_latin1. Used by the leak test in napi.test.ts.
 static napi_value create_latin1_string(const Napi::CallbackInfo &info) {
@@ -615,6 +659,7 @@ void register_js_test_helpers(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, perform_set);
   REGISTER_FUNCTION(env, exports, define_properties);
   REGISTER_FUNCTION(env, exports, perform_instanceof);
+  REGISTER_FUNCTION(env, exports, perform_get_prototype);
   REGISTER_FUNCTION(env, exports, throw_error);
   REGISTER_FUNCTION(env, exports, create_and_throw_error);
   REGISTER_FUNCTION(env, exports, call_fatal_exception);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1197,6 +1197,65 @@ nativeTests.test_napi_instanceof = () => {
   dump("undefined ctor", nativeTests.perform_instanceof({}, undefined));
 };
 
+// Each line reports what napi_get_prototype did with an argument whose
+// [[GetPrototypeOf]] throws. result= is "untouched" when *result was left
+// alone and "null handle" when a NULL napi_value was written (see
+// perform_get_prototype in js_test_helpers.cpp).
+nativeTests.test_napi_get_prototype_exceptions = () => {
+  const trapError = new RangeError("from getPrototypeOf trap");
+
+  function dump(label, object) {
+    const r = nativeTests.perform_get_prototype(object);
+    const result =
+      typeof r.result === "string" ? r.result : r.result === Object.prototype ? "Object.prototype" : String(r.result);
+    const exception =
+      r.exception === undefined
+        ? "none"
+        : r.exception === trapError
+          ? "the trap's error"
+          : r.exception instanceof TypeError
+            ? "TypeError"
+            : String(r.exception);
+    console.log(`${label}: status=${r.status} pending=${r.pending} result=${result} exception=${exception}`);
+  }
+
+  dump("plain object", {});
+  dump("null prototype", Object.create(null));
+
+  dump(
+    "trap throws",
+    new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw trapError;
+        },
+      },
+    ),
+  );
+
+  // The engine throws a TypeError for these two: a trap result that is neither
+  // an object nor null, and a revoked proxy.
+  dump(
+    "trap returns a number",
+    new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          return 42;
+        },
+      },
+    ),
+  );
+  const revocable = Proxy.revocable({}, {});
+  revocable.revoke();
+  dump("revoked proxy", revocable.proxy);
+
+  // Each exception above was reported to and cleared by the addon, so nothing
+  // is left pending.
+  dump("plain object again", {});
+};
+
 nativeTests.test_get_value_string = () => {
   function to16Bit(string) {
     if (typeof Bun != "object") return string;

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -1197,17 +1197,26 @@ nativeTests.test_napi_instanceof = () => {
   dump("undefined ctor", nativeTests.perform_instanceof({}, undefined));
 };
 
-// Each line reports what napi_get_prototype did with an argument whose
-// [[GetPrototypeOf]] throws. result= is "untouched" when *result was left
-// alone and "null handle" when a NULL napi_value was written (see
-// perform_get_prototype in js_test_helpers.cpp).
-nativeTests.test_napi_get_prototype_exceptions = () => {
+// V8's Object::GetPrototype (what napi_get_prototype wraps in Node) returns null
+// for a Proxy without running its getPrototypeOf trap, so the proxy lines below
+// all read "result=null" with nothing pending, whatever the trap would do.
+// result= is "untouched" if *result was not written and "null handle" if a NULL
+// napi_value was written (see perform_get_prototype in js_test_helpers.cpp).
+nativeTests.test_napi_get_prototype_proxy = () => {
   const trapError = new RangeError("from getPrototypeOf trap");
+  let trapCalls = 0;
+  const chainProxy = new Proxy({}, {});
+  const names = [
+    [Object.prototype, "Object.prototype"],
+    [Array.prototype, "Array.prototype"],
+    [Function.prototype, "Function.prototype"],
+    [chainProxy, "the proxy"],
+  ];
 
   function dump(label, object) {
     const r = nativeTests.perform_get_prototype(object);
-    const result =
-      typeof r.result === "string" ? r.result : r.result === Object.prototype ? "Object.prototype" : String(r.result);
+    const named = names.find(([value]) => value === r.result);
+    const result = typeof r.result === "string" ? r.result : named ? named[1] : String(r.result);
     const exception =
       r.exception === undefined
         ? "none"
@@ -1222,6 +1231,21 @@ nativeTests.test_napi_get_prototype_exceptions = () => {
   dump("plain object", {});
   dump("null prototype", Object.create(null));
 
+  dump("proxy without traps", new Proxy([], {}));
+  dump("callable proxy", new Proxy(function () {}, {}));
+  dump(
+    "trap returns Array.prototype",
+    new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          trapCalls++;
+          return Array.prototype;
+        },
+      },
+    ),
+  );
+  console.log(`getPrototypeOf trap calls: ${trapCalls}`);
   dump(
     "trap throws",
     new Proxy(
@@ -1233,9 +1257,6 @@ nativeTests.test_napi_get_prototype_exceptions = () => {
       },
     ),
   );
-
-  // The engine throws a TypeError for these two: a trap result that is neither
-  // an object nor null, and a revoked proxy.
   dump(
     "trap returns a number",
     new Proxy(
@@ -1251,8 +1272,10 @@ nativeTests.test_napi_get_prototype_exceptions = () => {
   revocable.revoke();
   dump("revoked proxy", revocable.proxy);
 
-  // Each exception above was reported to and cleared by the addon, so nothing
-  // is left pending.
+  // Only the object itself is special-cased; a proxy further up the chain is
+  // returned like any other prototype.
+  dump("object whose prototype is a proxy", Object.create(chainProxy));
+
   dump("plain object again", {});
 };
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1779,6 +1779,32 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
     });
   });
 
+  describe("napi_get_prototype", () => {
+    it("returns napi_pending_exception and leaves *result untouched when [[GetPrototypeOf]] throws", async () => {
+      // Bun runs the Proxy's getPrototypeOf trap (Object.getPrototypeOf
+      // semantics), so a throwing trap has to be reported the way every other
+      // Node-API call reports JS that threw: napi_pending_exception (10), the
+      // exception left for napi_get_and_clear_last_exception, *result not
+      // written. This is not a checkSameOutput test because V8's
+      // Object::GetPrototype never runs proxy traps: Node prints
+      // "status=0 ... result=null exception=none" for all three proxies.
+      const output = await runOn(bunExe(), "test_napi_get_prototype_exceptions", []);
+      const lines = output
+        .trim()
+        .split(/\r?\n/)
+        // remove all debug logs
+        .filter(line => !/^\[\w+\]/.test(line));
+      expect(lines).toEqual([
+        "plain object: status=0 pending=false result=Object.prototype exception=none",
+        "null prototype: status=0 pending=false result=null exception=none",
+        "trap throws: status=10 pending=true result=untouched exception=the trap's error",
+        "trap returns a number: status=10 pending=true result=untouched exception=TypeError",
+        "revoked proxy: status=10 pending=true result=untouched exception=TypeError",
+        "plain object again: status=0 pending=false result=Object.prototype exception=none",
+      ]);
+    });
+  });
+
   describe("napi_object_freeze and napi_object_seal", () => {
     it("should handle arrays with indexed properties", async () => {
       const output = await checkSameOutput("test_napi_freeze_seal_indexed", []);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1780,26 +1780,24 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
   });
 
   describe("napi_get_prototype", () => {
-    it("returns napi_pending_exception and leaves *result untouched when [[GetPrototypeOf]] throws", async () => {
-      // Bun runs the Proxy's getPrototypeOf trap (Object.getPrototypeOf
-      // semantics), so a throwing trap has to be reported the way every other
-      // Node-API call reports JS that threw: napi_pending_exception (10), the
-      // exception left for napi_get_and_clear_last_exception, *result not
-      // written. This is not a checkSameOutput test because V8's
-      // Object::GetPrototype never runs proxy traps: Node prints
-      // "status=0 ... result=null exception=none" for all three proxies.
-      const output = await runOn(bunExe(), "test_napi_get_prototype_exceptions", []);
-      const lines = output
-        .trim()
-        .split(/\r?\n/)
-        // remove all debug logs
-        .filter(line => !/^\[\w+\]/.test(line));
-      expect(lines).toEqual([
+    it("returns null for a Proxy without running its getPrototypeOf trap, like Node", async () => {
+      // Before this was special-cased, Bun ran the trap: a proxy without traps
+      // reported its target's prototype, and a throwing trap reported napi_ok
+      // with a NULL handle written to *result and the exception left pending.
+      const output = await checkSameOutput("test_napi_get_prototype_proxy", []);
+      // checkSameOutput already asserted parity with Node; pin the values so a
+      // shared failure cannot pass.
+      expect(output.split(/\r?\n/)).toEqual([
         "plain object: status=0 pending=false result=Object.prototype exception=none",
         "null prototype: status=0 pending=false result=null exception=none",
-        "trap throws: status=10 pending=true result=untouched exception=the trap's error",
-        "trap returns a number: status=10 pending=true result=untouched exception=TypeError",
-        "revoked proxy: status=10 pending=true result=untouched exception=TypeError",
+        "proxy without traps: status=0 pending=false result=null exception=none",
+        "callable proxy: status=0 pending=false result=null exception=none",
+        "trap returns Array.prototype: status=0 pending=false result=null exception=none",
+        "getPrototypeOf trap calls: 0",
+        "trap throws: status=0 pending=false result=null exception=none",
+        "trap returns a number: status=0 pending=false result=null exception=none",
+        "revoked proxy: status=0 pending=false result=null exception=none",
+        "object whose prototype is a proxy: status=0 pending=false result=the proxy exception=none",
         "plain object again: status=0 pending=false result=Object.prototype exception=none",
       ]);
     });


### PR DESCRIPTION
### Problem
- `napi_get_prototype` on a Proxy runs the Proxy's `getPrototypeOf` trap. Node does not: V8's `Object::GetPrototype`, which Node's `napi_get_prototype` wraps, cannot run JS and returns `null` for any Proxy (verified with Node 26.3, output in the details below).
- Running the trap also makes the failure mode wrong: when the trap throws (or returns a non-object, or the proxy is revoked) the call returns `napi_ok`, writes a NULL `napi_value` into `*result`, and leaves the exception pending without telling the addon. Current canary on the new fixture: `trap throws: status=0 pending=true result=null handle exception=the trap's error`.
- This is an unreleased regression from #33731 (86caf6e65e): `napi_get_prototype` used to call the JSC C API's `JSObjectGetPrototype`, which is `getPrototypeDirect()`, and JSC creates Proxy structures with a null prototype, so 1.3.14 already returned `null` for a Proxy without running anything. #33731 replaced it with `JSValue::get_prototype`, JSC's full `[[GetPrototypeOf]]` (traps included), which returned a bare `JSValue` that is empty (encoded 0, i.e. a NULL handle) when it threw, so the call site in `src/runtime/napi/napi_body.rs` could not tell success from failure. Affects 1.4.0 canary only; the `napi_get_prototype` line in the #36801 audit ("already avoids the trap") describes the pre-#33731 state.
- The other `getPrototype` exception-handling sites found by the same reading (the inspect property walk, `napi_get_all_property_names`, `util.isError`) are separate fixes in #29642, #32263 and #37202; this PR merges cleanly in either order with them.

### Fix
- `napi_get_prototype` returns `null` for a `ProxyObject` without touching its handler, the same result Node produces and the same result 1.3.14 produced. Every other object type's `[[GetPrototypeOf]]` in JSC is a plain read (`JSGlobalProxy` forwards to the global object, `ImportMetaObject` returns null, primitives get their wrapper prototype), so the function no longer runs JS for any input, like Node's.
- `JSValue::get_prototype` (`src/jsc/JSValue.rs`) now returns `JsResult<JSValue>` through `host_fn::from_js_host_call`, the wrapper `JSValue::call` and `unwrap_boxed_primitive` already use for JSC calls that return empty exactly when they threw. This is what let the empty value reach `*result`, and the remaining callers (`ConsoleObject.rs`, `pretty_format.rs`, `ScopeFunctions.rs`, all already returning `JsResult`) now propagate with `?` instead of holding a possibly-empty value. They only ever see ordinary objects (the formatters print a Proxy's target), so their output is unchanged. In `napi_get_prototype` the `Err` arm maps to `napi_pending_exception` as the generic Node-API protocol; with the Proxy case handled above it is not reachable with today's object types.
- Test: `test/napi/napi.test.ts` (`napi_get_prototype`) runs fixture `test_napi_get_prototype_proxy` (`napi-app/module.js`) through `checkSameOutput`, so the output is compared byte for byte with Node, and then pins the lines. The helper `perform_get_prototype` (`napi-app/js_test_helpers.cpp`) pre-fills `*result` with a sentinel so the output distinguishes a real `null` from "not written" and from a NULL handle. Cases: proxy without traps, callable proxy, a trap that counts its calls (must stay 0), a trap that throws, a trap returning a number, a revoked proxy, plus plain / null-prototype objects and an object whose prototype is a proxy (returned as-is, only the object itself is special-cased).
- Fails under `USE_SYSTEM_BUN=1` (1.4.0-canary.1: 7 of 11 lines differ from Node, see details), passes with `bun bd test test/napi/napi.test.ts`.
- Also run on the debug build: the rest of `test/napi/napi.test.ts`, Node's own `test_general` suite (`test/napi/node-napi-tests/.../test_general/do.test.ts`, which asserts `napi_get_prototype` matches `Object.getPrototypeOf` for ordinary objects), `test/js/bun/util/inspect.test.js`, `test/js/bun/test/printing/diffexample.test.ts`, `jest-each.test.ts`, `describe.test.ts`, `pretty-format-overflow.test.ts`, `console-table.test.ts`; plus a script formatting classes, functions, null-prototype objects and proxies, and a `bun test` file exercising `describe.each` / `test.each` / `skipIf` and class-instance `toEqual` diffs, both clean under `BUN_JSC_validateExceptionChecks=1`.
- Noted while reviewing the other Proxy-receiver paths, not changed here (different function and file): `napi_remove_wrap` on a Proxy or on `globalThis` reports success but leaves the wrap attached, because `src/jsc/bindings/napi.cpp` removes it with the virtual `deleteProperty` (which `ProxyObject` refuses for private names and `JSGlobalProxy` forwards to its target) while `napi_wrap` / `napi_unwrap` use `putDirect` / `getDirect`; Node removes it. Probe output is in the second details block.

### Background
- `[[GetPrototypeOf]]` is the spec operation behind `Object.getPrototypeOf`. For ordinary objects it reads a field and cannot fail; a Proxy implements it by calling its handler's `getPrototypeOf` trap, so it can run arbitrary JS and throw. V8's `Object::GetPrototype` returns a plain `Local<Value>` rather than a `MaybeLocal`, so it cannot run a trap, and it reports `null` for a Proxy; that is the behavior Node-API addons are written against.
- `getPrototypeDirect()` is JSC's raw read of the prototype stored in an object's Structure, bypassing any override; `getPrototype()` is the full operation that dispatches to `ProxyObject`'s trap. The JSC C API's `JSObjectGetPrototype` is the former.
- JSC signals a throw from a value-returning operation by returning the empty `JSValue` (encoding 0) and leaving the exception on the VM. `host_fn::from_js_host_call` maps that to `Err(JsError::Thrown)` and, in debug builds, asserts the value is empty if and only if an exception is pending.
- A `napi_value` is an encoded `JSValue`, so storing the empty value hands the addon a NULL handle.
- `napi_pending_exception` is the status a Node-API call returns when JS it ran threw; the exception stays pending for `napi_get_and_clear_last_exception` and out-params are left unwritten.

<details>
<summary>Fixture output: Node 26.3 (and this branch, identical) vs current canary</summary>

Node v26.3.0, and this branch:

```
plain object: status=0 pending=false result=Object.prototype exception=none
null prototype: status=0 pending=false result=null exception=none
proxy without traps: status=0 pending=false result=null exception=none
callable proxy: status=0 pending=false result=null exception=none
trap returns Array.prototype: status=0 pending=false result=null exception=none
getPrototypeOf trap calls: 0
trap throws: status=0 pending=false result=null exception=none
trap returns a number: status=0 pending=false result=null exception=none
revoked proxy: status=0 pending=false result=null exception=none
object whose prototype is a proxy: status=0 pending=false result=the proxy exception=none
plain object again: status=0 pending=false result=Object.prototype exception=none
```

Bun 1.4.0-canary.1 (`USE_SYSTEM_BUN=1`):

```
plain object: status=0 pending=false result=Object.prototype exception=none
null prototype: status=0 pending=false result=null exception=none
proxy without traps: status=0 pending=false result=Array.prototype exception=none
callable proxy: status=0 pending=false result=Function.prototype exception=none
trap returns Array.prototype: status=0 pending=false result=Array.prototype exception=none
getPrototypeOf trap calls: 1
trap throws: status=0 pending=true result=null handle exception=the trap's error
trap returns a number: status=0 pending=true result=null handle exception=TypeError
revoked proxy: status=0 pending=true result=null handle exception=TypeError
object whose prototype is a proxy: status=0 pending=false result=the proxy exception=none
plain object again: status=0 pending=false result=Object.prototype exception=none
```

</details>

<details>
<summary>napi_remove_wrap follow-up: probe output (existing try_wrap / try_remove_wrap / try_unwrap helpers from napi-app, wrapping the number 6, then trying to re-wrap with 7)</summary>

Node v26.3.0:

```
plain: wrap=true remove=6 unwrap_after=undefined rewrap=true
proxy: wrap=true remove=6 unwrap_after=undefined rewrap=true
callable proxy: wrap=true remove=6 unwrap_after=undefined rewrap=true
globalThis: wrap=true remove=6 unwrap_after=undefined rewrap=true
```

Bun (this branch, unchanged in this respect):

```
plain: wrap=true remove=6 unwrap_after=undefined rewrap=true
proxy: wrap=true remove=6 unwrap_after=6 rewrap=false
callable proxy: wrap=true remove=6 unwrap_after=6 rewrap=false
globalThis: wrap=true remove=6 unwrap_after=6 rewrap=false
```

</details>

<details>
<summary>Earlier version of this PR</summary>

The first revision kept running the trap and changed only the failure report: `napi_pending_exception` with `*result` untouched when the trap threw, tested on Bun alone since Node never reaches that path. Review asked to match Node instead and not run JS, which is the current shape; the `JsResult` change to `JSValue::get_prototype` is unchanged from that revision.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->