### PR TITLE
Test Uint8Array.prototype.setFromBase64 into a zero-length target

### DIFF
--- a/test/js/bun/jsc/uint8array-base64.test.ts
+++ b/test/js/bun/jsc/uint8array-base64.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "bun:test";
+
+// Uint8Array.prototype.setFromBase64 passes the target's length to FromBase64 as
+// maxLength, and FromBase64 step 3 returns { read: 0, written: 0 } for maxLength 0
+// before looking at the string. So a zero-length target never rejects its input and
+// never reports whitespace as read, no matter which options are in effect.
+// https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64
+
+const lastChunkHandlings = ["loose", "strict", "stop-before-partial"] as const;
+const alphabets = ["base64", "base64url"] as const;
+
+const inputs = [
+  "!!!",
+  "#",
+  "a#",
+  "aa#",
+  "aaa#",
+  "aaaa#",
+  "Q", // partial chunk of one character: a SyntaxError even in loose mode once there is room
+  "QQ",
+  "QQ=",
+  "QQ===", // too much padding
+  "Q===",
+  "QQ==!!!", // garbage after a complete chunk
+  "QUJD", // valid, but nowhere to put it
+  " ",
+  "  ",
+  " QUJD ",
+  "\tQQ==\n",
+  "+/", // only valid in the base64 alphabet
+  "-_", // only valid in the base64url alphabet
+  "\u00a0", // non-ASCII whitespace is not whitespace to base64
+  "\u2212==",
+  "\uff21\uff21", // 16-bit string
+].map(input => [input.replace(/[^\x21-\x7e]/g, c => `\\u${c.charCodeAt(0).toString(16).padStart(4, "0")}`), input]);
+
+function zeroLengthTargets() {
+  const buffer = new Uint8Array([1, 2, 3, 4]);
+
+  const resizable = new ArrayBuffer(4, { maxByteLength: 8 });
+  const lengthTracking = new Uint8Array(resizable);
+  resizable.resize(0);
+
+  const grown = new ArrayBuffer(2, { maxByteLength: 8 });
+  const fixedAtOldEnd = new Uint8Array(grown, 2, 0);
+  grown.resize(8);
+
+  return {
+    "new Uint8Array(0)": new Uint8Array(0),
+    "zero-length subarray": buffer.subarray(2, 2),
+    "length-tracking view of a buffer resized to 0": lengthTracking,
+    "fixed zero-length view of a grown buffer": fixedAtOldEnd,
+    buffer,
+  };
+}
+
+describe("Uint8Array.prototype.setFromBase64 into a zero-length target", () => {
+  test.each(inputs)('"%s" is not parsed', (_, input) => {
+    const { buffer, ...views } = zeroLengthTargets();
+
+    for (const [name, view] of Object.entries(views)) {
+      expect(view.setFromBase64(input), name).toEqual({ read: 0, written: 0 });
+      for (const alphabet of alphabets) {
+        for (const lastChunkHandling of lastChunkHandlings) {
+          const options = { alphabet, lastChunkHandling };
+          expect(view.setFromBase64(input, options), `${name} ${alphabet} ${lastChunkHandling}`).toEqual({
+            read: 0,
+            written: 0,
+          });
+        }
+      }
+    }
+
+    expect(Array.from(buffer)).toEqual([1, 2, 3, 4]);
+  });
+
+  test("the result is a fresh ordinary object with read before written", () => {
+    const target = new Uint8Array(0);
+    const first = target.setFromBase64("!!!");
+    const second = target.setFromBase64("!!!");
+    expect(first).not.toBe(second);
+    expect(Object.getPrototypeOf(first)).toBe(Object.prototype);
+    expect(Object.keys(first)).toEqual(["read", "written"]);
+  });
+
+  test("the argument and option checks that precede FromBase64 still run", () => {
+    const target = new Uint8Array(0);
+
+    for (const notAString of [undefined, null, 42, {}, [], Object("!!!")]) {
+      expect(() => target.setFromBase64(notAString as any), String(notAString)).toThrow(TypeError);
+    }
+    for (const notAnObject of [null, false, 42, "!!!"]) {
+      expect(() => target.setFromBase64("!!!", notAnObject as any), String(notAnObject)).toThrow(TypeError);
+    }
+    for (const alphabet of [null, 42, "hex", Object("base64")]) {
+      expect(() => target.setFromBase64("!!!", { alphabet: alphabet as any }), String(alphabet)).toThrow(TypeError);
+    }
+    for (const lastChunkHandling of [null, 42, "lenient", Object("loose")]) {
+      const options = { lastChunkHandling: lastChunkHandling as any };
+      expect(() => target.setFromBase64("!!!", options), String(lastChunkHandling)).toThrow(TypeError);
+    }
+
+    const calls: string[] = [];
+    const options = {
+      get alphabet() {
+        calls.push("alphabet");
+        return "base64url" as const;
+      },
+      get lastChunkHandling() {
+        calls.push("lastChunkHandling");
+        return "strict" as const;
+      },
+    };
+    expect(target.setFromBase64("!!!", options)).toEqual({ read: 0, written: 0 });
+    expect(calls).toEqual(["alphabet", "lastChunkHandling"]);
+
+    class GetterError extends Error {}
+    expect(() =>
+      target.setFromBase64("!!!", {
+        get alphabet(): "base64" {
+          throw new GetterError();
+        },
+      }),
+    ).toThrow(GetterError);
+  });
+
+  test("a detached or out-of-bounds zero-length target is still a TypeError", () => {
+    const detached = new Uint8Array(0);
+    detached.buffer.transfer();
+    expect(() => detached.setFromBase64("!!!")).toThrow(TypeError);
+    expect(() => detached.setFromBase64("")).toThrow(TypeError);
+
+    const detachedByGetter = new Uint8Array(0);
+    expect(() =>
+      detachedByGetter.setFromBase64("!!!", {
+        get lastChunkHandling() {
+          detachedByGetter.buffer.transfer();
+          return undefined;
+        },
+      }),
+    ).toThrow(TypeError);
+
+    const resizable = new ArrayBuffer(4, { maxByteLength: 8 });
+    const outOfBounds = new Uint8Array(resizable, 4, 0);
+    resizable.resize(2);
+    expect(() => outOfBounds.setFromBase64("!!!")).toThrow(TypeError);
+  });
+
+  test("a target with room still parses the string", () => {
+    expect(() => new Uint8Array(1).setFromBase64("!!!")).toThrow(SyntaxError);
+    expect(() => new Uint8Array(1).setFromBase64("Q", { lastChunkHandling: "strict" })).toThrow(SyntaxError);
+    expect(() => new Uint8Array(1).setFromBase64("QQ==!!!")).toThrow(SyntaxError);
+    expect(new Uint8Array(1).setFromBase64("  ")).toEqual({ read: 2, written: 0 });
+
+    const target = new Uint8Array(1);
+    expect(target.setFromBase64("/w==")).toEqual({ read: 4, written: 1 });
+    expect(target[0]).toBe(255);
+
+    const resizable = new ArrayBuffer(0, { maxByteLength: 8 });
+    const lengthTracking = new Uint8Array(resizable);
+    expect(lengthTracking.setFromBase64("!!!")).toEqual({ read: 0, written: 0 });
+    resizable.resize(1);
+    expect(() => lengthTracking.setFromBase64("!!!")).toThrow(SyntaxError);
+    expect(lengthTracking.setFromBase64("/w==")).toEqual({ read: 4, written: 1 });
+    expect(lengthTracking[0]).toBe(255);
+  });
+
+  test("Uint8Array.fromBase64 has no maxLength and still rejects unparseable input", () => {
+    for (const input of ["!!!", "#", "Q", "=", "Q#"]) {
+      expect(() => Uint8Array.fromBase64(input), input).toThrow(SyntaxError);
+    }
+    expect(Uint8Array.fromBase64("")).toEqual(new Uint8Array(0));
+    expect(Uint8Array.fromBase64("  ")).toEqual(new Uint8Array(0));
+    expect(Uint8Array.fromBase64("/w==")).toEqual(new Uint8Array([255]));
+  });
+});
+
+describe("Uint8Array.prototype.setFromHex", () => {
+  test("reports read and written in that order", () => {
+    const target = new Uint8Array(2);
+    const result = target.setFromHex("ff00");
+    expect(Object.keys(result)).toEqual(["read", "written"]);
+    expect(result).toEqual({ read: 4, written: 2 });
+    expect(Array.from(target)).toEqual([255, 0]);
+    expect(new Uint8Array(1).setFromHex("ff00")).toEqual({ read: 2, written: 1 });
+  });
+
+  test("a zero-length target skips the digits but not the odd-length check", () => {
+    // FromHex rejects an odd length before it looks at maxLength, so unlike
+    // setFromBase64 this one still throws for a zero-length target.
+    expect(new Uint8Array(0).setFromHex("zz")).toEqual({ read: 0, written: 0 });
+    expect(new Uint8Array(0).setFromHex("")).toEqual({ read: 0, written: 0 });
+    expect(() => new Uint8Array(0).setFromHex("z")).toThrow(SyntaxError);
+    expect(() => new Uint8Array(1).setFromHex("zz")).toThrow(SyntaxError);
+  });
+});


