### PR TITLE
webview: pass --no-sandbox to Chrome when Bun is root, and --disable-dev-shm-usage always

### DIFF
--- a/docs/runtime/webview.mdx
+++ b/docs/runtime/webview.mdx
@@ -156,8 +156,10 @@ When spawning, Bun passes a minimal flag set:
 --no-default-browser-check --disable-gpu --disable-extensions
 --disable-background-networking --disable-background-timer-throttling
 --disable-backgrounding-occluded-windows --disable-renderer-backgrounding
---disable-ipc-flooding-protection --no-startup-window
+--disable-ipc-flooding-protection --no-startup-window --disable-dev-shm-usage
 ```
+
+`--disable-dev-shm-usage` makes Chrome put its shared memory files in the temporary directory instead of `/dev/shm`, which Docker limits to 64 MB by default. On Linux, Bun also passes `--no-sandbox` when it runs as root, because Chrome does not start as root with its sandbox enabled. If you run Bun as another user in a container that does not let Chrome set up its sandbox, pass `argv: ["--no-sandbox"]` yourself.
 
 Append your own with `argv` — Chrome resolves duplicate switches last-wins, so you can override any default:
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9172,8 +9172,15 @@ declare module "bun" {
      * call's `path`/`argv`/`dataStore.directory` win; subsequent views reuse
      * the same Chrome instance via `Target.createTarget`.
      *
-     * Default flags: `--remote-debugging-pipe --headless --no-first-run
-     * --no-default-browser-check --disable-gpu --user-data-dir=<temp>`.
+     * Default flags: `--user-data-dir=<temp> --remote-debugging-pipe
+     * --headless --no-first-run --no-default-browser-check --disable-gpu
+     * --disable-extensions --disable-background-networking
+     * --disable-background-timer-throttling
+     * --disable-backgrounding-occluded-windows --disable-renderer-backgrounding
+     * --disable-ipc-flooding-protection --no-startup-window
+     * --disable-dev-shm-usage`. On Linux, Bun also passes `--no-sandbox` when
+     * it runs as root: Chrome does not start as root with its sandbox
+     * enabled.
      */
     type Backend =
       | "webkit"

--- a/src/runtime/webview/ChromeProcess.rs
+++ b/src/runtime/webview/ChromeProcess.rs
@@ -567,7 +567,17 @@ fn spawn(
             // No startup window — targets are Target.createTarget'd, not the
             // default about:blank. Saves one tab and the visual-complete wait.
             c"--no-startup-window".as_ptr(),
+            // Shared memory files in the temp dir instead of /dev/shm, which Docker
+            // caps at 64MB (a third 1280x720 tab kills Chrome). Playwright and
+            // puppeteer both ship this.
+            c"--disable-dev-shm-usage".as_ptr(),
         ];
+        // With the sandbox on, Chrome exits at startup when it is root
+        // (crbug.com/638180), which is what it inherits from a root Bun.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if bun_sys::c::geteuid() == 0 {
+            argv.push(c"--no-sandbox".as_ptr());
+        }
         // User extras last so they can override built-in flags (Chrome's
         // CommandLine last-wins for duplicate switches). Memory is the caller's
         // CString Vector — lives until Bun__Chrome__ensure returns, after which

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4948,13 +4948,14 @@ pub mod c {
     use core::ffi::{c_char, c_void};
     #[cfg(unix)]
     pub use libc::fchmod;
-    // `getuid`/`getgid` take no args and read kernel
+    // `getuid`/`geteuid`/`getgid` take no args and read kernel
     // process state — no preconditions, never fail. Declared locally as
     // `safe fn` (instead of re-exporting the `libc` crate's raw decls) so
     // callers need no per-site proof.
     #[cfg(unix)]
     unsafe extern "C" {
         pub safe fn getuid() -> libc::uid_t;
+        pub safe fn geteuid() -> libc::uid_t;
         pub safe fn getgid() -> libc::gid_t;
     }
     #[cfg(unix)]

--- a/test/js/bun/webview/webview-chrome-disconnect.test.ts
+++ b/test/js/bun/webview/webview-chrome-disconnect.test.ts
@@ -244,8 +244,7 @@ const chromeInstalled =
         bunExe(),
         "-e",
         `
