### PR TITLE
node:inspector: type the CDP adapter's JSC side against the protocol snapshot and typecheck it in CI

### DIFF
--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -8,11 +8,8 @@
 // are preserved by giving backend commands their own id space and correlating
 // the responses.
 //
-// The backend side is typed against the JSC protocol snapshot, which is
-// generated from the WebKit Bun links against (bun-inspector-protocol/scripts/
-// generate-protocol.ts), so a field WebKit renames or drops fails to typecheck
-// here instead of turning into `undefined` in a DevTools event. The import is
-// type-only, so the builtin bundler erases it.
+// The backend side is typed against the protocol snapshot generated from the
+// WebKit Bun links against; the type-only import is erased by the builtin bundler.
 import type { JSC } from "../../../../packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts";
 
 const { pathToFileURL, fileURLToPath } = require("node:url");
@@ -20,17 +17,15 @@ const { isAbsolute } = require("node:path");
 
 const EXECUTION_CONTEXT_ID = 1;
 
-// CDP (client-facing) shapes are built ad hoc and stay untyped.
+// CDP (client-facing) shapes stay untyped.
 type AnyObject = Record<string, any>;
 
 type BackendResult = JSC.ResponseMap[keyof JSC.ResponseMap];
 
-// The `error` member of a failed response (InspectorBackendDispatcher.cpp,
-// BackendDispatcher::sendPendingErrors); `code` is already a JSON-RPC number.
+// BackendDispatcher::sendPendingErrors in InspectorBackendDispatcher.cpp.
 type BackendError = { code: number; message: string };
 
