### PR TITLE
Bun.markdown: implement the hardSoftBreaks and collapseWhitespace options

### DIFF
--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -270,7 +270,7 @@ impl Parser<'_> {
                         while sp > text_start && content[sp - 1] == b' ' {
                             sp -= 1;
                         }
-                        if emit_end - sp >= 2 {
+                        if emit_end - sp >= 2 || self.flags.hard_soft_breaks {
                             // Also strip any trailing tabs/spaces before the space run
                             while sp > text_start
                                 && (content[sp - 1] == b' ' || content[sp - 1] == b'\t')
@@ -279,6 +279,16 @@ impl Parser<'_> {
                             }
                             emit_end = sp;
                             is_hard = true;
+                        } else if self.flags.collapse_whitespace {
+                            // Trailing whitespace before a soft break collapses away.
+                            while sp > text_start
+                                && (content[sp - 1] == b' '
+                                    || content[sp - 1] == b'\t'
+                                    || content[sp - 1] == b'\r')
+                            {
+                                sp -= 1;
+                            }
+                            emit_end = sp;
                         }
                     }
                     if emit_end > text_start {
@@ -291,6 +301,34 @@ impl Parser<'_> {
                     }
                     i += 1;
                     text_start = i;
+                    continue;
+                }
+
+                // Whitespace run (space/tab/CR are mark chars only when
+                // collapse_whitespace is set). md4c's MD_FLAG_COLLAPSEWHITESPACE
+                // replaces a non-trivial run (longer than one char, or not a
+                // plain space) with a single space.
+                if self.flags.collapse_whitespace && (c == b' ' || c == b'\t' || c == b'\r') {
+                    let mut end = i + 1;
+                    while end < content.len()
+                        && (content[end] == b' ' || content[end] == b'\t' || content[end] == b'\r')
+                    {
+                        end += 1;
+                    }
+                    if end < content.len() && content[end] == b'\n' {
+                        // Trailing run before a line break: the newline branch
+                        // above decides hard-break vs collapse.
+                        i = end;
+                        continue;
+                    }
+                    if end - i > 1 || c != b' ' {
+                        if i > text_start {
+                            self.emit_text(TextType::Normal, &content[text_start..i])?;
+                        }
+                        self.emit_text(TextType::Normal, b" ")?;
+                        text_start = end;
+                    }
+                    i = end;
                     continue;
                 }
 

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -304,10 +304,8 @@ impl Parser<'_> {
                     continue;
                 }
 
-                // Whitespace run (space/tab/CR are mark chars only when
-                // collapse_whitespace is set). md4c's MD_FLAG_COLLAPSEWHITESPACE
-                // replaces a non-trivial run (longer than one char, or not a
-                // plain space) with a single space.
+                // md4c's MD_FLAG_COLLAPSEWHITESPACE: a non-trivial whitespace
+                // run (longer than one char, or not a plain space) becomes one space.
                 if self.flags.collapse_whitespace && (c == b' ' || c == b'\t' || c == b'\r') {
                     let mut end = i + 1;
                     while end < content.len()
@@ -316,8 +314,7 @@ impl Parser<'_> {
                         end += 1;
                     }
                     if end < content.len() && content[end] == b'\n' {
-                        // Trailing run before a line break: the newline branch
-                        // above decides hard-break vs collapse.
+                        // The newline branch above handles a trailing run.
                         i = end;
                         continue;
                     }

--- a/src/md/root.rs
+++ b/src/md/root.rs
@@ -116,6 +116,7 @@ impl Options {
             wiki_links: self.wiki_links,
             latex_math: self.latex_math,
             collapse_whitespace: self.collapse_whitespace,
+            hard_soft_breaks: self.hard_soft_breaks,
             permissive_atx_headers: self.permissive_atx_headers,
             no_indented_code_blocks: self.no_indented_code_blocks,
             no_html_blocks: self.no_html_blocks,

--- a/src/md/types.rs
+++ b/src/md/types.rs
@@ -222,6 +222,7 @@ pub(crate) const BLOCK_REF_DEF_ONLY: u32 = 0x20;
 #[derive(Copy, Clone)]
 pub struct Flags {
     pub(crate) collapse_whitespace: bool,
+    pub(crate) hard_soft_breaks: bool,
     pub(crate) permissive_atx_headers: bool,
     pub(crate) permissive_url_autolinks: bool,
     pub(crate) permissive_www_autolinks: bool,

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1382,3 +1382,66 @@ describe.concurrent("importing .md modules", () => {
     expect(exitCode).not.toBe(0);
   });
 });
