### PR TITLE
bun:ffi: propagate a failure to read the viewSource descriptors

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -30,7 +30,6 @@
 "reimplemented_helper:src/react_compiler/reactive_scopes/propagate_early_returns.rs" = 1
 
 [bun_runtime]
-"defaulted_failure:src/runtime/ffi/ffi_body.rs" = 1
 "defaulted_failure:src/runtime/server/RequestContext.rs" = 1
 "defaulted_failure:src/runtime/test_runner/pretty_format.rs" = 4
 "error_collapsed_to_bool:src/runtime/api/bun/Terminal.rs" = 1

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1402,9 +1402,7 @@ impl FFI {
         let mut symbols = StringArrayHashMap::<Function>::default();
         // SAFETY: `get_object()` returned a non-null `*mut JSObject`; `object` keeps it alive.
         let obj = unsafe { &*obj };
-        if let Some(val) =
-            generate_symbols(global, &mut symbols, obj).unwrap_or(Some(JSValue::ZERO))
-        {
+        if let Some(val) = generate_symbols(global, &mut symbols, obj)? {
             // an error while validating symbols
             // keys/arg_types freed by Drop
             return Ok(val);

--- a/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
+++ b/test/js/bun/ffi/ffi-viewSource-non-object.test.ts
@@ -29,6 +29,32 @@ describe("FFI viewSource", () => {
     expect((err as TypeError).message).toContain("bogus_type");
   });
 
+  // Reading the descriptors can run user code; what it throws is what the
+  // caller sees, and a rejected descriptor is never mistaken for source.
+  test.each(["args", "returns"])("rethrows what a %s getter throws", property => {
+    const boom = new Error(`boom from ${property}`);
+    const descriptor = { args: ["i32"], returns: "i32" } as Record<string, unknown>;
+    Object.defineProperty(descriptor, property, {
+      get() {
+        throw boom;
+      },
+    });
+    expect(thrown(() => viewSource({ foo: descriptor as any }))).toBe(boom);
+    expect(thrown(() => viewSource({ ok: { args: [], returns: "void" }, foo: descriptor as any }))).toBe(boom);
+  });
+
+  test("rethrows what a symbols getter throws", () => {
+    const boom = new Error("boom from symbols");
+    const symbols = {};
+    Object.defineProperty(symbols, "foo", {
+      enumerable: true,
+      get() {
+        throw boom;
+      },
+    });
+    expect(thrown(() => viewSource(symbols as any))).toBe(boom);
+  });
+
   test.each([null, undefined, 42])("throws on non-object options argument %p", value => {
     const err = thrown(() => viewSource(value as any));
     expect(err).toBeInstanceOf(TypeError);


### PR DESCRIPTION
### Problem
- mordant's `defaulted_failure` lint has one finding in `src/runtime/ffi/ffi_body.rs`, recorded in `mordant-baseline.toml` as `"defaulted_failure:src/runtime/ffi/ffi_body.rs" = 1`.
- The site is `FFI::print`, the native half of `bun:ffi`'s `viewSource()`: `generate_symbols(global, &mut symbols, obj).unwrap_or(Some(JSValue::ZERO))`, followed by `return Ok(val)`. `generate_symbols` fails when reading the descriptors runs user code that throws (a getter on the symbols object or on a descriptor's `args` / `returns`), or on an allocation failure.
- For a thrown exception this returns `Ok(empty value)` with the exception still pending, which happens to be exactly what `to_js_host_fn_result` (`src/jsc/host_fn.rs`) produces for `Err(JsError::Thrown)`, so callers see the right exception today by accident. For `JsError::OutOfMemory` it returns an empty value with no exception pending, which the debug build's host function assertion rejects and which `to_js_host_fn_result` would otherwise have turned into an `OutOfMemoryError`.
- The other three callers of `generate_symbols` in the same file (`dlopen`, `linkSymbols`, `cc`) already use `?`.

### Fix
- `FFI::print` uses `?` as well, so both failure kinds reach `to_js_host_fn_result` and are handled there; the baseline line is removed.
- Verified:
  - `test/js/bun/ffi/ffi-viewSource-non-object.test.ts`: new cases pin that `viewSource()` rethrows the exact error thrown by a descriptor `args` / `returns` getter (alone and after a valid symbol) and by a getter on the symbols object itself, and never reports it as source. They pass before and after the change: every failure a test can provoke is `JsError::Thrown`, and `to_js_host_fn_result` turns that into the same empty return the old code built by hand, so no test can tell the two apart. The only path that changes is `JsError::OutOfMemory`, which nothing in a test can trigger. The tests are there to pin the contract the `?` now guarantees structurally, not as a failing-before proof; this PR has none.
  - `bun bd test` on that file and on `test/js/bun/ffi/ffi.test.js` passes; `cargo fmt --check` is clean.

### Background
- A host function in this codebase returns `JsResult<JSValue>`; `JsError::Thrown` means the exception is already pending in the VM, `JsError::OutOfMemory` means the caller still has to throw one. `to_js_host_fn_result` is the single place that converts both into what JSC expects (an empty return value plus a pending exception), which is why Rust code is expected to propagate with `?` instead of building the empty value itself.
- `defaulted_failure` flags a call to a function that can reject its input whose rejection is replaced with a fixed value. `mordant-baseline.toml` is a ratchet: CI tolerates the recorded number of findings per lint and file and fails on more, so fixing the code behind an entry lets the entry be removed.

