### PR TITLE
share one lazy init lambda per string table

### DIFF
--- a/src/jsc/bindings/BunCommonStrings.cpp
+++ b/src/jsc/bindings/BunCommonStrings.cpp
@@ -12,34 +12,53 @@
 namespace Bun {
 using namespace JSC;
 
-#define BUN_COMMON_STRINGS_LAZY_PROPERTY_DEFINITION(jsName)                        \
-    this->m_commonString_##jsName.initLater(                                       \
-        [](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) { \
-            auto& names = WebCore::builtinNames(init.vm);                          \
-            auto name = names.jsName##PublicName();                                \
-            init.set(jsOwnedString(init.vm, name.string()));                       \
-        });
+#define BUN_COMMON_STRINGS_LITERAL_ENTRY(name) ASCIILiteral(),
+#define BUN_COMMON_STRINGS_LITERAL_ENTRY_NOT_BUILTIN_NAMES(name, literal) literal##_s,
+// clang-format off
+static constexpr ASCIILiteral commonStringLiterals[] = {
+    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_LITERAL_ENTRY)
+    BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_LITERAL_ENTRY_NOT_BUILTIN_NAMES)
+};
+// clang-format on
+#undef BUN_COMMON_STRINGS_LITERAL_ENTRY
+#undef BUN_COMMON_STRINGS_LITERAL_ENTRY_NOT_BUILTIN_NAMES
+static_assert(std::size(commonStringLiterals) == static_cast<size_t>(CommonStrings::Index::Count));
 
-#define BUN_COMMON_STRINGS_LAZY_PROPERTY_DEFINITION_NOT_BUILTIN_NAMES(methodName, stringLiteral) \
-    this->m_commonString_##methodName.initLater(                                                 \
-        [](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) {               \
-            init.set(jsString(init.vm, AtomString(stringLiteral##_s)));                          \
-        });
-
-#define BUN_COMMON_STRINGS_LAZY_PROPERTY_VISITOR(name) this->m_commonString_##name.visit(visitor);
-#define BUN_COMMON_STRINGS_LAZY_PROPERTY_VISITOR_NOT_BUILTIN_NAMES(name, literal) this->m_commonString_##name.visit(visitor);
+static const JSC::Identifier& builtinNameAt(VM& vm, CommonStrings::Index index)
+{
+    auto& names = WebCore::builtinNames(vm);
+    switch (index) {
+#define BUN_COMMON_STRINGS_BUILTIN_NAME_CASE(name) \
+    case CommonStrings::Index::name:               \
+        return names.name##PublicName();
+        BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_BUILTIN_NAME_CASE)
+#undef BUN_COMMON_STRINGS_BUILTIN_NAME_CASE
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
 
 void CommonStrings::initialize()
 {
-    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_LAZY_PROPERTY_DEFINITION)
-    BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_LAZY_PROPERTY_DEFINITION_NOT_BUILTIN_NAMES)
+    for (auto& string : m_strings) {
+        string.initLater([](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) {
+            auto& self = defaultGlobalObject(init.owner)->commonStrings();
+            size_t i = &init.property - self.m_strings;
+            auto literal = commonStringLiterals[i];
+            if (literal.isNull()) {
+                init.set(jsOwnedString(init.vm, builtinNameAt(init.vm, static_cast<Index>(i)).string()));
+                return;
+            }
+            init.set(jsString(init.vm, AtomString(literal)));
+        });
+    }
 }
 
 template<typename Visitor>
 void CommonStrings::visit(Visitor& visitor)
 {
-    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_LAZY_PROPERTY_VISITOR)
-    BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_LAZY_PROPERTY_VISITOR_NOT_BUILTIN_NAMES)
+    for (auto& string : m_strings)
+        string.visit(visitor);
 }
 
 template void CommonStrings::visit(JSC::AbstractSlotVisitor&);

--- a/src/jsc/bindings/BunCommonStrings.h
+++ b/src/jsc/bindings/BunCommonStrings.h
@@ -115,25 +115,30 @@
 
 // clang-format on
 
