### PR TITLE
sql: support AbortSignal in reserve() so a pending reservation can be cancelled

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1002,6 +1002,13 @@ try {
 } // Automatically released
 ```
 
+When every connection is busy, `reserve()` waits until one frees up. Pass an `AbortSignal` to stop waiting: the promise rejects with `signal.reason` and no connection is taken from the pool. Aborting after the promise resolved has no effect, so a connection you received must still be released.
+
+```ts
+// Give up if no connection frees up within 5 seconds
+using reserved = await sql.reserve({ signal: AbortSignal.timeout(5000) });
+```
+
 ---
 
 ## LISTEN / NOTIFY (PostgreSQL)

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -92,8 +92,12 @@ declare module "bun" {
      * Inside a transaction, `reserve()` returns a brand new connection, not
      * one related to the transaction. This matches the behaviour of the
      * `postgres` package.
+     *
+     * @param options `signal` aborts the reservation while it is still
+     * waiting for a connection; the returned promise rejects with
+     * `signal.reason` and no connection is taken from the pool.
      */
-    reserve(): Promise<ReservedSQL>;
+    reserve(options?: { signal?: AbortSignal }): Promise<ReservedSQL>;
   }
 
   namespace SQL {
@@ -720,6 +724,12 @@ declare module "bun" {
      * Calling `reserve()` on a reserved client returns a new reserved
      * connection, not the same one (behavior matches the `postgres` package).
      *
+     * @param options `signal` aborts the reservation while it is still
+     * waiting for a connection; the returned promise rejects with
+     * `signal.reason` and no connection is taken from the pool. Aborting
+     * after the promise resolved has no effect: the caller owns the
+     * connection and must `release()` it.
+     *
      * @throws {Error} If the adapter does not support connection pooling (e.g., SQLite)
      *
      * @example
@@ -740,9 +750,12 @@ declare module "bun" {
      * // so `using` releases the connection at the end of the scope
      * using reserved = await sql.reserve()
      * await reserved`select * from users`
+     *
+     * // Give up on the reservation if no connection frees up in time
+     * const reserved = await sql.reserve({ signal: AbortSignal.timeout(5000) });
      * ```
      */
