### PR TITLE
napi: export uv_tty_reset_mode on posix

### DIFF
--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -44,6 +44,8 @@ int uv__tcsetattr(int fd, int how, const struct termios* term)
 
 // Part of the uv_* surface napi addons link against (see uv-posix-polyfills.c).
 // Listing it in linker.lds/symbols.txt is not enough under -fvisibility=hidden.
+// Like every uv_* function, it reports failure as a negative errno (UV_E*);
+// uv__tcsetattr() above returns a positive one for ttySetMode()'s callers.
 extern "C" BUN_EXPORT int uv_tty_reset_mode(void)
 {
     int saved_errno;
@@ -52,11 +54,11 @@ extern "C" BUN_EXPORT int uv_tty_reset_mode(void)
     saved_errno = errno;
 
     if (atomic_exchange(&orig_termios_spinlock, 1))
-        return 16; // UV_EBUSY; /* In uv_tty_set_mode(). */
+        return -EBUSY; // UV_EBUSY: a ttySetMode() is taking the snapshot.
 
     err = 0;
     if (orig_termios_fd != -1)
-        err = uv__tcsetattr(orig_termios_fd, TCSANOW, &orig_termios);
+        err = -uv__tcsetattr(orig_termios_fd, TCSANOW, &orig_termios);
 
     atomic_store(&orig_termios_spinlock, 0);
     errno = saved_errno;

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -42,10 +42,6 @@ int uv__tcsetattr(int fd, int how, const struct termios* term)
     return 0;
 }
 
-// Part of the uv_* surface napi addons link against (see uv-posix-polyfills.c).
-// Listing it in linker.lds/symbols.txt is not enough under -fvisibility=hidden.
-// Like every uv_* function, it reports failure as a negative errno (UV_E*);
-// uv__tcsetattr() above returns a positive one for ttySetMode()'s callers.
 extern "C" BUN_EXPORT int uv_tty_reset_mode(void)
 {
     int saved_errno;
@@ -54,11 +50,11 @@ extern "C" BUN_EXPORT int uv_tty_reset_mode(void)
     saved_errno = errno;
 
     if (atomic_exchange(&orig_termios_spinlock, 1))
-        return -EBUSY; // UV_EBUSY: a ttySetMode() is taking the snapshot.
+        return -EBUSY; // UV_EBUSY, ttySetMode() is taking the snapshot
 
     err = 0;
     if (orig_termios_fd != -1)
-        err = -uv__tcsetattr(orig_termios_fd, TCSANOW, &orig_termios);
+        err = -uv__tcsetattr(orig_termios_fd, TCSANOW, &orig_termios); // UV__ERR(errno)
 
     atomic_store(&orig_termios_spinlock, 0);
     errno = saved_errno;

--- a/src/jsc/bindings/wtf-bindings.cpp
+++ b/src/jsc/bindings/wtf-bindings.cpp
@@ -42,7 +42,9 @@ int uv__tcsetattr(int fd, int how, const struct termios* term)
     return 0;
 }
 
