### PR TITLE
install: trust npm: aliased packages by the same name in bun pm trust, the installer and bun.lock

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -2001,12 +2001,11 @@ impl<'a> PackageInstaller<'a> {
                                 resolution,
                             ) {
                                 if is_trusted_through_update_request {
-                                    let (trusted_name, trusted_name_hash) =
-                                        if resolution.tag == resolution::Tag::Npm {
-                                            (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
-                                        } else {
-                                            (alias, truncated_dep_name_hash)
-                                        };
+                                    let (trusted_name, trusted_name_hash) = resolution
+                                        .trusted_name(
+                                            (alias, truncated_dep_name_hash),
+                                            (pkg_name, pkg_name_hash as TruncatedPackageNameHash),
+                                        );
                                     self.manager_mut()
                                         .trusted_deps_to_add_to_package_json
                                         .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
@@ -2263,8 +2262,10 @@ impl<'a> PackageInstaller<'a> {
 
             let dep = &self.lockfile().buffers.dependencies.as_slice()[dependency_id as usize];
             let dep_behavior = dep.behavior;
-            let truncated_dep_name_hash: TruncatedPackageNameHash =
-                dep.name_hash as TruncatedPackageNameHash;
+            let (trusted_name, trusted_name_hash) = resolution.trusted_name(
+                (alias, dep.name_hash as TruncatedPackageNameHash),
+                (pkg_name, pkg_name_hash as TruncatedPackageNameHash),
+            );
             let (is_trusted, is_trusted_through_update_request, add_to_lockfile) = 'brk: {
                 // trusted through a --trust dependency. need to enqueue scripts, write to package.json, and add to lockfile
                 if self
@@ -2278,10 +2279,10 @@ impl<'a> PackageInstaller<'a> {
                     .manager()
                     .summary
                     .added_trusted_dependencies
-                    .get(&truncated_dep_name_hash)
+                    .get(&trusted_name_hash)
                 {
                     // is a new trusted dependency. need to enqueue scripts and maybe add to lockfile
-                    if *added.name == *alias.slice(string_buf!())
+                    if *added.name == *trusted_name.slice(string_buf!())
                         && self.lockfile().has_trusted_dependency(
                             alias.slice(string_buf!()),
                             pkg_name.slice(string_buf!()),
@@ -2339,13 +2340,6 @@ impl<'a> PackageInstaller<'a> {
                         dep_behavior.contains(crate::dependency::Behavior::OPTIONAL),
                         resolution,
                     ) {
-                        let (trusted_name, trusted_name_hash) =
-                            if resolution.tag == resolution::Tag::Npm {
-                                (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
-                            } else {
-                                (alias, truncated_dep_name_hash)
-                            };
-
                         if is_trusted_through_update_request {
                             self.manager_mut()
                                 .trusted_deps_to_add_to_package_json

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1695,15 +1695,13 @@ impl Task {
                             entry_scripts[self.entry_id.get() as usize].set(Some(clone));
 
                             if is_trusted_through_update_request {
-                                let (trusted_name, trusted_name_hash) =
-                                    if pkg_res.tag == ResolutionTag::Npm {
-                                        (
-                                            pkg_name.slice(string_buf),
-                                            pkg_name_hash as TruncatedPackageNameHash,
-                                        )
-                                    } else {
-                                        (dep.name.slice(string_buf), truncated_dep_name_hash)
-                                    };
+                                let (trusted_name, trusted_name_hash) = pkg_res.trusted_name(
+                                    (dep.name.slice(string_buf), truncated_dep_name_hash),
+                                    (
+                                        pkg_name.slice(string_buf),
+                                        pkg_name_hash as TruncatedPackageNameHash,
+                                    ),
+                                );
                                 let trusted_dep_to_add: Box<[u8]> = Box::from(trusted_name);
 
                                 let _unlock = installer.trusted_dependencies_mutex.lock_guard();

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -3142,11 +3142,7 @@ impl Lockfile {
         resolution: &Resolution,
     ) -> bool {
         if let Some(trusted_dependencies) = &self.trusted_dependencies {
-            let trusted_name = if resolution.tag == ResolutionTag::Npm {
-                pkg_name
-            } else {
-                alias
-            };
+            let trusted_name = resolution.trusted_name(alias, pkg_name);
             let hash = SemverStringBuilder::string_hash(trusted_name) as u32;
             let name_is_trusted = match trusted_dependencies.get(&hash) {
                 Some(name) => !name.is_empty() && **name == *trusted_name,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -518,11 +518,13 @@ impl Stringifier {
 
                     // intentionally not checking default trusted dependencies
                     if let Some(trusted_dependencies) = &lockfile.trusted_dependencies {
+                        let (name, name_hash) =
+                            res.trusted_name((dep.name, dep.name_hash), (pkg_name, pkg_name_hash));
                         if let Some(trusted_name) =
-                            trusted_dependencies.get(&(dep.name_hash as TruncatedPackageNameHash))
+                            trusted_dependencies.get(&(name_hash as TruncatedPackageNameHash))
                         {
-                            if **trusted_name == *dep.name.slice(buf) {
-                                found_trusted_dependencies.insert(dep.name_hash, dep.name);
+                            if **trusted_name == *name.slice(buf) {
+                                found_trusted_dependencies.insert(name_hash, name);
                             }
                         }
                     }

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -50,6 +50,24 @@ impl Resolution {
 
         false
     }
+
+    /// Picks the name a `trustedDependencies` entry has to carry to apply to a
+    /// dependency resolving to this package (or anything keyed by that name,
+    /// such as a `(name, hash)` pair): the package's own name for a registry
+    /// package, because a dependent chooses the aliases of its dependencies and
+    /// `"x": "npm:y"` must not inherit trust given to `x`; the declared alias
+    /// for everything else, which has no registry-backed name.
+    ///
+    /// Every reader and writer of trust entries has to pick the same side, or
+    /// an entry written by one command is ignored by the next.
+    #[inline]
+    pub fn trusted_name<T>(&self, by_alias: T, by_pkg_name: T) -> T {
+        if self.tag == Tag::Npm {
+            by_pkg_name
+        } else {
+            by_alias
+        }
+    }
 }
 
 #[repr(C)]

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -51,15 +51,10 @@ impl Resolution {
         false
     }
 
-    /// Picks the name a `trustedDependencies` entry has to carry to apply to a
-    /// dependency resolving to this package (or anything keyed by that name,
-    /// such as a `(name, hash)` pair): the package's own name for a registry
-    /// package, because a dependent chooses the aliases of its dependencies and
-    /// `"x": "npm:y"` must not inherit trust given to `x`; the declared alias
-    /// for everything else, which has no registry-backed name.
-    ///
-    /// Every reader and writer of trust entries has to pick the same side, or
-    /// an entry written by one command is ignored by the next.
+    /// The name (or anything keyed by it) a `trustedDependencies` entry must
+    /// carry to apply to a dependency resolving to this package: a registry
+    /// package's own name, since a dependent picks its aliases (`"x": "npm:y"`
+    /// must not inherit trust given to `x`); the declared alias otherwise.
     #[inline]
     pub fn trusted_name<T>(&self, by_alias: T, by_pkg_name: T) -> T {
         if self.tag == Tag::Npm {

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -51,10 +51,8 @@ impl Resolution {
         false
     }
 
-    /// The name (or anything keyed by it) a `trustedDependencies` entry must
-    /// carry to apply to a dependency resolving to this package: a registry
-    /// package's own name, since a dependent picks its aliases (`"x": "npm:y"`
-    /// must not inherit trust given to `x`); the declared alias otherwise.
+    /// The name (or anything keyed by it) that `trustedDependencies` identifies
+    /// a dependency resolving to this package by.
     #[inline]
     pub fn trusted_name<T>(&self, by_alias: T, by_pkg_name: T) -> T {
         if self.tag == Tag::Npm {

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -51,8 +51,7 @@ impl Resolution {
         false
     }
 
-    /// The name (or anything keyed by it) that `trustedDependencies` identifies
-    /// a dependency resolving to this package by.
+    /// Which of a dependency's two names `trustedDependencies` entries match.
     #[inline]
     pub fn trusted_name<T>(&self, by_alias: T, by_pkg_name: T) -> T {
         if self.tag == Tag::Npm {

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -206,8 +206,7 @@ impl UntrustedCommand {
     }
 }
 
-/// `print_scripts` names a package by its folder. For an `npm:` alias that is
-/// not the name `trustedDependencies` and `bun pm trust` take, so say which is.
+/// Follows `print_scripts`, which names the package by its folder.
 fn print_trusted_name_if_aliased(lockfile: &Lockfile, dep_id: DependencyID) {
     let buf = lockfile.buffers.string_bytes.as_slice();
     let alias = lockfile.buffers.dependencies.as_slice()[dep_id as usize]
@@ -255,15 +254,13 @@ impl TrustCommand {
         }
     }
 
-    /// `aliases_named` maps each CLI argument that only matched the alias of an
-    /// `npm:` aliased package to the name that package is trusted under.
-    fn print_aliases_named(aliases_named: &StringArrayHashMap<Box<[u8]>>) {
-        if aliases_named.count() == 0 {
+    fn print_aliased_args(aliased_args: &StringArrayHashMap<Box<[u8]>>) {
+        if aliased_args.count() == 0 {
             return;
         }
         // the listing above went to stdout; keep the notes after it on a terminal
         Output::flush();
-        for (alias, trusted_name) in aliases_named.keys().iter().zip(aliases_named.values()) {
+        for (alias, trusted_name) in aliased_args.keys().iter().zip(aliased_args.values()) {
             bun_core::note!(
                 "{} is an alias of {}, run 'bun pm trust {}' to trust it",
                 bun_core::fmt::quote(alias),
@@ -372,7 +369,8 @@ impl TrustCommand {
         let mut node_modules_path = AutoAbsPath::init_top_level_dir();
 
         let mut package_names_to_add: StringArrayHashMap<()> = StringArrayHashMap::new();
-        let mut aliases_named: StringArrayHashMap<Box<[u8]>> = StringArrayHashMap::new();
+        // alias given on the command line -> the name its package is trusted under
+        let mut aliased_args: StringArrayHashMap<Box<[u8]>> = StringArrayHashMap::new();
         let mut scripts_at_depth: ArrayHashMap<usize, Vec<ScriptInfo>> = ArrayHashMap::new();
 
         let mut scripts_count: usize = 0;
@@ -438,7 +436,7 @@ impl TrustCommand {
                     };
                     let skip = !trust_all && !named(trusted_name);
                     if skip && trusted_name != alias && named(alias) {
-                        aliases_named.put(alias, Box::<[u8]>::from(trusted_name))?;
+                        aliased_args.put(alias, Box::<[u8]>::from(trusted_name))?;
                     }
 
                     let total = scripts_list.total as usize;
@@ -465,7 +463,7 @@ impl TrustCommand {
 
         if scripts_at_depth.count() == 0 || package_names_to_add.count() == 0 {
             Self::print_error_zero_untrusted_dependencies_found(trust_all, &packages_to_trust);
-            Self::print_aliases_named(&aliases_named);
+            Self::print_aliased_args(&aliased_args);
             Global::crash();
         }
 
@@ -732,7 +730,7 @@ impl TrustCommand {
                 if total_skipped_packages > 1 { "s" } else { "" },
             );
         }
-        Self::print_aliases_named(&aliases_named);
+        Self::print_aliased_args(&aliased_args);
 
         Ok(())
     }

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -392,25 +392,13 @@ impl TrustCommand {
                 };
 
                 if let Some(scripts_list) = maybe_scripts_list {
-                    let skip = 'brk: {
-                        if trust_all {
-                            break 'brk false;
-                        }
+                    let trusted_name = resolution
+                        .trusted_name(alias, packages.items_name()[package_id as usize].slice(buf));
 
-                        for package_name_from_cli in &packages_to_trust {
-                            if strings::eql_long(package_name_from_cli, alias, true)
-                                && !lockfile.has_trusted_dependency(
-                                    alias,
-                                    packages.items_name()[package_id as usize].slice(buf),
-                                    resolution,
-                                )
-                            {
-                                break 'brk false;
-                            }
-                        }
-
-                        true
-                    };
+                    let skip = !trust_all
+                        && !packages_to_trust.iter().any(|package_name_from_cli| {
+                            strings::eql_long(package_name_from_cli, trusted_name, true)
+                        });
 
                     let total = scripts_list.total as usize;
                     // even if it is skipped we still add to scripts_at_depth for logging later
@@ -425,7 +413,7 @@ impl TrustCommand {
                     });
 
                     if !skip {
-                        package_names_to_add.put(alias, ())?;
+                        package_names_to_add.put(trusted_name, ())?;
                         scripts_count += total;
                     }
                 }

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -16,7 +16,7 @@ use bun_install::package_manager_real::{
 };
 use bun_install::{
     self as install, DEFAULT_TRUSTED_DEPENDENCIES_LIST, DependencyID, LifecycleScriptSubprocess,
-    PackageID, PackageManager, Resolution,
+    PackageManager, Resolution,
 };
 use bun_paths::AutoAbsPath;
 
@@ -181,6 +181,7 @@ impl UntrustedCommand {
             let resolution = &lockfile.packages.items_resolution()[package_id as usize];
 
             scripts_list.print_scripts(resolution, buf, PrintFormat::Untrusted);
+            print_trusted_name_if_aliased(lockfile, dep_id);
             bun_core::pretty!("\n");
         }
 
@@ -205,11 +206,27 @@ impl UntrustedCommand {
     }
 }
 
+/// `print_scripts` names a package by its folder. For an `npm:` alias that is
+/// not the name `trustedDependencies` and `bun pm trust` take, so say which is.
+fn print_trusted_name_if_aliased(lockfile: &Lockfile, dep_id: DependencyID) {
+    let buf = lockfile.buffers.string_bytes.as_slice();
+    let alias = lockfile.buffers.dependencies.as_slice()[dep_id as usize]
+        .name
+        .slice(buf);
+    let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize] as usize;
+    let packages = lockfile.packages.slice();
+    let trusted_name = packages.items_resolution()[package_id]
+        .trusted_name(alias, packages.items_name()[package_id].slice(buf));
+    if trusted_name != alias {
+        bun_core::pretty!(" <d>alias of<r> {}\n", bun_core::fmt::quote(trusted_name));
+    }
+}
+
 pub(crate) struct TrustCommand;
 
 /// Value type stored in `scripts_at_depth`.
 struct ScriptInfo {
-    package_id: PackageID,
+    dep_id: DependencyID,
     scripts_list: ScriptsList,
     skip: bool,
 }
@@ -235,6 +252,24 @@ impl TrustCommand {
             for arg in packages_to_trust {
                 bun_core::pretty_error!(" <d>-<r> {}\n", bstr::BStr::new(arg));
             }
+        }
+    }
+
+    /// `aliases_named` maps each CLI argument that only matched the alias of an
+    /// `npm:` aliased package to the name that package is trusted under.
+    fn print_aliases_named(aliases_named: &StringArrayHashMap<Box<[u8]>>) {
+        if aliases_named.count() == 0 {
+            return;
+        }
+        // the listing above went to stdout; keep the notes after it on a terminal
+        Output::flush();
+        for (alias, trusted_name) in aliases_named.keys().iter().zip(aliases_named.values()) {
+            bun_core::note!(
+                "{} is an alias of {}, run 'bun pm trust {}' to trust it",
+                bun_core::fmt::quote(alias),
+                bun_core::fmt::quote(trusted_name),
+                bun_core::fmt::quote(trusted_name),
+            );
         }
     }
 
@@ -337,6 +372,7 @@ impl TrustCommand {
         let mut node_modules_path = AutoAbsPath::init_top_level_dir();
 
         let mut package_names_to_add: StringArrayHashMap<()> = StringArrayHashMap::new();
+        let mut aliases_named: StringArrayHashMap<Box<[u8]>> = StringArrayHashMap::new();
         let mut scripts_at_depth: ArrayHashMap<usize, Vec<ScriptInfo>> = ArrayHashMap::new();
 
         let mut scripts_count: usize = 0;
@@ -395,10 +431,15 @@ impl TrustCommand {
                     let trusted_name = resolution
                         .trusted_name(alias, packages.items_name()[package_id as usize].slice(buf));
 
-                    let skip = !trust_all
-                        && !packages_to_trust.iter().any(|package_name_from_cli| {
-                            strings::eql_long(package_name_from_cli, trusted_name, true)
-                        });
+                    let named = |name: &[u8]| {
+                        packages_to_trust.iter().any(|package_name_from_cli| {
+                            strings::eql_long(package_name_from_cli, name, true)
+                        })
+                    };
+                    let skip = !trust_all && !named(trusted_name);
+                    if skip && trusted_name != alias && named(alias) {
+                        aliases_named.put(alias, Box::<[u8]>::from(trusted_name))?;
+                    }
 
                     let total = scripts_list.total as usize;
                     // even if it is skipped we still add to scripts_at_depth for logging later
@@ -407,7 +448,7 @@ impl TrustCommand {
                         *entry.value_ptr = Vec::new();
                     }
                     entry.value_ptr.push(ScriptInfo {
-                        package_id,
+                        dep_id,
                         scripts_list,
                         skip,
                     });
@@ -424,6 +465,7 @@ impl TrustCommand {
 
         if scripts_at_depth.count() == 0 || package_names_to_add.count() == 0 {
             Self::print_error_zero_untrusted_dependencies_found(trust_all, &packages_to_trust);
+            Self::print_aliases_named(&aliases_named);
             Global::crash();
         }
 
@@ -583,7 +625,8 @@ impl TrustCommand {
         let buf = lockfile.buffers.string_bytes.as_slice();
         for entry in scripts_at_depth.values().iter().rev() {
             for info in entry.iter() {
-                let resolution = &lockfile.packages.items_resolution()[info.package_id as usize];
+                let package_id = lockfile.buffers.resolutions.as_slice()[info.dep_id as usize];
+                let resolution = &lockfile.packages.items_resolution()[package_id as usize];
                 if info.skip {
                     info.scripts_list
                         .print_scripts(resolution, buf, PrintFormat::Untrusted);
@@ -594,6 +637,7 @@ impl TrustCommand {
                     info.scripts_list
                         .print_scripts(resolution, buf, PrintFormat::Completed);
                 }
+                print_trusted_name_if_aliased(lockfile, info.dep_id);
                 Output::print(format_args!("\n"));
             }
         }
@@ -688,6 +732,7 @@ impl TrustCommand {
                 if total_skipped_packages > 1 { "s" } else { "" },
             );
         }
+        Self::print_aliases_named(&aliases_named);
 
         Ok(())
     }

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -333,118 +333,118 @@ test.concurrent(
   },
 );
 
-describe.concurrent("bun pm trust with an npm: aliased dependency", () => {
-  const dependencies = { "esbuild": "npm:uses-what-bin@1.0.0" };
+describe.concurrent.each(["hoisted", "isolated"] as const)(
+  "bun pm trust with an npm: aliased dependency (%s)",
+  linker => {
+    // lifecycle-postinstall's script needs no dependency bins, which are not on
+    // PATH when `bun pm trust` runs a script through the isolated linker's
+    // root symlink.
+    const dependencies = { "esbuild": "npm:lifecycle-postinstall@1.0.0" };
 
-  async function installBlocked(ctx: TestCtx) {
-    const { packageDir, packageJson, env } = ctx;
-    await writeFile(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", dependencies }));
+    function scriptRan(ctx: TestCtx) {
+      return exists(join(ctx.packageDir, "node_modules", "esbuild", "postinstall.txt"));
+    }
 
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "install"],
-      cwd: packageDir,
-      stdout: "pipe",
-      stdin: "ignore",
-      stderr: "pipe",
-      env,
+    async function run(ctx: TestCtx, ...args: string[]) {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), ...args],
+        cwd: ctx.packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: ctx.env,
+      });
+      const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      return { out, err, exitCode };
+    }
+
+    async function installBlocked(ctx: TestCtx) {
+      await verdaccio.writeBunfig(ctx.packageDir, { linker });
+      await writeFile(ctx.packageJson, JSON.stringify({ name: "foo", version: "1.0.0", dependencies }));
+
+      const { err, exitCode } = await run(ctx, "install");
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      expect(await scriptRan(ctx)).toBeFalse();
+      expect(exitCode).toBe(0);
+    }
+
+    // The entry `bun pm trust` wrote is only useful if a fresh install honors it.
+    // It also wrote the entry to bun.lock, so the install has no reason to save it again.
+    async function expectFreshInstallRunsScripts(ctx: TestCtx) {
+      await rm(join(ctx.packageDir, "node_modules"), { recursive: true, force: true });
+
+      const { out, err, exitCode } = await run(ctx, "install");
+      expect(err).not.toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      expect(out).not.toContain("Blocked");
+      expect(await scriptRan(ctx)).toBeTrue();
+      expect(exitCode).toBe(0);
+    }
+
+    async function expectTrusted(ctx: TestCtx, names: string[]) {
+      expect(await file(ctx.packageJson).json()).toEqual({
+        name: "foo",
+        version: "1.0.0",
+        dependencies,
+        trustedDependencies: names,
+      });
+      const lockfile = await file(join(ctx.packageDir, "bun.lock")).text();
+      const trusted = lockfile.match(/"trustedDependencies":\s*\[([^\]]*)\]/);
+      expect(trusted).not.toBeNull();
+      expect(trusted![1].match(/"[^"]*"/g)).toEqual(names.map(name => `"${name}"`));
+    }
+
+    test("<name> matches the resolved package name and writes it", async () => {
+      using ctx = await setupTest();
+      await installBlocked(ctx);
+
+      // The listing is by folder name, so it has to say which name the package
+      // is trusted under.
+      let { out, err, exitCode } = await run(ctx, "pm", "untrusted");
+      expect(err).not.toContain("error:");
+      expect(out).toContain('alias of "lifecycle-postinstall"');
+      expect(exitCode).toBe(0);
+
+      // The alias is not the package's name. A package controls the aliases it
+      // declares for its own dependencies, so matching on it would let any
+      // package in the tree claim a name the user is trusting.
+      ({ out, err, exitCode } = await run(ctx, "pm", "trust", "esbuild"));
+      expect(err).toContain("0 scripts ran");
+      expect(err).toContain(" - esbuild");
+      expect(err).toContain(
+        `note: "esbuild" is an alias of "lifecycle-postinstall", run 'bun pm trust "lifecycle-postinstall"' to trust it`,
+      );
+      expect(exitCode).toBe(1);
+      expect(await scriptRan(ctx)).toBeFalse();
+      expect(await file(ctx.packageJson).json()).toEqual({ name: "foo", version: "1.0.0", dependencies });
+
+      ({ out, err, exitCode } = await run(ctx, "pm", "trust", "lifecycle-postinstall"));
+      expect(err).not.toContain("error:");
+      expect(out).toContain('alias of "lifecycle-postinstall"');
+      expect(out).toContain("1 script ran across 1 package");
+      expect(exitCode).toBe(0);
+      expect(await scriptRan(ctx)).toBeTrue();
+
+      await expectTrusted(ctx, ["lifecycle-postinstall"]);
+      await expectFreshInstallRunsScripts(ctx);
     });
 
-    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
-    expect(err).toContain("Saved lockfile");
-    expect(err).not.toContain("error:");
-    expect(out).toContain("Blocked 1 postinstall");
-    expect(await exists(join(packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeFalse();
-    expect(exitCode).toBe(0);
-  }
+    test("--all writes the resolved package name", async () => {
+      using ctx = await setupTest();
+      await installBlocked(ctx);
 
-  async function pmTrust(ctx: TestCtx, ...args: string[]) {
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "pm", "trust", ...args],
-      cwd: ctx.packageDir,
-      stdout: "pipe",
-      stdin: "ignore",
-      stderr: "pipe",
-      env: ctx.env,
+      const { out, err, exitCode } = await run(ctx, "pm", "trust", "--all");
+      expect(err).not.toContain("error:");
+      expect(out).toContain("1 script ran across 1 package");
+      expect(exitCode).toBe(0);
+      expect(await scriptRan(ctx)).toBeTrue();
+
+      await expectTrusted(ctx, ["lifecycle-postinstall"]);
+      await expectFreshInstallRunsScripts(ctx);
     });
-    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
-    return { out, err, exitCode };
-  }
-
-  // The entry `bun pm trust` wrote is only useful if a fresh install honors it.
-  // It also wrote the entry to bun.lock, so the install has no reason to save it again.
-  async function expectFreshInstallRunsScripts(ctx: TestCtx) {
-    const { packageDir, env } = ctx;
-    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "install"],
-      cwd: packageDir,
-      stdout: "pipe",
-      stdin: "ignore",
-      stderr: "pipe",
-      env,
-    });
-
-    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
-    expect(err).not.toContain("Saved lockfile");
-    expect(err).not.toContain("error:");
-    expect(out).not.toContain("Blocked");
-    expect(await exists(join(packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeTrue();
-    expect(exitCode).toBe(0);
-  }
-
-  async function expectTrusted(ctx: TestCtx, names: string[]) {
-    expect(await file(ctx.packageJson).json()).toEqual({
-      name: "foo",
-      version: "1.0.0",
-      dependencies,
-      trustedDependencies: names,
-    });
-    const lockfile = await file(join(ctx.packageDir, "bun.lock")).text();
-    const trusted = lockfile.match(/"trustedDependencies":\s*\[([^\]]*)\]/);
-    expect(trusted).not.toBeNull();
-    expect(trusted![1].match(/"[^"]*"/g)).toEqual(names.map(name => `"${name}"`));
-  }
-
-  test("<name> matches the resolved package name and writes it", async () => {
-    using ctx = await setupTest();
-    await installBlocked(ctx);
-
-    // The alias is not the package's name. A package controls the aliases it
-    // declares for its own dependencies, so matching on it would let any
-    // package in the tree claim a name the user is trusting.
-    let { err, exitCode } = await pmTrust(ctx, "esbuild");
-    expect(err).toContain("0 scripts ran");
-    expect(err).toContain(" - esbuild");
-    expect(exitCode).toBe(1);
-    expect(await exists(join(ctx.packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeFalse();
-    expect(await file(ctx.packageJson).json()).toEqual({ name: "foo", version: "1.0.0", dependencies });
-
-    let out: string;
-    ({ out, err, exitCode } = await pmTrust(ctx, "uses-what-bin"));
-    expect(err).not.toContain("error:");
-    expect(out).toContain("1 script ran across 1 package");
-    expect(exitCode).toBe(0);
-    expect(await exists(join(ctx.packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeTrue();
-
-    await expectTrusted(ctx, ["uses-what-bin"]);
-    await expectFreshInstallRunsScripts(ctx);
-  });
-
-  test("--all writes the resolved package name", async () => {
-    using ctx = await setupTest();
-    await installBlocked(ctx);
-
-    const { out, err, exitCode } = await pmTrust(ctx, "--all");
-    expect(err).not.toContain("error:");
-    expect(out).toContain("1 script ran across 1 package");
-    expect(exitCode).toBe(0);
-    expect(await exists(join(ctx.packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeTrue();
-
-    await expectTrusted(ctx, ["uses-what-bin"]);
-    await expectFreshInstallRunsScripts(ctx);
-  });
-});
+  },
+);
 
 test.concurrent("node-gyp shim directory added to lifecycle script PATH gets a randomized name", async () => {
   using ctx = await setupTest();

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -259,6 +259,193 @@ test.concurrent(
   },
 );
 
+test.concurrent(
+  "trustedDependencies added on a later install runs the scripts of an already installed npm: aliased package",
+  async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson, env } = ctx;
+
+    const dependencies = { "esbuild": "npm:uses-what-bin@1.0.0" };
+    await writeFile(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", dependencies }));
+
+    let { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    });
+
+    let err = await stderr.text();
+    let out = await stdout.text();
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Blocked 1 postinstall");
+    expect(await exists(join(packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeFalse();
+    expect(await exited).toBe(0);
+
+    // Same name `trustedDependencies` is matched against on a fresh install.
+    // The package is already in node_modules, so this install has to notice
+    // the new entry and run the scripts without a reinstall.
+    await writeFile(
+      packageJson,
+      JSON.stringify({ name: "foo", version: "1.0.0", dependencies, trustedDependencies: ["uses-what-bin"] }),
+    );
+
+    ({ stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    }));
+
+    err = await stderr.text();
+    out = await stdout.text();
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).not.toContain("Blocked");
+    expect(await exists(join(packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeTrue();
+    expect(await exited).toBe(0);
+
+    // The entry is persisted to bun.lock under the same name, so the next
+    // install sees nothing new: no lockfile rewrite, scripts not run again.
+    await rm(join(packageDir, "node_modules", "esbuild", "what-bin.txt"));
+
+    ({ stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    }));
+
+    err = await stderr.text();
+    out = await stdout.text();
+    expect(err).not.toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("(no changes)");
+    expect(await exists(join(packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeFalse();
+    expect(await exited).toBe(0);
+  },
+);
+
+describe.concurrent("bun pm trust with an npm: aliased dependency", () => {
+  const dependencies = { "esbuild": "npm:uses-what-bin@1.0.0" };
+
+  async function installBlocked(ctx: TestCtx) {
+    const { packageDir, packageJson, env } = ctx;
+    await writeFile(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", dependencies }));
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    });
+
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("Blocked 1 postinstall");
+    expect(await exists(join(packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeFalse();
+    expect(exitCode).toBe(0);
+  }
+
+  async function pmTrust(ctx: TestCtx, ...args: string[]) {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "trust", ...args],
+      cwd: ctx.packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: ctx.env,
+    });
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    return { out, err, exitCode };
+  }
+
+  // The entry `bun pm trust` wrote is only useful if a fresh install honors it.
+  // It also wrote the entry to bun.lock, so the install has no reason to save it again.
+  async function expectFreshInstallRunsScripts(ctx: TestCtx) {
+    const { packageDir, env } = ctx;
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    });
+
+    const [out, err, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).not.toContain("Saved lockfile");
+    expect(err).not.toContain("error:");
+    expect(out).not.toContain("Blocked");
+    expect(await exists(join(packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeTrue();
+    expect(exitCode).toBe(0);
+  }
+
+  async function expectTrusted(ctx: TestCtx, names: string[]) {
+    expect(await file(ctx.packageJson).json()).toEqual({
+      name: "foo",
+      version: "1.0.0",
+      dependencies,
+      trustedDependencies: names,
+    });
+    const lockfile = await file(join(ctx.packageDir, "bun.lock")).text();
+    const trusted = lockfile.match(/"trustedDependencies":\s*\[([^\]]*)\]/);
+    expect(trusted).not.toBeNull();
+    expect(trusted![1].match(/"[^"]*"/g)).toEqual(names.map(name => `"${name}"`));
+  }
+
+  test("<name> matches the resolved package name and writes it", async () => {
+    using ctx = await setupTest();
+    await installBlocked(ctx);
+
+    // The alias is not the package's name. A package controls the aliases it
+    // declares for its own dependencies, so matching on it would let any
+    // package in the tree claim a name the user is trusting.
+    let { err, exitCode } = await pmTrust(ctx, "esbuild");
+    expect(err).toContain("0 scripts ran");
+    expect(err).toContain(" - esbuild");
+    expect(exitCode).toBe(1);
+    expect(await exists(join(ctx.packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeFalse();
+    expect(await file(ctx.packageJson).json()).toEqual({ name: "foo", version: "1.0.0", dependencies });
+
+    let out: string;
+    ({ out, err, exitCode } = await pmTrust(ctx, "uses-what-bin"));
+    expect(err).not.toContain("error:");
+    expect(out).toContain("1 script ran across 1 package");
+    expect(exitCode).toBe(0);
+    expect(await exists(join(ctx.packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeTrue();
+
+    await expectTrusted(ctx, ["uses-what-bin"]);
+    await expectFreshInstallRunsScripts(ctx);
+  });
+
+  test("--all writes the resolved package name", async () => {
+    using ctx = await setupTest();
+    await installBlocked(ctx);
+
+    const { out, err, exitCode } = await pmTrust(ctx, "--all");
+    expect(err).not.toContain("error:");
+    expect(out).toContain("1 script ran across 1 package");
+    expect(exitCode).toBe(0);
+    expect(await exists(join(ctx.packageDir, "node_modules", "esbuild", "what-bin.txt"))).toBeTrue();
+
+    await expectTrusted(ctx, ["uses-what-bin"]);
+    await expectFreshInstallRunsScripts(ctx);
+  });
+});
+
 test.concurrent("node-gyp shim directory added to lifecycle script PATH gets a randomized name", async () => {
   using ctx = await setupTest();
   const { packageDir, packageJson, env } = ctx;


### PR DESCRIPTION
### Problem

For a dependency declared through an `npm:` alias, for example `"zzz": "npm:my-esbuild-fork@1.0.0"`, `Lockfile::has_trusted_dependency` (`src/install/lockfile.rs`) matches `trustedDependencies` entries against the resolved package name (`my-esbuild-fork`), while three other paths still key trust on the alias (`zzz`). Every user-facing way of trusting such a package is broken as a result:

- `bun pm trust my-esbuild-fork` exits 1 with "0 scripts ran ... don't exist", because `src/runtime/cli/pm_trusted_command.rs` compares the CLI argument against the alias.
- `bun pm trust zzz` and `bun pm trust --all` run the scripts once, but write `"trustedDependencies": ["zzz"]`, which the next `bun install` ignores (scripts blocked again after `rm -rf node_modules`). For registry packages, matching on the alias also means `bun pm trust <name>` runs the scripts of whatever package some dependency in the tree aliases as `<name>`, which is what the resolved-name rule closed for `trustedDependencies` itself.
- Adding `"trustedDependencies": ["my-esbuild-fork"]` to package.json after the package is already installed does nothing on the next `bun install`: the installer's "entry added since the last install" lookup in `src/install/PackageInstaller.rs` uses the alias hash and compares against the alias, so neither spelling satisfies both it and `has_trusted_dependency`.
- The `bun.lock` writer (`src/install/lockfile/bun.lock.rs`) only persists entries matching a dependency alias, so the `my-esbuild-fork` entry never reaches `bun.lock` and is diffed as newly added on every install. With only the installer fix above, that would re-run the package's scripts on every `bun install`.

`bun add --trust` and the isolated installer already write the resolved name; plain `bun install` of a not-yet-installed package already honors it (covered by the existing tests at the top of `bun-install-lifecycle-scripts.test.ts`).

### Fix

- Add `Resolution::trusted_name(by_alias, by_pkg_name)` (`src/install/resolution.rs`), the one place that picks the package name for registry resolutions and the alias for everything else, and use it in `has_trusted_dependency`, both installers' `--trust` write paths, the installer's newly-added lookup, the `bun.lock` writer, and `bun pm trust` (matching and writing).
- This is correct because a trust entry is only useful if the name that is written is the name that is later looked up. `has_trusted_dependency` is the check `bun install` applies, and its rule (resolved name for npm, since a dependent chooses its own aliases; alias otherwise) is the documented one, so the other paths move to it rather than the other way around. `bun pm trust X` now does exactly what `"trustedDependencies": ["X"]` does, plus runs the scripts immediately, which is how the docs describe it.
- Since the folder name shown by `bun pm untrusted` is no longer accepted for an aliased package, both listings print `alias of "my-esbuild-fork"` under such a package, and `bun pm trust zzz` adds `note: "zzz" is an alias of "my-esbuild-fork", run 'bun pm trust "my-esbuild-fork"' to trust it` (a `bun pm trust` argument that matched only an alias). `List::print_scripts` itself is unchanged. Output for non-aliased packages is unchanged.
- Behavior change for non-aliased dependencies: none. Alias and package name are the same string there, and the `bun.lock` writer keys on the same hash value as before, so existing lockfiles serialize byte for byte the same. For aliased dependencies, `bun pm trust <alias>` no longer matches, and a stale alias entry (which `bun install` has not honored since the resolved-name rule landed) is dropped from `bun.lock` on the next save.
- The redundant `!has_trusted_dependency(...)` inside the `bun pm trust` match loop is removed: every candidate there came from `untrusted_dep_ids`, which is built with the same call a few lines earlier.
- Intentionally unchanged:
  - Non-npm resolutions keep matching and writing the alias, as before. Whether an entry for a transitive `git:`/`file:` dependency is honored is decided separately by `declared_by_root_or_workspace` in `has_trusted_dependency`, and `bun pm trust` does not consult that; this PR only makes the name consistent.
  - `Scripts::get_list` still passes the alias as the package name to `has_trusted_dependency`; that branch is only reachable for packages parsed from a package.json (git, tarball, folder, workspace), whose trust name is the alias, because npm packages never have their scripts recorded in the lockfile (`process_extracted_tarball_package` deliberately discards them).
- Overlap with open PRs: #36387 (name-keyed trusted set) and #35106 (isolated `bun pm trust`) add or keep alias-keyed lookups at the same sites; whichever lands second needs to go through `Resolution::trusted_name`.
- Tests (`test/cli/install/bun-install-lifecycle-scripts.test.ts`):
  - `bun pm trust` with `"esbuild": "npm:lifecycle-postinstall@1.0.0"`, under both linkers: `bun pm untrusted` prints the package name; `bun pm trust esbuild` is refused with the note and changes nothing; `bun pm trust lifecycle-postinstall` runs the script and writes `lifecycle-postinstall` to package.json and `bun.lock`; a fresh install then runs the script without re-saving the lockfile. Same write and fresh-install checks for `--all`.
  - Hoisted, with `"esbuild": "npm:uses-what-bin@1.0.0"`: adding `trustedDependencies: ["uses-what-bin"]` after the first install runs the script on the second install and saves the entry to `bun.lock`; a third install is a no-op (no lockfile save, script not run again). The isolated installer has no equivalent already-installed path, so this case is hoisted only.
  - Every new test fails on the released build (1.4.0-canary.1) and passes with this change; with only the `bun.lock` writer change reverted, they still fail, so each of the three sites is covered.
  - Also run: the rest of `bun-install-lifecycle-scripts.test.ts` (the only local failures are the two PATH-dependent node/node-gyp shim tests, which fail the same way on an unmodified debug build here and passed in CI), `bun-lock.test.ts`, `bun-pm.test.ts`, the `pm trust` tests in `bun-install-registry.test.ts`, the `--trust` test in `bun-add.test.ts`, and the trustedDependencies tests in `bun-prune.test.ts` and `bun-dedupe.test.ts`.

### Background

- `npm:` alias: `"zzz": "npm:my-esbuild-fork@1.0.0"` installs the registry package `my-esbuild-fork` into `node_modules/zzz`. In the lockfile the dependency's `name` is the alias (`zzz`) and the package's `name` is the resolved name (`my-esbuild-fork`); they only differ for aliased dependencies.
- `trustedDependencies`: the package.json allow list of packages whose lifecycle scripts may run. The lockfile keeps the same list in `Lockfile.trusted_dependencies`, a map from the truncated hash of an entry to the entry's text, which is also how it is written to `bun.lock`.
- Newly-added trust detection: on each `bun install`, `Diff::generate` compares the lockfile's trusted list with package.json's and records the additions in `added_trusted_dependencies`. For packages that are already in `node_modules`, the hoisted installer consults that set to run the scripts of packages that were just trusted. The list persisted to `bun.lock` therefore has to contain every entry that applied to a package, or the entry is reported as newly added on every install.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-lifecycle-scripts.test.ts

<!-- robobun:evidence:end -->