### PR TITLE
Bun.markdown: do not pair emphasis delimiters across wiki link boundaries

### DIFF
--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -717,6 +717,21 @@ impl Parser<'_> {
                     }
                 }
             }
+            // Skip wiki link constructs — like regular links they are
+            // resolved before emphasis, and the emit walk renders them as a
+            // unit, so a delimiter inside the target must not pair with one
+            // outside. The label gets its own collection pass when its frame
+            // is entered.
+            if c == b'['
+                && self.flags.wiki_links
+                && i + 1 < content.len()
+                && content[i + 1] == b'['
+            {
+                if let Some(m) = self.match_wiki_link(content, i) {
+                    i = m.inner_end + 2;
+                    continue;
+                }
+            }
             // Skip link/image constructs — links take precedence over emphasis (CommonMark §6.3)
             if c == b'[' || (c == b'!' && i + 1 < content.len() && content[i + 1] == b'[') {
                 let is_img = c == b'!';

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -722,10 +722,7 @@ impl Parser<'_> {
             // unit, so a delimiter inside the target must not pair with one
             // outside. The label gets its own collection pass when its frame
             // is entered.
-            if c == b'['
-                && self.flags.wiki_links
-                && i + 1 < content.len()
-                && content[i + 1] == b'['
+            if c == b'[' && self.flags.wiki_links && i + 1 < content.len() && content[i + 1] == b'['
             {
                 if let Some(m) = self.match_wiki_link(content, i) {
                     i = m.inner_end + 2;

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -717,11 +717,8 @@ impl Parser<'_> {
                     }
                 }
             }
