### PR TITLE
node:http2: take inbound header names from the per-VM HTTPHeaderIdentifiers cache

### DIFF
--- a/src/jsc/bindings/H2HeadersMaterializer.cpp
+++ b/src/jsc/bindings/H2HeadersMaterializer.cpp
@@ -2,9 +2,7 @@
 // native pass: the flat raw-headers array ([name1, value1, name2, value2, ...]),
 // the node-shaped headers object (toHeaderObject semantics from node:http2),
 // and the sensitive-names array. Replaces per-field JSArray::push round trips
-// from the Rust engine sink with one call per block, and takes header names
-// from the per-VM HTTPHeaderIdentifiers cache so pseudo-headers and the names
-// in HTTPHeaderNames.in allocate nothing.
+// from the Rust engine sink with one call per block.
 
 #include "root.h"
 #include "ZigGlobalObject.h"
@@ -101,9 +99,6 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__h2__materializ
         // Wire names are validated lowercase ASCII before they reach this point.
         WTF::StringView nameView(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(nameBytes), nameLen));
 
-        // Recognized names share the VM's cached JSString and Identifier. Any
-        // other name is atomized straight from the wire bytes and its
-        // rawHeaders entry wraps that atom, so the name is copied at most once.
         JSString* nameStr;
         Identifier ident;
         bool isStatus = false;
@@ -121,6 +116,7 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__h2__materializ
             isCookie = headerName == WebCore::HTTPHeaderName::Cookie;
             isSetCookie = headerName == WebCore::HTTPHeaderName::SetCookie;
         } else {
+            // Atomize first so the rawHeaders string shares the atom instead of a second copy.
             ident = Identifier::fromString(vm, nameView.span8());
             nameStr = jsString(vm, ident.string());
         }

--- a/src/jsc/bindings/H2HeadersMaterializer.cpp
+++ b/src/jsc/bindings/H2HeadersMaterializer.cpp
@@ -2,11 +2,13 @@
 // native pass: the flat raw-headers array ([name1, value1, name2, value2, ...]),
 // the node-shaped headers object (toHeaderObject semantics from node:http2),
 // and the sensitive-names array. Replaces per-field JSArray::push round trips
-// from the Rust engine sink with one call per block, and reuses WebCore's
-// interned header-name strings so known header names allocate nothing.
+// from the Rust engine sink with one call per block, and takes header names
+// from the per-VM HTTPHeaderIdentifiers cache so pseudo-headers and the names
+// in HTTPHeaderNames.in allocate nothing.
 
 #include "root.h"
 #include "ZigGlobalObject.h"
+#include "BunClientData.h"
 #include "helpers.h"
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/JSArray.h>
@@ -16,6 +18,7 @@
 #include <wtf/text/SymbolImpl.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringView.h>
+#include "HTTPHeaderIdentifiers.h"
 #include "HTTPHeaderNames.h"
 #include "wtf/SIMDUTF.h"
 
@@ -80,6 +83,7 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__h2__materializ
     JSC::JSObject* obj = JSC::constructEmptyObject(vm, globalObject->nullPrototypeObjectStructure());
     RETURN_IF_EXCEPTION(scope, {});
     JSC::JSArray* sensitive = nullptr;
+    auto& identifiers = WebCore::clientData(vm)->httpHeaderIdentifiers();
 
     size_t offset = 0;
     unsigned rawIndex = 0;
@@ -97,13 +101,28 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__h2__materializ
         // Wire names are validated lowercase ASCII before they reach this point.
         WTF::StringView nameView(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(nameBytes), nameLen));
 
+        // Recognized names share the VM's cached JSString and Identifier. Any
+        // other name is atomized straight from the wire bytes and its
+        // rawHeaders entry wraps that atom, so the name is copied at most once.
         JSString* nameStr;
+        Identifier ident;
+        bool isStatus = false;
+        bool isCookie = false;
+        bool isSetCookie = false;
+        WebCore::HTTP2PseudoHeaderName pseudoHeaderName;
         WebCore::HTTPHeaderName headerName;
-        if (WebCore::findHTTPHeaderName(nameView, headerName)) {
-            // Interned: no allocation, and the atom's hash is cached.
-            nameStr = jsString(vm, WTF::String(WTF::httpHeaderNameStringImpl(headerName)));
+        if (WebCore::findHTTP2PseudoHeaderName(nameView, pseudoHeaderName)) {
+            nameStr = identifiers.stringFor(globalObject, pseudoHeaderName);
+            ident = identifiers.identifierFor(vm, pseudoHeaderName);
+            isStatus = pseudoHeaderName == WebCore::HTTP2PseudoHeaderName::Status;
+        } else if (WebCore::findHTTPHeaderName(nameView, headerName)) {
+            nameStr = identifiers.stringFor(globalObject, headerName);
+            ident = identifiers.identifierFor(vm, headerName);
+            isCookie = headerName == WebCore::HTTPHeaderName::Cookie;
+            isSetCookie = headerName == WebCore::HTTPHeaderName::SetCookie;
         } else {
-            nameStr = jsString(vm, nameView.toString());
+            ident = Identifier::fromString(vm, nameView.span8());
+            nameStr = jsString(vm, ident.string());
         }
 
         JSString* valueStr = h2ValueToJS(vm, valueBytes, valueLen);
@@ -126,19 +145,14 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__h2__materializ
             RETURN_IF_EXCEPTION(scope, {});
         }
 
