### PR TITLE
test(bake): assert the served document and page state after each edit in ecosystem.test.ts

### DIFF
--- a/test/bake/dev/ecosystem.test.ts
+++ b/test/bake/dev/ecosystem.test.ts
@@ -3,7 +3,85 @@
 // discovered, but it easy and still a reasonable idea to just test the library
 // entirely.
 import { expect } from "bun:test";
-import { devTest } from "../bake-harness";
+import { Client, Dev, devTest } from "../bake-harness";
+
+/**
+ * The document served for `/`, with the names bake generates replaced (the
+ * stylesheet name is a hash, and the route script's name ends in a generation
+ * that is re-randomized whenever the route's client bundle is invalidated) and
+ * adjacent tags put on separate lines, matching `expectedDocument`.
+ */
+async function servedDocument(dev: Dev) {
+  const response = await dev.fetch("/");
+  const html = await response.text();
+  // A throw during SSR is served as bun's fallback error page instead of the route.
+  expect(response.status).toBe(200);
+  return html
+    .replaceAll("><", ">\n<")
+    .replace(/\/_bun\/asset\/[0-9a-f]+\./, "/_bun/asset/<hash>.")
+    .replace(/\/_bun\/client\/route-[0-9a-f]+\./, "/_bun/client/route-<id>.");
+}
+
+/** What the fixture serves for `/` while its two components contain the given text. */
+function expectedDocument({ server, island }: { server: string; island: string }) {
+  return [
+    "<!DOCTYPE html>",
+    "<html>",
+    "<head>",
+    // Only the island's stylesheet: the plugin gives each component's CSS the
+    // component's own path in another namespace, and the bundler currently
+    // merges the server component's CSS into the component itself (#36549).
+    '<link rel="stylesheet" href="/_bun/asset/<hash>.css">',
+    "</head>",
+    "<body>",
+    "<!--[-->",
+    '<main class="svelte-1f5jrvn">',
+    `<h1 class="svelte-1f5jrvn">hello</h1> <p id="server_text">${server}</p> <p>Bun v${Bun.version}</p> <bake-island id="I:0">`,
+    '<div class="svelte-lmhtl6">',
+    `<p id="counter_text" class="svelte-lmhtl6">${island}</p> <button>Clicked 5 times</button>`,
+    "</div>",
+    "</bake-island>",
+    "<!---->",
+    "</main>",
+    "<!--]-->",
+    "</body>",
+    '<script>self.$islands={"pages/_Counter.svelte":[[0,"default",{initial:5}]]}</script>',
+    '<script type="module" src="/_bun/client/route-<id>.js">',
+    "</script>",
+    "</html>",
+  ].join("\n");
+}
+
+/** The text of the server component, the island and the island's button, as currently rendered by the page. */
+function pageState(c: Client) {
+  return c.js<{ server: string; island: string; button: string }>`
+    return {
+      server: document.querySelector("#server_text").textContent,
+      island: document.querySelector("#counter_text").textContent,
+      button: document.querySelector("button").textContent,
+    };
+  `;
+}
+
+/**
+ * Clicks the island's button and returns its text once svelte has flushed the
+ * resulting DOM update, which happens asynchronously after the click.
+ */
+function clickButton(c: Client) {
+  return c.js<string>`
+    const button = document.querySelector("button");
+    const before = button.textContent;
+    const changed = new Promise(resolve => {
+      new MutationObserver((_, observer) => {
+        if (button.textContent === before) return;
+        observer.disconnect();
+        resolve(button.textContent);
+      }).observe(button, { childList: true, characterData: true, subtree: true });
+    });
+    button.click();
+    return await changed;
+  `;
+}
 
 // Bugs discovered thanks to Svelte:
 // - Circular import situations
