### PR TITLE
bun build: error when --outdir and --outfile are both passed

### DIFF
--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2462,6 +2462,11 @@ fn parse_build_command_options(
         ctx.bundler_options.windows.copyright = Some(copyright.into());
     }
 
+    if args.option(b"--outdir").is_some() && args.option(b"--outfile").is_some() {
+        Output::err_generic("cannot use both --outdir and --outfile", ());
+        Global::crash();
+    }
+
     if let Some(outdir) = args.option(b"--outdir") {
         if !outdir.is_empty() {
             ctx.bundler_options.outdir = outdir.into();

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -516,6 +516,22 @@ describe("CLI argument error messages", () => {
     expect(stderr).toContain("key=value");
     expect(exitCode).toBe(1);
   });
+
+  test("--outdir together with --outfile errors instead of silently dropping --outfile", async () => {
+    using dir = tempDir("build-outdir-outfile-err", { "main.ts": "export const x = 1;" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "main.ts", "--outdir=dist", "--outfile=myfile.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("cannot use both --outdir and --outfile");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+    expect(fs.existsSync(path.join(String(dir), "dist"))).toBe(false);
+  });
 });
 
 describe.concurrent("modules that fail to print", () => {

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -529,8 +529,8 @@ describe("CLI argument error messages", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("cannot use both --outdir and --outfile");
     expect(stdout).toBe("");
-    expect(exitCode).toBe(1);
     expect(fs.existsSync(path.join(String(dir), "dist"))).toBe(false);
+    expect(exitCode).toBe(1);
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

Fixes #21406. `bun build main.ts --outdir=dist --outfile=myfile.js` wrote `dist/main.js` and exited 0. `--outfile` was silently dropped, with no warning.

`parse_build_command_options` reads the two flags as a single `if let Some(outdir) ... else if let Some(outfile)` chain (`Arguments.rs:2470`, unchanged by this PR), so `--outfile` is only ever looked at when `--outdir` is absent. Nothing downstream can tell that the flag was passed, so there is no later point where a diagnostic could be produced.

The two flags are mutually exclusive by design. One names a directory bun picks filenames inside, the other names a single output file. So the pair is now rejected before either one is stored:

```console
$ bun build main.ts --outdir=dist --outfile=myfile.js
error: cannot use both --outdir and --outfile
```

This matches esbuild, which errors with `Cannot use both "outfile" and "outdir"`, and it matches the neighbouring check at `build_command.rs:305` that already refuses `--compile` together with `--outdir`.

This redoes PR #21442 by RiskyMH against the Rust tree. That PR made the same change in `src/cli/Arguments.zig` and was closed as stale in June with "this PR predates the Rust rewrite ... if the underlying change is still wanted, it will need to be redone against the current Rust/C++ tree". Same message text, same test file.

Five things worth a look in review:

- The check is on flag presence, not on flag value, so `--outdir= --outfile=x.js` errors too. That is what esbuild does and it keeps the rule to one sentence.
- Only `bun build` is affected. `parse_build_command_options` runs behind `cmd == CommandTag::BuildCommand` (`Arguments.rs:1517`), so `bun test --reporter-outfile` and the other commands that read an outfile-shaped flag are untouched.
- The check reads the flag table only, so a `[bundle] outdir` in bunfig.toml (`bunfig.rs:855`) cannot trigger it. Only passing both flags on the command line does.
- `--compile --outdir x --outfile y` previously reached `cannot use --compile with --outdir`. It now stops one step earlier with the new message. Still an error, still exit 1.
- The issue also floated inferring `<outdir>/<outfile>` for a single entry point. I did not do that. It would make `--outfile` mean a path relative to `--outdir` in one case and a path relative to cwd in another, and it has no answer for multiple entry points. Erroring is the option the issue lists first and the one esbuild takes.

### How did you verify your code works?

Debug build (`bun bd`) on Linux x64, branch based on `4fa055c323`.

**1. Reproduced it first.** On the debug build before the fix:

```console
$ cat main.ts
export const x = 1;
$ bun build main.ts --outdir=dist --outfile=myfile.js
Bundled 1 module in 1553ms

  main.js  57 bytes  (entry point)

$ echo $?
0
$ ls dist
main.js
```

No `myfile.js` anywhere, exit 0, nothing printed about `--outfile`.

**2. The new test fails without the fix.** Against the released 1.3.14:

```console
$ USE_SYSTEM_BUN=1 bun test test/bundler/cli.test.ts -t "outdir together"
error: expect(received).toContain(expected)

Expected to contain: "cannot use both --outdir and --outfile"
Received: ""
(fail) CLI argument error messages > --outdir together with --outfile errors instead of silently dropping --outfile
 0 pass
 1 fail
```

**3. With the fix.**

```console
$ bun bd test test/bundler/cli.test.ts --timeout 120000
 20 pass
 2 skip
 0 fail
Ran 22 tests across 1 file. [21.56s]
```

The raised timeout is not hiding anything. At the default 5000 ms this file has 13 failures on a debug ASAN build on this machine, every one of them `this test timed out after 5000ms`, including tests that never touch either flag. Each `--compile` case alone takes 20 to 53 seconds to link here.

**4. Every combination of the two flags, by hand.**

| command | before | after |
| --- | --- | --- |
| `--outdir=dist --outfile=myfile.js` | writes `dist/main.js`, exit 0 | `error: cannot use both --outdir and --outfile`, exit 1, no `dist` created |
| `--outdir=dist` | `dist/main.js`, exit 0 | unchanged |
| `--outfile=myfile.js` | `myfile.js`, exit 0 | unchanged |
| neither | prints to stdout | unchanged |
| `--compile --outfile=mybin` | writes `mybin`, exit 0 | unchanged |
| `--compile --outdir=dist` | `error: cannot use --compile with --outdir` | unchanged |
| `--compile --outdir=dist --outfile=mybin` | `error: cannot use --compile with --outdir` | `error: cannot use both --outdir and --outfile` |

`test/bundler/expectBundled.ts:797` and `:847` already choose one flag or the other with a ternary, and a grep over the repo finds no command line anywhere that passes both, so nothing existing exercised the combination.

I also ran the bunfig case rather than only reading the code for it. With `[bundle] outdir = "fromconfig"` in `bunfig.toml` and `--outfile=my.js` on the command line, the build still succeeds and writes `my.js`, unchanged by this PR. bunfig's `outdir` lands in `ctx.args.output_dir` and never enters the flag table the new check reads.

**5. Lints.** All clean.

```console
$ cargo fmt --all --check
$ echo $?
0

$ bun run lint
$ oxlint --config=oxlint.json --format=github src/js
Found 0 warnings and 0 errors.
Finished in 9.9s on 203 files with 88 rules using 8 threads.

$ bunx prettier --check test/bundler/cli.test.ts
Checking formatting...
All matched files use Prettier code style!

$ bun bd test test/internal/source-lints/ --timeout 120000
 170 pass
 0 fail
Ran 170 tests across 24 files. [5212.16s]

$ cargo clippy -p bun_runtime --no-deps
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 12m 05s
$ echo $?
0

$ bun run rust:clippy
$ cargo clippy --workspace --no-deps --keep-going
$ echo $?
0
```
