### PR TITLE
process: throw from a lazy property whose builder fails instead of storing undefined

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -2914,12 +2914,7 @@ static JSValue constructNodeWorkerStdioStream(JSC::JSGlobalObject* globalObject,
     args.append(JSC::jsNumber(fd));
     args.append(ports);
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getStream, JSC::getCallData(getStream), globalObject->globalThis(), args);
-    if (auto* exception = scope.exception()) {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        RETURN_IF_EXCEPTION(scope, jsUndefined());
-        return jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     return result;
 }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1770,13 +1770,9 @@ static JSValue constructLoadEnvFile(VM& vm, JSObject* processObject)
     return JSC::JSFunction::create(vm, globalObject, processObjectInternalsLoadEnvFileCodeGenerator(vm), globalObject);
 }
 
-// A lazy PropertyCallback builder that fails returns empty and leaves the exception pending:
-// reifyStaticProperty then stores nothing, the access that triggered it throws, and the next
-// access runs the builder again. Both JSC callers (setUpStaticFunctionSlot for a single access,
-// reifyAllStaticProperties for delete/spread, which stops at the failing entry and leaves the
-// rest lazy) defer termination around the builder and check for the exception afterwards with
-// vm.exceptionForInspection(). That check does not satisfy a ThrowScope's simulated throw, so
-// builders use a TopExceptionScope.
+// A builder that fails returns empty with the exception pending: nothing is stored, the access
+// throws, and the next access runs the builder again. TopExceptionScope rather than ThrowScope:
+// the JSC callers check with vm.exceptionForInspection(), which does not satisfy a simulated throw.
 static JSValue callLazyProcessBuilder(VM& vm, JSC::JSGlobalObject* globalObject, JSC::FunctionExecutable* (*generator)(VM&), const JSC::ArgList& args)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1770,9 +1770,7 @@ static JSValue constructLoadEnvFile(VM& vm, JSObject* processObject)
     return JSC::JSFunction::create(vm, globalObject, processObjectInternalsLoadEnvFileCodeGenerator(vm), globalObject);
 }
 
-// A builder that fails returns empty with the exception pending: nothing is stored, the access
-// throws, and the next access runs the builder again. TopExceptionScope rather than ThrowScope:
-// the JSC callers check with vm.exceptionForInspection(), which does not satisfy a simulated throw.
+// TopExceptionScope, not ThrowScope: JSC checks a failed builder with vm.exceptionForInspection().
 static JSValue callLazyProcessBuilder(VM& vm, JSC::JSGlobalObject* globalObject, JSC::FunctionExecutable* (*generator)(VM&), const JSC::ArgList& args)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1770,20 +1770,19 @@ static JSValue constructLoadEnvFile(VM& vm, JSObject* processObject)
     return JSC::JSFunction::create(vm, globalObject, processObjectInternalsLoadEnvFileCodeGenerator(vm), globalObject);
 }
 
-// Lazy PropertyCallback builders that enter JS. reifyAllStaticProperties wraps these in
-// DeferTerminationForAWhile; a non-termination throw is cleared+reported so the worker's
-// reifyAllStaticProperties (node:worker_threads preload) doesn't leave a pending exception.
+// A lazy PropertyCallback builder that fails returns empty and leaves the exception pending:
+// reifyStaticProperty then stores nothing, the access that triggered it throws, and the next
+// access runs the builder again. Both JSC callers (setUpStaticFunctionSlot for a single access,
+// reifyAllStaticProperties for delete/spread, which stops at the failing entry and leaves the
+// rest lazy) defer termination around the builder and check for the exception afterwards with
+// vm.exceptionForInspection(). That check does not satisfy a ThrowScope's simulated throw, so
+// builders use a TopExceptionScope.
 static JSValue callLazyProcessBuilder(VM& vm, JSC::JSGlobalObject* globalObject, JSC::FunctionExecutable* (*generator)(VM&), const JSC::ArgList& args)
 {
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* function = JSC::JSFunction::create(vm, globalObject, generator(vm), globalObject);
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, function, JSC::getCallData(function), globalObject->globalThis(), args);
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        RETURN_IF_EXCEPTION(scope, jsUndefined());
-        return jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     return result;
 }
 
@@ -2783,18 +2782,11 @@ __attribute__((minsize)) static JSValue constructProcessConfigObject(VM& vm, JSO
     //      v8_use_snapshot: 1
     //    }
     // }
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::JSObject* config = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
     JSC::JSObject* variables = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 2);
     JSC::JSArray* shareableBuiltins = JSC::constructEmptyArray(globalObject, nullptr);
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        RETURN_IF_EXCEPTION(scope, JSC::jsUndefined());
-        return JSC::jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     putDirectNamed(vm, variables, "v8_enable_i18n_support"_s, JSC::jsNumber(1));
     putDirectNamed(vm, variables, "enable_lto"_s, JSC::jsBoolean(false));
     // Node 26's common.gypi evaluates enable_thin_lto/lto_jobs conditions; gyp