@@ -11,45 +89,60 @@ import { devTest } from "../bake-harness";
 // - export { x as y }
 devTest("svelte component islands example", {
   fixture: "svelte-component-islands",
-  timeoutMultiplier: 2,
   skip: ["win32"],
   async test(dev) {
-    const html = await dev.fetch("/").text();
-    if (html.includes("Bun__renderFallbackError")) throw new Error("failed");
-
     // Expect SSR
-    expect(html).toContain('self.$islands={"pages/_Counter.svelte":[[0,"default",{initial:5}]]}');
-    expect(html).toContain(`<p>This is my svelte server component (non-interactive)</p> <p>Bun v${Bun.version}</p>`);
-    expect(html).toContain(`>This is a client component (interactive island)</p>`);
+    expect(await servedDocument(dev)).toBe(
+      expectedDocument({
+        server: "This is my svelte server component (non-interactive)",
+        island: "This is a client component (interactive island)",
+      }),
+    );
 
     await using c = await dev.client("/");
-    expect(await c.elemText("button")).toBe("Clicked 5 times");
-    const result = await c.js`
-      document.querySelector("button").click();
-      await new Promise(resolve => setTimeout(resolve, 10));
-      return document.querySelector("button").textContent;
-    `;
-    expect(result).toBe("Clicked 6 times");
+    expect(await pageState(c)).toEqual({
+      server: "This is my svelte server component (non-interactive)",
+      island: "This is a client component (interactive island)",
+      button: "Clicked 5 times",
+    });
+    // The island hydrated: its event handler is attached.
+    expect(await clickButton(c)).toBe("Clicked 6 times");
 
+    // Editing the server component reloads the page, which is rendered with
+    // the edit, hydrated again, and so starts over from the initial count.
     await c.expectReload(async () => {
       await dev.patch("pages/index.svelte", {
         find: "non-interactive",
         replace: "awesome",
       });
     });
+    expect(await pageState(c)).toEqual({
+      server: "This is my svelte server component (awesome)",
+      island: "This is a client component (interactive island)",
+      button: "Clicked 5 times",
+    });
+    expect(await clickButton(c)).toBe("Clicked 6 times");
 
+    // Editing the client component is a hot update delivered to the reloaded
+    // page: the server component is untouched, and svelte re-mounts the island,
+    // which is interactive again.
     await dev.patch("pages/_Counter.svelte", {
       find: "interactive island",
       replace: "magical",
     });
+    expect(await pageState(c)).toEqual({
+      server: "This is my svelte server component (awesome)",
+      island: "This is a client component (magical)",
+      button: "Clicked 5 times",
+    });
+    expect(await clickButton(c)).toBe("Clicked 6 times");
 
-    expect(await c.elemText("#counter_text")).toInclude("magical");
-
-    const html2 = await dev.fetch("/").text();
-    if (html2.includes("Bun__renderFallbackError")) throw new Error("failed");
-
-    // Expect SSR
-    expect(html2).toContain(`<p>This is my svelte server component (awesome)</p> <p>Bun v${Bun.version}</p>`);
-    expect(html2).toContain(`>This is a client component (magical)</p>`);
+    // Expect SSR of both edits
+    expect(await servedDocument(dev)).toBe(
+      expectedDocument({
+        server: "This is my svelte server component (awesome)",
+        island: "This is a client component (magical)",
+      }),
+    );
   },
 });

