### PR TITLE
Fix crashes when a lazy Bun property throws while being initialized

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5643,10 +5643,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -1,6 +1,7 @@
 import { env } from "bun";
 import { hasNonReifiedStatic } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
 test("hasNonReifiedStatic", () => {
   expect(hasNonReifiedStatic(Bun), "do not eagerly initialize the Bun object. This will make Bun much slower.").toBe(
     true,
@@ -32,4 +33,79 @@ test("await import('bun')", async () => {
     expect(BunESM[property]).toBe(Bun[property]);
   }
   expect(BunESM.default).toBe(Bun);
+});
+
+// Bun.sql is initialized by running an internal module. Touching it for the
+// first time with almost no stack left makes that initializer throw.
+test.concurrent("Bun.sql initializer throwing does not crash or report an uncaught error", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        let result;
+        function recurse() {
+          try {
+            recurse();
+          } catch {}
+          if (result === undefined) {
+            try {
+              Bun.sql;
+              result = "initialized";
+            } catch (e) {
+              result = e.constructor.name;
+            }
+          }
+        }
+        recurse();
+        console.log(JSON.stringify({ result, sql: typeof Bun.sql }));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ result: "RangeError", sql: "function" });
+  expect(exitCode).toBe(0);
+});
+
+// Bun.$ is the first entry in the Bun object's property table and its
+// initializer calls into JavaScript. Inspecting Bun with just enough stack for
+// the formatter to start enumerating makes that initializer throw while the
+// following entries are still initialized and printed.
+test.concurrent("inspecting Bun while a lazy property initializer throws", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        let out;
+        function recurse() {
+          try {
+            recurse();
+          } catch {}
+          if (out === undefined) {
+            try {
+              out = Bun.inspect(Bun, { depth: 0 });
+            } catch {}
+          }
+        }
+        recurse();
+        console.log(JSON.stringify({ archive: out.includes("Archive:"), shell: out.includes("$:"), $: typeof Bun.$ }));
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { shell, ...rest } = JSON.parse(stdout);
+  expect(rest).toEqual({ archive: true, $: "function" });
+  // On Windows the formatter's own stack headroom is larger than JSC's, so the
+  // initializer never gets to fail there.
+  if (!isWindows) expect(shell).toBe(false);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fuzzing found a crash while formatting the `Bun` object close to the stack limit (`expect(Bun).toBeFalse()` inside a recursion that had just overflowed). The fingerprint is `JSValue::getObject()` being called on an empty value (`JSCJSValueCell.h:92`, member call on a null `JSCell`). Two things go wrong when one of `Bun`'s lazy static properties throws while it is being initialized, which a stack overflow makes easy to trigger for the ones that run JavaScript (`Bun.$`, `Bun.sql`, `Bun.postgres`, `Bun.SQL`):

1. `defaultBunSQLObject` / `constructBunSQLObject` (`BunObject.cpp`) had a debug-only `reportUncaughtExceptionAtEventLoop` call in front of their `RETURN_IF_EXCEPTION`. The exception is not uncaught at that point (it is about to be propagated to whoever touched `Bun.sql`), and the uncaught-exception machinery runs `process._fatalException` lookups and the default error printer with the exception still pending. Depending on the state of the process object that either trips JSC assertions, or clears the exception, in which case `RETURN_IF_EXCEPTION` no longer fires and `sqlValue.getObject()` runs on the empty value `requireId` returned. That is the fuzzer's crash. Either way the script's own `catch` was also undermined: the error got printed and the exit code set to 1. The debug block is removed; the error simply propagates like it does in release builds.

2. `JSC__JSValue__forEachPropertyImpl` (`bindings.cpp`, used by `Bun.inspect`, `console.log` and the `expect` failure messages) did `continue` when `getPropertySlot` returned false, before its `CLEAR_IF_EXCEPTION`. When the slot was missing because the initializer threw, the exception stayed pending while the loop went on to the next property. In debug and ASAN builds the next Rust-backed lazy property then aborts in `to_js_host_call` (`Unexpected exception observed`), which is what the reproducer hits on a current debug build. In release builds `setUpStaticFunctionSlot` sees the stale exception and reports every following not-yet-initialized static property as missing, so `Bun.inspect(Bun)` silently drops everything between `$` and the first property that had already been initialized. The exception is now cleared before the `continue`, matching what the fast path and `forEachPropertyOrdered` in the same file already do.

### How did you verify your code works?

- The fuzzer script aborted on the debug build before (`releaseAssertNoException` in `BunObject_lazyPropCb_Archive`); with this change it runs to completion and exits with the expected `toBeFalse` error, with nothing from the sanitizers or assertions.
- Two tests in `test/js/bun/util/BunObject.test.ts`. Each recurses until the stack overflows and then touches `Bun.sql` or calls `Bun.inspect(Bun)` while unwinding. Without this change the first one aborts on debug builds (it passes on release builds, since the code it covers is debug-only), and the second one aborts on debug builds and fails on release builds because `Archive:` is missing from the output. Both pass with the change, in well under a second each on a debug build.
- `test/js/bun/util/inspect*.test.js`, `test/js/bun/console/`, `test/js/node/util/` and the node `test-util-inspect-proxy.js` / `getters-accessing-this.js` tests still pass.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/BunObject.test.ts

<!-- robobun:evidence:end -->