-        // --no-sandbox: Chrome refuses to start as root otherwise (containers).
-        const view = new Bun.WebView({ backend: { type: "chrome", url: false, argv: ["--no-sandbox"] }, width: 100, height: 100 });
+        const view = new Bun.WebView({ backend: { type: "chrome", url: false }, width: 100, height: 100 });
         await view.navigate("data:text/html,<body></body>");
 
         // The document commits, but its <img> request is never answered, so

--- a/test/js/bun/webview/webview-chrome-pipe.test.ts
+++ b/test/js/bun/webview/webview-chrome-pipe.test.ts
@@ -10,7 +10,7 @@
 // scenario prints one JSON value; `outcome()` turns a promise into
 // { resolved } or { rejected: message }.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isAndroid, isLinux, isWindows, tempDir } from "harness";
 import { join } from "node:path";
 
 const fixture = join(import.meta.dir, "fake-chrome-fixture.ts");
@@ -38,9 +38,9 @@ const prelude = /* js */ `
   const big = ${BIG};
 `;
 
-async function runScenario(body: string): Promise<unknown> {
+async function runScenario(body: string, wrapper: string[] = []): Promise<unknown> {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", prelude + body],
+    cmd: [...wrapper, bunExe(), "-e", prelude + body],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
@@ -72,6 +72,88 @@ test.concurrent("navigate, events and evaluate cross the pipes", async () => {
     value: { answer: 42, text: "from the fake" },
     undef: "undefined",
   });
+});
+
+// The switches the runtime launches the browser with. They land in the fake's
+// process.execArgv (bun accepts and ignores them); backend.argv, the fixture
+// path here, comes after them and is the script. The list is the one
+// docs/runtime/webview.mdx publishes. Chrome refuses to start as root with
+// its sandbox on (crbug.com/638180), so on Linux the runtime adds --no-sandbox
+// when it is root itself, and only then.
+const launchSwitches = (userDataDir: unknown, noSandbox: boolean) => [
+  userDataDir,
+  "--remote-debugging-pipe",
+  "--headless",
+  "--no-first-run",
+  "--no-default-browser-check",
+  "--disable-gpu",
+  "--disable-extensions",
+  "--disable-background-networking",
+  "--disable-background-timer-throttling",
+  "--disable-backgrounding-occluded-windows",
+  "--disable-renderer-backgrounding",
+  "--disable-ipc-flooding-protection",
+  "--no-startup-window",
+  "--disable-dev-shm-usage",
+  ...(noSandbox ? ["--no-sandbox"] : []),
+];
+// The runtime's root check is compiled in for target_os linux and android.
+const hasRootCheck = isLinux || isAndroid;
+
+test.concurrent("the browser is launched with the documented switches", async () => {
+  const result = await runScenario(`
+    const view = newView();
+    await view.navigate("http://fake/");
+    print(await view.evaluate("process.execArgv"));
+    view.close();
+  `);
+  const root = hasRootCheck && process.geteuid!() === 0;
+  expect(result).toEqual(launchSwitches(expect.stringMatching(/^--user-data-dir=.+/), root));
+});
+
+// The test above only sees --no-sandbox when the test run itself is root,
+// which CI is not. A user namespace makes this user root inside it (uid 0 is
+// what getuid() and geteuid() return there) without any privilege, so the
+// positive side of the check is covered wherever unprivileged user namespaces
+// are allowed. The probe runs what the scenario needs, bun spawning bun inside
+// the namespace; where it fails (no unshare, or namespaces disabled, as in
+// most containers) the root run of the test above is the only coverage.
+// -U: new user namespace, -r: map this user to root in it. Short flags, since
+// busybox's unshare has them too.
+const unshare = ["unshare", "-U", "-r"];
+function userNamespaceWorks(): boolean {
+  if (!hasRootCheck) return false;
+  try {
+    const probe = Bun.spawnSync({
+      cmd: [
+        ...unshare,
+        bunExe(),
+        "-e",
+        `process.stdout.write(String(Bun.spawnSync([process.execPath, "-e", "process.stdout.write(String(process.geteuid()))"]).stdout))`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    return probe.exitCode === 0 && probe.stdout.toString() === "0";
+  } catch {
+    return false;
+  }
+}
+
+(userNamespaceWorks() ? test.concurrent : test.skip)("--no-sandbox is added when bun is root", async () => {
+  // dataStore.directory is passed through as the profile directory, so the
+  // expected list is literal.
+  const result = await runScenario(
+    `
+    const view = new Bun.WebView({ backend, width: 100, height: 100, dataStore: { directory: "/profile-dir" } });
+    await view.navigate("http://fake/");
+    print({ uid: process.getuid(), euid: process.geteuid(), execArgv: await view.evaluate("process.execArgv") });
+    view.close();
+  `,
+    unshare,
+  );
+  expect(result).toEqual({ uid: 0, euid: 0, execArgv: launchSwitches("--user-data-dir=/profile-dir", true) });
 });
 
 test.concurrent("a reply larger than the read buffer is reassembled", async () => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -646,11 +646,7 @@ it("chrome: views orphaned by a Chrome death are closed, even after a new view r
       bunExe(),
       "-e",
       `
-        // Spawn args come from whichever construction spawns Chrome, so every
-        // view passes them: the one constructed after closeAll() spawns the
-        // second Chrome. --no-sandbox: Chrome refuses to start as root
-        // (containers) otherwise.
-        const backend = { type: "chrome", url: false, argv: ["--no-sandbox"] };
+        const backend = { type: "chrome", url: false };
         const open = () => new Bun.WebView({ backend, width: 200, height: 200 });
         // An op on a dead view must throw synchronously, not hand back a
         // promise. The catch handler keeps an unfixed build's promise from


### PR DESCRIPTION
### Problem
- On Linux, `new Bun.WebView({ backend: "chrome" })` never works when Bun runs as root, which is how most containers run it. Chrome exits during startup and the constructor or the first `navigate()` fails with `error: Chrome exited`. Chrome's own message is only visible with `backend.stderr: "inherit"`: `zygote_host_impl_linux.cc: Running as root without --no-sandbox is not supported. See https://crbug.com/638180.`
- The flag list the runtime launches Chrome with (`src/runtime/webview/ChromeProcess.rs`, the `argv` vector in `spawn()`) has no `--no-sandbox`. A user can add it through `backend.argv`, except on one path: when auto-detect finds a stale `DevToolsActivePort` file and the WebSocket connect fails, `ChromeBackend.cpp` respawns with an empty argv, so that spawn cannot be fixed from JS.
- Once Chrome starts in a container, the next default gets it: Docker gives `/dev/shm` 64 MB, Chrome puts its shared memory there, and in this container the third 1280x720 view (the size of the docs example) dies with `Chrome killed by signal 5`. Playwright and puppeteer both pass `--disable-dev-shm-usage` by default, as do both puppeteer harnesses in this repo (`test/scripts/browser.js`, `test/integration/next-pages/test/dev-server-puppeteer.ts`).
- The tests show the same gap. As root, `test/js/bun/webview/webview-chrome.test.ts` fails 48 of 57 tests, and the workaround is being copied per test instead: two tests on main hardcode `argv: ["--no-sandbox"]` (`webview-chrome-disconnect.test.ts`, and the test #39097 added to `webview-chrome.test.ts`), and #39085, #39090 and #39091 each carry a further variant. CI does not see any of this because its agents are not root.

### Fix
- `ChromeProcess.rs::spawn()` appends `--no-sandbox` after the fixed flags, before `backend.argv`, when the target is Linux and `geteuid()` is 0. `--disable-dev-shm-usage` joins the fixed flags on every platform (Chrome ignores it where there is no `/dev/shm`), as in Playwright and puppeteer. These two hunks are the fix; `src/sys/lib.rs` only adds `geteuid` next to the existing `getuid` safe declaration.
- Why a runtime default is correct: as root, Chrome has exactly one configuration that launches, so the flag removes nothing a root user could have had. It turns a launch that always fails into the launch Playwright gives every user by default (its `chromiumSandbox` option defaults to false, and this flag set already follows Playwright's, see the comments in `spawn()`). Every non-root user keeps the sandbox, and the argv they get gains only `--disable-dev-shm-usage`. A user who already passes either flag gets a duplicate switch, which Chrome accepts.
- Why only root: Chrome's check also refuses a process whose real and effective ids differ, but whether such a process hands Chrome mixed ids depends on the launcher (the `google-chrome` launcher script is bash, which makes the ids uniform again), so no fixed rule for that case is right on both paths, and nobody has reported it. Details in the notes. A non-root container that blocks Chrome's sandbox is a separate case the runtime cannot detect; the docs now say to pass `argv: ["--no-sandbox"]` there.
- Linux only for `--no-sandbox` (`target_os = "linux"` or `"android"`): the refusal comes from Chrome's Linux-only zygote host (`zygote_host_impl_linux.cc`, the file named in the error), so there is nothing to add on macOS, and Windows has no uid.
- The docs flag list (`docs/runtime/webview.mdx`) and the `Backend` JSDoc in `bun.d.ts` state the new defaults (the JSDoc list was already missing half of the flags, so it now carries the full list). The two hardcoded `--no-sandbox` copies in the tests are removed, since the runtime now supplies the flag.
- Tests, in `test/js/bun/webview/webview-chrome-pipe.test.ts`. The fake browser there is bun running `fake-chrome-fixture.ts`, so the switches the runtime passes show up in its `process.execArgv` and no browser is needed:
  - "the browser is launched with the documented switches": the exact documented list, plus `--no-sandbox` exactly when the test process itself is root. Runs on every lane. On the unfixed build it fails everywhere (no `--disable-dev-shm-usage`); as root it also fails for the missing `--no-sandbox`.
  - "--no-sandbox is added when bun is root": runs the scenario under `unshare -U -r`, which makes the unprivileged CI user root inside a user namespace, and asserts the flag literally. It probes first (bun spawning bun inside the namespace) and skips where user namespaces are unavailable. In CI build 101118 it ran and passed on the Debian 13 lanes (the file reports 9 pass, 2 skip there, the 2 being the Windows-only tests) and skipped on Ubuntu 25.04 (8 pass, 3 skip), which restricts unprivileged user namespaces. It also skips in the container used for the work here.
  - The two real-Chrome tests that lost their hardcoded flag, and the untouched rest of `webview-chrome.test.ts`, are verified by hand as root: `bun bd test test/js/bun/webview/` with Google Chrome 151 installed passes in full (48 failures in `webview-chrome.test.ts` before).
  - The argv handed to the browser, recorded with `BUN_CHROME_PATH` pointed at a script that dumps `"$@"`: as uid 1500 it is the unfixed list plus `--disable-dev-shm-usage`, as root it additionally ends in `--no-sandbox`.
  - Six 1280x720 views with screenshots in this container (64 MB `/dev/shm`): Chrome dies at the third view without `--disable-dev-shm-usage` and survives all six with it.
  - `bun run rust:check-all`: 12 targets ok. `test/integration/bun-types/bun-types.test.ts` passes.

### Background
- `Bun.WebView`'s Chrome backend spawns one Chrome per process with a fixed flag list and talks to it over `--remote-debugging-pipe`. `backend.argv` is appended after that list, and only the first `new Bun.WebView()` in a process decides the flags, because later views reuse the running Chrome.
- Chrome's Linux sandbox starts renderer processes through a zygote process. Before it starts the zygote, Chrome checks its own ids and exits when it is root, unless `--no-sandbox` is passed. Chrome made this a hard exit on purpose (crbug.com/638180), so there is no other flag or environment setting that makes Chrome start as root.
- `/dev/shm` is the tmpfs Chrome uses by default for the shared memory that carries rendered tiles between its processes. Docker mounts it with a 64 MB limit unless `--shm-size` is given. `--disable-dev-shm-usage` makes Chrome create those files in the temporary directory instead.
- Auto-detect: with a plain `backend: "chrome"`, Bun first looks for a running Chrome's `DevToolsActivePort` file and connects to it. If the file is stale, the connection fails and Bun falls back to spawning its own Chrome. That fallback spawn does not carry the options from the constructor call, which is why the flag has to live in the runtime's own list to cover it.
- A user namespace (`unshare -U -r`) lets an unprivileged process see itself as uid 0 inside the namespace without gaining any privilege outside it. The runtime's `geteuid()` returns 0 there, which is what the second test relies on.

<details><summary>Notes</summary>

**Chrome's full check.** `ZygoteHostImpl::Init` calls `sandbox::Credentials::GetRESIds()`, which fails when the real, effective and saved uids are not all equal or the gids are not all equal, and exits with the "Running as root" message when that call fails or the uid is 0. Confirmed against Chrome 151 by starting `/opt/google/chrome/chrome` directly after `setresuid`/`setresgid` (with `--disable-crash-reporter`, because in this container the crash handler otherwise dies first in every non-root state):

| uids (real, effective, saved) | gids (real, effective, saved) | result |
| --- | --- | --- |
| 0, 0, 0 | 0, 0, 0 | refused |
| 0, 65534, 65534 | 65534, 65534, 65534 | refused |
| 65534, 0, 0 | 0, 0, 0 | refused |
| 1000, 1001, 1001 | 1000, 1000, 1000 | refused (no root involved) |
| 65534, 65534, 65534 | 0, 65534, 65534 | refused (gids mixed) |
| 65534, 65534, 65534 | 65534, 65534, 65534 | passes the check |
| 65534, 65534, 65534 | 0, 0, 0 | passes the check (uniform gid 0 is fine) |

Every refused row starts with `--no-sandbox` added.

**Why the mixed-id rows are not handled.** The rows only describe a directly executed binary. The first candidates `find_chrome()` looks for (`google-chrome-stable`, `google-chrome`, most distro `chromium` entries) are shell scripts, and a shell started with differing ids resets the effective ids to the real ones, so through them Chrome sees uniform ids: a process with real uid 0 and a dropped effective uid launches a root Chrome (flag needed), while the mixed non-root rows launch a uniform non-root Chrome that the sandbox check accepts (flag harmful). Passing the flag for mixed ids therefore fixes the direct-binary path and removes a working sandbox on the default path, and not passing it does the reverse. Earlier versions of this PR tried `getuid() == 0 || geteuid() == 0` and then Chrome's full rule; with no report of either situation, the PR keeps the rule to the case that is reproduced, and `backend.argv` remains the way to handle the others.

**Earlier versions.** The first version changed only `webview-chrome.test.ts`, threading a root-conditional argv through its launch sites. Self-review pointed out that this was another copy of the per-test workaround and could never cover the argv-less fallback spawn, so the fix moved into the launcher. Later rounds added `--disable-dev-shm-usage` (the container the docs describe still killed Chrome after two views), widened the uid rule as described above, and then narrowed it back.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome.test.ts, test/js/bun/webview/webview-chrome-pipe.test.ts, test/js/bun/webview/webview-chrome-disconnect.test.ts

<!-- robobun:evidence:end -->