### PR TITLE
route react compiler sorts through the shared index sort

### DIFF
--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -14,6 +14,7 @@
     reason = "interops with vendored react_compiler_hir which uses std::collections"
 )]
 
+use bun_collections::index_sort;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
@@ -656,7 +657,7 @@ fn codegen_reactive_scope(
     let mut change_exprs: Vec<Expr> = Vec::new();
 
     let mut deps = scope_deps;
-    deps.sort_unstable_by(|a, b| compare_scope_dependency(a, b, cx.env));
+    index_sort::sort_slice_unstable_by(&mut deps, |a, b| compare_scope_dependency(a, b, cx.env));
 
     let cache_name = cx.synthesize_name("$");
     let cache_ref = cx
@@ -700,7 +701,9 @@ fn codegen_reactive_scope(
     let mut first_output_index: Option<u32> = None;
 
     let mut decls = scope_decls;
-    decls.sort_unstable_by(|(_a, a), (_b, b)| compare_scope_declaration(a, b, cx.env));
+    index_sort::sort_slice_unstable_by(&mut decls, |(_a, a), (_b, b)| {
+        compare_scope_declaration(a, b, cx.env)
+    });
 
     let mut output_declarators: Vec<G::Decl> = Vec::new();
     for (_ident_id, decl) in &decls {

--- a/src/react_compiler/imports.rs
+++ b/src/react_compiler/imports.rs
@@ -7,6 +7,7 @@
  */
 
 use crate::collections::{IndexMap, IndexSet};
+use bun_collections::index_sort;
 
 use crate::diagnostics::{CompilerError, CompilerErrorDetail, ErrorCategory};
 use bun_alloc::{AstAlloc, AstVec};
@@ -238,7 +239,7 @@ pub(crate) fn add_imports_to_program(
 
     let mut new_stmts: Vec<Stmt> = Vec::new();
     let mut sorted_modules: Vec<_> = context.imports.iter().collect();
-    sorted_modules.sort_unstable_by(|(a, _), (b, _)| {
+    index_sort::sort_slice_unstable_by(&mut sorted_modules, |(a, _), (b, _)| {
         a.bytes()
             .map(|c| c.to_ascii_lowercase())
             .cmp(b.bytes().map(|c| c.to_ascii_lowercase()))
@@ -247,7 +248,7 @@ pub(crate) fn add_imports_to_program(
     for (module_name, imports_map) in sorted_modules {
         let sorted_imports = {
             let mut sorted: Vec<_> = imports_map.values().collect();
-            sorted.sort_unstable_by_key(|s| s.imported);
+            index_sort::sort_slice_unstable_by(&mut sorted, |a, b| a.imported.cmp(&b.imported));
             sorted
         };
 

--- a/src/react_compiler/imports.rs
+++ b/src/react_compiler/imports.rs
@@ -248,7 +248,7 @@ pub(crate) fn add_imports_to_program(
     for (module_name, imports_map) in sorted_modules {
         let sorted_imports = {
             let mut sorted: Vec<_> = imports_map.values().collect();
-            index_sort::sort_slice_unstable_by(&mut sorted, |a, b| a.imported.cmp(&b.imported));
+            index_sort::sort_slice_unstable_by(&mut sorted, |a, b| a.imported.cmp(b.imported));
             sorted
         };
 

--- a/src/react_compiler/inference/build_reactive_scope_terminals_hir.rs
+++ b/src/react_compiler/inference/build_reactive_scope_terminals_hir.rs
@@ -11,6 +11,7 @@
 //!
 //! Ported from TypeScript `src/HIR/BuildReactiveScopeTerminalsHIR.ts`.
 
+use bun_collections::index_sort;
 use std::collections::HashSet;
 
 use crate::collections::IdMap;
@@ -107,7 +108,7 @@ fn collect_scope_rewrites(func: &HirFunction, env: &mut Environment) -> Vec<Term
 
     // Sort: ascending by start, descending by end for ties
     let mut items: Vec<ScopeId> = scope_ids;
-    items.sort_unstable_by(|a, b| {
+    index_sort::sort_slice_unstable_by(&mut items, |a, b| {
         let a_range = &env.scopes[a.0 as usize].range;
         let b_range = &env.scopes[b.0 as usize].range;
         let start_diff = a_range.start.0.cmp(&b_range.start.0);

--- a/src/react_compiler/inference/merge_overlapping_reactive_scopes_hir.rs
+++ b/src/react_compiler/inference/merge_overlapping_reactive_scopes_hir.rs
@@ -15,6 +15,7 @@
 //!
 //! Ported from TypeScript `src/HIR/MergeOverlappingReactiveScopesHIR.ts`.
 
+use bun_collections::index_sort;
 use std::cmp;
 use std::collections::HashMap;
 
@@ -158,13 +159,13 @@ fn collect_scope_info(func: &HirFunction, env: &Environment) -> ScopeInfo {
         .into_iter()
         .map(|(id, scopes)| ScopeStartEntry { id, scopes })
         .collect();
-    scope_starts.sort_unstable_by(|a, b| b.id.cmp(&a.id));
+    index_sort::sort_slice_unstable_by(&mut scope_starts, |a, b| b.id.cmp(&a.id));
 
     let mut scope_ends: Vec<ScopeEndEntry> = scope_ends_map
         .into_iter()
         .map(|(id, scopes)| ScopeEndEntry { id, scopes })
         .collect();
-    scope_ends.sort_unstable_by(|a, b| b.id.cmp(&a.id));
+    index_sort::sort_slice_unstable_by(&mut scope_ends, |a, b| b.id.cmp(&a.id));
 
     ScopeInfo {
         scope_starts,
@@ -190,7 +191,7 @@ fn visit_instruction_id(
 
             // Sort scopes by start descending (matching active_scopes order)
             let mut scopes_sorted = scope_end_entry.scopes;
-            scopes_sorted.sort_unstable_by(|a, b| {
+            index_sort::sort_slice_unstable_by(&mut scopes_sorted, |a, b| {
                 let a_start = env.scopes[a.0 as usize].range.start;
                 let b_start = env.scopes[b.0 as usize].range.start;
                 b_start.cmp(&a_start)
@@ -218,7 +219,7 @@ fn visit_instruction_id(
 
             // Sort by end descending
             let mut scopes_sorted = scope_start_entry.scopes;
-            scopes_sorted.sort_unstable_by(|a, b| {
+            index_sort::sort_slice_unstable_by(&mut scopes_sorted, |a, b| {
                 let a_end = env.scopes[a.0 as usize].range.end;
                 let b_end = env.scopes[b.0 as usize].range.end;
                 b_end.cmp(&a_end)

--- a/src/react_compiler/inference/propagate_scope_dependencies_hir.rs
+++ b/src/react_compiler/inference/propagate_scope_dependencies_hir.rs
@@ -13,6 +13,7 @@
 //! - `src/HIR/DeriveMinimalDependenciesHIR.ts`
 
 use crate::collections::{IdMap, IndexMap};
+use bun_collections::index_sort;
 use std::collections::BTreeSet;
 
 use crate::collections::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -1560,7 +1561,7 @@ impl ReactiveScopeDependencyTreeHIR {
         // instruction-based entries, and the first insertion determines the
         // root access type.
         let mut sorted_deps: Vec<&ReactiveScopeDependency> = hoistable_objects.collect();
-        sorted_deps.sort_unstable_by(|a, b| {
+        index_sort::sort_slice_unstable_by(&mut sorted_deps, |a, b| {
             let a_optional = !a.path.is_empty() && a.path[0].optional;
             let b_optional = !b.path.is_empty() && b.path[0].optional;
             b_optional.cmp(&a_optional)

--- a/src/react_compiler/lowering/build_hir/mod.rs
+++ b/src/react_compiler/lowering/build_hir/mod.rs
@@ -27,6 +27,7 @@ use crate::hir::{
 use bun_ast::expr::Data as ExprData;
 use bun_ast::stmt::Data as StmtData;
 use bun_ast::{self as ast, Expr, G, Loc, Ref, Stmt, StmtOrExpr, b};
+use bun_collections::index_sort;
 
 use super::find_context_identifiers::find_context_identifiers;
 use super::hir_builder::{
@@ -448,7 +449,7 @@ pub(super) fn gather_captured_context<'h>(
     // Sort captured entries by source position so context declarations appear
     // in source order, matching the TS compiler's position-ordered traversal.
     let mut sorted: Vec<_> = captured.into_iter().collect();
-    sorted.sort_unstable_by_key(|(_, (pos, _))| *pos);
+    index_sort::sort_slice_unstable_by(&mut sorted, |(_, (a, _)), (_, (b, _))| a.cmp(b));
 
     sorted
         .into_iter()

--- a/src/react_compiler/validation/validate_exhaustive_dependencies.rs
+++ b/src/react_compiler/validation/validate_exhaustive_dependencies.rs
@@ -1,3 +1,4 @@
+use bun_collections::index_sort;
 use std::collections::HashSet;
 
 use crate::collections::IdMap;
@@ -1144,7 +1145,7 @@ fn validate_dependencies(
     types: &[Type],
 ) -> Result<Option<CompilerDiagnostic>, CompilerDiagnostic> {
     // Sort dependencies by name and path
-    inferred.sort_unstable_by(|a, b| {
+    index_sort::sort_slice_unstable_by(&mut inferred, |a, b| {
         match (a, b) {
             (
                 InferredDependency::Global { binding: ab },

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -1065,6 +1065,88 @@ describe("bundler", () => {
       expect(out).toMatch(/__MEMO_CACHE_SENTINEL\)\s*\{[^}]*globalFn\(\)/);
     },
   });
+
+  // The compiler's sorts (src/react_compiler, via bun_collections::index_sort)
+  // decide the order of everything below. std's unstable sort is a plain
+  // insertion sort up to 20 elements and only switches to the real quicksort
+  // above that, so every list here has more than 20 entries; shorter lists
+  // would pass with any sort that gets the small case right. Names are
+  // compared bytewise, so `a10` sorts between `a1` and `a2`.
+  const deps = Array.from({ length: 22 }, (_, i) => `a${i}`);
+  const decls = Array.from({ length: 21 }, (_, i) => `b${i}`);
+  const scopes = Array.from({ length: 22 }, (_, i) => `c${i}`);
+
+  // One scope whose 22 dependencies all reach it through a closure:
+  // gather_captured_context (build_hir) orders the captured variables, and
+  // codegen orders the `$[n] !== dep` checks by name.
+  itBundled("react-compiler/SortsLargeDependencyList", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        export function Comp({ ${deps.join(", ")} }) {
+          const cb = () => [${deps.join(", ")}];
+          return <div onClick={cb} />;
+        }
+      `,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    external: ["*"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      const checked = Array.from(out.matchAll(/\$\[\d+\] !== (\w+)/g), m => m[1]);
+      expect(checked).toEqual(deps.toSorted());
+    },
+  });
+
+  // One scope with 21 declarations (`link` may mutate all of them, so they
+  // share a scope, and the JSX that reads them is a separate scope because it
+  // also depends on `props.title`): codegen orders the cache slots the
+  // declarations are written to by name.
+  itBundled("react-compiler/SortsLargeDeclarationList", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        export function Comp(props) {
+          ${decls.map(name => `const ${name} = {};`).join("\n")}
+          link(${decls.join(", ")});
+          return <div title={props.title}>{[${decls.join(", ")}]}</div>;
+        }
+      `,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    external: ["*"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      const cached = Array.from(out.matchAll(/\$\[\d+\] = (\w+)/g), m => m[1]);
+      expect(cached.filter(name => name.startsWith("b"))).toEqual(decls.toSorted());
+    },
+  });
+
+  // 22 independent scopes plus the JSX scope that depends on all of them:
+  // build_reactive_scope_terminals_hir and merge_overlapping_reactive_scopes_hir
+  // order the scopes, so the per-scope checks come out in source order
+  // (p.x0, p.x1, ..., p.x21), followed by the JSX scope's 22 checks in name order.
+  itBundled("react-compiler/SortsLargeScopeList", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        export function Comp(p) {
+          ${scopes.map((name, i) => `const ${name} = [p.x${i}];`).join("\n")}
+          return <div>{[${scopes.join(", ")}]}</div>;
+        }
+      `,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "cli",
+    external: ["*"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      const checked = Array.from(out.matchAll(/\$\[\d+\] !== ([\w.]+)/g), m => m[1]);
+      expect(checked).toEqual([...scopes.map((_, i) => `p.x${i}`), ...scopes.toSorted()]);
+    },
+  });
 });
 
 // validate_locals_not_reassigned_after_render (src/react_compiler/validation)


### PR DESCRIPTION
Follow-up to #39324. Twelve sort_unstable_by / sort_unstable_by_key sites in bun_react_compiler each stamped their own copy of std's ipnsort (quicksort, heapsort, median3, small sort): 81 symbols, 64 KB in the linux-x64 binary, and two instances differ only in the inlined comparator's field offset. They now go through bun_collections::index_sort::sort_slice_unstable_by, the shared u32 index sort added in #39324. Pre-LTO the bun_react_compiler rlib text drops by 71 KB (quicksort/ipnsort/heapsort/partition instances go to 0; the shared stub is 3 KB).

These sorts run once per reactive scope or once per function in the React compiler transform, on small lists; for n <= 20 both the std sort and the index sort use insertion sort so the tie order for typical lists is unchanged, and larger-n tie order was already unspecified under sort_unstable. Left alone on purpose: image quantize's per-pixel sort (real throughput cost) and two cfg-gated sites. react-compiler and bundler_jsx tests pass on the debug build.

### Tests

`test/bundler/transpiler/react-compiler.test.ts` gains three cases (`SortsLargeDependencyList`, `SortsLargeDeclarationList`, `SortsLargeScopeList`). Each compiles a component whose dependency list, declaration list, or scope list has more than 20 entries, so the sort goes past the insertion sort cutoff and through the shared quicksort, and asserts the order of the emitted `$[n] !== dep` checks and `$[n] = decl` writes. Between them they drive the converted sites in codegen.rs, build_hir (captured context), build_reactive_scope_terminals_hir.rs and merge_overlapping_reactive_scopes_hir.rs; the import and exhaustive-deps sites are covered by the existing fixture suite.

This is a refactor, so the ordering these tests pin is the same before and after the change and they pass on both (verified against the release build of main as well). They are sensitive to the sort itself: with `sort_slice_unstable_by` turned into a no-op, all three fail (the scope case trips the "Invalid nesting in program blocks or scopes" invariant in collect_scope_rewrites).

Also fixed along the way: clippy's needless_borrow on the imports.rs specifier comparator (`imported` is already a `&'static str`).
