### PR TITLE
dev server: re-bundle a failed route once per file change and close the descriptors the watcher declines

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -68,7 +68,14 @@ mod EventLoop {
 #[derive(bun_core::EnumTag)]
 #[enum_tag(existing = ContentsOrFdTag)]
 pub enum ContentsOrFd {
-    Fd { dir: Fd, file: Fd },
+    Fd {
+        dir: Fd,
+        file: Fd,
+        /// `file` was opened by this task's read rather than borrowed from the
+        /// resolver's entry cache. It is kept open for the watcher; if the
+        /// watcher does not adopt it, the bundle thread closes it.
+        owns_file: bool,
+    },
     // The `'static` is ownership-erased: contents may be arena-owned,
     // plugin-owned, or truly static (runtime source). The producer keeps the
     // backing allocation alive for the duration of the bundle pass.
@@ -161,6 +168,9 @@ impl ResultValue {
 pub(crate) struct WatcherData {
     pub(crate) fd: Fd,
     pub(crate) dir_fd: Fd,
+    /// See [`ContentsOrFd::Fd::owns_file`]. When set and the watcher does not
+    /// adopt `fd`, the bundle thread closes it.
+    pub(crate) owns_fd: bool,
 }
 
 impl WatcherData {
@@ -168,6 +178,7 @@ impl WatcherData {
     pub(crate) const NONE: WatcherData = WatcherData {
         fd: Fd::INVALID,
         dir_fd: Fd::INVALID,
+        owns_fd: false,
     };
 }
 
@@ -263,6 +274,7 @@ impl ParseTask {
             contents_or_fd: ContentsOrFd::Fd {
                 dir: resolve_result.dirname_fd,
                 file: resolve_result.file_fd,
+                owns_file: false,
             },
             side_effects: resolve_result.primary_side_effects_data,
             // D042: resolver-side and bundler-side `jsx::Pragma` are the SAME
@@ -1393,7 +1405,7 @@ pub mod parse_worker {
         _loader: Loader,
     ) -> core::result::Result<CacheEntry, AnyError> {
         match &task.contents_or_fd {
-            ContentsOrFd::Fd { dir, file } => 'brk: {
+            ContentsOrFd::Fd { dir, file, .. } => 'brk: {
                 let contents_dir = *dir;
                 let contents_file = *file;
                 let _trace = perf::trace("Bundler.readFile");
@@ -2326,20 +2338,21 @@ pub mod parse_worker {
         // there); closing it leaves a stale fd for the next in-process build.
         let opened_own_fd =
             matches!(task.contents_or_fd, ContentsOrFd::Fd { file, .. } if !file.is_valid());
-        let will_close_file_descriptor = opened_own_fd
-            && entry.fd.is_valid()
-            && entry.fd.stdio_tag().is_none()
-            && worker_ctx.bun_watcher.is_none();
-        if will_close_file_descriptor {
+        let owns_fd = opened_own_fd && entry.fd.is_valid() && entry.fd.stdio_tag().is_none();
+        if owns_fd && worker_ctx.bun_watcher.is_none() {
             let _ = entry.close_fd();
             task.contents_or_fd = ContentsOrFd::Fd {
                 file: Fd::INVALID,
                 dir: Fd::INVALID,
+                owns_file: false,
             };
         } else if matches!(task.contents_or_fd, ContentsOrFd::Fd { .. }) {
+            // With a watcher, the descriptor stays open and `on_parse_task_complete`
+            // either hands it to the watcher or closes it.
             task.contents_or_fd = ContentsOrFd::Fd {
                 file: entry.fd,
                 dir: Fd::INVALID,
+                owns_file: owns_fd,
             };
         }
         *step = Step::Parse;
@@ -2825,9 +2838,14 @@ pub mod parse_worker {
             // doesn't derive `Copy`, so move it out (task is consumed here).
             external: core::mem::take(&mut this.external_free_function),
             watcher_data: match this.contents_or_fd {
-                ContentsOrFd::Fd { file, dir } => WatcherData {
+                ContentsOrFd::Fd {
+                    file,
+                    dir,
+                    owns_file,
+                } => WatcherData {
                     fd: file,
                     dir_fd: dir,
+                    owns_fd: owns_file,
                 },
                 ContentsOrFd::Contents(_) => WatcherData::NONE,
             },

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4750,6 +4750,7 @@ pub mod bv2_impl {
                                 contents_or_fd: parse_task::ContentsOrFd::Fd {
                                     dir: bun_sys::Fd::INVALID,
                                     file: bun_sys::Fd::INVALID,
+                                    owns_file: false,
                                 },
                                 side_effects: bun_ast::SideEffects::HasSideEffects,
                                 jsx: this
@@ -6905,28 +6906,34 @@ pub mod bv2_impl {
             }
 
             // To minimize contention, watchers are appended on the bundle thread.
-            if this.bun_watcher.is_some() {
-                if parse_result.watcher_data.fd != bun_sys::Fd::INVALID {
-                    let source_index = parse_result.value.source_index();
-                    // borrowck — read the source path before
-                    // `should_add_watcher(&self)` so the column borrow is released.
-                    let source_path = this.graph.input_files.items_source()[source_index as usize]
-                        .path
-                        .text;
-                    if this.should_add_watcher(source_path) {
+            let watcher_data = &parse_result.watcher_data;
+            if this.bun_watcher.is_some() && watcher_data.fd.is_valid() {
+                let source_index = parse_result.value.source_index();
+                // borrowck — read the source path before
+                // `should_add_watcher(&self)` so the column borrow is released.
+                let source_path = this.graph.input_files.items_source()[source_index as usize]
+                    .path
+                    .text;
+                let adopted = this.should_add_watcher(source_path)
+                    && matches!(
                         // const generic `CLONE_FILE_PATH = isWindows`
                         // matches `cfg!(windows)` at compile time.
-                        let _ = this
-                            .bun_watcher_mut()
+                        this.bun_watcher_mut()
                             .unwrap()
                             .add_file::<{ cfg!(windows) }>(
-                                parse_result.watcher_data.fd,
+                                watcher_data.fd,
                                 source_path,
                                 bun_wyhash::hash(source_path) as u32,
-                                parse_result.watcher_data.dir_fd,
+                                watcher_data.dir_fd,
                                 None,
-                            );
-                    }
+                            ),
+                        Ok(bun_watcher::FdOwnership::Watcher)
+                    );
+                // The file is already watched (every re-parse under the dev
+                // server) or excluded from watching: nothing else will close
+                // the descriptor this parse opened.
+                if !adopted && watcher_data.owns_fd {
+                    let _ = bun_sys::close(watcher_data.fd);
                 }
             }
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -423,6 +423,16 @@ pub struct DevServer {
     pub(crate) emit_memory_visualizer_events: u32,
     pub(crate) memory_visualizer_timer: EventLoopTimer,
 
+    /// Perfect incremental bundling would mean the code that bundles, watches
+    /// and rebuilds routes has no bugs, so a route's stored failures are always
+    /// accurate. Since it is not perfect, when this is false a request for a
+    /// route with failures re-bundles everything the route imports before
+    /// showing them (`check_route_failures`). This happens once per route per
+    /// file change (`RouteBundle::rebundled_for_failures`); otherwise a page
+    /// sitting on an error page would rebuild the route on every request.
+    ///
+    /// Disabled in release builds, enabled in debug builds; override with
+    /// `BUN_ASSUME_PERFECT_INCREMENTAL`.
     pub(crate) assume_perfect_incremental_bundling: bool,
 
     /// If true, console logs from the browser will be echoed to the server console.
@@ -2259,6 +2269,9 @@ fn check_route_failures(
     resp: DevResponse,
 ) -> crate::Result<CheckResult> {
     let mut gts = dev.init_graph_trace_state(0)?;
+    // Still holds whatever the last bundle added; the trace below must only
+    // collect the failures this route can reach.
+    dev.incremental_result.failures_added.clear();
     // Note: erase to a raw pointer so the deferred cleanup only fires on
     // scope exit when no other borrow of `dev` is live.
     let dev_ptr = std::ptr::from_mut::<DevServer>(dev);
@@ -2278,8 +2291,11 @@ fn check_route_failures(
         TraceImportGoal::FindErrors,
     )?;
     if !dev.incremental_result.failures_added.is_empty() {
-        // See comment on this field for information
-        if !dev.assume_perfect_incremental_bundling {
+        let assume_perfect_incremental_bundling = dev.assume_perfect_incremental_bundling;
+        let rb = dev.route_bundle_ptr(route_bundle_index);
+        // See `assume_perfect_incremental_bundling`.
+        if !assume_perfect_incremental_bundling && !rb.rebundled_for_failures {
+            rb.rebundled_for_failures = true;
             // Cache bust EVERYTHING reachable
             {
                 let mut it = gts.client_bits.iterator::<true, true>();
@@ -3146,6 +3162,12 @@ impl DevServer {
         debug_assert!(self.current_bundle.is_none());
         debug_assert!(!entry_points.set.is_empty());
         self.log.clear_and_free();
+
+        if had_reload_event {
+            for route_bundle in &mut self.route_bundles {
+                route_bundle.rebundled_for_failures = false;
+            }
+        }
 
         // Notify inspector about bundle start
         if let Some(agent) = self.inspector() {
@@ -5253,6 +5275,7 @@ impl DevServer {
             server_state: route_bundle::State::Unqueued,
             client_bundle: None,
             active_viewers: 0,
+            rebundled_for_failures: false,
         });
         // SAFETY: index_location still valid (route_bundles is a separate field)
         unsafe { *index_location = Some(bundle_index) };

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -157,6 +157,12 @@ pub struct RouteBundle {
     pub(crate) client_bundle: Option<StaticRouteRef>,
     pub(crate) client_script_generation: u32,
     pub(crate) active_viewers: u32,
+    /// A request already re-bundled everything this route imports because
+    /// the route had bundling failures (see
+    /// `DevServer::assume_perfect_incremental_bundling`), and no file has
+    /// changed since. Further requests serve the stored failures instead of
+    /// bundling again; cleared whenever a hot-reload bundle starts.
+    pub(crate) rebundled_for_failures: bool,
 }
 
 impl RouteBundle {

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -279,6 +279,49 @@ export class Dev extends EventEmitter {
     });
   }
 
+  /**
+   * Resolves once the dev server finishes its next bundle, whether it
+   * succeeded or failed. Call this before triggering the bundle.
+   */
+  waitForBundle(): Promise<void> {
+    return new Promise<void>(resolve => {
+      const handle = (kind: WatchSynchronization) => {
+        if (
+          kind === WatchSynchronization.AnyBuildFinished ||
+          kind === WatchSynchronization.AnyBuildFinishedWaitForWebSockets
+        ) {
+          this.off("watch_synchronization", handle);
+          resolve();
+        }
+      };
+      this.on("watch_synchronization", handle);
+    });
+  }
+
+  /**
+   * Returns how many bundles (successful or failed) the dev server finished
+   * while `fn` ran. `dev.write` and friends wait for the bundle they trigger,
+   * so those are counted too.
+   */
+  async countBundles(fn: () => Promise<void>): Promise<number> {
+    let count = 0;
+    const handle = (kind: WatchSynchronization) => {
+      if (
+        kind === WatchSynchronization.AnyBuildFinished ||
+        kind === WatchSynchronization.AnyBuildFinishedWaitForWebSockets
+      ) {
+        count++;
+      }
+    };
+    this.on("watch_synchronization", handle);
+    try {
+      await fn();
+    } finally {
+      this.off("watch_synchronization", handle);
+    }
+    return count;
+  }
+
   async batchChanges(options: { errors?: null | ErrorSpec[]; snapshot?: string } = {}) {
     if (this.batchingChanges) {
       this.batchingChanges.write?.();

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1,5 +1,6 @@
 // Bundle tests are tests concerning bundling bugs that only occur in DevServer.
 import { expect } from "bun:test";
+import { readdirSync, readlinkSync } from "node:fs";
 import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 devTest("import identifier doesnt get renamed", {
@@ -272,6 +273,96 @@ devTest("deleting imported file shows error then recovers", {
     await c.expectNoWebSocketActivity(async () => {
       await dev.delete("unrelated.ts");
     });
+  },
+});
+devTest("requests for a route with build errors do not re-bundle it every time", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { value } from "./other";
+      console.log(value);
+    `,
+    "other.ts": `
+      export const value = 1;
+    `,
+  },
+  async test(dev) {
+    expect((await dev.fetch("/")).status).toBe(200);
+
+    const expectErrorPage = async () => {
+      const response = await dev.fetch("/");
+      expect(await response.text()).toContain("Build Failed");
+      expect(response.status).toBe(500);
+    };
+
+    for (const broken of ["export const value = <<<SYNTAX_ERROR>>>;", "export const value = <<<ANOTHER_ONE>>>;"]) {
+      await dev.write("other.ts", broken);
+
+      // The first request after a file change re-bundles the route once, in
+      // case the incremental build got the failures wrong.
+      const rebundled = dev.waitForBundle();
+      await expectErrorPage();
+      await rebundled;
+
+      // Until another file changes, requests serve the failures that bundle
+      // produced. The fixed server never starts a bundle here, so any count
+      // observed by the time the responses arrive is a regression.
+      expect(
+        await dev.countBundles(async () => {
+          for (let i = 0; i < 5; i++) {
+            await expectErrorPage();
+          }
+        }),
+      ).toBe(0);
+    }
+
+    await dev.write("other.ts", "export const value = 2;");
+    expect((await dev.fetch("/")).status).toBe(200);
+  },
+});
+devTest("re-bundling a watched file does not leak a file descriptor", {
+  // Counts the dev server's descriptors through /proc.
+  skip: ["win32", "darwin"],
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { value } from "./other";
+      console.log(value);
+    `,
+    "other.ts": `
+      export const value = 0;
+    `,
+  },
+  async test(dev) {
+    expect((await dev.fetch("/")).status).toBe(200);
+
+    const other = dev.join("other.ts");
+    const fdDir = `/proc/${dev.devProcess.pid}/fd`;
+    const descriptorsForOther = () => {
+      let count = 0;
+      for (const fd of readdirSync(fdDir)) {
+        let target: string;
+        try {
+          target = readlinkSync(`${fdDir}/${fd}`);
+        } catch {
+          continue;
+        }
+        if (target === other) count++;
+      }
+      return count;
+    };
+
+    // The watcher keeps one descriptor for the file. Each re-bundle opens
+    // another one to read it, which must be closed once the watcher declines it.
+    const before = descriptorsForOther();
+    for (let i = 1; i <= 5; i++) {
+      await dev.write("other.ts", `export const value = ${i};`);
+    }
+    expect(descriptorsForOther()).toBe(before);
   },
 });
 // Regression test: DirectoryWatchStore.Dep.source_file_path borrows the key


### PR DESCRIPTION
### Problem
- While a `bun ./index.html` app (or `Bun.serve({development: true, routes})`) sits on a build error, every request for the page re-bundles everything the route imports: `check_route_failures` (`src/runtime/bake/DevServer.rs`) marks all reachable files stale and returns `Rebuild` whenever failures are reachable, and nothing records that this was already done, so the failed bundle puts the route straight back into the same state for the next request.
- Each of those re-bundles leaks one file descriptor per module, permanently. With a watcher present, `ParseTask` keeps the descriptor it read the file through so the bundle thread can hand it to the watcher, but `on_parse_task_complete` (`src/bundler/bundle_v2.rs`) discarded the `FdOwnership` result of `Watcher::add_file`. For a file that is already watched (every re-parse under the dev server, including a plain hot reload of an already watched file) `add_file` declines the descriptor and nobody closed it.
- Two pipelined requests in that state got no response at all. That is a consequence of the first point: uWS closes a connection when a second pipelined request arrives while the first one is still deferred, and the re-bundle deferred every request.
- Release behaviour only: `assume_perfect_incremental_bundling` defaults to true in debug builds, which is why the bake test harness sets `BUN_ASSUME_PERFECT_INCREMENTAL=0` for every test. The doc comment explaining the field was lost in the port; this restores it.

### Fix
- `RouteBundle::rebundled_for_failures`: `check_route_failures` re-bundles a failing route once and sets the flag; later requests serve the stored failures directly (the same path `BUN_ASSUME_PERFECT_INCREMENTAL=1` takes, so the page is served synchronously and pipelined requests are answered). `start_async_bundle` clears the flag on every route when a hot-reload bundle starts, so each file change allows exactly one more re-bundle per route. This keeps the escape hatch the field documents (a refresh after a save still gets a full re-bundle) without making it fire on every request.
- `check_route_failures` now clears `incremental_result.failures_added` before tracing. It still held the previous bundle's list, and the trace appends to it; without this the first served page after the re-bundle listed every failure twice (verified: 368 byte payload vs 184 with the clear).
- `ContentsOrFd::Fd` / `WatcherData` carry `owns_file` / `owns_fd`, set only when the parse opened the descriptor itself (not when it was borrowed from the resolver's entry cache, which is why the earlier fix in #37050 left this site alone). `on_parse_task_complete` closes an owned descriptor the watcher did not adopt. Behaviour without a watcher is unchanged (the descriptor is still closed right after the read, as before).
- Tests in `test/bake/dev/bundle.test.ts`, both fail against the current release and pass with this change:
  - "requests for a route with build errors do not re-bundle it every time": one bundle after each broken write, then 5 requests with 0 bundles (was 5), twice to cover the flag being cleared by the second write, then recovery. Uses two small harness helpers (`dev.waitForBundle`, `dev.countBundles`) built on the existing watch-synchronization events.
  - "re-bundling a watched file does not leak a file descriptor" (Linux, reads `/proc/<pid>/fd`): 5 hot reloads leave the descriptor count for the file unchanged (was +1 per reload).
- The report's reproduction (100 modules, 200 requests on a broken build) on a debug build with `BUN_ASSUME_PERFECT_INCREMENTAL=0`: fds 117 -> 3207 and 0 pipelined responses before; fds 116 -> 116, 2 bundles total, pipelined pair answered 500 + 500 after.
- `test/bake/dev/*` (bundle, css, html, hot, esm, react-spa, plugins, sourcemap, server-sourcemap), `test/bake/framework-router.test.ts`, `test/bake/deinitialization.test.ts`, `test/bake/dev-and-prod.test.ts`, `test/bundler/{bundler_files,bundler_plugin,bundler_defer,bun-build-api}.test.ts` and `test/cli/watch/watch.test.ts` pass on the debug build; `cargo clippy` is clean for `bun_bundler` and `bun_runtime`.

### Background
- The dev server keeps two incremental graphs (client and server) of every bundled file. A route is served from the graphs; `RouteBundle::server_state` tracks whether the route still needs bundling, and `PossibleBundlingFailures` means "some file somewhere failed, trace this route's imports to find out whether one of them is reachable" (`check_route_failures`).
- Bundling failures are stored per file in `bundling_failures`; `incremental_result.failures_added` is scratch space that a bundle fills while indexing failures and that the `FindErrors` trace also appends to. `send_serialized_failures` renders whatever list it is given into the error page.
- `assume_perfect_incremental_bundling` is the dev server's distrust of its own incremental tracking: when false (release builds), a route with failures is fully re-bundled before its errors are shown, so a bug in incremental invalidation cannot leave a stale error page. The flag added here bounds that to once per file change.
- With a file watcher attached to the bundler, each parse keeps the descriptor it read from and `on_parse_task_complete` hands it to `Watcher::add_file` on the bundle thread (kqueue needs one descriptor per watched file; on Linux the watcher just stores and later closes it). `add_file` returns `FdOwnership::Watcher` when it stored the descriptor and `FdOwnership::Caller` when the file was already in the watchlist, in which case the caller still owns it. The resolver can also cache a descriptor for symlinked files and lend it to the parse, which is the case `owns_file` distinguishes: that descriptor must never be closed here.
- A related note, not changed here: `start_next_bundle_if_present` starts no bundle when the queued routes produce no entry points, but leaves the requests that were deferred to that bundle unanswered and the routes in the `Bundling` state. The synchronous path in `ensure_route_is_bundled` handles that case ("possible with layouts"); the deferred path does not. It is independent of this change, since the re-bundle issued by `check_route_failures` always produces entry points (it marks the route's own files stale).

<details>
<summary>Reproduction used (from the report, Linux)</summary>

```ts
import fs from "node:fs"; import net from "node:net"; import os from "node:os";
const N = 100, d = fs.mkdtempSync(os.tmpdir() + "/e-"); fs.mkdirSync(d + "/m");
fs.writeFileSync(d + "/index.html", `<script type=module src=./app.ts></script>`);
fs.writeFileSync(d + "/app.ts", [...Array(N)].map((_, i) => `import {v${i}} from "./m/m${i}.ts";`).join("\n") + `\nimport {g} from "./lib.ts"; console.log(g,${[...Array(N)].map((_, i) => "v" + i).join("+")});`);
for (let i = 0; i < N; i++) fs.writeFileSync(`${d}/m/m${i}.ts`, `export const v${i}=${i};`);
fs.writeFileSync(d + "/lib.ts", "export const g=1;\n");
// Debug builds need BUN_ASSUME_PERFECT_INCREMENTAL=0 in the child's env to behave like a release build.
const p = Bun.spawn([process.execPath, "./index.html", "--host=127.0.0.1", "--port=0"], { cwd: d, stdout: "pipe" });
let port, acc = ""; for await (const c of p.stdout) { acc += new TextDecoder().decode(c); const m = /127\.0\.0\.1:(\d+)/.exec(acc); if (m) { port = m[1]; break; } }
const fds = () => fs.readdirSync(`/proc/${p.pid}/fd`).length, get = async () => (await fetch(`http://127.0.0.1:${port}/`)).status, sleep = ms => new Promise(r => setTimeout(r, ms));
const pipe2 = () => new Promise(r => { let b = ""; const s = net.connect(+port, "127.0.0.1", () => s.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n".repeat(2))); s.on("data", x => b += x); s.on("close", () => r((b.match(/HTTP\/1.1 \d+/g) || []).length + " responses")); setTimeout(() => s.destroy(), 2000); });
await get(); for (let i = 0; i < 200; i++) await get(); console.log("healthy 200 req: fds", fds(), "| pipelined:", await pipe2());
fs.writeFileSync(d + "/lib.ts", "export const g=1;\n@@@\n"); await sleep(800);
for (let i = 0; i < 200; i++) await get(); console.log("error-state 200 req: fds", fds(), "| pipelined:", await pipe2());
fs.writeFileSync(d + "/lib.ts", "export const g=1;\n"); await sleep(800); console.log("fixed:", await get(), "fds", fds()); p.kill(9);
```

Bun 1.4.0 release: `healthy 200 req: fds 116 | pipelined: 2 responses`, `error-state 200 req: fds 20716 | pipelined: 0 responses`, `fixed: 200 fds 20820`.

This branch (debug build, `BUN_ASSUME_PERFECT_INCREMENTAL=0`, 50 requests): `healthy: fds 116 | 2 responses`, `error-state: fds 116 -> 116 | 2 responses`, `fixed: 200 fds 116`; the build error is printed twice in total (the reload and the single re-bundle) instead of once per request.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.0 (8326d1bd3)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-YUue3k
[0;30mdev|[0m Started development server: http://localhost:42491
[0;30mdev|[0m [32mBundled page in 192ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 62ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 45ms[
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-Kq2jLQ
[0;30mdev|[0m Started development server: http://localhost:34581
[0;30mdev|[0m [32mBundled page in 3ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 2ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 1ms[0m[2m:[0m routes/index.ts
(pass)  DEV:bundle-1: import identifier doesnt get renamed [214.08ms]
[0;30mdev|[0m Started development server: http://localhos
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.0 (8326d1bd3)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-CrJ94B
[0;30mdev|[0m Started development server: http://localhost:36235
[0;30mdev|[0m [32mBundled page in 200ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 70ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 70ms[
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     773bb14b96
  features     baseline

22 deps, 120 codegen, 1174 objects in 843ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1235] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 107 installs across 153 packages (no changes) [27.00ms]
[2/1235] gen ErrorCode+*.h
[3/1235] gen bindgenv2
[4/1235] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [4.00ms]
[5/1235] fetch tinycc
[tinycc] up to date
[6/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[7/1234] fetch zlib
[zlib] up to date
[8/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1234] gen .bind.ts → GeneratedBindings.cpp
[10/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/ParseTask.rs                    | 34 ++++++++---
 src/bundler/bundle_v2.rs                    | 37 +++++++-----
 src/runtime/bake/DevServer.rs               | 27 ++++++++-
 src/runtime/bake/dev_server/route_bundle.rs |  6 ++
 test/bake/bake-harness.ts                   | 43 ++++++++++++++
 test/bake/dev/bundle.test.ts                | 91 +++++++++++++++++++++++++++++
 6 files changed, 213 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/bundler/ParseTask.rs                        11      8      0
src/bundler/bundle_v2.rs                         7      5      0
src/runtime/bake/DevServer.rs                   12      6      0
src/runtime/bake/dev_server/route_bundle.rs      1      1      0
test/bake/bake-harness.ts                        4      1      0
test/bake/dev/bundle.test.ts                     2      4      0
```

</details>

<!-- robobun:evidence:end -->