### PR TITLE
url: strip ASCII tab and newline in the host, hostname and pathname setters before inspecting the value

### DIFF
--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -38,6 +38,14 @@ static bool hasAcceptableHost(const WTF::URL& url)
     return Bun::hasValidPunycodeHost(url.host()) || !url.hasSpecialScheme();
 }
 
+// The basic URL parser removes these before any state runs. The host, hostname
+// and pathname setters look at the value (empty check, port digits, leading "/")
+// before WTF::URL reparses it, so they have to remove them up front too.
+static String removeTabAndNewline(const String& value)
+{
+    return value.removeCharacters([](char16_t c) { return c == '\t' || c == '\n' || c == '\r'; });
+}
+
 String URLDecomposition::origin() const
 {
     auto fullURL = this->fullURL();
@@ -113,9 +121,11 @@ static unsigned countASCIIDigits(StringView string)
     return length;
 }
 
-void URLDecomposition::setHost(StringView value)
+void URLDecomposition::setHost(const String& input)
 {
     auto fullURL = this->fullURL();
+    String strippedInput = removeTabAndNewline(input);
+    StringView value = strippedInput;
     if (value.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
         return;
 
@@ -154,9 +164,10 @@ String URLDecomposition::hostname() const
     return fullURL().host().toString();
 }
 
-void URLDecomposition::setHostname(StringView host)
+void URLDecomposition::setHostname(const String& input)
 {
     auto fullURL = this->fullURL();
+    String host = removeTabAndNewline(input);
     if (host.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
         return;
     if (fullURL.hasOpaquePath())
@@ -218,13 +229,12 @@ String URLDecomposition::pathname() const
     return fullURL().path().toString();
 }
 
-void URLDecomposition::setPathname(const String& value)
+void URLDecomposition::setPathname(const String& input)
 {
     auto fullURL = this->fullURL();
     if (fullURL.hasOpaquePath())
         return;
-    // URL::setPath picks the leading "/" before its reparse strips tab and newline.
-    String path = value.removeCharacters([](char16_t c) { return c == '\t' || c == '\n' || c == '\r'; });
+    String path = removeTabAndNewline(input);
     fullURL.setPath(path);
     setFullURL(fullURL);
 }

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -223,9 +223,7 @@ void URLDecomposition::setPathname(const String& value)
     auto fullURL = this->fullURL();
     if (fullURL.hasOpaquePath())
         return;
-    // The basic URL parser removes ASCII tab and newline before anything else.
-    // URL::setPath only drops them in its reparse, after choosing the leading "/"
-    // (and the "/." guard) from the raw value, so "\n/a/b" reparsed as "//a/b".
+    // URL::setPath picks the leading "/" before its reparse strips tab and newline.
     String path = value.removeCharacters([](char16_t c) { return c == '\t' || c == '\n' || c == '\r'; });
     fullURL.setPath(path);
     setFullURL(fullURL);

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -218,12 +218,16 @@ String URLDecomposition::pathname() const
     return fullURL().path().toString();
 }
 
-void URLDecomposition::setPathname(StringView value)
+void URLDecomposition::setPathname(const String& value)
 {
     auto fullURL = this->fullURL();
     if (fullURL.hasOpaquePath())
         return;
-    fullURL.setPath(value);
+    // The basic URL parser removes ASCII tab and newline before anything else.
+    // URL::setPath only drops them in its reparse, after choosing the leading "/"
+    // (and the "/." guard) from the raw value, so "\n/a/b" reparsed as "//a/b".
+    String path = value.removeCharacters([](char16_t c) { return c == '\t' || c == '\n' || c == '\r'; });
+    fullURL.setPath(path);
     setFullURL(fullURL);
 }
 

--- a/src/jsc/bindings/URLDecomposition.cpp
+++ b/src/jsc/bindings/URLDecomposition.cpp
@@ -38,9 +38,7 @@ static bool hasAcceptableHost(const WTF::URL& url)
     return Bun::hasValidPunycodeHost(url.host()) || !url.hasSpecialScheme();
 }
 