+
+// ============================================================================
+// hardSoftBreaks / collapseWhitespace (issue #39491)
+// ============================================================================
+
+describe("hardSoftBreaks", () => {
+  test("soft line breaks become hard breaks", () => {
+    expect(Markdown.html("a\nb\n", { hardSoftBreaks: true })).toBe("<p>a<br />\nb</p>\n");
+  });
+
+  test("trailing whitespace before the forced break is dropped", () => {
+    expect(Markdown.html("a \nb\n", { hardSoftBreaks: true })).toBe("<p>a<br />\nb</p>\n");
+    expect(Markdown.html("a\t\nb\n", { hardSoftBreaks: true })).toBe("<p>a<br />\nb</p>\n");
+  });
+
+  test("existing hard breaks still work", () => {
+    expect(Markdown.html("a  \nb\n", { hardSoftBreaks: true })).toBe("<p>a<br />\nb</p>\n");
+    expect(Markdown.html("a\\\nb\n", { hardSoftBreaks: true })).toBe("<p>a<br />\nb</p>\n");
+  });
+
+  test("disabled by default", () => {
+    expect(Markdown.html("a\nb\n")).toBe("<p>a\nb</p>\n");
+    expect(Markdown.html("a\nb\n", { hardSoftBreaks: false })).toBe("<p>a\nb</p>\n");
+  });
+});
+
+describe("collapseWhitespace", () => {
+  test("collapses whitespace runs in normal text", () => {
+    expect(Markdown.html("a    b\n", { collapseWhitespace: true })).toBe("<p>a b</p>\n");
+    expect(Markdown.html("a \t b\n", { collapseWhitespace: true })).toBe("<p>a b</p>\n");
+  });
+
+  test("a single tab collapses to a space", () => {
+    expect(Markdown.html("a\tb\n", { collapseWhitespace: true })).toBe("<p>a b</p>\n");
+  });
+
+  test("a single space is left alone", () => {
+    expect(Markdown.html("a b\n", { collapseWhitespace: true })).toBe("<p>a b</p>\n");
+  });
+
+  test("collapses inside emphasis and link labels", () => {
+    expect(Markdown.html("*a    b*\n", { collapseWhitespace: true })).toBe("<p><em>a b</em></p>\n");
+    expect(Markdown.html("[a    b](u)\n", { collapseWhitespace: true })).toBe('<p><a href="u">a b</a></p>\n');
+  });
+
+  test("does not touch code spans or code blocks", () => {
+    expect(Markdown.html("`a    b`\n", { collapseWhitespace: true })).toBe("<p><code>a    b</code></p>\n");
+    expect(Markdown.html("    a    b\n", { collapseWhitespace: true })).toBe("<pre><code>a    b\n</code></pre>\n");
+  });
+
+  test("two trailing spaces still produce a hard break", () => {
+    expect(Markdown.html("a  \nb\n", { collapseWhitespace: true })).toBe("<p>a<br />\nb</p>\n");
+  });
+
+  test("trailing whitespace before a soft break collapses away", () => {
+    expect(Markdown.html("a \nb\n", { collapseWhitespace: true })).toBe("<p>a\nb</p>\n");
+  });
+
+  test("disabled by default", () => {
+    expect(Markdown.html("a    b\n")).toBe("<p>a    b</p>\n");
+    expect(Markdown.html("a    b\n", { collapseWhitespace: false })).toBe("<p>a    b</p>\n");
+  });
+});