-#define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)                           \
-    JSC::JSString* name##String(JSC::JSGlobalObject* globalObject)             \
-    {                                                                          \
-        return m_commonString_##name.getInitializedOnMainThread(globalObject); \
+#define BUN_COMMON_STRINGS_INDEX_ENTRY(name) name,
+#define BUN_COMMON_STRINGS_INDEX_ENTRY_NOT_BUILTIN_NAMES(name, literal) name,
+
+#define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)                                                 \
+    JSC::JSString* name##String(JSC::JSGlobalObject* globalObject)                                   \
+    {                                                                                                \
+        return m_strings[static_cast<size_t>(Index::name)].getInitializedOnMainThread(globalObject); \
     }
 
 #define BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES(name, literal) \
     BUN_COMMON_STRINGS_ACCESSOR_DEFINITION(name)
 
-#define BUN_COMMON_STRINGS_LAZY_PROPERTY_DECLARATION(name) \
-    JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString> m_commonString_##name;
-
-#define BUN_COMMON_STRINGS_LAZY_PROPERTY_DECLARATION_NOT_BUILTIN_NAMES(name, literal) \
-    BUN_COMMON_STRINGS_LAZY_PROPERTY_DECLARATION(name)
-
 namespace Bun {
 
 class CommonStrings {
 public:
+    // clang-format off
+    enum class Index : uint8_t {
+        BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_INDEX_ENTRY)
+        BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_INDEX_ENTRY_NOT_BUILTIN_NAMES)
+        Count
+    };
+    // clang-format on
+
     BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION)
     BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES)
     void initialize();
@@ -142,13 +147,12 @@ public:
     void visit(Visitor& visitor);
 
 private:
-    BUN_COMMON_STRINGS_EACH_NAME(BUN_COMMON_STRINGS_LAZY_PROPERTY_DECLARATION)
-    BUN_COMMON_STRINGS_EACH_NAME_NOT_BUILTIN_NAMES(BUN_COMMON_STRINGS_LAZY_PROPERTY_DECLARATION_NOT_BUILTIN_NAMES)
+    JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString> m_strings[static_cast<size_t>(Index::Count)];
 };
 
 } // namespace Bun
 
+#undef BUN_COMMON_STRINGS_INDEX_ENTRY
+#undef BUN_COMMON_STRINGS_INDEX_ENTRY_NOT_BUILTIN_NAMES
 #undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION
-#undef BUN_COMMON_STRINGS_LAZY_PROPERTY_DECLARATION
 #undef BUN_COMMON_STRINGS_ACCESSOR_DEFINITION_NOT_BUILTIN_NAMES
-#undef BUN_COMMON_STRINGS_LAZY_PROPERTY_DECLARATION_NOT_BUILTIN_NAMES

--- a/src/jsc/bindings/BunMarkdownTagStrings.cpp
+++ b/src/jsc/bindings/BunMarkdownTagStrings.cpp
@@ -11,24 +11,28 @@
 namespace Bun {
 using namespace JSC;
 
-#define MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_DEFINITION(name, str, idx)              \
-    this->m_strings[idx].initLater(                                                \
-        [](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) { \
-            init.set(jsOwnedString(init.vm, str));                                 \
-        });
-
-#define MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_VISITOR(name, str, idx) \
-    this->m_strings[idx].visit(visitor);
+#define MARKDOWN_TAG_STRINGS_LITERAL_ENTRY(name, str, idx) str,
+static constexpr ASCIILiteral tagLiterals[] = {
+    MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_LITERAL_ENTRY)
+};
+#undef MARKDOWN_TAG_STRINGS_LITERAL_ENTRY
+static_assert(std::size(tagLiterals) == MARKDOWN_TAG_STRINGS_COUNT);
 
 void MarkdownTagStrings::initialize()
 {
-    MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_DEFINITION)
+    for (auto& string : m_strings) {
+        string.initLater([](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) {
+            auto& self = defaultGlobalObject(init.owner)->markdownTagStrings();
+            init.set(jsOwnedString(init.vm, tagLiterals[&init.property - self.m_strings]));
+        });
+    }
 }
 
 template<typename Visitor>
 void MarkdownTagStrings::visit(Visitor& visitor)
 {
-    MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_LAZY_PROPERTY_VISITOR)
+    for (auto& string : m_strings)
+        string.visit(visitor);
 }
 
 template void MarkdownTagStrings::visit(JSC::AbstractSlotVisitor&);
