### PR TITLE
Pin the invariants the shared string table init lambdas rely on

### DIFF
--- a/src/jsc/bindings/BunCommonStrings.cpp
+++ b/src/jsc/bindings/BunCommonStrings.cpp
@@ -44,6 +44,7 @@ void CommonStrings::initialize()
         string.initLater([](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) {
             auto& self = defaultGlobalObject(init.owner)->commonStrings();
             size_t i = &init.property - self.m_strings;
+            ASSERT(i < std::size(self.m_strings));
             auto literal = commonStringLiterals[i];
             if (literal.isNull()) {
                 init.set(jsOwnedString(init.vm, builtinNameAt(init.vm, static_cast<Index>(i)).string()));

--- a/src/jsc/bindings/BunMarkdownTagStrings.cpp
+++ b/src/jsc/bindings/BunMarkdownTagStrings.cpp
@@ -12,18 +12,34 @@ namespace Bun {
 using namespace JSC;
 
 #define MARKDOWN_TAG_STRINGS_LITERAL_ENTRY(name, str, idx) str,
+#define MARKDOWN_TAG_STRINGS_INDEX_ENTRY(name, str, idx) idx,
 static constexpr ASCIILiteral tagLiterals[] = {
     MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_LITERAL_ENTRY)
 };
+static constexpr size_t tagIndexOfEntry[] = {
+    MARKDOWN_TAG_STRINGS_EACH_NAME(MARKDOWN_TAG_STRINGS_INDEX_ENTRY)
+};
 #undef MARKDOWN_TAG_STRINGS_LITERAL_ENTRY
+#undef MARKDOWN_TAG_STRINGS_INDEX_ENTRY
+static constexpr bool entriesFollowTagIndexOrder()
+{
+    for (size_t i = 0; i < std::size(tagIndexOfEntry); i++) {
+        if (tagIndexOfEntry[i] != i)
+            return false;
+    }
+    return true;
+}
 static_assert(std::size(tagLiterals) == MARKDOWN_TAG_STRINGS_COUNT);
+static_assert(entriesFollowTagIndexOrder(), "MARKDOWN_TAG_STRINGS_EACH_NAME must be listed in idx order");
 
 void MarkdownTagStrings::initialize()
 {
     for (auto& string : m_strings) {
         string.initLater([](const JSC::LazyProperty<JSGlobalObject, JSString>::Initializer& init) {
             auto& self = defaultGlobalObject(init.owner)->markdownTagStrings();
-            init.set(jsOwnedString(init.vm, tagLiterals[&init.property - self.m_strings]));
+            size_t i = &init.property - self.m_strings;
+            ASSERT(i < std::size(self.m_strings));
+            init.set(jsOwnedString(init.vm, tagLiterals[i]));
         });
     }
 }

--- a/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderIdentifiers.cpp
@@ -42,6 +42,7 @@ HTTPHeaderIdentifiers::HTTPHeaderIdentifiers()
         string.initLater([](const JSC::LazyProperty<JSC::JSGlobalObject, JSC::JSString>::Initializer& init) {
             auto& ids = WebCore::clientData(init.vm)->httpHeaderIdentifiers();
             size_t i = &init.property - ids.m_strings;
+            ASSERT(i < std::size(ids.m_strings));
             init.set(jsOwnedString(init.vm, ids.identifierAt(init.vm, i).string()));
         });
     }

--- a/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamsRuntime.cpp
@@ -58,7 +58,9 @@ void JSStreamsRuntime::initialize(Zig::GlobalObject* globalObject)
     for (auto& handler : m_handlers) {
         handler.initLater([](const HandlerProperty::Initializer& init) {
             auto* self = JSStreamsRuntime::from(init.owner);
-            auto& entry = handlerTable[&init.property - self->m_handlers];
+            size_t i = &init.property - self->m_handlers;
+            ASSERT(i < std::size(self->m_handlers));
+            auto& entry = handlerTable[i];
             init.set(JSFunction::create(init.vm, init.owner, 2, String(entry.name),
                 entry.function, ImplementationVisibility::Private));
         });

--- a/test/js/bun/md/md-react.test.ts
+++ b/test/js/bun/md/md-react.test.ts
@@ -218,6 +218,84 @@ This is **bold** and *italic*.
     }
   });
 