-            // Skip wiki link constructs — like regular links they are
-            // resolved before emphasis, and the emit walk renders them as a
-            // unit, so a delimiter inside the target must not pair with one
-            // outside. The label gets its own collection pass when its frame
-            // is entered.
+            // Skip wiki links — like regular links they resolve before
+            // emphasis; the label gets its own collection pass.
             if c == b'[' && self.flags.wiki_links && i + 1 < content.len() && content[i + 1] == b'['
             {
                 if let Some(m) = self.match_wiki_link(content, i) {

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -50,8 +50,7 @@ pub(crate) enum LabelLeave {
     Wikilink,
 }
 
-/// Result of `match_wiki_link`: the construct spans `start..inner_end + 2`,
-/// with the target at `inner_start..pipe_pos.unwrap_or(inner_end)`.
+/// Result of `match_wiki_link`; the construct ends at `inner_end + 2`.
 pub(crate) struct WikiLinkMatch {
     pub(crate) inner_start: usize,
     pub(crate) pipe_pos: Option<usize>,
@@ -854,9 +853,8 @@ impl Parser<'_> {
         false
     }
 
-    /// Lookahead-only match of a wiki link: [[destination]] or
-    /// [[destination|label]]. Shared by `process_wiki_link` and the emphasis
-    /// collection phase so both agree on what forms a wiki link.
+    /// Lookahead-only match of `[[destination]]` / `[[destination|label]]`,
+    /// shared by rendering and emphasis collection so they agree.
     pub(crate) fn match_wiki_link(&self, content: &[u8], start: usize) -> Option<WikiLinkMatch> {
         // start points at first '[', next char is also '['
         let mut pos = start + 2;

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -50,6 +50,15 @@ pub(crate) enum LabelLeave {
     Wikilink,
 }
 
+/// Result of `match_wiki_link`: the construct spans `start..inner_end + 2`,
+/// with the target at `inner_start..pipe_pos.unwrap_or(inner_end)`.
+pub(crate) struct WikiLinkMatch {
+    pub(crate) inner_start: usize,
+    pub(crate) pipe_pos: Option<usize>,
+    /// Position of the first closing `]`.
+    pub(crate) inner_end: usize,
+}
+
 /// Result of `find_autolink`.
 pub(crate) struct Autolink {
     pub(crate) end_pos: usize,
@@ -845,12 +854,10 @@ impl Parser<'_> {
         false
     }
 
-    /// Process wiki link: [[destination]] or [[destination|label]]
-    pub(crate) fn process_wiki_link(
-        &mut self,
-        content: &[u8],
-        start: usize,
-    ) -> Result<Option<LabelParse>, parser::Error> {
+    /// Lookahead-only match of a wiki link: [[destination]] or
+    /// [[destination|label]]. Shared by `process_wiki_link` and the emphasis
+    /// collection phase so both agree on what forms a wiki link.
+    pub(crate) fn match_wiki_link(&self, content: &[u8], start: usize) -> Option<WikiLinkMatch> {
         // start points at first '[', next char is also '['
         let mut pos = start + 2;
 
@@ -861,12 +868,12 @@ impl Parser<'_> {
 
         while pos < content.len() {
             if content[pos] == b'\n' || content[pos] == b'\r' {
-                return Ok(None);
+                return None;
             }
             if content[pos] == b'[' {
                 bracket_depth += 1;
                 if bracket_depth > MAX_WIKI_BRACKET_DEPTH {
-                    return Ok(None);
+                    return None;
                 }
             } else if content[pos] == b']' {
                 if bracket_depth > 0 {
@@ -875,7 +882,7 @@ impl Parser<'_> {
                     break;
                 } else {
                     // Single ] without matching [, not a valid close
-                    return Ok(None);
+                    return None;
                 }
             } else if content[pos] == b'|' && pipe_pos.is_none() && bracket_depth == 0 {
                 pipe_pos = Some(pos);
@@ -885,22 +892,35 @@ impl Parser<'_> {
 
         // Must end with ]]
         if pos >= content.len() || content[pos] != b']' {
-            return Ok(None);
+            return None;
         }
 
         let inner_end = pos;
 
-        // Determine the target
-        let target = if let Some(pp) = pipe_pos {
-            &content[inner_start..pp]
-        } else {
-            &content[inner_start..inner_end]
+        // Target must not exceed 100 characters
+        let target_end = pipe_pos.unwrap_or(inner_end);
+        if target_end - inner_start > 100 {
+            return None;
+        }
+
+        Some(WikiLinkMatch {
+            inner_start,
+            pipe_pos,
+            inner_end,
+        })
+    }
+
+    /// Process wiki link: [[destination]] or [[destination|label]]
+    pub(crate) fn process_wiki_link(
+        &mut self,
+        content: &[u8],
+        start: usize,
+    ) -> Result<Option<LabelParse>, parser::Error> {
+        let Some(m) = self.match_wiki_link(content, start) else {
+            return Ok(None);
         };
 
-        // Target must not exceed 100 characters
-        if target.len() > 100 {
-            return Ok(None);
-        }
+        let target = &content[m.inner_start..m.pipe_pos.unwrap_or(m.inner_end)];
 
         // Render the wikilink
         self.renderer.enter_span(
@@ -910,15 +930,14 @@ impl Parser<'_> {
                 ..Default::default()
             },
         )?;
-        let label_start = if let Some(pp) = pipe_pos {
-            pp + 1
-        } else {
-            inner_start
+        let label_start = match m.pipe_pos {
+            Some(pp) => pp + 1,
+            None => m.inner_start,
         };
         Ok(Some(LabelParse {
             label_start,
-            label_end: inner_end,
-            link_end: pos + 2, // skip both ']'
+            label_end: m.inner_end,
+            link_end: m.inner_end + 2, // skip both ']'
             leave: LabelLeave::Wikilink,
         }))
     }

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -686,12 +686,8 @@ describe("pathological bracket inputs", () => {
     );
     // Emphasis fully inside the label, or fully outside the construct,
     // still resolves.
-    expect(Markdown.html("[[a|*b* c]]\n", o)).toBe(
-      '<p><x-wikilink data-target="a"><em>b</em> c</x-wikilink></p>\n',
-    );
-    expect(Markdown.html("*x [[a]] y*\n", o)).toBe(
-      '<p><em>x <x-wikilink data-target="a">a</x-wikilink> y</em></p>\n',
-    );
+    expect(Markdown.html("[[a|*b* c]]\n", o)).toBe('<p><x-wikilink data-target="a"><em>b</em> c</x-wikilink></p>\n');
+    expect(Markdown.html("*x [[a]] y*\n", o)).toBe('<p><em>x <x-wikilink data-target="a">a</x-wikilink> y</em></p>\n');
   });
 
   test("wiki link bracket nesting is capped", () => {

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -681,6 +681,7 @@ describe("pathological bracket inputs", () => {
     expect(Markdown.html("*a [[b*|c]] d\n", o)).toBe('<p>*a <x-wikilink data-target="b*">c</x-wikilink> d</p>\n');
     expect(Markdown.html("[[a *b|c]] d* e\n", o)).toBe('<p><x-wikilink data-target="a *b">c</x-wikilink> d* e</p>\n');
     expect(Markdown.html("**a [[b**|c]]\n", o)).toBe('<p>**a <x-wikilink data-target="b**">c</x-wikilink></p>\n');
+    expect(Markdown.html("_a [[b_|c]] d\n", o)).toBe('<p>_a <x-wikilink data-target="b_">c</x-wikilink> d</p>\n');
     expect(Markdown.html("~a [[b~|c]] d\n", { wikiLinks: true, strikethrough: true })).toBe(
       '<p>~a <x-wikilink data-target="b~">c</x-wikilink> d</p>\n',
     );

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -671,6 +671,29 @@ describe("pathological bracket inputs", () => {
     expect(Markdown.html(`[${label1000}]: /url\n\n[${label1000}]\n`)).not.toContain("<a href=");
   });
 
+  // Emphasis delimiters inside a wiki link target used to pair with
+  // delimiters outside the construct; the emit walk renders the wiki link as
+  // a unit, so one half of each pair was never emitted, producing unbalanced
+  // HTML (issue #39492). Bracket constructs resolve before emphasis, so the
+  // delimiters stay literal.
+  test("delimiters inside a wiki link target do not pair with delimiters outside", () => {
+    const o = { wikiLinks: true };
+    expect(Markdown.html("*a [[b*|c]] d\n", o)).toBe('<p>*a <x-wikilink data-target="b*">c</x-wikilink> d</p>\n');
+    expect(Markdown.html("[[a *b|c]] d* e\n", o)).toBe('<p><x-wikilink data-target="a *b">c</x-wikilink> d* e</p>\n');
+    expect(Markdown.html("**a [[b**|c]]\n", o)).toBe('<p>**a <x-wikilink data-target="b**">c</x-wikilink></p>\n');
+    expect(Markdown.html("~a [[b~|c]] d\n", { wikiLinks: true, strikethrough: true })).toBe(
+      '<p>~a <x-wikilink data-target="b~">c</x-wikilink> d</p>\n',
+    );
+    // Emphasis fully inside the label, or fully outside the construct,
+    // still resolves.
+    expect(Markdown.html("[[a|*b* c]]\n", o)).toBe(
+      '<p><x-wikilink data-target="a"><em>b</em> c</x-wikilink></p>\n',
+    );
+    expect(Markdown.html("*x [[a]] y*\n", o)).toBe(
+      '<p><em>x <x-wikilink data-target="a">a</x-wikilink> y</em></p>\n',
+    );
+  });
+
   test("wiki link bracket nesting is capped", () => {
     const wiki = (depth: number) => "[[t|" + "[".repeat(depth) + "x" + "]".repeat(depth) + "]]\n";
     // Within the cap the whole construct is one wiki link targeting "t".


### PR DESCRIPTION
Fixes #39492

### Problem

- With `wikiLinks: true`, emphasis delimiters inside a `[[target|label]]` target pair with delimiters outside the construct, producing unbalanced HTML: `Bun.markdown.html("*a [[b*|c]] d\n", { wikiLinks: true })` returns `<p><em>a <x-wikilink data-target="b*">c</x-wikilink> d</p>` (the `<em>` is never closed). Same for `**`/`<strong>` and `~`/`<del>`.
- Cause: `collect_emphasis_delimiters` (src/md/inlines.rs) skips regular link/image constructs because bracket constructs resolve before emphasis, but it did not skip wiki links. A `*` inside the target was collected and resolved against a `*` outside. The emit walk then renders the wiki link as a unit, so one half of each resolved pair is never emitted.

### Fix

- Extract the lookahead part of `process_wiki_link` into a pure `match_wiki_link` (src/md/links.rs), so matching and rendering share one definition of what forms a wiki link.
- In `collect_emphasis_delimiters`, when wiki links are enabled and `[[` matches a wiki link, skip the whole construct, the same way regular links are skipped. This covers every delimiter kind collected in that phase (`*`, `_`, `~`).
- Emphasis fully inside the label still resolves: the label is rendered as its own slice with its own collection pass, unchanged by this.
- Verified: new test in test/js/bun/md/md-edge-cases.test.ts fails on the released bun and passes with this change; all 1069 tests in test/js/bun/md/ pass.

### Background

- `Bun.markdown` renders inlines in two phases: a collection pass records `*`/`_`/`~` delimiter runs and resolves them into pairs (CommonMark emphasis algorithm), then an emit walk renders the text using those resolved pairs. Constructs the emit walk treats as opaque units (code spans, HTML tags, links) must be skipped during collection, or the two phases disagree about which delimiters exist.
- A wiki link `[[target]]` or `[[target|label]]` renders as `<x-wikilink data-target="...">label</x-wikilink>`; the target is an attribute, so delimiters inside it are always literal text.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [74.26ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [9.68ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [1.80ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [7.47ms]
(pass) fuzzer-like edge cases > control characters in input [1.66ms]
(pass) fuzzer-like edge cases > Buffer input works [1.73ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [4.64ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [7.62ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.28ms]
(pass) fuzzer-like edge cases > deeply nested lists [7.59ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [145.34ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [96.66ms]
(pa
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [1.24ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [0.13ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [0.04ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [0.09ms]
(pass) fuzzer-like edge cases > control characters in input [0.02ms]
(pass) fuzzer-like edge cases > Buffer input works [0.02ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [0.06ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [0.13ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [0.04ms]
(pass) fuzzer-like edge cases > deeply nested lists [0.07ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [7.28ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [5.17ms]
(pass) fuzzer-like edge cases > deeply nested emphasis [0.07ms]
(pass) fuzzer-like edge cases > deeply nested links [0.06ms]
(pass) fuzzer-like edge cases > very long s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [72.95ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [9.38ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [1.88ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [7.07ms]
(pass) fuzzer-like edge cases > control characters in input [2.18ms]
(pass) fuzzer-like edge cases > Buffer input works [1.73ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [4.81ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [8.25ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.96ms]
(pass) fuzzer-like edge cases > deeply nested lists [8.78ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [144.53ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [95.40ms]
(pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     6d99108eb6
  features     baseline

22 deps, 120 codegen, 1144 objects in 816ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1206] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 26 installs across 63 packages (no changes) [9.00ms]
[2/1206] gen ErrorCode+*.h
[3/1206] gen bindgenv2
[4/1206] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1206] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [6.00ms]
[6/1206] fetch tinycc
[tinycc] up to date
[7/1205] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[8/1205] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[9/1205] gen .bind.ts → GeneratedBindings.cpp
[10/1205] fetch zlib
[zlib] up to date
[11/1205] gen ProcessBindingConstants.lut.h
Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/md/inlines.rs                    |  9 +++++
 src/md/links.rs                      | 67 ++++++++++++++++++++++--------------
 test/js/bun/md/md-edge-cases.test.ts | 20 +++++++++++
 3 files changed, 71 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/md/inlines.rs                         3      3      0
src/md/links.rs                           3      3      0
test/js/bun/md/md-edge-cases.test.ts      1      2      0
```

</details>

**root cause** · written by the author bot

The emphasis delimiter collection pass skipped over regular links and images but not wiki link constructs, so asterisk, underscore, and tilde delimiters inside a `[[target|label]]` were collected and paired with delimiters outside it. Because the emit walk renders a wiki link as a single unit, one half of each such pair was never emitted, yielding unbalanced HTML like an unclosed `<em>`. The fix extracts a shared `match_wiki_link` lookahead used by both rendering and delimiter collection, so the collection pass now skips complete wiki link constructs exactly as it does regular links, leavin…

<!-- robobun:evidence:end -->