@@ -42,18 +46,5 @@ extern "C" JSC::EncodedJSValue BunMarkdownTagStrings__getTagString(Zig::GlobalOb
     if (tagIndex >= MARKDOWN_TAG_STRINGS_COUNT)
         return JSC::JSValue::encode(JSC::jsUndefined());
 
-    auto& tagStrings = globalObject->markdownTagStrings();
-
-    // Use a switch to call the appropriate accessor
-    switch (tagIndex) {
-#define MARKDOWN_TAG_STRINGS_CASE(name, str, idx) \
-    case idx:                                     \
-        return JSC::JSValue::encode(tagStrings.name##String(globalObject));
-
-        MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_CASE)
-
-#undef MARKDOWN_TAG_STRINGS_CASE
-    default:
-        return JSC::JSValue::encode(JSC::jsUndefined());
-    }
+    return JSC::JSValue::encode(globalObject->markdownTagStrings().stringAt(globalObject, tagIndex));
 }

--- a/src/jsc/bindings/BunMarkdownTagStrings.h
+++ b/src/jsc/bindings/BunMarkdownTagStrings.h
@@ -48,15 +48,17 @@ using namespace JSC;
 
 class MarkdownTagStrings {
 public:
-#define MARKDOWN_TAG_STRINGS_ACCESSOR_DEFINITION(name, str, idx)        \
-    JSC::JSString* name##String(JSC::JSGlobalObject* globalObject)      \
-    {                                                                   \
-        return m_strings[idx].getInitializedOnMainThread(globalObject); \
-    }
+#define MARKDOWN_TAG_STRINGS_ACCESSOR_DEFINITION(name, str, idx) \
+    JSC::JSString* name##String(JSC::JSGlobalObject* globalObject) { return stringAt(globalObject, idx); }
 
     MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_ACCESSOR_DEFINITION)
 
 #undef MARKDOWN_TAG_STRINGS_ACCESSOR_DEFINITION
+
+    JSC::JSString* stringAt(JSC::JSGlobalObject* globalObject, size_t index)
+    {
+        return m_strings[index].getInitializedOnMainThread(globalObject);
+    }
 
     void initialize();
 

--- a/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp
@@ -6,49 +6,18 @@
 
 namespace WebCore {
 
-#define HTTP_HEADERS_LAZY_PROPERTY_DEFINITION(literal, name)                                 \
-    m_##name##String.initLater(                                                              \
-        [](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString>::Initializer& init) { \
-            auto& ids = WebCore::clientData(init.vm)->httpHeaderIdentifiers();               \
-            auto& id = ids.name##Identifier(init.vm);                                        \
-            init.set(jsOwnedString(init.vm, id.string()));                                   \
-        });
-
-HTTPHeaderIdentifiers::HTTPHeaderIdentifiers()
-{
-    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_LAZY_PROPERTY_DEFINITION);
-    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_LAZY_PROPERTY_DEFINITION);
-}
-
-#undef HTTP_HEADERS_LAZY_PROPERTY_DEFINITION
-
-#define HTTP_HEADERS_ACCESSOR_DEFINITIONS(literal, name)                                  \
-    JSC::Identifier& HTTPHeaderIdentifiers::name##Identifier(JSC::VM& vm)                 \
-    {                                                                                     \
-        if (m_##name##Identifier.isEmpty())                                               \
-            m_##name##Identifier = JSC::Identifier::fromString(vm, literal);              \
-        return m_##name##Identifier;                                                      \
-    }                                                                                     \
-    JSC::JSString* HTTPHeaderIdentifiers::name##String(JSC::JSGlobalObject* globalObject) \
-    {                                                                                     \
-        return m_##name##String.getInitializedOnMainThread(globalObject);                 \
-    }
-
-HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DEFINITIONS);
-HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DEFINITIONS);
-
-#undef HTTP_HEADERS_ACCESSOR_DEFINITIONS
-
-using IdentifierGetter = JSC::Identifier& (HTTPHeaderIdentifiers::*)(JSC::VM&);
-using StringGetter = JSC::JSString* (HTTPHeaderIdentifiers::*)(JSC::JSGlobalObject*);
-
-#define HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES(literal, name) \
-    &HTTPHeaderIdentifiers::name##Identifier,
-#define HTTP_HEADERS_STRING_ARRAY_ENTRIES(literal, name) \
-    &HTTPHeaderIdentifiers::name##String,
+#define HTTP_HEADERS_LITERAL_ENTRY(literal, name) literal##_s,
 #define HTTP_HEADERS_ENUM_ENTRIES(literal, name) HTTPHeaderName::name,
 
