### PR TITLE
Bun.serve: report a native body error that arrives after the status was sent

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2874,9 +2874,6 @@ where
             self.render_metadata();
         }
 
-        // The dev error page writes into `resp`, which must not be
-        // dereferenced once the sink has already ended the response (see
-        // `end_already_responded_stream`).
         if self.report_committed_body_error(err, !ended_response) {
             return;
         }
@@ -2891,21 +2888,15 @@ where
         self.close_failed_body();
     }
 
-    /// The body's producer failed after the status and headers went out, so
-    /// the server's `error()` hook can no longer answer the request. In
-    /// development mode, print the error like an uncaught exception so it does
-    /// not vanish; under a bake dev server, while `resp` may still be written
-    /// to, also render the error page as the rest of the body and end the
-    /// response, returning `true`. Production mode stays quiet. On `false` the
-    /// caller still owns the response and terminates it with
-    /// [`Self::close_failed_body`].
+    /// The body failed after its status went out, so `error()` can no longer
+    /// answer. Development mode prints the error (and, under a bake dev server
+    /// with `resp` still writable, renders its error page into the body and
+    /// ends the response, returning `true`); production stays quiet. On
+    /// `false` the caller terminates the response with [`Self::close_failed_body`].
     ///
-    /// This is the policy for failures that arrive from the body later, from a
-    /// JS `ReadableStream` (`handle_reject_stream`) or a native `ByteStream`
-    /// such as a proxied `fetch()` or an `HTMLRewriter` transform
-    /// (`end_chunk`). A body that fails synchronously while the handler's
-    /// Response is still being rendered is reported in both modes instead
-    /// (`handle_reject`, `do_render_stream`).
+    /// Used for failures the body delivers later (`handle_reject_stream`,
+    /// `end_chunk`); a body failing synchronously during render is reported
+    /// in both modes (`handle_reject`, `do_render_stream`).
     fn report_committed_body_error(&self, err: JSValue, resp_writable: bool) -> bool {
         if !DEBUG_MODE || err.is_empty_or_undefined_or_null() {
             return false;
@@ -2938,11 +2929,9 @@ where
         true
     }
 
-    /// Terminate a response whose body failed after the status went out
-    /// (`handle_reject`, `handle_reject_stream`, `end_chunk`). Once body bytes
-    /// were written, close without the terminating chunk (RFC 9112 section 7)
-    /// so the client sees an incomplete message rather than a truncated body
-    /// that looks complete; otherwise end it normally.
+    /// Once body bytes went out, close without the terminating chunk (RFC 9112
+    /// section 7) so the client sees an incomplete message; otherwise end the
+    /// response normally.
     fn close_failed_body(&self) {
         if let Some(resp) = self.resp.get() {
             let state = resp.state();
@@ -3242,8 +3231,6 @@ where
                 this.run_error_handler(js_err);
                 return;
             }
-            // The status is already on the wire: report and close the same
-            // way `handle_reject_stream` does for a JS body failing mid-stream.
             if DEBUG_MODE && this.report_committed_body_error(err.to_js(global_this), true) {
                 return;
             }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -962,12 +962,7 @@ where
             {
                 server.vm().as_mut().run_error_handler(value, None);
             }
-            let state = resp.state();
-            if state.is_http_write_called() && state.is_response_pending() {
-                self.force_close();
-            } else {
-                self.end_stream(self.should_close_connection());
-            }
+            self.close_failed_body();
             return;
         }
 
@@ -2896,17 +2891,21 @@ where
         self.close_failed_body();
     }
 
-    /// The body failed after the status and headers went out, so the server's
-    /// `error()` hook can no longer answer the request. In development mode,
-    /// print the error like an uncaught exception so it does not vanish;
-    /// under a bake dev server, while `resp` may still be written to, also
-    /// render the error page as the rest of the body and end the response,
-    /// returning `true`. Production mode stays quiet. On `false` the caller
-    /// still owns the response and terminates it ([`Self::close_failed_body`]).
+    /// The body's producer failed after the status and headers went out, so
+    /// the server's `error()` hook can no longer answer the request. In
+    /// development mode, print the error like an uncaught exception so it does
+    /// not vanish; under a bake dev server, while `resp` may still be written
+    /// to, also render the error page as the rest of the body and end the
+    /// response, returning `true`. Production mode stays quiet. On `false` the
+    /// caller still owns the response and terminates it with
+    /// [`Self::close_failed_body`].
     ///
