### PR TITLE
test(require-cache): measure the leak fixtures without the ASAN quarantine and give them lane-sized budgets

### DIFF
--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -14,6 +14,23 @@ import {
 } from "harness";
 import { join } from "path";
 
+// Environment for the eight leak fixtures below, which compare RSS before and after a
+// load/evict loop. Under ASAN every freed allocation parks in the allocator quarantine
+// (default quarantine_size_mb=256) instead of being returned, so with nothing leaking the
+// readings reach the fixtures' bounds (507 MB against 320 in build 100180, 407 against 400 in
+// build 87834). Disable the quarantine for the measuring process; harmless when the binary is
+// not ASAN-built. The fixtures' own widened ASAN bounds predate this and are only margin now: a
+// debug ASAN build without the quarantine reads 22-33 MB where the release bounds are 48-120 MB.
+//
+// Their 300_000 ms budgets: the loops are sized for release builds, where the slowest fixture
+// takes up to ~18 s. On the release+ASAN lane the same loops take 48-56 s on a typical agent
+// and longer on a slow one, so the previous 20-60 s budgets timed out there on every attempt
+// (builds 97573, 99491, 99519, 100192). The runner's per-file limit still bounds a hang.
+const leakFixtureEnv = {
+  ...bunEnv,
+  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+};
+
 describe.concurrent("require.cache", () => {
   test("require.cache is not an empty object literal when inspected", () => {
     const inspected = Bun.inspect(require.cache);
@@ -101,13 +118,13 @@ describe.concurrent("require.cache", () => {
       console.log({ dir });
       await using proc = Bun.spawn({
         cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
-        env: bunEnv,
+        env: leakFixtureEnv,
         stdio: ["inherit", "inherit", "inherit"],
       });
 
       const exitCode = await proc.exited;
       expect(exitCode).toBe(0);
-    }, 60000);
+    }, 300_000);
 
     test("via await import() with a lot of function calls", async () => {
       let text = "function i() { return 1; }\n";
@@ -154,13 +171,13 @@ describe.concurrent("require.cache", () => {
       });
       await using proc = Bun.spawn({
         cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
-        env: bunEnv,
+        env: leakFixtureEnv,
         stdio: ["inherit", "inherit", "inherit"],
       });
 
       const exitCode = await proc.exited;
       expect(exitCode).toBe(0);
-    }, 60000); // takes 4s on an M1 in release build
+    }, 300_000); // takes 4s on an M1 in release build
 
     test("via import() with a lot of long export names", async () => {
       let text = "";
@@ -205,13 +222,13 @@ describe.concurrent("require.cache", () => {
       console.log({ dir });
       await using proc = Bun.spawn({
         cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
-        env: bunEnv,
+        env: leakFixtureEnv,
         stdio: ["inherit", "inherit", "inherit"],
       });
 
       const exitCode = await proc.exited;
       expect(exitCode).toBe(0);
-    }, 60000);
+    }, 300_000);
 
     test.todoIf(
       // Flaky specifically on macOS CI, and on musl-aarch64 under ThinLTO +
@@ -270,14 +287,14 @@ describe.concurrent("require.cache", () => {
         });
         await using proc = Bun.spawn({
           cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
-          env: bunEnv,
+          env: leakFixtureEnv,
           stdio: ["inherit", "inherit", "inherit"],
         });
 
         const exitCode = await proc.exited;
         expect(exitCode).toBe(0);
       },
-      60000,
+      300_000,
     ); // takes 4s on an M1 in release build
   });
 
@@ -285,7 +302,7 @@ describe.concurrent("require.cache", () => {
     test("via require()", async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "run", join(import.meta.dir, "require-cache-bug-leak-fixture.js")],
-        env: bunEnv,
+        env: leakFixtureEnv,
         stderr: "inherit",
       });
 
@@ -293,12 +310,12 @@ describe.concurrent("require.cache", () => {
 
       expect(stdout.trim()).toEndWith("--pass--");
       expect(exitCode).toBe(0);
-    }, 20000);
+    }, 300_000);
 
     test("via import()", async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "run", join(import.meta.dir, "esm-bug-leak-fixture.mjs")],
-        env: bunEnv,
+        env: leakFixtureEnv,
         stderr: "inherit",
       });
 
@@ -306,7 +323,7 @@ describe.concurrent("require.cache", () => {
 
       expect(stdout.trim()).toEndWith("--pass--");
       expect(exitCode).toBe(0);
-    }, 20000);
+    }, 300_000);
   });
 
   // These tests are extra slow in debug builds