-// The tables below are indexed by HTTPHeaderName.
+// Indexed by HTTPHeaderIdentifiers::Index: HTTPHeaderName entries first, then pseudo-headers.
+// clang-format off
+static constexpr ASCIILiteral headerLiterals[] = {
+    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_LITERAL_ENTRY)
+    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_LITERAL_ENTRY)
+};
+// clang-format on
+static_assert(std::size(headerLiterals) == static_cast<size_t>(HTTPHeaderIdentifiers::Index::Count));
+
 static constexpr HTTPHeaderName headerNameOfEntry[] = {
     HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_ENUM_ENTRIES)
 };
@@ -62,44 +31,27 @@ static constexpr bool entriesFollowHTTPHeaderNameOrder()
 }
 static_assert(std::size(headerNameOfEntry) == numHTTPHeaderNames, "HTTP_HEADERS_EACH_NAME must list every HTTPHeaderName");
 static_assert(entriesFollowHTTPHeaderNameOrder(), "HTTP_HEADERS_EACH_NAME must follow the HTTPHeaderName enum order");
+static_assert(static_cast<size_t>(HTTPHeaderIdentifiers::Index::Authority) == numHTTPHeaderNames);
 
-static const IdentifierGetter headerIdentifierFields[] = {
-    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES)
-};
-static const StringGetter headerStringFields[] = {
-    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_STRING_ARRAY_ENTRIES)
-};
-
-// Indexed by HTTP2PseudoHeaderName, generated from the same list.
-static const IdentifierGetter pseudoHeaderIdentifierFields[] = {
-    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES)
-};
-static const StringGetter pseudoHeaderStringFields[] = {
-    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_STRING_ARRAY_ENTRIES)
-};
-
-#undef HTTP_HEADERS_IDENTIFIER_ARRAY_ENTRIES
-#undef HTTP_HEADERS_STRING_ARRAY_ENTRIES
+#undef HTTP_HEADERS_LITERAL_ENTRY
 #undef HTTP_HEADERS_ENUM_ENTRIES
 
-JSC::Identifier& HTTPHeaderIdentifiers::identifierFor(JSC::VM& vm, HTTPHeaderName name)
+HTTPHeaderIdentifiers::HTTPHeaderIdentifiers()
 {
-    return (this->*headerIdentifierFields[static_cast<size_t>(name)])(vm);
+    for (auto& string : m_strings) {
+        string.initLater([](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString>::Initializer& init) {
+            auto& ids = WebCore::clientData(init.vm)->httpHeaderIdentifiers();
+            size_t i = &init.property - ids.m_strings;
+            init.set(jsOwnedString(init.vm, ids.identifierAt(init.vm, i).string()));
+        });
+    }
 }
 
-JSC::JSString* HTTPHeaderIdentifiers::stringFor(JSC::JSGlobalObject* globalObject, HTTPHeaderName name)
+JSC::Identifier& HTTPHeaderIdentifiers::identifierAt(JSC::VM& vm, size_t i)
 {
-    return (this->*headerStringFields[static_cast<size_t>(name)])(globalObject);
-}
-
-JSC::Identifier& HTTPHeaderIdentifiers::identifierFor(JSC::VM& vm, HTTP2PseudoHeaderName name)
-{
-    return (this->*pseudoHeaderIdentifierFields[static_cast<size_t>(name)])(vm);
-}
-
-JSC::JSString* HTTPHeaderIdentifiers::stringFor(JSC::JSGlobalObject* globalObject, HTTP2PseudoHeaderName name)
-{
-    return (this->*pseudoHeaderStringFields[static_cast<size_t>(name)])(globalObject);
+    if (m_identifiers[i].isEmpty())
+        m_identifiers[i] = JSC::Identifier::fromString(vm, headerLiterals[i]);
+    return m_identifiers[i];
 }
 
 #define HTTP2_PSEUDO_HEADERS_FIND(literal, name) \