+  test("every cached tag name resolves to its own tag", () => {
+    // Element types come from a per-global table of cached tag strings
+    // (BunMarkdownTagStrings), so one document exercising every tag the
+    // parser emits checks that each slot holds the right name.
+    const md = [
+      "# H1",
+      "## H2",
+      "### H3",
+      "#### H4",
+      "##### H5",
+      "###### H6",
+      "",
+      "Para *em* **strong** ~~del~~ `code` [a](x) ![i](y.png)  ",
+      "after br",
+      "",
+      "> quote",
+      "",
+      "- ul item",
+      "",
+      "1. ol item",
+      "",
+      "```",
+      "pre",
+      "```",
+      "",
+      "---",
+      "",
+      "<div>raw</div>",
+      "",
+      "| A |",
+      "|---|",
+      "| 1 |",
+      "",
+    ].join("\n");
+
+    const types: string[] = [];
+    function walk(node: any) {
+      if (typeof node !== "object" || node === null) return;
+      types.push(node.type);
+      const kids = node.props.children;
+      if (Array.isArray(kids)) kids.forEach(walk);
+    }
+    children(md).forEach(walk);
+
+    expect(types).toEqual([
+      "h1",
+      "h2",
+      "h3",
+      "h4",
+      "h5",
+      "h6",
+      "p",
+      "em",
+      "strong",
+      "del",
+      "code",
+      "a",
+      "img",
+      "br",
+      "blockquote",
+      "p",
+      "ul",
+      "li",
+      "ol",
+      "li",
+      "pre",
+      "hr",
+      "html",
+      "table",
+      "thead",
+      "tr",
+      "th",
+      "tbody",
+      "tr",
+      "td",
+    ]);
+  });
+
   test("blockquote contains nested React elements", () => {
     const bq = children("> quoted text\n")[0];
     expect(bq.$$typeof).toBe(REACT_TRANSITIONAL_SYMBOL);


### PR DESCRIPTION
Follow-up to #39486, which I was asked to adopt; it merged before this landed on the branch, so here it is separately.

### Problem
- #39486 gave each of the four string tables (`CommonStrings`, `MarkdownTagStrings`, `HTTPHeaderIdentifiers`, the `JSStreamsRuntime` handler list) one shared init lambda that recovers its slot with `&init.property - table.m_strings`. That only works if the table looked up inside the lambda is the one that holds the property being initialized. Every current caller satisfies this (the header table is per VM, the other three are fetched through the same `defaultGlobalObject(owner)` mapping the lambda uses), but nothing checks it, and a bad index reads past the literal table.
- `BunMarkdownTagStrings.cpp` now fills `tagLiterals` in macro list order while `stringAt()` and `BunMarkdownTagStrings__getTagString` index it by the `idx` column. Before #39486 both sides were keyed on `idx`, so the list order did not matter. It does now, and a reordered or inserted entry would silently hand out the wrong tag name.

### Fix
- `ASSERT(i < std::size(...))` on the recovered index in all four lambdas. Debug builds (which is what CI runs the test suite on) fail loudly at the lambda instead of reading out of bounds; release code is unchanged.
- `static_assert(entriesFollowTagIndexOrder())` in `BunMarkdownTagStrings.cpp`, same shape as `entriesFollowHTTPHeaderNameOrder()` in `HTTPHeaderIdentifiers.cpp`, so the list order and the `idx` column cannot drift apart.
- `test/js/bun/md/md-react.test.ts`: one `Bun.markdown.react()` document that produces every tag name the parser can currently emit (27 of the 30 cached; `div`, `math` and `u` are unreachable today) and checks the exact sequence of element types. Existing tests never asserted `html` or `tr` by name. This is the runtime backstop for the same invariant the static_assert pins: it passes on current main, with or without the src change, because main's table is in order today; it fails as soon as the table is not.
- There is deliberately no test that fails without the src change: the src change is a compile-time assertion plus debug-only assertions over invariants that main currently satisfies, so it has no behavior a test could observe on an unmodified tree. The static_assert is exercised below by breaking the invariant it guards.
- Verified on a debug build: `md-react.test.ts`, `web/streams/streams.test.js`, `web/fetch/headers.test.ts`, `node/http2/node-http2.test.js`, `node/crypto/crypto.key-objects.test.ts` all pass, plus a script that lazily materializes entries from all four tables (markdown react, jwk export, node:http request and response headers, tee/pipeTo/async iteration) with the asserts enabled.

### Background
- `JSC::LazyProperty` stores a pointer to a stateless callback and runs it on first `get()`, passing an `Initializer` with `vm`, `owner` (the global object handed to the accessor) and `property` (a reference to the `LazyProperty` itself). The shared lambdas use `property`'s address to find their slot, and `owner` / `vm` to find the table.
- `MARKDOWN_TAG_STRINGS_EACH_NAME` carries an explicit `idx` per entry because the Rust side (`TagIndex` in `src/runtime/api/MarkdownObject.rs`) passes those numbers across the FFI boundary.

<details>
<summary>static_assert check: swapping the h1 and h2 lines in BunMarkdownTagStrings.h (idx column left as is)</summary>

With this branch, the TU no longer compiles:

```
src/jsc/bindings/BunMarkdownTagStrings.cpp:33:15: error: static assertion failed due to requirement 'entriesFollowTagIndexOrder()': MARKDOWN_TAG_STRINGS_EACH_NAME must be listed in idx order
```

On main the same edit compiles; `tagLiterals[0]` becomes `"h2"`, so `h1String()` and `getTagString(0)` return `"h2"`, which the new `md-react.test.ts` case reports as a wrong element type.

</details>
