### PR TITLE
postgres: encode Date and object parameters correctly with prepare: false

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -64,9 +64,7 @@ type ArrayType =
   | "PG_DATABASE"
   | (string & {});
 export type { ArrayType, SQLArrayParameter, SQLResultArray };
-// Only the tagged-template path unwraps this (adapter.bindParam); the insert/update/in helpers and
-// sql.unsafe bind the object itself. Native binds string-like values as text and JSON-serializes
-// other objects, so this has to look like a string to reach the server as an array literal.
+// Helpers and sql.unsafe bind this object itself (only bindParam unwraps it). Native binds a String object as text.
 class SQLArrayParameter extends PublicString {
   serializedValues: string;
   arrayType: ArrayType;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1,6 +1,7 @@
 import type { Query as QueryType } from "./query";
 
 const PublicArray = globalThis.Array;
+const PublicString = globalThis.String;
 const {
   Query,
   SQLQueryFlags,
@@ -63,10 +64,14 @@ type ArrayType =
   | "PG_DATABASE"
   | (string & {});
 export type { ArrayType, SQLArrayParameter, SQLResultArray };
-class SQLArrayParameter {
+// Only the tagged-template path unwraps this (adapter.bindParam); the insert/update/in helpers and
+// sql.unsafe bind the object itself. Native binds string-like values as text and JSON-serializes
+// other objects, so this has to look like a string to reach the server as an array literal.
+class SQLArrayParameter extends PublicString {
   serializedValues: string;
   arrayType: ArrayType;
   constructor(serializedValues: string, arrayType: ArrayType) {
+    super(serializedValues);
     this.serializedValues = serializedValues;
     this.arrayType = arrayType;
   }

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1,7 +1,6 @@
 import type { Query as QueryType } from "./query";
 
 const PublicArray = globalThis.Array;
-const PublicString = globalThis.String;
 const {
   Query,
   SQLQueryFlags,
@@ -64,12 +63,10 @@ type ArrayType =
   | "PG_DATABASE"
   | (string & {});
 export type { ArrayType, SQLArrayParameter, SQLResultArray };
-// Helpers and sql.unsafe bind this object itself (only bindParam unwraps it). Native binds a String object as text.
-class SQLArrayParameter extends PublicString {
+class SQLArrayParameter {
   serializedValues: string;
   arrayType: ArrayType;
   constructor(serializedValues: string, arrayType: ArrayType) {
-    super(serializedValues);
     this.serializedValues = serializedValues;
     this.arrayType = arrayType;
   }

--- a/src/sql/postgres/types/Tag.rs
+++ b/src/sql/postgres/types/Tag.rs
@@ -179,6 +179,16 @@ pg_tags! {
 }
 
 impl Tag {
+    /// OID 0: Parse left the parameter type unspecified and the server infers it.
+    /// `Signature::generate` declares every non-numeric parameter this way. Bind
+    /// still sees this tag when it is written before the server's
+    /// ParameterDescription arrives, which is always the case for unnamed
+    /// statements (`prepare: false`). Such a parameter is sent as text, and the
+    /// server parses that text as whatever type it inferred.
+    pub fn is_unspecified(self) -> bool {
+        self.0 == 0
+    }
+
     pub fn is_binary_format_supported(self) -> bool {
         match self {
             // TODO: .int2_array, .float8_array,

--- a/src/sql/postgres/types/Tag.rs
+++ b/src/sql/postgres/types/Tag.rs
@@ -179,12 +179,8 @@ pg_tags! {
 }
 
 impl Tag {
-    /// OID 0: Parse left the parameter type unspecified and the server infers it.
-    /// `Signature::generate` declares every non-numeric parameter this way. Bind
-    /// still sees this tag when it is written before the server's
-    /// ParameterDescription arrives, which is always the case for unnamed
-    /// statements (`prepare: false`). Such a parameter is sent as text, and the
-    /// server parses that text as whatever type it inferred.
+    /// Parse declared no type (OID 0), so the server infers one. `Signature::generate` declares
+    /// non-numeric parameters this way, and Bind still sees it on unnamed statements.
     pub fn is_unspecified(self) -> bool {
         self.0 == 0
     }

--- a/src/sql/postgres/types/Tag.rs
+++ b/src/sql/postgres/types/Tag.rs
@@ -179,8 +179,7 @@ pg_tags! {
 }
 
 impl Tag {
-    /// Parse declared no type (OID 0), so the server infers one. `Signature::generate` declares
-    /// non-numeric parameters this way, and Bind still sees it on unnamed statements.
+    /// OID 0 in Parse: the server infers the type. Bind still sees it on unnamed statements.
     pub fn is_unspecified(self) -> bool {
         self.0 == 0
     }

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -169,7 +169,17 @@ pub(crate) fn write_bind<Context: WriterContext>(
             match crate::postgres::types::tag_jsc::from_js(global, value)
                 .map_err(js_error_to_postgres)?
             {
-                types::Tag::json => effective_tag = types::Tag::json,
+                // An object with its own toString() (decimal.js, sql.array(), ...) still binds as
+                // that string. Arrays and plain objects have no text form other than JSON.
+                types::Tag::json => {
+                    if value.is_array()
+                        || !value
+                            .implements_to_string(global)
+                            .map_err(js_error_to_postgres)?
+                    {
+                        effective_tag = types::Tag::json;
+                    }
+                }
                 types::Tag::timestamptz => {
                     let mut buf = [0u8; 64];
                     // An invalid Date has no ISO form and falls through to toString().

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -165,23 +165,16 @@ pub(crate) fn write_bind<Context: WriterContext>(
             tag
         };
 
-        // OID 0 is what Signature::generate declared for every non-numeric
-        // value (the server infers the type). It is still the tag here when
-        // Bind is written before the server's ParameterDescription arrives,
-        // which is always the case on the unnamed-statement (prepare: false)
-        // path. Such parameters are sent in text format either way, so send
-        // the text form of the type Signature inferred instead of the generic
-        // toString() below: the server rejects "[object Object]" for json and
-        // Date.prototype.toString() output for timestamps.
-        if effective_tag == types::Tag(0) {
+        if effective_tag.is_unspecified() {
+            // Send the text form of the type Signature inferred for the value.
+            // The toString() output of the generic arm is not valid json or timestamp input.
             match crate::postgres::types::tag_jsc::from_js(global, value)
                 .map_err(js_error_to_postgres)?
             {
                 types::Tag::json => effective_tag = types::Tag::json,
                 types::Tag::timestamptz => {
                     let mut buf = [0u8; 64];
-                    // None for an invalid Date, which falls through to
-                    // toString() and is rejected by the server.
+                    // An invalid Date has no ISO form and falls through to toString().
                     if let Some(iso) = value.to_iso_string(global, &mut buf) {
                         let l = writer.length()?;
                         writer.write(iso)?;

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -166,8 +166,6 @@ pub(crate) fn write_bind<Context: WriterContext>(
         };
 
         if effective_tag.is_unspecified() {
-            // Send the text form of the type Signature inferred for the value.
-            // The toString() output of the generic arm is not valid json or timestamp input.
             match crate::postgres::types::tag_jsc::from_js(global, value)
                 .map_err(js_error_to_postgres)?
             {

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -169,8 +169,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
             match crate::postgres::types::tag_jsc::from_js(global, value)
                 .map_err(js_error_to_postgres)?
             {
-                // An object with its own toString() (decimal.js, sql.array(), ...) still binds as
-                // that string. Arrays and plain objects have no text form other than JSON.
+                // Objects with their own toString() (decimal.js, sql.array(), ...) keep binding as that string.
                 types::Tag::json => {
                     if value.is_array()
                         || !value

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -202,6 +202,7 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 let l = writer.length()?;
                 writer.write(slice.slice())?;
                 l.write_excluding_self()?;
+
             }
             types::Tag::bool => {
                 let l = writer.length()?;

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -159,11 +159,39 @@ pub(crate) fn write_bind<Context: WriterContext>(
         // for mistakes on our end, such as stripping the timezone
         // differently than what Postgres does when given a timestamp with
         // timezone.
-        let effective_tag = if tag.is_binary_format_supported() && value.is_string() {
+        let mut effective_tag = if tag.is_binary_format_supported() && value.is_string() {
             types::Tag::text
         } else {
             tag
         };
+
+        // OID 0 means Parse told the server to infer this parameter's type
+        // (Signature::generate emits it for every non-numeric value), and it
+        // reaches here whenever Bind is written before the server's
+        // ParameterDescription arrives — the unnamed-statement path
+        // (prepare: false). These parameters are text format, but the generic
+        // toString() arm below would send Date.prototype.toString() output and
+        // "[object Object]", which the server cannot parse. Encode from the JS
+        // type instead: Dates as ISO-8601, objects/arrays as JSON.
+        if effective_tag == types::Tag(0) {
+            if value.is_date() {
+                let mut buf = [0u8; 64];
+                if let Some(iso) = value.to_iso_string(global, &mut buf) {
+                    let l = writer.length()?;
+                    writer.write(iso)?;
+                    l.write_excluding_self()?;
+                    i += 1;
+                    continue;
+                }
+                // Invalid Date: fall through to toString(); the server
+                // rejects it with a descriptive error.
+            } else if crate::postgres::types::tag_jsc::from_js(global, value)
+                .map_err(js_error_to_postgres)?
+                == types::Tag::json
+            {
+                effective_tag = types::Tag::json;
+            }
+        }
         match effective_tag {
             types::Tag::jsonb | types::Tag::json => {
                 // Use jsonStringifyFast for SIMD-optimized serialization

--- a/src/sql_jsc/postgres/PostgresRequest.rs
+++ b/src/sql_jsc/postgres/PostgresRequest.rs
@@ -165,31 +165,32 @@ pub(crate) fn write_bind<Context: WriterContext>(
             tag
         };
 
-        // OID 0 means Parse told the server to infer this parameter's type
-        // (Signature::generate emits it for every non-numeric value), and it
-        // reaches here whenever Bind is written before the server's
-        // ParameterDescription arrives — the unnamed-statement path
-        // (prepare: false). These parameters are text format, but the generic
-        // toString() arm below would send Date.prototype.toString() output and
-        // "[object Object]", which the server cannot parse. Encode from the JS
-        // type instead: Dates as ISO-8601, objects/arrays as JSON.
+        // OID 0 is what Signature::generate declared for every non-numeric
+        // value (the server infers the type). It is still the tag here when
+        // Bind is written before the server's ParameterDescription arrives,
+        // which is always the case on the unnamed-statement (prepare: false)
+        // path. Such parameters are sent in text format either way, so send
+        // the text form of the type Signature inferred instead of the generic
+        // toString() below: the server rejects "[object Object]" for json and
+        // Date.prototype.toString() output for timestamps.
         if effective_tag == types::Tag(0) {
-            if value.is_date() {
-                let mut buf = [0u8; 64];
-                if let Some(iso) = value.to_iso_string(global, &mut buf) {
-                    let l = writer.length()?;
-                    writer.write(iso)?;
-                    l.write_excluding_self()?;
-                    i += 1;
-                    continue;
-                }
-                // Invalid Date: fall through to toString(); the server
-                // rejects it with a descriptive error.
-            } else if crate::postgres::types::tag_jsc::from_js(global, value)
+            match crate::postgres::types::tag_jsc::from_js(global, value)
                 .map_err(js_error_to_postgres)?
-                == types::Tag::json
             {
-                effective_tag = types::Tag::json;
+                types::Tag::json => effective_tag = types::Tag::json,
+                types::Tag::timestamptz => {
+                    let mut buf = [0u8; 64];
+                    // None for an invalid Date, which falls through to
+                    // toString() and is rejected by the server.
+                    if let Some(iso) = value.to_iso_string(global, &mut buf) {
+                        let l = writer.length()?;
+                        writer.write(iso)?;
+                        l.write_excluding_self()?;
+                        i += 1;
+                        continue;
+                    }
+                }
+                _ => {}
             }
         }
         match effective_tag {
@@ -202,7 +203,6 @@ pub(crate) fn write_bind<Context: WriterContext>(
                 let l = writer.length()?;
                 writer.write(slice.slice())?;
                 l.write_excluding_self()?;
-
             }
             types::Tag::bool => {
                 let l = writer.length()?;

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -110,6 +110,28 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
     expect(rows[1].val).toBe("world");
   });
 
+  // https://github.com/oven-sh/bun/issues/39450
+  test("Date and object parameters are encoded the same as with prepare: true", async () => {
+    await container.ready;
+    await using db = new SQL(options());
+
+    const date = new Date("2026-08-17T13:06:14.904Z");
+    const [{ ts }] = await db`SELECT ${date}::timestamptz AS ts`;
+    expect(ts).toEqual(date);
+
+    const [{ j }] = await db`SELECT ${{ a: 1 }}::jsonb AS j`;
+    expect(j).toEqual({ a: 1 });
+
+    const [{ arr }] = await db`SELECT ${[1, 2, 3]}::jsonb AS arr`;
+    expect(arr).toEqual([1, 2, 3]);
+
+    // Same shape as the issue's repro: insert into typed columns via unsafe.
+    await db.unsafe(`CREATE TEMP TABLE prepare_false_encoding (ts timestamptz, j jsonb)`);
+    await db.unsafe(`INSERT INTO prepare_false_encoding (ts, j) VALUES ($1, $2)`, [date, { a: 1 }]);
+    const rows = await db.unsafe(`SELECT ts, j FROM prepare_false_encoding`);
+    expect(rows).toEqual([{ ts: date, j: { a: 1 } }]);
+  });
+
   test("concurrent parameterized queries with high concurrency", async () => {
     await container.ready;
     await using db = new SQL({ ...options(), max: 8 });

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -1,5 +1,5 @@
 import { SQL } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
 
 // Tests for `prepare: false` (unnamed prepared statements).
@@ -110,28 +110,6 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
     expect(rows[1].val).toBe("world");
   });
 
-  // https://github.com/oven-sh/bun/issues/39450
-  test("Date and object parameters are encoded the same as with prepare: true", async () => {
-    await container.ready;
-    await using db = new SQL(options());
-
-    const date = new Date("2026-08-17T13:06:14.904Z");
-    const [{ ts }] = await db`SELECT ${date}::timestamptz AS ts`;
-    expect(ts).toEqual(date);
-
-    const [{ j }] = await db`SELECT ${{ a: 1 }}::jsonb AS j`;
-    expect(j).toEqual({ a: 1 });
-
-    const [{ arr }] = await db`SELECT ${[1, 2, 3]}::jsonb AS arr`;
-    expect(arr).toEqual([1, 2, 3]);
-
-    // Same shape as the issue's repro: insert into typed columns via unsafe.
-    await db.unsafe(`CREATE TEMP TABLE prepare_false_encoding (ts timestamptz, j jsonb)`);
-    await db.unsafe(`INSERT INTO prepare_false_encoding (ts, j) VALUES ($1, $2)`, [date, { a: 1 }]);
-    const rows = await db.unsafe(`SELECT ts, j FROM prepare_false_encoding`);
-    expect(rows).toEqual([{ ts: date, j: { a: 1 } }]);
-  });
-
   test("concurrent parameterized queries with high concurrency", async () => {
     await container.ready;
     await using db = new SQL({ ...options(), max: 8 });
@@ -146,5 +124,104 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
     for (const { expected, actual } of results) {
       expect(actual).toBe(expected);
     }
+  });
+
+  // https://github.com/oven-sh/bun/issues/39450
+  // https://github.com/oven-sh/bun/issues/30221
+  // With unnamed statements Bind is written before the server has described the
+  // parameter types, so every non-numeric parameter is bound with an unknown
+  // type (OID 0). Dates and objects used to go out as toString() output there:
+  // a Date.prototype.toString() string the server rejects for timestamps, and
+  // "[object Object]".
+  describe("Date and object parameters", () => {
+    const date = new Date("2026-08-17T13:06:14.904Z");
+    const obj = { a: 1, b: [null, true], c: "hi" };
+
+    test("Date param binds to timestamptz and timestamp", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      const [row] = await db`SELECT ${date}::timestamptz AS tz, ${date}::timestamp AS naive`;
+      expect(row).toEqual({ tz: date, naive: date });
+    });
+
+    test("invalid Date is rejected by the server", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      const err = await db`SELECT ${new Date(NaN)}::timestamptz AS ts`.catch(e => e);
+      expect(err.message).toBe('invalid input syntax for type timestamp with time zone: "Invalid Date"');
+    });
+
+    test("object param binds to jsonb and json", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      const [row] = await db`SELECT ${obj}::jsonb AS jb, ${obj}::json AS j`;
+      expect(row).toEqual({ jb: obj, j: obj });
+    });
+
+    test("array param binds to jsonb", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      const arr = [1, "two", { three: 3 }];
+      const [{ v }] = await db`SELECT ${arr}::jsonb AS v`;
+      expect(v).toEqual(arr);
+    });
+
+    test("object param bound where the server infers text is JSON text, not [object Object]", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      const [{ v }] = await db`SELECT ${obj}::text AS v`;
+      expect(v).toBe(JSON.stringify(obj));
+    });
+
+    test("Date and object params via sql.unsafe into typed columns", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      await db.unsafe(`CREATE TEMP TABLE prepare_false_unsafe (ts timestamptz, j jsonb)`);
+      await db.unsafe(`INSERT INTO prepare_false_unsafe (ts, j) VALUES ($1, $2)`, [date, obj]);
+      expect(await db.unsafe(`SELECT ts, j FROM prepare_false_unsafe`)).toEqual([{ ts: date, j: obj }]);
+    });
+
+    test("Date and object params via the INSERT helper into typed columns", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      await db`CREATE TEMP TABLE prepare_false_helper (ts timestamptz, j jsonb)`;
+      await db`INSERT INTO prepare_false_helper ${db({ ts: date, j: obj })}`;
+      expect(await db`SELECT ts, j FROM prepare_false_helper`).toEqual([{ ts: date, j: obj }]);
+    });
+
+    test("string params are still bound verbatim", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      const literal = JSON.stringify(obj);
+      const [row] =
+        await db`SELECT ${literal}::text AS t, ${literal}::jsonb AS j, ${date.toISOString()}::timestamptz AS ts`;
+      expect(row).toEqual({ t: literal, j: obj, ts: date });
+    });
+  });
+
+  // The helpers and sql.unsafe hand the sql.array() wrapper itself to native (only the
+  // tagged-template path unwraps it), so it must still bind as text rather than being
+  // JSON-serialized like other objects.
+  describe("sql.array()", () => {
+    test("inside an UPDATE helper still binds as an array literal", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      await db`CREATE TEMP TABLE prepare_false_arr (id SERIAL PRIMARY KEY, name TEXT NOT NULL, roles TEXT[])`;
+      const [{ id }] =
+        await db`INSERT INTO prepare_false_arr (name, roles) VALUES (${"a"}, ${db.array(["a", "b"], "TEXT")}) RETURNING id`;
+      const [row] =
+        await db`UPDATE prepare_false_arr SET ${db({ name: "b", roles: db.array(["c", "d"], "TEXT") })} WHERE id = ${id} RETURNING name, roles`;
+      expect(row).toEqual({ name: "b", roles: ["c", "d"] });
+    });
+
+    test("passed to sql.unsafe still binds as an array literal", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      const param = db.array(["a", "b"], "TEXT");
+      const args = [param];
+      const [{ v }] = await db.unsafe("SELECT $1::TEXT[] AS v", args);
+      expect(v).toEqual(["a", "b"]);
+      expect(args[0]).toBe(param);
+    });
   });
 });

--- a/test/js/sql/sql-prepare-false.test.ts
+++ b/test/js/sql/sql-prepare-false.test.ts
@@ -130,9 +130,10 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
   // https://github.com/oven-sh/bun/issues/30221
   // With unnamed statements Bind is written before the server has described the
   // parameter types, so every non-numeric parameter is bound with an unknown
-  // type (OID 0). Dates and objects used to go out as toString() output there:
-  // a Date.prototype.toString() string the server rejects for timestamps, and
-  // "[object Object]".
+  // type (OID 0) and used to go out as toString() output: a Date.prototype.toString()
+  // string the server rejects for timestamps, and "[object Object]". Dates now go
+  // out as ISO-8601 and arrays and plain objects as JSON. Objects that define their
+  // own toString() keep binding as that string.
   describe("Date and object parameters", () => {
     const date = new Date("2026-08-17T13:06:14.904Z");
     const obj = { a: 1, b: [null, true], c: "hi" };
@@ -166,11 +167,46 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
       expect(v).toEqual(arr);
     });
 
-    test("object param bound where the server infers text is JSON text, not [object Object]", async () => {
+    test("instance of a class without toString() binds as JSON", async () => {
       await container.ready;
       await using db = new SQL(options());
-      const [{ v }] = await db`SELECT ${obj}::text AS v`;
-      expect(v).toBe(JSON.stringify(obj));
+      class Payload {
+        constructor(public a = 1) {}
+      }
+      const [{ v }] = await db`SELECT ${new Payload()}::jsonb AS v`;
+      expect(v).toEqual({ a: 1 });
+    });
+
+    test("object with its own toString() still binds as that string", async () => {
+      await container.ready;
+      await using db = new SQL(options());
+      class Point {
+        toString() {
+          return "(1,2)";
+        }
+      }
+      class Decimal {
+        toString() {
+          return "1.50";
+        }
+        toJSON() {
+          return "1.50";
+        }
+      }
+      const [row] = await db`SELECT ${new Point()}::point AS p, ${new Decimal()}::numeric AS n`;
+      expect(row).toEqual({ p: "(1,2)", n: "1.50" });
+    });
+
+    test("prepare: true still binds objects by the server-reported type", async () => {
+      await container.ready;
+      await using db = new SQL({ ...options(), prepare: true });
+      class Point {
+        toString() {
+          return "(1,2)";
+        }
+      }
+      const [row] = await db`SELECT ${obj}::jsonb AS j, ${obj}::text AS t, ${new Point()}::point AS p`;
+      expect(row).toEqual({ j: obj, t: "[object Object]", p: "(1,2)" });
     });
 
     test("Date and object params via sql.unsafe into typed columns", async () => {
@@ -200,8 +236,8 @@ describeWithContainer("PostgreSQL prepare: false", { image: "postgres_plain" }, 
   });
 
   // The helpers and sql.unsafe hand the sql.array() wrapper itself to native (only the
-  // tagged-template path unwraps it), so it must still bind as text rather than being
-  // JSON-serialized like other objects.
+  // tagged-template path unwraps it). It defines toString(), so it must keep binding as
+  // the array literal instead of being JSON-encoded like a plain object.
   describe("sql.array()", () => {
     test("inside an UPDATE helper still binds as an array literal", async () => {
       await container.ready;


### PR DESCRIPTION
### Problem

- With `prepare: false`, a `Date` parameter fails with `invalid input syntax for type timestamp with time zone: "Mon Aug 17 2026 13:06:14 GMT+0000 (Coordinated Universal Time)"` (#39450).
- With `prepare: false`, a plain object or array parameter is sent as `[object Object]` or `1,2,3`. A json or jsonb target fails with `invalid input syntax for type json` (#30221, #39450).
- The same queries work with the default `prepare: true`.
- Cause: `Signature::generate` (src/sql_jsc/postgres/Signature.rs:84) declares every non-numeric parameter with OID 0. With unnamed statements, `parse_and_bind_and_execute` (src/sql_jsc/postgres/PostgresRequest.rs) writes Parse, Bind and Execute as one batch. Bind is written before the server's ParameterDescription arrives, so the tag in `write_bind` is still 0. OID 0 matches no typed arm, and every value falls into the generic `toString()` arm.

### Fix

- `write_bind`: when the tag is unspecified (`Tag::is_unspecified`, new, OID 0), classify the value with `tag_jsc::from_js`, the function `Signature::generate` used when it declared OID 0. A `Date` is sent as ISO-8601 text. An array, or an object that does not define its own `toString()`, goes through the existing JSON arm. Every other value still goes through `toString()`.
- The `toString()` check is `JSValue::implements_to_string`, which ignores `Object.prototype`. Objects such as decimal.js values, custom geometry types, `Error` and the `sql.array()` wrapper bound as their `toString()` output before this change, and still do. A plain object or a class instance without `toString()` has no text form other than JSON, so JSON is the only encoding that can work for it. A bare array is JSON in Bun's model (`sql.array()` is the way to bind a SQL array).
- This is correct because an OID 0 parameter is sent in text format either way, and the server parses the text as the type it infers. ISO-8601 is valid input for timestamptz, timestamp, date and text. JSON text is valid input for json, jsonb and text. postgres.js serializes a `Date` with `toISOString()` and json values with `JSON.stringify()`.
- The change is gated on OID 0. The server never reports OID 0 in a ParameterDescription, so `prepare: true` binds exactly as before. #33575 (closed in favor of this PR) applied JSON to every non-binary OID instead, which also changes `prepare: true` for objects bound to text or custom type columns. postgres.js sends `'' + x` for an object in a text slot too, so that path is left alone. The `prepare: true` test in this PR pins it.
- Rebased onto main after #40238, which made `bun_core::String` own its WTF ref. The earlier commit that wrapped the json arm's `json_stringify_fast` result in `OwnedString` is no longer needed: the function now returns an owned `String` and the rebase keeps main's form. That was the only conflict.
- Verified with test/js/sql/sql-prepare-false.test.ts. With `src/` at the merge base, 6 of the 20 tests fail with the errors above. With this branch, all 20 pass. The other 14 include the guards for this rule: objects with `toString()`, `sql.array()` through the update helper and through `sql.unsafe`, plain strings, and a `prepare: true` control. The two `sql.array()` guards come from #33575 and fail if the JSON encoding is applied to every object.
- The PostgreSQL suite in test/js/sql/sql.test.ts (853 tests) has the same 17 failures with and without this change on the local server (SQL_ASCII encoding, no md5 or scram users). `reserve connection` is timing based and also fails on main when it runs alone.

### Notes

- Merge order: a JSON encoding that throws (for example `{ id: 1n }`) throws from the middle of the Bind message, and the partial message stays in the write buffer. On 1.4.0 this already happens with `prepare: true` (`TypeError: JSON.stringify cannot serialize BigInt`, then `Connection closed` on the next query). With `prepare: false` such an object used to produce a per-query server error, and with this change it hits the same partial-write path. #34708 (mergeable) and #34732 roll the write buffer back at these call sites. This PR should land after one of them. It does not copy that rollback, to avoid a second version of it.
- Intended `prepare: false` differences from 1.4.0 besides the fixes: a plain object, array or `Date` bound where the server infers text now stores JSON text or the ISO string instead of `[object Object]`, `1,2` or the `Date.prototype.toString()` output. None of this is pinned by a test.
- `tag_jsc::from_js` itself cannot throw here: `Signature::generate` already called it for the same values before anything was written. `json_stringify_fast` and a `toString` getter can, see the first note.
- #33579 (array parameters as array literals) edits the same block. Its array-literal branch is gated on "tag is not json or jsonb", which also matches OID 0. With both changes, that gate has to become "tag is an array OID", or the `prepare: false` array test here breaks.
- #41976 rewrites the same `write_bind` block and also sends a `Date` as ISO 8601 in text format, so the two overlap on the `Date` half of #29010 and will conflict. #41976 does not cover the object half: its JSON arm runs only when the tag is already json or jsonb, so a plain object under `prepare: false` still goes out as `[object Object]` there. If #41976 lands first, this PR reduces to the OID 0 object classification (`tag_jsc::from_js` plus the `implements_to_string` guard) and its tests.

### Background

- The extended query protocol sends a query as Parse, Bind and Execute. Parse declares the parameter types by OID. OID 0 means "infer the type from the query". A Describe makes the server answer with ParameterDescription, the list of types it inferred. Bind sends each value, in text format or in the type's binary format.
- With `prepare: true`, Bun waits for ParameterDescription and binds with the reported types. A `Date` bound to timestamptz goes out in binary, an object bound to jsonb goes out as JSON.
- `prepare: false` uses unnamed statements and sends Parse, Describe, Bind and Execute as one batch. This keeps a pooler such as PgBouncer in transaction mode from splitting them across server connections. The reported types are therefore never available when Bind is written. The only information at that point is the JS value itself.
- `tag_jsc::from_js` (src/sql_jsc/postgres/types/tag_jsc.rs) returns text for string-like values, timestamptz for a `Date`, json for arrays and other indexable objects, and throws for objects it cannot bind (Map, URL, ...).
- `JSValue::implements_to_string` (src/jsc/JSValue.rs) reports whether an object has a callable `toString` on its prototype chain below `Object.prototype`. The shell uses the same check to decide whether an interpolated object is text.

<details>
<summary>Earlier revisions of this PR</summary>

- Revision 1 encoded every object as JSON when the OID was 0.
- Revision 2 folded #33575 into this PR: it made `SQLArrayParameter` extend `String`, because revision 1 JSON-quoted the `sql.array()` wrapper on the helper and `sql.unsafe` paths (`malformed array literal`). It also pinned JSON text for an object bound to a `::text` slot.
- Revision 3 (current) keeps objects with their own `toString()` on the `toString()` path instead. That removes the `String` subclass, removes the regression for decimal and geometry style objects that revisions 1 and 2 had, and drops the `::text` pin. The `sql.array()` guard tests stay.

</details>

Fixes #30221
Fixes #39450

Fixes #29010 (#30221 and #39450 were closed as duplicates of it; all three are the `prepare: false` parameter encoding).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-prepare-false.test.ts
bun test v1.4.1 (4448a2e21)

test/js/sql/sql-prepare-false.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) PostgreSQL prepare: false > basic parameterized query [225.10ms]
(pass) PostgreSQL prepare: false > multiple parameterized queries sequentially [44.13ms]
(pass) PostgreSQL prepare: false > same query repeated with different params [66.69ms]
(pass) PostgreSQL prepare: false > concurrent queries with different tables return correct results [93.94ms]
(pass) PostgreSQL prepare: false > parameterized query with multiple params [23.03ms]
(pass) PostgreSQL prepare: false > query without params still works [21.81ms]
(pass) PostgreSQL prepare: false > transactions with parameterized queries [98.10ms]
(pass) PostgreSQL prepare: false > concurrent parameterized queries with high concurrency [217.04ms]
PostgresError: invalid input syntax for type timestamp with time zone: "Mon Aug 17 2026 13:06:14 GMT+0000 (Coordinated Universal Time)"
    errno: "22007",
 severity: "E
... (truncated)

release without fix: 6 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/sql/sql-prepare-false.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) PostgreSQL prepare: false > basic parameterized query [6.80ms]
(pass) PostgreSQL prepare: false > multiple parameterized queries sequentially [3.13ms]
(pass) PostgreSQL prepare: false > same query repeated with different params [3.25ms]
(pass) PostgreSQL prepare: false > concurrent queries with different tables return correct results [16.11ms]
(pass) PostgreSQL prepare: false > parameterized query with multiple params [3.74ms]
(pass) PostgreSQL prepare: false > query without params still works [2.49ms]
(pass) PostgreSQL prepare: false > transactions with parameterized queries [7.68ms]
(pass) PostgreSQL prepare: false > concurrent parameterized queries with high concurrency [4.45ms]
PostgresError: invalid input syntax for type timestamp with time zone: "Mon Aug 17 2026 13:06:14 GMT+0000 (Coordinated Universal Time)"
    errno: "22007",
 severity: "ERROR",
    where: "unnamed portal parameter $1 = '...'",
     file: "datetime.c",
  routine: "DateTimeParseError",
     code: "ERR_POSTGRES_SERVER_ERROR"

      at wrapPos
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-prepare-false.test.ts
bun test v1.4.1 (4448a2e21)

test/js/sql/sql-prepare-false.test.ts:
Container ready via docker-compose: postgres_plain at 127.0.0.1:5432
(pass) PostgreSQL prepare: false > basic parameterized query [222.25ms]
(pass) PostgreSQL prepare: false > multiple parameterized queries sequentially [46.25ms]
(pass) PostgreSQL prepare: false > same query repeated with different params [64.18ms]
(pass) PostgreSQL prepare: false > concurrent queries with different tables return correct results [89.87ms]
(pass) PostgreSQL prepare: false > parameterized query with multiple params [23.48ms]
(pass) PostgreSQL prepare: false > query without params still works [20.92ms]
(pass) PostgreSQL prepare: false > transactions with parameterized queries [94.96ms]
(pass) PostgreSQL prepare: false > concurrent parameterized queries with high concurrency [219.10ms]
(pass) PostgreSQL prepare: false > Date and object parameters > Date param binds to timestamptz and timestamp [24.77ms]
(pass) PostgreSQL prepare: false > Date and objec
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3545fa5819
  features     baseline

23 deps, 129 codegen, 1172 objects in 712ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [10.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [4.00ms]
[7/1217] fetch tinycc
[tinycc] up to date
[8/1216] gen .bind.ts → GeneratedBindings.cpp
[9/1216] fetch zlib
[zlib] up to date
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/sql/postgres/types/Tag.rs           |   5 ++
 src/sql_jsc/postgres/PostgresRequest.rs |  31 +++++++-
 test/js/sql/sql-prepare-false.test.ts   | 137 +++++++++++++++++++++++++++++++-
 3 files changed, 171 insertions(+), 2 deletions(-)
```

</details>

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/sql/postgres/types/Tag.rs                2      3      0
src/sql_jsc/postgres/PostgresRequest.rs      5      8      0
test/js/sql/sql-prepare-false.test.ts        2      3      0
```

</details>

**root cause** · written by the author bot

With prepare set to false, parameters are sent with unspecified types over the text protocol, and the bind path fell back to generic string conversion, so Date values were stringified via toString() and plain objects were not JSON-serialized, producing text PostgreSQL could not parse. The fix adds a Tag::is_unspecified check and teaches write_bind to encode valid Date values as ISO-8601 text and objects or arrays as JSON when the type is server-inferred, matching the encoding used with prepared statements. Regression tests cover Date, object, array, string, sql.unsafe, the INSERT helper, an…

<!-- robobun:evidence:end -->
