### PR TITLE
Route ICU's allocations through mimalloc

### DIFF
--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -220,10 +220,12 @@ fn use_mimalloc_in_dependencies() {
     }
     Bun__useMimallocForICU();
 
-    // libuv (only linked on Windows). Must precede the first uv call.
+    // libuv (only linked on Windows). Must precede the first uv call. Left on
+    // the CRT heap under ASAN like ICU and BoringSSL, so the sanitizer sees
+    // its allocations too (the global allocator is `System` there as well).
     // SAFETY: mimalloc fns match the libuv allocator signatures; called
     // exactly once before any uv handle is created.
-    #[cfg(windows)]
+    #[cfg(all(windows, not(bun_asan)))]
     unsafe {
         let _ = bun_sys::windows::libuv::uv_replace_allocator(
             Some(bun_alloc::mimalloc::mi_malloc),

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -160,12 +160,7 @@ pub(crate) unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) ->
     // 1. Crash handler first so anything below gets a usable trace.
     bun_crash_handler::init();
 
-    // Before anything can reach ICU: its allocator hook does not tolerate
-    // blocks allocated before the switch.
-    unsafe extern "C" {
-        safe fn Bun__useMimallocForICU();
-    }
-    Bun__useMimallocForICU();
+    use_mimalloc_in_dependencies();
 
     // SIGPIPE/SIGXFSZ → SIG_IGN.
     // SAFETY: `SIGPIPE`/`SIGXFSZ` are valid signal numbers and `SIG_IGN` is a
@@ -177,21 +172,10 @@ pub(crate) unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) ->
         libc::signal(libc::SIGXFSZ, libc::SIG_IGN);
     }
 
-    // Windows-only startup. Must run BEFORE the first libuv
-    // call (uv allocator) and before anything reads `Bun.env`/`process.env`
-    // (env conversion).
+    // Windows-only startup. Must run before anything reads
+    // `Bun.env`/`process.env` (env conversion).
     #[cfg(windows)]
     {
-        // SAFETY: mimalloc fns match the libuv allocator signatures; called
-        // exactly once before any uv handle is created.
-        unsafe {
-            let _ = bun_sys::windows::libuv::uv_replace_allocator(
-                Some(bun_alloc::mimalloc::mi_malloc),
-                Some(bun_alloc::mimalloc::mi_realloc),
-                Some(bun_alloc::mimalloc::mi_calloc),
-                Some(bun_alloc::mimalloc::mi_free),
-            );
-        }
         // `bun.handleOom(convertEnvToWTF8())` — converts the OS UTF-16 env
         // block to WTF-8 and publishes it via `bun_core::os::set_environ()`.
         // Without this, `Bun.env`/`process.env` see only `.env`-file vars.
@@ -215,4 +199,37 @@ pub(crate) unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) ->
     bun_runtime::cli::Cli::start();
     // `Global::exit` is `-> !`; it coerces to the `c_int` return type.
     Global::exit(0)
+}
+
+/// Point the bundled C/C++ dependencies that have an allocator hook at
+/// mimalloc, so the whole process shares one allocator (and, on Windows, one
+/// policy for transient commit-limit failures instead of the UCRT heap's
+/// immediate NULL). Runs first thing in `main()`: these hooks only swap
+/// function pointers, so nothing may have allocated through the library yet.
+///
+/// The two dependencies not switched here:
+/// - c-ares: `ares_library_init_mem(.., mi_malloc, mi_free, mi_realloc)` in
+///   `bun_cares_sys`, because it is part of the (lazy) library init.
+/// - BoringSSL: link-time `OPENSSL_memory_alloc/free/get_size` definitions in
+///   `bun_boringssl` (`BORINGSSL_REQUIRE_MEMORY_HOOKS`, off under ASAN).
+fn use_mimalloc_in_dependencies() {
+    // ICU: `u_setMemoryFunctions` (bun_icu_malloc.cpp; no-op under ASAN and
+    // on macOS, where ICU is the system libicucore).
+    unsafe extern "C" {
+        safe fn Bun__useMimallocForICU();
+    }
+    Bun__useMimallocForICU();
+
+    // libuv (only linked on Windows). Must precede the first uv call.
+    // SAFETY: mimalloc fns match the libuv allocator signatures; called
+    // exactly once before any uv handle is created.
+    #[cfg(windows)]
+    unsafe {
+        let _ = bun_sys::windows::libuv::uv_replace_allocator(
+            Some(bun_alloc::mimalloc::mi_malloc),
+            Some(bun_alloc::mimalloc::mi_realloc),
+            Some(bun_alloc::mimalloc::mi_calloc),
+            Some(bun_alloc::mimalloc::mi_free),
+        );
+    }
 }