-        const String nameString = nameStr->getString(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-        const auto ident = Identifier::fromString(vm, nameString);
-
         JSValue fieldValue = valueStr;
-        if (nameView == ":status"_s) {
+        if (isStatus) {
             // toHeaderObject: `value |= 0` — exact ToInt32(ToNumber(string)).
             double num = valueStr->toNumber(globalObject);
             RETURN_IF_EXCEPTION(scope, {});
             fieldValue = jsNumber(JSC::toInt32(num));
         }
 
-        const bool isSetCookie = nameView == "set-cookie"_s;
         // All-digit header names ("123") are valid HTTP tokens. putDirect()
         // ASSERT(!parseIndex(propertyName)) trips in debug builds; route the
         // index-like case through *Index variants like NodeHTTP.cpp does.
@@ -176,7 +190,7 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__h2__materializ
                 RETURN_IF_EXCEPTION(scope, {});
                 auto valueString = valueStr->getString(globalObject);
                 RETURN_IF_EXCEPTION(scope, {});
-                auto joined = nameView == "cookie"_s
+                auto joined = isCookie
                     ? WTF::makeString(existingString, "; "_s, valueString)
                     : WTF::makeString(existingString, ", "_s, valueString);
                 obj->putDirect(vm, ident, jsString(vm, WTF::move(joined)), 0);

--- a/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp
@@ -47,8 +47,7 @@ using StringGetter = JSC::JSString* (HTTPHeaderIdentifiers::*)(JSC::JSGlobalObje
 #define HTTP_HEADERS_STRING_ARRAY_ENTRIES(literal, name) \
     &HTTPHeaderIdentifiers::name##String,
 
-// Indexed by HTTPHeaderName: HTTP_HEADERS_EACH_NAME lists the names in the
-// same order as HTTPHeaderNames.in.
+// Indexed by HTTPHeaderName; HTTP_HEADERS_EACH_NAME follows HTTPHeaderNames.in's order.
 static const IdentifierGetter headerIdentifierFields[] = {
     HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES)
 };
@@ -58,7 +57,7 @@ static const StringGetter headerStringFields[] = {
 static_assert(std::size(headerIdentifierFields) == numHTTPHeaderNames);
 static_assert(std::size(headerStringFields) == numHTTPHeaderNames);
 
-// Indexed by HTTP2PseudoHeaderName, which is generated from the same list.
+// Indexed by HTTP2PseudoHeaderName, generated from the same list.
 static const IdentifierGetter pseudoHeaderIdentifierFields[] = {
     HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES)
 };

--- a/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp
@@ -46,16 +46,29 @@ using StringGetter = JSC::JSString* (HTTPHeaderIdentifiers::*)(JSC::JSGlobalObje
     &HTTPHeaderIdentifiers::name##Identifier,
 #define HTTP_HEADERS_STRING_ARRAY_ENTRIES(literal, name) \
     &HTTPHeaderIdentifiers::name##String,
+#define HTTP_HEADERS_ENUM_ENTRIES(literal, name) HTTPHeaderName::name,
 
-// Indexed by HTTPHeaderName; HTTP_HEADERS_EACH_NAME follows HTTPHeaderNames.in's order.
+// The tables below are indexed by HTTPHeaderName.
+static constexpr HTTPHeaderName headerNameOfEntry[] = {
+    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_ENUM_ENTRIES)
+};
+static constexpr bool entriesFollowHTTPHeaderNameOrder()
+{
+    for (size_t i = 0; i < std::size(headerNameOfEntry); i++) {
+        if (static_cast<size_t>(headerNameOfEntry[i]) != i)
+            return false;
+    }
+    return true;
+}
+static_assert(std::size(headerNameOfEntry) == numHTTPHeaderNames, "HTTP_HEADERS_EACH_NAME must list every HTTPHeaderName");
+static_assert(entriesFollowHTTPHeaderNameOrder(), "HTTP_HEADERS_EACH_NAME must follow the HTTPHeaderName enum order");
+
 static const IdentifierGetter headerIdentifierFields[] = {
     HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES)
 };
 static const StringGetter headerStringFields[] = {
     HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_STRING_ARRAY_ENTRIES)
 };
