### PR TITLE
sql(postgres): floor binary timestamp microseconds to ms instead of truncating toward zero

### DIFF
--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -20,12 +20,8 @@ pub(crate) fn from_binary(bytes: &[u8]) -> f64 {
     if microseconds == i64::MIN {
         return f64::NEG_INFINITY;
     }
-    // Floor to whole ms before converting: the text decoders drop the sub-ms
-    // digits, and a fractional f64 would instead be truncated toward zero by
-    // timeClip in DateInstance::create, landing pre-1970 instants 1 ms late
-    // (1969-12-31 23:59:59.9996 came back as 1970-01-01T00:00:00.000Z).
-    // |µs / 1000| <= ~9.2e15, so the epoch shift cannot overflow, and every
-    // result JS Date accepts (±8.64e15) is below 2^53, so the cast is exact.
+    // Floor in integers: a fractional f64 would be truncated toward zero by
+    // timeClip, landing pre-1970 instants 1 ms late. Text decoding floors.
     (microseconds.div_euclid(US_PER_MS) + POSTGRES_EPOCH_DATE) as f64
 }
 
@@ -63,8 +59,6 @@ pub(crate) fn timestamp_text_to_ms_utc(
             i32::from(parsed.hour),
             i32::from(parsed.minute),
             i32::from(parsed.second),
-            // Fractional seconds → milliseconds; drops the sub-ms digits, as
-            // `from_binary` does.
             (parsed.microsecond / 1000) as i32,
         )
         .ok()

--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -20,8 +20,13 @@ pub(crate) fn from_binary(bytes: &[u8]) -> f64 {
     if microseconds == i64::MIN {
         return f64::NEG_INFINITY;
     }
-    let double_microseconds: f64 = microseconds as f64;
-    (double_microseconds / US_PER_MS as f64) + POSTGRES_EPOCH_DATE as f64
+    // Floor to whole ms before converting: the text decoders drop the sub-ms
+    // digits, and a fractional f64 would instead be truncated toward zero by
+    // timeClip in DateInstance::create, landing pre-1970 instants 1 ms late
+    // (1969-12-31 23:59:59.9996 came back as 1970-01-01T00:00:00.000Z).
+    // |µs / 1000| <= ~9.2e15, so the epoch shift cannot overflow, and every
+    // result JS Date accepts (±8.64e15) is below 2^53, so the cast is exact.
+    (microseconds.div_euclid(US_PER_MS) + POSTGRES_EPOCH_DATE) as f64
 }
 
 /// `'infinity'` / `'-infinity'` as Postgres emits them for date / timestamp /
@@ -58,8 +63,8 @@ pub(crate) fn timestamp_text_to_ms_utc(
             i32::from(parsed.hour),
             i32::from(parsed.minute),
             i32::from(parsed.second),
-            // Fractional seconds → milliseconds (JS Date is ms-precision, like
-            // the binary path's f64 truncation).
+            // Fractional seconds → milliseconds; drops the sub-ms digits, as
+            // `from_binary` does.
             (parsed.microsecond / 1000) as i32,
         )
         .ok()

--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -20,8 +20,6 @@ pub(crate) fn from_binary(bytes: &[u8]) -> f64 {
     if microseconds == i64::MIN {
         return f64::NEG_INFINITY;
     }
-    // Floor in integers: a fractional f64 would be truncated toward zero by
-    // timeClip, landing pre-1970 instants 1 ms late. Text decoding floors.
     (microseconds.div_euclid(US_PER_MS) + POSTGRES_EPOCH_DATE) as f64
 }
 

--- a/test/js/sql/postgres-infinity-date.test.ts
+++ b/test/js/sql/postgres-infinity-date.test.ts
@@ -10,6 +10,12 @@
 // Driven by a scripted v3 backend so the exact wire bytes each path sees are
 // deterministic. A finite value is included in every case to show that Date
 // decoding for ordinary values is unaffected.
+//
+// The same scripted backends also pin how finite sub-millisecond values are
+// reduced to JS Date's millisecond precision on the two scalar paths (the
+// "sub-ms" section below): both must drop the extra digits, so that a binary
+// (extended protocol) query and a text (simple) query decode the same stored
+// value to the same instant.
 
 import { SQL } from "bun";
 import { afterAll, expect, test } from "bun:test";
