### PR TITLE
Bump WebKit (oven-sh/WebKit#466 preview): restore the out-of-line GC liveness checks

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "eeab04040fa61fd595695980f9d054b7fc0ed855";
+export const WEBKIT_VERSION = "autobuild-preview-pr-466-b9632ab6";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.


### PR DESCRIPTION
### Problem

- `test/cli/install/bun-audit.test.ts` went red on `:alpine: 3.23 x64` in build 100350: 130 tests in, every remaining case failed with `Unable to connect` / `GET ... - 500`. The test file is the victim. Its verdaccio registry, which the harness runs under the bun being tested, died with `panic: Segmentation fault at address 0x9036000020` in a GC marking thread (`HeapHelper` core): `MarkedBlock::aboutToMark` <- `SlotVisitor::appendHiddenUnbarriered` <- `SlotVisitor::appendValuesHidden` <- `JSObjectWithButterfly::visitButterflyImpl` (the contiguous-elements lambda, JSObject.cpp:138) <- `JSObjectWithButterfly::visitChildren`. A slot of a contiguous butterfly held a non-pointer: the object being visited had already been collected and its butterfly memory reused.
- Same lane, same four days, nothing else in common: build 97509 (08-15, `bun-patch.test.ts`, byte-identical stack, fault `0x3E1D000020`, 2.5 s into verdaccio's startup) and build 96675 (08-14, `test-http-proxy-request.mjs`, fault `0xD0` in `MethodTable::visitChildren`, i.e. a zapped cell popped off the mark stack). No other lane has hit this, and a scan of the annotations of all 3081 failed builds from 07-29 to 08-18 (plus the canceled ones from 08-08 on) shows nothing comparable before 08-14 on any lane.
- Cause: #37352 (08-11) bumped in oven-sh/WebKit#403, which removed the December 2025 arrangement that kept JSC's GC liveness checks (`Heap::isMarked`, `MarkedBlock::isMarked`, `MarkedBlock::Handle::isLive`, `Dependency::fence` / `loadAndFence`) out of line and used `std::atomic_thread_fence` for the x86_64 fences. That arrangement was added for exactly this configuration (linux x64 musl LTO, objects collected while still live, `blob-write.test.ts` at the time). #403 attributed the December failure to the upstream `WTF::opaque()` volatility fix, but on x86_64 none of those paths use `opaque()` (`Dependency::fence` discards it, `loadAndFence` only uses it on ARM), so the fix it cited never reached the code that failed, and removing the arrangement brought the failure back. The full write-up is in oven-sh/WebKit#466.

### Fix

- Bumps `WEBKIT_VERSION` to oven-sh/WebKit#466, which puts back what #403 removed (function bodies unchanged; comments now record what is and is not known so the next attempt to inline these starts from the evidence). Currently pinned to the PR's preview artifacts to run the full matrix; to be re-pinned to the merged main sha before this merges. Bun is at the fork's current tip (eeab04040fa6), so nothing else rides along.
- Why this is correct to have: the mechanism behind the musl x64 failure is still unknown, so the configuration with evidence behind it is the one that ran quiet on this lane for eight months, and this restores exactly that. The `ObjectPrototypeInlines.h` include from #37352 stays correct either way. Cost is the pre-#403 codegen Bun shipped through 1.3.x.
- No test: the failure is a concurrent-GC liveness race that shows up roughly once per thousand CI builds on one lane and does not reproduce on glibc at all (50 verdaccio startups under `BUN_JSC_useZombieMode=1 BUN_JSC_collectContinuously=1` on a glibc release build carrying #403 stayed clean), so there is nothing a test can fail on before and pass on after. The measure of this change is the alpine x64 lane staying quiet again; if it does not, the mimalloc dev3 sync (#37367, 08-13) is the next candidate (fits on timing, fits worse on architecture since alpine aarch64 has not hit this).
- Verified: the modified JSC files compile against the current prebuilt's headers and flags (`-fsyntax-only`, clang 21); the preview build covers the WebKit side of the matrix; this PR's CI covers Bun's build and link against it.

### Background

- JSC's collector marks concurrently with the mutator and in parallel across helper threads. Each `MarkedBlock` header holds a marking version and a mark bitmap; `isMarked` / `isLive` read the version, then the bits, and `isLive` validates the read against the block's `CountingLock`. On x86_64 the ordering between those reads is expressed only as compiler fences, which is why how these functions get compiled is where the protocol can go wrong, and why the December stopgap took them out of the inliner's hands.
- Both crash shapes are what a liveness error looks like one collection later: something still referenced a cell the collector had freed, and the next cycle's marking walked into it.
- The lane differs from the glibc x64 lanes in its inputs to ThinLTO (WebKit bitcode produced by Alpine's clang, final codegen in Bun's link), and from alpine aarch64 in that ARM64 uses real dependency ordering rather than compiler-only fences.
