### PR TITLE
ci: drop the [1m] model suffix from the issue-triage workflows

### DIFF
--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Claude Code slash command
         uses: anthropics/claude-code-action/base-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         env:
-          ANTHROPIC_MODEL: claude-opus-5[1m]
+          ANTHROPIC_MODEL: claude-opus-5
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           prompt: "/dedupe ${{ github.repository }}/issues/${{ github.event.issue.number || inputs.issue_number }}"

--- a/.github/workflows/claude-find-issues-for-pr.yml
+++ b/.github/workflows/claude-find-issues-for-pr.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Find issues this PR may fix
         uses: anthropics/claude-code-action/base-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         env:
-          ANTHROPIC_MODEL: claude-opus-5[1m]
+          ANTHROPIC_MODEL: claude-opus-5
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           prompt: "/find-issues ${{ github.repository }}/pull/${{ github.event.pull_request.number || inputs.pr_number }}"
@@ -43,7 +43,7 @@ jobs:
         if: always()
         uses: anthropics/claude-code-action/base-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         env:
-          ANTHROPIC_MODEL: claude-opus-5[1m]
+          ANTHROPIC_MODEL: claude-opus-5
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           prompt: "/find-duplicate-prs ${{ github.repository }}/pull/${{ github.event.pull_request.number || inputs.pr_number }}"


### PR DESCRIPTION
Fixes #39461

### Problem

- `claude-dedupe-issues.yml` has failed on every run since 2026-08-16T01:33Z (last success: run 31916887092). `claude-find-issues-for-pr.yml` fails identically.
- Failure mode: the API call is rejected immediately after init (391ms, 1 turn, $0 cost, `is_error: true`), then the action fails with `Claude result reported subtype success with is_error:true`.
- No in-repo change explains it: the workflow files were last touched 2026-08-03 (074656dd73), and `git log` between the last green run and the first red run shows zero commits under `.github/` or `.claude/`.
- Both workflows set `ANTHROPIC_MODEL: claude-opus-5[1m]`. The `[1m]` suffix requests the 1M-context variant; an instant up-front rejection with an otherwise unchanged, SHA-pinned action and pinned CLI version points at that model string no longer resolving (the variant retired, or the key losing access to it) as of 2026-08-16.

### Fix

- Drop the `[1m]` suffix, leaving `ANTHROPIC_MODEL: claude-opus-5` in both workflows (3 occurrences).
- `claude-opus-5` is the plain form of the alias these workflows already use (previously `claude-opus-4-6[1m]`), so this keeps the same model family while removing the variant that started failing.
- I could not exercise the API from my environment (no key), and `issues: opened` workflows run from the default branch, so this can only be proven after merge. Both workflows support `workflow_dispatch`, so a maintainer can verify with a manual run against any issue/PR number right after merging.
- I considered enabling `show_full_output: true` so the real API error text lands in logs next time, but the action's own docs warn it can echo sensitive data into public logs, so I left it off given the recent workflow hardening (#36778).

### Background

- These are the issue-triage automations: on `issues: opened` the dedupe workflow posts likely-duplicate links, and on `pull_request: opened` the other one links issues the PR may fix.
- `ANTHROPIC_MODEL` is read by the pinned claude-code-action to pick the model; a `[1m]` suffix on the model string opts into the 1M-token context beta variant of that model.

<details>
<summary>Failure log excerpt (run 32064780454)</summary>

```
SDK options: {
  "model": "claude-opus-5[1m]",
  ...
}
{
  "type": "result",
  "subtype": "success",
  "is_error": true,
  "duration_ms": 391,
  "num_turns": 1,
  "total_cost_usd": 0,
  "permission_denials_count": 0
}
##[error]Claude result reported subtype success with is_error:true (run did not complete successfully)
```

The action hides the underlying API error text unless `show_full_output` is enabled, so the exact rejection message is not visible in the logs.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->