### PR TITLE
Clear the exception left by a failed lazy property in forEachProperty

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5643,10 +5643,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -579,6 +579,84 @@ it("Bun.inspect huge sparse array summarizes holes without iterating them", asyn
   });
 });
 
+// When a lazily initialized property throws while being looked up, the property walk used to
+// leave that exception pending. The next lazy property was then initialized with an exception
+// already set (an assertion in debug builds), and in release builds every property after the
+// failing one was dropped from the output until an already-initialized property was reached.
+describe("Bun.inspect and lazy properties whose initializer throws", () => {
+  it.concurrent("only the property that failed is left out", async () => {
+    // An unparseable REDIS_URL makes the Bun.redis initializer throw. The properties declared
+    // after it (secrets, write, zstd*) must still be printed.
+    const code = `
+      try {
+        Bun.redis;
+      } catch (e) {
+        console.log("Bun.redis threw:", e.message);
+      }
+      const out = Bun.inspect(Bun, { depth: 0 });
+      for (const name of ["redis", "secrets", "write", "zstdDecompress"]) {
+        console.log(name + ":", out.includes("\\n  " + name + ": "));
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: { ...bunEnv, REDIS_URL: "not a url" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(
+      [
+        "Bun.redis threw: Invalid URL format",
+        "redis: false",
+        "secrets: true",
+        "write: true",
+        "zstdDecompress: true",
+        "",
+      ].join("\n"),
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("initializers that run out of stack", async () => {
+    // Bun.$, Bun.sql and friends run JS to build their value, so with (almost) no JS stack left
+    // they throw and are left out. Unwind a stack overflow one frame at a time and check the
+    // first Bun.inspect(Bun) call that completes: Archive (declared right after $) and version
+    // have initializers that cannot fail, so they must be in the output.
+    const code = `
+      let result;
+      function recurse() {
+        try {
+          recurse();
+        } catch {}
+        if (result !== undefined) return;
+        let out;
+        try {
+          out = Bun.inspect(Bun, { depth: 0 });
+        } catch {
+          return;
+        }
+        result = out.includes("\\n  Archive: ") && out.includes("\\n  version: ") ? "ok" : out;
+      }
+      recurse();
+      console.log(result);
+      const out = Bun.inspect(Bun, { depth: 0 });
+      console.log(out.includes("\\n  $: ") && out.includes("\\n  Archive: ") && out.includes("\\n  version: ") ? "ok" : out);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("ok\nok\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("console.logging function displays async and generator names", async () => {
   const cases = [
     function () {},


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found assertion failure (`ExceptionScope::releaseAssertNoException`, "Unexpected exception observed") in the native property walk behind `Bun.inspect` / `console.log`.

Reduced repro: catch a stack overflow and, with the stack still almost full, inspect an object that has lazily initialized static properties:

```js
function f() {
  try { f(); } catch {}
  Bun.inspect(Bun);
}
f();
```

The fuzzer got there through `new CompressionStream(globalThis)`, whose `ERR_INVALID_ARG_VALUE` message inspects the argument.

Root cause: `Bun.$` is a static lazy property whose initializer runs JS. With no JS stack left it throws, `reifyStaticProperty` stores nothing, and `setUpStaticFunctionSlot` returns false with the exception still pending (that is the contract in our JSC fork: the caller of `getPropertySlot` has to look at the exception). `JSC__JSValue__forEachPropertyImpl` did

```cpp
if (!object->getPropertySlot(globalObject, property, slot))
    continue;
CLEAR_IF_EXCEPTION(scope);
```

so the `continue` skipped the clear. The next property in the table, `Bun.Archive`, was then reified with the exception still set, and its Rust-side `to_js_host_call` wrapper asserts on exactly that. In release builds the damage is different: `setUpStaticFunctionSlot` checks `vm.exceptionForInspection()` after reifying, so with a stale exception every following lazy property is reified but reported as missing, until the walk reaches a property that was already reified (that lookup takes the normal path and clears the exception). With an invalid `REDIS_URL`, `Bun.inspect(Bun)` on current release builds prints nothing after `RedisClient`: `redis` legitimately fails, and `secrets`, `write` and the `zstd*` functions go missing with it.

The fix is the hunk in `bindings.cpp`: call `getPropertySlot`, clear, then `continue`, which is what `JSC__JSValue__forEachPropertyOrdered` already does a few lines further down. I checked the other slot lookups in the bindings: `JSC__JSValue__getPropertyValue` returns on the exception, and `JSPropertyIterator` goes through `from_js_host_call_generic`, so the exception propagates there.

With that fixed, the same repro hit a second assertion (`Structure::storedPrototype`) further along the same unwind. The `Bun.sql` / `Bun.SQL` builders had a debug-only block that reported the `require` failure through `reportUncaughtExceptionAtEventLoop` while the exception was still pending. The reporter looks up `process._fatalException`, which is itself a lazy property, so that lookup ran into the same stale-exception situation one level down. Every other caller of `reportUncaughtExceptionAtEventLoop` clears first. The block is removed: `RETURN_IF_EXCEPTION` right below it already hands the error to whoever touched `Bun.sql`, which is the more useful place for it to show up anyway.

Not changed here: the lazy builders on `process` use a different policy (`callLazyProcessBuilder` clears, reports the error as uncaught and stores `undefined`). Running the same unwind against `process` leaves `process.nextTick`, `process.stdout` and a few others permanently `undefined` and prints six RangeErrors. That is pre-existing and a separate piece of code; tracking it separately.

### How did you verify your code works?

Two tests added to `test/js/bun/util/inspect.test.js`:

* `only the property that failed is left out`: `REDIS_URL` set to garbage, so `Bun.redis` throws, then checks that `secrets`, `write` and `zstdDecompress` are still printed. No stack tricks involved.
* `initializers that run out of stack`: the reduced repro above. It unwinds a stack overflow one frame at a time and checks the first `Bun.inspect(Bun)` call that returns; `Archive` (declared right after `$`) and `version` have to be in the output.

Both fail before the fix: on the release build they fail on the printed output (`secrets: false` etc., and a `Bun {` dump that starts at `inspect:`), on a debug build both child processes die on the assertions above. Both pass with `bun bd test`, and I ran them eight times in a row on the debug build. After the fix the first completing inspect at the bottom of the unwind is missing exactly `$`, `sql`, `postgres` and `SQL` (the four builders that run JS); before, it was missing 85 of the 115 properties.

The fuzzer script itself (bounded to the deepest 1500 frames of the unwind, the full version inspects `globalThis` at every one of ~50k frames and takes ages on a debug build) now runs to completion on the debug build; the unfixed debug binary still aborts on it. Also ran `inspect.test.js`, `BunObject.test.ts`, the `test/js/bun/console` tests and the sql adapter tests on the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->