@@ -314,7 +331,7 @@ describe.concurrent("require.cache", () => {
     test("via require()", async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "--smol", "run", join(import.meta.dir, "cjs-fixture-leak-small.js")],
-        env: bunEnv,
+        env: leakFixtureEnv,
         stderr: "inherit",
       });
 
@@ -322,24 +339,19 @@ describe.concurrent("require.cache", () => {
 
       expect(stdout.trim()).toEndWith("--pass--");
       expect(exitCode).toBe(0);
-    }, 30000);
+    }, 300_000);
 
-    test(
-      "via import()",
-      async () => {
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "--smol", "run", join(import.meta.dir, "esm-fixture-leak-small.mjs")],
-          env: bunEnv,
-          stderr: "inherit",
-        });
+    test("via import()", async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", "run", join(import.meta.dir, "esm-fixture-leak-small.mjs")],
+        env: leakFixtureEnv,
+        stderr: "inherit",
+      });
 
-        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
 
-        expect(stdout.trim()).toEndWith("--pass--");
-        expect(exitCode).toBe(0);
-      },
-      // TODO: Investigate why this is so slow on Windows
-      isWindows ? 60000 : 30000,
-    );
+      expect(stdout.trim()).toEndWith("--pass--");
+      expect(exitCode).toBe(0);
+    }, 300_000);
   });
 });


### PR DESCRIPTION
### Problem

- `test/cli/run/require-cache.test.ts` fails on every retry on the slower `:debian: 13 x64-asan` shards (builds 97573, 99491, 99519, 100192; flaky in 100061 and 100180). The failures are its leak fixtures hitting their own per-test budgets:
  ```
  ✗ require.cache > files transpiled and loaded don't leak file paths > via import() [30001.44ms]
    ^ this test timed out after 30000ms.
  ✗ require.cache > files transpiled and loaded don't leak the output source code > via import() with a lot of long export names [60000.11ms]
    ^ this test timed out after 60000ms.
  ```
  In 99519 all four inline fixtures timed out at once. Build 100180 also failed the `import()` long-export-names fixture on its RSS bound: `RSS diff 507 MB` against the 320 MB ASAN bound.
- Culprit: #36780 removed the `[ ASAN ] test/cli/run/require-cache.test.ts` entry from `test/expectations.txt`, which had kept the file off the ASAN lane since that lane was created (d8a69d68). The file's budgets were never sized for that lane. It now runs there in 48-56 s when it passes (shard logs of builds 90500, 92500, 94548, 95500, 96500, 97000, 98000, flat over two weeks), with the slowest fixture finishing at 45-60 s against a 60 s budget and `esm-fixture-leak-small.mjs` at about 30 s against 30 s. The failing builds are slower agents: in 97573 all four attempts ran on the same agent and took 56-57 s of file time each. On the release lanes the slowest fixture takes up to 18 s (build 100145).
- The RSS side: under ASAN, freed allocations sit in the quarantine (256 MB by default) instead of being returned, so RSS grows with what the fixture freed. Measured with `bun bd` (also ASAN) against the fixtures' release bounds: `cjs-fixture-leak-small.js` reads 72 MB (bound 48) with the quarantine and 33 MB without it, `require-cache-bug-leak-fixture.js` 214 MB (bound 120) and 22 MB, `esm-fixture-leak-small.mjs` 407 MB (the build 87834 figure) and 27 MB, and the four inline fixtures 34 / 112 / 153 / 115 MB and 3 / -3 / -12 / 32 MB at their full loop counts. The widened ASAN bounds (320-500 MB) only absorb the quarantine on average; build 100180 shows they do not always.

### Fix