--- a/test/js/bun/md/md-spec.test.ts
+++ b/test/js/bun/md/md-spec.test.ts
@@ -240,6 +240,7 @@ const specFiles = [
   { name: "GFM Strikethrough", file: "spec-strikethrough.txt" },
   { name: "GFM Tasklists", file: "spec-tasklists.txt" },
   { name: "Permissive Autolinks", file: "spec-permissive-autolinks.txt" },
+  { name: "Hard Soft Breaks", file: "spec-hard-soft-breaks.txt" },
   { name: "GFM", file: "spec-gfm.txt" },
   { name: "Coverage", file: "coverage.txt" },
   { name: "Regressions", file: "regressions.txt" },


### PR DESCRIPTION
Fixes #39491

### Problem

- `Bun.markdown.html("a\nb\n", { hardSoftBreaks: true })` returns `"<p>a\nb</p>\n"` and `Bun.markdown.html("a    b\n", { collapseWhitespace: true })` returns `"<p>a    b</p>\n"`: both options are documented (docs/runtime/markdown.mdx, `Bun.markdown.Options`) but do nothing.
- `hard_soft_breaks` is parsed into `Options` (src/md/root.rs) but dropped by `Options::to_flags()`; `Flags` (src/md/types.rs) had no such field.
- `collapse_whitespace` reaches `Flags` and marks space/tab/CR in the mark char map (src/md/parser.rs:351), but `process_inline_content` (src/md/inlines.rs) had no branch for those characters, so they fell through as literal text.

### Fix

- Adds `hard_soft_breaks` to `Flags` and threads it through `to_flags()`. The newline handler in `process_inline_content` now forces a hard break when the flag is set, dropping trailing whitespace before the break, matching md4c's `MD_FLAG_HARD_SOFT_BREAKS` (first call above now returns `"<p>a<br />\nb</p>\n"`).
- Adds a whitespace-run branch to `process_inline_content`: when `collapse_whitespace` is set, a non-trivial run (longer than one character, or not a plain space) in normal text is emitted as a single space, matching md4c's `MD_FLAG_COLLAPSEWHITESPACE` (second call above now returns `"<p>a b</p>\n"`). A run immediately before a newline is left for the existing hard-break detection, so `"a  \n"` still produces `<br />`. Code spans and code blocks are untouched (they never go through this path).
- Verified: new tests in test/js/bun/md/md-edge-cases.test.ts fail on current bun and pass with this change; md4c's checked-in `spec-hard-soft-breaks.txt` is now enabled in test/js/bun/md/md-spec.test.ts and passes; all 1082 tests in test/js/bun/md/ pass (including the full CommonMark spec suite, so no behavior change with the flags off).
- Intentionally excluded: `underline` and `latexMath` are the same bug class but are span-type options handled separately in #39493, so they are not touched here.

### Background

- `Bun.markdown` is a Rust port of md4c. Block structure is parsed first; each leaf block's lines are merged into one buffer and walked by `process_inline_content`, which dispatches on a per-parser "mark char map" (a 256-bit set of characters that need special handling, built once from the flags).
- In md4c, soft breaks (`MD_TEXT_SOFTBR`) render as `\n` and hard breaks (`MD_TEXT_BR`) as `<br />\n`. `MD_FLAG_HARD_SOFT_BREAKS` turns every soft break into a hard break; `MD_FLAG_COLLAPSEWHITESPACE` replaces each whitespace run that is more than a single space with one space.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/md/md-edge-cases.test.ts test/js/bun/md/md-spec.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/md/md-spec.test.ts:
(pass) CommonMark > example 1 (line 355): Tabs [31.86ms]
(pass) CommonMark > example 2 (line 362): Tabs [6.42ms]
(pass) CommonMark > example 3 (line 369): Tabs [6.49ms]
(pass) CommonMark > example 4 (line 382): Tabs [12.83ms]
(pass) CommonMark > example 5 (line 395): Tabs [15.02ms]
(pass) CommonMark > example 6 (line 418): Tabs [9.48ms]
(pass) CommonMark > example 7 (line 427): Tabs [11.89ms]
(pass) CommonMark > example 8 (line 439): Tabs [6.30ms]
(pass) CommonMark > example 9 (line 448): Tabs [25.98ms]
(pass) CommonMark > example 10 (line 466): Tabs [5.95ms]
(pass) CommonMark > example 11 (line 472): Tabs [3.40ms]
(pass) CommonMark > example 12 (line 489): Backslash escapes [5.15ms]
(pass) CommonMark > example 13 (line 499): Backslash escapes [4.19ms]
(pass) CommonMark > example 14 (line 509): Backslash escapes [6.61ms]
(pass) CommonMark > example 15 (line 534): Backslash escapes [6.59ms]
(pass) CommonMark >
... (truncated)

release without fix: 8 FAILED
bun test v1.4.0-canary.1 (6e906e468)

test/js/bun/md/md-spec.test.ts:
(pass) CommonMark > example 1 (line 355): Tabs [0.76ms]
(pass) CommonMark > example 2 (line 362): Tabs [0.05ms]
(pass) CommonMark > example 3 (line 369): Tabs [0.03ms]
(pass) CommonMark > example 4 (line 382): Tabs [0.13ms]
(pass) CommonMark > example 5 (line 395): Tabs [0.07ms]
(pass) CommonMark > example 6 (line 418): Tabs [0.05ms]
(pass) CommonMark > example 7 (line 427): Tabs [0.06ms]
(pass) CommonMark > example 8 (line 439): Tabs [0.04ms]
(pass) CommonMark > example 9 (line 448): Tabs [0.10ms]
(pass) CommonMark > example 10 (line 466): Tabs [0.04ms]
(pass) CommonMark > example 11 (line 472): Tabs [0.02ms]
(pass) CommonMark > example 12 (line 489): Backslash escapes [0.05ms]
(pass) CommonMark > example 13 (line 499): Backslash escapes [0.03ms]
(pass) CommonMark > example 14 (line 509): Backslash escapes [0.05ms]
(pass) CommonMark > example 15 (line 534): Backslash escapes [0.10ms]
(pass) CommonMark > example 16 (line 543): Backslash escapes [0.05ms]
(pass) CommonMark > example 17 (line 555): Backslash escapes [0.03ms]
(pass) CommonMark > example 18 (line 562): Backslash escapes [0.03ms]
(pass)
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/md/md-edge-cases.test.ts test/js/bun/md/md-spec.test.ts
bun test v1.4.0 (6e906e468)

test/js/bun/md/md-spec.test.ts:
(pass) CommonMark > example 1 (line 355): Tabs [32.12ms]
(pass) CommonMark > example 2 (line 362): Tabs [6.42ms]
(pass) CommonMark > example 3 (line 369): Tabs [6.17ms]
(pass) CommonMark > example 4 (line 382): Tabs [13.01ms]
(pass) CommonMark > example 5 (line 395): Tabs [14.59ms]
(pass) CommonMark > example 6 (line 418): Tabs [9.32ms]
(pass) CommonMark > example 7 (line 427): Tabs [11.27ms]
(pass) CommonMark > example 8 (line 439): Tabs [6.17ms]
(pass) CommonMark > example 9 (line 448): Tabs [24.90ms]
(pass) CommonMark > example 10 (line 466): Tabs [8.24ms]
(pass) CommonMark > example 11 (line 472): Tabs [3.71ms]
(pass) CommonMark > example 12 (line 489): Backslash escapes [5.01ms]
(pass) CommonMark > example 13 (line 499): Backslash escapes [4.50ms]
(pass) CommonMark > example 14 (line 509): Backslash escapes [6.61ms]
(pass) CommonMark > example 15 (line 534): Backslash escapes [6.00ms]
(pass) CommonMark >
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e63331534b
  features     baseline

23 deps, 129 codegen, 1172 objects in 708ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1244] fetch tinycc
[tinycc] up to date
[5/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1216] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[7/1216] gen bindgenv2
[8/1216] fetch zlib
[zlib] up to date
[9/1216] gen node-fallbacks/react-refresh.js
Bundled 1 module in 14ms

  react-refresh.js  4.81 KB  (entry point)

[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/md/inlines.rs                    | 37 ++++++++++++++++++++-
 src/md/root.rs                       |  1 +
 src/md/types.rs                      |  1 +
 test/js/bun/md/md-edge-cases.test.ts | 63 ++++++++++++++++++++++++++++++++++++
 test/js/bun/md/md-spec.test.ts       |  1 +
 5 files changed, 102 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/md/inlines.rs                         4      3      0
src/md/root.rs                            1      1      0
src/md/types.rs                           2      2      0
test/js/bun/md/md-edge-cases.test.ts      2      0      0
test/js/bun/md/md-spec.test.ts            1      1      0
```

</details>

**root cause** · written by the author bot

The hardSoftBreaks and collapseWhitespace options were parsed from the JavaScript options object but never took effect, because hard_soft_breaks was dropped in Options::to_flags and the inline processing loop had no handling for either behavior, so soft breaks always became Softbr and whitespace runs passed through as plain text. The fix threads both flags through to the parser, makes the newline handling emit a hard break and strip preceding trailing whitespace when hard_soft_breaks is set, and adds a branch that collapses non-trivial whitespace runs into a single space when collapse_white…

<!-- robobun:evidence:end -->
