### PR TITLE
Bump WebKit (oven-sh/WebKit#462 preview): file: drive letter quirk with a host, before ?/#, after dot segments, and as a relative base

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "1cb96a7b0edd24a18927c4c05007b0649abda4f4";
+export const WEBKIT_VERSION = "autobuild-preview-pr-462-9904593e";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/web/url/url.test.ts
+++ b/test/js/web/url/url.test.ts
@@ -442,6 +442,265 @@ describe("url", () => {
     });
   });
 
+  // URL Standard, file host state step 1.1 and path state step 1.3.1: in a file: URL a first path segment of the form
+  // "C|" or "C:" (followed by a slash, "?", "#" or the end) is a Windows drive letter, its "|" becomes ":", and a path
+  // consisting of the drive letter alone is never shortened. The quirk applies whenever the path is empty at that
+  // point, with or without a host. Expected values match Node and the whatwg-url reference implementation.
+  describe("file: Windows drive letter quirk", () => {
+    const parse = (inputs: string[]) =>
+      Object.fromEntries(
+        inputs.map(input => {
+          const url = new URL(input);
+          return [input, { href: url.href, host: url.host, pathname: url.pathname }];
+        }),
+      );
+    const hrefs = (inputs: string[]) => Object.fromEntries(inputs.map(input => [input, new URL(input).href]));
+
+    it("is the whole path when ? or # follows it in the host position", () => {
+      expect(
+        parse(["file://C|?q", "file://C:#f", "file://C|?q#f", "file:\\\\C|?q", "file://C|?", "file://C|"]),
+      ).toEqual({
+        "file://C|?q": { href: "file:///C:?q", host: "", pathname: "/C:" },
+        "file://C:#f": { href: "file:///C:#f", host: "", pathname: "/C:" },
+        "file://C|?q#f": { href: "file:///C:?q#f", host: "", pathname: "/C:" },
+        "file:\\\\C|?q": { href: "file:///C:?q", host: "", pathname: "/C:" },
+        "file://C|?": { href: "file:///C:?", host: "", pathname: "/C:" },
+        "file://C|": { href: "file:///C:", host: "", pathname: "/C:" },
+      });
+      // An explicit slash after the drive letter is a separator as before.
+      expect(
+        hrefs(["file://C|/", "file://C|/?q", "file://C|/x#f", "file://C|\\x", "file://C|/..", "file://C|/D|/x"]),
+      ).toEqual({
+        "file://C|/": "file:///C:/",
+        "file://C|/?q": "file:///C:/?q",
+        "file://C|/x#f": "file:///C:/x#f",
+        "file://C|\\x": "file:///C:/x",
+        "file://C|/..": "file:///C:/",
+        "file://C|/D|/x": "file:///C:/D|/x",
+      });
+    });
+
+    it("is normalized under a host too", () => {
+      expect(
+        parse([
+          "file://host/C|/x",
+          "file://host/C|",
+          "file://host/c|?q",
+          "file://HOST/C|#f",
+          "file://host\\C|\\x",
+          "file://1.2.3.4/C|/x",
+          "file://[::1]/C|/x",
+          "file://host/C|/..",
+          "file://host/C|/x/../..",
+        ]),
+      ).toEqual({
+        "file://host/C|/x": { href: "file://host/C:/x", host: "host", pathname: "/C:/x" },
+        "file://host/C|": { href: "file://host/C:", host: "host", pathname: "/C:" },
+        "file://host/c|?q": { href: "file://host/c:?q", host: "host", pathname: "/c:" },
+        "file://HOST/C|#f": { href: "file://host/C:#f", host: "host", pathname: "/C:" },
+        "file://host\\C|\\x": { href: "file://host/C:/x", host: "host", pathname: "/C:/x" },
+        "file://1.2.3.4/C|/x": { href: "file://1.2.3.4/C:/x", host: "1.2.3.4", pathname: "/C:/x" },
+        "file://[::1]/C|/x": { href: "file://[::1]/C:/x", host: "[::1]", pathname: "/C:/x" },
+        "file://host/C|/..": { href: "file://host/C:/", host: "host", pathname: "/C:/" },
+        "file://host/C|/x/../..": { href: "file://host/C:/", host: "host", pathname: "/C:/" },
+      });
+      // Only an exact drive letter in the first segment of a file: URL.
+      expect(
+        hrefs([
+          "file://host/C:/x",
+          "file://host/C|x",
+          "file://host/C||/x",
+          "file://host/C%7C/x",
+          "file://host/1|/x",
+          "file://host/C|/D|/x",
+          "file://host//C|/x",
+          "file://host/x/C|/y",
+          "file://host?q",
+          "file://host#f",
+          "http://host/C|/x",
+        ]),
+      ).toEqual({
+        "file://host/C:/x": "file://host/C:/x",
+        "file://host/C|x": "file://host/C|x",
+        "file://host/C||/x": "file://host/C||/x",
+        "file://host/C%7C/x": "file://host/C%7C/x",
+        "file://host/1|/x": "file://host/1|/x",
+        "file://host/C|/D|/x": "file://host/C:/D|/x",
+        "file://host//C|/x": "file://host//C|/x",
+        "file://host/x/C|/y": "file://host/x/C|/y",
+        "file://host?q": "file://host/?q",
+        "file://host#f": "file://host/#f",
+        "http://host/C|/x": "http://host/C|/x",
+      });
+    });
+
+    it("serializes the same with a dropped localhost as without a host", () => {
+      expect(
+        parse([
+          "file://localhost/C|/x",
+          "file://localhost/C|",
+          "file://LOCALHOST/C|?q",
+          "file://localhost/C|/..",
+          "file://localhost/C|x",
+          "file://localhost//C|/x",
+        ]),
+      ).toEqual({
+        "file://localhost/C|/x": { href: "file:///C:/x", host: "", pathname: "/C:/x" },
+        "file://localhost/C|": { href: "file:///C:", host: "", pathname: "/C:" },
+        "file://LOCALHOST/C|?q": { href: "file:///C:?q", host: "", pathname: "/C:" },
+        "file://localhost/C|/..": { href: "file:///C:/", host: "", pathname: "/C:/" },
+        "file://localhost/C|x": { href: "file:///C|x", host: "", pathname: "/C|x" },
+        "file://localhost//C|/x": { href: "file:////C|/x", host: "", pathname: "//C|/x" },
+      });
+    });
+
+    it("still applies after dot segments that leave the path empty", () => {
+      expect(
+        hrefs([
+          "file:///./C|",
+          "file:///../C|/x",
+          "file:///a/../C|",
+          "file:///a/b/../../C|?q",
+          "file:///%2e/C|#f",
+          "file:./C|",
+          "file://host/./C|/..",
+          "file://localhost/../C|",
+          "file:///./C|x",
+          "file:///a/./C|",
+          "file:////./C|",
+          "http://host/./C|",
+        ]),
+      ).toEqual({
+        "file:///./C|": "file:///C:",
+        "file:///../C|/x": "file:///C:/x",
+        "file:///a/../C|": "file:///C:",
+        "file:///a/b/../../C|?q": "file:///C:?q",
+        "file:///%2e/C|#f": "file:///C:#f",
+        "file:./C|": "file:///C:",
+        "file://host/./C|/..": "file://host/C:/",
+        "file://localhost/../C|": "file:///C:",
+        "file:///./C|x": "file:///C|x",
+        "file:///a/./C|": "file:///a/C|",
+        "file:////./C|": "file:////C|",
+        "http://host/./C|": "http://host/C|",
+      });
+    });
+
+    it("every serialization above parses back to itself", () => {
+      const inputs = [
+        "file://C|?q",
+        "file://C:#f",
+        "file://C|",
+        "file://C|/..",
+        "file://host/C|/x",
+        "file://host/C|",
+        "file://host/C|?q",
+        "file://host/C|/..",
+        "file://[::1]/C|",
+        "file://localhost/C|/x",
+        "file://localhost/C|",
+        "file://LOCALHOST/C|?q",
+        "file://localhost/C|x",
+        "file://localhost//C|/x",
+        "file:///./C|",
+        "file:///a/../C|/x",
+        "file://host/./C|",
+      ];
+      const roundTrips = inputs.map(input => {
+        const href = new URL(input).href;
+        return [input, href, new URL(href).href];
+      });
+      expect(roundTrips.filter(([, href, reparsed]) => href !== reparsed)).toEqual([]);
+    });
+
+    it("is kept when resolving a relative path against a URL whose path is a drive letter alone", () => {
+      const resolve = (pairs: [string, string][]) =>
+        Object.fromEntries(pairs.map(([input, base]) => [`${input} against ${base}`, new URL(input, base).href]));
+      expect(
+        resolve([
+          ["x", "file:///C:"],
+          ["x", "file://C|"],
+          ["x", "file:///C:?q#f"],
+          ["x/y", "file://host/C|"],
+          ["file:x", "file:///C:"],
+          ["..", "file:///C:"],
+          [".", "file:///C:"],
+          ["../../y", "file://host/C|/a/b"],
+          ["../../C|", "file:///a/b"],
+          ["./C|", "file:///tmp/mock/path"],
+          ["?q", "file:///C:"],
+          ["D|", "file:///C:"],
+          ["D|/z", "file:///C:"],
+          ["/x", "file:///C:"],
+          ["//C|#f", "file://host/dir/file"],
+        ]),
+      ).toEqual({
+        "x against file:///C:": "file:///C:/x",
+        "x against file://C|": "file:///C:/x",
+        "x against file:///C:?q#f": "file:///C:/x",
+        "x/y against file://host/C|": "file://host/C:/x/y",
+        "file:x against file:///C:": "file:///C:/x",
+        ".. against file:///C:": "file:///C:/",
+        ". against file:///C:": "file:///C:/",
+        "../../y against file://host/C|/a/b": "file://host/C:/y",
+        "../../C| against file:///a/b": "file:///C:",
+        "./C| against file:///tmp/mock/path": "file:///tmp/mock/C|",
+        "?q against file:///C:": "file:///C:?q",
+        "D| against file:///C:": "file:///D:",
+        "D|/z against file:///C:": "file:///D:/z",
+        "/x against file:///C:": "file:///C:/x",
+        "//C|#f against file://host/dir/file": "file:///C:#f",
+      });
+      // Any other lone segment is dropped by the relative path, as before.
+      expect(
+        resolve([
+          ["x", "file:///ab:"],
+          ["x", "file:///1:"],
+          ["x", "file:///C"],
+          ["x", "file:///"],
+          ["x", "file://host/a"],
+          ["x", "file:///C:/"],
+          ["x", "file:///C:/a"],
+        ]),
+      ).toEqual({
+        "x against file:///ab:": "file:///x",
+        "x against file:///1:": "file:///x",
+        "x against file:///C": "file:///x",
+        "x against file:///": "file:///x",
+        "x against file://host/a": "file://host/x",
+        "x against file:///C:/": "file:///C:/x",
+        "x against file:///C:/a": "file:///C:/x",
+      });
+    });
+
+    it("applies through the setters, which re-parse the URL", () => {
+      const set = (input: string, property: "pathname" | "host" | "hostname" | "search" | "href", value: string) => {
+        const url = new URL(input);
+        url[property] = value;
+        return url.href;
+      };
+      expect({
+        "file://host/x pathname=/C|/y": set("file://host/x", "pathname", "/C|/y"),
+        "file://host/x pathname=C|": set("file://host/x", "pathname", "C|"),
+        "file:///x pathname=/C|/y": set("file:///x", "pathname", "/C|/y"),
+        "file:///C:/y host=h": set("file:///C:/y", "host", "h"),
+        "file://h/C|/y host=": set("file://h/C|/y", "host", ""),
+        "file://h/C|/y hostname=localhost": set("file://h/C|/y", "hostname", "localhost"),
+        "file://C|?q search=": set("file://C|?q", "search", ""),
+        "http://x href=file://host/C|?q": set("http://x", "href", "file://host/C|?q"),
+      }).toEqual({
+        "file://host/x pathname=/C|/y": "file://host/C:/y",
+        "file://host/x pathname=C|": "file://host/C:",
+        "file:///x pathname=/C|/y": "file:///C:/y",
+        "file:///C:/y host=h": "file://h/C:/y",
+        "file://h/C|/y host=": "file:///C:/y",
+        "file://h/C|/y hostname=localhost": "file:///C:/y",
+        "file://C|?q search=": "file:///C:",
+        "http://x href=file://host/C|?q": "file://host/C:?q",
+      });
+    });
+  });
+
   // Web IDL record conversion interleaves Get with value conversion: mutations made by a
   // value's toString() are observed by the keys that follow it. Node agrees.
   it("URLSearchParams constructed from an object interleaves Get with value conversion", () => {


### PR DESCRIPTION
Bumps `WEBKIT_VERSION` to pick up oven-sh/WebKit#462 and adds the `bun:test` coverage for it.

Pinned to the preview build of oven-sh/WebKit#462 so CI exercises the change; to be re-pinned to the merged oven-sh/WebKit commit before this merges.

### Problem
- `new URL()` gets the file: Windows drive letter quirk wrong whenever the URL has an authority, and in two related spots. Node (Ada) and the whatwg-url reference implementation give the expected values below; every Bun release and upstream WebKit give the Bun values. Found by the WebKit vs Ada differential run.

  ```js
  new URL("file://C|?q").href            // Bun: "file:///C:/?q"    expected "file:///C:?q"    (pathname "/C:", same for "#f" and for "C:")
  new URL("file://host/C|/x").href       // Bun: "file://host/C|/x" expected "file://host/C:/x"
  new URL("file://localhost/C|/x").href  // Bun: "file:///C|/x"     expected "file:///C:/x"
  new URL("file:///./C|").href           // Bun: "file:///C|"       expected "file:///C:"
  new URL("x", "file:///C:").href        // Bun: "file:///x"        expected "file:///C:/x"
  new URL("x", "file://C|").href         // Bun: "file:///C:x"      expected "file:///C:/x"
  ```

- The `localhost` and dot-segment forms are not serialize/parse idempotent: `new URL(new URL("file://localhost/C|/x").href).href` is `"file:///C:/x"`, so anything keyed by `href` sees two different keys for one URL across a round trip. The setters re-parse, so `url.pathname = "/C|/y"` on a URL with a host and `url.search = ""` on `file://C|?q` hit the same bugs.
- Cause: all in `Source/WTF/wtf/URLParser.cpp` in oven-sh/WebKit (Bun's `URL` is a thin layer over `WTF::URL`, no Bun source is involved). The file host state appends `/?` / `/#` after a drive letter, the host case of the file host state goes to a path state that does not know about drive letters, the path state forgets the quirk after removing dot segments, and relative resolution copies a file: base up to its last slash, which for a path of `/C:` removes the drive letter. The vendored WPT `urltestdata.json` only has the `C:` form with a host and relative `C|` forms, which all work, so it does not catch these.

### Fix
- oven-sh/WebKit#462 (details there) fixes the four spots. The branch is directly on top of `1cb96a7b0e`, the commit main pins (#40417), so the new pin is exactly the current engine plus that change.
- Behavior change to be aware of: relative resolution against a base whose path is a drive letter alone (`new URL("x", "file:///C:")`) now keeps the drive letter, as in Node. Bases with anything after the drive letter (`file:///C:/`, `file:///C:/a`) resolve as before.
- Tests: `test/js/web/url/url.test.ts`, a `file: Windows drive letter quirk` block: `?` / `#` after the drive letter, drive letters under `host`, an uppercase host, IPv4, IPv6 and `localhost`, dot segments before the drive letter, relative resolution onto bare drive letters, the `pathname` / `host` / `hostname` / `search` / `href` setters, an explicit round-trip test over the inputs that used to be non-idempotent, and the shapes that must not change (`C|x`, `C||`, `C%7C`, `1|`, a drive letter as the second segment or after `//`, `http:` URLs, `?` / `#` directly after a host, other lone segments as bases). Expected values were checked against Node 26 and whatwg-url 14.
- Verification: on the previous pin the 7 new tests fail (`USE_SYSTEM_BUN=1 bun test test/js/web/url/url.test.ts`: 24 pass, 7 fail; the round-trip test lists exactly the five non-idempotent inputs). Against this pin, `bun bd test` over `test/js/web/url`, `test/js/node/url`, `test/js/deno/url`, `test/js/web/urlpattern` and the WebKit prebuilt URL lint: 1611 tests across 25 files, 1587 pass, 1 fail (`URL.canParse > repeatedly called produces same result`, a 1e5-iteration loop that also times out on the previous pin in this debug ASAN build). Node's own `test-url-*` / `test-whatwg-url-*` files (43, including `test-url-fileurltopath.js` and `test-url-pathtofileurl.js`) all pass. The WebKit change itself was checked in oven-sh/WebKit#462 with WebKit's `WTF_URLParser` gtests, the WPT corpus (byte-identical before and after), and 7932 generated inputs against whatwg-url (736 differences before, 0 after).

### Background
- URL Standard, file host state step 1.1 and path state step 1.3.1: in a file: URL, a first path segment that is a letter followed by `:` or `|` (and then a slash, `?`, `#` or the end) is a Windows drive letter; `|` is rewritten to `:`, and "shorten a URL's path" never removes a path that is only a drive letter. `file://C|/x` is the same quirk seen from the host position: the drive letter becomes the path of a host-less URL.
- `WEBKIT_VERSION` in `scripts/build/deps/webkit.ts` is the only place the engine version lives; CI and `bun bd` download the prebuilt `autobuild-<version>` release for it from oven-sh/WebKit. Preview builds of a WebKit PR are published as `autobuild-preview-pr-<n>-<sha>` and can be pinned the same way.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 5 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/url/url.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/url/url.test.ts
bun test v1.4.1 (adc354d99)

test/js/web/url/url.test.ts:
(pass) url > URL throws [17.27ms]
(pass) url > ERR_INVALID_URL carries input and, when given, base [16.98ms]
(pass) url > should have correct origin and protocol [15.54ms]
(pass) url > blob urls [12.41ms]
(pass) url > leaves opaque (non-special-scheme) hosts unchanged [13.36ms]
(pass) url > special-scheme hosts use the Unicode 16 IDNA table [6.96ms]
(pass) url > rejects invalid punycode labels however they are spelled in the input (like Node) [22.62ms]
(pass) url > judges literal punycode labels like Node (fast path and ICU path) [34.46ms]
(pass) url > resolves against repeated, alternating and invalid string bases consistently [32.90ms]
(pass) url > href, toString and toJSON agree before and after mutation [130.98ms]
(pass) url > prints [164.91ms]
(pass) url > URLContext offsets account for the /. pathname guard [78.75ms]
(pass) url > works [21.56ms]
(pass) url > URL.canParse > URL.canParse(undefined, undefined) [2.95ms]
(pass) url > URL.canParse > URL.canParse(a:b, undefined) [0.62ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:b) [1.04ms]
(pass) url > URL.canParse > URL.canParse(a:/b, undefined) [0.36ms]
(pass) url > URL.canParse > URL.canParse(undefined, a:/b) [0.45ms]
(pass) url > URL.canParse > URL.canParse(https://test:test, undefined) [0.33ms]
(pass) url > URL.canParse > URL.canParse(a, https://b/) [0.45ms]
(pass) url > URL.canParse > URL.canParse.length should be 1 [2.50ms]
(pass) url > file: Windows drive letter quirk > is the whole path when ? or # follows it in the host position [29.90ms]
(pass) url > file: Windows drive letter quirk > is normalized under a host too [15.66ms]
(pass) url > file: Windows drive letter quirk > serializes the same with a dropped localhost as without a host [8.54ms]
(pass) url > file: Windows drive letter quirk > still applies after dot segmen
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts |   2 +-
 test/js/web/url/url.test.ts  | 259 +++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 260 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 8 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                          reads  edits  tests
scripts/build/deps/webkit.ts      8      8      0
test/js/web/url/url.test.ts       3      3      0
```

</details>

<!-- robobun:evidence:end -->






