### PR TITLE
node:http: remove the unused setServerIdleTimeout binding

### DIFF
--- a/mordant-baseline.toml
+++ b/mordant-baseline.toml
@@ -45,7 +45,6 @@
 "unchecked_construction:src/runtime/api/js_bundle_completion_task.rs" = 1
 "unchecked_construction:src/runtime/cli/pack_command.rs" = 2
 "unchecked_construction:src/runtime/server/HTMLBundle.rs" = 2
-"unchecked_construction:src/runtime/server/mod.rs" = 1
 "unchecked_construction:src/runtime/server/server_body.rs" = 5
 
 [bun_sql_jsc]

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -1,6 +1,6 @@
 const { isIPv4 } = require("internal/net/isIP");
 
-const { setServerCustomOptions, setServerAppFlags, drainMicrotasks, setServerIdleTimeout } = $cpp(
+const { setServerCustomOptions, setServerAppFlags, drainMicrotasks } = $cpp(
   "NodeHTTP.cpp",
   "createNodeHTTPInternalBinding",
 ) as {
@@ -21,7 +21,6 @@ const { setServerCustomOptions, setServerAppFlags, drainMicrotasks, setServerIdl
     httpAllowHalfOpen: boolean,
   ) => void;
   drainMicrotasks: () => void;
-  setServerIdleTimeout: (server: any, timeout: number) => void;
 };
 
 const getRawKeys = $newCppFunction("JSFetchHeaders.cpp", "jsFetchHeaders_getRawKeys", 0);
@@ -614,7 +613,6 @@ export {
   setMaxHTTPHeaderSize,
   setServerAppFlags,
   setServerCustomOptions,
-  setServerIdleTimeout,
   statusCodeSymbol,
   statusMessageSymbol,
   timeoutTimerSymbol,

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -27,7 +27,6 @@ using namespace JSC;
 using namespace WebCore;
 
 BUN_DECLARE_HOST_FUNCTION(Bun__drainMicrotasksFromJS);
-extern "C" void Server__setIdleTimeout(EncodedJSValue, EncodedJSValue, JSC::JSGlobalObject*);
 extern "C" EncodedJSValue Server__setAppFlags(JSC::JSGlobalObject*, EncodedJSValue, bool require_host_header, bool use_strict_method_validation, uint8_t lenient_http_flags, bool http_allow_half_open);
 extern "C" EncodedJSValue Server__setOnClientError(JSC::JSGlobalObject*, EncodedJSValue, EncodedJSValue);
 extern "C" EncodedJSValue Server__setOnConnection(JSC::JSGlobalObject*, EncodedJSValue, EncodedJSValue);
@@ -801,22 +800,6 @@ extern "C" EncodedJSValue NodeHTTPServer__onRequest_https(
         nodeHttpResponsePtr);
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsHTTPSetServerIdleTimeout, (JSGlobalObject * globalObject, CallFrame* callFrame))
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    // This is an internal binding.
-    JSValue serverValue = callFrame->uncheckedArgument(0);
-    JSValue seconds = callFrame->uncheckedArgument(1);
-
-    ASSERT(callFrame->argumentCount() == 2);
-
-    Server__setIdleTimeout(JSValue::encode(serverValue), JSValue::encode(seconds), globalObject);
-
-    return JSValue::encode(jsUndefined());
-}
-
 JSC_DEFINE_HOST_FUNCTION(jsHTTPSetCustomOptions, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -882,10 +865,6 @@ JSValue createNodeHTTPInternalBinding(Zig::GlobalObject* globalObject)
 {
     auto* obj = constructEmptyObject(globalObject);
     VM& vm = globalObject->vm();
-    obj->putDirect(
-        vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "setServerIdleTimeout"_s)),
-        JSC::JSFunction::create(vm, globalObject, 2, "setServerIdleTimeout"_s, jsHTTPSetServerIdleTimeout, ImplementationVisibility::Public), 0);
-
     obj->putDirect(
         vm, JSC::PropertyName(JSC::Identifier::fromString(vm, "setServerCustomOptions"_s)),
         JSC::JSFunction::create(vm, globalObject, 2, "setServerCustomOptions"_s, jsHTTPSetCustomOptions, ImplementationVisibility::Public), 0);

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1624,10 +1624,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         self.listener.is_some() || (Self::HAS_H3 && self.h3_listener.is_some())
     }
 