-    reserve(): Promise<ReservedSQL>;
+    reserve(options?: { signal?: AbortSignal }): Promise<ReservedSQL>;
 
     /**
      * Creates a SQL array parameter

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -10,6 +10,7 @@ const { SQLiteAdapter } = require("internal/sql/sqlite");
 const { SQLHelper, parseOptions } = require("internal/sql/shared");
 
 const { SQLError, PostgresError, SQLiteError, MySQLError } = require("internal/sql/errors");
+const { validateAbortSignal } = require("internal/validators");
 
 const defineProperties = Object.defineProperties;
 
@@ -352,7 +353,7 @@ const SQL: typeof Bun.SQL = function SQL(
 
     // reserve is allowed to be called inside reserved connection but will return a new reserved connection from the pool
     // this matchs the behavior of the postgres package
-    reserved_sql.reserve = () => sql.reserve();
+    reserved_sql.reserve = (options?: { signal?: AbortSignal }) => sql.reserve(options);
     reserved_sql.array = sql.array;
     reserved_sql.listen = listen;
     reserved_sql.notify = makeNotify(reserved_sql);
@@ -629,7 +630,7 @@ const SQL: typeof Bun.SQL = function SQL(
     };
     // reserve is allowed to be called inside transaction connection but will return a new reserved connection from the pool and will not be part of the transaction
     // this matchs the behavior of the postgres package
-    transaction_sql.reserve = () => sql.reserve();
+    transaction_sql.reserve = (options?: { signal?: AbortSignal }) => sql.reserve(options);
     transaction_sql.array = sql.array;
     transaction_sql.listen = listen;
     transaction_sql.notify = makeNotify(transaction_sql);
@@ -859,7 +860,7 @@ const SQL: typeof Bun.SQL = function SQL(
       });
   };
 
-  sql.reserve = () => {
+  sql.reserve = (options?: { signal?: AbortSignal }) => {
     if (pool.closed) {
       return Promise.$reject(pool.connectionClosedError());
     }
@@ -869,9 +870,39 @@ const SQL: typeof Bun.SQL = function SQL(
       return Promise.$reject(new Error("This adapter doesn't support connection reservation"));
     }
 
+    const signal = options?.signal;
+    if (signal !== undefined) {
+      try {
+        validateAbortSignal(signal, "options.signal");
+      } catch (err) {
+        return Promise.$reject(err);
+      }
+      if (signal.aborted) {
+        return Promise.$reject(signal.reason);
+      }
+    }
+
     // Try to reserve a connection - adapters that support it will handle appropriately
     const promiseWithResolvers = Promise.withResolvers();
-    pool.connect(onReserveConnected.bind(promiseWithResolvers), true);
+    if (signal === undefined) {
+      pool.connect(onReserveConnected.bind(promiseWithResolvers), true);
+      return promiseWithResolvers.promise;
+    }
+
+    const boundOnReserveConnected = onReserveConnected.bind(promiseWithResolvers);
+    const onConnected = (err: Error | null, pooledConnection) => {
+      signal.removeEventListener("abort", onAbort);
+      boundOnReserveConnected(err, pooledConnection);
+    };
+    const onAbort = () => {
+      // Once the callback left the queue a connection was handed out; the
+      // caller owns it and must release() it, so abort becomes a no-op.
+      if (pool.cancelReserve && pool.cancelReserve(onConnected)) {
+        promiseWithResolvers.reject(signal.reason);
+      }
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    pool.connect(onConnected, true);
     return promiseWithResolvers.promise;
   };
 

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -919,6 +919,12 @@ const SQL: typeof Bun.SQL = function SQL(
     // stopImmediatePropagation() must not starve the cancellation.
     signal.addEventListener("abort", state.onAbort, resistStopPropagation({ __proto__: null, once: true }));
     pool.connect(state.onConnected, true);
+    // connect() can run user code synchronously (e.g. a function-valued
+    // password) before queueing the callback; an abort from inside that window
+    // finds nothing to cancel, so re-check. onReserveAbort is idempotent.
+    if (signal.aborted) {
+      onReserveAbort.$call(state);
+    }
     return promiseWithResolvers.promise;
   };
 

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -11,6 +11,7 @@ const { SQLHelper, parseOptions } = require("internal/sql/shared");
 
 const { SQLError, PostgresError, SQLiteError, MySQLError } = require("internal/sql/errors");
 const { validateAbortSignal } = require("internal/validators");
+const { resistStopPropagation } = require("internal/shared");
 
 const defineProperties = Object.defineProperties;
 
@@ -914,7 +915,9 @@ const SQL: typeof Bun.SQL = function SQL(
     const state: ReserveAbortState = { signal, promiseWithResolvers, onConnected: null, onAbort: null };
     state.onConnected = onReserveConnectedWithSignal.bind(state);
     state.onAbort = onReserveAbort.bind(state);
-    signal.addEventListener("abort", state.onAbort, { once: true });
+    // resistStopPropagation: a user listener on the same signal calling
+    // stopImmediatePropagation() must not starve the cancellation.
+    signal.addEventListener("abort", state.onAbort, resistStopPropagation({ __proto__: null, once: true }));
     pool.connect(state.onConnected, true);
     return promiseWithResolvers.promise;
   };

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -28,6 +28,15 @@ interface TransactionState {
   queries: Set<Query<any, any>>;
 }
 
+/// Bound as `this` to both callbacks of a reserve({ signal }) call, so each can
+/// reach the other without a per-call closure.
+interface ReserveAbortState {
+  signal: AbortSignal;
+  promiseWithResolvers: { promise: Promise<any>; resolve: (value: any) => void; reject: (reason?: any) => void };
+  onConnected: ((err: Error | null, pooledConnection: any) => void) | null;
+  onAbort: (() => void) | null;
+}
+
 function adapterFromOptions(options: Bun.SQL.__internal.DefinedOptions) {
   switch (options.adapter) {
     case "postgres":
@@ -492,6 +501,19 @@ const SQL: typeof Bun.SQL = function SQL(
     reserved_sql.end = reserved_sql.close;
     resolve(reserved_sql);
   }
+
+  function onReserveConnectedWithSignal(this: ReserveAbortState, err: Error | null, pooledConnection) {
+    this.signal.removeEventListener("abort", this.onAbort!);
+    onReserveConnected.$call(this.promiseWithResolvers, err, pooledConnection);
+  }
+
+  function onReserveAbort(this: ReserveAbortState) {
+    // Once the callback left the queue a connection was handed out; the
+    // caller owns it and must release() it, so abort becomes a no-op.
+    if (pool.cancelReserve && pool.cancelReserve(this.onConnected!)) {
+      this.promiseWithResolvers.reject(this.signal.reason);
+    }
+  }
   async function onTransactionConnected(
     callback,
     options,
@@ -889,20 +911,11 @@ const SQL: typeof Bun.SQL = function SQL(
       return promiseWithResolvers.promise;
     }
 
-    const boundOnReserveConnected = onReserveConnected.bind(promiseWithResolvers);
-    const onConnected = (err: Error | null, pooledConnection) => {
-      signal.removeEventListener("abort", onAbort);
-      boundOnReserveConnected(err, pooledConnection);
-    };
-    const onAbort = () => {
-      // Once the callback left the queue a connection was handed out; the
-      // caller owns it and must release() it, so abort becomes a no-op.
-      if (pool.cancelReserve && pool.cancelReserve(onConnected)) {
-        promiseWithResolvers.reject(signal.reason);
-      }
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
-    pool.connect(onConnected, true);
+    const state: ReserveAbortState = { signal, promiseWithResolvers, onConnected: null, onAbort: null };
+    state.onConnected = onReserveConnectedWithSignal.bind(state);
+    state.onAbort = onReserveAbort.bind(state);
+    signal.addEventListener("abort", state.onAbort, { once: true });
+    pool.connect(state.onConnected, true);
     return promiseWithResolvers.promise;
   };
 

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1005,6 +1005,11 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
       return false;
     }
     this.reservedQueue.splice(index, 1);
+    // the cancelled reservation may have been the last pending work; a
+    // graceful close() is waiting on this callback
+    if (this.onAllQueriesFinished && !this.hasPendingQueries()) {
+      this.onAllQueriesFinished();
+    }
     return true;
   }
 

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -996,6 +996,18 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
     return true;
   }
 
+  /// Removes a pending reserve callback that is still waiting for a
+  /// connection. Returns false when the callback already ran (the caller owns
+  /// a connection and must release() it) or was never queued.
+  cancelReserve(onConnected: (err: Error | null, result: any) => void): boolean {
+    const index = this.reservedQueue.indexOf(onConnected);
+    if (index === -1) {
+      return false;
+    }
+    this.reservedQueue.splice(index, 1);
+    return true;
+  }
+
   getConnectionForQuery(pooledConnection: PooledConnection) {
     return pooledConnection.connection;
   }
@@ -2158,6 +2170,7 @@ export interface DatabaseAdapter<Connection, ConnectionHandle, QueryHandle> {
   get closed(): boolean;
 
   supportsReservedConnections?(): boolean;
+  cancelReserve?(onConnected: OnConnected<Connection>): boolean;
   getConnectionForQuery?(pooledConnection: Connection): ConnectionHandle | null;
   attachConnectionCloseHandler?(connection: Connection, handler: () => void): void;
   detachConnectionCloseHandler?(connection: Connection, handler: () => void): void;

--- a/test/js/sql/sql-reserve-abort.test.ts
+++ b/test/js/sql/sql-reserve-abort.test.ts
@@ -1,0 +1,85 @@
+// sql.reserve({ signal }): a caller waiting for a connection can give up.
+// Without cancellation, a reserve() whose promise is abandoned (for example
+// the loser of a Promise.race timeout) still receives a connection once one
+// frees up; nobody releases it, so the pool permanently shrinks and
+// sql.end() never resolves (issue #39451).
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer } from "harness";
+
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  const connect = () =>
+    new SQL(`postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`, { max: 1 });
+
+  test("aborting a queued reserve() keeps the pool intact and lets end() resolve", async () => {
+    await container.ready;
+    await using sql = connect();
+    const reserved = await sql.reserve();
+
+    const controller = new AbortController();
+    const reason = new Error("gave up waiting");
+    const pending = sql.reserve({ signal: controller.signal });
+    controller.abort(reason);
+    await expect(pending).rejects.toBe(reason);
+
+    reserved.release();
+
+    // the aborted reservation must not have consumed the pool's only
+    // connection: a query and a fresh reserve both succeed
+    expect((await sql`select 1 as x`)[0].x).toBe(1);
+    const again = await sql.reserve();
+    again.release();
+
+    // hangs forever if the aborted reserve still holds a connection
+    await sql.end();
+  });
+
+  test("abort while the pool is still establishing its first connection", async () => {
+    await container.ready;
+    await using sql = connect();
+
+    const controller = new AbortController();
+    const reason = new Error("gave up waiting");
+    const pending = sql.reserve({ signal: controller.signal });
+    controller.abort(reason);
+    await expect(pending).rejects.toBe(reason);
+
+    expect((await sql`select 2 as x`)[0].x).toBe(2);
+    await sql.end();
+  });
+
+  test("an already aborted signal rejects without taking a connection", async () => {
+    await container.ready;
+    await using sql = connect();
+
+    const reason = new Error("already aborted");
+    await expect(sql.reserve({ signal: AbortSignal.abort(reason) })).rejects.toBe(reason);
+
+    const reserved = await sql.reserve();
+    reserved.release();
+    await sql.end();
+  });
+
+  test("aborting after reserve() resolved does not revoke the connection", async () => {
+    await container.ready;
+    await using sql = connect();
+
+    const controller = new AbortController();
+    const reserved = await sql.reserve({ signal: controller.signal });
+    controller.abort();
+
+    expect((await reserved`select 3 as x`)[0].x).toBe(3);
+    reserved.release();
+    await sql.end();
+  });
+
+  test("a non-AbortSignal signal option rejects with ERR_INVALID_ARG_TYPE", async () => {
+    await container.ready;
+    await using sql = connect();
+
+    await expect(sql.reserve({ signal: 123 as unknown as AbortSignal })).rejects.toMatchObject({
+      code: "ERR_INVALID_ARG_TYPE",
+    });
+    await sql.end();
+  });
+});

--- a/test/js/sql/sql-reserve-abort.test.ts
+++ b/test/js/sql/sql-reserve-abort.test.ts
@@ -35,6 +35,25 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     await sql.end();
   });
 
+  test("a user abort listener calling stopImmediatePropagation() cannot starve the cancellation", async () => {
+    await container.ready;
+    await using sql = connect();
+    const reserved = await sql.reserve();
+
+    const controller = new AbortController();
+    const reason = new Error("gave up waiting");
+    // registered before reserve(), so it runs first on dispatch
+    controller.signal.addEventListener("abort", e => e.stopImmediatePropagation());
+    const pending = sql.reserve({ signal: controller.signal });
+    controller.abort(reason);
+    try {
+      await expect(pending).rejects.toBe(reason);
+    } finally {
+      reserved.release();
+    }
+    await sql.end();
+  });
+
   test("end() resolves when an aborted reserve was the only pending work", async () => {
     await container.ready;
     await using sql = connect();

--- a/test/js/sql/sql-reserve-abort.test.ts
+++ b/test/js/sql/sql-reserve-abort.test.ts
@@ -19,9 +19,11 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     const reason = new Error("gave up waiting");
     const pending = sql.reserve({ signal: controller.signal });
     controller.abort(reason);
-    await expect(pending).rejects.toBe(reason);
-
-    reserved.release();
+    try {
+      await expect(pending).rejects.toBe(reason);
+    } finally {
+      reserved.release();
+    }
 
     // the aborted reservation must not have consumed the pool's only
     // connection: a query and a fresh reserve both succeed
@@ -31,6 +33,20 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
 
     // hangs forever if the aborted reserve still holds a connection
     await sql.end();
+  });
+
+  test("end() resolves when an aborted reserve was the only pending work", async () => {
+    await container.ready;
+    await using sql = connect();
+
+    const controller = new AbortController();
+    const reason = new Error("gave up waiting");
+    const pending = sql.reserve({ signal: controller.signal });
+    // the queued reservation is pending work the graceful close waits for
+    const ended = sql.end();
+    controller.abort(reason);
+    await expect(pending).rejects.toBe(reason);
+    await ended;
   });
 
   test("abort while the pool is still establishing its first connection", async () => {
@@ -67,8 +83,11 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
     const reserved = await sql.reserve({ signal: controller.signal });
     controller.abort();
 
-    expect((await reserved`select 3 as x`)[0].x).toBe(3);
-    reserved.release();
+    try {
+      expect((await reserved`select 3 as x`)[0].x).toBe(3);
+    } finally {
+      reserved.release();
+    }
     await sql.end();
   });
 

--- a/test/js/sql/sql-reserve-abort.test.ts
+++ b/test/js/sql/sql-reserve-abort.test.ts
@@ -8,8 +8,7 @@ import { expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
 
 describeWithContainer("postgres", { image: "postgres_plain" }, container => {
-  const connect = () =>
-    new SQL(`postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`, { max: 1 });
+  const connect = () => new SQL(`postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`, { max: 1 });
 
   test("aborting a queued reserve() keeps the pool intact and lets end() resolve", async () => {
     await container.ready;


### PR DESCRIPTION
### Problem

- `sql.reserve()` cannot be cancelled. When the caller stops awaiting it (the loser of a `Promise.race` timeout, for example), the queued reservation still receives a connection once one frees up; nobody calls `release()`, so the pool permanently loses a connection and `sql.end()` never resolves (#39451).
- Cause: the reserve callback sits in the adapter's `reservedQueue` (`src/js/internal/sql/shared.ts`) until a connection frees, and nothing can remove it; `release()` hands the freed connection to it unconditionally (`shared.ts:1128`).

### Fix

- `reserve()` now accepts `{ signal?: AbortSignal }`. While the reservation is still queued, aborting removes the callback from `reservedQueue` (new `cancelReserve()` on the pool adapter) and rejects the promise with `signal.reason`; no connection is taken from the pool, so queries, later `reserve()` calls, and `end()` all proceed normally.
- Aborting after the promise resolved is a no-op: the caller owns the connection and must `release()` it. An already-aborted signal rejects immediately; a non-AbortSignal value rejects with `ERR_INVALID_ARG_TYPE`.
- There is no window where abort can strand a connection: a queued callback is either still in `reservedQueue` (cancellable) or was invoked synchronously with a connection when `release()` shifted it out (caller owns it).
- A `preReserved` flag left behind by a cancelled reservation clears itself on the connection's next `release()` with zero queries, the same path that clears it today.
- Verified with `test/js/sql/sql-reserve-abort.test.ts` (postgres via `describeWithContainer`): abort while queued, abort during initial pool connect, pre-aborted signal, abort after resolution, invalid signal type. All 5 fail on the unfixed build (the first three by `end()`/reserve hanging) and pass with the fix.
- Types (`packages/bun-types/sql.d.ts`) and docs (`docs/runtime/sql.mdx`) updated; `ReservedSQL.reserve()` and `TransactionSQL.reserve()` forward the options.

### Background

- `Bun.SQL` pools connections per instance. `reserve()` takes one connection out of the pool and returns a client bound to it; the connection only returns to the pool when the caller calls `release()` (or disposes via `using`).
- When every connection is busy, `reserve()` queues a callback in the adapter's `reservedQueue`. Whenever a connection's query count drops to zero, `release()` hands that connection to the first queued callback, which resolves the `reserve()` promise.
- `sql.end()` waits for all reservations to be released, which is why one leaked reservation made it hang forever.
- Related: #35117 (open) bounds pool-slot waits with `connectionTimeout` and reclaims resolved-but-dropped reserve handles on GC. It does not provide deterministic cancellation of a pending `reserve()`, which is what this issue asks for; the two are complementary.
