### PR TITLE
bundler: stop appending plugin-resolved paths to the FilenameStore on every bundle

### DIFF
--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -1928,6 +1928,16 @@ impl<const COUNT: usize, const ITEM_LENGTH: usize> BSSStringList<COUNT, ITEM_LEN
         Some(unsafe { core::slice::from_raw_parts(value.as_ptr(), value.len()) })
     }
 
+    /// Number of strings appended so far (`bun:internal-for-testing` probe).
+    ///
+    /// SAFETY: see [`append`](Self::append); concurrent appenders are allowed.
+    pub unsafe fn count(this: *mut Self) -> usize {
+        // SAFETY: `this` is live; the mutex serializes the reads against `do_append`.
+        let _guard = unsafe { (*this).mutex.lock() };
+        // SAFETY: mutex held.
+        unsafe { (*this).slice_buf_used as usize + (*this).overflow_list.count as usize }
+    }
+
     /// Append `value` and return a mutable slice over the freshly-reserved bytes.
     ///
     /// Takes `*mut Self` (not `&mut self`) so callers can pass the raw

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -403,7 +403,7 @@ impl<'a> LinkerContext<'a> {
         &mut self,
         path: &bun_paths::fs::Path<'static>,
         arena: &Bump,
-    ) -> Result<bun_paths::fs::Path<'static>, BunError> {
+    ) -> bun_paths::fs::Path<'static> {
         let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
         generic_path_with_pretty_initialized(path, self.options.target, top_level_dir, arena)
     }