-    pub(crate) fn set_idle_timeout(&mut self, seconds: core::ffi::c_uint) {
-        self.config.idle_timeout = seconds.min(255) as u8;
-    }
-
     pub(crate) fn set_flags(
         &mut self,
         require_host_header: bool,

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3746,54 +3746,6 @@ bun_jsc::impl_js_class_via_generated!(DebugHTTPServer => crate::generated_classe
 bun_jsc::impl_js_class_via_generated!(DebugHTTPSServer => crate::generated_classes::js_DebugHTTPSServer, no_constructor);
 
 // ─── Exported fns ────────────────────────────────────────────────────────────
-#[unsafe(no_mangle)]
-extern "C" fn Server__setIdleTimeout(server: JSValue, seconds: JSValue, global: &JSGlobalObject) {
-    match server_set_idle_timeout(server, seconds, global) {
-        Ok(()) => {}
-        Err(JsError::Thrown) => {}
-        Err(JsError::OutOfMemory) => {
-            let _ = global.throw_out_of_memory_value();
-        }
-    }
-}
-
-fn server_set_idle_timeout(
-    server: JSValue,
-    seconds: JSValue,
-    global: &JSGlobalObject,
-) -> JsResult<()> {
-    if !server.is_object() {
-        return Err(global.throw(format_args!(
-            "Failed to set timeout: The 'this' value is not a Server."
-        )));
-    }
-
-    if !seconds.is_number() {
-        return Err(global.throw(format_args!(
-            "Failed to set timeout: The provided value is not of type 'number'."
-        )));
-    }
-    let value = seconds.to_u32();
-    if let Some(this) = server.as_::<HTTPServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_idle_timeout(value);
-    } else if let Some(this) = server.as_::<HTTPSServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_idle_timeout(value);
-    } else if let Some(this) = server.as_::<DebugHTTPServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_idle_timeout(value);
-    } else if let Some(this) = server.as_::<DebugHTTPSServer>() {
-        // SAFETY: `as_` returned a non-null `*mut` to a live JS-wrapped server.
-        unsafe { &mut *this }.set_idle_timeout(value);
-    } else {
-        return Err(global.throw(format_args!(
-            "Failed to set timeout: The 'this' value is not a Server."
-        )));
-    }
-    Ok(())
-}
-
 fn server_set_on_client_error(
     global: &JSGlobalObject,
     server: JSValue,


### PR DESCRIPTION
### Problem
- mordant's `unchecked_construction` lint has one finding in `src/runtime/server/mod.rs`, recorded in `mordant-baseline.toml` as `"unchecked_construction:src/runtime/server/mod.rs" = 1`: `NewServer::set_idle_timeout` writes `config.idle_timeout` directly, a field that `ServerConfig::from_js` validates (`idleTimeout` must be an integer of 255 or less).
- The code behind it is unreachable. `set_idle_timeout` is only called from the exported `Server__setIdleTimeout` (`src/runtime/server/server_body.rs`), which is only called from `jsHTTPSetServerIdleTimeout`, which `createNodeHTTPInternalBinding` (`src/jsc/bindings/NodeHTTP.cpp`) exposes as `setServerIdleTimeout`. `src/js/internal/http.ts` re-exports that function and nothing imports it: its one caller, `Server.prototype.setTimeout`, stopped using it in #32488, which moved node:http's server timeouts into JS and passes `idleTimeout: 0` to the native server (`src/js/node/_http_server.ts`).

### Fix
- Removes the chain end to end: the `internal/http` re-export and binding type, the C++ host function and its `putDirect`, the Rust export with its helper, and `NewServer::set_idle_timeout`. `idle_timeout` is now only set by `ServerConfig::from_js`, so the baseline line goes as well. 77 lines removed, no replacement code.
- No user-visible behavior changes: the binding was only reachable from built-in modules, and none used it. Verified with `bun bd test` on `test/js/node/http/node-http-server-timeouts.test.ts`, `node-http-res-settimeout-unref.test.ts` and `node-http.test.ts` (one test there, `request via http proxy`, fails with `ECONNREFUSED` identically on the unmodified release build in this environment), plus a smoke check that `server.setTimeout()` on a node:http server and `idleTimeout` on `Bun.serve()` still work. `cargo fmt`, `clang-format` and prettier are clean.
- The same deletion is part of the much larger #35437, which is currently conflicting; this is only that slice.

### Background
- `createNodeHTTPInternalBinding` is the object `internal/http.ts` gets from `$cpp(...)`: native helpers that node:http's JS implementation calls on the underlying `Bun.serve` server. A function on it that no built-in module reads is dead code, since user code cannot reach internal modules.
- `unchecked_construction` flags a write to a field outside the constructor that validates it. The baseline is a ratchet: CI tolerates the recorded number of findings per lint and file and fails on more, so removing the code behind an entry lets the entry be removed.