### PR DESCRIPTION
Adds the `bun:test` coverage for `Uint8Array.prototype.setFromBase64` into a zero-length target. The engine fix itself is already on `main` since #40276 (upstream WebKit `b1701b348908`, "[JSC] Check maxLength == 0 when specified in fromBase64"), so this PR is test-only.

### Problem

- `Uint8Array.prototype.setFromBase64` into a zero-length target used to parse the string. Found by a fuzz differential against node (every one of the 183 mismatches had a zero-length target; targets of 1 byte and up matched node everywhere):

  ```js
  new Uint8Array(0).setFromBase64('!!!')                                 // Bun 1.4.0: SyntaxError               node 26: { read: 0, written: 0 }
  new Uint8Array(0).setFromBase64('Q', { lastChunkHandling: 'strict' })  // Bun 1.4.0: SyntaxError               node 26: { read: 0, written: 0 }
  new Uint8Array(0).setFromBase64('  ')                                  // Bun 1.4.0: { read: 2, written: 0 }   node 26: { read: 0, written: 0 }
  ```

  node has it right: `setFromBase64` passes the target's length to FromBase64 as maxLength, and FromBase64 step 3 returns `{ read: 0, written: 0 }` for maxLength 0 before looking at the string. test262 covers it in `setFromBase64/trailing-garbage-empty.js`.