-    /// Shared by JS `ReadableStream` bodies (`handle_reject_stream`) and
-    /// native `ByteStream` bodies such as a proxied `fetch()` or an
-    /// `HTMLRewriter` transform (`end_chunk`).
+    /// This is the policy for failures that arrive from the body later, from a
+    /// JS `ReadableStream` (`handle_reject_stream`) or a native `ByteStream`
+    /// such as a proxied `fetch()` or an `HTMLRewriter` transform
+    /// (`end_chunk`). A body that fails synchronously while the handler's
+    /// Response is still being rendered is reported in both modes instead
+    /// (`handle_reject`, `do_render_stream`).
     fn report_committed_body_error(&self, err: JSValue, resp_writable: bool) -> bool {
         if !DEBUG_MODE || err.is_empty_or_undefined_or_null() {
             return false;
@@ -2939,10 +2938,11 @@ where
         true
     }
 
-    /// Terminate a response whose body failed after the status went out. Once
-    /// body bytes were written, close without the terminating chunk (RFC 9112
-    /// section 7) so the client sees an incomplete message rather than a
-    /// truncated body that looks complete; otherwise end it normally.
+    /// Terminate a response whose body failed after the status went out
+    /// (`handle_reject`, `handle_reject_stream`, `end_chunk`). Once body bytes
+    /// were written, close without the terminating chunk (RFC 9112 section 7)
+    /// so the client sees an incomplete message rather than a truncated body
+    /// that looks complete; otherwise end it normally.
     fn close_failed_body(&self) {
         if let Some(resp) = self.resp.get() {
             let state = resp.state();

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2888,15 +2888,11 @@ where
         self.close_failed_body();
     }
 
-    /// The body failed after its status went out, so `error()` can no longer
-    /// answer. Development mode prints the error (and, under a bake dev server
-    /// with `resp` still writable, renders its error page into the body and
-    /// ends the response, returning `true`); production stays quiet. On
-    /// `false` the caller terminates the response with [`Self::close_failed_body`].
-    ///
-    /// Used for failures the body delivers later (`handle_reject_stream`,
-    /// `end_chunk`); a body failing synchronously during render is reported
-    /// in both modes (`handle_reject`, `do_render_stream`).
+    /// Development-mode report for a body that failed after its status went
+    /// out (`error()` can no longer answer). Returns `true` when a bake dev
+    /// server's error page ended the response; otherwise the caller runs
+    /// [`Self::close_failed_body`]. A body failing synchronously during render
+    /// is reported in both modes instead (`handle_reject`, `do_render_stream`).
     fn report_committed_body_error(&self, err: JSValue, resp_writable: bool) -> bool {
         if !DEBUG_MODE || err.is_empty_or_undefined_or_null() {
             return false;
@@ -2929,9 +2925,8 @@ where
         true
     }
 
-    /// Once body bytes went out, close without the terminating chunk (RFC 9112
-    /// section 7) so the client sees an incomplete message; otherwise end the
-    /// response normally.
+    /// After body bytes went out, close without the chunked terminator so the
+    /// client sees an incomplete message (RFC 9112 section 7); else end normally.
     fn close_failed_body(&self) {
         if let Some(resp) = self.resp.get() {
             let state = resp.state();

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2879,50 +2879,11 @@ where
             self.render_metadata();
         }
 
-        if DEBUG_MODE {
-            if let Some(server) = self.server.get() {
-                if !err.is_empty_or_undefined_or_null() {
-                    let server = &*server;
-                    let mut exception_list: jsc::ExceptionList = Vec::new();
-                    server
-                        .vm()
-                        .as_mut()
-                        .run_error_handler(err, Some(&mut exception_list));
-
-                    // The fallback page below writes into `resp`, which must
-                    // not be dereferenced once the sink has already ended the
-                    // response (see `end_already_responded_stream`).
-                    if !ended_response && server.dev_server().is_some() {
-                        // Render the error fallback HTML page like renderDefaultError does
-                        if !self.flags.has_written_status() {
-                            self.flags.set_has_written_status(true);
-                            if let Some(resp) = self.resp.get() {
-                                resp.write_status(b"500 Internal Server Error");
-                                resp.write_header(
-                                    b"content-type",
-                                    &bun_http_types::MimeType::HTML.value,
-                                );
-                            }
-                        }
-
-                        let bb = DevErrorPage {
-                            message: b"Stream error during server-side rendering",
-                            cwd: bun_resolver::fs::FileSystem::get().top_level_dir,
-                            exceptions: &exception_list,
-                            log: None,
-                        }
-                        .render();
-
-                        if let Some(resp) = self.resp.get() {
-                            // SAFETY: FFI handle
-                            resp.write(&bb);
-                        }
-
-                        self.end_stream(self.should_close_connection());
-                        return;
-                    }
-                }
-            }
+        // The dev error page writes into `resp`, which must not be
+        // dereferenced once the sink has already ended the response (see
+        // `end_already_responded_stream`).
+        if self.report_committed_body_error(err, !ended_response) {
+            return;
         }
         // HTTP/1 only: the sink already fully ended the response, so `resp`
         // can no longer be dereferenced (see `end_already_responded_stream`).
@@ -2932,9 +2893,57 @@ where
             self.end_already_responded_stream();
             return;
         }
-        // Body bytes were already written: close without the terminating chunk
-        // (RFC 9112 section 7) so the client sees an incomplete message, not a
-        // truncated body that looks like a complete, successful response.
+        self.close_failed_body();
+    }
+
+    /// The body failed after the status and headers went out, so the server's
+    /// `error()` hook can no longer answer the request. In development mode,
+    /// print the error like an uncaught exception so it does not vanish;
+    /// under a bake dev server, while `resp` may still be written to, also
+    /// render the error page as the rest of the body and end the response,
+    /// returning `true`. Production mode stays quiet. On `false` the caller
+    /// still owns the response and terminates it ([`Self::close_failed_body`]).
+    ///
+    /// Shared by JS `ReadableStream` bodies (`handle_reject_stream`) and
+    /// native `ByteStream` bodies such as a proxied `fetch()` or an
+    /// `HTMLRewriter` transform (`end_chunk`).
+    fn report_committed_body_error(&self, err: JSValue, resp_writable: bool) -> bool {
+        if !DEBUG_MODE || err.is_empty_or_undefined_or_null() {
+            return false;
+        }
+        let server = self.server();
+        let mut exception_list: jsc::ExceptionList = Vec::new();
+        server
+            .vm()
+            .as_mut()
+            .run_error_handler(err, Some(&mut exception_list));
+
+        if !resp_writable || server.dev_server().is_none() {
+            return false;
+        }
+
+        let bb = DevErrorPage {
+            message: b"Stream error during server-side rendering",
+            cwd: bun_resolver::fs::FileSystem::get().top_level_dir,
+            exceptions: &exception_list,
+            log: None,
+        }
+        .render();
+
+        if let Some(resp) = self.resp.get() {
+            // SAFETY: FFI handle
+            resp.write(&bb);
+        }
+
+        self.end_stream(self.should_close_connection());
+        true
+    }
+
+    /// Terminate a response whose body failed after the status went out. Once
+    /// body bytes were written, close without the terminating chunk (RFC 9112
+    /// section 7) so the client sees an incomplete message rather than a
+    /// truncated body that looks complete; otherwise end it normally.
+    fn close_failed_body(&self) {
         if let Some(resp) = self.resp.get() {
             let state = resp.state();
             if state.is_http_write_called() && state.is_response_pending() {
@@ -3219,13 +3228,13 @@ where
             return;
         }
         if let Some(err) = err {
+            let global_this = this.server().global_this();
             // No status committed yet: the upstream producer (e.g. a
             // suspended `HTMLRewriter` transform whose async handler
             // rejected) failed before any bytes were emitted. Detach the
             // ByteStream state and hand the error to the server's
             // `error()` hook so it can supply the response.
             if !this.flags.has_written_status() {
-                let global_this = this.server().global_this();
                 let js_err = err.to_js(global_this);
                 this.byte_stream.set(None);
                 this.response_body_readable_stream_ref
@@ -3233,14 +3242,15 @@ where
                 this.run_error_handler(js_err);
                 return;
             }
-            if let Some(resp) = this.resp.get() {
-                let state = resp.state();
-                if state.is_http_write_called() && state.is_response_pending() {
-                    this.force_close();
-                    return;
-                }
+            // The status is already on the wire: report and close the same
+            // way `handle_reject_stream` does for a JS body failing mid-stream.
+            if DEBUG_MODE && this.report_committed_body_error(err.to_js(global_this), true) {
+                return;
             }
-        } else if !this.flags.has_written_status() {
+            this.close_failed_body();
+            return;
+        }
+        if !this.flags.has_written_status() {
             // Upstream ended cleanly before any chunk: flush the deferred
             // status/headers so the client sees them before the terminator.
             if let Some(resp) = this.resp.get() {

--- a/test/js/bun/http/serve-stream-body-error-fixture.html
+++ b/test/js/bun/http/serve-stream-body-error-fixture.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<!-- Imported by serve-stream-body-error-fixture.ts purely so that Bun.serve runs a dev server; never requested. -->
+<title>dev server page</title>

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -1,9 +1,10 @@
 // An error thrown by a ReadableStream used as a Response body must never
 // escape as a global unhandledRejection. Bun's default unhandledRejection
 // policy exits the process, so before the fix a single bad request took the
-// entire server down.
+// entire server down. The `nativeBodies` variants pin the same wire and
+// reporting contract for bodies Bun.serve streams without a JS ReadableStream.
 //
-// argv[2]: variant name (see `sources` below)
+// argv[2]: variant name (see `sources` and `nativeBodies` below)
 // argv[3]: "development" to run the server with development: true
 //
 // Prints a single JSON object on stdout and exits 0.
@@ -12,10 +13,19 @@ import net from "node:net";
 const variant = process.argv[2];
 const development = process.argv[3] === "development";
 
-// Set by the mid-stream variant so it only errors once its chunk has provably
-// reached the client socket, i.e. after the 200 response is committed on the
-// wire. Called from the raw request's data handler below.
+// Set by the mid-stream variants so they only error once their chunk has
+// provably reached the client socket, i.e. after the 200 response is committed
+// on the wire. Called from the raw request's data handler below.
 let midStreamResolve: (() => void) | undefined;
+
+// Arms `midStreamResolve` for one request. Every mid-stream variant calls this
+// before it emits "chunk-a", so the resolver is in place by the time the
+// client can see the chunk.
+function chunkReachedClient(): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  midStreamResolve = resolve;
+  return promise;
+}
 
 // Set by the cancel variants: resolved once the source's cancel() has run, so
 // the test observes any resulting rejection before declaring success.
@@ -66,10 +76,9 @@ const sources: Record<string, () => ReadableStream> = {
   "mid-stream-reject": () =>
     new ReadableStream({
       async pull(c) {
-        const { promise, resolve } = Promise.withResolvers<void>();
-        midStreamResolve = resolve;
+        const reached = chunkReachedClient();
         c.enqueue("chunk-a");
-        await promise;
+        await reached;
         throw new Error("boom");
       },
     }),
@@ -112,8 +121,69 @@ const sources: Record<string, () => ReadableStream> = {
     }),
 };
 
+// HTMLRewriter input that lets the rewritten "<b>chunk-a</b>" reach the client
+// before delivering the element whose handler fails.
+function rewriterInput(): ReadableStream {
+  const reached = chunkReachedClient();
+  let pulls = 0;
+  return new ReadableStream({
+    async pull(c) {
+      if (pulls++ === 0) {
+        c.enqueue("<b>chunk-a</b>");
+        return;
+      }
+      await reached;
+      c.enqueue("<p>x</p>");
+      c.close();
+    },
+  });
+}
+
+function rewriterResponse(element: () => void | Promise<void>): Response {
+  return new HTMLRewriter()
+    .on("p", { element })
+    .transform(new Response(rewriterInput(), { headers: { "content-type": "text/html" } }));
+}
+
+// Upstream for the proxied variant: answers with one chunk, then drops the
+// connection once that chunk has made it through the proxy to the client.
+let upstream: net.Server | undefined;
+async function proxiedResponse(): Promise<Response> {
+  if (!upstream) {
+    upstream = net.createServer(sock => {
+      sock.once("data", () => {
+        const reached = chunkReachedClient();
+        sock.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n7\r\nchunk-a\r\n");
+        reached.then(() => sock.destroy());
+      });
+    });
+    await new Promise<void>(resolve => upstream!.listen(0, "127.0.0.1", resolve));
+  }
+  const { port } = upstream.address() as net.AddressInfo;
+  return fetch(`http://127.0.0.1:${port}/`);
+}
+
+// Bodies Bun.serve streams natively (no JS ReadableStream pump) that fail
+// after their first chunk is already on the wire. The status cannot be taken
+// back, so the contract is the same as for "mid-stream-reject": the connection
+// is closed without the terminating chunk, error() is not invoked, and in
+// development mode the failure is reported on stderr.
+const nativeBodies: Record<string, () => Response | Promise<Response>> = {
+  "rewriter-mid-stream-throw": () =>
+    rewriterResponse(() => {
+      throw new Error("boom");
+    }),
+  "rewriter-mid-stream-reject": () =>
+    rewriterResponse(async () => {
+      await Bun.sleep(0);
+      throw new Error("boom");
+    }),
+  "proxied-fetch-mid-stream": proxiedResponse,
+};
+
 const source = sources[variant];
-if (!source) {
+const nativeBody = nativeBodies[variant];
+if (!source && !nativeBody) {
   console.error(`unknown variant: ${variant}`);
   process.exit(3);
 }
@@ -136,7 +206,7 @@ await using server = Bun.serve({
     return new Response("err-body", { status: 500 });
   },
   fetch() {
-    return new Response(source());
+    return nativeBody ? nativeBody() : new Response(source());
   },
 });
 
@@ -175,6 +245,7 @@ const secondWire = await rawRequest(clientAborts);
 // Cycle the event loop so any stray rejected promise reaches the
 // unhandledRejection reporter before we declare success.
 for (let i = 0; i < 10; i++) await Bun.sleep(0);
+upstream?.close();
 
 console.log(
   JSON.stringify({

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -145,29 +145,40 @@ function rewriterResponse(element: () => void | Promise<void>): Response {
     .transform(new Response(rewriterInput(), { headers: { "content-type": "text/html" } }));
 }
 
-// Upstream for the proxied variant: answers with one chunk, then drops the
-// connection once that chunk has made it through the proxy to the client.
-let upstream: net.Server | undefined;
-async function proxiedResponse(): Promise<Response> {
-  if (!upstream) {
-    upstream = net.createServer(sock => {
-      sock.once("data", () => {
-        const reached = chunkReachedClient();
-        sock.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n7\r\nchunk-a\r\n");
-        reached.then(() => sock.destroy());
-      });
-    });
-    await new Promise<void>(resolve => upstream!.listen(0, "127.0.0.1", resolve));
-  }
+// Upstream for the proxied variants: a scratch server for one request that
+// answers with `firstWrite` (announcing more body than it will ever send), so
+// the fetch() body fails deterministically when `fail()` closes the connection.
+async function fetchFromFailingUpstream(firstWrite: string) {
+  const sockets: net.Socket[] = [];
+  const upstream = net.createServer(socket => {
+    sockets.push(socket);
+    socket.resume();
+    socket.on("error", () => {});
+    socket.write(firstWrite);
+  });
+  await new Promise<void>(resolve => upstream.listen(0, "127.0.0.1", resolve));
+  // Must never be what keeps the process alive if fail() is not reached.
+  upstream.unref();
   const { port } = upstream.address() as net.AddressInfo;
-  return fetch(`http://127.0.0.1:${port}/`);
+  const res = await fetch(`http://127.0.0.1:${port}/`);
+  return {
+    res,
+    fail() {
+      for (const socket of sockets) socket.end();
+      upstream.close();
+    },
+  };
 }
 
-// Bodies Bun.serve streams natively (no JS ReadableStream pump) that fail
-// after their first chunk is already on the wire. The status cannot be taken
-// back, so the contract is the same as for "mid-stream-reject": the connection
-// is closed without the terminating chunk, error() is not invoked, and in
-// development mode the failure is reported on stderr.
+// Set by the after-status variant: called as soon as anything of the response
+// is on the client's wire, i.e. once Bun.serve has committed the status line.
+let statusOnWire: (() => void) | undefined;
+
+// Bodies Bun.serve streams natively (no JS ReadableStream pump) whose producer
+// fails after the status line is committed. error() can no longer answer, so
+// the contract is that of "mid-stream-reject": the body is terminated (without
+// the terminating chunk once body bytes went out) and, in development mode, the
+// failure is reported on stderr.
 const nativeBodies: Record<string, () => Response | Promise<Response>> = {
   "rewriter-mid-stream-throw": () =>
     rewriterResponse(() => {
@@ -178,7 +189,23 @@ const nativeBodies: Record<string, () => Response | Promise<Response>> = {
       await Bun.sleep(0);
       throw new Error("boom");
     }),
-  "proxied-fetch-mid-stream": proxiedResponse,
+  // `return fetch(...)` whose upstream dies once its first chunk has made it
+  // through to our client.
+  "proxied-fetch-mid-stream": async () => {
+    const reached = chunkReachedClient();
+    const { res, fail } = await fetchFromFailingUpstream("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nchunk-a");
+    reached.then(fail);
+    return res;
+  },
+  // Same, but the upstream dies before producing a single body byte. Bun.serve
+  // commits the status as soon as it attaches to a fetch() body, so the error
+  // still arrives after the status; with nothing written there is nothing to
+  // force-close and the body is ended empty.
+  "proxied-fetch-after-status": async () => {
+    const { res, fail } = await fetchFromFailingUpstream("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n");
+    statusOnWire = fail;
+    return res;
+  },
 };
 
 const source = sources[variant];
@@ -213,7 +240,7 @@ await using server = Bun.serve({
 // Sends one request over a raw socket and returns everything received before
 // the server closed the connection, so the test can assert on the HTTP
 // framing. A forced close (ECONNRESET) is an expected, asserted-on outcome
-// for the mid-stream variant, so socket errors are not fatal.
+// for the mid-stream variants, so socket errors are not fatal.
 function rawRequest(abort: boolean): Promise<string> {
   const chunks: Buffer[] = [];
   return new Promise(resolve => {
@@ -222,6 +249,8 @@ function rawRequest(abort: boolean): Promise<string> {
     });
     sock.on("data", d => {
       chunks.push(d);
+      statusOnWire?.();
+      statusOnWire = undefined;
       if (Buffer.concat(chunks).includes("chunk-a")) {
         midStreamResolve?.();
         // The cancel variants tear down the socket once a body chunk has
@@ -245,7 +274,6 @@ const secondWire = await rawRequest(clientAborts);
 // Cycle the event loop so any stray rejected promise reaches the
 // unhandledRejection reporter before we declare success.
 for (let i = 0; i < 10; i++) await Bun.sleep(0);
-upstream?.close();
 
 console.log(
   JSON.stringify({

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -5,13 +5,19 @@
 // reporting contract for bodies Bun.serve streams without a JS ReadableStream.
 //
 // argv[2]: variant name (see `sources` and `nativeBodies` below)
-// argv[3]: "development" to run the server with development: true
+// argv[3..]: "development" to run the server with development: true;
+//            "dev-server" to also give it an HTML route, which makes the
+//            development server run a bake dev server (the requests below
+//            still go to fetch())
 //
 // Prints a single JSON object on stdout and exits 0.
 import net from "node:net";
+import devServerPage from "./serve-stream-body-error-fixture.html";
 
 const variant = process.argv[2];
-const development = process.argv[3] === "development";
+const flags = process.argv.slice(3);
+const development = flags.includes("development");
+const devServer = flags.includes("dev-server");
 
 // Set by the mid-stream variants so they only error once their chunk has
 // provably reached the client socket, i.e. after the 200 response is committed
@@ -228,6 +234,7 @@ let errorCb = 0;
 await using server = Bun.serve({
   port: 0,
   development,
+  ...(devServer ? { routes: { "/dev-server-page": devServerPage } } : {}),
   error() {
     errorCb++;
     return new Response("err-body", { status: 500 });

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -8,6 +8,8 @@
 //   3. A body that errored after chunks were already sent was still terminated
 //      with a clean `0\r\n\r\n`, so the client could not tell the truncated
 //      body apart from a complete one.
+// The natively streamed bodies further down (HTMLRewriter, proxied fetch) pin
+// the same mid-stream contract for the non-ReadableStream path.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 import { join } from "node:path";
@@ -116,6 +118,56 @@ test.concurrent("mid-stream error in development mode: reported and not terminat
     exitCode: 0,
   });
   expect(stderr).toContain("boom");
+});
+
+// Bodies that Bun.serve streams natively (an HTMLRewriter transform, a proxied
+// fetch() Response) reach the server through RequestContext::end_chunk rather
+// than handle_reject_stream. Once the status is on the wire, error() cannot
+// answer any more, so the failure has to be reported the way the JS stream
+// above is: force-closed without the terminating chunk and, in development
+// mode, printed. Before the fix end_chunk force-closed and dropped the error,
+// so a handler that threw after the first byte left no trace anywhere.
+const nativeBodies = [
+  ["rewriter-mid-stream-throw", "e\r\n<b>chunk-a</b>\r\n", "boom"],
+  ["rewriter-mid-stream-reject", "e\r\n<b>chunk-a</b>\r\n", "boom"],
+  ["proxied-fetch-mid-stream", "7\r\nchunk-a\r\n", "ECONNRESET"],
+] as const;
+
+test.concurrent.each(nativeBodies)(
+  "%s in development mode: reported and not terminated as complete",
+  async (variant, body, reported) => {
+    const { stdout, stderr, exitCode } = await runFixture(variant, "development");
+    expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+      result: {
+        statusLine: "HTTP/1.1 200 OK",
+        cleanChunkedTerminator: false,
+        body,
+        errorCb: 0,
+        unhandled: 0,
+        secondStatusLine: "HTTP/1.1 200 OK",
+      },
+      exitCode: 0,
+    });
+    expect(stderr).toContain(reported);
+  },
+);
+
+// `development: false` stays quiet on this path too, exactly like
+// "mid-stream-reject" above; only the wire contract applies.
+test.concurrent.each(nativeBodies)("%s: the chunked body is not terminated as complete", async (variant, body) => {
+  const { stdout, stderr, exitCode } = await runFixture(variant);
+  expect({ result: JSON.parse(stdout), stderr, exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: false,
+      body,
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    stderr: "",
+    exitCode: 0,
+  });
 });
 
 // The client aborts the download mid-stream, which makes Bun cancel the body

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -176,6 +176,33 @@ test.concurrent.each(nativeBodies)("%s: the body is terminated", async (variant,
   });
 });
 
+// When the development server also runs a bake dev server (it has an HTML
+// route), the report additionally renders the dev error page as the rest of
+// the body and ends the response normally, so the browser shows the error
+// after whatever was already streamed. The JS stream has always taken this
+// branch; the native body now goes through the same code.
+test.concurrent.each([
+  ["rewriter-mid-stream-throw", "e\r\n<b>chunk-a</b>\r\n"],
+  ["mid-stream-reject", "7\r\nchunk-a\r\n"],
+])("%s under a dev server: the error page is appended to the body", async (variant, firstChunk) => {
+  const { stdout, stderr, exitCode } = await runFixture(variant, "development", "dev-server");
+  const { body, ...result } = JSON.parse(stdout);
+  expect({ result, exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: true,
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+  expect(body).toStartWith(firstChunk);
+  expect(body).toContain("Stream error during server-side rendering");
+  expect(body).toContain("boom");
+  expect(stderr).toContain("boom");
+});
+
 // The client aborts the download mid-stream, which makes Bun cancel the body
 // ReadableStream. The source's cancel() throws, but the rejected promise is
 // one Bun created internally: it must be marked handled rather than surfacing

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -123,24 +123,29 @@ test.concurrent("mid-stream error in development mode: reported and not terminat
 // Bodies that Bun.serve streams natively (an HTMLRewriter transform, a proxied
 // fetch() Response) reach the server through RequestContext::end_chunk rather
 // than handle_reject_stream. Once the status is on the wire, error() cannot
-// answer any more, so the failure has to be reported the way the JS stream
-// above is: force-closed without the terminating chunk and, in development
-// mode, printed. Before the fix end_chunk force-closed and dropped the error,
-// so a handler that threw after the first byte left no trace anywhere.
+// answer any more, so the failure gets the treatment the JS stream above gets:
+// the body is terminated (force-closed without the terminating chunk once body
+// bytes went out, ended empty otherwise) and, in development mode, the error is
+// printed. Before the fix end_chunk terminated the body and dropped the error,
+// so a rewriter handler that threw after the first byte left no trace anywhere.
+//
+// [variant, body bytes on the wire, ends with the clean terminator, what the
+// development-mode report must name]
 const nativeBodies = [
-  ["rewriter-mid-stream-throw", "e\r\n<b>chunk-a</b>\r\n", "boom"],
-  ["rewriter-mid-stream-reject", "e\r\n<b>chunk-a</b>\r\n", "boom"],
-  ["proxied-fetch-mid-stream", "7\r\nchunk-a\r\n", "ECONNRESET"],
+  ["rewriter-mid-stream-throw", "e\r\n<b>chunk-a</b>\r\n", false, "boom"],
+  ["rewriter-mid-stream-reject", "e\r\n<b>chunk-a</b>\r\n", false, "boom"],
+  ["proxied-fetch-mid-stream", "7\r\nchunk-a\r\n", false, "ECONNRESET"],
+  ["proxied-fetch-after-status", "0\r\n\r\n", true, "ECONNRESET"],
 ] as const;
 
 test.concurrent.each(nativeBodies)(
-  "%s in development mode: reported and not terminated as complete",
-  async (variant, body, reported) => {
+  "%s in development mode: reported, and the body is terminated",
+  async (variant, body, cleanChunkedTerminator, reported) => {
     const { stdout, stderr, exitCode } = await runFixture(variant, "development");
     expect({ result: JSON.parse(stdout), exitCode }).toEqual({
       result: {
         statusLine: "HTTP/1.1 200 OK",
-        cleanChunkedTerminator: false,
+        cleanChunkedTerminator,
         body,
         errorCb: 0,
         unhandled: 0,
@@ -152,20 +157,21 @@ test.concurrent.each(nativeBodies)(
   },
 );
 
-// `development: false` stays quiet on this path too, exactly like
-// "mid-stream-reject" above; only the wire contract applies.
-test.concurrent.each(nativeBodies)("%s: the chunked body is not terminated as complete", async (variant, body) => {
-  const { stdout, stderr, exitCode } = await runFixture(variant);
-  expect({ result: JSON.parse(stdout), stderr, exitCode }).toEqual({
+// The same wire contract with `development: false`. As for "mid-stream-reject"
+// above, stderr is deliberately not asserted: whether production mode should
+// also report a body that fails after the status is committed is one question
+// for the JS and native paths alike, and these tests do not take a position.
+test.concurrent.each(nativeBodies)("%s: the body is terminated", async (variant, body, cleanChunkedTerminator) => {
+  const { stdout, exitCode } = await runFixture(variant);
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
     result: {
       statusLine: "HTTP/1.1 200 OK",
-      cleanChunkedTerminator: false,
+      cleanChunkedTerminator,
       body,
       errorCb: 0,
       unhandled: 0,
       secondStatusLine: "HTTP/1.1 200 OK",
     },
-    stderr: "",
     exitCode: 0,
   });
 });


### PR DESCRIPTION
### Problem

- A `Bun.serve` handler returns `rewriter.transform(response)` and a content handler throws (or its returned promise rejects) after the rewriter has already emitted output. The client gets `HTTP/1.1 200 OK` with a truncated body, `error()` is not called, and nothing is printed, in either `development` mode. The exception is gone.
- The same handler failing before the first output byte is routed to `error()` and answered with a 500 (since #36733), so only the after-first-byte case is silent. A plain `new Response(readableStream)` whose stream errors mid-body also commits the 200, but prints the error in development mode.
- Cause: `src/runtime/server/RequestContext.rs`, `end_chunk`. This is where a natively streamed body (`Source::Bytes`: an `HTMLRewriter` output, a `fetch()` Response returned as-is) delivers its terminal error. With no status written it converts the error and runs `error()`; with the status already written it only called `force_close()` and never looked at `err`. The JS stream twin, `handle_reject_stream`, reports the error through `vm.run_error_handler` in development mode before force-closing.
- Reproduces on the 1.4 canary in this container (8326d1bd3); the code on main is the same. 1.3 buffered the whole rewrite before handing it to the server, so the error surfaced there, which is why this is new in 1.4.

### Fix

- `RequestContext` had three copies of "the body failed after the status went out": `handle_reject` (a direct stream's `pull()` throwing synchronously during render, #33810: reports in both modes), `handle_reject_stream` (the pump's promise rejecting later: reports in development mode, plus the bake dev server error page), and `end_chunk` (native producers: reported nothing). This PR extracts the development-mode report into `report_committed_body_error` and the force-close-or-end decision into `close_failed_body`; `handle_reject_stream` and `end_chunk` use both, `handle_reject` uses `close_failed_body` and keeps its unconditional report. The `is_http_write_called() &&` decision now exists once instead of three times.
- Why `end_chunk` gets the `handle_reject_stream` policy: the errors it receives arrive from the body after the handler's Response was rendered, which is the situation `handle_reject_stream` handles for JS bodies; the two sync sites are a different moment (the handler is still being rendered). Whether production mode should also report these late failures applies to the JS and native paths alike and is not decided here; with the shared helper it becomes a one-place change (#35229 proposes it inside a larger JS stream rework and has been conflicting since July; it would rebase onto these helpers). The new production-mode tests therefore assert only the wire, like the existing `mid-stream-reject` test. The default `development: true` reports.
- Behavior of the pre-first-byte branch of `end_chunk`, of the JS stream path, and of `handle_reject` is unchanged. Two things dropped while moving the block were dead: the `if let Some(server)` (`is_aborted_or_ended()` just returned false, and it checks the same field) and the `500` fallback inside the dev server branch (`render_metadata()` runs unconditionally right before it whenever `resp` is still writable, so the status is always written there). In production mode `end_chunk` does not build the JS error at all.
- Same branch, other producer: a proxied `fetch()` body whose upstream dies after the status is committed now prints the fetch `ECONNRESET` TypeError in development mode, whether or not a body byte went out. The wire is unchanged in both cases (force-close after bytes, `0\r\n\r\n` with none; the latter is also what #38003's after-attach test pins).
- Out of scope, same family: `new Response(Bun.file(...))` bodies report a read/sendfile failure through `on_file_stream_error` (likewise `FileRoute` and `DirectoryRoute`), which discards a `bun_sys::Error` after the stream has already closed the socket itself. Reporting there needs an errno split first (a peer reset during sendfile is not worth printing), so it is a separate change.
- Tests: `test/js/bun/http/serve-stream-body-error.test.ts` gains four fixture variants (rewriter handler throwing synchronously, rewriter async handler rejecting, proxied upstream dying after `chunk-a` reached the client, proxied upstream dying after only the status reached the client), each run with `development: true` (wire plus the stderr report) and `development: false` (wire), plus two rows under a bake dev server (the fixture gets an HTML route, which is what makes `Bun.serve` run one): the native body now gets the dev error page appended and a normal end, with the JS stream as the control that always behaved that way. The proxied variants use a per-request raw upstream that announces more body than it sends, the shape #38003 adds to the same fixture, so the two sets of variants fold into one table whichever lands second.
  - Unfixed bun (main's `RequestContext.rs` built into this tree): the four development-mode tests fail with `Received: ""` for stderr while the wire assertions already hold; the native dev server row fails on all of terminator, page and stderr (the body is force-closed after `chunk-a`, which also confirms dev server requests reach `end_chunk`); the production-mode tests and the JS dev server row pass.
  - Fixed debug build: 25/25 in that file; `serve-direct-readable-stream.test.ts` (its two "sync pull() throw after status is written" tests cover the `handle_reject` change), `serve-stream-reject-flush-leak.test.ts`, `async-iterator-stream.test.ts`, `serve-error-handler-stream.test.ts` and `test/js/workerd/html-rewriter.test.js` (169) pass; `serve.test.ts` and `bun-server.test.ts` show the same IPv6/root-only failures as the unmodified binary in this container.
  - The script from the report prints `error: boom` for both after-first-byte cases under the fix and stays quiet with `development: false`, matching its JS stream control case both ways.

### Background

- `Bun.serve` streams a Response body in one of two ways. A JS `ReadableStream` is pumped by JS into a `ResponseStream` sink; the pump's promise settles into `handle_resolve_stream` / `handle_reject_stream`, except that a source throwing synchronously inside the first render lands in `handle_reject`. A body that is already native (a `ByteStream`: what `fetch()` produces, and what an `HTMLRewriter` transform writes its output into) is attached directly with `SinkHandle::ServerResponse`; the `ByteStream` then calls `write_chunk` per chunk and `end_chunk(err)` once, with `err` set when the producer failed.
- `has_written_status` records that the status line and headers were handed to uWS. For rewriter output this is deferred until the first output byte, precisely so that an earlier failure can still reach `error()`; for other native bodies it is set when the body is attached.
- `RequestContext` is monomorphized on `DEBUG_MODE`, which is `development: true` (the default unless `NODE_ENV=production` or `development: false`). `vm.run_error_handler` is the printer used for uncaught errors; it formats the value to stderr and nothing else. The dev server error page branch only applies when the server runs a bake dev server.
- Force-closing a chunked response without its `0\r\n\r\n` terminator is how the client is told the body is incomplete (RFC 9112 section 7); that part predates this change.

<details>
<summary>Output of the report's script on this branch</summary>

```
# development (default)
leading=0&async=0 -> "HTTP/1.1 500 Internal Server Error" body: "from error(): boom" error(): called
leading=0&async=1 -> "HTTP/1.1 500 Internal Server Error" body: "from error(): boom" error(): called
error: boom
      at <anonymous> (rewriter-serve.ts:50:25)
leading=1&async=0 -> "HTTP/1.1 200 OK" body: "" error(): NOT called
error: boom
      at <anonymous> (rewriter-serve.ts:47:25)
leading=1&async=1 -> "HTTP/1.1 200 OK" body: "c\r\n<html><body>\r\n" error(): NOT called
error: js-boom            # control: plain ReadableStream body, unchanged
js=1 -> "HTTP/1.1 200 OK" body: "c\r\n<html><body>\r\n" error(): NOT called

# development: false
(same four wire results, nothing printed for either the rewriter or the control case)
```

Before this change the two `leading=1` lines printed nothing in either mode.

</details>

<details>
<summary>First revision of this PR</summary>

The first push used the two helpers from `handle_reject_stream` and `end_chunk` only, described development-mode-only reporting as a contract settled by #32842 (that PR preserved the production silence of the async path rather than deciding it; #33810 later chose to report in both modes on the sync path), and pinned `stderr` empty in the production-mode tests. The current revision routes `handle_reject` through `close_failed_body` as well, states the actual split above, asserts only the wire in production mode, and adds the zero-body-bytes variant; a later push added the dev server rows.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-stream-body-error.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/http/serve-stream-body-error.test.ts:
(pass) controller-error: the rejection is handled and the error is still reported [1342.12ms]
(pass) pull-throw: the rejection is handled and the error is still reported [1403.80ms]
(pass) pull-async-reject: the rejection is handled and the error is still reported [1374.95ms]
(pass) start-async-reject: the rejection is handled and the error is still reported [1374.27ms]
(pass) deferred-pull-throw: the rejection is handled and the error is still reported [1381.81ms]
(pass) pull-throw in development mode: the rejection is handled [1322.65ms]
(pass) mid-stream error: the chunked body is not terminated as complete [1310.78ms]
(pass) mid-stream error in development mode: reported and not terminated as complete [1314.23ms]
151 |         unhandled: 0,
152 |         secondStatusLine: "HTTP/1.1 200 OK",
153 |       },
154 |       exitCode: 0,
155 |     });
156 |     expect(stderr).toContain(reported);
                 
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (674e3e803)

test/js/bun/http/serve-stream-body-error.test.ts:
(pass) start-async-reject: the rejection is handled and the error is still reported [36.76ms]
(pass) mid-stream error: the chunked body is not terminated as complete [35.02ms]
(pass) pull-throw: the rejection is handled and the error is still reported [39.05ms]
(pass) deferred-pull-throw: the rejection is handled and the error is still reported [37.68ms]
(pass) pull-throw in development mode: the rejection is handled [41.56ms]
(pass) pull-async-reject: the rejection is handled and the error is still reported [43.76ms]
(pass) controller-error: the rejection is handled and the error is still reported [43.67ms]
(pass) rewriter-mid-stream-throw in development mode: reported, and the body is terminated [40.48ms]
(pass) rewriter-mid-stream-reject: the body is terminated [44.41ms]
(pass) mid-stream error in development mode: reported and not terminated as complete [64.09ms]
(pass) a stream body error does not kill the server process [29.52ms]
(pass) mid-stream-reject under a dev server: the error page is appended to the body [38.09ms]
(pass) rewriter-mid-stream-reject in development mod
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-stream-body-error.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/http/serve-stream-body-error.test.ts:
(pass) start-async-reject: the rejection is handled and the error is still reported [1338.64ms]
(pass) deferred-pull-throw: the rejection is handled and the error is still reported [1351.54ms]
(pass) pull-throw: the rejection is handled and the error is still reported [1413.35ms]
(pass) controller-error: the rejection is handled and the error is still reported [1378.21ms]
(pass) pull-async-reject: the rejection is handled and the error is still reported [1395.03ms]
(pass) mid-stream error in development mode: reported and not terminated as complete [1300.92ms]
(pass) mid-stream error: the chunked body is not terminated as complete [1316.07ms]
(pass) pull-throw in development mode: the rejection is handled [1340.84ms]
(pass) rewriter-mid-stream-throw in development mode: reported, and the body is terminated [1318.24ms]
(pass) rewriter-mid-stream-reject in development mode: reported, and the body is terminated [
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     a706dc726a
  features     baseline

22 deps, 120 codegen, 1174 objects in 663ms

ninja: Entering directory `/workspace/bun/build/release'
[1/8] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/8] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/8] gen cpp.rs (cppbind)
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_alloc v0.0.0 (/workspace/bun/src/bun_alloc)
[1m[92m   Compiling[0m bun_libdeflate_sys v0.0.0 (/workspace/bun/src/libdeflate_sys)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/RequestContext.rs               | 114 +++++++++---------
 .../bun/http/serve-stream-body-error-fixture.html  |   3 +
 .../js/bun/http/serve-stream-body-error-fixture.ts | 132 +++++++++++++++++++--
 test/js/bun/http/serve-stream-body-error.test.ts   |  85 +++++++++++++
 4 files changed, 260 insertions(+), 74 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/runtime/server/RequestContext.rs                      19     13      0
test/js/bun/http/serve-stream-body-error-fixture.html      0      1      0
test/js/bun/http/serve-stream-body-error-fixture.ts        4     12      0
test/js/bun/http/serve-stream-body-error.test.ts           3      5      0
```

</details>

<!-- robobun:evidence:end -->