-// One JSON message from the backend: a response to a command this adapter sent
-// (`id`, then either `result` or `error`) or a domain event (`method`).
+// A response to one of this adapter's commands, or an event.
 type BackendMessage = {
   id?: number | null;
   result?: BackendResult;
@@ -39,16 +34,10 @@ type BackendMessage = {
   params?: unknown;
 };
 
-// Keyed on `method` so that switching over it narrows `params` to that event's
-// shape (unlike JSC.Event, whose default instantiation is a single object type
-// with every event's params unioned together).
+// Discriminated on `method`, which JSC.Event's default instantiation is not.
 type BackendEvent = { [M in keyof JSC.EventMap]: { method: M; params: JSC.EventMap[M] } }[keyof JSC.EventMap];
 
-// The JSC response behind each CDP command whose result #translateResult
-// reshapes, keyed by the CDP method because that is what #pending records. The
-// JSC command that produced the response is not always the namesake:
-// Debugger.getPossibleBreakpoints is served by Debugger.getBreakpointLocations
-// and a Runtime.evaluate with awaitPromise by Runtime.awaitPromise.
+// The JSC response answering each CDP command that #translateResult reshapes.
 type TranslatedResponses = {
   "Runtime.evaluate": JSC.Runtime.EvaluateResponse | JSC.Runtime.AwaitPromiseResponse;
   "Runtime.callFunctionOn": JSC.Runtime.CallFunctionOnResponse;
@@ -144,8 +133,7 @@ class InspectorCDPAdapter {
     {
       clientId: number | string | null;
       method: string;
-      // Typed per command by #sendToBackend; erased here because one map holds
-      // the callbacks of every in-flight command.
+      // Typed per command at #sendToBackend.
       onResult?: (result: any, error?: BackendError) => void;
     }
   >();
@@ -199,8 +187,6 @@ class InspectorCDPAdapter {
       return;
     }
     if (typeof method === "string") {
-      // Events without params (Debugger.resumed) arrive without a `params`
-      // key at all; anything the switch does not recognise hits its default.
       this.#translateBackendEvent({ method, params: parsed.params || {} } as BackendEvent);
     }
   }
@@ -219,8 +205,8 @@ class InspectorCDPAdapter {
 
   // `clientId` undefined/null marks an adapter-internal command whose response
   // is dropped instead of being forwarded to the client. `onResult` intercepts
-  // the response for adapter-side chaining (e.g. Runtime.evaluate awaitPromise);
-  // when `error` is set it receives `{}` as the result, so check `error` first.
+  // the response for adapter-side chaining (e.g. Runtime.evaluate awaitPromise)
+  // and gets `{}` as the result when `error` is set.
   #sendToBackend<M extends keyof JSC.RequestMap>(
     method: M,
     params?: JSC.RequestMap[M],
@@ -389,8 +375,6 @@ class InspectorCDPAdapter {
         return;
       }
 
-      // CDP and JSC agree on these commands' parameters, so the client's are
-      // forwarded as they are.
       case "Runtime.releaseObject":
       case "Runtime.releaseObjectGroup":
         this.#sendToBackend(method, params as JSC.RequestMap[typeof method], id, method);
@@ -426,7 +410,6 @@ class InspectorCDPAdapter {
         this.#sendToBackend("Debugger.setPauseOnDebuggerStatements", { enabled: true }, id, method);
         return;
 
-      // Forwarded as they are, like Runtime.releaseObject above.
       case "Debugger.disable":
       case "Debugger.pause":
       case "Debugger.resume":

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -7,9 +7,8 @@
 // JSC-protocol JSON from the backend connection. Command ids from the client
 // are preserved by giving backend commands their own id space and correlating
 // the responses.
-//
-// The backend side is typed against the protocol snapshot generated from the
-// WebKit Bun links against; the type-only import is erased by the builtin bundler.
+
+// Type-only, so the builtin bundler erases it.
 import type { JSC } from "../../../../packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts";
 
 const { pathToFileURL, fileURLToPath } = require("node:url");
@@ -205,8 +204,7 @@ class InspectorCDPAdapter {
 
   // `clientId` undefined/null marks an adapter-internal command whose response
   // is dropped instead of being forwarded to the client. `onResult` intercepts
-  // the response for adapter-side chaining (e.g. Runtime.evaluate awaitPromise)
-  // and gets `{}` as the result when `error` is set.
+  // the response for adapter-side chaining; on a backend error it gets `{}`.
   #sendToBackend<M extends keyof JSC.RequestMap>(
     method: M,
     params?: JSC.RequestMap[M],

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -7,12 +7,55 @@
 // JSC-protocol JSON from the backend connection. Command ids from the client
 // are preserved by giving backend commands their own id space and correlating
 // the responses.
+//
+// The backend side is typed against the JSC protocol snapshot, which is
+// generated from the WebKit Bun links against (bun-inspector-protocol/scripts/
+// generate-protocol.ts), so a field WebKit renames or drops fails to typecheck
+// here instead of turning into `undefined` in a DevTools event. The import is
+// type-only, so the builtin bundler erases it.
+import type { JSC } from "../../../../packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts";
+
 const { pathToFileURL, fileURLToPath } = require("node:url");
 const { isAbsolute } = require("node:path");
 
 const EXECUTION_CONTEXT_ID = 1;
 
+// CDP (client-facing) shapes are built ad hoc and stay untyped.
 type AnyObject = Record<string, any>;
+
+type BackendResult = JSC.ResponseMap[keyof JSC.ResponseMap];
+
+// The `error` member of a failed response (InspectorBackendDispatcher.cpp,
+// BackendDispatcher::sendPendingErrors); `code` is already a JSON-RPC number.
+type BackendError = { code: number; message: string };
+
+// One JSON message from the backend: a response to a command this adapter sent
+// (`id`, then either `result` or `error`) or a domain event (`method`).
+type BackendMessage = {
+  id?: number | null;
+  result?: BackendResult;
+  error?: BackendError;
+  method?: string;
+  params?: unknown;
+};
+
+// Keyed on `method` so that switching over it narrows `params` to that event's
+// shape (unlike JSC.Event, whose default instantiation is a single object type
+// with every event's params unioned together).
+type BackendEvent = { [M in keyof JSC.EventMap]: { method: M; params: JSC.EventMap[M] } }[keyof JSC.EventMap];
+
+// The JSC response behind each CDP command whose result #translateResult
+// reshapes, keyed by the CDP method because that is what #pending records. The
+// JSC command that produced the response is not always the namesake:
+// Debugger.getPossibleBreakpoints is served by Debugger.getBreakpointLocations
+// and a Runtime.evaluate with awaitPromise by Runtime.awaitPromise.
+type TranslatedResponses = {
+  "Runtime.evaluate": JSC.Runtime.EvaluateResponse | JSC.Runtime.AwaitPromiseResponse;
+  "Runtime.callFunctionOn": JSC.Runtime.CallFunctionOnResponse;
+  "Debugger.evaluateOnCallFrame": JSC.Debugger.EvaluateOnCallFrameResponse;
+  "Runtime.getProperties": JSC.Runtime.GetPropertiesResponse;
+  "Debugger.getPossibleBreakpoints": JSC.Debugger.GetBreakpointLocationsResponse;
+};
 
 function toCdpUrl(url: string): string {
   // V8 reports filesystem-backed scripts with file:// URLs; JSC script URLs
@@ -54,7 +97,7 @@ function breakpointUrlRegex(url: string): string {
   return Array.from(candidates, candidate => `^${escapeRegex(candidate)}$`).join("|");
 }
 
-const SCOPE_TYPE_MAP: Record<string, string> = {
+const SCOPE_TYPE_MAP: Record<JSC.Debugger.Scope["type"], string> = {
   global: "global",
   with: "with",
   closure: "closure",
@@ -68,7 +111,7 @@ const SCOPE_TYPE_MAP: Record<string, string> = {
 // { type: "log", level: "warning"/"error"/... }, so a type-level match on "log"
 // would mask the level. #translateConsoleMessage falls through to
 // CONSOLE_LEVEL_MAP for those and for console.log itself.
-const CONSOLE_TYPE_MAP: Record<string, string> = {
+const CONSOLE_TYPE_MAP: Partial<Record<NonNullable<JSC.Console.ConsoleMessage["type"]>, string>> = {
   dir: "dir",
   dirxml: "dirxml",
   table: "table",
@@ -83,7 +126,7 @@ const CONSOLE_TYPE_MAP: Record<string, string> = {
   profileEnd: "profileEnd",
 };
 
-const CONSOLE_LEVEL_MAP: Record<string, string> = {
+const CONSOLE_LEVEL_MAP: Record<JSC.Console.ConsoleMessage["level"], string> = {
   log: "log",
   info: "info",
   warning: "warning",
@@ -98,7 +141,13 @@ class InspectorCDPAdapter {
   #nextExceptionId = 1;
   #pending = new Map<
     number,
-    { clientId: number | string | null; method: string; onResult?: (result: AnyObject, error?: AnyObject) => void }
+    {
+      clientId: number | string | null;
+      method: string;
+      // Typed per command by #sendToBackend; erased here because one map holds
+      // the callbacks of every in-flight command.
+      onResult?: (result: any, error?: BackendError) => void;
+    }
   >();
   #scripts = new Map<string, { cdpUrl: string; endLine: number; endColumn: number }>();
 
@@ -125,7 +174,7 @@ class InspectorCDPAdapter {
   }
 
   handleBackendMessage(message: string): void {
-    let parsed: AnyObject;
+    let parsed: BackendMessage;
     try {
       parsed = JSON.parse(message);
     } catch {
@@ -150,7 +199,9 @@ class InspectorCDPAdapter {
       return;
     }
     if (typeof method === "string") {
-      this.#translateBackendEvent(method, parsed.params || {});
+      // Events without params (Debugger.resumed) arrive without a `params`
+      // key at all; anything the switch does not recognise hits its default.
+      this.#translateBackendEvent({ method, params: parsed.params || {} } as BackendEvent);
     }
   }
 
@@ -168,13 +219,14 @@ class InspectorCDPAdapter {
 
   // `clientId` undefined/null marks an adapter-internal command whose response
   // is dropped instead of being forwarded to the client. `onResult` intercepts
-  // the response for adapter-side chaining (e.g. Runtime.evaluate awaitPromise).
-  #sendToBackend(
-    method: string,
-    params?: AnyObject,
+  // the response for adapter-side chaining (e.g. Runtime.evaluate awaitPromise);
+  // when `error` is set it receives `{}` as the result, so check `error` first.
+  #sendToBackend<M extends keyof JSC.RequestMap>(
+    method: M,
+    params?: JSC.RequestMap[M],
     clientId: number | string | null = null,
-    clientMethod = method,
-    onResult?: (result: AnyObject, error?: AnyObject) => void,
+    clientMethod: string = method,
+    onResult?: (result: JSC.ResponseMap[M], error?: BackendError) => void,
   ): void {
     const id = this.#nextBackendId++;
     this.#pending.$set(id, { clientId, method: clientMethod, onResult });
@@ -220,7 +272,7 @@ class InspectorCDPAdapter {
       case "Runtime.evaluate": {
         // JSC's JSGlobalObjectRuntimeAgent rejects any contextId ("only one
         // execution context"), so drop it even though CDP clients echo it.
-        const jscParams = {
+        const jscParams: JSC.Runtime.EvaluateRequest = {
           expression: params.expression,
           objectGroup: params.objectGroup,
           includeCommandLineAPI: params.includeCommandLineAPI,
@@ -292,7 +344,7 @@ class InspectorCDPAdapter {
 
       case "Runtime.callFunctionOn": {
         const { objectId, executionContextId } = params;
-        const forward = (targetObjectId: unknown) =>
+        const forward = (targetObjectId: JSC.Runtime.RemoteObjectId) =>
           this.#sendToBackend(
             "Runtime.callFunctionOn",
             {
@@ -337,9 +389,11 @@ class InspectorCDPAdapter {
         return;
       }
 
+      // CDP and JSC agree on these commands' parameters, so the client's are
+      // forwarded as they are.
       case "Runtime.releaseObject":
       case "Runtime.releaseObjectGroup":
-        this.#sendToBackend(method, params, id, method);
+        this.#sendToBackend(method, params as JSC.RequestMap[typeof method], id, method);
         return;
 
       case "Runtime.getIsolateId":
@@ -372,6 +426,7 @@ class InspectorCDPAdapter {
         this.#sendToBackend("Debugger.setPauseOnDebuggerStatements", { enabled: true }, id, method);
         return;
 
+      // Forwarded as they are, like Runtime.releaseObject above.
       case "Debugger.disable":
       case "Debugger.pause":
       case "Debugger.resume":
@@ -382,7 +437,7 @@ class InspectorCDPAdapter {
       case "Debugger.removeBreakpoint":
       case "Debugger.continueToLocation":
       case "Debugger.getScriptSource":
-        this.#sendToBackend(method, params, id, method);
+        this.#sendToBackend(method, params as JSC.RequestMap[typeof method], id, method);
         return;
 
       case "Debugger.setPauseOnExceptions":
@@ -400,9 +455,9 @@ class InspectorCDPAdapter {
 
       case "Debugger.setBreakpointByUrl": {
         const { condition, urlRegex, url } = params;
-        const options: AnyObject = {};
+        const options: JSC.Debugger.BreakpointOptions = {};
         if (condition) options.condition = condition;
-        const jscParams: AnyObject = {
+        const jscParams: JSC.Debugger.SetBreakpointByUrlRequest = {
           lineNumber: params.lineNumber,
           columnNumber: params.columnNumber,
           options,
@@ -520,14 +575,16 @@ class InspectorCDPAdapter {
     }
   }
 
-  #translateResult(method: string, result: AnyObject): AnyObject {
+  // `method` is the CDP command being answered; see TranslatedResponses.
+  #translateResult(method: string, response: BackendResult): AnyObject {
     switch (method) {
       case "Debugger.enable":
-        return { debuggerId: "(bun)", ...result };
+        return { debuggerId: "(bun)", ...response };
 
       case "Runtime.evaluate":
       case "Runtime.callFunctionOn":
       case "Debugger.evaluateOnCallFrame": {
+        const result = response as TranslatedResponses[typeof method];
         const out: AnyObject = { result: result.result ?? { type: "undefined" } };
         if (result.wasThrown) {
           out.exceptionDetails = {
@@ -542,7 +599,8 @@ class InspectorCDPAdapter {
       }
 
       case "Runtime.getProperties": {
-        const properties = (result.properties ?? []).map((property: AnyObject) => ({
+        const result = response as TranslatedResponses[typeof method];
+        const properties = (result.properties ?? []).map(property => ({
           configurable: false,
           enumerable: false,
           ...property,
@@ -553,15 +611,17 @@ class InspectorCDPAdapter {
         return out;
       }
 
-      case "Debugger.getPossibleBreakpoints":
+      case "Debugger.getPossibleBreakpoints": {
+        const result = response as TranslatedResponses[typeof method];
         return { locations: result.locations ?? [] };
+      }
 
       default:
-        return result;
+        return response;
     }
   }
 
-  #translateBackendEvent(method: string, params: AnyObject): void {
+  #translateBackendEvent({ method, params }: BackendEvent): void {
     switch (method) {
       case "Debugger.scriptParsed": {
         const url = params.sourceURL || params.url || "";
@@ -590,12 +650,12 @@ class InspectorCDPAdapter {
       }
 
       case "Debugger.paused": {
-        const callFrames = (params.callFrames ?? []).map((frame: AnyObject) => ({
+        const callFrames = (params.callFrames ?? []).map(frame => ({
           callFrameId: frame.callFrameId,
           functionName: frame.functionName ?? "",
           location: frame.location,
           url: this.#scripts.$get(frame.location?.scriptId)?.cdpUrl ?? "",
-          scopeChain: (frame.scopeChain ?? []).map((scope: AnyObject) => ({
+          scopeChain: (frame.scopeChain ?? []).map(scope => ({
             type: SCOPE_TYPE_MAP[scope.type] ?? "closure",
             object: scope.object,
             name: scope.name,
@@ -612,9 +672,11 @@ class InspectorCDPAdapter {
           case "assert":
             cdpParams.reason = "assert";
             break;
-          case "Breakpoint":
-            if (data?.breakpointId) cdpParams.hitBreakpoints = [data.breakpointId];
+          case "Breakpoint": {
+            const hit = data as JSC.Debugger.BreakpointPauseReason | undefined;
+            if (hit?.breakpointId) cdpParams.hitBreakpoints = [hit.breakpointId];
             break;
+          }
         }
         if (asyncStackTrace) cdpParams.asyncStackTrace = this.#translateStackTrace(asyncStackTrace);
         this.#emitToClient("Debugger.paused", cdpParams);
@@ -637,7 +699,7 @@ class InspectorCDPAdapter {
         return;
 
       case "Console.messageAdded":
-        this.#translateConsoleMessage(params.message || {});
+        this.#translateConsoleMessage(params.message);
         return;
 
       default:
@@ -646,10 +708,10 @@ class InspectorCDPAdapter {
     }
   }
 
-  #translateStackTrace(stackTrace: AnyObject | undefined): AnyObject | undefined {
+  #translateStackTrace(stackTrace: JSC.Console.StackTrace | undefined): AnyObject | undefined {
     if (!stackTrace) return undefined;
     const translated: AnyObject = {
-      callFrames: (stackTrace.callFrames ?? []).map((frame: AnyObject) => ({
+      callFrames: (stackTrace.callFrames ?? []).map(frame => ({
         functionName: frame.functionName ?? "",
         scriptId: frame.scriptId ?? "",
         url: toCdpUrl(frame.url ?? ""),
@@ -664,7 +726,7 @@ class InspectorCDPAdapter {
     return translated;
   }
 
-  #translateConsoleMessage(message: AnyObject): void {
+  #translateConsoleMessage(message: JSC.Console.ConsoleMessage): void {
     const level = message.level ?? "log";
     const args = message.parameters?.length ? message.parameters : [{ type: "string", value: message.text ?? "" }];
 

--- a/test/cli/inspect/bun-inspector-protocol.test.ts
+++ b/test/cli/inspect/bun-inspector-protocol.test.ts
@@ -1,14 +1,19 @@
 // packages/bun-inspector-protocol ships a snapshot of the inspector protocol of the WebKit
 // build bun links against (src/protocol/jsc/protocol.json, from which index.d.ts is
-// generated). Nothing regenerates it when WebKit is bumped, so this test runs a short
+// generated). Nothing regenerates it when WebKit is bumped, so the first test runs a short
 // debugging session against this build of bun and validates every message it sends
 // against the snapshot. If it fails after a WebKit upgrade, regenerate the snapshot:
 //
 //   bun packages/bun-inspector-protocol/scripts/generate-protocol.ts
+//
+// The second test typechecks src/js/internal/inspector/cdp.ts, the node:inspector CDP adapter,
+// which reads JSC's messages through index.d.ts. Regenerating the snapshot therefore also
+// reports every field the adapter still reads under a name WebKit no longer sends.
 import { spawn } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
-import { basename } from "node:path";
+import { bunEnv, bunExe, nodeExe, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { basename, join } from "node:path";
 import protocolJson from "../../../packages/bun-inspector-protocol/src/protocol/jsc/protocol.json";
 import type { Property, Protocol } from "../../../packages/bun-inspector-protocol/src/protocol/schema";
 
@@ -262,3 +267,56 @@ test("the protocol snapshot in packages/bun-inspector-protocol matches what bun 
     ]),
   );
 });
+
+const snapshotPath = join(import.meta.dir, "../../../packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts");
+
+/**
+ * Typechecks cdp.ts (see cdp-protocol-types-fixture.mts) and returns the diagnostics as
+ * `file:line: message` strings. `snapshotReplacement` is a file to use in place of index.d.ts.
+ *
+ * Runs under node rather than in this process: the debug build of bun spends tens of seconds
+ * transpiling typescript.js alone, and the check has nothing to do with the bun under test.
+ */
+async function typecheckCdpAdapter(snapshotReplacement?: string): Promise<string[]> {
+  await using proc = spawn({
+    cmd: [
+      nodeExe()!,
+      join(import.meta.dir, "cdp-protocol-types-fixture.mts"),
+      ...(snapshotReplacement === undefined ? [] : [snapshotReplacement]),
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
+
+test.skipIf(!nodeExe())(
+  "src/js/internal/inspector/cdp.ts reads JSC messages through the snapshot's types",
+  async () => {
+    // Renaming things in the snapshot has to surface at the adapter's uses of them, otherwise the
+    // typecheck below proves nothing. One event parameter, one response field, one request parameter.
+    const renamed = ["scriptType", "wasThrown", "doNotPauseOnExceptionsAndMuteConsole"];
+    let snapshot = readFileSync(snapshotPath, "utf8");
+    for (const name of renamed) {
+      const withRename = snapshot.replaceAll(new RegExp(`\\b${name}\\b`, "g"), `${name}Renamed`);
+      if (withRename === snapshot) throw new Error(`${name} is no longer in the snapshot; rename something else here`);
+      snapshot = withRename;
+    }
+    using dir = tempDir("cdp-protocol-types", { "index.d.ts": snapshot });
+
+    const [diagnostics, diagnosticsAfterRenames] = await Promise.all([
+      typecheckCdpAdapter(),
+      typecheckCdpAdapter(join(String(dir), "index.d.ts")),
+    ]);
+    // Failures here after regenerating the snapshot are the fields WebKit renamed or dropped that
+    // cdp.ts still reads or sends, one diagnostic per use site.
+    expect(diagnostics).toEqual([]);
+    expect(
+      renamed.filter(name => diagnosticsAfterRenames.some(diagnostic => diagnostic.includes(`'${name}'`))),
+    ).toEqual(renamed);
+  },
+);

--- a/test/cli/inspect/cdp-protocol-types-fixture.mts
+++ b/test/cli/inspect/cdp-protocol-types-fixture.mts
@@ -1,0 +1,53 @@
+// Run under node by bun-inspector-protocol.test.ts: typechecks src/js/internal/inspector/cdp.ts
+// with the options of `tsc -p src/js` and prints the diagnostics as a JSON array of
+// "file:line: message" strings. An optional argument is a file whose contents stand in for the
+// protocol snapshot (packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts) cdp.ts imports.
+//
+// builtins.d.ts declares the `$` intrinsics cdp.ts uses. What the real project layers on top of it,
+// the build's codegen output that builtins.d.ts references and the @types auto-include (between
+// them, the per-module typing of `require()`), is left out: the codegen output does not exist in a
+// test checkout and none of it bears on the JSC side, so `require()` is declared loosely instead.
+import { readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import ts from "typescript";
+
+const repoRoot = join(import.meta.dirname, "../../..");
+const jsDir = join(repoRoot, "src/js");
+const configPath = join(jsDir, "tsconfig.json");
+const builtinsPath = join(jsDir, "builtins.d.ts");
+const snapshotPath = join(repoRoot, "packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts");
+// Only exists inside the compiler host below.
+const requireStubPath = join(jsDir, "require.d.ts");
+const snapshotReplacement = process.argv[2] === undefined ? undefined : readFileSync(process.argv[2], "utf8");
+
+// TypeScript reports paths with forward slashes on every platform.
+function samePath(a: string, b: string): boolean {
+  return a.replaceAll("\\", "/") === b.replaceAll("\\", "/");
+}
+
+const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile);
+if (error) throw new Error(ts.flattenDiagnosticMessageText(error.messageText, "\n"));
+const { options, fileNames } = ts.parseJsonConfigFileContent(
+  { ...config, include: undefined, files: ["internal/inspector/cdp.ts", "builtins.d.ts"] },
+  ts.sys,
+  jsDir,
+  { composite: false, types: [] },
+  configPath,
+);
+
+const host = ts.createCompilerHost(options);
+const { fileExists, readFile } = host;
+host.fileExists = file => samePath(file, requireStubPath) || fileExists(file);
+host.readFile = file => {
+  if (samePath(file, requireStubPath)) return "declare function require(id: string): any;\n";
+  if (samePath(file, snapshotPath) && snapshotReplacement !== undefined) return snapshotReplacement;
+  const text = readFile(file);
+  return samePath(file, builtinsPath) ? text?.replaceAll(/^\/\/\/ <reference .*$/gm, "") : text;
+};
+
+const program = ts.createProgram([...fileNames, requireStubPath], options, host);
+const diagnostics = ts.getPreEmitDiagnostics(program).map(({ file, start, messageText }) => {
+  const where = file ? `${basename(file.fileName)}:${file.getLineAndCharacterOfPosition(start!).line + 1}: ` : "";
+  return where + ts.flattenDiagnosticMessageText(messageText, "\n");
+});
+console.log(JSON.stringify(diagnostics));


### PR DESCRIPTION
Follow-up to #39051.

### Problem
- `src/js/internal/inspector/cdp.ts` reads every JSC event and response as `AnyObject` (`Record<string, any>`): `#translateBackendEvent(method, params: AnyObject)`, `#translateResult`, `#translateConsoleMessage`, `#translateStackTrace`, the `onResult` callbacks, and the request objects it builds.
- That is how `params.module` kept being read after WebKit renamed it to `scriptType` (#39051): the read type-checked and the field silently became `undefined` in `Debugger.scriptParsed`.
- `packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts` is generated from the pinned WebKit (#39110) and already describes every shape this file touches, but nothing in `src/js` referenced it, and nothing in CI typechecks `src/js` (`bun run typecheck` covers neither the root solution file's zero sources nor, via `test/tsconfig.json`, this file; `tsc -p src/js` has unrelated pre-existing errors).

### Fix
- `import type { JSC } from ".../bun-inspector-protocol/src/protocol/jsc/index.d.ts"` in cdp.ts. Type-only, so the builtin bundler erases it; the bundled `internal/inspector/cdp.js` is unchanged apart from the one edit noted below.
- `#sendToBackend<M extends keyof JSC.RequestMap>(method: M, params?: JSC.RequestMap[M], ..., onResult?: (result: JSC.ResponseMap[M], error?) => void)`: command names, the request objects built for JSC (excess property checks catch a renamed parameter) and the chained `onResult` callbacks are typed per command. The two places that forward client params verbatim cast them to `JSC.RequestMap[typeof method]`.
- `#translateBackendEvent({ method, params }: BackendEvent)`: `BackendEvent` is `JSC.EventMap` turned into a union discriminated on `method`, so each `case` narrows `params` to that event's type (`JSC.Debugger.ScriptParsedEvent`, `PausedEvent`, `BreakpointResolvedEvent`, `JSC.Console.MessageAddedEvent`). The `Breakpoint` pause reason reads `data` as `JSC.Debugger.BreakpointPauseReason`, as `bun-debug-adapter-protocol` does.
- `#translateResult(method, response)`: `TranslatedResponses` records which JSC response answers each reshaped CDP command (not always the namesake: `getPossibleBreakpoints` is served by `getBreakpointLocations`, `evaluate` with `awaitPromise` by `Runtime.awaitPromise`); each case narrows with `response as TranslatedResponses[typeof method]`.
- `#translateConsoleMessage` / `#translateStackTrace` take `JSC.Console.ConsoleMessage` / `JSC.Console.StackTrace`; `SCOPE_TYPE_MAP`, `CONSOLE_TYPE_MAP` and `CONSOLE_LEVEL_MAP` are keyed by the snapshot's enums, so a renamed scope type, console type or level fails too.
- `handleBackendMessage` parses into a small `BackendMessage` envelope type (`error.code` is a number, per `BackendDispatcher::sendPendingErrors`).
- The client-facing CDP shapes (`#dispatchClientCommand` params, everything passed to `#replyToClient` / `#emitToClient`) stay `AnyObject`, as requested.
- No runtime behavior change. Existing defensive fallbacks (`?? 0`, `?.`) are left in place even where the snapshot marks the field required; the one that does not type-check, `params.message || {}` on `Console.messageAdded` (where `message` is required), is dropped.
- Test: `test/cli/inspect/bun-inspector-protocol.test.ts` already checks that the snapshot matches what this build of bun sends. It now also typechecks cdp.ts against the snapshot (`cdp-protocol-types-fixture.mts`, the options of `tsc -p src/js` restricted to this file), so regenerating the snapshot after a WebKit bump reports each field cdp.ts still reads or sends under the old name. It then renames an event parameter (`scriptType`), a response field (`wasThrown`) and a request parameter (`doNotPauseOnExceptionsAndMuteConsole`) in a copy of the snapshot and checks that each is reported at cdp.ts; against the current `AnyObject` version of cdp.ts nothing is reported, so this half fails without the cdp.ts change. The fixture runs under node (present on every CI lane, and already used this way by other tests) because the debug build of bun takes about 20 seconds just to load typescript.js; the test takes ~0.6s.
- Verified:
  - `bun bd test test/cli/inspect/bun-inspector-protocol.test.ts`: passes; fails as described above with main's cdp.ts swapped in.
  - `bun bd test test/js/node/inspector/inspector.test.ts` (24 pass) and `inspector-profiler.test.ts` (45 pass).
  - `tsc --noEmit -p src/js`: no diagnostics in `inspector/` before or after; the project's pre-existing error count elsewhere is unchanged. Renaming five further snapshot fields by hand produced 0 errors in cdp.ts on main and 7 on this branch (output below).
  - The fixture and the new test also pass on Windows (paths are compared with separators normalized, since TypeScript reports forward slashes there).

### Sequencing
- This touches most of cdp.ts, so it conflicts with the open PRs that also edit it: #34719 (large, active; adds ~870 lines to cdp.ts, all `AnyObject`), #35752, #36457. Opened as a draft so it is not merged under them; the intent is to rebase it on whatever lands first and type the code those PRs add. #39031 is test-only and does not conflict.

### Background
- node:inspector clients (DevTools, vscode-js-debug) speak V8's Chrome DevTools Protocol; Bun's inspector backend speaks WebKit's JSC inspector protocol. cdp.ts is the per-connection translator between the two: it rewrites client commands into JSC commands, correlates the responses, and rewrites JSC events into CDP events.
- `bun-inspector-protocol/src/protocol/jsc/index.d.ts` is a generated TypeScript description of the JSC protocol: one type per event, request and response (`JSC.Debugger.ScriptParsedEvent`, `JSC.Runtime.EvaluateRequest`, ...) plus `EventMap` / `RequestMap` / `ResponseMap` indexing them by protocol method name. `scripts/generate-protocol.ts` regenerates it from the WebKit version `bun bd` links against, which is what makes a type error here equivalent to "WebKit changed this field".
- A discriminated union is a union of object types that share a literal-typed property (`method` here); TypeScript narrows the whole object, including `params`, inside a `switch` on that property. `typeof method` inside a `case` is the narrowed literal type, so `TranslatedResponses[typeof method]` is the response type for exactly the commands listed in that case.
- `src/js/builtins.d.ts` declares the `$`-prefixed intrinsics builtins use (`map.$get`, ...). The fixture loads it but drops its references to the build's codegen output (which is what types `require()` per module and does not exist in a test checkout) and declares `require()` loosely instead; only the JSC side is under test.

<details>
<summary>Simulated snapshot renames (manual, in addition to the three the test performs)</summary>

Applied to `jsc/index.d.ts`: `scriptType` -> `module`, pause reason `"Breakpoint"` -> `"BreakpointHit"`, `doNotPauseOnExceptionsAndMuteConsole` -> `muteConsole`, `StackTrace.parentStackTrace` -> `parent`, `GetPropertiesResponse.internalProperties` -> `internals`.

On main: `tsc --noEmit -p src/js 2>&1 | grep inspector/` prints nothing.

On this branch:

```
cdp.ts(280,11): error TS2353: Object literal may only specify known properties, and 'doNotPauseOnExceptionsAndMuteConsole' does not exist in type 'EvaluateRequest'.
cdp.ts(355,15): error TS2353: Object literal may only specify known properties, and 'doNotPauseOnExceptionsAndMuteConsole' does not exist in type 'CallFunctionOnRequest'.
cdp.ts(520,13): error TS2353: Object literal may only specify known properties, and 'doNotPauseOnExceptionsAndMuteConsole' does not exist in type 'EvaluateOnCallFrameRequest'.
cdp.ts(610,17): error TS2339: Property 'internalProperties' does not exist on type 'GetPropertiesResponse'.
cdp.ts(635,17): error TS2339: Property 'scriptType' does not exist on type 'ScriptParsedEvent'.
cdp.ts(676,16): error TS2678: Type '"Breakpoint"' is not comparable to type '"URL" | "assert" | ... | "BreakpointHit" | ... | "other"'.
cdp.ts(723,13): error TS2339: Property 'parentStackTrace' does not exist on type 'StackTrace'.
```
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/bun-inspector-protocol.test.ts
bun test v1.4.0 (8326d1bd3)

test/cli/inspect/bun-inspector-protocol.test.ts:
(pass) the protocol snapshot in packages/bun-inspector-protocol matches what bun sends [889.41ms]
315 |     // Failures here after regenerating the snapshot are the fields WebKit renamed or dropped that
316 |     // cdp.ts still reads or sends, one diagnostic per use site.
317 |     expect(diagnostics).toEqual([]);
318 |     expect(
319 |       renamed.filter(name => diagnosticsAfterRenames.some(diagnostic => diagnostic.includes(`'${name}'`))),
320 |     ).toEqual(renamed);
            ^
error: expect(received).toEqual(expected)

- [
-   "scriptType",
-   "wasThrown",
-   "doNotPauseOnExceptionsAndMuteConsole",
- ]
+ []

- Expected  - 5
+ Received  + 1

      at <anonymous> (/workspace/bun/test/cli/inspect/bun-inspector-protocol.test.ts:320:7)
(fail) src/js/internal/inspector/cdp.ts reads JSC messages through the snapshot's types [606.56ms]

 1 pass
 1 fail
 10 expect() calls
Ran 2 tests across 1 file. [3.87s]
e
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/cli/inspect/bun-inspector-protocol.test.ts:
(pass) the protocol snapshot in packages/bun-inspector-protocol matches what bun sends [20.74ms]
315 |     // Failures here after regenerating the snapshot are the fields WebKit renamed or dropped that
316 |     // cdp.ts still reads or sends, one diagnostic per use site.
317 |     expect(diagnostics).toEqual([]);
318 |     expect(
319 |       renamed.filter(name => diagnosticsAfterRenames.some(diagnostic => diagnostic.includes(`'${name}'`))),
320 |     ).toEqual(renamed);
            ^
error: expect(received).toEqual(expected)

- [
-   "scriptType",
-   "wasThrown",
-   "doNotPauseOnExceptionsAndMuteConsole",
- ]
+ []

- Expected  - 5
+ Received  + 1

      at <anonymous> (/workspace/bun/test/cli/inspect/bun-inspector-protocol.test.ts:320:7)
(fail) src/js/internal/inspector/cdp.ts reads JSC messages through the snapshot's types [562.26ms]

 1 pass
 1 fail
 10 expect() calls
Ran 2 tests across 1 file. [736.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/bun-inspector-protocol.test.ts
bun test v1.4.0 (8326d1bd3)

test/cli/inspect/bun-inspector-protocol.test.ts:
(pass) the protocol snapshot in packages/bun-inspector-protocol matches what bun sends [931.13ms]
(pass) src/js/internal/inspector/cdp.ts reads JSC messages through the snapshot's types [684.73ms]

 2 pass
 0 fail
 10 expect() calls
Ran 2 tests across 1 file. [4.00s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     936d384c8f
  features     baseline

22 deps, 120 codegen, 1174 objects in 688ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1235] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 26 installs across 63 packages (no changes) [11.00ms]
[2/1235] gen ErrorCode+*.h
[3/1235] gen bindgenv2
[4/1235] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [2.00ms]
[5/1235] fetch tinycc
[tinycc] up to date
[6/1234] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[7/1234] fetch zlib
[zlib] up to date
[8/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1234] gen .bind.ts → GeneratedBindings.cpp
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/inspector/cdp.ts                | 107 +++++++++++++++++-------
 test/cli/inspect/bun-inspector-protocol.test.ts |  64 +++++++++++++-
 test/cli/inspect/cdp-protocol-types-fixture.mts |  53 ++++++++++++
 3 files changed, 189 insertions(+), 35 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/js/internal/inspector/cdp.ts                    13     34      0
test/cli/inspect/bun-inspector-protocol.test.ts      5      6      0
test/cli/inspect/cdp-protocol-types-fixture.mts      1      1      0
```

</details>

<!-- robobun:evidence:end -->