-extern "C" int uv_tty_reset_mode(void)
+// Part of the uv_* surface napi addons link against (see uv-posix-polyfills.c).
+// Listing it in linker.lds/symbols.txt is not enough under -fvisibility=hidden.
+extern "C" BUN_EXPORT int uv_tty_reset_mode(void)
 {
     int saved_errno;
     int err;

--- a/test/napi/uv-stub-stuff/uv_impl.c
+++ b/test/napi/uv-stub-stuff/uv_impl.c
@@ -131,6 +131,16 @@ static napi_value test_hrtime(napi_env env, napi_callback_info info) {
   return obj;
 }
 
+// Test uv_tty_reset_mode, the one implemented uv_* function that lives in bun's
+// C++ (wtf-bindings.cpp) instead of uv-posix-polyfills.c, so the one that can
+// end up missing from bun's export table. Referenced directly, like a real
+// addon would.
+static napi_value test_tty_reset_mode(napi_env env, napi_callback_info info) {
+  napi_value ret;
+  napi_create_int32(env, uv_tty_reset_mode(), &ret);
+  return ret;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   // Register all test functions
   napi_value fn;
@@ -152,6 +162,9 @@ napi_value Init(napi_env env, napi_value exports) {
 
   napi_create_function(env, NULL, 0, test_hrtime, NULL, &fn);
   napi_set_named_property(env, exports, "testHrtime", fn);
+
+  napi_create_function(env, NULL, 0, test_tty_reset_mode, NULL, &fn);
+  napi_set_named_property(env, exports, "testTtyResetMode", fn);
 
   return exports;
 }

--- a/test/napi/uv-stub-stuff/uv_impl.c
+++ b/test/napi/uv-stub-stuff/uv_impl.c
@@ -1,5 +1,6 @@
 #include <node_api.h>
 
+#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
@@ -141,6 +142,51 @@ static napi_value test_tty_reset_mode(napi_env env, napi_callback_info info) {
   return ret;
 }
 
+// uv_tty_reset_mode() holds its lock across the tcsetattr() that restores the
+// snapshot, so two threads calling it back to back collide constantly once a
+// snapshot exists. Every result must be 0 or UV_EBUSY; "busy" says how many
+// collisions this run happened to produce.
+#define TTY_RESET_ITERATIONS 4000
+
+static pthread_mutex_t tty_reset_counts = PTHREAD_MUTEX_INITIALIZER;
+static int tty_reset_busy;
+static int tty_reset_unexpected;
+
+static void *tty_reset_hammer(void *arg) {
+  for (int i = 0; i < TTY_RESET_ITERATIONS; i++) {
+    int result = uv_tty_reset_mode();
+    if (result == 0) continue;
+    pthread_mutex_lock(&tty_reset_counts);
+    if (result == UV_EBUSY)
+      tty_reset_busy++;
+    else
+      tty_reset_unexpected++;
+    pthread_mutex_unlock(&tty_reset_counts);
+  }
+  return NULL;
+}
+
+static napi_value test_tty_reset_mode_concurrent(napi_env env,
+                                                 napi_callback_info info) {
+  pthread_t thread;
+  tty_reset_busy = 0;
+  tty_reset_unexpected = 0;
+  if (pthread_create(&thread, NULL, tty_reset_hammer, NULL) != 0) {
+    napi_throw_error(env, NULL, "pthread_create failed");
+    return NULL;
+  }
+  tty_reset_hammer(NULL);
+  pthread_join(thread, NULL);
+
+  napi_value obj, busy, unexpected;
+  napi_create_object(env, &obj);
+  napi_create_int32(env, tty_reset_busy, &busy);
+  napi_create_int32(env, tty_reset_unexpected, &unexpected);
+  napi_set_named_property(env, obj, "busy", busy);
+  napi_set_named_property(env, obj, "unexpected", unexpected);
+  return obj;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   // Register all test functions
   napi_value fn;
@@ -165,6 +211,10 @@ napi_value Init(napi_env env, napi_value exports) {
 
   napi_create_function(env, NULL, 0, test_tty_reset_mode, NULL, &fn);
   napi_set_named_property(env, exports, "testTtyResetMode", fn);
+
+  napi_create_function(env, NULL, 0, test_tty_reset_mode_concurrent, NULL,
+                       &fn);
+  napi_set_named_property(env, exports, "testTtyResetModeConcurrent", fn);
 
   return exports;
 }

--- a/test/napi/uv.test.ts
+++ b/test/napi/uv.test.ts
@@ -11,6 +11,7 @@ describe.if(!isWindows)("uv stubs", () => {
   const cwd = process.cwd();
   let tempdir: string = "";
   let outdir: string = "";
+  let addonPath: string = "";
   let nativeModule: any;
 
   beforeAll(async () => {
@@ -57,7 +58,8 @@ describe.if(!isWindows)("uv stubs", () => {
     // root binding.gyp package; build:napi below is the single, explicit gyp build.
     await Bun.$`${bunExe()} i --ignore-scripts && ${bunExe()} build:napi`.env(bunEnv).cwd(tempdir);
 
-    nativeModule = require(path.join(tempdir, "./build/Release/uv_test.node"));
+    addonPath = path.join(tempdir, "./build/Release/uv_test.node");
+    nativeModule = require(addonPath);
   });
 
   afterEach(() => {
@@ -111,5 +113,22 @@ describe.if(!isWindows)("uv stubs", () => {
     // 3. The difference shouldn't be unreasonably large
     // Let's say not more than 100ms (100,000,000 ns)
     expect(diff <= 100_000_000n).toBe(true);
+  });
+
+  test("uv_tty_reset_mode", async () => {
+    // Returns 0 because nothing put a tty into raw mode, so there is nothing to
+    // restore. Runs in a child process because when bun does not export the
+    // symbol, the lazily bound call kills the process on Linux (on macOS the
+    // require() throws), and that should fail this test, not the test runner.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.log(require(${JSON.stringify(addonPath)}).testTtyResetMode())`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("0\n");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/napi/uv.test.ts
+++ b/test/napi/uv.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
+import { existsSync, readFileSync } from "node:fs";
+import { constants } from "node:os";
 import path from "node:path";
 import { symbols, test_skipped } from "../../src/jsc/bindings/libuv/generate_uv_posix_stubs_constants";
 import source from "./uv-stub-stuff/uv_impl.c";
@@ -129,6 +131,51 @@ describe.if(!isWindows)("uv stubs", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(stdout).toBe("0\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("uv_tty_reset_mode after setRawMode", async () => {
+    // The child runs in a pty so that setRawMode() takes the termios snapshot
+    // uv_tty_reset_mode() restores. Restoring it succeeds (0); once the fd it
+    // was taken on is closed, the failure comes back libuv-style, as -errno.
+    // The child reports through a file because all of its stdio is the pty.
+    const resultPath = path.join(tempdir, "tty-reset-result.json");
+    const decoder = new TextDecoder();
+    let output = "";
+    const proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const fs = require("node:fs");
+          const addon = require(${JSON.stringify(addonPath)});
+          const isTTY = process.stdin.isTTY;
+          process.stdin.setRawMode(true);
+          const afterRaw = addon.testTtyResetMode();
+          fs.closeSync(0);
+          const afterClose = addon.testTtyResetMode();
+          fs.writeFileSync(${JSON.stringify(resultPath)}, JSON.stringify({ isTTY, afterRaw, afterClose }));
+        `,
+      ],
+      env: bunEnv,
+      terminal: {
+        data(_terminal, chunk: Uint8Array) {
+          output += decoder.decode(chunk, { stream: true });
+        },
+      },
+    });
+    const exitCode = await proc.exited;
+    proc.terminal?.close();
+    if (!existsSync(resultPath)) {
+      throw new Error(
+        `child exited with ${exitCode} without writing a result; terminal output: ${JSON.stringify(output)}`,
+      );
+    }
+    expect(JSON.parse(readFileSync(resultPath, "utf8"))).toEqual({
+      isTTY: true,
+      afterRaw: 0,
+      afterClose: -constants.errno.EBADF,
+    });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/napi/uv.test.ts
+++ b/test/napi/uv.test.ts
@@ -136,8 +136,11 @@ describe.if(!isWindows)("uv stubs", () => {
 
   test("uv_tty_reset_mode after setRawMode", async () => {
     // The child runs in a pty so that setRawMode() takes the termios snapshot
-    // uv_tty_reset_mode() restores. Restoring it succeeds (0); once the fd it
-    // was taken on is closed, the failure comes back libuv-style, as -errno.
+    // uv_tty_reset_mode() restores. Restoring it succeeds (0); two threads
+    // restoring it at once see UV_EBUSY (thousands of times per run on a
+    // multi-core machine, possibly never on a single core, so only the absence
+    // of any other code is asserted); once the fd the snapshot was taken on is
+    // closed, the failure comes back libuv-style, as -errno.
     // The child reports through a file because all of its stdio is the pty.
     const resultPath = path.join(tempdir, "tty-reset-result.json");
     const decoder = new TextDecoder();
@@ -152,9 +155,10 @@ describe.if(!isWindows)("uv stubs", () => {
           const isTTY = process.stdin.isTTY;
           process.stdin.setRawMode(true);
           const afterRaw = addon.testTtyResetMode();
+          const concurrent = addon.testTtyResetModeConcurrent();
           fs.closeSync(0);
           const afterClose = addon.testTtyResetMode();
-          fs.writeFileSync(${JSON.stringify(resultPath)}, JSON.stringify({ isTTY, afterRaw, afterClose }));
+          fs.writeFileSync(${JSON.stringify(resultPath)}, JSON.stringify({ isTTY, afterRaw, concurrent, afterClose }));
         `,
       ],
       env: bunEnv,
@@ -174,6 +178,7 @@ describe.if(!isWindows)("uv stubs", () => {
     expect(JSON.parse(readFileSync(resultPath, "utf8"))).toEqual({
       isTTY: true,
       afterRaw: 0,
+      concurrent: { busy: expect.any(Number), unexpected: 0 },
       afterClose: -constants.errno.EBADF,
     });
     expect(exitCode).toBe(0);


### PR DESCRIPTION
### Problem
- A napi addon that references `uv_tty_reset_mode()` cannot use it on Linux or macOS. On macOS `require()` of the addon fails with `Symbol not found: _uv_tty_reset_mode`; on Linux the addon loads (bun dlopens addons with `RTLD_LAZY`) and the process dies on the first call with `bun: symbol lookup error: .../addon.node: undefined symbol: uv_tty_reset_mode`.
- Every darwin build on main warns at link time: `rust-lld: warning: cannot export hidden symbol uv_tty_reset_mode`. On Linux, ld.lld drops the symbol silently.
- `src/linker.lds:287` and `src/symbols.txt:630` already list the symbol. Of the 316 `uv_*` symbols in `src/linker.lds`, it is the only one missing from `nm -D` of the built binary (315 exported).
- Cause: the other posix `uv_*` functions are compiled from `uv-posix-stubs.c` / `uv-posix-polyfills.c`, which include `<uv.h>` with `UV_EXTERN` set to `__attribute__((visibility("default")))`, so their definitions pick up default visibility from the declarations. `uv_tty_reset_mode` is the one function implemented elsewhere, as a plain `extern "C"` definition in `src/jsc/bindings/wtf-bindings.cpp:45` with no attribute and no `<uv.h>` declaration in scope. Bun's C++ is built with `-fvisibility=hidden` (`scripts/build/flags.ts:394`), so the object file carries it as `GLOBAL HIDDEN`, and a hidden symbol cannot be exported by a version script or `-exported_symbols_list` no matter what the lists say.
- Secondary (raised in review): the same function returned its two failures as positive numbers (a literal `16` for the busy case, and `tcsetattr`'s errno), while every `uv_*` function, including bun's own polyfills in `uv-posix-polyfills.c`, returns `UV_E*` codes, which are `-errno` on posix. Unobservable while the symbol was hidden; visible to addons once it is exported.

### Fix
- `src/jsc/bindings/wtf-bindings.cpp`: define the function as `extern "C" BUN_EXPORT int uv_tty_reset_mode(void)`. `BUN_EXPORT` (from `root.h`) is `__attribute__((visibility("default")))` on posix, the same attribute `UV_EXTERN` gives the other `uv_*` functions, and the same idiom `node.h` uses for `node_module_register`, the other `extern "C"` entry point addons link against. The definition sits inside `#if !OS(WINDOWS)`; on Windows the real libuv provides the symbol and `symbols.def` exports it, so nothing changes there.
- Exporting it is correct because the export lists, the `keep_symbols!` reference in `src/runtime/napi/napi_body.rs`, and Windows all already treat `uv_tty_reset_mode` as part of the exported uv surface; the visibility attribute was the only piece missing. Calls from inside bun (the atexit hooks in the same file) bind directly within the executable as before.
- Same function: return `-EBUSY` (what `UV_EBUSY` expands to on posix) and negate the errno from `uv__tcsetattr`, so addons get the values real libuv returns. `uv__tcsetattr` itself is unchanged: `ttySetMode` / `Bun__ttySetMode` return its positive errno to `node:tty` (`setRawMode failed with errno: N`) and to `bun_core::tty`, and those callers are not touched. The only internal callers of `uv_tty_reset_mode` are the atexit hooks, which ignore the result.
- Tests, in `test/napi/uv.test.ts`, whose `uv-stub-stuff/uv_impl.c` addon is the one this file already builds for the implemented uv functions (`uv_mutex_*`, `uv_once`, `uv_hrtime`, ...). The stub symbols are covered the same way by `uv_stub.test.ts`, generated from the stub list that deliberately excludes this function, so this was the one exported uv function without a test:
  - `uv_tty_reset_mode`: the addon references the function directly; a child bun process calls it with no snapshot taken and must print `0`. Without the export the child dies with the `undefined symbol` error above (on macOS, the in-process `require()` in `beforeAll` throws instead).
  - `uv_tty_reset_mode after setRawMode`: a child spawned in a pty calls `process.stdin.setRawMode(true)` so a snapshot exists, then expects `0` from a restore, `{ unexpected: 0 }` from two addon threads calling it 4000 times each (every result must be `0` or `UV_EBUSY` as defined by `uv.h`; the busy count itself is reported but not asserted, since a single-core machine may never collide), and `-EBADF` after closing fd 0. With the previous positive returns this reports `afterClose: 9` and several thousand `unexpected` results.
- Verified: without the `src/` change, `bun bd test test/napi/uv.test.ts` fails both new tests with the child's `symbol lookup error: ... undefined symbol: uv_tty_reset_mode`; with only the export and the old return values it fails the second test (`afterClose: 9`, `unexpected: 4784`); with the branch as pushed, 8/8 pass, repeated 5 times.
- Verified: `nm -D build/debug/bun-debug` now lists `uv_tty_reset_mode@@BUN_1.2`, and all 316 `uv_*` entries in `src/linker.lds` are exported.
- Verified on macOS via CI logs: the darwin build jobs for the base commit on main print `rust-lld: warning: cannot export hidden symbol uv_tty_reset_mode`; the darwin build jobs for this branch do not, and the darwin test shards (which run `test/napi/uv.test.ts`) pass.

### Background
- Symbol visibility: with `-fvisibility=hidden`, every function a C/C++ file defines is marked hidden in the object file unless it (or a prior declaration of it) carries `__attribute__((visibility("default")))`. Hidden symbols are resolved within the executable but never placed in its dynamic export table.
- Export lists: `src/linker.lds` (Linux/FreeBSD version script) and `src/symbols.txt` (macOS `-exported_symbols_list`) tell the linker which of the already visible symbols to export. They can narrow the export table, not widen it, so listing a hidden symbol has no effect (on macOS the linker warns, on Linux it does not).
- uv on posix: bun does not link libuv on Linux/macOS. Addons that call `uv_*` get either a generated stub that crashes with a helpful message (`uv-posix-stubs.c`) or a real implementation (`uv-posix-polyfills.c` for mutexes, `uv_once`, `uv_hrtime`, pids; `wtf-bindings.cpp` for `uv_tty_reset_mode`, which shares the termios snapshot with bun's own raw-mode code). All of these are exported from the bun executable so that `dlopen` of an addon can resolve them.
- `uv_tty_reset_mode` contract: restores the termios snapshot taken by the first raw-mode switch (in bun, `setRawMode(true)`), returning `0` when there is nothing to restore or the restore worked, `UV_EBUSY` when another thread is inside the snapshot/restore critical section, and `-errno` when `tcsetattr` fails. The critical section spans the `tcsetattr` call, which is why two threads collide reliably in the test once a snapshot exists.

<details>
<summary>Export table before and after (Linux)</summary>

```
$ nm -D build/release/bun | grep ' uv_tty_'        # main, before
T uv_tty_get_vterm_state@@BUN_1.2
T uv_tty_get_winsize@@BUN_1.2
T uv_tty_init@@BUN_1.2
T uv_tty_set_mode@@BUN_1.2
T uv_tty_set_vterm_state@@BUN_1.2

$ readelf -sW build/debug/obj/unified/UnifiedSource-src_jsc_bindings-22.cpp.o | grep ' uv_tty_reset_mode$'   # before
FUNC    GLOBAL HIDDEN  1997 uv_tty_reset_mode

$ nm -D build/debug/bun-debug | grep ' uv_tty_'    # with this change
T uv_tty_get_vterm_state@@BUN_1.2
T uv_tty_get_winsize@@BUN_1.2
T uv_tty_init@@BUN_1.2
T uv_tty_reset_mode@@BUN_1.2
T uv_tty_set_mode@@BUN_1.2
T uv_tty_set_vterm_state@@BUN_1.2
```

</details>

<details>
<summary>Result file from the pty test on this 8-core box (debug build)</summary>

```
{"isTTY":true,"afterRaw":0,"concurrent":{"busy":7193,"unexpected":0},"afterClose":-9}
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/uv.test.ts

<!-- robobun:evidence:end -->