### PR TITLE
fs.watch(windows): resolve symlinks with realpath instead of passing the readlink target to libuv

### DIFF
--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -10,7 +10,6 @@ use bun_collections::{ArrayHashMap, StringArrayHashMap};
 use bun_core::{String as BunString, ZStr};
 use bun_jsc as jsc;
 use bun_jsc::JsCell;
-use bun_paths::PathBuffer;
 use bun_sys as sys;
 use bun_sys::ReturnCodeExt as _;
 use bun_sys::windows::libuv as uv;
@@ -339,23 +338,21 @@ impl PathWatcher {
         path: &ZStr,
         recursive: bool,
     ) -> sys::Result<*mut PathWatcher> {
-        let mut outbuf = PathBuffer::uninit();
-        // Windows `sys::readlink` returns the byte length; the link target is
-        // written into `outbuf[..len]` with `outbuf[len] == 0` (sys_uv NUL-terminates). Reconstruct
-        // the NUL-terminated string via `ZStr::from_buf`.
-        let readlink_result = sys::readlink(path, &mut outbuf);
-        let event_path: &ZStr = match readlink_result {
-            sys::Result::Err(err) => 'brk: {
-                if err.errno == sys::E::NOENT as _ {
-                    return sys::Result::Err(sys::Error {
-                        errno: err.errno,
-                        syscall: sys::Tag::open,
-                        ..Default::default()
-                    });
-                }
-                break 'brk path;
+        // Watch (and dedup on) the resolved path, like the posix backend. Not the
+        // raw readlink target: a symlink's stored target may be relative to the
+        // link's directory, and libuv resolves relative paths against the cwd.
+        let mut resolve_buf = bun_paths::path_buffer_pool::get();
+        let event_path: &ZStr = match sys::realpath(path, &mut resolve_buf) {
+            Ok(resolved) => {
+                let len = resolved.len();
+                resolve_buf[len] = 0;
+                ZStr::from_buf(&resolve_buf[..], len)
             }
-            sys::Result::Ok(len) => ZStr::from_buf(outbuf.as_slice(), len),
+            // The path (or, for a symlink, its target) does not exist.
+            Err(err) if err.get_errno() == sys::E::ENOENT => return Err(err),
+            // Exists but could not be opened (permissions, sharing): libuv only
+            // needs the parent directory to watch a file, so let it try.
+            Err(_) => path,
         };
 
         // SAFETY: `manager` is the live heap pointer for the calling VM's

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -338,8 +338,6 @@ impl PathWatcher {
         path: &ZStr,
         recursive: bool,
     ) -> sys::Result<*mut PathWatcher> {
-        // Resolve symlinks here rather than passing libuv the readlink() target:
-        // a relative target is relative to the link's directory, not the cwd.
         let mut resolve_buf = bun_paths::path_buffer_pool::get();
         let event_path: &ZStr = match sys::realpath(path, &mut resolve_buf) {
             Ok(resolved) => {

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -348,10 +348,9 @@ impl PathWatcher {
                 resolve_buf[len] = 0;
                 ZStr::from_buf(&resolve_buf[..], len)
             }
-            // The path (or, for a symlink, its target) does not exist.
-            Err(err) if err.get_errno() == sys::E::ENOENT => return Err(err),
-            // Exists but could not be opened (permissions, sharing): libuv only
-            // needs the parent directory to watch a file, so let it try.
+            // Best effort: uv_fs_event_start reports a missing path itself, and it
+            // watches a file through its parent directory, so it can still succeed
+            // on a file that exists but cannot be opened (permissions, sharing).
             Err(_) => path,
         };
 

--- a/src/runtime/node/win_watcher.rs
+++ b/src/runtime/node/win_watcher.rs
@@ -338,9 +338,8 @@ impl PathWatcher {
         path: &ZStr,
         recursive: bool,
     ) -> sys::Result<*mut PathWatcher> {
-        // Watch (and dedup on) the resolved path, like the posix backend. Not the
-        // raw readlink target: a symlink's stored target may be relative to the
-        // link's directory, and libuv resolves relative paths against the cwd.
+        // Resolve symlinks here rather than passing libuv the readlink() target:
+        // a relative target is relative to the link's directory, not the cwd.
         let mut resolve_buf = bun_paths::path_buffer_pool::get();
         let event_path: &ZStr = match sys::realpath(path, &mut resolve_buf) {
             Ok(resolved) => {
@@ -348,9 +347,7 @@ impl PathWatcher {
                 resolve_buf[len] = 0;
                 ZStr::from_buf(&resolve_buf[..], len)
             }
-            // Best effort: uv_fs_event_start reports a missing path itself, and it
-            // watches a file through its parent directory, so it can still succeed
-            // on a file that exists but cannot be opened (permissions, sharing).
+            // Missing or unopenable: uv_fs_event_start decides, as it does for node.
             Err(_) => path,
         };
 

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1202,15 +1202,15 @@ test.skipIf(!isWindows)("retrying a failed fs.watch does not crash (windows)", a
     symlinkSync(target, link, "junction"); // junctions need no admin rights on Windows
     rmdirSync(target);                     // junction now dangles
 
-    // Call 1: readlink(link) SUCCEEDS (returns the vanished target path into
-    // a stack-local buffer), then uv_fs_event_start(target) fails ENOENT.
+    // Call 1: realpath(link) fails (the junction cannot be followed), so the
+    // link path itself goes to uv_fs_event_start, which follows the junction
+    // and fails ENOENT after the watcher was allocated.
     // On unpatched builds: map entry left with dangling key + uninit value.
     try { watch(link); throw new Error("expected first watch to fail"); }
     catch (e) { if (e.code !== "ENOENT") throw e; }
 
-    // Call 2: identical stack frame layout -> identical outbuf address ->
-    // identical key slice -> getOrPut returns found_existing=true ->
-    // returns uninitialized value as a *PathWatcher -> segfault on unpatched builds.
+    // Call 2: the same key; on unpatched builds this found the poisoned entry
+    // and returned its uninitialized value as a *PathWatcher -> segfault.
     // Correct behaviour: throw ENOENT again.
     try { watch(link); throw new Error("expected second watch to fail"); }
     catch (e) { if (e.code !== "ENOENT") throw e; }
@@ -1515,49 +1515,57 @@ test.skipIf(!isWindows)(
 // (symlink("target.txt", "dir/link.txt")) was resolved against the process cwd
 // instead of the link's directory: ENOENT unless the cwd happened to be the
 // link's directory, or a same-named entry in the cwd silently watched instead.
-// The fixtures run with the cwd set to an unrelated directory, and the watched
-// link is passed as an absolute path so that only the link target is relative.
+// The watched path is now resolved with realpath() first; when that fails, the
+// path goes to libuv as given, like in node (the dangling junction test above
+// covers that arm).
+//
+// Both fixtures run with their cwd set to an unrelated directory and receive the
+// link as an absolute path, so the only relative path involved is the link's
+// stored target.
 describe.concurrent.skipIf(!isWindows)("fs.watch on a symlink with a relative target (windows)", () => {
-  test("file symlink: the target is resolved against the link's directory, not the cwd", async () => {
+  async function runFixture(fixture: string, cwd: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      cwd,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim().split(/\r?\n/), stderr, exitCode };
+  }
+
+  test("file symlink with a relative target is resolved against the link's directory, not the cwd", async () => {
     using dir = tempDir("fswatch-relative-symlink-file", {
       "links/target.txt": "hello",
       "cwd/.keep": "",
     });
     const links = path.join(String(dir), "links");
     const link = path.join(links, "link.txt");
-    const target = path.join(links, "target.txt");
     fs.symlinkSync("target.txt", link, "file");
 
     const fixture = /* js */ `
       const fs = require("node:fs");
-      // Unfixed builds throw ENOENT here: "target.txt" does not exist in the cwd.
+      // Unfixed builds throw ENOENT here: there is no "target.txt" in the cwd.
       const watcher = fs.watch(${JSON.stringify(link)}, event => {
         console.log(JSON.stringify(event));
         watcher.close();
       });
       // The watch is armed synchronously, so a single write is enough.
-      fs.writeFileSync(${JSON.stringify(target)}, "changed");
+      fs.writeFileSync(${JSON.stringify(path.join(links, "target.txt"))}, "changed");
     `;
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture],
-      cwd: path.join(String(dir), "cwd"),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+    expect(await runFixture(fixture, path.join(String(dir), "cwd"))).toEqual({
+      stdout: ['"change"'],
+      stderr: "",
+      exitCode: 0,
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe('"change"');
-    expect(exitCode).toBe(0);
   });
 
-  test("directory symlink: a same-named directory in the cwd is not watched instead of the target", async () => {
+  test("directory symlink with a relative target does not watch a same-named directory in the cwd", async () => {
     using dir = tempDir("fswatch-relative-symlink-dir", {
       "links/real/.keep": "",
-      // Same name as the link target, but in the cwd: the directory unfixed
-      // builds end up watching.
+      // Same name as the link target, but in the cwd: what unfixed builds watch.
       "cwd/real/.keep": "",
     });
     const links = path.join(String(dir), "links");
@@ -1571,25 +1579,18 @@ describe.concurrent.skipIf(!isWindows)("fs.watch on a symlink with a relative ta
         console.log(JSON.stringify([event, filename]));
         watcher.close();
       });
-      // Only one of these is inside the watched directory; the first event
-      // delivered says which directory the watcher is attached to.
+      // Only one of these lands in the watched directory, so the first event
+      // says which directory the watcher is attached to.
       fs.writeFileSync(path.join(process.cwd(), "real", "decoy.txt"), "");
       fs.writeFileSync(${JSON.stringify(path.join(links, "real", "real.txt"))}, "");
     `;
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture],
-      cwd: path.join(String(dir), "cwd"),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+    expect(await runFixture(fixture, path.join(String(dir), "cwd"))).toEqual({
+      // Unfixed builds print ["rename","decoy.txt"].
+      stdout: ['["rename","real.txt"]'],
+      stderr: "",
+      exitCode: 0,
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).toBe("");
-    // Unfixed builds print ["rename","decoy.txt"].
-    expect(stdout.trim()).toBe('["rename","real.txt"]');
-    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1510,6 +1510,89 @@ test.skipIf(!isWindows)(
   30000,
 );
 
+// On Windows, fs.watch() on a symlink watches the link's target. It used to hand
+// the raw readlink() result to libuv, so a link whose stored target is relative
+// (symlink("target.txt", "dir/link.txt")) was resolved against the process cwd
+// instead of the link's directory: ENOENT unless the cwd happened to be the
+// link's directory, or a same-named entry in the cwd silently watched instead.
+// The fixtures run with the cwd set to an unrelated directory, and the watched
+// link is passed as an absolute path so that only the link target is relative.
+describe.concurrent.skipIf(!isWindows)("fs.watch on a symlink with a relative target (windows)", () => {
+  test("file symlink: the target is resolved against the link's directory, not the cwd", async () => {
+    using dir = tempDir("fswatch-relative-symlink-file", {
+      "links/target.txt": "hello",
+      "cwd/.keep": "",
+    });
+    const links = path.join(String(dir), "links");
+    const link = path.join(links, "link.txt");
+    const target = path.join(links, "target.txt");
+    fs.symlinkSync("target.txt", link, "file");
+
+    const fixture = /* js */ `
+      const fs = require("node:fs");
+      // Unfixed builds throw ENOENT here: "target.txt" does not exist in the cwd.
+      const watcher = fs.watch(${JSON.stringify(link)}, event => {
+        console.log(JSON.stringify(event));
+        watcher.close();
+      });
+      // The watch is armed synchronously, so a single write is enough.
+      fs.writeFileSync(${JSON.stringify(target)}, "changed");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      cwd: path.join(String(dir), "cwd"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe('"change"');
+    expect(exitCode).toBe(0);
+  });
+
+  test("directory symlink: a same-named directory in the cwd is not watched instead of the target", async () => {
+    using dir = tempDir("fswatch-relative-symlink-dir", {
+      "links/real/.keep": "",
+      // Same name as the link target, but in the cwd: the directory unfixed
+      // builds end up watching.
+      "cwd/real/.keep": "",
+    });
+    const links = path.join(String(dir), "links");
+    const link = path.join(links, "link");
+    fs.symlinkSync("real", link, "dir");
+
+    const fixture = /* js */ `
+      const fs = require("node:fs");
+      const path = require("node:path");
+      const watcher = fs.watch(${JSON.stringify(link)}, (event, filename) => {
+        console.log(JSON.stringify([event, filename]));
+        watcher.close();
+      });
+      // Only one of these is inside the watched directory; the first event
+      // delivered says which directory the watcher is attached to.
+      fs.writeFileSync(path.join(process.cwd(), "real", "decoy.txt"), "");
+      fs.writeFileSync(${JSON.stringify(path.join(links, "real", "real.txt"))}, "");
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      cwd: path.join(String(dir), "cwd"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    // Unfixed builds print ["rename","decoy.txt"].
+    expect(stdout.trim()).toBe('["rename","real.txt"]');
+    expect(exitCode).toBe(0);
+  });
+});
+
 // FSWatcher::init joins the user-supplied watch path with the process cwd into a
 // fixed pooled path buffer. The raw-path length validator only bounds the path
 // itself, so a relative path just under the platform path limit used to overflow


### PR DESCRIPTION
### Problem
- Windows only. `fs.watch()` on a symlink whose stored target is relative (`fs.symlinkSync("target.txt", "C:/t/link.txt")`) throws `ENOENT: no such file or directory, watch 'C:/t/link.txt'` unless the process cwd happens to be the link's directory. If the cwd contains an entry with the target's name, the call succeeds and silently watches that entry instead of the link target. A chain of such links (`a -> b -> target`) fails even from the link's directory.
- Cause: `PathWatcher::init` (`src/runtime/node/win_watcher.rs:346-358`) calls `readlink()` on the watched path and passes the raw result (`target.txt`) to `uv_fs_event_start` (`win_watcher.rs:397`), which resolves a relative path against the cwd (`GetFileAttributesW`, and `GetCurrentDirectoryW` in `uv__split_path` for a separator-less file path). The user's path is joined onto the cwd in `node_fs_watcher.rs:1142`, but the link target is never joined onto the link's directory. The same raw string was also the key of the watcher dedup map (`win_watcher.rs:423`).
- Reproduced with the 1.4.0 canary (7aad387): watching `C:/t/link.txt` from `C:\` throws ENOENT; from `C:\t` it works.

### Fix
- `PathWatcher::init` resolves the path with `bun_sys::realpath` and uses the result both as the path handed to libuv and as the dedup key. If `realpath` fails for any reason, the path is handed to libuv as given, which is what node does on every call, and libuv reports the error or sets up the watch.
- Why this is right: the Windows backend already intends to watch the link target (the existing symlink tests in `fs.watch.test.ts` write through a link and expect events, which only works if the target is watched; it is also what `fs.watch` does on Linux and macOS, where `path_watcher.rs` keys and watches by realpath as well). `realpath` makes the kernel resolve the stored target against the link's real location, which also covers `..` targets and link chains, neither of which a one-level `readlink` join would. Not looking at why `realpath` failed keeps a file that exists but cannot be opened watchable (libuv only opens the parent directory) and means nothing here depends on how `realpath` reports errors; #38365 rewrites the Windows `realpath` and its error mapping and needs no change here.
- Error behaviour: missing paths and dangling directory links or junctions still throw `ENOENT` with `syscall: "watch"` and the user's path (libuv fails to open them; `node_fs_watcher.rs:1221` builds the JS error either way), and `throwIfNoEntry: false` still works. The one difference from the current release: a dangling *file* symlink used to throw ENOENT (its readlink target did not exist) and now gets whatever libuv does with the link path, which with bun's libuv (1.51) is a watch on the link entry in its directory, the same as node on libuv 1.51 (node 24). libuv 1.52 made `uv_fs_event_start` open the path first, so node 26 throws ENOENT there and bun will again once it updates libuv. No test pins this, since it follows the libuv version.
- Narrow case: `bun_sys::realpath` on Windows currently opens the path for read, so a symlink whose target exists but cannot be opened for read watches the link entry instead of the target (the fallback). Plain paths in that state behave exactly as before; #38365's zero-access open removes the case.
- Side effect: libuv no longer receives a separator-less path from `fs.watch`, so the `uv__split_path` `_wcsdup` crash on close that #39472 patches in libuv is no longer reachable through `fs.watch`; #39472 remains the fix for libuv itself.
- Tests: `test/js/node/watch/fs.watch.test.ts`, describe block "fs.watch on a symlink with a relative target (windows)". Both spawn bun with the cwd set to an unrelated directory and pass the link as an absolute path, so only the link target is relative. The file case asserts a `change` event for a write to the target (unfixed: ENOENT thrown). The directory case puts a same-named decoy directory in the cwd and asserts the first event names the file created in the real target (unfixed: it names the file created in the decoy). Both fail on the unfixed canary and pass on a Windows x64 debug build of this branch; they are skipped off Windows because the POSIX backend is not involved. The existing dangling junction test now exercises the fallback arm (`realpath` fails, libuv fails, the half-initialised watcher is torn down); its comments were updated and the debug log confirms the path taken (`uv open(...) = -4058`, then `[fs.watch] deinit`).
- Other runs on the same Windows x64 debug build: all of `test/js/node/watch/*.test.ts` (fs.watch.test.ts: 44 pass, 8 platform skips, including the existing symlink tests) and the 42 `test/js/node/test/parallel/test-fs-watch*` / `test-fs-promises-watch*` files pass. Probes below.

### Background
- A Windows symlink stores its target as written; the kernel resolves a relative target against the directory containing the link. `readlink()` returns that stored string unchanged, so it is only meaningful relative to the link's directory.
- `uv_fs_event_start` (libuv `src/win/fs-event.c`, the version bun builds is 1.51-based) takes a path string, classifies it with `GetFileAttributesW` (which does not follow reparse points), then for a file watches its parent directory filtered to that name, and for a directory opens the directory itself with `CreateFileW`, which does follow reparse points. Anything relative in that string is resolved against the process cwd. libuv 1.52 replaced the `GetFileAttributesW` step with a `CreateFileW` of the path itself.
- `bun_sys::realpath` on Windows opens the path and asks `GetFinalPathNameByHandle` for its canonical DOS path (`\\?\` prefix stripped), following every reparse point on the way.
- `PathWatcherManager.watchers` maps the path given to libuv to one `uv_fs_event_t` shared by every `fs.watch()` call that resolves to it; `uv_fs_event_start` copies the string and the map owns its own copy of the key, so the pooled buffer only has to live for the duration of `init`.

<details>
<summary>Manual probes (Windows x64, this branch's debug build vs the 1.4.0 canary, plus node 26 where it differs)</summary>

Each line is a child bun process started with its cwd in an unrelated directory; `->` is what the first watch event printed.

```
                                 canary 7aad387            this branch
a/link.txt -> target.txt,
  write target                   threw ENOENT              "change"          (node 26: watch ok, no event)
a/link (dir) -> real,
  cwd also has ./real            ["rename","decoy.txt"]    ["rename","real.txt"]
a/dotdot.txt -> ../b/t.txt       change                    change
a/chain.txt -> dotdot.txt        threw ENOENT              change
dangling dir link / junction     threw ENOENT              threw ENOENT
dangling file link, unlink it    threw ENOENT              ["rename","dangling.txt"]   (node 26: threw ENOENT, see Fix)
watch link + watch target,
  one write                      both fired                both fired (one uv handle)
fs.watch("C:\\")                 ok                        ok
missing path, file/x             ENOENT, syscall watch     ENOENT, syscall watch
```

Debug log of a directory link watch on this branch:

```
uv open(C:\t\probe-root2\links\link-dir, 0, 420) = 3
GetFinalPathNameByHandleW(0x2a8) = \\?\C:\t\probe-root2\links\sub
```

Debug log of the dangling junction test's first call on this branch:

```
uv open(C:\t\junc\link, 0, 420) = -4058
[fs.watch] deinit
threw ENOENT
[fs.watch] onClose
```
</details>

<details>
<summary>Earlier revision of this PR</summary>

The first push returned `realpath`'s error directly when it was ENOENT and fell back to the given path otherwise. Review pointed out that this tied the existence check to how `realpath` spells its failures (after #38365 a failed DOS-name lookup on an existing file would also be ENOENT) and that the dangling junction test no longer reached libuv's failure path. The current revision falls back unconditionally, which removes both issues; the dangling file link behaviour described under Fix is the only observable difference between the two revisions.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/watch/fs.watch.test.ts

<!-- robobun:evidence:end -->