### PR TITLE
Bump WebKit (oven-sh/WebKit#460 preview): URL.pathname keeps a dotted first segment in host-less URLs, fixing custom-scheme URLPatterns

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "c4ddc0cf5255ec9cc209e6369292739b78e3ca80";
+export const WEBKIT_VERSION = "autobuild-preview-pr-460-37291f35";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -323,6 +323,121 @@ describe("url", () => {
 }`);
     // A path whose first segment merely starts with "." gets no guard.
     expect(util.inspect(new URL("foo:/.foo"), { showHidden: true })).toContain("pathname_start: 4,");
+    // search_start is derived from the pathname's length, so it is only right if the pathname getter keeps the "/.".
+    const inspected = util.inspect(new URL("foo:/.foo?x"), { showHidden: true });
+    expect(inspected).toContain("pathname: '/.foo',");
+    expect(inspected).toContain("pathname_start: 4,");
+    expect(inspected).toContain("search_start: 9,");
+  });
+
+  // URL Standard section 4.5 step 3: a URL with a null host serializes a path whose first segment is empty with a "/."
+  // guard in front of it (foo:/.//b), and the pathname getter leaves that guard out. The guard is only ever in front of
+  // "//"; a first segment that merely starts with "." (foo:/.a, git:/.git/config) is part of the pathname.
+  describe("pathname of a host-less URL whose first segment starts with a dot", () => {
+    const pathnames = (inputs: string[]) => Object.fromEntries(inputs.map(input => [input, new URL(input).pathname]));
+
+    it("keeps the dotted first segment", () => {
+      expect(
+        pathnames([
+          "foo:/.a/b",
+          "git:/.git/config",
+          "myapp:/.well-known/assetlinks.json",
+          "foo:/..a",
+          "foo:/.a",
+          "foo:/.a?q#f",
+          "foo:/.%2Fa",
+          "foo:/.a//b",
+          "foo:/./.a",
+        ]),
+      ).toEqual({
+        "foo:/.a/b": "/.a/b",
+        "git:/.git/config": "/.git/config",
+        "myapp:/.well-known/assetlinks.json": "/.well-known/assetlinks.json",
+        "foo:/..a": "/..a",
+        "foo:/.a": "/.a",
+        "foo:/.a?q#f": "/.a",
+        "foo:/.%2Fa": "/.%2Fa",
+        "foo:/.a//b": "/.a//b",
+        "foo:/./.a": "/.a",
+      });
+    });
+
+    it("still omits the /. guard and normalizes dot segments", () => {
+      expect(
+        pathnames([
+          "foo:/.//b",
+          "foo:/..//b",
+          "foo:/.//.a",
+          "foo:/./b",
+          "foo:/.",
+          "foo://h/.a",
+          "foo:///.a",
+          "https://h/.a",
+          "file:/.a",
+        ]),
+      ).toEqual({
+        "foo:/.//b": "//b",
+        "foo:/..//b": "//b",
+        "foo:/.//.a": "//.a",
+        "foo:/./b": "/b",
+        "foo:/.": "/",
+        "foo://h/.a": "/.a",
+        "foo:///.a": "/.a",
+        "https://h/.a": "/.a",
+        "file:/.a": "/.a",
+      });
+      expect(new URL("foo:/.//b").href).toBe("foo:/.//b");
+      expect(new URL("foo:/.a/b").href).toBe("foo:/.a/b");
+    });
+
+    it("resolves relative references against such a URL", () => {
+      const resolve = (input: string, base: string) => {
+        const url = new URL(input, base);
+        return { href: url.href, pathname: url.pathname };
+      };
+      expect({
+        "x against foo:/.a/b": resolve("x", "foo:/.a/b"),
+        "../y against foo:/.a/b/c": resolve("../y", "foo:/.a/b/c"),
+        "/.a against foo:/.//b": resolve("/.a", "foo:/.//b"),
+        "//b against foo:/.a": resolve("//b", "foo:/.a"),
+      }).toEqual({
+        "x against foo:/.a/b": { href: "foo:/.a/x", pathname: "/.a/x" },
+        "../y against foo:/.a/b/c": { href: "foo:/.a/y", pathname: "/.a/y" },
+        "/.a against foo:/.//b": { href: "foo:/.a", pathname: "/.a" },
+        "//b against foo:/.a": { href: "foo://b", pathname: "" },
+      });
+    });
+
+    it("setters", () => {
+      const set = (input: string, property: "pathname" | "host" | "search" | "protocol", value: string) => {
+        const url = new URL(input);
+        url[property] = value;
+        return { href: url.href, host: url.host, pathname: url.pathname };
+      };
+      expect({
+        "foo:/x pathname=/.a/b": set("foo:/x", "pathname", "/.a/b"),
+        "foo:/.a pathname=/b": set("foo:/.a", "pathname", "/b"),
+        "foo:/.a pathname=//b": set("foo:/.a", "pathname", "//b"),
+        "foo:/.//b pathname=/.c": set("foo:/.//b", "pathname", "/.c"),
+        "foo:/.a search=?x": set("foo:/.a", "search", "?x"),
+        "foo:/.a protocol=bar": set("foo:/.a", "protocol", "bar"),
+        "foo:/.a host=h": set("foo:/.a", "host", "h"),
+        "foo:/.a host=h:1": set("foo:/.a", "host", "h:1"),
+        "foo:/.//b host=h": set("foo:/.//b", "host", "h"),
+        "foo:/.//b host=h:1": set("foo:/.//b", "host", "h:1"),
+      }).toEqual({
+        "foo:/x pathname=/.a/b": { href: "foo:/.a/b", host: "", pathname: "/.a/b" },
+        "foo:/.a pathname=/b": { href: "foo:/b", host: "", pathname: "/b" },
+        "foo:/.a pathname=//b": { href: "foo:/.//b", host: "", pathname: "//b" },
+        "foo:/.//b pathname=/.c": { href: "foo:/.c", host: "", pathname: "/.c" },
+        "foo:/.a search=?x": { href: "foo:/.a?x", host: "", pathname: "/.a" },
+        "foo:/.a protocol=bar": { href: "bar:/.a", host: "", pathname: "/.a" },
+        "foo:/.a host=h": { href: "foo://h/.a", host: "h", pathname: "/.a" },
+        "foo:/.a host=h:1": { href: "foo://h:1/.a", host: "h:1", pathname: "/.a" },
+        "foo:/.//b host=h": { href: "foo://h//b", host: "h", pathname: "//b" },
+        "foo:/.//b host=h:1": { href: "foo://h:1//b", host: "h:1", pathname: "//b" },
+      });
+    });
   });
   it("works", () => {
     const inputs = [

--- a/test/js/web/urlpattern/urlpattern.test.ts
+++ b/test/js/web/urlpattern/urlpattern.test.ts
@@ -161,6 +161,81 @@ describe("URLPattern", () => {
     });
   });
 
+  // For a non-special scheme, the pathname is canonicalized by parsing it as the path of a host-less dummy URL and
+  // reading the pathname back, so a first segment starting with "." must survive that round trip (see the URL tests
+  // for the "/." guard that a host-less URL serializes in front of a path starting with "//").
+  describe("non-special scheme with a pathname whose first segment starts with a dot", () => {
+    test("constructor string with a host", () => {
+      const pattern = new URLPattern("myapp://host/.well-known/:file");
+      expect(pattern.pathname).toBe("/.well-known/:file");
+      expect(pattern.test("myapp://host/.well-known/assetlinks.json")).toBe(true);
+      expect(pattern.exec("myapp://host/.well-known/assetlinks.json")!.pathname).toEqual({
+        input: "/.well-known/assetlinks.json",
+        groups: { file: "assetlinks.json" },
+      });
+      expect(pattern.test("myapp://host/well-known/assetlinks.json")).toBe(false);
+    });
+
+    test("wildcard after the dotted segment", () => {
+      const pattern = new URLPattern("git://h/.git/:rest*");
+      expect(pattern.pathname).toBe("/.git/:rest*");
+      expect(pattern.test("git://h/.git/config")).toBe(true);
+      expect(pattern.exec("git://h/.git/refs/heads/main")!.pathname.groups).toEqual({ rest: "refs/heads/main" });
+    });
+
+    test("URLPatternInit", () => {
+      expect({
+        wellKnown: new URLPattern({ protocol: "myapp", pathname: "/.well-known/*" }).pathname,
+        doubleDot: new URLPattern({ protocol: "myapp", pathname: "/..a" }).pathname,
+        dotSlashSlash: new URLPattern({ protocol: "myapp", pathname: "/.//a" }).pathname,
+        laterSegment: new URLPattern({ protocol: "myapp", pathname: "/x/.a" }).pathname,
+      }).toEqual({
+        wellKnown: "/.well-known/*",
+        doubleDot: "/..a",
+        dotSlashSlash: "//a",
+        laterSegment: "/x/.a",
+      });
+      const pattern = new URLPattern({ protocol: "foo", pathname: "/.a" });
+      expect(pattern.test("foo:/.a")).toBe(true);
+      expect(pattern.test("foo://h/.a")).toBe(true);
+      expect(pattern.test({ protocol: "foo", pathname: "/.a" })).toBe(true);
+      expect(pattern.test("foo:/a")).toBe(false);
+    });
+
+    test("baseURL", () => {
+      expect({
+        relativeString: new URLPattern("./c", "foo://h/.a/b").pathname,
+        relativeInit: new URLPattern({ pathname: "c", baseURL: "foo:/.a/b" }).pathname,
+        inheritedFromBase: new URLPattern({ baseURL: "foo:/.a/b" }).pathname,
+      }).toEqual({
+        relativeString: "/.a/c",
+        relativeInit: "/.a/c",
+        inheritedFromBase: "/.a/b",
+      });
+    });
+
+    test("the matched input reports the full pathname", () => {
+      expect(new URLPattern({ protocol: "foo" }).exec("foo:/.a/b")!.pathname).toEqual({
+        input: "/.a/b",
+        groups: { "0": "/.a/b" },
+      });
+    });
+
+    test("unaffected patterns", () => {
+      expect({
+        special: new URLPattern("https://h/.well-known/:file").pathname,
+        noProtocol: new URLPattern({ pathname: "/.well-known/*" }).pathname,
+        hostAndLaterSegment: new URLPattern("foo://h/x/.b").pathname,
+      }).toEqual({
+        special: "/.well-known/:file",
+        noProtocol: "/.well-known/*",
+        hostAndLaterSegment: "/x/.b",
+      });
+      expect(new URLPattern("https://h/.well-known/:file").test("https://h/.well-known/x")).toBe(true);
+      expect(new URLPattern("foo://h/x/.b").test("foo://h/x/.b")).toBe(true);
+    });
+  });
+
   describe("hasRegExpGroups", () => {
     test("match-everything pattern", () => {
       expect(new URLPattern({}).hasRegExpGroups).toBe(false);


### PR DESCRIPTION
Bumps `WEBKIT_VERSION` to pick up oven-sh/WebKit#460 and adds the `bun:test` coverage for it.

Pinned to the preview build of oven-sh/WebKit#460 so CI exercises the change; to be re-pinned to the merged oven-sh/WebKit commit before this merges.

### Problem
- `URL.prototype.pathname` drops the leading `/.` of a URL that has no host and whose first path segment starts with a dot. `href` is right, only the getter is wrong, and the same happens through the `pathname` setter:

  ```js
  new URL("foo:/.a/b").pathname          // Bun: "a/b"         Node 26 and Deno 2.9: "/.a/b"   (href is "foo:/.a/b" everywhere)
  new URL("git:/.git/config").pathname   // Bun: "git/config"  expected "/.git/config"
  new URL("foo:/..a").pathname           // Bun: ".a"          expected "/..a"
  ```

  `new URL("foo:/.//b").pathname` is `//b` everywhere, and URLs with a host (`foo://h/.a`, `https://h/.a`, `file:/.a`) are unaffected.
- Every `URLPattern` with a custom scheme and a pathname starting with a dot is compiled wrong as a result, because for non-special schemes the pathname text is canonicalized by parsing it as the path of a host-less dummy URL and reading the pathname back (`src/jsc/bindings/webcore/URLPatternCanonical.cpp`, `canonicalizeOpaquePathname`). The pattern's host makes no difference since the dummy URL never has one:

  ```js
  new URLPattern("myapp://host/.well-known/:f").pathname                      // Bun: "well-known/:f", expected "/.well-known/:f"
  new URLPattern("myapp://host/.well-known/:f").test("myapp://host/.well-known/assetlinks.json")   // Bun: false
  new URLPattern("git://h/.git/:rest*").test("git://h/.git/config")           // Bun: false
  new URLPattern({ protocol: "myapp", pathname: "/.well-known/*" }).pathname  // Bun: "well-known/*"
  ```

  `https` patterns and `{ pathname: "/.well-known/*" }` without a protocol are unaffected. `u.host = "h:1"` on such a URL was also silently ignored, and `util.inspect(url, { showHidden: true })` reported no `search_start` for `foo:/.foo?x`, since both are computed from the same offset.
- Cause: `WTF::URL::pathStart()` (`Source/WTF/wtf/URL.cpp` in oven-sh/WebKit, the offset every path accessor and setter uses) skips a `/.` directly after the scheme without checking that a `/` follows it. That `/.` is meant to be the guard the serializer puts in front of a path starting with `//` in a host-less URL, but the check also matches a real first segment such as `.a` or `.git`. No Bun source is involved: `URLDecomposition::pathname()` returns `URL::path()`, and the URLPattern canonicalizers read the same accessor. Same in upstream WebKit and in every Bun release; the WPT `urltestdata.json` and URLPattern corpora that Bun runs have no host-less URL with a dotted first segment, which is why this was only found by a differential run against Node and Deno.

### Fix
- oven-sh/WebKit#460 makes `pathStart()` also require the character after `/.` to be `/` (the only shape the parser ever inserts, and the same test its relative-URL path already used). The branch is directly on top of `c4ddc0cf52`, the commit main is pinned to, so the new pin is exactly the current engine plus that change. Since the fix is in the offset itself, `pathname`, the `pathname` and `host` setters, relative resolution, URLPattern and the inspect offsets are all fixed at once.
- Tests, in the existing files for these APIs:
  - `test/js/web/url/url.test.ts`: the dotted first segments above (including `?q#f`, `%2F`, `/.a//b`, `/./.a`), control rows showing the `/.` guard is still omitted for `foo:/.//b`, `foo:/..//b`, `foo:/.//.a` and that hosts and special schemes are unchanged, relative resolution against and onto such URLs, the `pathname`, `search`, `protocol` and `host` setters (both `h` and `h:1`, on a dotted path and on a `/.//` path), and `search_start` in the inspected `URLContext`.
  - `test/js/web/urlpattern/urlpattern.test.ts`: the constructor-string, `URLPatternInit` and `baseURL` forms with a non-special scheme, `test()` and `exec()` results including the matched `pathname.input`, and unaffected `https` / protocol-less / later-segment patterns. Every expected value was checked against Node 26.
- On the previous pin 9 of these tests fail (`USE_SYSTEM_BUN=1 bun test` on the two files: 436 pass, 9 fail, all in the new blocks plus the extended `URLContext` test) and the two control tests pass. Against this pin the two files pass in full under `bun bd test`, including the WPT URL constructor and URLPattern corpora they already contain. The WebKit change itself was also checked by compiling WebKit's own `WTF_URL` / `WTF_URLParser` gtest files (with the rows added in oven-sh/WebKit#460) against the `1817c3c3` debug ASAN prebuilt: 3 of 31 tests fail with the stock `libWTF.a`, 31 of 31 pass with the patched `URL.cpp` linked in front of it.

### Background
- URL Standard, serializer step for the path: when a URL has no host and its path starts with an empty segment, the serialization is `scheme:/.` followed by the path (`foo:/.//b` for the path `//b`), because `foo://b` would re-parse `b` as a host. The `pathname` getter returns the path without that guard, and only the guard; a first segment that merely starts with `.` is ordinary path text.
- WTF's `URL` keeps the serialized string plus component offsets and derives the start of the path from the end of the host and port, which is where the guard special case lives. Bun's `URL` (`src/jsc/bindings/URLDecomposition.cpp`) and URLPattern (`src/jsc/bindings/webcore/URLPattern*.cpp`) are thin layers over it.
- `WEBKIT_VERSION` in `scripts/build/deps/webkit.ts` is the only place the engine version lives; CI and `bun bd` download the prebuilt `autobuild-<version>` release for it from oven-sh/WebKit. Preview builds of a WebKit PR are published as `autobuild-preview-pr-<n>-<sha>` and can be pinned the same way.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 8 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/url/url.test.ts' 'test/js/web/urlpattern/urlpattern.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/url/url.test.ts test/js/web/urlpattern/urlpattern.test.ts
bun test v1.4.1 (65362b53b)

test/js/web/url/url.test.ts:
(pass) url > URL throws [14.89ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [9.00ms]
(pass) url > should have correct origin and protocol [10.95ms]
(pass) url > blob urls [7.03ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [6.91ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [5.09ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [19.52ms]
(pass) url > judges literal punycode labels like Node (fast path and ICU path) [22.88ms]
(pass) url > resolves against repeated, alternating and invalid string bases consistently [21.29ms]
(pass) url > href, toString and toJSON agree before and after mutation [99.91ms]
(pass) url > prints [99.19ms]
(pass) url > URLContext offsets account for the /. pathname guard [58.43ms]
(pass) url > pathname of a host-less URL whose first segment starts with a dot > keeps the dotted first segment [8.67ms]
(pass) url > pathname of a host-less URL whose first segment starts with a dot > still omits the /. guard and normalizes dot segments [5.29ms]
(pass) url > pathname of a host-less URL whose first segment starts with a dot > resolves relative references against such a URL [5.23ms]
(pass) url > pathname of a host-less URL whose first segment starts with a dot > setters [10.78ms]
(pass) url > works [11.68ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [1.62ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined) [0.32ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:b) [0.23ms]
(pass) url > URL.canParse > URL.canParse(a:/b, undefined) [0.20ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:/b) [0.26ms]
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined) [0.19ms]
(pa
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts              |   2 +-
 test/js/web/url/url.test.ts               | 115 ++++++++++++++++++++++++++++++
 test/js/web/urlpattern/urlpattern.test.ts |  75 +++++++++++++++++++
 3 files changed, 191 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 14 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
scripts/build/deps/webkit.ts                  16     17      0
test/js/web/url/url.test.ts                    1      1      0
test/js/web/urlpattern/urlpattern.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->