--- a/src/bun_bin/lib.rs
+++ b/src/bun_bin/lib.rs
@@ -160,6 +160,13 @@ pub(crate) unsafe extern "C" fn main(argc: c_int, argv: *const *const c_char) ->
     // 1. Crash handler first so anything below gets a usable trace.
     bun_crash_handler::init();
 
+    // Before anything can reach ICU: its allocator hook does not tolerate
+    // blocks allocated before the switch.
+    unsafe extern "C" {
+        safe fn Bun__useMimallocForICU();
+    }
+    Bun__useMimallocForICU();
+
     // SIGPIPE/SIGXFSZ → SIG_IGN.
     // SAFETY: `SIGPIPE`/`SIGXFSZ` are valid signal numbers and `SIG_IGN` is a
     // valid disposition; called once on the main thread before any other

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -41,6 +41,14 @@ export const highwayStringsForTesting: (
   arg: number | Uint8Array,
 ) => number = $newCppFunction("highway_strings_testing.cpp", "Bun__highwayStringsForTesting", 3);
 
+// Whether ICU's heap is routed through mimalloc (src/jsc/bindings/bun_icu_malloc.cpp)
+// and how many ICU allocations have gone through it.
+export const icuAllocatorForTesting: () => { installed: boolean; allocations: number } = $newCppFunction(
+  "bun_icu_malloc.cpp",
+  "Bun__icuAllocatorForTesting",
+  0,
+);
+
 export const SQL = $cpp("JSSQLStatement.cpp", "createJSSQLStatementConstructor");
 
 export const patchInternals = {

--- a/src/jsc/bindings/bun_icu_malloc.cpp
+++ b/src/jsc/bindings/bun_icu_malloc.cpp
@@ -1,0 +1,95 @@
+// Route ICU's heap (uprv_malloc / uprv_realloc / uprv_free, which also back
+// ICU's `UMemory::operator new/delete`) through mimalloc, like libuv, c-ares
+// and BoringSSL already are. Otherwise ICU is on plain `malloc`, which on
+// Windows is the static UCRT heap: it returns NULL on the first commit-limit
+// refusal, with none of the retry mimalloc applies (`mi_option_retry_on_oom`),
+// and `ubrk_clone` turns that NULL into "failed to initialize Segments" or a
+// null dereference in RuleBasedBreakIterator.
+
+#include "root.h"
+
+#include "bun_icu_malloc.h"
+
+#include "ZigGlobalObject.h"
+#include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/ObjectConstructor.h>
+#include <atomic>
+
+// Under ASAN, keep ICU on the allocator the sanitizer tracks (same reason
+// BoringSSL's hooks are off there). On macOS ICU is the system libicucore,
+// shared with frameworks that may have allocated from it before main().
+#if USE(BUN_MIMALLOC) && !ASAN_ENABLED && !OS(DARWIN)
+
+#include "mimalloc.h"
+#include <unicode/uclean.h>
+
+namespace Bun {
+namespace ICUMalloc {
+
+static bool s_installed = false;
+static std::atomic<size_t> s_allocations { 0 };
+
+static void* U_CALLCONV icuAlloc(const void*, size_t size)
+{
+    s_allocations.fetch_add(1, std::memory_order_relaxed);
+    return mi_malloc(size);
+}
+
+static void* U_CALLCONV icuRealloc(const void*, void* p, size_t size)
+{
+    // A block ICU allocated before install() would be from another heap.
+    ASSERT_WITH_MESSAGE(!p || mi_is_in_heap_region(p), "ICU realloc of a non-mimalloc pointer %p", p);
+    return mi_realloc(p, size);
+}
+
+static void U_CALLCONV icuFree(const void*, void* p)
+{
+    ASSERT_WITH_MESSAGE(!p || mi_is_in_heap_region(p), "ICU free of a non-mimalloc pointer %p", p);
+    mi_free(p);
+}
+
+// Must run before ICU allocates anything: u_setMemoryFunctions only swaps the
+// function pointers, so an earlier block would later reach mi_free.
+static void install()
+{
+    UErrorCode status = U_ZERO_ERROR;
+    u_setMemoryFunctions(nullptr, icuAlloc, icuRealloc, icuFree, &status);
+    RELEASE_ASSERT(U_SUCCESS(status));
+    s_installed = true;
+}
+
+} // namespace ICUMalloc
+} // namespace Bun
+
+extern "C" void Bun__useMimallocForICU()
+{
+    Bun::ICUMalloc::install();
+}
+
+#else
+
+extern "C" void Bun__useMimallocForICU()
+{
+}
+
+#endif
+
+namespace Bun {
+
+BUN_DEFINE_HOST_FUNCTION(Bun__icuAllocatorForTesting, (JSC::JSGlobalObject * globalObject, JSC::CallFrame*))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto* object = JSC::constructEmptyObject(globalObject);
+#if USE(BUN_MIMALLOC) && !ASAN_ENABLED && !OS(DARWIN)
+    bool installed = ICUMalloc::s_installed;
+    size_t allocations = ICUMalloc::s_allocations.load(std::memory_order_relaxed);
+#else
+    bool installed = false;
+    size_t allocations = 0;
+#endif
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "installed"_s), JSC::jsBoolean(installed));
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "allocations"_s), JSC::jsNumber(allocations));
+    return JSC::JSValue::encode(object);
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/bun_icu_malloc.h
+++ b/src/jsc/bindings/bun_icu_malloc.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "root.h"
+
+namespace Bun {
+
+// () => { installed: boolean, allocations: number }
+BUN_DECLARE_HOST_FUNCTION(Bun__icuAllocatorForTesting);
+
+} // namespace Bun