--- a/test/bake/fixtures/svelte-component-islands/framework/server.ts
+++ b/test/bake/fixtures/svelte-component-islands/framework/server.ts
@@ -6,6 +6,7 @@ import { uneval } from "devalue";
 export function render(req: Request, meta: Bake.RouteMetadata) {
   isInsideIsland = false;
   islands = {};
+  nextIslandId = 0;
   const { body, head } = svelte.render(meta.pageModule.default, {
     props: {
       params: meta.params,

--- a/test/bake/fixtures/svelte-component-islands/pages/index.svelte
+++ b/test/bake/fixtures/svelte-component-islands/pages/index.svelte
@@ -3,7 +3,7 @@
 </script>
 <main>
     <h1>hello</h1>
-    <p>This is my svelte server component (non-interactive)</p>
+    <p id="server_text">This is my svelte server component (non-interactive)</p>
     <p>Bun v{Bun.version}</p>
     <Counter initial={5} />
 </main>


### PR DESCRIPTION
### Problem
- `test/bake/dev/ecosystem.test.ts` (one test, the svelte islands fixture) was flagged by the slow-test sweep at 11-13s on the release Linux lanes. Measured locally it is 3.9s, of which 3.0s is the harness's fixed poll for an error overlay (`Client.expectErrorOverlay`, `bake-harness.ts:1046`: 5 x 200ms, no early exit when nothing is shown), paid once in `dev.client()` and once after each of the two writes; the dev server, both bundles, the client and the test's own work add up to about 0.3s. On the 13s CI run (build 99854, where this was the third file the job ran) the log timestamps put 4.8s in starting the dev server (it imports the svelte compiler), 3.8s in starting node + happy-dom, 3.0s in the polls and about 0.25s in the rest, so the CI number is mostly the cold box.
- The poll lives in the harness and #37866 (open) removes it for every connect and write site in `test/bake`, which takes this file to about 0.9s without touching it. A per-file `errors: null` opt-out would cover two of this file's three polls and become dead as soon as that lands (#37866 deletes the one existing opt-out of that kind; the other `errors: null` uses in `test/bake` are for writes that expect errors or have no client), so this PR does not add one; the speed of this file is #37866's.
- What this file can improve on its own is its assertions: an SSR failure was `throw new Error("failed")`, the served HTML was checked with three `toContain`s, the click waited a fixed 10ms, the hot update was checked with `toInclude("magical")`, and the page was not looked at after the reload at all.

### Fix
- `servedDocument()` asserts the response is 200 (a throw during SSR is served as the 500 fallback page; the error itself is in the dev server output the harness echoes) and returns the whole document with bake's generated names normalized and one tag per line; it is compared with `toBe` against `expectedDocument({ server, island })` before and after the edits, so the two fetches are shown to differ exactly by the two edited strings, and the stylesheet link, island wrapper and `$islands` script are covered as well. A template rather than a snapshot because snapshot matchers throw outside `bun test`, which would break the harness's interactive mode (`bun test/bake/dev/ecosystem.test.ts svelte`); checked that mode still passes.
- The template pins the document as served today, which has only the island's stylesheet: the fixture's plugin gives each component's CSS the component's own path in the `svelte-css` namespace, and the bundler currently merges the server component's CSS into the component (the module identity bug #36549 fixes; with distinct paths both stylesheets are served). The line carries a comment saying so, so that #36549 knows to add the second link here when it lands.
- `pageState()` reads the server component text, the island text and the button text in one round trip and is compared with `toEqual` after connecting, after the reload and after the hot update. The post-reload page is now asserted at all (new server text, and its counter started over), and the hot update is checked for its exact text and for leaving the server text alone.
- `clickButton()` waits for the button's text to change with a `MutationObserver` registered before the click instead of sleeping 10ms, and is repeated after the reload and after the hot update, so the reloaded page and the re-mounted island are shown to be interactive, not just rendered.
- Fixture: `render()` resets the island counter per render (it already reset the island map), so the document after the edits has `I:0` like the first one instead of a counter carried across renders; the server component's paragraph gets an `id` for `pageState()`.
- `timeoutMultiplier: 2` is dropped: it predates `WAIT_MULTIPLIER`, which now scales the base 30s by 3 for debug, 3 for ASAN and 2 for CI; the release CI budget becomes 60s and the ASAN one 180s for a test that took at most 13s on a cold lane.
- Verified: `bun bd test test/bake/dev/ecosystem.test.ts` passes (debug + ASAN); 10/10 runs with the release binary at 3.85-3.94s, i.e. unchanged from before (3.87-3.99s), as expected since the time is the poll; the interactive-mode run above.

<details>
<summary>Earlier version of this PR</summary>

The first push also passed `errors: null` to the two writes, which took the file from 3.9s to 1.86s locally (median of 30 runs) and passed 131 of 132 runs under 5x CPU oversubscription; the one failure was a late watcher event rebuilding `index.svelte` in the next batch, which the previous version of the test is equally exposed to. Review pointed out that this duplicates #37866 for two of the file's ~three poll sites while that PR removes the same opt-out elsewhere, so it was dropped; the assertions are unaffected, since `dev.patch()` resolves on the client's ack either way.

</details>

### Background
- Bake is bun's dev server. `test/bake` drives it through `bake-harness.ts`: `dev.patch()` edits a file and resolves once the rebuild is done and every connected client has acked it; `dev.client()` loads the page in a node process running happy-dom (`client-fixture.mjs`); `c.js` evaluates code inside that page. Running a test file directly instead of through `bun test` runs one case interactively, stopping before each step.
- The fixture is a minimal svelte framework: `pages/index.svelte` is a server component rendered with `svelte/server`; `_Counter.svelte` is marked `"use client"`, so the server renders it inside a `<bake-island>` and the client bundle hydrates it from the `self.$islands` script. Editing the island is a hot update applied in place (svelte's HMR re-mounts the component, which is why its count goes back to 5); editing the server component makes the runtime reload the page, which the test allows with `c.expectReload()`.
- The route script URL is `/_bun/client/route-<index><generation>.js`, where the generation is randomized every time the route's client bundle is invalidated, and the stylesheet URL is a hash, which is why both are normalized before the comparison.
