### PR TITLE
Bun.markdown: implement the latexMath and underline options

### DIFF
--- a/docs/runtime/markdown.mdx
+++ b/docs/runtime/markdown.mdx
@@ -61,8 +61,8 @@ All available options:
 | `headings`             | `false` | Heading IDs and autolinks — see [Heading IDs](#heading-ids) |
 | `hardSoftBreaks`       | `false` | Treat soft line breaks as hard breaks                       |
 | `wikiLinks`            | `false` | Enable `[[wiki links]]`                                     |
-| `underline`            | `false` | `__text__` renders as `<u>` instead of `<strong>`           |
-| `latexMath`            | `false` | Enable `$inline$` and `$$display$$` math                    |
+| `underline`            | `false` | `_` emphasis renders as `<u>` instead of `<em>`/`<strong>`  |
+| `latexMath`            | `false` | `$inline$` and `$$display$$` math render as `<x-equation>`  |
 | `collapseWhitespace`   | `false` | Collapse whitespace in text                                 |
 | `permissiveAtxHeaders` | `false` | ATX headers without space after `#`                         |
 | `noIndentedCodeBlocks` | `false` | Disable indented code blocks                                |
@@ -357,6 +357,8 @@ You can override every HTML tag the parser produces:
 | `img`        | `{ src, alt?, title? }`      | Image (no children)                                             |
 | `code`       | `{ children }`               | Inline code                                                     |
 | `del`        | `{ children }`               | Strikethrough (`~~text~~`)                                      |
+| `u`          | `{ children }`               | Underline (`_text_` with the `underline` option)                |
+| `math`       | `{ display?, children }`     | Math span (`latexMath` option). `display` is set for `$$text$$` |
 | `br`         | `{}`                         | Hard line break (no children)                                   |
 
 ### React 18 and older

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1323,9 +1323,17 @@ declare module "bun" {
       hardSoftBreaks?: boolean;
       /** Enable wiki-style links (`[[target]]` or `[[target|label]]`). Default: `false`. */
       wikiLinks?: boolean;
-      /** Enable underline syntax (`__text__` renders as `<u>` instead of `<strong>`). Default: `false`. */
+      /**
+       * Render underscore emphasis as underline: `_text_` produces `<u>`
+       * instead of `<em>`, and `__text__` produces nested `<u>` instead of
+       * `<strong>`. Asterisk emphasis is unchanged. Default: `false`.
+       */
       underline?: boolean;
-      /** Enable LaTeX math (`$inline$` and `$$display$$`). Default: `false`. */
+      /**
+       * Enable LaTeX math spans: `$inline$` renders as `<x-equation>` and
+       * `$$display$$` as `<x-equation type="display">`. The content of a math
+       * span is passed through verbatim, like a code span. Default: `false`.
+       */
       latexMath?: boolean;
       /** Collapse whitespace in text content. Default: `false`. */
       collapseWhitespace?: boolean;
@@ -1410,6 +1418,10 @@ declare module "bun" {
       /** Image title attribute. */
       title?: string;
     }
+    interface MathProps extends ChildrenProps {
+      /** Set for display math (`$$text$$`); absent for inline math (`$text$`). */
+      display?: true;
+    }
 
     /**
      * Component overrides for `react()`.
@@ -1452,7 +1464,9 @@ declare module "bun" {
       img?: Component<ImageProps>;
       code?: Component<ChildrenProps>;
       del?: Component<ChildrenProps>;
-      math?: Component<ChildrenProps>;
+      /** LaTeX math span. Only produced with the `latexMath` option. */
+      math?: Component<MathProps>;
+      /** Underline span. Only produced with the `underline` option. */
       u?: Component<ChildrenProps>;
       br?: Component<{}>;
     }

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1657,8 +1657,8 @@ declare module "bun" {
      * Render markdown to an ANSI-colored terminal string.
      *
      * Supports headings, lists, tables, inline styles, syntax-highlighted
-     * code blocks, links, images, and blockquotes. By default, enables all
-     * GFM extensions plus wikilinks, underline, and LaTeX math.
+     * code blocks, links, images, and blockquotes. Enables all GFM
+     * extensions plus wikilinks, autolinks, and LaTeX math spans.
      *
      * @param input The markdown string or buffer to render
      * @param theme Optional theme overrides

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -701,7 +701,11 @@ impl<'a> AnsiRenderer<'a> {
             TextType::Code | TextType::Latexmath => {
                 // A line break inside the span is a space (as in the HTML renderer).
                 if strings::contains_char(content, b'\n') {
-                    let mut one_line = content.to_vec();
+                    let mut one_line: Vec<u8> = Vec::new();
+                    try_extend(&mut self.out.oom, &mut one_line, content);
+                    if self.out.oom {
+                        return;
+                    }
                     for byte in &mut one_line {
                         if *byte == b'\n' {
                             *byte = b' ';

--- a/src/md/ansi_renderer.rs
+++ b/src/md/ansi_renderer.rs
@@ -698,10 +698,20 @@ impl<'a> AnsiRenderer<'a> {
             // them at internal spaces. writeStyled with empty prefix routes
             // the content through the active buffer + updates col in one
             // pass, without the paragraph word-wrap logic.
-            TextType::Code => self.write_styled(b"", content),
-            // LaTeX math spans are atomic like .code — don't let
-            // writeWrapped split `$E = mc^2$` at internal spaces.
-            TextType::Latexmath => self.write_styled(b"", content),
+            TextType::Code | TextType::Latexmath => {
+                // A line break inside the span is a space (as in the HTML renderer).
+                if strings::contains_char(content, b'\n') {
+                    let mut one_line = content.to_vec();
+                    for byte in &mut one_line {
+                        if *byte == b'\n' {
+                            *byte = b' ';
+                        }
+                    }
+                    self.write_styled(b"", &one_line);
+                } else {
+                    self.write_styled(b"", content);
+                }
+            }
             _ => self.write_content(content),
         }
     }

--- a/src/md/helpers.rs
+++ b/src/md/helpers.rs
@@ -55,6 +55,10 @@ pub(crate) fn is_unicode_punctuation(codepoint: u32) -> bool {
     is_unicode_punctuation_extended(codepoint)
 }
 
+pub(crate) fn is_unicode_whitespace_or_punctuation(codepoint: u32) -> bool {
+    is_unicode_whitespace(codepoint) || is_unicode_punctuation(codepoint)
+}
+
 /// Check if byte is ASCII punctuation per CommonMark spec.
 #[inline]
 pub(crate) fn is_ascii_punctuation(c: u8) -> bool {

--- a/src/md/html_renderer.rs
+++ b/src/md/html_renderer.rs
@@ -371,8 +371,8 @@ impl<'src> HtmlRenderer<'src> {
                 }
             }
             TextType::Entity => self.write_entity(content),
-            TextType::Code => {
-                // In code spans, newlines become spaces
+            TextType::Code | TextType::Latexmath => {
+                // In code and math spans, newlines become spaces
                 let mut start: usize = 0;
                 for (j, &byte) in content.iter().enumerate() {
                     if byte == b'\n' {

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -31,15 +31,13 @@ pub struct EmphDelim {
     pub(crate) remaining: usize,   // chars not yet consumed
     pub(crate) open_count: usize,  // total chars consumed as opener
     pub(crate) close_count: usize, // total chars consumed as closer
+    pub(crate) close_pos: usize,   // matched `$` openers only: start of the closing run
     // Individual match sizes in order (each is 1 for em, 2 for strong)
     pub(crate) open_sizes: [u8; MAX_EMPH_MATCHES],
     pub(crate) open_num: u8, // number of open matches
     pub(crate) close_sizes: [u8; MAX_EMPH_MATCHES],
     pub(crate) close_num: u8, // number of close matches
     pub(crate) active: bool,  // false if deactivated between matched pairs
-    // `$` openers only: position of the closing run this opener was matched
-    // with. The span's content is `content[pos + count..close_pos]`.
-    pub(crate) close_pos: usize,
 }
 
 impl Default for EmphDelim {
@@ -53,12 +51,12 @@ impl Default for EmphDelim {
             remaining: 0,
             open_count: 0,
             close_count: 0,
+            close_pos: 0,
             open_sizes: [0; MAX_EMPH_MATCHES],
             open_num: 0,
             close_sizes: [0; MAX_EMPH_MATCHES],
             close_num: 0,
             active: true,
-            close_pos: 0,
         }
     }
 }
@@ -335,12 +333,7 @@ impl Parser<'_> {
                     continue;
                 }
 
-                // Math span (`$...$` or `$$...$$`), paired up in
-                // resolve_math_delim. The whole span is emitted here and its
-                // content is verbatim, so the walk skips to the closing run. A
-                // run that did not open a span is text; that includes a closer
-                // whose opener was consumed by a construct emitted before it
-                // (a wiki link whose target contains a `$`).
+                // Math span: emitted whole at its opener, so any other `$` run here is text.
                 if c == b'$' && self.flags.latex_math {
                     while delim_cursor < resolved.len() && resolved[delim_cursor].pos < i {
                         delim_cursor += 1;
@@ -383,17 +376,20 @@ impl Parser<'_> {
 
                         let d = &resolved[delim_cursor];
                         let run_end = d.pos + d.count;
+                        // md4c's MD_FLAG_UNDERLINE: every matched underscore is one U span.
+                        let underline = d.emph_char == b'_' && self.flags.underline;
 
                         // Emit closing tags first (innermost to outermost)
                         if d.emph_char == b'~' {
                             if d.close_count > 0 {
                                 self.leave_span(SpanType::Del)?;
                             }
+                        } else if underline {
+                            for _ in 0..d.close_count {
+                                self.leave_span(SpanType::U)?;
+                            }
                         } else {
-                            self.emit_emph_close_tags(
-                                d.emph_char,
-                                &d.close_sizes[0..d.close_num as usize],
-                            )?;
+                            self.emit_emph_close_tags(&d.close_sizes[0..d.close_num as usize])?;
                         }
 
                         // Emit remaining delimiter chars as text
@@ -407,11 +403,12 @@ impl Parser<'_> {
                             if d.open_count > 0 {
                                 self.enter_span(SpanType::Del)?;
                             }
+                        } else if underline {
+                            for _ in 0..d.open_count {
+                                self.enter_span(SpanType::U)?;
+                            }
                         } else {
-                            self.emit_emph_open_tags(
-                                d.emph_char,
-                                &d.open_sizes[0..d.open_num as usize],
-                            )?;
+                            self.emit_emph_open_tags(&d.open_sizes[0..d.open_num as usize])?;
                         }
 
                         delim_cursor += 1;
@@ -655,28 +652,12 @@ impl Parser<'_> {
         self.renderer.text(text_type, content)
     }
 
-    /// With the underline extension, `_` runs still pair up by the CommonMark
-    /// emphasis rules, but every matched underscore becomes one `U` span
-    /// instead of an em (1) or strong (2) span, as in md4c's MD_FLAG_UNDERLINE.
-    fn emits_underline(&self, emph_char: u8) -> bool {
-        emph_char == b'_' && self.flags.underline
-    }
-
     /// Emit emphasis opening tags (outermost to innermost).
-    pub(crate) fn emit_emph_open_tags(
-        &mut self,
-        emph_char: u8,
-        sizes: &[u8],
-    ) -> crate::types::JsResult<()> {
-        if self.emits_underline(emph_char) {
-            for _ in 0..sizes.iter().map(|&size| usize::from(size)).sum::<usize>() {
-                self.enter_span(SpanType::U)?;
-            }
-            return Ok(());
-        }
+    pub(crate) fn emit_emph_open_tags(&mut self, sizes: &[u8]) -> crate::types::JsResult<()> {
         // First match = innermost, so emit in reverse (outermost first in HTML)
-        for &size in sizes.iter().rev() {
-            if size == 2 {
+        for idx in 0..sizes.len() {
+            let j = sizes.len() - 1 - idx;
+            if sizes[j] == 2 {
                 self.enter_span(SpanType::Strong)?;
             } else {
                 self.enter_span(SpanType::Em)?;
@@ -687,17 +668,7 @@ impl Parser<'_> {
 
     /// Emit emphasis closing tags (innermost to outermost).
     /// First entry in sizes was matched first (innermost), emit in forward order.
-    pub(crate) fn emit_emph_close_tags(
-        &mut self,
-        emph_char: u8,
-        sizes: &[u8],
-    ) -> crate::types::JsResult<()> {
-        if self.emits_underline(emph_char) {
-            for _ in 0..sizes.iter().map(|&size| usize::from(size)).sum::<usize>() {
-                self.leave_span(SpanType::U)?;
-            }
-            return Ok(());
-        }
+    pub(crate) fn emit_emph_close_tags(&mut self, sizes: &[u8]) -> crate::types::JsResult<()> {
         for &size in sizes {
             if size == 2 {
                 self.leave_span(SpanType::Strong)?;
@@ -826,9 +797,7 @@ impl Parser<'_> {
                 });
                 continue;
             }
-            // Math span delimiter (1 or 2 dollars only; a longer run is text).
-            // md4c's rule: a run can open only after whitespace or punctuation
-            // and close only before them, so `$5 and $10` stays text.
+            // Math span delimiter, with md4c's flanking rule (it keeps `$5 and $10` as text).
             if c == b'$' && self.flags.latex_math {
                 let run_start = i;
                 while i < content.len() && content[i] == b'$' {
@@ -1032,10 +1001,7 @@ impl Parser<'_> {
         }
     }
 
-    /// Pair `$` runs the way md4c's `md_analyze_dollar` does: a run closes the
-    /// most recent pending opener only if both runs have the same length
-    /// (`$` vs `$$`); otherwise it becomes a pending opener itself, if it may
-    /// open. A match discards every pending opener, so math spans never nest.
+    /// md4c's `md_analyze_dollar`: only same-length runs pair, and a match drops every pending opener.
     fn resolve_math_delim(
         &mut self,
         idx: usize,
@@ -1053,8 +1019,7 @@ impl Parser<'_> {
                     opener.close_pos = run.pos;
                     self.emph_delims[idx].remaining = 0;
                     self.emph_delims[idx].close_count = run.count;
-                    // The span's content is verbatim, so nothing inside it may
-                    // still pair up with a delimiter outside of it.
+                    // Nothing inside the verbatim span may pair with a delimiter outside it.
                     for inner in &mut self.emph_delims[oi + 1..idx] {
                         inner.active = false;
                     }

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -25,7 +25,7 @@ pub(crate) struct LabelFrame {
 pub struct EmphDelim {
     pub(crate) pos: usize,    // start position in content
     pub(crate) count: usize,  // original run length
-    pub(crate) emph_char: u8, // * or _
+    pub(crate) emph_char: u8, // *, _, ~ or $ (math span delimiter)
     pub(crate) can_open: bool,
     pub(crate) can_close: bool,
     pub(crate) remaining: usize,   // chars not yet consumed
@@ -37,6 +37,9 @@ pub struct EmphDelim {
     pub(crate) close_sizes: [u8; MAX_EMPH_MATCHES],
     pub(crate) close_num: u8, // number of close matches
     pub(crate) active: bool,  // false if deactivated between matched pairs
+    // `$` openers only: position of the closing run this opener was matched
+    // with. The span's content is `content[pos + count..close_pos]`.
+    pub(crate) close_pos: usize,
 }
 
 impl Default for EmphDelim {
@@ -55,6 +58,7 @@ impl Default for EmphDelim {
             close_sizes: [0; MAX_EMPH_MATCHES],
             close_num: 0,
             active: true,
+            close_pos: 0,
         }
     }
 }
@@ -331,6 +335,40 @@ impl Parser<'_> {
                     continue;
                 }
 
+                // Math span (`$...$` or `$$...$$`), paired up in
+                // resolve_math_delim. The whole span is emitted here and its
+                // content is verbatim, so the walk skips to the closing run. A
+                // run that did not open a span is text; that includes a closer
+                // whose opener was consumed by a construct emitted before it
+                // (a wiki link whose target contains a `$`).
+                if c == b'$' && self.flags.latex_math {
+                    while delim_cursor < resolved.len() && resolved[delim_cursor].pos < i {
+                        delim_cursor += 1;
+                    }
+                    let Some(d) = resolved
+                        .get(delim_cursor)
+                        .filter(|d| d.pos == i && d.open_count > 0)
+                    else {
+                        i += 1;
+                        continue;
+                    };
+                    if i > text_start {
+                        self.emit_text(TextType::Normal, &content[text_start..i])?;
+                    }
+                    let span_type = if d.count == 2 {
+                        SpanType::LatexmathDisplay
+                    } else {
+                        SpanType::Latexmath
+                    };
+                    self.enter_span(span_type)?;
+                    self.emit_text(TextType::Latexmath, &content[i + d.count..d.close_pos])?;
+                    self.leave_span(span_type)?;
+                    delim_cursor += 1;
+                    i = d.close_pos + d.count;
+                    text_start = i;
+                    continue;
+                }
+
                 // Emphasis/strikethrough with * or _ or ~ — use resolved delimiters
                 if c == b'*' || c == b'_' || (c == b'~' && self.flags.strikethrough) {
                     // Find the corresponding resolved delimiter
@@ -352,7 +390,10 @@ impl Parser<'_> {
                                 self.leave_span(SpanType::Del)?;
                             }
                         } else {
-                            self.emit_emph_close_tags(&d.close_sizes[0..d.close_num as usize])?;
+                            self.emit_emph_close_tags(
+                                d.emph_char,
+                                &d.close_sizes[0..d.close_num as usize],
+                            )?;
                         }
 
                         // Emit remaining delimiter chars as text
@@ -367,7 +408,10 @@ impl Parser<'_> {
                                 self.enter_span(SpanType::Del)?;
                             }
                         } else {
-                            self.emit_emph_open_tags(&d.open_sizes[0..d.open_num as usize])?;
+                            self.emit_emph_open_tags(
+                                d.emph_char,
+                                &d.open_sizes[0..d.open_num as usize],
+                            )?;
                         }
 
                         delim_cursor += 1;
@@ -611,12 +655,28 @@ impl Parser<'_> {
         self.renderer.text(text_type, content)
     }
 
+    /// With the underline extension, `_` runs still pair up by the CommonMark
+    /// emphasis rules, but every matched underscore becomes one `U` span
+    /// instead of an em (1) or strong (2) span, as in md4c's MD_FLAG_UNDERLINE.
+    fn emits_underline(&self, emph_char: u8) -> bool {
+        emph_char == b'_' && self.flags.underline
+    }
+
     /// Emit emphasis opening tags (outermost to innermost).
-    pub(crate) fn emit_emph_open_tags(&mut self, sizes: &[u8]) -> crate::types::JsResult<()> {
+    pub(crate) fn emit_emph_open_tags(
+        &mut self,
+        emph_char: u8,
+        sizes: &[u8],
+    ) -> crate::types::JsResult<()> {
+        if self.emits_underline(emph_char) {
+            for _ in 0..sizes.iter().map(|&size| usize::from(size)).sum::<usize>() {
+                self.enter_span(SpanType::U)?;
+            }
+            return Ok(());
+        }
         // First match = innermost, so emit in reverse (outermost first in HTML)
-        for idx in 0..sizes.len() {
-            let j = sizes.len() - 1 - idx;
-            if sizes[j] == 2 {
+        for &size in sizes.iter().rev() {
+            if size == 2 {
                 self.enter_span(SpanType::Strong)?;
             } else {
                 self.enter_span(SpanType::Em)?;
@@ -627,7 +687,17 @@ impl Parser<'_> {
 
     /// Emit emphasis closing tags (innermost to outermost).
     /// First entry in sizes was matched first (innermost), emit in forward order.
-    pub(crate) fn emit_emph_close_tags(&mut self, sizes: &[u8]) -> crate::types::JsResult<()> {
+    pub(crate) fn emit_emph_close_tags(
+        &mut self,
+        emph_char: u8,
+        sizes: &[u8],
+    ) -> crate::types::JsResult<()> {
+        if self.emits_underline(emph_char) {
+            for _ in 0..sizes.iter().map(|&size| usize::from(size)).sum::<usize>() {
+                self.leave_span(SpanType::U)?;
+            }
+            return Ok(());
+        }
         for &size in sizes {
             if size == 2 {
                 self.leave_span(SpanType::Strong)?;
@@ -756,6 +826,39 @@ impl Parser<'_> {
                 });
                 continue;
             }
+            // Math span delimiter (1 or 2 dollars only; a longer run is text).
+            // md4c's rule: a run can open only after whitespace or punctuation
+            // and close only before them, so `$5 and $10` stays text.
+            if c == b'$' && self.flags.latex_math {
+                let run_start = i;
+                while i < content.len() && content[i] == b'$' {
+                    i += 1;
+                }
+                let count = i - run_start;
+                if count > 2 {
+                    continue;
+                }
+                let can_open = run_start == 0
+                    || helpers::is_unicode_whitespace_or_punctuation(
+                        helpers::decode_utf8_backward(content, run_start).codepoint,
+                    );
+                let can_close = i >= content.len()
+                    || helpers::is_unicode_whitespace_or_punctuation(
+                        helpers::decode_utf8(content, i).codepoint,
+                    );
+                if can_open || can_close {
+                    self.emph_delims.push(EmphDelim {
+                        pos: run_start,
+                        count,
+                        emph_char: b'$',
+                        can_open,
+                        can_close,
+                        remaining: count,
+                        ..Default::default()
+                    });
+                }
+                continue;
+            }
             // Strikethrough delimiter (1 or 2 tildes only)
             if c == b'~' && self.flags.strikethrough {
                 let run_start = i;
@@ -800,10 +903,17 @@ impl Parser<'_> {
         };
         let mut openers_bottom: [usize; 18] = [0; 18];
         let mut prev_candidate: Vec<usize> = (0..len).map(|i| i.wrapping_sub(1)).collect();
+        // Indices of `$` runs that may still open a math span, oldest first.
+        let mut math_openers: Vec<usize> = Vec::new();
 
         // Process potential closers from left to right
         let mut closer_idx: usize = 0;
         while closer_idx < len {
+            if self.emph_delims[closer_idx].emph_char == b'$' {
+                self.resolve_math_delim(closer_idx, &mut math_openers, &mut prev_candidate);
+                closer_idx += 1;
+                continue;
+            }
             if !self.emph_delims[closer_idx].can_close
                 || self.emph_delims[closer_idx].remaining == 0
             {
@@ -890,6 +1000,9 @@ impl Parser<'_> {
                         self.emph_delims[k].active = false;
                         k = prev_candidate[k];
                     }
+                    while math_openers.last().is_some_and(|&m| m > oi) {
+                        math_openers.pop();
+                    }
                     prev_candidate[closer_idx] = oi;
 
                     found_match = true;
@@ -916,6 +1029,43 @@ impl Parser<'_> {
             }
 
             closer_idx = closer_idx.wrapping_add(1);
+        }
+    }
+
+    /// Pair `$` runs the way md4c's `md_analyze_dollar` does: a run closes the
+    /// most recent pending opener only if both runs have the same length
+    /// (`$` vs `$$`); otherwise it becomes a pending opener itself, if it may
+    /// open. A match discards every pending opener, so math spans never nest.
+    fn resolve_math_delim(
+        &mut self,
+        idx: usize,
+        math_openers: &mut Vec<usize>,
+        prev_candidate: &mut [usize],
+    ) {
+        let run = self.emph_delims[idx];
+        if run.can_close {
+            if let Some(&oi) = math_openers.last() {
+                let opener = &mut self.emph_delims[oi];
+                debug_assert!(opener.active && opener.remaining > 0);
+                if opener.count == run.count {
+                    opener.remaining = 0;
+                    opener.open_count = run.count;
+                    opener.close_pos = run.pos;
+                    self.emph_delims[idx].remaining = 0;
+                    self.emph_delims[idx].close_count = run.count;
+                    // The span's content is verbatim, so nothing inside it may
+                    // still pair up with a delimiter outside of it.
+                    for inner in &mut self.emph_delims[oi + 1..idx] {
+                        inner.active = false;
+                    }
+                    prev_candidate[idx] = oi;
+                    math_openers.clear();
+                    return;
+                }
+            }
+        }
+        if run.can_open {
+            math_openers.push(idx);
         }
     }
 

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -370,8 +370,8 @@ impl<'a> Parser<'a> {
     //   emit_text, emit_emph_open_tags, emit_emph_close_tags,
     //   find_code_span_end, normalize_code_span_content, is_left_flanking,
     //   is_right_flanking, can_open_emphasis, can_close_emphasis,
-    //   collect_emphasis_delimiters, resolve_emphasis_delimiters,
-    //   resolve_math_delim, find_entity, find_html_tag
+    //   collect_emphasis_delimiters, resolve_emphasis_delimiters, find_entity,
+    //   find_html_tag, resolve_math_delim
     //
     // links.rs — impl Parser:
     //   compute_bracket_matches, match_bracket, scan_bracket_close,

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -370,8 +370,8 @@ impl<'a> Parser<'a> {
     //   emit_text, emit_emph_open_tags, emit_emph_close_tags,
     //   find_code_span_end, normalize_code_span_content, is_left_flanking,
     //   is_right_flanking, can_open_emphasis, can_close_emphasis,
-    //   collect_emphasis_delimiters, resolve_emphasis_delimiters, find_entity,
-    //   find_html_tag
+    //   collect_emphasis_delimiters, resolve_emphasis_delimiters,
+    //   resolve_math_delim, find_entity, find_html_tag
     //
     // links.rs — impl Parser:
     //   compute_bracket_matches, match_bracket, scan_bracket_close,

--- a/src/md/root.rs
+++ b/src/md/root.rs
@@ -115,6 +115,7 @@ impl Options {
                 || self.permissive_autolinks,
             wiki_links: self.wiki_links,
             latex_math: self.latex_math,
+            underline: self.underline,
             collapse_whitespace: self.collapse_whitespace,
             permissive_atx_headers: self.permissive_atx_headers,
             no_indented_code_blocks: self.no_indented_code_blocks,

--- a/src/md/root.rs
+++ b/src/md/root.rs
@@ -99,7 +99,8 @@ impl Options {
         permissive_www_autolinks: true,
         permissive_email_autolinks: true,
         wiki_links: true,
-        underline: true,
+        // Off pending #39560: on, every `_em_` in a README would render underlined.
+        underline: false,
         latex_math: true,
         ..Self::NONE
     };

--- a/src/md/types.rs
+++ b/src/md/types.rs
@@ -233,6 +233,7 @@ pub struct Flags {
     pub(crate) strikethrough: bool,
     pub(crate) tasklists: bool,
     pub(crate) latex_math: bool,
+    pub(crate) underline: bool,
     pub(crate) wiki_links: bool,
 }
 

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -41,6 +41,10 @@ describe("bun <file.md>", () => {
     expect(await runMd("**bold** *italic* ~~strike~~ `code` regular\n")).toMatchSnapshot();
   });
 
+  test("renders underline and math spans (enabled by the terminal preset)", async () => {
+    expect(await runMd("_under_ and $x$\n")).toBe("\x1b[4munder\x1b[24m and \x1b[35m$x$\x1b[39m\x1b[0m\n");
+  });
+
   test("renders ordered, unordered, and task lists", async () => {
     expect(
       await runMd(

--- a/test/cli/run/markdown-entrypoint.test.ts
+++ b/test/cli/run/markdown-entrypoint.test.ts
@@ -41,8 +41,8 @@ describe("bun <file.md>", () => {
     expect(await runMd("**bold** *italic* ~~strike~~ `code` regular\n")).toMatchSnapshot();
   });
 
-  test("renders underline and math spans (enabled by the terminal preset)", async () => {
-    expect(await runMd("_under_ and $x$\n")).toBe("\x1b[4munder\x1b[24m and \x1b[35m$x$\x1b[39m\x1b[0m\n");
+  test("renders math spans; underscores stay emphasis", async () => {
+    expect(await runMd("_em_ and $x$\n")).toBe("\x1b[3mem\x1b[23m and \x1b[35m$x$\x1b[39m\x1b[0m\n");
   });
 
   test("renders ordered, unordered, and task lists", async () => {

--- a/test/integration/bun-types/fixture/markdown.ts
+++ b/test/integration/bun-types/fixture/markdown.ts
@@ -1,0 +1,27 @@
+import { expectType } from "./utilities";
+
+expectType(Bun.markdown.html("$x$", { latexMath: true, underline: true })).is<string>();
+expectType(Bun.markdown.render("_x_", {}, { underline: true })).is<string>();
+
+Bun.markdown.react(
+  "$x$ $$y$$ _z_",
+  {
+    math: ({ display, children }) => {
+      expectType(display).is<true | undefined>();
+      expectType(children).is<Bun.markdown.ChildrenProps["children"]>();
+      return null;
+    },
+    u: ({ children }) => {
+      expectType(children).is<Bun.markdown.ChildrenProps["children"]>();
+      return null;
+    },
+  },
+  { latexMath: true, underline: true },
+);
+
+// A component that only takes children still satisfies the math override.
+const Plain = (props: Bun.markdown.ChildrenProps) => props.children;
+Bun.markdown.react("$x$", { math: Plain, u: Plain }, { latexMath: true });
+
+// @ts-expect-error
+Bun.markdown.html("$x$", { latexMath: "yes" });

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1537,6 +1537,23 @@ describe("underline option", () => {
     expect(underline(input)).toBe(expected);
   });
 
+  // The em/strong emitter records at most MAX_EMPH_MATCHES (6) matches per
+  // delimiter run; underline is emitted from the consumed character counts
+  // instead, so long runs get exactly one <u> per underscore on both sides.
+  const fill = (n: number, unit: string) => Buffer.alloc(n * unit.length, unit).toString();
+
+  test("long runs underline once per underscore", () => {
+    expect(underline(`${fill(14, "_")}foo${fill(14, "_")}\n`)).toBe(
+      `<p>${fill(14, "<u>")}foo${fill(14, "</u>")}</p>\n`,
+    );
+  });
+
+  test("one opener consumed by many closers stays balanced", () => {
+    expect(underline(`${fill(14, "_")}a__ b__ c__ d__ e__ f__ g__\n`)).toBe(
+      `<p>${fill(14, "<u>")}a</u></u> b</u></u> c</u></u> d</u></u> e</u></u> f</u></u> g</u></u></p>\n`,
+    );
+  });
+
   test("ansi() enables underline", () => {
     expect(Markdown.ansi("_a_ *b*\n")).toBe("\x1b[4ma\x1b[24m \x1b[3mb\x1b[23m\x1b[0m\n");
   });

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -479,14 +479,16 @@ code
   });
 
   test("latex math edge cases", () => {
-    const inputs = [
-      "$$ $$\n", // empty display math
-      "$ $\n", // empty inline math
-      "$a$b$c$\n", // adjacent math
-      "$$\n\\frac{1}{2}\n$$\n", // multi-line display math
+    const cases = [
+      ["$$ $$\n", '<p><x-equation type="display"> </x-equation></p>\n'],
+      ["$ $\n", "<p><x-equation> </x-equation></p>\n"],
+      // The inner dollars sit between word characters, so they can neither
+      // open nor close and the outer pair spans across them.
+      ["$a$b$c$\n", "<p><x-equation>a$b$c</x-equation></p>\n"],
+      ["$$\n\\frac{1}{2}\n$$\n", '<p><x-equation type="display"> \\frac{1}{2} </x-equation></p>\n'],
     ];
-    for (const input of inputs) {
-      expect(typeof Markdown.html(input, { latexMath: true })).toBe("string");
+    for (const [input, expected] of cases) {
+      expect(Markdown.html(input, { latexMath: true })).toBe(expected);
     }
   });
 
@@ -1380,5 +1382,162 @@ describe.concurrent("importing .md modules", () => {
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
     expect(stderr).toContain("Missing 'default' export");
     expect(exitCode).not.toBe(0);
+  });
+});
+
+// ============================================================================
+// md4c's LaTeX math extension (`latexMath`): `$...$` and `$$...$$` become
+// <x-equation> spans whose content is verbatim, like a code span.
+// ============================================================================
+
+describe("latexMath option", () => {
+  const math = (md: string) => Markdown.html(md, { latexMath: true });
+
+  test("is off by default", () => {
+    expect(Markdown.html("$a$ $$b$$\n")).toBe("<p>$a$ $$b$$</p>\n");
+    expect(Markdown.html("$a$ $$b$$\n", { latexMath: false })).toBe("<p>$a$ $$b$$</p>\n");
+  });
+
+  test.each([
+    ["inline", "$a+b$ text\n", "<p><x-equation>a+b</x-equation> text</p>\n"],
+    ["display", "$$a+b$$\n", '<p><x-equation type="display">a+b</x-equation></p>\n'],
+    [
+      "inline and display in one paragraph",
+      "$a$ and $$b$$\n",
+      '<p><x-equation>a</x-equation> and <x-equation type="display">b</x-equation></p>\n',
+    ],
+    [
+      "content is verbatim and HTML-escaped",
+      "$a_1 * b_2 & <c>$\n",
+      "<p><x-equation>a_1 * b_2 &amp; &lt;c&gt;</x-equation></p>\n",
+    ],
+    ["emphasis inside math is not emphasis", "$*a*$\n", "<p><x-equation>*a*</x-equation></p>\n"],
+    ["backslashes inside math are kept", "$\\{x\\}$\n", "<p><x-equation>\\{x\\}</x-equation></p>\n"],
+    ["a link inside math is text", "$[a](/u)$\n", "<p><x-equation>[a](/u)</x-equation></p>\n"],
+    ["a code span inside math is text", "$a `b` c$\n", "<p><x-equation>a `b` c</x-equation></p>\n"],
+    ["newlines inside math become spaces", "$a\nb$\n", "<p><x-equation>a b</x-equation></p>\n"],
+    ["multi-line display math", "$$\na\nb\n$$\n", '<p><x-equation type="display"> a b </x-equation></p>\n'],
+    ["escaped opener", "\\$a$\n", "<p>$a$</p>\n"],
+    ["a dollar inside a code span is not a delimiter", "`$a` b$\n", "<p><code>$a</code> b$</p>\n"],
+    ["unclosed", "$a b\n", "<p>$a b</p>\n"],
+    ["prices: openers followed by a digit never close", "costs $5 and $10\n", "<p>costs $5 and $10</p>\n"],
+    ["opener preceded by a word character", "x$a$\n", "<p>x$a$</p>\n"],
+    ["closer followed by a word character", "$a$x\n", "<p>$a$x</p>\n"],
+    ["$$ does not close $", "$a$$\n", "<p>$a$$</p>\n"],
+    ["$ does not close $$", "$$a$ b\n", "<p>$$a$ b</p>\n"],
+    ["only the most recent pending opener is considered", "$$a $b c$$\n", "<p>$$a $b c$$</p>\n"],
+    [
+      "no nesting: the inner pair wins and the outer opener is dropped",
+      "$$a $b$ c$$\n",
+      "<p>$$a <x-equation>b</x-equation> c$$</p>\n",
+    ],
+    ["three or more dollars are text", "$$$a$$$\n", "<p>$$$a$$$</p>\n"],
+    ["math inside emphasis", "*a $b$ c*\n", "<p><em>a <x-equation>b</x-equation> c</em></p>\n"],
+    ["emphasis closing inside a pending math span wins", "*a $b* c$\n", "<p><em>a $b</em> c$</p>\n"],
+    ["math closing inside a pending emphasis wins", "$a *b$ c*\n", "<p><x-equation>a *b</x-equation> c*</p>\n"],
+    ["strikethrough opener inside math is dropped", "$a ~~b$ c~~\n", "<p><x-equation>a ~~b</x-equation> c~~</p>\n"],
+    ["math inside a link label", "[$a$](/u)\n", '<p><a href="/u"><x-equation>a</x-equation></a></p>\n'],
+    ["math in image alt text contributes its content", "![$a$](/i.png)\n", '<p><img src="/i.png" alt="a" /></p>\n'],
+    ["math in a heading", "# $E$\n", "<h1><x-equation>E</x-equation></h1>\n"],
+    [
+      "math in a table cell",
+      "| a |\n| - |\n| $x$ |\n",
+      "<table>\n<thead>\n<tr><th>a</th></tr>\n</thead>\n<tbody>\n<tr><td><x-equation>x</x-equation></td></tr>\n</tbody>\n</table>\n",
+    ],
+    ["delimiters next to non-ASCII punctuation", "«$a$»\n", "<p>«<x-equation>a</x-equation>»</p>\n"],
+    ["delimiters next to non-ASCII letters", "é$a$\n", "<p>é$a$</p>\n"],
+  ])("html: %s", (_name, input, expected) => {
+    expect(math(input)).toBe(expected);
+  });
+
+  test("snake_case option name is accepted", () => {
+    expect(Markdown.html("$a$\n", { latex_math: true } as any)).toBe("<p><x-equation>a</x-equation></p>\n");
+  });
+
+  test("combines with underline", () => {
+    expect(Markdown.html("_a $b$_\n", { latexMath: true, underline: true })).toBe(
+      "<p><u>a <x-equation>b</x-equation></u></p>\n",
+    );
+  });
+
+  test("ansi() enables math and styles the span", () => {
+    expect(Markdown.ansi("x $a+b$ y\n")).toBe("x \x1b[35m$a+b$\x1b[39m y\x1b[0m\n");
+    expect(Markdown.ansi("$$a$$\n", { colors: false })).toBe("$$a$$\n");
+  });
+
+  test("math delimiter floods render in linear time", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        const n = 100000;
+        // n pending openers, then n closers: the first closer pairs with the
+        // last opener and every other delimiter must be dismissed in O(1).
+        let html = Bun.markdown.html(fill(n, "$a ") + fill(n, "a$ "), { latexMath: true });
+        if (!html.includes("<x-equation>a a</x-equation>")) throw new Error("expected a math span: " + JSON.stringify(html.slice(-200)));
+        // One mismatched pending opener that every closer is checked against.
+        html = Bun.markdown.html("$$a " + fill(n, "a$ "), { latexMath: true });
+        if (html.includes("<x-equation")) throw new Error("unexpected math span");
+        // Openers inside emphasis are popped again when the emphasis closes.
+        html = Bun.markdown.html(fill(n, "*$a $a $a $a a* "), { latexMath: true });
+        if (!html.startsWith("<p><em>$a $a $a $a a</em> <em>")) throw new Error("expected emphasis: " + JSON.stringify(html.slice(0, 120)));
+        const ansi = Bun.markdown.ansi(fill(n / 2, "$a ") + fill(n / 2, "a$ "), { colors: false });
+        if (typeof ansi !== "string" || ansi.length === 0) throw new Error("unexpected ansi output");
+        console.log("DONE");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 30_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("DONE");
+    expect(exitCode).toBe(0);
+  }, 90_000);
+});
+
+// ============================================================================
+// md4c's underline extension (`underline`): underscores still pair up by the
+// CommonMark emphasis rules, but every matched underscore is a <u> span
+// instead of <em> / <strong>. Asterisks are unaffected.
+// ============================================================================
+
+describe("underline option", () => {
+  const underline = (md: string) => Markdown.html(md, { underline: true });
+
+  test("is off by default", () => {
+    expect(Markdown.html("_a_ __b__\n")).toBe("<p><em>a</em> <strong>b</strong></p>\n");
+    expect(Markdown.html("_a_ __b__\n", { underline: false })).toBe("<p><em>a</em> <strong>b</strong></p>\n");
+  });
+
+  test.each([
+    ["single underscores", "_a_\n", "<p><u>a</u></p>\n"],
+    ["double underscores", "__a__\n", "<p><u><u>a</u></u></p>\n"],
+    ["asterisks are unaffected", "*a* **b**\n", "<p><em>a</em> <strong>b</strong></p>\n"],
+    ["underline inside emphasis", "*_a_*\n", "<p><em><u>a</u></em></p>\n"],
+    ["emphasis inside underline", "_*a*_\n", "<p><u><em>a</em></u></p>\n"],
+    ["underline inside strikethrough", "~~_a_~~\n", "<p><del><u>a</u></del></p>\n"],
+    ["partially matched run leaves the extra underscore as text", "__a_\n", "<p>_<u>a</u></p>\n"],
+    ["intra-word underscores are text", "snake_case_name\n", "<p>snake_case_name</p>\n"],
+    ["unclosed underscore is text", "_a b\n", "<p>_a b</p>\n"],
+    ["escaped underscores are text", "\\_a\\_\n", "<p>_a_</p>\n"],
+    ["underline inside a link label", "[_a_](/u)\n", '<p><a href="/u"><u>a</u></a></p>\n'],
+    [
+      "underline in image alt text contributes its content",
+      "![_a_](/i.png)\n",
+      '<p><img src="/i.png" alt="a" /></p>\n',
+    ],
+    ["underline in a heading", "# _a_\n", "<h1><u>a</u></h1>\n"],
+  ])("html: %s", (_name, input, expected) => {
+    expect(underline(input)).toBe(expected);
+  });
+
+  test("ansi() enables underline", () => {
+    expect(Markdown.ansi("_a_ *b*\n")).toBe("\x1b[4ma\x1b[24m \x1b[3mb\x1b[23m\x1b[0m\n");
   });
 });

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1465,6 +1465,22 @@ describe("latexMath option", () => {
     expect(Markdown.ansi("$$a$$\n", { colors: false })).toBe("$$a$$\n");
   });
 
+  // A span that continues on the next line reaches the renderer as one chunk
+  // with the line break inside it. It has to stay one line of output, or the
+  // continuation loses the list indent / quote gutter and the column count.
+  test("ansi(): line breaks inside math and code spans become spaces", () => {
+    expect(Markdown.ansi("x $a +\nb$ y\n")).toBe("x \x1b[35m$a + b$\x1b[39m y\x1b[0m\n");
+    const plain = (md: string, columns?: number) => Markdown.ansi(md, { colors: false, columns });
+    expect(plain("- item\n  $$\n  x\n  $$\n- next\n")).toBe("  * item $$ x $$\n  * next\n");
+    expect(plain("> quote $$\n> x\n> $$ end\n")).toBe("| quote $$ x $$ end\n");
+    expect(plain("- The value $a +\n  b$ matters\n")).toBe("  * The value $a + b$ matters\n");
+    expect(plain("- item `a\n  b` tail\n- next\n")).toBe("  * item a b tail\n  * next\n");
+    // The column count stays accurate after the span, so the wrap falls where it did for plain text.
+    expect(plain("$$\nabcdefghij\nklmnopqrst\n$$ one two three four five six\n", 30)).toBe(
+      "$$ abcdefghij klmnopqrst $$\none two three four five six\n",
+    );
+  });
+
   test("math delimiter floods render in linear time", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -1554,7 +1570,9 @@ describe("underline option", () => {
     );
   });
 
-  test("ansi() enables underline", () => {
-    expect(Markdown.ansi("_a_ *b*\n")).toBe("\x1b[4ma\x1b[24m \x1b[3mb\x1b[23m\x1b[0m\n");
+  // The terminal preset (ansi() and `bun file.md`) deliberately leaves the
+  // option off: underscores keep rendering as emphasis there.
+  test("ansi() keeps underscores as emphasis", () => {
+    expect(Markdown.ansi("_a_ __b__\n")).toBe("\x1b[3ma\x1b[23m \x1b[1mb\x1b[22m\x1b[0m\n");
   });
 });

--- a/test/js/bun/md/md-react.test.ts
+++ b/test/js/bun/md/md-react.test.ts
@@ -353,6 +353,40 @@ This is **bold** and *italic*.
     expect(del.props.children).toEqual(["deleted"]);
   });
 
+  test("latexMath: inline math is a math element", () => {
+    const math = children("$a+b$\n", undefined, { latexMath: true })[0].props.children[0];
+    expect(math.$$typeof).toBe(REACT_TRANSITIONAL_SYMBOL);
+    expect(math.type).toBe("math");
+    expect(math.props).toEqual({ children: ["a+b"] });
+  });
+
+  test("latexMath: display math is a math element with display: true", () => {
+    const math = children("$$a+b$$\n", undefined, { latexMath: true })[0].props.children[0];
+    expect(math.$$typeof).toBe(REACT_TRANSITIONAL_SYMBOL);
+    expect(math.type).toBe("math");
+    expect(math.props).toEqual({ display: true, children: ["a+b"] });
+  });
+
+  test("latexMath: math content is a single verbatim string", () => {
+    const math = children("$a *b* &amp; \\c$\n", undefined, { latexMath: true })[0].props.children[0];
+    expect(math.props).toEqual({ children: ["a *b* &amp; \\c"] });
+  });
+
+  test("latexMath off: dollars are plain text", () => {
+    expect(children("$a+b$\n")[0].props.children).toEqual(["$a+b$"]);
+  });
+
+  test("underline: underscores produce u elements", () => {
+    const u = children("_a_\n", undefined, { underline: true })[0].props.children[0];
+    expect(u.$$typeof).toBe(REACT_TRANSITIONAL_SYMBOL);
+    expect(u.type).toBe("u");
+    expect(u.props).toEqual({ children: ["a"] });
+  });
+
+  test("underline off: underscores produce em elements", () => {
+    expect(children("_a_\n")[0].props.children[0].type).toBe("em");
+  });
+
   test("unordered list children are React elements", () => {
     const ul = children("- a\n- b\n")[0];
     expect(ul.type).toBe("ul");
@@ -409,6 +443,14 @@ describe("Bun.markdown.react renderToString", () => {
 
   test("strikethrough", () => {
     expect(reactRender("~~deleted~~\n")).toBe("<p><del>deleted</del></p>");
+  });
+
+  test("inline math with latexMath", () => {
+    expect(reactRender("$a+b$\n", undefined, { latexMath: true })).toBe("<p><math>a+b</math></p>");
+  });
+
+  test("underline with underline option", () => {
+    expect(reactRender("__a__\n", undefined, { underline: true })).toBe("<p><u><u>a</u></u></p>");
   });
 
   test("inline code", () => {
@@ -602,6 +644,24 @@ describe("Bun.markdown.react component overrides", () => {
     expect(el.type).toBe("custom-hr");
     expect(el.props).toEqual({});
   });
+
+  test("math override receives children and display", () => {
+    function MathSpan({ display, children }: any) {
+      return React.createElement("span", { className: display ? "display" : "inline" }, ...children);
+    }
+    const [inline, _space, display] = children("$a$ $$b$$\n", { math: MathSpan }, { latexMath: true })[0].props
+      .children;
+    expect(inline.type).toBe(MathSpan);
+    expect(inline.props).toEqual({ children: ["a"] });
+    expect(display.type).toBe(MathSpan);
+    expect(display.props).toEqual({ display: true, children: ["b"] });
+  });
+
+  test("u override replaces type", () => {
+    const u = children("_a_\n", { u: "ins" }, { underline: true })[0].props.children[0];
+    expect(u.type).toBe("ins");
+    expect(u.props).toEqual({ children: ["a"] });
+  });
 });
 
 describe("Bun.markdown.react renderToString with component overrides", () => {
@@ -666,5 +726,21 @@ describe("Bun.markdown.react renderToString with component overrides", () => {
     }
     const html = reactRender("# Title\n\nParagraph\n", { h1: H1 });
     expect(html).toBe('<h1 class="big">Title</h1><p>Paragraph</p>');
+  });
+
+  test("custom math component", () => {
+    function MathSpan({ display, children }: any) {
+      return React.createElement("span", { className: display ? "katex-display" : "katex" }, ...children);
+    }
+    const html = reactRender("$a<b$ and $$c$$\n", { math: MathSpan }, { latexMath: true });
+    expect(html).toBe('<p><span class="katex">a&lt;b</span> and <span class="katex-display">c</span></p>');
+  });
+
+  test("custom underline component", () => {
+    function Underline({ children }: any) {
+      return React.createElement("span", { className: "underline" }, ...children);
+    }
+    const html = reactRender("_a_ and *b*\n", { u: Underline }, { underline: true });
+    expect(html).toBe('<p><span class="underline">a</span> and <em>b</em></p>');
   });
 });

--- a/test/js/bun/md/md-render-callback.test.ts
+++ b/test/js/bun/md/md-render-callback.test.ts
@@ -375,6 +375,38 @@ describe("Bun.markdown.render", () => {
     expect(result).toContain("[www.example.com]");
   });
 
+  test("latexMath option: math content passes through and reaches the text callback", () => {
+    const seen: string[] = [];
+    const result = Markdown.render(
+      "x $a *b*$ $$c$$\n",
+      {
+        paragraph: (children: string) => children,
+        emphasis: () => "<never>",
+        text: (text: string) => {
+          seen.push(text);
+          return `[${text}]`;
+        },
+      },
+      { latexMath: true },
+    );
+    expect(result).toBe("[x ][a *b*][ ][c]");
+    expect(seen).toEqual(["x ", "a *b*", " ", "c"]);
+  });
+
+  test("underline option: underscores no longer reach the emphasis callback", () => {
+    const render = (opts?: any) =>
+      Markdown.render(
+        "_a_ *b*\n",
+        {
+          paragraph: (children: string) => children,
+          emphasis: (children: string) => `<em>${children}</em>`,
+        },
+        opts,
+      );
+    expect(render({ underline: true })).toBe("a <em>b</em>");
+    expect(render()).toBe("<em>a</em> <em>b</em>");
+  });
+
   test("headings option provides id in heading meta", () => {
     const result = Markdown.render(
       "## Hello World\n",

--- a/test/js/bun/md/md-spec.test.ts
+++ b/test/js/bun/md/md-spec.test.ts
@@ -240,6 +240,8 @@ const specFiles = [
   { name: "GFM Strikethrough", file: "spec-strikethrough.txt" },
   { name: "GFM Tasklists", file: "spec-tasklists.txt" },
   { name: "Permissive Autolinks", file: "spec-permissive-autolinks.txt" },
+  { name: "LaTeX Math", file: "spec-latex-math.txt" },
+  { name: "Underline", file: "spec-underline.txt" },
   { name: "GFM", file: "spec-gfm.txt" },
   { name: "Coverage", file: "coverage.txt" },
   { name: "Regressions", file: "regressions.txt" },


### PR DESCRIPTION
### Problem

- `Bun.markdown`'s `latexMath` and `underline` options do nothing, although both are documented (docs/runtime/markdown.mdx, bun.d.ts) and the terminal preset used by `Bun.markdown.ansi()` and `bun ./file.md` lists both:
  - `Bun.markdown.html("$a+b$", { latexMath: true })` returns `<p>$a+b$</p>` (documented: `<x-equation>a+b</x-equation>`)
  - `Bun.markdown.html("_x_", { underline: true })` returns `<p><em>x</em></p>` (documented: `<u>x</u>`)
- `latexMath`: `src/md/parser.rs` adds `$` to the mark character map, but nothing in `src/md/inlines.rs` handles a `$` mark, so it falls through as text. Nothing ever emits `SpanType::Latexmath` / `LatexmathDisplay`.
- `underline`: `Options::to_flags()` in `src/md/root.rs` drops the field because `Flags` (`src/md/types.rs`) has no `underline`, and nothing ever emits `SpanType::U`.
- Neither option was ever implemented: the Zig parser this crate was ported from had the same gap, so this is not a regression. The HTML, ANSI, React and callback renderers all already handle the three span types; only the parser side is missing. md4c's test files for both extensions (`test/js/bun/md/spec-latex-math.txt`, `spec-underline.txt`) are checked in but were not in `md-spec.test.ts`'s list.

### Fix

- `src/md/inlines.rs`, `collect_emphasis_delimiters`: with `latex_math`, a run of one or two `$` becomes a delimiter entry (`emph_char == b'$'`). It can open if it starts the slice or follows whitespace/punctuation, and close if it ends the slice or precedes whitespace/punctuation (md4c's rule; `$5 and $10` stays text). Longer runs are text.
- `resolve_emphasis_delimiters` hands `$` entries to the new `resolve_math_delim`, which is md4c's `md_analyze_dollar`: a closer pairs with the most recent pending opener only if both runs have the same length (`$` vs `$$`), otherwise it becomes a pending opener itself; a match consumes both runs, deactivates every delimiter between them, records the closer position on the opener (`EmphDelim::close_pos`, the one new field) and discards all pending openers, so spans never nest. When an emphasis/strikethrough pair resolves, pending `$` openers inside it are discarded too (md4c's `md_pop_openers`), so emphasis and math cannot cross: whichever closes first wins, as in md4c.
- The emit walk renders a matched opener as one atomic span: `enter_span(Latexmath | LatexmathDisplay)`, the raw bytes up to the closer as `TextType::Latexmath`, `leave_span`, then skips past the closer. Unmatched runs are text. Because a span is only ever emitted at its opener, output is well formed even when another construct consumed the opener first.
- `src/md/html_renderer.rs` and `src/md/ansi_renderer.rs`: `TextType::Latexmath` shares the `TextType::Code` arm, and in both renderers a newline inside the span becomes a space (md4c's output for the multi-line example in spec-latex-math.txt). The ANSI renderer did not do this for code spans either: a span continuing on the next line was written verbatim, so the continuation lost its list indent or quote gutter and the column count went stale. That was already wrong for multi-line code spans on main and would have become reachable for math through the terminal preset; the shared arm fixes both.
- `underline`: `Flags` gains the field, `to_flags` passes it, and the emit walk gets an underline arm next to the strikethrough one: for a `_` run with the flag set it emits one `U` span per consumed underscore, straight from the run's `close_count` / `open_count`, instead of the em/strong tags. Pairing is unchanged, so intra-word underscores, the rule of three, etc. behave as before. `__x__` therefore renders `<u><u>x</u></u>`, which is md4c's documented output (spec-underline.txt example 2 has `___foo___` as three nested `<u>`). Using the counts rather than the per-run match-size arrays also keeps long runs exact: those arrays hold at most `MAX_EMPH_MATCHES` (6) entries, which is a pre-existing limitation of the em/strong output (#39496) that underline does not inherit.
- Terminal preset (`Options::TERMINAL`, used by `ansi()` and `bun ./file.md`): `latex_math` stays on, so math spans are now styled there (`$x$` in magenta). `underline` is switched off explicitly. It was listed in the preset but never worked, so terminal output has always rendered `_x_` / `__x__` as italic / bold; making it live would change that for every document that uses underscore emphasis, with no opt-out (`ansi()` takes no parser options), and the preset author's intent (md4c's all-underscores semantic, or only `__x__` as the old docs table said) is not recorded. #39560 holds that decision; it also notes the ANSI `U` styling bug that would need fixing first. Two tests pin the terminal behavior as unchanged (`ansi() keeps underscores as emphasis`, and the `bun ./file.md` case). The `ansi()` JSDoc no longer claims underline.
- Why this is the right behavior: the parser is a port of md4c, the renderers were written against md4c's span model (`<x-equation>` is md2html's output, `"math"` / `display: true` in the React renderer, `$` styling in the ANSI renderer), and md4c's own test files for both extensions are already in the tree. The implementation was checked against md4c's current `md_collect_marks` / `md_analyze_dollar` / `md_process_inlines`; both spec files pass unmodified.
- Cost when the options are off: `$` is not a mark character and `collect_emphasis_delimiters` never pushes `$` entries, so the default parsing path only sees `EmphDelim` grow from 64 to 72 bytes (it is copied once per block that contains emphasis delimiters); the ANSI renderer additionally scans each code span's bytes once for a newline. Every new resolution step is O(1) amortized; doubling the input doubles the time for six adversarial delimiter floods (see details).
- Docs and types: the options table and the React overrides table (`u`, `math`) in docs/runtime/markdown.mdx, the JSDoc for both options, and a `MathProps` type carrying the `display` prop the React renderer already sets. `test/integration/bun-types/fixture/markdown.ts` compiles realistic usage.
- Not changed here, tracked separately: `hardSoftBreaks` and `collapseWhitespace` are also documented options that do nothing (#39491, being implemented in #39495); emphasis delimiters inside a wiki link target can pair with delimiters outside it (#39492, pre-existing, fixed in #39494). This PR and #39494 are independent and land in either order: a math span is only ever emitted at its opener, so output stays well formed, and #39494's skip in the collection phase covers `$` runs too. Whichever of the two lands second should add exact cases for `$` / `_` runs on both sides of a wiki link boundary (noted on #39494). Em/strong output of a run with more than six matches is wrong on main independently of this PR (#39496). The terminal underline decision is #39560.
- Verification (the new tests fail on the unfixed build and pass with the fix; the negative-contract cases, such as options off and the preset's unchanged underscore rendering, pass both ways by design):
  - `test/js/bun/md/md-spec.test.ts` now runs `spec-latex-math.txt` and `spec-underline.txt` (6 examples fail before)
  - `test/js/bun/md/md-edge-cases.test.ts`: `latexMath option` / `underline option` blocks cover both flags on and off, both option spellings, precedence against code spans, links, images, emphasis, strikethrough, escapes, headings and table cells, non-ASCII neighbors, the `ansi()` preset, and a linear-time flood test, plus two long-run cases (14 underscores, and one run closed by seven closers) that the match-size arrays would truncate
  - `ansi(): line breaks inside math and code spans become spaces` (md-edge-cases.test.ts): list item, blockquote, soft-wrapped inline math, a multi-line code span (fails on main today) and a `columns` case; `ansi() keeps underscores as emphasis` pins the preset
  - `test/js/bun/md/md-react.test.ts`: `math` (with `display`) and `u` elements, default tags and component overrides
  - `test/js/bun/md/md-render-callback.test.ts`: math text reaches the `text` callback, `_` no longer reaches `emphasis`
  - `test/cli/run/markdown-entrypoint.test.ts`: `bun ./file.md` styles math and still renders `_x_` as italic
  - `bun test test/integration/bun-types/bun-types.test.ts` passes (and fails when the fixture's `display` assertion is changed)
  - The whole `test/js/bun/md/` directory passes on the debug build; no existing snapshot changes

### Background

- Inline parsing in this crate runs per slice (a paragraph, heading or table cell, or a link label inside one) in two phases: `collect_emphasis_delimiters` records every `*`, `_`, `~` run as an `EmphDelim`, `resolve_emphasis_delimiters` pairs them with the CommonMark algorithm, and a second walk over the text emits spans at the recorded positions. This PR adds `$` runs to that list; they are paired by their own rule but share the bookkeeping that stops emphasis and math from crossing each other.
- md4c is the C CommonMark parser this crate was ported from. Its `MD_FLAG_LATEXMATHSPANS` produces `MD_SPAN_LATEXMATH` / `MD_SPAN_LATEXMATH_DISPLAY` with the span's text as `MD_TEXT_LATEXMATH` (verbatim, newlines as spaces, like a code span); its `MD_FLAG_UNDERLINE` makes underscores produce `MD_SPAN_U`. The `SpanType` and `TextType` enums here mirror those, and the `<x-equation>` HTML is what md4c's md2html prints.
- `Options` (`src/md/root.rs`) is the user-facing option set; `Flags` (`src/md/types.rs`) is the subset the parser reads. An option that exists in `Options` but not in `Flags` is silently ignored, which is how `underline` was lost.

<details>
<summary>Flood timings on the debug (ASAN) build, n = 50k / 100k / 200k repetitions</summary>

```
openers then closers                            74 / 147 / 295 ms
mismatched pending opener                       37 /  77 / 145 ms
openers popped by emphasis                     409 / 832 / 1664 ms
alternating pairs                              158 / 322 / 646 ms
emphasis closers over pending math openers     133 / 268 / 526 ms
pending $$ openers and $ closers interleaved    76 / 155 / 309 ms
```

Inputs, in order: `"$a "*n + "a$ "*n`, `"$$a " + "a$ "*n`, `"*$a $a $a $a a* "*n`, `"$a$ "*n`, `"$a "*n + "a* "*n`, `"$$a a$ "*n`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 15 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/markdown-entrypoint.test.ts test/js/bun/md/md-edge-cases.test.ts test/js/bun/md/md-react.test.ts test/js/bun/md/md-render-callback.test.ts test/js/bun/md/md-spec.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/180] gen .bind.ts → GeneratedBindings.cpp
[2/180] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/180] gen cpp.rs (cppbind)
[4/180] gen BunProcess.lut.h
Generating /workspace/bun/build/debug/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/180] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[6/180] gen JS modules (bundle-modules)
Preprocess modules (12787ms)
Bundle modules (68ms)
Postprocesss modules (177ms)
Bundle Functions (952ms)
Generate Code (22ms)

[14.03s] Bundled "src/js" for development
  2819 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[6/180] ca
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (9f0c2c74c)

test/cli/run/markdown-entrypoint.test.ts:
(pass) bun <file.md> > renders headings with underlines [4.92ms]
(pass) bun <file.md> > renders bold, italic, strikethrough, inline code [3.12ms]
(pass) bun <file.md> > renders math spans; underscores stay emphasis [2.71ms]
(pass) bun <file.md> > renders ordered, unordered, and task lists [2.27ms]
(pass) bun <file.md> > renders blockquotes and nested blockquotes [2.10ms]
(pass) bun <file.md> > renders horizontal rules [2.18ms]
(pass) bun <file.md> > renders fenced code block with JS syntax highlighting [2.01ms]
(pass) bun <file.md> > renders fenced code block without language [2.05ms]
(pass) bun <file.md> > renders link text with url fallback when no TTY [2.12ms]
(pass) bun <file.md> > emits OSC 8 escape for links when hyperlinks are enabled [20.14ms]
(pass) bun <file.md> > renders link with text + url pair fallback [4.57ms]
(pass) bun <file.md> > renders images as alt text with link [3.04ms]
(pass) bun <file.md> > renders wikilinks [3.31ms]
(pass) bun <file.md> > falls back to literal text when `[[` never closes [2.85ms]
(pass) bun <file.md> > renders simple table with alignment [2.19ms
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/markdown-entrypoint.test.ts test/js/bun/md/md-edge-cases.test.ts test/js/bun/md/md-react.test.ts test/js/bun/md/md-render-callback.test.ts test/js/bun/md/md-spec.test.ts
bun test v1.4.0 (6e906e468)

test/cli/run/markdown-entrypoint.test.ts:
(pass) bun <file.md> > renders headings with underlines [171.73ms]
(pass) bun <file.md> > renders bold, italic, strikethrough, inline code [115.50ms]
(pass) bun <file.md> > renders math spans; underscores stay emphasis [119.48ms]
(pass) bun <file.md> > renders ordered, unordered, and task lists [116.59ms]
(pass) bun <file.md> > renders blockquotes and nested blockquotes [117.08ms]
(pass) bun <file.md> > renders horizontal rules [111.13ms]
(pass) bun <file.md> > renders fenced code block with JS syntax highlighting [116.53ms]
(pass) bun <file.md> > renders fenced code block without language [125.89ms]
(pass) bun <file.md> > renders link text with url fallback when no TTY [136.40ms]
(pass) bun <file.md> > emits OSC 8 escape for links when hyperlinks are enabled [1107.25ms]
(pass) bun <fil
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 699ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/139] gen .bind.ts → GeneratedBindings.cpp
[2/139] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[3/139] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[4/139] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[5/139] gen cpp.rs (cppbind)
[6/139] gen JS modules (bundle-modules)
Preprocess modules (8484ms)
Bundle modules (145ms)
Postprocesss modules (344ms)
Bundle Functions (867ms)
Generate Code (29ms)

[9.89s] Bundled "src/js" for production
  2628 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[6/138] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/markdown.mdx                      |   6 +-
 packages/bun-types/bun.d.ts                    |  24 ++-
 src/md/ansi_renderer.rs                        |  22 ++-
 src/md/helpers.rs                              |   4 +
 src/md/html_renderer.rs                        |   4 +-
 src/md/inlines.rs                              | 117 +++++++++++++-
 src/md/parser.rs                               |   2 +-
 src/md/root.rs                                 |   4 +-
 src/md/types.rs                                |   1 +
 test/cli/run/markdown-entrypoint.test.ts       |   4 +
 test/integration/bun-types/fixture/markdown.ts |  27 ++++
 test/js/bun/md/md-edge-cases.test.ts           | 208 ++++++++++++++++++++++++-
 test/js/bun/md/md-react.test.ts                |  76 +++++++++
 test/js/bun/md/md-render-callback.test.ts      |  32 ++++
 test/js/bun/md/md-spec.test.ts                 |   2 +
 15 files changed, 510 insertions(+), 23 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
docs/runtime/markdown.mdx                           2      2      0
packages/bun-types/bun.d.ts                         5      5      0
src/md/ansi_renderer.rs                             4      2      0
src/md/helpers.rs                                   1      1      0
src/md/html_renderer.rs                             1      1      0
src/md/inlines.rs                                  14     25      0
src/md/parser.rs                                    2      2      0
src/md/root.rs                                      2      4      0
src/md/types.rs                                     1      2      0
test/cli/run/markdown-entrypoint.test.ts            2      3      0
test/integration/bun-types/fixture/markdown.ts      0      2      0
test/js/bun/md/md-edge-cases.test.ts                6     11      0
test/js/bun/md/md-react.test.ts                     3      5      0
test/js/bun/md/md-render-callback.test.ts           1      1      0
test/js/bun/md/md-spec.test.ts                      1      1      0
```

</details>

<!-- robobun:evidence:end -->