@@ -1778,9 +1778,7 @@ impl<'a> LinkerContext<'a> {
                         // Use the pretty path as the file name since it should be platform-
                         // independent (relative paths and the "/" path separator)
                         if source.path.text.as_ptr() == source.path.pretty.as_ptr() {
-                            source.path = self
-                                .path_with_pretty_initialized(&source.path, arena)
-                                .expect("OOM");
+                            source.path = self.path_with_pretty_initialized(&source.path, arena);
                         }
                         // Note: `Path::assert_pretty_is_valid` lives on the
                         // resolver-side `Path<'a>`; the logger `Path` has no

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2603,9 +2603,7 @@ pub mod bv2_impl {
             if let Some(existing) = self.path_to_source_index_map(target).get(path.text) {
                 out_source_index = Some(Index::init(existing));
             } else {
-                path = self
-                    .path_with_pretty_initialized(&path, target)
-                    .expect("oom");
+                path = self.path_with_pretty_initialized(&path, target);
                 // The borrowck-reshape above cloned
                 // `path` out, so write the prettified path back so
                 // `ParseTask::init(&resolve_result, ..)` (via `enqueue_parse_task`)
@@ -2627,7 +2625,7 @@ pub mod bv2_impl {
                     // HTML is only allowed at the entry point.
                 };
                 let mut tmp_source = bun_ast::Source {
-                    path: path_as_static(&path.dupe_alloc(self.arena()).expect("oom")),
+                    path: path_as_static(&path.dupe_alloc(self.arena())),
                     contents: std::borrow::Cow::Borrowed(&b""[..]),
                     ..Default::default()
                 };
@@ -2723,7 +2721,7 @@ pub mod bv2_impl {
             let source_index = Index::source(self.graph.input_files.len() as u32);
             let loader = self.requested_file_loader(&path, loader);
 
-            path = self.path_with_pretty_initialized(&path, target)?;
+            path = self.path_with_pretty_initialized(&path, target);
             path.assert_pretty_is_valid();
             // see `enqueue_entry_item` — write the prettified path back
             // into `result` so `ParseTask::init(&result, ..)` reads the relativized
@@ -2816,21 +2814,21 @@ pub mod bv2_impl {
             // outlives the bundle pass; erase the arena lifetime back to the resolver's
             // `Path<'static>` alias so `path` doesn't keep `self` borrowed.
             path = unsafe {
-                self.path_with_pretty_initialized(&path, target)?
+                self.path_with_pretty_initialized(&path, target)
                     .into_static()
             };
             path.assert_pretty_is_valid();
-            // intern via `dupe_alloc` BEFORE writing back into `result` /
+            // copy via `dupe_alloc` BEFORE writing back into `result` /
             // the path-to-source-index map. The dev-server path builds a fresh
             // `bake_types::EntryPointList` with `Box<[u8]>` keys (DevServer.rs:3027)
             // that drops as soon as `enqueue_entry_points_dev_server` returns;
             // `resolve_with_framework` then lifetime-erases that key into the
-            // returned `Path`, so without interning here `ParseTask.path.text` (and
+            // returned `Path`, so without the copy here `ParseTask.path.text` (and
             // the map key) would dangle once the entry-point list is freed —
             // surfacing as "Failed to load bundled module
             // 'bun-framework-react/server.tsx'" when the worker can no longer match
             // `built_in_modules`.
-            path = path.dupe_alloc(self.arena()).expect("oom");
+            path = path.dupe_alloc(self.arena());
             // The borrowck-reshape
             // above cloned `path` out, which left `result.path_pair` with the
             // unrelativized `pretty` — and `ParseTask::init(&result, ..)` reads
@@ -4915,12 +4913,10 @@ pub mod bv2_impl {
                             // when the Box itself is moved into the Vec.
                             this.free_list.push(result.namespace);
                             this.free_list.push(result.path);
-                            path = this
-                                .path_with_pretty_initialized(
-                                    &path,
-                                    resolve.import_record.original_target,
-                                )
-                                .expect("oom");
+                            path = this.path_with_pretty_initialized(
+                                &path,
+                                resolve.import_record.original_target,
+                            );
                             // `GetOrPutResult` has no `key_ptr` — `get_or_put` already
                             // duped the key into the map (see PathToSourceIndexMap.rs).
 
@@ -5938,18 +5934,17 @@ pub mod bv2_impl {
             &self,
             path: &Fs::Path<'static>,
             target: options::Target,
-        ) -> Result<Fs::Path<'static>, Error> {
+        ) -> Fs::Path<'static> {
             // SAFETY: arena outlives the bundle pass; erase the `&self` lifetime so the
             // returned `Path<'static>` doesn't keep `self` borrowed (borrowck).
             let bump: &'static bun_alloc::Arena =
                 unsafe { bun_ptr::detach_lifetime_ref::<bun_alloc::Arena>(self.arena()) };
-            let out = generic_path_with_pretty_initialized(
+            generic_path_with_pretty_initialized(
                 path,
                 target,
                 self.transpiler.fs().top_level_dir,
                 bump,
-            )?;
-            Ok(out)
+            )
         }
 
         fn reserve_source_indexes_for_bake(&mut self) -> Result<(), Error> {
@@ -6693,9 +6688,7 @@ pub mod bv2_impl {
                                 import_record.path.text = path.text;
                                 import_record.path.pretty = rel;
                                 import_record.path = path_as_static(
-                                    &self
-                                        .path_with_pretty_initialized(path, target)
-                                        .expect("oom"),
+                                    &self.path_with_pretty_initialized(path, target),
                                 );
                                 if loader == Loader::Html
                                     || entry.kind == bake_types::CacheKind::Css
@@ -6757,9 +6750,7 @@ pub mod bv2_impl {
                     continue;
                 }
 
-                *path = self
-                    .path_with_pretty_initialized(path, target)
-                    .expect("oom");
+                *path = self.path_with_pretty_initialized(path, target);
 
                 import_record.path = path_as_static(path);
                 // key already interned by get_or_put — no key_ptr on StringHashMapGetOrPut
@@ -7448,14 +7439,10 @@ pub mod bv2_impl {
                             // `fs_path_from_logger`/`fs_path_to_logger` until the
                             // three `Path` mirrors unify.
                             ssr_source.path.pretty = ssr_source.path.text;
-                            ssr_source.path = path_as_static(
-                                &this
-                                    .path_with_pretty_initialized(
-                                        &ssr_source.path,
-                                        Target::ServerComponentsSsr,
-                                    )
-                                    .expect("oom"),
-                            );
+                            ssr_source.path = path_as_static(&this.path_with_pretty_initialized(
+                                &ssr_source.path,
+                                Target::ServerComponentsSsr,
+                            ));
                             let ssr_index = this
                                 .enqueue_parse_task2(
                                     &mut ssr_source,
@@ -7471,14 +7458,11 @@ pub mod bv2_impl {
                                 this.graph.input_files.items_source()[result_source_index].clone();
                             server_source.path.pretty = server_source.path.text;
                             let server_target = this.transpiler.options.target;
-                            server_source.path = path_as_static(
-                                &this
-                                    .path_with_pretty_initialized(
-                                        &server_source.path,
-                                        server_target,
-                                    )
-                                    .expect("oom"),
-                            );
+                            server_source.path =
+                                path_as_static(&this.path_with_pretty_initialized(
+                                    &server_source.path,
+                                    server_target,
+                                ));
                             let server_index = this
                                 .enqueue_parse_task2(
                                     &mut server_source,
@@ -7782,7 +7766,7 @@ pub mod bv2_impl {
         target: options::Target,
         top_level_dir: &[u8],
         bump: &bun_alloc::Arena,
-    ) -> crate::Result<bun_paths::fs::Path<'static>> {
+    ) -> bun_paths::fs::Path<'static> {
         use crate::bun_fs::PathResolverExt as _;
         use crate::bun_node_fallbacks;
         use bun_io::Write as _;
@@ -7794,7 +7778,7 @@ pub mod bv2_impl {
             && (strings::has_prefix(path.text, bun_node_fallbacks::IMPORT_PATH)
                 || !bun_paths::is_absolute(path.text))
         {
-            return Ok(*path);
+            return *path;
         }
 
         if path.is_file() || is_node {
@@ -7813,7 +7797,7 @@ pub mod bv2_impl {
             } else {
                 path_clone.pretty = rel;
             }
-            path_clone.dupe_alloc_fix_pretty(bump).map_err(Into::into)
+            path_clone.dupe_alloc_fix_pretty(bump)
         } else {
             let mut path_clone: crate::bun_fs::Path<'_> = *path;
             let mut fbs = bun_io::FixedBufferStream::new_mut(&mut buf.0[..]);
@@ -7825,7 +7809,7 @@ pub mod bv2_impl {
             let _ = fbs.write_all(path_clone.text);
             let written = fbs.pos;
             path_clone.pretty = &buf.0[..written];
-            path_clone.dupe_alloc_fix_pretty(bump).map_err(Into::into)
+            path_clone.dupe_alloc_fix_pretty(bump)
         }
     }
 

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -190,12 +190,12 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 source_ref.path.pretty.as_ptr(),
             ) {
                 let top_level_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
-                let new_path = bun_core::handle_oom(generic_path_with_pretty_initialized(
+                let new_path = generic_path_with_pretty_initialized(
                     &source_ref.path,
                     c.options.target,
                     top_level_dir,
                     arena,
-                ));
+                );
                 source_storage = bun_ast::Source {
                     path: new_path,
                     // SAFETY: `source_ref` is `&'static Source`, so re-borrowing its

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -48,6 +48,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "ipc.rs": "runtime/ipc_host.rs",
   "Counters.rs": "jsc/Counters.rs",
   "FrameworkRouter.rs": "runtime/bake/FrameworkRouter.rs",
+  "JSBundler.rs": "runtime/api/JSBundler.rs",
   "Listener.rs": "runtime/socket/Listener.rs",
   "MarkdownObject.rs": "runtime/api/MarkdownObject.rs",
   "SecureContext.rs": "runtime/api/bun/SecureContext.rs",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -558,6 +558,13 @@ export const decodeURIComponentSIMD = $newCppFunction(
 );
 
 export const getDevServerDeinitCount = $bindgenFn("DevServer.bind.ts", "getDeinitCountForTesting");
+export const bundlerInternals = {
+  /** Sizes of the resolver's append-only, process-lifetime path stores. */
+  pathStoreCounts: $newRustFunction("JSBundler.rs", "TestingAPIs.pathStoreCounts", 0) as () => {
+    filenames: number;
+    dirnames: number;
+  },
+};
 export const getCounters = $newRustFunction("Counters.rs", "createCountersObject", 0);
 export const linearFifoOrderedRemoveProbe = $newRustFunction(
   "collections/linear_fifo.rs",

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -128,6 +128,11 @@ pub mod fs {
                     // SAFETY: see `append_slice`; the singleton is `'static`.
                     unsafe { &*$backing() }.as_interned(value)
                 }
+                /// Number of strings interned so far (the store never shrinks).
+                pub fn count(&self) -> usize {
+                    // SAFETY: see `append_slice`.
+                    unsafe { bun_alloc::BSSStringList::count($backing()) }
+                }
             }
         };
     }

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -492,15 +492,13 @@ pub mod fs {
             .or_else(|| FilenameStore::instance().as_interned(value))
     }
 
-    /// Intern a `Path.namespace` for `dupe_alloc`. The common `file`/empty
-    /// namespace is a static literal (no allocation); anything else is interned
-    /// into the process-lifetime `FilenameStore`.
-    #[inline]
-    fn dupe_namespace(namespace: &[u8]) -> crate::CrateResult<&'static [u8]> {
-        match namespace {
-            b"" | b"file" => Ok(b"file"),
-            ns => FilenameStore::instance().append_slice(ns),
-        }
+    /// `slice` when it is interned, else a NUL-terminated copy in the bundle's arena.
+    fn interned_or_arena<'b>(slice: &[u8], alloc: &'b bun_alloc::MimallocArena) -> &'b [u8] {
+        as_interned_path(slice).unwrap_or_else(|| {
+            let copy: &mut [u8] = alloc.alloc_slice_fill_copy(slice.len() + 1, 0u8);
+            copy[..slice.len()].copy_from_slice(slice);
+            &copy[..slice.len()]
+        })
     }
 
     /// Resolver-tier `Path` methods that pull deps `bun_paths` can't
@@ -508,168 +506,67 @@ pub mod fs {
     /// `bun_string`). Import this trait to call `.loader()` / `.dupe_alloc()`
     /// on a `Path`.
     pub trait PathResolverExt<'a> {
-        /// Intern `text`/`pretty` into the process-lifetime `FilenameStore`
-        /// (reusing an already-interned `text`); when `pretty` is not a
-        /// sub-string of `text`, `pretty` and any not-yet-interned
-        /// `text`/`namespace` go in `alloc` (the per-build bundle arena)
-        /// instead. See the impl for why.
-        fn dupe_alloc(&self, alloc: &bun_alloc::MimallocArena)
-        -> crate::CrateResult<Path<'static>>;
-        fn dupe_alloc_fix_pretty(
-            &self,
-            alloc: &bun_alloc::MimallocArena,
-        ) -> crate::CrateResult<Path<'static>>;
+        /// The graph's `Path` for `self`: every slice is interned or lives in `alloc`.
+        fn dupe_alloc(&self, alloc: &bun_alloc::MimallocArena) -> Path<'static>;
+        fn dupe_alloc_fix_pretty(&self, alloc: &bun_alloc::MimallocArena) -> Path<'static>;
         fn loader(&self, loaders: &bun_ast::LoaderHashTable) -> Option<bun_ast::Loader>;
     }
 
     impl<'a> PathResolverExt<'a> for Path<'a> {
-        /// Interns `text`/`pretty` into the
-        /// process-static `FilenameStore` so the returned `Path` borrows `'static`
-        /// data.
-        ///
-        /// Short-circuit: if `text` (and, where relevant,
-        /// `pretty`) already points into a process-lifetime store
-        /// (`FilenameStore` or `DirnameStore`), the slices are already `'static`
-        /// and we return the path unchanged instead of appending a duplicate.
-        /// Skipping this check makes the append-only `FilenameStore` grow without
-        /// bound across repeated in-process `Bun.build()` calls, eventually
-        /// tripping the overflow-block cap (index-out-of-bounds panic).
-        fn dupe_alloc(
-            &self,
-            alloc: &bun_alloc::MimallocArena,
-        ) -> crate::CrateResult<Path<'static>> {
-            let is_interned = |slice: &[u8]| as_interned_path(slice).is_some();
-            // Returning `self` unchanged widens `text`/`pretty`/`namespace` to
-            // `'static`; the caller has already proven `text`/`pretty` are
-            // interned, so assert `namespace` is too (static literal or store-
-            // interned) — a transient namespace here would dangle.
-            let return_self_static = || {
-                debug_assert!(
-                    matches!(self.namespace, b"" | b"file") || is_interned(self.namespace),
-                    "dupe_alloc: returning interned path with transient namespace",
-                );
-                // SAFETY: `text`/`pretty` point into a process-lifetime store
-                // (checked by the caller), and `namespace` is static/interned
-                // (asserted above). All three outlive the program.
-                Ok(unsafe { (*self).into_static() })
-            };
-
-            if core::ptr::eq(self.text.as_ptr(), self.pretty.as_ptr())
-                && self.text.len() == self.pretty.len()
-            {
-                if is_interned(self.text) {
-                    return return_self_static();
-                }
-                // `Path::init` sets `pretty == text`, matching the aliased input.
-                let text = FilenameStore::instance().append_slice(self.text)?;
-                let mut new_path = Path::<'static>::init(text);
-                new_path.namespace = dupe_namespace(self.namespace)?;
-                new_path.is_symlink = self.is_symlink;
-                new_path.is_disabled = self.is_disabled;
-                Ok(new_path)
-            } else if self.pretty.is_empty() {
-                if is_interned(self.text) {
-                    return return_self_static();
-                }
-                let text = FilenameStore::instance().append_slice(self.text)?;
-                let mut new_path = Path::<'static>::init(text);
-                new_path.pretty = b"";
-                new_path.namespace = dupe_namespace(self.namespace)?;
-                new_path.is_symlink = self.is_symlink;
-                new_path.is_disabled = self.is_disabled;
-                Ok(new_path)
+        /// Valid for the bundle pass; whatever outlives it copies (`Location::clone`,
+        /// `Watcher::add_file::<true>`, the dev server's graph keys).
+        fn dupe_alloc(&self, alloc: &bun_alloc::MimallocArena) -> Path<'static> {
+            let text = interned_or_arena(self.text, alloc);
+            let pretty: &[u8] = if self.pretty.is_empty() {
+                b""
             } else if let Some([offset, len]) =
                 bun_alloc::range_of_slice_in_buffer(self.pretty, self.text)
             {
-                // `pretty` is a sub-slice of `text`.
-                if is_interned(self.text) {
-                    return return_self_static();
-                }
-                let text = FilenameStore::instance().append_slice(self.text)?;
-                let mut new_path = Path::<'static>::init(text);
-                new_path.pretty = &text[offset as usize..][..len as usize];
-                new_path.namespace = dupe_namespace(self.namespace)?;
-                new_path.is_symlink = self.is_symlink;
-                new_path.is_disabled = self.is_disabled;
-                Ok(new_path)
+                &text[offset as usize..][..len as usize]
+            } else if let Some(offset) = bun_core::strings::index_of(self.text, self.pretty) {
+                &text[offset..][..self.pretty.len()]
             } else {
-                if is_interned(self.text) && is_interned(self.pretty) {
-                    return return_self_static();
+                interned_or_arena(self.pretty, alloc)
+            };
+            let namespace: &[u8] = match self.namespace {
+                b"" | b"file" => b"file",
+                namespace => interned_or_arena(namespace, alloc),
+            };
+            // SAFETY: every slice is interned or arena-backed (see the trait doc).
+            unsafe {
+                Path {
+                    text,
+                    pretty,
+                    namespace,
+                    is_symlink: self.is_symlink,
+                    is_disabled: self.is_disabled,
                 }
-                let mut new_path =
-                    if let Some(offset) = bun_core::strings::index_of(self.text, self.pretty) {
-                        // `text` contains `pretty`; re-slice the interned copy.
-                        let text = match as_interned_path(self.text) {
-                            Some(text) => text,
-                            None => FilenameStore::instance().append_slice(self.text)?,
-                        };
-                        let mut p = Path::<'static>::init(text);
-                        p.pretty = &text[offset..][..self.pretty.len()];
-                        p
-                    } else {
-                        // Disjoint `text`/`pretty`: a file outside `top_level_dir`
-                        // (`pretty` starts with `../`) or a plugin module in a
-                        // non-`file` namespace (`pretty` is `<ns>:<text>`). `pretty` is
-                        // recomputed every build, and so are `text`/`namespace` unless
-                        // the resolver already interned them, so they go in the
-                        // per-build arena rather than growing the append-only stores
-                        // on every `Bun.build()`. Holders that outlive the bundle (the
-                        // file watcher) copy.
-                        let arena_z = |s: &[u8]| -> &'static [u8] {
-                            let buf: &mut [u8] = alloc.alloc_slice_fill_copy(s.len() + 1, 0u8);
-                            buf[..s.len()].copy_from_slice(s);
-                            // SAFETY: arena memory lives for the whole bundle pass; the
-                            // consuming `Path` (graph/import-record) never outlives it.
-                            unsafe { core::slice::from_raw_parts(buf.as_ptr(), s.len()) }
-                        };
-                        let mut p = Path::<'static>::init(
-                            as_interned_path(self.text).unwrap_or_else(|| arena_z(self.text)),
-                        );
-                        p.pretty = arena_z(self.pretty);
-                        p.namespace = match self.namespace {
-                            b"" | b"file" => b"file",
-                            ns => as_interned_path(ns).unwrap_or_else(|| arena_z(ns)),
-                        };
-                        p.is_symlink = self.is_symlink;
-                        p.is_disabled = self.is_disabled;
-                        return Ok(p);
-                    };
-                new_path.namespace = dupe_namespace(self.namespace)?;
-                new_path.is_symlink = self.is_symlink;
-                new_path.is_disabled = self.is_disabled;
-                Ok(new_path)
+                .into_static()
             }
         }
 
-        fn dupe_alloc_fix_pretty(
-            &self,
-            alloc: &bun_alloc::MimallocArena,
-        ) -> crate::CrateResult<Path<'static>> {
+        fn dupe_alloc_fix_pretty(&self, alloc: &bun_alloc::MimallocArena) -> Path<'static> {
             #[cfg(not(windows))]
             {
                 self.dupe_alloc(alloc)
             }
             #[cfg(windows)]
             {
-                // If `pretty` contains no backslashes it is already POSIX-style.
-                // Short-circuiting preserves the `pretty.ptr == text.ptr` aliasing
-                // optimisation inside `dupe_alloc` and avoids a fresh FilenameStore alloc.
+                // A `pretty` without backslashes is already POSIX-style, and
+                // `dupe_alloc` re-slices it out of `text` instead of the copy below.
                 if !bun_core::strings::contains_char(self.pretty, b'\\') {
                     return self.dupe_alloc(alloc);
                 }
                 let mut new = self.clone();
                 new.pretty = b"";
-                let mut new = new.dupe_alloc(alloc)?;
-                // The posix-normalized
-                // display path goes into the per-build arena, not the
-                // process-lifetime `FilenameStore` (it is recomputed each build).
+                let mut new = new.dupe_alloc(alloc);
                 let pretty: &mut [u8] = alloc.alloc_slice_copy(self.pretty);
                 bun_paths::resolve_path::platform_to_posix_in_place::<u8>(pretty);
                 // SAFETY: arena memory lives for the whole bundle pass; the
                 // consuming `Path` never outlives it.
                 new.pretty = unsafe { core::slice::from_raw_parts(pretty.as_ptr(), pretty.len()) };
                 new.assert_pretty_is_valid();
-                Ok(new)
+                new
             }
         }
 

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1913,6 +1913,31 @@ pub use js_bundler as JSBundler;
 pub use js_bundler::Plugin;
 pub(crate) use js_bundler::PluginJscExt;
 
+pub mod testing_apis {
+    use super::*;
+
+    /// `bundlerInternals.pathStoreCounts()` in `bun:internal-for-testing`.
+    pub(crate) fn path_store_counts(
+        global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let counts = JSValue::create_empty_object(global, 2);
+        counts.put(
+            global,
+            b"filenames",
+            JSValue::js_number(bun_resolver::fs::FilenameStore::instance().count() as f64),
+        );
+        counts.put(
+            global,
+            b"dirnames",
+            JSValue::js_number(bun_resolver::fs::DirnameStore::instance().count() as f64),
+        );
+        Ok(counts)
+    }
+}
+// `generated_js2native.rs` snake-cases `TestingAPIs` as `testing_ap_is`.
+pub use testing_apis as testing_ap_is;
+
 /// Full `.classes.ts` payload — wraps a `webcore::Blob` plus
 /// `loader/path/hash/output_kind`. `.sourcemap` lives on the JS wrapper
 /// (`m_sourcemap` WriteBarrier from `cache: true`), not here.

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -865,3 +865,82 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
   },
 });
+
+// Every rebuild runs `Path::dupe_alloc` on every import it re-resolves. A path
+// that a plugin resolved is not interned by the resolver, and `dupe_alloc` used
+// to append it to the process-lifetime FilenameStore on every call, so a dev
+// server grew by one copy of every such path per rebuild for as long as it ran.
+// Those paths now live in the bundle's arena and the file watcher copies them.
+// MIMALLOC_PURGE_DELAY=0 makes mimalloc return the arena's pages to the OS as
+// soon as the bundle ends, so a watcher left with a stale pointer would miss
+// the final edit instead of reading the old bytes.
+const PATH_STORE_MODULES = 20;
+const PATH_STORE_EDITS = 5;
+function pathStoreEntry(edit: number) {
+  return (
+    Array.from({ length: PATH_STORE_MODULES }, (_, i) => `import { v${i} } from "from-plugin:m${i}";`).join("\n") +
+    `\nimport.meta.hot.accept();\nconsole.log("edit ${edit}: " + (${Array.from({ length: PATH_STORE_MODULES }, (_, i) => `v${i}`).join(" + ")}));\n`
+  );
+}
+devTest("rebuilding after an edit does not intern plugin-resolved paths again", {
+  files: {
+    "bunfig.toml": `
+      [serve.static]
+      plugins = ["./plugin.ts"]
+    `,
+    "plugin.ts": `
+      import { join } from "node:path";
+      export default {
+        name: "from-plugin",
+        setup(build) {
+          build.onResolve({ filter: /^from-plugin:/ }, args => ({
+            path: join(import.meta.dir, "lib", args.path.slice("from-plugin:".length) + ".ts"),
+          }));
+        },
+      };
+    `,
+    "index.html": emptyHtmlFile({ scripts: ["src/entry.ts"] }),
+    "src/entry.ts": pathStoreEntry(0),
+    ...Object.fromEntries(
+      Array.from({ length: PATH_STORE_MODULES }, (_, i) => [`lib/m${i}.ts`, `export const v${i} = ${i};\n`]),
+    ),
+    // The harness-generated config only serves the HTML; the counts have to be
+    // read inside the dev server's process, so serve them from a route.
+    "bun.app.ts": `
+      import { bundlerInternals } from "bun:internal-for-testing";
+      import html from "./index.html";
+      export default {
+        static: { "/": html },
+        fetch(req) {
+          if (new URL(req.url).pathname === "/path-store-counts") {
+            return Response.json(bundlerInternals.pathStoreCounts());
+          }
+          return new Response("Not Found", { status: 404 });
+        },
+      };
+    `,
+  },
+  htmlFiles: [],
+  env: { MIMALLOC_PURGE_DELAY: "0", MIMALLOC_ABANDONED_PAGE_PURGE: "1" },
+  async test(dev) {
+    const counts = () => dev.fetch("/path-store-counts").json();
+    const sum = (PATH_STORE_MODULES * (PATH_STORE_MODULES - 1)) / 2;
+    await using c = await dev.client("/");
+    await c.expectMessage(`edit 0: ${sum}`);
+    const before = await counts();
+    for (let edit = 1; edit <= PATH_STORE_EDITS; edit++) {
+      await dev.write("src/entry.ts", pathStoreEntry(edit));
+      await c.expectMessage(`edit ${edit}: ${sum}`);
+    }
+    const after = await counts();
+    // Unfixed: PATH_STORE_MODULES more filenames per edit.
+    expect({
+      filenames: after.filenames - before.filenames,
+      dirnames: after.dirnames - before.dirnames,
+    }).toEqual({ filenames: 0, dirnames: 0 });
+
+    // The watcher still knows the plugin-resolved files by their copied paths.
+    await dev.write("lib/m0.ts", `export const v0 = 1000;\n`);
+    await c.expectMessage(`edit ${PATH_STORE_EDITS}: ${sum + 1000}`);
+  },
+});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1908,6 +1908,102 @@ test("Bun.build does not corrupt folded string ropes shared across chunks", asyn
   expect(exitCode).toBe(0);
 }, 180_000);
 
+// The resolver's FilenameStore/DirnameStore are append-only and live for the
+// whole process. `Path::dupe_alloc`, which runs for every file a bundle
+// discovers, used to append paths that were not already interned (a path a
+// plugin resolved, a plugin's namespace) to the FilenameStore on every call, so
+// a process that bundles the same files repeatedly (the dev server on each
+// rebuild, a `Bun.build()` loop) retained one more copy per bundle. The counts
+// must stop changing once the files have been bundled once.
+describe.concurrent("Bun.build of the same files again does not re-intern their paths", () => {
+  const MODULES = 20;
+  const BUILDS = 10;
+
+  async function pathStoreGrowth(files: Record<string, string>, buildScript: string) {
+    files["run.ts"] = `
+      import { bundlerInternals } from "bun:internal-for-testing";
+      ${buildScript}
+      // The first build interns every path it is going to intern; nothing
+      // after it may add more.
+      await build();
+      const before = bundlerInternals.pathStoreCounts();
+      for (let i = 0; i < ${BUILDS}; i++) await build();
+      const after = bundlerInternals.pathStoreCounts();
+      console.log(JSON.stringify({
+        filenames: after.filenames - before.filenames,
+        dirnames: after.dirnames - before.dirnames,
+      }));
+    `;
+    const dir = tempDirWithFiles("bun-build-path-store-growth", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run.ts"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout.trim());
+  }
+
+  test("files found by the resolver", async () => {
+    const files: Record<string, string> = {};
+    for (let i = 0; i < MODULES; i++) files[`lib/m${i}.ts`] = `export const v${i} = ${i};\n`;
+    files["entry.ts"] = Array.from({ length: MODULES }, (_, i) => `export { v${i} } from "./lib/m${i}.ts";`).join("\n");
+    const growth = await pathStoreGrowth(
+      files,
+      `
+      async function build() {
+        const result = await Bun.build({ entrypoints: ["./entry.ts"] });
+        if (!result.success) throw new AggregateError(result.logs, "build failed");
+      }
+    `,
+    );
+    expect(growth).toEqual({ filenames: 0, dirnames: 0 });
+  });
+
+  test("files and namespaces supplied by plugins", async () => {
+    const files: Record<string, string> = {};
+    for (let i = 0; i < MODULES; i++) files[`lib/m${i}.ts`] = `export const v${i} = ${i};\n`;
+    files["entry.ts"] = Array.from(
+      { length: MODULES },
+      (_, i) => `export { v${i} } from "real:m${i}"; export { w${i} } from "virtual:m${i}";`,
+    ).join("\n");
+    const growth = await pathStoreGrowth(
+      files,
+      `
+      import { join } from "node:path";
+      const plugin: import("bun").BunPlugin = {
+        name: "path-store-growth",
+        setup(builder) {
+          // Resolves to a file on disk, so the bundler reads it like any
+          // other file, but the path string comes from the plugin.
+          builder.onResolve({ filter: /^real:/ }, args => ({
+            path: join(import.meta.dir, "lib", args.path.slice("real:".length) + ".ts"),
+          }));
+          builder.onResolve({ filter: /^virtual:/ }, args => ({
+            path: args.path.slice("virtual:".length),
+            namespace: "virtual",
+          }));
+          builder.onLoad({ filter: /.*/, namespace: "virtual" }, args => ({
+            contents: "export const w" + args.path.slice(1) + " = " + args.path.slice(1) + ";",
+            loader: "ts",
+          }));
+        },
+      };
+      async function build() {
+        const result = await Bun.build({ entrypoints: ["./entry.ts"], plugins: [plugin] });
+        if (!result.success) throw new AggregateError(result.logs, "build failed");
+      }
+    `,
+    );
+    // Unfixed: 20 more filenames per build, the path of every plugin-resolved file.
+    expect(growth).toEqual({ filenames: 0, dirnames: 0 });
+  });
+});
+
 // A plugin module's namespace lives in the bundle's arena. The `BuildMessage`
 // objects in `result.logs` outlive the arena, so they must own a copy.
 // MIMALLOC_PURGE_DELAY=0 makes mimalloc return the arena's pages to the OS as


### PR DESCRIPTION
### Problem
- `Path::dupe_alloc` (`src/resolver/lib.rs`) appends every plugin-resolved path to the process-lifetime `FilenameStore` on every bundle, because the resolver never interned it. A dev server or a `Bun.build()` loop keeps one more copy per path per rebuild: 20 plugin-resolved modules give +20 filenames each time.
- `dupe_namespace` does the same for a non-`file` namespace.

### Fix
- `dupe_alloc` never appends. `text`, `pretty`, and `namespace` are reused when already interned and copied into the bundle's arena otherwise. Four branches collapse into one.
- Correct because the `Path` is bundle-graph data. Every holder that outlives the bundle copies: the watcher (since #40640), the dev server's graph keys, `BuildArtifact.path`, and `Location` (#40722).
- `dupe_alloc` can no longer fail, so it and the three `*path_with_pretty_initialized` wrappers return the `Path` directly. The dead `?` / `.expect("oom")` at 12 call sites are deleted.
- Verified: `test/bundler/bun-build-api.test.ts` (+200 filenames over 10 builds on main, 0 here) and `test/bake/dev/bundle.test.ts` (+20 per edit on main, 0 here, plugin-resolved file still hot-reloads). Also the bake dev and bundler suites. Clippy is clean.

### Background
- `FilenameStore` / `DirnameStore` (`bun_alloc::BSSStringList`) are append-only string stores that live for the whole process. The resolver interns each directory and resolved file once.
- `Path::dupe_alloc` turns a resolver's or a plugin's `Path` into the one the bundle graph stores: `text` is the absolute path, `pretty` the display path, `namespace` is `file` or a plugin namespace. Its `MimallocArena` dies with the bundle, and arena OOM aborts instead of returning `Err`.
- `bun:internal-for-testing` gains `bundlerInternals.pathStoreCounts()` as an exact gauge. The stores never shrink, so "unchanged" is precise.

<details>
<summary>Notes</summary>

**Origin.** The report was dev server RSS growth of about 270 bytes per re-parsed file per bundle. On a debug (ASAN) build the Rust global allocator is libc, so `__sanitizer_print_memory_profile` shows global-heap allocations and `mi_heap_visit_blocks` shows mimalloc blocks separately. Re-bundling a 52 module graph 400 times: the only global-heap context that grew was `FilenameStore::append_slice` from `dupe_alloc` (+5,167 allocations, one per file per rebuild), and the mimalloc main heap grew by about 237 blocks per bundle (the `AstAlloc` fallback, fixed by #39050). The dev server's own `memory_cost` accounting was flat, so neither leak is in the incremental graph or the source map store.

**Scope.** The tests cover the paths `dupe_alloc` sees. Other sites still append per build for inputs these tests do not use (a symlinked `node_modules` through `RealFS::kind`, browser-map-disabled imports in `resolver.rs`). They are outside this PR.

**History.** The first version deduplicated appends with a per-thread content index. Review pointed out that this adds a third copy of that pattern and that routing non-interned strings to the bundle arena fixes the growth for every graph size with less code. The second version did that, and also copied the watcher's path and made `Location.namespace` a `Cow`. #40640 then landed with the same watcher change and with `as_interned_path`, which stopped the growth for resolver-found files. This PR is rebased on it. The `Location` copy was split out as #40722 (merged) because #40640 made it a live use-after-free on its own. This PR was stacked on it and is now rebased onto main.

**Related PRs.** #39488 carries a pre-#40640 snapshot of this change (commit eedd92e649 and neighbors); it should rebase onto this once merged. #34276 adds a second store gauge (`append_count` / `dirnameStoreAppendCount`) with the same formula as `BSSStringList::count` here; one of the two should consume the other. #40196 waits on `pathStoreCounts()` to drop its build loop.

**Rebase conflicts resolved.** `src/resolver/lib.rs`: main's `as_interned` / `as_interned_path` are kept and `interned_or_arena` is built on them. Main's `dupe_namespace` is removed (the single-flow `dupe_alloc` replaces it). `src/bundler/bundle_v2.rs`: main's conditional watcher copy is kept unchanged. `src/bun_alloc/lib.rs`: main's `as_interned` and this PR's `count` both stay.

**Other suites on this build.** `test/bundler/bun-build-api.test.ts` in full: the two `bytecode:` tests time out at 5 s on this loaded host and are unrelated (they are unchanged from main).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->
