### PR TITLE
JSSink: drop the unmatched unprotect() of the pump controller in detach()

### DIFF
--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -255,12 +255,11 @@ impl<T: JsSinkAbi> JSSink<T> {
         result
     }
 
-    /// Disconnect the upstream source: JSController → unprotect + detachPtr; ByteStream → clear its SinkHandle.
+    /// Disconnect the upstream source: JSController → detachPtr; ByteStream → clear its SinkHandle.
     pub(crate) fn detach(source: &mut SourceHandle, _global: &crate::webcore::jsc::JSGlobalObject) {
         match *source {
             SourceHandle::JSController(value) => {
                 source.clear();
-                value.unprotect();
                 // detachPtr leaves m_needExceptionCheck set; wrap to satisfy the verifier.
                 let _ = ::bun_jsc::call_check_slow(_global, || {
                     streams::controller_abi::detach_ptr(value)

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -448,8 +448,7 @@ impl FetchTasklet {
             // FetchTasklet ref — `write_end_request` is the canonical release.
             sink.task = None;
             // `detach` may fire the controller's onClose; every terminal path
-            // here has already cleared it, so this just unprotects the cell and
-            // nulls m_sinkPtr.
+            // here has already cleared it, so this just nulls m_sinkPtr.
             JSSink::<FetchRequestBodySink>::detach(&mut sink.source, &self.global_this);
         }
         if let Some(buffer) = self.request_body_streaming_buffer.take() {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -180,6 +180,71 @@ describe("HTMLRewriter", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A direct stream's pull() receives the pump controller itself, so user code
+  // can hand it to an API that roots its argument with gcProtect (another
+  // rewriter's .on() does). The pipe never protects the controller, so when a
+  // failing rewrite detaches it, the detach must not gcUnprotect it either:
+  // that cancelled the other holder's root and the next GC collected the
+  // controller out from under it. The unreferenced run shows the controller
+  // is otherwise collectable, so "alive" below really is the holder's root.
+  it("detaching the pump controller of a failed rewrite keeps a gcProtect held elsewhere on it", async () => {
+    const fixture = /* js */ `
+      const holder = new HTMLRewriter();
+      async function failedRewrite(handToHolder) {
+        let ref;
+        const input = new Response(
+          new ReadableStream({
+            type: "direct",
+            pull(controller) {
+              ref = new WeakRef(controller);
+              if (handToHolder) holder.on("*", controller);
+              // The element handler below throws inside this write, so the pipe
+              // fails and detaches the controller while it is still attached.
+              controller.write("<p>x</p>");
+            },
+          }),
+        );
+        const out = new HTMLRewriter()
+          .on("p", {
+            element() {
+              throw new Error("handler threw");
+            },
+          })
+          .transform(input);
+        const outcome = await out.text().then(
+          () => "resolved",
+          err => "rejected with " + err.message,
+        );
+        return { ref, outcome };
+      }
+      for (const handToHolder of [false, true]) {
+        const { ref, outcome } = await failedRewrite(handToHolder);
+        for (let i = 0; i < 3; i++) {
+          await new Promise(resolve => setImmediate(resolve));
+          Bun.gc(true);
+        }
+        const liveness = ref.deref() === undefined ? "collected" : "alive";
+        console.log((handToHolder ? "handed to holder.on()" : "unreferenced") + ": " + outcome + ", controller " + liveness);
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe(
+      [
+        "unreferenced: rejected with handler threw, controller collected",
+        "handed to holder.on(): rejected with handler threw, controller alive",
+        "",
+      ].join("\n"),
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
   it("HTMLRewriter: async replacement", async () => {
     await gcTick();
     const res = new HTMLRewriter()


### PR DESCRIPTION
### Problem
- `JSSink::detach` in `src/runtime/webcore/Sink.rs` calls `value.unprotect()` on the `SourceHandle::JSController` cell before `detachPtr`.
- Nothing ever `protect()`s that cell. The only writer of `SourceHandle::JSController` is `JSSink::assign_to_stream` (`Sink.rs`), and the cell it stores comes straight from `${name}__createController` in the generated `JSSink.cpp`, which only calls `::create(...)`. There is no `gcProtect` in `generate-jssink.ts` or `BunStreamSource.cpp` either, and the doc comment on `js_controller_detached` already says the slot holds the cell "without rooting" it.
- `gcUnprotect` is a decrement on a counted set, so the unmatched call is a no-op only while nobody else holds a protect on the cell. The cell is user-reachable (a `type: "direct"` stream's `pull(controller)` receives it), so it can be handed to an API that does root its argument with gcProtect, for example another `HTMLRewriter`'s `.on()` (`ElementHandler::init`, `src/runtime/api/html_rewriter.rs`). When the rewrite then fails while the controller is still attached, `detach` removes that holder's root and the next GC collects the controller while the holder still points at it.
- The call dates back to the original Zig `detach` (2022) and was ported unchanged; it was unmatched then too.

### Fix
- Remove the `unprotect()` call and drop "unprotect" from the `detach` doc comment and from the call-site comment in `FetchTasklet::clear_sink`. `source.clear()`, the `call_check_slow` wrapper and `detach_ptr` are unchanged.
- The sink never took a protect on the controller, so it has none to give back. The controller is kept alive by the same GC edges as before (`readDirectStream` stores it in the stream's `m_controller` slot, `readStreamIntoSink` in the pump operation's `m_sink` slot, `BunStreamSource.cpp`) plus whatever roots other holders legitimately have.
- Test: `test/js/workerd/html-rewriter.test.js`, "detaching the pump controller of a failed rewrite keeps a gcProtect held elsewhere on it". A spawned fixture runs a failing direct-stream rewrite twice and checks a `WeakRef` to the controller after three full GCs: unreferenced it must be collected (control), handed to `holder.on()` it must still be alive. Without the fix the second line reads `collected` (10/10 runs against a debug build of main); with it, `alive` (10/10), and the whole file passes (171).
- Also run against the fixed debug build: the other three HTMLRewriter files (191 pass, 1 skip; every transform teardown goes through `JSSink::<RewriterPipe>::detach`) and `fetch.test.ts -t "fetch should allow duplex"` (11 pass; request body streams go through `JSSink::<FetchRequestBodySink>::detach`). The S3 `upload_stream` caller needs MinIO, which CI covers.

### Background
- A JSSink is a native sink (FileSink, HTMLRewriter pipe, fetch request body, S3 upload) that a JS `ReadableStream` can be pumped into. `assign_to_stream` creates a C++ `JSReadable*SinkController` cell pointing at the sink, records it as the sink's `SourceHandle::JSController`, and starts the pump. For a `type: "direct"` stream the pump passes that same cell to the user's `pull()`. `detach` is the sink cutting the controller off (`detachPtr` nulls its sink pointer) when the sink ends first, for instance when an HTMLRewriter handler throws.
- `protect()` / `unprotect()` are `JSC::gcProtect` / `gcUnprotect`: a counted set of cells the GC treats as roots. The count is per cell, not per holder, so an unpaired `unprotect` cancels whichever holder's protect happens to be there. HTMLRewriter roots its handler objects this way (`ProtectedJSValue`), which is what the test uses as the other holder.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/workerd/html-rewriter.test.js

<!-- robobun:evidence:end -->