### PR TITLE
turn cold const bool generics into runtime flags

### DIFF
--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -832,7 +832,7 @@ impl PackageManager {
         unsafe {
             let lf: *mut Lockfile = &raw mut *(*pm).lockfile;
             let log: *mut bun_ast::Log = (*pm).log;
-            (*lf).load_from_cwd::<ATTEMPT_OTHER>(Some(&mut *pm), &mut *log)
+            (*lf).load_from_cwd(Some(&mut *pm), &mut *log, ATTEMPT_OTHER)
         }
     }
 
@@ -2678,7 +2678,7 @@ fn init_with_runtime_once(
     };
     if has_lockb {
         let mut lockfile = core::mem::replace(&mut manager.lockfile, Box::new(Lockfile::default()));
-        match lockfile.load_from_cwd::<true>(Some(&mut *manager), log) {
+        match lockfile.load_from_cwd(Some(&mut *manager), log, true) {
             lockfile::LoadResult::Ok(_) => {}
             _ => lockfile.init_empty(),
         }

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -83,7 +83,7 @@ pub fn install_with_manager(
             let log = (*mgr).log;
             (*mgr)
                 .lockfile
-                .load_from_cwd::<true>(Some(&mut *mgr), &mut *log)
+                .load_from_cwd(Some(&mut *mgr), &mut *log, true)
         }
     } else {
         lockfile::LoadResult::NotFound
@@ -1261,26 +1261,15 @@ fn print_summary_tree(
     // We deliberately do not disable it after this.
     Output::enable_buffering();
     let writer = Output::writer_buffered();
-    // Runtime bool → const-generic dispatch.
-    if Output::enable_ansi_colors_stdout() {
-        LockfilePrinter::Tree::print::<_, true>(
-            &printer,
-            // SAFETY: `mgr` is the sole provenance root; `Tree::print` writes only fields
-            // disjoint from `printer`'s shared `lockfile`/`options`/`update_requests` borrows.
-            unsafe { &mut *mgr },
-            writer,
-            log_level,
-        )?;
-    } else {
-        LockfilePrinter::Tree::print::<_, false>(
-            &printer,
-            // SAFETY: `mgr` is the sole provenance root; `Tree::print` writes only fields
-            // disjoint from `printer`'s shared `lockfile`/`options`/`update_requests` borrows.
-            unsafe { &mut *mgr },
-            writer,
-            log_level,
-        )?;
-    }
+    LockfilePrinter::Tree::print(
+        &printer,
+        // SAFETY: `mgr` is the sole provenance root; `Tree::print` writes only fields
+        // disjoint from `printer`'s shared `lockfile`/`options`/`update_requests` borrows.
+        unsafe { &mut *mgr },
+        writer,
+        log_level,
+        Output::enable_ansi_colors_stdout(),
+    )?;
     Ok(())
 }
 

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -66,7 +66,7 @@ pub fn do_patch_commit(
     let mut folder_path_buf = PathBuffer::uninit();
     let mut lockfile: Box<Lockfile> = Box::default();
     let log = manager.log_mut();
-    match lockfile.load_from_cwd::<true>(Some(manager), log) {
+    match lockfile.load_from_cwd(Some(manager), log, true) {
         lockfile::LoadResult::NotFound => {
             Output::err_generic(
                 "Cannot find lockfile. Install packages with `<cyan>bun install<r>` before patching them.",

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -495,19 +495,21 @@ impl Lockfile {
             || (self.packages.len() == 1 && self.packages.get(0).resolutions.len == 0)
     }
 
-    pub fn load_from_cwd<'a, const ATTEMPT_LOADING_FROM_OTHER_LOCKFILE: bool>(
+    pub fn load_from_cwd<'a>(
         &'a mut self,
         manager: Option<&mut PackageManager>,
         log: &mut bun_ast::Log,
+        attempt_loading_from_other_lockfile: bool,
     ) -> LoadResult<'a> {
-        self.load_from_dir::<ATTEMPT_LOADING_FROM_OTHER_LOCKFILE>(Fd::cwd(), manager, log)
+        self.load_from_dir(Fd::cwd(), manager, log, attempt_loading_from_other_lockfile)
     }
 
-    pub fn load_from_dir<'a, const ATTEMPT_LOADING_FROM_OTHER_LOCKFILE: bool>(
+    pub fn load_from_dir<'a>(
         &'a mut self,
         dir: Fd,
         mut manager: Option<&mut PackageManager>,
         log: &mut bun_ast::Log,
+        attempt_loading_from_other_lockfile: bool,
     ) -> LoadResult<'a> {
         debug_assert!(Fs::INSTANCE_LOADED.load(core::sync::atomic::Ordering::Relaxed));
 
@@ -539,7 +541,7 @@ impl Lockfile {
                                 });
                             }
 
-                            if ATTEMPT_LOADING_FROM_OTHER_LOCKFILE {
+                            if attempt_loading_from_other_lockfile {
                                 if let Some(pm) = manager {
                                     // The format is carried inside the `LoadResult` itself.
                                     return migration::detect_and_load_other_lockfile(
@@ -1658,7 +1660,7 @@ impl<'a> Printer<'a> {
 
         let mut lockfile = Box::<Lockfile>::default();
 
-        let load_from_disk = lockfile.load_from_cwd::<false>(None, log);
+        let load_from_disk = lockfile.load_from_cwd(None, log, false);
         match load_from_disk {
             crate::lockfile::LoadResult::Err(cause) => {
                 match cause.step {

--- a/src/install/lockfile/printer/tree_printer.rs
+++ b/src/install/lockfile/printer/tree_printer.rs
@@ -14,11 +14,7 @@ use bun_sys::Fd;
 
 type Bitset = DynamicBitSet;
 
-fn print_installed_workspace_section<
-    W,
-    const ENABLE_ANSI_COLORS: bool,
-    const PRINT_SECTION_HEADER: bool,
->(
+fn print_installed_workspace_section<W>(
     this: &Printer,
     manager: &mut PackageManager,
     writer: &mut W,
@@ -27,6 +23,8 @@ fn print_installed_workspace_section<
     printed_new_install: &mut bool,
     id_map: Option<&mut [DependencyID]>,
     update_owners: &[PackageID],
+    enable_ansi_colors: bool,
+    print_section_header: bool,
 ) -> Result<(), crate::Error>
 where
     W: Write,
@@ -88,38 +86,34 @@ where
                     *printed_new_install = true;
                     printed_update = true;
 
-                    if PRINT_SECTION_HEADER {
+                    if print_section_header {
                         if !printed_section_header {
                             printed_section_header = true;
                             let workspace_name =
                                 names[workspace_package_id as usize].slice(string_buf);
                             bun_core::write_pretty!(
                                 writer,
-                                ENABLE_ANSI_COLORS,
+                                enable_ansi_colors,
                                 "<r>\n<cyan>{s}<r><d>:<r>\n",
                                 bstr::BStr::new(workspace_name),
                             )?;
                         }
                     }
 
-                    print_updated_package::<W, ENABLE_ANSI_COLORS>(
-                        this,
-                        manager,
-                        &update_info,
-                        writer,
-                    )?;
+                    print_updated_package(this, manager, &update_info, writer, enable_ansi_colors)?;
                 }
             }
         }
     }
 
-    if !PRINT_SECTION_HEADER {
-        if print_transitive_updates::<W, ENABLE_ANSI_COLORS>(
+    if !print_section_header {
+        if print_transitive_updates(
             this,
             manager,
             update_owners,
             installed,
             writer,
+            enable_ansi_colors,
         )? {
             *printed_new_install = true;
             printed_update = true;
@@ -161,13 +155,13 @@ where
 
         *printed_new_install = true;
 
-        if PRINT_SECTION_HEADER {
+        if print_section_header {
             if !printed_section_header {
                 printed_section_header = true;
                 let workspace_name = names[workspace_package_id as usize].slice(string_buf);
                 bun_core::write_pretty!(
                     writer,
-                    ENABLE_ANSI_COLORS,
+                    enable_ansi_colors,
                     "<r>\n<cyan>{s}<r><d>:<r>\n",
                     bstr::BStr::new(workspace_name),
                 )?;
@@ -178,7 +172,7 @@ where
             printed_update = false;
             writer.write_str("\n")?;
         }
-        print_installed_package::<W, ENABLE_ANSI_COLORS>(this, manager, dep, package_id, writer)?;
+        print_installed_package(this, manager, dep, package_id, writer, enable_ansi_colors)?;
     }
 
     Ok(())
@@ -282,11 +276,12 @@ fn should_print_package_install(
     ShouldPrintPackageInstallResult::Yes
 }
 
-fn print_updated_package<W, const ENABLE_ANSI_COLORS: bool>(
+fn print_updated_package<W>(
     this: &Printer,
     manager: &mut PackageManager,
     update_info: &PackageUpdatePrintInfo,
     writer: &mut W,
+    enable_ansi_colors: bool,
 ) -> Result<(), crate::Error>
 where
     W: Write,
@@ -306,7 +301,7 @@ where
     let Some(entry) = manager.updating_packages.get(dep_name) else {
         return Ok(());
     };
-    write_updated_row::<W, ENABLE_ANSI_COLORS>(
+    write_updated_row(
         writer,
         dep_name,
         update_info.version,
@@ -314,6 +309,7 @@ where
         update_info.resolution.npm().version,
         string_buf,
         later.as_deref(),
+        enable_ansi_colors,
     )
 }
 
@@ -332,7 +328,7 @@ fn later_version_text(
     Ok(Some(text))
 }
 
-fn write_updated_row<W, const ENABLE_ANSI_COLORS: bool>(
+fn write_updated_row<W>(
     writer: &mut W,
     name: &[u8],
     from: semver::Version,
@@ -340,11 +336,12 @@ fn write_updated_row<W, const ENABLE_ANSI_COLORS: bool>(
     to: semver::Version,
     to_buf: &[u8],
     later: Option<&[u8]>,
+    enable_ansi_colors: bool,
 ) -> Result<(), crate::Error>
 where
     W: Write,
 {
-    if ENABLE_ANSI_COLORS {
+    if enable_ansi_colors {
         write!(
             writer,
             bun_core::pretty_fmt!("<r><cyan>↑<r> <b>{s}<r> <d>{f} →<r> <b><cyan>{f}<r>", true),
@@ -365,7 +362,7 @@ where
     if let Some(later) = later {
         bun_core::write_pretty!(
             writer,
-            ENABLE_ANSI_COLORS,
+            enable_ansi_colors,
             " <d>(<blue>v{s} available<r><d>)<r>",
             bstr::BStr::new(later),
         )?;
@@ -376,12 +373,13 @@ where
 }
 
 /// Packages registered by the transitive half of `bun update` are not rows of the walked workspaces, so the walk above never reaches them; the walked workspaces' own targets stay with them.
-fn print_transitive_updates<W, const ENABLE_ANSI_COLORS: bool>(
+fn print_transitive_updates<W>(
     this: &Printer,
     manager: &mut PackageManager,
     update_owners: &[PackageID],
     installed: &Bitset,
     writer: &mut W,
+    enable_ansi_colors: bool,
 ) -> Result<bool, crate::Error>
 where
     W: Write,
@@ -439,7 +437,7 @@ where
         let Some(info) = manager.updating_packages.get(name) else {
             continue;
         };
-        write_updated_row::<W, ENABLE_ANSI_COLORS>(
+        write_updated_row(
             writer,
             name,
             original,
@@ -447,18 +445,20 @@ where
             version,
             string_buf,
             later.as_deref(),
+            enable_ansi_colors,
         )?;
         printed = true;
     }
     Ok(printed)
 }
 
-fn print_installed_package<W, const ENABLE_ANSI_COLORS: bool>(
+fn print_installed_package<W>(
     this: &Printer,
     manager: &mut PackageManager,
     dependency: &Dependency,
     package_id: PackageID,
     writer: &mut W,
+    enable_ansi_colors: bool,
 ) -> Result<(), crate::Error>
 where
     W: Write,
@@ -472,7 +472,7 @@ where
     if let Some(later_version_fmt) =
         manager.format_later_version_in_cache(package_name, dependency.name_hash, &resolution)
     {
-        if ENABLE_ANSI_COLORS {
+        if enable_ansi_colors {
             write!(
                 writer,
                 bun_core::pretty_fmt!(
@@ -496,7 +496,7 @@ where
         return Ok(());
     }
 
-    if ENABLE_ANSI_COLORS {
+    if enable_ansi_colors {
         write!(
             writer,
             bun_core::pretty_fmt!("<r><green>+<r> <b>{s}<r><d>@{f}<r>\n", true),
@@ -515,19 +515,20 @@ where
     Ok(())
 }
 
-fn print_installed_update_request<W, const ENABLE_ANSI_COLORS: bool>(
+fn print_installed_update_request<W>(
     writer: &mut W,
     dependency: &Dependency,
     resolution: &Resolution,
     string_buf: &[u8],
     has_binaries: bool,
+    enable_ansi_colors: bool,
 ) -> Result<(), crate::Error>
 where
     W: Write,
 {
     bun_core::write_pretty!(
         writer,
-        ENABLE_ANSI_COLORS,
+        enable_ansi_colors,
         "<r><green>installed<r> <b>{s}<r>",
         bstr::BStr::new(dependency.name.slice(string_buf)),
     )?;
@@ -535,7 +536,7 @@ where
     if let Some(npm) = dependency.version.try_npm().filter(|npm| npm.is_alias) {
         bun_core::write_pretty!(
             writer,
-            ENABLE_ANSI_COLORS,
+            enable_ansi_colors,
             "<d>@npm:<r><b>{s}<r>",
             bstr::BStr::new(npm.name.slice(string_buf)),
         )?;
@@ -543,7 +544,7 @@ where
 
     bun_core::write_pretty!(
         writer,
-        ENABLE_ANSI_COLORS,
+        enable_ansi_colors,
         "<d>@{f}<r>",
         resolution.fmt(string_buf, PathSep::Posix),
     )?;
@@ -558,11 +559,13 @@ where
 
 /// - Prints an empty newline with no diffs
 /// - Prints a leading and trailing blank newline with diffs
-pub(crate) fn print<W, const ENABLE_ANSI_COLORS: bool>(
+#[inline(never)]
+pub(crate) fn print<W>(
     this: &Printer,
     manager: &mut PackageManager,
     writer: &mut W,
     log_level: install::package_manager::Options::LogLevel,
+    enable_ansi_colors: bool,
 ) -> Result<(), crate::Error>
 where
     W: Write,
@@ -620,7 +623,7 @@ where
             }
             let _ = found_workspace_to_print;
 
-            print_installed_workspace_section::<W, ENABLE_ANSI_COLORS, false>(
+            print_installed_workspace_section(
                 this,
                 manager,
                 writer,
@@ -629,11 +632,13 @@ where
                 &mut had_printed_new_install,
                 None,
                 &[0],
+                enable_ansi_colors,
+                false,
             )?;
 
             for &workspace_dep_id in &workspaces_to_print {
                 let workspace_package_id = resolutions_buffer[workspace_dep_id as usize];
-                print_installed_workspace_section::<W, ENABLE_ANSI_COLORS, true>(
+                print_installed_workspace_section(
                     this,
                     manager,
                     writer,
@@ -642,6 +647,8 @@ where
                     &mut had_printed_new_install,
                     None,
                     &[workspace_package_id],
+                    enable_ansi_colors,
+                    true,
                 )?;
             }
         } else {
@@ -684,7 +691,7 @@ where
                 }
             }
 
-            print_installed_workspace_section::<W, ENABLE_ANSI_COLORS, false>(
+            print_installed_workspace_section(
                 this,
                 manager,
                 writer,
@@ -693,6 +700,8 @@ where
                 &mut had_printed_new_install,
                 Some(&mut id_map),
                 &update_owners,
+                enable_ansi_colors,
+                false,
             )?;
         }
     } else {
@@ -729,7 +738,7 @@ where
 
             bun_core::write_pretty!(
                 writer,
-                ENABLE_ANSI_COLORS,
+                enable_ansi_colors,
                 " <r><b>{s}<r><d>@<b>{f}<r>\n",
                 bstr::BStr::new(package_name),
                 resolved[package_id as usize].fmt(string_buf, PathSep::Auto),
@@ -763,8 +772,13 @@ where
             bin::Tag::None | bin::Tag::Dir => {
                 printed_installed_update_request = true;
 
-                print_installed_update_request::<W, ENABLE_ANSI_COLORS>(
-                    writer, dependency, resolution, string_buf, false,
+                print_installed_update_request(
+                    writer,
+                    dependency,
+                    resolution,
+                    string_buf,
+                    false,
+                    enable_ansi_colors,
                 )?;
             }
             bin::Tag::Map | bin::Tag::File | bin::Tag::NamedFile => {
@@ -783,8 +797,13 @@ where
                     extern_string_buf: this.lockfile.buffers.extern_strings.as_slice(),
                 };
 
-                print_installed_update_request::<W, ENABLE_ANSI_COLORS>(
-                    writer, dependency, resolution, string_buf, true,
+                print_installed_update_request(
+                    writer,
+                    dependency,
+                    resolution,
+                    string_buf,
+                    true,
+                    enable_ansi_colors,
                 )?;
 
                 {
@@ -796,7 +815,7 @@ where
 
                             bun_core::write_pretty!(
                                 writer,
-                                ENABLE_ANSI_COLORS,
+                                enable_ansi_colors,
                                 "<r> <d>- <r><b>{s}<r>\n",
                                 bstr::BStr::new(&owned[..]),
                             )?;
@@ -808,7 +827,7 @@ where
                     while let Some(bin_name) = iterator.next().unwrap_or(None) {
                         bun_core::write_pretty!(
                             writer,
-                            ENABLE_ANSI_COLORS,
+                            enable_ansi_colors,
                             "<r> <d>- <r><b>{s}<r>\n",
                             bstr::BStr::new(bin_name),
                         )?;

--- a/src/install_jsc/install_binding.rs
+++ b/src/install_jsc/install_binding.rs
@@ -80,7 +80,7 @@ pub mod bun_install_js_bindings {
         let manager = vm.package_manager();
 
         let load_result: LoadResult<'_> =
-            lockfile_.load_from_dir::<true>(*dir, Some(manager), &mut log);
+            lockfile_.load_from_dir(*dir, Some(manager), &mut log, true);
 
         match load_result {
             LoadResult::Err(err) => {

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -2634,10 +2634,10 @@ pub mod formatter {
 
         /// Mirror of `Formatter::print_comma` routed through the wrapped
         /// `ctx` writer + borrowed `estimated_line_length`.
-        pub(crate) fn print_comma<const ENABLE_ANSI_COLORS: bool>(&mut self) {
+        pub(crate) fn print_comma(&mut self, enable_ansi_colors: bool) {
             if self
                 .ctx
-                .write_all(pfmt!("<r><d>,<r>", ENABLE_ANSI_COLORS).as_bytes())
+                .write_all(pfmt!("<r><d>,<r>", enable_ansi_colors).as_bytes())
                 .is_err()
             {
                 self.failed = true;
@@ -3091,7 +3091,7 @@ pub mod formatter {
                 estimated_line_length: &mut ctx.formatter.estimated_line_length,
             };
             if ctx.i > 0 {
-                writer.print_comma::<C>();
+                writer.print_comma(C);
             }
 
             let i_before = ctx.i;
@@ -3343,7 +3343,7 @@ pub mod formatter {
                 Tag::JSX => self.print_jsx::<ENABLE_ANSI_COLORS>(writer_, value),
                 Tag::Object => self.print_object::<ENABLE_ANSI_COLORS>(writer_, value, js_type),
                 Tag::TypedArray => {
-                    self.print_typed_array::<ENABLE_ANSI_COLORS>(writer_, value, js_type)
+                    self.print_typed_array(writer_, value, js_type, ENABLE_ANSI_COLORS)
                 }
                 Tag::RevokedProxy => self.print_revoked_proxy::<ENABLE_ANSI_COLORS>(writer_),
                 Tag::Proxy => self.print_proxy::<ENABLE_ANSI_COLORS>(writer_, value),
@@ -4327,7 +4327,7 @@ pub mod formatter {
                         continue;
                     }
                     if nonempty_count >= 100 {
-                        writer.print_comma::<C>();
+                        writer.print_comma(C);
                         writer.write_all(b"\n"); // we want the line break to be unconditional here
                         *writer.estimated_line_length = 0;
                         writer.write_indent(self.indent);
@@ -4346,7 +4346,7 @@ pub mod formatter {
 
                     if let Some(empty) = empty_start {
                         if empty > 0 {
-                            writer.print_comma::<C>();
+                            writer.print_comma(C);
                             if !self.single_line
                                 && (self.ordered_properties
                                     || writer.good_time_for_a_new_line(self.indent))
@@ -4379,7 +4379,7 @@ pub mod formatter {
                         empty_start = None;
                     }
 
-                    writer.print_comma::<C>();
+                    writer.print_comma(C);
                     if !self.single_line
                         && (self.ordered_properties || writer.good_time_for_a_new_line(self.indent))
                     {
@@ -4407,7 +4407,7 @@ pub mod formatter {
 
                 if let Some(empty) = empty_start.take() {
                     if empty > 0 {
-                        writer.print_comma::<C>();
+                        writer.print_comma(C);
                         if !self.single_line
                             && (self.ordered_properties
                                 || writer.good_time_for_a_new_line(self.indent))
@@ -5451,11 +5451,12 @@ pub mod formatter {
         }
 
         #[inline(never)]
-        fn print_typed_array<const C: bool>(
+        fn print_typed_array(
             &mut self,
             writer_: &mut dyn bun_io::Write,
             value: JSValue,
             js_type: jsc::JSType,
+            colors: bool,
         ) -> JsResult<()> {
             let mut writer = WrappedWriter {
                 ctx: writer_,
@@ -5469,7 +5470,7 @@ pub mod formatter {
                 && js_type == jsc::JSType::Uint8Array
                 && bun_core::strings::is_valid_utf8(slice)
             {
-                if C {
+                if colors {
                     writer.write_all(pfmt!("<r><green>", true).as_bytes());
                 }
                 let _ = JSPrinter::write_json_string(
@@ -5477,7 +5478,7 @@ pub mod formatter {
                     &mut *writer.ctx,
                     JSPrinter::Encoding::Utf8,
                 );
-                if C {
+                if colors {
                     writer.write_all(pfmt!("<r>", true).as_bytes());
                 }
                 return Ok(());
@@ -5512,28 +5513,38 @@ pub mod formatter {
             // `bytemuck::cast_slice` alignment/size checks always pass.
             use bytemuck::cast_slice;
             match js_type {
-                T::Int8Array => Self::write_typed_array::<i8, C>(&mut writer, cast_slice(slice)),
-                T::Int16Array => Self::write_typed_array::<i16, C>(&mut writer, cast_slice(slice)),
-                T::Uint16Array => Self::write_typed_array::<u16, C>(&mut writer, cast_slice(slice)),
-                T::Int32Array => Self::write_typed_array::<i32, C>(&mut writer, cast_slice(slice)),
-                T::Uint32Array => Self::write_typed_array::<u32, C>(&mut writer, cast_slice(slice)),
+                T::Int8Array => {
+                    Self::write_typed_array::<i8>(&mut writer, cast_slice(slice), colors)
+                }
+                T::Int16Array => {
+                    Self::write_typed_array::<i16>(&mut writer, cast_slice(slice), colors)
+                }
+                T::Uint16Array => {
+                    Self::write_typed_array::<u16>(&mut writer, cast_slice(slice), colors)
+                }
+                T::Int32Array => {
+                    Self::write_typed_array::<i32>(&mut writer, cast_slice(slice), colors)
+                }
+                T::Uint32Array => {
+                    Self::write_typed_array::<u32>(&mut writer, cast_slice(slice), colors)
+                }
                 T::Float16Array => {
-                    Self::write_typed_array::<bun_core::f16, C>(&mut writer, cast_slice(slice))
+                    Self::write_typed_array::<bun_core::f16>(&mut writer, cast_slice(slice), colors)
                 }
                 T::Float32Array => {
-                    Self::write_typed_array::<f32, C>(&mut writer, cast_slice(slice))
+                    Self::write_typed_array::<f32>(&mut writer, cast_slice(slice), colors)
                 }
                 T::Float64Array => {
-                    Self::write_typed_array::<f64, C>(&mut writer, cast_slice(slice))
+                    Self::write_typed_array::<f64>(&mut writer, cast_slice(slice), colors)
                 }
                 T::BigInt64Array => {
-                    Self::write_typed_array::<i64, C>(&mut writer, cast_slice(slice))
+                    Self::write_typed_array::<i64>(&mut writer, cast_slice(slice), colors)
                 }
                 T::BigUint64Array => {
-                    Self::write_typed_array::<u64, C>(&mut writer, cast_slice(slice))
+                    Self::write_typed_array::<u64>(&mut writer, cast_slice(slice), colors)
                 }
                 // Uint8Array, Uint8ClampedArray, DataView, ArrayBuffer
-                _ => Self::write_typed_array::<u8, C>(&mut writer, slice),
+                _ => Self::write_typed_array::<u8>(&mut writer, slice, colors),
             }
 
             writer.write_all(b" ]");
@@ -5547,50 +5558,53 @@ pub mod formatter {
         // `WrappedWriter` that already borrows `&mut self.estimated_line_length`
         // without tripping E0499. The only `self` use was `print_comma`, which
         // `WrappedWriter` mirrors.
-        fn write_typed_array<N: TypedArrayElement, const C: bool>(
+        fn write_typed_array<N: TypedArrayElement>(
             writer: &mut WrappedWriter<'_>,
             slice: &[N],
+            colors: bool,
         ) {
             // Only the per-element `Display` differs by `N`; the loop is shared.
-            Self::write_typed_array_elements::<C>(
+            Self::write_typed_array_elements(
                 writer,
                 slice.len(),
                 N::IS_BIGINT,
                 &mut |w, i| w.print(format_args!("{}", N::display(slice[i]))),
+                colors,
             );
         }
 
-        fn write_typed_array_elements<const C: bool>(
+        fn write_typed_array_elements(
             writer: &mut WrappedWriter<'_>,
             len: usize,
             is_bigint: bool,
             print_element: &mut dyn FnMut(&mut WrappedWriter<'_>, usize),
+            colors: bool,
         ) {
             let suffix = if is_bigint { "n" } else { "" };
-            writer.write_all(pfmt!("<r><yellow>", C).as_bytes());
+            writer.write_all(pfmt!("<r><yellow>", colors).as_bytes());
             print_element(writer, 0);
-            writer.print(format_args!("{}{}", suffix, pfmt!("<r>", C)));
+            writer.print(format_args!("{}{}", suffix, pfmt!("<r>", colors)));
             const MAX: usize = 512;
             let shown = len.min(MAX + 1);
             for i in 1..shown {
-                writer.print_comma::<C>();
+                writer.print_comma(colors);
                 if writer.failed {
                     return;
                 }
                 writer.space();
 
-                writer.write_all(pfmt!("<r><yellow>", C).as_bytes());
+                writer.write_all(pfmt!("<r><yellow>", colors).as_bytes());
                 print_element(writer, i);
-                writer.print(format_args!("{}{}", suffix, pfmt!("<r>", C)));
+                writer.print(format_args!("{}{}", suffix, pfmt!("<r>", colors)));
             }
 
             if len > MAX + 1 {
                 writer.print(format_args!(
                     "{}{}, ... {} more{}",
-                    pfmt!("<r><d>", C),
+                    pfmt!("<r><d>", colors),
                     suffix,
                     len - MAX - 1,
-                    pfmt!("<r>", C),
+                    pfmt!("<r>", colors),
                 ));
             }
         }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -305,6 +305,7 @@ pub(crate) fn spawn_sync(
     result
 }
 
+#[inline(never)]
 fn spawn_maybe_sync(
     is_sync: bool,
     global_this: &JSGlobalObject,
@@ -1038,7 +1039,7 @@ fn spawn_maybe_sync(
     // also pass `jsc_vm` into `spawn_sync_event_loop`/`prepare`/`cleanup` while
     // holding it. Route through a raw `*mut VirtualMachineRef` for the duration.
     let jsc_vm_ptr: *mut jsc::VirtualMachineRef = jsc_vm;
-    // For is_sync, use the isolated loop's `event_loop` (created by
+    // For spawnSync, use the isolated loop's `event_loop` (created by
     // `SpawnSyncEventLoop::init`) so stdio readers/writers register on it
     // instead of the main loop.
     let event_loop: *mut jsc::event_loop::EventLoop = if is_sync {

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -101,11 +101,12 @@ impl OutdatedCommand {
         let lockfile: &mut bun_install::lockfile::Lockfile = unsafe { &mut *(*pm_ptr).lockfile };
         // SAFETY: `manager.log` is set non-null by `PackageManager::init`.
         let log = unsafe { &mut *log_ptr };
-        match lockfile.load_from_cwd::<true>(
+        match lockfile.load_from_cwd(
             // SAFETY: see comment above — `load_from_cwd` accesses `manager`
             // fields disjoint from `lockfile`.
             Some(unsafe { &mut *pm_ptr }),
             log,
+            true,
         ) {
             LoadResult::NotFound => {
                 if not_silent {

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -221,8 +221,11 @@ impl PackCommand {
         // SAFETY: `manager_ptr`/`log_ptr` came from live `&mut`; reborrowed
         // disjointly (`log` is a separate allocation from the manager fields
         // `load_from_cwd` touches).
-        let load_from_disk_result = lockfile
-            .load_from_cwd::<false>(Some(unsafe { &mut *manager_ptr }), unsafe { &mut *log_ptr });
+        let load_from_disk_result = lockfile.load_from_cwd(
+            Some(unsafe { &mut *manager_ptr }),
+            unsafe { &mut *log_ptr },
+            false,
+        );
 
         let lockfile_ref: Option<&Lockfile> = match load_from_disk_result {
             LoadResult::Ok(ok) => Some(&*ok.lockfile),
@@ -278,7 +281,7 @@ impl PackCommand {
         };
 
         // just pack the current workspace
-        if let Err(err) = pack::<false>(&mut pack_ctx, &abs_pkg_json) {
+        if let Err(err) = pack(&mut pack_ctx, &abs_pkg_json, false) {
             match err {
                 PackError::OutOfMemory => bun_core::out_of_memory(),
                 PackError::MissingPackageName | PackError::MissingPackageVersion => {
@@ -295,7 +298,7 @@ impl PackCommand {
                     );
                     Global::crash();
                 }
-                // for_publish-only variants — unreachable when FOR_PUBLISH=false.
+                // publish-only variants.
                 PackError::RestrictedUnscopedPackage | PackError::PrivatePackage => unreachable!(),
             }
         }
@@ -308,7 +311,7 @@ impl PackCommand {
 // ───────────────────────────────────────────────────────────────────────────
 
 #[derive(thiserror::Error, strum::IntoStaticStr, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PackError<const FOR_PUBLISH: bool> {
+pub enum PackError {
     #[error("OutOfMemory")]
     OutOfMemory,
     #[error("MissingPackageName")]
@@ -319,16 +322,14 @@ pub enum PackError<const FOR_PUBLISH: bool> {
     MissingPackageVersion,
     #[error("InvalidPackageVersion")]
     InvalidPackageVersion,
-    // The following two are only valid when FOR_PUBLISH == true (const-generic
-    // enums cannot conditionally include variants, so both instantiations
-    // share one enum).
+    // The following two are only returned when packing for publish.
     #[error("RestrictedUnscopedPackage")]
     RestrictedUnscopedPackage,
     #[error("PrivatePackage")]
     PrivatePackage,
 }
 
-impl<const FOR_PUBLISH: bool> From<AllocError> for PackError<FOR_PUBLISH> {
+impl From<AllocError> for PackError {
     fn from(_: AllocError) -> Self {
         PackError::OutOfMemory
     }
@@ -1884,11 +1885,6 @@ fn opt_pack_gzip_level(m: &PackageManager) -> Option<&[u8]> {
 // pack()
 // ───────────────────────────────────────────────────────────────────────────
 
-// Const generics cannot vary the
-// return type directly, so both instantiations return an Option that is
-// `Some` only when FOR_PUBLISH == true.
-pub(crate) type PackReturn<'a, const FOR_PUBLISH: bool> = Option<Publish::Context<'a, true>>;
-
 /// Everything `bun pm pack` would put in the tarball besides package.json: bins, then either the `files` list or
 /// the whole tree minus ignores. Shared with `bun pm diff`, whose local side is "what would be published".
 pub(crate) fn published_files(
@@ -2000,10 +1996,12 @@ pub(crate) fn published_files(
     Ok((pack_queue, bins))
 }
 
-pub(crate) fn pack<const FOR_PUBLISH: bool>(
+/// Returns `Some` only when `for_publish` is set.
+pub(crate) fn pack(
     ctx: &mut Context<'_>,
     abs_package_json_path: &ZStr,
-) -> Result<PackReturn<'static, FOR_PUBLISH>, PackError<FOR_PUBLISH>> {
+    for_publish: bool,
+) -> Result<Option<Publish::Context<'static, true>>, PackError> {
     // Raw pointer for the `pm_workspace_cache`/`pm_log` disjoint-field
     // projections and the `'static` lifetime extension when returning
     // `Publish::Context`.
@@ -2041,7 +2039,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         WorkspacePackageJSONCache::GetResult::Entry(entry) => entry,
     };
 
-    if FOR_PUBLISH {
+    if for_publish {
         if let Some(config) = json.root.get(b"publishConfig") {
             if ctx.manager.options.publish_config.tag.is_empty() {
                 if let Some(tag) = config.get_string_cloned(bump, b"tag")? {
@@ -2075,7 +2073,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     let mut package_name = package_name_expr
         .as_string_cloned(bump)?
         .ok_or(PackError::InvalidPackageName)?;
-    if FOR_PUBLISH {
+    if for_publish {
         let is_scoped = bun_install::dependency::is_scoped_package_name(package_name)
             .map_err(|_| PackError::InvalidPackageName)?;
         if let Some(access) = ctx.manager.options.publish_config.access {
@@ -2099,7 +2097,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         return Err(PackError::InvalidPackageVersion);
     }
 
-    if FOR_PUBLISH {
+    if for_publish {
         if let Some(private) = json.root.get(b"private") {
             if let Some(is_private) = private.as_bool() {
                 if is_private {
@@ -2177,7 +2175,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         // Track whether any scripts ran that could modify package.json
         let mut did_run_scripts = false;
 
-        if FOR_PUBLISH {
+        if for_publish {
             if let Some(prepublish_only_script_str) = scripts.expr.get(b"prepublishOnly") {
                 if let Some(prepublish_only) = prepublish_only_script_str.as_string(bump) {
                     did_run_scripts = true;
@@ -2226,7 +2224,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             postpack_script = postpack.as_string(bump).map(Box::from);
         }
 
-        if FOR_PUBLISH {
+        if for_publish {
             let mut publish_script: Option<Box<[u8]>> = None;
             let mut postpublish_script: Option<Box<[u8]>> = None;
             if let Some(publish) = scripts.expr.get(b"publish") {
@@ -2296,7 +2294,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         };
 
         // Re-validate private flag after scripts may have modified it.
-        if FOR_PUBLISH {
+        if for_publish {
             if let Some(private) = json.root.get(b"private") {
                 if let Some(is_private) = private.as_bool() {
                     if is_private {
@@ -2365,7 +2363,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     // `find_workspace_readme` opens its own directory handle because
     // `root_dir` is iterated below and its kernel readdir offset gets
     // exhausted.
-    let workspace_readme: Option<Publish::ReadmeInfo> = if FOR_PUBLISH {
+    let workspace_readme: Option<Publish::ReadmeInfo> = if for_publish {
         Publish::PublishCommand::find_workspace_readme(abs_workspace_path)
     } else {
         None
@@ -2399,7 +2397,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             0,
         );
 
-        if !FOR_PUBLISH {
+        if !for_publish {
             if opt_pack_destination(ctx.manager).is_empty()
                 && opt_pack_filename(ctx.manager).is_empty()
             {
@@ -2441,7 +2439,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             )?;
         }
 
-        if FOR_PUBLISH {
+        if for_publish {
             let mut dest_buf = PathBuffer::uninit();
             let (abs_tarball_dest, _) = tarball_destination(
                 opt_pack_destination(ctx.manager),
@@ -2805,7 +2803,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         let mut sha1 = sha::SHA1::init();
         let mut sha512 = sha::SHA512::init();
 
-        if FOR_PUBLISH {
+        if for_publish {
             let bytes = match tarball_file.read_to_end() {
                 Ok(b) => b,
                 Err(err) => {
@@ -2871,7 +2869,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         File::from_fd(Fd::invalid()),
     );
 
-    let normalized_pkg_info: Option<Box<[u8]>> = if FOR_PUBLISH {
+    let normalized_pkg_info: Option<Box<[u8]>> = if for_publish {
         // The mutated tree is consumed inside `normalized_package` (it prints
         // the JSON itself), so the copy doesn't need to flow back into `json.root`.
         let mut root_full = json.root;
@@ -2896,7 +2894,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         edited_package_json.len(),
     );
 
-    if !FOR_PUBLISH {
+    if !for_publish {
         if opt_pack_destination(ctx.manager).is_empty() && opt_pack_filename(ctx.manager).is_empty()
         {
             Context::print_tarball_path(
@@ -2910,7 +2908,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
 
     Context::print_summary(ctx.stats, Some(&shasum), Some(&integrity), log_level);
 
-    if FOR_PUBLISH {
+    if for_publish {
         Output::flush();
     }
 
@@ -2926,7 +2924,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         )?;
     }
 
-    if FOR_PUBLISH {
+    if for_publish {
         return Ok(Some(Publish::Context {
             // SAFETY: `manager_ptr` was derived from `&mut *ctx.manager`; the
             // process-lifetime singleton outlives the returned `Publish::Context`.
@@ -2953,14 +2951,14 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
 // Helper extracted from repeated `RunCommand.runPackageScriptForeground` blocks.
 // Note: hoisted from repeated inline blocks to avoid 5x duplication of the
 // same `match err { MissingShell, OutOfMemory }` arms. Behavior identical.
-fn run_lifecycle_script<const FOR_PUBLISH: bool>(
+fn run_lifecycle_script(
     command_ctx: &mut Command::ContextData,
     script: &[u8],
     name: &[u8],
     abs_workspace_path: &[u8],
     env: &mut bun_dotenv::Loader,
     silent: bool,
-) -> Result<(), PackError<FOR_PUBLISH>> {
+) -> Result<(), PackError> {
     let use_system_shell = command_ctx.debug.use_system_shell;
     match RunCommand::run_package_script_foreground(
         command_ctx,

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -388,7 +388,7 @@ fn installed_version(pm: &mut PackageManager, name: &[u8]) -> Option<Vec<u8>> {
     let mut lockfile = core::mem::take(&mut pm.lockfile);
     let mut log = bun_ast::Log::init();
     let log_level = pm.options.log_level;
-    let loaded = match lockfile.load_from_cwd::<true>(Some(pm), &mut log) {
+    let loaded = match lockfile.load_from_cwd(Some(pm), &mut log, true) {
         LoadResult::Ok(_) => true,
         LoadResult::NotFound => false,
         // A lockfile that exists but will not load is reported as that, not as "package not installed".

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -131,7 +131,7 @@ pub enum FromTarballError {
 }
 bun_core::oom_from_alloc!(FromTarballError);
 
-pub(crate) type FromWorkspaceError = pack::PackError<true>;
+pub(crate) type FromWorkspaceError = pack::PackError;
 
 impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
     /// Retrieve information for publishing from a tarball path, `bun publish path/to/tarball.tgz`
@@ -465,7 +465,7 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
         // `log` borrows the disjoint `.log` field, so the re-derived `&mut`
         // never touches memory the live `log` borrow covers.
         let load_from_disk_result =
-            lockfile.load_from_cwd::<false>(Some(unsafe { &mut *manager_ptr }), log);
+            lockfile.load_from_cwd(Some(unsafe { &mut *manager_ptr }), log, false);
 
         let lockfile_ref: Option<&Lockfile> = match load_from_disk_result {
             LoadResult::Ok(ok) => Some(&*ok.lockfile),
@@ -520,9 +520,8 @@ impl<'a, const DIRECTORY_PUBLISH: bool> Context<'a, DIRECTORY_PUBLISH> {
             stats: pack::Stats::default(),
         };
 
-        // `pack::<true>` returns `Some(Context<true>)` on success.
-        Ok(pack::pack::<true>(&mut pack_ctx, &abs_pkg_json)?
-            .expect("pack::<true> always yields a publish context"))
+        Ok(pack::pack(&mut pack_ctx, &abs_pkg_json, true)?
+            .expect("packing for publish always yields a publish context"))
     }
 }
 

--- a/src/runtime/cli/scan_command.rs
+++ b/src/runtime/cli/scan_command.rs
@@ -43,11 +43,12 @@ impl ScanCommand {
             // SAFETY: `lockfile` is the owned `Box<Lockfile>` field on the singleton;
             // no other live `&mut Lockfile` exists at this point.
             let lockfile: &mut Lockfile = unsafe { &mut *(*pm_ptr).lockfile };
-            let load_result = lockfile.load_from_cwd::<true>(
+            let load_result = lockfile.load_from_cwd(
                 // SAFETY: see comment above — `load_from_cwd` accesses `manager`
                 // fields disjoint from `lockfile`.
                 Some(unsafe { &mut *pm_ptr }),
                 log,
+                true,
             );
             PackageManagerCommand::handle_load_lockfile_errors_for(&load_result, log_level, "scan");
         }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1516,17 +1516,6 @@ pub(crate) fn print_coverage_reports(
     opts: &mut CodeCoverageOptions,
     reports: &[CodeCoverageReport<'_>],
 ) -> bun_sys::Result<()> {
-    if Output::enable_ansi_colors_stderr() {
-        print_coverage_reports_::<true>(opts, reports)
-    } else {
-        print_coverage_reports_::<false>(opts, reports)
-    }
-}
-
-fn print_coverage_reports_<const COLORS: bool>(
-    opts: &mut CodeCoverageOptions,
-    reports: &[CodeCoverageReport<'_>],
-) -> bun_sys::Result<()> {
     let relative_dir = FileSystem::get().top_level_dir;
     let thresholds = opts.fractions;
 
@@ -1535,7 +1524,14 @@ fn print_coverage_reports_<const COLORS: bool>(
     opts.fractions.failing = failing;
 
     if opts.reporters.text {
-        print_coverage_table::<COLORS>(relative_dir, &thresholds, reports, &fractions, failing);
+        print_coverage_table(
+            relative_dir,
+            &thresholds,
+            reports,
+            &fractions,
+            failing,
+            Output::enable_ansi_colors_stderr(),
+        );
     }
     if opts.reporters.lcov {
         write_lcov_report(opts, relative_dir, reports)?;
@@ -1543,12 +1539,13 @@ fn print_coverage_reports_<const COLORS: bool>(
     Ok(())
 }
 
-fn print_coverage_table<const COLORS: bool>(
+fn print_coverage_table(
     relative_dir: &[u8],
     thresholds: &Fraction,
     reports: &[CodeCoverageReport<'_>],
     fractions: &[Fraction],
     failing: bool,
+    colors: bool,
 ) {
     use coverage::text;
     let thresholds = *thresholds;
@@ -1582,21 +1579,21 @@ fn print_coverage_table<const COLORS: bool>(
     // Writes below target a Vec and cannot fail.
     let mut out: Vec<u8> = Vec::new();
     let separator = |out: &mut Vec<u8>| {
-        let _ = bun_core::write_pretty!(out, COLORS, "<r><d>");
+        let _ = bun_core::write_pretty!(out, colors, "<r><d>");
         out.resize(out.len() + max_filepath_length + 2, b'-');
         let _ =
-            bun_core::write_pretty!(out, COLORS, "|---------|---------|-------------------<r>\n");
+            bun_core::write_pretty!(out, colors, "|---------|---------|-------------------<r>\n");
     };
     separator(&mut out);
     out.extend_from_slice(b"File");
     out.resize(out.len() + max_filepath_length - b"File".len() + 1, b' ');
     let _ = bun_core::write_pretty!(
         out,
-        COLORS,
+        colors,
         " <d>|<r> % Funcs <d>|<r> % Lines <d>|<r> Uncovered Line #s\n"
     );
     separator(&mut out);
-    let _ = text::write_format_with_values::<COLORS>(
+    let _ = text::write_format_with_values(
         b"All files",
         max_filepath_length,
         avg,
@@ -1604,16 +1601,18 @@ fn print_coverage_table<const COLORS: bool>(
         failing,
         &mut out,
         false,
+        colors,
     );
-    let _ = bun_core::write_pretty!(out, COLORS, "<r><d> |<r>\n");
+    let _ = bun_core::write_pretty!(out, colors, "<r><d> |<r>\n");
     for (report, fraction) in reports.iter().zip(fractions) {
-        let _ = text::write_format::<COLORS>(
+        let _ = text::write_format(
             report,
             max_filepath_length,
             fraction,
             &thresholds,
             relative_dir,
             &mut out,
+            colors,
         );
         out.push(b'\n');
     }

--- a/src/runtime/cli/why_command.rs
+++ b/src/runtime/cli/why_command.rs
@@ -349,7 +349,7 @@ impl WhyCommand {
         let log = unsafe { ctx.log_mut() };
 
         let mut lockfile_box: Box<Lockfile> = core::mem::take(&mut pm.lockfile);
-        let load_lockfile = lockfile_box.load_from_cwd::<true>(Some(pm), log);
+        let load_lockfile = lockfile_box.load_from_cwd(Some(pm), log, true);
         PackageManagerCommand::handle_load_lockfile_errors(&load_lockfile, log_level);
 
         if top_only {

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -352,26 +352,35 @@ impl MergedReport {
 
 pub mod text {
     use super::*;
-    // The `pretty_fmt!` macro only accepts literal `true`/`false` today,
-    // so call the runtime rewriter for the `ENABLE_COLORS` const-generic sites.
-    // PERF: runtime `pretty_fmt` allocates a small Vec per call — if hot,
-    // hoist into `const` once the proc-macro lands.
-    use bun_core::output::pretty_fmt;
 
-    pub fn write_format_with_values<const ENABLE_COLORS: bool>(
+    // Local front for `bun_core::pretty_fmt!` that accepts a runtime bool. The
+    // proc-macro only matches `true`/`false` literals, so branch here. Both
+    // arms yield `&'static str`.
+    macro_rules! pfmt {
+        ($fmt:expr, $colors:expr) => {
+            if $colors {
+                ::bun_core::pretty_fmt!($fmt, true)
+            } else {
+                ::bun_core::pretty_fmt!($fmt, false)
+            }
+        };
+    }
+
+    pub fn write_format_with_values(
         filename: &[u8],
         max_filename_length: usize,
         vals: Fraction,
         failing: Fraction,
         failed: bool,
-        writer: &mut impl bun_io::Write,
+        writer: &mut dyn bun_io::Write,
         indent_name: bool,
+        enable_colors: bool,
     ) -> bun_io::Result<()> {
-        if ENABLE_COLORS {
+        if enable_colors {
             if failed {
-                writer.write_all(&pretty_fmt::<true>("<r><b><red>"))?;
+                writer.write_all(bun_core::pretty_fmt!("<r><b><red>", true).as_bytes())?;
             } else {
-                writer.write_all(&pretty_fmt::<true>("<r><b><green>"))?;
+                writer.write_all(bun_core::pretty_fmt!("<r><b><green>", true).as_bytes())?;
             }
         }
 
@@ -384,13 +393,13 @@ pub mod text {
             b' ',
             max_filename_length - filename.len() + usize::from(!indent_name),
         )?;
-        writer.write_all(&pretty_fmt::<ENABLE_COLORS>("<r><d> | <r>"))?;
+        writer.write_all(pfmt!("<r><d> | <r>", enable_colors).as_bytes())?;
 
-        if ENABLE_COLORS {
+        if enable_colors {
             if vals.functions < failing.functions {
-                writer.write_all(&pretty_fmt::<true>("<b><red>"))?;
+                writer.write_all(bun_core::pretty_fmt!("<b><red>", true).as_bytes())?;
             } else {
-                writer.write_all(&pretty_fmt::<true>("<b><green>"))?;
+                writer.write_all(bun_core::pretty_fmt!("<b><green>", true).as_bytes())?;
             }
         }
 
@@ -404,13 +413,13 @@ pub mod text {
         //     // }
         // }
         // write!(writer, "{:>8.2}", vals.stmts * 100.0)?;
-        writer.write_all(&pretty_fmt::<ENABLE_COLORS>("<r><d> | <r>"))?;
+        writer.write_all(pfmt!("<r><d> | <r>", enable_colors).as_bytes())?;
 
-        if ENABLE_COLORS {
+        if enable_colors {
             if vals.lines < failing.lines {
-                writer.write_all(&pretty_fmt::<true>("<b><red>"))?;
+                writer.write_all(bun_core::pretty_fmt!("<b><red>", true).as_bytes())?;
             } else {
-                writer.write_all(&pretty_fmt::<true>("<b><green>"))?;
+                writer.write_all(bun_core::pretty_fmt!("<b><green>", true).as_bytes())?;
             }
         }
 
@@ -420,20 +429,21 @@ pub mod text {
 
     /// One table row: name, the two percentages from `fraction` (coloured
     /// against `thresholds`), and the uncovered line ranges.
-    pub fn write_format<const ENABLE_COLORS: bool>(
+    pub fn write_format(
         report: &Report,
         max_filename_length: usize,
         fraction: &Fraction,
         thresholds: &Fraction,
         base_path: &[u8],
-        writer: &mut impl bun_io::Write,
+        writer: &mut dyn bun_io::Write,
+        enable_colors: bool,
     ) -> bun_io::Result<()> {
         let mut filename: &[u8] = &report.source_url;
         if !base_path.is_empty() {
             filename = bun_paths::resolve_path::relative(base_path, filename);
         }
 
-        write_format_with_values::<ENABLE_COLORS>(
+        write_format_with_values(
             filename,
             max_filename_length,
             *fraction,
@@ -441,9 +451,10 @@ pub mod text {
             fraction.failing,
             writer,
             true,
+            enable_colors,
         )?;
 
-        writer.write_all(&pretty_fmt::<ENABLE_COLORS>("<r><d> | <r>"))?;
+        writer.write_all(pfmt!("<r><d> | <r>", enable_colors).as_bytes())?;
 
         let mut executable_lines_that_havent_been_executed = report
             .lines_which_have_executed
@@ -456,19 +467,16 @@ pub mod text {
 
         let mut iter = executable_lines_that_havent_been_executed.iterator::<true, true>();
 
-        // `concat!(pretty_fmt!(..), "{}")` requires a literal; split into a
-        // prefix `write_all` + plain `write!` so the const-generic `ENABLE_COLORS` can
-        // route through the runtime rewriter.
-        let red = pretty_fmt::<ENABLE_COLORS>("<red>");
-        let comma = pretty_fmt::<ENABLE_COLORS>("<r><d>,<r>");
+        let red = pfmt!("<red>", enable_colors).as_bytes();
+        let comma = pfmt!("<r><d>,<r>", enable_colors).as_bytes();
 
         let mut is_first = true;
         let mut emit =
             |writer: &mut dyn bun_io::Write, start: usize, end: usize| -> bun_io::Result<()> {
                 if !core::mem::take(&mut is_first) {
-                    writer.write_all(&comma)?;
+                    writer.write_all(comma)?;
                 }
-                writer.write_all(&red)?;
+                writer.write_all(red)?;
                 if start == end {
                     write!(writer, "{}", start + 1)
                 } else {
@@ -1089,13 +1097,14 @@ extern "C" fn ByteRangeMapping__findExecutedLines(
     // std.Io.Writer.Allocating → Vec<u8> byte buffer (bun_io::Write target).
     let mut buf: Vec<u8> = Vec::new();
 
-    if text::write_format::<false>(
+    if text::write_format(
         &report,
         source_url.utf8_byte_length(),
         &report.fraction(&thresholds),
         &thresholds,
         b"",
         &mut buf,
+        false,
     )
     .is_err()
     {

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -697,3 +697,94 @@ test("calls second", () => {
   expect(record).toMatch(/FNF:2\nFNH:2\n/);
   expect(exitCode).toBe(0);
 });
+
+// The text reporter takes its color flag at runtime. Pin the exact escape
+// sequences of every row kind (header, "All files", a passing file, a failing
+// file with uncovered ranges) and check the NO_COLOR run is the same table
+// with the escapes removed.
+test("text reporter colors", () => {
+  using dir = tempDir("cov-colors", {
+    "bunfig.toml": `
+[test]
+coverageSkipTestFiles = true
+coverageThreshold = { lines = 0.9, functions = 0.9 }
+`,
+    "covered.ts": `export function covered() {
+  return 1;
+}
+`,
+    "partial.ts": `export function a() {
+  return 1;
+}
+export function b() {
+  const x = 2;
+  const y = x + 1;
+  return y;
+}
+export function c() {
+  return 3;
+}
+export function d() {
+  const x = 4;
+  const y = x + 1;
+  return y;
+}
+`,
+    "demo.test.ts": `
+import { test, expect } from "bun:test";
+import { covered } from "./covered";
+import { a, c } from "./partial";
+
+test("runs", () => {
+  expect(covered()).toBe(1);
+  expect(a()).toBe(1);
+  expect(c()).toBe(3);
+});
+`,
+  });
+
+  function coverageTable(env: Record<string, string | undefined>) {
+    const result = Bun.spawnSync([bunExe(), "test", "--coverage"], {
+      cwd: dir,
+      env,
+      stdio: [null, null, "pipe"],
+    });
+    const lines = result.stderr.toString("utf-8").split(/\r?\n/);
+    const isRule = (line: string) => line.includes("|---------|---------|");
+    const table = lines.slice(lines.findIndex(isRule), lines.findLastIndex(isRule) + 1);
+    return { table, exitCode: result.exitCode };
+  }
+
+  const R = "\x1b[0m";
+  const B = "\x1b[1m";
+  const D = "\x1b[2m";
+  const RED = "\x1b[31m";
+  const GREEN = "\x1b[32m";
+  const rule = "------------|---------|---------|-------------------";
+
+  const colored = coverageTable({ ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: "1" });
+  expect(colored.table).toEqual([
+    `${R}${D}${rule}${R}`,
+    `File        ${D}|${R} % Funcs ${D}|${R} % Lines ${D}|${R} Uncovered Line #s`,
+    `${R}${D}${rule}${R}`,
+    `${R}${B}${RED}All files  ${R}${D} | ${R}${B}${RED}  75.00${R}${D} | ${R}${B}${RED}  70.00${R}${D} |${R}`,
+    `${R}${B}${GREEN} covered.ts${R}${D} | ${R}${B}${GREEN} 100.00${R}${D} | ${R}${B}${GREEN} 100.00${R}${D} | ${R}`,
+    `${R}${B}${RED} partial.ts${R}${D} | ${R}${B}${RED}  50.00${R}${D} | ${R}${B}${RED}  40.00${R}${D} | ${R}${RED}4-6${R}${D},${R}${RED}12-14`,
+    `${R}${D}${rule}${R}`,
+  ]);
+  // partial.ts is below the threshold.
+  expect(colored.exitCode).toBe(1);
+
+  const plain = coverageTable(bunEnv);
+  expect(plain.table).toEqual(colored.table.map(line => Bun.stripANSI(line)));
+  expect(plain.table).toEqual([
+    rule,
+    "File        | % Funcs | % Lines | Uncovered Line #s",
+    rule,
+    "All files   |   75.00 |   70.00 |",
+    " covered.ts |  100.00 |  100.00 | ",
+    " partial.ts |   50.00 |   40.00 | 4-6,12-14",
+    rule,
+  ]);
+  expect(plain.exitCode).toBe(1);
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -249,23 +249,23 @@ it("TypedArray prints with colors", () => {
     `BigInt64Array(2) [ ${num("1n")}${comma}${num("2n")} ]`,
   );
   expect(Bun.inspect(new Uint8Array(0), { colors: true })).toBe("Uint8Array(0) []");
+});
 
-  for (let TypedArray of [
-    Uint8Array,
-    Uint16Array,
-    Uint32Array,
-    Uint8ClampedArray,
-    Int8Array,
-    Int16Array,
-    Int32Array,
-    Float32Array,
-    Float64Array,
-  ]) {
-    const buffer = new TypedArray([1, 2, 3]);
-    const plain = Bun.inspect(buffer, { colors: false });
-    expect(plain).toBe(`${TypedArray.name}(3) [ 1, 2, 3 ]`);
-    expect(Bun.stripANSI(Bun.inspect(buffer, { colors: true }))).toBe(plain);
-  }
+it.each([
+  ["Uint8Array", Uint8Array],
+  ["Uint16Array", Uint16Array],
+  ["Uint32Array", Uint32Array],
+  ["Uint8ClampedArray", Uint8ClampedArray],
+  ["Int8Array", Int8Array],
+  ["Int16Array", Int16Array],
+  ["Int32Array", Int32Array],
+  ["Float32Array", Float32Array],
+  ["Float64Array", Float64Array],
+])("%s with colors strips to the plain output", (name, TypedArray) => {
+  const buffer = new TypedArray([1, 2, 3]);
+  const plain = Bun.inspect(buffer, { colors: false });
+  expect(plain).toBe(`${name}(3) [ 1, 2, 3 ]`);
+  expect(Bun.stripANSI(Bun.inspect(buffer, { colors: true }))).toBe(plain);
 });
 
 it("BigIntArray", () => {

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -232,6 +232,42 @@ it("TypedArray prints", () => {
   }
 });
 
+it("TypedArray prints with colors", () => {
+  const R = "\x1b[0m";
+  const D = "\x1b[2m";
+  const YELLOW = "\x1b[33m";
+  const num = n => `${R}${YELLOW}${n}${R}`;
+  const comma = `${R}${D},${R} `;
+
+  expect(Bun.inspect(new Uint8Array([1, 2, 3]), { colors: true })).toBe(
+    `Uint8Array(3) [ ${num(1)}${comma}${num(2)}${comma}${num(3)} ]`,
+  );
+  expect(Bun.inspect(new Float32Array([0.5, 1.5]), { colors: true })).toBe(
+    `Float32Array(2) [ ${num("0.5")}${comma}${num("1.5")} ]`,
+  );
+  expect(Bun.inspect(new BigInt64Array([1n, 2n]), { colors: true })).toBe(
+    `BigInt64Array(2) [ ${num("1n")}${comma}${num("2n")} ]`,
+  );
+  expect(Bun.inspect(new Uint8Array(0), { colors: true })).toBe("Uint8Array(0) []");
+
+  for (let TypedArray of [
+    Uint8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8ClampedArray,
+    Int8Array,
+    Int16Array,
+    Int32Array,
+    Float32Array,
+    Float64Array,
+  ]) {
+    const buffer = new TypedArray([1, 2, 3]);
+    const plain = Bun.inspect(buffer, { colors: false });
+    expect(plain).toBe(`${TypedArray.name}(3) [ 1, 2, 3 ]`);
+    expect(Bun.stripANSI(Bun.inspect(buffer, { colors: true }))).toBe(plain);
+  }
+});
+
 it("BigIntArray", () => {
   for (let TypedArray of [BigInt64Array, BigUint64Array]) {
     const buffer = new TypedArray([1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n, 10n]);


### PR DESCRIPTION
Five cold code paths were compiled once per const bool combination: bun test's coverage reporter (generate_code_coverage over text/lcov/colors, 5 distinct copies, 24 KB), Bun.spawn's spawn_maybe_sync<IS_SYNC> (2 copies, 33 KB), bun pm pack's pack<FOR_PUBLISH> (2 copies, 24 KB), console.log's typed-array printer print_typed_array<COLORS> (2 copies, 17 KB) and the install summary tree printer plus Lockfile::load_from_dir (2 copies each). Sizes are from the linux-x64 symbol table.

Each const generic becomes a runtime bool parameter, so one body exists per function; the shared bodies are `#[inline(never)]` where LTO would otherwise re-clone them into each caller. Pre-LTO the Rust rlib text drops by 44 KB. All of these run once per command, once per spawned child, or once per printed typed array, so a few extra predictable branches are not measurable; the unix blocking spawn fast path is unchanged.

Behavior is unchanged: the bool flows to the same `if`s the const did (checked every use in the diff, no inversions). Coverage, spawn, spawnSync, pack, publish, install and inspect tests pass on the debug build. bun pm diff's caller of load_from_cwd (new on main) is updated to the runtime argument.


Rebases. #39770 landed the same conversion for `spawn_maybe_sync` (runtime `is_sync`) and split the typed array loop into a shared `write_typed_array_elements`. #40678 then rewrote the coverage reporter: the table is now built by `print_coverage_table`, which main still compiles twice through `print_coverage_reports_::<COLORS>`. Conflicts were resolved in favor of main, and the PR's conversions were re-applied on top. What this PR adds on top of main:

- `CodeCoverage.rs`: `text::write_format` and `write_format_with_values` take the color flag at runtime and a `dyn Write`, and the literal templates go through a local `pfmt!` (the compile-time `pretty_fmt!` form, since clippy disallows `pretty_fmt_rt` for literals). `ByteRangeMapping__findExecutedLines` passes `false`.
- `test_command.rs`: `print_coverage_reports_::<COLORS>` is folded into `print_coverage_reports`, and `print_coverage_table` takes `colors: bool` (its `write_pretty!` calls already accept a runtime flag). One copy each instead of two.
- `ConsoleObject.rs`: `print_typed_array`, `write_typed_array`, `write_typed_array_elements` and `WrappedWriter::print_comma` take `colors` at runtime.
- `pack`, `PackError`, the install tree printer and `Lockfile::load_from_dir` as described above.
- `spawn_maybe_sync` keeps main's signature and only gains `#[inline(never)]`.

Coverage table bytes are identical to main with colors on and off.

Tests: the existing coverage and inspect tests only ran with colors off, so the runtime color arguments had no coverage in the colors-on configuration. `test/cli/test/coverage.test.ts` ("text reporter colors") pins the exact escape sequences of each row kind of the table and checks the NO_COLOR table is the same text stripped. `test/js/bun/util/inspect.test.js` ("TypedArray prints with colors", plus one `it.each` case per constructor) does the same for typed array elements and commas. Passing the inverted flag through `text::write_format` fails the coverage test. Since this PR does not change behavior, both tests also pass on main.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->