### PR TITLE
build: pin the build-std feature set and disallow std::backtrace

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -82,6 +82,7 @@ disallowed-types = [
   { path = "std::collections::HashSet", reason = "use bun_collections (wyhash)" },
   { path = "std::fs::File", reason = "use bun_sys::File" },
   { path = "std::process::Command", reason = "use bun_core::util::spawn_sync_inherit (CLI helpers) or bun_spawn_sys (full control)" },
+  { path = "std::backtrace::Backtrace", reason = "release builds compile std without its `backtrace` feature (scripts/build/rust.ts), so this captures frames it cannot symbolize; use bun_core::dump_current_stack_trace (bun_crash_handler)" },
 ]
 
 disallowed-macros = [

--- a/test/internal/source-lints/build-rust.test.ts
+++ b/test/internal/source-lints/build-rust.test.ts
@@ -138,6 +138,44 @@ describe("allRustTargets", () => {
   });
 });
 
+describe("build-std feature set", () => {
+  /** The `-Zbuild-std*` args, in order: which std gets built and with which features. */
+  function buildStdArgs(cfg: Config): string[] {
+    return cargoBuildInvocation(cfg).args.filter(arg => arg.startsWith("-Zbuild-std"));
+  }
+
+  // Cargo's default is `panic-unwind,backtrace,default`. `backtrace` is std's
+  // in-process symbolizer (gimli/addr2line/object/miniz_oxide, ~200 KB on the
+  // unix targets); nothing in the binary reads it (the panic hook in
+  // bun_crash_handler captures and reports frames itself, and clippy.toml
+  // disallows std::backtrace::Backtrace), so shipped builds leave it out.
+  const release = [cargoBuildStdArg, "-Zbuild-std-features=panic-unwind,default"];
+
+  test("release builds drop std's `backtrace` feature on every shipped platform family", () => {
+    const linuxX64 = resolve({ os: "linux", arch: "x64", abi: "gnu", linuxSysroot: "/fake" });
+    expect(buildStdArgs(linuxX64)).toEqual(release);
+    expect(buildStdArgs(withAbi(linuxX64, "musl"))).toEqual(release);
+    expect(buildStdArgs(withAbi(linuxX64, "android"))).toEqual(release);
+    expect(buildStdArgs(resolve({ os: "darwin", arch: "aarch64", mode: "rust-only" }))).toEqual(release);
+    expect(buildStdArgs(resolve({ os: "windows", arch: "x64", winsysroot: "/fake" }))).toEqual(release);
+    expect(buildStdArgs(resolve({ os: "freebsd", arch: "x64", freebsdSysroot: "/fake" }))).toEqual(release);
+    // Tier 3: builds std from source either way; release still trims it.
+    expect(buildStdArgs(resolve({ os: "freebsd", arch: "aarch64", freebsdSysroot: "/fake" }))).toEqual(release);
+  });
+
+  test("builds that rebuild std for other reasons keep cargo's default feature set", () => {
+    const linuxX64: PartialConfig = { os: "linux", arch: "x64", abi: "gnu", linuxSysroot: "/fake" };
+    // release-asan and debug-asan rebuild std for the instrumentation.
+    expect(buildStdArgs(resolve({ ...linuxX64, asan: true }))).toEqual([cargoBuildStdArg]);
+    expect(buildStdArgs(resolve({ ...linuxX64, buildType: "Debug", asan: true }))).toEqual([cargoBuildStdArg]);
+    // A Tier 3 debug build rebuilds std only because there is no prebuilt one.
+    const freebsdArm64: PartialConfig = { os: "freebsd", arch: "aarch64", freebsdSysroot: "/fake", buildType: "Debug" };
+    expect(buildStdArgs(resolve(freebsdArm64))).toEqual([cargoBuildStdArg]);
+    // A plain debug build links the prebuilt std: no build-std args at all.
+    expect(buildStdArgs(resolve({ ...linuxX64, buildType: "Debug", asan: false }))).toEqual([]);
+  });
+});
+
 describe("CPU baseline", () => {
   /** The rustflags that choose the ISA the build assumes. */
   function cpuFlags(cfg: Config): string[] {


### PR DESCRIPTION
Follow-up to #39326, where @alii asked how we make sure building std without its `backtrace` feature stays safe. The verification itself is written up in https://github.com/oven-sh/bun/pull/39326#issuecomment-5313931551; this PR turns the two invariants it rests on into checks.

### Problem
- #39326 passes `-Zbuild-std-features=panic-unwind,default` to release builds, so `std::backtrace::Backtrace` now captures frames it cannot symbolize on the unix targets (std's vendored backtrace crate selects its noop symbolizer when the feature is off), and `RUST_BACKTRACE` no longer does anything.
- That is fine today because nothing in the workspace uses `std::backtrace` (the last use, a FileSink probe, went away in #32474), but nothing stopped a new use from coming back and quietly printing bare addresses.
- Nothing pinned which build configurations get the flag; the `cfg.release && !cfg.asan` gate in scripts/build/rust.ts:429 was untested.

### Fix
- clippy.toml: add `std::backtrace::Backtrace` to `disallowed-types`. The workspace sets `disallowed_types = "deny"` and the rust-lints workflow runs clippy on every PR touching `src/**/*.rs` or clippy.toml, so a new use fails CI with a message pointing at the build flag and at `bun_core::dump_current_stack_trace`.
- test/internal/source-lints/build-rust.test.ts: assert the exact `-Zbuild-std*` args per configuration. Release gets `-Zbuild-std=... -Zbuild-std-features=panic-unwind,default` on linux gnu/musl/android, darwin, windows, freebsd x64 and the tier 3 freebsd aarch64; release-asan, debug-asan and tier 3 debug get bare `-Zbuild-std`; plain debug gets neither.
- Verified:
  - `bun test test/internal/source-lints/` (the documented way to run this directory; it never touches the built binary): 172 pass. Also ran build-rust.test.ts through `bun bd test`.
  - With scripts/build/rust.ts taken from the commit before #39326, the first new test fails; with the `!cfg.asan` guard removed, the second one fails.
  - The clippy entry was checked against a scratch crate containing `std::backtrace::Backtrace::force_capture()` inline (the shape the FileSink probe had), `use std::backtrace::Backtrace;`, the type in a signature and `Backtrace::capture()`: all four are reported as errors. Scratch code not included.
  - `cargo clippy -p bun_core -p bun_ptr -p bun_crash_handler --no-deps` is clean with the new entry locally, and the rust-lints workflow's full-workspace `cargo clippy` passed on this PR, so the entry does not fire on any existing code.
- Nothing under src/ changes. The test pins scripts/build/rust.ts and the clippy entry is checked by the rust-lints workflow, so the fail/pass evidence for this PR is the pre-#39326 rust.ts run above, not a src diff. The comments at src/bun_core/Global.rs:155 and src/ptr/ref_count.rs:24 still describe a "std::backtrace fallback" that is not in the tree; left for a separate cleanup to keep this PR to the checks.

### Background
- `-Zbuild-std` makes cargo compile std from source as part of the build; `-Zbuild-std-features` chooses std's cargo features. Cargo's default set is `panic-unwind,backtrace,default`, and `backtrace` is what compiles the in-process symbolizer (gimli, addr2line, object, miniz_oxide) into std for `std::backtrace` and the default panic hook's `RUST_BACKTRACE` output.
- bun never relies on either: `bun_crash_handler::init()` installs its own panic hook as the first thing `main` does, and that hook captures frames with a frame pointer walk and emits a trace string that bun.report symbolizes out of process.
- clippy's `disallowed-types` is the repo's existing mechanism for banning specific std items (`std::fs::File`, `std::sync::Mutex`, ...); `disallowed_types` is set to `deny` in the workspace lints, so an entry there is a CI failure, not a warning.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/source-lints/build-rust.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/source-lints/build-rust.test.ts
bun test v1.4.0 (8326d1bd3)

test/internal/source-lints/build-rust.test.ts:
(pass) allRustTargets > is exactly the set of triples .buildkite/ci.mjs builds [31.94ms]
(pass) allRustTargets > rust-toolchain.toml preinstalls std for exactly the triples that have a prebuilt one [10.30ms]
(pass) allRustTargets > a Tier 3 target builds std from source with the flag rust:check-all shares [101.89ms]
(pass) build-std feature set > release builds drop std's `backtrace` feature on every shipped platform family [183.79ms]
(pass) build-std feature set > builds that rebuild std for other reasons keep cargo's default feature set [77.06ms]
(pass) CPU baseline > arm64 linux, freebsd and windows assume armv8-a+crc tuned for Ampere, like the C++ side [71.72ms]
(pass) CPU baseline > arm64 android assumes armv8-a+crc tuned for Cortex-A78, like the C++ side [23.69ms]
(pass) CPU baseline > darwin arm64 and x64 name the C++ side's CPU model directly [62.14ms]

 8 pass
 0 fail
 29 expect() calls
Ran 8 tests across 1 file. [4.10s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
clippy.toml                                   |  1 +
 test/internal/source-lints/build-rust.test.ts | 38 +++++++++++++++++++++++++++
 2 files changed, 39 insertions(+)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
clippy.toml                                        1      1      0
test/internal/source-lints/build-rust.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->