--- a/test/js/web/intl/icu-allocator-fixture.ts
+++ b/test/js/web/intl/icu-allocator-fixture.ts
@@ -1,0 +1,111 @@
+// Child process for icu-allocator.test.ts (Windows only).
+//
+// The parent puts this process in a Job Object with a per-process commit limit
+// a little above the commit reported in READY, lifts it shortly after EDGE and
+// then sends LIFTED. While the limit is in place this process clones ICU break
+// iterators (Intl.Segmenter#segment) in a loop, arranged so that those clones
+// are the only thing that needs fresh commit:
+//  - the IntlSegments JS cells come from free cells left by a warm-up pass, so
+//    JSC does not have to commit new blocks,
+//  - the break iterators freed by that warm-up are taken up again by live
+//    segment iterators, so ICU's heap has no spare room,
+//  - the remaining headroom is taken with raw VirtualAlloc(MEM_COMMIT).
+import { dlopen, FFIType, ptr } from "bun:ffi";
+
+const k32 = dlopen("kernel32.dll", {
+  GetCurrentProcess: { args: [], returns: FFIType.ptr },
+  K32GetProcessMemoryInfo: { args: [FFIType.ptr, FFIType.ptr, FFIType.u32], returns: FFIType.i32 },
+  VirtualAlloc: { args: [FFIType.ptr, FFIType.u64, FFIType.u32, FFIType.u32], returns: FFIType.ptr },
+}).symbols;
+const counters = new Uint8Array(80); // PROCESS_MEMORY_COUNTERS_EX
+const countersView = new DataView(counters.buffer);
+function commitMB(): number {
+  countersView.setUint32(0, 80, true);
+  if (!k32.K32GetProcessMemoryInfo(k32.GetCurrentProcess(), ptr(counters), 80)) {
+    throw new Error("K32GetProcessMemoryInfo failed");
+  }
+  return Number(countersView.getBigUint64(72, true)) / 1048576; // PrivateUsage
+}
+const MEM_COMMIT_RESERVE = 0x1000 | 0x2000;
+const PAGE_READWRITE = 0x04;
+
+let stdinReader: ReturnType<ReturnType<typeof Bun.stdin.stream>["getReader"]> | undefined;
+let buffered = "";
+async function waitFor(word: string): Promise<string> {
+  const fromArgv = process.argv.find(a => a.startsWith(word + "="));
+  if (fromArgv) return fromArgv.slice(word.length + 1);
+  stdinReader ??= Bun.stdin.stream().getReader();
+  for (;;) {
+    const nl = buffered.indexOf("\n");
+    if (nl >= 0) {
+      const line = buffered.slice(0, nl);
+      buffered = buffered.slice(nl + 1);
+      if (line.startsWith(word)) return line.slice(word.length).trim();
+      continue;
+    }
+    const { value, done } = await stdinReader.read();
+    if (done) throw new Error("stdin closed while waiting for " + word);
+    buffered += new TextDecoder().decode(value);
+  }
+}
+
+const N = 60_000;
+const segmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+{
+  let warm: unknown[] = [];
+  for (let i = 0; i < N; i++) warm.push(segmenter.segment("x"));
+  warm = [];
+  Bun.gc(true);
+}
+const pinned = segmenter.segment("x");
+const iterators: unknown[] = [];
+for (let i = 0; i < N; i++) iterators.push(pinned[Symbol.iterator]());
+
+const keep: unknown[] = new Array(N).fill(null);
+let kept = 0;
+let errors = 0;
+const messages = new Set<string>();
+
+process.stdout.write(`READY ${Math.ceil(commitMB())}\n`);
+const limitMB = Number(await waitFor("GO"));
+
+// Commit charge is what the job limit counts, so untouched MEM_COMMIT pages
+// are enough; stop at the first refusal.
+for (const chunk of [4 << 20, 256 << 10, 64 << 10]) {
+  while (commitMB() + chunk / 1048576 < limitMB && k32.VirtualAlloc(null, chunk, MEM_COMMIT_RESERVE, PAGE_READWRITE)) {}
+}
+const edgeMB = +commitMB().toFixed(2);
+
+process.stdout.write("EDGE\n");
+const t0 = performance.now();
+for (let i = 0; i < N; i++) {
+  try {
+    keep[kept++] = segmenter.segment("x");
+  } catch (e) {
+    errors++;
+    messages.add(String(e));
+  }
+}
+const elapsed = Math.round(performance.now() - t0);
+process.stdout.write(`LOOP ${errors}\n`);
+
+await waitFor("LIFTED");
+
+// ICU must still be usable afterwards.
+let after = "";
+try {
+  let n = 0;
+  for (const _ of segmenter.segment("después 👍🏽 ok")) n++;
+  after += `${n} `;
+  after += [...new Intl.Segmenter("ja", { granularity: "word" }).segment("テスト中")].length;
+  after += " " + new Intl.NumberFormat("en").format(1234567.891);
+} catch (e) {
+  errors++;
+  messages.add("after: " + String(e));
+}
+
+process.stdout.write(
+  `RESULT ${JSON.stringify({ errors, messages: [...messages], kept, after, limitMB, edgeMB, elapsed })}\n`,
+);
+process.exit(0);

