### PR TITLE
Bump WebKit (oven-sh/WebKit#458 preview): Math.sumPrecise rounds negative sums to nearest

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+export const WEBKIT_VERSION = "autobuild-preview-pr-458-668c1f16";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc-stress/fixtures/math-sum-precise-negative-rounding.js
+++ b/test/js/bun/jsc-stress/fixtures/math-sum-precise-negative-rounding.js
@@ -1,0 +1,123 @@
+// @bun
+// Math.sumPrecise rounds a negative sum the same way as a positive one: to nearest, ties to even.
+//
+// The rounding step of the xsum port behind it (WTF::Xsum::XsumSmall::compute) used to round
+// every negative sum whose discarded bits were all zero away from zero. Every exactly
+// representable negative sum came out one ulp too large in magnitude (Math.sumPrecise([-1]) was
+// -1.0000000000000002 and Math.sumPrecise([-Number.MAX_VALUE]) was -Infinity), and a negative
+// sum just inside a power of two was rounded onto it.
+
+function describe(input) {
+    if (input.length > 8)
+        return `[${input.slice(0, 4).join(", ")}, ... ${input.length} values]`;
+    return `[${input.join(", ")}]`;
+}
+
+function shouldBe(actual, expected, input) {
+    if (!Object.is(actual, expected))
+        throw new Error(`Math.sumPrecise(${describe(input)}) returned ${actual}, expected ${expected}`);
+}
+
+const MAX = Number.MAX_VALUE;
+const MIN_NORMAL = 2 ** -1022;
+const MIN_SUBNORMAL = Number.MIN_VALUE;
+const ULP = 2 ** -52; // The distance between consecutive doubles in [1, 2).
+
+const cases = [
+    // Exactly representable negative sums. Every expected value here is computed by double
+    // arithmetic that is itself exact.
+    [[-1], -1],
+    [[-0.5], -0.5],
+    [[-1, -1], -2],
+    [[1, -2], -1],
+    [[-3, 1], -2],
+    [[-0.1], -0.1],
+    [[-(2 ** 53)], -(2 ** 53)],
+    [[-(2 ** 1000), -(2 ** 999)], -1.5 * 2 ** 1000],
+    [[-(1 + ULP)], -(1 + ULP)],
+    [[-1, -ULP], -(1 + ULP)],
+    [[-1, ULP], -(1 - ULP)],
+    [[-2, ULP], -(2 - ULP)],
+    [[-2, 2 * ULP], -(2 - 2 * ULP)],
+    [[-MAX], -MAX],
+    [[-MAX, -MAX, MAX], -MAX],
+    [[-MIN_NORMAL], -MIN_NORMAL],
+    [[-MIN_NORMAL, -MIN_SUBNORMAL], -(MIN_NORMAL + MIN_SUBNORMAL)],
+    [[-MIN_SUBNORMAL], -MIN_SUBNORMAL],
+    [[-MIN_SUBNORMAL, -MIN_SUBNORMAL], -2 * MIN_SUBNORMAL],
+
+    // Inexact negative sums were already right; keep them that way.
+    [[-0.1, -0.2], -0.30000000000000004],
+    [[-1, -1e-30], -1],
+
+    // Less than half an ulp beyond a double: truncate towards it.
+    [[-1, -ULP / 4], -1],
+    [[-1, -ULP / 2, MIN_SUBNORMAL], -1],
+    [[-(1 + ULP), -ULP / 2, MIN_SUBNORMAL], -(1 + ULP)],
+    [[-MAX, -(2 ** 969)], -MAX],
+    [[-MAX, -(2 ** 969), -(2 ** 968)], -MAX],
+    [[-MAX, -(2 ** 970), 2 ** 900], -MAX],
+    [[-MAX, 1], -MAX],
+
+    // More than half an ulp beyond: round away from zero.
+    [[-1, -ULP * 3 / 4], -(1 + ULP)],
+    [[-1, -ULP / 2, -MIN_SUBNORMAL], -(1 + ULP)],
+    [[-(1 + ULP), -ULP / 2, -MIN_SUBNORMAL], -(1 + 2 * ULP)],
+
+    // Exactly half an ulp beyond: round to the neighbour with the even mantissa.
+    [[-1, -ULP / 2], -1],
+    [[-(1 + ULP), -ULP / 2], -(1 + 2 * ULP)],
+    [[-MAX, -(2 ** 970)], -Infinity],
+
+    // Sums whose magnitude is just inside a power of two, so the result has one more bit of
+    // precision than the top of the accumulator suggests.
+    [[-2, ULP / 2], -2],                                   // a tie between 2 - ULP (odd) and 2 (even)
+    [[-2, ULP / 4], -2],
+    [[-2, ULP * 3 / 4], -(2 - ULP)],
+    [[-(2 ** 60), 1], -(2 ** 60)],                         // 2 ** 60 - 1 is not representable
+    [[-(2 ** 60), 2 ** 7], -(2 ** 60 - 2 ** 7)],           // the double just below 2 ** 60
+    [[-(2 ** 60), 2 ** 6], -(2 ** 60)],                    // a tie, and 2 ** 60 is the even neighbour
+    [[-(2 ** 60), 2 ** 6, MIN_SUBNORMAL], -(2 ** 60 - 2 ** 7)],
+    [[-(2 ** 60), 2 ** 6, -MIN_SUBNORMAL], -(2 ** 60)],
+
+    // The positive mirror images, which were always right.
+    [[1], 1],
+    [[1, ULP / 4], 1],
+    [[1, ULP * 3 / 4], 1 + ULP],
+    [[1, ULP / 2], 1],
+    [[1, ULP / 2, MIN_SUBNORMAL], 1 + ULP],
+    [[1 + ULP, ULP / 2], 1 + 2 * ULP],
+    [[1 + ULP, ULP / 2, -MIN_SUBNORMAL], 1 + ULP],
+    [[2, -ULP / 2], 2],
+    [[2, -ULP * 3 / 4], 2 - ULP],
+    [[2 ** 60, -(2 ** 6)], 2 ** 60],
+    [[2 ** 60, -(2 ** 6), -MIN_SUBNORMAL], 2 ** 60 - 2 ** 7],
+    [[MAX], MAX],
+    [[MAX, MAX, -MAX], MAX],
+    [[MAX, 2 ** 969], MAX],
+    [[MAX, 2 ** 970], Infinity],
+
+    // A negative sum that cancels to zero is +0.
+    [[-1, 1], 0],
+];
+
+// An array longer than 1000 elements is summed with the large accumulator, which is rounded through
+// the same code. 500 cancelling pairs pad each case out to that length.
+{
+    const padding = [];
+    for (let i = 0; i < 500; ++i)
+        padding.push(2 ** 500, -(2 ** 500));
+
+    for (const [input, expected] of cases.slice())
+        cases.push([padding.concat(input), expected]);
+
+    cases.push([new Array(1001).fill(-1), -1001]);
+    cases.push([new Array(1001).fill(-0.25), -250.25]);
+    cases.push([new Array(1001).fill(-MIN_SUBNORMAL), -1001 * MIN_SUBNORMAL]);
+}
+
+for (const [input, expected] of cases) {
+    shouldBe(Math.sumPrecise(input), expected, input);
+    // Any other iterable is summed with the small accumulator whatever its length.
+    shouldBe(Math.sumPrecise((function* () { yield* input; })()), expected, input);
+}

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -121,6 +121,8 @@ const jsFixtures = [
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",
   "licm-no-pre-header.js",
+  // Runtime: Math.sumPrecise rounding of negative sums (oven-sh/WebKit#458)
+  "math-sum-precise-negative-rounding.js",
 ];
 
 const wasmFixtures = [


### PR DESCRIPTION
### Problem
- `Math.sumPrecise` returns every exactly representable negative sum one ulp too large in magnitude: `Math.sumPrecise([-1])` is `-1.0000000000000002`, `[-0.5]` is `-0.5000000000000001`, `[1, -2]` is `-1.0000000000000002`, `[-Number.MAX_VALUE]` is `-Infinity`. A negative sum just inside a power of two is rounded onto it too (`[-2, 2 ** -52]` gives `-2` instead of `-1.9999999999999998`). Positive sums and inexact negative sums are right. Same on Bun 1.3.14, so not a 1.4 regression; found by a differential fuzz run against an exact reference, where all 468 of 10,000 mismatching arrays fell into this one bucket.
- The cause is in JavaScriptCore, not in Bun: `WTF::Xsum::XsumSmall::compute()` (`Source/WTF/wtf/PreciseSum.cpp`, the port of xsum that `Math.sumPrecise` sums into; arrays longer than 1000 elements use `XsumLarge`, which is rounded by the same function). Its negative branch rounds away from zero whenever no bit below the two guard bits is set, where the original xsum only does so for guard bits `11`, or `10` on an odd mantissa (a tie). An exactly representable sum has no bits set below the mantissa, so it always took that path. Upstream WebKit has the same code.

### Fix
- oven-sh/WebKit#458 restores xsum's decision table for negative sums; the positive branch is unchanged. Verified there by linking the changed file against the `c6cfe90c` prebuilt WTF and comparing it bit for bit with Radford Neal's `xsum.c` on 3.75 million generated inputs (805,856 with a negative, exactly representable sum; the unmodified file mismatches on 20% of them), plus a 30,000 input sample against exact rational arithmetic.
- This PR pins `WEBKIT_VERSION` at that PR's preview build, `autobuild-preview-pr-458-668c1f16`, so CI runs Bun against it. The WebKit branch is the fix commit on `ceb9f90f`, the fork main commit main pins since #40767, so the preview is exactly the current pin plus the fix.
- Before landing, oven-sh/WebKit#458 has to merge and `WEBKIT_VERSION` has to be repointed at the resulting main sha (the build prints that instruction itself once the preview release disappears); I will push that repoint when the merge happens. If another bump that already contains #458 lands first, this PR reduces to the fixture and its registration.
- Test: `test/js/bun/jsc-stress/fixtures/math-sum-precise-negative-rounding.js`, the `JSTests/stress` file from the WebKit PR with the usual `// @bun` first line, registered in `jsc-stress.test.ts`. It checks 58 cases: the sums from the report, each rounding outcome for a negative sum (quarter ulp, three quarters, ties on even and odd mantissas, the same ties with one subnormal added or removed so the scan of the lower accumulator chunks decides, magnitudes just inside a power of two, the `-MAX_VALUE` neighbourhood including the `-Infinity` tie) and the positive mirror images. Each case runs as an array, as the same array padded past the 1000 element `XsumLarge` threshold with cancelling pairs, and as a generator (always `XsumSmall`), plus three plain 1001 element arrays. All 119 expected values were checked against exact rational arithmetic independently of any engine.
- Fail before: `bun bd test test/js/bun/jsc-stress/jsc-stress.test.ts -t math-sum-precise` fails at the fixture's first case with `Math.sumPrecise([-1]) returned -1.0000000000000002, expected -1` on every pin main has had since this PR was opened (`1817c3c3` was the last one run locally, with `process.versions.webkit` checked; `PreciseSum.cpp` is byte for byte the same in the current pin `ceb9f90f`) and on the released `bun` (92 of the fixture's 238 assertions fail on those engines). Upstream WebKit as of 6b879687ee still has the bug.
- Pass after: with this pin (`process.versions.webkit` reports `preview-pr-458-668c1f16`), the fixture passes and the whole `jsc-stress.test.ts` passes its 117 fixtures (debug + ASAN build; the new fixture takes about 1 s there and 30 ms on the release `jsc` shell). Earlier revisions with a published preview passed every CI job six times (builds 100401, 102225, 104071, 104891, 106394 and 107650); the other builds had only red lanes from tests that fail the same way on main (see the details block).

### Background
- Bun links a prebuilt JavaScriptCore from oven-sh/WebKit; `scripts/build/deps/webkit.ts` pins which build. An engine fix lands as a WebKit PR plus a pin bump here, and the `autobuild-preview-pr-*` releases let the bump PR run Bun's suite against the WebKit PR before it merges.
- `test/js/bun/jsc-stress/` runs files taken verbatim from WebKit's `JSTests/stress` under `bun`, so the engine test is shared with the WebKit PR as is.
- xsum keeps the sum exactly, in an array of 64-bit chunks that each hold a window of the sum's binary expansion, and rounds once at the end. After carry propagation the top chunk carries the sign and all chunks below it are non-negative, so for a negative sum the bits that get discarded reduce the magnitude rather than add to it, which is why the rounding rules for the two signs are different tables and the negative one could be wrong on its own.
- A sum is "exactly representable" when it fits in a double's 53 bit mantissa, which is the common case for real inputs (integers, money in cents, anything with few significant bits); those are exactly the inputs with nothing below the guard bits, so the bug hit the common case and spared the inexact one.

<details>
<summary>Earlier revisions of this PR</summary>

Each time main's pin moved while oven-sh/WebKit#458 was open, the fix commit was re-applied on the new fork main and this PR was rebased and repinned to the new preview; the only conflict each time was the `WEBKIT_VERSION` line. Revisions: `autobuild-preview-pr-458-7051f3b5` (fix on the pre-47f7250137c6 main, before #39371 landed), `ffe26339` (fix on `eeab0404`; CI build 100401 passed all 179 jobs), `f423272e` (fix on `0f966e81`; its preview release was never produced because the fork's x64 runners were failing every PR's preview build at the time), `b185619b` (fix on `b7f217b4`; CI build 102225 passed all 179 jobs), `0609b9b5` (fix on `aea1f010`; CI build 104071 passed all 181 jobs), `a16c8644` (fix on `c148a12d`; CI build 104891 passed all 181 jobs), `9767dac3` (fix on `cb61607f`; CI build 105561 passed 179 of 181, the two red lanes being a gitlab.com 502 in bun-install.test.ts and the require-cache.test.ts RSS threshold that also fails on main), `b7be8936` (fix on `1cb96a7b`; CI build 105946 passed 180 of 181, the red lane being require-cache.test.ts again, pre-existing on main), `5dba0487` (fix on `76882271`; CI build 106136 passed 180 of 181, the red lane again require-cache.test.ts), `754b429c` (fix on `2da33d53`; CI build 106394 passed all 181 jobs), `6ab847b8` (fix on `72597399`; its preview release was never produced: the fork's Windows arm64 job failed in its scoop based runner setup on 19 attempts, fixed on fork main by oven-sh/WebKit#523), `58784255` (fix on `d9feedfc`; CI build 106939 passed 168 of 181, every red lane a test that fails the same way on main's own builds), `c7b3aabb` (fix on `0bb01ed5`; CI build 107133 passed 179 of 181, the two red lanes require-cache.test.ts and url.test.ts, both pre-existing on main), `98b0c6c0` (fix on `f5deafe0`; CI build 107212 passed 180 of 181, the red lane url.test.ts, pre-existing on main), `31d19b15` (fix on `1817c3c3`, the 6b879687ee upstream upgrade; CI build 107614 had no non-flaky failures; superseded within the hour by the next pin bump), `443e5b3e` (fix on `c4ddc0cf`; CI build 107650 passed all 181 jobs), now `668c1f16` (fix on `ceb9f90f`, after #40767).

</details>

<details>
<summary>Repro</summary>

```js
for (const c of [[-1], [-0.5], [-1, -1], [1, -2], [-(2 ** 53)], [-Number.MAX_VALUE], [-0.1], [-0.1, -0.2], [1]])
  console.log(JSON.stringify(c), Math.sumPrecise(c));
```

```
bun 1.4.0 (WebKit c6cfe90c):
[-1] -1.0000000000000002
[-0.5] -0.5000000000000001
[-1,-1] -2.0000000000000004
[1,-2] -1.0000000000000002
[-9007199254740992] -9007199254740994
[-1.7976931348623157e+308] -Infinity
[-0.1] -0.10000000000000002
[-0.1,-0.2] -0.30000000000000004
[1] 1

this PR:
[-1] -1
[-0.5] -0.5
[-1,-1] -2
[1,-2] -1
[-9007199254740992] -9007199254740992
[-1.7976931348623157e+308] -1.7976931348623157e+308
[-0.1] -0.1
[-0.1,-0.2] -0.30000000000000004
[1] 1
```

</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 14 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc-stress/jsc-stress.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc-stress/jsc-stress.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/jsc-stress/jsc-stress.test.ts:
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsin.js [346.28ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithcos.js [317.42ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsqrt.js [313.33ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-equality.js [307.42ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithtan.js [369.61ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-strict-equality.js [307.98ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-library-substring.js [365.64ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-ident-equality.js [377.67ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-exec.js [373.77ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-test.js [441.66ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength.js [293.70ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength-inline.js [296.87ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val.js [342.82ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined.js [409.82ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined-and-not-inlined.js [438.97ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-exception.js [369.58ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-varargs-exception.js [328.26ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-exception-no-catch.js [408.84ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-try-catch-arith-sub-exception.js [382.42ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DF
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   2 +-
 .../fixtures/math-sum-precise-negative-rounding.js | 123 +++++++++++++++++++++
 test/js/bun/jsc-stress/jsc-stress.test.ts          |   2 +
 3 files changed, 126 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 13 passed · 1 rejected · iteration 14

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                  1      2      0
…c-stress/fixtures/math-sum-precise-negative-rounding.js      0      0      0
test/js/bun/jsc-stress/jsc-stress.test.ts                     1      1      0
```

</details>

<!-- robobun:evidence:end -->