@@ -205,6 +211,68 @@ test.each(["timestamp", "timestamptz"] as const)("scalar %s binary DT_NOEND/DT_N
   expect(row.neg).toBe(-Infinity);
   expect(row.fin).toBeInstanceOf(Date);
   expect((row.fin as Date).getTime()).toBe(Date.UTC(2000, 0, 2));
+});
+
+// --- sub-ms precision: binary must floor like text does --------------------
+// Each case is an instant at ms precision plus the sub-ms microseconds Postgres
+// stored on top of it. Decoding must yield the ms instant itself, i.e. drop the
+// extra digits, exactly as the text decoders (and Date.parse) do. The binary
+// decoder used to convert µs to a fractional f64 and let the Date constructor's
+// timeClip truncate it toward zero, which for instants before 1970 lands 1 ms
+// late: the first case came back as 1970-01-01T00:00:00.000Z.
+const SUB_MS_CASES = [
+  // [column, ms-precision instant, extra µs stored beyond the ms]
+  ["pre_1970_high_remainder", "1969-12-31T23:59:59.999Z", 600],
+  ["pre_1970_low_remainder", "1969-12-31T23:59:59.000Z", 400],
+  ["pre_1970_far", "1883-11-18T12:00:00.123Z", 456],
+  ["pre_1970_whole_ms", "1969-12-31T23:59:59.999Z", 0],
+  // Before the Postgres epoch (2000) but after 1970: negative on the wire,
+  // positive as unix ms. Already correct before; must stay so.
+  ["pre_2000", "1999-12-31T23:59:59.999Z", 600],
+  ["post_2000", "2024-06-01T12:00:00.123Z", 456],
+] as const;
+
+const SUB_MS_EXPECTED = Object.fromEntries(SUB_MS_CASES.map(([name, iso]) => [name, iso]));
+
+/** Postgres binary timestamp/timestamptz: µs since 2000-01-01T00:00:00Z. */
+function pgMicroseconds(isoMs: string, extraMicros: number): bigint {
+  const unixMs = BigInt(Date.parse(isoMs));
+  return (unixMs - 946_684_800_000n) * 1000n + BigInt(extraMicros);
+}
+
+/**
+ * The server's ISO DateStyle text for the same value, e.g.
+ * `1969-12-31 23:59:59.9996` (`+00` appended for timestamptz in a UTC session);
+ * Postgres strips trailing zeros from the fraction.
+ */
+function pgText(isoMs: string, extraMicros: number, withOffset: boolean): string {
+  const fraction = (isoMs.slice(-4, -1) + String(extraMicros).padStart(3, "0")).replace(/0+$/, "");
+  return `${isoMs.slice(0, 10)} ${isoMs.slice(11, 19)}${fraction && "." + fraction}${withOffset ? "+00" : ""}`;
+}
+
+function isoStrings(row: Record<string, unknown>): Record<string, string> {
+  return Object.fromEntries(
+    SUB_MS_CASES.map(([name]) => {
+      const v = row[name];
+      return [name, v instanceof Date ? v.toISOString() : Object.prototype.toString.call(v)];
+    }),
+  );
+}
+
+test.each(["timestamp", "timestamptz"] as const)("scalar %s binary sub-ms values floor to the ms instant", async t => {
+  const row = await runExtended(
+    SUB_MS_CASES.map(([name]) => ({ name, typeOid: OID[t], format: 1 })),
+    SUB_MS_CASES.map(([, iso, extra]) => be64(pgMicroseconds(iso, extra))),
+  );
+  expect(isoStrings(row)).toEqual(SUB_MS_EXPECTED);
+});
+
+test.each(["timestamp", "timestamptz"] as const)("scalar %s text sub-ms values floor to the ms instant", async t => {
+  const row = await runSimple(
+    SUB_MS_CASES.map(([name]) => ({ name, typeOid: OID[t] })),
+    SUB_MS_CASES.map(([, iso, extra]) => Buffer.from(pgText(iso, extra, t === "timestamptz"))),
+  );
+  expect(isoStrings(row)).toEqual(SUB_MS_EXPECTED);
 });
 
 // --- array text path -------------------------------------------------------

--- a/test/js/sql/postgres-infinity-date.test.ts
+++ b/test/js/sql/postgres-infinity-date.test.ts
@@ -12,10 +12,13 @@
 // decoding for ordinary values is unaffected.
 //
 // The same scripted backends also pin how finite sub-millisecond values are
-// reduced to JS Date's millisecond precision on the two scalar paths (the
-// "sub-ms" section below): both must drop the extra digits, so that a binary
-// (extended protocol) query and a text (simple) query decode the same stored
-// value to the same instant.
+// reduced to JS Date's millisecond precision by the two scalar decoders (the
+// "sub-ms" and "range boundaries" sections below): both must drop the extra
+// digits, so that a value arriving in binary decodes to the same instant as
+// its text rendering. Which decoder runs is selected by the format code the
+// scripted RowDescription declares per column (format: 1 below); against a
+// real server the binary decoder is reached when Bind requests binary results,
+// which sql-postgres-datetime-tz-fixture.ts covers.
 
 import { SQL } from "bun";
 import { afterAll, expect, test } from "bun:test";