--- a/test/js/web/intl/icu-allocator.test.ts
+++ b/test/js/web/intl/icu-allocator.test.ts
@@ -1,0 +1,126 @@
+// ICU's heap is routed through mimalloc (src/jsc/bindings/bun_icu_malloc.cpp),
+// so on Windows a transient commit-limit refusal is retried instead of turning
+// into "failed to initialize Segments" / a segfault inside ubrk_clone.
+import { dlopen, FFIType, ptr } from "bun:ffi";
+import { icuAllocatorForTesting } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, isMacOS, isWindows } from "harness";
+import { join } from "path";
+
+describe("ICU allocator", () => {
+  // macOS uses the system libicucore and ASAN builds keep ICU on the
+  // sanitizer's allocator; everywhere else the hook is installed at startup.
+  test.skipIf(isMacOS || isASAN)("ICU allocations go through mimalloc", () => {
+    const before = icuAllocatorForTesting();
+    expect(before.installed).toBe(true);
+    const segments = [...new Intl.Segmenter("en", { granularity: "word" }).segment("routes through mimalloc")];
+    expect(segments.length).toBe(5);
+    expect(icuAllocatorForTesting().allocations).toBeGreaterThan(before.allocations);
+  });
+
+  // Puts a child in a Job Object with a commit cap right above its current
+  // commit, lets it run into the cap while cloning ICU break iterators, and
+  // lifts the cap 150ms later — a transient refusal, like a slow pagefile
+  // growth step. With ICU on the CRT heap, its malloc got NULL immediately and
+  // Intl.Segmenter threw "failed to initialize Segments" or segfaulted in
+  // RuleBasedBreakIterator::BreakCache::reset.
+  test.skipIf(!isWindows)(
+    "Intl.Segmenter survives a transient commit-limit failure",
+    async () => {
+      const k32 = dlopen("kernel32.dll", {
+        CreateJobObjectW: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.ptr },
+        SetInformationJobObject: { args: [FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.u32], returns: FFIType.i32 },
+        AssignProcessToJobObject: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.i32 },
+        OpenProcess: { args: [FFIType.u32, FFIType.i32, FFIType.u32], returns: FFIType.ptr },
+        CloseHandle: { args: [FFIType.ptr], returns: FFIType.i32 },
+        GetLastError: { args: [], returns: FFIType.u32 },
+      }).symbols;
+
+      const JobObjectExtendedLimitInformation = 9;
+      const JOB_OBJECT_LIMIT_PROCESS_MEMORY = 0x100;
+      const PROCESS_SET_QUOTA = 0x0100;
+      const PROCESS_TERMINATE = 0x0001;
+      // JOBOBJECT_EXTENDED_LIMIT_INFORMATION: LimitFlags @16, ProcessMemoryLimit @112, 144 bytes.
+      const info = new Uint8Array(144);
+      const setLimit = (job: unknown, bytes: number) => {
+        const dv = new DataView(info.buffer);
+        dv.setUint32(16, bytes > 0 ? JOB_OBJECT_LIMIT_PROCESS_MEMORY : 0, true);
+        dv.setBigUint64(112, BigInt(Math.max(bytes, 0)), true);
+        if (!k32.SetInformationJobObject(job, JobObjectExtendedLimitInformation, ptr(info), info.byteLength)) {
+          throw new Error("SetInformationJobObject failed: " + k32.GetLastError());
+        }
+      };
+
+      const runOnce = async () => {
+        const job = k32.CreateJobObjectW(null, null);
+        expect(job).toBeTruthy();
+        try {
+          await using proc = Bun.spawn({
+            cmd: [bunExe(), join(import.meta.dir, "icu-allocator-fixture.ts")],
+            env: bunEnv,
+            stdin: "pipe",
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          const stderrPromise = proc.stderr.text();
+
+          let stdout = "";
+          let result: { errors: number; messages: string[]; kept: number; after: string } | undefined;
+          let assigned = false;
+          let lifted = false;
+          const decoder = new TextDecoder();
+          for await (const chunk of proc.stdout) {
+            stdout += decoder.decode(chunk, { stream: true });
+            if (!assigned) {
+              const ready = /READY (\d+)\n/.exec(stdout);
+              if (ready) {
+                assigned = true;
+                const limitMB = Number(ready[1]) + 48;
+                setLimit(job, limitMB * 1048576);
+                const handle = k32.OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, proc.pid);
+                expect(handle).toBeTruthy();
+                try {
+                  if (!k32.AssignProcessToJobObject(job, handle)) {
+                    throw new Error("AssignProcessToJobObject failed: " + k32.GetLastError());
+                  }
+                } finally {
+                  k32.CloseHandle(handle);
+                }
+                proc.stdin.write(`GO ${limitMB}\n`);
+                await proc.stdin.flush();
+              }
+            }
+            if (!lifted && stdout.includes("EDGE\n")) {
+              lifted = true;
+              // The refusal has to outlast the allocation attempt but stay well
+              // inside every allocator's retry budget (mimalloc 400ms, libpas 500ms).
+              await Bun.sleep(150);
+              setLimit(job, 0);
+              proc.stdin.write("LIFTED\n");
+              await proc.stdin.flush();
+            }
+            const done = /RESULT (.+)\n/.exec(stdout);
+            if (done) result = JSON.parse(done[1]);
+          }
+          const [stderr, exitCode] = await Promise.all([stderrPromise, proc.exited]);
+          return { stdout, stderr, exitCode, result };
+        } finally {
+          k32.CloseHandle(job);
+        }
+      };
+
+      for (let i = 0; i < 3; i++) {
+        const { stdout, stderr, exitCode, result } = await runOnce();
+        const output = stdout + stderr;
+        expect(output).not.toContain("failed to initialize");
+        expect(output).not.toContain("Segmentation fault");
+        expect(result).toBeDefined();
+        expect(result!.messages).toEqual([]);
+        expect(result!.errors).toBe(0);
+        expect(result!.after).toBe("12 2 1,234,567.891");
+        expect(exitCode).toBe(0);
+      }
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
### What does this PR do?

Makes ICU allocate through mimalloc (`u_setMemoryFunctions`), like libuv (`uv_replace_allocator`), c-ares (`ares_library_init_mem`) and BoringSSL (`OPENSSL_memory_*`) already do. ICU was the one large dependency still on plain `malloc`.

That matters on Windows, where plain `malloc` is the static UCRT heap: it returns NULL on the first commit-limit refusal, while mimalloc (`mi_option_retry_on_oom`) and libpas wait such refusals out because they are frequently transient (the pagefile is still growing, or other processes free commit moments later). A healthy process could therefore see a single ICU allocation fail while JS kept running, and `ubrk_clone` turns that NULL into `TypeError: failed to initialize Segments` or a null dereference in `RuleBasedBreakIterator::BreakCache::reset` (`Segmentation fault at address 0x10`, #32133). Now ICU only sees NULL once mimalloc's own retry is exhausted, same as the rest of the process. Genuine, persistent exhaustion is still oven-sh/WebKit#441's to report cleanly.

The hook is installed from `main()` before anything can reach ICU (it only swaps function pointers, so an earlier block would later be handed to `mi_free`); debug builds assert ICU only frees mimalloc pointers. It is off under ASAN (ICU stays on the allocator the sanitizer tracks, like the BoringSSL hooks) and on macOS (system `libicucore`, shared with frameworks).

### How did you verify your code works?

`test/js/web/intl/icu-allocator.test.ts`: the hook is installed and counts ICU allocations; on Windows a child in a Job Object hits a per-process commit limit while cloning break iterators and the limit is lifted 150 ms later. Before: `Segmentation fault at address 0x10` in every run. After: no errors and exit 0 on debug and release Windows builds (20+ runs). Also ran `test/js/web/intl`, `test/js/web/encoding`, `test/js/node/url`, stringWidth and the node ICU tests on a Windows debug build with the provenance assertion.
