### PR TITLE
test: pass tempDir() handles to node:path as strings

### DIFF
--- a/test/bake/dev/response-to-bake-response.test.ts
+++ b/test/bake/dev/response-to-bake-response.test.ts
@@ -39,7 +39,7 @@ test("Response -> import { Response } from 'bun:app' transform in server compone
 
   // Build with server components enabled for server-side
   const serverResult =
-    await Bun.$`${bunExe()} build ${path.join(dir, "server-component.js")} --target=bun --server-components`
+    await Bun.$`${bunExe()} build ${path.join(String(dir), "server-component.js")} --target=bun --server-components`
       .env(bunEnv)
       .text();
 
@@ -51,7 +51,7 @@ test("Response -> import { Response } from 'bun:app' transform in server compone
   expect(serverResult).toContain("import_bun_app.Response.render");
 
   // Build client component (should not have the transform)
-  const clientResult = await Bun.$`${bunExe()} build ${path.join(dir, "client-component.js")} --target=browser`
+  const clientResult = await Bun.$`${bunExe()} build ${path.join(String(dir), "client-component.js")} --target=browser`
     .env(bunEnv)
     .text();
 
@@ -88,7 +88,7 @@ test("Response import is added for global Response in various contexts", async (
     `,
   });
 
-  const result = await Bun.$`${bunExe()} build ${path.join(dir, "server.js")} --target=bun --server-components`
+  const result = await Bun.$`${bunExe()} build ${path.join(String(dir), "server.js")} --target=bun --server-components`
     .env(bunEnv)
     .text();
 
@@ -141,16 +141,17 @@ test("Response import is not added when Response is already imported or shadowed
     `,
   });
 
-  const result1 = await Bun.$`${bunExe()} build ${path.join(dir, "server.js")} --target=bun --server-components`
+  const result1 = await Bun.$`${bunExe()} build ${path.join(String(dir), "server.js")} --target=bun --server-components`
     .env(bunEnv)
     .text();
 
   // When Response is already imported from another source, no bun:app import should be added
   expect(result1).not.toContain('import { Response } from "bun:app"');
 
-  const result2 = await Bun.$`${bunExe()} build ${path.join(dir, "server2.js")} --target=bun --server-components`
-    .env(bunEnv)
-    .text();
+  const result2 =
+    await Bun.$`${bunExe()} build ${path.join(String(dir), "server2.js")} --target=bun --server-components`
+      .env(bunEnv)
+      .text();
 
   // Should preserve local variable
   expect(result2).toContain("return new CustomResponse");
@@ -196,7 +197,7 @@ test("Response import is NOT added in client components", async () => {
   });
 
   // Test 1: Client component - Response should NOT be transformed
-  const clientResult = await Bun.$`${bunExe()} build ${path.join(dir, "client-component.js")} --target=browser`
+  const clientResult = await Bun.$`${bunExe()} build ${path.join(String(dir), "client-component.js")} --target=browser`
     .env(bunEnv as any)
     .text();
 
@@ -209,7 +210,7 @@ test("Response import is NOT added in client components", async () => {
 
   // Test 2: Server component - Response SHOULD be transformed
   const serverResult =
-    await Bun.$`${bunExe()} build ${path.join(dir, "server-component.js")} --target=bun --server-components`
+    await Bun.$`${bunExe()} build ${path.join(String(dir), "server-component.js")} --target=bun --server-components`
       .env(bunEnv as any)
       .text();
 
@@ -234,7 +235,7 @@ test("Response import is added when Response is global, but not when shadowed", 
   });
 
   const serverResult =
-    await Bun.$`${bunExe()} build ${path.join(dir, "server-component.js")} --target=bun --server-components`
+    await Bun.$`${bunExe()} build ${path.join(String(dir), "server-component.js")} --target=bun --server-components`
       .env(bunEnv as any)
       .text();
 

--- a/test/bake/framework-router.test.ts
+++ b/test/bake/framework-router.test.ts
@@ -93,14 +93,14 @@ test("discovers from filesystem paths", () => {
     children: [
       {
         part: "/:world",
-        page: path.join(dir, "[world].tsx"),
+        page: path.join(String(dir), "[world].tsx"),
         layout: null,
         children: [],
       },
       {
         part: "/meow",
         page: null,
-        layout: path.join(dir, "meow/_layout.tsx"),
+        layout: path.join(String(dir), "meow/_layout.tsx"),
         children: [
           {
             part: "/bark",
@@ -114,7 +114,7 @@ test("discovers from filesystem paths", () => {
                 children: [
                   {
                     part: "/hello",
-                    page: path.join(dir, "meow/bark/[param]/hello.tsx"),
+                    page: path.join(String(dir), "meow/bark/[param]/hello.tsx"),
                     layout: null,
                     children: [],
                   },
@@ -126,7 +126,7 @@ test("discovers from filesystem paths", () => {
       },
       {
         part: "/hello",
-        page: path.join(dir, "hello.tsx"),
+        page: path.join(String(dir), "hello.tsx"),
         layout: null,
         children: [],
       },

--- a/test/bundler/bun-build-compile-wasm.test.ts
+++ b/test/bundler/bun-build-compile-wasm.test.ts
@@ -95,9 +95,9 @@ describe("Bun.build compile with wasm", () => {
 
     // Test compilation with default target (current platform)
     const result = await Bun.build({
-      entrypoints: [join(dir, "app.js")],
+      entrypoints: [join(String(dir), "app.js")],
       compile: {
-        outfile: join(dir, "app-wasm"),
+        outfile: join(String(dir), "app-wasm"),
       },
     });
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -188,10 +188,10 @@ server.close();`,
 
     expect(() =>
       Bun.build({
-        entrypoints: [join(dir, "index.js")],
+        entrypoints: [join(String(dir), "index.js")],
         compile: {
           target: "bun-invalid-platform",
-          outfile: join(dir, "invalid-app"),
+          outfile: join(String(dir), "invalid-app"),
         },
       }),
     ).toThrowErrorMatchingInlineSnapshot(`"Unknown compile target: bun-invalid-platform"`);

--- a/test/bundler/bundler_defer.test.ts
+++ b/test/bundler/bundler_defer.test.ts
@@ -142,7 +142,7 @@ describe("defer", () => {
       });
       try {
         const result = await Bun.build({
-          entrypoints: [path.join(folder, "index.ts")],
+          entrypoints: [path.join(String(folder), "index.ts")],
           minify: true,
           plugins: [
             {
@@ -531,10 +531,10 @@ warn: (msg: string) => console.warn(\`[WARN] \${msg}\`)
 `,
     });
 
-    const entrypoint = path.join(folder, "src", "index.ts");
+    const entrypoint = path.join(String(folder), "src", "index.ts");
     await Bun.$`${bunExe()} install`.env(bunEnv).cwd(folder);
 
-    const outdir = path.join(folder, "dist");
+    const outdir = path.join(String(folder), "dist");
 
     let onFinalizeCallCount = 0;
     let onFinalizeCallRegistry = new FinalizationRegistry(() => {
@@ -607,7 +607,7 @@ warn: (msg: string) => console.warn(\`[WARN] \${msg}\`)
 
     expect(result.success).toBeTrue();
     await Bun.$`${bunExe()} run ${result.outputs[0].path}`;
-    const output = await Bun.$`cat ${path.join(folder, "dist", "output.json")}`.json();
+    const output = await Bun.$`cat ${path.join(String(folder), "dist", "output.json")}`.json();
     expect(output).toStrictEqual({
       "index.ts": {
         "imports": [

--- a/test/bundler/html-import-manifest.test.ts
+++ b/test/bundler/html-import-manifest.test.ts
@@ -372,8 +372,8 @@ console.log("About manifest:", aboutHtml);
     });
 
     async function buildAndReadManifest() {
-      const out = join(dir, "out");
-      const r = await Bun.build({ entrypoints: [join(dir, "server.ts")], outdir: out, target: "bun" });
+      const out = join(String(dir), "out");
+      const r = await Bun.build({ entrypoints: [join(String(dir), "server.ts")], outdir: out, target: "bun" });
       expect(r.success).toBe(true);
       const js = readFileSync(join(out, "server.js"), "utf8");
       const m = js.match(/__jsonParse\("(.+?)"\)/s)!;
@@ -383,7 +383,7 @@ console.log("About manifest:", aboutHtml);
     }
 
     const a = await buildAndReadManifest();
-    writeFileSync(join(dir, "app.ts"), `console.log(2);`);
+    writeFileSync(join(String(dir), "app.ts"), `console.log(2);`);
     const b = await buildAndReadManifest();
 
     const htmlA = a.files.find(f => f.loader === "html")!;
@@ -418,8 +418,8 @@ console.log("About manifest:", aboutHtml);
     });
 
     const build = await Bun.build({
-      entrypoints: [join(dir, "server.ts")],
-      outdir: join(dir, "out"),
+      entrypoints: [join(String(dir), "server.ts")],
+      outdir: join(String(dir), "out"),
       target: "bun",
       sourcemap: "external",
       minify: { whitespace: true },

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -21,7 +21,7 @@ describe("--hot with many directories", () => {
       const maxCount = 3;
       for (let i = 0; i < dirCount; i++) {
         const dirName = `dir-${i.toString().padStart(4, "0")}`;
-        const dirPath = join(tmpdir, dirName);
+        const dirPath = join(String(tmpdir), dirName);
         mkdirSync(dirPath, { recursive: true });
 
         // Create an index.js in each directory
@@ -35,7 +35,7 @@ describe("--hot with many directories", () => {
       }).join("\n");
 
       writeFileSync(
-        join(tmpdir, "entry.js"),
+        join(String(tmpdir), "entry.js"),
         `
 ${imports}
 console.log('Loaded', ${dirCount}, 'directories');
@@ -71,7 +71,7 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
 
         for (let i = 0; i < dirCount; i++) {
           const dirName = `dir-${i.toString().padStart(4, "0")}`;
-          const filePath = join(tmpdir, dirName, "index.js");
+          const filePath = join(String(tmpdir), dirName, "index.js");
 
           updatePromises.push(
             Bun.write(filePath, `export const value${i} = ${i};\nexport const timestamp${i} = ${timestamp};`),
@@ -150,7 +150,7 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
       // entrypoint is added fd-less before its first transpile; dep's stored
       // fd settles on its first edited reload).
       for (let i = 1; i <= 2; i++) {
-        writeFileSync(join(dir, "lib", "dep.js"), `export const value = ${i};`);
+        writeFileSync(join(String(dir), "lib", "dep.js"), `export const value = ${i};`);
         await waitForReload(i);
       }
       const before = countFileFds();
@@ -161,7 +161,7 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
 
       const reloads = 15;
       for (let i = 3; i <= reloads + 2; i++) {
-        writeFileSync(join(dir, "lib", "dep.js"), `export const value = ${i};`);
+        writeFileSync(join(String(dir), "lib", "dep.js"), `export const value = ${i};`);
         await waitForReload(i);
       }
       const after = countFileFds();
@@ -230,7 +230,7 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
 
     await waitForLine("RELOAD 0");
     for (let i = 1; i <= edits; i++) {
-      writeFileSync(join(dir, "lib", "dep.js"), `export const value = ${i};`);
+      writeFileSync(join(String(dir), "lib", "dep.js"), `export const value = ${i};`);
       await waitForLine(`RELOAD ${i}`);
     }
     const [stderr, exitCode] = await Promise.all([stderrText, proc.exited]);

--- a/test/cli/hot/watch.test.ts
+++ b/test/cli/hot/watch.test.ts
@@ -13,9 +13,9 @@ describe.todoIf(isBroken && isWindows)("--watch works", async () => {
         "package.json": JSON.stringify({ name: "foo", version: "0.0.1" }),
       });
       await Bun.sleep(1000);
-      const tmpfile = join(tmpdir_, "tmp.js");
+      const tmpfile = join(String(tmpdir_), "tmp.js");
       const process = spawn({
-        cmd: [bunExe(), "--watch", join(tmpdir_, watchedFile)],
+        cmd: [bunExe(), "--watch", join(String(tmpdir_), watchedFile)],
         cwd: tmpdir_,
         env: bunEnv,
         stdio: ["ignore", "pipe", "inherit"],

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -39,9 +39,9 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
 
     expect(await exited).toBe(0);
 
-    const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
+    const pkg = JSON.parse(fs.readFileSync(path.join(String(temp), "package.json"), "utf8"));
     expect(pkg).toEqual({
-      "name": path.basename(temp).toLowerCase().replaceAll(" ", "-"),
+      "name": path.basename(String(temp)).toLowerCase().replaceAll(" ", "-"),
       "module": "index.ts",
       "type": "module",
       "private": true,
@@ -52,15 +52,15 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
         "typescript": "^7",
       },
     });
-    const readme = fs.readFileSync(path.join(temp, "README.md"), "utf8");
-    expect(readme).toStartWith("# " + path.basename(temp).toLowerCase().replaceAll(" ", "-") + "\n");
+    const readme = fs.readFileSync(path.join(String(temp), "README.md"), "utf8");
+    expect(readme).toStartWith("# " + path.basename(String(temp)).toLowerCase().replaceAll(" ", "-") + "\n");
     expect(readme).toInclude("v" + Bun.version.replaceAll("-debug", ""));
     expect(readme).toInclude("index.ts");
 
-    expect(fs.existsSync(path.join(temp, "index.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, ".gitignore"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "node_modules"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "index.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), ".gitignore"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "node_modules"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "tsconfig.json"))).toBe(true);
   }, 30_000);
 
   test("bun init falls back to --yes when stdin is not a TTY", async () => {
@@ -85,9 +85,9 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(stderr).not.toContain("\x1b[");
     expect(exitCode).toBe(0);
 
-    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "index.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "index.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "tsconfig.json"))).toBe(true);
   }, 30_000);
 
   // Ctrl-D is EOF only on a POSIX tty; the Windows console has no equivalent
@@ -134,7 +134,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(output).not.toContain("An internal error occurred");
     expect(output).not.toContain("EndOfStream");
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(false);
+    expect(fs.existsSync(path.join(String(temp), "package.json"))).toBe(false);
   });
 
   test("bun init in folder", async () => {
@@ -155,7 +155,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     });
     expect(await exited).toBe(0);
     expect(readdirSync(temp).sort()).toEqual(["mydir"]);
-    expect(readdirSync(path.join(temp, "mydir")).sort()).toMatchInlineSnapshot(`
+    expect(readdirSync(path.join(String(temp), "mydir")).sort()).toMatchInlineSnapshot(`
     [
       ".gitignore",
       "README.md",
@@ -180,7 +180,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     });
     expect(await exited).not.toBe(0);
     expect(readdirSync(temp).sort()).toEqual(["mydir"]);
-    expect(await Bun.file(path.join(temp, "mydir")).text()).toBe("don't delete me!!!");
+    expect(await Bun.file(path.join(String(temp), "mydir")).text()).toBe("don't delete me!!!");
   });
 
   test("bun init utf-8", async () => {
@@ -193,8 +193,8 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     });
     expect(await exited).toBe(0);
     expect(readdirSync(temp).sort()).toEqual(["u t f ∞™"]);
-    expect(readdirSync(path.join(temp, "u t f ∞™")).sort()).toEqual(["subpath"]);
-    expect(readdirSync(path.join(temp, "u t f ∞™/subpath")).sort()).toMatchInlineSnapshot(`
+    expect(readdirSync(path.join(String(temp), "u t f ∞™")).sort()).toEqual(["subpath"]);
+    expect(readdirSync(path.join(String(temp), "u t f ∞™/subpath")).sort()).toMatchInlineSnapshot(`
     [
       ".gitignore",
       "README.md",
@@ -217,7 +217,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     });
     expect(await exited).toBe(0);
     expect(readdirSync(temp).sort()).toEqual(["mydir"]);
-    expect(readdirSync(path.join(temp, "mydir")).sort()).toMatchInlineSnapshot(`
+    expect(readdirSync(path.join(String(temp), "mydir")).sort()).toMatchInlineSnapshot(`
     [
       ".gitignore",
       "README.md",
@@ -228,17 +228,17 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
       "tsconfig.json",
     ]
   `);
-    await Bun.write(path.join(temp, "mydir/index.ts"), "my edited index.ts");
-    await Bun.write(path.join(temp, "mydir/README.md"), "my edited README.md");
-    await Bun.write(path.join(temp, "mydir/.gitignore"), "my edited .gitignore");
+    await Bun.write(path.join(String(temp), "mydir/index.ts"), "my edited index.ts");
+    await Bun.write(path.join(String(temp), "mydir/README.md"), "my edited README.md");
+    await Bun.write(path.join(String(temp), "mydir/.gitignore"), "my edited .gitignore");
     await Bun.write(
-      path.join(temp, "mydir/package.json"),
+      path.join(String(temp), "mydir/package.json"),
       JSON.stringify({
-        ...(await Bun.file(path.join(temp, "mydir/package.json")).json()),
+        ...(await Bun.file(path.join(String(temp), "mydir/package.json")).json()),
         name: "my edited package.json",
       }),
     );
-    await Bun.write(path.join(temp, "mydir/tsconfig.json"), `my edited tsconfig.json`);
+    await Bun.write(path.join(String(temp), "mydir/tsconfig.json"), `my edited tsconfig.json`);
     const { exited: exited2, stderr } = Bun.spawn({
       cmd: [bunExe(), "init", "mydir"],
       cwd: temp,
@@ -251,7 +251,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(await stderr.text()).toMatchInlineSnapshot(`""`);
     expect(await exited2).toBe(0);
     expect(readdirSync(temp).sort()).toEqual(["mydir"]);
-    expect(readdirSync(path.join(temp, "mydir")).sort()).toMatchInlineSnapshot(`
+    expect(readdirSync(path.join(String(temp), "mydir")).sort()).toMatchInlineSnapshot(`
     [
       ".gitignore",
       "README.md",
@@ -262,10 +262,16 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
       "tsconfig.json",
     ]
   `);
-    expect(await Bun.file(path.join(temp, "mydir/index.ts")).text()).toMatchInlineSnapshot(`"my edited index.ts"`);
-    expect(await Bun.file(path.join(temp, "mydir/README.md")).text()).toMatchInlineSnapshot(`"my edited README.md"`);
-    expect(await Bun.file(path.join(temp, "mydir/.gitignore")).text()).toMatchInlineSnapshot(`"my edited .gitignore"`);
-    expect(await Bun.file(path.join(temp, "mydir/package.json")).json()).toMatchInlineSnapshot(`
+    expect(await Bun.file(path.join(String(temp), "mydir/index.ts")).text()).toMatchInlineSnapshot(
+      `"my edited index.ts"`,
+    );
+    expect(await Bun.file(path.join(String(temp), "mydir/README.md")).text()).toMatchInlineSnapshot(
+      `"my edited README.md"`,
+    );
+    expect(await Bun.file(path.join(String(temp), "mydir/.gitignore")).text()).toMatchInlineSnapshot(
+      `"my edited .gitignore"`,
+    );
+    expect(await Bun.file(path.join(String(temp), "mydir/package.json")).json()).toMatchInlineSnapshot(`
     {
       "devDependencies": {
         "@types/bun": "latest",
@@ -279,7 +285,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
       "type": "module",
     }
   `);
-    expect(await Bun.file(path.join(temp, "mydir/tsconfig.json")).text()).toMatchInlineSnapshot(
+    expect(await Bun.file(path.join(String(temp), "mydir/tsconfig.json")).text()).toMatchInlineSnapshot(
       `"my edited tsconfig.json"`,
     );
   });
@@ -296,16 +302,16 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
 
     expect(await exited).toBe(0);
 
-    const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
+    const pkg = JSON.parse(fs.readFileSync(path.join(String(temp), "package.json"), "utf8"));
     expect(pkg).toHaveProperty("dependencies.react");
     expect(pkg).toHaveProperty("dependencies.react-dom");
     expect(pkg).toHaveProperty("devDependencies.@types/react");
     expect(pkg).toHaveProperty("devDependencies.@types/react-dom");
     expect(pkg.peerDependencies).toEqual({ typescript: "^7" });
 
-    expect(fs.existsSync(path.join(temp, "src"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "src/index.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "src"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "src/index.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "tsconfig.json"))).toBe(true);
   }, 30_000);
 
   test("bun init --react=tailwind works", async () => {
@@ -320,7 +326,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
 
     expect(await exited).toBe(0);
 
-    const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
+    const pkg = JSON.parse(fs.readFileSync(path.join(String(temp), "package.json"), "utf8"));
     expect(pkg).toHaveProperty("dependencies.react");
     expect(pkg).toHaveProperty("dependencies.react-dom");
     expect(pkg).toHaveProperty("devDependencies.@types/react");
@@ -328,8 +334,8 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(pkg).toHaveProperty("dependencies.bun-plugin-tailwind");
     expect(pkg.peerDependencies).toEqual({ typescript: "^7" });
 
-    expect(fs.existsSync(path.join(temp, "src"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "src/index.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "src"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "src/index.ts"))).toBe(true);
   }, 30_000);
 
   test("bun init --react=shadcn works", async () => {
@@ -344,7 +350,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
 
     expect(await exited).toBe(0);
 
-    const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
+    const pkg = JSON.parse(fs.readFileSync(path.join(String(temp), "package.json"), "utf8"));
     expect(pkg).toHaveProperty("dependencies.react");
     expect(pkg).toHaveProperty("dependencies.react-dom");
     expect(pkg).toHaveProperty("dependencies.@radix-ui/react-slot");
@@ -353,10 +359,10 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(pkg).toHaveProperty("dependencies.bun-plugin-tailwind");
     expect(pkg.peerDependencies).toEqual({ typescript: "^7" });
 
-    expect(fs.existsSync(path.join(temp, "src"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "src/index.ts"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "src/components"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "src/components/ui"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "src"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "src/index.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "src/components"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "src/components/ui"))).toBe(true);
   }, 30_000);
 
   // Every template declares `typescript: "^7"`, so the `bun install` that
@@ -380,7 +386,9 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
       ]);
       expect({ initStdout, initStderr, initExited }).toMatchObject({ initExited: 0 });
 
-      const tsPkg = JSON.parse(fs.readFileSync(path.join(temp, "node_modules/typescript/package.json"), "utf8"));
+      const tsPkg = JSON.parse(
+        fs.readFileSync(path.join(String(temp), "node_modules/typescript/package.json"), "utf8"),
+      );
       expect(tsPkg.version).toStartWith("7.");
 
       // TypeScript 7's bin/tsc is a small ESM shim that execs the native
@@ -400,7 +408,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
       // bun-plugin-tailwind's `bun` peer dep links a node_modules/.bin/bun that
       // would otherwise shadow bunExe() in the nested `bun run build.ts`, so
       // pass --bun.
-      const pkg = JSON.parse(fs.readFileSync(path.join(temp, "package.json"), "utf8"));
+      const pkg = JSON.parse(fs.readFileSync(path.join(String(temp), "package.json"), "utf8"));
       if (pkg.scripts?.build) {
         await using build = Bun.spawn({
           cmd: [bunExe(), "--bun", "run", "build"],
@@ -441,7 +449,7 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     // proves the child's stdout reached us.
     expect(stdout).toContain("bun install");
     expect(stdout).toMatch(/\bpackages? installed\b/);
-    expect(fs.existsSync(path.join(temp, "node_modules"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "node_modules"))).toBe(true);
     expect(exitCode).toBe(0);
   }, 30_000);
 
@@ -464,14 +472,14 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(await exited).toBe(0);
 
     // Should create package.json and tsconfig.json
-    expect(fs.existsSync(path.join(temp, "package.json"))).toBe(true);
-    expect(fs.existsSync(path.join(temp, "tsconfig.json"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "package.json"))).toBe(true);
+    expect(fs.existsSync(path.join(String(temp), "tsconfig.json"))).toBe(true);
 
     // Should NOT create these extra files with --minimal
-    expect(fs.existsSync(path.join(temp, "index.ts"))).toBe(false);
-    expect(fs.existsSync(path.join(temp, ".gitignore"))).toBe(false);
-    expect(fs.existsSync(path.join(temp, "README.md"))).toBe(false);
-    expect(fs.existsSync(path.join(temp, "CLAUDE.md"))).toBe(false);
-    expect(fs.existsSync(path.join(temp, ".cursor"))).toBe(false);
+    expect(fs.existsSync(path.join(String(temp), "index.ts"))).toBe(false);
+    expect(fs.existsSync(path.join(String(temp), ".gitignore"))).toBe(false);
+    expect(fs.existsSync(path.join(String(temp), "README.md"))).toBe(false);
+    expect(fs.existsSync(path.join(String(temp), "CLAUDE.md"))).toBe(false);
+    expect(fs.existsSync(path.join(String(temp), ".cursor"))).toBe(false);
   });
 });

--- a/test/cli/inspect/inspect.test.ts
+++ b/test/cli/inspect/inspect.test.ts
@@ -483,12 +483,12 @@ test.todo("junit reporter", async () => {
       });
     `,
   });
-  const path = randomSocketPathFn(tempdir)();
+  const path = randomSocketPathFn(String(tempdir))();
   let { resolve, reject, promise } = Promise.withResolvers();
   const [socket, subprocess] = await Promise.all([
     connect(`unix://${path}`, resolve),
     spawn({
-      cmd: [bunExe(), "--inspect-wait=unix:" + path, "test", join(tempdir, "a.test.js")],
+      cmd: [bunExe(), "--inspect-wait=unix:" + path, "test", join(String(tempdir), "a.test.js")],
       env: bunEnv,
       stdout: "inherit",
       stderr: "inherit",

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -195,10 +195,10 @@ function writeBunfig(
   install: Record<string, unknown> = {},
 ) {
   return write(
-    join(dir, "bunfig.toml"),
+    join(String(dir), "bunfig.toml"),
     Bun.TOML.stringify({
       install: {
-        cache: join(dir, ".bun-cache"),
+        cache: join(String(dir), ".bun-cache"),
         registry: typeof server === "string" ? server : server.url.href,
         saveTextLockfile: true,
         ...(scopes && { scopes }),
@@ -218,7 +218,7 @@ async function deadRegistryHref() {
 
 // The CI runner exports one BUN_INSTALL_CACHE_DIR per file, which overrides the bunfig cache the concurrent cases rely on.
 function installEnv(dir: string) {
-  return { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache") };
+  return { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache") };
 }
 
 async function setup(
@@ -235,15 +235,15 @@ async function setup(
 }
 
 function pkgJson(dir: string, ...segments: string[]) {
-  return file(join(dir, ...segments, "package.json")).json();
+  return file(join(String(dir), ...segments, "package.json")).json();
 }
 
 function pkgJsonText(dir: string, ...segments: string[]) {
-  return file(join(dir, ...segments, "package.json")).text();
+  return file(join(String(dir), ...segments, "package.json")).text();
 }
 
 async function reinstall(dir: string, pkgJson: object) {
-  await write(join(dir, "package.json"), JSON.stringify(pkgJson));
+  await write(join(String(dir), "package.json"), JSON.stringify(pkgJson));
   await runBunInstall(installEnv(dir), dir);
 }
 
@@ -296,16 +296,16 @@ function audit(dir: string, ...args: string[]) {
 }
 
 function lock(dir: string) {
-  return file(join(dir, "bun.lock")).text();
+  return file(join(String(dir), "bun.lock")).text();
 }
 
 async function installedVersion(dir: string, ...segments: string[]) {
-  return (await file(join(dir, "node_modules", ...segments, "package.json")).json()).version;
+  return (await file(join(String(dir), "node_modules", ...segments, "package.json")).json()).version;
 }
 
 // The version `dependent` resolves `name` to under the hoisted layout: its nested copy, else the root one.
 async function resolvedVersion(dir: string, dependent: string, name: string) {
-  if (await exists(join(dir, "node_modules", dependent, "node_modules", name))) {
+  if (await exists(join(String(dir), "node_modules", dependent, "node_modules", name))) {
     return installedVersion(dir, dependent, "node_modules", name);
   }
   return installedVersion(dir, name);
@@ -320,7 +320,7 @@ async function expectInstall(dir: string, ...args: string[]) {
 // Written after `setup` so the initial install runs without it; records the `name@version`s it was sent in scanned.json and flags the listed ones as fatal.
 async function configureScanner(dir: string, server: Registry, fatal: string[] = []) {
   await write(
-    join(dir, "scanner.ts"),
+    join(String(dir), "scanner.ts"),
     `import { writeFileSync } from "node:fs";
      import { join } from "node:path";
      export const scanner = {
@@ -339,7 +339,7 @@ async function configureScanner(dir: string, server: Registry, fatal: string[] =
 }
 
 function scanned(dir: string): Promise<string[]> {
-  return file(join(dir, "scanned.json")).json();
+  return file(join(String(dir), "scanned.json")).json();
 }
 
 // a-dep@1.0.2 stays installed after the range is widened because the still-satisfied edge is not re-resolved.
@@ -998,15 +998,15 @@ describe("`bun audit --omit`", () => {
     expect(fromRootOmit.stdout).toBe(fromRoot.stdout);
     expect(fromRootOmit.exitCode).toBe(1);
 
-    expectClean(await run(join(dir, "packages", "a"), ["audit", "--prod"], dir), 0);
+    expectClean(await run(join(String(dir), "packages", "a"), ["audit", "--prod"], dir), 0);
 
-    const fromB = await run(join(dir, "packages", "b"), ["audit", "--prod"], dir);
+    const fromB = await run(join(String(dir), "packages", "b"), ["audit", "--prod"], dir);
     expect(fromB.stdout).toContain("a-dep");
     expect(fromB.stdout).not.toContain("no-deps");
     expect(fromB.stdout).toContain("1 vulnerability (1 high)");
     expect(fromB.exitCode).toBe(1);
 
-    const fromAAll = await run(join(dir, "packages", "a"), ["audit"], dir);
+    const fromAAll = await run(join(String(dir), "packages", "a"), ["audit"], dir);
     expect(fromAAll.stdout).toContain("a-dep");
     expect(fromAAll.stdout).toContain("no-deps");
     expect(fromAAll.stdout).toContain("2 vulnerabilities (2 high)");
@@ -1304,7 +1304,7 @@ describe("`bun audit fix`", () => {
   test.concurrent("fixes a direct dependency to the lowest safe version, not the newest", async () => {
     await using server = startRegistry({ "a-dep": [adv("<1.0.4")] });
     using dir = await setupVulnerableADep(server);
-    const pkgJsonBefore = await file(join(dir, "package.json")).text();
+    const pkgJsonBefore = await file(join(String(dir), "package.json")).text();
 
     const { stdout, stderr, exitCode } = await auditFix(dir);
     expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
@@ -1326,7 +1326,7 @@ describe("`bun audit fix`", () => {
     expect(lockfile).not.toContain('"a-dep@1.0.2"');
     expect(lockfile).not.toContain('"a-dep@1.0.10"');
     expect(await installedVersion(dir, "a-dep")).toBe("1.0.4");
-    expect(await file(join(dir, "package.json")).text()).toBe(pkgJsonBefore);
+    expect(await file(join(String(dir), "package.json")).text()).toBe(pkgJsonBefore);
 
     const recheck = await audit(dir);
     expectClean(recheck, 1);
@@ -1486,7 +1486,7 @@ describe("`bun audit fix`", () => {
     expect(stdout).toContain("Would fix 1 vulnerability in 1 package");
     expect(stdout).not.toContain("FATAL");
     expect(exitCode).toBe(0);
-    expect(await exists(join(dir, "scanned.json"))).toBe(false);
+    expect(await exists(join(String(dir), "scanned.json"))).toBe(false);
     expect(await lock(dir)).toBe(lockBefore);
     expect(await installedVersion(dir, "a-dep")).toBe("1.0.2");
   });
@@ -1688,7 +1688,7 @@ describe("`bun audit fix`", () => {
     using dir = await setupVulnerableADep(server);
     const lockBefore = await lock(dir);
     const stale = JSON.stringify({ name: "foo", dependencies: { "a-dep": "^1.0.2", "no-deps": "1.0.0" } });
-    await write(join(dir, "package.json"), stale);
+    await write(join(String(dir), "package.json"), stale);
 
     const { stdout, stderr, exitCode } = await auditFix(dir);
     expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
@@ -1700,7 +1700,7 @@ describe("`bun audit fix`", () => {
     expect(await lock(dir)).toBe(lockBefore);
     expect(await pkgJsonText(dir)).toBe(stale);
     expect(await installedVersion(dir, "a-dep")).toBe("1.0.2");
-    expect(await exists(join(dir, "node_modules", "no-deps"))).toBe(false);
+    expect(await exists(join(String(dir), "node_modules", "no-deps"))).toBe(false);
 
     const dryRun = await auditFix(dir, "--dry-run");
     expect(dryRun.stderr).toContain("error: bun.lock does not match package.json, nothing to fix");
@@ -1769,8 +1769,8 @@ describe("`bun audit fix`", () => {
       "packages/a/package.json": workspace("a", "1.0.0"),
       "packages/b/package.json": workspace("b", "1.0.1"),
     });
-    await write(join(dir, "packages", "a", "package.json"), workspace("a", "1.0.0 || >=1.1.0"));
-    await write(join(dir, "packages", "b", "package.json"), workspace("b", "^1.0.1"));
+    await write(join(String(dir), "packages", "a", "package.json"), workspace("a", "1.0.0 || >=1.1.0"));
+    await write(join(String(dir), "packages", "b", "package.json"), workspace("b", "^1.0.1"));
     await runBunInstall(installEnv(dir), dir);
     let lockfile = await lock(dir);
     expect(lockfile).toContain('"no-deps@1.0.0"');
@@ -2417,7 +2417,7 @@ describe("`bun audit fix`", () => {
     using dir = tempDir("audit-fix-", { "package.json": rootPkgJson("1.0.1") });
     await writeBunfig(dir, server);
     await expectInstall(dir);
-    await write(join(dir, "package.json"), rootPkgJson("^1.0.0"));
+    await write(join(String(dir), "package.json"), rootPkgJson("^1.0.0"));
     await expectInstall(dir);
     expect(await lock(dir)).toContain('"no-deps@1.0.1"');
 
@@ -2460,20 +2460,24 @@ describe("`bun audit fix`", () => {
     using dir = tempDir("audit-fix-", { "package.json": rootPkgJson, "packages/a/package.json": member("1.0.2") });
     await writeBunfig(dir, server);
     await expectInstall(dir, "--linker", "hoisted");
-    await write(join(dir, "packages", "a", "package.json"), member("^1.0.2"));
+    await write(join(String(dir), "packages", "a", "package.json"), member("^1.0.2"));
     await expectInstall(dir, "--linker", "hoisted");
     expect(await lock(dir)).toContain('"a-dep@1.0.2"');
 
-    const { stdout, exitCode } = await run(join(dir, "packages", "a"), ["audit", "fix", "--linker", "hoisted"], dir);
+    const { stdout, exitCode } = await run(
+      join(String(dir), "packages", "a"),
+      ["audit", "fix", "--linker", "hoisted"],
+      dir,
+    );
     expect(stdout).toContain("  ^ a-dep 1.0.2 -> 1.0.4");
     expect(exitCode).toBe(0);
 
     const lockfile = await lock(dir);
     expect(lockfile).toContain('"a-dep@1.0.4"');
     expect(lockfile).not.toContain('"a-dep@1.0.2"');
-    expect(await exists(join(dir, "packages", "a", "bun.lock"))).toBeFalse();
-    expect(await file(join(dir, "package.json")).text()).toBe(rootPkgJson);
-    expect(await file(join(dir, "packages", "a", "package.json")).text()).toBe(member("^1.0.2"));
+    expect(await exists(join(String(dir), "packages", "a", "bun.lock"))).toBeFalse();
+    expect(await file(join(String(dir), "package.json")).text()).toBe(rootPkgJson);
+    expect(await file(join(String(dir), "packages", "a", "package.json")).text()).toBe(member("^1.0.2"));
     expect(await installedVersion(dir, "a-dep")).toBe("1.0.4");
 
     const frozen = await run(dir, ["install", "--frozen-lockfile", "--linker", "hoisted"]);
@@ -2488,17 +2492,20 @@ describe("`bun audit fix`", () => {
     });
     await writeBunfig(dir, server);
     await expectInstall(dir, "--linker", "isolated");
-    await write(join(dir, "package.json"), JSON.stringify({ name: "foo", dependencies: { "a-dep": "^1.0.2" } }));
+    await write(
+      join(String(dir), "package.json"),
+      JSON.stringify({ name: "foo", dependencies: { "a-dep": "^1.0.2" } }),
+    );
     await expectInstall(dir, "--linker", "isolated");
     expect(await lock(dir)).toContain('"a-dep@1.0.2"');
-    expect(await readlink(join(dir, "node_modules", "a-dep"))).toContain("a-dep@1.0.2");
+    expect(await readlink(join(String(dir), "node_modules", "a-dep"))).toContain("a-dep@1.0.2");
 
     const { stdout, exitCode } = await auditFix(dir, "--linker", "isolated");
     expect(stdout).toContain("Fixed 1 vulnerability in 1 package");
     expect(exitCode).toBe(0);
 
     expect(await lock(dir)).toContain('"a-dep@1.0.4"');
-    expect(await readlink(join(dir, "node_modules", "a-dep"))).toContain("a-dep@1.0.4");
+    expect(await readlink(join(String(dir), "node_modules", "a-dep"))).toContain("a-dep@1.0.4");
     expect(await installedVersion(dir, "a-dep")).toBe("1.0.4");
 
     const frozen = await run(dir, ["install", "--frozen-lockfile", "--linker", "isolated"]);
@@ -2648,7 +2655,7 @@ describe("`bun audit fix`", () => {
     expect(normalizeBunSnapshot(stderr)).toBe(MISSING_LOCKFILE);
     expect(normalizeBunSnapshot(stdout)).toBe("bun audit fix <version> (<revision>)");
     expect(exitCode).toBe(1);
-    expect(await exists(join(dir, "bun.lock"))).toBeFalse();
+    expect(await exists(join(String(dir), "bun.lock"))).toBeFalse();
   });
 
   test.concurrent("refuses --no-save before contacting the registry", async () => {
@@ -2807,7 +2814,7 @@ describe("`bun audit fix`", () => {
     expect(lockfile).toContain('"a-dep@1.0.4"');
     expect(lockfile).toContain('"a-dep": "1.0.4"');
     expect(lockfile).not.toContain("a-dep@1.0.2");
-    expect(await exists(join(dir, "packages", "a", "bun.lock"))).toBeFalse();
+    expect(await exists(join(String(dir), "packages", "a", "bun.lock"))).toBeFalse();
 
     await runBunInstall(installEnv(dir), dir, { frozenLockfile: true });
   });
@@ -2823,13 +2830,17 @@ describe("`bun audit fix`", () => {
     await expectInstall(dir, "--linker", "hoisted");
     expect(await lock(dir)).toContain('"a-dep@1.0.2"');
 
-    const { stdout, exitCode } = await run(join(dir, "packages", "a"), ["audit", "fix", "--linker", "hoisted"], dir);
+    const { stdout, exitCode } = await run(
+      join(String(dir), "packages", "a"),
+      ["audit", "fix", "--linker", "hoisted"],
+      dir,
+    );
     expect(stdout).toContain("  ^ a-dep 1.0.2 -> 1.0.4\n    packages/a/package.json: 1.0.2 -> 1.0.4\n");
     expect(exitCode).toBe(0);
 
     expect((await pkgJson(dir, "packages", "a")).dependencies).toStrictEqual({ "a-dep": "1.0.4" });
     expect(await pkgJsonText(dir)).toBe(rootPkgJson);
-    expect(await exists(join(dir, "packages", "a", "bun.lock"))).toBeFalse();
+    expect(await exists(join(String(dir), "packages", "a", "bun.lock"))).toBeFalse();
     expect(await lock(dir)).toContain('"a-dep@1.0.4"');
     expect(await installedVersion(dir, "a-dep")).toBe("1.0.4");
 
@@ -2909,7 +2920,7 @@ describe("`bun audit fix`", () => {
     const lockfile = await lock(dir);
     expect(lockfile).not.toContain('"no-deps@1.1.0"');
     expect(lockfile).not.toContain('"one-range-dep/no-deps"');
-    expect(await exists(join(dir, "node_modules", "one-range-dep", "node_modules", "no-deps"))).toBe(false);
+    expect(await exists(join(String(dir), "node_modules", "one-range-dep", "node_modules", "no-deps"))).toBe(false);
     expect(await resolvedVersion(dir, "one-range-dep", "no-deps")).toBe("1.0.1");
     expect(await installedVersion(dir, "no-deps")).toBe("1.0.1");
 
@@ -2927,7 +2938,7 @@ describe("`bun audit fix`", () => {
     });
     await writeBunfig(dir, server);
     await expectInstall(dir, "--linker", "isolated");
-    await write(join(dir, "package.json"), rootPkgJson({ "one-range-dep": "1.0.0", "one-fixed-dep": "1.0.0" }));
+    await write(join(String(dir), "package.json"), rootPkgJson({ "one-range-dep": "1.0.0", "one-fixed-dep": "1.0.0" }));
     await expectInstall(dir, "--linker", "isolated");
     const lockBefore = await lock(dir);
     expect(lockBefore).toContain('"no-deps@1.0.0"');
@@ -4142,9 +4153,14 @@ describe("`bun audit fix --latest`", () => {
     await using server = noDeps1x();
     using dir = await setup(server, { name: "foo", dependencies: { "no-deps": "^1.0.0" } });
     await write(
-      join(dir, "bunfig.toml"),
+      join(String(dir), "bunfig.toml"),
       Bun.TOML.stringify({
-        install: { cache: join(dir, ".bun-cache"), registry: server.url.href, saveTextLockfile: true, exact: true },
+        install: {
+          cache: join(String(dir), ".bun-cache"),
+          registry: server.url.href,
+          saveTextLockfile: true,
+          exact: true,
+        },
       }),
     );
 
@@ -4181,7 +4197,7 @@ describe("`bun audit fix --latest`", () => {
     expect(lockfile).toContain('"no-deps@2.0.0"');
     expect(lockfile).toContain('"no-deps": "^2.0.0"');
     expect(lockfile).not.toContain('"no-deps@1.1.0"');
-    expect(await exists(join(dir, "packages", "a", "bun.lock"))).toBeFalse();
+    expect(await exists(join(String(dir), "packages", "a", "bun.lock"))).toBeFalse();
 
     await runBunInstall(installEnv(dir), dir, { frozenLockfile: true });
   });

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -557,7 +557,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
         },
       };
 
-      await Bun.write(join(filedir, "package.json"), JSON.stringify(pkgjsonWithPatch));
+      await Bun.write(join(String(filedir), "package.json"), JSON.stringify(pkgjsonWithPatch));
       await using proc = Bun.spawn({
         cmd: [bunExe(), "install", "--linker=hoisted"],
         env: bunEnv,
@@ -604,7 +604,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
         patchOutput.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
         patchOutput.match(/edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim();
       expect(relativePatchPath).toBeTruthy();
-      const patchPath = join(filedir, relativePatchPath!);
+      const patchPath = join(String(filedir), relativePatchPath!);
 
       // Edit the patched package
       const indexPath = join(patchPath, "index.js");
@@ -627,11 +627,11 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       expect(commitStderrText).not.toContain("panic:");
 
       // Verify patch file was created
-      const patchFile = join(filedir, "patches", "is-even@1.0.0.patch");
+      const patchFile = join(String(filedir), "patches", "is-even@1.0.0.patch");
       expect(await Bun.file(patchFile).exists()).toBe(true);
 
       // Verify package.json was updated
-      const pkgJson = await Bun.file(join(filedir, "package.json")).json();
+      const pkgJson = await Bun.file(join(String(filedir), "package.json")).json();
       expect(pkgJson.patchedDependencies).toEqual({
         "is-even@1.0.0": "patches/is-even@1.0.0.patch",
       });
@@ -667,7 +667,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
         patchOutput.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
         patchOutput.match(/edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim();
       expect(relativePatchPath).toBeTruthy();
-      const patchPath = join(filedir, relativePatchPath!);
+      const patchPath = join(String(filedir), relativePatchPath!);
 
       // Edit the patched package
       const indexPath = join(patchPath, "index.js");
@@ -720,7 +720,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
         patchOutput.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
         patchOutput.match(/edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim();
       expect(relativePatchPath).toBeTruthy();
-      const patchPath = join(filedir, relativePatchPath!);
+      const patchPath = join(String(filedir), relativePatchPath!);
 
       // Create a new index.js in the patched package
       const indexPath = join(patchPath, "index.js");
@@ -745,7 +745,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
 
       // Update index.ts to actually use the patched module
       await Bun.write(
-        join(filedir, "index.ts"),
+        join(String(filedir), "index.ts"),
         /* ts */ `import hlsDl from '@zackradisic/hls-dl'; console.log(hlsDl());`,
       );
 
@@ -784,7 +784,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
         patchOutput.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
         patchOutput.match(/edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim();
       expect(relativePatchPath).toBeTruthy();
-      const patchPath = join(filedir, relativePatchPath!);
+      const patchPath = join(String(filedir), relativePatchPath!);
 
       // Edit the patched package
       const indexPath = join(patchPath, "index.js");
@@ -807,13 +807,15 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       expect(commitStderrText).not.toContain("panic:");
 
       // Verify root package.json was updated
-      const rootPkgJson = await Bun.file(join(filedir, "package.json")).json();
+      const rootPkgJson = await Bun.file(join(String(filedir), "package.json")).json();
       expect(rootPkgJson.patchedDependencies).toEqual({
         "is-even@1.0.0": "patches/is-even@1.0.0.patch",
       });
 
       // Run from workspace package to verify patch was applied
-      const { stdout, stderr } = await $`${bunExe()} run index.ts`.env(patchEnv).cwd(join(filedir, "packages", "app"));
+      const { stdout, stderr } = await $`${bunExe()} run index.ts`
+        .env(patchEnv)
+        .cwd(join(String(filedir), "packages", "app"));
       expect(stderr.toString()).toBe("");
       expect(stdout.toString()).toContain("WORKSPACE PATCH with isolated!");
     });
@@ -841,7 +843,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
         patchOutput.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
         patchOutput.match(/edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim();
       expect(relativePatchPath).toBeTruthy();
-      const patchPath = join(filedir, relativePatchPath!);
+      const patchPath = join(String(filedir), relativePatchPath!);
 
       const indexPath = join(patchPath, "index.js");
       const originalContent = await Bun.file(indexPath).text();
@@ -854,7 +856,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       await $`${bunExe()} patch --commit '${relativePatchPath}'`.env(patchEnv).cwd(filedir);
 
       // Delete node_modules and reinstall with isolated linker
-      rmSync(join(filedir, "node_modules"), { force: true, recursive: true });
+      rmSync(join(String(filedir), "node_modules"), { force: true, recursive: true });
       await $`${bunExe()} install --linker=isolated`.env(patchEnv).cwd(filedir);
 
       // Verify patch is still applied
@@ -892,7 +894,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
         patchOutput1.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
         patchOutput1.match(/edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim();
       expect(relativePatchPath1).toBeTruthy();
-      const patchPath1 = join(filedir, relativePatchPath1!);
+      const patchPath1 = join(String(filedir), relativePatchPath1!);
 
       const indexPath1 = join(patchPath1, "index.js");
       const originalContent1 = await Bun.file(indexPath1).text();
@@ -917,7 +919,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
         patchOutput2.match(/To patch .+, edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim() ||
         patchOutput2.match(/edit the following folder:\s*\n\s*(.+)/)?.[1]?.trim();
       expect(relativePatchPath2).toBeTruthy();
-      const patchPath2 = join(filedir, relativePatchPath2!);
+      const patchPath2 = join(String(filedir), relativePatchPath2!);
 
       const indexPath2 = join(patchPath2, "index.js");
       const originalContent2 = await Bun.file(indexPath2).text();
@@ -942,7 +944,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       expect(stdout.toString()).toContain("is-odd PATCHED with isolated!");
 
       // Verify package.json has both patches
-      const pkgJson = await Bun.file(join(filedir, "package.json")).json();
+      const pkgJson = await Bun.file(join(String(filedir), "package.json")).json();
       expect(pkgJson.patchedDependencies).toEqual({
         "is-even@1.0.0": "patches/is-even@1.0.0.patch",
         "is-odd@3.0.1": "patches/is-odd@3.0.1.patch",
@@ -983,7 +985,7 @@ index 0000000000000000000000000000000000000000..2f9a147b6e5d17254f1bfce0d4e109a2
       await using proc = Bun.spawn({
         cmd: [bunExe(), "install"],
         cwd: filedir,
-        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(filedir, "cache-with-patch") },
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(filedir), "cache-with-patch") },
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -991,13 +993,13 @@ index 0000000000000000000000000000000000000000..2f9a147b6e5d17254f1bfce0d4e109a2
       expect(stderr).not.toContain("error:");
       expect(exitCode).toBe(0);
     }
-    expect(await Bun.file(join(filedir, "node_modules", "is-odd", "bun-patch-test.txt")).exists()).toBe(true);
-    expect(await Bun.file(join(filedir, "bun.lock")).text()).toContain("patchedDependencies");
+    expect(await Bun.file(join(String(filedir), "node_modules", "is-odd", "bun-patch-test.txt")).exists()).toBe(true);
+    expect(await Bun.file(join(String(filedir), "bun.lock")).text()).toContain("patchedDependencies");
 
     // Remove the patch from package.json (bun.lock still references it) and
     // install again with an empty cache so the package has to be downloaded.
     await Bun.write(
-      join(filedir, "package.json"),
+      join(String(filedir), "package.json"),
       JSON.stringify({
         name: "remove-patch-test",
         dependencies: {
@@ -1013,7 +1015,7 @@ index 0000000000000000000000000000000000000000..2f9a147b6e5d17254f1bfce0d4e109a2
       await using proc = Bun.spawn({
         cmd: [bunExe(), "install"],
         cwd: filedir,
-        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(filedir, "cache-empty") },
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(filedir), "cache-empty") },
         stdout: "pipe",
         stderr: "pipe",
       });
@@ -1023,12 +1025,12 @@ index 0000000000000000000000000000000000000000..2f9a147b6e5d17254f1bfce0d4e109a2
     }
 
     // The package is reinstalled without the patch.
-    expect(await Bun.file(join(filedir, "node_modules", "is-odd", "package.json")).json()).toMatchObject({
+    expect(await Bun.file(join(String(filedir), "node_modules", "is-odd", "package.json")).json()).toMatchObject({
       name: "is-odd",
       version: "3.0.1",
     });
-    expect(await Bun.file(join(filedir, "node_modules", "is-odd", "bun-patch-test.txt")).exists()).toBe(false);
-    expect(await Bun.file(join(filedir, "bun.lock")).text()).not.toContain("patchedDependencies");
+    expect(await Bun.file(join(String(filedir), "node_modules", "is-odd", "bun-patch-test.txt")).exists()).toBe(false);
+    expect(await Bun.file(join(String(filedir), "bun.lock")).text()).not.toContain("patchedDependencies");
   });
 });
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -7033,7 +7033,7 @@ test("doesn't error when the migration is out of sync", async () => {
   expect(out.lastIndexOf("no-deps")).toEqual(out.indexOf("no-deps"));
   expect(exitCode).toBe(0);
 
-  expect(await file(join(cwd, "node_modules/no-deps/package.json")).json()).toMatchObject({
+  expect(await file(join(String(cwd), "node_modules/no-deps/package.json")).json()).toMatchObject({
     version: "1.0.0",
     name: "no-deps",
   });

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -1416,7 +1416,7 @@ describe("files", () => {
 
     const { out } = await pack(dir, bunEnv);
     expect(out).toContain("Total files: 2");
-    const tarball = readTarball(join(dir, "pack-excluded-entries-from-files-1.0.0.tgz"));
+    const tarball = readTarball(join(String(dir), "pack-excluded-entries-from-files-1.0.0.tgz"));
     expect(tarball.entries).toMatchObject([
       { "pathname": "package/package.json" },
       { "pathname": "package/src/index.ts" },

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -22,7 +22,7 @@ async function runPmPkg(args: string[], cwd: string, expectSuccess = true) {
   return { output: stdout, error: stderr, code: exitCode };
 }
 
-const readPkg = (dir: string) => Bun.file(join(dir, "package.json")).json();
+const readPkg = (dir: string) => Bun.file(join(String(dir), "package.json")).json();
 
 function createTestPackageJson(overrides = {}) {
   return JSON.stringify(
@@ -291,7 +291,7 @@ describe.concurrent("bun pm pkg", () => {
       using dir = makeTestDir();
       await runPmPkg(["set", "version=1.0.1"], dir);
 
-      const modifiedContent = await Bun.file(join(dir, "package.json")).text();
+      const modifiedContent = await Bun.file(join(String(dir), "package.json")).text();
       expect(modifiedContent).toContain('  "version": "1.0.1"');
       expect(JSON.parse(modifiedContent).version).toBe("1.0.1");
     });
@@ -467,7 +467,7 @@ describe.concurrent("bun pm pkg", () => {
         }),
       });
 
-      const pkgDir = join(workspaceDir, "packages", "pkg-a");
+      const pkgDir = join(String(workspaceDir), "packages", "pkg-a");
       const { output, code } = await runPmPkg(["get", "name"], pkgDir);
       expect(output.trim()).toBe('"@workspace/pkg-a"');
       expect(code).toBe(0);
@@ -488,7 +488,7 @@ describe.concurrent("bun pm pkg", () => {
         }),
       });
 
-      const pkgDir = join(workspaceDir, "packages", "pkg-a");
+      const pkgDir = join(String(workspaceDir), "packages", "pkg-a");
       const { code } = await runPmPkg(["set", "description=Updated Package A"], pkgDir);
       expect(code).toBe(0);
 
@@ -517,8 +517,8 @@ describe.concurrent("bun pm pkg", () => {
       expect(code).toBe(0);
 
       expect((await readPkg(workspaceDir)).version).toBe("1.0.1");
-      expect((await readPkg(join(workspaceDir, "packages", "pkg-a"))).version).toBe("1.0.0");
-      expect((await readPkg(join(workspaceDir, "packages", "pkg-b"))).version).toBe("2.0.0");
+      expect((await readPkg(join(String(workspaceDir), "packages", "pkg-a"))).version).toBe("1.0.0");
+      expect((await readPkg(join(String(workspaceDir), "packages", "pkg-b"))).version).toBe("2.0.0");
     });
   });
 
@@ -528,7 +528,7 @@ describe.concurrent("bun pm pkg", () => {
         "package.json": JSON.stringify({ name: "root-package", version: "1.0.0" }, null, 2),
       });
 
-      const deepPath = join(dir, "src", "components", "ui", "buttons", "primary");
+      const deepPath = join(String(dir), "src", "components", "ui", "buttons", "primary");
       mkdirSync(deepPath, { recursive: true });
 
       const { output, code } = await runPmPkg(["get", "name"], deepPath);
@@ -541,7 +541,7 @@ describe.concurrent("bun pm pkg", () => {
         "package.json": JSON.stringify({ name: "root-package", version: "1.0.0" }, null, 2),
       });
 
-      const uiDir = join(dir, "packages", "ui");
+      const uiDir = join(String(dir), "packages", "ui");
       mkdirSync(uiDir, { recursive: true });
       writeFileSync(join(uiDir, "package.json"), JSON.stringify({ name: "ui-package", version: "2.0.0" }, null, 2));
 
@@ -567,7 +567,7 @@ describe.concurrent("bun pm pkg", () => {
         "package.json": JSON.stringify({ name: "my-project", version: "1.0.0", scripts: { test: "jest" } }, null, 2),
       });
 
-      const deepDir = join(dir, "src", "utils", "helpers", "string");
+      const deepDir = join(String(dir), "src", "utils", "helpers", "string");
       mkdirSync(deepDir, { recursive: true });
 
       const { code: setCode } = await runPmPkg(["set", "scripts.build=webpack"], deepDir);
@@ -816,10 +816,10 @@ describe.concurrent("bun pm pkg", () => {
         ),
       });
 
-      const beforeContent = await Bun.file(join(goodDir, "package.json")).text();
+      const beforeContent = await Bun.file(join(String(goodDir), "package.json")).text();
       const { code } = await runPmPkg(["fix"], goodDir);
       expect(code).toBe(0);
-      expect(await Bun.file(join(goodDir, "package.json")).text()).toBe(beforeContent);
+      expect(await Bun.file(join(String(goodDir), "package.json")).text()).toBe(beforeContent);
     });
 
     it("should handle package.json with existing bin files", async () => {

--- a/test/cli/install/bun-pm-scan.test.ts
+++ b/test/cli/install/bun-pm-scan.test.ts
@@ -135,7 +135,7 @@ describe("bun pm scan", () => {
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
 
       // Add config after install
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -177,7 +177,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -220,7 +220,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -285,7 +285,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -368,7 +368,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -414,7 +414,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -457,7 +457,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -493,7 +493,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -531,7 +531,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -578,7 +578,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -616,7 +616,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],
@@ -657,7 +657,7 @@ describe("bun pm scan", () => {
       });
 
       await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
-      await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+      await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
 
       const proc = Bun.spawn({
         cmd: [bunExe(), "pm", "scan"],

--- a/test/cli/install/bun-pm-version.test.ts
+++ b/test/cli/install/bun-pm-version.test.ts
@@ -692,8 +692,8 @@ describe.concurrent("bun pm version", () => {
         stdout: "ignore",
       }).exited;
 
-      expect(await Bun.file(join(testDir1, "lifecycle.log")).exists()).toBe(true);
-      const logContent = await Bun.file(join(testDir1, "lifecycle.log")).text();
+      expect(await Bun.file(join(String(testDir1), "lifecycle.log")).exists()).toBe(true);
+      const logContent = await Bun.file(join(String(testDir1), "lifecycle.log")).text();
       expect(logContent.trim()).toBe("step1\nstep2\nstep3");
 
       await using testDir2 = tempDir(`version-${i++}`, {
@@ -717,11 +717,11 @@ describe.concurrent("bun pm version", () => {
         stdout: "ignore",
       }).exited;
 
-      expect(Bun.file(join(testDir2, "event.log")).exists()).resolves.toBe(true);
-      expect(Bun.file(join(testDir2, "script.log")).exists()).resolves.toBe(true);
+      expect(Bun.file(join(String(testDir2), "event.log")).exists()).resolves.toBe(true);
+      expect(Bun.file(join(String(testDir2), "script.log")).exists()).resolves.toBe(true);
 
-      const eventContent = await Bun.file(join(testDir2, "event.log")).text();
-      const scriptContent = await Bun.file(join(testDir2, "script.log")).text();
+      const eventContent = await Bun.file(join(String(testDir2), "event.log")).text();
+      const scriptContent = await Bun.file(join(String(testDir2), "script.log")).text();
 
       expect(eventContent.trim()).toBe("preversion");
       expect(scriptContent.trim()).toContain("echo $npm_lifecycle_event");
@@ -751,7 +751,7 @@ describe.concurrent("bun pm version", () => {
       expect(proc.exitCode).toBe(1);
       expect(await proc.stderr.text()).toContain('script "preversion" exited with code 1');
 
-      const packageJson = await Bun.file(join(testDir3, "package.json")).json();
+      const packageJson = await Bun.file(join(String(testDir3), "package.json")).json();
       expect(packageJson.version).toBe("1.0.0");
 
       await using testDir4 = tempDir(`version-${i++}`, {
@@ -777,10 +777,10 @@ describe.concurrent("bun pm version", () => {
         stdout: "ignore",
       }).exited;
 
-      expect(Bun.file(join(testDir4, "version-output.txt")).exists()).resolves.toBe(true);
-      expect(Bun.file(join(testDir4, "build")).exists()).resolves.toBe(false);
+      expect(Bun.file(join(String(testDir4), "version-output.txt")).exists()).resolves.toBe(true);
+      expect(Bun.file(join(String(testDir4), "build")).exists()).resolves.toBe(false);
 
-      const content = await Bun.file(join(testDir4, "version-output.txt")).text();
+      const content = await Bun.file(join(String(testDir4), "version-output.txt")).text();
       expect(content.trim()).toBe("built");
 
       await using testDir5 = tempDir(`version-${i++}`, {
@@ -807,10 +807,10 @@ describe.concurrent("bun pm version", () => {
       expect(code5).toBe(0);
       expect(output5.trim()).toBe("v1.0.1");
 
-      const packageJson5 = await Bun.file(join(testDir5, "package.json")).json();
+      const packageJson5 = await Bun.file(join(String(testDir5), "package.json")).json();
       expect(packageJson5.version).toBe("1.0.1");
 
-      expect(await Bun.file(join(testDir5, "ignored.log")).exists()).toBe(false);
+      expect(await Bun.file(join(String(testDir5), "ignored.log")).exists()).toBe(false);
     });
   });
 
@@ -844,7 +844,7 @@ describe.concurrent("bun pm version", () => {
 
       const { output, code } = await runCommand(
         [bunExe(), "pm", "version", "patch", "--no-git-tag-version"],
-        join(testDir, "src"),
+        join(String(testDir), "src"),
       );
 
       expect(code).toBe(0);

--- a/test/cli/install/bun-run-bunfig.test.ts
+++ b/test/cli/install/bun-run-bunfig.test.ts
@@ -201,7 +201,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
       stderr: "inherit",
       stdout: "pipe",
       stdin: "ignore",
-      cwd: pathJoin(cwd, "./subdir"),
+      cwd: pathJoin(String(cwd), "./subdir"),
     });
     const nodeBin = result.stdout.toString().trim();
 
@@ -235,7 +235,7 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
       cmd: [bunExe(), "--silent", ...runCmd, "where-node"],
       env: {
         ...bunEnv,
-        HOME: pathJoin(cwd, "./my-home"),
+        HOME: pathJoin(String(cwd), "./my-home"),
       },
       stderr: "inherit",
       stdout: "pipe",

--- a/test/cli/install/bun-security-scanner-workspaces.test.ts
+++ b/test/cli/install/bun-security-scanner-workspaces.test.ts
@@ -73,7 +73,7 @@ describe.concurrent("security scanner workspaces", () => {
     await using dir = tempDir("scanner-workspaces", files);
 
     await Bun.write(
-      join(dir, "bunfig.toml"),
+      join(String(dir), "bunfig.toml"),
       Bun.TOML.stringify({
         install: {
           cache: { disable: true },
@@ -151,7 +151,7 @@ describe.concurrent("security scanner workspaces", () => {
     await using dir = tempDir("scanner-workspaces-hoisted", files);
 
     await Bun.write(
-      join(dir, "bunfig.toml"),
+      join(String(dir), "bunfig.toml"),
       Bun.TOML.stringify({
         install: {
           cache: { disable: true },
@@ -228,7 +228,7 @@ describe.concurrent("security scanner workspaces", () => {
     await using dir = tempDir("scanner-workspaces-isolated", files);
 
     await Bun.write(
-      join(dir, "bunfig.toml"),
+      join(String(dir), "bunfig.toml"),
       Bun.TOML.stringify({
         install: {
           cache: { disable: true },
@@ -322,10 +322,10 @@ describe.concurrent("security scanner workspaces", () => {
         ]);
         expect(stdoutText + stderrText).toContain("Security scanner installed successfully");
         expect(exitCode).toBe(0);
-        expect(await Bun.file(join(dir, ...leftPad, "package.json")).exists()).toBe(true);
+        expect(await Bun.file(join(String(dir), ...leftPad, "package.json")).exists()).toBe(true);
         expect(
           await Bun.file(
-            join(dir, "node_modules", ".bun", "left-pad@1.3.0", "node_modules", "left-pad", "package.json"),
+            join(String(dir), "node_modules", ".bun", "left-pad@1.3.0", "node_modules", "left-pad", "package.json"),
           ).exists(),
         ).toBe(linker === "isolated");
       }
@@ -348,13 +348,13 @@ describe.concurrent("security scanner workspaces", () => {
         ]);
         expect(stdoutText + stderrText).toContain("Security scanner installed successfully");
         expect(exitCode).toBe(0);
-        expect(await Bun.file(join(dir, ...leftPad, "package.json")).exists()).toBe(true);
+        expect(await Bun.file(join(String(dir), ...leftPad, "package.json")).exists()).toBe(true);
         expect(
           await Bun.file(
-            join(dir, "node_modules", ".bun", "left-pad@1.3.0", "node_modules", "left-pad", "package.json"),
+            join(String(dir), "node_modules", ".bun", "left-pad@1.3.0", "node_modules", "left-pad", "package.json"),
           ).exists(),
         ).toBe(linker === "isolated");
-        const app1 = await Bun.file(join(dir, "packages", "app1", "package.json")).json();
+        const app1 = await Bun.file(join(String(dir), "packages", "app1", "package.json")).json();
         expect(app1.dependencies).toHaveProperty("is-odd");
       }
     },

--- a/test/cli/install/bun-update-security-edge-cases.test.ts
+++ b/test/cli/install/bun-update-security-edge-cases.test.ts
@@ -19,7 +19,7 @@ describe("bun update security edge cases", () => {
 
     // Now add scanner and update package.json to allow updates
     await Bun.write(
-      join(dir, "package.json"),
+      join(String(dir), "package.json"),
       JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -29,7 +29,7 @@ describe("bun update security edge cases", () => {
     );
 
     await Bun.write(
-      join(dir, "bunfig.toml"),
+      join(String(dir), "bunfig.toml"),
       `
 [install.security]
 scanner = "./scanner.js"
@@ -37,7 +37,7 @@ scanner = "./scanner.js"
     );
 
     await Bun.write(
-      join(dir, "scanner.js"),
+      join(String(dir), "scanner.js"),
       `
 module.exports = {
   scanner: {
@@ -175,7 +175,7 @@ module.exports = {
 
     // Now add scanner configuration
     await Bun.write(
-      join(dir, "bunfig.toml"),
+      join(String(dir), "bunfig.toml"),
       `
 [install.security]
 scanner = "./scanner.js"
@@ -184,7 +184,7 @@ scanner = "./scanner.js"
 
     // Now add scanner that knows about the vulnerability
     await Bun.write(
-      join(dir, "scanner.js"),
+      join(String(dir), "scanner.js"),
       `
 module.exports = {
   scanner: {
@@ -273,7 +273,7 @@ module.exports = {
     });
 
     // Install without scanner first
-    const tempBunfig = join(dir, "bunfig.toml");
+    const tempBunfig = join(String(dir), "bunfig.toml");
     const fs = await import("node:fs/promises");
     await fs.rename(tempBunfig, `${tempBunfig}.bak`);
     await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
@@ -345,7 +345,7 @@ module.exports = {
 
     // Update package.json to use caret range
     await Bun.write(
-      join(dir, "package.json"),
+      join(String(dir), "package.json"),
       JSON.stringify({
         name: "test-app",
         dependencies: {
@@ -397,9 +397,9 @@ module.exports = {
     await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
 
     // Add scanner with updated vulnerability database
-    await Bun.write(join(dir, "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
+    await Bun.write(join(String(dir), "bunfig.toml"), `[install.security]\nscanner = "./scanner.js"`);
     await Bun.write(
-      join(dir, "scanner.js"),
+      join(String(dir), "scanner.js"),
       `
 module.exports = {
   scanner: {

--- a/test/cli/install/bun-update-security-scan-all.test.ts
+++ b/test/cli/install/bun-update-security-scan-all.test.ts
@@ -55,7 +55,7 @@ module.exports = {
     });
 
     // First install to create lockfile (temporarily disable scanner)
-    const bunfigPath = join(dir, "bunfig.toml");
+    const bunfigPath = join(String(dir), "bunfig.toml");
     const bunfigContent = await Bun.file(bunfigPath).text();
     await Bun.write(bunfigPath, ""); // Remove scanner config
     await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
@@ -136,7 +136,7 @@ module.exports = {
     await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
 
     await Bun.write(
-      join(dir, "bunfig.toml"),
+      join(String(dir), "bunfig.toml"),
       `
 [install.security]
 scanner = "./scanner.js"
@@ -235,7 +235,7 @@ module.exports = {
     await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
 
     await Bun.write(
-      join(dir, "bunfig.toml"),
+      join(String(dir), "bunfig.toml"),
       `
 [install.security]
 scanner = "./scanner.js"
@@ -363,7 +363,7 @@ module.exports = {
     await Bun.$`${bunExe()} install`.cwd(dir).env(bunEnv).quiet();
 
     await Bun.write(
-      join(dir, "bunfig.toml"),
+      join(String(dir), "bunfig.toml"),
       `
 [install.security]
 scanner = "./scanner.js"

--- a/test/cli/install/migrate-bun-lockb-v2.test.ts
+++ b/test/cli/install/migrate-bun-lockb-v2.test.ts
@@ -83,7 +83,7 @@ for (const testInfo of tests) {
     const oldLockfileContents = await file(join(import.meta.dir, "fixtures", testInfo.lockfile)).text();
     using testDir = tempDir(testInfo.name, testInfo.files);
 
-    await cp(join(import.meta.dir, "fixtures", testInfo.lockfile), join(testDir, "bun.lockb"));
+    await cp(join(import.meta.dir, "fixtures", testInfo.lockfile), join(String(testDir), "bun.lockb"));
 
     let { stderr, exited } = spawn({
       cmd: [bunExe(), "install"],
@@ -98,7 +98,7 @@ for (const testInfo of tests) {
     expect(await exited).toBe(0);
     expect(err).toContain("Saved lockfile");
 
-    const newLockfileContents = await file(join(testDir, "bun.lockb")).bytes();
+    const newLockfileContents = await file(join(String(testDir), "bun.lockb")).bytes();
     const newLockfile = parseLockfile(testDir);
 
     // contents should be different due to semver numbers changing size
@@ -117,7 +117,7 @@ for (const testInfo of tests) {
 
     expect(await exited).toBe(0);
 
-    const newLockfileContents2 = await file(join(testDir, "bun.lockb")).bytes();
+    const newLockfileContents2 = await file(join(String(testDir), "bun.lockb")).bytes();
     const newLockfile2 = parseLockfile(testDir);
     expect(newLockfileContents2).toEqual(newLockfileContents);
     expect(newLockfile2).toEqual(newLockfile);

--- a/test/cli/install/migration/migrate.test.ts
+++ b/test/cli/install/migration/migrate.test.ts
@@ -157,8 +157,8 @@ for (const lockfile of lockfiles) {
 
     expect(
       await Promise.all([
-        fs.promises.exists(join(testDir, "bun.lock")),
-        fs.promises.exists(join(testDir, "bun.lockb")),
+        fs.promises.exists(join(String(testDir), "bun.lock")),
+        fs.promises.exists(join(String(testDir), "bun.lockb")),
       ]),
     ).toEqual([true, false]);
   });
@@ -213,8 +213,10 @@ test("npm lockfile migration skips extraneous packages that also declare inBundl
   expect(err).toContain("migrated lockfile from package-lock.json");
   expect(err).not.toContain("InvalidNPMLockfile");
   expect(exitCode).toBe(0);
-  expect(await Bun.file(join(testDir, "node_modules", "pkg0", "package.json")).json()).toEqual({ name: "pkg0" });
-  expect(fs.existsSync(join(testDir, "bun.lock"))).toBeTrue();
+  expect(await Bun.file(join(String(testDir), "node_modules", "pkg0", "package.json")).json()).toEqual({
+    name: "pkg0",
+  });
+  expect(fs.existsSync(join(String(testDir), "bun.lock"))).toBeTrue();
 });
 
 test("package-lock.json migration requires integrity for tarball URLs outside the configured registry", async () => {
@@ -276,7 +278,7 @@ test("package-lock.json migration requires integrity for tarball URLs outside th
   expect(tarballRequests).toBe(0);
   expect(exitCode).toBe(0);
   // The install still succeeds by ignoring the lockfile and resolving lodash@4.17.21 from the registry.
-  expect(await Bun.file(join(testDir, "node_modules", "lodash", "package.json")).json()).toHaveProperty(
+  expect(await Bun.file(join(String(testDir), "node_modules", "lodash", "package.json")).json()).toHaveProperty(
     "version",
     "4.17.21",
   );
@@ -327,7 +329,7 @@ test("package-lock.json migration rejects git committish values that are not a s
   expect(err).not.toContain("migrated lockfile from package-lock.json");
   expect(exitCode).toBe(0);
   // The install still succeeds by ignoring the lockfile and resolving jquery@3.7.1 from the registry.
-  expect(await Bun.file(join(testDir, "node_modules", "jquery", "package.json")).json()).toHaveProperty(
+  expect(await Bun.file(join(String(testDir), "node_modules", "jquery", "package.json")).json()).toHaveProperty(
     "version",
     "3.7.1",
   );
@@ -384,11 +386,11 @@ test("package-lock.json migration keeps dependencies declared as arbitrary tarba
 
   expect(err).not.toContain("InvalidNPMLockfile");
   expect(err).toContain("migrated lockfile from package-lock.json");
-  expect(await Bun.file(join(testDir, "node_modules", "baz", "package.json")).json()).toHaveProperty(
+  expect(await Bun.file(join(String(testDir), "node_modules", "baz", "package.json")).json()).toHaveProperty(
     "version",
     "0.0.3",
   );
-  expect(fs.existsSync(join(testDir, "bun.lock"))).toBeTrue();
+  expect(fs.existsSync(join(String(testDir), "bun.lock"))).toBeTrue();
   expect(exitCode).toBe(0);
 });
 
@@ -449,11 +451,11 @@ test.concurrent("package-lock.json migration does not platform-skip a regular fi
   expect(stderr).toContain("migrated lockfile from package-lock.json");
   expect(stderr).not.toContain("InvalidNPMLockfile");
   expect(exitCode).toBe(0);
-  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
+  expect(await Bun.file(join(String(testDir), "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
 
   // The migrated bun.lock matches what a fresh resolve of the same package.json writes:
   // the folder package keeps its real name and carries no os/cpu constraint.
-  expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"a": ["a@file:vendor/a", {}]`);
+  expect(await Bun.file(join(String(testDir), "bun.lock")).text()).toContain(`"a": ["a@file:vendor/a", {}]`);
 });
 
 test.concurrent.each([
@@ -471,7 +473,9 @@ test.concurrent.each([
     const first = await install(testDir);
     expect(first.stderr).toContain("migrated lockfile from package-lock.json");
     expect(first.exitCode).toBe(0);
-    expect(await Bun.file(join(testDir, "bun.lock")).text()).toContain(`"${name}": ["${name}@file:${folder}", {}]`);
+    expect(await Bun.file(join(String(testDir), "bun.lock")).text()).toContain(
+      `"${name}": ["${name}@file:${folder}", {}]`,
+    );
 
     // The second install consumes the bun.lock the migration just wrote. It must parse,
     // otherwise --frozen-lockfile is permanently broken after an npm migration.
@@ -479,7 +483,10 @@ test.concurrent.each([
     expect(second.stderr).not.toContain("Invalid package name");
     expect(second.stderr).not.toContain("Ignoring lockfile");
     expect(second.exitCode).toBe(0);
-    expect(await Bun.file(join(testDir, "node_modules", name, "package.json")).json()).toHaveProperty("name", name);
+    expect(await Bun.file(join(String(testDir), "node_modules", name, "package.json")).json()).toHaveProperty(
+      "name",
+      name,
+    );
   },
 );
 
@@ -532,7 +539,7 @@ test.concurrent(
     expect(first.stderr).toContain("migrated lockfile from package-lock.json");
     expect(first.exitCode).toBe(0);
 
-    const lock = await Bun.file(join(testDir, "bun.lock")).text();
+    const lock = await Bun.file(join(String(testDir), "bun.lock")).text();
     expect(lock).toContain('"gamma/delta"');
     expect(lock).not.toContain("optionalPeers");
 
@@ -543,7 +550,7 @@ test.concurrent(
     // A plain re-install of the unchanged tree must not rewrite the lockfile.
     const second = await install(testDir);
     expect(second.exitCode).toBe(0);
-    expect(await Bun.file(join(testDir, "bun.lock")).text()).toBe(lock);
+    expect(await Bun.file(join(String(testDir), "bun.lock")).text()).toBe(lock);
   },
 );
 
@@ -557,11 +564,11 @@ test.concurrent("package-lock.json migration does not platform-skip a regular fi
     "src-a/package.json": JSON.stringify({ name: "a", version: "1.0.0", ...nonMatching }),
   });
 
-  await pack(join(testDir, "src-a"), bunEnv, "--destination", testDir);
-  expect(fs.existsSync(join(testDir, "a-1.0.0.tgz"))).toBeTrue();
+  await pack(join(String(testDir), "src-a"), bunEnv, "--destination", testDir);
+  expect(fs.existsSync(join(String(testDir), "a-1.0.0.tgz"))).toBeTrue();
 
   await Bun.write(
-    join(testDir, "package-lock.json"),
+    join(String(testDir), "package-lock.json"),
     JSON.stringify({
       name: "repro",
       lockfileVersion: 3,
@@ -577,7 +584,7 @@ test.concurrent("package-lock.json migration does not platform-skip a regular fi
   expect(stderr).toContain("migrated lockfile from package-lock.json");
   expect(stderr).not.toContain("InvalidNPMLockfile");
   expect(exitCode).toBe(0);
-  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
+  expect(await Bun.file(join(String(testDir), "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
 });
 
 // npm records a file: link target's own dependencies but never nests them, so a target that reaches its own name resolves through the root link and the hoist tree must cut the cycle.
@@ -611,12 +618,12 @@ test.concurrent.each<[string, Record<string, string>, string[]]>([
   const first = await install(testDir);
   expect(first.stderr).toContain("migrated lockfile from package-lock.json");
   expect(first.exitCode).toBe(0);
-  const lock = Bun.JSONC.parse(await Bun.file(join(testDir, "bun.lock")).text()) as {
+  const lock = Bun.JSONC.parse(await Bun.file(join(String(testDir), "bun.lock")).text()) as {
     packages: Record<string, unknown>;
   };
   expect(Object.keys(lock.packages).sort()).toStrictEqual(lockPackages);
   for (const name of Object.keys(JSON.parse(files["package.json"]).dependencies)) {
-    expect(await Bun.file(join(testDir, "node_modules", name, "package.json")).json()).toStrictEqual(
+    expect(await Bun.file(join(String(testDir), "node_modules", name, "package.json")).json()).toStrictEqual(
       JSON.parse(files[`${name}/package.json`]),
     );
   }
@@ -640,7 +647,7 @@ test.concurrent(
     expect(stderr).toContain('Workspace dependency "foo" not found');
     expect(stderr).toContain("foo@workspace:. failed to resolve");
     expect(exitCode).toBe(1);
-    expect(fs.existsSync(join(testDir, "bun.lock"))).toBeFalse();
+    expect(fs.existsSync(join(String(testDir), "bun.lock"))).toBeFalse();
   },
 );
 
@@ -689,7 +696,7 @@ test.concurrent("pnpm-lock.yaml migration does not platform-skip a regular file:
   const { stderr, exitCode } = await install(testDir);
   expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
   expect(exitCode).toBe(0);
-  expect(await Bun.file(join(testDir, "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
+  expect(await Bun.file(join(String(testDir), "node_modules", "a", "package.json")).json()).toHaveProperty("name", "a");
 });
 
 describe("package-lock.json migration fixes", () => {

--- a/test/cli/install/migration/pnpm-comprehensive.test.ts
+++ b/test/cli/install/migration/pnpm-comprehensive.test.ts
@@ -323,9 +323,9 @@ snapshots:
     }
     expect(exitCode).toBe(0);
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("large-single-package");
   }, 200000);
 
@@ -751,9 +751,9 @@ snapshots:
     }
     expect(exitCode).toBe(0);
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("complex-monorepo");
   });
 
@@ -889,9 +889,9 @@ snapshots:
     }
     expect(exitCode).toBe(0);
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("patches-overrides");
   });
 
@@ -1053,9 +1053,9 @@ snapshots:
     }
     expect(exitCode).toBe(0);
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("peer-deps-auto-install");
   });
 });

--- a/test/cli/install/migration/pnpm-lock-migration.test.ts
+++ b/test/cli/install/migration/pnpm-lock-migration.test.ts
@@ -74,10 +74,10 @@ snapshots:
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
 
     // Check that bun.lock was created
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
     // Read and snapshot the migrated lockfile
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("simple-pnpm-migration");
 
     // Verify install works with migrated lockfile
@@ -103,8 +103,8 @@ snapshots:
     expect(installExitCode).toBe(0);
 
     // Verify packages were installed
-    expect(fs.existsSync(join(tmpDir, "node_modules/is-number"))).toBe(true);
-    expect(fs.existsSync(join(tmpDir, "node_modules/left-pad"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "node_modules/is-number"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "node_modules/left-pad"))).toBe(true);
   });
 
   test("pnpm workspace lockfile migration", async () => {
@@ -253,11 +253,11 @@ snapshots:
     // Check migration message in stderr
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
 
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("workspace-pnpm-migration");
-    const packageJson = JSON.parse(fs.readFileSync(join(tmpDir, "package.json"), "utf8"));
+    const packageJson = JSON.parse(fs.readFileSync(join(String(tmpDir), "package.json"), "utf8"));
     expect(packageJson).toMatchSnapshot("workspace-pnpm-migration-package-json");
   });
 
@@ -341,9 +341,9 @@ snapshots:
     // Check migration message in stderr
     expect(stderr).toContain("migrated lockfile from pnpm-lock.yaml");
 
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("npm-aliases-pnpm-migration");
   });
 
@@ -375,7 +375,7 @@ snapshots:
 
     const v8ExitCode = await v8Proc.exited;
     expect(v8ExitCode).toBe(0);
-    expect(fs.existsSync(join(v8Dir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(v8Dir), "bun.lock"))).toBe(true);
   });
 
   test("handles missing pnpm-lock.yaml gracefully", async () => {

--- a/test/cli/install/migration/pnpm-migration-complete.test.ts
+++ b/test/cli/install/migration/pnpm-migration-complete.test.ts
@@ -85,7 +85,7 @@ snapshots:
     expect(basicExitCode).toBe(0);
     expect(basicStderr).toContain("migrated lockfile from pnpm-lock.yaml");
 
-    const basicLockfile = fs.readFileSync(join(basicTest, "bun.lock"), "utf8");
+    const basicLockfile = fs.readFileSync(join(String(basicTest), "bun.lock"), "utf8");
     expect(basicLockfile).toContain('"lodash": "^4.17.21"');
     expect(basicLockfile).toContain('"react": "^18.2.0"');
     expect(basicLockfile).toContain('"typescript": "^5.3.3"');
@@ -148,7 +148,7 @@ snapshots:
     const [canaryStderr, canaryExitCode] = await Promise.all([canaryProc.stderr.text(), canaryProc.exited]);
 
     expect(canaryExitCode).toBe(0);
-    const canaryLockfile = fs.readFileSync(join(canaryTest, "bun.lock"), "utf8");
+    const canaryLockfile = fs.readFileSync(join(String(canaryTest), "bun.lock"), "utf8");
 
     // Verify canary versions are preserved exactly
     expect(canaryLockfile).toContain('"react@19.2.0-canary-a96a0f39-20250815"');
@@ -232,7 +232,7 @@ snapshots:
     const [monorepoStderr, monorepoExitCode] = await Promise.all([monorepoProc.stderr.text(), monorepoProc.exited]);
 
     expect(monorepoExitCode).toBe(0);
-    const monorepoLockfile = fs.readFileSync(join(monorepoTest, "bun.lock"), "utf8");
+    const monorepoLockfile = fs.readFileSync(join(String(monorepoTest), "bun.lock"), "utf8");
 
     // Verify workspaces are created
     expect(monorepoLockfile).toContain('"packages/shared"');
@@ -309,7 +309,7 @@ snapshots:
     const [patchesStderr, patchesExitCode] = await Promise.all([patchesProc.stderr.text(), patchesProc.exited]);
 
     expect(patchesExitCode).toBe(0);
-    const patchesLockfile = fs.readFileSync(join(patchesTest, "bun.lock"), "utf8");
+    const patchesLockfile = fs.readFileSync(join(String(patchesTest), "bun.lock"), "utf8");
 
     expect(patchesLockfile).toContain('"patchedDependencies"');
     expect(patchesLockfile).toContain('"lodash@4.17.21": "patches/lodash@4.17.21.patch"');
@@ -371,7 +371,7 @@ snapshots:
     const [fileLinksStderr, fileLinksExitCode] = await Promise.all([fileLinksProc.stderr.text(), fileLinksProc.exited]);
 
     expect(fileLinksExitCode).toBe(0);
-    const fileLinksLockfile = fs.readFileSync(join(fileLinksTest, "bun.lock"), "utf8");
+    const fileLinksLockfile = fs.readFileSync(join(String(fileLinksTest), "bun.lock"), "utf8");
 
     expect(fileLinksLockfile).toContain('"local-pkg": "file:./local-pkg"');
     expect(fileLinksLockfile).toContain('"config": "file:./shared/config"');
@@ -423,7 +423,7 @@ snapshots:
     ]);
 
     expect(registriesExitCode).toBe(0);
-    const registriesLockfile = fs.readFileSync(join(registriesTest, "bun.lock"), "utf8");
+    const registriesLockfile = fs.readFileSync(join(String(registriesTest), "bun.lock"), "utf8");
 
     expect(registriesLockfile).toContain('"@company/private-pkg": "^1.0.0"');
     // Registry URLs are stored in the package entries
@@ -526,7 +526,7 @@ snapshots:
     const [peerDepsStderr, peerDepsExitCode] = await Promise.all([peerDepsProc.stderr.text(), peerDepsProc.exited]);
 
     expect(peerDepsExitCode).toBe(0);
-    const peerDepsLockfile = fs.readFileSync(join(peerDepsTest, "bun.lock"), "utf8");
+    const peerDepsLockfile = fs.readFileSync(join(String(peerDepsTest), "bun.lock"), "utf8");
 
     expect(peerDepsLockfile).toContain('"@mui/material": "^5.15.0"');
     expect(peerDepsLockfile).toContain('"react": "^18.2.0"');
@@ -613,7 +613,7 @@ snapshots:
     ]);
 
     expect(duplicatesExitCode).toBe(0);
-    const duplicatesLockfile = fs.readFileSync(join(duplicatesTest, "bun.lock"), "utf8");
+    const duplicatesLockfile = fs.readFileSync(join(String(duplicatesTest), "bun.lock"), "utf8");
 
     // Both versions of shared-dep should exist
     expect(duplicatesLockfile).toContain('"shared-dep@2.0.0"');
@@ -712,7 +712,7 @@ snapshots:
     const [catalogsStderr, catalogsExitCode] = await Promise.all([catalogsProc.stderr.text(), catalogsProc.exited]);
 
     expect(catalogsExitCode).toBe(0);
-    const catalogsLockfile = fs.readFileSync(join(catalogsTest, "bun.lock"), "utf8");
+    const catalogsLockfile = fs.readFileSync(join(String(catalogsTest), "bun.lock"), "utf8");
 
     // Catalogs are resolved to actual versions during migration
     expect(catalogsLockfile).toContain('"react": "18.2.0"');
@@ -766,7 +766,7 @@ snapshots:
     const [integrityStderr, integrityExitCode] = await Promise.all([integrityProc.stderr.text(), integrityProc.exited]);
 
     expect(integrityExitCode).toBe(0);
-    const integrityLockfile = fs.readFileSync(join(integrityTest, "bun.lock"), "utf8");
+    const integrityLockfile = fs.readFileSync(join(String(integrityTest), "bun.lock"), "utf8");
 
     // Check integrity hashes are preserved
     expect(integrityLockfile).toContain(
@@ -815,7 +815,7 @@ snapshots:
     ]);
 
     expect(versionZeroExitCode).toBe(0);
-    const versionZeroLockfile = fs.readFileSync(join(versionZeroTest, "bun.lock"), "utf8");
+    const versionZeroLockfile = fs.readFileSync(join(String(versionZeroTest), "bun.lock"), "utf8");
 
     expect(versionZeroLockfile).toContain('"package-with-zero": "0.0.0"');
     expect(versionZeroLockfile).toContain('"package-with-zero@0.0.0"');
@@ -902,7 +902,7 @@ snapshots:
     const [mixedDepsStderr, mixedDepsExitCode] = await Promise.all([mixedDepsProc.stderr.text(), mixedDepsProc.exited]);
 
     expect(mixedDepsExitCode).toBe(0);
-    const mixedDepsLockfile = fs.readFileSync(join(mixedDepsTest, "bun.lock"), "utf8");
+    const mixedDepsLockfile = fs.readFileSync(join(String(mixedDepsTest), "bun.lock"), "utf8");
 
     // Dependencies version should win
     expect(mixedDepsLockfile).toContain('"typescript": "^4.0.0"');
@@ -993,7 +993,7 @@ snapshots:
     const [circularStderr, circularExitCode] = await Promise.all([circularProc.stderr.text(), circularProc.exited]);
 
     expect(circularExitCode).toBe(0);
-    const circularLockfile = fs.readFileSync(join(circularTest, "bun.lock"), "utf8");
+    const circularLockfile = fs.readFileSync(join(String(circularTest), "bun.lock"), "utf8");
 
     // All workspaces should be created despite circular dependencies
     expect(circularLockfile).toContain('"packages/pkg1"');

--- a/test/cli/install/migration/yarn-lock-migration.test.ts
+++ b/test/cli/install/migration/yarn-lock-migration.test.ts
@@ -45,9 +45,9 @@ is-number@^7.0.0:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("simple-yarn-migration");
   });
 
@@ -142,9 +142,9 @@ to-fast-properties@^2.0.0:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
 
     // Verify that long build tags are preserved correctly
     expect(bunLockContent).toContain("4.16.1-1.4bc8b6e1b66cb932731fb1bdbbc550d1e010de81");
@@ -208,7 +208,7 @@ test-package@1.0.0-alpha.beta.gamma.delta.epsilon.zeta.eta.theta.iota.kappa.lamb
     const exitCode = await migrateResult.exited;
     expect(exitCode).toBe(0);
 
-    const bunLockPath = join(tmpDir, "bun.lock");
+    const bunLockPath = join(String(tmpDir), "bun.lock");
     expect(fs.existsSync(bunLockPath)).toBe(true);
 
     const bunLockContent = fs.readFileSync(bunLockPath, "utf8");
@@ -728,9 +728,9 @@ vary@~1.1.2:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("complex-yarn-migration");
   });
 
@@ -800,9 +800,9 @@ undici-types@~5.26.4:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("aliases-yarn-migration");
 
     // Verify that npm aliases are handled correctly
@@ -873,7 +873,7 @@ needs-node-types@1.0.0:
       env: {
         ...bunEnv,
         BUN_CONFIG_REGISTRY: registry.url.href,
-        BUN_INSTALL_CACHE_DIR: join(tmpDir, ".bun-cache"),
+        BUN_INSTALL_CACHE_DIR: join(String(tmpDir), ".bun-cache"),
       },
       stdout: "pipe",
       stderr: "pipe",
@@ -886,7 +886,7 @@ needs-node-types@1.0.0:
     expect(stderr).toContain("migrated lockfile from yarn.lock");
     expect(exitCode).toBe(0);
 
-    const lock = Bun.JSONC.parse(await Bun.file(join(tmpDir, "bun.lock")).text()) as { packages: unknown };
+    const lock = Bun.JSONC.parse(await Bun.file(join(String(tmpDir), "bun.lock")).text()) as { packages: unknown };
     expect(lock.packages).toStrictEqual({
       "@aliased/node-types": ["@types/node@20.11.5", "", {}, typesNode20Integrity],
       "@types/node": ["@types/node@18.19.0", "", {}, typesNode18Integrity],
@@ -983,9 +983,9 @@ webpack@^5.89.0:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("resolutions-yarn-migration");
 
     // Verify resolutions are handled
@@ -1036,7 +1036,7 @@ is-number@^7.0.0:
     await using proc = Bun.spawn({
       cmd: [bunExe(), "pm", "migrate", "-f"],
       cwd: tmpDir,
-      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(tmpDir, ".bun-cache") },
+      env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(tmpDir), ".bun-cache") },
       stdout: "pipe",
       stderr: "pipe",
       stdin: "ignore",
@@ -1051,7 +1051,7 @@ is-number@^7.0.0:
     expect(stderr).toContain("migrated lockfile from yarn.lock");
     expect(exitCode).toBe(0);
 
-    const lock = Bun.JSONC.parse(await Bun.file(join(tmpDir, "bun.lock")).text()) as { overrides: unknown };
+    const lock = Bun.JSONC.parse(await Bun.file(join(String(tmpDir), "bun.lock")).text()) as { overrides: unknown };
     expect(lock.overrides).toStrictEqual({
       "acorn": "^8.11.3",
       "is-even": "1.0.0",
@@ -1148,9 +1148,9 @@ lodash@^4.17.21:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("workspace-yarn-migration");
 
     // TODO: Workspace dependencies are not yet supported in yarn migration
@@ -1263,9 +1263,9 @@ babel-loader/chalk@^2.4.2:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("scoped-yarn-migration");
 
     // Verify scoped packages are at the bottom
@@ -1483,9 +1483,9 @@ webpack@^5.75.0:
 
     const exitCode = await migrateResult.exited;
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("complex-realistic-yarn-migration");
 
     // Verify key features are migrated
@@ -1527,9 +1527,9 @@ describe("bun pm migrate for existing yarn.lock", () => {
     });
 
     expect(migrateResult.exited).resolves.toBe(0);
-    expect(Bun.file(join(tmpDir, "bun.lock")).exists()).resolves.toBe(true);
+    expect(Bun.file(join(String(tmpDir), "bun.lock")).exists()).resolves.toBe(true);
 
-    const bunLockContent = await Bun.file(join(tmpDir, "bun.lock")).text();
+    const bunLockContent = await Bun.file(join(String(tmpDir), "bun.lock")).text();
     expect(bunLockContent).toMatchSnapshot(folder);
   });
 
@@ -1628,9 +1628,9 @@ fsevents@^2.3.2:
     ]);
 
     expect(exitCode).toBe(0);
-    expect(fs.existsSync(join(tmpDir, "bun.lock"))).toBe(true);
+    expect(fs.existsSync(join(String(tmpDir), "bun.lock"))).toBe(true);
 
-    const bunLockContent = fs.readFileSync(join(tmpDir, "bun.lock"), "utf8");
+    const bunLockContent = fs.readFileSync(join(String(tmpDir), "bun.lock"), "utf8");
     expect(bunLockContent).toMatchSnapshot("os-cpu-yarn-migration");
 
     // Verify that the lockfile contains the expected os/cpu metadata by checking the snapshot

--- a/test/cli/install/test-dev-peer-dependency-priority.test.ts
+++ b/test/cli/install/test-dev-peer-dependency-priority.test.ts
@@ -92,7 +92,7 @@ test.concurrent("workspace devDependencies should take priority over peerDepende
   expect(stderr).not.toContain("http");
 
   // Check that the lockfile was created correctly
-  const lockfilePath = join(dir, "bun.lock");
+  const lockfilePath = join(String(dir), "bun.lock");
   expect(await Bun.file(lockfilePath).exists()).toBe(true);
 
   // Verify that version 2.0.0 (devDependency) was linked
@@ -168,7 +168,7 @@ test.concurrent("devDependencies and peerDependencies with different versions sh
   expect(exitCode).toBe(0);
 
   // Check that the lockfile was created correctly
-  const lockfilePath = join(dir, "bun.lock");
+  const lockfilePath = join(String(dir), "bun.lock");
   expect(await Bun.file(lockfilePath).exists()).toBe(true);
 });
 
@@ -215,7 +215,7 @@ test.concurrent("dependency behavior comparison prioritizes devDependencies", as
   expect(exitCode).toBe(0);
 
   // Check that the lockfile was created correctly
-  const lockfilePath = join(dir, "bun.lock");
+  const lockfilePath = join(String(dir), "bun.lock");
   expect(await Bun.file(lockfilePath).exists()).toBe(true);
 });
 
@@ -304,7 +304,7 @@ test.concurrent("Next.js monorepo scenario should not make unnecessary network r
   expect(stderr).not.toContain("http");
 
   // Check that the lockfile was created correctly
-  const lockfilePath = join(dir, "bun.lock");
+  const lockfilePath = join(String(dir), "bun.lock");
   expect(await Bun.file(lockfilePath).exists()).toBe(true);
 
   // Verify that version 15.0.0-canary.119 (devDependency) was used

--- a/test/cli/run/as-node.test.ts
+++ b/test/cli/run/as-node.test.ts
@@ -7,7 +7,7 @@ describe("fake node cli", () => {
     using temp = tempDir("fake-node", {
       "index.ts": "console.log(Bun.version)",
     });
-    expect(fakeNodeRun(temp, join(temp, "index.ts")).stdout).toBe(Bun.version);
+    expect(fakeNodeRun(temp, join(String(temp), "index.ts")).stdout).toBe(Bun.version);
   });
   test("doesnt resolve bins", () => {
     using temp = tempDir("fake-node", {
@@ -93,7 +93,7 @@ describe("fake node cli", () => {
     });
     expect(fakeNodeRun(temp, ["index", "a", "b", "c"]).stdout).toBe(
       // note: no extension here is INTENTIONAL
-      JSON.stringify([join(temp, "index"), "a", "b", "c"]),
+      JSON.stringify([join(String(temp), "index"), "a", "b", "c"]),
     );
   });
 

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -876,7 +876,7 @@ console.log(process.env.NODE_ENV, process.env.YOLO);`,
     });
     expect(
       (
-        await bunRun(path.join(tmp, "index.ts"), {
+        await bunRun(path.join(String(tmp), "index.ts"), {
           NODE_ENV: undefined,
           YOLO: "boo",
         })
@@ -892,7 +892,7 @@ console.log(process.env.NODE_ENV, process.env.YOLO);`,
     });
     expect(
       (
-        await bunRun(path.join(tmp, "index.ts"), {
+        await bunRun(path.join(String(tmp), "index.ts"), {
           NODE_ENV: "production",
           YOLO: "boo",
         })
@@ -908,7 +908,7 @@ console.log(process.env.NODE_ENV, process.env.YOLO);`,
     });
     expect(
       (
-        await bunRun(path.join(tmp, "index.ts"), {
+        await bunRun(path.join(String(tmp), "index.ts"), {
           NODE_ENV: "buh",
           YOLO: "boo",
         })
@@ -925,7 +925,7 @@ console.log(process.env.NODE_ENV, process.env.YOLO);`,
 });`,
     });
     expect(
-      bunTest(path.join(tmp, "index.test.ts"), {
+      bunTest(path.join(String(tmp), "index.test.ts"), {
         YOLO: "boo",
       }).stdout,
     ).toBe(`bun test ${Bun.version_with_sha}\n` + "test\ndevelopment woo!");
@@ -940,7 +940,7 @@ console.log(process.env.NODE_ENV, process.env.YOLO);`,
 });`,
     });
     expect(
-      bunTest(path.join(tmp, "index.test.ts"), {
+      bunTest(path.join(String(tmp), "index.test.ts"), {
         YOLO: "boo",
         NODE_ENV: "production",
       }).stdout,
@@ -955,7 +955,7 @@ test("my test", () => {
   console.log(dynamic().NODE_ENV);
 });`,
     });
-    expect(bunTest(path.join(tmp, "index.test.ts"), {}).stdout).toBe(
+    expect(bunTest(path.join(String(tmp), "index.test.ts"), {}).stdout).toBe(
       `bun test ${Bun.version_with_sha}\n` + "test\nproduction",
     );
   });
@@ -968,7 +968,7 @@ test("my test", () => {
   console.log(dynamic().NODE_ENV);
 });`,
     });
-    expect(bunTest(path.join(tmp, "index.test.ts"), { NODE_ENV: "development" }).stdout).toBe(
+    expect(bunTest(path.join(String(tmp), "index.test.ts"), { NODE_ENV: "development" }).stdout).toBe(
       `bun test ${Bun.version_with_sha}\n` + "development\nproduction",
     );
   });
@@ -983,7 +983,7 @@ process.env.NODE_ENV = "production";
 console.log(dynamic().NODE_ENV);
 `,
   });
-  expect((await bunRun(path.join(tmp, "index.ts"), {})).stdout).toBe("undefined\nundefined\nproduction");
+  expect((await bunRun(path.join(String(tmp), "index.ts"), {})).stdout).toBe("undefined\nundefined\nproduction");
 });
 
 test("NODE_ENV default is not propogated in bun run", () => {
@@ -1169,8 +1169,8 @@ test.skipIf(!canUseRunuser)("process.env is preserved when cwd lacks read permis
     "noread/.keep": "",
   });
 
-  const noreadDir = path.join(dir, "noread");
-  const scriptPath = path.join(dir, "script.ts");
+  const noreadDir = path.join(String(dir), "noread");
+  const scriptPath = path.join(String(dir), "script.ts");
 
   // Allow "nobody" to traverse the temp dir and read the script. Under
   // restrictive umasks the temp files can default to 0o640 which nobody
@@ -1227,7 +1227,7 @@ test.skipIf(!isASAN || isWindows)(".env with a huge lying st_size does not abort
     "app.js": `console.log("reached user code");`,
   });
   // 1 TiB sparse `.env`: fstat reports 2**40 bytes, nothing is actually stored.
-  fs.truncateSync(path.join(dir, ".env"), 2 ** 40);
+  fs.truncateSync(path.join(String(dir), ".env"), 2 ** 40);
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "app.js"],

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -690,7 +690,7 @@ describe("bun", () => {
     });
     // "junction" so the link is creatable on unprivileged Windows; the type is
     // ignored on POSIX.
-    symlinkSync(join(dir, "packages", "cyc"), join(dir, "packages", "cyc", "loop"), "junction");
+    symlinkSync(join(String(dir), "packages", "cyc"), join(String(dir), "packages", "cyc", "loop"), "junction");
 
     const { exitCode, stdout, stderr } = spawnSync({
       cwd: dir,

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -100,7 +100,7 @@ describe.concurrent("require.cache", () => {
       });
       console.log({ dir });
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
+        cmd: [bunExe(), "run", "--smol", join(String(dir), "require-cache-bug-leak-fixture.js")],
         env: bunEnv,
         stdio: ["inherit", "inherit", "inherit"],
       });
@@ -153,7 +153,7 @@ describe.concurrent("require.cache", () => {
         `,
       });
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
+        cmd: [bunExe(), "run", "--smol", join(String(dir), "require-cache-bug-leak-fixture.js")],
         env: bunEnv,
         stdio: ["inherit", "inherit", "inherit"],
       });
@@ -204,7 +204,7 @@ describe.concurrent("require.cache", () => {
       });
       console.log({ dir });
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
+        cmd: [bunExe(), "run", "--smol", join(String(dir), "require-cache-bug-leak-fixture.js")],
         env: bunEnv,
         stdio: ["inherit", "inherit", "inherit"],
       });
@@ -269,7 +269,7 @@ describe.concurrent("require.cache", () => {
         `,
         });
         await using proc = Bun.spawn({
-          cmd: [bunExe(), "run", "--smol", join(dir, "require-cache-bug-leak-fixture.js")],
+          cmd: [bunExe(), "run", "--smol", join(String(dir), "require-cache-bug-leak-fixture.js")],
           env: bunEnv,
           stdio: ["inherit", "inherit", "inherit"],
         });

--- a/test/cli/run/tsconfig-override.test.ts
+++ b/test/cli/run/tsconfig-override.test.ts
@@ -35,7 +35,7 @@ describe("bun run --tsconfig-override", () => {
     });
 
     await using failProc = Bun.spawn({
-      cmd: [bunExe(), "run", path.join(dir, "index.ts")],
+      cmd: [bunExe(), "run", path.join(String(dir), "index.ts")],
       env: bunEnv,
       cwd: dir,
       stdout: "pipe",
@@ -48,7 +48,13 @@ describe("bun run --tsconfig-override", () => {
     expect(failExitCode).not.toBe(0);
 
     await using successProc = Bun.spawn({
-      cmd: [bunExe(), "run", "--tsconfig-override", path.join(dir, "custom-tsconfig.json"), path.join(dir, "index.ts")],
+      cmd: [
+        bunExe(),
+        "run",
+        "--tsconfig-override",
+        path.join(String(dir), "custom-tsconfig.json"),
+        path.join(String(dir), "index.ts"),
+      ],
       env: bunEnv,
       cwd: dir,
       stdout: "pipe",

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -52,9 +52,9 @@ export class Y {
   });
   expect(result.exitCode).toBe(0);
   expect(result.signalCode).toBeUndefined();
-  expect(normalizeBunSnapshot(readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8"), dir)).toMatchSnapshot(
-    "lcov-coverage-reporter-output",
-  );
+  expect(
+    normalizeBunSnapshot(readFileSync(path.join(String(dir), "coverage", "lcov.info"), "utf-8"), dir),
+  ).toMatchSnapshot("lcov-coverage-reporter-output");
 });
 
 test("coverage excludes node_modules directory", () => {
@@ -376,7 +376,7 @@ test("should call both functions", () => {
     stdio: [null, null, "pipe"],
   });
 
-  let lcovContent = readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8");
+  let lcovContent = readFileSync(path.join(String(dir), "coverage", "lcov.info"), "utf-8");
   // Normalize LCOV content for cross-platform consistency
   lcovContent = normalizeBunSnapshot(lcovContent, dir);
 

--- a/test/cli/test/test-randomize.test.ts
+++ b/test/cli/test/test-randomize.test.ts
@@ -84,7 +84,7 @@ test("--randomize: files whose u32-truncated path hashes collide get distinct pe
   const seen = new Map<number, number>();
   const mask = 0xffffffffn;
   for (let i = 0; i < 400_000; i++) {
-    const h = Number(Bun.hash(join(tmpRoot, `f${i}.test.ts`)) & mask);
+    const h = Number(Bun.hash(join(String(tmpRoot), `f${i}.test.ts`)) & mask);
     if (seen.has(h)) {
       aIdx = seen.get(h)!;
       bIdx = i;
@@ -103,8 +103,8 @@ test("--randomize: files whose u32-truncated path hashes collide get distinct pe
         (word) => { console.log("RUN ${tag} " + word); expect(typeof word).toBe("string"); },
       );
     `;
-  await Bun.write(join(tmpRoot, `f${aIdx}.test.ts`), body("A"));
-  await Bun.write(join(tmpRoot, `f${bIdx}.test.ts`), body("B"));
+  await Bun.write(join(String(tmpRoot), `f${aIdx}.test.ts`), body("A"));
+  await Bun.write(join(String(tmpRoot), `f${bIdx}.test.ts`), body("B"));
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "--randomize", "--seed=42"],

--- a/test/cli/update_interactive_formatting.test.ts
+++ b/test/cli/update_interactive_formatting.test.ts
@@ -253,7 +253,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stderr + stdout).toContain("Saved lockfile");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(packageJson.dependencies["no-deps"]).toBe("2.0.0");
   });
 
@@ -281,7 +281,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stderr + stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const appPackageJson = await Bun.file(join(dir, "packages/app/package.json")).json();
+    const appPackageJson = await Bun.file(join(String(dir), "packages/app/package.json")).json();
     expect(appPackageJson.dependencies["no-deps"]).toBe("2.0.0");
   });
 
@@ -311,10 +311,10 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const rootPackageJson = await Bun.file(join(dir, "package.json")).json();
+    const rootPackageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(rootPackageJson.catalog["no-deps"]).toBe("2.0.0");
 
-    const appPackageJson = await Bun.file(join(dir, "packages/app/package.json")).json();
+    const appPackageJson = await Bun.file(join(String(dir), "packages/app/package.json")).json();
     expect(appPackageJson.dependencies["no-deps"]).toBe("catalog:");
   });
 
@@ -345,14 +345,14 @@ describe.concurrent("bun update --interactive", () => {
     await install(dir);
     const { stdout, exitCode } = await updateInteractive(dir, {
       args: ["-r", "--latest"],
-      cwd: join(dir, "packages/app1"),
+      cwd: join(String(dir), "packages/app1"),
     });
 
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const app1Json = await Bun.file(join(dir, "packages/app1/package.json")).json();
-    const app2Json = await Bun.file(join(dir, "packages/app2/package.json")).json();
+    const app1Json = await Bun.file(join(String(dir), "packages/app1/package.json")).json();
+    const app2Json = await Bun.file(join(String(dir), "packages/app2/package.json")).json();
 
     expect(app1Json.dependencies["no-deps"]).toBe("2.0.0");
     expect(app2Json.dependencies["dep-with-tags"]).toBe("3.0.0");
@@ -394,7 +394,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(packageJson.workspaces.catalogs).toEqual({
       tools: { "no-deps": "^2.0.0", "dep-with-tags": "~3.0.0" },
       // a-dep >=1.0.5 already resolves to latest (1.0.10) so it is not listed
@@ -402,7 +402,7 @@ describe.concurrent("bun update --interactive", () => {
       frameworks: { "a-dep": ">=1.0.5", "normal-dep-and-dev-dep": "^1.0.0" },
     });
 
-    const appJson = await Bun.file(join(dir, "packages/app/package.json")).json();
+    const appJson = await Bun.file(join(String(dir), "packages/app/package.json")).json();
     expect(appJson.dependencies).toEqual({
       "no-deps": "catalog:tools",
       "dep-with-tags": "catalog:tools",
@@ -431,7 +431,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Selected 1 package to update");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     let updatedCount = 0;
     if (packageJson.dependencies["no-deps"] !== "1.0.0") updatedCount++;
     if (packageJson.dependencies["dep-with-tags"] !== "1.0.0") updatedCount++;
@@ -462,10 +462,10 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const appJson = await Bun.file(join(dir, "packages/app/package.json")).json();
+    const appJson = await Bun.file(join(String(dir), "packages/app/package.json")).json();
     expect(appJson.dependencies["no-deps"]).toBe("^2.0.0");
 
-    const rootJson = await Bun.file(join(dir, "package.json")).json();
+    const rootJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(Object.keys(rootJson.catalog)).toHaveLength(0);
   });
 
@@ -487,7 +487,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Cancelled");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(packageJson.dependencies["no-deps"]).toBe("1.0.0");
   });
 
@@ -511,7 +511,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(packageJson.dependencies).toEqual({
       "no-deps": "2.0.0",
       "dep-with-tags": "^3.0.0",
@@ -549,7 +549,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(packageJson.workspaces.catalog).toEqual({ "no-deps": "^2.0.0", "dep-with-tags": "~3.0.0" });
   });
 
@@ -582,7 +582,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(packageJson.catalog).toEqual({
       "@types/no-deps": "^2.0.0",
       "no-deps": ">=2.0.0",
@@ -622,7 +622,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(packageJson.catalog["dep-with-tags"]).toBe("~3.0.0");
     // app1 was filtered out, so its catalog entry is untouched.
     expect(packageJson.catalog["no-deps"]).toBe("^1.0.0");
@@ -663,7 +663,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(packageJson.workspaces.catalogs.dev).toEqual({ "no-deps": "^2.0.0" });
     // group_catalog_dependencies currently keys the interactive list by package
     // name alone, so the catalog:prod reference is deduped with catalog:dev and
@@ -698,7 +698,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(packageJson.catalog).toEqual({
       "no-deps": "^1.0.0 || ^2.0.0",
       "dep-with-tags": ">=3.0.0",
@@ -777,14 +777,14 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const rootPackageJson = await Bun.file(join(dir, "package.json")).json();
+    const rootPackageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(rootPackageJson.catalog).toEqual({ "no-deps": "^2.0.0", "dep-with-tags": "~3.0.0" });
     // a-dep ^1.0.5 and normal-dep-and-dev-dep ^1.0.0 already resolve to their
     // latest versions so they are not listed as outdated.
     expect(rootPackageJson.dependencies["a-dep"]).toBe("^1.0.5");
     expect(rootPackageJson.devDependencies["normal-dep-and-dev-dep"]).toBe("^1.0.0");
 
-    const app1Json = await Bun.file(join(dir, "packages/app1/package.json")).json();
+    const app1Json = await Bun.file(join(String(dir), "packages/app1/package.json")).json();
     expect(app1Json.dependencies).toEqual({
       "no-deps": "catalog:",
       "dep-with-tags": "catalog:",
@@ -792,11 +792,11 @@ describe.concurrent("bun update --interactive", () => {
     });
     expect(app1Json.devDependencies["normal-dep-and-dev-dep"]).toBe("^1.0.0");
 
-    const app2Json = await Bun.file(join(dir, "packages/app2/package.json")).json();
+    const app2Json = await Bun.file(join(String(dir), "packages/app2/package.json")).json();
     expect(app2Json.dependencies).toEqual({ "no-deps": "catalog:", "a-dep": "^1.0.5" });
     expect(app2Json.devDependencies["dep-with-tags"]).toBe("^3.0.0");
 
-    const lockfileExists = await Bun.file(join(dir, "bun.lock")).exists();
+    const lockfileExists = await Bun.file(join(String(dir), "bun.lock")).exists();
     expect(lockfileExists).toBe(true);
 
     // bun install again should make no further changes.
@@ -849,13 +849,13 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const rootJson = await Bun.file(join(dir, "package.json")).json();
+    const rootJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(rootJson.catalog["no-deps"]).toBe("^2.0.0");
 
-    const frontendJson = await Bun.file(join(dir, "packages/frontend/package.json")).json();
+    const frontendJson = await Bun.file(join(String(dir), "packages/frontend/package.json")).json();
     expect(frontendJson.dependencies["a-dep"]).toBe("^1.0.5");
 
-    const backendJson = await Bun.file(join(dir, "packages/backend/package.json")).json();
+    const backendJson = await Bun.file(join(String(dir), "packages/backend/package.json")).json();
     expect(backendJson.dependencies["dep-with-tags"]).toBe("^1.0.0");
   });
 
@@ -873,7 +873,7 @@ describe.concurrent("bun update --interactive", () => {
     });
 
     await install(dir);
-    const originalContent = await Bun.file(join(dir, "package.json")).text();
+    const originalContent = await Bun.file(join(String(dir), "package.json")).text();
 
     const { stdout, exitCode } = await updateInteractive(dir, { args: ["--latest", "--dry-run"] });
 
@@ -881,7 +881,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("would be updated");
     expect(exitCode).toBe(0);
 
-    const afterContent = await Bun.file(join(dir, "package.json")).text();
+    const afterContent = await Bun.file(join(String(dir), "package.json")).text();
     expect(afterContent).toBe(originalContent);
   });
 
@@ -904,7 +904,7 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const packageJson = await Bun.file(join(dir, "package.json")).json();
+    const packageJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(packageJson.dependencies["my-alias"]).toBe("npm:no-deps@2.0.0");
     expect(packageJson.dependencies["@my/alias"]).toBe("npm:@types/no-deps@^2.0.0");
   });
@@ -957,18 +957,18 @@ describe.concurrent("bun update --interactive", () => {
     expect(stdout).toContain("Installing updates...");
     expect(exitCode).toBe(0);
 
-    const rootJson = await Bun.file(join(dir, "package.json")).json();
+    const rootJson = await Bun.file(join(String(dir), "package.json")).json();
     expect(rootJson.catalog["a-dep"]).toBe("^1.0.5");
     expect(rootJson.dependencies["no-deps"]).toBe("^2.0.0");
     expect(rootJson.devDependencies["dep-with-tags"]).toBe("~3.0.0");
     expect(rootJson.peerDependencies["a-dep"]).toBe(">=1.0.5");
     expect(rootJson.optionalDependencies["normal-dep-and-dev-dep"]).toBe("^1.0.0");
 
-    const ws1Json = await Bun.file(join(dir, "packages/workspace1/package.json")).json();
+    const ws1Json = await Bun.file(join(String(dir), "packages/workspace1/package.json")).json();
     expect(ws1Json.dependencies).toEqual({ "a-dep": "catalog:", "@test/workspace2": "workspace:*" });
     expect(ws1Json.devDependencies["no-deps"]).toBe("^2.0.0");
 
-    const ws2Json = await Bun.file(join(dir, "packages/workspace2/package.json")).json();
+    const ws2Json = await Bun.file(join(String(dir), "packages/workspace2/package.json")).json();
     expect(ws2Json.dependencies["a-dep"]).toBe("catalog:");
   });
 });

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2024,11 +2024,11 @@ export class VerdaccioRegistry {
   ) {
     await rm(join(dirname(this.configPath), "htpasswd"), { force: true });
     await rm(join(this.packagesPath, "private-pkg-dont-touch"), { force: true });
-    const packageDir = tempDir("verdaccio-test-", opts.files ?? {});
+    const packageDir = String(tempDir("verdaccio-test-", opts.files ?? {}));
     const packageJson = join(packageDir, "package.json");
     await this.writeBunfig(packageDir, opts.bunfigOpts);
     this.users = {};
-    return { packageDir: String(packageDir), packageJson };
+    return { packageDir, packageJson };
   }
 
   async writeBunfig(dir: string, opts: BunfigOpts = {}) {

--- a/test/js/bun/fetch/node-use-system-ca.test.ts
+++ b/test/js/bun/fetch/node-use-system-ca.test.ts
@@ -113,7 +113,7 @@ for (const testCase of testCases) {
 process.exit(allPassed ? 0 : 1);
 `;
 
-    await fs.writeFile(join(testDir, "test-env-parsing.js"), testScript);
+    await fs.writeFile(join(String(testDir), "test-env-parsing.js"), testScript);
 
     const proc = Bun.spawn({
       cmd: [bunExe(), "test-env-parsing.js"],

--- a/test/js/bun/glob/proto.test.ts
+++ b/test/js/bun/glob/proto.test.ts
@@ -9,18 +9,18 @@ test("Object prototype followSymlinks", async () => {
     "symed/file2.txt": "file",
   });
 
-  await symlink(path.join(dir, "symed"), path.join(dir, "abc/def/sym"), "dir");
+  await symlink(path.join(String(dir), "symed"), path.join(String(dir), "abc/def/sym"), "dir");
   const glob = new Bun.Glob("**/*.txt");
 
   const zero = glob.scanSync({
-    "cwd": path.join(dir, "abc"),
+    "cwd": path.join(String(dir), "abc"),
     onlyFiles: true,
     followSymlinks: true,
   });
   expect([...zero].map(a => a.replaceAll("\\", "/")).sort()).toEqual(["def/file.txt", "def/sym/file2.txt"]);
 
   const first = glob.scanSync({
-    "cwd": path.join(dir, "abc"),
+    "cwd": path.join(String(dir), "abc"),
     onlyFiles: true,
   });
   expect([...first].map(a => a.replaceAll("\\", "/"))).toEqual(["def/file.txt"]);
@@ -32,14 +32,14 @@ test("Object prototype followSymlinks", async () => {
     enumerable: true,
   });
   const second = glob.scanSync({
-    "cwd": path.join(dir, "abc"),
+    "cwd": path.join(String(dir), "abc"),
     onlyFiles: true,
   });
   expect([...second].map(a => a.replaceAll("\\", "/"))).toEqual(["def/file.txt"]);
   delete Object.prototype.followSymlinks;
 
   const third = glob.scanSync({
-    "cwd": path.join(dir, "abc"),
+    "cwd": path.join(String(dir), "abc"),
     onlyFiles: true,
   });
   expect([...third].map(a => a.replaceAll("\\", "/"))).toEqual(["def/file.txt"]);

--- a/test/js/bun/http/bun-serve-html-405.test.ts
+++ b/test/js/bun/http/bun-serve-html-405.test.ts
@@ -6,7 +6,7 @@ test("dev server html route: non-GET/HEAD requests complete without hanging", as
   await using dir = tempDir("html-route-405", {
     "index.html": `<!DOCTYPE html><html><head><title>t</title></head><body>hi</body></html>`,
   });
-  const { default: html } = await import(join(dir, "index.html"));
+  const { default: html } = await import(join(String(dir), "index.html"));
 
   using server = Bun.serve({
     port: 0,
@@ -70,7 +70,7 @@ test.skipIf(!isASAN || isWindows)(
           await (await fetch(server.url)).text();
           server.stop(true);
         `,
-        join(dir, "index.html"),
+        join(String(dir), "index.html"),
       ],
       env: {
         ...bunEnv,

--- a/test/js/bun/http/bun-serve-html-manifest.test.ts
+++ b/test/js/bun/http/bun-serve-html-manifest.test.ts
@@ -42,7 +42,7 @@ describe("Bun.serve HTML manifest", () => {
     });
 
     const proc = Bun.spawn({
-      cmd: [bunExe(), "run", join(dir, "server.ts")],
+      cmd: [bunExe(), "run", join(String(dir), "server.ts")],
       cwd: dir,
       env: bunEnv,
       stdout: "pipe",
@@ -152,7 +152,7 @@ describe("Bun.serve HTML manifest", () => {
 
     // Build first
     const buildProc = Bun.spawn({
-      cmd: [bunExe(), "run", join(dir, "build.ts")],
+      cmd: [bunExe(), "run", join(String(dir), "build.ts")],
       cwd: dir,
       env: bunEnv,
       stdout: "pipe",
@@ -165,8 +165,8 @@ describe("Bun.serve HTML manifest", () => {
 
     // Run the built server
     const serverProc = Bun.spawn({
-      cmd: [bunExe(), "run", join(dir, "dist", "server.js")],
-      cwd: join(dir, "dist"),
+      cmd: [bunExe(), "run", join(String(dir), "dist", "server.js")],
+      cwd: join(String(dir), "dist"),
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
@@ -252,7 +252,7 @@ describe("Bun.serve HTML manifest", () => {
     });
 
     const proc = Bun.spawn({
-      cmd: [bunExe(), "run", join(dir, "test.ts")],
+      cmd: [bunExe(), "run", join(String(dir), "test.ts")],
       cwd: dir,
       env: bunEnv,
       stdout: "pipe",
@@ -306,7 +306,15 @@ describe("Bun.serve HTML manifest", () => {
 
     // Build first to generate the manifest
     await using buildProc = Bun.spawn({
-      cmd: [bunExe(), "build", join(dir, "server.ts"), "--outdir", join(dir, "dist"), "--target", "bun"],
+      cmd: [
+        bunExe(),
+        "build",
+        join(String(dir), "server.ts"),
+        "--outdir",
+        join(String(dir), "dist"),
+        "--target",
+        "bun",
+      ],
       cwd: dir,
       env: bunEnv,
       stdout: "pipe",
@@ -319,8 +327,8 @@ describe("Bun.serve HTML manifest", () => {
 
     // Run the built server
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", join(dir, "dist", "server.js")],
-      cwd: join(dir, "dist"),
+      cmd: [bunExe(), "run", join(String(dir), "dist", "server.js")],
+      cwd: join(String(dir), "dist"),
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -101,8 +101,8 @@ test("serve html", async () => {
     port,
     hostname,
   } = await waitForServer(dir, {
-    "/": join(dir, "index.html"),
-    "/dashboard": join(dir, "dashboard.html"),
+    "/": join(String(dir), "index.html"),
+    "/dashboard": join(String(dir), "dashboard.html"),
   });
   await using subprocess = subprocess1;
 
@@ -405,7 +405,7 @@ export default p;
       port,
       hostname,
     } = await waitForServer(dir, {
-      "/": join(dir, "index.html"),
+      "/": join(String(dir), "index.html"),
     });
     await using subprocess = subprocess1;
     const response = await fetch(`http://${hostname}:${port}/`);
@@ -459,7 +459,7 @@ plugins = []`,
       port,
       hostname,
     } = await waitForServer(dir, {
-      "/": join(dir, "index.html"),
+      "/": join(String(dir), "index.html"),
     });
     await using subprocess = subprocess1;
     const response = await fetch(`http://${hostname}:${port}/`);
@@ -535,16 +535,16 @@ export default {
       port,
       hostname,
     } = await waitForServer(dir, {
-      "/": join(dir, "index.html"),
-      "/about": join(dir, "about.html"),
-      "/contact": join(dir, "contact.html"),
-      "/products": join(dir, "products.html"),
-      "/services": join(dir, "services.html"),
-      "/blog": join(dir, "blog.html"),
-      "/team": join(dir, "team.html"),
-      "/careers": join(dir, "careers.html"),
-      "/faq": join(dir, "faq.html"),
-      "/ooga": join(dir, "ooga.html"),
+      "/": join(String(dir), "index.html"),
+      "/about": join(String(dir), "about.html"),
+      "/contact": join(String(dir), "contact.html"),
+      "/products": join(String(dir), "products.html"),
+      "/services": join(String(dir), "services.html"),
+      "/blog": join(String(dir), "blog.html"),
+      "/team": join(String(dir), "team.html"),
+      "/careers": join(String(dir), "careers.html"),
+      "/faq": join(String(dir), "faq.html"),
+      "/ooga": join(String(dir), "ooga.html"),
     });
     console.log("done waiting for server");
     await using subprocess = subprocess1;
@@ -640,7 +640,7 @@ test("serve html error handling", async () => {
     `,
   });
   async function getServers() {
-    const path = join(dir, "index.html");
+    const path = join(String(dir), "index.html");
 
     const { default: html } = await import(path);
     let servers: Server[] = [];
@@ -1137,7 +1137,7 @@ test("wildcard static routes", async () => {
       throw new Error("Error on purpose");
     `,
   });
-  const { default: html } = await import(join(dir, "index.html"));
+  const { default: html } = await import(join(String(dir), "index.html"));
   for (let development of [true, false]) {
     using server = Bun.serve({
       port: 0,

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -2353,7 +2353,7 @@ describe.concurrent("HEAD requests #15355", () => {
       "hello": "Hello World",
     });
 
-    const filename = path.join(dir, "hello");
+    const filename = path.join(String(dir), "hello");
     using server = Bun.serve({
       port: 0,
       fetch(req) {

--- a/test/js/bun/io/bun-write-leak.test.ts
+++ b/test/js/bun/io/bun-write-leak.test.ts
@@ -12,8 +12,8 @@ test.concurrent(
       "out.bin": "here",
     });
 
-    const dest = path.join(dir, "out.bin");
-    expect(await bunRun([path.join(dir, "bun-write-leak-fixture.js"), dest])).toSpawn();
+    const dest = path.join(String(dir), "out.bin");
+    expect(await bunRun([path.join(String(dir), "bun-write-leak-fixture.js"), dest])).toSpawn();
   },
   30 * 1000,
 );

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -25,15 +25,15 @@ const IS_UV_FS_COPYFILE_DISABLED =
   it("Bun.write blob", async () => {
     using tmpbase = tempDir("bun-write-blob", {});
     await Bun.write(
-      Bun.file(join(tmpbase, "response-file.test.txt")),
+      Bun.file(join(String(tmpbase), "response-file.test.txt")),
       Bun.file(path.resolve(import.meta.dir, "fetch.js.txt")),
     );
     await gcTick();
-    await Bun.write(Bun.file(join(tmpbase, "response-file.test.txt")), "blah blah blha");
+    await Bun.write(Bun.file(join(String(tmpbase), "response-file.test.txt")), "blah blah blha");
     await gcTick();
-    await Bun.write(Bun.file(join(tmpbase, "response-file.test.txt")), new Uint32Array(1024));
+    await Bun.write(Bun.file(join(String(tmpbase), "response-file.test.txt")), new Uint32Array(1024));
     await gcTick();
-    await Bun.write(join(tmpbase, "response-file.test.txt"), new Uint32Array(1024));
+    await Bun.write(join(String(tmpbase), "response-file.test.txt"), new Uint32Array(1024));
     await gcTick();
     expect(await Bun.write(new TextEncoder().encode(tmpbase + "response-file.test.txt"), new Uint32Array(1024))).toBe(
       new Uint32Array(1024).byteLength,
@@ -107,8 +107,8 @@ const IS_UV_FS_COPYFILE_DISABLED =
 
   it("Bun.write file not found returns ENOENT, issue#6336", async () => {
     using tmpbase = tempDir("bun-write-enoent", {});
-    const dst = Bun.file(path.join(tmpbase, join("does", "not", "exist.txt")));
-    fs.rmSync(join(tmpbase, "does"), { force: true, recursive: true });
+    const dst = Bun.file(path.join(String(tmpbase), join("does", "not", "exist.txt")));
+    fs.rmSync(join(String(tmpbase), "does"), { force: true, recursive: true });
 
     try {
       await gcTick();
@@ -122,7 +122,7 @@ const IS_UV_FS_COPYFILE_DISABLED =
       }
     }
 
-    const src = Bun.file(path.join(tmpbase, `test-bun-write-${Date.now()}.txt`));
+    const src = Bun.file(path.join(String(tmpbase), `test-bun-write-${Date.now()}.txt`));
 
     await Bun.write(src, "");
     try {
@@ -220,7 +220,7 @@ const IS_UV_FS_COPYFILE_DISABLED =
 
   it("Bun.write('out.txt', 'string')", async () => {
     using tmpbase = tempDir("bun-write-string", {});
-    const outpath = path.join(tmpbase, "out." + ((Math.random() * 102400) | 0).toString(32) + "txt");
+    const outpath = path.join(String(tmpbase), "out." + ((Math.random() * 102400) | 0).toString(32) + "txt");
     for (let erase of [true, false]) {
       if (erase) {
         try {
@@ -242,11 +242,11 @@ const IS_UV_FS_COPYFILE_DISABLED =
   it("Bun.file -> Bun.file", async () => {
     using tmpbase = tempDir("bun-file-to-file", {});
     try {
-      fs.unlinkSync(path.join(tmpbase, "fetch.js.in"));
+      fs.unlinkSync(path.join(String(tmpbase), "fetch.js.in"));
     } catch (e) {}
     await gcTick();
     try {
-      fs.unlinkSync(path.join(tmpbase, "fetch.js.out"));
+      fs.unlinkSync(path.join(String(tmpbase), "fetch.js.out"));
     } catch (e) {}
     await gcTick();
 

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -108,8 +108,8 @@ describe("apply", () => {
       b: {},
     });
 
-    const afolder = join(tempdir, "a");
-    const bfolder = join(tempdir, "b");
+    const afolder = join(String(tempdir), "a");
+    const bfolder = join(String(tempdir), "b");
 
     const patchfile = await makeDiff(afolder, bfolder, tempdir);
     expect(patchfile).toBe("");
@@ -128,8 +128,8 @@ describe("apply", () => {
       };
       await using tempdir = tempDir("patch-test", files);
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       console.log("makeDiff args", afolder, bfolder);
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
@@ -153,8 +153,8 @@ describe("apply", () => {
       };
       await using tempdir = tempDir("patch-test", files);
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
 
@@ -170,8 +170,8 @@ describe("apply", () => {
       };
       await using tempdir = tempDir("patch-test", files);
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
 
@@ -189,8 +189,8 @@ describe("apply", () => {
       };
       await using tempdir = tempDir("patch-test", files);
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
 
@@ -275,8 +275,8 @@ describe("apply", () => {
       };
       await using tempdir = tempDir("patch-test", files);
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
 
@@ -317,8 +317,8 @@ describe("apply", () => {
 
       await using tempdir = tempDir("patch-test", files);
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       await fs.chmod(join(bfolder, "hi.txt"), 0o755);
 
@@ -342,8 +342,8 @@ describe("apply", () => {
         "b/hello.txt": bfile,
       });
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
 
@@ -361,8 +361,8 @@ describe("apply", () => {
         "b/hello.txt": bfile,
       });
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
 
@@ -380,8 +380,8 @@ describe("apply", () => {
         "b/hello.txt": bfile,
       });
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
 
@@ -399,8 +399,8 @@ describe("apply", () => {
         "b/hello.txt": bfile,
       });
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
 
@@ -460,8 +460,8 @@ describe("apply", () => {
         "b/hello.txt": bfile,
       });
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
 
@@ -521,8 +521,8 @@ describe("apply", () => {
         "b/hello.txt": bfile,
       });
 
-      const afolder = join(tempdir, "a");
-      const bfolder = join(tempdir, "b");
+      const afolder = join(String(tempdir), "a");
+      const bfolder = join(String(tempdir), "b");
 
       const patchfile = await makeDiff(afolder, bfolder, tempdir);
 

--- a/test/js/bun/resolve/bun-lock.test.ts
+++ b/test/js/bun/resolve/bun-lock.test.ts
@@ -23,5 +23,5 @@ test.concurrent("import bun.lock file as json", async () => {
     `,
   });
 
-  expect(await bunRun(join(dir, "index.ts"))).toSpawn();
+  expect(await bunRun(join(String(dir), "index.ts"))).toSpawn();
 });

--- a/test/js/bun/resolve/jsonc.test.ts
+++ b/test/js/bun/resolve/jsonc.test.ts
@@ -9,7 +9,7 @@ test.concurrent("empty jsonc - package.json", async () => {
     if (JSON.stringify(pkg) !== '{}') throw new Error('package.json should be empty');
     `,
   });
-  expect(await bunRun(join(dir, "index.ts"))).toSpawn();
+  expect(await bunRun(join(String(dir), "index.ts"))).toSpawn();
 });
 
 test.concurrent("empty jsonc - tsconfig.json", async () => {
@@ -20,7 +20,7 @@ test.concurrent("empty jsonc - tsconfig.json", async () => {
     if (JSON.stringify(tsconfig) !== '{}') throw new Error('tsconfig.json should be empty');
     `,
   });
-  expect(await bunRun(join(dir, "index.ts"))).toSpawn();
+  expect(await bunRun(join(String(dir), "index.ts"))).toSpawn();
 });
 
 test.concurrent("import anything.jsonc as json", async () => {
@@ -36,7 +36,7 @@ test.concurrent("import anything.jsonc as json", async () => {
     if (!Bun.deepEquals(file, _file)) throw new Error('anything.jsonc wasnt imported as jsonc');
     `,
   });
-  expect(await bunRun(join(dir, "index.ts"))).toSpawn();
+  expect(await bunRun(join(String(dir), "index.ts"))).toSpawn();
 });
 
 test.concurrent("imported JSON strings match JSON.parse exactly (escapes, lone surrogates, non-ASCII)", async () => {
@@ -55,5 +55,5 @@ test.concurrent("imported JSON strings match JSON.parse exactly (escapes, lone s
     if (units(Bun.JSONC.parse(file)) !== units(expected)) throw new Error("Bun.JSONC.parse != JSON.parse");
     `,
   });
-  expect(await bunRun(join(dir, "index.ts"))).toSpawn();
+  expect(await bunRun(join(String(dir), "index.ts"))).toSpawn();
 });

--- a/test/js/bun/resolve/resolver-permission-denied-ancestor.test.ts
+++ b/test/js/bun/resolve/resolver-permission-denied-ancestor.test.ts
@@ -18,7 +18,7 @@ describe.skipIf(isWindows || process.getuid?.() === 0)("resolver with unreadable
       "outer/project/index.js": `console.log("XONLY-OK", require("./dep.js"));`,
       "outer/project/dep.js": `module.exports = 42;`,
     });
-    const outer = join(dir, "outer");
+    const outer = join(String(dir), "outer");
     chmodSync(outer, 0o111);
     try {
       const proc = Bun.spawnSync({
@@ -39,7 +39,7 @@ describe.skipIf(isWindows || process.getuid?.() === 0)("resolver with unreadable
     using dir = tempDir("unreadable-cwd", {
       "project/package.json": JSON.stringify({ name: "p", scripts: { start: "echo should-not-run" } }),
     });
-    const project = join(dir, "project");
+    const project = join(String(dir), "project");
     // Execute-only: chdir succeeds, but `bun run` must read the requested
     // directory for script discovery, which is denied -- unlike ancestors,
     // this stays fatal ("error loading current directory").

--- a/test/js/bun/s3/s3.leak.test.ts
+++ b/test/js/bun/s3/s3.leak.test.ts
@@ -20,10 +20,10 @@ describe.skipIf(!s3Options.accessKeyId)("s3", () => {
           "out.bin": "here",
         });
 
-        const dest = path.join(dir, "out.bin");
+        const dest = path.join(String(dir), "out.bin");
 
         const { exitCode, stderr } = Bun.spawnSync(
-          [bunExe(), "--smol", path.join(dir, "s3-stream-leak-fixture.js"), dest],
+          [bunExe(), "--smol", path.join(String(dir), "s3-stream-leak-fixture.js"), dest],
           {
             env: {
               ...bunEnv,
@@ -50,10 +50,10 @@ describe.skipIf(!s3Options.accessKeyId)("s3", () => {
           "out.bin": "here",
         });
 
-        const dest = path.join(dir, "out.bin");
+        const dest = path.join(String(dir), "out.bin");
 
         const { exitCode, stderr } = Bun.spawnSync(
-          [bunExe(), "--smol", path.join(dir, "s3-text-leak-fixture.js"), dest],
+          [bunExe(), "--smol", path.join(String(dir), "s3-text-leak-fixture.js"), dest],
           {
             env: {
               ...bunEnv,
@@ -81,10 +81,10 @@ describe.skipIf(!s3Options.accessKeyId)("s3", () => {
           "out.bin": "here",
         });
 
-        const dest = path.join(dir, "out.bin");
+        const dest = path.join(String(dir), "out.bin");
 
         const { exitCode, stderr } = Bun.spawnSync(
-          [bunExe(), "--smol", path.join(dir, "s3-writer-leak-fixture.js"), dest],
+          [bunExe(), "--smol", path.join(String(dir), "s3-writer-leak-fixture.js"), dest],
           {
             env: {
               ...bunEnv,
@@ -112,10 +112,10 @@ describe.skipIf(!s3Options.accessKeyId)("s3", () => {
           "out.bin": "here",
         });
 
-        const dest = path.join(dir, "out.bin");
+        const dest = path.join(String(dir), "out.bin");
 
         const { exitCode, stderr } = Bun.spawnSync(
-          [bunExe(), "--smol", path.join(dir, "s3-write-leak-fixture.js"), dest],
+          [bunExe(), "--smol", path.join(String(dir), "s3-write-leak-fixture.js"), dest],
           {
             env: {
               ...bunEnv,
@@ -144,10 +144,10 @@ describe.skipIf(!s3Options.accessKeyId)("s3", () => {
           "out.bin": "here",
         });
 
-        const dest = path.join(dir, "out.bin");
+        const dest = path.join(String(dir), "out.bin");
 
         const { exitCode, stderr } = Bun.spawnSync(
-          [bunExe(), "--smol", path.join(dir, "bun-write-leak-fixture.js"), dest],
+          [bunExe(), "--smol", path.join(String(dir), "bun-write-leak-fixture.js"), dest],
           {
             env: {
               ...bunEnv,

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1033,7 +1033,10 @@ for (let credentials of allCredentials) {
           });
           const tmp_filename = `${randomUUID()}.txt`;
 
-          await Bun.write(s3(tmp_filename, { ...s3Options, bucket: S3Bucket }), file(path.join(dir, "hello.txt")));
+          await Bun.write(
+            s3(tmp_filename, { ...s3Options, bucket: S3Bucket }),
+            file(path.join(String(dir), "hello.txt")),
+          );
           await s3(tmp_filename, { ...s3Options, bucket: S3Bucket }).unlink();
         });
         it("Bun.write(s3file, file) should throw if the file does not exist", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -1061,7 +1061,7 @@ booga"
 
     test.if(isPosix && !isRoot)("glob over an unreadable directory reports the real error", async () => {
       await using dir = tempDir("glob-eacces", { "placeholder.txt": "" });
-      const noaccess = join(dir, "noaccess").replaceAll("\\", "/");
+      const noaccess = join(String(dir), "noaccess").replaceAll("\\", "/");
       mkdirSync(noaccess);
       chmodSync(noaccess, 0o000);
       try {
@@ -1288,7 +1288,7 @@ booga"
     // (e.g. EACCES, ELOOP) left the shell promise unresolved forever.
     test.if(isPosix && !isRoot)("cd with EACCES fails with exit code 1 instead of hanging", async () => {
       await using dir = tempDir("cd-eacces", { "placeholder.txt": "" });
-      const noaccess = join(dir, "noaccess");
+      const noaccess = join(String(dir), "noaccess");
       mkdirSync(noaccess);
       chmodSync(noaccess, 0o000);
       try {

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -72,13 +72,13 @@ describe.concurrent("bunshell rm", () => {
 
     // test on a directory
     {
-      let subDir = path.join(tempdir, "folder", "sub");
+      let subDir = path.join(String(tempdir), "folder", "sub");
       mkdirSync(subDir, { recursive: true });
       let subFile = path.join(subDir, "file.txt");
       writeFileSync(subFile, "test");
-      const { stdout, exitCode } = await $`rm -rv ${path.join(tempdir, "folder")}`;
+      const { stdout, exitCode } = await $`rm -rv ${path.join(String(tempdir), "folder")}`;
       expect(sortedShellOutput(stdout.toString())).toEqual(
-        sortedShellOutput(`${subFile}\n${subDir}\n${path.join(tempdir, "folder")}\n`),
+        sortedShellOutput(`${subFile}\n${subDir}\n${path.join(String(tempdir), "folder")}\n`),
       );
       expect(exitCode).toBe(0);
 
@@ -263,9 +263,9 @@ test.skipIf(process.platform === "win32")(
         }
       }
       await using root = tempDir(`rm-swap-${iter}`, files);
-      const victimDir = path.join(root, "victim");
+      const victimDir = path.join(String(root), "victim");
       const victimFile = path.join(victimDir, "keep.txt");
-      const target = path.join(root, "target");
+      const target = path.join(String(root), "target");
 
       // Start the recursive delete on the worker pool, then immediately
       // replace each subdirectory with a symlink pointing at the victim
@@ -274,7 +274,7 @@ test.skipIf(process.platform === "win32")(
       for (let i = 0; i < ENTRIES; i++) {
         const entry = path.join(target, `d${i}`);
         try {
-          renameSync(entry, path.join(root, "stash", `d${i}`));
+          renameSync(entry, path.join(String(root), "stash", `d${i}`));
           symlinkSync(victimDir, entry);
         } catch {
           // The walker may have already deleted this entry; that's fine.

--- a/test/js/bun/shell/lazy.test.ts
+++ b/test/js/bun/shell/lazy.test.ts
@@ -8,7 +8,7 @@ test("$ is lazy", async () => {
   await using base = tempDir("bun-lazy-test", {
     "bun-lazy": "789",
   });
-  const path = join(base, "bun-lazy");
+  const path = join(String(base), "bun-lazy");
   rmSync(path, { force: true, recursive: true });
   const pending = $`echo 123 > ${path}`;
   expect(async () => await Bun.file(path).text()).toThrow();

--- a/test/js/bun/shell/leak.test.ts
+++ b/test/js/bun/shell/leak.test.ts
@@ -95,7 +95,7 @@ describe.concurrent("fd leak", () => {
         "script.ts": testcode + impl,
       });
 
-      const { exited, stderr: stream } = Bun.spawn([process.argv0, "--smol", "test", join(dir, "script.ts")], {
+      const { exited, stderr: stream } = Bun.spawn([process.argv0, "--smol", "test", join(String(dir), "script.ts")], {
         env: bunEnv,
         stderr: "pipe",
       });
@@ -154,7 +154,7 @@ describe.concurrent("fd leak", () => {
         "script.ts": testcode + impl,
       });
 
-      const { exited, stderr: stream } = Bun.spawn([process.argv0, "--smol", "test", join(dir, "script.ts")], {
+      const { exited, stderr: stream } = Bun.spawn([process.argv0, "--smol", "test", join(String(dir), "script.ts")], {
         env: bunEnv,
         stderr: "pipe",
       });
@@ -242,11 +242,14 @@ describe.concurrent("fd leak", () => {
           "script.ts": testcode + impl,
         });
 
-        const { stderr: stream, exited } = Bun.spawn([process.argv0, "--smol", "test", join(dir, "script.ts")], {
-          env: bunEnv,
-          stdout: "ignore",
-          stderr: "pipe",
-        });
+        const { stderr: stream, exited } = Bun.spawn(
+          [process.argv0, "--smol", "test", join(String(dir), "script.ts")],
+          {
+            env: bunEnv,
+            stdout: "ignore",
+            stderr: "pipe",
+          },
+        );
         const [exitCode, stderr] = await Promise.all([exited, stream.text()]);
         if (exitCode != 0) {
           console.log("\n\nSTDERR:", stderr);

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -1664,7 +1664,7 @@ it("issue#7147", () => {
 
 it("should close with WAL enabled", () => {
   using dir = tempDir("sqlite-wal-test", { "empty.txt": "" });
-  const file = path.join(dir, "my.db");
+  const file = path.join(String(dir), "my.db");
   const db = new Database(file);
   db.exec("PRAGMA journal_mode = WAL");
   db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, 0);
@@ -2449,7 +2449,7 @@ it("run() reports a closed database when a bound parameter's getter closes it", 
 // as-is and overflowed.
 it("fileControl rejects result TypedArrays smaller than 8 bytes", () => {
   using dir = tempDir("sqlite-fcntl-bounds", { "empty.txt": "" });
-  const db = new Database(path.join(dir, "my.db"));
+  const db = new Database(path.join(String(dir), "my.db"));
 
   expect(() => db.fileControl(constants.SQLITE_FCNTL_PERSIST_WAL, new Uint8Array(1))).toThrow(
     "TypedArray must be at least 8 bytes",
@@ -2697,11 +2697,11 @@ it("exit-time WAL checkpoint runs even with a never-finalized prepared statement
   });
   const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stdout).toBe("true\n");
-  const wal = path.join(dir, "exit.db-wal");
+  const wal = path.join(String(dir), "exit.db-wal");
   // TRUNCATE moved every frame into exit.db (or the sidecar was unlinked
   // by a full close). Either way, no un-checkpointed data is stranded.
   expect(existsSync(wal) ? statSync(wal).size : 0).toBe(0);
-  const verify = new Database(path.join(dir, "exit.db"));
+  const verify = new Database(path.join(String(dir), "exit.db"));
   expect(verify.query("SELECT x FROM t").get().x).toBe(42);
   verify.close();
   expect(exitCode).toBe(0);

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -7,7 +7,7 @@ test("delete() and stat() should work with unicode paths", async () => {
   await using dir = tempDir("delete-stat-unicode-path", {
     "another-file.txt": "HEY",
   });
-  const filename = join(dir, "🌟.txt");
+  const filename = join(String(dir), "🌟.txt");
 
   expect(async () => {
     await Bun.file(filename).delete();
@@ -29,7 +29,7 @@ test("writer.end() should not close the fd if it does not own the fd", async () 
   await using dir = tempDir("writer-end-fd", {
     "tmp.txt": "HI",
   });
-  const filename = join(dir, "tmp.txt");
+  const filename = join(String(dir), "tmp.txt");
 
   for (let i = 0; i < 30; i++) {
     const fileHandle = await fsPromises.open(filename, "w", 0o666);
@@ -67,7 +67,7 @@ test("Bun.write() errors include async stack frames", async () => {
   // Windows. Bun.write recursively creates directories, so a plain
   // /nonexistent-path/ would succeed on Windows where / is the drive root.
   await using dir = tempDir("bun-write-async-stack", { "blocker.txt": "x" });
-  const badPath = join(dir, "blocker.txt", "cannot-write.txt");
+  const badPath = join(String(dir), "blocker.txt", "cannot-write.txt");
   // Bun.write uses a sync fast path for inputs under 256KB on POSIX — use
   // 512KB to force the async (threadpool) path so we're actually testing the
   // rejected-from-native-callback stack attachment.
@@ -140,7 +140,7 @@ test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async
   });
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), join(dir, "read.js"), dir],
+    cmd: [bunExe(), join(String(dir), "read.js"), dir],
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",

--- a/test/js/bun/util/which.test.ts
+++ b/test/js/bun/util/which.test.ts
@@ -307,11 +307,11 @@ test("Bun.which does look in the current directory when given a path with a slas
 
     const suffix = isWindows ? ".cmd" : "";
 
-    expect(which("./some_program_name")).toBe(join(dir, "some_program_name" + suffix));
+    expect(which("./some_program_name")).toBe(join(String(dir), "some_program_name" + suffix));
     expect((await $`./some_program_name`.text()).trim()).toBe(isWindows ? "win32" : "posix");
-    expect(which("./folder/other_app")).toBe(join(dir, "folder/other_app" + suffix));
+    expect(which("./folder/other_app")).toBe(join(String(dir), "folder/other_app" + suffix));
     expect((await $`./folder/other_app`.text()).trim()).toBe(isWindows ? "win32" : "posix");
-    expect(which("folder/other_app")).toBe(join(dir, "folder/other_app" + suffix));
+    expect(which("folder/other_app")).toBe(join(String(dir), "folder/other_app" + suffix));
     expect((await $`folder/other_app`.text()).trim()).toBe(isWindows ? "win32" : "posix");
   } finally {
     process.chdir(cwd);
@@ -332,7 +332,7 @@ test("Bun.which can find executables in a non-ascii directory", async () => {
     }
 
     const suffix = isWindows ? ".cmd" : "";
-    expect(which("./some_program_name")).toBe(join(dir, "some_program_name" + suffix));
+    expect(which("./some_program_name")).toBe(join(String(dir), "some_program_name" + suffix));
     expect((await $`./some_program_name`.text()).trim()).toBe(isWindows ? "win32" : "posix");
   } finally {
     process.chdir(cwd);

--- a/test/js/junit-reporter/junit.test.js
+++ b/test/js/junit-reporter/junit.test.js
@@ -398,7 +398,7 @@ describe("junit reporter", () => {
         'test("keeps\\twhitespace\\nfine", () => {});\n',
     });
 
-    const junitPath = join(tmpDir, "junit.xml");
+    const junitPath = join(String(tmpDir), "junit.xml");
     await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
       cwd: tmpDir,
       env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
@@ -442,7 +442,7 @@ describe("junit reporter", () => {
       `,
     });
 
-    const junitPath = join(tmpDir, "junit.xml");
+    const junitPath = join(String(tmpDir), "junit.xml");
     await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
       cwd: tmpDir,
       env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
@@ -481,7 +481,7 @@ describe("junit reporter", () => {
       `,
     });
 
-    const junitPath = join(tmpDir, "junit.xml");
+    const junitPath = join(String(tmpDir), "junit.xml");
     await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
       cwd: tmpDir,
       env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
@@ -514,7 +514,7 @@ describe("junit reporter", () => {
       `,
     });
 
-    const junitPath = join(tmpDir, "junit.xml");
+    const junitPath = join(String(tmpDir), "junit.xml");
     await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
       cwd: tmpDir,
       // FORCE_COLOR so the matcher builds a coloured message, to exercise the
@@ -585,7 +585,7 @@ describe("junit reporter", () => {
       `,
     });
 
-    const junitPath = join(tmpDir, "junit.xml");
+    const junitPath = join(String(tmpDir), "junit.xml");
     await using proc = spawn([bunExe(), "test", "--reporter=junit", "--reporter-outfile", junitPath], {
       cwd: tmpDir,
       env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -231,14 +231,14 @@ for (const [name, copy] of impls) {
         "from/keep": "",
       });
 
-      const origTarget = join(basename, "target.txt");
+      const origTarget = join(String(basename), "target.txt");
 
       // Absolute target — exercises the isAbsolute fast path.
-      const srcAbs = join(basename, "from", "abs_link");
+      const srcAbs = join(String(basename), "from", "abs_link");
       fs.symlinkSync(origTarget, srcAbs);
 
       // Relative target — exercises the dirname(src) resolve path.
-      const srcRel = join(basename, "from", "rel_link");
+      const srcRel = join(String(basename), "from", "rel_link");
       fs.symlinkSync(join("..", "target.txt"), srcRel);
 
       await copy(basename + "/from", basename + "/to", { recursive: true });
@@ -247,7 +247,7 @@ for (const [name, copy] of impls) {
         ["abs_link", srcAbs],
         ["rel_link", srcRel],
       ] as const) {
-        const copiedLink = join(basename, "to", which);
+        const copiedLink = join(String(basename), "to", which);
         expect(fs.lstatSync(copiedLink).isSymbolicLink()).toBe(true);
 
         // The copied link's target string must not be the path of the source
@@ -259,8 +259,8 @@ for (const [name, copy] of impls) {
       // Deleting the source tree must not break the absolute link, since its
       // target lives outside the source tree. With the bug, the copied link
       // pointed at from/abs_link and would dangle once from/ was removed.
-      fs.rmSync(join(basename, "from"), { recursive: true, force: true });
-      expect(fs.readFileSync(join(basename, "to", "abs_link"), "utf8")).toBe("hello");
+      fs.rmSync(join(String(basename), "from"), { recursive: true, force: true });
+      expect(fs.readFileSync(join(String(basename), "to", "abs_link"), "utf8")).toBe("hello");
     });
 
     test("symlinks - relative target inside the tree is resolved against the source tree", async () => {
@@ -271,13 +271,13 @@ for (const [name, copy] of impls) {
         "from/a.txt": "a",
         "from/sub/keep.txt": "keep",
       });
-      fs.symlinkSync(join("..", "a.txt"), join(basename, "from", "sub", "link"));
+      fs.symlinkSync(join("..", "a.txt"), join(String(basename), "from", "sub", "link"));
 
-      await copy(join(basename, "from"), join(basename, "result"), { recursive: true });
+      await copy(join(String(basename), "from"), join(String(basename), "result"), { recursive: true });
 
-      const copiedLink = join(basename, "result", "sub", "link");
+      const copiedLink = join(String(basename), "result", "sub", "link");
       expect(fs.lstatSync(copiedLink).isSymbolicLink()).toBe(true);
-      expect(fs.readlinkSync(copiedLink)).toBe(join(basename, "from", "a.txt"));
+      expect(fs.readlinkSync(copiedLink)).toBe(join(String(basename), "from", "a.txt"));
       expect(fs.readFileSync(copiedLink, "utf8")).toBe("a");
     });
 
@@ -285,15 +285,15 @@ for (const [name, copy] of impls) {
       await using basename = tempDir("cp", {
         "from/d/f.txt": "x",
       });
-      fs.chmodSync(join(basename, "from", "d", "f.txt"), 0o600);
-      fs.chmodSync(join(basename, "from", "d"), 0o700);
+      fs.chmodSync(join(String(basename), "from", "d", "f.txt"), 0o600);
+      fs.chmodSync(join(String(basename), "from", "d"), 0o700);
 
-      await copy(join(basename, "from"), join(basename, "result"), { recursive: true });
+      await copy(join(String(basename), "from"), join(String(basename), "result"), { recursive: true });
 
       expect({
-        dirMode: fs.statSync(join(basename, "result", "d")).mode & 0o777,
-        fileMode: fs.statSync(join(basename, "result", "d", "f.txt")).mode & 0o777,
-        content: fs.readFileSync(join(basename, "result", "d", "f.txt"), "utf8"),
+        dirMode: fs.statSync(join(String(basename), "result", "d")).mode & 0o777,
+        fileMode: fs.statSync(join(String(basename), "result", "d", "f.txt")).mode & 0o777,
+        content: fs.readFileSync(join(String(basename), "result", "d", "f.txt"), "utf8"),
       }).toEqual({
         dirMode: 0o700,
         fileMode: 0o600,
@@ -305,10 +305,12 @@ for (const [name, copy] of impls) {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",
       });
-      mkfifo(join(basename, "from", "pipe"), 0o666);
-      expect(fs.lstatSync(join(basename, "from", "pipe")).isFIFO()).toBe(true);
+      mkfifo(join(String(basename), "from", "pipe"), 0o666);
+      expect(fs.lstatSync(join(String(basename), "from", "pipe")).isFIFO()).toBe(true);
 
-      const e = await copyShouldThrow(join(basename, "from"), join(basename, "result"), { recursive: true });
+      const e = await copyShouldThrow(join(String(basename), "from"), join(String(basename), "result"), {
+        recursive: true,
+      });
       expect(e.code).toBe("ERR_FS_CP_FIFO_PIPE");
     });
 
@@ -344,7 +346,7 @@ for (const [name, copy] of impls) {
       let prev = process.cwd();
       process.chdir(String(basename));
 
-      await copy(join(basename, "from"), join(basename, "result"), {
+      await copy(join(String(basename), "from"), join(String(basename), "result"), {
         filter,
         recursive: true,
       });
@@ -352,9 +354,9 @@ for (const [name, copy] of impls) {
       process.chdir(prev);
 
       expect(filter.mock.calls.sort((a, b) => a[0].localeCompare(b[0]))).toEqual([
-        [join(basename, "from"), join(basename, "result")],
-        [join(basename, "from", "a.txt"), join(basename, "result", "a.txt")],
-        [join(basename, "from", "b.txt"), join(basename, "result", "b.txt")],
+        [join(String(basename), "from"), join(String(basename), "result")],
+        [join(String(basename), "from", "a.txt"), join(String(basename), "result", "a.txt")],
+        [join(String(basename), "from", "b.txt"), join(String(basename), "result", "b.txt")],
       ]);
     });
 
@@ -454,15 +456,15 @@ test.skipIf(!isWindows)("cpSync over symlinks does not leak Windows handles", ()
     "from/target.txt": "hello",
   });
   for (let i = 0; i < N; i++) {
-    fs.symlinkSync(join(basename, "from", "target.txt"), join(basename, "from", `link${i}.txt`));
+    fs.symlinkSync(join(String(basename), "from", "target.txt"), join(String(basename), "from", `link${i}.txt`));
   }
 
   // Warm up once so any lazy init (thread pool, path buffers, etc.) doesn't
   // count against the measured delta.
-  fs.cpSync(join(basename, "from"), join(basename, "warmup"), { recursive: true });
+  fs.cpSync(join(String(basename), "from"), join(String(basename), "warmup"), { recursive: true });
 
   const before = handleCount();
-  fs.cpSync(join(basename, "from"), join(basename, "result"), { recursive: true });
+  fs.cpSync(join(String(basename), "from"), join(String(basename), "result"), { recursive: true });
   const after = handleCount();
 
   // Without the fix every symlink leaks a handle, so `after - before` is >= N.
@@ -479,18 +481,18 @@ test.skipIf(!isWindows)("cpSync recursive copies a junction as a link to the ori
   using basename = tempDir("cp-junction", {
     "from/real/inner.txt": "inner",
   });
-  fs.symlinkSync(join(basename, "from", "real"), join(basename, "from", "junction"), "junction");
+  fs.symlinkSync(join(String(basename), "from", "real"), join(String(basename), "from", "junction"), "junction");
 
-  fs.cpSync(join(basename, "from"), join(basename, "result"), { recursive: true });
+  fs.cpSync(join(String(basename), "from"), join(String(basename), "result"), { recursive: true });
 
-  const copied = join(basename, "result", "junction");
+  const copied = join(String(basename), "result", "junction");
   expect(fs.lstatSync(copied).isSymbolicLink()).toBe(true);
   // Pin the stored link target, not just that creation succeeded: a relative or
   // otherwise wrong target still produces a link that lstat reports as a symlink.
   const copiedTarget = fs.readlinkSync(copied);
   expect(isAbsolute(copiedTarget)).toBe(true);
-  expect(fs.realpathSync(copiedTarget)).toBe(fs.realpathSync(join(basename, "from", "real")));
-  expect(fs.realpathSync(copied)).toBe(fs.realpathSync(join(basename, "from", "real")));
+  expect(fs.realpathSync(copiedTarget)).toBe(fs.realpathSync(join(String(basename), "from", "real")));
+  expect(fs.realpathSync(copied)).toBe(fs.realpathSync(join(String(basename), "from", "real")));
   expect(fs.readFileSync(join(copied, "inner.txt"), "utf8")).toBe("inner");
 });
 
@@ -504,14 +506,14 @@ test.skipIf(!isWindows)("cpSync recursive copies a directory symlink to a UNC ta
   });
   // Administrative-share spelling of `real`, like the "windows path handling"
   // suite in fs.test.ts relies on.
-  const real = fs.realpathSync(join(basename, "real"));
+  const real = fs.realpathSync(join(String(basename), "real"));
   const uncReal = `\\\\localhost\\${real[0]}$\\${real.slice(3)}`;
   expect(fs.readFileSync(join(uncReal, "inner.txt"), "utf8")).toBe("inner");
-  fs.symlinkSync(uncReal, join(basename, "from", "link"), "dir");
+  fs.symlinkSync(uncReal, join(String(basename), "from", "link"), "dir");
 
-  fs.cpSync(join(basename, "from"), join(basename, "result"), { recursive: true });
+  fs.cpSync(join(String(basename), "from"), join(String(basename), "result"), { recursive: true });
 
-  const copied = join(basename, "result", "link");
+  const copied = join(String(basename), "result", "link");
   expect(fs.lstatSync(copied).isSymbolicLink()).toBe(true);
   const copiedTarget = fs.readlinkSync(copied);
   expect(isAbsolute(copiedTarget)).toBe(true);

--- a/test/js/node/fs/fs-birthtime-linux.test.ts
+++ b/test/js/node/fs/fs-birthtime-linux.test.ts
@@ -9,7 +9,7 @@ describe.skipIf(!isLinux)("birthtime", () => {
       "test.txt": "initial content",
     });
 
-    const filepath = join(dir, "test.txt");
+    const filepath = join(String(dir), "test.txt");
     const stats = statSync(filepath);
 
     // On Linux with statx support, birthtime should be > 0
@@ -20,7 +20,7 @@ describe.skipIf(!isLinux)("birthtime", () => {
 
   it("birthtime should remain constant while other timestamps change", () => {
     using dir = tempDir("birthtime-immutable", {});
-    const filepath = join(dir, "immutable-test.txt");
+    const filepath = join(String(dir), "immutable-test.txt");
 
     // Create file and capture birthtime
     writeFileSync(filepath, "original");
@@ -55,7 +55,7 @@ describe.skipIf(!isLinux)("birthtime", () => {
       "test.txt": "content",
     });
 
-    const filepath = join(dir, "test.txt");
+    const filepath = join(String(dir), "test.txt");
 
     const statResult = statSync(filepath);
     const lstatResult = lstatSync(filepath);
@@ -77,7 +77,7 @@ describe.skipIf(!isLinux)("birthtime", () => {
       "test.txt": "content",
     });
 
-    const filepath = join(dir, "test.txt");
+    const filepath = join(String(dir), "test.txt");
 
     const regularStats = statSync(filepath);
     const bigintStats = statSync(filepath, { bigint: true });
@@ -95,7 +95,7 @@ describe.skipIf(!isLinux)("birthtime", () => {
 
   it("birthtime should be less than or equal to all other timestamps on creation", () => {
     using dir = tempDir("birthtime-ordering", {});
-    const filepath = join(dir, "new-file.txt");
+    const filepath = join(String(dir), "new-file.txt");
 
     writeFileSync(filepath, "new content");
     const stats = statSync(filepath);

--- a/test/js/node/fs/fs-stat-seccomp-linux.test.ts
+++ b/test/js/node/fs/fs-stat-seccomp-linux.test.ts
@@ -189,9 +189,9 @@ describe.skipIf(!isLinux)("fs.stat seccomp statx fallback", () => {
       await using targetDir = tempDir("stat-seccomp-target", { "file.txt": "hello" });
       // symlink created here rather than via tempDirWithFiles (which only
       // supports regular files).
-      symlinkSync("file.txt", join(targetDir, "link.txt"));
+      symlinkSync("file.txt", join(String(targetDir), "link.txt"));
 
-      const out = await runUnderSeccomp(helperBin, EPERM, c.snippet(c.target(targetDir)));
+      const out = await runUnderSeccomp(helperBin, EPERM, c.snippet(c.target(String(targetDir))));
       if (out == null) {
         console.warn(`SKIP fs.${c.name} seccomp: seccomp not permitted in this environment`);
         return;

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -294,7 +294,7 @@ it("fs.readv returns object", async done => {
 
 it("fs.writev returns object", async done => {
   await using outpath = tempDir("fswritevtest", { "a.txt": "b" });
-  const fd = await promisify(fs.open)(join(outpath, "b.txt"), "w");
+  const fd = await promisify(fs.open)(join(String(outpath), "b.txt"), "w");
   const buffers = [Buffer.alloc(10), Buffer.alloc(10)];
   fs.writev(fd, buffers, 0, (err, bytesWritten, output) => {
     promisify(fs.close)(fd);

--- a/test/js/node/fs/promises.test.js
+++ b/test/js/node/fs/promises.test.js
@@ -306,7 +306,7 @@ test("fs.promises async stack with Promise.all", async () => {
 
 it("an unused FileHandle.writer() does not prevent close()", async () => {
   await using dir = tempDir("unused-writer", { "x.txt": "hello" });
-  const fh = await fsPromises.open(join(dir, "x.txt"), "r+");
+  const fh = await fsPromises.open(join(String(dir), "x.txt"), "r+");
   fh.writer(); // never written to, never ended
   // must not hang: the writer only refs the handle once a write happens
   await fh.close();
@@ -315,7 +315,7 @@ it("an unused FileHandle.writer() does not prevent close()", async () => {
 
 it("sources created before close() refuse to use the stale fd", async () => {
   await using dir = tempDir("stale-fd", { "x.txt": "hello" });
-  const file = join(dir, "x.txt");
+  const file = join(String(dir), "x.txt");
 
   // writer
   {
@@ -349,7 +349,7 @@ it("sources created before close() refuse to use the stale fd", async () => {
 
 it("rm and promises.rm report ERR_FS_EISDIR for directories like rmSync", async () => {
   await using dir = tempDir("rm-eisdir", { "sub/a.txt": "x" });
-  const target = join(dir, "sub");
+  const target = join(String(dir), "sub");
   await expect(fsPromises.rm(target)).rejects.toMatchObject({ code: "ERR_FS_EISDIR" });
   const { promise, resolve } = Promise.withResolvers();
   fs.rm(target, err => resolve(err));
@@ -361,7 +361,7 @@ it("rm and promises.rm report ERR_FS_EISDIR for directories like rmSync", async 
 
 it("close() while an operation is in flight actually closes the fd", async () => {
   await using dir = tempDir("deferred-close", { "x.txt": "hello" });
-  const fh = await fsPromises.open(join(dir, "x.txt"), "r");
+  const fh = await fsPromises.open(join(String(dir), "x.txt"), "r");
   const fd = fh.fd;
   // take an extra ref so close() defers, then release it
   const read = fh.read(Buffer.alloc(5), 0, 5, 0);
@@ -379,32 +379,32 @@ it("fail()/end() with autoClose defer the close past an in-flight write", async 
   // fail() while a large write is on the threadpool must not close the fd
   // under it; the write completes, then the handle closes.
   {
-    const fh = await fsPromises.open(join(dir, "a.bin"), "w");
+    const fh = await fsPromises.open(join(String(dir), "a.bin"), "w");
     const w = fh.writer({ autoClose: true });
     const big = Buffer.alloc(8 << 20, 65);
     const pending = w.write(big);
     w.fail(new Error("stop"));
     await pending; // must not reject with EBADF
-    expect(fs.statSync(join(dir, "a.bin")).size).toBe(big.byteLength);
+    expect(fs.statSync(join(String(dir), "a.bin")).size).toBe(big.byteLength);
     expect(fh.fd).toBe(-1); // deferred teardown closed the handle
   }
   // end() while a write is pending waits for it and reports all bytes
   {
-    const fh = await fsPromises.open(join(dir, "b.bin"), "w");
+    const fh = await fsPromises.open(join(String(dir), "b.bin"), "w");
     const w = fh.writer({ autoClose: true });
     const big = Buffer.alloc(8 << 20, 66);
     const pending = w.write(big);
     const total = await w.end();
     await pending;
     expect(total).toBe(big.byteLength);
-    expect(fs.statSync(join(dir, "b.bin")).size).toBe(big.byteLength);
+    expect(fs.statSync(join(String(dir), "b.bin")).size).toBe(big.byteLength);
     expect(fh.fd).toBe(-1);
   }
 });
 
 it("teardown waits for every concurrent in-flight write", async () => {
   await using dir = tempDir("writer-concurrent", { "a.bin": "" });
-  const fh = await fsPromises.open(join(dir, "a.bin"), "w");
+  const fh = await fsPromises.open(join(String(dir), "a.bin"), "w");
   const w = fh.writer({ autoClose: true, start: 0 });
   const big = Buffer.alloc(4 << 20, 65);
   // two unawaited writes in flight; the first one finishing must not run the
@@ -414,7 +414,7 @@ it("teardown waits for every concurrent in-flight write", async () => {
   w.fail(new Error("stop"));
   await p1;
   await p2; // must not reject with EBADF
-  expect(fs.statSync(join(dir, "a.bin")).size).toBe(big.byteLength * 2);
+  expect(fs.statSync(join(String(dir), "a.bin")).size).toBe(big.byteLength * 2);
   expect(fh.fd).toBe(-1);
 });
 
@@ -439,7 +439,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     const signal = AbortSignal.abort();
     expect.assertions(4);
     try {
-      await fsPromises.readFile(join(dir, "f.txt"), { signal });
+      await fsPromises.readFile(join(String(dir), "f.txt"), { signal });
     } catch (err) {
       expectNodeAbortError(err, signal.reason);
     }
@@ -450,7 +450,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     const reason = new Error("my reason");
     expect.assertions(4);
     try {
-      await fsPromises.readFile(join(dir, "f.txt"), { signal: AbortSignal.abort(reason) });
+      await fsPromises.readFile(join(String(dir), "f.txt"), { signal: AbortSignal.abort(reason) });
     } catch (err) {
       expectNodeAbortError(err, reason);
     }
@@ -460,7 +460,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     await using dir = tempDir("fs-abort-readfile-inflight", { "f.txt": "hello" });
     const ac = new AbortController();
     const reason = new Error("stop");
-    const promise = fsPromises.readFile(join(dir, "f.txt"), { signal: ac.signal });
+    const promise = fsPromises.readFile(join(String(dir), "f.txt"), { signal: ac.signal });
     ac.abort(reason);
     expect.assertions(4);
     try {
@@ -475,7 +475,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   test("readFile aborted while in flight with the default abort reason", async () => {
     await using dir = tempDir("fs-abort-readfile-inflight-default", { "f.txt": "hello" });
     const ac = new AbortController();
-    const promise = fsPromises.readFile(join(dir, "f.txt"), { signal: ac.signal });
+    const promise = fsPromises.readFile(join(String(dir), "f.txt"), { signal: ac.signal });
     ac.abort();
     expect.assertions(4);
     try {
@@ -490,7 +490,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     const signal = AbortSignal.abort();
     expect.assertions(4);
     try {
-      await fsPromises.appendFile(join(dir, "f.txt"), "data", { signal });
+      await fsPromises.appendFile(join(String(dir), "f.txt"), "data", { signal });
     } catch (err) {
       expectNodeAbortError(err, signal.reason);
     }
@@ -501,7 +501,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     const signal = AbortSignal.abort();
     expect.assertions(4);
     try {
-      await fsPromises.writeFile(join(dir, "f.txt"), "data", { signal });
+      await fsPromises.writeFile(join(String(dir), "f.txt"), "data", { signal });
     } catch (err) {
       expectNodeAbortError(err, signal.reason);
     }
@@ -513,7 +513,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     expect.assertions(4);
     try {
       await fsPromises.writeFile(
-        join(dir, "f.txt"),
+        join(String(dir), "f.txt"),
         (async function* () {
           yield "a";
         })(),
@@ -530,7 +530,7 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
     expect.assertions(4);
     try {
       await fsPromises.writeFile(
-        join(dir, "f.txt"),
+        join(String(dir), "f.txt"),
         (async function* () {
           yield "a";
           ac.abort();
@@ -546,9 +546,9 @@ describe("AbortSignal rejections use node's AbortError shape", () => {
   test("callback readFile and writeFile with a pre-aborted signal", async () => {
     await using dir = tempDir("fs-abort-callback", { "f.txt": "hello" });
     const signal = AbortSignal.abort();
-    const readErr = await new Promise(resolve => fs.readFile(join(dir, "f.txt"), { signal }, resolve));
+    const readErr = await new Promise(resolve => fs.readFile(join(String(dir), "f.txt"), { signal }, resolve));
     expectNodeAbortError(readErr, signal.reason);
-    const writeErr = await new Promise(resolve => fs.writeFile(join(dir, "o.txt"), "x", { signal }, resolve));
+    const writeErr = await new Promise(resolve => fs.writeFile(join(String(dir), "o.txt"), "x", { signal }, resolve));
     expectNodeAbortError(writeErr, signal.reason);
   });
 });

--- a/test/js/node/module/require-extensions.test.ts
+++ b/test/js/node/module/require-extensions.test.ts
@@ -186,7 +186,7 @@ test("mutating extensions is banned by some files", () => {
 
   let n = 0;
   for (const file of files) {
-    require(path.join(fixture, file));
+    require(path.join(String(fixture), file));
     n++;
     expect(globalThis.pass).toBe(n);
   }

--- a/test/js/node/process/process-on.test.ts
+++ b/test/js/node/process/process-on.test.ts
@@ -27,7 +27,7 @@ describe("process.on", () => {
       }`,
     });
     const result1 = Bun.spawnSync({
-      cmd: [bunExe(), "build", "--compile", path.join(dir, "./process-on-fixture.ts"), "--outfile=./out"],
+      cmd: [bunExe(), "build", "--compile", path.join(String(dir), "./process-on-fixture.ts"), "--outfile=./out"],
       env: bunEnv,
       cwd: dir,
       stdin: "inherit",
@@ -64,7 +64,7 @@ describe("process.on", () => {
 
     expect(
       Bun.spawnSync({
-        cmd: [bunExe(), "build", "--target=bun", path.join(dir, "entry.ts"), "--outfile=./out.ts"],
+        cmd: [bunExe(), "build", "--target=bun", path.join(String(dir), "entry.ts"), "--outfile=./out.ts"],
         env: bunEnv,
         cwd: dir,
         stdin: "inherit",

--- a/test/js/node/tls/test-node-extra-ca-certs.test.ts
+++ b/test/js/node/tls/test-node-extra-ca-certs.test.ts
@@ -21,7 +21,7 @@ xAz7TbGPHUBH5dqMzlWqEkZxcY9u9GL19SJPpC7dl8K8V5dKBwvgOubcLp4qLvZU
       "test.js": `console.log('OK');`,
     });
 
-    const certPath = join(dir, "extra-ca.pem");
+    const certPath = join(String(dir), "extra-ca.pem");
 
     // Test that NODE_EXTRA_CA_CERTS loads the certificate
     await using proc = spawn({
@@ -43,7 +43,7 @@ xAz7TbGPHUBH5dqMzlWqEkZxcY9u9GL19SJPpC7dl8K8V5dKBwvgOubcLp4qLvZU
       "test.js": `console.log('OK');`,
     });
 
-    const nonExistentPath = join(dir, "non-existent.pem");
+    const nonExistentPath = join(String(dir), "non-existent.pem");
 
     // Test that missing file doesn't crash the process
     await using proc = spawn({
@@ -75,7 +75,7 @@ aWRnaXRzIFB0eSBMdGQwHhcNMTgwNDEwMDgwNzQ4WhcNMjgwNDA3MDgwNzQ4WjBF
       "test.js": `console.log('OK');`,
     });
 
-    const certPath = join(dir, "extra-ca.pem");
+    const certPath = join(String(dir), "extra-ca.pem");
 
     // Test that both work together
     await using proc = spawn({

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -368,7 +368,7 @@ describe("fs.watchFile", () => {
     await using dir = tempDir("watchfile-throw", {
       ".keep": "",
     });
-    const target = path.join(dir, "does-not-exist.txt");
+    const target = path.join(String(dir), "does-not-exist.txt");
 
     const fixture = /* js */ `
       const fs = require("fs");

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12366,7 +12366,7 @@ CREATE TABLE ${table_name} (
           describe("SQLite errors", () => {
             test("SQLite constraint violation throws SQLiteError", async () => {
               await using dir = tempDir("sqlite-error-test", {});
-              const dbPath = path.join(dir, "test.db");
+              const dbPath = path.join(String(dir), "test.db");
 
               const db = new SQL({ filename: dbPath, adapter: "sqlite" });
 
@@ -12394,7 +12394,7 @@ CREATE TABLE ${table_name} (
 
             test("SQLite syntax error throws SQLiteError", async () => {
               await using dir = tempDir("sqlite-syntax-error-test", {});
-              const dbPath = path.join(dir, "test.db");
+              const dbPath = path.join(String(dir), "test.db");
 
               const db = new SQL({ filename: dbPath, adapter: "sqlite" });
 
@@ -12413,7 +12413,7 @@ CREATE TABLE ${table_name} (
 
             test("SQLite database locked throws SQLiteError", async () => {
               await using dir = tempDir("sqlite-locked-test", {});
-              const dbPath = path.join(dir, "test.db");
+              const dbPath = path.join(String(dir), "test.db");
 
               await using db1 = new SQL({ filename: dbPath, adapter: "sqlite" });
               await using db2 = new SQL({ filename: dbPath, adapter: "sqlite" });

--- a/test/js/sql/sqlite-sql.test.ts
+++ b/test/js/sql/sqlite-sql.test.ts
@@ -31,7 +31,7 @@ describe("Connection & Initialization", () => {
 
   test("should connect to file-based SQLite database", async () => {
     await using dir = tempDir("sqlite-db-test", {});
-    const dbPath = path.join(dir, "test.db");
+    const dbPath = path.join(String(dir), "test.db");
 
     const sql = new SQL(`sqlite://${dbPath}`);
     expect(sql).toBeDefined();
@@ -84,7 +84,7 @@ describe("Connection & Initialization", () => {
 
   test("onconnect receives Error when open fails (readonly non-existent)", async () => {
     await using dir = tempDir("sqlite-onconnect-error", {});
-    const dbPath = join(dir, "missing.db");
+    const dbPath = join(String(dir), "missing.db");
 
     const onconnect = mock((err?: any) => {});
     const onclose = mock((err?: any) => {});
@@ -111,7 +111,7 @@ describe("Connection & Initialization", () => {
 
   test("should create database file if it doesn't exist", async () => {
     await using dir = tempDir("sqlite-create-test", {});
-    const dbPath = path.join(dir, "new.db");
+    const dbPath = path.join(String(dir), "new.db");
 
     const sql = new SQL(`sqlite://${dbPath}`);
     await sql`CREATE TABLE test (id INTEGER)`;
@@ -127,11 +127,11 @@ describe("Connection & Initialization", () => {
     await using dir = tempDir("sqlite-test", {});
     const sql = new SQL({
       adapter: "sqlite",
-      filename: path.join(dir, "test.db"),
+      filename: path.join(String(dir), "test.db"),
     });
 
     await sql`CREATE TABLE test (id INTEGER)`;
-    const stats = await stat(path.join(dir, "test.db"));
+    const stats = await stat(path.join(String(dir), "test.db"));
     expect(stats.isFile()).toBe(true);
 
     await sql.close();
@@ -159,7 +159,7 @@ describe("Connection & Initialization", () => {
 
     test("should use DATABASE_URL for SQLite when it's a SQLite URL", async () => {
       await using dir = tempDir("sqlite-env-test", {});
-      const dbPath = path.join(dir, "env-test.db");
+      const dbPath = path.join(String(dir), "env-test.db");
 
       Bun.env.DATABASE_URL = `sqlite://${dbPath}`;
 
@@ -192,7 +192,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle SQLITE_URL env var when specified", async () => {
       await using dir = tempDir("sqlite-url-test", {});
-      const dbPath = path.join(dir, "sqlite-url.db");
+      const dbPath = path.join(String(dir), "sqlite-url.db");
 
       // This doesn't exist in the current implementation but testing anyway
       Bun.env.SQLITE_URL = `sqlite://${dbPath}`;
@@ -288,7 +288,7 @@ describe("Connection & Initialization", () => {
   describe("file:// Protocol URLs", () => {
     test("should handle file:// URLs", async () => {
       await using dir = tempDir("file-protocol-test", {});
-      const dbPath = path.join(dir, "file-test.db");
+      const dbPath = path.join(String(dir), "file-test.db");
 
       const sql = new SQL(`file://${dbPath}`);
       expect(sql.options.adapter).toBe("sqlite");
@@ -304,7 +304,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle file: URLs without slashes", async () => {
       await using dir = tempDir("file-no-slash-test", {});
-      const dbPath = path.join(dir, "file-noslash.db");
+      const dbPath = path.join(String(dir), "file-noslash.db");
 
       const sql = new SQL(`file:${dbPath}`);
       expect(sql.options.adapter).toBe("sqlite");
@@ -329,7 +329,7 @@ describe("Connection & Initialization", () => {
   describe("Query Parameters in SQLite URLs", () => {
     test("should handle mode=ro (readonly)", async () => {
       await using dir = tempDir("readonly-test", {});
-      const dbPath = path.join(dir, "readonly.db");
+      const dbPath = path.join(String(dir), "readonly.db");
 
       // First create a database
       const createSql = new SQL(`sqlite://${dbPath}`);
@@ -356,7 +356,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle mode=rw (read-write)", async () => {
       await using dir = tempDir("readwrite-test", {});
-      const dbPath = path.join(dir, "readwrite.db");
+      const dbPath = path.join(String(dir), "readwrite.db");
 
       // Create database first
       const createSql = new SQL(`sqlite://${dbPath}`);
@@ -377,7 +377,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle mode=rwc (read-write-create)", async () => {
       await using dir = tempDir("rwc-test", {});
-      const dbPath = path.join(dir, "rwc.db");
+      const dbPath = path.join(String(dir), "rwc.db");
 
       const sql = new SQL(`sqlite://${dbPath}?mode=rwc`);
       expect(sql.options.adapter).toBe("sqlite");
@@ -395,7 +395,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle multiple query parameters", async () => {
       await using dir = tempDir("multi-param-test", {});
-      const dbPath = path.join(dir, "multi.db");
+      const dbPath = path.join(String(dir), "multi.db");
 
       // Note: Only mode is supported for SQLite, other params should be ignored
       const sql = new SQL(`sqlite://${dbPath}?mode=rwc&cache=shared&timeout=5000`);
@@ -409,7 +409,7 @@ describe("Connection & Initialization", () => {
 
     test("should ignore fragment in URL", async () => {
       await using dir = tempDir("fragment-test", {});
-      const dbPath = path.join(dir, "test#file.db");
+      const dbPath = path.join(String(dir), "test#file.db");
 
       // # is a valid filename character in SQLite
       const sql = new SQL(`sqlite://${dbPath}`);
@@ -428,7 +428,7 @@ describe("Connection & Initialization", () => {
   describe("Special Characters in Filenames", () => {
     test("should handle spaces in filename", async () => {
       await using dir = tempDir("space-test", {});
-      const dbPath = path.join(dir, "test database.db");
+      const dbPath = path.join(String(dir), "test database.db");
 
       const sql = new SQL(`sqlite://${dbPath}`);
       expect(sql.options.adapter).toBe("sqlite");
@@ -444,7 +444,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle special characters # and % in filename", async () => {
       await using dir = tempDir("special-chars-test", {});
-      const dbPath = path.join(dir, "test#123%data.db");
+      const dbPath = path.join(String(dir), "test#123%data.db");
 
       const sql = new SQL(`sqlite://${dbPath}`);
       expect(sql.options.adapter).toBe("sqlite");
@@ -460,7 +460,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle unicode characters in filename", async () => {
       await using dir = tempDir("unicode-test", {});
-      const dbPath = path.join(dir, "测试数据库.db");
+      const dbPath = path.join(String(dir), "测试数据库.db");
 
       const sql = new SQL(`sqlite://${dbPath}`);
       expect(sql.options.adapter).toBe("sqlite");
@@ -476,7 +476,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle dots in filename", async () => {
       await using dir = tempDir("dots-test", {});
-      const dbPath = path.join(dir, "my.app.v2.0.db");
+      const dbPath = path.join(String(dir), "my.app.v2.0.db");
 
       const sql = new SQL(`sqlite://${dbPath}`);
       expect(sql.options.adapter).toBe("sqlite");
@@ -494,7 +494,7 @@ describe("Connection & Initialization", () => {
   describe("Path Handling", () => {
     test("should handle absolute paths", async () => {
       await using dir = tempDir("absolute-test", {});
-      const dbPath = path.resolve(dir, "absolute.db");
+      const dbPath = path.resolve(String(dir), "absolute.db");
 
       const sql = new SQL(`sqlite://${dbPath}`);
       expect(sql.options.adapter).toBe("sqlite");
@@ -520,7 +520,7 @@ describe("Connection & Initialization", () => {
         expect(sql.options.filename).toBe("./test.db");
 
         await sql`CREATE TABLE test (id INTEGER)`;
-        const stats = await stat(path.join(dir, "test.db"));
+        const stats = await stat(path.join(String(dir), "test.db"));
         expect(stats.isFile()).toBe(true);
 
         await sql.close();
@@ -532,7 +532,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle paths with ../", async () => {
       await using parentDir = tempDir("parent-test", {});
-      const childDir = path.join(parentDir, "child");
+      const childDir = path.join(String(parentDir), "child");
       await Bun.$`mkdir -p ${childDir}`;
       const originalCwd = process.cwd();
 
@@ -544,7 +544,7 @@ describe("Connection & Initialization", () => {
         expect(sql.options.filename).toBe("../parent.db");
 
         await sql`CREATE TABLE test (id INTEGER)`;
-        const stats = await stat(path.join(parentDir, "parent.db"));
+        const stats = await stat(path.join(String(parentDir), "parent.db"));
         expect(stats.isFile()).toBe(true);
 
         await sql.close();
@@ -556,7 +556,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle nested paths", async () => {
       await using dir = tempDir("nested-test", {});
-      const nestedPath = path.join(dir, "data", "databases", "app.db");
+      const nestedPath = path.join(String(dir), "data", "databases", "app.db");
       await Bun.$`mkdir -p ${path.dirname(nestedPath)}`;
 
       const sql = new SQL(`sqlite://${nestedPath}`);
@@ -624,8 +624,8 @@ describe("Connection & Initialization", () => {
   describe("Mixed Configurations", () => {
     test("should prefer explicit URL over env var", async () => {
       await using dir = tempDir("explicit-test", {});
-      const envPath = path.join(dir, "env.db");
-      const explicitPath = path.join(dir, "explicit.db");
+      const envPath = path.join(String(dir), "env.db");
+      const explicitPath = path.join(String(dir), "explicit.db");
 
       Bun.env.DATABASE_URL = `sqlite://${envPath}`;
 
@@ -644,8 +644,8 @@ describe("Connection & Initialization", () => {
 
     test("should prefer options object over URL", async () => {
       await using dir = tempDir("options-override-test", {});
-      const urlPath = path.join(dir, "url.db");
-      const optionsPath = path.join(dir, "options.db");
+      const urlPath = path.join(String(dir), "url.db");
+      const optionsPath = path.join(String(dir), "options.db");
 
       const sql = new SQL(`sqlite://${urlPath}`, {
         adapter: "sqlite",
@@ -665,7 +665,7 @@ describe("Connection & Initialization", () => {
 
     test("should handle URL in options object", async () => {
       await using dir = tempDir("url-in-options-test", {});
-      const dbPath = path.join(dir, "url-options.db");
+      const dbPath = path.join(String(dir), "url-options.db");
 
       const sql = new SQL({
         adapter: "sqlite",
@@ -700,7 +700,7 @@ describe("Connection & Initialization", () => {
 
     test("SQLite readonly mode creates connection but fails on missing file access", async () => {
       await using dir = tempDir("ro-nonexist-test", {});
-      const dbPath = path.join(dir, "nonexistent.db");
+      const dbPath = path.join(String(dir), "nonexistent.db");
 
       const sql = new SQL(`sqlite://${dbPath}?mode=ro`);
       expect(sql.options.adapter).toBe("sqlite");
@@ -1333,7 +1333,7 @@ describe("SQLite-specific features", () => {
 
   test("ATTACH DATABASE", async () => {
     await using dir = tempDir("sqlite-attach-test", {});
-    const attachPath = path.join(dir, "attached.db");
+    const attachPath = path.join(String(dir), "attached.db");
 
     await sql`ATTACH DATABASE ${attachPath} AS attached`;
     await sql`CREATE TABLE attached.other_table (id INTEGER)`;
@@ -1689,9 +1689,9 @@ describe("SQL helpers", () => {
       "query.sql": `SELECT COUNT(*) as count FROM file_test`,
     });
 
-    await sql.file(path.join(dir, "schema.sql"));
+    await sql.file(path.join(String(dir), "schema.sql"));
 
-    const result = await sql.file(path.join(dir, "query.sql"));
+    const result = await sql.file(path.join(String(dir), "query.sql"));
     expect(result[0].count).toBe(3);
   });
 
@@ -1700,7 +1700,7 @@ describe("SQL helpers", () => {
       "query.sql": `SELECT ? as param1, ? as param2`,
     });
 
-    const result = await sql.file(path.join(dir, "query.sql"), ["value1", "value2"]);
+    const result = await sql.file(path.join(String(dir), "query.sql"), ["value1", "value2"]);
     expect(result[0].param1).toBe("value1");
     expect(result[0].param2).toBe("value2");
   });
@@ -1714,7 +1714,7 @@ describe("SQL helpers", () => {
     await strictSql`CREATE TABLE file_named_test (id INTEGER, name TEXT)`;
     await strictSql.unsafe("INSERT INTO file_named_test VALUES (:id, :name)", { id: 1, name: "Alice" });
 
-    const result = await strictSql.file(path.join(dir, "query.sql"), { name: "Alice" });
+    const result = await strictSql.file(path.join(String(dir), "query.sql"), { name: "Alice" });
     expect(result).toEqual([{ id: 1, name: "Alice" }]);
 
     // Non-strict connections use the same file with prefixed keys.
@@ -1722,7 +1722,7 @@ describe("SQL helpers", () => {
     await defaultSql`CREATE TABLE file_named_test (id INTEGER, name TEXT)`;
     await defaultSql.unsafe("INSERT INTO file_named_test VALUES (:id, :name)", { ":id": 2, ":name": "Bob" });
 
-    const defaultResult = await defaultSql.file(path.join(dir, "query.sql"), { ":name": "Bob" });
+    const defaultResult = await defaultSql.file(path.join(String(dir), "query.sql"), { ":name": "Bob" });
     expect(defaultResult).toEqual([{ id: 2, name: "Bob" }]);
   });
 });
@@ -2180,7 +2180,7 @@ describe("Performance & Edge Cases", () => {
 describe("WAL mode and concurrency", () => {
   test("can enable WAL mode", async () => {
     await using dir = tempDir("sqlite-wal-test", {});
-    const dbPath = path.join(dir, "wal-test.db");
+    const dbPath = path.join(String(dir), "wal-test.db");
     const sql = new SQL(`sqlite://${dbPath}`);
 
     await sql`PRAGMA journal_mode = WAL`;
@@ -2291,7 +2291,7 @@ describe("Connection URL Edge Cases", () => {
   test("handles various file:// URL formats", async () => {
     await using dir = tempDir("sqlite-url-test", {});
 
-    const dbPath1 = path.join(dir, "test1.db");
+    const dbPath1 = path.join(String(dir), "test1.db");
     const sql1 = new SQL(`file://${dbPath1}`);
     await sql1`CREATE TABLE test (id INTEGER)`;
     await sql1`INSERT INTO test VALUES (1)`;
@@ -2299,7 +2299,7 @@ describe("Connection URL Edge Cases", () => {
     expect(result1).toHaveLength(1);
     await sql1.close();
 
-    const dbPath2 = path.join(dir, "test2.db");
+    const dbPath2 = path.join(String(dir), "test2.db");
     const sql2 = new SQL(`file:${dbPath2}`);
     await sql2`CREATE TABLE test (id INTEGER)`;
     await sql2.close();
@@ -2325,7 +2325,7 @@ describe("Connection URL Edge Cases", () => {
 
     for (const name of specialNames) {
       await using dir = tempDir(`sqlite-special-${Math.random()}`, {});
-      const dbPath = path.join(dir, name);
+      const dbPath = path.join(String(dir), name);
 
       const sql = new SQL(`sqlite://${dbPath}`);
       await sql`CREATE TABLE test (id INTEGER)`;
@@ -2334,7 +2334,7 @@ describe("Connection URL Edge Cases", () => {
       const result = await sql`SELECT * FROM test`;
       expect(result).toHaveLength(1);
 
-      expect(sql.options.filename).toBe(join(dir, name));
+      expect(sql.options.filename).toBe(join(String(dir), name));
 
       await sql.close();
       await rm(dir, { recursive: true });
@@ -2352,9 +2352,9 @@ describe("Connection URL Edge Cases", () => {
       await sql1`CREATE TABLE test (id INTEGER)`;
       await sql1.close();
 
-      expect(existsSync(path.join(dir, "relative.db"))).toBe(true);
+      expect(existsSync(path.join(String(dir), "relative.db"))).toBe(true);
 
-      const absPath = path.join(dir, "absolute.db");
+      const absPath = path.join(String(dir), "absolute.db");
       const sql2 = new SQL(`sqlite://${absPath}`);
       await sql2`CREATE TABLE test (id INTEGER)`;
       await sql2.close();
@@ -2368,7 +2368,7 @@ describe("Connection URL Edge Cases", () => {
 
   test("handles readonly mode via URL parameters", async () => {
     await using dir = tempDir("sqlite-readonly-test", {});
-    const dbPath = path.join(dir, "readonly.db");
+    const dbPath = path.join(String(dir), "readonly.db");
 
     const sql1 = new SQL(`sqlite://${dbPath}`);
     await sql1`CREATE TABLE test (id INTEGER)`;
@@ -2394,7 +2394,7 @@ describe("Connection URL Edge Cases", () => {
 
   test("handles URI parameters for cache and other settings", async () => {
     await using dir = tempDir("sqlite-uri-test", {});
-    const dbPath = path.join(dir, "uri.db");
+    const dbPath = path.join(String(dir), "uri.db");
 
     const sql = new SQL(`sqlite://${dbPath}?cache=shared&mode=rwc`);
 
@@ -2796,7 +2796,7 @@ describe("Indexes and Query Optimization", () => {
 describe("VACUUM and Database Maintenance", () => {
   test("VACUUM command", async () => {
     await using dir = tempDir("sqlite-vacuum-test", {});
-    const dbPath = path.join(dir, "vacuum.db");
+    const dbPath = path.join(String(dir), "vacuum.db");
     const sql = new SQL(`sqlite://${dbPath}`);
 
     await sql`CREATE TABLE vacuum_test (id INTEGER, data TEXT)`;
@@ -2825,7 +2825,7 @@ describe("VACUUM and Database Maintenance", () => {
 
   test("incremental VACUUM with auto_vacuum", async () => {
     await using dir = tempDir("sqlite-auto-vacuum-test", {});
-    const dbPath = path.join(dir, "auto_vacuum.db");
+    const dbPath = path.join(String(dir), "auto_vacuum.db");
     const sql = new SQL(`sqlite://${dbPath}`);
 
     await sql`PRAGMA auto_vacuum = 2`;
@@ -2853,8 +2853,8 @@ describe("VACUUM and Database Maintenance", () => {
 describe("Backup and Restore Operations", () => {
   test("backup to another file", async () => {
     await using dir = tempDir("sqlite-backup-test", {});
-    const sourcePath = path.join(dir, "source.db");
-    const backupPath = path.join(dir, "backup.db");
+    const sourcePath = path.join(String(dir), "source.db");
+    const backupPath = path.join(String(dir), "backup.db");
 
     const source = new SQL(`sqlite://${sourcePath}`);
 
@@ -3323,7 +3323,7 @@ describe("WITHOUT ROWID Tables", () => {
 describe("Concurrency and Locking", () => {
   test("concurrent reads work correctly", async () => {
     await using dir = tempDir("sqlite-concurrent-test", {});
-    const dbPath = path.join(dir, "concurrent.db");
+    const dbPath = path.join(String(dir), "concurrent.db");
 
     const sql1 = new SQL(`sqlite://${dbPath}`);
     await sql1`CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)`;
@@ -3355,7 +3355,7 @@ describe("Concurrency and Locking", () => {
 
   test("write lock prevents concurrent writes", async () => {
     await using dir = tempDir("sqlite-write-lock-test", {});
-    const dbPath = path.join(dir, "writelock.db");
+    const dbPath = path.join(String(dir), "writelock.db");
 
     const sql = new SQL(`sqlite://${dbPath}`);
     await sql`CREATE TABLE counter (id INTEGER PRIMARY KEY, value INTEGER)`;
@@ -3387,7 +3387,7 @@ describe("Concurrency and Locking", () => {
 
   test("busy timeout handling", async () => {
     await using dir = tempDir("sqlite-busy-test", {});
-    const dbPath = path.join(dir, "busy.db");
+    const dbPath = path.join(String(dir), "busy.db");
 
     const sql1 = new SQL(`sqlite://${dbPath}`);
     await sql1`CREATE TABLE test (id INTEGER PRIMARY KEY, value TEXT)`;
@@ -3982,7 +3982,7 @@ describe("System Tables and Introspection", () => {
 describe("Error Recovery and Database Integrity", () => {
   test("handles corrupted data gracefully", async () => {
     await using dir = tempDir("sqlite-corrupt-test", {});
-    const dbPath = path.join(dir, "test.db");
+    const dbPath = path.join(String(dir), "test.db");
     const sql = new SQL(`sqlite://${dbPath}`);
 
     await sql`CREATE TABLE test (id INTEGER PRIMARY KEY, data TEXT)`;
@@ -4073,8 +4073,8 @@ describe("Temp Tables and Attached Databases", () => {
 
   test("cross-database queries with ATTACH", async () => {
     await using dir = tempDir("sqlite-attach-cross-test", {});
-    const mainPath = path.join(dir, "main.db");
-    const attachPath = path.join(dir, "attached.db");
+    const mainPath = path.join(String(dir), "main.db");
+    const attachPath = path.join(String(dir), "attached.db");
 
     const mainSql = new SQL(`sqlite://${mainPath}`);
     await mainSql`CREATE TABLE main_table (id INTEGER, data TEXT)`;

--- a/test/js/third_party/body-parser/express-bun-build-compile.test.ts
+++ b/test/js/third_party/body-parser/express-bun-build-compile.test.ts
@@ -12,7 +12,7 @@ test("Express hello world app supports bun build --compile --minify --sourcemap"
     "out.exe": "",
   });
 
-  const file = join(dir, "out.exe");
+  const file = join(String(dir), "out.exe");
   await $`${bunExe()} build --compile --minify --sourcemap ${join(import.meta.dir, "express-compile-fixture.ts")} --outfile=${file}`;
   await $`${file}`;
 });

--- a/test/js/web/fetch/blob-write.test.ts
+++ b/test/js/web/fetch/blob-write.test.ts
@@ -43,16 +43,16 @@ test("blob.delete() throws for data-backed blob", () => {
 
 test("Bun.file(path).unlink() does not throw", async () => {
   await using dir = tempDir("bun-unlink", { a: "Hello, world!" });
-  const file = Bun.file(path.join(dir, "a"));
+  const file = Bun.file(path.join(String(dir), "a"));
   expect(file.unlink()).resolves.toBeUndefined();
-  expect(await Bun.file(path.join(dir, "a")).exists()).toBe(false);
+  expect(await Bun.file(path.join(String(dir), "a")).exists()).toBe(false);
 });
 
 test("Bun.file(path).delete() does not throw", async () => {
   await using dir = tempDir("bun-unlink", { a: "Hello, world!" });
-  const file = Bun.file(path.join(dir, "a"));
+  const file = Bun.file(path.join(String(dir), "a"));
   expect(file.delete()).resolves.toBeUndefined();
-  expect(await Bun.file(path.join(dir, "a")).exists()).toBe(false);
+  expect(await Bun.file(path.join(String(dir), "a")).exists()).toBe(false);
 });
 
 test("blob.writer() throws for data-backed blob", () => {
@@ -91,7 +91,7 @@ test("blob.stat() returns undefined for data-backed blob", async () => {
 
 test("Bun.file(path).stat() returns stats", async () => {
   await using dir = tempDir("bun-stat", { a: "Hello, world!" });
-  const file = Bun.file(path.join(dir, "a"));
+  const file = Bun.file(path.join(String(dir), "a"));
   const stat = await file.stat();
   expect(stat).toBeDefined();
   expect(stat.size).toBe(13); // "Hello, world!" is 13 bytes

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -100,7 +100,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
 
         for (let exec of target === "bun" ? [bunExe()] : [bunExe(), await nodeExeMatchingAbi()]) {
           const result = spawnSync({
-            cmd: [exec, join(dir, "main.js"), "self"],
+            cmd: [exec, join(String(dir), "main.js"), "self"],
             env: bunEnv,
             stdin: "inherit",
             stderr: "inherit",
@@ -124,7 +124,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
               }),
             });
 
-            const exe = join(dir, "main" + (process.platform === "win32" ? ".exe" : ""));
+            const exe = join(String(dir), "main" + (process.platform === "win32" ? ".exe" : ""));
             const build = spawnSync({
               cmd: [
                 bunExe(),
@@ -191,7 +191,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
 
         for (let exec of target === "bun" ? [bunExe()] : [bunExe(), await nodeExeMatchingAbi()]) {
           const result = spawnSync({
-            cmd: [exec, join(dir, "main.js"), "self"],
+            cmd: [exec, join(String(dir), "main.js"), "self"],
             env: bunEnv,
             stdin: "inherit",
             stderr: "inherit",

--- a/test/regression/issue/09555.test.ts
+++ b/test/regression/issue/09555.test.ts
@@ -130,8 +130,8 @@ describe("#09555", () => {
     await using dir = tempDir("09555", {
       "/file.blob": full,
     });
-    await Bun.write(join(dir, "file.blob"), full);
-    const web = Bun.file(join(dir, "file.blob")).stream();
+    await Bun.write(join(String(dir), "file.blob"), full);
+    const web = Bun.file(join(String(dir), "file.blob")).stream();
     const stream = Readable.fromWeb(web);
 
     const chunks = [];

--- a/test/regression/issue/09559.test.ts
+++ b/test/regression/issue/09559.test.ts
@@ -15,8 +15,8 @@ test("bun build --target bun should support non-ascii source", async () => {
   await using source = tempDir("source", files);
 
   $.throws(true);
-  await $`${bunExe()} build --target bun ${join(source, "index.js")} --outfile ${join(source, "bundle.js")}`;
-  const result = await $`${bunExe()} ${join(source, "bundle.js")}`.text();
+  await $`${bunExe()} build --target bun ${join(String(source), "index.js")} --outfile ${join(String(source), "bundle.js")}`;
+  const result = await $`${bunExe()} ${join(String(source), "bundle.js")}`.text();
 
   expect(result).toBe(`{"\u{6211}":"a"}\n{"\u{6211}":"b"}\n`);
 });

--- a/test/regression/issue/11664.test.ts
+++ b/test/regression/issue/11664.test.ts
@@ -42,5 +42,5 @@ test.concurrent("does not segfault", async () => {
       },
     }),
   });
-  expect(await bunRun(join(dir, "dir/a.ts"))).toSpawn();
+  expect(await bunRun(join(String(dir), "dir/a.ts"))).toSpawn();
 });

--- a/test/regression/issue/22317.test.ts
+++ b/test/regression/issue/22317.test.ts
@@ -14,8 +14,12 @@ test("issue 22317: build with CSS file entry points mixed with JS should not cra
   });
 
   const result = await Bun.build({
-    entrypoints: [join(dir, "src/index.ts"), join(dir, "public/assets/index.css"), join(dir, "src/server.worker.ts")],
-    outdir: join(dir, "build"),
+    entrypoints: [
+      join(String(dir), "src/index.ts"),
+      join(String(dir), "public/assets/index.css"),
+      join(String(dir), "src/server.worker.ts"),
+    ],
+    outdir: join(String(dir), "build"),
   });
 
   expect(result.success).toBeTrue();

--- a/test/regression/issue/23649.test.ts
+++ b/test/regression/issue/23649.test.ts
@@ -19,7 +19,7 @@ const object = {
   });
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "build", join(dir, "input.js")],
+    cmd: [bunExe(), "build", join(String(dir), "input.js")],
     env: bunEnv,
     cwd: dir,
     stdout: "pipe",
@@ -74,7 +74,7 @@ b: async function(first) {
   });
 
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "build", join(dir, "input.js")],
+    cmd: [bunExe(), "build", join(String(dir), "input.js")],
     env: bunEnv,
     cwd: dir,
     stdout: "pipe",

--- a/test/regression/issue/25716.test.ts
+++ b/test/regression/issue/25716.test.ts
@@ -22,7 +22,7 @@ test.each(["browser", "bun"] as const)("Bun.build reactFastRefresh works with ta
 
   // With reactFastRefresh: true, output should contain $RefreshReg$ and $RefreshSig$
   const buildEnabled = await Bun.build({
-    entrypoints: [join(dir, "component.tsx")],
+    entrypoints: [join(String(dir), "component.tsx")],
     reactFastRefresh: true,
     target,
     external: ["react"],
@@ -37,7 +37,7 @@ test.each(["browser", "bun"] as const)("Bun.build reactFastRefresh works with ta
 
   // Without reactFastRefresh (default), output should NOT contain refresh calls
   const buildDisabled = await Bun.build({
-    entrypoints: [join(dir, "component.tsx")],
+    entrypoints: [join(String(dir), "component.tsx")],
     target,
     external: ["react"],
   });

--- a/test/regression/issue/26647.test.ts
+++ b/test/regression/issue/26647.test.ts
@@ -11,7 +11,7 @@ test("Bun.file().stat() should handle UTF-8 paths with German umlauts", async ()
   await using dir = tempDir("utf8-german-umlaut", {
     "über café résumé.txt": content,
   });
-  const filepath = join(dir, "über café résumé.txt");
+  const filepath = join(String(dir), "über café résumé.txt");
 
   // Verify Node.js fs works correctly
   expect(existsSync(filepath)).toBe(true);
@@ -32,7 +32,7 @@ test("Bun.file().stat() should handle UTF-8 paths with Japanese characters", asy
   await using dir = tempDir("utf8-japanese", {
     "日本語ファイル.txt": content,
   });
-  const filepath = join(dir, "日本語ファイル.txt");
+  const filepath = join(String(dir), "日本語ファイル.txt");
 
   expect(existsSync(filepath)).toBe(true);
   const bunStat = await Bun.file(filepath).stat();
@@ -46,7 +46,7 @@ test("Bun.file().stat() should handle UTF-8 paths with emoji", async () => {
   await using dir = tempDir("utf8-emoji", {
     "🌟.txt": content,
   });
-  const filepath = join(dir, "🌟.txt");
+  const filepath = join(String(dir), "🌟.txt");
 
   expect(existsSync(filepath)).toBe(true);
   const bunStat = await Bun.file(filepath).stat();
@@ -60,7 +60,7 @@ test("Bun.file().stat() should handle UTF-8 paths with mixed special characters"
   await using dir = tempDir("utf8-mixed", {
     "café_résumé_ñ_test.md": content,
   });
-  const filepath = join(dir, "café_résumé_ñ_test.md");
+  const filepath = join(String(dir), "café_résumé_ñ_test.md");
 
   expect(existsSync(filepath)).toBe(true);
   const bunStat = await Bun.file(filepath).stat();
@@ -73,7 +73,7 @@ test("Bun.file().delete() should handle UTF-8 paths", async () => {
   await using dir = tempDir("utf8-unlink", {
     "delete_üñíçödé.txt": "delete me",
   });
-  const filepath = join(dir, "delete_üñíçödé.txt");
+  const filepath = join(String(dir), "delete_üñíçödé.txt");
 
   expect(existsSync(filepath)).toBe(true);
 
@@ -90,7 +90,7 @@ test("Bun.file().text() should handle UTF-8 paths with special characters", asyn
   await using dir = tempDir("utf8-text", {
     "read_äöü.txt": content,
   });
-  const filepath = join(dir, "read_äöü.txt");
+  const filepath = join(String(dir), "read_äöü.txt");
 
   const text = await Bun.file(filepath).text();
   expect(text).toBe(content);

--- a/test/regression/issue/3657.test.ts
+++ b/test/regression/issue/3657.test.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 describe.skipIf(!isLinux)("GitHub Issue #3657", () => {
   test("fs.watch on directory emits 'change' events for files created after watch starts", async () => {
     await using testDir = tempDir("issue-3657", {});
-    const testFile = path.join(testDir, "test.txt");
+    const testFile = path.join(String(testDir), "test.txt");
 
     const events: Array<{ eventType: string; filename: string | null }> = [];
     let resolver: () => void;
@@ -58,7 +58,7 @@ describe.skipIf(!isLinux)("GitHub Issue #3657", () => {
 
   test("fs.watch emits multiple 'change' events for repeated modifications", async () => {
     await using testDir = tempDir("issue-3657-multi", {});
-    const testFile = path.join(testDir, "multi.txt");
+    const testFile = path.join(String(testDir), "multi.txt");
 
     const events: Array<{ eventType: string; filename: string | null }> = [];
     let resolver: () => void;

--- a/test/regression/issue/8254.test.ts
+++ b/test/regression/issue/8254.test.ts
@@ -12,7 +12,7 @@ test("Bun.write() should write past 2GB boundary without corruption", async () =
   const CHUNK_SIZE = 1024 * 1024; // 1MB
   // Force a second write iteration by crossing the 2GB boundary
   const NUM_CHUNKS = Math.floor(TWO_GB / CHUNK_SIZE) + 1;
-  const path = join(tmpbase, "large-file.bin");
+  const path = join(String(tmpbase), "large-file.bin");
 
   // Only 256 distinct fill values exist, so back the >2GB part list with 256
   // shared 1MB buffers instead of 2049 distinct ones. The blob is still >2GB

--- a/test/regression/issue/ctrl-c.test.ts
+++ b/test/regression/issue/ctrl-c.test.ts
@@ -35,7 +35,7 @@ test.skipIf(isWindows)("verify that we can call sigint 4096 times", () => {
   });
 
   const result = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "index.js")],
+    cmd: [bunExe(), join(String(dir), "index.js")],
     cwd: dir,
     env: bunEnv,
     stdout: "inherit",

--- a/test/regression/issue/cyclic-imports-async-bundler.test.js
+++ b/test/regression/issue/cyclic-imports-async-bundler.test.js
@@ -87,7 +87,7 @@ test("cyclic imports with async dependencies should generate async wrappers", as
   await buildResult.exited;
 
   // Read the bundled output
-  const bundledPath = join(dir, "dist", "entryBuild.js");
+  const bundledPath = join(String(dir), "dist", "entryBuild.js");
   const bundled = await Bun.file(bundledPath).text();
 
   expect(bundled).toMatchInlineSnapshot(`

--- a/test/regression/issue/hashbang-still-works.test.ts
+++ b/test/regression/issue/hashbang-still-works.test.ts
@@ -32,7 +32,7 @@ describe.concurrent("hashbang-still-works", () => {
     // Using Bun.build to exercise the lexer directly
     try {
       await Bun.build({
-        entrypoints: [path.join(dir, "single-hash.js")],
+        entrypoints: [path.join(String(dir), "single-hash.js")],
         target: "node",
       });
       expect.unreachable();

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -8,7 +8,7 @@ test("Invalid escape sequence \\x in identifier shows helpful error message", as
   });
 
   const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "test.js")],
+    cmd: [bunExe(), join(String(dir), "test.js")],
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
@@ -28,7 +28,7 @@ test("Invalid escaped double quote in identifier shows helpful error message", a
   });
 
   const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "test.js")],
+    cmd: [bunExe(), join(String(dir), "test.js")],
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
@@ -48,7 +48,7 @@ test("Invalid escaped single quote in identifier shows helpful error message", a
   });
 
   const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "test.js")],
+    cmd: [bunExe(), join(String(dir), "test.js")],
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
@@ -68,7 +68,7 @@ test("Invalid escaped backtick in identifier shows helpful error message", async
   });
 
   const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "test.js")],
+    cmd: [bunExe(), join(String(dir), "test.js")],
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
@@ -88,7 +88,7 @@ test("Invalid escaped backslash in identifier shows helpful error message", asyn
   });
 
   const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "test.js")],
+    cmd: [bunExe(), join(String(dir), "test.js")],
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
@@ -108,7 +108,7 @@ test("Invalid escaped z in identifier shows helpful error message", async () => 
   });
 
   const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "test.js")],
+    cmd: [bunExe(), join(String(dir), "test.js")],
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
@@ -137,7 +137,7 @@ test("invalid \\x followed by multi-byte codepoint does not panic (#30893)", asy
   });
 
   const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "test.js")],
+    cmd: [bunExe(), join(String(dir), "test.js")],
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
@@ -157,7 +157,7 @@ test("invalid \\x with second hex digit being multi-byte codepoint does not pani
   });
 
   const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "test.js")],
+    cmd: [bunExe(), join(String(dir), "test.js")],
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
@@ -175,7 +175,7 @@ test("invalid \\u followed by multi-byte codepoint does not panic (#30893)", asy
   });
 
   const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "test.js")],
+    cmd: [bunExe(), join(String(dir), "test.js")],
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
@@ -193,7 +193,7 @@ test("invalid \\u{ followed by multi-byte codepoint does not panic (#30893)", as
   });
 
   const { stderr, exitCode } = Bun.spawnSync({
-    cmd: [bunExe(), join(dir, "test.js")],
+    cmd: [bunExe(), join(String(dir), "test.js")],
     env: bunEnv,
     stderr: "pipe",
     stdout: "pipe",
@@ -212,7 +212,7 @@ test("Valid unicode escapes in identifiers should work", async () => {
     });
 
     const { stdout, exitCode } = Bun.spawnSync({
-      cmd: [bunExe(), join(dir, "valid1.js")],
+      cmd: [bunExe(), join(String(dir), "valid1.js")],
       env: bunEnv,
       stderr: "pipe",
       stdout: "pipe",
@@ -230,7 +230,7 @@ test("Valid unicode escapes in identifiers should work", async () => {
     });
 
     const { stdout, exitCode } = Bun.spawnSync({
-      cmd: [bunExe(), join(dir, "valid2.js")],
+      cmd: [bunExe(), join(String(dir), "valid2.js")],
       env: bunEnv,
       stderr: "pipe",
       stdout: "pipe",
@@ -326,7 +326,7 @@ describe("invalid-escape caret points at the backslash (#31134)", () => {
   test.each(cases)("$name → column $expectCol", ({ source, msg, pattern, expectCol }) => {
     using dir = tempDir("caret-pos", { "test.js": source });
     const { stderr, exitCode } = Bun.spawnSync({
-      cmd: [bunExe(), join(dir, "test.js")],
+      cmd: [bunExe(), join(String(dir), "test.js")],
       env: bunEnv,
       stderr: "pipe",
       stdout: "pipe",
@@ -368,7 +368,7 @@ describe("pathological `\\u{...}` escapes (#30825)", () => {
   const run = (source: string) => {
     using dir = tempDir("u-brace", { "test.js": source });
     const { stdout, stderr, exitCode } = Bun.spawnSync({
-      cmd: [bunExe(), join(dir, "test.js")],
+      cmd: [bunExe(), join(String(dir), "test.js")],
       env: bunEnv,
       stderr: "pipe",
       stdout: "pipe",

--- a/test/regression/issue/minify-new-array-with-if.test.ts
+++ b/test/regression/issue/minify-new-array-with-if.test.ts
@@ -9,12 +9,12 @@ test("minifying new Array(if (0) 1 else 2) works", async () => {
   });
 
   await build({
-    entrypoints: [join(testDir, "entry.js")],
+    entrypoints: [join(String(testDir), "entry.js")],
     minify: true,
-    outdir: join(testDir, "outdir"),
+    outdir: join(String(testDir), "outdir"),
   });
 
-  expect(await file(join(testDir, "outdir/entry.js")).text()).toMatchInlineSnapshot(`
+  expect(await file(join(String(testDir), "outdir/entry.js")).text()).toMatchInlineSnapshot(`
     "console.log(Array(Math.random()>-1?1:2));
     "
   `);


### PR DESCRIPTION
### Problem
- `tempDir()` in test/harness.ts returns a `DisposableString` (a `String` subclass, so that `using dir = tempDir(...)` can remove the directory when the test ends).
- About 660 call sites in 86 test files pass that object straight into `path.join()` / `path.resolve()` / `path.basename()` and friends. Node rejects a `String` object there with `ERR_INVALID_ARG_TYPE` (`validateString` only accepts primitives); Bun's current `node:path` happens to coerce it, which is the only reason these call sites work.
- #37305 makes Bun's `node:path` validate like Node, and these tests are what fails on its CI (see its review thread). The call sites are wrong in either case, so this migrates them separately from that PR.

### Fix
- Wrap the handle in `String(...)` where it reaches a `node:path` function. This is already how the rest of the suite does it (about 920 existing `join(String(dir), ...)` sites on main), so no new pattern is introduced.
- `VerdaccioRegistry.createTestDir()` in harness.ts converts once instead of joining on the handle and converting only on return.
- Most sites are the handle itself; in a few files the handle goes through a local helper, and the wrap is inside the helper (`bun-audit.test.ts`, `bun-pm-pkg.test.ts`) or at the one call that hands it to a callback (`inspect.test.ts`, `fs-stat-seccomp-linux.test.ts`).
- No test logic changes; the diff is the wraps plus prettier's reflow of a few lines that got longer.
- Verified: the affected files were run against a build of #37305 (which throws on `String` objects); before this change 80 of them failed with `Received an instance of DisposableString`, after it none do. They were also run with the current release, where they pass as before. The site list was produced by resolving each `node:path` call through the TypeScript checker and wrapping every argument whose type includes `DisposableString` (or a parameter such a value flows into), so it also covers sites that only run on other platforms.

### Background
- `using` / `await using` (explicit resource management) calls `[Symbol.dispose]` on the bound value when the scope ends. Only objects can carry that method, which is why the harness hands out a `String` object rather than a primitive; `String(handle)` is the conversion back.
- `node:path` in Node validates every path argument with `validateString`, which checks `typeof value === "string"`, so a `String` object is rejected even though it stringifies fine.
