### PR TITLE
markdown: emit balanced tags when an emphasis run matches more than 6 times

### DIFF
--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -4,14 +4,13 @@ use crate::links::{BracketMatches, LabelLeave};
 use crate::parser::{self, Parser};
 use crate::types::{SpanType, TextType, VerbatimLine};
 
-/// Inline capacity of `EmphSizes`, chosen so the `Inline` variant is no
-/// larger than the `Heap` one (Vec = 3 words, +tag +len = 32 bytes).
+/// Inline capacity of `EmphSizes`; 30 makes the `Inline` variant the same
+/// 32-byte size as the `Heap` variant.
 const EMPH_SIZES_INLINE_CAP: usize = 30;
 
 /// Ordered match sizes (1 = em, 2 = strong) for one side of an emphasis
-/// delimiter run. A run can match arbitrarily many times (e.g. 14 `*`
-/// opened against seven `**` closers), so overflow spills to the heap:
-/// dropping a recorded match would emit unbalanced HTML.
+/// delimiter run. A run can match arbitrarily many times, so sizes past
+/// the inline capacity spill to the heap instead of being dropped.
 #[derive(Clone)]
 pub(crate) enum EmphSizes {
     Inline {

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -3,58 +3,13 @@ use crate::helpers;
 use crate::links::{BracketMatches, LabelLeave};
 use crate::parser::{self, Parser};
 use crate::types::{SpanType, TextType, VerbatimLine};
-
-/// Inline capacity of `EmphSizes`; 30 makes the `Inline` variant the same
-/// 32-byte size as the `Heap` variant.
-const EMPH_SIZES_INLINE_CAP: usize = 30;
+use bun_collections::SmallList;
 
 /// Ordered match sizes (1 = em, 2 = strong) for one side of an emphasis
 /// delimiter run. A run can match arbitrarily many times, so sizes past
-/// the inline capacity spill to the heap instead of being dropped.
-#[derive(Clone)]
-pub(crate) enum EmphSizes {
-    Inline {
-        len: u8,
-        buf: [u8; EMPH_SIZES_INLINE_CAP],
-    },
-    Heap(Vec<u8>),
-}
-
-impl EmphSizes {
-    pub(crate) fn push(&mut self, size: u8) {
-        match self {
-            EmphSizes::Inline { len, buf } => {
-                let n = *len as usize;
-                if n < EMPH_SIZES_INLINE_CAP {
-                    buf[n] = size;
-                    *len += 1;
-                } else {
-                    let mut v = Vec::with_capacity(n + 1);
-                    v.extend_from_slice(&buf[..n]);
-                    v.push(size);
-                    *self = EmphSizes::Heap(v);
-                }
-            }
-            EmphSizes::Heap(v) => v.push(size),
-        }
-    }
-
-    pub(crate) fn as_slice(&self) -> &[u8] {
-        match self {
-            EmphSizes::Inline { len, buf } => &buf[..*len as usize],
-            EmphSizes::Heap(v) => v,
-        }
-    }
-}
-
-impl Default for EmphSizes {
-    fn default() -> Self {
-        EmphSizes::Inline {
-            len: 0,
-            buf: [0; EMPH_SIZES_INLINE_CAP],
-        }
-    }
-}
+/// the inline capacity (24 keeps the type at 32 bytes) spill to the heap
+/// instead of being dropped.
+pub(crate) type EmphSizes = SmallList<u8, 24>;
 
 /// Snapshot of an enclosing slice's walk state while one of its link/image/
 /// wikilink labels is rendered. `base..end` locate the enclosing slice
@@ -397,7 +352,7 @@ impl Parser<'_> {
                                 self.leave_span(SpanType::Del)?;
                             }
                         } else {
-                            self.emit_emph_close_tags(d.close_sizes.as_slice())?;
+                            self.emit_emph_close_tags(&d.close_sizes)?;
                         }
 
                         // Emit remaining delimiter chars as text
@@ -412,7 +367,7 @@ impl Parser<'_> {
                                 self.enter_span(SpanType::Del)?;
                             }
                         } else {
-                            self.emit_emph_open_tags(d.open_sizes.as_slice())?;
+                            self.emit_emph_open_tags(&d.open_sizes)?;
                         }
 
                         delim_cursor += 1;
@@ -917,12 +872,12 @@ impl Parser<'_> {
                     self.emph_delims[oi].open_count += use_;
                     self.emph_delims[oi]
                         .open_sizes
-                        .push(u8::try_from(use_).expect("int cast"));
+                        .append(u8::try_from(use_).expect("int cast"));
                     self.emph_delims[closer_idx].remaining -= use_;
                     self.emph_delims[closer_idx].close_count += use_;
                     self.emph_delims[closer_idx]
                         .close_sizes
