### PR TITLE
share one body per shape across the valkey command methods

### DIFF
--- a/src/runtime/valkey_jsc/ValkeyCommand.rs
+++ b/src/runtime/valkey_jsc/ValkeyCommand.rs
@@ -142,10 +142,14 @@ bitflags::bitflags! {
     }
 }
 
+impl Meta {
+    /// supports_auto_pipelining defaults to true, rest false.
+    pub const DEFAULT: Meta = Meta::SUPPORTS_AUTO_PIPELINING;
+}
+
 impl Default for Meta {
     fn default() -> Self {
-        // supports_auto_pipelining defaults to true, rest false.
-        Meta::SUPPORTS_AUTO_PIPELINING
+        Self::DEFAULT
     }
 }
 

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -100,13 +100,6 @@ fn promise_to_js(p: *mut JSPromise) -> JSValue {
 /// Shared epilog for every Valkey prototype method: build a `Command`,
 /// `this.send()` it, and convert the result to a `JsResult<JSValue>` —
 /// `Ok(promise.toJS())` on success, a JS-side Redis error value on failure.
-///
-/// All 7 `cmd_*!` macros and ~24 hand-written methods (`get`, `getBuffer`,
-/// `set`, `incr`, `decr`, `exists`, `expire`, `ttl`, `srem`, `sadd`,
-/// `sismember`, `hmget`, `hincrby`, `hset`, `smove`, `publish`,
-/// `send_unsubscribe_request_and_cleanup`, …) duplicated this 15-line block
-/// byte-identically; the only per-caller variation is the args slice, the
-/// `meta` flags, and the error-message prefix.
 #[inline]
 fn send_cmd(
     this: &JSValkeyClient,

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -138,7 +138,7 @@ fn send_cmd(
 pub(crate) mod compile {
     use super::*;
 
-    #[derive(Clone, Copy, PartialEq, Eq, core::marker::ConstParamTy)]
+    #[derive(Clone, Copy, PartialEq, Eq)]
     pub(crate) enum ClientStateRequirement {
         /// The client must not be a subscriber (not in subscription mode).
         NotSubscriber,
@@ -146,17 +146,257 @@ pub(crate) mod compile {
         DontCare,
     }
 
-    pub(crate) fn test_correct_state<const REQ: ClientStateRequirement>(
-        this: &JSValkeyClient,
-        js_client_prototype_function_name: &[u8],
-    ) -> JsResult<()> {
-        match REQ {
-            ClientStateRequirement::NotSubscriber => {
-                require_not_subscriber(this, js_client_prototype_function_name)
-            }
+    pub(crate) fn test_correct_state(this: &JSValkeyClient, spec: &CmdSpec) -> JsResult<()> {
+        match spec.state {
+            ClientStateRequirement::NotSubscriber => require_not_subscriber(this, spec.name),
             ClientStateRequirement::DontCare => Ok(()),
         }
     }
+}
+
+/// Everything that distinguishes one `cmd_*!` prototype method from another
+/// of the same shape. Each method owns one `static CmdSpec` and hands it to
+/// the shared `*_impl` body for its shape, so the body is compiled once.
+pub(crate) struct CmdSpec {
+    /// JS-visible method name (`RedisClient.prototype.<name>`), ASCII.
+    name: &'static [u8],
+    /// Wire command, e.g. `b"SDIFFSTORE"`.
+    command: &'static [u8],
+    /// Argument names for `throw_invalid_argument_type`; unused slots are `""`.
+    arg_names: [&'static str; 3],
+    state: compile::ClientStateRequirement,
+    meta: CommandMeta,
+    err_msg: &'static str,
+}
+
+#[inline(never)]
+fn noargs_impl(
+    this: &JSValkeyClient,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    spec: &CmdSpec,
+) -> JsResult<JSValue> {
+    compile::test_correct_state(this, spec)?;
+    send_cmd(
+        this,
+        global,
+        frame.this(),
+        spec.command,
+        CommandArgs::Args(&[]),
+        spec.meta,
+        spec.err_msg,
+    )
+}
+
+#[inline(never)]
+fn key_impl(
+    this: &JSValkeyClient,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    spec: &CmdSpec,
+) -> JsResult<JSValue> {
+    compile::test_correct_state(this, spec)?;
+
+    let Some(key) = from_js(global, frame.argument(0))? else {
+        return Err(global.throw_invalid_argument_type(
+            bname(spec.name),
+            spec.arg_names[0],
+            "string or buffer",
+        ));
+    };
+    send_cmd(
+        this,
+        global,
+        frame.this(),
+        spec.command,
+        CommandArgs::Args(&[key]),
+        spec.meta,
+        spec.err_msg,
+    )
+}
+
+#[inline(never)]
+fn key_varargs_impl(
+    this: &JSValkeyClient,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    spec: &CmdSpec,
+) -> JsResult<JSValue> {
+    compile::test_correct_state(this, spec)?;
+
+    if frame.argument(0).is_undefined_or_null() {
+        return Err(global.throw_missing_arguments_value(&[spec.arg_names[0]]));
+    }
+
+    let arguments = frame.arguments();
+    let mut args: Vec<JSArgument> = Vec::with_capacity(arguments.len());
+
+    for arg in arguments {
+        if arg.is_undefined_or_null() {
+            continue;
+        }
+
+        let Some(another) = from_js(global, *arg)? else {
+            return Err(global.throw_invalid_argument_type(
+                bname(spec.name),
+                "additional arguments",
+                "string or buffer",
+            ));
+        };
+        args.push(another);
+    }
+    send_cmd(
+        this,
+        global,
+        frame.this(),
+        spec.command,
+        CommandArgs::Args(&args),
+        spec.meta,
+        spec.err_msg,
+    )
+}
+
+#[inline(never)]
+fn key_value_impl(
+    this: &JSValkeyClient,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    spec: &CmdSpec,
+) -> JsResult<JSValue> {
+    compile::test_correct_state(this, spec)?;
+
+    let Some(key) = from_js(global, frame.argument(0))? else {
+        return Err(global.throw_invalid_argument_type(
+            bname(spec.name),
+            spec.arg_names[0],
+            "string or buffer",
+        ));
+    };
+    let Some(value) = from_js(global, frame.argument(1))? else {
+        return Err(global.throw_invalid_argument_type(
+            bname(spec.name),
+            spec.arg_names[1],
+            "string or buffer",
+        ));
+    };
+    send_cmd(
+        this,
+        global,
+        frame.this(),
+        spec.command,
+        CommandArgs::Args(&[key, value]),
+        spec.meta,
+        spec.err_msg,
+    )
+}
+
+#[inline(never)]
+fn key_value_value2_impl(
+    this: &JSValkeyClient,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    spec: &CmdSpec,
+) -> JsResult<JSValue> {
+    compile::test_correct_state(this, spec)?;
+
+    let Some(key) = from_js(global, frame.argument(0))? else {
+        return Err(global.throw_invalid_argument_type(
+            bname(spec.name),
+            spec.arg_names[0],
+            "string or buffer",
+        ));
+    };
+    let Some(value) = from_js(global, frame.argument(1))? else {
+        return Err(global.throw_invalid_argument_type(
+            bname(spec.name),
+            spec.arg_names[1],
+            "string or buffer",
+        ));
+    };
+    let Some(value2) = from_js(global, frame.argument(2))? else {
+        return Err(global.throw_invalid_argument_type(
+            bname(spec.name),
+            spec.arg_names[2],
+            "string or buffer",
+        ));
+    };
+    send_cmd(
+        this,
+        global,
+        frame.this(),
+        spec.command,
+        CommandArgs::Args(&[key, value, value2]),
+        spec.meta,
+        spec.err_msg,
+    )
+}
+
+#[inline(never)]
+fn strings_varargs_impl(
+    this: &JSValkeyClient,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    spec: &CmdSpec,
+) -> JsResult<JSValue> {
+    compile::test_correct_state(this, spec)?;
+
+    let mut args: Vec<JSArgument> = Vec::with_capacity(frame.arguments().len());
+
+    for arg in frame.arguments() {
+        let Some(another) = from_js(global, *arg)? else {
+            return Err(global.throw_invalid_argument_type(
+                bname(spec.name),
+                "additional arguments",
+                "string or buffer",
+            ));
+        };
+        args.push(another);
+    }
+    send_cmd(
+        this,
+        global,
+        frame.this(),
+        spec.command,
+        CommandArgs::Args(&args),
+        spec.meta,
+        spec.err_msg,
+    )
+}
+
+#[inline(never)]
+fn key_value_varargs_impl(
+    this: &JSValkeyClient,
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+    spec: &CmdSpec,
+) -> JsResult<JSValue> {
+    compile::test_correct_state(this, spec)?;
+
+    let mut args: Vec<JSArgument> = Vec::with_capacity(frame.arguments().len());
+
+    for arg in frame.arguments() {
+        if arg.is_undefined_or_null() {
+            continue;
+        }
+
+        let Some(another) = from_js(global, *arg)? else {
+            return Err(global.throw_invalid_argument_type(
+                bname(spec.name),
+                "additional arguments",
+                "string or buffer",
+            ));
+        };
+        args.push(another);
+    }
+    send_cmd(
+        this,
+        global,
+        frame.this(),
+        spec.command,
+        CommandArgs::Args(&args),
+        spec.meta,
+        spec.err_msg,
+    )
 }
 
 // Note: each command-shape generator is a `macro_rules!` that emits a
@@ -167,272 +407,128 @@ pub(crate) mod compile {
 // cmd_key_value_value2! (key: RedisKey, value: RedisValue, value2: RedisValue),
 // cmd_strings_varargs! (...strings: string[]),
 // cmd_key_value_varargs! (key: RedisKey, value: RedisValue, ...args: RedisValue)
+//
+// Every generator accepts optional trailing `, meta = <const expr>` and
+// `, err = <literal>` arguments; the defaults are `CommandMeta::DEFAULT` and
+// `"Failed to send <COMMAND>"`.
 
-macro_rules! cmd_noargs {
-    ($fn_name:ident, $name:literal, $command:literal, $state:ident) => {
+macro_rules! cmd_spec {
+    ($name:literal, $command:literal, $args:expr, $state:ident) => {
+        cmd_spec!($name, $command, $args, $state, meta = CommandMeta::DEFAULT)
+    };
+    ($name:literal, $command:literal, $args:expr, $state:ident, err = $err:literal) => {
+        cmd_spec!(
+            $name,
+            $command,
+            $args,
+            $state,
+            meta = CommandMeta::DEFAULT,
+            err = $err
+        )
+    };
+    ($name:literal, $command:literal, $args:expr, $state:ident, meta = $meta:expr) => {
+        cmd_spec!(
+            $name,
+            $command,
+            $args,
+            $state,
+            meta = $meta,
+            err = concat!("Failed to send ", $command)
+        )
+    };
+    ($name:literal, $command:literal, $args:expr, $state:ident, meta = $meta:expr, err = $err:expr) => {
+        CmdSpec {
+            name: $name,
+            command: $command.as_bytes(),
+            arg_names: $args,
+            state: compile::ClientStateRequirement::$state,
+            meta: $meta,
+            err_msg: $err,
+        }
+    };
+}
+
+macro_rules! cmd_method {
+    ($fn_name:ident, $imp:ident, $spec:expr) => {
         #[bun_jsc::host_fn(method)]
         pub fn $fn_name(
             this: &Self,
             global: &JSGlobalObject,
             frame: &CallFrame,
         ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
-            send_cmd(
-                this,
-                global,
-                frame.this(),
-                $command.as_bytes(),
-                CommandArgs::Args(&[]),
-                CommandMeta::default(),
-                concat!("Failed to send ", $command),
-            )
+            static SPEC: CmdSpec = $spec;
+            $imp(this, global, frame, &SPEC)
         }
+    };
+}
+
+macro_rules! cmd_noargs {
+    ($fn_name:ident, $name:literal, $command:literal, $state:ident $($rest:tt)*) => {
+        cmd_method!(
+            $fn_name,
+            noargs_impl,
+            cmd_spec!($name, $command, ["", "", ""], $state $($rest)*)
+        );
     };
 }
 
 macro_rules! cmd_key {
-    ($fn_name:ident, $name:literal, $command:literal, $arg0_name:literal, $state:ident) => {
-        #[bun_jsc::host_fn(method)]
-        pub fn $fn_name(
-            this: &Self,
-            global: &JSGlobalObject,
-            frame: &CallFrame,
-        ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
-
-            let Some(key) = from_js(global, frame.argument(0))? else {
-                return Err(global.throw_invalid_argument_type(
-                    bname($name),
-                    $arg0_name,
-                    "string or buffer",
-                ));
-            };
-            send_cmd(
-                this,
-                global,
-                frame.this(),
-                $command.as_bytes(),
-                CommandArgs::Args(&[key]),
-                CommandMeta::default(),
-                concat!("Failed to send ", $command),
-            )
-        }
+    ($fn_name:ident, $name:literal, $command:literal, $arg0_name:literal, $state:ident $($rest:tt)*) => {
+        cmd_method!(
+            $fn_name,
+            key_impl,
+            cmd_spec!($name, $command, [$arg0_name, "", ""], $state $($rest)*)
+        );
     };
 }
 
 macro_rules! cmd_key_varargs {
-    ($fn_name:ident, $name:literal, $command:literal, $arg0_name:literal, $state:ident) => {
-        #[bun_jsc::host_fn(method)]
-        pub fn $fn_name(
-            this: &Self,
-            global: &JSGlobalObject,
-            frame: &CallFrame,
-        ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
-
-            if frame.argument(0).is_undefined_or_null() {
-                return Err(global.throw_missing_arguments_value(&[$arg0_name]));
-            }
-
-            let arguments = frame.arguments();
-            let mut args: Vec<JSArgument> = Vec::with_capacity(arguments.len());
-
-            for arg in arguments {
-                if arg.is_undefined_or_null() {
-                    continue;
-                }
-
-                let Some(another) = from_js(global, *arg)? else {
-                    return Err(global.throw_invalid_argument_type(
-                        bname($name),
-                        "additional arguments",
-                        "string or buffer",
-                    ));
-                };
-                args.push(another);
-            }
-            send_cmd(
-                this,
-                global,
-                frame.this(),
-                $command.as_bytes(),
-                CommandArgs::Args(&args),
-                CommandMeta::default(),
-                concat!("Failed to send ", $command),
-            )
-        }
+    ($fn_name:ident, $name:literal, $command:literal, $arg0_name:literal, $state:ident $($rest:tt)*) => {
+        cmd_method!(
+            $fn_name,
+            key_varargs_impl,
+            cmd_spec!($name, $command, [$arg0_name, "", ""], $state $($rest)*)
+        );
     };
 }
 
 macro_rules! cmd_key_value {
-    ($fn_name:ident, $name:literal, $command:literal, $arg0_name:literal, $arg1_name:literal, $state:ident) => {
-        #[bun_jsc::host_fn(method)]
-        pub fn $fn_name(
-            this: &Self,
-            global: &JSGlobalObject,
-            frame: &CallFrame,
-        ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
-
-            let Some(key) = from_js(global, frame.argument(0))? else {
-                return Err(global.throw_invalid_argument_type(
-                    bname($name),
-                    $arg0_name,
-                    "string or buffer",
-                ));
-            };
-            let Some(value) = from_js(global, frame.argument(1))? else {
-                return Err(global.throw_invalid_argument_type(
-                    bname($name),
-                    $arg1_name,
-                    "string or buffer",
-                ));
-            };
-            send_cmd(
-                this,
-                global,
-                frame.this(),
-                $command.as_bytes(),
-                CommandArgs::Args(&[key, value]),
-                CommandMeta::default(),
-                concat!("Failed to send ", $command),
-            )
-        }
+    ($fn_name:ident, $name:literal, $command:literal, $arg0_name:literal, $arg1_name:literal, $state:ident $($rest:tt)*) => {
+        cmd_method!(
+            $fn_name,
+            key_value_impl,
+            cmd_spec!($name, $command, [$arg0_name, $arg1_name, ""], $state $($rest)*)
+        );
     };
 }
 
 macro_rules! cmd_key_value_value2 {
-    ($fn_name:ident, $name:literal, $command:literal, $arg0_name:literal, $arg1_name:literal, $arg2_name:literal, $state:ident) => {
-        #[bun_jsc::host_fn(method)]
-        pub fn $fn_name(
-            this: &Self,
-            global: &JSGlobalObject,
-            frame: &CallFrame,
-        ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
-
-            let Some(key) = from_js(global, frame.argument(0))? else {
-                return Err(global.throw_invalid_argument_type(
-                    bname($name),
-                    $arg0_name,
-                    "string or buffer",
-                ));
-            };
-            let Some(value) = from_js(global, frame.argument(1))? else {
-                return Err(global.throw_invalid_argument_type(
-                    bname($name),
-                    $arg1_name,
-                    "string or buffer",
-                ));
-            };
-            let Some(value2) = from_js(global, frame.argument(2))? else {
-                return Err(global.throw_invalid_argument_type(
-                    bname($name),
-                    $arg2_name,
-                    "string or buffer",
-                ));
-            };
-            send_cmd(
-                this,
-                global,
-                frame.this(),
-                $command.as_bytes(),
-                CommandArgs::Args(&[key, value, value2]),
-                CommandMeta::default(),
-                concat!("Failed to send ", $command),
-            )
-        }
+    ($fn_name:ident, $name:literal, $command:literal, $arg0_name:literal, $arg1_name:literal, $arg2_name:literal, $state:ident $($rest:tt)*) => {
+        cmd_method!(
+            $fn_name,
+            key_value_value2_impl,
+            cmd_spec!($name, $command, [$arg0_name, $arg1_name, $arg2_name], $state $($rest)*)
+        );
     };
 }
 
 macro_rules! cmd_strings_varargs {
-    ($fn_name:ident, $name:literal, $command:literal, $state:ident) => {
-        cmd_strings_varargs!($fn_name, $name, $command, $state, CommandMeta::default());
-    };
-    ($fn_name:ident, $name:literal, $command:literal, $state:ident, $meta:expr) => {
-        #[bun_jsc::host_fn(method)]
-        pub fn $fn_name(
-            this: &Self,
-            global: &JSGlobalObject,
-            frame: &CallFrame,
-        ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
-
-            let mut args: Vec<JSArgument> = Vec::with_capacity(frame.arguments().len());
-
-            for arg in frame.arguments() {
-                let Some(another) = from_js(global, *arg)? else {
-                    return Err(global.throw_invalid_argument_type(
-                        bname($name),
-                        "additional arguments",
-                        "string or buffer",
-                    ));
-                };
-                args.push(another);
-            }
-            send_cmd(
-                this,
-                global,
-                frame.this(),
-                $command.as_bytes(),
-                CommandArgs::Args(&args),
-                $meta,
-                concat!("Failed to send ", $command),
-            )
-        }
+    ($fn_name:ident, $name:literal, $command:literal, $state:ident $($rest:tt)*) => {
+        cmd_method!(
+            $fn_name,
+            strings_varargs_impl,
+            cmd_spec!($name, $command, ["", "", ""], $state $($rest)*)
+        );
     };
 }
 
 macro_rules! cmd_key_value_varargs {
-    ($fn_name:ident, $name:literal, $command:literal, $state:ident) => {
-        #[bun_jsc::host_fn(method)]
-        pub fn $fn_name(
-            this: &Self,
-            global: &JSGlobalObject,
-            frame: &CallFrame,
-        ) -> JsResult<JSValue> {
-            compile::test_correct_state::<{ compile::ClientStateRequirement::$state }>(
-                this, $name,
-            )?;
-
-            let mut args: Vec<JSArgument> = Vec::with_capacity(frame.arguments().len());
-
-            for arg in frame.arguments() {
-                if arg.is_undefined_or_null() {
-                    continue;
-                }
-
-                let Some(another) = from_js(global, *arg)? else {
-                    return Err(global.throw_invalid_argument_type(
-                        bname($name),
-                        "additional arguments",
-                        "string or buffer",
-                    ));
-                };
-                args.push(another);
-            }
-            send_cmd(
-                this,
-                global,
-                frame.this(),
-                $command.as_bytes(),
-                CommandArgs::Args(&args),
-                CommandMeta::default(),
-                concat!("Failed to send ", $command),
-            )
-        }
+    ($fn_name:ident, $name:literal, $command:literal, $state:ident $($rest:tt)*) => {
+        cmd_method!(
+            $fn_name,
+            key_value_varargs_impl,
+            cmd_spec!($name, $command, ["", "", ""], $state $($rest)*)
+        );
     };
 }
 
@@ -486,45 +582,24 @@ impl JSValkeyClient {
         Ok(promise_to_js(promise))
     }
 
-    #[bun_jsc::host_fn(method)]
-    pub fn get(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"get")?;
+    cmd_key!(
+        get,
+        b"get",
+        "GET",
+        "key",
+        NotSubscriber,
+        err = "Failed to send GET command"
+    );
 
-        let Some(key) = from_js(global, frame.argument(0))? else {
-            return Err(global.throw_invalid_argument_type("get", "key", "string or buffer"));
-        };
-        send_cmd(
-            this,
-            global,
-            frame.this(),
-            b"GET",
-            CommandArgs::Args(&[key]),
-            CommandMeta::default(),
-            "Failed to send GET command",
-        )
-    }
-
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn get_buffer(
-        this: &Self,
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"getBuffer")?;
-
-        let Some(key) = from_js(global, frame.argument(0))? else {
-            return Err(global.throw_invalid_argument_type("getBuffer", "key", "string or buffer"));
-        };
-        send_cmd(
-            this,
-            global,
-            frame.this(),
-            b"GET",
-            CommandArgs::Args(&[key]),
-            CommandMeta::RETURN_AS_BUFFER | CommandMeta::SUPPORTS_AUTO_PIPELINING,
-            "Failed to send GET command",
-        )
-    }
+    cmd_key!(
+        get_buffer,
+        b"getBuffer",
+        "GET",
+        "key",
+        NotSubscriber,
+        meta = CommandMeta::RETURN_AS_BUFFER.union(CommandMeta::SUPPORTS_AUTO_PIPELINING),
+        err = "Failed to send GET command"
+    );
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn set(
@@ -578,72 +653,33 @@ impl JSValkeyClient {
         )
     }
 
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn incr(
-        this: &Self,
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"incr")?;
+    cmd_key!(
+        incr,
+        b"incr",
+        "INCR",
+        "key",
+        NotSubscriber,
+        err = "Failed to send INCR command"
+    );
 
-        let Some(key) = from_js(global, frame.argument(0))? else {
-            return Err(global.throw_invalid_argument_type("incr", "key", "string or buffer"));
-        };
-        send_cmd(
-            this,
-            global,
-            frame.this(),
-            b"INCR",
-            CommandArgs::Args(&[key]),
-            CommandMeta::default(),
-            "Failed to send INCR command",
-        )
-    }
+    cmd_key!(
+        decr,
+        b"decr",
+        "DECR",
+        "key",
+        NotSubscriber,
+        err = "Failed to send DECR command"
+    );
 
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn decr(
-        this: &Self,
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"decr")?;
-
-        let Some(key) = from_js(global, frame.argument(0))? else {
-            return Err(global.throw_invalid_argument_type("decr", "key", "string or buffer"));
-        };
-        send_cmd(
-            this,
-            global,
-            frame.this(),
-            b"DECR",
-            CommandArgs::Args(&[key]),
-            CommandMeta::default(),
-            "Failed to send DECR command",
-        )
-    }
-
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn exists(
-        this: &Self,
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"exists")?;
-
-        let Some(key) = from_js(global, frame.argument(0))? else {
-            return Err(global.throw_invalid_argument_type("exists", "key", "string or buffer"));
-        };
-        // Send EXISTS command with special Exists type for boolean conversion
-        send_cmd(
-            this,
-            global,
-            frame.this(),
-            b"EXISTS",
-            CommandArgs::Args(&[key]),
-            CommandMeta::RETURN_AS_BOOL | CommandMeta::SUPPORTS_AUTO_PIPELINING,
-            "Failed to send EXISTS command",
-        )
-    }
+    cmd_key!(
+        exists,
+        b"exists",
+        "EXISTS",
+        "key",
+        NotSubscriber,
+        meta = CommandMeta::RETURN_AS_BOOL.union(CommandMeta::SUPPORTS_AUTO_PIPELINING),
+        err = "Failed to send EXISTS command"
+    );
 
     #[bun_jsc::host_fn(method)]
     pub(crate) fn expire(
@@ -698,27 +734,14 @@ impl JSValkeyClient {
         )
     }
 
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn ttl(
-        this: &Self,
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"ttl")?;
-
-        let Some(key) = from_js(global, frame.argument(0))? else {
-            return Err(global.throw_invalid_argument_type("ttl", "key", "string or buffer"));
-        };
-        send_cmd(
-            this,
-            global,
-            frame.this(),
-            b"TTL",
-            CommandArgs::Args(&[key]),
-            CommandMeta::default(),
-            "Failed to send TTL command",
-        )
-    }
+    cmd_key!(
+        ttl,
+        b"ttl",
+        "TTL",
+        "key",
+        NotSubscriber,
+        err = "Failed to send TTL command"
+    );
 
     // Implement srem (remove value from a set)
     #[bun_jsc::host_fn(method)]
@@ -808,28 +831,14 @@ impl JSValkeyClient {
         )
     }
 
-    // Implement smembers (get all members of a set)
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn smembers(
-        this: &Self,
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"smembers")?;
-
-        let Some(key) = from_js(global, frame.argument(0))? else {
-            return Err(global.throw_invalid_argument_type("smembers", "key", "string or buffer"));
-        };
-        send_cmd(
-            this,
-            global,
-            frame.this(),
-            b"SMEMBERS",
-            CommandArgs::Args(&[key]),
-            CommandMeta::default(),
-            "Failed to send SMEMBERS command",
-        )
-    }
+    cmd_key!(
+        smembers,
+        b"smembers",
+        "SMEMBERS",
+        "key",
+        NotSubscriber,
+        err = "Failed to send SMEMBERS command"
+    );
 
     // Implement spop (pop a random member from a set)
     #[bun_jsc::host_fn(method)]
@@ -915,35 +924,16 @@ impl JSValkeyClient {
         )
     }
 
-    // Implement sismember (check if value is member of a set)
-    #[bun_jsc::host_fn(method)]
-    pub(crate) fn sismember(
-        this: &Self,
-        global: &JSGlobalObject,
-        frame: &CallFrame,
-    ) -> JsResult<JSValue> {
-        require_not_subscriber(this, b"sismember")?;
-
-        let Some(key) = from_js(global, frame.argument(0))? else {
-            return Err(global.throw_invalid_argument_type("sismember", "key", "string or buffer"));
-        };
-        let Some(value) = from_js(global, frame.argument(1))? else {
-            return Err(global.throw_invalid_argument_type(
-                "sismember",
-                "value",
-                "string or buffer",
-            ));
-        };
-        send_cmd(
-            this,
-            global,
-            frame.this(),
-            b"SISMEMBER",
-            CommandArgs::Args(&[key, value]),
-            CommandMeta::RETURN_AS_BOOL | CommandMeta::SUPPORTS_AUTO_PIPELINING,
-            "Failed to send SISMEMBER command",
-        )
-    }
+    cmd_key_value!(
+        sismember,
+        b"sismember",
+        "SISMEMBER",
+        "key",
+        "value",
+        NotSubscriber,
+        meta = CommandMeta::RETURN_AS_BOOL.union(CommandMeta::SUPPORTS_AUTO_PIPELINING),
+        err = "Failed to send SISMEMBER command"
+    );
 
     // Implement hmget (get multiple values from hash)
     #[bun_jsc::host_fn(method)]
@@ -1698,14 +1688,14 @@ impl JSValkeyClient {
         b"psubscribe",
         "PSUBSCRIBE",
         DontCare,
-        CommandMeta::default() | CommandMeta::SUBSCRIPTION_REQUEST
+        meta = CommandMeta::DEFAULT.union(CommandMeta::SUBSCRIPTION_REQUEST)
     );
     cmd_strings_varargs!(
         punsubscribe,
         b"punsubscribe",
         "PUNSUBSCRIBE",
         DontCare,
-        CommandMeta::default() | CommandMeta::SUBSCRIPTION_REQUEST
+        meta = CommandMeta::DEFAULT.union(CommandMeta::SUBSCRIPTION_REQUEST)
     );
     cmd_strings_varargs!(pubsub, b"pubsub", "PUBSUB", DontCare);
     cmd_strings_varargs!(copy, b"copy", "COPY", NotSubscriber);

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -944,6 +944,20 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         }).toThrowErrorMatchingInlineSnapshot(`"Expected key to be a string or buffer for 'setrange'."`);
       });
 
+      test("should reject invalid start in GETRANGE", async () => {
+        const redis = ctx.redis;
+        expect(async () => {
+          await redis.getrange("getrange-invalid-start", {} as any, 5);
+        }).toThrowErrorMatchingInlineSnapshot(`"Expected start to be a string or buffer for 'getrange'."`);
+      });
+
+      test("should reject invalid end in GETRANGE", async () => {
+        const redis = ctx.redis;
+        expect(async () => {
+          await redis.getrange("getrange-invalid-end", 0, null as any);
+        }).toThrowErrorMatchingInlineSnapshot(`"Expected end to be a string or buffer for 'getrange'."`);
+      });
+
       test("should reject invalid key in INCRBY", async () => {
         const redis = ctx.redis;
         expect(async () => {
@@ -6680,6 +6694,41 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
         );
 
         await subscriber.unsubscribe(testChannel());
+      });
+
+      test("every command shape is rejected in subscriber mode with its own method name", async () => {
+        const subscriber = await ctx.newSubscriberClient(connectionType);
+        const channel = testChannel();
+        await subscriber.subscribe(channel, () => {});
+
+        const key = testKey();
+        const value = testValue();
+        // One command per shared implementation: no args, key, key + varargs,
+        // key + value, key + value + value, strings varargs, key + value + varargs.
+        const calls: [name: string, call: () => unknown][] = [
+          ["dbsize", () => subscriber.dbsize()],
+          ["get", () => subscriber.get(key)],
+          ["del", () => subscriber.del(key)],
+          ["sismember", () => subscriber.sismember(key, value)],
+          ["lrange", () => subscriber.lrange(key, 0, -1)],
+          ["mset", () => subscriber.mset(key, value)],
+          ["lpush", () => subscriber.lpush(key, value)],
+        ];
+
+        const messages = calls.map(([, call]) => {
+          try {
+            call();
+            return "did not throw";
+          } catch (error) {
+            return (error as Error).message;
+          }
+        });
+
+        expect(messages).toEqual(
+          calls.map(([name]) => `RedisClient.prototype.${name} cannot be called while in subscriber mode.`),
+        );
+
+        await subscriber.unsubscribe(channel);
       });
 
       test("setting after unsubscribing works", async () => {


### PR DESCRIPTION
### Problem
- The seven `cmd_*!` macros in `src/runtime/valkey_jsc/js_valkey_functions.rs` expanded a complete host-function body for every Redis command method they generate. Within one shape the bodies are identical except for the immediates baked into them (method name, wire command bytes, argument names, the "Failed to send X" message).
- Eight hand-written methods (`get`, `getBuffer`, `incr`, `decr`, `exists`, `ttl`, `smembers`, `sismember`) were copies of the `key` / `key, value` shapes with a different `meta` or error string, so they could not use the macros.
- Measured on two linux-x64 release builds that differ only in these files: the 186 affected `RedisClientPrototype__*` functions took 220,420 bytes of `.text` (about 1.2 KB each).

### Fix
- Each shape gets one `#[inline(never)]` body (`noargs_impl`, `key_impl`, `key_varargs_impl`, `key_value_impl`, `key_value_value2_impl`, `strings_varargs_impl`, `key_value_varargs_impl`) that reads the per-command data from a `&'static CmdSpec` (method name, command bytes, argument names, state requirement, `Meta` flags, error message).
- Every generated method is now `static SPEC: CmdSpec = ...;` plus a call into the body for its shape. The macros accept optional trailing `meta = ...` and `err = ...`, which is what lets the eight hand-written methods above become macro invocations with their existing flags and error strings.
- `test_correct_state` takes the spec instead of a const generic, so `ClientStateRequirement` no longer needs `ConstParamTy`. `Meta::DEFAULT` is added because a `static` initializer has to be const (`Default::default()` and `|` are not), which is also why the specs use `.union()`.
- Result on the same A/B pair of release builds (`bun run build:release`, Rust fat LTO, codegen-units=1): the 186 functions shrink to 20,072 bytes (104 to 108 bytes each), the seven shared bodies add 7,410 bytes, the 186 spec statics add 19,344 bytes of `.rodata`. Net `.text` is 193,536 bytes smaller, `.rodata` 20,096 bytes larger, and the stripped `bun` binary goes from 76,846,088 to 76,682,248 bytes (160 KiB smaller).
- Runtime cost is a few loads from a static per call, in functions that already convert arguments, write to a socket and allocate a promise.
- Behavior is unchanged: same argument checks, same subscriber-mode error, same error strings and `meta` flags.
- Verification:
  - `test/js/valkey/valkey.test.ts`: added one subscriber-mode rejection per shared body (the error message carries the method name, which now comes from the spec) and checks for the second and third argument names of a `key, value, value` command. The existing subscriber-mode tests only went through hand-written methods (`set`, `publish`) and nothing covered the third argument slot. Since this change is meant to be behavior-preserving, these tests pass on main as well; they pin the behavior that now flows through the specs rather than demonstrate a bug.
  - Ran all of `test/js/valkey` on the debug build against a local redis 8 configured like `docker-unified` (plain, TLS, ACL users): unit 60/60, `valkey.test.ts` 1053 pass, integration and reliability 129 pass.
  - The remaining local failures are not from this change: `high volume pub/sub` (1 GB through a debug+ASAN build in 5s) times out identically on a debug build of main, and three reliability tests fail identically with the unmodified release binary because the local server's error text and the sandbox's routing differ from CI.

### Background
- A host function is a native function JSC calls when JS invokes a method such as `RedisClient.prototype.sdiffstore`. `#[bun_jsc::host_fn(method)]` generates the C ABI entry point (`RedisClientPrototype__sdiffstore` in the binary) that unwraps `this` and calls the Rust body; there is one per JS-visible method, so the stub per command stays, only the body is shared.
- `CmdSpec` is a plain struct of `'static` references and `Copy` flags, so one can be built in a `static` initializer and handed to the shared body by reference.
- `#[inline(never)]` on the shared bodies is what makes the change stick: the spec passed to each call is a known constant, so if LLVM inlined the body into the stubs it would fold the spec fields back into immediates and regenerate the per-command copies.
- `Meta` is the bitflags set attached to each command (return as buffer, return as bool, subscription request, auto-pipelining). `Meta::DEFAULT` has the same value as `Meta::default()`, which now delegates to it.

<details>
<summary>Original description</summary>

The seven cmd_* macros in js_valkey_functions.rs expand a full host-function body per Redis command: 133 functions, 156 KB in the linux-x64 binary, and the bodies within a shape are byte-identical except for three immediates (the command name, the wire command bytes, the "Failed to send X" message). Disassembly of sdiffstore against its 56 siblings confirms it.

Each shape now has one `#[inline(never)]` body that takes a `&'static CmdSpec` (name, command bytes, error message, flags), and each command is a static spec plus a one-line stub. Pre-LTO the bun_runtime rlib text drops by 126 KB. Every affected function is a per-call host function that already does the JS to native transition, argument conversion, a socket write and a promise allocation, so loading a few fields from a static instead of immediates is not measurable.

Behavior is unchanged: same argument checks, same subscriber-mode error, same error strings. The valkey unit tests pass on the debug build; the docker-backed integration tests were not run locally.

</details>

<details>
<summary>Size measurement details</summary>

Two `bun run build:release` runs in the same build directory, first with main's versions of `js_valkey_functions.rs` and `ValkeyCommand.rs`, then with this branch's. Numbers are from the linker maps of `bun-profile` and `size(1)` on the stripped `bun`.

```
output section      main        pr          delta
.text               54085132    53891596    -193536
.rodata             21950120    21970216    +20096
.eh_frame             830584      831184       +600

RedisClientPrototype__* (210 symbols): 251208 -> 50860 bytes
  186 shrank:   220420 -> 20072 bytes (stubs are 104 to 108 bytes each)
  24 unchanged (hand-written methods)
shared bodies (pr):   noargs 336, key 721, key_varargs 1247, key_value 1233,
                      key_value_value2 1647, strings_varargs 1132, key_value_varargs 1094
JSValkeyClient::*::SPEC statics: 186 x 104 bytes = 19344 bytes

stripped bun:        76846088 -> 76682248 bytes
bun-profile:        280353264 -> 280108912 bytes
```

Example: `RedisClientPrototype__sdiffstore` is 1206 bytes on main and 108 bytes here, plus a 104 byte spec.

</details>
