### PR TITLE
bun test: report a test that completes after its timeout as timed out

### DIFF
--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -766,8 +766,7 @@ impl Execution {
         }
     }
 
-    /// A callback that blocked past its deadline finishes before the timer can fire, so it is judged as its
-    /// completion arrives; by the time `step` processes the queued completion, other callbacks may have blocked.
+    /// Judged here rather than in `step`: other callbacks may block before the queued completion is processed.
     pub(crate) fn handle_callback_completed(&mut self, user_data: &RefDataValue) {
         let _g = group_begin!();
 

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -371,8 +371,16 @@ impl Execution {
                     _ => unreachable!(),
                 };
 
-                // SAFETY: sequence_ptr points into this.sequences; valid while BunTest is alive.
-                debug_assert!(unsafe { sequence_ptr.as_ref() }.active_entry.is_some());
+                // SAFETY: sequence_ptr points into this.sequences; valid while BunTest is alive. This
+                // `&mut` is dead before `this` is touched again.
+                let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
+                debug_assert!(sequence.active_entry.is_some());
+                if let Some(completed_entry) = sequence.active_entry {
+                    // A callback that blocked past its deadline completes before the timeout timer can
+                    // fire, so check the deadline here like the synchronous-return path in step_sequence_one.
+                    // SAFETY: arena-owned entry, alive for lifetime of BunTest
+                    let _ = unsafe { completed_entry.as_ref() }.evaluate_timeout(sequence, &now, true);
+                }
                 Execution::advance_sequence(buntest_ptr, sequence_ptr, group_ptr);
 
                 let sequence_result =
@@ -980,7 +988,7 @@ fn step_sequence_one(
         };
         // SAFETY: arena-owned entry
         let active_entry = unsafe { &mut *active_entry_ptr.as_ptr() };
-        if active_entry.evaluate_timeout(sequence, now) {
+        if active_entry.evaluate_timeout(sequence, now, false) {
             Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
             return Ok(None); // run again
         }
@@ -1044,7 +1052,7 @@ fn step_sequence_one(
             // SAFETY: re-deref after run_test_callback; sequence_ptr still valid (sequences is a
             // Box<[ExecutionSequence]>, never reallocated during execution).
             let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
-            let _ = next_item.evaluate_timeout(sequence, now);
+            let _ = next_item.evaluate_timeout(sequence, now, true);
 
             // the result is available immediately; advance the sequence and run again.
             Execution::advance_sequence(buntest_ptr, sequence_ptr, group);

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -371,16 +371,8 @@ impl Execution {
                     _ => unreachable!(),
                 };
 
-                // SAFETY: sequence_ptr points into this.sequences; valid while BunTest is alive. This
-                // `&mut` is dead before `this` is touched again.
-                let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
-                debug_assert!(sequence.active_entry.is_some());
-                if let Some(completed_entry) = sequence.active_entry {
-                    // A callback that blocked past its deadline completes before the timeout timer can
-                    // fire, so check the deadline here like the synchronous-return path in step_sequence_one.
-                    // SAFETY: arena-owned entry, alive for lifetime of BunTest
-                    let _ = unsafe { completed_entry.as_ref() }.evaluate_timeout(sequence, &now, true);
-                }
+                // SAFETY: sequence_ptr points into this.sequences; valid while BunTest is alive.
+                debug_assert!(unsafe { sequence_ptr.as_ref() }.active_entry.is_some());
                 Execution::advance_sequence(buntest_ptr, sequence_ptr, group_ptr);
 
                 let sequence_result =
@@ -772,6 +764,30 @@ impl Execution {
         if let Some(runner) = super::jest::Jest::runner() {
             runner.snapshots.reset_counts();
         }
+    }
+
+    /// A callback that blocked past its deadline finishes before the timer can fire, so it is judged as its
+    /// completion arrives; by the time `step` processes the queued completion, other callbacks may have blocked.
+    pub(crate) fn handle_callback_completed(&mut self, user_data: &RefDataValue) {
+        let _g = group_begin!();
+
+        let Some((sequence_ptr, _group_ptr)) =
+            self.get_current_and_valid_execution_sequence(user_data)
+        else {
+            return;
+        };
+        // SAFETY: sequence_ptr points into self.sequences; `self` is not accessed for the
+        // remainder of this function, so this is the unique live `&mut` to that element.
+        let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
+        let Some(entry) = sequence.active_entry else {
+            return;
+        };
+        // SAFETY: arena-owned entry, alive for lifetime of BunTest
+        let _ = unsafe { entry.as_ref() }.evaluate_timeout(
+            sequence,
+            &Timespec::now_force_real_time(),
+            true,
+        );
     }
 
     pub(crate) fn handle_uncaught_exception(

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1943,10 +1943,7 @@ impl ExecutionEntry {
         entry
     }
 
-    /// Records a timeout failure on `sequence` if this entry's deadline has passed. `callback_completed`
-    /// is set when the callback has already finished (returned, settled, or called `done`) and merely
-    /// took too long; the "before its done callback was called" hint is only reported while it is still
-    /// running.
+    /// `callback_completed`: the callback already finished, so the missing-`done()` hint does not apply.
     pub(crate) fn evaluate_timeout(
         &self,
         sequence: &mut Execution::ExecutionSequence,

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1943,10 +1943,15 @@ impl ExecutionEntry {
         entry
     }
 
+    /// Records a timeout failure on `sequence` if this entry's deadline has passed. `callback_completed`
+    /// is set when the callback has already finished (returned, settled, or called `done`) and merely
+    /// took too long; the "before its done callback was called" hint is only reported while it is still
+    /// running.
     pub(crate) fn evaluate_timeout(
         &self,
         sequence: &mut Execution::ExecutionSequence,
         now: &Timespec,
+        callback_completed: bool,
     ) -> bool {
         if !self.timespec.eql(&Timespec::EPOCH) && self.timespec.order(now) == core::cmp::Ordering::Less {
             // timed out
@@ -1954,13 +1959,14 @@ impl ExecutionEntry {
             let is_test_entry = sequence
                 .test_entry
                 .is_some_and(|p| core::ptr::eq(p.as_ptr().cast_const(), self));
+            let waiting_for_done = self.has_done_parameter && !callback_completed;
             sequence.result = if is_test_entry {
-                if self.has_done_parameter {
+                if waiting_for_done {
                     Execution::Result::FailBecauseTimeoutWithDoneCallback
                 } else {
                     Execution::Result::FailBecauseTimeout
                 }
-            } else if self.has_done_parameter {
+            } else if waiting_for_done {
                 Execution::Result::FailBecauseHookTimeoutWithDoneCallback
             } else {
                 Execution::Result::FailBecauseHookTimeout

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -777,6 +777,7 @@ impl BunTest {
             return Ok(());
         }
 
+        this.on_callback_completed(&refdata.phase);
         this.add_result(refdata.phase);
         // `this` borrow ends here (NLL); `run_next_tick` re-derives via `.get()`.
         Self::run_next_tick(&refdata.buntest_weak, global_this, refdata.phase);
@@ -852,7 +853,9 @@ impl BunTest {
         };
         // SAFETY: `&mut` derived via `UnsafeCell`; borrow ends before
         // `run_next_tick` re-derives.
-        strong.get().add_result(ref_in.phase);
+        let this = strong.get();
+        this.on_callback_completed(&ref_in.phase);
+        this.add_result(ref_in.phase);
         Self::run_next_tick(&ref_in.buntest_weak, global_this, ref_in.phase);
 
         Ok(JSValue::UNDEFINED)
@@ -914,6 +917,13 @@ impl BunTest {
         strong.get().wants_wakeup = true;
         // we need to wake up the event loop so autoTick() doesn't wait for 16-100ms because we just enqueued a task
         vm.enqueue_task(task);
+    }
+
+    /// Call before `add_result` with the completion of a test or hook callback.
+    pub(crate) fn on_callback_completed(&mut self, data: &RefDataValue) {
+        if self.phase == Phase::Execution {
+            self.execution.handle_callback_completed(data);
+        }
     }
 
     pub(crate) fn add_result(&mut self, result: RefDataValue) {

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -569,8 +569,8 @@ describe("a test that completes after its timeout has passed is reported as time
       stderr: "pipe",
       env: bunEnv,
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    return { stderr: normalizeBunSnapshot(stderr), exitCode };
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: normalizeBunSnapshot(stdout), stderr: normalizeBunSnapshot(stderr), exitCode };
   }
 
   test.concurrent("sequential test, Bun.sleepSync after an await", async () => {
@@ -600,6 +600,7 @@ describe("a test that completes after its timeout has passed is reported as time
        1 fail
       Ran 2 tests across 1 file."
       ,
+        "stdout": "bun test <version> (<revision>)",
       }
     `);
   });
@@ -632,6 +633,7 @@ describe("a test that completes after its timeout has passed is reported as time
        1 fail
       Ran 2 tests across 1 file."
       ,
+        "stdout": "bun test <version> (<revision>)",
       }
     `);
   });
@@ -666,6 +668,7 @@ describe("a test that completes after its timeout has passed is reported as time
        1 fail
       Ran 2 tests across 1 file."
       ,
+        "stdout": "bun test <version> (<revision>)",
       }
     `);
   });
@@ -702,6 +705,7 @@ describe("a test that completes after its timeout has passed is reported as time
        2 fail
       Ran 2 tests across 1 file."
       ,
+        "stdout": "bun test <version> (<revision>)",
       }
     `);
   });

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
 import { copyFileSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "fs";
 import { rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 
@@ -552,6 +552,159 @@ it("test timeouts when expected", () => {
   const err = stderr!.toString();
   expect(err).toHaveTestTimedOutAfter(10);
   expect(err).not.toContain("unreachable code");
+});
+
+describe("a test that completes after its timeout has passed is reported as timed out", () => {
+  // Each body blocks synchronously for longer than its timeout, so the timeout timer cannot fire until the
+  // callback has already completed, and the verdict has to come from the completion itself.
+  async function runFixture(name: string, code: string) {
+    using dir = tempDir("late-timeout-" + name, {
+      "blocks.test.js": code,
+      "package.json": "{}",
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "test", "blocks.test.js"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: bunEnv,
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stderr: normalizeBunSnapshot(stderr), exitCode };
+  }
+
+  test.concurrent("sequential test, Bun.sleepSync after an await", async () => {
+    const result = await runFixture(
+      "sequential",
+      /*js*/ `
+        import { test } from "bun:test";
+        test("sleeps synchronously after an await", async () => {
+          await Bun.sleep(1);
+          Bun.sleepSync(300);
+        }, 100);
+        test("next test still runs", async () => {
+          await Bun.sleep(1);
+        });
+      `,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "exitCode": 1,
+        "stderr": 
+      "blocks.test.js:
+      (fail) sleeps synchronously after an await
+        ^ this test timed out after 100ms.
+      (pass) next test still runs
+
+       1 pass
+       1 fail
+      Ran 2 tests across 1 file."
+      ,
+      }
+    `);
+  });
+
+  test.concurrent("concurrent test with a sibling still pending, busy loop after an await", async () => {
+    const result = await runFixture(
+      "concurrent-busy-loop",
+      /*js*/ `
+        import { test } from "bun:test";
+        test.concurrent("busy loops after an await", async () => {
+          await Bun.sleep(1);
+          const start = Date.now();
+          while (Date.now() - start < 300) {}
+        }, 100);
+        test.concurrent("sibling", async () => {
+          await Bun.sleep(10);
+        }, 30_000);
+      `,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "exitCode": 1,
+        "stderr": 
+      "blocks.test.js:
+      (fail) busy loops after an await
+        ^ this test timed out after 100ms.
+      (pass) sibling
+
+       1 pass
+       1 fail
+      Ran 2 tests across 1 file."
+      ,
+      }
+    `);
+  });
+
+  test.concurrent("concurrent test with a sibling still pending, Bun.spawnSync after an await", async () => {
+    // With a sibling running, spawnSync's wait loop cannot tell whose child it is waiting on and uses
+    // the sibling's later deadline, so this test's own deadline is only checked once the callback
+    // completes.
+    const result = await runFixture(
+      "concurrent-spawnSync",
+      /*js*/ `
+        import { test } from "bun:test";
+        test.concurrent("spawnSync outlives the timeout", async () => {
+          await Bun.sleep(1);
+          Bun.spawnSync({ cmd: [process.execPath, "-e", "Bun.sleepSync(300)"] });
+        }, 100);
+        test.concurrent("sibling", async () => {
+          await Bun.sleep(10);
+        }, 30_000);
+      `,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "exitCode": 1,
+        "stderr": 
+      "blocks.test.js:
+      (fail) spawnSync outlives the timeout
+        ^ this test timed out after 100ms.
+      (pass) sibling
+
+       1 pass
+       1 fail
+      Ran 2 tests across 1 file."
+      ,
+      }
+    `);
+  });
+
+  test.concurrent("done() called after the timeout has passed", async () => {
+    // done() was called, so the hint about a missing done() call does not apply to either test.
+    const result = await runFixture(
+      "done-callback",
+      /*js*/ `
+        import { test } from "bun:test";
+        test("done() from a timer callback", done => {
+          setTimeout(() => {
+            Bun.sleepSync(300);
+            done();
+          }, 1);
+        }, 100);
+        test("done() synchronously", done => {
+          Bun.sleepSync(300);
+          done();
+        }, 100);
+      `,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "exitCode": 1,
+        "stderr": 
+      "blocks.test.js:
+      (fail) done() from a timer callback
+        ^ this test timed out after 100ms.
+      (fail) done() synchronously
+        ^ this test timed out after 100ms.
+
+       0 pass
+       2 fail
+      Ran 2 tests across 1 file."
+      ,
+      }
+    `);
+  });
 });
 
 test("jest.setTimeout will change default timeout", () => {

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -709,6 +709,42 @@ describe("a test that completes after its timeout has passed is reported as time
       }
     `);
   });
+
+  test.concurrent("a test that finished in time is not blamed for a sibling blocking afterwards", async () => {
+    // The first test's completion is queued as soon as it returns, but the runner only processes the queue
+    // once the sibling, resumed by the microtask the first test queues on its way out, has finished
+    // blocking. The verdict has to be based on when the completion arrived, not on when it was processed.
+    const result = await runFixture(
+      "sibling-blocks-after-completion",
+      /*js*/ `
+        import { test } from "bun:test";
+        const { promise: firstReturned, resolve: markFirstReturned } = Promise.withResolvers();
+        test.concurrent("finishes within its timeout", async () => {
+          await Bun.sleep(1);
+          queueMicrotask(markFirstReturned);
+        }, 100);
+        test.concurrent("blocks once the first test has returned", async () => {
+          await firstReturned;
+          Bun.sleepSync(300);
+        }, 30_000);
+      `,
+    );
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "exitCode": 0,
+        "stderr": 
+      "blocks.test.js:
+      (pass) finishes within its timeout
+      (pass) blocks once the first test has returned
+
+       2 pass
+       0 fail
+      Ran 2 tests across 1 file."
+      ,
+        "stdout": "bun test <version> (<revision>)",
+      }
+    `);
+  });
 });
 
 test("jest.setTimeout will change default timeout", () => {


### PR DESCRIPTION
### Problem
- A test whose callback resumes from the event loop (after an `await`, or in a timer callback) and then blocks synchronously past its timeout is reported as `(pass)`. Blocking with a busy loop, `Bun.sleepSync`, or `Bun.spawnSync` all reproduce it, for plain `test()` as well as `test.concurrent()`:
  ```ts
  test("c1", async () => { await Bun.sleep(50); Bun.sleepSync(3000); }, 300);  // (pass) c1 [3050ms]
  ```
- Cause: the timeout timer cannot fire while the callback is blocking. When the callback finishes, its completion (`bun_test_then` / `done()`, `src/runtime/test_runner/bun_test.rs`) is queued without looking at the entry's deadline, and `Execution::step` (`src/runtime/test_runner/Execution.rs`) advances the sequence as a pass. The timer fires afterwards and finds the sequence already finished. The synchronous-return path in `step_sequence_one` already calls `evaluate_timeout` after the callback returns; the asynchronous completion path had no equivalent.
- The `spawnSync` flavour inside a `test.concurrent` group with a sibling still running used to fail correctly in 1.3.14 (the wait loop fired the runner's timeout callback at the earliest deadline in the group). Since #33832, `TestRunner::get_active_timeout` returns the latest deadline in the group when the caller is no longer on the stack (`src/runtime/test_runner/jest.rs`), so it no longer kills a sibling's child, and the verdict was left to the completion path above, which dropped it. #38883 is not the cause: its deferred callback still reports the verdict whenever the wait loop does hit a deadline.

### Fix
- `BunTest::on_callback_completed`, called from the promise handler and from `done()` right before the completion is queued, runs `Execution::handle_callback_completed`: if the completion still belongs to the running entry, `evaluate_timeout` is applied against the current time. This is the same check the synchronous-return path makes, made at the equivalent moment for asynchronous callbacks.
- It runs when the completion arrives rather than in `step`, because the queued completion may only be processed after other callbacks have run; a test that finished in time must not be blamed for a sibling that blocks afterwards (found in review on an earlier revision, covered by the last fixture below).
- Resulting semantics: a callback is judged against its deadline at the moment it finishes, whatever blocked until then. In a `test.concurrent` group this includes a test held up by a sibling blocking the event loop; its printed duration already exceeds its timeout in that case, and on main such a test passed or failed depending on the order in which its resume and the timeout timer happened to fire after the block. `spawnSync` in a multi-test concurrent group still waits for the child (there is no way to tell which test the child belongs to); the test is reported as timed out when the callback completes.
- A test ended by an unhandled rejection (`on_unhandled_rejection`, `src/runtime/test_runner/jest.rs`) is aborted rather than completed and is already a failure, so that path is intentionally left alone. Today `done(err)` also reports through it, so a sequential test that overruns and then calls `done(err)` still prints the error with a plain `(fail)` rather than the timed-out line (unchanged from main; the concurrent variant does get the line). #39112 changes `done(err)` to report directly against its own entry, after which the `on_callback_completed` call in `bun_test_done_callback` covers it too, so this PR does not restructure that block.
- Precedence is unchanged: the timeout replaces whatever the body produced, including a thrown error or a `test.failing` pass. The synchronous-return path and the timer path already behave this way on main (`test.failing` bodies that overrun are reported as `timed out` on both); the asynchronous completion path was the only one that did not.
- `ExecutionEntry::evaluate_timeout` takes a `callback_completed` flag. Both completion paths (synchronous return and the new one) record `FailBecauseTimeout` / `FailBecauseHookTimeout`; the `...WithDoneCallback` variants, whose message is "timed out ..., before its done callback was called. If a done callback was not intended, remove the last parameter", are now only produced by the timer path, where the callback really is still waiting. Previously a `done` test that blocked and then called `done()` synchronously printed that hint although `done()` had been called. Every other consumer of those variants (junit, GitHub annotations, summary counts) already treats them identically to the plain ones.
- Tests: `test/js/bun/test/test-test.test.ts`, describe `a test that completes after its timeout has passed is reported as timed out`, five fixtures run through `bun test`: sequential `Bun.sleepSync` after an `await` (the next test still runs); `test.concurrent` busy loop with a sibling pending; `test.concurrent` `Bun.spawnSync` with a sibling pending; `done()` called late both from a timer callback and synchronously; and a `test.concurrent` test that returns in time while its sibling blocks for 300ms before the runner processes the completion, which must pass. On main the first three fixtures report `2 pass`, the fourth reports the timer test as `(pass)` and the synchronous one with the done-callback hint, and the fifth passes; the fifth fails on the earlier revision of this branch that checked the deadline in `step`. With the fix all five match their snapshots (5 consecutive runs on the debug build). The overrunning fixtures block for 300ms against a 100ms timeout, and the timer heap fires in deadline order, so none of the outcomes depend on scheduling.
- Also run on the debug build: `test/js/bun/test/{bun_test,concurrent,concurrent_immediate,done-async,test-retry-repeats-basic,test-on-test-finished,failure-skip,jest-hooks,test-error-code-done-callback,test-failing}.test.ts`, `test/cli/test/{test-timeout-behavior,retry-flag,rerun-each}.test.ts`, `test/cli/test/bun-test.test.ts -t timeout`, `test/js/node/test_runner/node-test.test.ts`; `cargo fmt --all -- --check` is clean.
- Open PRs #38153 and #39089 also touch `evaluate_timeout` (different bugs); whichever lands second has a one-line conflict in its signature or call sites.

### Background
- Execution entry: one test callback or one hook, with a `timespec` deadline set when it starts (`on_entry_started`). A sequence is a test plus its `beforeEach`/`afterEach` entries; a concurrent group holds the sequences that may run at the same time (one sequence for a plain `test()`).
- How a completion arrives: `run_test_callback` either gets a result synchronously (returns `Some`, handled in `step_sequence_one`) or registers `then`/`catch` handlers on the returned promise and a `done` callback. When the last of those fires, it pushes a `RefDataValue` naming the entry onto the file's result queue and schedules a task; `BunTest::run` later drains the queue into `Execution::step`, which checks that the entry is still the sequence's active one (`get_current_and_valid_execution_sequence`) and advances it. The new hook sits at the push and reuses that same validity check; `step` is unchanged.
- Timeout timer: one timer per file, armed for the earliest deadline of the running entries. When it fires, `handle_timeout` pushes a `Start` onto the same queue and `step_group` re-walks the running sequences, calling `evaluate_timeout` on each one still executing. It is the only other place a timeout verdict comes from, and it cannot run while JavaScript is blocking.
- `spawnSync` in `bun test`: the wait loop ticks an isolated event loop and asks the runner for a deadline to wake up at (`get_active_timeout`); when that deadline passes it kills the child and, since #38883, reports the timeout once the loop is torn down. With several concurrent tests running and no caller on the stack it uses the latest deadline so that it never kills a child belonging to a test that still has time.

<details>
<summary>Behaviour on 1.3.14, main, and this branch for the reported repros</summary>

Body runs after `await Bun.sleep(50)` in a test with a 300ms timeout; "sibling" is a second `test.concurrent` with a 5s timeout.

| body | 1.3.14 | main | this branch |
| --- | --- | --- | --- |
| busy loop, sequential | pass | pass | fail, timed out |
| busy loop, concurrent alone | pass | pass | fail, timed out |
| busy loop, concurrent with sibling | pass | pass | fail, timed out; sibling passes |
| spawnSync, sequential | fail at 300ms, child killed | fail at 300ms, child killed | unchanged |
| spawnSync, concurrent alone | fail at 300ms, child killed | fail at 300ms, child killed | unchanged |
| spawnSync, concurrent with sibling | fail at 300ms, child not killed | pass | fail when the child exits, child not killed; sibling passes |

</details>

<details>
<summary>Earlier revision</summary>

The first revision evaluated the deadline inside `Execution::step`, i.e. when the queued completion was processed. A review comment pointed out that a sibling blocking between a test's completion being queued and the queue being drained then got that test reported as timed out; reproduced and replaced by the completion-time hook above, with the fifth fixture covering it.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/test/test-test.test.ts

<!-- robobun:evidence:end -->