-                        .push(u8::try_from(use_).expect("int cast"));
+                        .append(u8::try_from(use_).expect("int cast"));
 
                     // Remove all delimiters between opener and closer (CommonMark §6.4)
                     let mut k = prev_candidate[closer_idx];

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -4,8 +4,58 @@ use crate::links::{BracketMatches, LabelLeave};
 use crate::parser::{self, Parser};
 use crate::types::{SpanType, TextType, VerbatimLine};
 
-/// Emphasis delimiter entry for CommonMark emphasis algorithm.
-pub(crate) const MAX_EMPH_MATCHES: usize = 6;
+/// Inline capacity of `EmphSizes`, chosen so the `Inline` variant is no
+/// larger than the `Heap` one (Vec = 3 words, +tag +len = 32 bytes).
+const EMPH_SIZES_INLINE_CAP: usize = 30;
+
+/// Ordered match sizes (1 = em, 2 = strong) for one side of an emphasis
+/// delimiter run. A run can match arbitrarily many times (e.g. 14 `*`
+/// opened against seven `**` closers), so overflow spills to the heap:
+/// dropping a recorded match would emit unbalanced HTML.
+#[derive(Clone)]
+pub(crate) enum EmphSizes {
+    Inline {
+        len: u8,
+        buf: [u8; EMPH_SIZES_INLINE_CAP],
+    },
+    Heap(Vec<u8>),
+}
+
+impl EmphSizes {
+    pub(crate) fn push(&mut self, size: u8) {
+        match self {
+            EmphSizes::Inline { len, buf } => {
+                let n = *len as usize;
+                if n < EMPH_SIZES_INLINE_CAP {
+                    buf[n] = size;
+                    *len += 1;
+                } else {
+                    let mut v = Vec::with_capacity(n + 1);
+                    v.extend_from_slice(&buf[..n]);
+                    v.push(size);
+                    *self = EmphSizes::Heap(v);
+                }
+            }
+            EmphSizes::Heap(v) => v.push(size),
+        }
+    }
+
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        match self {
+            EmphSizes::Inline { len, buf } => &buf[..*len as usize],
+            EmphSizes::Heap(v) => v,
+        }
+    }
+}
+
+impl Default for EmphSizes {
+    fn default() -> Self {
+        EmphSizes::Inline {
+            len: 0,
+            buf: [0; EMPH_SIZES_INLINE_CAP],
+        }
+    }
+}
 
 /// Snapshot of an enclosing slice's walk state while one of its link/image/
 /// wikilink labels is rendered. `base..end` locate the enclosing slice
@@ -21,7 +71,7 @@ pub(crate) struct LabelFrame {
     leave: LabelLeave,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct EmphDelim {
     pub(crate) pos: usize,    // start position in content
     pub(crate) count: usize,  // original run length
@@ -32,11 +82,9 @@ pub struct EmphDelim {
     pub(crate) open_count: usize,  // total chars consumed as opener
     pub(crate) close_count: usize, // total chars consumed as closer
     // Individual match sizes in order (each is 1 for em, 2 for strong)
-    pub(crate) open_sizes: [u8; MAX_EMPH_MATCHES],
-    pub(crate) open_num: u8, // number of open matches
-    pub(crate) close_sizes: [u8; MAX_EMPH_MATCHES],
-    pub(crate) close_num: u8, // number of close matches
-    pub(crate) active: bool,  // false if deactivated between matched pairs
+    pub(crate) open_sizes: EmphSizes,
+    pub(crate) close_sizes: EmphSizes,
+    pub(crate) active: bool, // false if deactivated between matched pairs
 }
 
 impl Default for EmphDelim {
@@ -50,10 +98,8 @@ impl Default for EmphDelim {
             remaining: 0,
             open_count: 0,
             close_count: 0,
-            open_sizes: [0; MAX_EMPH_MATCHES],
-            open_num: 0,
-            close_sizes: [0; MAX_EMPH_MATCHES],
-            close_num: 0,
+            open_sizes: EmphSizes::default(),
+            close_sizes: EmphSizes::default(),
             active: true,
         }
     }
@@ -352,7 +398,7 @@ impl Parser<'_> {
                                 self.leave_span(SpanType::Del)?;
                             }
                         } else {
-                            self.emit_emph_close_tags(&d.close_sizes[0..d.close_num as usize])?;
+                            self.emit_emph_close_tags(d.close_sizes.as_slice())?;
                         }
 
                         // Emit remaining delimiter chars as text
@@ -367,7 +413,7 @@ impl Parser<'_> {
                                 self.enter_span(SpanType::Del)?;
                             }
                         } else {
-                            self.emit_emph_open_tags(&d.open_sizes[0..d.open_num as usize])?;
+                            self.emit_emph_open_tags(d.open_sizes.as_slice())?;
                         }
 
                         delim_cursor += 1;
