### PR TITLE
inspect: don't leave an exception pending while walking an object's properties

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5643,10 +5643,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property builders.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5718,7 +5719,11 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // A Proxy "getPrototypeOf" trap can throw, in which case `prototype` is empty.
+            if (scope.exception()) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -579,6 +579,70 @@ it("Bun.inspect huge sparse array summarizes holes without iterating them", asyn
   });
 });
 
+// Bun.$ is built lazily the first time it is read, and building it reads process.env. When that throws while
+// Bun.inspect walks the object, only that one property should be left out; the exception used to stay pending
+// and make every later lazy property on the object fail too (and trip an assertion in debug builds).
+it("Bun.inspect skips a lazy property whose initializer throws and still prints the rest", async () => {
+  const code = `
+    Object.defineProperty(process, "env", {
+      get() {
+        throw new Error("nope");
+      },
+    });
+    const names = Object.getOwnPropertyNames(Bun);
+    const printed = new Set();
+    for (const line of Bun.inspect(Bun).split("\\n")) {
+      const match = /^  ([^\\s:]+): /.exec(line);
+      if (match) printed.add(match[1]);
+    }
+    console.log(JSON.stringify(names.filter(name => !printed.has(name))));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: '["$"]\n', stderr: "", exitCode: 0 });
+});
+
+// Inherited properties are printed too, so Proxy traps on a prototype run while the object is being walked.
+// A throwing trap used to leave its exception pending, and the walk then dereferenced the empty value it got
+// back for the next prototype.
+it("Bun.inspect survives Proxy traps on the prototype chain that throw", async () => {
+  const code = `
+    const getThrows = new Proxy({ a: 1, b: 2, c: 3 }, {
+      get(target, key, receiver) {
+        if (key === "a") throw new Error("get trap");
+        return Reflect.get(target, key, receiver);
+      },
+    });
+    const getPrototypeOfThrows = new Proxy({ b: 2 }, {
+      getPrototypeOf() {
+        throw new Error("getPrototypeOf trap");
+      },
+    });
+    for (const proto of [getThrows, getPrototypeOfThrows]) {
+      const obj = Object.create(proto);
+      obj.own = 0;
+      console.log(JSON.stringify(Bun.inspect(obj)));
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: '"{\\n  own: 0,\\n  b: 2,\\n  c: 3,\\n}"\n' + '"{\\n  own: 0,\\n  b: 2,\\n}"\n',
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 describe("console.logging function displays async and generator names", async () => {
   const cases = [
     function () {},


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found assertion failure (and, as it turns out, a release-build segfault) in `JSC__JSValue__forEachProperty` in `src/jsc/bindings/bindings.cpp`, the property walk behind `Bun.inspect`, `console.log` and the "received" value in matcher error messages.

The fuzzer hit it by formatting the `Bun` object while the lazy `Bun.$` initializer threw:

```
ASSERTION FAILED: Unexpected exception observed ...
Error Exception: undefined is not an object (evaluating 'createShellInterpreter')
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

Root cause: in the slow path of the walk, when `getPropertySlot` returned false the loop did `continue` without clearing the exception that made it return false. That happens when a lazy static property's initializer throws (`setUpStaticFunctionSlot` reports the property as missing in that case) or when a Proxy `get` trap on a prototype throws. The exception then stayed pending while the next property was looked up:

* On an object with a static table, like `Bun`, the next lazy initializer runs with the exception still pending. Its `to_js_host_call` wrapper asserts that a returned value means no exception is pending, which is the crash above (stack: `to_js_host_call<BunObject_lazyPropCb_Archive>` <- `reifyStaticProperty` <- `setUpStaticFunctionSlot` <- `getPropertySlot` <- `JSC__JSValue__forEachPropertyImpl`). In release builds every later property on the object silently fails its lookup and is dropped from the output: with `Bun.$` throwing, `Bun.inspect(Bun)` lost 55 properties.
* When the prototype being walked is a Proxy, the pending exception makes `getPrototype()` bail out and return the empty value, and `.getObject()` on it dereferences null. Release builds segfault (`Segmentation fault at address 0x5`) on `console.log(Object.create(new Proxy({ a: 1 }, { get() { throw new Error() } })))`. A `getPrototypeOf` trap that throws reaches the same dereference without any stale exception.

The fix is two lines of behavior in that function:

* clear the exception after `getPropertySlot` whether or not it found the property (this is what the sibling `forEachPropertyOrdered` already does), and
* check for an exception after `getPrototype()` and stop walking the chain instead of using the empty value. This follows what the fast path in the same function already does for prototype traversal (ignore the trap's exception); the final `tryClearException()` in the function clears it.

A property whose initializer or trap throws is still left out of the output, matching how the formatter already treats throwing getters; everything else on the object is now printed. The `JSPropertyIterator` path was checked too: it propagates the exception rather than iterating past it, so it is not affected.

### How did you verify your code works?

Two tests added to `test/js/bun/util/inspect.test.js`, both running the scenario in a child process:

* `Bun.inspect skips a lazy property whose initializer throws and still prints the rest`: makes `process.env` throw (the `Bun.$` initializer reads it, which is the fuzzer's path) and checks that `$` is the only own property missing from `Bun.inspect(Bun)`. Unfixed release build: 55 properties missing. Unfixed debug build: the assertion above.
* `Bun.inspect survives Proxy traps on the prototype chain that throw`: a prototype Proxy with a throwing `get` trap and one with a throwing `getPrototypeOf` trap. Unfixed release build: exit 139 on the first case; with only the first hunk applied, the second case still fails (UBSan null member call in debug, segfault in release).

Both fail with `USE_SYSTEM_BUN=1 bun test` and pass with `bun bd test`. The fuzzer's original script, and a reduced version of it going through `expect(Bun).toHaveReturnedTimes()`, run cleanly on the fixed debug build; the reduced version reproduces the assertion on the unfixed one. `inspect.test.js`, `bun-inspect.test.ts`, `custom-inspect.test.js`, `console-table.test.ts`, `console-log.test.ts` and `builtin-esm-lazy-exports.test.ts` pass with the debug build. (`inspect-error.test.js` has two "Error inside minified file" snapshot failures with a debug build of current main without this change as well; unrelated.)

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->