### PR TITLE
test: lower the jsresult-swallow inventory entry for h2_frame_parser.rs to 4

### DIFF
--- a/test/internal/source-lints/jsresult-swallow.inventory.json
+++ b/test/internal/source-lints/jsresult-swallow.inventory.json
@@ -7,7 +7,7 @@
     "taken exception discarded": 1
   },
   "src/runtime/api/bun/h2_frame_parser.rs": {
-    "discarded result of a call that enters script": 5
+    "discarded result of a call that enters script": 4
   },
   "src/runtime/ipc.rs": {
     "discarded result of a call that enters script": 4,


### PR DESCRIPTION
### Problem
- `test/internal/source-lints/jsresult-swallow.test.ts` fails on main: `inventory shrinks when a swallow is fixed` reports `src/runtime/api/bun/h2_frame_parser.rs: "discarded result of a call that enters script" is 4 now, inventory says 5`.
- The source-lints workflow on main has been red with exactly this one failure since 9f6748857b (#39448); the run for the commit before it (8d9cbbdb3b) was green.
- Cause: `jsresult-swallow.inventory.json` landed in #38660 counting 5 sites in `h2_frame_parser.rs`. #39448 was opened before that, so its CI never saw the ratchet, and it deleted one of the 5 (the `let _ = self.handlers.get().call_event_handler(` in the legacy inbound path) without lowering the count. The file now has 4 (`h2_frame_parser.rs:2487`, `:2511`, `:2529`, `:2554`).

### Fix
- Lowers the `h2_frame_parser.rs` entry from 5 to 4. The file was regenerated with the command the test header documents (`bun test/internal/source-lints/jsresult-swallow.test.ts --update`); this line is the only thing it changed, so every other entry still matches the tree.
- Correct because a ratchet entry is a count of today's matches, and the test exists to force the count down when a match goes away; 4 is the number of matches left.
- The remaining 4 are left alone on purpose. `call_event_handler` and `call_write_callback` (`h2_frame_parser.rs:762-795`) return a `bool` ("was the callback dispatched") and run the callback through `EventLoop::run_callback` (`src/jsc/event_loop.rs:409`), which already folds an `Err` with `report_error_or_terminate`, so those `let _ =` lines discard a `bool`, not a `JsResult`; the lint counts them because its pattern names those helpers (`jsresult-swallow.test.ts:32`). Whether to retire them by narrowing the pattern or reshaping the helpers is a change to the ratchet itself, separate from unbreaking main.
- Verified: `bun test test/internal/source-lints/jsresult-swallow.test.ts` fails on main (7aad387416) with the message above and passes with this change. `bun test test/internal/source-lints/` is green with it (183 pass across 27 files; these lints read the source tree and do not run the built binary, per the directory README).

### Background
- `test/internal/source-lints/` holds lints that grep `src/**`; they run in the `source-lints` GitHub workflow against a released bun, not against the build under test.
- `jsresult-swallow.test.ts` is a ratchet: it greps Rust sources for patterns that discard a `JsResult` (a pending JS exception or a worker termination) and compares per-file counts with `jsresult-swallow.inventory.json`. A count above the inventory fails (`no new swallowed JsResult`); a count below it also fails (`inventory shrinks when a swallow is fixed`), so the inventory can only move down and must be lowered in the same change that removes a site.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->