### PR TITLE
Bump WebKit to eeab04040fa6 (URLParser: SIMD scan for Unicode/percent-encoded hosts)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-455-8fc20b18";
+export const WEBKIT_VERSION = "eeab04040fa61fd595695980f9d054b7fc0ed855";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
Pins WebKit to oven-sh/WebKit@eeab04040fa6 = the upstream `47f7250137c6` upgrade (oven-sh/WebKit#455) **plus** oven-sh/WebKit#463 (URLParser: SIMD scan for percent-encoded/Unicode hosts, SIMD forbidden-host check, surrogate validation only when needed — IDN URLs 8176 → 7867 instr/URL).

Stacked on #39371 (the Bun side of the upstream upgrade — `HandleSet.h` removal etc.), since #463 landed after #455 in oven-sh/WebKit; this PR's own diff is just the pin. GitHub will retarget it to `main` when #39371 merges. The `autobuild-eeab0404…` release is already published (42 assets).