### PR TITLE
buffer: decode hex from the low byte of each UTF-16 code unit like node

### DIFF
--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -1535,7 +1535,15 @@ pub enum DecodeHexError {
 /// `u16` (UTF-16). The associated function routes full pairs through the
 /// matching Highway kernel while `_decode_hex_to_bytes` keeps the generic
 /// scalar path for short inputs.
-pub trait HexChar: Copy + Into<u32> {
+///
+/// A UTF-16 code unit is classified by its low byte, which is what Node's
+/// `Buffer` hex decoder does (`Buffer.from("\uff41", "hex")` sees `'A'`):
+/// a unit above 0xFF decodes when its low byte is a hex digit and stops the
+/// decode when it is not. The Highway kernels apply the same narrowing.
+pub trait HexChar: Copy {
+    /// The byte the decoder classifies and looks up in `HEX_TABLE`.
+    fn hex_byte(self) -> u8;
+
     /// Decode up to `min(src.len() / 2, dst.len())` hex pairs with SIMD,
     /// stopping at the first pair containing a non-hex character.
     /// Returns the number of bytes written.
@@ -1544,12 +1552,22 @@ pub trait HexChar: Copy + Into<u32> {
 
 impl HexChar for u8 {
     #[inline(always)]
+    fn hex_byte(self) -> u8 {
+        self
+    }
+
+    #[inline(always)]
     fn decode_hex_highway(src: &[Self], dst: &mut [u8]) -> usize {
         highway::decode_hex(src, dst)
     }
 }
 
 impl HexChar for u16 {
+    #[inline(always)]
+    fn hex_byte(self) -> u8 {
+        self as u8
+    }
+
     #[inline(always)]
     fn decode_hex_highway(src: &[Self], dst: &mut [u8]) -> usize {
         highway::decode_hex_u16(src, dst)
@@ -1603,18 +1621,8 @@ fn _decode_hex_to_bytes<Char: HexChar, const TRUNCATE: bool>(
     let mut input = source;
 
     while !remain.is_empty() && input.len() > 1 {
-        let int0: u32 = input[0].into();
-        let int1: u32 = input[1].into();
-        if core::mem::size_of::<Char>() > 1 {
-            if int0 > u8::MAX as u32 || int1 > u8::MAX as u32 {
-                if TRUNCATE {
-                    break;
-                }
-                return Err(DecodeHexError::InvalidByteSequence);
-            }
-        }
-        let a = HEX_TABLE[(int0 as u8) as usize];
-        let b = HEX_TABLE[(int1 as u8) as usize];
+        let a = HEX_TABLE[input[0].hex_byte() as usize];
+        let b = HEX_TABLE[input[1].hex_byte() as usize];
         if a == INVALID_CHAR || b == INVALID_CHAR {
             if TRUNCATE {
                 break;

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -662,8 +662,9 @@ pub fn decode_hex(src: &[u8], dst: &mut [u8]) -> usize {
     written
 }
 
-/// UTF-16 variant of [`decode_hex`]. Code units above 0xFF are treated as
-/// invalid characters (they stop decoding), never truncated to a byte.
+/// UTF-16 variant of [`decode_hex`]. Each code unit is decoded by its low
+/// byte, as Node's `Buffer` hex decoder does: U+FF41 decodes as `'A'`, and a
+/// unit whose low byte is not a hex digit stops decoding.
 #[inline(always)]
 pub fn decode_hex_u16(src: &[u16], dst: &mut [u8]) -> usize {
     let pairs = (src.len() / 2).min(dst.len());

--- a/src/jsc/bindings/highway_strings.cpp
+++ b/src/jsc/bindings/highway_strings.cpp
@@ -1997,9 +1997,10 @@ void EncodeHexLowerImpl(const uint8_t* HWY_RESTRICT input, size_t len, uint8_t* 
 // --- Hex decoding (Buffer.from(str, "hex"), buf.write(str, "hex")) ---
 //
 // Helpers shared by DecodeHex8Impl / DecodeHex16Impl. `D` is a u8 or u16 tag;
-// code units outside [0-9A-Fa-f] (including UTF-16 units > 0xFF) are invalid.
-// Both helpers are inlined into the same loop body, so the common
-// subexpressions (case fold, alpha classification) are computed once.
+// a UTF-16 code unit is classified by its low byte (what Node's hex decoder
+// does, so U+FF41 counts as 'A'), and anything outside [0-9A-Fa-f] after that
+// narrowing is invalid. Both helpers are inlined into the same loop body, so
+// the common subexpressions (case fold, alpha classification) are computed once.
 
 template<class D>
 static HWY_INLINE hn::Mask<D> IsAsciiHexAlpha(D d, hn::Vec<D> chars)
@@ -2055,8 +2056,13 @@ static HWY_INLINE size_t DecodeHexVectorLoop(D d, const hn::TFromD<D>* HWY_RESTR
 
     const size_t simd_out = out + ((out_len - out) - ((out_len - out) % N));
     for (; out < simd_out; out += N) {
-        const auto chars0 = hn::LoadU(d, input + out * 2);
-        const auto chars1 = hn::LoadU(d, input + out * 2 + N);
+        auto chars0 = hn::LoadU(d, input + out * 2);
+        auto chars1 = hn::LoadU(d, input + out * 2 + N);
+        if constexpr (sizeof(hn::TFromD<D>) == 2) {
+            const auto low_byte = hn::Set(d, hn::TFromD<D> { 0xFF });
+            chars0 = hn::And(chars0, low_byte);
+            chars1 = hn::And(chars1, low_byte);
+        }
 
         const auto valid = hn::And(IsAsciiHexDigit(d, chars0), IsAsciiHexDigit(d, chars1));
         if (!hn::AllTrue(d, valid)) {
@@ -2108,9 +2114,10 @@ size_t DecodeHex8Impl(const uint8_t* HWY_RESTRICT input, uint8_t* HWY_RESTRICT o
     return out_len;
 }
 
-// UTF-16 variant of DecodeHex8Impl (for two-byte JS strings). Code units above
-// 0xFF never classify as hex digits, so they stop decoding like any other
-// invalid character.
+// UTF-16 variant of DecodeHex8Impl (for two-byte JS strings). Each code unit
+// is decoded by its low byte, like Node: U+FF41 decodes as 'A', while a unit
+// whose low byte is not a hex digit stops decoding like any other invalid
+// character.
 size_t DecodeHex16Impl(const uint16_t* HWY_RESTRICT input, uint8_t* HWY_RESTRICT output, size_t out_len)
 {
     const hn::ScalableTag<uint16_t> d16;
@@ -2121,8 +2128,8 @@ size_t DecodeHex16Impl(const uint16_t* HWY_RESTRICT input, uint8_t* HWY_RESTRICT
 #endif
 
     for (; out < out_len; out++) {
-        const uint8_t hi = ScalarHexNibble(input[out * 2]);
-        const uint8_t lo = ScalarHexNibble(input[out * 2 + 1]);
+        const uint8_t hi = ScalarHexNibble(static_cast<uint8_t>(input[out * 2]));
+        const uint8_t lo = ScalarHexNibble(static_cast<uint8_t>(input[out * 2 + 1]));
         if (hi == 0xFF || lo == 0xFF) {
             return out;
         }

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, withoutAggressiveGC } from "harness";
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 
 test("Bun.file in CryptoHasher is not supported yet", () => {
   expect(() => Bun.SHA1.hash(Bun.file(import.meta.path))).toThrow();
@@ -51,6 +51,21 @@ test("CryptoHasher.update(str, 'hex') rejects odd-length hex like node:crypto", 
   expect(new Bun.CryptoHasher("sha1").update(Buffer.from("abc"), "hex").digest("hex")).toBe(
     createHash("sha1").update(Buffer.from("abc")).digest("hex"),
   );
+});
+test("update(str, 'hex') decodes two-byte strings from the low byte of each code unit like node", () => {
+  // U+FF41 narrows to 'A', so "f\uff41" is the byte 0xfa; U+0147 narrows to 'G' and stops decoding.
+  for (const [input, bytes] of [
+    ["f\uff41", [0xfa]],
+    ["\uff46\uff41\u0147\u0147cd", [0xfa]],
+    ["\u0131\u0132\u0133\u0134", [0x12, 0x34]],
+  ] as const) {
+    const expected = createHash("sha1").update(Buffer.from(bytes)).digest("hex");
+    expect(new Bun.CryptoHasher("sha1").update(input, "hex").digest("hex"), JSON.stringify(input)).toBe(expected);
+    expect(new Bun.CryptoHasher("sha1", "key").update(input, "hex").digest("hex"), JSON.stringify(input)).toBe(
+      createHmac("sha1", "key").update(Buffer.from(bytes)).digest("hex"),
+    );
+    expect(createHash("sha1").update(input, "hex").digest("hex"), JSON.stringify(input)).toBe(expected);
+  }
 });
 test("CryptoHasher throws on non-latin1 algorithm names instead of crashing", () => {
   // @ts-expect-error

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -1050,6 +1050,48 @@ for (let withOverridenBufferWrite of [false, true]) {
         expect(buf).toEqual(Buffer.from([0xab, 0, 0, 0]));
       });
 
+      // Like Node.js, two-byte (UTF-16) strings are decoded from the low byte
+      // of each code unit: U+FF41 and U+0141 both act like 'A', while a unit
+      // whose low byte is not a hex digit stops decoding like any other
+      // invalid character.
+      it("hex decoding of two-byte strings uses the low byte of each code unit", () => {
+        expect(Buffer.from("f\uff41", "hex")).toStrictEqual(Buffer.from([0xfa]));
+        expect(Buffer.from("\uff46\uff41", "hex")).toStrictEqual(Buffer.from([0xfa]));
+        expect(Buffer.from("fa\uff41\uff41", "hex")).toStrictEqual(Buffer.from([0xfa, 0xaa]));
+        expect(Buffer.from("f\u0141", "hex")).toStrictEqual(Buffer.from([0xfa]));
+        // U+0130 -> '0', U+3061 -> 'a', U+0131..U+0134 -> '1'..'4'
+        expect(Buffer.from("\u0130\u0130\u3061\u3061", "hex")).toStrictEqual(Buffer.from([0x00, 0xaa]));
+        expect(Buffer.from("\u0131\u0132\u0133\u0134", "hex")).toStrictEqual(Buffer.from([0x12, 0x34]));
+
+        // low byte is not a hex digit: U+0100 -> 0x00, U+0147 -> 'G', U+01FF -> 0xff,
+        // U+D83D (first unit of an emoji) -> '='
+        expect(Buffer.from("\u0100\u0100", "hex").length).toBe(0);
+        expect(Buffer.from("ab\u0147\u0147cd", "hex")).toStrictEqual(Buffer.from([0xab]));
+        expect(Buffer.from("ab\u01ff\u01ffcd", "hex")).toStrictEqual(Buffer.from([0xab]));
+        expect(Buffer.from("ab\u{1F600}cd", "hex")).toStrictEqual(Buffer.from([0xab]));
+        expect(Buffer.from("\u6d4b\u8bd5ab", "hex").length).toBe(0);
+
+        // write(), hexWrite(), fill() and indexOf() narrow the same way
+        {
+          const b = Buffer.alloc(4, 0xcc);
+          expect(b.write("fa\uff41\uff41\u0147\u0147cd", "hex")).toBe(2);
+          expect(b).toStrictEqual(Buffer.from([0xfa, 0xaa, 0xcc, 0xcc]));
+        }
+        {
+          const b = Buffer.alloc(4, 0xcc);
+          expect(b.hexWrite("\uff46\uff41", 1)).toBe(1);
+          expect(b).toStrictEqual(Buffer.from([0xcc, 0xfa, 0xcc, 0xcc]));
+        }
+        expect(Buffer.alloc(5).fill("fa\uff41\uff41", "hex")).toStrictEqual(
+          Buffer.from([0xfa, 0xaa, 0xfa, 0xaa, 0xfa]),
+        );
+        expect(Buffer.alloc(3, "f\uff41", "hex")).toStrictEqual(Buffer.from([0xfa, 0xfa, 0xfa]));
+        expect(() => Buffer.alloc(2).fill("\u0147\u0147", "hex")).toThrow(
+          expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+        );
+        expect(Buffer.from([0x01, 0xfa, 0xaa]).indexOf("f\uff41\uff41\uff41", 0, "hex")).toBe(1);
+      });
+
       // The hex decoder takes a SIMD path once the input has at least 16 byte
       // pairs and falls back to scalar code for short inputs, vector tails and
       // the block containing the first invalid character. These tests sweep the
@@ -1061,11 +1103,12 @@ for (let withOverridenBufferWrite of [false, true]) {
           if (c >= 0x41 && c <= 0x46) return c - 0x41 + 10;
           return -1;
         };
+        // Like Node's decoder, each code unit is narrowed to its low byte first.
         const referenceHexDecode = (str, maxBytes = Infinity) => {
           const out = [];
           for (let i = 0; i + 1 < str.length && out.length < maxBytes; i += 2) {
-            const hi = hexDigitValue(str.charCodeAt(i));
-            const lo = hexDigitValue(str.charCodeAt(i + 1));
+            const hi = hexDigitValue(str.charCodeAt(i) & 0xff);
+            const lo = hexDigitValue(str.charCodeAt(i + 1) & 0xff);
             if (hi < 0 || lo < 0) break;
             out.push((hi << 4) | lo);
           }
@@ -1116,18 +1159,53 @@ for (let withOverridenBufferWrite of [false, true]) {
           }
         });
 
-        it("treats UTF-16 code units above 0xFF as invalid even when their low byte is a hex digit", () => {
-          // U+0130, U+0141, U+3061, U+FF41 truncate to '0', 'A', 'a', 'A' — the
-          // decoder must reject them rather than decode the truncated byte.
-          const pairs = 64;
-          for (const bad of ["\u0130", "\u0141", "\u3061", "\uff41"]) {
-            for (const pos of [0, 1, 31, 32, 63, 64, 97, 126, 127]) {
+        // 75 pairs: on every target the input spans whole vector blocks (pairs
+        // 0-63), the 128-bit mop-up blocks of wide targets (64-71) and the
+        // scalar tail (72-74). The positions below put the two-byte unit in
+        // each of those regions and on the block boundaries between them.
+        const wideUnitPairs = 75;
+        const wideUnitPositions = [0, 1, 31, 32, 63, 64, 127, 128, 143, 144, 149];
+
+        it("decodes UTF-16 code units above 0xFF from their low byte, like Node", () => {
+          // U+0130, U+0141, U+3061, U+FF41 narrow to '0', 'A', 'a', 'A'.
+          const pairs = wideUnitPairs;
+          for (const wide of ["\u0130", "\u0141", "\u3061", "\uff41"]) {
+            const narrow = String.fromCharCode(wide.charCodeAt(0) & 0xff);
+            for (const pos of wideUnitPositions) {
+              const chars = patternHex(pairs).split("");
+              chars[pos] = wide;
+              const hex = chars.join("");
+              chars[pos] = narrow;
+              const expected = Buffer.from(chars.join(""), "hex");
+              expect(expected.length).toBe(pairs);
+              expect(expected).toEqual(referenceHexDecode(hex));
+
+              expect(Buffer.from(hex, "hex")).toEqual(expected);
+
+              const target = Buffer.alloc(pairs);
+              expect(target.write(hex, "hex")).toBe(pairs);
+              expect(target).toEqual(expected);
+            }
+          }
+        });
+
+        it("stops at a UTF-16 code unit above 0xFF whose low byte is not a hex digit", () => {
+          // U+0100, U+0147, U+01FF, U+3000 narrow to 0x00, 'G', 0xFF, 0x00.
+          const pairs = wideUnitPairs;
+          for (const bad of ["\u0100", "\u0147", "\u01ff", "\u3000"]) {
+            for (const pos of wideUnitPositions) {
               const chars = patternHex(pairs).split("");
               chars[pos] = bad;
               const hex = chars.join("");
               const expected = referenceHexDecode(hex);
               expect(expected.length).toBe(Math.floor(pos / 2));
+
               expect(Buffer.from(hex, "hex")).toEqual(expected);
+
+              const target = Buffer.alloc(pairs, 0xaa);
+              expect(target.write(hex, "hex")).toBe(expected.length);
+              expect(target.subarray(0, expected.length)).toEqual(expected);
+              expect(target.subarray(expected.length)).toEqual(Buffer.alloc(pairs - expected.length, 0xaa));
             }
           }
         });


### PR DESCRIPTION
### Problem

- `Buffer.from(str, "hex")` on a two-byte string stops decoding at the first code unit above 0xFF. Node decodes such a unit from its low byte instead:

  ```js
  Buffer.from("f\uff41", "hex")        // node: <Buffer fa>     bun: <Buffer >
  Buffer.from("fa\uff41\uff41", "hex") // node: <Buffer fa aa>  bun: <Buffer fa>
  Buffer.from("f\u0141", "hex")        // node: <Buffer fa>     bun: <Buffer >
  ```

- The same decoder is behind every hex-encoded string input (`buf.write`, `buf.hexWrite`, `buf.fill`, `Buffer.alloc(n, str, "hex")`, `buf.indexOf(str, 0, "hex")`, `createHash().update(str, "hex")`, `Bun.CryptoHasher.update(str, "hex")`, `fs.writeFileSync(p, str, "hex")`, ...), so all of them differ from node the same way.
- Cause: the `u16` instantiation of `_decode_hex_to_bytes` (`src/bun_core/string/immutable.rs`) had an explicit `> u8::MAX` bail-out in the scalar loop, and the Highway kernel `DecodeHex16Impl` (`src/jsc/bindings/highway_strings.cpp`) classified the full 16-bit lane, so a unit above 0xFF never passed as a hex digit.
- One-byte (Latin-1) strings already matched node; only strings stored as UTF-16 were affected.

### Fix

- `HexChar` gains `hex_byte()`, the byte the decoder classifies: identity for `u8`, the low byte for `u16`. The scalar loop looks that byte up in the table, and the `> u8::MAX` check is gone.
- `DecodeHexVectorLoop` masks 16-bit lanes with `0xFF` before classifying them (two extra `And`s per iteration on the UTF-16 path only; the 8-bit path is unchanged), and the kernel's scalar tail narrows the same way. The two paths still agree, which the `HIGHWAY_MIN_PAIRS` split relies on.
- Why this is correct: it matches node. Node's hex decoder narrows each code unit with `static_cast<uint8_t>` before looking it up, so a unit above 0xFF whose low byte is a hex digit decodes as that digit, and one whose low byte is not a hex digit stops the decode. The second half is unchanged here; only the first half was missing. Bun already made the same call for base64/base64url two-byte strings in #31423, and this brings hex in line with that.
- Blast radius: the `u16` decoder is only instantiated from `construct_from_u16` and `write_u16` in `src/runtime/webcore/encoding.rs` (the node encoding paths). The other callers of the shared decoder (csrf tokens, postgres bytea, IPC, dev server) pass byte slices and compile to the unchanged `u8` instantiation. `Buffer.byteLength(str, "hex")` is `length / 2` and is unaffected. `Uint8Array.fromHex` is JSC's own implementation and does not go through this code.
- Tests:
  - `test/js/node/buffer.test.js`: a short-input test (scalar path) covering `Buffer.from`, `write`, `hexWrite`, `fill`, `Buffer.alloc(n, str, "hex")` and `indexOf`; and, in the SIMD boundary block, the test that pinned the old behaviour is replaced by two tests placing a wide unit inside the vector blocks, in the 128-bit mop-up region of wide targets and in the scalar tail of a 75-pair input, one for units that decode and one for units that stop the decode. The block's JS reference decoder now narrows like node. The "decodes" tests fail on the released bun and pass with this change; the "stops" tests pass both ways and guard the unchanged half.
  - `test/js/bun/util/bun-cryptohasher.test.ts`: `Bun.CryptoHasher` (the `String::encode` entry point), its HMAC form and `node:crypto`'s `createHash` hash the narrowed bytes.
  - Every expected value in the new tests was checked against node v26.3.0.
  - `bun bd test test/js/node/buffer.test.js` (637 pass), `bun bd test test/js/bun/util/bun-cryptohasher.test.ts` (403 pass), `test/js/bun/util/csrf.test.ts`, and the vendored node tests `test-buffer-badhex`, `-alloc`, `-fill`, `-write`, `-from`, `-bytelength`, `-indexof`, `-includes` pass with the debug build. The local machine has AVX-512 (VBMI), so the widest kernel, its 128-bit mop-up and the scalar tail all ran.
  - A 4000-case randomized corpus (details below) is byte-for-byte identical between node v26.3.0 and the debug build; the released bun differs from node on 812 of the lines.

### Background

- JSC stores a string either as one byte per character (Latin-1) or as UTF-16 code units; a string becomes two-byte as soon as it contains any character above U+00FF, and stays two-byte through `substring`/`slice` even if the remaining characters are ASCII (that is how hex strings end up on this path in practice, see #4919). `encoding.rs` dispatches the two representations to the `u8` and `u16` instantiations of the same decoder.
- Node's `Buffer` string decoders (hex, base64, latin1) work on the low byte of each UTF-16 code unit; they never reject a unit for being above 0xFF. For hex this means a non-hex unit stops the decode exactly like an ASCII `'g'` would, and a unit whose low byte is a hex digit contributes that digit.
- The shared decoder (`_decode_hex_to_bytes`) hands inputs of 16 or more pairs to a runtime-dispatched Highway kernel and decodes shorter inputs in a scalar loop. The kernel decodes whole vector blocks and returns at the first block containing an invalid pair; its own scalar tail then finds the exact pair. On wide targets (AVX2/AVX-512) a 128-bit pass mops up the remainder before the scalar tail. The semantics therefore live in three places (Rust scalar loop, vector loop, kernel scalar tail), and all three are changed together here.

<details>
<summary>Differential corpus</summary>

Generator: 4000 strings of up to 200 code units drawn from ASCII hex digits, wide units whose low byte is a hex digit, wide units with an arbitrary low byte, Latin-1 bytes, lone surrogates and fullwidth forms (U+FF00..U+FF5F), half of them forced into two-byte storage even when every unit fits in a byte. For each string the script prints `Buffer.byteLength`, `Buffer.from(s, "hex")`, the return value and resulting contents of `buf.write(s, "hex")` into a buffer of random length 0..63, `Buffer.alloc(7).fill(s, "hex")` (or the thrown error code), and `indexOf(s, 0, "hex")` on a buffer containing the decoded bytes at offset 1.

| binary | lines differing from node v26.3.0 |
| --- | --- |
| this branch (debug build) | 0 / 4000 |
| released bun (1.4.0 canary) | 812 / 4000 |

</details>