-static_assert(std::size(headerIdentifierFields) == numHTTPHeaderNames);
-static_assert(std::size(headerStringFields) == numHTTPHeaderNames);
 
 // Indexed by HTTP2PseudoHeaderName, generated from the same list.
 static const IdentifierGetter pseudoHeaderIdentifierFields[] = {
@@ -67,6 +80,7 @@ static const StringGetter pseudoHeaderStringFields[] = {
 
 #undef HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES
 #undef HTTP_HEADERS_STRING_ARRAY_ENTRIES
+#undef HTTP_HEADERS_ENUM_ENTRIES
 
 JSC::Identifier& HTTPHeaderIdentifiers::identifierFor(JSC::VM& vm, HTTPHeaderName name)
 {

--- a/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp
@@ -1,6 +1,8 @@
 #include "BunClientData.h"
 #include "HTTPHeaderIdentifiers.h"
 #include <JavaScriptCore/LazyPropertyInlines.h>
+#include <wtf/text/StringView.h>
+#include <iterator>
 
 namespace WebCore {
 
@@ -12,8 +14,10 @@ namespace WebCore {
             init.set(jsOwnedString(init.vm, id.string()));                                   \
         });
 
-HTTPHeaderIdentifiers::HTTPHeaderIdentifiers() {
-    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_LAZY_PROPERTY_DEFINITION)
+HTTPHeaderIdentifiers::HTTPHeaderIdentifiers()
+{
+    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_LAZY_PROPERTY_DEFINITION);
+    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_LAZY_PROPERTY_DEFINITION);
 }
 
 #undef HTTP_HEADERS_LAZY_PROPERTY_DEFINITION
@@ -30,35 +34,87 @@ HTTPHeaderIdentifiers::HTTPHeaderIdentifiers() {
         return m_##name##String.getInitializedOnMainThread(globalObject);                 \
     }
 
-HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DEFINITIONS)
+HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DEFINITIONS);
+HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DEFINITIONS);
 
 #undef HTTP_HEADERS_ACCESSOR_DEFINITIONS
 
+using IdentifierGetter = JSC::Identifier& (HTTPHeaderIdentifiers::*)(JSC::VM&);
+using StringGetter = JSC::JSString* (HTTPHeaderIdentifiers::*)(JSC::JSGlobalObject*);
+
+#define HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES(literal, name) \
+    &HTTPHeaderIdentifiers::name##Identifier,
 #define HTTP_HEADERS_STRING_ARRAY_ENTRIES(literal, name) \
     &HTTPHeaderIdentifiers::name##String,
 
-    using StringGetter
-    = JSC::JSString * (HTTPHeaderIdentifiers::*)(JSC::JSGlobalObject*);
+// Indexed by HTTPHeaderName: HTTP_HEADERS_EACH_NAME lists the names in the
+// same order as HTTPHeaderNames.in.
+static const IdentifierGetter headerIdentifierFields[] = {
+    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES)
+};
+static const StringGetter headerStringFields[] = {
+    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_STRING_ARRAY_ENTRIES)
+};
+static_assert(std::size(headerIdentifierFields) == numHTTPHeaderNames);
+static_assert(std::size(headerStringFields) == numHTTPHeaderNames);
 
-static StringGetter headerStringFields[]
-    = {
-          HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_STRING_ARRAY_ENTRIES)
-      };
+// Indexed by HTTP2PseudoHeaderName, which is generated from the same list.
+static const IdentifierGetter pseudoHeaderIdentifierFields[] = {
+    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES)
+};
+static const StringGetter pseudoHeaderStringFields[] = {
+    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_STRING_ARRAY_ENTRIES)
+};
+
+#undef HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES
+#undef HTTP_HEADERS_STRING_ARRAY_ENTRIES
+
+JSC::Identifier& HTTPHeaderIdentifiers::identifierFor(JSC::VM& vm, HTTPHeaderName name)
+{
+    return (this->*headerIdentifierFields[static_cast<size_t>(name)])(vm);
+}
 
 JSC::JSString* HTTPHeaderIdentifiers::stringFor(JSC::JSGlobalObject* globalObject, HTTPHeaderName name)
 {
     return (this->*headerStringFields[static_cast<size_t>(name)])(globalObject);
 }
 
