### PR TITLE
bun-inspector-protocol: carry the types other domains refer to into the JSC snapshot

### DIFF
--- a/packages/bun-inspector-protocol/scripts/generate-protocol.ts
+++ b/packages/bun-inspector-protocol/scripts/generate-protocol.ts
@@ -240,17 +240,13 @@ async function downloadV8(): Promise<Protocol> {
   return Promise.all([
     download<Protocol>(`${baseUrl}/js_protocol.json`),
     download<Protocol>(`${baseUrl}/browser_protocol.json`),
-  ]).then(([js, browser]) => {
-    const all = [...js.domains, ...browser.domains];
-    return {
-      name: "V8",
-      version: js.version,
-      domains: withReferencedTypes(
-        all.filter(domain => !domains.includes(domain.domain)),
-        all,
-      ),
-    };
-  });
+  ]).then(([js, browser]) => ({
+    name: "V8",
+    version: js.version,
+    domains: [...js.domains, ...browser.domains]
+      .filter(domain => !domains.includes(domain.domain))
+      .sort((a, b) => a.domain.localeCompare(b.domain)),
+  }));
 }
 
 async function download<V>(url: string): Promise<V> {

--- a/packages/bun-inspector-protocol/scripts/generate-protocol.ts
+++ b/packages/bun-inspector-protocol/scripts/generate-protocol.ts
@@ -12,13 +12,17 @@
 //
 // Pass --v8 to also refresh src/protocol/v8 from the Chrome DevTools protocol
 // repository (requires network access).
+//
+// test/cli/inspect/bun-inspector-protocol.test.ts imports the exported functions
+// and checks the generated files, so only the `import.meta.main` block below may
+// have side effects.
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import type { Domain, Property, Protocol } from "../src/protocol/schema";
 
-function formatProtocol(protocol: Protocol, extraTs?: string): string {
+export function formatProtocol(protocol: Protocol, extraTs?: string): string {
   const { name, domains } = protocol;
   const eventMap = new Map();
   const commandMap = new Map();
@@ -57,7 +61,7 @@ function formatProtocol(protocol: Protocol, extraTs?: string): string {
         properties: returns,
       });
     }
-    body += "};";
+    body += "}";
   }
   for (const type of ["Event", "Request", "Response"]) {
     const sourceMap = type === "Event" ? eventMap : commandMap;
@@ -74,7 +78,7 @@ function formatProtocol(protocol: Protocol, extraTs?: string): string {
   if (extraTs) {
     body += extraTs;
   }
-  return body + "};";
+  return body + "}";
 }
 
 function formatProperty(property: Property): string {
@@ -133,6 +137,101 @@ function formatProperty(property: Property): string {
 }
 
 /**
+ * Besides a type of the referring domain (`RemoteObject`) or of another one (`Network.RequestId`), a
+ * `$ref` may name one of these, the types WebKit's protocol generator predeclares
+ * (inspector/scripts/codegen/models.py, resolve_types): Runtime.PropertyDescriptor.isPrivate is a
+ * `$ref` to `boolean`. There is nothing to declare for them.
+ */
+export const primitiveTypes: ReadonlySet<string> = new Set(["any", "boolean", "integer", "number", "object", "string"]);
+
+/**
+ * The domains of the snapshot: those of `all` (a CombinedDomains.json) that a JavaScript debuggable (a bun
+ * process, as opposed to a web page or a service worker) speaks, by the rule WebKit's own frontend applies
+ * in InspectorBackend.activateDomain (a domain applies to the debuggable types it lists, and one that lists
+ * none, like GenericTypes, applies to every debuggable), except `domainsWithoutAgent`; plus the types they
+ * refer to in the remaining domains.
+ */
+export function selectJscDomains(all: readonly Domain[], domainsWithoutAgent: ReadonlySet<string>): Domain[] {
+  const selected = all.filter(
+    ({ domain, debuggableTypes }) =>
+      (debuggableTypes === undefined || debuggableTypes.includes("javascript")) && !domainsWithoutAgent.has(domain),
+  );
+  return withReferencedTypes(selected, all);
+}
+
+/**
+ * `selected`, plus a types-only copy of every other domain of `all` whose types they `$ref`
+ * (Console.ConsoleMessage has a Network.RequestId, although Network itself is a web page domain),
+ * holding just the referenced types and whatever those refer to in turn. Without them, index.d.ts
+ * names namespaces it does not declare, which every consumer compiles with skipLibCheck, so the
+ * affected properties silently type-check as anything.
+ */
+function withReferencedTypes(selected: readonly Domain[], all: readonly Domain[]): Domain[] {
+  const allByName = new Map(all.map(domain => [domain.domain, domain]));
+  const selectedNames = new Set(selected.map(domain => domain.domain));
+  /** Domain name to the ids of its types that `selected` refers to, for domains outside `selected`. */
+  const referenced = new Map<string, Set<string>>();
+
+  function visit(property: Property, domain: string): void {
+    if ("$ref" in property) {
+      const { $ref } = property;
+      const [refDomain, id] = $ref.includes(".") ? $ref.split(".") : [domain, $ref];
+      if (selectedNames.has(refDomain)) {
+        return;
+      }
+      const type = allByName.get(refDomain)?.types?.find(type => type.id === id);
+      if (!type) {
+        if (primitiveTypes.has($ref)) {
+          return;
+        }
+        throw new Error(`${domain} refers to ${$ref}, which no domain declares`);
+      }
+      const ids = referenced.get(refDomain) ?? new Set();
+      referenced.set(refDomain, ids);
+      if (!ids.has(id)) {
+        ids.add(id);
+        visit(type, refDomain);
+      }
+    } else if (property.type === "array") {
+      if (property.items) {
+        visit(property.items, domain);
+      }
+    } else if (property.type === "object") {
+      for (const member of property.properties ?? []) {
+        visit(member, domain);
+      }
+    }
+  }
+
+  for (const { domain, types = [], commands = [], events = [] } of selected) {
+    for (const type of types) {
+      visit(type, domain);
+    }
+    for (const { parameters = [], returns = [] } of commands) {
+      for (const property of [...parameters, ...returns]) {
+        visit(property, domain);
+      }
+    }
+    for (const { parameters = [] } of events) {
+      for (const property of parameters) {
+        visit(property, domain);
+      }
+    }
+  }
+
+  const referencedDomains = [...referenced].map(([name, ids]): Domain => {
+    const { debuggableTypes, types = [] } = allByName.get(name)!;
+    return {
+      domain: name,
+      description: "Only the types that the other domains of this snapshot refer to.",
+      debuggableTypes,
+      types: types.filter(type => ids.has(type.id!)),
+    };
+  });
+  return [...selected, ...referencedDomains].sort((a, b) => a.domain.localeCompare(b.domain));
+}
+
+/**
  * @link https://github.com/ChromeDevTools/devtools-protocol/tree/master/json
  */
 async function downloadV8(): Promise<Protocol> {
@@ -141,13 +240,17 @@ async function downloadV8(): Promise<Protocol> {
   return Promise.all([
     download<Protocol>(`${baseUrl}/js_protocol.json`),
     download<Protocol>(`${baseUrl}/browser_protocol.json`),
-  ]).then(([js, browser]) => ({
-    name: "V8",
-    version: js.version,
-    domains: [...js.domains, ...browser.domains]
-      .filter(domain => !domains.includes(domain.domain))
-      .sort((a, b) => a.domain.localeCompare(b.domain)),
-  }));
+  ]).then(([js, browser]) => {
+    const all = [...js.domains, ...browser.domains];
+    return {
+      name: "V8",
+      version: js.version,
+      domains: withReferencedTypes(
+        all.filter(domain => !domains.includes(domain.domain)),
+        all,
+      ),
+    };
+  });
 }
 
 async function download<V>(url: string): Promise<V> {
@@ -202,49 +305,49 @@ function findPinnedCombinedDomains(): string | undefined {
  */
 const domainsWithoutAgent = new Set(["File", "Process"]);
 
-const args = process.argv.slice(2);
-const includeV8 = args.includes("--v8");
-const combinedDomainsPath = args.find(arg => !arg.startsWith("--")) ?? findPinnedCombinedDomains();
-if (!combinedDomainsPath) {
-  console.error(
-    "Could not find CombinedDomains.json for the pinned WebKit version. " +
-      "Run `bun bd` first or pass the path to a WebKit build's CombinedDomains.json.",
-  );
-  process.exit(1);
-}
-console.log(`Reading ${combinedDomainsPath}`);
-const combinedDomains: { domains: Domain[] } = await Bun.file(combinedDomainsPath).json();
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const includeV8 = args.includes("--v8");
+  const combinedDomainsPath = args.find(arg => !arg.startsWith("--")) ?? findPinnedCombinedDomains();
+  if (!combinedDomainsPath) {
+    console.error(
+      "Could not find CombinedDomains.json for the pinned WebKit version. " +
+        "Run `bun bd` first or pass the path to a WebKit build's CombinedDomains.json.",
+    );
+    process.exit(1);
+  }
+  console.log(`Reading ${combinedDomainsPath}`);
+  const combinedDomains: { domains: Domain[] } = await Bun.file(combinedDomainsPath).json();
 
-const protocolDir = path.resolve(import.meta.dir, "..", "src", "protocol");
-const written: string[] = [];
-const write = (name: string, data: string) => {
-  const filePath = path.join(protocolDir, name);
-  writeFileSync(filePath, data);
-  written.push(filePath);
-};
-const base = readFileSync(path.join(protocolDir, "protocol.d.ts"), "utf-8");
-const baseNoComments = base.replace(/\/\/.*/g, "");
+  const protocolDir = path.resolve(import.meta.dir, "..", "src", "protocol");
+  const written: string[] = [];
+  const write = (name: string, data: string) => {
+    const filePath = path.join(protocolDir, name);
+    writeFileSync(filePath, data);
+    written.push(filePath);
+  };
+  const base = readFileSync(path.join(protocolDir, "protocol.d.ts"), "utf-8");
+  const baseNoComments = base.replace(/\/\/.*/g, "");
 
-const jsc: Protocol = {
-  name: "JSC",
-  version: {
-    major: 1,
-    minor: 4,
-  },
-  domains: combinedDomains.domains
-    .filter(domain => domain.debuggableTypes?.includes("javascript") && !domainsWithoutAgent.has(domain.domain))
-    .sort((a, b) => a.domain.localeCompare(b.domain)),
-};
-write("jsc/protocol.json", JSON.stringify(jsc, null, 2));
-write("jsc/index.d.ts", "// GENERATED - DO NOT EDIT\n" + formatProtocol(jsc, baseNoComments));
+  const jsc: Protocol = {
+    name: "JSC",
+    version: {
+      major: 1,
+      minor: 4,
+    },
+    domains: selectJscDomains(combinedDomains.domains, domainsWithoutAgent),
+  };
+  write("jsc/protocol.json", JSON.stringify(jsc, null, 2));
+  write("jsc/index.d.ts", "// GENERATED - DO NOT EDIT\n" + formatProtocol(jsc, baseNoComments));
 
-if (includeV8) {
-  const v8 = await downloadV8();
-  write("v8/protocol.json", JSON.stringify(v8));
-  write("v8/index.d.ts", "// GENERATED - DO NOT EDIT\n" + formatProtocol(v8, baseNoComments));
-}
+  if (includeV8) {
+    const v8 = await downloadV8();
+    write("v8/protocol.json", JSON.stringify(v8));
+    write("v8/index.d.ts", "// GENERATED - DO NOT EDIT\n" + formatProtocol(v8, baseNoComments));
+  }
 
-const { status } = spawnSync("bunx", ["prettier", "--write", ...written], { cwd: repoRoot, stdio: "inherit" });
-if (status !== 0) {
-  process.exit(status ?? 1);
+  const { status } = spawnSync("bunx", ["prettier", "--write", ...written], { cwd: repoRoot, stdio: "inherit" });
+  if (status !== 0) {
+    process.exit(status ?? 1);
+  }
 }

--- a/packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts
+++ b/packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts
@@ -1393,6 +1393,21 @@ export namespace JSC {
      */
     export type SetBlackboxBreakpointEvaluationsResponse = {};
   }
+  export namespace GenericTypes {
+    /**
+     * Search match in a resource.
+     */
+    export type SearchMatch = {
+      /**
+       * Line number in resource content.
+       */
+      lineNumber: number;
+      /**
+       * Line with match content.
+       */
+      lineContent: string;
+    };
+  }
   export namespace Heap {
     /**
      * Information about a garbage collection.
@@ -2039,6 +2054,16 @@ export namespace JSC {
        */
       argv: string[];
     };
+  }
+  export namespace Network {
+    /**
+     * Unique frame identifier.
+     */
+    export type FrameId = string;
+    /**
+     * Unique request identifier.
+     */
+    export type RequestId = string;
   }
   export namespace Runtime {
     /**

--- a/packages/bun-inspector-protocol/src/protocol/jsc/protocol.json
+++ b/packages/bun-inspector-protocol/src/protocol/jsc/protocol.json
@@ -1604,6 +1604,29 @@
       ]
     },
     {
+      "domain": "GenericTypes",
+      "description": "Exposes generic types to be used by any domain.",
+      "types": [
+        {
+          "id": "SearchMatch",
+          "type": "object",
+          "description": "Search match in a resource.",
+          "properties": [
+            {
+              "name": "lineNumber",
+              "type": "number",
+              "description": "Line number in resource content."
+            },
+            {
+              "name": "lineContent",
+              "type": "string",
+              "description": "Line with match content."
+            }
+          ]
+        }
+      ]
+    },
+    {
       "domain": "Heap",
       "description": "Heap domain exposes JavaScript heap attributes and capabilities.",
       "debuggableTypes": ["itml", "javascript", "service-worker", "web-page", "wasm-debugger"],
@@ -2345,6 +2368,23 @@
               }
             }
           ]
+        }
+      ]
+    },
+    {
+      "domain": "Network",
+      "description": "Only the types that the other domains of this snapshot refer to.",
+      "debuggableTypes": ["itml", "service-worker", "web-page"],
+      "types": [
+        {
+          "id": "FrameId",
+          "type": "string",
+          "description": "Unique frame identifier."
+        },
+        {
+          "id": "RequestId",
+          "type": "string",
+          "description": "Unique request identifier."
         }
       ]
     },

--- a/packages/bun-inspector-protocol/src/protocol/schema.d.ts
+++ b/packages/bun-inspector-protocol/src/protocol/schema.d.ts
@@ -11,6 +11,7 @@ export type Protocol = {
 
 export type Domain = {
   readonly domain: string;
+  readonly description?: string;
   readonly debuggableTypes?: readonly string[];
   readonly dependencies?: readonly string[];
   readonly types?: readonly Property[];
@@ -54,6 +55,10 @@ export type Property = {
     }
   | {
       readonly type: undefined;
+      /**
+       * A type of the same domain (`RemoteObject`), of another domain (`Network.RequestId`), or one of
+       * the primitives in `primitiveTypes` of scripts/generate-protocol.ts (`boolean`).
+       */
       readonly $ref: string;
     }
 );

--- a/test/cli/inspect/bun-inspector-protocol.test.ts
+++ b/test/cli/inspect/bun-inspector-protocol.test.ts
@@ -170,7 +170,7 @@ const ref = ($ref: string, name?: string): Property => ({ name, type: undefined,
 const debuggerDomain: Domain = {
   domain: "Debugger",
   debuggableTypes: ["javascript", "web-page"],
-  types: [{ id: "Location", type: "object", properties: [ref("Page.FrameId", "frameId"), ref("Process.Id", "pid")] }],
+  types: [{ id: "Location", type: "object", properties: [ref("Page.Frame", "frame"), ref("Process.Id", "pid")] }],
   commands: [
     { name: "searchInContent", returns: [{ name: "result", type: "array", items: ref("GenericTypes.SearchMatch") }] },
   ],
@@ -190,10 +190,14 @@ const combinedDomains: Domain[] = [
     domain: "Page",
     debuggableTypes: ["web-page"],
     types: [
-      // Referred to by Debugger; refers on to a primitive and, by its bare name, to LoaderId, which refers on
-      // to a third domain.
-      { id: "FrameId", type: "object", properties: [ref("boolean", "isMainFrame"), ref("LoaderId", "loaderId")] },
-      { id: "LoaderId", type: "array", items: ref("Network.RequestId") },
+      // Referred to by Debugger. Refers on to a primitive, to itself (the walk has to notice that to
+      // terminate) and, by bare name, to RequestIds, which refers on to a third domain.
+      {
+        id: "Frame",
+        type: "object",
+        properties: [ref("boolean", "isMainFrame"), ref("Frame", "parent"), ref("RequestIds", "requests")],
+      },
+      { id: "RequestIds", type: "array", items: ref("Network.RequestId") },
       { id: "PauseReason", type: "string", enum: ["breakpoint", "exception"] },
       { id: "Unreferenced", type: "string" },
     ],
@@ -229,7 +233,7 @@ test("generate-protocol.ts carries along the types that the JavaScript domains r
       domain: "Page",
       description: expect.any(String),
       debuggableTypes: ["web-page"],
-      types: ["FrameId", "LoaderId", "PauseReason"],
+      types: ["Frame", "RequestIds", "PauseReason"],
     },
     { domain: "Process", description: expect.any(String), debuggableTypes: ["javascript"], types: ["Id"] },
   ]);

--- a/test/cli/inspect/bun-inspector-protocol.test.ts
+++ b/test/cli/inspect/bun-inspector-protocol.test.ts
@@ -275,7 +275,7 @@ test("the protocol snapshot in packages/bun-inspector-protocol matches what bun 
       console.log("hello");
       reportError(new Error("reported"));
       debugger;
-      setInterval(() => {}, 60_000);
+      debugger;
     `,
     "dep.cjs": `module.exports = 1;`,
   });
@@ -401,9 +401,15 @@ test("the protocol snapshot in packages/bun-inspector-protocol matches what bun 
     await send("Debugger.evaluateOnCallFrame", { callFrameId: callFrames[0].callFrameId, expression: "globalThis" });
     await send("LifecycleReporter.getModuleGraph");
 
+    // The reported error makes bun exit (with code 1) as soon as the module finishes evaluating, and
+    // that exit races the delivery of whatever the inspector sent last. So the fixture's second
+    // debugger statement stops it again right after it resumes: everything sent in between is
+    // delivered while it sits in that pause, and the session ends (ws.close below) while it is paused.
     const resumed = waitForEvent("Debugger.resumed");
+    const pausedAgain = waitForEvent("Debugger.paused");
     await send("Debugger.resume");
     await resumed;
+    await pausedAgain;
   } finally {
     ws.close();
   }

--- a/test/cli/inspect/bun-inspector-protocol.test.ts
+++ b/test/cli/inspect/bun-inspector-protocol.test.ts
@@ -1,19 +1,64 @@
 // packages/bun-inspector-protocol ships a snapshot of the inspector protocol of the WebKit
 // build bun links against (src/protocol/jsc/protocol.json, from which index.d.ts is
-// generated). Nothing regenerates it when WebKit is bumped, so this test runs a short
-// debugging session against this build of bun and validates every message it sends
+// generated). Nothing regenerates it when WebKit is bumped, so the last test here runs a
+// short debugging session against this build of bun and validates every message it sends
 // against the snapshot. If it fails after a WebKit upgrade, regenerate the snapshot:
 //
 //   bun packages/bun-inspector-protocol/scripts/generate-protocol.ts
+//
+// The tests before it check that the snapshot is self-contained: the domains it holds refer
+// to types of domains that only exist for web pages (Network.RequestId), which the generator
+// has to carry along for index.d.ts to type-check. Its consumers compile with skipLibCheck,
+// so a reference it leaves dangling is not a compile error for them, just a property that
+// silently types as anything.
 import { spawn } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
-import { basename } from "node:path";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { basename, join } from "node:path";
+import {
+  formatProtocol,
+  primitiveTypes,
+  selectJscDomains,
+} from "../../../packages/bun-inspector-protocol/scripts/generate-protocol";
 import protocolJson from "../../../packages/bun-inspector-protocol/src/protocol/jsc/protocol.json";
-import type { Property, Protocol } from "../../../packages/bun-inspector-protocol/src/protocol/schema";
+import type { Domain, Property, Protocol } from "../../../packages/bun-inspector-protocol/src/protocol/schema";
 
+const protocolDir = join(import.meta.dir, "../../../packages/bun-inspector-protocol/src/protocol");
 const protocol = protocolJson as Protocol;
 const domains = new Map(protocol.domains.map(domain => [domain.domain, domain]));
+/** The domains that are in the snapshot only because domains bun speaks refer to their types. */
+const typesOnlyDomains = protocol.domains
+  .filter(domain => !domain.commands && !domain.events)
+  .map(domain => domain.domain);
+
+/**
+ * The snapshot's declaration of the type a `$ref` names (a bare name is a type of the referring domain),
+ * or an equivalent declaration when it names a primitive; see `$ref` in schema.d.ts.
+ */
+function resolveRef($ref: string, domain: string): { type: Property; domain: string } | undefined {
+  const [refDomain, id] = $ref.includes(".") ? $ref.split(".") : [domain, $ref];
+  const type = domains.get(refDomain)?.types?.find(type => type.id === id);
+  if (type) return { type, domain: refDomain };
+  if (primitiveTypes.has($ref)) return { type: { type: $ref } as Property, domain };
+  return undefined;
+}
+
+/** What tsc reports for a .d.ts checked on its own, i.e. what a consumer would see without skipLibCheck. */
+async function typeErrors(dtsPath: string): Promise<string[]> {
+  // Loading typescript takes tens of seconds in a debug build of bun, so only the test that needs it pays for it.
+  const ts = (await import("typescript")).default;
+  const program = ts.createProgram([dtsPath], {
+    strict: true,
+    noEmit: true,
+    skipLibCheck: false,
+    lib: ["lib.es5.d.ts"],
+    types: [],
+  });
+  return ts.getPreEmitDiagnostics(program).map(({ file, start, messageText }) => {
+    const line = file && start !== undefined ? file.getLineAndCharacterOfPosition(start).line + 1 : "?";
+    return `${basename(file?.fileName ?? "")}:${line}: ${ts.flattenDiagnosticMessageText(messageText, "\n")}`;
+  });
+}
 
 function declaredEventParameters(method: string): readonly Property[] | undefined {
   const [domain, name] = method.split(".");
@@ -30,11 +75,12 @@ function declaredCommandReturns(method: string): readonly Property[] | undefined
 /** Appends to `problems` every way `value` disagrees with `property`, the snapshot's declaration of it. */
 function check(value: unknown, property: Property, domain: string, where: string, problems: string[]): void {
   if ("$ref" in property) {
-    const [refDomain, refId] = property.$ref.includes(".") ? property.$ref.split(".") : [domain, property.$ref];
-    const type = domains.get(refDomain)?.types?.find(type => type.id === refId);
-    // A few JavaScriptCore types reference domains that only exist for web pages (e.g. Network.RequestId).
-    // Those domains are not part of the snapshot, and bun never sends values of those types.
-    if (type) check(value, type, refDomain, where, problems);
+    const target = resolveRef(property.$ref, domain);
+    if (target) {
+      check(value, target.type, target.domain, where, problems);
+    } else {
+      problems.push(`${where}: ${property.$ref} is not in the snapshot`);
+    }
     return;
   }
   switch (property.type) {
@@ -93,6 +139,127 @@ function checkObject(
     if (!declaredNames.has(name)) problems.push(`${where}: property ${name} is not in the snapshot`);
   }
 }
+
+test("every type the snapshot refers to is in the snapshot", () => {
+  const dangling: string[] = [];
+  function visit(property: Property, domain: string, where: string): void {
+    if ("$ref" in property) {
+      if (!resolveRef(property.$ref, domain)) dangling.push(`${where}: ${property.$ref}`);
+    } else if (property.type === "array") {
+      if (property.items) visit(property.items, domain, `${where}[]`);
+    } else if (property.type === "object") {
+      for (const member of property.properties ?? []) visit(member, domain, `${where}.${member.name}`);
+    }
+  }
+  for (const { domain, types = [], commands = [], events = [] } of protocol.domains) {
+    for (const type of types) visit(type, domain, `${domain}.${type.id}`);
+    for (const { name, parameters = [], returns = [] } of commands) {
+      for (const parameter of parameters) visit(parameter, domain, `${domain}.${name} parameter ${parameter.name}`);
+      for (const returned of returns) visit(returned, domain, `${domain}.${name} returns ${returned.name}`);
+    }
+    for (const { name, parameters = [] } of events) {
+      for (const parameter of parameters) visit(parameter, domain, `${domain}.${name} parameter ${parameter.name}`);
+    }
+  }
+  expect(dangling).toEqual([]);
+});
+
+const ref = ($ref: string, name?: string): Property => ({ name, type: undefined, $ref });
+// A miniature CombinedDomains.json, in which Debugger is the only domain declared for JavaScript debuggables
+// that bun has an agent for.
+const debuggerDomain: Domain = {
+  domain: "Debugger",
+  debuggableTypes: ["javascript", "web-page"],
+  types: [{ id: "Location", type: "object", properties: [ref("Page.FrameId", "frameId"), ref("Process.Id", "pid")] }],
+  commands: [
+    { name: "searchInContent", returns: [{ name: "result", type: "array", items: ref("GenericTypes.SearchMatch") }] },
+  ],
+  events: [{ name: "paused", parameters: [ref("Page.PauseReason", "reason")] }],
+};
+const combinedDomains: Domain[] = [
+  debuggerDomain,
+  // Declares no debuggableTypes, so it applies to every debuggable and is kept whole.
+  {
+    domain: "GenericTypes",
+    types: [
+      { id: "SearchMatch", type: "string" },
+      { id: "Unreferenced", type: "string" },
+    ],
+  },
+  {
+    domain: "Page",
+    debuggableTypes: ["web-page"],
+    types: [
+      // Referred to by Debugger; refers on to a primitive and, by its bare name, to LoaderId, which refers on
+      // to a third domain.
+      { id: "FrameId", type: "object", properties: [ref("boolean", "isMainFrame"), ref("LoaderId", "loaderId")] },
+      { id: "LoaderId", type: "array", items: ref("Network.RequestId") },
+      { id: "PauseReason", type: "string", enum: ["breakpoint", "exception"] },
+      { id: "Unreferenced", type: "string" },
+    ],
+    commands: [{ name: "navigate" }],
+    events: [{ name: "loaded" }],
+  },
+  {
+    domain: "Network",
+    debuggableTypes: ["web-page"],
+    types: [
+      { id: "RequestId", type: "string" },
+      { id: "Unreferenced", type: "string" },
+    ],
+  },
+  // Nothing refers to it.
+  { domain: "DOM", debuggableTypes: ["web-page"], types: [{ id: "NodeId", type: "integer" }] },
+  // Declared for JavaScript, but bun has no agent for it, so only what Debugger refers to is kept.
+  {
+    domain: "Process",
+    debuggableTypes: ["javascript"],
+    types: [{ id: "Id", type: "integer" }],
+    commands: [{ name: "enable" }],
+  },
+];
+
+test("generate-protocol.ts carries along the types that the JavaScript domains refer to in other domains", () => {
+  const selected = selectJscDomains(combinedDomains, new Set(["Process"]));
+  expect(selected.map(domain => ({ ...domain, types: domain.types?.map(type => type.id) }))).toEqual([
+    { ...debuggerDomain, types: ["Location"] },
+    { domain: "GenericTypes", types: ["SearchMatch", "Unreferenced"] },
+    { domain: "Network", description: expect.any(String), debuggableTypes: ["web-page"], types: ["RequestId"] },
+    {
+      domain: "Page",
+      description: expect.any(String),
+      debuggableTypes: ["web-page"],
+      types: ["FrameId", "LoaderId", "PauseReason"],
+    },
+    { domain: "Process", description: expect.any(String), debuggableTypes: ["javascript"], types: ["Id"] },
+  ]);
+});
+
+// The two tests above check the same thing at the protocol.json level; this one is what the consumers of the
+// package would see, but type-checking takes tens of seconds in a debug build of bun.
+test.skipIf(isDebug)("the generated index.d.ts type-checks without skipLibCheck", async () => {
+  expect(await typeErrors(join(protocolDir, "jsc/index.d.ts"))).toEqual([]);
+
+  const version = { major: 1, minor: 0 };
+  using dir = tempDir("bun-inspector-protocol-generated", {
+    "selected.d.ts": formatProtocol({
+      name: "JSC",
+      version,
+      domains: selectJscDomains(combinedDomains, new Set(["Process"])),
+    }),
+    // The JavaScript domains on their own, which is what the generator used to emit.
+    "debugger-only.d.ts": formatProtocol({ name: "JSC", version, domains: [debuggerDomain] }),
+  });
+  expect(await typeErrors(join(String(dir), "selected.d.ts"))).toEqual([]);
+  expect(
+    (await typeErrors(join(String(dir), "debugger-only.d.ts"))).map(error => error.replace(/^.*?:\d+: /, "")).sort(),
+  ).toEqual([
+    "Cannot find namespace 'GenericTypes'.",
+    "Cannot find namespace 'Page'.",
+    "Cannot find namespace 'Page'.",
+    "Cannot find namespace 'Process'.",
+  ]);
+});
 
 // An ES module and a CommonJS module, so Debugger.scriptParsed is sent for both script types.
 const fixtureFiles = ["entry.mjs", "dep.cjs"];
@@ -212,12 +379,13 @@ test("the protocol snapshot in packages/bun-inspector-protocol matches what bun 
       send("Debugger.setPauseOnDebuggerStatements", { enabled: true }),
     ]);
 
-    // Conversely, these domains are left out of the snapshot by generate-protocol.ts because bun has
-    // no agent for them. Once bun answers, remove the domain from the generator's list and regenerate.
-    for (const domain of ["File", "Process"]) {
+    // Conversely, bun has no agent for these domains: generate-protocol.ts leaves File and Process out
+    // of the snapshot for that reason, and holds only the types of the others. Once bun answers one of
+    // them, its commands belong in the snapshot: update the generator's list and regenerate.
+    for (const domain of ["File", "Process", ...typesOnlyDomains]) {
       const { error } = await request(`${domain}.enable`);
       if (error?.message !== `'${domain}' domain was not found`) {
-        problems.push(`${domain}: bun implements this domain, but generate-protocol.ts excludes it from the snapshot`);
+        problems.push(`${domain}: bun implements this domain, but the snapshot has none of its commands`);
       }
     }
 
@@ -237,20 +405,24 @@ test("the protocol snapshot in packages/bun-inspector-protocol matches what bun 
   }
 
   expect([...new Set(problems)]).toEqual([]);
-  // JavaScriptCore's own domains plus the agents bun registers in src/jsc/bindings/BunDebugger.cpp.
+  // JavaScriptCore's own domains, the agents bun registers in src/jsc/bindings/BunDebugger.cpp, and the
+  // domains those refer to the types of.
   expect(protocol.domains.map(domain => domain.domain)).toEqual([
     "Audit",
     "BunFrontendDevServer",
     "Console",
     "Debugger",
+    "GenericTypes",
     "Heap",
     "HTTPServer",
     "Inspector",
     "LifecycleReporter",
+    "Network",
     "Runtime",
     "ScriptProfiler",
     "TestReporter",
   ]);
+  expect(typesOnlyDomains).toEqual(["GenericTypes", "Network"]);
   expect(scriptTypes).toEqual({ "entry.mjs": "module", "dep.cjs": "program" });
   expect([...eventsSeen].sort()).toEqual(
     expect.arrayContaining([

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -31,6 +31,7 @@
     "../src/js/internal-for-testing.ts",
     "../scripts/glob-sources.ts",
     "../scripts/build/error.ts",
+    "../packages/bun-inspector-protocol/scripts/generate-protocol.ts",
     "bake/exit-code-map.mjs",
     "docker/prestart-map.mjs",
     "../src/runtime/bake/client/**.ts"


### PR DESCRIPTION
### Problem

- `packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts` refers to two namespaces it does not declare. `tsc --strict` on the file alone reports `error TS2503: Cannot find namespace 'Network'` at lines 313 (`Console.ConsoleMessage.networkRequestId`), 753 (`Debugger.ScriptParsedEvent.requestId`) and 2324 (`Runtime.ExecutionContextDescription.frameId`), and `Cannot find namespace 'GenericTypes'` at line 1153 (`Debugger.SearchInContentResponse.result`).
- Every consumer (`bun-debug-adapter-protocol`, `bun-vscode`) compiles with `skipLibCheck`, which suppresses errors inside `.d.ts` files, so nothing fails: those four properties silently have the error type (behaves like `any`) instead of `string` and `GenericTypes.SearchMatch[]`. None of the current consumers reads those four properties, so nothing is wrong for a user today; this matters for code that is about to be typed against the file (#39471 types `src/js/internal/inspector/cdp.ts` with it) and for every future regeneration after a WebKit bump, since any new cross-domain reference WebKit adds would dangle the same way and nothing would report it.
- Cause: `scripts/generate-protocol.ts` keeps only the domains of WebKit's `CombinedDomains.json` whose `debuggableTypes` include `"javascript"` (the `jsc` object at the bottom of the script) and `formatProperty` emits every `$ref` verbatim. `Network` is a web page domain and `GenericTypes` declares no `debuggableTypes` at all, so both are dropped, while `Console`, `Debugger` and `Runtime` keep referring to their types. Three of the four references predate #39110 (which regenerated the snapshot); `Debugger.ScriptParsedEvent.requestId` arrived with it.

### Fix

- `selectJscDomains` keeps a domain that declares no `debuggableTypes`, which is how WebKit's own frontend treats one (`InspectorBackend.activateDomain` activates such a domain for every debuggable type); `GenericTypes` is the only such domain in the pinned WebKit, and it comes in whole.
- `withReferencedTypes` walks every `$ref` of the selected domains (types, command parameters and returns, event parameters, through arrays and nested objects) and, for each domain that is not selected, emits a copy holding only the referenced types, following references inside those types in turn. For the pinned WebKit that is `Network` with `FrameId` and `RequestId`. The copy keeps the domain's `debuggableTypes` and gets a description saying what it is, so `protocol.json` documents why a domain with no commands is in it.
- This is the right shape because `index.d.ts` is a pure function of `protocol.json` and each `$ref` becomes a name in it, so a `protocol.json` that is closed under `$ref` gives a `.d.ts` that declares every name it uses, with the referenced types keeping their protocol names (`JSC.Network.RequestId`) rather than being inlined; nothing claimed by the snapshot changes, since the copies carry no commands or events and bun has no agent for either domain (the test checks that it still answers `'Network' domain was not found`).
- A `$ref` may also name a primitive: `Runtime.PropertyDescriptor.isPrivate` is `{"$ref": "boolean"}`, which WebKit's generator resolves through the primitives it predeclares (`models.py`, `resolve_types`). The walk leaves those alone instead of failing on them (`primitiveTypes`, documented on `$ref` in `schema.d.ts`; `schema.d.ts` also gains the `description` field the JSON already has on domains).
- The `--v8` path of the generator and the committed `v8/` files are left as they are: nothing exports or imports them (`src/protocol/index.d.ts` exports only `JSC`), they have not been regenerated since 2024, and `v8/index.d.ts` has the same kind of unresolved references (83 of them) by construction of its domain filter. Extending that path without being able to regenerate or test its output would add an unverified change to dead code; removing the path is the better follow-up, and is independent of this PR. The new tests cover the JSC snapshot only.
- Namespaces are now closed with `}` instead of `};`, so the generator's raw output is a valid `.d.ts` (a stray `;` is a statement, which ambient contexts reject); prettier was already removing them, so the committed files do not change because of this.
- The script's command line handling moved under `import.meta.main` so the test can import `formatProtocol` / `selectJscDomains` / `primitiveTypes` without side effects (`test/tsconfig.json` lists the file for the same reason it lists `scripts/build/error.ts`). Running the script is unchanged.
- Regenerated `jsc/protocol.json` and `jsc/index.d.ts`; the diff of both is exactly the added `GenericTypes` and `Network` entries. The generator is idempotent on the result, and the pinned WebKit's `CombinedDomains.json` is byte-identical to the one #39110 used, so nothing else moved.
- Tests, in `test/cli/inspect/bun-inspector-protocol.test.ts`:
  - every `$ref` in `protocol.json` resolves to a type in it; against the old snapshot it fails naming the four properties above (output below);
  - `selectJscDomains` on a small `CombinedDomains.json` keeps a `debuggableTypes`-less domain whole, a referenced web page domain and a referenced no-agent domain as just their referenced types (including a type reached only through a bare same-domain reference and one reached through a second domain), leaves an unreferenced domain out, tolerates a primitive `$ref`, and terminates on a type that refers to itself (without the already-visited check in the walk this test dies with `Maximum call stack size exceeded`; checked by removing it);
  - the committed `index.d.ts`, and the `.d.ts` generated from that fixture, type-check with `skipLibCheck` off, while the fixture's JavaScript domains on their own (what the generator used to emit) produce the `Cannot find namespace` errors; skipped in debug builds, where loading `typescript` alone takes about 25s;
  - the existing debugging-session test now reports an unresolvable `$ref` as a problem instead of skipping it, pins the domain list with the two new entries, and checks that bun has no agent for the domains the snapshot holds only the types of.
- Also fixes (separate commit) the flake the debugging-session test has had since it landed in #39110 (flagged in 8 of the 9 `main` builds since, and once on this PR): the fixture's `reportError` makes bun exit with code 1 as soon as the entry module finishes evaluating, i.e. right after `Debugger.resume`, and that exit raced the delivery of the resume response and the `Debugger.resumed` event (`WebSocket closed (1006) (inspectee exit: 1)`). The fixture now has a second `debugger` statement, so the inspectee pauses again right after resuming and the session is closed while it is paused; 20 of 160 runs failed before under 16-way parallel load, 0 of 160 after.
- Verified: `bun bd test test/cli/inspect/bun-inspector-protocol.test.ts` passes (3 pass, 1 skip); `USE_SYSTEM_BUN=1 bun test` on it passes all 4; with `packages/` stashed the file fails; `./node_modules/.bin/tsc --ignoreConfig --noEmit --strict --target esnext packages/bun-inspector-protocol/src/protocol/jsc/index.d.ts` exits 0 (4 errors before); `tsc` on `bun-inspector-protocol`, `bun-debug-adapter-protocol` and `bun-vscode` reports the same pre-existing errors before and after (1, 5 and 1), and no consumer uses the four affected properties; `cd test && tsc --noEmit` has one error fewer than before (the `TS6307` that importing the script would otherwise add) and none in the touched files.

### Background

- Inspector protocol: the JSON-RPC style protocol behind `bun --inspect`, split into domains (`Debugger`, `Runtime`, ...) that declare types, commands and events. WebKit defines each domain in `Source/JavaScriptCore/inspector/protocol/<Domain>.json` and its build concatenates them into `CombinedDomains.json`, which is what the generator reads (from the prebuilt WebKit in the build cache after `bun bd`).
- `debuggableTypes`: the per-domain list of the kinds of target a domain applies to (`javascript` for a JSContext such as a bun process, `web-page`, `service-worker`, ...). The generator uses it to pick bun's domains. A domain may omit it, which WebKit reads as "all of them".
- `$ref`: how a property in those JSON files names a declared type instead of spelling out a primitive: bare (`RemoteObject`, a type of the same domain), qualified (`Network.RequestId`), or, rarely, a primitive name. Domains reference each other freely because WebKit's C++ generator always builds all domains together; only this package selects a subset.
- `bun-inspector-protocol` snapshot: `protocol.json` is the selected subset of `CombinedDomains.json`; `index.d.ts` is generated from it as one namespace per domain (`JSC.Console.ConsoleMessage`, ...), with each `$ref` emitted as written, so a reference to a domain outside the subset becomes a reference to a namespace that does not exist.
- `skipLibCheck`: a tsc option that skips type-checking the bodies of `.d.ts` files. With it on, an undeclared name inside a `.d.ts` is not reported; the property just gets the error type, which is assignable to and from anything.

<details>
<summary>New tests against the old generated files</summary>

```
(fail) every type the snapshot refers to is in the snapshot
  + "Console.ConsoleMessage.networkRequestId: Network.RequestId",
  + "Debugger.searchInContent returns result[]: GenericTypes.SearchMatch",
  + "Debugger.scriptParsed parameter requestId: Network.RequestId",
  + "Runtime.ExecutionContextDescription.frameId: Network.FrameId",

(fail) the generated index.d.ts type-checks without skipLibCheck
  + "index.d.ts:313: Cannot find namespace 'Network'.",
  + "index.d.ts:753: Cannot find namespace 'Network'.",
  + "index.d.ts:1153: Cannot find namespace 'GenericTypes'.",
  + "index.d.ts:2324: Cannot find namespace 'Network'.",

(fail) the protocol snapshot in packages/bun-inspector-protocol matches what bun sends
  domain list lacks "GenericTypes" and "Network"
```

With the old generator script as well, the file fails to load: `Export named 'formatProtocol' not found`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/bun-inspector-protocol.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/172] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 242 extern-C blocks audited
[2/172] gen cpp.rs (cppbind)
[3/172] gen BunProcess.lut.h
Generating /workspace/bun/build/debug/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/172] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFi
... (truncated)

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (8326d1bd3)

test/cli/inspect/bun-inspector-protocol.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'formatProtocol' not found in module '/workspace/bun/packages/bun-inspector-protocol/scripts/generate-protocol.ts'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [168.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/inspect/bun-inspector-protocol.test.ts
bun test v1.4.0 (8326d1bd3)

test/cli/inspect/bun-inspector-protocol.test.ts:
(pass) every type the snapshot refers to is in the snapshot [92.69ms]
(pass) generate-protocol.ts carries along the types that the JavaScript domains refer to in other domains [489.53ms]
(skip) the generated index.d.ts type-checks without skipLibCheck
(pass) the protocol snapshot in packages/bun-inspector-protocol matches what bun sends [914.96ms]

 3 pass
 1 skip
 0 fail
 7 expect() calls
Ran 4 tests across 1 file. [3.95s]
__F:0:S:1

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 678ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/130] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/130] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/130] gen cpp.rs (cppbind)
[4/130] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes f
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../scripts/generate-protocol.ts                   | 193 ++++++++++++++-----
 .../src/protocol/jsc/index.d.ts                    |  25 +++
 .../src/protocol/jsc/protocol.json                 |  40 ++++
 .../src/protocol/schema.d.ts                       |   5 +
 test/cli/inspect/bun-inspector-protocol.test.ts    | 214 +++++++++++++++++++--
 test/tsconfig.json                                 |   1 +
 6 files changed, 415 insertions(+), 63 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…ges/bun-inspector-protocol/scripts/generate-protocol.ts      7     12      0
…ages/bun-inspector-protocol/src/protocol/jsc/index.d.ts      0      0      0
…s/bun-inspector-protocol/src/protocol/jsc/protocol.json      0      0      0
packages/bun-inspector-protocol/src/protocol/schema.d.ts      1      3      0
test/cli/inspect/bun-inspector-protocol.test.ts              12     19      0
test/tsconfig.json                                            1      1      0
```

</details>

<!-- robobun:evidence:end -->