@@ -118,16 +70,12 @@ bool findHTTP2PseudoHeaderName(WTF::StringView view, HTTP2PseudoHeaderName& resu
 
 #undef HTTP2_PSEUDO_HEADERS_FIND
 
-#define HTTP_HEADERS_LAZY_PROPERTY_VISITOR(literal, name) m_##name##String.visit(visitor);
-
 template<typename Visitor>
 void HTTPHeaderIdentifiers::visit(Visitor& visitor)
 {
-    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_LAZY_PROPERTY_VISITOR);
-    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_LAZY_PROPERTY_VISITOR);
+    for (auto& string : m_strings)
+        string.visit(visitor);
 }
-
-#undef HTTP_HEADERS_LAZY_PROPERTY_VISITOR
 
 template void HTTPHeaderIdentifiers::visit(JSC::AbstractSlotVisitor&);
 template void HTTPHeaderIdentifiers::visit(JSC::SlotVisitor&);

--- a/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.h
@@ -120,36 +120,50 @@ enum class HTTP2PseudoHeaderName : uint8_t {
 
 bool findHTTP2PseudoHeaderName(WTF::StringView, HTTP2PseudoHeaderName&);
 
-#define HTTP_HEADERS_ACCESSOR_DECLARATIONS(literal, name) \
-    JSC::Identifier& name##Identifier(JSC::VM& vm);       \
-    JSC::JSString* name##String(JSC::JSGlobalObject* globalObject);
+#define HTTP_HEADERS_INDEX_ENTRY(literal, name) name,
 
-#define HTTP_HEADERS_PROPERTY_DECLARATIONS(literal, name)                   \
-    JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString> m_##name##String; \
-    JSC::Identifier m_##name##Identifier;
+#define HTTP_HEADERS_ACCESSOR_DEFINITIONS(literal, name)                                     \
+    JSC::Identifier& name##Identifier(JSC::VM& vm) { return identifierAt(vm, Index::name); } \
+    JSC::JSString* name##String(JSC::JSGlobalObject* g) { return stringAt(g, Index::name); }
 
 // Per-VM cache: one Identifier and one JSString per header name, for the lifetime of the VM.
 class HTTPHeaderIdentifiers {
 public:
-    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DECLARATIONS)
-    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DECLARATIONS)
+    // clang-format off
+    enum class Index : uint8_t {
+        HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_INDEX_ENTRY)
+        HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_INDEX_ENTRY)
+        Count
+    };
+    // clang-format on
+
+    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DEFINITIONS)
+    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_ACCESSOR_DEFINITIONS)
 
     HTTPHeaderIdentifiers();
 
-    JSC::Identifier& identifierFor(JSC::VM&, HTTPHeaderName);
-    JSC::JSString* stringFor(JSC::JSGlobalObject*, HTTPHeaderName);
-    JSC::Identifier& identifierFor(JSC::VM&, HTTP2PseudoHeaderName);
-    JSC::JSString* stringFor(JSC::JSGlobalObject*, HTTP2PseudoHeaderName);
+    JSC::Identifier& identifierFor(JSC::VM& vm, HTTPHeaderName name) { return identifierAt(vm, static_cast<size_t>(name)); }
+    JSC::JSString* stringFor(JSC::JSGlobalObject* g, HTTPHeaderName name) { return stringAt(g, static_cast<size_t>(name)); }
+    JSC::Identifier& identifierFor(JSC::VM& vm, HTTP2PseudoHeaderName name) { return identifierAt(vm, PseudoOffset + static_cast<size_t>(name)); }
+    JSC::JSString* stringFor(JSC::JSGlobalObject* g, HTTP2PseudoHeaderName name) { return stringAt(g, PseudoOffset + static_cast<size_t>(name)); }
 
     template<typename Visitor>
     void visit(Visitor& visitor);
 
 private:
-    HTTP_HEADERS_EACH_NAME(HTTP_HEADERS_PROPERTY_DECLARATIONS)
-    HTTP2_PSEUDO_HEADERS_EACH_NAME(HTTP_HEADERS_PROPERTY_DECLARATIONS)
+    static constexpr size_t Count = static_cast<size_t>(Index::Count);
+    static constexpr size_t PseudoOffset = numHTTPHeaderNames;
+
+    JSC::Identifier& identifierAt(JSC::VM&, size_t);
+    JSC::Identifier& identifierAt(JSC::VM& vm, Index i) { return identifierAt(vm, static_cast<size_t>(i)); }
+    JSC::JSString* stringAt(JSC::JSGlobalObject* g, size_t i) { return m_strings[i].getInitializedOnMainThread(g); }
+    JSC::JSString* stringAt(JSC::JSGlobalObject* g, Index i) { return stringAt(g, static_cast<size_t>(i)); }
+
+    JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString> m_strings[Count];
+    JSC::Identifier m_identifiers[Count];
 };
 
 } // namespace WebCore
 