-// The basic URL parser removes these before any state runs. The host, hostname
-// and pathname setters look at the value (empty check, port digits, leading "/")
-// before WTF::URL reparses it, so they have to remove them up front too.
+// The basic URL parser removes these first; the setters below inspect the value before WTF::URL reparses it.
 static String removeTabAndNewline(const String& value)
 {
     return value.removeCharacters([](char16_t c) { return c == '\t' || c == '\n' || c == '\r'; });

--- a/src/jsc/bindings/URLDecomposition.h
+++ b/src/jsc/bindings/URLDecomposition.h
@@ -60,7 +60,7 @@ public:
     void setPort(StringView);
 
     WEBCORE_EXPORT String pathname() const;
-    void setPathname(StringView);
+    void setPathname(const String&);
 
     WEBCORE_EXPORT String search() const;
     void setSearch(const String&);

--- a/src/jsc/bindings/URLDecomposition.h
+++ b/src/jsc/bindings/URLDecomposition.h
@@ -51,10 +51,10 @@ public:
     void setPassword(StringView);
 
     WEBCORE_EXPORT String host() const;
-    void setHost(StringView);
+    void setHost(const String&);
 
     WEBCORE_EXPORT String hostname() const;
-    void setHostname(StringView);
+    void setHostname(const String&);
 
     WEBCORE_EXPORT String port() const;
     void setPort(StringView);

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -249,6 +249,42 @@ describe("url", () => {
     // A path whose first segment merely starts with "." gets no guard.
     expect(util.inspect(new URL("foo:/.foo"), { showHidden: true })).toContain("pathname_start: 4,");
   });
+
+  it("pathname setter removes ASCII tab and newline before looking at the leading slash", () => {
+    // https://url.spec.whatwg.org/#concept-basic-url-parser removes tab, LF and CR from the value first, so
+    // "\n/x" is the same assignment as "/x". Expected values are Node's. On a host-less URL the unstripped
+    // value used to reparse as "//evil.com/y", which made evil.com the host.
+    const cases: [href: string, value: string, expected: { href: string; host: string; pathname: string }][] = [
+      ["foo:/a", "\n/evil.com/y", { href: "foo:/evil.com/y", host: "", pathname: "/evil.com/y" }],
+      ["foo:/a", "\t/evil.com/y", { href: "foo:/evil.com/y", host: "", pathname: "/evil.com/y" }],
+      ["foo:/a", "\r/evil.com/y", { href: "foo:/evil.com/y", host: "", pathname: "/evil.com/y" }],
+      ["foo:/a", "\t\n\r/evil.com/y", { href: "foo:/evil.com/y", host: "", pathname: "/evil.com/y" }],
+      // Two leading slashes on a host-less URL get the /. guard instead of becoming an empty host.
+      ["foo:/a", "\n//evil.com/y", { href: "foo:/.//evil.com/y", host: "", pathname: "//evil.com/y" }],
+      ["foo:/a", "\tevil.com/y", { href: "foo:/evil.com/y", host: "", pathname: "/evil.com/y" }],
+      ["foo:/.//p", "\t/x", { href: "foo:/x", host: "", pathname: "/x" }],
+      ["foo:/.//p", "\t//x", { href: "foo:/.//x", host: "", pathname: "//x" }],
+      ["foo://host/a", "\n/x/y", { href: "foo://host/x/y", host: "host", pathname: "/x/y" }],
+      // A value that strips down to "" empties the path of a non-special URL with a host.
+      ["foo://host/a", "\t", { href: "foo://host", host: "host", pathname: "" }],
+      ["http://h/", "\t/x", { href: "http://h/x", host: "h", pathname: "/x" }],
+      ["http://h/", "\n/x", { href: "http://h/x", host: "h", pathname: "/x" }],
+      ["http://h/", "\r/x", { href: "http://h/x", host: "h", pathname: "/x" }],
+      ["http://h/", "\t//x", { href: "http://h//x", host: "h", pathname: "//x" }],
+      ["http://h/", "\t\\x", { href: "http://h/x", host: "h", pathname: "/x" }],
+      ["http://h/", "\tx", { href: "http://h/x", host: "h", pathname: "/x" }],
+      ["http://h/", "\t/a\tb/\nc", { href: "http://h/ab/c", host: "h", pathname: "/ab/c" }],
+      ["http://h/", "/x\n", { href: "http://h/x", host: "h", pathname: "/x" }],
+      ["file:///a", "\t/x", { href: "file:///x", host: "", pathname: "/x" }],
+    ];
+    const results = cases.map(([href, value]) => {
+      const url = new URL(href);
+      url.pathname = value;
+      return [href, value, { href: url.href, host: url.host, pathname: url.pathname }];
+    });
+    expect(results).toEqual(cases);
+  });
+
   it("works", () => {
     const inputs = [
       [

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -250,11 +250,11 @@ describe("url", () => {
     expect(util.inspect(new URL("foo:/.foo"), { showHidden: true })).toContain("pathname_start: 4,");
   });
 
-  it("pathname setter removes ASCII tab and newline before looking at the leading slash", () => {
+  describe("pathname setter removes ASCII tab and newline before looking at the leading slash", () => {
     // https://url.spec.whatwg.org/#concept-basic-url-parser removes tab, LF and CR from the value first, so
     // "\n/x" is the same assignment as "/x". Expected values are Node's. On a host-less URL the unstripped
     // value used to reparse as "//evil.com/y", which made evil.com the host.
-    const cases: [href: string, value: string, expected: { href: string; host: string; pathname: string }][] = [
+    test.each<[href: string, value: string, expected: { href: string; host: string; pathname: string }]>([
       ["foo:/a", "\n/evil.com/y", { href: "foo:/evil.com/y", host: "", pathname: "/evil.com/y" }],
       ["foo:/a", "\t/evil.com/y", { href: "foo:/evil.com/y", host: "", pathname: "/evil.com/y" }],
       ["foo:/a", "\r/evil.com/y", { href: "foo:/evil.com/y", host: "", pathname: "/evil.com/y" }],
@@ -276,13 +276,11 @@ describe("url", () => {
       ["http://h/", "\t/a\tb/\nc", { href: "http://h/ab/c", host: "h", pathname: "/ab/c" }],
       ["http://h/", "/x\n", { href: "http://h/x", host: "h", pathname: "/x" }],
       ["file:///a", "\t/x", { href: "file:///x", host: "", pathname: "/x" }],
-    ];
-    const results = cases.map(([href, value]) => {
+    ])("new URL(%p).pathname = %p", (href, value, expected) => {
       const url = new URL(href);
       url.pathname = value;
-      return [href, value, { href: url.href, host: url.host, pathname: url.pathname }];
+      expect({ href: url.href, host: url.host, pathname: url.pathname }).toEqual(expected);
     });
-    expect(results).toEqual(cases);
   });
 
   it("works", () => {

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -252,7 +252,7 @@ describe("url", () => {
 
   describe("pathname setter removes ASCII tab and newline before looking at the leading slash", () => {
     // https://url.spec.whatwg.org/#concept-basic-url-parser removes tab, LF and CR from the value first, so
-    // "\n/x" is the same assignment as "/x". Expected values are Node's. On a host-less URL the unstripped
+    // "\n/x" is the same assignment as "/x". Expected values are Node 26's. On a host-less URL the unstripped
     // value used to reparse as "//evil.com/y", which made evil.com the host.
     test.each<[href: string, value: string, expected: { href: string; host: string; pathname: string }]>([
       ["foo:/a", "\n/evil.com/y", { href: "foo:/evil.com/y", host: "", pathname: "/evil.com/y" }],
@@ -284,7 +284,7 @@ describe("url", () => {
   });
 
   describe("host and hostname setters remove ASCII tab and newline before looking at the value", () => {
-    // Same parser rule as the pathname setter above; expected values are Node's. The host setter used to count
+    // Same parser rule as the pathname setter above; expected values are Node 26's. The host setter used to count
     // the port digits in the raw value, so a tab after the colon dropped or truncated the port, and a value
     // that is only whitespace skipped the empty-value no-op and reparsed "http:///p" with "p" as the host.
     test.each<

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -283,6 +283,41 @@ describe("url", () => {
     });
   });
 
+  describe("host and hostname setters remove ASCII tab and newline before looking at the value", () => {
+    // Same parser rule as the pathname setter above; expected values are Node's. The host setter used to count
+    // the port digits in the raw value, so a tab after the colon dropped or truncated the port, and a value
+    // that is only whitespace skipped the empty-value no-op and reparsed "http:///p" with "p" as the host.
+    test.each<
+      [
+        href: string,
+        setter: "host" | "hostname",
+        value: string,
+        expected: { href: string; host: string; pathname: string },
+      ]
+    >([
+      ["http://h/p", "host", "x.com:\t81", { href: "http://x.com:81/p", host: "x.com:81", pathname: "/p" }],
+      ["http://h/p", "host", "x.com:8\n1", { href: "http://x.com:81/p", host: "x.com:81", pathname: "/p" }],
+      ["http://h/p", "host", "x.com:\r81\r", { href: "http://x.com:81/p", host: "x.com:81", pathname: "/p" }],
+      ["http://h/p", "host", "[::2]:\t81", { href: "http://[::2]:81/p", host: "[::2]:81", pathname: "/p" }],
+      // With a state override the port ends at the first non-digit, so only the "8" is taken.
+      ["http://h/p", "host", "x.com:\t8a", { href: "http://x.com:8/p", host: "x.com:8", pathname: "/p" }],
+      ["http://h/p", "host", "x.com:\t80", { href: "http://x.com/p", host: "x.com", pathname: "/p" }],
+      ["foo://h/p", "host", "x.com:\t81", { href: "foo://x.com:81/p", host: "x.com:81", pathname: "/p" }],
+      ["foo:/p", "host", "x.com:\n81", { href: "foo://x.com:81/p", host: "x.com:81", pathname: "/p" }],
+      // A file URL cannot take a port, so this assignment is a no-op rather than a host change.
+      ["file:///p", "host", "x.com:\t81", { href: "file:///p", host: "", pathname: "/p" }],
+      ["http://h/p", "host", "\t", { href: "http://h/p", host: "h", pathname: "/p" }],
+      ["http://h/p", "host", "\n", { href: "http://h/p", host: "h", pathname: "/p" }],
+      ["http://h/p", "hostname", "\r", { href: "http://h/p", host: "h", pathname: "/p" }],
+      ["http://h/p", "hostname", "\t\n\r", { href: "http://h/p", host: "h", pathname: "/p" }],
+      ["http://h/p", "hostname", "\tx.com\n", { href: "http://x.com/p", host: "x.com", pathname: "/p" }],
+    ])("new URL(%p).%s = %p", (href, setter, value, expected) => {
+      const url = new URL(href);
+      url[setter] = value;
+      expect({ href: url.href, host: url.host, pathname: url.pathname }).toEqual(expected);
+    });
+  });
+
   it("works", () => {
     const inputs = [
       [


### PR DESCRIPTION
### Problem
- `u = new URL("foo:/a"); u.pathname = "\n/evil.com/y"` gives `foo://evil.com/y` with `u.host === "evil.com"`. Node (and the URL Standard) give `foo:/evil.com/y` with an empty host. On special schemes the same leading character doubles the slash: `new URL("http://h/").pathname = "\t/x"` gives `http://h//x`.
- The host and hostname setters have the same class of bug. `u = new URL("http://h/p"); u.host = "\t"` (or `u.hostname = "\t"`) gives `http://p/`: the first path segment becomes the host. `u.host = "x.com:\t81"` drops the port and `u.host = "x.com:8\t1"` sets port 8; Node sets 81 in both.
- Cause: the setters in `src/jsc/bindings/URLDecomposition.cpp` inspect the raw value before WTF reparses it, and only the reparse removes tab, LF and CR. `setPathname` hands the value to WTF `URL::setPath` (vendor/WebKit/Source/WTF/wtf/URL.cpp:840), which decides from the raw value whether to prepend `/` and whether to insert the `/.` guard, so `"\n/evil.com/y"` gets a `/` prepended and reparses as `foo://evil.com/y`. `setHost` and `setHostname` run their empty-value no-op check on the raw value (so a whitespace-only value reaches WTF as an empty host and `http:///p` reparses with `p` as the host), and `setHost` also counts the port digits (`countASCIIDigits`) in the raw value.
- The basic URL parser removes ASCII tab or newline from its input before any state runs (https://url.spec.whatwg.org/#concept-basic-url-parser), and these three setters are defined as that parser with a state override, so `"\n/x"` has to mean the same as `"/x"` and `"x.com:\t81"` the same as `"x.com:81"`.

### Fix
- `setHost`, `setHostname` and `setPathname` remove tab, LF and CR from the value first (shared `removeTabAndNewline` helper) and then run unchanged. They now take `const String&` (as `setSearch` already does) so `String::removeCharacters` can be used; it returns the same string without allocating when there is nothing to remove. The only caller, the `URL.prototype` setters in `JSDOMURL.cpp`, already holds a `String`.
- Correct because this is exactly the parser's first step, and with a value that contains no tab or newline these setters already produced the spec result (checked below). WebKit is a prebuilt dependency here, so the setter layer is where this lives.
- Not changed, on purpose: `search` and `hash` strip their leading `?`/`#` from the raw value by spec and already match Node; `username`/`password` percent-encode the value rather than parsing it, so `%09` is correct there; `port` already skips these characters while parsing digits.
- Verified: two `test.each` tables in `test/js/web/url/url.test.ts` (pathname: 19 rows, host/hostname: 14 rows; expected values are Node's). 16 pathname rows and 12 host/hostname rows fail on the current release build, all pass with the fix.
- A 1008-cell differential (every setter, tab/LF/CR at each position, 7 base URLs) goes from 123 mismatches against Node to 24, and every remaining one also reproduces with the whitespace removed, i.e. they are separate pre-existing setter bugs (listed below), not this class.
- `test/js/web/url/`, `test/js/web/urlpattern/` and the vendored `test-whatwg-url-*` Node tests pass with the fix.

### Background
- `URLDecomposition` is the WebCore class behind `URL.prototype`'s component getters and setters; each setter copies the WTF `URL`, edits one component, and stores it back.
- WTF `URL::setPath` / `setHost` / `setHostAndPort` do not edit a field. They splice the new component into the URL string and reparse the whole string with the WHATWG parser, which is where tab and newline were being removed.
- The `/.` guard: a URL with a null host whose path starts with an empty segment (e.g. `foo:/.//x`) is serialized with `/.` before the path so that `//x` is not read back as a host.

<details>
<summary>Remaining setter differences against Node that do not involve tab or newline (tracked separately)</summary>

```
new URL("http://h:90/p").host = "x.com:80"     node http://x.com/p       bun http://x.com:90/p   (default port should clear the port; old port kept)
new URL("foo:/p").host = ""  (or .hostname)    node foo:/p               bun foo:///p
new URL("file:///p").host = "x.com:"           node file:///p            bun file://x.com/p
new URL("http://h:90/p").port = "\t"           node http://h:90/p        bun http://h/p          (spec clears the port only for the raw empty string; parsePort treats whitespace-only as empty)
```
</details>

<details>
<summary>Original report (pathname only)</summary>

Node vs Bun 1.4.0 on 30 pathname assignments with a tab or newline: Bun differed in 16, all of them a leading tab/LF/CR or a value that strips down to empty. Pre-stripping the value in JS before assigning made Bun match Node in all 30, which is what the fix does natively.

```
foo:/a            "\n/evil.com/y"   node foo:/evil.com/y (host "")     bun foo://evil.com/y (host evil.com)
foo:/a            "\n//evil.com/y"  node foo:/.//evil.com/y            bun foo:///evil.com/y
foo://host/a      "\n/x/y"          node foo://host/x/y                bun foo://host//x/y
foo://host/a      "\t"              node foo://host (pathname "")      bun foo://host/
http://h/         "\t/x"            node http://h/x                    bun http://h//x
http://h/         "\t\\x"           node http://h/x                    bun http://h//x
file:///a         "\t/x"            node file:///x                     bun file:////x
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 28 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/web/url/url.test.ts:
(pass) url > URL throws [17.94ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [10.87ms]
(pass) url > should have correct origin and protocol [11.89ms]
(pass) url > blob urls [7.65ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [7.62ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [5.12ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [23.36ms]
(pass) url > prints [102.14ms]
(pass) url > URLContext offsets account for the /. pathname guard [52.84ms]
277 |       ["http://h/", "/x\n", { href: "http://h/x", host: "h", pathname: "/x" }],
278 |       ["file:///a", "\t/x", { href: "file:///x", host: "", pathname: "/x" }],
279 |     ])("new URL(%p).pathname = %p", (href, value, expected) => {
280 |       const url = new URL(href);
281 |       url.pathname = value;
282 |       expect({ href: url.href, host: url.host, pathname: url.pathname }).toEqual(ex
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (73e62de83)

test/js/web/url/url.test.ts:
(pass) url > URL throws [0.18ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [0.19ms]
(pass) url > should have correct origin and protocol [0.21ms]
(pass) url > blob urls [0.11ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [0.12ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [0.13ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [0.37ms]
(pass) url > prints [2.40ms]
(pass) url > URLContext offsets account for the /. pathname guard [0.70ms]
(pass) url > pathname setter removes ASCII tab and newline before looking at the leading slash > new URL("foo:/a").pathname = "\n/evil.com/y" [0.05ms]
(pass) url > pathname setter removes ASCII tab and newline before looking at the leading slash > new URL("foo:/a").pathname = "\t/evil.com/y"
(pass) url > pathname setter removes ASCII tab and newline before looking at the leading slash > new URL("foo:/a").pathname = "\r/evil.com/y"
(pass) url > pathname setter removes ASCII tab and newline before looking at the leading slash > new URL("foo:/a").pathname = "
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/url/url.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/web/url/url.test.ts:
(pass) url > URL throws [17.90ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [15.11ms]
(pass) url > should have correct origin and protocol [17.31ms]
(pass) url > blob urls [11.16ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [10.19ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [7.30ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [34.73ms]
(pass) url > prints [150.77ms]
(pass) url > URLContext offsets account for the /. pathname guard [70.17ms]
(pass) url > pathname setter removes ASCII tab and newline before looking at the leading slash > new URL("foo:/a").pathname = "\n/evil.com/y" [4.14ms]
(pass) url > pathname setter removes ASCII tab and newline before looking at the leading slash > new URL("foo:/a").pathname = "\t/evil.com/y" [1.19ms]
(pass) url > pathname setter removes ASCII tab and newline before looking at the leading slash > ne
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 891ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/131] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (73e62de83)

Checked 129 installs across 147 packages (no changes) [4.00ms]
[2/131] gen node-fallbacks/react-refresh.js
Bundled 1 module in 4ms

  react-refresh.js  4.81 KB  (entry point)

[3/131] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[4/131] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[5/131] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.c
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/URLDecomposition.cpp | 18 +++++++--
 src/jsc/bindings/URLDecomposition.h   |  6 +--
 test/js/web/url/url.test.ts           | 69 +++++++++++++++++++++++++++++++++++
 3 files changed, 86 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/bindings/URLDecomposition.cpp      5      8      0
src/jsc/bindings/URLDecomposition.h        2      3      0
test/js/web/url/url.test.ts                6      7      0
```

</details>

<!-- robobun:evidence:end -->