### PR TITLE
fix(loader): keep a file:// URL's query in module keys

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3634,7 +3634,10 @@ JSC::Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* jsGlobalObject
         if (moduleName->startsWith("file://"_s)) {
             auto url = WTF::URL(moduleName);
             if (url.isValid() && !url.isEmpty()) {
-                keyZ = Bun::toStringRef(url.fileSystemPath());
+                auto query = url.queryWithLeadingQuestionMark();
+                keyZ = query.isEmpty()
+                    ? Bun::toStringRef(url.fileSystemPath())
+                    : Bun::toStringRef(makeString(url.fileSystemPath(), query));
             } else {
                 keyZ = Bun::toStringRef(moduleName);
             }
@@ -3771,7 +3774,10 @@ JSC::JSPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* jsGlobalO
         if (moduleName.startsWith("file://"_s)) {
             auto url = WTF::URL(moduleName);
             if (url.isValid() && !url.isEmpty()) {
-                moduleStringHolder = url.fileSystemPath();
+                auto query = url.queryWithLeadingQuestionMark();
+                moduleStringHolder = query.isEmpty()
+                    ? url.fileSystemPath()
+                    : makeString(url.fileSystemPath(), query);
                 moduleNameZ = Bun::toStringRef(moduleStringHolder);
             } else {
                 moduleNameZ = Bun::toStringRef(moduleName);

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1172,7 +1172,25 @@ fn do_resolve_with_args<const IS_FILE_PATH: bool>(
     // by value without `dupe_ref()`/`deref()` refcount churn. Only the
     // URL-decoded branch produces a string we must release.
     let specifier_for_resolve = if specifier.has_prefix_comptime(b"file://") {
-        owned.decoded_specifier = jsc::URL::path_from_file_url(specifier);
+        // The query of a `file://` URL is part of the module key (#21346).
+        // `path_from_file_url` returns the pathname only, so re-append the
+        // raw query bytes and let the resolver split them off again — the
+        // same way a relative specifier's query flows through.
+        let query: Option<Vec<u8>> = {
+            let utf8 = specifier.to_utf8();
+            strings::index_of_char_usize(utf8.slice(), b'?').map(|i| utf8.slice()[i..].to_vec())
+        };
+        let decoded = jsc::URL::path_from_file_url(specifier);
+        owned.decoded_specifier = match query {
+            Some(query) => {
+                let mut combined: Vec<u8> = Vec::with_capacity(1024);
+                // Vec<u8> writes are infallible.
+                let _ = write!(&mut combined, "{}", decoded);
+                combined.extend_from_slice(&query);
+                BunString::clone_utf8(&combined)
+            }
+            None => decoded,
+        };
         owned.decoded_specifier
     } else {
         specifier

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -265,6 +265,61 @@ test("Bun.resolveSync keeps a file:// URL's query in the resolved key", async ()
   expect(exitCode).toBe(0);
 });
 
+test("import.meta.resolveSync keeps a file:// URL's query in the resolved key", async () => {
+  using dir = tempDir("resolve-query-file-url-meta", {
+    "target.js": ``,
+    "entry.mjs": `
+      const base = new URL("./target.js", import.meta.url);
+      console.log(JSON.stringify([
+        import.meta.resolveSync(base.href),
+        import.meta.resolveSync(base.href + "?v=1"),
+        import.meta.resolveSync("./target.js?v=2"),
+      ]));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const [plain, v1, rel] = JSON.parse(stdout.trim());
+  expect(plain).toEndWith("target.js");
+  expect(v1).toBe(plain + "?v=1");
+  expect(rel).toBe(plain + "?v=2");
+  expect(exitCode).toBe(0);
+});
+
+test("import.meta.resolve keeps a file:// URL's query", async () => {
+  using dir = tempDir("resolve-url-query-file-url-meta", {
+    "target.js": ``,
+    "entry.mjs": `
+      const base = new URL("./target.js", import.meta.url);
+      console.log(JSON.stringify([
+        import.meta.resolve(base.href + "?v=1"),
+        import.meta.resolve("./target.js?v=2"),
+      ]));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const [fileURL, rel] = JSON.parse(stdout.trim());
+  expect(fileURL.startsWith("file://")).toBe(true);
+  expect(fileURL).toEndWith("target.js?v=1");
+  expect(rel).toEndWith("target.js?v=2");
+  expect(exitCode).toBe(0);
+});
+
 // A file:// URL's query is part of the module key, the same way a relative
 // specifier's query is: distinct queries must evaluate distinct module
 // instances, and import.meta.url keeps the query.

--- a/test/js/bun/resolve/import-query.test.ts
+++ b/test/js/bun/resolve/import-query.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
 globalThis.importQueryFixtureOrder = [];
 const resolvedPath = require.resolve("./import-query-fixture.ts");
 const resolvedURL = Bun.pathToFileURL(resolvedPath).href;
@@ -232,5 +234,110 @@ test("Bun.resolveSync with non-ASCII specifier and query string", async () => {
   expect(stderr).toBe("");
   const resolved = JSON.parse(stdout.trim());
   expect(resolved).toEndWith("target.js?v=caf\u00e9-\u65e5\u672c\u8a9e");
+  expect(exitCode).toBe(0);
+});
+
+test("Bun.resolveSync keeps a file:// URL's query in the resolved key", async () => {
+  using dir = tempDir("resolve-query-file-url", {
+    "target.js": ``,
+    "entry.js": `
+      const base = new URL("./target.js", import.meta.url);
+      console.log(JSON.stringify([
+        Bun.resolveSync(base.href, "."),
+        Bun.resolveSync(base.href + "?v=1", "."),
+        Bun.resolveSync(base.href + "?v=2", "."),
+      ]));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const [plain, v1, v2] = JSON.parse(stdout.trim());
+  expect(plain).toEndWith("target.js");
+  expect(v1).toBe(plain + "?v=1");
+  expect(v2).toBe(plain + "?v=2");
+  expect(exitCode).toBe(0);
+});
+
+// A file:// URL's query is part of the module key, the same way a relative
+// specifier's query is: distinct queries must evaluate distinct module
+// instances, and import.meta.url keeps the query.
+// https://github.com/oven-sh/bun/issues/21346
+test("dynamic import of a file:// URL with distinct queries evaluates distinct module instances", async () => {
+  using dir = tempDir("import-query-file-url-dynamic", {
+    "target.js": `export const captured = globalThis.__token;
+export const url = import.meta.url;
+`,
+    "entry.js": `
+      const base = new URL("./target.js", import.meta.url);
+      globalThis.__token = "one";
+      const first = await import(base.href + "?v=1");
+      globalThis.__token = "two";
+      const second = await import(base.href + "?v=2");
+      const repeat = await import(base.href + "?v=1");
+      console.log(JSON.stringify({
+        first: first.captured,
+        second: second.captured,
+        repeat: repeat.captured,
+        firstURL: first.url,
+        secondURL: second.url,
+      }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { first, second, repeat, firstURL, secondURL } = JSON.parse(stdout.trim());
+  expect(first).toBe("one");
+  expect(second).toBe("two");
+  expect(repeat).toBe(first);
+  expect(firstURL).toEndWith("target.js?v=1");
+  expect(secondURL).toEndWith("target.js?v=2");
+  expect(exitCode).toBe(0);
+});
+
+test("static import of a file:// URL with distinct queries evaluates distinct module instances", async () => {
+  using dir = tempDir("import-query-file-url-static", {
+    "target.js": `export const captured = globalThis.__token;
+`,
+    "setup1.js": `globalThis.__token = "one";
+`,
+    "setup2.js": `globalThis.__token = "two";
+`,
+  });
+  const targetURL = Bun.pathToFileURL(join(String(dir), "target.js")).href;
+  writeFileSync(
+    join(String(dir), "entry.js"),
+    [
+      `import "./setup1.js"`,
+      `import { captured as first } from ${JSON.stringify(targetURL + "?v=1")}`,
+      `import "./setup2.js"`,
+      `import { captured as second } from ${JSON.stringify(targetURL + "?v=2")}`,
+      `console.log(JSON.stringify({ first, second }))`,
+    ].join("\n"),
+  );
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  // Node prints {"first":"one","second":"two"}: "?v=2" is a fresh instance.
+  expect(JSON.parse(stdout.trim())).toEqual({ first: "one", second: "two" });
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Summary

A `file://` URL's query string is part of its module identity, exactly like a
relative specifier's query already is: distinct queries must evaluate to
distinct module instances. Before this change, the two module-loader entry
points decoded a `file://` specifier to a filesystem path via
`WTF::URL::fileSystemPath()` — which returns the pathname only — so the query
was dropped before the module key was built. Every
`import("file:///...?v=1")`, `import("file:///...?v=2")`, … collapsed onto the
same registry entry and returned the first evaluation's cached instance,
while `import("./target.js?v=1")` / `import("./target.js?v=2")` correctly
produced fresh instances.

`Bun.resolveSync` / `import.meta.resolve` have the same drop
(`URL::path_from_file_url` returns the pathname only), fixed the same way.

Fixes #21346

## What changed

The referrer side of `moduleLoaderImportModule` already preserved the query
this way (`ZigGlobalObject.cpp`, `queryWithLeadingQuestionMark()` +
`makeString`) — this change applies the identical pattern to the imported
specifier at the three remaining module-key sites:

- `GlobalObject::moduleLoaderResolve` (static imports / re-resolution)
- `GlobalObject::moduleLoaderImportModule` (dynamic `import()`)
- `VirtualMachine`-facing `do_resolve_with_args` in `BunObject.rs`
  (`Bun.resolveSync` / `import.meta.resolve`): the raw query bytes are
  re-appended to the decoded path before resolution, so the existing
  split-at-`?` machinery in `normalize_specifier_for_resolution` treats it
  exactly like a relative specifier's query.

`URL__pathFromFileURL` itself is untouched: it is a path API also used by
sourcemaps and `import.meta`, where dropping the query is correct.

**Intentionally not changed:** `BunPlugin.cpp`'s `onResolve` handling of
`file:` specifiers strips the query the same way, but it feeds the plugin
virtual-module machinery (`mustDoExpensiveRelativeLookup`), which needs its
own test coverage; out of scope here.

## Behavior

```js
// entry.mjs — Node and Bun (after) print the same thing
globalThis.__token = "one";
const first = await import(new URL("./target.js", import.meta.url) + "?v=1");
globalThis.__token = "two";
const second = await import(new URL("./target.js", import.meta.url) + "?v=2");
console.log(first.captured, second.captured); // "one two" (was "one one")
```

Also unchanged-but-now-consistent: `import.meta.url` of a query-suffixed
module keeps its query; repeating a previously-imported query returns the
cached instance for that query.

## Test plan

Added to `test/js/bun/resolve/import-query.test.ts` (existing file for this
area), covering the variant matrix alongside the relative-specifier tests:

- dynamic `import()` of a `file://` URL with distinct queries → distinct
  instances, repeated query returns the same instance, `import.meta.url`
  keeps the query
- static `import` of `file://` URLs with distinct queries → distinct
  instances (setup side-effect ordering, matching Node's output)
- `Bun.resolveSync` with a `file://` + query specifier keeps the query in
  the resolved key

Verified against Node v26.4.0 for the expected semantics, and
`USE_SYSTEM_BUN=1 bun test` fails on the new tests (current release) while
`bun bd test` passes with the fix.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/js/bun/resolve/import-query.test.ts` — the
  three new tests fail on the current release (test validity), all pre-existing
  tests unchanged
- `bun bd test test/js/bun/resolve/import-query.test.ts` — **18/18 pass** with
  the fix
- `bun bd test test/js/bun/resolve/` (full directory, 362 tests) — failure set
  with and without this change is **identical** (6 pre-existing debug-build
  timeouts: TOML deep-nesting ×3, 2000×-load ×2, reflect-metadata/tsyringe ×1),
  i.e. zero regressions from this change