@@ -111,9 +114,10 @@ async function runSimple(cols: PgRowDescriptionColumn[], row: (Buffer | null)[])
 }
 
 // Extended-protocol backend: answers Parse with the latched RowDescription,
-// answers Bind with the latched DataRow. The client requests binary result
-// format for timestamp/timestamptz, so the DataRow here carries DT_NOEND /
-// DT_NOBEGIN as raw i64.
+// answers Bind with the latched DataRow. The RowDescription's per-column
+// `format: 1` is what routes each cell to the binary decoder (the client's own
+// Bind for this parameterless query asks for text), so the DataRow here
+// carries raw big-endian i64 microseconds.
 let extReply!: { cols: PgRowDescriptionColumn[]; row: (Buffer | null)[] };
 const extended = await listeningServer(socket => {
   const reply = () => extReply;
@@ -219,25 +223,36 @@ test.each(["timestamp", "timestamptz"] as const)("scalar %s binary DT_NOEND/DT_N
 // extra digits, exactly as the text decoders (and Date.parse) do. The binary
 // decoder used to convert µs to a fractional f64 and let the Date constructor's
 // timeClip truncate it toward zero, which for instants before 1970 lands 1 ms
-// late: the first case came back as 1970-01-01T00:00:00.000Z.
+// late (the first case came back as 1970-01-01T00:00:00.000Z). More than 2^53
+// µs from 2000-01-01 (about 285 years either side) the f64 conversion itself
+// was lossy as well, so large remainders rounded up to the next ms there even
+// after 1970; the 1000, 2300 and 3000 cases cover that.
 const SUB_MS_CASES = [
   // [column, ms-precision instant, extra µs stored beyond the ms]
-  ["pre_1970_high_remainder", "1969-12-31T23:59:59.999Z", 600],
-  ["pre_1970_low_remainder", "1969-12-31T23:59:59.000Z", 400],
+  ["pre_1970_high_remainder", "1969-12-31T23:59:59.999Z", 999],
+  ["pre_1970_low_remainder", "1969-12-31T23:59:59.000Z", 1],
   ["pre_1970_far", "1883-11-18T12:00:00.123Z", 456],
+  ["pre_1970_beyond_2p53_us", "1000-06-15T01:02:03.999Z", 999],
   ["pre_1970_whole_ms", "1969-12-31T23:59:59.999Z", 0],
   // Before the Postgres epoch (2000) but after 1970: negative on the wire,
   // positive as unix ms. Already correct before; must stay so.
   ["pre_2000", "1999-12-31T23:59:59.999Z", 600],
   ["post_2000", "2024-06-01T12:00:00.123Z", 456],
+  ["post_2000_beyond_2p53_us", "2300-01-01T00:00:00.000Z", 999],
+  ["post_2000_far", "3000-06-01T12:00:00.123Z", 999],
 ] as const;
 
 const SUB_MS_EXPECTED = Object.fromEntries(SUB_MS_CASES.map(([name, iso]) => [name, iso]));
 
+const POSTGRES_EPOCH_UNIX_MS = 946_684_800_000n;
+
 /** Postgres binary timestamp/timestamptz: µs since 2000-01-01T00:00:00Z. */
+function pgMicrosecondsFromUnixMs(unixMs: bigint, extraMicros: bigint): bigint {
+  return (unixMs - POSTGRES_EPOCH_UNIX_MS) * 1000n + extraMicros;
+}
+
 function pgMicroseconds(isoMs: string, extraMicros: number): bigint {
-  const unixMs = BigInt(Date.parse(isoMs));
-  return (unixMs - 946_684_800_000n) * 1000n + BigInt(extraMicros);
+  return pgMicrosecondsFromUnixMs(BigInt(Date.parse(isoMs)), BigInt(extraMicros));
 }
 
 /**
@@ -250,21 +265,25 @@ function pgText(isoMs: string, extraMicros: number, withOffset: boolean): string
   return `${isoMs.slice(0, 10)} ${isoMs.slice(11, 19)}${fraction && "." + fraction}${withOffset ? "+00" : ""}`;
 }
 
-function isoStrings(row: Record<string, unknown>): Record<string, string> {
+/** Each named column rendered as its ISO instant, "Invalid Date", or its type tag if not a Date. */
+function isoStrings(row: Record<string, unknown>, columns: readonly string[]): Record<string, string> {
   return Object.fromEntries(
-    SUB_MS_CASES.map(([name]) => {
+    columns.map(name => {
       const v = row[name];
-      return [name, v instanceof Date ? v.toISOString() : Object.prototype.toString.call(v)];
+      if (!(v instanceof Date)) return [name, Object.prototype.toString.call(v)];
+      return [name, Number.isNaN(v.getTime()) ? "Invalid Date" : v.toISOString()];
     }),
   );
 }
+
+const SUB_MS_COLUMNS = SUB_MS_CASES.map(([name]) => name);
 
 test.each(["timestamp", "timestamptz"] as const)("scalar %s binary sub-ms values floor to the ms instant", async t => {
   const row = await runExtended(
     SUB_MS_CASES.map(([name]) => ({ name, typeOid: OID[t], format: 1 })),
     SUB_MS_CASES.map(([, iso, extra]) => be64(pgMicroseconds(iso, extra))),
   );
-  expect(isoStrings(row)).toEqual(SUB_MS_EXPECTED);
+  expect(isoStrings(row, SUB_MS_COLUMNS)).toEqual(SUB_MS_EXPECTED);
 });
 
 test.each(["timestamp", "timestamptz"] as const)("scalar %s text sub-ms values floor to the ms instant", async t => {
@@ -272,7 +291,42 @@ test.each(["timestamp", "timestamptz"] as const)("scalar %s text sub-ms values f
     SUB_MS_CASES.map(([name]) => ({ name, typeOid: OID[t] })),
     SUB_MS_CASES.map(([, iso, extra]) => Buffer.from(pgText(iso, extra, t === "timestamptz"))),
   );
-  expect(isoStrings(row)).toEqual(SUB_MS_EXPECTED);
+  expect(isoStrings(row, SUB_MS_COLUMNS)).toEqual(SUB_MS_EXPECTED);
+});
+
+// --- range boundaries (binary) ---------------------------------------------
+// The wire values next to the DT_NOEND / DT_NOBEGIN sentinels must divide
+// without overflowing and come out as Invalid Date (past JS Date's range), and
+// because the decoder floors to a whole ms before timeClip sees the value, a
+// sub-ms remainder on JS Date's extreme instants floors onto them: the maximum
+// plus 999 µs used to become Invalid Date, and 1 µs below the minimum floors
+// out of range.
+const JS_DATE_MAX_UNIX_MS = 8_640_000_000_000_000n;
+const JS_DATE_MAX_ISO = "+275760-09-13T00:00:00.000Z";
+const JS_DATE_MIN_ISO = "-271821-04-20T00:00:00.000Z";
+
+const BOUNDARY_CASES = [
+  // [column, wire value, decoded]
+  ["below_dt_noend", PG_INT64_MAX - 1n, "Invalid Date"],
+  ["above_dt_nobegin", PG_INT64_MIN + 1n, "Invalid Date"],
+  ["js_max", pgMicrosecondsFromUnixMs(JS_DATE_MAX_UNIX_MS, 0n), JS_DATE_MAX_ISO],
+  ["js_max_plus_999us", pgMicrosecondsFromUnixMs(JS_DATE_MAX_UNIX_MS, 999n), JS_DATE_MAX_ISO],
+  ["js_max_plus_1ms", pgMicrosecondsFromUnixMs(JS_DATE_MAX_UNIX_MS + 1n, 0n), "Invalid Date"],
+  ["js_min", pgMicrosecondsFromUnixMs(-JS_DATE_MAX_UNIX_MS, 0n), JS_DATE_MIN_ISO],
+  ["js_min_plus_999us", pgMicrosecondsFromUnixMs(-JS_DATE_MAX_UNIX_MS, 999n), JS_DATE_MIN_ISO],
+  ["js_min_minus_1us", pgMicrosecondsFromUnixMs(-JS_DATE_MAX_UNIX_MS, -1n), "Invalid Date"],
+] as const;
+
+const BOUNDARY_COLUMNS = BOUNDARY_CASES.map(([name]) => name);
+
+test.each(["timestamp", "timestamptz"] as const)("scalar %s binary values at the JS Date range boundaries", async t => {
+  const row = await runExtended(
+    BOUNDARY_CASES.map(([name]) => ({ name, typeOid: OID[t], format: 1 })),
+    BOUNDARY_CASES.map(([, wire]) => be64(wire)),
+  );
+  expect(isoStrings(row, BOUNDARY_COLUMNS)).toEqual(
+    Object.fromEntries(BOUNDARY_CASES.map(([name, , iso]) => [name, iso])),
+  );
 });
 
 // --- array text path -------------------------------------------------------

--- a/test/js/sql/sql-postgres-datetime-tz-fixture.ts
+++ b/test/js/sql/sql-postgres-datetime-tz-fixture.ts
@@ -7,6 +7,12 @@
 //
 // The driving test spawns this fixture under several TZ values against a real
 // Postgres server and asserts binary and text decode to the same instant.
+//
+// It also checks in-band that the "binary" query really received binary
+// results (the `0.1::real` sentinel), and sweeps sub-millisecond instants from
+// 4714 BC to the JS Date limit against the server's own
+// floor(extract(epoch) * 1000), which covers the ranges where the text path
+// cannot serve as the oracle.
 
 import { SQL, randomUUIDv7 } from "bun";
 
@@ -72,12 +78,97 @@ function checkRows(protocol: string, rows: Array<{ ts: Date; tstz: Date; d: Date
   }
 }
 
+// `0.1::real` tells the two result formats apart in-band: the 4-byte binary
+// float4 decodes to Math.fround(0.1), the text rendering "0.1" to 0.1.
+function checkFormat(protocol: string, rows: Array<{ fmt: number }>, want: number) {
+  if (rows[0]?.fmt !== want) {
+    failures.push(`${protocol} query: format sentinel 0.1::real decoded to ${rows[0]?.fmt}, want ${want}`);
+  }
+}
+
 // The bound parameter matters: a statement without parameters is prepared and
 // executed in one round trip, before the result types are known, so its Bind
 // asks for text results. With a parameter, Bind is sent after Describe and
-// requests binary for timestamp/timestamptz.
-checkRows("binary", await sql`SELECT ts, tstz, d FROM ${sql(t)} WHERE id >= ${0} ORDER BY id`);
-checkRows("text", await sql`SELECT ts, tstz, d FROM ${sql(t)} ORDER BY id`.simple());
+// requests binary for timestamp/timestamptz; the sentinel proves which one
+// each query got.
+const binaryRows = await sql`SELECT ts, tstz, d, 0.1::real AS fmt FROM ${sql(t)} WHERE id >= ${0} ORDER BY id`;
+const textRows = await sql`SELECT ts, tstz, d, 0.1::real AS fmt FROM ${sql(t)} ORDER BY id`.simple();
+checkFormat("binary", binaryRows, Math.fround(0.1));
+checkFormat("text", textRows, 0.1);
+checkRows("binary", binaryRows);
+checkRows("text", textRows);
+
+// Sub-millisecond sweep, checked against the server's own arithmetic:
+// floor(extract(epoch) * 1000) is numeric (exact) on PostgreSQL 14+, and,
+// unlike the text path, is also an oracle where the text decoders are known to
+// differ and are not this decoder's business: BC dates, 5+ digit years and,
+// for timestamptz, years 1-99 fall back to Date.parse, which yields Invalid
+// Date for BC, reads a 5+ digit year `timestamp` as local time, and windows
+// years 1-99 into 19xx/20xx. Those literals are checked on the binary path
+// only. Values beyond JS Date's +/-8.64e15 ms decode to Invalid Date.
+const subMsLiterals: Array<[literal: string, textToo: boolean]> = [
+  ["4714-11-24 00:00:00.000001 BC", false], // the Postgres minimum
+  ["0001-12-31 23:59:59.999999 BC", false],
+  ["0001-01-01 00:00:00.123456", false],
+  ["0099-12-31 23:59:59.999999", false],
+  ["0100-01-01 00:00:00.000999", true],
+  // More than 2^53 µs from 2000-01-01: the old f64 conversion was lossy here
+  // on top of truncating toward zero, on both sides of 1970.
+  ["1000-06-15 01:02:03.999999", true],
+  ["2300-01-01 00:00:00.000999", true],
+  ["3000-06-01 12:00:00.123999", true],
+  ["1600-02-29 12:00:00.000001", true],
+  ["1969-12-31 23:59:59.999999", true],
+  ["1969-12-31 23:59:59.000001", true],
+  ["1970-01-01 00:00:00.000001", true],
+  ["1970-01-01 00:00:00.999999", true],
+  ["1999-12-31 23:59:59.999999", true],
+  ["2000-01-01 00:00:00.000001", true],
+  ["275760-09-13 00:00:00.000999", false], // JS Date's maximum instant plus 999 µs floors onto the maximum
+  ["275760-09-14 00:00:00", false], // past the JS Date range: Invalid Date
+];
+const JS_DATE_MAX_MS = 8.64e15;
+
+for (const type of ["timestamp", "timestamptz"] as const) {
+  const columns = (value: (i: number) => string) =>
+    subMsLiterals
+      .map(
+        (_, i) =>
+          `${value(i)}::${type} AS v${i}, floor(extract(epoch FROM ${value(i)}::${type}) * 1000)::text AS ms${i}`,
+      )
+      .concat("0.1::real AS fmt")
+      .join(", ");
+  // With parameters this is an extended query whose results arrive binary;
+  // without, unsafe() sends a simple query whose results arrive as text.
+  const binaryResult = await sql.unsafe(
+    `SELECT ${columns(i => `$${i + 1}`)}`,
+    subMsLiterals.map(([literal]) => literal),
+  );
+  const textResult = await sql.unsafe(`SELECT ${columns(i => `'${subMsLiterals[i][0]}'`)}`);
+  checkFormat(`binary ${type} sweep`, binaryResult, Math.fround(0.1));
+  checkFormat(`text ${type} sweep`, textResult, 0.1);
+  const [binary] = binaryResult;
+  const [text] = textResult;
+
+  for (let i = 0; i < subMsLiterals.length; i++) {
+    const [literal, textToo] = subMsLiterals[i];
+    const serverMs = Number(binary[`ms${i}`]);
+    const want = Math.abs(serverMs) <= JS_DATE_MAX_MS ? serverMs : NaN;
+    for (const [protocol, row] of [
+      ["binary", binary],
+      ["text", text],
+    ] as const) {
+      if (protocol === "text" && !textToo) continue;
+      const got = row[`v${i}`];
+      const gotMs = got instanceof Date ? got.getTime() : undefined;
+      if (!(gotMs === want || (Number.isNaN(gotMs) && Number.isNaN(want)))) {
+        failures.push(
+          `${protocol} '${literal}'::${type}: want ${want} got ${gotMs ?? Object.prototype.toString.call(got)} (server says ${binary[`ms${i}`]} ms)`,
+        );
+      }
+    }
+  }
+}
 
 if (failures.length) {
   console.error(`FAIL TZ=${process.env.TZ} offsetMin=${new Date().getTimezoneOffset()}`);

--- a/test/js/sql/sql-postgres-datetime-tz-fixture.ts
+++ b/test/js/sql/sql-postgres-datetime-tz-fixture.ts
@@ -33,6 +33,13 @@ const rowsIn = [
   { id: 0, ts: "2024-06-15 12:00:00", tstz: "2024-06-15 12:00:00+00", d: "2024-06-15" },
   { id: 1, ts: "2024-01-15 00:30:00", tstz: "2024-01-15 00:30:00+00", d: "2024-01-15" },
   { id: 2, ts: "2024-12-31 23:45:00", tstz: "2024-12-31 23:45:00+00", d: "2024-12-31" },
+  // Sub-millisecond instants. Both protocols must drop the extra digits; the
+  // binary decoder used to round the pre-1970 ones 1 ms later instead (id 3
+  // came back as 1970-01-01T00:00:00.000Z). id 5 is before the Postgres
+  // epoch (2000) but after 1970, which was already correct and must stay so.
+  { id: 3, ts: "1969-12-31 23:59:59.9996", tstz: "1969-12-31 23:59:59.9996+00", d: "1969-12-31" },
+  { id: 4, ts: "1883-11-18 12:00:00.123456", tstz: "1883-11-18 12:00:00.123456+00", d: "1883-11-18" },
+  { id: 5, ts: "1999-12-31 23:59:59.9996", tstz: "1999-12-31 23:59:59.9996+00", d: "1999-12-31" },
 ];
 for (const r of rowsIn) {
   await sql.unsafe(`INSERT INTO ${t} (id, ts, tstz, d) VALUES (${r.id}, '${r.ts}', '${r.tstz}', '${r.d}')`);
@@ -43,6 +50,9 @@ const expected = [
   { ts: "2024-06-15T12:00:00.000Z", tstz: "2024-06-15T12:00:00.000Z", d: "2024-06-15T00:00:00.000Z" },
   { ts: "2024-01-15T00:30:00.000Z", tstz: "2024-01-15T00:30:00.000Z", d: "2024-01-15T00:00:00.000Z" },
   { ts: "2024-12-31T23:45:00.000Z", tstz: "2024-12-31T23:45:00.000Z", d: "2024-12-31T00:00:00.000Z" },
+  { ts: "1969-12-31T23:59:59.999Z", tstz: "1969-12-31T23:59:59.999Z", d: "1969-12-31T00:00:00.000Z" },
+  { ts: "1883-11-18T12:00:00.123Z", tstz: "1883-11-18T12:00:00.123Z", d: "1883-11-18T00:00:00.000Z" },
+  { ts: "1999-12-31T23:59:59.999Z", tstz: "1999-12-31T23:59:59.999Z", d: "1999-12-31T00:00:00.000Z" },
 ];
 
 const failures: string[] = [];
@@ -62,7 +72,11 @@ function checkRows(protocol: string, rows: Array<{ ts: Date; tstz: Date; d: Date
   }
 }
 
-checkRows("binary", await sql`SELECT ts, tstz, d FROM ${sql(t)} ORDER BY id`);
+// The bound parameter matters: a statement without parameters is prepared and
+// executed in one round trip, before the result types are known, so its Bind
+// asks for text results. With a parameter, Bind is sent after Describe and
+// requests binary for timestamp/timestamptz.
+checkRows("binary", await sql`SELECT ts, tstz, d FROM ${sql(t)} WHERE id >= ${0} ORDER BY id`);
 checkRows("text", await sql`SELECT ts, tstz, d FROM ${sql(t)} ORDER BY id`.simple());
 
 if (failures.length) {

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -473,15 +473,22 @@ if (isDockerEnabled()) {
         (NULL, NULL)
     `;
 
-          // Query the data
+          // Query the data. The bound parameter makes Bind request binary
+          // results (a parameterless statement is prepared and executed in one
+          // round trip and gets text), which is what routes `time` through the
+          // binary decoder this test is about; the float4 sentinel proves the
+          // rows really arrived in binary (text "0.1" would decode to 0.1).
           const result = await db`
       SELECT
         id,
         regular_time,
-        time_with_tz
+        time_with_tz,
+        0.1::real AS fmt
       FROM bun_time_test
+      WHERE id >= ${0}
       ORDER BY id
     `;
+          expect(result[0].fmt).toBe(Math.fround(0.1));
 
           // Verify that time values are returned as strings, not binary data
           expect(result[0].regular_time).toBe("09:00:00");


### PR DESCRIPTION
### Problem
- Bun.SQL (postgres) decodes a binary `timestamp` / `timestamptz` carrying sub-millisecond digits 1 ms later than the text path decodes the same value, and later than the value prints as, for every instant before 1970: `'1969-12-31 23:59:59.9996'::timestamptz` comes back as `1970-01-01T00:00:00.000Z` from a parameterized query and as `1969-12-31T23:59:59.999Z` from a simple query; `'1883-11-18 12:00:00.123456'` comes back as `.124Z` vs `.123Z`.
- The same decoder is also off by 1 ms after 1970 once the value is more than 2^53 microseconds (about 285 years) away from 2000, where large remainders round up in the conversion (`'2300-01-01 00:00:00.000999'` decodes as `.001Z`), and it turns JS Date's maximum instant plus a sub-ms remainder into `Invalid Date`.
- Cause: `from_binary` in `src/sql_jsc/postgres/types/date.rs` converted the i64 microsecond count to f64, divided by 1000 and passed the fractional millisecond value to `JSC::DateInstance::create` (`src/jsc/bindings/SQLClient.cpp`), whose `timeClip` truncates toward zero: a round toward the future for negative unix times. The `as f64` conversion of the microsecond count is itself inexact beyond 2^53. The text decoders (`timestamp_text_to_ms_utc`, `Date.parse`) drop the extra digits, i.e. always floor.
- Reproduced with bun 1.4.0 against PostgreSQL 17.11 (output in the details block); not covered by #35505 (text path) or #34707 (bind direction), which leave `from_binary` untouched.

### Fix
- `from_binary` divides the microsecond count with `i64::div_euclid` (floor division) and converts the resulting whole millisecond count to f64. The `i64::MAX` / `i64::MIN` infinity handling above it and the encode direction (`from_js`, already integer arithmetic) are unchanged; the now stale comment in `timestamp_text_to_ms_utc` is removed.
- Why floor is the right reduction: dropping the fractional digits of a printed timestamp always yields the instant at or before it, whatever the year, so floor is the only rounding under which the binary result equals the text result and `toISOString()` of the decoded Date is a prefix of what Postgres prints. It is also what `Date.parse` does with extra fraction digits.
- Why the arithmetic is safe: `|us / 1000|` is at most about 9.2e15, so adding the epoch offset cannot overflow i64, and every result JS Date accepts (within +/-8.64e15 ms) is below 2^53, so the final cast is exact. Values past that range still become `Invalid Date`; a sub-ms remainder on the extreme instants now floors onto them.
- Verified:
  - `test/js/sql/postgres-infinity-date.test.ts` (scripted backend, deterministic wire bytes): sub-ms vectors for 1000, 1883, 1969 (remainders 1 and 999), 1999, 2024, 2300 and 3000 decoded in binary and from the server's text rendering, plus a binary-only set at the i64 endpoints minus one and at JS Date's range limits. On the released build 6 of the 9 binary sub-ms vectors and 3 of the 8 boundary vectors decode wrong (4 tests fail, 14 pass); all 18 pass with the fix. The text vectors pass on both and pin the contract the binary path must match.
  - `test/js/sql/sql-postgres-datetime-roundtrip.test.ts` (real server, docker in CI): the fixture's "binary" query now binds a parameter, because a parameterless statement is prepared and executed in one round trip and its Bind asks for text results, so the check was decoding text before; a `0.1::real` column (binary float4 decodes to `Math.fround(0.1)`, text to `0.1`) proves in-band which format each query received. It also sweeps 17 sub-ms literals from 4714 BC to past the JS Date limit against the server's own `floor(extract(epoch) * 1000)`: every literal on the binary path, and the 11 that the text decoders handle on the text path as well. Fails on the released build against a local PostgreSQL 17 (24 binary cells, 0 text cells, 0 sentinel failures), passes with the fix under all three TZ values.
  - `test/js/sql/sql.test.ts` Time/TimeZ: the only other real-server test that relied on a parameterless query to reach a binary decoder; it now binds a parameter and checks the same sentinel. Verified against the local server by running the describe block standalone.
- Observed while doing this, pre-existing and not changed here: the text path returns `Invalid Date` for BC values, windows `timestamptz` years 1-99 into 19xx/20xx via `Date.parse` (the path #35505 replaces), and reads a 5+ digit year `timestamp` as local time (the documented `Date.parse` fallback in `date.rs`). The sweep checks those literals on the binary path only.

### Background
- Postgres wire format for `timestamp` / `timestamptz`: a signed 64-bit count of microseconds since 2000-01-01 00:00:00 UTC, sent big-endian when the client asks for binary results. Bun requests binary for these two types (`Tag::is_binary_format_supported`) whenever Bind is sent after the statement has been described, which in practice means any query with parameters; simple queries and parameterless statements receive the text rendering. In the scripted tests the RowDescription's per-column format code selects the decoder directly.
- `timeClip` is the ECMAScript step that normalizes a Date's time value: NaN outside +/-8.64e15 ms, otherwise truncation toward zero. `DateInstance::create` applies it to whatever double it is given, so passing a non-integral value delegates the rounding to it.
- `i64::div_euclid(1000)` is floor division for a positive divisor: `-400 / 1000` is `0`, `(-400).div_euclid(1000)` is `-1`.
- f64 holds integers exactly only up to 2^53; above that consecutive representable values are 2, 4, ... apart, so `1000 * x + 999` can round to `1000 * (x + 1)` before the division happens.

<details>
<summary>Repro output (bun 1.4.0, PostgreSQL 17.11, session TZ UTC)</summary>

```
timestamptz  1883-11-18 12:00:00.123456+00  text=1883-11-18T12:00:00.123Z binary=1883-11-18T12:00:00.124Z   <-- MISMATCH
timestamptz  1969-12-31 23:59:59.999600+00  text=1969-12-31T23:59:59.999Z binary=1970-01-01T00:00:00.000Z   <-- MISMATCH
timestamptz  1969-12-31 23:59:59.000400+00  text=1969-12-31T23:59:59.000Z binary=1969-12-31T23:59:59.001Z   <-- MISMATCH
timestamptz  1999-12-31 23:59:59.999600+00  text=1999-12-31T23:59:59.999Z binary=1999-12-31T23:59:59.999Z
timestamptz  2024-06-01 12:00:00.123456+00  text=2024-06-01T12:00:00.123Z binary=2024-06-01T12:00:00.123Z
timestamp    1883-11-18 12:00:00.123456     text=1883-11-18T12:00:00.123Z binary=1883-11-18T12:00:00.124Z   <-- MISMATCH
timestamp    1969-12-31 23:59:59.999600     text=1969-12-31T23:59:59.999Z binary=1970-01-01T00:00:00.000Z   <-- MISMATCH
timestamp    1969-12-31 23:59:59.000400     text=1969-12-31T23:59:59.000Z binary=1969-12-31T23:59:59.001Z   <-- MISMATCH
timestamp    1999-12-31 23:59:59.999600     text=1999-12-31T23:59:59.999Z binary=1999-12-31T23:59:59.999Z
timestamp    2024-06-01 12:00:00.123456     text=2024-06-01T12:00:00.123Z binary=2024-06-01T12:00:00.123Z
```

Text path: `sql.unsafe("select '<lit>'::timestamptz as v")`. Binary path: `` sql`select ${1}::int as p, ${lit}::timestamptz as v` ``.

Released build against the server-side oracle (`floor(extract(epoch) * 1000)`), binary path, same for both types: wrong for `0001-12-31 23:59:59.999999 BC`, `0001-01-01 00:00:00.123456`, `0099-12-31 23:59:59.999999`, `0100-01-01 00:00:00.000999`, `1000-06-15 01:02:03.999999`, `1969-12-31 23:59:59.999999`, `1969-12-31 23:59:59.000001`, `2300-01-01 00:00:00.000999`, `3000-06-01 12:00:00.123999` (all 1 ms late) and `275760-09-13 00:00:00.000999` (Invalid Date instead of the maximum Date). All correct with the fix.

</details>
