### PR TITLE
js_parser: write a substituted child back to its parent in one place

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -13,9 +13,6 @@
 "defaulted_failure:src/install/npm.rs" = 1
 "interchangeable_aliases:src/install/lockfile/Tree.rs" = 1
 
-[bun_js_parser]
-"same_match_twice:src/js_parser/p.rs" = 3
-
 [bun_js_printer]
 "parallel_vecs:src/js_printer/lib.rs" = 1
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2201,118 +2201,77 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
                 js_ast::ExprData::ENew(mut new) => {
-                    match self.substitute_single_use_symbol_in_expr(
-                        new.target,
+                    if let Some(done) = self.substitute_single_use_symbol_in_child(
+                        &mut new.target,
+                        expr,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
-                        Substitution::Continue => {}
-                        Substitution::Success(result) => {
-                            new.target = result;
-                            return Substitution::Success(expr);
-                        }
-                        Substitution::Failure(result) => {
-                            new.target = result;
-                            return Substitution::Failure(expr);
-                        }
+                        return done;
                     }
 
                     if replacement_can_be_removed {
                         for arg in new.args.slice_mut() {
-                            match self.substitute_single_use_symbol_in_expr(
-                                *arg,
+                            if let Some(done) = self.substitute_single_use_symbol_in_child(
+                                arg,
+                                expr,
                                 r#ref,
                                 replacement,
                                 replacement_can_be_removed,
                             ) {
-                                Substitution::Continue => {}
-                                Substitution::Success(result) => {
-                                    *arg = result;
-                                    return Substitution::Success(expr);
-                                }
-                                Substitution::Failure(result) => {
-                                    *arg = result;
-                                    return Substitution::Failure(expr);
-                                }
+                                return done;
                             }
                         }
                     }
                 }
                 js_ast::ExprData::ESpread(mut spread) => {
-                    match self.substitute_single_use_symbol_in_expr(
-                        spread.value,
+                    if let Some(done) = self.substitute_single_use_symbol_in_child(
+                        &mut spread.value,
+                        expr,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
-                        Substitution::Continue => {}
-                        Substitution::Success(result) => {
-                            spread.value = result;
-                            return Substitution::Success(expr);
-                        }
-                        Substitution::Failure(result) => {
-                            spread.value = result;
-                            return Substitution::Failure(expr);
-                        }
+                        return done;
                     }
                 }
                 js_ast::ExprData::EAwait(mut await_expr) => {
-                    match self.substitute_single_use_symbol_in_expr(
-                        await_expr.value,
+                    if let Some(done) = self.substitute_single_use_symbol_in_child(
+                        &mut await_expr.value,
+                        expr,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
-                        Substitution::Continue => {}
-                        Substitution::Success(result) => {
-                            await_expr.value = result;
-                            return Substitution::Success(expr);
-                        }
-                        Substitution::Failure(result) => {
-                            await_expr.value = result;
-                            return Substitution::Failure(expr);
-                        }
+                        return done;
                     }
                 }
                 js_ast::ExprData::EYield(mut yield_) => {
-                    let value = yield_.value.unwrap_or(Expr {
+                    let mut value = yield_.value.unwrap_or(Expr {
                         data: js_ast::ExprData::EMissing(E::Missing {}),
                         loc: expr.loc,
                     });
-                    match self.substitute_single_use_symbol_in_expr(
-                        value,
+                    if let Some(done) = self.substitute_single_use_symbol_in_child(
+                        &mut value,
+                        expr,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
-                        Substitution::Continue => {}
-                        Substitution::Success(result) => {
-                            yield_.value = Some(result);
-                            return Substitution::Success(expr);
-                        }
-                        Substitution::Failure(result) => {
-                            yield_.value = Some(result);
-                            return Substitution::Failure(expr);
-                        }
+                        yield_.value = Some(value);
+                        return done;
                     }
                 }
                 js_ast::ExprData::EImport(mut import) => {
-                    match self.substitute_single_use_symbol_in_expr(
-                        import.expr,
+                    if let Some(done) = self.substitute_single_use_symbol_in_child(
+                        &mut import.expr,
+                        expr,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
-                        Substitution::Continue => {}
-                        Substitution::Success(result) => {
-                            import.expr = result;
-                            return Substitution::Success(expr);
-                        }
-                        Substitution::Failure(result) => {
-                            import.expr = result;
-                            return Substitution::Failure(expr);
-                        }
+                        return done;
                     }
 
                     // The "import()" expression has side effects but the side effects are
@@ -2335,60 +2294,41 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         | js_ast::op::Code::UnDelete => {
                             // Do not substitute into an assignment position
                         }
-                        _ => match self.substitute_single_use_symbol_in_expr(
-                            e.value,
-                            r#ref,
-                            replacement,
-                            replacement_can_be_removed,
-                        ) {
-                            Substitution::Continue => {}
-                            Substitution::Success(result) => {
-                                e.value = result;
-                                return Substitution::Success(expr);
+                        _ => {
+                            if let Some(done) = self.substitute_single_use_symbol_in_child(
+                                &mut e.value,
+                                expr,
+                                r#ref,
+                                replacement,
+                                replacement_can_be_removed,
+                            ) {
+                                return done;
                             }
-                            Substitution::Failure(result) => {
-                                e.value = result;
-                                return Substitution::Failure(expr);
-                            }
-                        },
+                        }
                     }
                 }
                 js_ast::ExprData::EDot(mut e) => {
-                    match self.substitute_single_use_symbol_in_expr(
-                        e.target,
+                    if let Some(done) = self.substitute_single_use_symbol_in_child(
+                        &mut e.target,
+                        expr,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
-                        Substitution::Continue => {}
-                        Substitution::Success(result) => {
-                            e.target = result;
-                            return Substitution::Success(expr);
-                        }
-                        Substitution::Failure(result) => {
-                            e.target = result;
-                            return Substitution::Failure(expr);
-                        }
+                        return done;
                     }
                 }
                 js_ast::ExprData::EBinary(mut e) => {
                     // Do not substitute into an assignment position
                     if js_ast::op::Code::binary_assign_target(e.op) == js_ast::AssignTarget::None {
-                        match self.substitute_single_use_symbol_in_expr(
-                            e.left,
+                        if let Some(done) = self.substitute_single_use_symbol_in_child(
+                            &mut e.left,
+                            expr,
                             r#ref,
                             replacement,
                             replacement_can_be_removed,
                         ) {
-                            Substitution::Continue => {}
-                            Substitution::Success(result) => {
-                                e.left = result;
-                                return Substitution::Success(expr);
-                            }
-                            Substitution::Failure(result) => {
-                                e.left = result;
-                                return Substitution::Failure(expr);
-                            }
+                            return done;
                         }
                     } else if !self.expr_can_be_removed_if_unused(&e.left) {
                         // Do not reorder past a side effect in an assignment target, as that may
@@ -2415,39 +2355,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     // If we get here then it should be safe to attempt to substitute the
                     // replacement past the left operand into the right operand.
-                    match self.substitute_single_use_symbol_in_expr(
-                        e.right,
+                    if let Some(done) = self.substitute_single_use_symbol_in_child(
+                        &mut e.right,
+                        expr,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
-                        Substitution::Continue => {}
-                        Substitution::Success(result) => {
-                            e.right = result;
-                            return Substitution::Success(expr);
-                        }
-                        Substitution::Failure(result) => {
-                            e.right = result;
-                            return Substitution::Failure(expr);
-                        }
+                        return done;
                     }
                 }
                 js_ast::ExprData::EIf(mut e) => {
-                    match self.substitute_single_use_symbol_in_expr(
-                        e.test,
+                    if let Some(done) = self.substitute_single_use_symbol_in_child(
+                        &mut e.test,
+                        expr,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
-                        Substitution::Continue => {}
-                        Substitution::Success(result) => {
-                            e.test = result;
-                            return Substitution::Success(expr);
-                        }
-                        Substitution::Failure(result) => {
-                            e.test = result;
-                            return Substitution::Failure(expr);
-                        }
+                        return done;
                     }
 
                     // Do not substitute our unconditionally-executed value into a branch
@@ -2491,41 +2417,27 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
                 js_ast::ExprData::EIndex(mut index) => {
-                    match self.substitute_single_use_symbol_in_expr(
-                        index.target,
+                    if let Some(done) = self.substitute_single_use_symbol_in_child(
+                        &mut index.target,
+                        expr,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
-                        Substitution::Continue => {}
-                        Substitution::Success(result) => {
-                            index.target = result;
-                            return Substitution::Success(expr);
-                        }
-                        Substitution::Failure(result) => {
-                            index.target = result;
-                            return Substitution::Failure(expr);
-                        }
+                        return done;
                     }
 
                     // Do not substitute our unconditionally-executed value into a branch
                     // unless the value itself has no side effects
                     if replacement_can_be_removed || index.optional_chain.is_none() {
-                        match self.substitute_single_use_symbol_in_expr(
-                            index.index,
+                        if let Some(done) = self.substitute_single_use_symbol_in_child(
+                            &mut index.index,
+                            expr,
                             r#ref,
                             replacement,
                             replacement_can_be_removed,
                         ) {
-                            Substitution::Continue => {}
-                            Substitution::Success(result) => {
-                                index.index = result;
-                                return Substitution::Success(expr);
-                            }
-                            Substitution::Failure(result) => {
-                                index.index = result;
-                                return Substitution::Failure(expr);
-                            }
+                            return done;
                         }
                     }
                 }
@@ -2541,63 +2453,42 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         _ => {}
                     }
 
-                    match self.substitute_single_use_symbol_in_expr(
-                        e.target,
+                    if let Some(done) = self.substitute_single_use_symbol_in_child(
+                        &mut e.target,
+                        expr,
                         r#ref,
                         replacement,
                         replacement_can_be_removed,
                     ) {
-                        Substitution::Continue => {}
-                        Substitution::Success(result) => {
-                            e.target = result;
-                            return Substitution::Success(expr);
-                        }
-                        Substitution::Failure(result) => {
-                            e.target = result;
-                            return Substitution::Failure(expr);
-                        }
+                        return done;
                     }
 
                     // Do not substitute our unconditionally-executed value into a branch
                     // unless the value itself has no side effects
                     if replacement_can_be_removed || e.optional_chain.is_none() {
                         for arg in e.args.slice_mut() {
-                            match self.substitute_single_use_symbol_in_expr(
-                                *arg,
+                            if let Some(done) = self.substitute_single_use_symbol_in_child(
+                                arg,
+                                expr,
                                 r#ref,
                                 replacement,
                                 replacement_can_be_removed,
                             ) {
-                                Substitution::Continue => {}
-                                Substitution::Success(result) => {
-                                    *arg = result;
-                                    return Substitution::Success(expr);
-                                }
-                                Substitution::Failure(result) => {
-                                    *arg = result;
-                                    return Substitution::Failure(expr);
-                                }
+                                return done;
                             }
                         }
                     }
                 }
                 js_ast::ExprData::EArray(mut e) => {
                     for item in e.items.slice_mut() {
-                        match self.substitute_single_use_symbol_in_expr(
-                            *item,
+                        if let Some(done) = self.substitute_single_use_symbol_in_child(
+                            item,
+                            expr,
                             r#ref,
                             replacement,
                             replacement_can_be_removed,
                         ) {
-                            Substitution::Continue => {}
-                            Substitution::Success(result) => {
-                                *item = result;
-                                return Substitution::Success(expr);
-                            }
-                            Substitution::Failure(result) => {
-                                *item = result;
-                                return Substitution::Failure(expr);
-                            }
+                            return done;
                         }
                     }
                 }
@@ -2605,21 +2496,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     for property in e.properties.slice_mut() {
                         // Check the key
                         if property.flags.contains(Flags::Property::IsComputed) {
-                            match self.substitute_single_use_symbol_in_expr(
-                                property.key.expect("infallible: prop has key"),
+                            let key = property.key.as_mut().expect("infallible: prop has key");
+                            if let Some(done) = self.substitute_single_use_symbol_in_child(
+                                key,
+                                expr,
                                 r#ref,
                                 replacement,
                                 replacement_can_be_removed,
                             ) {
-                                Substitution::Continue => {}
-                                Substitution::Success(result) => {
-                                    property.key = Some(result);
-                                    return Substitution::Success(expr);
-                                }
-                                Substitution::Failure(result) => {
-                                    property.key = Some(result);
-                                    return Substitution::Failure(expr);
-                                }
+                                return done;
                             }
 
                             // Stop now because both computed keys and property spread have side effects
@@ -2627,53 +2512,32 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         }
 
                         // Check the value
-                        if let Some(value) = property.value {
-                            match self.substitute_single_use_symbol_in_expr(
+                        if let Some(value) = property.value.as_mut() {
+                            if let Some(done) = self.substitute_single_use_symbol_in_child(
                                 value,
+                                expr,
                                 r#ref,
                                 replacement,
                                 replacement_can_be_removed,
                             ) {
-                                Substitution::Continue => {}
-                                Substitution::Success(result) => {
-                                    property.value =
-                                        if matches!(result.data, js_ast::ExprData::EMissing(_)) {
-                                            None
-                                        } else {
-                                            Some(result)
-                                        };
-                                    return Substitution::Success(expr);
+                                if matches!(value.data, js_ast::ExprData::EMissing(_)) {
+                                    property.value = None;
                                 }
-                                Substitution::Failure(result) => {
-                                    property.value =
-                                        if matches!(result.data, js_ast::ExprData::EMissing(_)) {
-                                            None
-                                        } else {
-                                            Some(result)
-                                        };
-                                    return Substitution::Failure(expr);
-                                }
+                                return done;
                             }
                         }
                     }
                 }
                 js_ast::ExprData::ETemplate(mut e) => {
                     if let Some(tag) = e.tag.as_mut() {
-                        match self.substitute_single_use_symbol_in_expr(
-                            *tag,
+                        if let Some(done) = self.substitute_single_use_symbol_in_child(
+                            tag,
+                            expr,
                             r#ref,
                             replacement,
                             replacement_can_be_removed,
                         ) {
-                            Substitution::Continue => {}
-                            Substitution::Success(result) => {
-                                *tag = result;
-                                return Substitution::Success(expr);
-                            }
-                            Substitution::Failure(result) => {
-                                *tag = result;
-                                return Substitution::Failure(expr);
-                            }
+                            return done;
                         }
                     }
 
@@ -2682,22 +2546,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // SAFETY: arena-owned slice; single-threaded visit pass has exclusive
                     // access and no other borrow of this slice is live across the loop body.
                     for part in e.parts_mut().iter_mut() {
-                        match self.substitute_single_use_symbol_in_expr(
-                            part.value,
+                        if let Some(done) = self.substitute_single_use_symbol_in_child(
+                            &mut part.value,
+                            expr,
                             r#ref,
                             replacement,
                             replacement_can_be_removed,
                         ) {
-                            Substitution::Continue => {}
-                            Substitution::Success(result) => {
-                                part.value = result;
-                                // todo: mangle template parts
-                                return Substitution::Success(expr);
-                            }
-                            Substitution::Failure(result) => {
-                                part.value = result;
-                                return Substitution::Failure(expr);
-                            }
+                            // todo: mangle template parts
+                            return done;
                         }
                     }
                 }
@@ -2718,6 +2575,36 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // Otherwise we should stop trying to substitute past this point
         Substitution::Failure(expr)
+    }
+
+    /// Substitutes into the child expression held in `slot`. `Continue` leaves
+    /// the child alone and returns `None` so the caller moves on to the next
+    /// child; `Success` and `Failure` store the rewritten child back into `slot`
+    /// and become the same outcome for `parent`, which the caller returns.
+    fn substitute_single_use_symbol_in_child(
+        &mut self,
+        slot: &mut Expr,
+        parent: Expr,
+        r#ref: Ref,
+        replacement: Expr,
+        replacement_can_be_removed: bool,
+    ) -> Option<Substitution> {
+        match self.substitute_single_use_symbol_in_expr(
+            *slot,
+            r#ref,
+            replacement,
+            replacement_can_be_removed,
+        ) {
+            Substitution::Continue => None,
+            Substitution::Success(child) => {
+                *slot = child;
+                Some(Substitution::Success(parent))
+            }
+            Substitution::Failure(child) => {
+                *slot = child;
+                Some(Substitution::Failure(parent))
+            }
+        }
     }
 
     pub(crate) fn prepare_for_visit_pass(&mut self) -> Result<(), crate::Error> {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2577,10 +2577,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Substitution::Failure(expr)
     }
 
-    /// Substitutes into the child expression held in `slot`. `Continue` leaves
-    /// the child alone and returns `None` so the caller moves on to the next
-    /// child; `Success` and `Failure` store the rewritten child back into `slot`
-    /// and become the same outcome for `parent`, which the caller returns.
+    /// `None` is `Continue`; otherwise `slot` was rewritten and this is `parent`'s outcome.
     fn substitute_single_use_symbol_in_child(
         &mut self,
         slot: &mut Expr,

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1398,6 +1398,77 @@ describe("bundler", () => {
       expect(code).toMatch(/=>\s*\{\s*return a \+ 1;?\s*\}/);
     },
   });
+
+  // A single-use `let` is substituted into whichever child of the next
+  // expression reads it. `a` is used where the substitution must happen;
+  // `keep` where a side effect in between must block it.
+  itBundled("minify/SingleUseSubstitutionIntoEachChild", {
+    files: {
+      "/entry.js": /* js */ `
+        export function newTarget(c) { let a = c; return new a(); }
+        export function spread(v) { let a = v; return [...a]; }
+        export async function awaited(v) { let a = v; return await a; }
+        export function* yielded(v) { let a = v; yield a; }
+        export function dynamicImport(v) { let a = v; return import(a); }
+        export function unary(v) { let a = v; return -a; }
+        export function dot(v) { let a = v; return a.b; }
+        export function binaryLeft(v, w) { let a = v; return a + w; }
+        export function binaryRight(v, w) { let a = v; return w + a; }
+        export function ifTest(v, w, u) { let a = v; return a ? w : u; }
+        export function ifYes(v, w, u) { let a = v; return w ? a : u; }
+        export function ifNo(v, w, u) { let a = v; return w ? u : a; }
+        export function indexTarget(v, i) { let a = v; return a[i]; }
+        export function indexIndex(v, i) { let a = i; return v[a]; }
+        export function callTarget(v) { let a = v; return a(); }
+        export function array(v) { let a = v; return [1, a, 2]; }
+        export function objectValue(v) { let a = v; return { k: 1, v: a }; }
+        export function objectComputedKey(v) { let a = v; return { [a]: 1 }; }
+        export function templateTag(t) { let a = t; return a\`x\`; }
+        export function templateParts(v) { let a = v; return \`1-\${v}-\${a}\`; }
+
+        export function newArgsAfterSideEffect() { let keep = g(); return new Foo(keep); }
+        export function mutatingUnary(v) { let keep = v; return keep++; }
+        export function binaryRightAfterSideEffect(w) { let keep = g(); return w.z + keep; }
+        export function updateAssignment() { let keep = g(); total += keep; }
+        export function ifBranchWithSideEffect(w, u) { let keep = g(); return w ? keep : u; }
+        export function optionalCallArg() { let keep = g(); return f?.(keep); }
+        export function callTargetChangingThis(o) { let keep = o.m; return keep(); }
+        export function objectValueAfterComputedKey() { let keep = g(); return { [k()]: 1, v: keep }; }
+        export function templatePartAfterSideEffect() { let keep = g(); return \`\${h()}-\${keep}\`; }
+      `,
+    },
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).not.toContain("let a");
+      for (const substituted of [
+        "new c;",
+        "[...v]",
+        "await v",
+        "yield v",
+        "import(v)",
+        "return -v",
+        "return v.b",
+        "return v + w",
+        "return w + v",
+        "v ? w : u",
+        "w ? v : u",
+        "w ? u : v",
+        "return v()",
+        "[1, v, 2]",
+        "{ k: 1, v }",
+        "{ [v]: 1 }",
+        "t`x`",
+        "`1-${v}-${v}`",
+      ]) {
+        expect(code).toContain(substituted);
+      }
+      // indexTarget and indexIndex both end up here.
+      expect(code.match(/return v\[i\];/g)).toHaveLength(2);
+      expect(code.match(/let keep = /g)).toHaveLength(9);
+    },
+  });
 });
 
 // The runtime transpiler (`bun run`/`bun test`) implicitly enables

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -1406,6 +1406,7 @@ describe("bundler", () => {
     files: {
       "/entry.js": /* js */ `
         export function newTarget(c) { let a = c; return new a(); }
+        export function newArgs(c, v) { let a = v; return new c(1, a); }
         export function spread(v) { let a = v; return [...a]; }
         export async function awaited(v) { let a = v; return await a; }
         export function* yielded(v) { let a = v; yield a; }
@@ -1426,7 +1427,8 @@ describe("bundler", () => {
         export function templateTag(t) { let a = t; return a\`x\`; }
         export function templateParts(v) { let a = v; return \`1-\${v}-\${a}\`; }
 
-        export function newArgsAfterSideEffect() { let keep = g(); return new Foo(keep); }
+        export function newArgsWithSideEffect(c) { let keep = g(); return new c(keep); }
+        export function* yieldWithoutOperand(v) { let keep = v; yield; return keep; }
         export function mutatingUnary(v) { let keep = v; return keep++; }
         export function binaryRightAfterSideEffect(w) { let keep = g(); return w.z + keep; }
         export function updateAssignment() { let keep = g(); total += keep; }
@@ -1444,6 +1446,7 @@ describe("bundler", () => {
       expect(code).not.toContain("let a");
       for (const substituted of [
         "new c;",
+        "new c(1, v)",
         "[...v]",
         "await v",
         "yield v",
@@ -1466,7 +1469,7 @@ describe("bundler", () => {
       }
       // indexTarget and indexIndex both end up here.
       expect(code.match(/return v\[i\];/g)).toHaveLength(2);
-      expect(code.match(/let keep = /g)).toHaveLength(9);
+      expect(code.match(/let keep = /g)).toHaveLength(10);
     },
   });
 });


### PR DESCRIPTION
### Problem
- mordant's `same_match_twice` lint has three findings in `src/js_parser/p.rs`, recorded in `mordant-baseline.toml` as `"same_match_twice:src/js_parser/p.rs" = 3`.
- `P::substitute_single_use_symbol_in_expr` (`src/js_parser/p.rs`) handles every child of an expression with the same match on the recursive result: `Continue` does nothing, `Success(child)` and `Failure(child)` store the child back into its slot and return the parent with the same outcome. The `new` arguments, call arguments, array items and template tag copies are token for token identical, which is what the lint counts; sixteen more copies differ only in the slot they write to, and three more (yield operand, computed object key, object property value) only in how they write it.

### Fix
- Adds `P::substitute_single_use_symbol_in_child(slot: &mut Expr, parent, ..) -> Option<Substitution>`, which runs the recursion on `*slot`, writes the rewritten child back and returns the parent's outcome, or `None` on `Continue`. Every child site is now `if let Some(done) = ... { return done; }`; the three `Option` slots substitute into a local or `as_mut()` borrow and then update the `Option` exactly as before (the property value still becomes `None` when the child was rewritten to `EMissing`).
- Removes the baseline line; `[bun_js_parser]` had no other entries, so the section goes too.
- No behavior change. Verified:
  - `bun build --minify-syntax` of a file exercising every child kind (new target and arguments, spread, await, yield with and without an operand, `import()`, unary, dot, both binary operands, all three `?:` operands, index target and index, call target and arguments, array, object value and computed key, template tag and parts, plus the side-effect cases that must refuse) prints byte-identical output on the release build before this change and on the debug build with it.
  - `test/bundler/bundler_minify.test.ts`: new `minify/SingleUseSubstitutionIntoEachChild` pins that behavior (passes with and without this change, as a refactor should); the rest of the file, `test/bundler/esbuild/default.test.ts` and `test/bundler/esbuild/dce.test.ts` pass with `bun bd test`.
  - `cargo fmt --check` is clean.

### Background
- Single-use substitution is the minify-syntax pass (ported from esbuild) that folds `let a = x; return a.b;` into `return x.b;`. For each expression after the declaration it walks the children in evaluation order: substituting into a child either succeeds, fails (a side effect between the declaration and the use makes reordering unsafe, so the walk stops) or continues past a child that neither uses the symbol nor has side effects. `Substitution` (`src/js_parser/parser.rs`) is that three-way result; the `Expr` it carries is the rewritten subtree, which the parent has to store back because `Expr` is a `Copy` value, not a reference into the arena.
- The baseline is a ratchet: CI tolerates up to the recorded number of findings per lint and file and fails on more, so fixing the code behind an entry lets the entry be removed.