@@ -2955,12 +2947,7 @@ static JSValue constructStdioWriteStream(JSC::JSGlobalObject* globalObject, JSC:
     JSC::CallData callData = JSC::getCallData(getStdioWriteStream);
 
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getStdioWriteStream, callData, globalObject->globalThis(), args);
-    if (auto* exception = scope.exception()) {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        RETURN_IF_EXCEPTION(scope, jsUndefined());
-        return jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
 
     ASSERT_WITH_MESSAGE(JSC::isJSArray(result), "Expected an array from getStdioWriteStream");
     JSC::JSArray* resultObject = uncheckedDowncast<JSC::JSArray>(result);
@@ -2984,12 +2971,12 @@ static JSValue constructStdioWriteStream(JSC::JSGlobalObject* globalObject, JSC:
 #endif
     if (forceSync) {
         JSValue sink = resultObject->getIndex(globalObject, 1);
-        RETURN_IF_EXCEPTION(scope, jsUndefined());
+        RETURN_IF_EXCEPTION(scope, {});
         Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio(globalObject, JSValue::encode(sink));
     }
 
     JSValue stream = resultObject->getIndex(globalObject, 0);
-    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    RETURN_IF_EXCEPTION(scope, {});
     return stream;
 }
 
@@ -3023,12 +3010,7 @@ static JSValue constructStdin(VM& vm, JSObject* processObject)
     JSC::CallData callData = JSC::getCallData(getStdinStream);
 
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, getStdinStream, callData, globalObject, args);
-    if (auto* exception = scope.exception()) {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        RETURN_IF_EXCEPTION(scope, jsUndefined());
-        return jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     return result;
 }
 
@@ -3261,16 +3243,9 @@ static JSValue constructRevision(VM& vm, JSObject* processObject)
 static JSValue constructEnv(VM& vm, JSObject* processObject)
 {
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(processObject->globalObject());
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue env = globalObject->processEnvObject();
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        RETURN_IF_EXCEPTION(scope, JSC::jsUndefined());
-        return JSC::jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     return env;
 }
 