-#undef HTTP_HEADERS_STRING_ARRAY_ENTRIES
+JSC::Identifier& HTTPHeaderIdentifiers::identifierFor(JSC::VM& vm, HTTP2PseudoHeaderName name)
+{
+    return (this->*pseudoHeaderIdentifierFields[static_cast<size_t>(name)])(vm);
+}
+
+JSC::JSString* HTTPHeaderIdentifiers::stringFor(JSC::JSGlobalObject* globalObject, HTTP2PseudoHeaderName name)
+{
+    return (this->*pseudoHeaderStringFields[static_cast<size_t>(name)])(globalObject);
+}
+
+#define HTTP2_PSEUDO_HEADERS_FIND(literal, name) \
+    if (view == literal##_s) {                   \
+        result = HTTP2PseudoHeaderName::name;    \
+        return true;                             \
+    }
+
+bool findHTTP2PseudoHeaderName(WTF::StringView view, HTTP2PseudoHeaderName& result)
+{
+    if (view.isEmpty() || view[0] != ':')
+        return false;
+    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP2_PSEUDO_HEADERS_FIND);
+    return false;
+}
+
+#undef HTTP2_PSEUDO_HEADERS_FIND
 
 #define HTTP_HEADERS_LAZY_PROPERTY_VISITOR(literal, name) m_##name##String.visit(visitor);
 
 template<typename Visitor>
 void HTTPHeaderIdentifiers::visit(Visitor& visitor)
 {
-    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_LAZY_PROPERTY_VISITOR)
+    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_LAZY_PROPERTY_VISITOR);
+    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_LAZY_PROPERTY_VISITOR);
 }
+
+#undef HTTP_HEADERS_LAZY_PROPERTY_VISITOR
 
 template void HTTPHeaderIdentifiers::visit(JSC::AbstractSlotVisitor&);
 template void HTTPHeaderIdentifiers::visit(JSC::SlotVisitor&);

--- a/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.h
@@ -101,9 +101,7 @@ namespace WebCore {
     macro("x-temp-tablet", XTempTablet)                                                    \
     macro("x-xss-protection", XXSSProtection)
 
-// HTTP/2 pseudo-header fields (RFC 9113 section 8.3). They are not header
-// fields, so HTTPHeaderNames.in does not list them, but every HTTP/2 request
-// block carries four of them and every response block carries :status.
+// RFC 9113 pseudo-headers; not header fields, so HTTPHeaderName has no entries for them.
 #define HTTP2_PSEUDO_HEADERS_EACH_NAME(macro) \
     macro(":authority", Authority)            \
     macro(":method", Method)                  \
@@ -130,9 +128,7 @@ bool findHTTP2PseudoHeaderName(WTF::StringView, HTTP2PseudoHeaderName&);
     JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString> m_##name##String; \
     JSC::Identifier m_##name##Identifier;
 
-// Per-VM cache of one atomized Identifier and one JSString per header name, so
-// materializing inbound headers (NodeHTTP.cpp, H2HeadersMaterializer.cpp)
-// allocates nothing for the names it recognizes.
+// Per-VM cache: one Identifier and one JSString per header name, for the lifetime of the VM.
 class HTTPHeaderIdentifiers {
 public:
     HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DECLARATIONS)

--- a/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.h
@@ -100,7 +100,27 @@ namespace WebCore {
     macro("x-sourcemap", XSourceMap)                                                       \
     macro("x-temp-tablet", XTempTablet)                                                    \
     macro("x-xss-protection", XXSSProtection)
+
+// HTTP/2 pseudo-header fields (RFC 9113 section 8.3). They are not header
+// fields, so HTTPHeaderNames.in does not list them, but every HTTP/2 request
+// block carries four of them and every response block carries :status.
+#define HTTP2_PSEUDO_HEADERS_EACH_NAME(macro) \
+    macro(":authority", Authority)            \
+    macro(":method", Method)                  \
+    macro(":path", Path)                      \
+    macro(":scheme", Scheme)                  \
+    macro(":status", Status)
 // clang-format on
+
+#define HTTP2_PSEUDO_HEADERS_ENUM_ENTRY(literal, name) name,
+
+enum class HTTP2PseudoHeaderName : uint8_t {
+    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP2_PSEUDO_HEADERS_ENUM_ENTRY)
+};
+
+#undef HTTP2_PSEUDO_HEADERS_ENUM_ENTRY
+
+bool findHTTP2PseudoHeaderName(WTF::StringView, HTTP2PseudoHeaderName&);
 
 #define HTTP_HEADERS_ACCESSOR_DECLARATIONS(literal, name) \
     JSC::Identifier& name##Identifier(JSC::VM& vm);       \
@@ -110,19 +130,27 @@ namespace WebCore {
     JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString> m_##name##String; \
     JSC::Identifier m_##name##Identifier;
 
+// Per-VM cache of one atomized Identifier and one JSString per header name, so
+// materializing inbound headers (NodeHTTP.cpp, H2HeadersMaterializer.cpp)
+// allocates nothing for the names it recognizes.
 class HTTPHeaderIdentifiers {
 public:
     HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DECLARATIONS)
+    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DECLARATIONS)
 
     HTTPHeaderIdentifiers();
 
+    JSC::Identifier& identifierFor(JSC::VM&, HTTPHeaderName);
     JSC::JSString* stringFor(JSC::JSGlobalObject*, HTTPHeaderName);
+    JSC::Identifier& identifierFor(JSC::VM&, HTTP2PseudoHeaderName);
+    JSC::JSString* stringFor(JSC::JSGlobalObject*, HTTP2PseudoHeaderName);
 
     template<typename Visitor>
     void visit(Visitor& visitor);
 
 private:
     HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_PROPERTY_DECLARATIONS)