- Spawn the eight leak fixtures with `ASAN_OPTIONS` extended by `quarantine_size_mb=0`, the form the other spawned RSS leak tests use (`test/js/bun/archive.test.ts`, `test/js/web/streams/compression.test.ts`, `test/js/node/module/node-module-module.test.js`, 8 files in total). The readings above then measure retained memory again. It is a no-op for a binary that is not ASAN-built, and the fixtures' existing ASAN bounds stay as they are: with the quarantine off they are margin, and tightening them wants a few ASAN CI runs of this change first (the inline fixtures print their readings in the job log).
- Set the eight budgets to 300 s, the budget the leak fixtures that already run on that lane use (`test/js/node/url/pathToFileURL.test.ts`, `test/js/node/fs/abort-signal-leak-read-write-file.test.ts`, both also un-quarantined by #36780, and neither has a failure annotation in the last 180 builds with test results). This is a budget correction, not a regression being covered: the fixtures' time on the lane has been 48-56 s in every passing run sampled since the first week they ran there, 3-4x the release figure, which is the normal release-asan slowdown, and the old budgets were equal to it. The budgets cannot be left to the runner's `--timeout` (90 s, 270 s under ASAN) because a third argument overrides it and a plain `bun test` run would otherwise apply 5 s. The runner's per-file limit (180 s, 360 s under ASAN) still bounds a hang.
- The `isWindows ? 60000 : 30000` budget on the `file paths > via import()` test and its TODO go away with the uniform budget.
- Verified:
  - `bun bd test test/cli/run/require-cache.test.ts -t "(leak file paths|leak the AST).*via require"`: on main both fail (`leaked: "69 MB"` against 48, and a 20 s timeout with `leaked: "169 MB"` against 120); with this change both pass in 23 s and 30 s. The other fixtures need 6-26 minutes each on a debug build, as before (#38148 is about that).
  - The two fixtures run directly under `bun-debug`: 72 MB and 214 MB with the default quarantine, 33 MB and 22 MB with `quarantine_size_mb=0`.
  - `USE_SYSTEM_BUN=1 bun test test/cli/run/require-cache.test.ts` (release, not ASAN): 11 pass in each of 3 runs, with the usual RSS figures and nothing on stderr from the extra `ASAN_OPTIONS`.
  - Test-only change, so there is no src-stash proof; the ASAN lane of this PR's own CI run is the check for the lane itself.
- Does not touch the lines the other open PRs on these files change: #37586 (inline fixture bodies), #37562 (`esm-fixture-leak-small.mjs`), #38165 (`esm-bug-leak-fixture.mjs`), #35081 (the fixtures' ASAN detection) and #38148 (`isDebug` skip on the describe headers, for local debug builds).

### Background

- ASAN quarantine: AddressSanitizer parks freed allocations in a quarantine (256 MB by default) so that a later use of freed memory can be reported. The freed memory stays resident, so under ASAN a process's RSS grows with how much it has freed, which is what an RSS-delta leak check reads as a leak. `quarantine_size_mb=0` in `ASAN_OPTIONS` turns this off for that process only; the rest of ASAN's checks stay on.
- The ASAN lane runs the `release-asan` profile (optimized plus ASAN, binary `bun-asan`), 3-4x slower than release on these loops. `bun bd` builds the `debug` profile, which is also ASAN-instrumented, and much slower again because JSC's debug assertions are on.
- Per-test budgets: the third argument of `test()` takes precedence over `bun test --timeout`, which is how `scripts/runner.node.mjs` applies its lane multipliers; without either, `bun test` uses 5 s.
- `test/expectations.txt` removes whole files from the run on the lanes its modifier matches, which is how this file stayed off the ASAN lane until #36780.

<details>
<summary>Per-build data from the x64-asan shard logs and annotations</summary>

File time on the x64-asan shard while passing (from the `Ran 11 tests` line): 90500: 51.3 s, 92500: 47.7 s, 94548: 52.3 s, 95500: 50.6 s, 96500: 55.6 s, 97000: 48.5 s, 98000: 47.9 s.

Build 100192, attempt 2 (times relative to the file starting): `require()` long names finished at 45.3 s (`RSS diff 44 MB`), the next two inline fixtures at 54.5 s (`198 MB`) and 59.6 s (`136 MB`), and `import()` long names timed out at 60 s. Attempts 1, 3 and 4 failed the same way (attempt 1 also timed out `file paths > via import()`).

Failures on the lane, by build: 97573: `file paths > via import()` timed out on all 4 attempts (file time 56.3-56.9 s each, agent ip-172-31-4-9); 99491: that plus three inline fixtures; 99519: that plus all four inline fixtures; 100061 (flaky): `file paths > via import()`; 100180 (flaky): `file paths > via import()` timed out and `import()` long names failed its bound at 507 MB; 100192: `file paths > via import()` and `import()` long names timed out.

Inline fixture RSS readings on passing ASAN runs with the default quarantine, in the order the fixtures finish: 46/220/127/151 (94548), 48/315/120/137 (96500), 45/277/119/180 (97000), 43/283/123/143 (98000), 42/277/109/200 (100061) MB, against bounds of 400/320/320/320.

July shard logs (for example build 72800) list `cli/run/require-cache.test.ts` in the runner's "Skipping tests" output on every x64-asan shard, and `test/expected-durations.json` (generated 2026-08-02) has no `asan` column for the file.

</details>

<details>
<summary>Earlier version of this PR</summary>

The first version skipped the three leak describe blocks under `isASAN` and removed the fixtures' ASAN bounds, on the claim that the RSS comparison has no signal under ASAN. A review of it measured the fixtures with the quarantine disabled (the numbers in Problem), which shows the comparison does have signal without the quarantine and that the timeouts are the only remaining problem, so the PR now keeps the fixtures running on the lane instead.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->