@@ -4320,16 +4295,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_stubFunctionReturningArray, (JSGlobalObject * g
 
 static JSValue Process_stubEmptyArray(VM& vm, JSObject* processObject)
 {
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSC::JSArray* array = JSC::constructEmptyArray(processObject->globalObject(), nullptr);
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(processObject->globalObject(), exception);
-        RETURN_IF_EXCEPTION(scope, {});
-        return JSC::jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     return array;
 }
 
@@ -4456,27 +4424,15 @@ extern "C" void Bun__Process__queueNextTick2(GlobalObject* globalObject, Encoded
 // return require.cache.get(Bun.main)
 static JSValue constructMainModuleProperty(VM& vm, JSObject* processObject)
 {
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(processObject->globalObject());
     auto* bun = globalObject->bunObject();
     auto& builtinNames = Bun::builtinNames(vm);
     JSValue mainValue = bun->get(globalObject, builtinNames.mainPublicName());
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        RETURN_IF_EXCEPTION(scope, {});
-        return JSC::jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     auto* requireMap = globalObject->requireMap();
     JSValue mainModule = requireMap->get(globalObject, mainValue);
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        RETURN_IF_EXCEPTION(scope, {});
-        return JSC::jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     return mainModule;
 }
 
@@ -4498,16 +4454,9 @@ JSValue Process::constructNextTickFn(JSC::VM& vm, Zig::GlobalObject* globalObjec
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionDrainMicrotaskQueue, ImplementationVisibility::Private));
     args.append(JSC::JSFunction::create(vm, globalObject, 1, String(), jsFunctionReportUncaughtException, ImplementationVisibility::Private));
 
-    // Lazy property builder: exceptions must not propagate into
-    // reifyStaticProperty, which performs no exception check.
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     JSValue nextTickFunction = JSC::profiledCall(globalObject, ProfilingReason::API, initializer, JSC::getCallData(initializer), globalObject->globalThis(), args);
-    if (auto* exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        Zig::GlobalObject::reportUncaughtExceptionAtEventLoop(globalObject, exception);
-        RETURN_IF_EXCEPTION(scope, {});
-        return JSC::jsUndefined();
-    }
+    RETURN_IF_EXCEPTION(scope, {});
     if (nextTickFunction && nextTickFunction.isObject()) {
         this->m_nextTickFunction.set(vm, this, nextTickFunction.getObject());
     }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2668,12 +2668,13 @@ JSC_DEFINE_CUSTOM_GETTER(getConsoleConstructor, (JSGlobalObject * globalObject, 
 JSC_DEFINE_CUSTOM_GETTER(getConsoleStdout, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName property))
 {
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto console = JSValue::decode(thisValue).getObject();
     auto global = uncheckedDowncast<Zig::GlobalObject>(globalObject);
 
     // instead of calling the constructor builtin, go through the process.stdout getter to ensure it's only created once.
     auto stdoutValue = global->processObject()->get(globalObject, Identifier::fromString(vm, "stdout"_s));
-    if (!stdoutValue) return {};
+    RETURN_IF_EXCEPTION(scope, {});
 
     console->putDirect(vm, property, stdoutValue, PropertyAttribute::DontEnum | 0);
     return JSValue::encode(stdoutValue);
@@ -2683,12 +2684,13 @@ JSC_DEFINE_CUSTOM_GETTER(getConsoleStdout, (JSGlobalObject * globalObject, Encod
 JSC_DEFINE_CUSTOM_GETTER(getConsoleStderr, (JSGlobalObject * globalObject, EncodedJSValue thisValue, PropertyName property))
 {
     auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto console = JSValue::decode(thisValue).getObject();
     auto global = uncheckedDowncast<Zig::GlobalObject>(globalObject);
 
-    // instead of calling the constructor builtin, go through the process.stdout getter to ensure it's only created once.
+    // instead of calling the constructor builtin, go through the process.stderr getter to ensure it's only created once.
     auto stderrValue = global->processObject()->get(globalObject, Identifier::fromString(vm, "stderr"_s));
-    if (!stderrValue) return {};
+    RETURN_IF_EXCEPTION(scope, {});
 
     console->putDirect(vm, property, stderrValue, PropertyAttribute::DontEnum | 0);
     return JSValue::encode(stderrValue);

--- a/test/js/node/process/process-stdio-stack-overflow-fixture.js
+++ b/test/js/node/process/process-stdio-stack-overflow-fixture.js
@@ -1,9 +1,9 @@
 // Exercise lazy process.stdin / process.stdout / process.stderr creation near
-// the stack limit. The property callbacks that create these streams report the
-// exception if stream construction fails with a stack overflow; that reporting
-// path must not observe the exception as still pending when it re-enters JS
-// to invoke the uncaughtException listener (Interpreter::executeCallImpl
-// asserts no pending exception on entry).
+// the stack limit. Stream construction fails with a stack overflow there, which
+// the property read throws (caught below). Nothing on that path may re-enter JS
+// while the exception is pending (Interpreter::executeCallImpl asserts no
+// pending exception on entry); an uncaughtException listener is what such a
+// re-entry would call.
 process.on("uncaughtException", () => {});
 const which = process.argv[2];
 function F(a, ...b) {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,7 +1,7 @@
 import { spawnSync, which } from "bun";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { basename, join, resolve } from "path";
 
 const process_sleep = resolve(import.meta.dir, "process-sleep.js");
@@ -2750,22 +2750,19 @@ describe.concurrent("lazy process properties whose builder throws", () => {
   // it or inspecting it at the stack limit still aborts the process (initializers of JSC
   // LazyPropertys, which cannot fail), so Bun.inspect(process) cannot be run there.
   it.skipIf(isWindows)("inspecting process while out of stack leaves every property buildable", async () => {
-    // Bun.inspect(process) reads every property, so it runs all of the builders in one go. Done
-    // while unwinding, the deepest inspections fail every builder that calls into JS. Whatever
-    // failed must be missing from that inspection only.
+    // Bun.inspect(process) reads every property, so it runs all of the builders in one go, and at
+    // the stack limit every one of them that calls into JS fails. They must only be missing from
+    // that one inspection.
     const listUndefinedProperties = `
       const undefinedProperties = Object.getOwnPropertyNames(process).filter(name => process[name] === undefined);
       process.nextTick(() => process.stdout.write(JSON.stringify(undefinedProperties) + "\\n"));
     `;
     const [outOfStack, baseline] = await Promise.all([
       run(`
-        let inspections = 0;
         function recurse() {
           try {
             recurse();
-          } catch {}
-          if (inspections < 50) {
-            inspections++;
+          } catch {
             try {
               Bun.inspect(process, { depth: 0 });
             } catch {}
@@ -2842,6 +2839,102 @@ describe.concurrent("lazy process properties whose builder throws", () => {
         finalization: "function",
       }) + "\n",
     );
+    expect(exitCode).toBe(0);
+  });
+
+  it("a failed builder only hides its own property from Bun.inspect", async () => {
+    // A failed lookup leaves its exception pending. Bun.inspect's property walk has to clear it
+    // before looking up the next property, or the lazy properties declared after the failed one
+    // (loadEnvFile, finalization, arch, ... up to the first non-lazy one) are reported as missing
+    // too. As above, allowedNodeEnvironmentFlags is made the one builder that fails. process.env
+    // is replaced because on Windows it has a custom inspect function, whose machinery needs
+    // modules that do not load without Set either.
+    const { stdout, stderr, exitCode } = await run(`
+      process.stdout; process.stderr; process.stdin; process.nextTick;
+      Object.defineProperty(process, "env", { value: {}, writable: true, configurable: true, enumerable: true });
+      const keysOf = inspected => [...inspected.matchAll(/^  ([A-Za-z_$][\\w$]*):/gm)].map(match => match[1]);
+      const RealSet = Set;
+      globalThis.Set = undefined;
+      const whileBroken = keysOf(Bun.inspect(process, { depth: 0 }));
+      globalThis.Set = RealSet;
+      const intact = keysOf(Bun.inspect(process, { depth: 0 }));
+      console.log(JSON.stringify({
+        hiddenWhileBroken: intact.filter(key => !whileBroken.includes(key)),
+        extraWhileBroken: whileBroken.filter(key => !intact.includes(key)),
+      }));
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ hiddenWhileBroken: ["allowedNodeEnvironmentFlags"], extraWhileBroken: [] });
+    expect(exitCode).toBe(0);
+  });
+
+  it("internal nextTick users see the builder failure and work once it can be built", async () => {
+    // process.emitWarning queues through the native Process::queueNextTick, which reads
+    // process.nextTick and so runs its builder on the first use. It used to fail for good after
+    // one failed build ("Failed to call nextTick" from every later warning, Worker, ...).
+    const { stdout, stderr, exitCode } = await run(`
+      process.removeAllListeners("warning");
+      let atLimit;
+      process.on("warning", warning => {
+        console.log(JSON.stringify({ atLimit, warning: warning.message, nextTick: typeof process.nextTick }));
+      });
+      function recurse() {
+        try {
+          recurse();
+        } catch {
+          try {
+            process.emitWarning("at the stack limit");
+            atLimit = "returned";
+          } catch (e) {
+            atLimit = "threw " + e.constructor.name;
+          }
+        }
+      }
+      recurse();
+      process.emitWarning("after unwinding");
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(
+      JSON.stringify({ atLimit: "threw RangeError", warning: "after unwinding", nextTick: "function" }) + "\n",
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  // Reading the property again every few frames while unwinding: the first reads fail, and the
+  // one that has enough stack builds it. The stdio builders load the stream modules, which read
+  // process.nextTick and so add a property to process before the build can still run out of stack;
+  // JSC's getPropertySlot then continues with the structure it read before the build, which is an
+  // assertion failure on builds with assertions (harmless otherwise: the prototype is the same).
+  // Until the engine reloads the structure there, those three only run on release builds.
+  const rebuiltWhileUnwinding = [
+    ["nextTick", "function"],
+    ["allowedNodeEnvironmentFlags", "object"],
+  ];
+  if (!isDebug && !isASAN) rebuiltWhileUnwinding.push(["stdout", "object"], ["stderr", "object"], ["stdin", "object"]);
+  it.each(rebuiltWhileUnwinding)("process.%s is built by a later read while unwinding", async (name, type) => {
+    // process.env is built first: on Windows its builder calls into JS as well.
+    const { stdout, stderr, exitCode } = await run(`
+      process.env;
+      let unwound = 0;
+      let failed = 0;
+      let built;
+      function recurse() {
+        try {
+          recurse();
+        } catch {}
+        if (built !== undefined || unwound++ % 64 !== 0) return;
+        try {
+          built = typeof process[${JSON.stringify(name)}];
+        } catch (e) {
+          if (!(e instanceof RangeError)) throw e;
+          failed++;
+        }
+      }
+      recurse();
+      console.log(JSON.stringify({ built, failedFirst: failed > 0, stillBuilt: typeof process[${JSON.stringify(name)}] }));
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ built: type, failedFirst: true, stillBuilt: type });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -2746,7 +2746,10 @@ describe.concurrent("lazy process properties whose builder throws", () => {
     expect(exitCode).toBe(0);
   });
 
-  it("inspecting process while out of stack leaves every property buildable", async () => {
+  // Windows: process.env is built by a JS builtin and has a JS custom inspect function. Building
+  // it or inspecting it at the stack limit still aborts the process (initializers of JSC
+  // LazyPropertys, which cannot fail), so Bun.inspect(process) cannot be run there.
+  it.skipIf(isWindows)("inspecting process while out of stack leaves every property buildable", async () => {
     // Bun.inspect(process) reads every property, so it runs all of the builders in one go. Done
     // while unwinding, the deepest inspections fail every builder that calls into JS. Whatever
     // failed must be missing from that inspection only.

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -2669,3 +2669,176 @@ it("no socket close handler runs after the 'exit' event", async () => {
   expect(stdout).toBe("exit\n");
   expect(exitCode).toBe(0);
 });
+
+// process.stdout/stderr/stdin/nextTick/finalization/allowedNodeEnvironmentFlags (and a few
+// more) are lazy: the first read runs a native builder that calls into JS. When that JS throws,
+// the read must throw and the property must stay unbuilt so that the next read builds it. The
+// builders used to swallow the error, report it as an uncaught exception (exit code 1 with no
+// handler) and store undefined in the property for the rest of the process.
+describe.concurrent("lazy process properties whose builder throws", () => {
+  async function run(code) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("a builder that runs out of stack throws, and the next read builds the property", async () => {
+    // Only the deepest frame reaches the catch block. There is less than one JS frame of stack
+    // left at that point, so every builder that has to call into JS fails with the RangeError.
+    const { stdout, stderr, exitCode } = await run(`
+      const names = ["stdout", "stderr", "stdin", "nextTick", "finalization", "allowedNodeEnvironmentFlags"];
+      const atLimit = {};
+      function recurse() {
+        try {
+          recurse();
+        } catch {
+          for (const name of names) {
+            try {
+              atLimit[name] = typeof process[name];
+            } catch (e) {
+              atLimit[name] = "threw " + e.constructor.name;
+            }
+          }
+          for (const name of ["_stdout", "_stderr"]) {
+            try {
+              atLimit["console" + name] = typeof console[name];
+            } catch (e) {
+              atLimit["console" + name] = "threw " + e.constructor.name;
+            }
+          }
+        }
+      }
+      recurse();
+      const afterwards = {};
+      for (const name of names) afterwards[name] = typeof process[name];
+      afterwards.console_stdout = console._stdout === process.stdout;
+      afterwards.console_stderr = console._stderr === process.stderr;
+      process.nextTick(() => process.stdout.write(JSON.stringify({ atLimit, afterwards }) + "\\n"));
+    `);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      atLimit: {
+        stdout: "threw RangeError",
+        stderr: "threw RangeError",
+        stdin: "threw RangeError",
+        nextTick: "threw RangeError",
+        finalization: "threw RangeError",
+        allowedNodeEnvironmentFlags: "threw RangeError",
+        console_stdout: "threw RangeError",
+        console_stderr: "threw RangeError",
+      },
+      afterwards: {
+        stdout: "object",
+        stderr: "object",
+        stdin: "object",
+        nextTick: "function",
+        finalization: "object",
+        allowedNodeEnvironmentFlags: "object",
+        console_stdout: true,
+        console_stderr: true,
+      },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  it("inspecting process while out of stack leaves every property buildable", async () => {
+    // Bun.inspect(process) reads every property, so it runs all of the builders in one go. Done
+    // while unwinding, the deepest inspections fail every builder that calls into JS. Whatever
+    // failed must be missing from that inspection only.
+    const listUndefinedProperties = `
+      const undefinedProperties = Object.getOwnPropertyNames(process).filter(name => process[name] === undefined);
+      process.nextTick(() => process.stdout.write(JSON.stringify(undefinedProperties) + "\\n"));
+    `;
+    const [outOfStack, baseline] = await Promise.all([
+      run(`
+        let inspections = 0;
+        function recurse() {
+          try {
+            recurse();
+          } catch {}
+          if (inspections < 50) {
+            inspections++;
+            try {
+              Bun.inspect(process, { depth: 0 });
+            } catch {}
+          }
+        }
+        recurse();
+        ${listUndefinedProperties}
+      `),
+      run(listUndefinedProperties),
+    ]);
+    expect(baseline.stderr).toBe("");
+    // e.g. ["channel", "disconnect", "exitCode", "mainModule", "send"]
+    expect(JSON.parse(baseline.stdout)).not.toContain("stdout");
+    expect(baseline.exitCode).toBe(0);
+    expect(outOfStack).toEqual(baseline);
+  });
+
+  it("a builder that throws is retried once the cause is gone, without reporting an uncaught exception", async () => {
+    // buildAllowedNodeEnvironmentFlags constructs a Set.
+    const { stdout, stderr, exitCode } = await run(`
+      process.on("uncaughtException", e => console.log("uncaughtException: " + e.constructor.name));
+      const RealSet = Set;
+      globalThis.Set = undefined;
+      let brokenRead;
+      try {
+        brokenRead = typeof process.allowedNodeEnvironmentFlags;
+      } catch (e) {
+        brokenRead = "threw " + e.constructor.name;
+      }
+      globalThis.Set = RealSet;
+      const flags = process.allowedNodeEnvironmentFlags;
+      console.log(JSON.stringify({
+        brokenRead,
+        sameObjectOnEveryRead: flags === process.allowedNodeEnvironmentFlags,
+        has: [flags.has("--no-warnings"), flags.has("--not-a-flag")],
+      }));
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(
+      JSON.stringify({ brokenRead: "threw TypeError", sameObjectOnEveryRead: true, has: [true, false] }) + "\n",
+    );
+    expect(exitCode).toBe(0);
+  });
+
+  it("a builder failure during bulk reification throws from the operation that triggered it", async () => {
+    // Deleting a property of process makes JSC build all of its remaining lazy properties first.
+    // The ones after the failing builder stay lazy and are built by the next such operation.
+    // The stdio builders load modules, which may need Set themselves, so they are built up front
+    // to make allowedNodeEnvironmentFlags the one builder that fails.
+    const { stdout, stderr, exitCode } = await run(`
+      process.stdout; process.stderr; process.stdin; process.nextTick;
+      const RealSet = Set;
+      globalThis.Set = undefined;
+      let brokenDelete;
+      try {
+        brokenDelete = "deleted: " + delete process._debugProcess;
+      } catch (e) {
+        brokenDelete = "threw " + e.constructor.name;
+      }
+      globalThis.Set = RealSet;
+      console.log(JSON.stringify({
+        brokenDelete,
+        deleteAfterwards: delete process._debugEnd,
+        flags: process.allowedNodeEnvironmentFlags.has("--no-warnings"),
+        finalization: typeof process.finalization.register,
+      }));
+    `);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(
+      JSON.stringify({
+        brokenDelete: "threw TypeError",
+        deleteAfterwards: true,
+        flags: true,
+        finalization: "function",
+      }) + "\n",
+    );
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -2808,24 +2808,24 @@ describe.concurrent("lazy process properties whose builder throws", () => {
   });
 
   it("a builder failure during bulk reification throws from the operation that triggered it", async () => {
-    // Deleting a property of process makes JSC build all of its remaining lazy properties first.
-    // The ones after the failing builder stay lazy and are built by the next such operation.
-    // The stdio builders load modules, which may need Set themselves, so they are built up front
-    // to make allowedNodeEnvironmentFlags the one builder that fails.
+    // Spreading process (like deleting one of its properties) makes JSC build all of its remaining
+    // lazy properties first. The ones after the failing builder stay lazy and are built by the
+    // next such operation. The stdio builders load modules, which may need Set themselves, so
+    // they are built up front to make allowedNodeEnvironmentFlags the one builder that fails.
     const { stdout, stderr, exitCode } = await run(`
       process.stdout; process.stderr; process.stdin; process.nextTick;
       const RealSet = Set;
       globalThis.Set = undefined;
-      let brokenDelete;
+      let brokenSpread;
       try {
-        brokenDelete = "deleted: " + delete process._debugProcess;
+        brokenSpread = "copied " + typeof { ...process }.allowedNodeEnvironmentFlags;
       } catch (e) {
-        brokenDelete = "threw " + e.constructor.name;
+        brokenSpread = "threw " + e.constructor.name;
       }
       globalThis.Set = RealSet;
       console.log(JSON.stringify({
-        brokenDelete,
-        deleteAfterwards: delete process._debugEnd,
+        brokenSpread,
+        spreadAfterwards: typeof { ...process }.allowedNodeEnvironmentFlags,
         flags: process.allowedNodeEnvironmentFlags.has("--no-warnings"),
         finalization: typeof process.finalization.register,
       }));
@@ -2833,8 +2833,8 @@ describe.concurrent("lazy process properties whose builder throws", () => {
     expect(stderr).toBe("");
     expect(stdout).toBe(
       JSON.stringify({
-        brokenDelete: "threw TypeError",
-        deleteAfterwards: true,
+        brokenSpread: "threw TypeError",
+        spreadAfterwards: "object",
         flags: true,
         finalization: "function",
       }) + "\n",


### PR DESCRIPTION
### Problem
- `process.stdout`, `stderr`, `stdin`, `nextTick`, `finalization` and `allowedNodeEnvironmentFlags` stay `undefined` for the rest of the process when they are first read at a moment their builder cannot run, and the process exits with code 1 although nothing was left uncaught. Repro: read one of them for the first time from the `catch` of a `RangeError: Maximum call stack size exceeded.` (logging from such a catch block does that), or `console.log(process)` there; stderr shows one `RangeError: Maximum call stack size exceeded.` uncaught-exception report per builder. Internal users break the same way: after one failed build every `process.emitWarning()`, `new Worker()`, ... fails with `Failed to call nextTick`.
- Cause: the builders in `src/jsc/bindings/BunProcess.cpp` (`callLazyProcessBuilder`, `constructStdioWriteStream`, `constructStdin`, `Process::constructNextTickFn`, `constructNodeWorkerStdioStream` (a worker's stdio, added by #39536 in the same shape), and with the same code `constructEnv`, `constructProcessConfigObject`, `constructMainModuleProperty`, `Process_stubEmptyArray`) clear the exception, pass it to `reportUncaughtExceptionAtEventLoop` and return `jsUndefined()`, which `reifyStaticProperty` stores as the property's value, so the builder never runs again.
- `getConsoleStdout` / `getConsoleStderr` (`src/jsc/bindings/ZigGlobalObject.cpp`) have the same bug one level up: when the `process.stdout` read throws, `JSObject::get` returns `undefined` (not an empty value, so the existing `if (!value)` never fires) and the getter caches it in `console._stdout`.

### Fix
- The builders return empty with the exception pending (`RETURN_IF_EXCEPTION(scope, {})`), like the other `process` builders (`versions`, `report`) and the `Bun.*` builders. The pinned JSC is built for this: `reifyStaticProperty` stores nothing for an empty result, `setUpStaticFunctionSlot` reports the slot as not found so the read throws the builder's error, and the next read runs the builder again. `constructStdioWriteStream` also checks its two `getIndex` reads so the whole function has that contract.
- Why this is right: the failure surfaces as an ordinary exception at the statement that caused it, like a throwing getter; nothing is reported as uncaught because nothing was; the property is only stored once it was actually built. Clear-and-report predates JSC supporting a failing builder (#29964, #30650); since oven-sh/WebKit#282 and #306 (in Bun via #34669) both JSC callers handle it. #31831 kept it out of caution about the worker preload deleting `process` properties, which reified the whole table at worker startup; #39536 has since removed those deletes, so no internal code bulk-reifies `process` any more.
- Bulk path (`reifyAllStaticProperties`, now only reached by user code: spread, `Object.assign`, `delete`): JSC stops at the failing builder, leaves the rest lazy and the triggering operation throws. The one-line comment on `callLazyProcessBuilder` records the remaining constraint: builders keep a `TopExceptionScope`, because JSC's `vm.exceptionForInspection()` check does not satisfy a `ThrowScope` (this is also what keeps the spread case below clean under `BUN_JSC_validateExceptionChecks=1`, which the ASAN lane runs this file with).
- `console._stdout` / `console._stderr` propagate the exception instead of caching `undefined`.
- `Bun.inspect` / `console.log` of an object with a failed builder needed the property walk to clear the failed lookup's exception before the next lookup (otherwise the lazy properties declared after the failed one are dropped, and builds with assertions abort with `ASSERTION FAILED: isCompilationThread() || Thread::mayBeGCThread() || object->structure() == this` in `Structure::storedPrototype`). That landed separately in #29642; this PR originally carried the same two lines and dropped them when rebasing onto it. The two inspect cases below exercise that on `process`, which with this change is the first object whose builders fail in ordinary programs.
- What the engine still does with a throwing builder on the current pin (`b7f217b4`), fixed by #39703 (oven-sh/WebKit#475, which supersedes #37001): the lookup loops walk on after the throw. Two consequences for this PR. Builds with assertions abort on the `storedPrototype` assertion above when a builder adds a property to `process` and then throws, which the stdio builders do when they get far enough to load the stream modules (they read `process.nextTick`) and then run out of stack, i.e. `process.stdout` first read a few hundred frames above the limit; release builds are fine there (same prototype, the read throws, the next one works), and the three cases below that reach it are limited to release builds until #39703 lands. And a megamorphic access site that saw the failed read records the miss, so that one site keeps returning `undefined` until #39703; every other site, and a fresh read, rebuild the property. Both are strictly better than main, where every site loses the property for good, and both disappear with #39703, after which the release-only restriction can be dropped.
- Tests, `test/js/node/process/process.test.js` > `lazy process properties whose builder throws`. Every case fails without the `src/` changes (0 pass / 8 fail on a debug build of the rebased base, 0 / 11 on the release binary, where the three release-only cases run too):
  - first read of the six properties and of `console._stdout`/`_stderr` from a stack overflow catch block throws `RangeError`; the next read builds them, `console._stdout === process.stdout`;
  - `process.emitWarning()` at the limit throws the builder's `RangeError` (the internal `Process::queueNextTick` path, which #30612 patched separately) and a later warning is delivered;
  - `process.nextTick` and `process.allowedNodeEnvironmentFlags`, and on release builds `stdout`/`stderr`/`stdin`, read again every 64 frames while unwinding: the first reads fail, a later one builds the property;
  - `Bun.inspect(process)` at the limit leaves the same undefined properties as a process that never overflowed. Skipped on Windows: there `process.env` is built by a JS builtin and has a JS custom inspect function, and both building and inspecting it at the stack limit abort the current canary too (`0xC0000409`, the `m_processEnvObject` / `m_utilInspectFunction` `LazyProperty` initializers, #38821 / #39382);
  - a builder failing for another reason (`Set` removed; `allowedNodeEnvironmentFlags` builds one) throws `TypeError`, does not call an `uncaughtException` listener, and the read works once `Set` is back;
  - the same failure during `{ ...process }` (bulk reification) throws from the spread; afterwards a spread copies the property and the remaining properties work;
  - the same failure during `Bun.inspect(process)` hides exactly that one property (#29642's walk behaviour on `process`: before it, `loadEnvFile`, `finalization` and `arch` disappeared as well, or the assertion above fired; verified against a build without those two lines before the rebase). Runs on every platform, nothing stack related in it.
- `constructNodeWorkerStdioStream` has no case of its own: the worker preload reads the three streams with a healthy stack before user code runs, so a failure there is not reachable from a test; it is converted so that every builder in the file has the same contract. `worker_threads.test.ts` (137 tests) passes on the rebased build.
- Also run on the debug build: the rest of `process.test.js` and the `process-*` tests (the existing stack overflow fixture's comment is updated; one pre-existing failure because `USER` is unset in this container), `worker-transfer-terminate-stress.test.ts`, `worker-terminate-lifetime.test.ts` (its dns case reports a `node_fs_binding` leak identically without this change), `test-worker-message-port-transfer-terminate.js` x3, `inspect.test.js`, `BunObject.test.ts`, `console.test.ts`. The repro scripts, plus a variant that removes `Set` before the stdio builders run (their module loading fails, they rebuild correctly afterwards), are clean under `BUN_JSC_validateExceptionChecks=1`.

### Overlap with open PRs
This PR is the one carrying the failure policy of the `process` builders (`BunProcess.cpp`) and the dependent console getters.
- Landed meanwhile and rebased onto: #29642 (the property walk; this PR's copy of it was dropped, comment-only conflict), #39536 (lazy worker stdio and the removal of the `_debugProcess` stubs from the table; its new builder is converted here, the bulk test uses a spread, which does not depend on those stubs), #39770 (`putDirectNamed` in `constructProcessConfigObject`, the one conflict of the second rebase: main's lines with this PR's `RETURN_IF_EXCEPTION`), #40410 (the exception lint added a `RETURN_IF_EXCEPTION` after the report inside each clear-and-report block, since the report runs JS; those blocks are exactly the code this PR deletes, so the third rebase resolved all ten conflicts to this PR's single `RETURN_IF_EXCEPTION(scope, {})`, and the two `getIndex` checks keep returning empty rather than main's `jsUndefined()`, which would store `undefined`).
- #38821 (env) touches `constructEnv` (same change) and the comments this PR removes; trivial in either order, the rest of it is independent. A note is on that PR.
- #39703: the engine-side landing described under Fix; its body names this PR. Preferably first, but this PR does not depend on it to be correct.
- #37258 (same builders, but keeping clear-and-report and deferring the report) and #30612 (a retry of the `nextTick` case inside `queueNextTick`) are closed in favour of this PR; the `emitWarning` case here is the regression test for #30612's internal path.

### Background
- `process`'s properties come from a static hash table (`processObjectTable`). A `PropertyCallback` entry is not built when `process` is created: the first read calls its builder and stores the result as an ordinary own property (`reifyStaticProperty`). Several builders run a JS builtin (`getStdioWriteStream`, `initializeNextTickQueue`, ...), so they can throw, for instance when there is no stack left to enter JS.
- Where the JSC side of the contract lives, in the WebKit main pins (`b7f217b4`, `scripts/build/deps/webkit.ts`): `runtime/Lookup.h`, the `PropertyCallback` branch of `reifyStaticProperty`, returns without `putDirect` when the builder returned empty; `runtime/Lookup.cpp`, `setUpStaticFunctionSlot`, runs the reify under `DeferTerminationForAWhile` and returns false (slot not found) when `vm.exceptionForInspection()` is set afterwards; `runtime/JSObject.cpp`, `reifyAllStaticProperties`, does the same per entry and returns without setting `staticPropertiesReified`, so the next bulk operation continues with the entries that are left.
- A JS exception is a flag on the VM that native code checks after each fallible call (`RETURN_IF_EXCEPTION`). A function propagates a failure by returning an empty value with the flag set; once control is back in JS the exception is thrown there. `JSObject::get` is the exception to the empty-value convention: it returns `undefined` on failure.
- `ThrowScope` vs `TopExceptionScope`: in exception-checking builds a `ThrowScope` pretends its function threw whenever it returns, so a caller without a check is flagged; a `TopExceptionScope` does not. JSC checks a builder's result with `vm.exceptionForInspection()`, which is not such a check, hence `TopExceptionScope` in the builders.
- `reifyAllStaticProperties` builds every remaining entry of the table at once; JSC does this when an operation cannot be answered from the table, such as deleting one of its properties or spreading the object.
- Lookup loops and caches: `JSObject::getPropertySlot` and the JIT's megamorphic helpers ask each object in the prototype chain for the property and walk on when it reports a miss; a throwing builder is reported as a miss on the current pin. The loop reads the object's `Structure` (its shape; adding a property moves the object to a new one) before the own-property step and uses it again afterwards, and the megamorphic helpers record a miss per structure. #39703 makes the loops stop at the throw instead, which removes both the stale read and the recorded miss.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/process/process.test.js

<!-- robobun:evidence:end -->