- Cause: JavaScriptCore handed the empty output span to `WTF::fromBase64`, and simdutf's `base64_to_binary_safe` validates the input even when there is nowhere to write. `setFromHex` was never affected (FromHex checks the odd-length case before maxLength), and no Bun source is involved: these methods are the engine's.

### Fix

- No Bun source change. Upstream WebKit `b1701b348908` adds an `OutputSizeIsMaxLength` argument to `WTF::fromBase64` and returns `{ 0, 0 }` for an empty output when it is set; `setFromBase64` passes `Yes`, `Uint8Array.fromBase64` (no maxLength) passes `No` and still rejects `"!"`. That commit is part of the `8c4fd56347` upgrade that #40276 pinned (`cb61607f1a`). The fork-side fix this PR originally pinned as a preview, oven-sh/WebKit#459, is closed as superseded.
- Test: `test/js/bun/jsc/uint8array-base64.test.ts`. 22 inputs (garbage, partial chunks, bad and excess padding, garbage after a complete chunk, whitespace-only, the other alphabet's characters, non-ASCII and 16-bit strings) against four zero-length targets (`new Uint8Array(0)`, a zero-length `subarray` inside a buffer whose bytes must stay untouched, a length-tracking view of a buffer resized to 0, a fixed zero-length view of a buffer that has since grown), each with no options and with all six `alphabet` x `lastChunkHandling` combinations; the result object's shape; the checks that still have to happen on a zero-length target (non-string argument, non-object options, bad option values, getter order, a throwing getter, detached before the call and from inside a getter, a zero-length view that went out of bounds); that a 1-byte target and a length-tracking view grown to 1 byte parse the string again; that `Uint8Array.fromBase64` still throws; and `setFromHex`'s result object.
- Results: on the 1.4.0 release engine the file fails 21 of its 29 tests (`USE_SYSTEM_BUN=1`; the 8 that pass are the detached, `fromBase64`, `setFromHex` tests and the four complete-chunk inputs, which simdutf already reported as `read: 0`). On `main`'s pin all 29 pass with `bun bd test` (debug ASAN build), a 54-cell comparison of `setFromBase64` results against node 26 (zero-length and exactly-full targets, every `lastChunkHandling`) has no differences (11 on 1.4.0, all zero-length), and test262's `trailing-garbage-empty.js` passes along with the ten other `setFromBase64` test262 files.
- Not covered on purpose: test262's sibling `trailing-garbage.js` (a 3-byte target and `"aaaa#"`: the spec stops after the chunk that fills the target, simdutf goes on and rejects the `#`). node 26 throws there too, so Bun keeps matching node; that one would be a simdutf change.

### Background

- FromBase64 is the spec operation behind both `Uint8Array.fromBase64` (no maxLength) and `setFromBase64` (maxLength = target length). It reports how many characters it consumed (`read`) and the decoded bytes (`written`); a too-small target decodes until it runs out of room, and step 3 makes a zero-length target a special case that never starts, so it cannot fail on the input.
- `test/js/bun/jsc/` holds the tests that pin engine-level behavior Bun depends on; neither repo's CI runs JSTests, so this file is the CI guard for the behavior across future engine bumps. `webkit-upgrade-8c4fd56347.test.ts` in the same directory already carries a three-assertion smoke check for this commit; this file is the full matrix behind it.

<details><summary>Notes</summary>

Earlier shape of this PR: it pinned preview builds of oven-sh/WebKit#459, a fork-side fix that returned early in `uint8ArrayPrototypeSetFromBase64` after the detached check (same semantics, different layer). That preview was re-based five times as `main` moved its pin (`c6cfe90c60`, `eeab04040f`, `0f966e81b7`, `b7f217b4a6`, `aea1f010b6`, `c148a12dd8`), with the same test results each time. #40276 brought in upstream's own fix, so the pin change was dropped and #459 closed. The same stress test from #459 (`JSTests/stress/uint8array-setFromBase64-empty-target.js`) also passes on `main`'s engine.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 6 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/uint8array-base64.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/bun/jsc/uint8array-base64.test.ts"
bun test v1.4.1 (861e9ae04)

test/js/bun/jsc/uint8array-base64.test.ts:
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "!!!" is not parsed [48.48ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "#" is not parsed [11.76ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "a#" is not parsed [10.39ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "aa#" is not parsed [10.33ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "aaa#" is not parsed [10.93ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "aaaa#" is not parsed [11.28ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "Q" is not parsed [11.13ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "QQ" is not parsed [10.84ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "QQ=" is not parsed [11.67ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "QQ===" is not parsed [9.44ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "Q===" is not parsed [9.55ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "QQ==!!!" is not parsed [9.56ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "QUJD" is not parsed [9.11ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "\u0020" is not parsed [9.12ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "\u0020\u0020" is not parsed [9.74ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "\u0020QUJD\u0020" is not parsed [9.75ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-length target > "\u0009QQ==\u000a" is not parsed [9.19ms]
(pass) Uint8Array.prototype.setFromBase64 into a zero-leng
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/jsc/uint8array-base64.test.ts | 196 ++++++++++++++++++++++++++++++
 1 file changed, 196 insertions(+)
```

</details>

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
test/js/bun/jsc/uint8array-base64.test.ts      0      4      0
```

</details>

<!-- robobun:evidence:end -->