+    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_PROPERTY_DECLARATIONS)
 };
 
 } // namespace WebCore

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4058,6 +4058,111 @@ it("http2 pushStream reports an unsendable array element through the callback", 
   expect(blocks).toEqual([]);
 });
 
+// Every kind of field name the native header-block materializer distinguishes, in one request and
+// one response: pseudo-headers, names WebCore knows (with the cookie and set-cookie special cases),
+// names it has never seen, and all-digit names. The second round trip on the same session is served
+// from the per-VM name cache the first one populated, so both must materialize identically.
+it("http2 materializes pseudo, known, unknown and all-digit header names the same way on every request", async () => {
+  const server = http2.createServer();
+  server.on("stream", (stream, headers, _flags, rawHeaders) => {
+    // Raw-array form so the wire order and the duplicate fields are exactly these; an explicit
+    // date keeps respond() from adding the current one.
+    stream.respond([
+      ...[":status", "201"],
+      ...["date", "Thu, 01 Jan 2026 00:00:00 GMT"],
+      ...["content-type", "text/plain"],
+      ...["set-cookie", "a=1", "set-cookie", "b=2"],
+      ...["x-unknown", "u1", "x-unknown", "u2"],
+      ...["123", "first", "123", "second"],
+    ]);
+    stream.end(JSON.stringify({ headers, rawHeaders, sensitive: headers[http2.sensitiveHeaders] }));
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const authority = `127.0.0.1:${server.address().port}`;
+  const client = http2.connect(`http://${authority}`);
+  try {
+    const roundTrip = () =>
+      new Promise((resolve, reject) => {
+        // authorization is never-indexed automatically (nghttp2 behavior), so the receiver lists
+        // it under sensitiveHeaders without the request having to mark anything.
+        const req = client.request({
+          ":method": "POST",
+          ":path": "/materialize",
+          "content-type": "text/plain",
+          "authorization": "Bearer t",
+          "cookie": ["c=1", "d=2"],
+          "x-unknown": ["u1", "u2"],
+          "123": "digits",
+        });
+        req.on("error", reject);
+        let response;
+        req.on("response", (headers, _flags, rawHeaders) => {
+          response = {
+            headers: Object.fromEntries(Object.entries(headers)),
+            rawHeaders,
+            sensitive: headers[http2.sensitiveHeaders],
+          };
+        });
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("data", chunk => (body += chunk));
+        req.on("end", () => resolve({ request: JSON.parse(body), response }));
+        req.end();
+      });
+
+    const first = await roundTrip();
+    const second = await roundTrip();
+    expect(second).toEqual(first);
+
+    expect(first.request).toEqual({
+      headers: {
+        ":method": "POST",
+        ":path": "/materialize",
+        ":authority": authority,
+        ":scheme": "http",
+        "123": "digits",
+        "content-type": "text/plain",
+        "authorization": "Bearer t",
+        "cookie": "c=1; d=2",
+        "x-unknown": "u1, u2",
+      },
+      // Wire order: the pseudo-headers, then the remaining fields in property enumeration order,
+      // which puts the all-digit name first.
+      rawHeaders: [
+        ...[":method", "POST", ":path", "/materialize", ":authority", authority, ":scheme", "http"],
+        ...["123", "digits"],
+        ...["content-type", "text/plain"],
+        ...["authorization", "Bearer t"],
+        ...["cookie", "c=1", "cookie", "d=2"],
+        ...["x-unknown", "u1", "x-unknown", "u2"],
+      ],
+      sensitive: ["authorization"],
+    });
+    expect(first.response).toEqual({
+      headers: {
+        ":status": 201,
+        "date": "Thu, 01 Jan 2026 00:00:00 GMT",
+        "content-type": "text/plain",
+        "set-cookie": ["a=1", "b=2"],
+        "x-unknown": "u1, u2",
+        "123": "first",
+      },
+      rawHeaders: [
+        ...[":status", "201"],
+        ...["date", "Thu, 01 Jan 2026 00:00:00 GMT"],
+        ...["content-type", "text/plain"],
+        ...["set-cookie", "a=1", "set-cookie", "b=2"],
+        ...["x-unknown", "u1", "x-unknown", "u2"],
+        ...["123", "first", "123", "second"],
+      ],
+      sensitive: [],
+    });
+  } finally {
+    client.close();
+    server.close();
+  }
+});
+
 it("http2 option range error messages use the options. prefix", () => {
   for (const opt of ["maxSessionInvalidFrames", "maxSessionRejectedStreams", "unknownProtocolTimeout"]) {
     let error;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,3 +1,4 @@
+import { jscDescribe } from "bun:jsc";
 import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe } from "harness";
 import { createTest } from "node-harness";
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -4156,6 +4157,64 @@ it("http2 materializes pseudo, known, unknown and all-digit header names the sam
         ...["123", "first", "123", "second"],
       ],
       sensitive: [],
+    });
+  } finally {
+    client.close();
+    server.close();
+  }
+});
+
+// The name strings in rawHeaders wrap the atoms the headers object is keyed by: the per-VM
+// HTTPHeaderIdentifiers entry for pseudo-headers and known names, the atom the block was keyed
+// with for anything else. jscDescribe reports such strings as atomic; a name string built per block
+// instead (a JSString over WebCore's static name string, or a copy of the wire bytes) is not.
+// Checked before the names are used as keys anywhere, since that can atomize a string in place.
+it("http2 hands out the cached name strings for pseudo-headers and known header names", async () => {
+  const atomicByName = rawHeaders => {
+    const entries = [];
+    for (let i = 0; i < rawHeaders.length; i += 2) {
+      entries.push([rawHeaders[i], jscDescribe(rawHeaders[i]).includes("(atomic)")]);
+    }
+    return Object.fromEntries(entries);
+  };
+
+  let request;
+  const server = http2.createServer();
+  server.on("stream", (stream, _headers, _flags, rawHeaders) => {
+    request = atomicByName(rawHeaders);
+    stream.respond([
+      ...[":status", "200"],
+      ...["date", "Thu, 01 Jan 2026 00:00:00 GMT"],
+      ...["content-type", "text/plain"],
+      ...["x-unknown", "u"],
+    ]);
+    stream.end();
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  try {
+    const response = await new Promise((resolve, reject) => {
+      const req = client.request({ ":method": "POST", ":path": "/", "content-type": "text/plain", "x-unknown": "u" });
+      req.on("error", reject);
+      req.on("response", (_headers, _flags, rawHeaders) => resolve(atomicByName(rawHeaders)));
+      req.end();
+    });
+
+    expect({ request, response }).toEqual({
+      request: {
+        ":method": true,
+        ":path": true,
+        ":scheme": true,
+        ":authority": true,
+        "content-type": true,
+        "x-unknown": true,
+      },
+      response: {
+        ":status": true,
+        "date": true,
+        "content-type": true,
+        "x-unknown": true,
+      },
     });
   } finally {
     client.close();


### PR DESCRIPTION
Follow-up to #39448, which deleted the dead `Http2CommonStrings` cache. This wires the live inbound path up to the cache that is actually in use.

### Problem
- `Bun__h2__materializeHeaders` (`src/jsc/bindings/H2HeadersMaterializer.cpp`) runs once per inbound HEADERS / PUSH_PROMISE / trailer block on both the client and the server. For every field it allocated a new `JSString` cell for the name (`jsString(vm, String(httpHeaderNameStringImpl(...)))`), then read it back and called `Identifier::fromString` on it for the headers-object put, which is an atom-table lookup per field.
- Pseudo-headers (`:method`, `:path`, `:scheme`, `:authority`, `:status`) are not in `HTTPHeaderNames.in`, so they took the unknown-name path: a new `StringImpl` copy plus a new `JSString` plus an atomization, on every request and every response.
- `WebCore::HTTPHeaderIdentifiers` (`src/jsc/bindings/webcore/HTTPHeaderIdentifiers.{h,cpp}`, reached through `clientData(vm)->httpHeaderIdentifiers()`) already caches one `JSString` and one `Identifier` per known header name for the lifetime of the VM, and `Bun__NodeHTTP__buildRawHeadersArray` in `NodeHTTP.cpp` already uses it. The HTTP/2 path did not, and the cache had no pseudo-header entries. Its `identifierFor()` was removed as dead code in #39420 earlier today.

### Fix
- `HTTPHeaderIdentifiers`: add `HTTP2_PSEUDO_HEADERS_EACH_NAME`, a second X-macro list with the five pseudo-headers, and feed it through the same declaration / lazy-init / accessor / visitor macros as the existing entries, so each pseudo-header gets the same `LazyProperty<JSString>` + cached `Identifier` pair. `HTTP2PseudoHeaderName` is generated from that list, so the enum and the lookup tables cannot drift apart; `findHTTP2PseudoHeaderName()` maps a wire name to it (one byte compare for names that do not start with `:`).
- Restore `identifierFor(VM&, HTTPHeaderName)` next to `stringFor()` and add the `HTTP2PseudoHeaderName` overloads. The regular-name tables are indexed by `HTTPHeaderName`, so a `static_assert` now checks that `HTTP_HEADERS_EACH_NAME` has one entry per enum value and in enum order (previously nothing checked either; a misplaced entry would have silently shifted every later slot).
- `H2HeadersMaterializer.cpp`: names found in either list take the cached `JSString` and `Identifier`, so they allocate nothing and are never atomized per request. Any other name is atomized straight from the wire bytes (the same atom-table lookup as before, minus the intermediate `StringImpl` copy) and its rawHeaders `JSString` wraps that atom, so the unknown path goes from two allocations to one. The `:status`, `cookie` and `set-cookie` special cases compare the enums instead of re-comparing the name bytes. Behavior of the produced rawHeaders array, headers object and sensitive list is unchanged.
- `BunHttp2CommonStrings` is not brought back.
- Verified:
  - `test/js/node/http2/node-http2.test.js`, `http2 hands out the cached name strings for pseudo-headers and known header names`: after one round trip, `jscDescribe()` from `bun:jsc` reports every name string in rawHeaders, on both the server and the client side, as atomic, which is only true of strings that wrap the atoms the headers object is keyed by (the cache entries, or the per-block atom for unknown names). On main all ten names come out non-atomic (a JSString over WebCore's static name string, or a copy of the wire bytes), so the test fails there and passes with this change.
  - Same file, `http2 materializes pseudo, known, unknown and all-digit header names the same way on every request`: pins the produced rawHeaders / headers object / sensitive list for all four name paths on both sides, including the cookie / set-cookie / `:status` special cases, and checks that a second round trip on the same session (served from the populated cache) materializes identically. Behavior-preservation test, passes before and after.
  - `bun bd test test/js/node/http2/` (all 9 files, including `h2-conformance.test.ts`): 477 pass, 0 fail, on the debug + ASAN build.
  - All 283 upstream `test/js/node/test/{parallel,sequential}/*http2*` files pass with the debug build.
  - The new test also passes with `BUN_JSC_validateExceptionChecks=1`.
  - The three touched C++ files are clang-format clean.

### Benchmark
Local h2c loop in one process: a `node:http2` server and client on 127.0.0.1, 64 streams in flight on one session. Each round trip carries 10 regular fields on the request and 10 on the response (70% names from `HTTPHeaderNames.in`, 30% `x-*`), so with the pseudo-headers it materializes 25 fields per round trip (14 on the server, 11 on the client). `bun run build:release` (non-LTO) of main at 9f6748857 with and without this diff, same machine (16 vCPU container on a shared, busy host), 7 interleaved trials each, 60k timed round trips per trial after a 5k warm-up.

| headers per message | metric | before | after | delta |
| --- | --- | ---: | ---: | ---: |
| 10 (25 fields/round trip) | header fields/sec, median | 576,473 | 589,189 | +2.2% |
| 10 | header fields/sec, best | 582,706 | 600,457 | +3.0% |
| 10 | round trips/sec, median | 23,059 | 23,568 | +2.2% |
| 50 (105 fields/round trip) | header fields/sec, median | 1,006,661 | 1,043,415 | +3.7% |
| 50 | header fields/sec, best | 1,032,850 | 1,062,902 | +2.9% |
| 50 | round trips/sec, median | 9,587 | 9,937 | +3.7% |

The loop measures the whole request path (stream objects, events, framing, HPACK, loopback sockets), of which name materialization is a small slice, so a few percent end to end is the expected size of this change. Per round trip with the 10-header mix (5 pseudo-headers, 15 known names, 5 `x-*` names) it removes 20 `JSString` allocations, 10 `StringImpl` copies and 20 atom-table lookups; the 5 `x-*` names keep their lookup and go from two allocations to one.

<details>
<summary>Benchmark script</summary>

```js
// usage: <bun> bench.mjs [regularHeadersPerMessage=10] [roundTrips=60000] [concurrency=64]
import http2 from "node:http2";
const regular = Number(process.argv[2] ?? 10), total = Number(process.argv[3] ?? 60000), concurrency = Number(process.argv[4] ?? 64);
const knownNames = ["content-type","cache-control","etag","vary","last-modified","accept","accept-encoding","user-agent",
  "authorization","accept-language","referer","origin","if-none-match","link","via"];
function buildHeaders(count, prefix) {
  const out = {}; let known = 0;
  for (let i = 0; i < count; i++) {
    if (i % 10 < 7 && known < knownNames.length) out[knownNames[known++]] = `${prefix}-value-${i}`;
    else out[`x-${prefix}-${i}`] = `${prefix}-value-${i}`;
  }
  return out;
}
const requestHeaders = { ":method": "POST", ":path": "/bench", ...buildHeaders(regular, "req") };
const responseHeaders = { ":status": 200, date: "Thu, 01 Jan 2026 00:00:00 GMT", ...buildHeaders(regular - 1, "res") };
const requestFields = 4 + regular, responseFields = 1 + regular;
const server = http2.createServer();
let serverFields = 0;
server.on("stream", stream => { serverFields += requestFields; stream.respond(responseHeaders, { endStream: true }); });
await new Promise(r => server.listen(0, "127.0.0.1", r));
const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
await new Promise(r => client.once("connect", r));
function run(n) {
  return new Promise((resolve, reject) => {
    let started = 0, finished = 0, clientFields = 0;
    function one() {
      started++;
      const req = client.request(requestHeaders, { endStream: true });
      req.on("error", reject);
      req.on("response", h => { if (h[":status"] !== 200) reject(new Error("bad status")); clientFields += responseFields; });
      req.on("close", () => { if (++finished === n) resolve(clientFields); else if (started < n) one(); });
    }
    for (let i = 0; i < Math.min(concurrency, n); i++) one();
  });
}
await run(Math.min(total, 5000)); // warm-up
serverFields = 0;
const t0 = performance.now();
const clientFields = await run(total);
const s = (performance.now() - t0) / 1000;
console.log(JSON.stringify({ regular, roundTripsPerSec: Math.round(total / s), headerFieldsPerSec: Math.round((clientFields + serverFields) / s) }));
client.close(); server.close();
```

</details>

### Background
- `HTTPHeaderNames.in` is WebCore's list of ~94 well-known HTTP header names. `findHTTPHeaderName()` maps a name to the `HTTPHeaderName` enum with a perfect hash. HTTP/2 pseudo-headers are not HTTP header fields, which is why they are not in that list.
- `WTF::AtomStringImpl` is the per-thread interning table for strings used as property keys. A `JSC::Identifier` is a handle to an atom; `Identifier::fromString` hashes the input and looks it up (allocating a new atom on a miss). `JSString` is the GC cell that wraps a `StringImpl` and is what JavaScript sees; several `JSString`s can share one `StringImpl`, including an atom.
- `JSC::LazyProperty<Owner, T>` is JSC's lazily-initialized GC slot: it stores an initializer until first use, and `visit()` marks the cell once created. `HTTPHeaderIdentifiers` lives in the per-VM `JSVMClientData` and is marked from `Zig::GlobalObject::visitChildren`, so the cached strings stay alive for the VM's lifetime and adding entries to the X-macro list extends both the initialization and the marking automatically.
- Sharing one `JSString` cell across many rawHeaders arrays is not observable from JavaScript: strings are compared by value, and the cells are immutable.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (8326d1bd3)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [842.82ms]
(pass) node none > Client Basics > should be able to send a POST request [564.28ms]
(pass) node none > Client Basics > constants [18.74ms]
(pass) node none > Client Basics > getDefaultSettings [7.14ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.56ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.48ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.35ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.25ms]
(pass) node none > Client Basics > should be able to send data using end [594.14ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [582.90ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release without fix: 6 skipped
bun test v1.4.0-canary.1 (b4a5e9abb)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.91ms]
(pass) node none > Client Basics > getDefaultSettings [0.15ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.39ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.11ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [1.72ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.72ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.65ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.09ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [34.66ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should fail to con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (8326d1bd3)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [860.23ms]
(pass) node none > Client Basics > should be able to send a POST request [575.20ms]
(pass) node none > Client Basics > constants [18.83ms]
(pass) node none > Client Basics > getDefaultSettings [7.39ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [23.12ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.63ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.68ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.08ms]
(pass) node none > Client Basics > should be able to send data using end [607.15ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [599.84ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1049ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/126] gen cpp.rs (cppbind)
[3/126] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 8 sinks, 96 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[4/126] gen JS modules (bundle-modules)
Preprocess modules (8180ms)
Bundle modules (39ms)
Postprocesss modules (36ms)
Bundle Functions (629ms)
Generate Code (22ms)

[8.92s] Bundled "src/js" for production
  2630 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/125] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_highway v0.0.0 (/workspace/bun/src/highway)
[1m[92m   Compilin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/H2HeadersMaterializer.cpp         |  36 +++--
 src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp |  91 ++++++++++--
 src/jsc/bindings/webcore/HTTPHeaderIdentifiers.h   |  24 +++
 test/js/node/http2/node-http2.test.js              | 164 +++++++++++++++++++++
 4 files changed, 291 insertions(+), 24 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/H2HeadersMaterializer.cpp              4     11      0
src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp      5     13      0
src/jsc/bindings/webcore/HTTPHeaderIdentifiers.h        2      3      0
test/js/node/http2/node-http2.test.js                   4      8      0
```

</details>

**root cause** · written by the author bot

The inbound node:http2 header path in H2HeadersMaterializer.cpp built a fresh JSString and then a separate Identifier for every header name on every HEADERS frame, and the pseudo-headers were absent from HTTPHeaderNames.in, so each request or response also paid for a new StringImpl plus atomization for :method, :path, :scheme, :authority and :status. The fix routes known names through the existing per-VM HTTPHeaderIdentifiers cache, as NodeHTTP.cpp already does, and adds the five pseudo-headers to that cache as lazily initialized strings with cached identifiers, so steady-state materializat…

<!-- robobun:evidence:end -->