### PR TITLE
bunx: allow multiple packages in a single temporary execution environment

### DIFF
--- a/docs/pm/bunx.mdx
+++ b/docs/pm/bunx.mdx
@@ -80,6 +80,18 @@ bunx -p renovate renovate-config-validator
 bunx --package @angular/cli ng
 ```
 
+Repeat `--package`/`-p` to install several packages into the same temporary execution environment. This is useful for a toolchain that depends on a pinned set of plugins without adding them to the project's dependencies:
+
+```bash terminal icon="terminal"
+bunx \
+  --package semantic-release@25 \
+  --package @semantic-release/exec@6.0.3 \
+  --package conventional-changelog-conventionalcommits@9 \
+  semantic-release
+```
+
+As with a single `--package`, the binary to run must always be given explicitly. None of the temporary packages become part of the project's `package.json`, lockfile, or `node_modules`.
+
 To force a script to always run with Bun, give it a `bun` shebang.
 
 ```js dist/index.js icon="/icons/javascript.svg"

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -46,8 +46,10 @@ pub struct Options {
     pub(crate) package_name: &'static [u8],
     /// The binary name to run (when using --package)
     pub(crate) binary_name: Option<&'static [u8]>,
-    /// The package to install (when using --package)
-    pub(crate) specified_package: Option<&'static [u8]>,
+    /// The packages to install (when using --package). `--package`/`-p` may
+    /// be repeated to install several packages into the same temporary
+    /// execution environment; empty when `--package` was not passed.
+    pub(crate) specified_packages: Vec<&'static [u8]>,
     // `--silent` and `--verbose` are not mutually exclusive. Both the
     // global CLI parser and `bun add` parser use them for different
     // purposes.
@@ -64,7 +66,7 @@ impl Default for Options {
             passthrough_list: Vec::new(),
             package_name: b"",
             binary_name: None,
-            specified_package: None,
+            specified_packages: Vec::new(),
             verbose_install: false,
             silent_install: false,
             no_install: false,
@@ -129,7 +131,7 @@ impl Options {
                         );
                         Global::exit(1);
                     }
-                    opts.specified_package = Some(argv[i].as_bytes());
+                    opts.specified_packages.push(argv[i].as_bytes());
                 } else if positional.starts_with(b"--package=") {
                     let package_value = &positional[b"--package=".len()..];
                     if package_value.is_empty() {
@@ -139,7 +141,7 @@ impl Options {
                         );
                         Global::exit(1);
                     }
-                    opts.specified_package = Some(package_value);
+                    opts.specified_packages.push(package_value);
                 } else if positional.starts_with(b"-p=") {
                     let package_value = &positional[b"-p=".len()..];
                     if package_value.is_empty() {
@@ -149,7 +151,7 @@ impl Options {
                         );
                         Global::exit(1);
                     }
-                    opts.specified_package = Some(package_value);
+                    opts.specified_packages.push(package_value);
                 }
             } else {
                 if !found_subcommand_name {
@@ -163,7 +165,7 @@ impl Options {
         }
 
         // Handle --package flag case differently
-        if let Some(specified_package) = opts.specified_package {
+        if !opts.specified_packages.is_empty() {
             if let Some(package_name) = maybe_package_name {
                 if package_name.is_empty() {
                     Output::err_generic(
@@ -186,7 +188,12 @@ impl Options {
                 Global::exit(1);
             }
             opts.binary_name = maybe_package_name;
-            opts.package_name = specified_package;
+            // `package_name` keeps its historical meaning of "the first
+            // requested package" — used by single-package-oriented code
+            // below when exactly one `--package` was given.
+            // `specified_packages` is the source of truth for the install
+            // and cache-key logic in every case.
+            opts.package_name = opts.specified_packages[0];
         } else {
             // Normal case: package_name is the first non-flag argument
             if maybe_package_name.is_none() || maybe_package_name.unwrap().is_empty() {
@@ -698,7 +705,7 @@ impl BunxCommand {
         // 1. Install TypeScript
         // 2. Run tsc
         // BUT: Skip this transformation if --package was explicitly specified
-        if opts.specified_package.is_none() {
+        if opts.specified_packages.is_empty() {
             if update_request.name == b"tsc" {
                 update_request.name = b"typescript".as_slice();
             } else if update_request.name == b"claude" {
@@ -1569,7 +1576,7 @@ impl BunxCommand {
             }
         }
 
-        if let (Some(_), Some(binary_name)) = (opts.specified_package, opts.binary_name) {
+        if let (false, Some(binary_name)) = (opts.specified_packages.is_empty(), opts.binary_name) {
             Output::err_generic(
                 "Package <b>{}<r> does not provide a binary named <b>{}<r>",
                 (BStr::new(&update_request.name), BStr::new(binary_name)),

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -12,7 +12,6 @@ use crate::run_command::RunCommand as Run;
 use bun_alloc::AllocError;
 use bun_ast::ExprData;
 use bun_bundler::Transpiler;
-use bun_collections::BoundedArray;
 use bun_core::{self, Global, Output};
 use bun_core::{ZStr, strings};
 use bun_install::dependency::VersionTag;
@@ -1408,36 +1407,35 @@ impl BunxCommand {
             let _ = package_json.write_all(b"{}\n");
         }
 
-        // TODO(next commit): only the first requested package is installed
-        // here — the fixed-size argv below is generalized to every entry in
-        // `install_params` right after this.
-        let install_args: [&[u8]; 4] = [
-            bun_core::self_exe_path()?.as_bytes(),
-            b"add",
-            install_params[0].as_slice(),
-            b"--no-summary",
-        ];
-        let mut args: BoundedArray<&[u8], 8> =
-            BoundedArray::from_slice(&install_args).expect("unreachable"); // upper bound is known
+        // `install_params` holds 1..=N targets (N > 1 only when multiple
+        // `--package` values were given), so the argv can't be a fixed-size
+        // array the way a single-package install could be.
+        let mut args: Vec<&[u8]> = Vec::with_capacity(install_params.len() + 6);
+        args.push(bun_core::self_exe_path()?.as_bytes());
+        args.push(b"add");
+        for p in &install_params {
+            args.push(p.as_slice());
+        }
+        args.push(b"--no-summary");
 
         if do_cache_bust {
             // disable the manifest cache when a tag is specified
             // so that @latest is fetched from the registry
-            args.append(b"--no-cache").expect("unreachable"); // upper bound is known
+            args.push(b"--no-cache");
 
             // forcefully re-install packages in this mode too
-            args.append(b"--force").expect("unreachable"); // upper bound is known
+            args.push(b"--force");
         }
 
         if opts.verbose_install {
-            args.append(b"--verbose").expect("unreachable"); // upper bound is known
+            args.push(b"--verbose");
         }
 
         if opts.silent_install {
-            args.append(b"--silent").expect("unreachable"); // upper bound is known
+            args.push(b"--silent");
         }
 
-        let argv_to_use = args.slice();
+        let argv_to_use = args.as_slice();
 
         bun_output::scoped_log!(
             bunx,

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -686,19 +686,58 @@ impl BunxCommand {
         // `UpdateRequest::parse` immediately below; it is not held across any
         // call that may itself reborrow the same `Log`.
         let ctx_log = unsafe { ctx.log_mut() };
-        let update_requests = UpdateRequest::parse(
-            None,
-            ctx_log,
-            &[opts.package_name],
-            &mut requests_buf,
-            bun_install::Subcommand::Add,
-        );
+        // With one or more `--package` values, every one of them needs its
+        // own install request; otherwise `package_name` (the bare positional)
+        // is the sole request, exactly as before.
+        let update_requests = if opts.specified_packages.is_empty() {
+            UpdateRequest::parse(
+                None,
+                ctx_log,
+                &[opts.package_name],
+                &mut requests_buf,
+                bun_install::Subcommand::Add,
+            )
+        } else {
+            UpdateRequest::parse(
+                None,
+                ctx_log,
+                &opts.specified_packages,
+                &mut requests_buf,
+                bun_install::Subcommand::Add,
+            )
+        };
 
         if update_requests.is_empty() {
             Self::exit_with_usage();
         }
 
-        debug_assert!(update_requests.len() == 1); // One positional cannot parse to multiple requests
+        debug_assert!(
+            // One positional cannot parse to multiple requests; N `--package`
+            // values parse to N requests.
+            update_requests.len()
+                == core::cmp::max(1, opts.specified_packages.len())
+        );
+        // The rest of this function is written against a single "primary"
+        // request — the historical, single-package behavior, still exactly
+        // correct when zero or one `--package` was given. The values that
+        // must reflect *every* requested package when more than one
+        // `--package` was given — the cache key and the install argv — are
+        // computed separately, below, from `update_requests` as a whole.
+        //
+        // Cache freshness also has to look at every request: if any
+        // requested package floats on a dist-tag (e.g. `@latest`), a
+        // previously-cached multi-package install can't be trusted blindly,
+        // so bust the cache and skip straight to a fresh install. Computed
+        // here, before `update_requests[0]` is borrowed mutably below, since
+        // that borrow stays live for the rest of the function. For N <= 1
+        // this reduces to exactly the single-package check it replaces.
+        let mut do_cache_bust = update_requests
+            .iter()
+            .any(|r| r.version.tag == VersionTag::DistTag);
+        let look_for_existing_bin = update_requests
+            .iter()
+            .all(|r| r.version.literal.is_empty() || r.version.tag != VersionTag::DistTag);
+
         let update_request = &mut update_requests[0];
 
         // if you type "tsc" and TypeScript is not installed:
@@ -1011,10 +1050,6 @@ impl BunxCommand {
         }
 
         let passthrough: &[Box<[u8]>] = opts.passthrough_list.as_slice();
-
-        let mut do_cache_bust = update_request.version.tag == VersionTag::DistTag;
-        let look_for_existing_bin = update_request.version.literal.is_empty()
-            || update_request.version.tag != VersionTag::DistTag;
 
         bun_output::scoped_log!(bunx, "try run existing? {}", look_for_existing_bin);
         if look_for_existing_bin {

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1665,7 +1665,7 @@ impl BunxCommand {
         if let (false, Some(binary_name)) = (opts.specified_packages.is_empty(), opts.binary_name) {
             Output::err_generic(
                 "Package <b>{}<r> does not provide a binary named <b>{}<r>",
-                (BStr::new(&update_request.name), BStr::new(binary_name)),
+                (BStr::new(&install_param_display), BStr::new(binary_name)),
             );
             bun_core::prettyln!(
                 "  <d>hint: try running without --package to install and run {} directly<r>",

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -935,6 +935,56 @@ impl BunxCommand {
             BStr::new(result_package_name)
         );
 
+        // With more than one `--package`, every raw specifier becomes its own
+        // `bun add` target — no name@version reconstruction needed, since
+        // `bun add` already parses raw specifiers itself, including
+        // github:/URL forms that don't reduce to a clean name. The cache key
+        // is derived from the same raw specifiers, sorted, so `--package a
+        // --package b` and `--package b --package a` share one cache
+        // directory, then hashed so the key stays short and filesystem-safe
+        // regardless of package name length, scoped-package slashes, or how
+        // many packages were requested. For 0 or 1 `--package` this is
+        // unreachable — the single-package `package_fmt`/`install_param`
+        // computed above are used unchanged.
+        let (package_fmt, install_params): (Vec<u8>, Vec<Vec<u8>>) =
+            if opts.specified_packages.len() <= 1 {
+                (package_fmt, vec![install_param])
+            } else {
+                let params: Vec<Vec<u8>> = opts
+                    .specified_packages
+                    .iter()
+                    .copied()
+                    .map(|p| p.to_vec())
+                    .collect();
+
+                let mut sorted: Vec<&[u8]> = opts.specified_packages.clone();
+                sorted.sort();
+                let mut combined_hash: u64 = 0;
+                for p in sorted.iter().copied() {
+                    combined_hash = combined_hash.wrapping_add(hash(p));
+                }
+                let mut key = Vec::new();
+                write!(&mut key, "multi-{}-{:x}", sorted.len(), combined_hash)
+                    .map_err(|_| crate::Error::Alloc(bun_alloc::AllocError))?;
+
+                (key, params)
+            };
+        bun_output::scoped_log!(bunx, "package_fmt (final): {}", BStr::new(&package_fmt));
+
+        // `install_param` was moved into `install_params` above; log/error
+        // messages further down need a single displayable string covering
+        // every requested package, not just the first.
+        let install_param_display: Vec<u8> = {
+            let mut v = Vec::new();
+            for (i, p) in install_params.iter().enumerate() {
+                if i > 0 {
+                    v.extend_from_slice(b", ");
+                }
+                v.extend_from_slice(p);
+            }
+            v
+        };
+
         let temp_dir = RealFS::platform_temp_dir();
 
         let path_for_bin_dirs: Vec<u8> = 'brk: {
@@ -1358,10 +1408,13 @@ impl BunxCommand {
             let _ = package_json.write_all(b"{}\n");
         }
 
+        // TODO(next commit): only the first requested package is installed
+        // here — the fixed-size argv below is generalized to every entry in
+        // `install_params` right after this.
         let install_args: [&[u8]; 4] = [
             bun_core::self_exe_path()?.as_bytes(),
             b"add",
-            install_param.as_slice(),
+            install_params[0].as_slice(),
             b"--no-summary",
         ];
         let mut args: BoundedArray<&[u8], 8> =
@@ -1436,7 +1489,7 @@ impl BunxCommand {
             Err(err) => {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: bunx failed to install <b>{}<r> due to error <b>{}<r>",
-                    BStr::new(&install_param),
+                    BStr::new(&install_param_display),
                     err.name(),
                 );
                 Global::exit(1);
@@ -1484,7 +1537,7 @@ impl BunxCommand {
             SpawnStatus::Err(err) => {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: bunx failed to install <b>{}<r> due to error:\n{}",
-                    BStr::new(&install_param),
+                    BStr::new(&install_param_display),
                     err,
                 );
                 Global::exit(1);

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -4,7 +4,7 @@ import { mkdir, rm, writeFile } from "fs/promises";
 import { bunEnv, bunExe, isWindows, readdirSorted, tmpdirSync } from "harness";
 import { chmodSync, copyFileSync, readdirSync, symlinkSync } from "node:fs";
 import { tmpdir } from "os";
-import { delimiter, join, resolve } from "path";
+import { basename, delimiter, join, resolve } from "path";
 import { dummyAfterAll, dummyBeforeAll, dummyBeforeEach, dummyRegistry, getPort, setHandler } from "./dummy.registry";
 
 setDefaultTimeout(1000 * 60 * 5);
@@ -563,6 +563,12 @@ describe("--package flag", () => {
     expect(exited).toBe(1);
   });
 
+  it("should error when multiple --package are provided without binary name", async () => {
+    const [err, out, exited] = await run("--package", "pkg-a", "--package", "pkg-b");
+    expect(err).toContain("When using --package, you must specify the binary to run");
+    expect(exited).toBe(1);
+  });
+
   describe("with mock registry", () => {
     let port: number;
 
@@ -836,6 +842,96 @@ console.log("EXECUTED: multi-tool-alt (alternate binary)");
       expect(out).toContain("EXECUTED: multi-tool-alt (alternate binary)");
       expect(out).not.toContain("EXECUTED: multi-tool (main binary)");
       expect(exited).toBe(0);
+    });
+
+    it("should install and run binaries from multiple --package values in the same environment", async () => {
+      const urls: string[] = [];
+
+      // Two distinct packages, each providing its own distinctly-named
+      // binary. Unlike `dummyRegistry` (whose "bin" metadata is the same
+      // for every requested package name), this handler varies the
+      // returned manifest by package name, since each package here has a
+      // different real bin.
+      const packages: Record<string, { bin: string; version: string }> = {
+        "multi-pkg-a": { bin: "bin-a", version: "1.0.0" },
+        "multi-pkg-b": { bin: "bin-b", version: "2.0.0" },
+      };
+
+      const buildDir = tmpdirSync();
+      const tgzDir = tmpdirSync();
+      for (const [name, { bin, version }] of Object.entries(packages)) {
+        const packageDir = join(buildDir, name, "package");
+        await Bun.$`mkdir -p ${packageDir}`;
+        await writeFile(
+          join(packageDir, "package.json"),
+          JSON.stringify({ name, version, bin: { [bin]: "index.js" } }),
+        );
+        await writeFile(join(packageDir, "index.js"), `#!/usr/bin/env node\nconsole.log("EXECUTED: ${bin}");\n`);
+        await Bun.$`chmod +x ${join(packageDir, "index.js")}`;
+        await Bun.$`cd ${join(buildDir, name)} && tar -czf ${join(tgzDir, `${name}-${version}.tgz`)} package`;
+      }
+
+      setHandler(async request => {
+        urls.push(request.url);
+        const pathname = new URL(request.url).pathname;
+        if (pathname.endsWith(".tgz")) {
+          return new Response(Bun.file(join(tgzDir, basename(pathname).toLowerCase())));
+        }
+
+        const name = decodeURIComponent(pathname.slice(1));
+        const info = packages[name];
+        if (!info) {
+          return new Response("not found", { status: 404 });
+        }
+        return new Response(
+          JSON.stringify({
+            name,
+            versions: {
+              [info.version]: {
+                name,
+                version: info.version,
+                bin: { [info.bin]: "index.js" },
+                dist: { tarball: `http://localhost:${port}/${name}-${info.version}.tgz` },
+              },
+            },
+            "dist-tags": { latest: info.version },
+          }),
+        );
+      });
+
+      const run1 = spawn({
+        cmd: [bunExe(), "x", "--package", "multi-pkg-a", "--package", "multi-pkg-b", "bin-a"],
+        cwd: x_dir,
+        stdout: "pipe",
+        stdin: "inherit",
+        stderr: "pipe",
+        env: { ...env, npm_config_registry: `http://localhost:${port}/` },
+      });
+      const [out1, exited1] = await Promise.all([run1.stdout.text(), run1.exited]);
+
+      expect(out1).toContain("EXECUTED: bin-a");
+      expect(exited1).toBe(0);
+      expect(urls.some(u => u.includes("/multi-pkg-a"))).toBe(true);
+      expect(urls.some(u => u.includes("/multi-pkg-b"))).toBe(true);
+
+      // Order independence: `--package b --package a` must resolve to the
+      // same cache directory as `--package a --package b` above, so this
+      // second run — which asks for the *other* package's binary — should
+      // find everything already installed and never touch the registry.
+      urls.length = 0;
+      const run2 = spawn({
+        cmd: [bunExe(), "x", "--package", "multi-pkg-b", "--package", "multi-pkg-a", "bin-b"],
+        cwd: x_dir,
+        stdout: "pipe",
+        stdin: "inherit",
+        stderr: "pipe",
+        env: { ...env, npm_config_registry: `http://localhost:${port}/` },
+      });
+      const [out2, exited2] = await Promise.all([run2.stdout.text(), run2.exited]);
+
+      expect(out2).toContain("EXECUTED: bin-b");
+      expect(exited2).toBe(0);
+      expect(urls).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #39444 — `--package`/`-p` can now be repeated to install several packages into the same temporary `bunx` execution environment, matching `npx --package a --package b cmd`.

- **Parsing**: `specified_package: Option<&[u8]>` becomes `specified_packages: Vec<&[u8]>`; `--package`/`-p`/`--package=`/`-p=` all accumulate instead of overwriting.
- **Install**: every `--package` value is parsed into its own `UpdateRequest` and passed to `bun add` as its own target (raw specifiers, unmodified — `bun add` already parses `name@version`, `github:`, URL forms itself, so no reconstruction needed). The install argv is a `Vec` now instead of a fixed-size `BoundedArray<_, 8>`, since the size is no longer bounded by a small constant.
- **Cache key**: the bunx cache directory name (`bunx-<uid>-<key>`) is derived from the sorted, hashed set of raw `--package` specifiers when more than one is given, so `--package a --package b` and `--package b --package a` share one cache directory. For 0 or 1 `--package` the key is byte-identical to before (existing caches aren't invalidated). The cache-clearing code in `package_manager_command.rs` only matches the `bunx-<uid>-` prefix, so it needed no changes.
- **Cache freshness** (`do_cache_bust`/`look_for_existing_bin`): aggregated across every requested package (any floating dist-tag busts the cache for the whole set) instead of reading only the first request.
- As with a single `--package` (existing behavior, unchanged), the binary to run must always be given explicitly — no bin-guessing is needed across multiple packages, since whichever package provides the named bin is found via the shared cache's `node_modules/.bin`.

Split into 6 commits by concern: CLI parsing → N-request parsing + cache-freshness aggregation → cache-key/install-target aggregation → generalizing the actual install argv → the missing-binary error message → docs/tests.

## Test plan
- `test/cli/install/bunx.test.ts`:
  - CLI validation: multiple `--package` without a trailing binary name still errors, same message as a single `--package`.
  - Functional: two distinct packages (each with its own bin) installed together via `--package a --package b`, binary from the first one runs; then re-run with the `--package` order reversed asking for the *other* binary — asserts zero registry requests, which only holds if the cache key is genuinely order-independent.
- `docs/pm/bunx.mdx`: added a repeated-`--package` example next to the existing single-package one.

**I could not compile or run any of this locally** — same constraint as on a recent PR in this repo: no `bun`, `cargo`, or C++ toolchain available in this environment. I reviewed the Rust changes carefully by hand (borrow-checker implications of computing `do_cache_bust`/`look_for_existing_bin` before `update_requests[0]` is borrowed mutably, the `install_param` → `install_params` move and its downstream display-string uses, `Vec<&[u8]>` lifetime consistency), and independently re-derived the final diff twice (once as a single pass, once reconstructed commit-by-commit) to confirm both produce byte-identical output — but none of it has been checked by actually building. `buildkite/bun` passing is load-bearing here.