### PR TITLE
share one slow path for creating iso subspaces

### DIFF
--- a/.claude/skills/implementing-jsc-classes-cpp/SKILL.md
+++ b/.claude/skills/implementing-jsc-classes-cpp/SKILL.md
@@ -29,10 +29,7 @@ static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm) {
         return nullptr;
     return WebCore::subspaceForImpl<MyClassT, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMyClassT.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMyClassT = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMyClassT.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMyClassT = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForMyClassT, &WebCore::DOMIsoSubspaces::m_subspaceForMyClassT);
 }
 ```
 

--- a/.github/workflows/source-lints.yml
+++ b/.github/workflows/source-lints.yml
@@ -13,8 +13,10 @@ on:
     branches: [main]
     paths:
       - "src/**/*.rs"
+      - "src/**/*.h"
+      - "src/**/*.cpp"
       - "src/**/*.classes.ts"
-      - "src/codegen/class-definitions.ts"
+      - "src/codegen/**"
       - "src/js/builtins.d.ts"
       - "src/jsc/bindings/**"
       - "packages/bun-types/redis.d.ts"
@@ -34,8 +36,10 @@ on:
   pull_request:
     paths:
       - "src/**/*.rs"
+      - "src/**/*.h"
+      - "src/**/*.cpp"
       - "src/**/*.classes.ts"
-      - "src/codegen/class-definitions.ts"
+      - "src/codegen/**"
       - "src/js/builtins.d.ts"
       - "src/jsc/bindings/**"
       - "packages/bun-types/redis.d.ts"

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -484,10 +484,7 @@ class ${name} final : public JSC::InternalFunction {
 
         return WebCore::subspaceForImpl<${name}, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.${clientSubspaceFor("BunClass")}Constructor.get(); },
-            [](auto& spaces, auto&& space) { spaces.${clientSubspaceFor("BunClass")}Constructor = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.${subspaceFor("BunClass")}Constructor.get(); },
-            [](auto& spaces, auto&& space) { spaces.${subspaceFor("BunClass")}Constructor = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::${clientSubspaceFor("BunClass")}Constructor, &WebCore::DOMIsoSubspaces::${subspaceFor("BunClass")}Constructor);
       }
 
       // Must be defined for each specialization class.
@@ -1129,10 +1126,7 @@ function generateClassHeader(typeName, obj: ClassDefinition) {
                 return nullptr;
             return WebCore::subspaceForImpl<${name}, WebCore::UseCustomHeapCellType::No>(
                 vm,
-                [](auto& spaces) { return spaces.${clientSubspaceFor(typeName)}.get(); },
-                [](auto& spaces, auto&& space) { spaces.${clientSubspaceFor(typeName)} = std::forward<decltype(space)>(space); },
-                [](auto& spaces) { return spaces.${subspaceFor(typeName)}.get(); },
-                [](auto& spaces, auto&& space) { spaces.${subspaceFor(typeName)} = std::forward<decltype(space)>(space); });
+                &WebCore::DOMClientIsoSubspaces::${clientSubspaceFor(typeName)}, &WebCore::DOMIsoSubspaces::${subspaceFor(typeName)});
         }
 
         static void destroy(JSC::JSCell*);

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -42,10 +42,7 @@ function header() {
                     return nullptr;                                                                                                                                                 
                 return WebCore::subspaceForImpl<${constructor}, WebCore::UseCustomHeapCellType::No>(                                                                    
                     vm,                                                                                                                                                             
-                    [](auto& spaces) { return spaces.m_clientSubspaceForJSSinkConstructor.get(); },                                                                                 
-                    [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSinkConstructor = std::forward<decltype(space)>(space); },                                                               
-                    [](auto& spaces) { return spaces.m_subspaceForJSSinkConstructor.get(); },                                                                                       
-                    [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSinkConstructor = std::forward<decltype(space)>(space); });                                                                    
+                    &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSSinkConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForJSSinkConstructor);                                                                    
             }                                                                                                                                                                       
                                                                                                                                                                                     
             static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)                                                          
@@ -81,10 +78,7 @@ function header() {
                     return nullptr;                                                                                                                                                 
                 return WebCore::subspaceForImpl<${className}, WebCore::UseCustomHeapCellType::No>(                                                                                 
                     vm,                                                                                                                                                             
-                    [](auto& spaces) { return spaces.m_clientSubspaceForJSSink.get(); },                                                                                            
-                    [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSink = std::forward<decltype(space)>(space); },                                                                          
-                    [](auto& spaces) { return spaces.m_subspaceForJSSink.get(); },                                                                                                  
-                    [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSink = std::forward<decltype(space)>(space); });                                                                               
+                    &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSSink, &WebCore::DOMIsoSubspaces::m_subspaceForJSSink);                                                                               
             }                                                                                                                                                                       
                                                                                                                                                                                     
             static void destroy(JSC::JSCell*);                                                                                                                                      
@@ -142,10 +136,7 @@ function header() {
                         return nullptr;
                     return WebCore::subspaceForImpl<${controller}, WebCore::UseCustomHeapCellType::No>(
                         vm,
-                        [](auto& spaces) { return spaces.m_clientSubspaceForJSSinkController.get(); },
-                        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSinkController = std::forward<decltype(space)>(space); },
-                        [](auto& spaces) { return spaces.m_subspaceForJSSinkController.get(); },
-                        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSinkController = std::forward<decltype(space)>(space); });
+                        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSSinkController, &WebCore::DOMIsoSubspaces::m_subspaceForJSSinkController);
                 }
 
                 static void destroy(JSC::JSCell*);

--- a/src/jsc/bindings/AsyncContextFrame.h
+++ b/src/jsc/bindings/AsyncContextFrame.h
@@ -38,10 +38,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<AsyncContextFrame, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForAsyncContextFrame.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForAsyncContextFrame = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForAsyncContextFrame.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForAsyncContextFrame = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForAsyncContextFrame, &WebCore::DOMIsoSubspaces::m_subspaceForAsyncContextFrame);
     }
 
     AsyncContextFrame(JSC::VM& vm, JSC::Structure* structure, JSC::JSValue callback_, JSC::JSValue context_)

--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -173,4 +173,23 @@ void JSVMClientData::create(VM* vm, void* bunVM, bool isWorkerVM)
     clientData->builtinFunctions().exportNames();
 }
 
+NEVER_INLINE JSC::GCClient::IsoSubspace* subspaceForImplSlow(JSC::VM& vm, ClientIsoSubspaceSlot clientSlot, ServerIsoSubspaceSlot serverSlot, const JSC::HeapCellType& cellType, size_t cellSize, uint8_t numberOfLowerTierPreciseCells, bool hasOutputConstraints)
+{
+    auto& clientData = *downcast<JSVMClientData>(vm.clientData);
+    auto& heapData = clientData.heapData();
+    Locker locker { heapData.lock() };
+
+    auto& space = heapData.subspaces().*serverSlot;
+    if (!space) {
+        // "T" matches what ISO_SUBSPACE_INIT(heap, cellType, T) stringized before.
+        space = makeUnique<JSC::IsoSubspace>("T"_s, vm.heap, cellType, cellSize, numberOfLowerTierPreciseCells);
+        if (hasOutputConstraints)
+            heapData.outputConstraintSpaces().append(space.get());
+    }
+
+    auto& clientSpace = clientData.clientSubspaces().*clientSlot;
+    clientSpace = makeUnique<JSC::GCClient::IsoSubspace>(*space);
+    return clientSpace.get();
+}
+
 } // namespace WebCore

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -257,48 +257,38 @@ SPECIALIZE_TYPE_TRAITS_END()
 
 namespace WebCore {
 
-template<typename T, UseCustomHeapCellType useCustomHeapCellType, typename GetClient, typename SetClient, typename GetServer, typename SetServer>
-ALWAYS_INLINE JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm, GetClient getClient, SetClient setClient, GetServer getServer, SetServer setServer, JSC::HeapCellType& (*getCustomHeapCellType)(JSHeapData&) = nullptr)
+using ClientIsoSubspaceSlot = std::unique_ptr<JSC::GCClient::IsoSubspace> DOMClientIsoSubspaces::*;
+using ServerIsoSubspaceSlot = std::unique_ptr<JSC::IsoSubspace> DOMIsoSubspaces::*;
+
+// Creates the server + client IsoSubspace for one cell type. Runs once per
+// (VM, type); everything hot stays in subspaceForImpl's inline fast path.
+JSC::GCClient::IsoSubspace* subspaceForImplSlow(JSC::VM&, ClientIsoSubspaceSlot, ServerIsoSubspaceSlot, const JSC::HeapCellType&, size_t cellSize, uint8_t numberOfLowerTierPreciseCells, bool hasOutputConstraints);
+
+template<typename T, UseCustomHeapCellType useCustomHeapCellType>
+ALWAYS_INLINE JSC::GCClient::IsoSubspace* subspaceForImpl(JSC::VM& vm, ClientIsoSubspaceSlot clientSlot, ServerIsoSubspaceSlot serverSlot, JSC::HeapCellType& (*getCustomHeapCellType)(JSHeapData&) = nullptr)
 {
     auto& clientData = *downcast<JSVMClientData>(vm.clientData);
-    auto& clientSubspaces = clientData.clientSubspaces();
-    if (auto* clientSpace = getClient(clientSubspaces))
+    if (auto* clientSpace = (clientData.clientSubspaces().*clientSlot).get())
         return clientSpace;
 
-    auto& heapData = clientData.heapData();
-    Locker locker { heapData.lock() };
+    static_assert(useCustomHeapCellType == UseCustomHeapCellType::Yes || std::is_base_of_v<JSC::JSDestructibleObject, T> || T::needsDestruction == JSC::DoesNotNeedDestruction);
+    const JSC::HeapCellType* cellType;
+    if constexpr (useCustomHeapCellType == UseCustomHeapCellType::Yes)
+        cellType = &getCustomHeapCellType(clientData.heapData());
+    else if constexpr (std::is_base_of_v<JSC::JSDestructibleObject, T>)
+        cellType = &vm.heap.destructibleObjectHeapCellType;
+    else
+        cellType = &vm.heap.cellHeapCellType;
 
-    auto& subspaces = heapData.subspaces();
-    JSC::IsoSubspace* space = getServer(subspaces);
-    if (!space) {
-        JSC::Heap& heap = vm.heap;
-        std::unique_ptr<JSC::IsoSubspace> uniqueSubspace;
-        static_assert(useCustomHeapCellType == UseCustomHeapCellType::Yes || std::is_base_of_v<JSC::JSDestructibleObject, T> || T::needsDestruction == JSC::DoesNotNeedDestruction);
-        if constexpr (useCustomHeapCellType == UseCustomHeapCellType::Yes)
-            uniqueSubspace = makeUnique<JSC::IsoSubspace> ISO_SUBSPACE_INIT(heap, getCustomHeapCellType(heapData), T);
-        else {
-            if constexpr (std::is_base_of_v<JSC::JSDestructibleObject, T>)
-                uniqueSubspace = makeUnique<JSC::IsoSubspace> ISO_SUBSPACE_INIT(heap, heap.destructibleObjectHeapCellType, T);
-            else
-                uniqueSubspace = makeUnique<JSC::IsoSubspace> ISO_SUBSPACE_INIT(heap, heap.cellHeapCellType, T);
-        }
-        space = uniqueSubspace.get();
-        setServer(subspaces, WTF::move(uniqueSubspace));
+    IGNORE_WARNINGS_BEGIN("unreachable-code")
+    IGNORE_WARNINGS_BEGIN("tautological-compare")
+    void (*myVisitOutputConstraint)(JSC::JSCell*, JSC::SlotVisitor&) = T::visitOutputConstraints;
+    void (*jsCellVisitOutputConstraint)(JSC::JSCell*, JSC::SlotVisitor&) = JSC::JSCell::visitOutputConstraints;
+    bool hasOutputConstraints = myVisitOutputConstraint != jsCellVisitOutputConstraint;
+    IGNORE_WARNINGS_END
+    IGNORE_WARNINGS_END
 
-        IGNORE_WARNINGS_BEGIN("unreachable-code")
-        IGNORE_WARNINGS_BEGIN("tautological-compare")
-        void (*myVisitOutputConstraint)(JSC::JSCell*, JSC::SlotVisitor&) = T::visitOutputConstraints;
-        void (*jsCellVisitOutputConstraint)(JSC::JSCell*, JSC::SlotVisitor&) = JSC::JSCell::visitOutputConstraints;
-        if (myVisitOutputConstraint != jsCellVisitOutputConstraint)
-            heapData.outputConstraintSpaces().append(space);
-        IGNORE_WARNINGS_END
-        IGNORE_WARNINGS_END
-    }
-
-    auto uniqueClientSubspace = makeUnique<JSC::GCClient::IsoSubspace>(*space);
-    auto* clientSpace = uniqueClientSubspace.get();
-    setClient(clientSubspaces, WTF::move(uniqueClientSubspace));
-    return clientSpace;
+    return subspaceForImplSlow(vm, clientSlot, serverSlot, *cellType, sizeof(T), T::numberOfLowerTierPreciseCells, hasOutputConstraints);
 }
 
 static JSVMClientData* clientData(JSC::VM& vm)

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -545,10 +545,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSBunInspectorConnection, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForBunInspectorConnection.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBunInspectorConnection = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForBunInspectorConnection.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForBunInspectorConnection = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForBunInspectorConnection, &WebCore::DOMIsoSubspaces::m_subspaceForBunInspectorConnection);
     }
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -429,10 +429,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSModuleMock, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSModuleMock.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSModuleMock = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSModuleMock.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSModuleMock = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSModuleMock, &WebCore::DOMIsoSubspaces::m_subspaceForJSModuleMock);
     }
 
     void finishCreation(JSC::VM&);

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -119,10 +119,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<Process, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForProcessObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForProcessObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForProcessObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForProcessObject = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForProcessObject, &WebCore::DOMIsoSubspaces::m_subspaceForProcessObject);
     }
 
     void finishCreation(JSC::VM& vm);

--- a/src/jsc/bindings/CallSite.h
+++ b/src/jsc/bindings/CallSite.h
@@ -66,10 +66,7 @@ public:
 
         return WebCore::subspaceForImpl<CallSite, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForCallSite.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCallSite = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForCallSite.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForCallSite = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCallSite, &WebCore::DOMIsoSubspaces::m_subspaceForCallSite);
     }
 
     JSC::JSValue thisValue() const { return m_thisValue.get(); }

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -43,10 +43,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<ErrorCodeCache, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForErrorCodeCache.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForErrorCodeCache = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForErrorCodeCache.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForErrorCodeCache = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForErrorCodeCache, &WebCore::DOMIsoSubspaces::m_subspaceForErrorCodeCache);
     }
 
     static ErrorCodeCache* create(VM& vm, Structure* structure);

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -61,10 +61,7 @@ public:
 
         return WebCore::subspaceForImpl<ImportMetaObject, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForImportMeta.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForImportMeta = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForImportMeta.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForImportMeta = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForImportMeta, &WebCore::DOMIsoSubspaces::m_subspaceForImportMeta);
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, bool isBake = false);

--- a/src/jsc/bindings/InternalModuleRegistry.h
+++ b/src/jsc/bindings/InternalModuleRegistry.h
@@ -43,10 +43,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<InternalModuleRegistry, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForInternalModuleRegistry.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForInternalModuleRegistry = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForInternalModuleRegistry.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForInternalModuleRegistry = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForInternalModuleRegistry, &WebCore::DOMIsoSubspaces::m_subspaceForInternalModuleRegistry);
     }
 
     static InternalModuleRegistry* create(VM& vm, Structure* structure);

--- a/src/jsc/bindings/JSBakeResponse.cpp
+++ b/src/jsc/bindings/JSBakeResponse.cpp
@@ -139,10 +139,7 @@ JSC::GCClient::IsoSubspace* JSBakeResponse::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSBakeResponse, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForBakeResponse.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBakeResponse = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForBakeResponse.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForBakeResponse = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForBakeResponse, &WebCore::DOMIsoSubspaces::m_subspaceForBakeResponse);
 }
 
 JSBakeResponse::JSBakeResponse(JSC::VM& vm, JSC::Structure* structure, void* sinkPtr)

--- a/src/jsc/bindings/JSBufferList.cpp
+++ b/src/jsc/bindings/JSBufferList.cpp
@@ -250,10 +250,7 @@ JSC::GCClient::IsoSubspace* JSBufferList::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSBufferList, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForBufferList.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBufferList = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForBufferList.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForBufferList = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForBufferList, &WebCore::DOMIsoSubspaces::m_subspaceForBufferList);
 }
 
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSBufferListPrototype, JSBufferListPrototype::Base);

--- a/src/jsc/bindings/JSBunRequest.cpp
+++ b/src/jsc/bindings/JSBunRequest.cpp
@@ -72,10 +72,7 @@ JSC::GCClient::IsoSubspace* JSBunRequest::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSBunRequest, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForBunRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBunRequest = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForBunRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForBunRequest = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForBunRequest, &WebCore::DOMIsoSubspaces::m_subspaceForBunRequest);
 }
 
 JSObject* JSBunRequest::params() const

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -146,10 +146,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSBundlerPlugin, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForBundlerPlugin.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBundlerPlugin = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForBundlerPlugin.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForBundlerPlugin = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForBundlerPlugin, &WebCore::DOMIsoSubspaces::m_subspaceForBundlerPlugin);
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)

--- a/src/jsc/bindings/JSCommonJSExtensions.h
+++ b/src/jsc/bindings/JSCommonJSExtensions.h
@@ -30,10 +30,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSCommonJSExtensions, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSCommonJSExtensions.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSCommonJSExtensions = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSCommonJSExtensions.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSCommonJSExtensions = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSCommonJSExtensions, &WebCore::DOMIsoSubspaces::m_subspaceForJSCommonJSExtensions);
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)

--- a/src/jsc/bindings/JSCommonJSModule.h
+++ b/src/jsc/bindings/JSCommonJSModule.h
@@ -139,10 +139,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSCommonJSModule, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSCommonJSModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSCommonJSModule = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSCommonJSModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSCommonJSModule = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSCommonJSModule, &WebCore::DOMIsoSubspaces::m_subspaceForJSCommonJSModule);
     }
 
     bool hasEvaluated = false;

--- a/src/jsc/bindings/JSFFIFunction.h
+++ b/src/jsc/bindings/JSFFIFunction.h
@@ -61,10 +61,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSFFIFunction, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForFFIFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForFFIFunction = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForFFIFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForFFIFunction = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForFFIFunction, &WebCore::DOMIsoSubspaces::m_subspaceForFFIFunction);
     }
 
     DECLARE_EXPORT_INFO;

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -170,10 +170,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSMockImplementation, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSMockImplementation.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMockImplementation = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSMockImplementation.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMockImplementation = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSMockImplementation, &WebCore::DOMIsoSubspaces::m_subspaceForJSMockImplementation);
     }
 
     // either a function or a return value, depends on kind
@@ -456,10 +453,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSMockFunction, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSMockFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMockFunction = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSMockFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMockFunction = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSMockFunction, &WebCore::DOMIsoSubspaces::m_subspaceForJSMockFunction);
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
@@ -1271,10 +1265,7 @@ JSC::GCClient::IsoSubspace* MockWithImplementationCleanupData::subspaceFor(JSC::
 {
     return WebCore::subspaceForImpl<MockWithImplementationCleanupData, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMockWithImplementationCleanupData.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMockWithImplementationCleanupData = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMockWithImplementationCleanupData.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMockWithImplementationCleanupData = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForMockWithImplementationCleanupData, &WebCore::DOMIsoSubspaces::m_subspaceForMockWithImplementationCleanupData);
 }
 
 MockWithImplementationCleanupData* MockWithImplementationCleanupData::create(VM& vm, Structure* structure)

--- a/src/jsc/bindings/JSNextTickQueue.cpp
+++ b/src/jsc/bindings/JSNextTickQueue.cpp
@@ -25,10 +25,7 @@ JSC::GCClient::IsoSubspace* JSNextTickQueue::subspaceFor(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSNextTickQueue, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSNextTickQueue.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSNextTickQueue = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSNextTickQueue.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSNextTickQueue = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSNextTickQueue, &WebCore::DOMIsoSubspaces::m_subspaceForJSNextTickQueue);
 }
 
 JSNextTickQueue* JSNextTickQueue::create(VM& vm, Structure* structure)

--- a/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
+++ b/src/jsc/bindings/JSNodePerformanceHooksHistogram.h
@@ -135,10 +135,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSNodePerformanceHooksHistogram, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSNodePerformanceHooksHistogram.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSNodePerformanceHooksHistogram = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSNodePerformanceHooksHistogram.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSNodePerformanceHooksHistogram = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSNodePerformanceHooksHistogram, &WebCore::DOMIsoSubspaces::m_subspaceForJSNodePerformanceHooksHistogram);
     }
 
     JSNodePerformanceHooksHistogram(JSC::VM& vm, JSC::Structure* structure, HistogramData&& histogramData)

--- a/src/jsc/bindings/JSSocketHandlers.cpp
+++ b/src/jsc/bindings/JSSocketHandlers.cpp
@@ -21,10 +21,7 @@ JSC::GCClient::IsoSubspace* JSSocketHandlers::subspaceFor(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSSocketHandlers, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSSocketHandlers.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSocketHandlers = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSSocketHandlers.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSocketHandlers = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSSocketHandlers, &WebCore::DOMIsoSubspaces::m_subspaceForJSSocketHandlers);
 }
 
 JSC::Structure* JSSocketHandlers::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)

--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -395,10 +395,7 @@ JSC::GCClient::IsoSubspace* JSStringDecoder::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSStringDecoder, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForStringDecoder.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForStringDecoder = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForStringDecoder.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForStringDecoder = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForStringDecoder, &WebCore::DOMIsoSubspaces::m_subspaceForStringDecoder);
 }
 
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSStringDecoderPrototype, JSStringDecoderPrototype::Base);

--- a/src/jsc/bindings/JSWrappingFunction.h
+++ b/src/jsc/bindings/JSWrappingFunction.h
@@ -43,10 +43,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSWrappingFunction, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForWrappingFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWrappingFunction = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForWrappingFunction.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForWrappingFunction = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForWrappingFunction, &WebCore::DOMIsoSubspaces::m_subspaceForWrappingFunction);
     }
 
     DECLARE_EXPORT_INFO;

--- a/src/jsc/bindings/JSX509Certificate.h
+++ b/src/jsc/bindings/JSX509Certificate.h
@@ -120,10 +120,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSX509Certificate, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSX509Certificate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSX509Certificate = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSX509Certificate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSX509Certificate = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSX509Certificate, &WebCore::DOMIsoSubspaces::m_subspaceForJSX509Certificate);
     }
 
     static JSValue computeSubject(ncrypto::X509View view, JSGlobalObject*, bool legacy);

--- a/src/jsc/bindings/ModuleLoader.h
+++ b/src/jsc/bindings/ModuleLoader.h
@@ -60,10 +60,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<PendingVirtualModuleResult, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForPendingVirtualModuleResult.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPendingVirtualModuleResult = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForPendingVirtualModuleResult.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForPendingVirtualModuleResult = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPendingVirtualModuleResult, &WebCore::DOMIsoSubspaces::m_subspaceForPendingVirtualModuleResult);
     }
 
     JS_EXPORT_PRIVATE static PendingVirtualModuleResult* create(VM&, Structure*);

--- a/src/jsc/bindings/NativePromiseContext.h
+++ b/src/jsc/bindings/NativePromiseContext.h
@@ -66,10 +66,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NativePromiseContext, WebCore::UseCustomHeapCellType::Yes>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNativePromiseContext.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNativePromiseContext = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNativePromiseContext.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNativePromiseContext = std::forward<decltype(space)>(space); },
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNativePromiseContext, &WebCore::DOMIsoSubspaces::m_subspaceForNativePromiseContext,
             [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForNativePromiseContext; });
     }
 

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -879,10 +879,7 @@ template<typename, JSC::SubspaceAccess mode> JSC::GCClient::IsoSubspace* NodeVMS
         return nullptr;
     return WebCore::subspaceForImpl<NodeVMSpecialSandbox, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeVMSpecialSandbox.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeVMSpecialSandbox = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeVMSpecialSandbox.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMSpecialSandbox = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeVMSpecialSandbox, &WebCore::DOMIsoSubspaces::m_subspaceForNodeVMSpecialSandbox);
 }
 
 NodeVMSpecialSandbox* NodeVMSpecialSandbox::create(VM& vm, NodeVMGlobalObject* globalObject)
@@ -939,10 +936,7 @@ template<typename, JSC::SubspaceAccess mode> JSC::GCClient::IsoSubspace* NodeVMG
         return nullptr;
     return WebCore::subspaceForImpl<NodeVMGlobalObject, WebCore::UseCustomHeapCellType::Yes>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeVMGlobalObject.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeVMGlobalObject = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeVMGlobalObject.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMGlobalObject = std::forward<decltype(space)>(space); },
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeVMGlobalObject, &WebCore::DOMIsoSubspaces::m_subspaceForNodeVMGlobalObject,
         [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForNodeVMGlobalObject; });
 }
 

--- a/src/jsc/bindings/NodeVMScript.h
+++ b/src/jsc/bindings/NodeVMScript.h
@@ -49,10 +49,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NodeVMScript, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNodeVMScript.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeVMScript = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNodeVMScript.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMScript = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeVMScript, &WebCore::DOMIsoSubspaces::m_subspaceForNodeVMScript);
     }
 
     static void destroy(JSC::JSCell*);

--- a/src/jsc/bindings/NodeVMSourceTextModule.h
+++ b/src/jsc/bindings/NodeVMSourceTextModule.h
@@ -17,10 +17,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NodeVMSourceTextModule, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNodeVMSourceTextModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeVMSourceTextModule = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNodeVMSourceTextModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMSourceTextModule = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeVMSourceTextModule, &WebCore::DOMIsoSubspaces::m_subspaceForNodeVMSourceTextModule);
     }
 
     static JSObject* createPrototype(VM& vm, JSGlobalObject* globalObject);

--- a/src/jsc/bindings/NodeVMSyntheticModule.h
+++ b/src/jsc/bindings/NodeVMSyntheticModule.h
@@ -19,10 +19,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NodeVMSyntheticModule, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNodeVMSyntheticModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeVMSyntheticModule = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNodeVMSyntheticModule.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeVMSyntheticModule = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeVMSyntheticModule, &WebCore::DOMIsoSubspaces::m_subspaceForNodeVMSyntheticModule);
     }
 
     static JSObject* createPrototype(VM& vm, JSGlobalObject* globalObject);

--- a/src/jsc/bindings/ProcessBindingTTYWrap.cpp
+++ b/src/jsc/bindings/ProcessBindingTTYWrap.cpp
@@ -128,10 +128,7 @@ public:
 
         return WebCore::subspaceForImpl<TTYWrapObject, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForTTYWrapObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTTYWrapObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForTTYWrapObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForTTYWrapObject = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForTTYWrapObject, &WebCore::DOMIsoSubspaces::m_subspaceForTTYWrapObject);
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSObject* prototype)

--- a/src/jsc/bindings/ServerRouteList.cpp
+++ b/src/jsc/bindings/ServerRouteList.cpp
@@ -79,10 +79,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<ServerRouteList, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForServerRouteList.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForServerRouteList = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForServerRouteList.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForServerRouteList = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForServerRouteList, &WebCore::DOMIsoSubspaces::m_subspaceForServerRouteList);
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/StrongRootBlock.cpp
+++ b/src/jsc/bindings/StrongRootBlock.cpp
@@ -22,10 +22,7 @@ JSC::GCClient::IsoSubspace* StrongRootBlock::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<StrongRootBlock, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForStrongRootBlock.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForStrongRootBlock = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForStrongRootBlock.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForStrongRootBlock = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForStrongRootBlock, &WebCore::DOMIsoSubspaces::m_subspaceForStrongRootBlock);
 }
 
 StrongRootBlock* StrongRootBlock::create(JSC::VM& vm, JSC::Structure* structure)

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3090,10 +3090,7 @@ JSC::GCClient::IsoSubspace* GlobalObject::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<GlobalObject, WebCore::UseCustomHeapCellType::Yes>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWorkerGlobalScope.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWorkerGlobalScope = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWorkerGlobalScope.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWorkerGlobalScope = std::forward<decltype(space)>(space); },
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForWorkerGlobalScope, &WebCore::DOMIsoSubspaces::m_subspaceForWorkerGlobalScope,
         [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForJSWorkerGlobalScope; });
 }
 

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -867,10 +867,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NapiClass, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNapiClass.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNapiClass = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNapiClass.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNapiClass = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNapiClass, &WebCore::DOMIsoSubspaces::m_subspaceForNapiClass);
     }
 
     DECLARE_EXPORT_INFO;

--- a/src/jsc/bindings/napi_external.h
+++ b/src/jsc/bindings/napi_external.h
@@ -39,10 +39,7 @@ public:
 
         return WebCore::subspaceForImpl<NapiExternal, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNapiExternal.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNapiExternal = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNapiExternal.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNapiExternal = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNapiExternal, &WebCore::DOMIsoSubspaces::m_subspaceForNapiExternal);
     }
 
     ~NapiExternal();

--- a/src/jsc/bindings/napi_handle_scope.h
+++ b/src/jsc/bindings/napi_handle_scope.h
@@ -35,10 +35,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NapiHandleScopeImpl, WebCore::UseCustomHeapCellType::Yes>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNapiHandleScopeImpl.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNapiHandleScopeImpl = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNapiHandleScopeImpl.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNapiHandleScopeImpl = std::forward<decltype(space)>(space); },
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNapiHandleScopeImpl, &WebCore::DOMIsoSubspaces::m_subspaceForNapiHandleScopeImpl,
             [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForNapiHandleScopeImpl; });
     }
 

--- a/src/jsc/bindings/napi_type_tag.h
+++ b/src/jsc/bindings/napi_type_tag.h
@@ -29,10 +29,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<NapiTypeTag, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForNapiTypeTag.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNapiTypeTag = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForNapiTypeTag.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForNapiTypeTag = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNapiTypeTag, &WebCore::DOMIsoSubspaces::m_subspaceForNapiTypeTag);
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.h
@@ -153,10 +153,7 @@ public:
 
         return WebCore::subspaceForImpl<JSNodeHTTPServerSocket, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSNodeHTTPServerSocket.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSNodeHTTPServerSocket = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSNodeHTTPServerSocket.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSNodeHTTPServerSocket = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSNodeHTTPServerSocket, &WebCore::DOMIsoSubspaces::m_subspaceForJSNodeHTTPServerSocket);
     }
 
     void detach();

--- a/src/jsc/bindings/node/crypto/JSCipher.h
+++ b/src/jsc/bindings/node/crypto/JSCipher.h
@@ -55,10 +55,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSCipher, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSCipher.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSCipher = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSCipher.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSCipher = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSCipher, &WebCore::DOMIsoSubspaces::m_subspaceForJSCipher);
     }
 
     bool checkCCMMessageLength(int32_t messageLen) const

--- a/src/jsc/bindings/node/crypto/JSDiffieHellman.h
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellman.h
@@ -40,10 +40,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSDiffieHellman, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSDiffieHellman.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSDiffieHellman = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSDiffieHellman.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSDiffieHellman = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSDiffieHellman, &WebCore::DOMIsoSubspaces::m_subspaceForJSDiffieHellman);
     }
 
 private:

--- a/src/jsc/bindings/node/crypto/JSDiffieHellmanGroup.h
+++ b/src/jsc/bindings/node/crypto/JSDiffieHellmanGroup.h
@@ -41,10 +41,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSDiffieHellmanGroup, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSDiffieHellmanGroup.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSDiffieHellmanGroup = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSDiffieHellmanGroup.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSDiffieHellmanGroup = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSDiffieHellmanGroup, &WebCore::DOMIsoSubspaces::m_subspaceForJSDiffieHellmanGroup);
     }
 
 private:

--- a/src/jsc/bindings/node/crypto/JSECDH.h
+++ b/src/jsc/bindings/node/crypto/JSECDH.h
@@ -37,10 +37,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSECDH, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSECDH.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSECDH = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSECDH.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSECDH = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSECDH, &WebCore::DOMIsoSubspaces::m_subspaceForJSECDH);
     }
 
     ncrypto::ECKeyPointer m_key;

--- a/src/jsc/bindings/node/crypto/JSHash.cpp
+++ b/src/jsc/bindings/node/crypto/JSHash.cpp
@@ -66,10 +66,7 @@ JSC::GCClient::IsoSubspace* JSHash::subspaceFor(JSC::VM& vm)
 
     return WebCore::subspaceForImpl<JSHash, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSHash.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSHash = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSHash.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSHash = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSHash, &WebCore::DOMIsoSubspaces::m_subspaceForJSHash);
 }
 
 JSHash* JSHash::create(JSC::VM& vm, JSC::Structure* structure)

--- a/src/jsc/bindings/node/crypto/JSHmac.cpp
+++ b/src/jsc/bindings/node/crypto/JSHmac.cpp
@@ -64,10 +64,7 @@ JSC::GCClient::IsoSubspace* JSHmac::subspaceFor(JSC::VM& vm)
 
     return WebCore::subspaceForImpl<JSHmac, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSHmac.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSHmac = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSHmac.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSHmac = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSHmac, &WebCore::DOMIsoSubspaces::m_subspaceForJSHmac);
 }
 
 JSHmac* JSHmac::create(JSC::VM& vm, JSC::Structure* structure)

--- a/src/jsc/bindings/node/crypto/JSPrivateKeyObject.h
+++ b/src/jsc/bindings/node/crypto/JSPrivateKeyObject.h
@@ -36,10 +36,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSPrivateKeyObject, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSPrivateKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSPrivateKeyObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSPrivateKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSPrivateKeyObject = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSPrivateKeyObject, &WebCore::DOMIsoSubspaces::m_subspaceForJSPrivateKeyObject);
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/node/crypto/JSPublicKeyObject.h
+++ b/src/jsc/bindings/node/crypto/JSPublicKeyObject.h
@@ -37,10 +37,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSPublicKeyObject, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSPublicKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSPublicKeyObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSPublicKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSPublicKeyObject = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSPublicKeyObject, &WebCore::DOMIsoSubspaces::m_subspaceForJSPublicKeyObject);
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/node/crypto/JSSecretKeyObject.h
+++ b/src/jsc/bindings/node/crypto/JSSecretKeyObject.h
@@ -36,10 +36,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSSecretKeyObject, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSSecretKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSecretKeyObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSSecretKeyObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSecretKeyObject = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSSecretKeyObject, &WebCore::DOMIsoSubspaces::m_subspaceForJSSecretKeyObject);
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/node/crypto/JSSign.cpp
+++ b/src/jsc/bindings/node/crypto/JSSign.cpp
@@ -97,10 +97,7 @@ JSC::GCClient::IsoSubspace* JSSign::subspaceFor(JSC::VM& vm)
         return nullptr;
     return WebCore::subspaceForImpl<JSSign, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSSign.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSign = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSSign.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSign = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSSign, &WebCore::DOMIsoSubspaces::m_subspaceForJSSign);
 }
 
 // JSSignPrototype implementation

--- a/src/jsc/bindings/node/crypto/JSVerify.cpp
+++ b/src/jsc/bindings/node/crypto/JSVerify.cpp
@@ -105,10 +105,7 @@ JSC::GCClient::IsoSubspace* JSVerify::subspaceFor(JSC::VM& vm)
         return nullptr;
     return WebCore::subspaceForImpl<JSVerify, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForJSVerify.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSVerify = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForJSVerify.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForJSVerify = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSVerify, &WebCore::DOMIsoSubspaces::m_subspaceForJSVerify);
 }
 
 // JSVerifyPrototype implementation

--- a/src/jsc/bindings/node/http/JSConnectionsList.h
+++ b/src/jsc/bindings/node/http/JSConnectionsList.h
@@ -32,10 +32,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSConnectionsList, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSConnectionsList.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSConnectionsList = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSConnectionsList.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSConnectionsList = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSConnectionsList, &WebCore::DOMIsoSubspaces::m_subspaceForJSConnectionsList);
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/node/http/JSHTTPParser.h
+++ b/src/jsc/bindings/node/http/JSHTTPParser.h
@@ -32,10 +32,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSHTTPParser, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSHTTPParser.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSHTTPParser = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSHTTPParser.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSHTTPParser = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSHTTPParser, &WebCore::DOMIsoSubspaces::m_subspaceForJSHTTPParser);
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/sqlite/JSSQLStatement.cpp
+++ b/src/jsc/bindings/sqlite/JSSQLStatement.cpp
@@ -500,10 +500,7 @@ public:
     {
         return WebCore::subspaceForImpl<JSSQLStatement, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSSQLStatement.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSSQLStatement = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSSQLStatement.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSSQLStatement = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSSQLStatement, &WebCore::DOMIsoSubspaces::m_subspaceForJSSQLStatement);
     }
     DECLARE_VISIT_CHILDREN;
     DECLARE_EXPORT_INFO;

--- a/src/jsc/bindings/sqlite/NodeSqlite.cpp
+++ b/src/jsc/bindings/sqlite/NodeSqlite.cpp
@@ -1199,10 +1199,7 @@ GCClient::IsoSubspace* JSDatabaseSync::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSDatabaseSync, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteDatabaseSync.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteDatabaseSync = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteDatabaseSync.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteDatabaseSync = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeSqliteDatabaseSync, &WebCore::DOMIsoSubspaces::m_subspaceForNodeSqliteDatabaseSync);
 }
 
 // ─── DatabaseSync prototype functions ───────────────────────────────────────
@@ -2586,10 +2583,7 @@ GCClient::IsoSubspace* JSStatementSync::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSStatementSync, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteStatementSync.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteStatementSync = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteStatementSync.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteStatementSync = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeSqliteStatementSync, &WebCore::DOMIsoSubspaces::m_subspaceForNodeSqliteStatementSync);
 }
 
 // ─── Parameter binding ──────────────────────────────────────────────────────
@@ -3071,10 +3065,7 @@ GCClient::IsoSubspace* JSStatementSyncIterator::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSStatementSyncIterator, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteStatementSyncIterator.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteStatementSyncIterator = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteStatementSyncIterator.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteStatementSyncIterator = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeSqliteStatementSyncIterator, &WebCore::DOMIsoSubspaces::m_subspaceForNodeSqliteStatementSyncIterator);
 }
 
 static inline JSObject* createIterResult(VM& vm, JSGlobalObject* globalObject, bool done, JSValue value)
@@ -3259,10 +3250,7 @@ GCClient::IsoSubspace* JSNodeSqliteSession::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSNodeSqliteSession, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteSession.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteSession = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteSession.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteSession = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeSqliteSession, &WebCore::DOMIsoSubspaces::m_subspaceForNodeSqliteSession);
 }
 
 #define THIS_SESSION()                                                                                                 \
@@ -3428,10 +3416,7 @@ GCClient::IsoSubspace* JSNodeSqliteLimits::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSNodeSqliteLimits, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteLimits.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteLimits = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteLimits.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteLimits = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeSqliteLimits, &WebCore::DOMIsoSubspaces::m_subspaceForNodeSqliteLimits);
 }
 
 bool JSNodeSqliteLimits::getOwnPropertySlot(JSObject* object, JSGlobalObject* globalObject, PropertyName propertyName, PropertySlot& slot)
@@ -3580,10 +3565,7 @@ GCClient::IsoSubspace* JSNodeSqliteTagStore::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSNodeSqliteTagStore, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNodeSqliteTagStore.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNodeSqliteTagStore = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNodeSqliteTagStore.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNodeSqliteTagStore = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNodeSqliteTagStore, &WebCore::DOMIsoSubspaces::m_subspaceForNodeSqliteTagStore);
 }
 
 JSStatementSync* JSNodeSqliteTagStore::prepare(JSGlobalObject* globalObject, ThrowScope& scope, CallFrame* callFrame)

--- a/src/jsc/bindings/v8/shim/Function.h
+++ b/src/jsc/bindings/v8/shim/Function.h
@@ -24,10 +24,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<Function, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForV8Function.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForV8Function = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForV8Function.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForV8Function = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForV8Function, &WebCore::DOMIsoSubspaces::m_subspaceForV8Function);
     }
 
     FunctionTemplate* functionTemplate() const { return m_functionTemplate.get(); }

--- a/src/jsc/bindings/v8/shim/FunctionTemplate.h
+++ b/src/jsc/bindings/v8/shim/FunctionTemplate.h
@@ -41,10 +41,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<FunctionTemplate, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForFunctionTemplate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForFunctionTemplate = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForFunctionTemplate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForFunctionTemplate = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForFunctionTemplate, &WebCore::DOMIsoSubspaces::m_subspaceForFunctionTemplate);
     }
 
     DECLARE_INFO;

--- a/src/jsc/bindings/v8/shim/GlobalInternals.h
+++ b/src/jsc/bindings/v8/shim/GlobalInternals.h
@@ -34,10 +34,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<GlobalInternals, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForV8GlobalInternals.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForV8GlobalInternals = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForV8GlobalInternals.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForV8GlobalInternals = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForV8GlobalInternals, &WebCore::DOMIsoSubspaces::m_subspaceForV8GlobalInternals);
     }
 
     JSC::Structure* objectTemplateStructure(JSC::JSGlobalObject* globalObject) const

--- a/src/jsc/bindings/v8/shim/HandleScopeBuffer.h
+++ b/src/jsc/bindings/v8/shim/HandleScopeBuffer.h
@@ -33,10 +33,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<HandleScopeBuffer, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForHandleScopeBuffer.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForHandleScopeBuffer = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForHandleScopeBuffer.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForHandleScopeBuffer = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForHandleScopeBuffer, &WebCore::DOMIsoSubspaces::m_subspaceForHandleScopeBuffer);
     }
 
     TaggedPointer* createHandle(JSC::JSCell* object, const Map* map, JSC::VM& vm);

--- a/src/jsc/bindings/v8/shim/InternalFieldObject.h
+++ b/src/jsc/bindings/v8/shim/InternalFieldObject.h
@@ -21,10 +21,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<InternalFieldObject, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForInternalFieldObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForInternalFieldObject = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForInternalFieldObject.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForInternalFieldObject = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForInternalFieldObject, &WebCore::DOMIsoSubspaces::m_subspaceForInternalFieldObject);
     }
 
     // never changes size

--- a/src/jsc/bindings/v8/shim/ObjectTemplate.h
+++ b/src/jsc/bindings/v8/shim/ObjectTemplate.h
@@ -28,10 +28,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<ObjectTemplate, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForObjectTemplate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForObjectTemplate = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForObjectTemplate.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForObjectTemplate = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForObjectTemplate, &WebCore::DOMIsoSubspaces::m_subspaceForObjectTemplate);
     }
 
     DECLARE_VISIT_CHILDREN;

--- a/src/jsc/bindings/webcore/JSAbortController.cpp
+++ b/src/jsc/bindings/webcore/JSAbortController.cpp
@@ -228,10 +228,7 @@ JSC::GCClient::IsoSubspace* JSAbortController::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSAbortController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForAbortController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForAbortController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForAbortController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForAbortController = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForAbortController, &WebCore::DOMIsoSubspaces::m_subspaceForAbortController);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSAbortSignal.cpp
+++ b/src/jsc/bindings/webcore/JSAbortSignal.cpp
@@ -353,10 +353,7 @@ JSC::GCClient::IsoSubspace* JSAbortSignal::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSAbortSignal, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForAbortSignal.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForAbortSignal = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForAbortSignal.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForAbortSignal = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForAbortSignal, &WebCore::DOMIsoSubspaces::m_subspaceForAbortSignal);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
@@ -416,10 +416,7 @@ JSC::GCClient::IsoSubspace* JSBroadcastChannel::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSBroadcastChannel, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForBroadcastChannel.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBroadcastChannel = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForBroadcastChannel.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForBroadcastChannel = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForBroadcastChannel, &WebCore::DOMIsoSubspaces::m_subspaceForBroadcastChannel);
 }
 
 void JSBroadcastChannel::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSCloseEvent.cpp
+++ b/src/jsc/bindings/webcore/JSCloseEvent.cpp
@@ -318,10 +318,7 @@ JSC::GCClient::IsoSubspace* JSCloseEvent::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSCloseEvent, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCloseEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCloseEvent = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCloseEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCloseEvent = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCloseEvent, &WebCore::DOMIsoSubspaces::m_subspaceForCloseEvent);
 }
 
 void JSCloseEvent::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -889,10 +889,7 @@ GCClient::IsoSubspace* JSCookie::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSCookie, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCookie.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCookie = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCookie.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCookie = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCookie, &WebCore::DOMIsoSubspaces::m_subspaceForCookie);
 }
 
 void JSCookie::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSCookieMap.cpp
+++ b/src/jsc/bindings/webcore/JSCookieMap.cpp
@@ -552,10 +552,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<CookieMapIterator, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForCookieMapIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCookieMapIterator = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForCookieMapIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForCookieMapIterator = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCookieMapIterator, &WebCore::DOMIsoSubspaces::m_subspaceForCookieMapIterator);
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
@@ -634,10 +631,7 @@ GCClient::IsoSubspace* JSCookieMap::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSCookieMap, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCookieMap.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCookieMap = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCookieMap.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCookieMap = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCookieMap, &WebCore::DOMIsoSubspaces::m_subspaceForCookieMap);
 }
 
 void JSCookieMap::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSCustomEvent.cpp
+++ b/src/jsc/bindings/webcore/JSCustomEvent.cpp
@@ -301,10 +301,7 @@ JSC::GCClient::IsoSubspace* JSCustomEvent::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSCustomEvent, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCustomEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCustomEvent = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCustomEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCustomEvent = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCustomEvent, &WebCore::DOMIsoSubspaces::m_subspaceForCustomEvent);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSDOMException.cpp
+++ b/src/jsc/bindings/webcore/JSDOMException.cpp
@@ -318,10 +318,7 @@ JSC::GCClient::IsoSubspace* JSDOMException::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSDOMException, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDOMException.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDOMException = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDOMException.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMException = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForDOMException, &WebCore::DOMIsoSubspaces::m_subspaceForDOMException);
 }
 
 void JSDOMException::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSDOMFormData.cpp
+++ b/src/jsc/bindings/webcore/JSDOMFormData.cpp
@@ -536,10 +536,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<DOMFormDataIterator, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForDOMFormDataIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDOMFormDataIterator = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForDOMFormDataIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMFormDataIterator = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForDOMFormDataIterator, &WebCore::DOMIsoSubspaces::m_subspaceForDOMFormDataIterator);
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
@@ -701,10 +698,7 @@ JSC::GCClient::IsoSubspace* JSDOMFormData::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSDOMFormData, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDOMFormData.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDOMFormData = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDOMFormData.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMFormData = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForDOMFormData, &WebCore::DOMIsoSubspaces::m_subspaceForDOMFormData);
 }
 
 void JSDOMFormData::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSDOMURL.cpp
+++ b/src/jsc/bindings/webcore/JSDOMURL.cpp
@@ -880,10 +880,7 @@ JSC::GCClient::IsoSubspace* JSDOMURL::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSDOMURL, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDOMURL.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDOMURL = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDOMURL.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDOMURL = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForDOMURL, &WebCore::DOMIsoSubspaces::m_subspaceForDOMURL);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSErrorEvent.cpp
+++ b/src/jsc/bindings/webcore/JSErrorEvent.cpp
@@ -375,10 +375,7 @@ JSC::GCClient::IsoSubspace* JSErrorEvent::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSErrorEvent, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForErrorEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForErrorEvent = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForErrorEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForErrorEvent = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForErrorEvent, &WebCore::DOMIsoSubspaces::m_subspaceForErrorEvent);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSEvent.cpp
+++ b/src/jsc/bindings/webcore/JSEvent.cpp
@@ -583,10 +583,7 @@ JSC::GCClient::IsoSubspace* JSEvent::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSEvent, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForEvent = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForEvent = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForEvent, &WebCore::DOMIsoSubspaces::m_subspaceForEvent);
 }
 
 void JSEvent::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSEventEmitter.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitter.cpp
@@ -511,10 +511,7 @@ JSC::GCClient::IsoSubspace* JSEventEmitter::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSEventEmitter, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForEventEmitter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForEventEmitter = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForEventEmitter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForEventEmitter = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForEventEmitter, &WebCore::DOMIsoSubspaces::m_subspaceForEventEmitter);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSEventTarget.cpp
+++ b/src/jsc/bindings/webcore/JSEventTarget.cpp
@@ -306,10 +306,7 @@ JSC::GCClient::IsoSubspace* JSEventTarget::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSEventTarget, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForEventTarget.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForEventTarget = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForEventTarget.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForEventTarget = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForEventTarget, &WebCore::DOMIsoSubspaces::m_subspaceForEventTarget);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSFetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/JSFetchHeaders.cpp
@@ -528,10 +528,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<FetchHeadersIterator, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForFetchHeadersIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForFetchHeadersIterator = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForFetchHeadersIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForFetchHeadersIterator = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForFetchHeadersIterator, &WebCore::DOMIsoSubspaces::m_subspaceForFetchHeadersIterator);
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
@@ -640,10 +637,7 @@ JSC::GCClient::IsoSubspace* JSFetchHeaders::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSFetchHeaders, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForFetchHeaders.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForFetchHeaders = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForFetchHeaders.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForFetchHeaders = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForFetchHeaders, &WebCore::DOMIsoSubspaces::m_subspaceForFetchHeaders);
 }
 
 void JSFetchHeaders::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSMIMEParams.h
+++ b/src/jsc/bindings/webcore/JSMIMEParams.h
@@ -22,10 +22,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<MyClassT, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSMIMEParams.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMIMEParams = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSMIMEParams.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMIMEParams = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSMIMEParams, &WebCore::DOMIsoSubspaces::m_subspaceForJSMIMEParams);
     }
 
     static JSMIMEParams* create(JSC::VM& vm, JSC::Structure* structure, JSC::JSMap* map);

--- a/src/jsc/bindings/webcore/JSMIMEType.h
+++ b/src/jsc/bindings/webcore/JSMIMEType.h
@@ -23,10 +23,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<MyClassT, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSMIMEType.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSMIMEType = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSMIMEType.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSMIMEType = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSMIMEType, &WebCore::DOMIsoSubspaces::m_subspaceForJSMIMEType);
     }
 
     static JSMIMEType* create(JSC::VM& vm, JSC::Structure* structure, WTF::String type, WTF::String subtype, JSMIMEParams* params);

--- a/src/jsc/bindings/webcore/JSMessageChannel.cpp
+++ b/src/jsc/bindings/webcore/JSMessageChannel.cpp
@@ -216,10 +216,7 @@ JSC::GCClient::IsoSubspace* JSMessageChannel::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSMessageChannel, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMessageChannel.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMessageChannel = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMessageChannel.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMessageChannel = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForMessageChannel, &WebCore::DOMIsoSubspaces::m_subspaceForMessageChannel);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSMessageEvent.cpp
+++ b/src/jsc/bindings/webcore/JSMessageEvent.cpp
@@ -464,10 +464,7 @@ JSC::GCClient::IsoSubspace* JSMessageEvent::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSMessageEvent, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMessageEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMessageEvent = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMessageEvent.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMessageEvent = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForMessageEvent, &WebCore::DOMIsoSubspaces::m_subspaceForMessageEvent);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -412,10 +412,7 @@ JSC::GCClient::IsoSubspace* JSMessagePort::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSMessagePort, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForMessagePort.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForMessagePort = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForMessagePort.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForMessagePort = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForMessagePort, &WebCore::DOMIsoSubspaces::m_subspaceForMessagePort);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSPerformance.cpp
+++ b/src/jsc/bindings/webcore/JSPerformance.cpp
@@ -541,10 +541,7 @@ JSC::GCClient::IsoSubspace* JSPerformance::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformance, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformance.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformance = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformance.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformance = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPerformance, &WebCore::DOMIsoSubspaces::m_subspaceForPerformance);
 }
 
 void JSPerformance::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSPerformanceEntry.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceEntry.cpp
@@ -256,10 +256,7 @@ JSC::GCClient::IsoSubspace* JSPerformanceEntry::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformanceEntry, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceEntry.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceEntry = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceEntry.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceEntry = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPerformanceEntry, &WebCore::DOMIsoSubspaces::m_subspaceForPerformanceEntry);
 }
 
 void JSPerformanceEntry::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSPerformanceMark.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceMark.cpp
@@ -207,10 +207,7 @@ JSC::GCClient::IsoSubspace* JSPerformanceMark::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformanceMark, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceMark.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceMark = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceMark.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceMark = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPerformanceMark, &WebCore::DOMIsoSubspaces::m_subspaceForPerformanceMark);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSPerformanceMeasure.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceMeasure.cpp
@@ -173,10 +173,7 @@ JSC::GCClient::IsoSubspace* JSPerformanceMeasure::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformanceMeasure, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceMeasure.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceMeasure = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceMeasure.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceMeasure = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPerformanceMeasure, &WebCore::DOMIsoSubspaces::m_subspaceForPerformanceMeasure);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSPerformanceObserver.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceObserver.cpp
@@ -331,10 +331,7 @@ JSC::GCClient::IsoSubspace* JSPerformanceObserver::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformanceObserver, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceObserver.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceObserver = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceObserver.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceObserver = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPerformanceObserver, &WebCore::DOMIsoSubspaces::m_subspaceForPerformanceObserver);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/JSPerformanceObserverEntryList.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceObserverEntryList.cpp
@@ -233,10 +233,7 @@ JSC::GCClient::IsoSubspace* JSPerformanceObserverEntryList::subspaceForImpl(JSC:
 {
     return WebCore::subspaceForImpl<JSPerformanceObserverEntryList, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceObserverEntryList.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceObserverEntryList = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceObserverEntryList.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceObserverEntryList = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPerformanceObserverEntryList, &WebCore::DOMIsoSubspaces::m_subspaceForPerformanceObserverEntryList);
 }
 
 void JSPerformanceObserverEntryList::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSPerformanceResourceTiming.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceResourceTiming.cpp
@@ -520,7 +520,7 @@ JSC_DEFINE_HOST_FUNCTION(jsPerformanceResourceTimingPrototypeFunction_toJSON, (J
 
 JSC::GCClient::IsoSubspace* JSPerformanceResourceTiming::subspaceForImpl(JSC::VM& vm)
 {
-    return WebCore::subspaceForImpl<JSPerformanceResourceTiming, UseCustomHeapCellType::No>(vm, [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceResourceTiming.get(); }, [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceResourceTiming = std::forward<decltype(space)>(space); }, [](auto& spaces) { return spaces.m_subspaceForPerformanceResourceTiming.get(); }, [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceResourceTiming = std::forward<decltype(space)>(space); });
+    return WebCore::subspaceForImpl<JSPerformanceResourceTiming, UseCustomHeapCellType::No>(vm, &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPerformanceResourceTiming, &WebCore::DOMIsoSubspaces::m_subspaceForPerformanceResourceTiming);
 }
 
 void JSPerformanceResourceTiming::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSPerformanceServerTiming.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceServerTiming.cpp
@@ -236,7 +236,7 @@ JSC_DEFINE_HOST_FUNCTION(jsPerformanceServerTimingPrototypeFunction_toJSON, (JSG
 
 JSC::GCClient::IsoSubspace* JSPerformanceServerTiming::subspaceForImpl(JSC::VM& vm)
 {
-    return WebCore::subspaceForImpl<JSPerformanceServerTiming, UseCustomHeapCellType::No>(vm, [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceServerTiming.get(); }, [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceServerTiming = std::forward<decltype(space)>(space); }, [](auto& spaces) { return spaces.m_subspaceForPerformanceServerTiming.get(); }, [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceServerTiming = std::forward<decltype(space)>(space); });
+    return WebCore::subspaceForImpl<JSPerformanceServerTiming, UseCustomHeapCellType::No>(vm, &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPerformanceServerTiming, &WebCore::DOMIsoSubspaces::m_subspaceForPerformanceServerTiming);
 }
 
 void JSPerformanceServerTiming::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSPerformanceTiming.cpp
+++ b/src/jsc/bindings/webcore/JSPerformanceTiming.cpp
@@ -561,10 +561,7 @@ JSC::GCClient::IsoSubspace* JSPerformanceTiming::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSPerformanceTiming, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPerformanceTiming.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPerformanceTiming = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPerformanceTiming.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPerformanceTiming = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPerformanceTiming, &WebCore::DOMIsoSubspaces::m_subspaceForPerformanceTiming);
 }
 
 void JSPerformanceTiming::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSTextEncoder.cpp
+++ b/src/jsc/bindings/webcore/JSTextEncoder.cpp
@@ -315,10 +315,7 @@ JSC::GCClient::IsoSubspace* JSTextEncoder::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSTextEncoder, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTextEncoder.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTextEncoder = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTextEncoder.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTextEncoder = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForTextEncoder, &WebCore::DOMIsoSubspaces::m_subspaceForTextEncoder);
 }
 
 void JSTextEncoder::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSURLPattern.cpp
+++ b/src/jsc/bindings/webcore/JSURLPattern.cpp
@@ -461,7 +461,7 @@ JSC_DEFINE_HOST_FUNCTION(jsURLPatternPrototypeFunction_exec, (JSGlobalObject * l
 
 JSC::GCClient::IsoSubspace* JSURLPattern::subspaceForImpl(JSC::VM& vm)
 {
-    return WebCore::subspaceForImpl<JSURLPattern, UseCustomHeapCellType::No>(vm, [](auto& spaces) { return spaces.m_clientSubspaceForURLPattern.get(); }, [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForURLPattern = std::forward<decltype(space)>(space); }, [](auto& spaces) { return spaces.m_subspaceForURLPattern.get(); }, [](auto& spaces, auto&& space) { spaces.m_subspaceForURLPattern = std::forward<decltype(space)>(space); });
+    return WebCore::subspaceForImpl<JSURLPattern, UseCustomHeapCellType::No>(vm, &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForURLPattern, &WebCore::DOMIsoSubspaces::m_subspaceForURLPattern);
 }
 
 void JSURLPattern::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSURLSearchParams.cpp
+++ b/src/jsc/bindings/webcore/JSURLSearchParams.cpp
@@ -680,10 +680,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<URLSearchParamsIterator, UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForURLSearchParamsIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForURLSearchParamsIterator = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForURLSearchParamsIterator.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForURLSearchParamsIterator = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForURLSearchParamsIterator, &WebCore::DOMIsoSubspaces::m_subspaceForURLSearchParamsIterator);
     }
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
@@ -762,10 +759,7 @@ JSC::GCClient::IsoSubspace* JSURLSearchParams::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSURLSearchParams, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForURLSearchParams.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForURLSearchParams = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForURLSearchParams.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForURLSearchParams = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForURLSearchParams, &WebCore::DOMIsoSubspaces::m_subspaceForURLSearchParams);
 }
 
 void JSURLSearchParams::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSWasmStreamingCompiler.cpp
+++ b/src/jsc/bindings/webcore/JSWasmStreamingCompiler.cpp
@@ -193,10 +193,7 @@ GCClient::IsoSubspace* JSWasmStreamingCompiler::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSWasmStreamingCompiler, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWasmStreamingCompiler.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWasmStreamingCompiler = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWasmStreamingCompiler.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWasmStreamingCompiler = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForWasmStreamingCompiler, &WebCore::DOMIsoSubspaces::m_subspaceForWasmStreamingCompiler);
 }
 
 void JSWasmStreamingCompiler::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/JSWebSocket.cpp
+++ b/src/jsc/bindings/webcore/JSWebSocket.cpp
@@ -947,10 +947,7 @@ JSC::GCClient::IsoSubspace* JSWebSocket::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSWebSocket, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWebSocket.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWebSocket = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWebSocket.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWebSocket = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForWebSocket, &WebCore::DOMIsoSubspaces::m_subspaceForWebSocket);
 }
 
 size_t JSWebSocket::estimatedSize(JSCell* cell, JSC::VM& vm)

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -952,10 +952,7 @@ JSC::GCClient::IsoSubspace* JSWorker::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSWorker, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWorker.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWorker = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWorker.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWorker = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForWorker, &WebCore::DOMIsoSubspaces::m_subspaceForWorker);
 }
 
 void JSWorker::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp
@@ -59,10 +59,7 @@ GCClient::IsoSubspace* JSAsyncIteratorSourceOperation::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSAsyncIteratorSourceOperation, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForAsyncIteratorSourceOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForAsyncIteratorSourceOperation = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForAsyncIteratorSourceOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForAsyncIteratorSourceOperation = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForAsyncIteratorSourceOperation, &WebCore::DOMIsoSubspaces::m_subspaceForAsyncIteratorSourceOperation);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp
@@ -84,10 +84,7 @@ GCClient::IsoSubspace* JSBunStandaloneTextSink::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSBunStandaloneTextSink, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForBunStandaloneTextSink.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBunStandaloneTextSink = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForBunStandaloneTextSink.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForBunStandaloneTextSink = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForBunStandaloneTextSink, &WebCore::DOMIsoSubspaces::m_subspaceForBunStandaloneTextSink);
 }
 
 DEFINE_VISIT_CHILDREN(JSBunStandaloneTextSink);
@@ -141,10 +138,7 @@ GCClient::IsoSubspace* JSOneShotDirectSink::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSOneShotDirectSink, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForOneShotDirectSink.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForOneShotDirectSink = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForOneShotDirectSink.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForOneShotDirectSink = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForOneShotDirectSink, &WebCore::DOMIsoSubspaces::m_subspaceForOneShotDirectSink);
 }
 
 DEFINE_VISIT_CHILDREN(JSOneShotDirectSink);
@@ -206,10 +200,7 @@ GCClient::IsoSubspace* JSReadableStreamIntoArrayOperation::subspaceForImpl(VM& v
 {
     return WebCore::subspaceForImpl<JSReadableStreamIntoArrayOperation, WebCore::UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamIntoArrayOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamIntoArrayOperation = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamIntoArrayOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamIntoArrayOperation = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableStreamIntoArrayOperation, &WebCore::DOMIsoSubspaces::m_subspaceForReadableStreamIntoArrayOperation);
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamIntoArrayOperation);

--- a/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
+++ b/src/jsc/bindings/webcore/streams/BunStreamSource.cpp
@@ -79,10 +79,7 @@ GCClient::IsoSubspace* JSNativeStreamSourceAdapter::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSNativeStreamSourceAdapter, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForNativeStreamSourceAdapter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForNativeStreamSourceAdapter = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForNativeStreamSourceAdapter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForNativeStreamSourceAdapter = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForNativeStreamSourceAdapter, &WebCore::DOMIsoSubspaces::m_subspaceForNativeStreamSourceAdapter);
 }
 
 template<typename Visitor>
@@ -124,10 +121,7 @@ GCClient::IsoSubspace* JSDirectSinkCloseState::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSDirectSinkCloseState, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDirectSinkCloseState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDirectSinkCloseState = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDirectSinkCloseState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDirectSinkCloseState = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForDirectSinkCloseState, &WebCore::DOMIsoSubspaces::m_subspaceForDirectSinkCloseState);
 }
 
 template<typename Visitor>
@@ -182,10 +176,7 @@ GCClient::IsoSubspace* JSReadStreamIntoSinkOperation::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadStreamIntoSinkOperation, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadStreamIntoSinkOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadStreamIntoSinkOperation = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadStreamIntoSinkOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadStreamIntoSinkOperation = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadStreamIntoSinkOperation, &WebCore::DOMIsoSubspaces::m_subspaceForReadStreamIntoSinkOperation);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp
@@ -94,10 +94,7 @@ template<> GCClient::IsoSubspace* JSByteLengthQueuingStrategyConstructor::subspa
 {
     return WebCore::subspaceForImpl<JSByteLengthQueuingStrategyConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForByteLengthQueuingStrategyConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForByteLengthQueuingStrategyConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForByteLengthQueuingStrategyConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForByteLengthQueuingStrategyConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForByteLengthQueuingStrategyConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForByteLengthQueuingStrategyConstructor);
 }
 
 template<> void JSByteLengthQueuingStrategyConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -231,10 +228,7 @@ GCClient::IsoSubspace* JSByteLengthQueuingStrategy::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSByteLengthQueuingStrategy, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForByteLengthQueuingStrategy.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForByteLengthQueuingStrategy = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForByteLengthQueuingStrategy.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForByteLengthQueuingStrategy = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForByteLengthQueuingStrategy, &WebCore::DOMIsoSubspaces::m_subspaceForByteLengthQueuingStrategy);
 }
 
 // Prototype accessors

--- a/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp
@@ -131,10 +131,7 @@ template<> GCClient::IsoSubspace* JSCompressionStreamConstructor::subspaceForImp
 {
     return WebCore::subspaceForImpl<JSCompressionStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCompressionStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCompressionStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCompressionStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCompressionStreamConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCompressionStreamConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForCompressionStreamConstructor);
 }
 
 template<> void JSCompressionStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -227,10 +224,7 @@ GCClient::IsoSubspace* JSCompressionStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSCompressionStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCompressionStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCompressionStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCompressionStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCompressionStream = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCompressionStream, &WebCore::DOMIsoSubspaces::m_subspaceForCompressionStream);
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsCompressionStreamPrototypeGetter_constructor, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCountQueuingStrategy.cpp
@@ -94,10 +94,7 @@ template<> GCClient::IsoSubspace* JSCountQueuingStrategyConstructor::subspaceFor
 {
     return WebCore::subspaceForImpl<JSCountQueuingStrategyConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCountQueuingStrategyConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCountQueuingStrategyConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCountQueuingStrategyConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCountQueuingStrategyConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCountQueuingStrategyConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForCountQueuingStrategyConstructor);
 }
 
 template<> void JSCountQueuingStrategyConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -231,10 +228,7 @@ GCClient::IsoSubspace* JSCountQueuingStrategy::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSCountQueuingStrategy, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCountQueuingStrategy.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCountQueuingStrategy = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCountQueuingStrategy.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCountQueuingStrategy = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCountQueuingStrategy, &WebCore::DOMIsoSubspaces::m_subspaceForCountQueuingStrategy);
 }
 
 // Prototype accessors

--- a/src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.cpp
+++ b/src/jsc/bindings/webcore/streams/JSCrossRealmTransformState.cpp
@@ -47,10 +47,7 @@ GCClient::IsoSubspace* JSCrossRealmTransformState::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSCrossRealmTransformState, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCrossRealmTransformState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCrossRealmTransformState = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCrossRealmTransformState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCrossRealmTransformState = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCrossRealmTransformState, &WebCore::DOMIsoSubspaces::m_subspaceForCrossRealmTransformState);
 }
 
 DEFINE_VISIT_CHILDREN(JSCrossRealmTransformState);

--- a/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp
@@ -131,10 +131,7 @@ template<> GCClient::IsoSubspace* JSDecompressionStreamConstructor::subspaceForI
 {
     return WebCore::subspaceForImpl<JSDecompressionStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDecompressionStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDecompressionStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDecompressionStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDecompressionStreamConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForDecompressionStreamConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForDecompressionStreamConstructor);
 }
 
 template<> void JSDecompressionStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -227,10 +224,7 @@ GCClient::IsoSubspace* JSDecompressionStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSDecompressionStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDecompressionStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDecompressionStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDecompressionStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDecompressionStream = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForDecompressionStream, &WebCore::DOMIsoSubspaces::m_subspaceForDecompressionStream);
 }
 
 JSC_DEFINE_CUSTOM_GETTER(jsDecompressionStreamPrototypeGetter_constructor, (JSGlobalObject * lexicalGlobalObject, JSC::EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -92,10 +92,7 @@ GCClient::IsoSubspace* JSDirectStreamController::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSDirectStreamController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForDirectStreamController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForDirectStreamController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForDirectStreamController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForDirectStreamController = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForDirectStreamController, &WebCore::DOMIsoSubspaces::m_subspaceForDirectStreamController);
 }
 
 DEFINE_VISIT_CHILDREN(JSDirectStreamController);

--- a/src/jsc/bindings/webcore/streams/JSPullIntoDescriptor.cpp
+++ b/src/jsc/bindings/webcore/streams/JSPullIntoDescriptor.cpp
@@ -51,10 +51,7 @@ GCClient::IsoSubspace* JSPullIntoDescriptor::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSPullIntoDescriptor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForPullIntoDescriptor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForPullIntoDescriptor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForPullIntoDescriptor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForPullIntoDescriptor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForPullIntoDescriptor, &WebCore::DOMIsoSubspaces::m_subspaceForPullIntoDescriptor);
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadRequest.cpp
@@ -71,10 +71,7 @@ GCClient::IsoSubspace* JSReadRequest::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadRequest, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadRequest = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadRequest = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadRequest, &WebCore::DOMIsoSubspaces::m_subspaceForReadRequest);
 }
 
 DEFINE_VISIT_CHILDREN(JSReadRequest);
@@ -276,10 +273,7 @@ GCClient::IsoSubspace* JSReadIntoRequest::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadIntoRequest, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadIntoRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadIntoRequest = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadIntoRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadIntoRequest = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadIntoRequest, &WebCore::DOMIsoSubspaces::m_subspaceForReadIntoRequest);
 }
 
 DEFINE_VISIT_CHILDREN(JSReadIntoRequest);

--- a/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableByteStreamController.cpp
@@ -352,10 +352,7 @@ GCClient::IsoSubspace* JSReadableByteStreamController::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableByteStreamController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableByteStreamController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableByteStreamController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableByteStreamController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableByteStreamController = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableByteStreamController, &WebCore::DOMIsoSubspaces::m_subspaceForReadableByteStreamController);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStream.cpp
@@ -287,10 +287,7 @@ template<> GCClient::IsoSubspace* JSReadableStreamConstructor::subspaceForImpl(J
 {
     return WebCore::subspaceForImpl<JSReadableStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableStreamConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForReadableStreamConstructor);
 }
 
 template<> void JSReadableStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -481,10 +478,7 @@ GCClient::IsoSubspace* JSReadableStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStream = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableStream, &WebCore::DOMIsoSubspaces::m_subspaceForReadableStream);
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStream);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamAsyncIterator.cpp
@@ -122,10 +122,7 @@ GCClient::IsoSubspace* JSReadableStreamAsyncIterator::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableStreamAsyncIterator, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamAsyncIterator.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamAsyncIterator = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamAsyncIterator.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamAsyncIterator = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableStreamAsyncIterator, &WebCore::DOMIsoSubspaces::m_subspaceForReadableStreamAsyncIterator);
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamAsyncIterator);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBReader.cpp
@@ -214,10 +214,7 @@ template<> GCClient::IsoSubspace* JSReadableStreamBYOBReaderConstructor::subspac
 {
     return WebCore::subspaceForImpl<JSReadableStreamBYOBReaderConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamBYOBReaderConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamBYOBReaderConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamBYOBReaderConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamBYOBReaderConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableStreamBYOBReaderConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForReadableStreamBYOBReaderConstructor);
 }
 
 template<> void JSReadableStreamBYOBReaderConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -348,10 +345,7 @@ GCClient::IsoSubspace* JSReadableStreamBYOBReader::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableStreamBYOBReader, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamBYOBReader.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamBYOBReader = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamBYOBReader.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamBYOBReader = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableStreamBYOBReader, &WebCore::DOMIsoSubspaces::m_subspaceForReadableStreamBYOBReader);
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamBYOBReader);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamBYOBRequest.cpp
@@ -173,10 +173,7 @@ GCClient::IsoSubspace* JSReadableStreamBYOBRequest::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableStreamBYOBRequest, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamBYOBRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamBYOBRequest = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamBYOBRequest.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamBYOBRequest = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableStreamBYOBRequest, &WebCore::DOMIsoSubspaces::m_subspaceForReadableStreamBYOBRequest);
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamBYOBRequest);

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultController.cpp
@@ -301,10 +301,7 @@ GCClient::IsoSubspace* JSReadableStreamDefaultController::subspaceForImpl(VM& vm
 {
     return WebCore::subspaceForImpl<JSReadableStreamDefaultController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamDefaultController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamDefaultController = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableStreamDefaultController, &WebCore::DOMIsoSubspaces::m_subspaceForReadableStreamDefaultController);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -516,10 +516,7 @@ template<> GCClient::IsoSubspace* JSReadableStreamDefaultReaderConstructor::subs
 {
     return WebCore::subspaceForImpl<JSReadableStreamDefaultReaderConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamDefaultReaderConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamDefaultReaderConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamDefaultReaderConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamDefaultReaderConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableStreamDefaultReaderConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForReadableStreamDefaultReaderConstructor);
 }
 
 template<> void JSReadableStreamDefaultReaderConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -653,10 +650,7 @@ GCClient::IsoSubspace* JSReadableStreamDefaultReader::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSReadableStreamDefaultReader, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForReadableStreamDefaultReader.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForReadableStreamDefaultReader = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForReadableStreamDefaultReader.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForReadableStreamDefaultReader = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForReadableStreamDefaultReader, &WebCore::DOMIsoSubspaces::m_subspaceForReadableStreamDefaultReader);
 }
 
 DEFINE_VISIT_CHILDREN(JSReadableStreamDefaultReader);

--- a/src/jsc/bindings/webcore/streams/JSStreamAlgorithmContexts.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamAlgorithmContexts.cpp
@@ -45,10 +45,7 @@ GCClient::IsoSubspace* JSStreamFromIterableContext::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSStreamFromIterableContext, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForStreamFromIterableContext.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForStreamFromIterableContext = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForStreamFromIterableContext.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForStreamFromIterableContext = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForStreamFromIterableContext, &WebCore::DOMIsoSubspaces::m_subspaceForStreamFromIterableContext);
 }
 
 DEFINE_VISIT_CHILDREN(JSStreamFromIterableContext);

--- a/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamPipeToOperation.cpp
@@ -65,10 +65,7 @@ GCClient::IsoSubspace* JSStreamPipeToOperation::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSStreamPipeToOperation, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForStreamPipeToOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForStreamPipeToOperation = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForStreamPipeToOperation.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForStreamPipeToOperation = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForStreamPipeToOperation, &WebCore::DOMIsoSubspaces::m_subspaceForStreamPipeToOperation);
 }
 
 DEFINE_VISIT_CHILDREN(JSStreamPipeToOperation);

--- a/src/jsc/bindings/webcore/streams/JSStreamTeeState.cpp
+++ b/src/jsc/bindings/webcore/streams/JSStreamTeeState.cpp
@@ -46,10 +46,7 @@ GCClient::IsoSubspace* JSStreamTeeState::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSStreamTeeState, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForStreamTeeState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForStreamTeeState = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForStreamTeeState.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForStreamTeeState = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForStreamTeeState, &WebCore::DOMIsoSubspaces::m_subspaceForStreamTeeState);
 }
 
 DEFINE_VISIT_CHILDREN(JSStreamTeeState);

--- a/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextDecoderStream.cpp
@@ -109,10 +109,7 @@ template<> GCClient::IsoSubspace* JSTextDecoderStreamConstructor::subspaceForImp
 {
     return WebCore::subspaceForImpl<JSTextDecoderStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTextDecoderStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTextDecoderStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTextDecoderStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTextDecoderStreamConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForTextDecoderStreamConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForTextDecoderStreamConstructor);
 }
 
 template<> void JSTextDecoderStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -266,10 +263,7 @@ GCClient::IsoSubspace* JSTextDecoderStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSTextDecoderStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTextDecoderStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTextDecoderStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTextDecoderStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTextDecoderStream = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForTextDecoderStream, &WebCore::DOMIsoSubspaces::m_subspaceForTextDecoderStream);
 }
 
 // Prototype accessors

--- a/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTextEncoderStream.cpp
@@ -109,10 +109,7 @@ template<> GCClient::IsoSubspace* JSTextEncoderStreamConstructor::subspaceForImp
 {
     return WebCore::subspaceForImpl<JSTextEncoderStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTextEncoderStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTextEncoderStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTextEncoderStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTextEncoderStreamConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForTextEncoderStreamConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForTextEncoderStreamConstructor);
 }
 
 template<> void JSTextEncoderStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -226,10 +223,7 @@ GCClient::IsoSubspace* JSTextEncoderStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSTextEncoderStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTextEncoderStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTextEncoderStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTextEncoderStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTextEncoderStream = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForTextEncoderStream, &WebCore::DOMIsoSubspaces::m_subspaceForTextEncoderStream);
 }
 
 // Prototype accessors

--- a/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStream.cpp
@@ -103,10 +103,7 @@ template<> GCClient::IsoSubspace* JSTransformStreamConstructor::subspaceForImpl(
 {
     return WebCore::subspaceForImpl<JSTransformStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTransformStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTransformStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTransformStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTransformStreamConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForTransformStreamConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForTransformStreamConstructor);
 }
 
 template<> void JSTransformStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -263,10 +260,7 @@ GCClient::IsoSubspace* JSTransformStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSTransformStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTransformStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTransformStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTransformStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTransformStream = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForTransformStream, &WebCore::DOMIsoSubspaces::m_subspaceForTransformStream);
 }
 
 DEFINE_VISIT_CHILDREN(JSTransformStream);

--- a/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSTransformStreamDefaultController.cpp
@@ -256,10 +256,7 @@ GCClient::IsoSubspace* JSTransformStreamDefaultController::subspaceForImpl(VM& v
 {
     return WebCore::subspaceForImpl<JSTransformStreamDefaultController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForTransformStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForTransformStreamDefaultController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForTransformStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForTransformStreamDefaultController = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForTransformStreamDefaultController, &WebCore::DOMIsoSubspaces::m_subspaceForTransformStreamDefaultController);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStream.cpp
@@ -105,10 +105,7 @@ template<> GCClient::IsoSubspace* JSWritableStreamConstructor::subspaceForImpl(J
 {
     return WebCore::subspaceForImpl<JSWritableStreamConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWritableStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWritableStreamConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWritableStreamConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWritableStreamConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForWritableStreamConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForWritableStreamConstructor);
 }
 
 template<> void JSWritableStreamConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -263,10 +260,7 @@ GCClient::IsoSubspace* JSWritableStream::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSWritableStream, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWritableStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWritableStream = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWritableStream.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWritableStream = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForWritableStream, &WebCore::DOMIsoSubspaces::m_subspaceForWritableStream);
 }
 
 DEFINE_VISIT_CHILDREN(JSWritableStream);

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultController.cpp
@@ -309,10 +309,7 @@ GCClient::IsoSubspace* JSWritableStreamDefaultController::subspaceForImpl(VM& vm
 {
     return WebCore::subspaceForImpl<JSWritableStreamDefaultController, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWritableStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWritableStreamDefaultController = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWritableStreamDefaultController.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWritableStreamDefaultController = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForWritableStreamDefaultController, &WebCore::DOMIsoSubspaces::m_subspaceForWritableStreamDefaultController);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
+++ b/src/jsc/bindings/webcore/streams/JSWritableStreamDefaultWriter.cpp
@@ -239,10 +239,7 @@ template<> GCClient::IsoSubspace* JSWritableStreamDefaultWriterConstructor::subs
 {
     return WebCore::subspaceForImpl<JSWritableStreamDefaultWriterConstructor, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWritableStreamDefaultWriterConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWritableStreamDefaultWriterConstructor = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWritableStreamDefaultWriterConstructor.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWritableStreamDefaultWriterConstructor = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForWritableStreamDefaultWriterConstructor, &WebCore::DOMIsoSubspaces::m_subspaceForWritableStreamDefaultWriterConstructor);
 }
 
 template<> void JSWritableStreamDefaultWriterConstructor::finishCreation(VM& vm, JSDOMGlobalObject& globalObject)
@@ -368,10 +365,7 @@ GCClient::IsoSubspace* JSWritableStreamDefaultWriter::subspaceForImpl(VM& vm)
 {
     return WebCore::subspaceForImpl<JSWritableStreamDefaultWriter, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForWritableStreamDefaultWriter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForWritableStreamDefaultWriter = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForWritableStreamDefaultWriter.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForWritableStreamDefaultWriter = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForWritableStreamDefaultWriter, &WebCore::DOMIsoSubspaces::m_subspaceForWritableStreamDefaultWriter);
 }
 
 DEFINE_VISIT_CHILDREN(JSWritableStreamDefaultWriter);

--- a/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
+++ b/src/jsc/bindings/webcrypto/JSCryptoKey.cpp
@@ -312,10 +312,7 @@ JSC::GCClient::IsoSubspace* JSCryptoKey::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSCryptoKey, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForCryptoKey.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForCryptoKey = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForCryptoKey.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForCryptoKey = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForCryptoKey, &WebCore::DOMIsoSubspaces::m_subspaceForCryptoKey);
 }
 
 template<typename Visitor>

--- a/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/JSSubtleCrypto.cpp
@@ -804,10 +804,7 @@ JSC::GCClient::IsoSubspace* JSSubtleCrypto::subspaceForImpl(JSC::VM& vm)
 {
     return WebCore::subspaceForImpl<JSSubtleCrypto, UseCustomHeapCellType::No>(
         vm,
-        [](auto& spaces) { return spaces.m_clientSubspaceForSubtleCrypto.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForSubtleCrypto = std::forward<decltype(space)>(space); },
-        [](auto& spaces) { return spaces.m_subspaceForSubtleCrypto.get(); },
-        [](auto& spaces, auto&& space) { spaces.m_subspaceForSubtleCrypto = std::forward<decltype(space)>(space); });
+        &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForSubtleCrypto, &WebCore::DOMIsoSubspaces::m_subspaceForSubtleCrypto);
 }
 
 void JSSubtleCrypto::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)

--- a/src/runtime/bake/BakeGlobalObject.h
+++ b/src/runtime/bake/BakeGlobalObject.h
@@ -17,10 +17,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<GlobalObject, WebCore::UseCustomHeapCellType::Yes>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForBakeGlobalScope.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForBakeGlobalScope = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForBakeGlobalScope.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForBakeGlobalScope = std::forward<decltype(space)>(space); },
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForBakeGlobalScope, &WebCore::DOMIsoSubspaces::m_subspaceForBakeGlobalScope,
             [](auto& server) -> JSC::HeapCellType& { return server.m_heapCellTypeForBakeGlobalObject; });
     }
 

--- a/src/runtime/webview/JSWebView.h
+++ b/src/runtime/webview/JSWebView.h
@@ -211,10 +211,7 @@ public:
             return nullptr;
         return WebCore::subspaceForImpl<JSWebView, WebCore::UseCustomHeapCellType::No>(
             vm,
-            [](auto& spaces) { return spaces.m_clientSubspaceForJSWebView.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSWebView = std::forward<decltype(space)>(space); },
-            [](auto& spaces) { return spaces.m_subspaceForJSWebView.get(); },
-            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSWebView = std::forward<decltype(space)>(space); });
+            &WebCore::DOMClientIsoSubspaces::m_clientSubspaceForJSWebView, &WebCore::DOMIsoSubspaces::m_subspaceForJSWebView);
     }
 
 private:

--- a/test/internal/source-lints/iso-subspace-creation.test.ts
+++ b/test/internal/source-lints/iso-subspace-creation.test.ts
@@ -1,0 +1,66 @@
+import { Glob } from "bun";
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Every JS class with C++ fields has a subspaceFor<T>() that JSC calls on each
+// allocation of T. Creating the IsoSubspace behind it (lock the heap, build it,
+// register it, build the per-VM GCClient::IsoSubspace, fill both slots) is about
+// 640 bytes of code that runs once per type. When that creation path lived in
+// the ALWAYS_INLINE WebCore::subspaceForImpl template it was duplicated into
+// every subspaceFor<T>: 249 copies in the linux-x64 binary, and moving them out
+// of line made the stripped binary about 160 KB smaller.
+//
+// It now lives in exactly one out-of-line function, subspaceForImplSlow in
+// BunClientData.cpp, which also owns the two subspaces JSHeapData constructs
+// eagerly. A new class needs a slot in DOMIsoSubspaces.h and
+// DOMClientIsoSubspaces.h and a subspaceFor that passes both slots to
+// WebCore::subspaceForImpl; it never constructs an IsoSubspace itself.
+const creationSite = "src/jsc/bindings/BunClientData.cpp";
+
+const constructsIsoSubspace =
+  /\bISO_SUBSPACE_INIT(?:_WITH_NAME)?\b|\b(?:makeUnique|makeUniqueWithoutFastMallocCheck|make_unique)\s*<\s*(?:JSC::)?(?:GCClient::)?IsoSubspace\s*>|\bnew\s+(?:JSC::)?(?:GCClient::)?IsoSubspace\b/;
+
+function linesConstructingIsoSubspace(source: string): number[] {
+  if (!constructsIsoSubspace.test(source)) return [];
+  const lines: number[] = [];
+  source.split("\n").forEach((line, index) => {
+    const commentStart = line.indexOf("//");
+    const code = commentStart === -1 ? line : line.slice(0, commentStart);
+    if (constructsIsoSubspace.test(code)) lines.push(index + 1);
+  });
+  return lines;
+}
+
+test("IsoSubspaces are only constructed in BunClientData.cpp", async () => {
+  const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+  const src = path.join(repoRoot, "src");
+
+  // The codegen templates are included because anything they emit is repeated
+  // once per generated class.
+  const globs = [new Glob("**/*.{h,cpp}"), new Glob("codegen/**/*.ts")];
+  const violations: string[] = [];
+  let scanned = 0;
+  let linesInCreationSite = 0;
+
+  for (const glob of globs) {
+    for await (const rel of glob.scan({ cwd: src })) {
+      scanned++;
+      const relFromRepo = path.join("src", rel).replaceAll("\\", "/");
+      const lines = linesConstructingIsoSubspace(readFileSync(path.join(src, rel), "utf8"));
+      if (relFromRepo === creationSite) {
+        linesInCreationSite = lines.length;
+        continue;
+      }
+      for (const line of lines) violations.push(`${relFromRepo}:${line}`);
+    }
+  }
+
+  // Guards against the scan passing vacuously: the globs must have found the
+  // tree, and the one permitted file must still be where the creation lives.
+  expect(scanned).toBeGreaterThan(1000);
+  expect(linesInCreationSite).toBeGreaterThan(0);
+
+  violations.sort();
+  expect(violations).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- `WebCore::subspaceForImpl` in `src/jsc/bindings/BunClientData.h` is `ALWAYS_INLINE`, so its IsoSubspace creation path (take the heap lock, pick the HeapCellType, construct the `IsoSubspace`, register it for output constraints, construct the per-VM `GCClient::IsoSubspace`, store both) is inlined into every `subspaceFor<T>` in the binary.
- That path is about 640 bytes of code and runs once per (VM, type). In the linux-x64 binary 249 Bun-side functions carry a copy of it; the copies differ only in two member offsets, the cell type, `sizeof(T)` and two constants.

### Fix
- The creation path is now one `NEVER_INLINE` function, `subspaceForImplSlow` in `BunClientData.cpp`, taking those per-type values as arguments. The slot to fill is passed as a pointer to member of `DOMClientIsoSubspaces` / `DOMIsoSubspaces`, replacing the four getter and setter lambdas each caller used to pass.
- `subspaceForImpl` keeps only the per-allocation fast path inline: load the client data, load the slot, return it if set, otherwise call the slow path. The `static_assert` on destructibility and the `visitOutputConstraints` check still happen per type at compile time, in the inline part.
- Same behavior as before: same subspace per type, same lock, same two slot writes. The `IsoSubspace` name stays `"T"`, which is what `ISO_SUBSPACE_INIT(heap, cellType, T)` stringized when `T` was a template parameter.
- Every caller is updated (129 files: the hand-written bindings plus the `generate-classes.ts` and `generate-jssink.ts` templates); a grep for the old lambda form finds nothing left in `src/`. The `implementing-jsc-classes-cpp` skill snippet that showed the old call form is updated too.
- Stripped binary size, this PR vs its base commit (main build of dc59d3e7), from CI's binary-size step:

  | target | delta |
  | --- | --- |
  | bun-darwin-aarch64 | -177.6 KB |
  | bun-darwin-x64 | -224.1 KB |
  | bun-linux-aarch64 | -128.0 KB |
  | bun-linux-x64 | -160.0 KB |
  | bun-linux-aarch64-musl | -128.0 KB |
  | bun-linux-x64-musl | -160.0 KB |
  | bun-linux-aarch64-android | -64.0 KB |
  | bun-linux-x64-android | -96.0 KB |
  | bun-freebsd-x64 | -112.0 KB |
  | bun-freebsd-aarch64 | -96.0 KB |
  | bun-windows-x64 | -240.0 KB |
  | bun-windows-aarch64 | -77.0 KB |

- Test: `test/internal/source-lints/iso-subspace-creation.test.ts` greps `src/**/*.{h,cpp}` and `src/codegen/**/*.ts` for anything constructing an `IsoSubspace` (`ISO_SUBSPACE_INIT`, `makeUnique<IsoSubspace>`, `new IsoSubspace`) outside `BunClientData.cpp`. It fails on the base commit (the four inlined constructions in `BunClientData.h`) and passes here, and keeps a future class from growing its own copy of the creation path. `source-lints.yml` now also triggers on the C++ and codegen files it reads.
- Verified on a debug build: workers, node:vm, Headers, streams, mock functions, bun:sqlite, node:sqlite, node:crypto (hmac, ecdh, x509), FormData, URLSearchParams, MessageChannel, AbortSignal and web-globals tests pass. The generated `ZigGeneratedClasses.h` uses the new form.

### Background
- JSC allocates every cell type that has C++ fields out of its own `IsoSubspace` (a size-segregated heap region per type, so a freed slot can only be reused by the same type). `JSC::IsoSubspace` is the per-heap object; `GCClient::IsoSubspace` is the per-VM allocator handle onto it. Bun creates both lazily the first time a type is allocated.
- `DOMIsoSubspaces` and `DOMClientIsoSubspaces` are structs with one `std::unique_ptr` slot per type (the heap-side and VM-side objects respectively). `subspaceFor<T>` is the static hook JSC calls on every allocation of `T` to find the right subspace, which is why its inline body matters and its creation path does not.
- A pointer to data member (`&DOMIsoSubspaces::m_subspaceForFoo`) is a compile-time offset; `obj.*slot` reads that field. Passing it lets one out-of-line function fill any slot without a per-type lambda.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 132 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/iso-subspace-creation.test.ts
bun test v1.4.0 (8326d1bd3)

test/internal/source-lints/iso-subspace-creation.test.ts:
60 |   // tree, and the one permitted file must still be where the creation lives.
61 |   expect(scanned).toBeGreaterThan(1000);
62 |   expect(linesInCreationSite).toBeGreaterThan(0);
63 | 
64 |   violations.sort();
65 |   expect(violations).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/jsc/bindings/BunClientData.h:278",
+   "src/jsc/bindings/BunClientData.h:281",
+   "src/jsc/bindings/BunClientData.h:283",
+   "src/jsc/bindings/BunClientData.h:298",
+ ]

- Expected  - 1
+ Received  + 6

      at <anonymous> (/workspace/bun/test/internal/source-lints/iso-subspace-creation.test.ts:65:22)
(fail) IsoSubspaces are only constructed in BunClientData.cpp [746.40ms]

 0 pass
 1 fail
 3 expect() calls
Ran 1 test across 1 file. [3.02s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/internal/source-lints/iso-subspace-creation.test.ts:
60 |   // tree, and the one permitted file must still be where the creation lives.
61 |   expect(scanned).toBeGreaterThan(1000);
62 |   expect(linesInCreationSite).toBeGreaterThan(0);
63 | 
64 |   violations.sort();
65 |   expect(violations).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/jsc/bindings/BunClientData.h:278",
+   "src/jsc/bindings/BunClientData.h:281",
+   "src/jsc/bindings/BunClientData.h:283",
+   "src/jsc/bindings/BunClientData.h:298",
+ ]

- Expected  - 1
+ Received  + 6

      at <anonymous> (/workspace/bun/test/internal/source-lints/iso-subspace-creation.test.ts:65:22)
(fail) IsoSubspaces are only constructed in BunClientData.cpp [43.44ms]

 0 pass
 1 fail
 3 expect() calls
Ran 1 test across 1 file. [193.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/iso-subspace-creation.test.ts
bun test v1.4.0 (8326d1bd3)

test/internal/source-lints/iso-subspace-creation.test.ts:
(pass) IsoSubspaces are only constructed in BunClientData.cpp [755.83ms]

 1 pass
 0 fail
 3 expect() calls
Ran 1 test across 1 file. [3.10s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     4045096fa5
  features     baseline

22 deps, 120 codegen, 1144 objects in 926ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1206] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 26 installs across 63 packages (no changes) [4.00ms]
[2/1206] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1206] gen ErrorCode+*.h
[4/1206] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[5/1206] gen bindgenv2
[6/1206] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1206] fetch zlib
[zlib] up to date
[8/1206] fetch tinycc
[tinycc] up to date
[9/1205] gen .bind.ts → GeneratedBindings.cpp
[10/1205] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1205] gen ProcessBindingConstants.lut.h
Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.../skills/implementing-jsc-classes-cpp/SKILL.md   |  5 +-
 .github/workflows/source-lints.yml                 |  8 ++-
 src/codegen/generate-classes.ts                    | 10 +---
 src/codegen/generate-jssink.ts                     | 15 +----
 src/jsc/bindings/AsyncContextFrame.h               |  5 +-
 src/jsc/bindings/BunClientData.cpp                 | 19 +++++++
 src/jsc/bindings/BunClientData.h                   | 66 +++++++++-------------
 src/jsc/bindings/BunDebugger.cpp                   |  5 +-
 src/jsc/bindings/BunPlugin.cpp                     |  5 +-
 src/jsc/bindings/BunProcess.h                      |  5 +-
 src/jsc/bindings/CallSite.h                        |  5 +-
 src/jsc/bindings/ErrorCode.h                       |  5 +-
 src/jsc/bindings/ImportMetaObject.h                |  5 +-
 src/jsc/bindings/InternalModuleRegistry.h          |  5 +-
 src/jsc/bindings/JSBakeResponse.cpp                |  5 +-
 src/jsc/bindings/JSBufferList.cpp                  |  5 +-
 src/jsc/bindings/JSBunRequest.cpp                  |  5 +-
 src/jsc/bindings/JSBundlerPlugin.cpp               |  5 +-
 src/jsc/bindings/JSCommonJSExtensions.h            |  5 +-
 src/jsc/bindings/JSCommonJSModule.h                |  5 +-
 src/jsc/bindings/JSFFIFunction.h                   |  5 +-
 src/jsc/bindings/JSMockFunction.cpp                | 15 +----
 src/jsc/bindings/JSNextTickQueue.cpp               |  5 +-
 src/jsc/bindings/JSNodePerformanceHooksHistogram.h |  5 +-
 src/jsc/bindings/JSSocketHandlers.cpp              |  5 +-
 src/jsc/bindings/JSStringDecoder.cpp               |  5 +-
 src/jsc/bindings/JSWrappingFunction.h              |  5 +-
 src/jsc/bindings/JSX509Certificate.h               |  5 +-
 src/jsc/bindings/ModuleLoader.h                    |  5 +-
 src/jsc/bindings/NativePromiseContext.h            |  5 +-
 src/jsc/bindings/NodeVM.cpp                        | 10 +---
 src/jsc/bindings/NodeVMScript.h                    |  5 +-
 src/jsc/bindings/NodeVMSourc
... (truncated)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
.claude/skills/implementing-jsc-classes-cpp/SKILL.md      1      1      0
.github/workflows/source-lints.yml                        1      1      0
src/codegen/generate-classes.ts                           0      0      0
src/codegen/generate-jssink.ts                            0      0      0
src/jsc/bindings/AsyncContextFrame.h                      0      0      0
src/jsc/bindings/BunClientData.cpp                        0      0      0
src/jsc/bindings/BunClientData.h                          1      0      0
src/jsc/bindings/BunDebugger.cpp                          0      0      0
src/jsc/bindings/BunPlugin.cpp                            0      0      0
src/jsc/bindings/BunProcess.h                             0      0      0
src/jsc/bindings/CallSite.h                               0      0      0
src/jsc/bindings/ErrorCode.h                              0      0      0
src/jsc/bindings/ImportMetaObject.h                       0      0      0
src/jsc/bindings/InternalModuleRegistry.h                 0      0      0
src/jsc/bindings/JSBakeResponse.cpp                       0      0      0
src/jsc/bindings/JSBufferList.cpp                         0      0      0
(+ 116 more files)
```

</details>

<!-- robobun:evidence:end -->