-#undef HTTP_HEADERS_ACCESSOR_DECLARATIONS
-#undef HTTP_HEADERS_PROPERTY_DECLARATIONS
+#undef HTTP_HEADERS_INDEX_ENTRY
+#undef HTTP_HEADERS_ACCESSOR_DEFINITIONS

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp
@@ -34,20 +34,35 @@ JSStreamsRuntime* JSStreamsRuntime::from(JSGlobalObject* globalObject)
     return defaultGlobalObject(globalObject)->streamsRuntime();
 }
 
+struct HandlerTableEntry {
+    ASCIILiteral name;
+    JSC::NativeFunction function;
+};
+
+#define WEB_STREAMS_HANDLER_TABLE_ENTRY(name) { #name ""_s, jsWebStreamsHandler_##name },
+// clang-format off
+static constexpr HandlerTableEntry handlerTable[] = {
+    FOR_EACH_WEB_STREAMS_REACTION_HANDLER(WEB_STREAMS_HANDLER_TABLE_ENTRY)
+    FOR_EACH_WEB_STREAMS_BOUND_HANDLER_TARGET(WEB_STREAMS_HANDLER_TABLE_ENTRY)
+};
+// clang-format on
+#undef WEB_STREAMS_HANDLER_TABLE_ENTRY
+static_assert(std::size(handlerTable) == static_cast<size_t>(JSStreamsRuntime::Handler::Count));
+
 void JSStreamsRuntime::initialize(Zig::GlobalObject* globalObject)
 {
     m_globalObject = globalObject;
 
     using HandlerProperty = JSC::LazyProperty<JSGlobalObject, JSC::JSFunction>;
 
-#define WEB_STREAMS_INIT_HANDLER(name)                                       \
-    m_##name.initLater([](const HandlerProperty::Initializer& init) {        \
-        init.set(JSFunction::create(init.vm, init.owner, 2, #name ""_s,      \
-            jsWebStreamsHandler_##name, ImplementationVisibility::Private)); \
-    });
-    FOR_EACH_WEB_STREAMS_REACTION_HANDLER(WEB_STREAMS_INIT_HANDLER)
-    FOR_EACH_WEB_STREAMS_BOUND_HANDLER_TARGET(WEB_STREAMS_INIT_HANDLER)
-#undef WEB_STREAMS_INIT_HANDLER
+    for (auto& handler : m_handlers) {
+        handler.initLater([](const HandlerProperty::Initializer& init) {
+            auto* self = JSStreamsRuntime::from(init.owner);
+            auto& entry = handlerTable[&init.property - self->m_handlers];
+            init.set(JSFunction::create(init.vm, init.owner, 2, String(entry.name),
+                entry.function, ImplementationVisibility::Private));
+        });
+    }
 
     // Spec: `%FooQueuingStrategy%.prototype.size` is ONE user-visible function object per realm.
     m_byteLengthQueuingStrategySizeFunction.initLater([](const HandlerProperty::Initializer& init) {
@@ -84,10 +99,8 @@ void JSStreamsRuntime::initialize(Zig::GlobalObject* globalObject)
 template<typename Visitor>
 void JSStreamsRuntime::visit(Visitor& visitor)
 {
-#define WEB_STREAMS_VISIT_HANDLER(name) m_##name.visit(visitor);
-    FOR_EACH_WEB_STREAMS_REACTION_HANDLER(WEB_STREAMS_VISIT_HANDLER)
-    FOR_EACH_WEB_STREAMS_BOUND_HANDLER_TARGET(WEB_STREAMS_VISIT_HANDLER)
-#undef WEB_STREAMS_VISIT_HANDLER
+    for (auto& handler : m_handlers)
+        handler.visit(visitor);
 
     m_byteLengthQueuingStrategySizeFunction.visit(visitor);
     m_countQueuingStrategySizeFunction.visit(visitor);

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.h
@@ -326,6 +326,17 @@ class JSStreamsRuntime final {
     WTF_MAKE_NONCOPYABLE(JSStreamsRuntime);
 
 public:
+    // Index of every handler in m_handlers, in macro order (both lists).
+    // clang-format off
+#define WEB_STREAMS_HANDLER_INDEX_ENTRY(name) name,
+    enum class Handler : uint8_t {
+        FOR_EACH_WEB_STREAMS_REACTION_HANDLER(WEB_STREAMS_HANDLER_INDEX_ENTRY)
+        FOR_EACH_WEB_STREAMS_BOUND_HANDLER_TARGET(WEB_STREAMS_HANDLER_INDEX_ENTRY)
+        Count
+    };
+#undef WEB_STREAMS_HANDLER_INDEX_ENTRY
+    // clang-format on
+
     JSStreamsRuntime() = default;
     void initialize(Zig::GlobalObject*);
 
@@ -333,7 +344,7 @@ public:
     // behind a free function so streams .cpp files do not include ZigGlobalObject.h.
     static JSStreamsRuntime* from(JSC::JSGlobalObject*);
 
-    // Called from Zig::GlobalObject::visitChildren. MUST visit EVERY m_<handler>
+    // Called from Zig::GlobalObject::visitChildren. MUST visit EVERY handler
     // LazyProperty (both macro lists), the two size-function LazyProperties, and every
     // LazyProperty in FOR_EACH_WEB_STREAMS_INTERNAL_STRUCTURE. Safe on a
     // default-constructed instance (LazyProperty::visit is a no-op for m_pointer == 0).
@@ -343,7 +354,7 @@ public:
     // The shared handler functions. Each LazyProperty materializes the JSFunction on FIRST
     // use; the global is the owner passed to `init.owner`.
 #define WEB_STREAMS_DECLARE_HANDLER_ACCESSOR(name) \
-    JSC::JSFunction* name() const { return m_##name.getInitializedOnMainThread(m_globalObject); }
+    JSC::JSFunction* name() const { return m_handlers[static_cast<size_t>(Handler::name)].getInitializedOnMainThread(m_globalObject); }
     FOR_EACH_WEB_STREAMS_REACTION_HANDLER(WEB_STREAMS_DECLARE_HANDLER_ACCESSOR)
     FOR_EACH_WEB_STREAMS_BOUND_HANDLER_TARGET(WEB_STREAMS_DECLARE_HANDLER_ACCESSOR)
 #undef WEB_STREAMS_DECLARE_HANDLER_ACCESSOR
@@ -366,11 +377,7 @@ public:
 private:
     JSC::JSGlobalObject* m_globalObject { nullptr };
 
-#define WEB_STREAMS_DECLARE_HANDLER_MEMBER(name) \
-    JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSFunction> m_##name;
-    FOR_EACH_WEB_STREAMS_REACTION_HANDLER(WEB_STREAMS_DECLARE_HANDLER_MEMBER)
-    FOR_EACH_WEB_STREAMS_BOUND_HANDLER_TARGET(WEB_STREAMS_DECLARE_HANDLER_MEMBER)
-#undef WEB_STREAMS_DECLARE_HANDLER_MEMBER
+    JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSFunction> m_handlers[static_cast<size_t>(Handler::Count)];
 
     JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSFunction> m_byteLengthQueuingStrategySizeFunction;
     JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSFunction> m_countQueuingStrategySizeFunction;


### PR DESCRIPTION
Four X-macro string caches (HTTPHeaderIdentifiers, BunCommonStrings, BunMarkdownTagStrings, the JSStreamsRuntime handler table) each stamp one JSC::LazyProperty init lambda per name plus an unrolled accessor and visitor per name. In the linux-x64 binary that is 251 lambda instances of about 500 to 720 bytes each (130 KB), 44 KB of HTTPHeaderIdentifiers accessors and 51 KB of unrolled visit functions, all of them the same code with a different index or literal.

Each table now has one shared init lambda that recovers its slot from the LazyProperty address, an array of literals, and a loop for visit. The per-name accessors stay as one-line inline forwards so callers do not change. HTTPHeaderIdentifiers keeps everything #39469 added (the pseudo-header list, identifierFor for both enums, the enum-order static_asserts); the pseudo-headers live in the same table after the regular names, with a static_assert pinning the offset.

Checked with node-http, streams and headers tests on the debug build; the touched TUs also type-check against the release compile flags. CI's size gate gives the real number, the local Rust-only measure cannot see C++.
