### PR TITLE
Always create the error when a native error message exceeds the string length limit

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -302,10 +302,6 @@ impl JSGlobalObject {
 
     pub fn throw_todo(&self, msg: &[u8]) -> JsError {
         let err = EncodedSlice::utf8(msg).to_error_instance(self);
-        if err.is_empty() {
-            debug_assert!(self.has_exception());
-            return JsError::Thrown;
-        }
         let name_value = match BunString::static_("TODOError").to_js(self) {
             Ok(v) => v,
             Err(_) => return JsError::Thrown,
@@ -787,10 +783,6 @@ impl JSGlobalObject {
 
     pub fn throw_sys_error(&self, opts: &SysErrOptions, message: Arguments<'_>) -> JsError {
         let err = self.create_error_instance(message);
-        if err.is_empty() {
-            debug_assert!(self.has_exception());
-            return JsError::Thrown;
-        }
         err.put(
             self,
             b"code",
@@ -810,12 +802,7 @@ impl JSGlobalObject {
     /// Note: If you are throwing an error within somewhere in the Bun API,
     /// chances are you should be using `.err(...).throw()` instead.
     pub fn throw(&self, args: Arguments<'_>) -> JsError {
-        let instance = self.create_error_instance(args);
-        if instance.is_empty() {
-            debug_assert!(self.has_exception());
-            return JsError::Thrown;
-        }
-        self.throw_value(instance)
+        self.throw_value(self.create_error_instance(args))
     }
 
     /// Queue a native callback as a microtask. Callers supply the C-ABI

--- a/src/jsc/bindings/BunString.cpp
+++ b/src/jsc/bindings/BunString.cpp
@@ -144,10 +144,8 @@ static WTF::String errorMessage(const BunString* str)
 extern "C" JSC::EncodedJSValue BunString__toErrorInstance(const BunString* str, JSC::JSGlobalObject* globalObject, BunErrorKind kind)
 {
     WTF::String message = errorMessage(str);
-    if (message.isNull() && !str->isEmpty()) [[unlikely]] {
-        // Allocation failed or the message exceeds the maximum string length.
-        return {};
-    }
+    if (message.isNull() && (str->tag == BunStringTag::Dead || !str->isEmpty())) [[unlikely]]
+        message = "The error message exceeds the maximum string length"_s;
     JSC::JSObject* result = nullptr;
     switch (kind) {
     case BunErrorKind::Error:

--- a/test/js/bun/util/native-error-message-too-long.test.ts
+++ b/test/js/bun/util/native-error-message-too-long.test.ts
@@ -1,0 +1,133 @@
+// Errors built from a natively formatted message that is longer than the
+// string length limit. The error object must still be created, with a stand-in
+// message: it used to come back as an empty value, so a failing expect() was
+// reported as passing, and the process crashed when the creator then set
+// properties on it or when JS touched the thrown value.
+//
+// Each case runs in its own process: setSyntheticAllocationLimitForTesting is
+// process-wide (floor 1 MiB), and the unfixed cases crash.
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const FALLBACK = "The error message exceeds the maximum string length";
+const LIMIT = 1024 * 1024;
+
+// Shared by every fixture: lowers the limit, and `caught(fn)` reports what `fn`
+// throws. Fixtures print one JSON line, which `run` returns as `report`.
+const prelude = /* ts */ `
+import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
+setSyntheticAllocationLimitForTesting(${LIMIT});
+const LIMIT = ${LIMIT};
+async function caught(fn) {
+  try {
+    await fn();
+  } catch (e) {
+    return { name: e.name, message: e.message };
+  }
+  return "did not throw";
+}
+`;
+
+async function run(files: Record<string, string>, ...cmd: string[]) {
+  using dir = tempDir("native-error-too-long", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...cmd],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // `bun test` prints its version banner to stdout ahead of the fixture's line.
+  // A crashed fixture prints nothing; report the whole run instead so the
+  // assertion failure shows what happened.
+  const line = stdout.split("\n").find(l => l.startsWith("{") || l.startsWith("["));
+  const report = line ? JSON.parse(line) : { stdout, stderr, exitCode };
+  return { report, stderr, exitCode };
+}
+
+describe.concurrent("native error whose message exceeds the string length limit", () => {
+  test("failing expect() throws an Error and bun test reports the failure", async () => {
+    const { report, stderr, exitCode } = await run(
+      {
+        "fixture.test.ts": /* ts */ `
+          ${prelude}
+          import { expect, test } from "bun:test";
+
+          // expect(value, label) starts the failure message with the label verbatim,
+          // so the message is label.length + suffix characters long.
+          const suffix = (await caught(() => expect(1, "L").toBe(2))).message.length - 1;
+          const longest = Buffer.alloc(LIMIT - suffix, "a").toString();
+          const tooLong = Buffer.alloc(LIMIT - suffix + 1, "a").toString();
+          // Fits in a string by itself; the failure message quoting it does not.
+          const big = Buffer.alloc(LIMIT - 16, "a").toString();
+
+          const results = {};
+          test("message exactly at the limit is kept", async () => {
+            const { name, message } = await caught(() => expect(1, longest).toBe(2));
+            results.atLimit = { name, length: message.length, startsWithLabel: message.startsWith(longest) };
+          });
+          test("message one past the limit", async () => {
+            results.onePast = await caught(() => expect(1, tooLong).toBe(2));
+          });
+          test("rendered received value takes the message past the limit", async () => {
+            results.renderedValue = await caught(() => expect(() => big).toThrow());
+            console.log(JSON.stringify(results));
+          });
+          test("uncaught", () => {
+            expect(1, tooLong).toBe(2);
+          });
+        `,
+      },
+      "test",
+      "fixture.test.ts",
+    );
+
+    expect(report).toEqual({
+      atLimit: { name: "Error", length: LIMIT, startsWithLabel: true },
+      onePast: { name: "Error", message: FALLBACK },
+      renderedValue: { name: "Error", message: FALLBACK },
+    });
+    expect(stderr).toContain(`error: ${FALLBACK}`);
+    expect(stderr).toContain("(fail) uncaught");
+    expect(stderr).toContain(" 3 pass\n");
+    expect(stderr).toContain(" 1 fail\n");
+    expect(exitCode).toBe(1);
+  });
+
+  test("Bun.listen, which sets properties on the error before throwing it, throws instead of crashing", async () => {
+    const { report, exitCode } = await run(
+      {
+        "listen.ts": /* ts */ `
+          ${prelude}
+          const unix = Buffer.alloc(LIMIT - 16, "a").toString();
+          console.log(JSON.stringify(await caught(() => Bun.listen({ unix, socket: { data() {} } }))));
+        `,
+      },
+      "listen.ts",
+    );
+
+    expect(report).toEqual({ name: "Error", message: FALLBACK });
+    expect(exitCode).toBe(0);
+  });
+
+  test("SyntaxError from Bun.JSONC.parse keeps its type and gets the fallback message", async () => {
+    const { report, exitCode } = await run(
+      {
+        "jsonc.ts": /* ts */ `
+          ${prelude}
+          const big = Buffer.alloc(LIMIT - 16, "a").toString();
+          console.log(JSON.stringify([await caught(() => Bun.JSONC.parse(big)), await caught(() => Bun.JSONC.parse("bbb"))]));
+        `,
+      },
+      "jsonc.ts",
+    );
+
+    expect(report).toEqual([
+      { name: "SyntaxError", message: FALLBACK },
+      { name: "SyntaxError", message: "JSONC Parse error: Unexpected bbb" },
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem

- A native error whose formatted message is longer than the string length limit is never created. In a release build a failing `expect()` whose failure message is over the limit reports as `(pass)`; a debug build panics with `assertion failed: self.has_exception()` in `JSGlobalObject::throw` (`src/jsc/JSGlobalObject.rs:815` on main), reached from `Expect::throw_rendered`.
- Same cause, different callers: `Bun.listen({ unix })` with a path whose "Failed to listen at ..." message is over the limit segfaults in release (`Segmentation fault at address 0x5`) and trips UBSan in debug (`bindings.cpp: member call on null pointer of type 'JSC::JSCell'`), because `src/runtime/socket/Listener.rs:504` creates the error and then `put`s `syscall`/`errno`/`address` on it. `Bun.JSONC.parse` of a ~1 MiB token throws the empty value itself (debug aborts on `ASSERT(!value.isEmpty())` in `JSC__VM__throwError`).
- Cause: `BunString__toErrorInstance` (`src/jsc/bindings/BunString.cpp:144` on main), the one C++ entry behind `create_error_instance`, `EncodedSlice::to_*_error_instance` and `String::to_*_error_instance` for all four error kinds, converts the message with `Zig::toStringCopy` / `toWTFString`, which return a null `WTF::String` when the text is longer than `Bun__stringSyntheticAllocationLimit` / `WTF::String::MaxLength` (or the copy fails to allocate). It then returned an empty `JSValue`. Nothing on that path throws, so `JSGlobalObject::throw` turned it into `JsError::Thrown` with no exception pending, and native code unwound as if it had thrown while JS observed nothing. The other callers (dozens of sites: promise rejections, callbacks, `put` on the result) assume they got an object.
- Reachable in practice through the 1 MiB floor of `setSyntheticAllocationLimitForTesting` (tests using it could silently pass) and, without it, through any message over 2^31 characters (#37310 hit this with a rendered happy-dom tree).

### Fix

- `BunString__toErrorInstance` always creates the error. When the message conversion came back null for a non-empty (or `Dead`, i.e. already failed to allocate) source, the error carries `"The error message exceeds the maximum string length"` instead. Name, type and the properties callers add afterwards (`code`, `errno`, `syscall`, ...) are unaffected; a message under the limit is byte-for-byte unchanged.
- Why a stand-in message rather than throwing or truncating: this is a constructor, not a throwing entry point, and its callers unconditionally throw, reject with, or decorate the result, so the only contract that makes every caller correct is "an error object always comes back" (the reasoning `ErrorCodeCache::createError` already documents for the `ErrorCode` path). Truncating here would mean materializing a message of up to 2 GiB; bounding rendered values belongs to the producer (#34179 and #37311 do that for `expect()` and remain useful independently; with this change the `throw()`-site fallback in #37311 becomes unreachable). For comparison, Node surfaces the analogous case (an `assert` message that overflows V8's string limit) as `RangeError: Invalid string length`, so the failure is still reported there as well; here the original error type and properties are kept.
- `JSGlobalObject.rs`: the `is_empty()` / `debug_assert!(has_exception())` branches in `throw`, `throw_sys_error` and `throw_todo` are deleted; the constructor can no longer return an empty value. `JSC__VM__throwError` still asserts a non-empty value in debug builds if that ever regresses.
- Intentionally not changed: `systemErrorToErrorInstance`, `Bun__createErrorWithCode` and the two `createAggregateError` helpers already always return an object, and their messages are `WTF`-backed strings built by `BunString::create_format`, so a missing message there needs a `Dead` string, i.e. a message over 2^31 characters, which the testing limit cannot reach. `EncodedSlice__toDOMExceptionInstance` is also left alone: `createDOMException` gives an empty message its own meaning per exception code (default texts; `InvalidURLError` stores the message as `.input`), so a stand-in string would be wrong there.
- Test: `test/js/bun/util/native-error-message-too-long.test.ts`, one subprocess per case since the limit is process-wide and the unfixed cases crash:
  - `expect()`: a failure message of exactly the limit is kept intact, one character past it gets the fallback, a rendered received value past the limit gets the fallback, and an uncaught one is reported by `bun test` as `(fail)` with `error: The error message exceeds the maximum string length` (exit code 1).
  - `Bun.listen` throws the Error instead of crashing.
  - `Bun.JSONC.parse` throws a `SyntaxError` with the fallback; a normal-sized parse error message is unchanged.
- Verified: every case fails on main in a debug build without the `src/` changes (UBSan null member call, abort, panic) and on the last release canary, and all pass with them. Also ran `expect-label`, `expect-unreaachable`, `plugins.test.ts`, `socketaddress.spec.ts` (covers `throw_sys_error`), `jsonc`, `error-name-preservation`: all pass.

### Background

- `BunString` / `bun_core::String`: the tagged string shared between Rust and C++. A `WTFStringImpl` tag shares an existing JSC string, `EncodedSlice` borrows Rust bytes (with encoding bits in the pointer) and is copied on the way in, `Dead` means a creation already failed. `create_error_instance` and friends format a Rust message into a buffer and hand it over as a UTF-8 `EncodedSlice`.
- String length limit: `WTF::String::MaxLength` is 2^31 - 1 code units. `Bun__stringSyntheticAllocationLimit` is a process-wide lower cap that `bun:internal-for-testing`'s `setSyntheticAllocationLimitForTesting` can set down to 1 MiB so tests can exercise the too-long paths without allocating gigabytes; `Zig::toStringCopy` honours both for `EncodedSlice` input.
- `JsError::Thrown`: the Rust-side marker meaning "a JS exception is now pending in the VM"; host functions return it and the thunk hands control back to JSC expecting `vm.exception()` to be set. Returning it with nothing pending is how the throw was lost.
- `JSValue::empty()` (Rust `JSValue::ZERO`): JSC's "no value" sentinel, not a JS value; using it as one (`put`, throwing it, `await`ing it) dereferences null.

<details><summary>Notes</summary>

The first revision of this PR predates the consolidation of the error constructors into `BunString__toErrorInstance` (the `ZigString` rename and the removal of `Zig::get*ErrorInstance`). It fixed the same defect in `helpers.h` for the four per-type helpers plus `createAggregateError`, whose message then arrived as a `ZigString` and was reachable through the testing limit; on current main that message is a `WTF`-backed string and the site is covered by the exclusion above. The branch was rebuilt on top of main rather than rebased, so the diff is the one described here.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/native-error-message-too-long.test.ts
bun test v1.4.1 (861e9ae04)

test/js/bun/util/native-error-message-too-long.test.ts:
106 |         `,
107 |       },
108 |       "listen.ts",
109 |     );
110 | 
111 |     expect(report).toEqual({ name: "Error", message: FALLBACK });
                         ^
error: expect(received).toEqual(expected)

  {
-   "message": "The error message exceeds the maximum string length",
-   "name": "Error",
+   "exitCode": 1,
+   "stderr": 
+ "../../src/jsc/bindings/bindings.cpp:4169:70: runtime error: member call on null pointer of type 'JSC::JSCell'
+ SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../../src/jsc/bindings/bindings.cpp:4169:70 
+ "
+ ,
+   "stdout": "",
  }

- Expected  - 2
+ Received  + 7

      at <anonymous> (/workspace/bun/test/js/bun/util/native-error-message-too-long.test.ts:111:20)
(fail) native error whose message exceeds the string length limit > Bun.listen, which sets properties on the error before throwing it, throws instead of crashing [2227.49ms]
122 |    
... (truncated)

release without fix: 3 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/js/bun/util/native-error-message-too-long.test.ts:
122 |         `,
123 |       },
124 |       "jsonc.ts",
125 |     );
126 | 
127 |     expect(report).toEqual([
                         ^
error: expect(received).toEqual(expected)

  [
    {
-     "message": "The error message exceeds the maximum string length",
+     "message": "",
      "name": "SyntaxError",
    },
    {
      "message": "JSONC Parse error: Unexpected bbb",
      "name": "SyntaxError",
    },
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/util/native-error-message-too-long.test.ts:127:20)
(fail) native error whose message exceeds the string length limit > SyntaxError from Bun.JSONC.parse keeps its type and gets the fallback message [45.31ms]
106 |         `,
107 |       },
108 |       "listen.ts",
109 |     );
110 | 
111 |     expect(report).toEqual({ name: "Error", message: FALLBACK });
                         ^
error: expect(received).toEqual(expected)

  {
-   "message": "The error message exceeds the maximum string length",
-   "name": "Error",
+   "exitCode": 139,
+   "stderr": 
+ "===========================
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/native-error-message-too-long.test.ts
bun test v1.4.1 (861e9ae04)

test/js/bun/util/native-error-message-too-long.test.ts:
(pass) native error whose message exceeds the string length limit > Bun.listen, which sets properties on the error before throwing it, throws instead of crashing [1783.80ms]
(pass) native error whose message exceeds the string length limit > SyntaxError from Bun.JSONC.parse keeps its type and gets the fallback message [1890.52ms]
(pass) native error whose message exceeds the string length limit > failing expect() throws an Error and bun test reports the failure [3153.53ms]

 3 pass
 0 fail
 10 expect() calls
Ran 3 tests across 1 file. [6.27s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     732b669b83
  features     baseline

23 deps, 129 codegen, 1172 objects in 968ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (861e9ae04)

Checked 26 installs across 63 packages (no changes) [6.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (861e9ae04)

Checked 1 install across 2 packages (no changes) [3.00ms]
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (861e9ae04)

Checked 111 installs across 104 packages (no changes) [9.00ms]
[6/1244] gen .bind.ts → GeneratedBindings.cpp
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 16ms

  react-refresh.js  4.81 KB  (entry point)

[9/1217] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSGlobalObject.rs                          |  15 +--
 src/jsc/bindings/BunString.cpp                     |   6 +-
 .../bun/util/native-error-message-too-long.test.ts | 133 +++++++++++++++++++++
 3 files changed, 136 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/jsc/JSGlobalObject.rs                                   7      8      0
src/jsc/bindings/BunString.cpp                              3      1      0
test/js/bun/util/native-error-message-too-long.test.ts      4      8      0
```

</details>

<!-- robobun:evidence:end -->