@@ -870,19 +916,14 @@ impl Parser<'_> {
 
                     self.emph_delims[oi].remaining -= use_;
                     self.emph_delims[oi].open_count += use_;
-                    if (self.emph_delims[oi].open_num as usize) < MAX_EMPH_MATCHES {
-                        let n = self.emph_delims[oi].open_num as usize;
-                        self.emph_delims[oi].open_sizes[n] = u8::try_from(use_).expect("int cast");
-                        self.emph_delims[oi].open_num += 1;
-                    }
+                    self.emph_delims[oi]
+                        .open_sizes
+                        .push(u8::try_from(use_).expect("int cast"));
                     self.emph_delims[closer_idx].remaining -= use_;
                     self.emph_delims[closer_idx].close_count += use_;
-                    if (self.emph_delims[closer_idx].close_num as usize) < MAX_EMPH_MATCHES {
-                        let n = self.emph_delims[closer_idx].close_num as usize;
-                        self.emph_delims[closer_idx].close_sizes[n] =
-                            u8::try_from(use_).expect("int cast");
-                        self.emph_delims[closer_idx].close_num += 1;
-                    }
+                    self.emph_delims[closer_idx]
+                        .close_sizes
+                        .push(u8::try_from(use_).expect("int cast"));
 
                     // Remove all delimiters between opener and closer (CommonMark §6.4)
                     let mut k = prev_candidate[closer_idx];

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -122,6 +122,39 @@ describe("fuzzer-like edge cases", () => {
     expect(typeof Markdown.html(input)).toBe("string");
   });
 
