### PR TITLE
fix(dotenv): unescape escaped quotes inside double-quoted .env values

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1021,6 +1021,10 @@ impl<'a> Parser<'a> {
                                             self.value_buffer.push(b'\r');
                                             i += 2;
                                         }
+                                        b'"' => {
+                                            self.value_buffer.push(b'"');
+                                            i += 2;
+                                        }
                                         _ => {
                                             self.value_buffer
                                                 .extend_from_slice(&self.src[i..i + 2]);

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -575,6 +575,15 @@ describe.concurrent(".env quoted value with trailing junk does not swallow follo
   });
 });
 
+test(".env escaped quote inside double quotes (issue #39351)", () => {
+  const dir = tempDirWithFiles("dotenv-issue-39351", {
+    ".env": 'FOO="{ \\"foo\\": true }"',
+    "index.ts": "console.log(process.env.FOO);",
+  });
+  const { stdout } = bunRun(`${dir}/index.ts`);
+  expect(stdout).toBe('{ "foo": true }');
+});
+
 describe.concurrent("boundary tests", () => {
   // TODO: this is a regression in bun ~1.0.15 ish
   test.todo("src boundary", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #39351: a `\"` sequence inside a double-quoted `.env` value was kept literally (`\"`), so JSON in `.env` files was mangled. Now it unescapes to `"`, matching shell and dotenv semantics.

```sh
# .env
FOO="{ \"foo\": true }"

# before
$ bun -e "console.log(process.env.FOO)"
{ \"foo\": true }

# after
$ bun -e "console.log(process.env.FOO)"
{ "foo": true }
```

`\n` and `\r` escapes and literal `\\` are unchanged.

- [x] Bug or feature? Bug
- [ ] Documentation added (if applicable)
- [x] Tests added

### How did you verify your code passes?

Added integration test `test/cli/run/env.test.ts` (".env escaped quote inside double quotes (issue #39351)") — fails on 1.3.14 (reproduced), passes with the fix. Existing escapes (`\n`, `\r`, `\\`) covered by the existing `#3911` and `boundary tests` suites remain green.