+  // Delimiter runs matching more than 6 times used to overflow a fixed-size
+  // match-size array, dropping tags (issue #39496).
+  test("emphasis run matched more than 6 times emits balanced tags", () => {
+    const stars = (n: number) => Buffer.alloc(n, "*").toString();
+    const count = (html: string, tag: string) => html.split(tag).length - 1;
+
+    // One 14-char opener closed by seven `**` closers.
+    const html = Markdown.html(stars(14) + "a** b** c** d** e** f** g**\n");
+    expect(html).toBe(
+      "<p>" +
+        "<strong>".repeat(7) +
+        "a</strong> b</strong> c</strong> d</strong> e</strong> f</strong> g</strong></p>\n",
+    );
+
+    // 14 chars on each side: seven nested <strong> pairs.
+    expect(Markdown.html(stars(14) + "foo" + stars(14) + "\n")).toBe(
+      "<p>" + "<strong>".repeat(7) + "foo" + "</strong>".repeat(7) + "</p>\n",
+    );
+
+    // 64 chars on each side: 32 nested pairs (spills past any inline capacity).
+    expect(Markdown.html(stars(64) + "foo" + stars(64) + "\n")).toBe(
+      "<p>" + "<strong>".repeat(32) + "foo" + "</strong>".repeat(32) + "</p>\n",
+    );
+
+    // Open/close tag counts stay balanced for every run length.
+    for (let n = 1; n <= 70; n++) {
+      const out = Markdown.html(stars(n) + "x" + stars(n) + "\n");
+      expect(count(out, "<strong>")).toBe(count(out, "</strong>"));
+      expect(count(out, "<em>")).toBe(count(out, "</em>"));
+      expect(out).not.toContain("*");
+    }
+  });
+
   test("deeply nested links", () => {
     let input = "";
     for (let i = 0; i < 30; i++) {

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -153,6 +153,14 @@ describe("fuzzer-like edge cases", () => {
       expect(count(out, "<em>")).toBe(count(out, "</em>"));
       expect(out).not.toContain("*");
     }
+
+    // Unequal runs: the unconsumed delimiter char stays as literal text.
+    expect(Markdown.html(stars(15) + "foo" + stars(14) + "\n")).toBe(
+      "<p>*" + "<strong>".repeat(7) + "foo" + "</strong>".repeat(7) + "</p>\n",
+    );
+    expect(Markdown.html(stars(14) + "foo" + stars(15) + "\n")).toBe(
+      "<p>" + "<strong>".repeat(7) + "foo" + "</strong>".repeat(7) + "*</p>\n",
+    );
   });
 
   test("deeply nested links", () => {


### PR DESCRIPTION
Fixes #39496

### Problem
- `Bun.markdown.html("**************a** b** c** d** e** f** g**\n")` emits 6 `<strong>` but 7 `</strong>`: unbalanced HTML.
- `"*".repeat(14) + "foo" + "*".repeat(14)` emits only 6 nested `<strong>` pairs and silently drops the remaining consumed asterisks (md4c emits 7).
- Cause: `EmphDelim` in src/md/inlines.rs records per-match sizes in fixed `[u8; 6]` arrays (`MAX_EMPH_MATCHES = 6`). `resolve_emphasis_delimiters` keeps consuming delimiter characters past the sixth match (so they are not printed as literal text), but the 7th and later match sizes are never recorded, and `emit_emph_open_tags` / `emit_emph_close_tags` only emit the recorded entries. The opener and each closer truncate independently, which is why the one-opener-many-closers case becomes unbalanced rather than merely lossy.

### Fix
- Replace the fixed arrays with `EmphSizes = bun_collections::SmallList<u8, 24>`: 24 match sizes inline (keeps the type at 32 bytes, same as a plain `Vec<u8>`), spilling to the heap beyond that.
- Every match recorded during resolution is now emitted, so the invariant holds: every consumed delimiter character produces a tag, and open/close tag counts always balance.
- `EmphDelim` drops `Copy` (it was only ever cloned or accessed by index); the common case still performs zero allocations.
- Verified: new test in test/js/bun/md/md-edge-cases.test.ts fails on the previous build and passes with this change; all 1069 tests in test/js/bun/md/ (including the CommonMark spec suite) pass.

### Background
- CommonMark emphasis resolution pairs opener and closer delimiter runs greedily, consuming 2 characters per match when both sides have at least 2 left (`<strong>`), otherwise 1 (`<em>`). A single long run can therefore participate in arbitrarily many matches: 14 `*` as an opener can be closed by seven separate `**` closers.
- The renderer replays these matches per delimiter run: closing tags in match order (innermost first), then any unconsumed characters as literal text, then opening tags in reverse match order. The order of 1s and 2s matters (it decides which nesting level is `<em>` vs `<strong>`), so the sequence must be stored, not just counted.
- `SmallList` is the repo's smallvec wrapper (inline storage overlaid on the heap pointer words), already used elsewhere in the markdown crate.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [89.77ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [9.52ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [1.72ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [6.81ms]
(pass) fuzzer-like edge cases > control characters in input [1.58ms]
(pass) fuzzer-like edge cases > Buffer input works [1.64ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [4.74ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [7.53ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.20ms]
(pass) fuzzer-like edge cases > deeply nested lists [7.69ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [238.75ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [100.81ms]
(p
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [1.17ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [0.10ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [0.03ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [0.08ms]
(pass) fuzzer-like edge cases > control characters in input [0.02ms]
(pass) fuzzer-like edge cases > Buffer input works [0.04ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [0.05ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [0.12ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [0.04ms]
(pass) fuzzer-like edge cases > deeply nested lists [0.07ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [7.21ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [5.09ms]
(pass) fuzzer-like edge cases > deeply nested emphasis [0.05ms]
128 |     const stars = (n: number) => Buffer.alloc(n, "*").toString();
129 |     const count = (html: s
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/md/md-edge-cases.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/md/md-edge-cases.test.ts:
(pass) fuzzer-like edge cases > empty string produces empty output across all APIs [73.56ms]
(pass) fuzzer-like edge cases > whitespace-only inputs [9.75ms]
(pass) fuzzer-like edge cases > null bytes are replaced with U+FFFD [1.79ms]
(pass) fuzzer-like edge cases > input with many null bytes does not crash [7.11ms]
(pass) fuzzer-like edge cases > control characters in input [1.66ms]
(pass) fuzzer-like edge cases > Buffer input works [1.72ms]
(pass) fuzzer-like edge cases > binary-ish buffer does not crash [4.52ms]
(pass) fuzzer-like edge cases > ansi: invalid UTF-8 lead bytes do not crash [7.54ms]
(pass) fuzzer-like edge cases > deeply nested blockquotes [2.26ms]
(pass) fuzzer-like edge cases > deeply nested lists [7.79ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested lists produce linear output [161.36ms]
(pass) fuzzer-like edge cases > ansi: pathologically nested blockquotes + lists produce linear output [95.88ms]
(pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 662ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_md v0.0.0 (/workspace/bun/src/md)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/md/inlines.rs                    | 45 ++++++++++++++++--------------------
 test/js/bun/md/md-edge-cases.test.ts | 41 ++++++++++++++++++++++++++++++++
 2 files changed, 61 insertions(+), 25 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/md/inlines.rs                         7      8      0
test/js/bun/md/md-edge-cases.test.ts      1      2      0
```

</details>

**root cause** · written by the author bot

The bug was that `EmphDelim` stored the per-match sizes of an emphasis delimiter run in fixed arrays capped at six entries, while the resolver kept consuming delimiter characters past the sixth match, so tag emission truncated independently on each side and produced unbalanced or silently dropped em and strong tags. The fix replaces the fixed arrays with `EmphSizes`, a `SmallList<u8, 24>` that stores match sizes inline and spills to the heap for longer runs, and removes the six-match recording guard so every match is captured. Tag emission now consumes the full dynamic slice, guaranteeing o…

<!-- robobun:evidence:end -->