### PR TITLE
standalone: check the enum bytes of each module record before reading it

### DIFF
--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -50,6 +50,7 @@ const MIRI_CRATES = [
   "bun_ptr",
   "bun_resolve_builtins",
   "bun_shell_parser",
+  "bun_standalone_graph",
   "bun_threading",
   "bun_wyhash",
 ];

--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -21,6 +21,7 @@ use enum_map::Enum;
     Debug,
     Hash,
     Enum,
+    strum::FromRepr,
     strum::IntoStaticStr,
     strum::VariantNames,
 )]

--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -21,9 +21,9 @@ use enum_map::Enum;
     Debug,
     Hash,
     Enum,
-    strum::FromRepr,
     strum::IntoStaticStr,
     strum::VariantNames,
+    strum::FromRepr,
 )]
 // The lower_snake names are exposed to JS (HTMLImportManifest
 // `"loader":`, BuildArtifact.loader) so the strum serialization must match exactly.

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -321,7 +321,7 @@ impl bun_resolver::StandaloneModuleGraph for StandaloneModuleGraph {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct CompiledModuleGraphFile {
     pub name: StringPointer,
     pub contents: StringPointer,
@@ -371,7 +371,7 @@ impl CompiledModuleGraphFile {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Default, strum::FromRepr)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, strum::FromRepr)]
 pub enum FileSide {
     #[default]
     Server = 0,
@@ -379,7 +379,7 @@ pub enum FileSide {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Default, strum::FromRepr)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, strum::FromRepr)]
 pub enum Encoding {
     Binary = 0,
     #[default]
@@ -389,7 +389,7 @@ pub enum Encoding {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Default, strum::FromRepr)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, strum::FromRepr)]
 pub enum ModuleFormat {
     #[default]
     None = 0,
@@ -2623,4 +2623,93 @@ pub(crate) fn serialize_json_source_map_for_standalone(
 
     debug_assert!(header_list.len() == string_payload_start_location);
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A record with a different value in every field and no enum left at its
+    /// default, plus its bytes as `to_bytes` serializes them.
+    fn record() -> (
+        CompiledModuleGraphFile,
+        [u8; size_of::<CompiledModuleGraphFile>()],
+    ) {
+        let pointer = |offset, length| StringPointer { offset, length };
+        let module = CompiledModuleGraphFile {
+            name: pointer(1, 2),
+            contents: pointer(3, 4),
+            sourcemap: pointer(5, 6),
+            bytecode: pointer(7, 8),
+            module_info: pointer(9, 10),
+            bytecode_origin_path: pointer(11, 12),
+            encoding: Encoding::Utf8,
+            loader: Loader::Xml,
+            module_format: ModuleFormat::Cjs,
+            side: FileSide::Client,
+        };
+        // SAFETY: `CompiledModuleGraphFile` is `repr(C)` without padding (six 8-byte
+        // pointers and then four bytes, 4-byte aligned), so every byte of it is
+        // initialized, and a byte array has no alignment requirement.
+        let bytes = unsafe {
+            core::ptr::from_ref(&module)
+                .cast::<[u8; size_of::<CompiledModuleGraphFile>()]>()
+                .read()
+        };
+        (module, bytes)
+    }
+
+    #[test]
+    fn read_decodes_what_to_bytes_writes() {
+        let (module, bytes) = record();
+        assert_eq!(CompiledModuleGraphFile::read(&bytes), Ok(module));
+    }
+
+    #[test]
+    fn read_checks_each_enum_byte_against_its_own_enum() {
+        let (_, valid) = record();
+        let enum_bytes: [(usize, fn(u8) -> bool, Corruption); 4] = [
+            (
+                offset_of!(CompiledModuleGraphFile, encoding),
+                |byte| Encoding::from_repr(byte).is_some(),
+                Corruption::ModuleEncoding,
+            ),
+            (
+                offset_of!(CompiledModuleGraphFile, loader),
+                |byte| Loader::from_repr(byte).is_some(),
+                Corruption::ModuleLoader,
+            ),
+            (
+                offset_of!(CompiledModuleGraphFile, module_format),
+                |byte| ModuleFormat::from_repr(byte).is_some(),
+                Corruption::ModuleFormat,
+            ),
+            (
+                offset_of!(CompiledModuleGraphFile, side),
+                |byte| FileSide::from_repr(byte).is_some(),
+                Corruption::ModuleSide,
+            ),
+        ];
+        // The enums are the whole tail of the record, so a new one needs an entry above.
+        assert_eq!(
+            enum_bytes.len(),
+            size_of::<CompiledModuleGraphFile>() - offset_of!(CompiledModuleGraphFile, encoding)
+        );
+        for (at, is_discriminant, what) in enum_bytes {
+            for byte in 0..=u8::MAX {
+                let mut record = valid;
+                record[at] = byte;
+                let expected: crate::Result<()> = if is_discriminant(byte) {
+                    Ok(())
+                } else {
+                    Err(what.into())
+                };
+                assert_eq!(
+                    CompiledModuleGraphFile::read(&record).map(|_| ()),
+                    expected,
+                    "byte {byte} at offset {at}"
+                );
+            }
+        }
+    }
 }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -338,11 +338,9 @@ pub(crate) struct CompiledModuleGraphFile {
 }
 
 impl CompiledModuleGraphFile {
-    /// Decodes one record as `to_bytes` laid it out. The bytes come from the
-    /// executable, so the four enum fields are checked on the way in: reading the
-    /// record straight into a `CompiledModuleGraphFile` would turn a byte outside
-    /// an enum's discriminants into a value the enum cannot hold, which is
-    /// undefined behavior before anything looks at it.
+    /// Decodes one record as `to_bytes` laid it out. The record is not read as a
+    /// whole because a byte outside one of its enums would make that read
+    /// undefined behavior, so each enum byte is checked first.
     fn read(record: &[u8; size_of::<Self>()]) -> crate::Result<Self> {
         let pointer = |field: usize| -> StringPointer {
             // SAFETY: `field` is the offset of a `StringPointer` field of `Self`, so
@@ -708,10 +706,9 @@ impl StandaloneModuleGraph {
                 Corruption::ModuleList,
             )?
         };
-        // Note: the modules blob sits at an arbitrary byte offset in the section, and
-        // `&[CompiledModuleGraphFile]` would require natural alignment (StringPointer's u32 fields
-        // → 4-byte). We instead split it into fixed-size byte records and decode each one with
-        // `CompiledModuleGraphFile::read`, so no `&T` ever points at unaligned memory.
+        // The blob sits at an arbitrary byte offset, so it is split into byte records for
+        // `CompiledModuleGraphFile::read` rather than viewed as a `&[CompiledModuleGraphFile]`,
+        // which would need 4-byte alignment.
         let (records, _) =
             modules_list_bytes.as_chunks::<{ size_of::<CompiledModuleGraphFile>() }>();
 
@@ -2629,8 +2626,7 @@ pub(crate) fn serialize_json_source_map_for_standalone(
 mod tests {
     use super::*;
 
-    /// A record with a different value in every field and no enum left at its
-    /// default, plus its bytes as `to_bytes` serializes them.
+    /// A record with a distinct value in every field, and its bytes as `to_bytes` writes them.
     fn record() -> (
         CompiledModuleGraphFile,
         [u8; size_of::<CompiledModuleGraphFile>()],

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -338,9 +338,8 @@ pub(crate) struct CompiledModuleGraphFile {
 }
 
 impl CompiledModuleGraphFile {
-    /// Decodes one record as `to_bytes` laid it out. The record is not read as a
-    /// whole because a byte outside one of its enums would make that read
-    /// undefined behavior, so each enum byte is checked first.
+    /// Decodes one record as `to_bytes` laid it out. Reading the record as a whole is
+    /// undefined behavior if a byte is outside its enum, so each enum byte is checked first.
     fn read(record: &[u8; size_of::<Self>()]) -> crate::Result<Self> {
         let pointer = |field: usize| -> StringPointer {
             // SAFETY: `field` is the offset of a `StringPointer` field of `Self`, so
@@ -706,9 +705,8 @@ impl StandaloneModuleGraph {
                 Corruption::ModuleList,
             )?
         };
-        // The blob sits at an arbitrary byte offset, so it is split into byte records for
-        // `CompiledModuleGraphFile::read` rather than viewed as a `&[CompiledModuleGraphFile]`,
-        // which would need 4-byte alignment.
+        // Byte records, not a `&[CompiledModuleGraphFile]`: the blob sits at an arbitrary byte
+        // offset and that slice would need 4-byte alignment.
         let (records, _) =
             modules_list_bytes.as_chunks::<{ size_of::<CompiledModuleGraphFile>() }>();
 

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2,7 +2,7 @@
 //! But this incurred a fixed 350ms overhead on every build, which is unacceptable
 //! so we give up on codesigning support on macOS for now until we can find a better solution
 
-use core::mem::size_of;
+use core::mem::{offset_of, size_of};
 use core::ptr::NonNull;
 use std::io::Write as _;
 use std::sync::Arc;
@@ -337,8 +337,41 @@ pub(crate) struct CompiledModuleGraphFile {
     pub side: FileSide,
 }
 
+impl CompiledModuleGraphFile {
+    /// Decodes one record as `to_bytes` laid it out. The bytes come from the
+    /// executable, so the four enum fields are checked on the way in: reading the
+    /// record straight into a `CompiledModuleGraphFile` would turn a byte outside
+    /// an enum's discriminants into a value the enum cannot hold, which is
+    /// undefined behavior before anything looks at it.
+    fn read(record: &[u8; size_of::<Self>()]) -> crate::Result<Self> {
+        let pointer = |field: usize| -> StringPointer {
+            // SAFETY: `field` is the offset of a `StringPointer` field of `Self`, so
+            // it lies inside `record`, which holds a whole `Self`; every bit pattern
+            // is a valid `StringPointer` (two `u32`s), and `read_unaligned` does not
+            // need `record` to be 4-byte aligned.
+            unsafe { core::ptr::read_unaligned(record.as_ptr().add(field).cast::<StringPointer>()) }
+        };
+        Ok(Self {
+            name: pointer(offset_of!(Self, name)),
+            contents: pointer(offset_of!(Self, contents)),
+            sourcemap: pointer(offset_of!(Self, sourcemap)),
+            bytecode: pointer(offset_of!(Self, bytecode)),
+            module_info: pointer(offset_of!(Self, module_info)),
+            bytecode_origin_path: pointer(offset_of!(Self, bytecode_origin_path)),
+            encoding: Encoding::from_repr(record[offset_of!(Self, encoding)])
+                .ok_or(Corruption::ModuleEncoding)?,
+            loader: Loader::from_repr(record[offset_of!(Self, loader)])
+                .ok_or(Corruption::ModuleLoader)?,
+            module_format: ModuleFormat::from_repr(record[offset_of!(Self, module_format)])
+                .ok_or(Corruption::ModuleFormat)?,
+            side: FileSide::from_repr(record[offset_of!(Self, side)])
+                .ok_or(Corruption::ModuleSide)?,
+        })
+    }
+}
+
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, strum::FromRepr)]
 pub enum FileSide {
     #[default]
     Server = 0,
@@ -346,7 +379,7 @@ pub enum FileSide {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, strum::FromRepr)]
 pub enum Encoding {
     Binary = 0,
     #[default]
@@ -356,7 +389,7 @@ pub enum Encoding {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, strum::FromRepr)]
 pub enum ModuleFormat {
     #[default]
     None = 0,
@@ -677,30 +710,22 @@ impl StandaloneModuleGraph {
         };
         // Note: the modules blob sits at an arbitrary byte offset in the section, and
         // `&[CompiledModuleGraphFile]` would require natural alignment (StringPointer's u32 fields
-        // → 4-byte). We instead iterate by index and `read_unaligned` each fixed-size record into a
-        // local (`CompiledModuleGraphFile` is `Copy`/POD), so no `&T` ever points at unaligned memory.
-        let modules_list_count = modules_list_bytes.len() / size_of::<CompiledModuleGraphFile>();
-        let modules_list_base = modules_list_bytes.as_ptr();
+        // → 4-byte). We instead split it into fixed-size byte records and decode each one with
+        // `CompiledModuleGraphFile::read`, so no `&T` ever points at unaligned memory.
+        let (records, _) =
+            modules_list_bytes.as_chunks::<{ size_of::<CompiledModuleGraphFile>() }>();
 
         // `entry_point()` indexes `files` by this id. `to_bytes` writes one file per
         // record with distinct names, and a repeated name is rejected below, so the
         // record count is the file count.
-        if offsets.entry_point_id as usize >= modules_list_count {
+        if offsets.entry_point_id as usize >= records.len() {
             return Err(Corruption::EntryPointId.into());
         }
 
         let mut modules = StringArrayHashMap::<File>::new();
-        modules.reserve(modules_list_count);
-        for i in 0..modules_list_count {
-            // SAFETY: index < count derived from byte length above; bytes live for 'static.
-            let module: CompiledModuleGraphFile = unsafe {
-                core::ptr::read_unaligned(
-                    modules_list_base
-                        .add(i * size_of::<CompiledModuleGraphFile>())
-                        .cast::<CompiledModuleGraphFile>(),
-                )
-            };
-            let module = &module;
+        modules.reserve(records.len());
+        for record in records {
+            let module = CompiledModuleGraphFile::read(record)?;
             // SAFETY: each name/contents/sourcemap/bytecode_origin_path subrange is checked
             // against `raw_len` and is disjoint from the writable bytecode/module_info
             // subranges (serialized by `to_bytes`); section bytes are a live 'static allocation.

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -1,7 +1,6 @@
 /// What `StandaloneModuleGraph::from_bytes` found wrong with the graph embedded
-/// in the executable. Every offset it reads comes from the file, so each one is
-/// checked before it is dereferenced, and every enum byte is checked before it
-/// becomes an enum.
+/// in the executable. Every offset and enum byte it reads comes from the file,
+/// so each one is checked before it is used.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Corruption {
     ByteCount,

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -1,6 +1,7 @@
 /// What `StandaloneModuleGraph::from_bytes` found wrong with the graph embedded
 /// in the executable. Every offset it reads comes from the file, so each one is
-/// checked before it is dereferenced.
+/// checked before it is dereferenced, and every enum byte is checked before it
+/// becomes an enum.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Corruption {
     ByteCount,
@@ -13,6 +14,10 @@ pub enum Corruption {
     ModuleBytecode,
     ModuleInfo,
     BytecodeOriginPath,
+    ModuleEncoding,
+    ModuleLoader,
+    ModuleFormat,
+    ModuleSide,
     CompileExecArgv,
 }
 
@@ -33,6 +38,10 @@ impl Corruption {
             Self::BytecodeOriginPath => {
                 "Corrupted module graph: bytecode origin path is out of range"
             }
+            Self::ModuleEncoding => "Corrupted module graph: module encoding is out of range",
+            Self::ModuleLoader => "Corrupted module graph: module loader is out of range",
+            Self::ModuleFormat => "Corrupted module graph: module format is out of range",
+            Self::ModuleSide => "Corrupted module graph: module side is out of range",
             Self::CompileExecArgv => "Corrupted module graph: compile exec argv is out of range",
         }
     }

--- a/src/standalone_graph/error.rs
+++ b/src/standalone_graph/error.rs
@@ -1,6 +1,6 @@
 /// What `StandaloneModuleGraph::from_bytes` found wrong with the graph embedded
-/// in the executable. Every offset and enum byte it reads comes from the file,
-/// so each one is checked before it is used.
+/// in the executable. Every offset it reads comes from the file, so each one is
+/// checked before it is dereferenced.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Corruption {
     ByteCount,

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -150,7 +150,8 @@ describe("compiled binary validity", () => {
   // The embedded module graph ends with `Offsets` (repr(C): byte_count u64, modules_ptr {offset u32, length u32},
   // entry_point_id u32, compile_exec_argv_ptr, flags) followed by the trailer. `byte_count` is the size of the
   // graph before `Offsets`, and `modules_ptr` points into it at the 52-byte `CompiledModuleGraphFile` records,
-  // each of which starts with the module name as {offset u32, length u32} into the graph.
+  // each of which starts with the module name as {offset u32, length u32} into the graph and ends with four
+  // one-byte enums: encoding, loader, module format, side.
   const GRAPH_TRAILER = "\n---- Bun! ----\n";
   const OFFSETS_SIZE = 32;
   const MODULE_RECORD_SIZE = 52;
@@ -168,11 +169,12 @@ describe("compiled binary validity", () => {
   }
   type ModuleGraphLayout = ReturnType<typeof locateModuleGraph>;
 
+  const oneFile = { "app.js": `console.log("should not run");` };
   const twoFiles = { "app.js": `console.log("should not run");`, "worker.js": `console.log("should not run");` };
   const corruptedGraphs = [
     {
       label: "entry_point_id equal to the module count",
-      files: { "app.js": `console.log("should not run");` },
+      files: oneFile,
       error: "entry point ID is out of range for the module list",
       corrupt(executable: Buffer, { moduleRecordCount, entryPointIdAt }: ModuleGraphLayout) {
         executable.writeUInt32LE(moduleRecordCount, entryPointIdAt);
@@ -205,6 +207,20 @@ describe("compiled binary validity", () => {
         executable.writeUInt32LE(0x7fffffff, modulesAt + MODULE_RECORD_SIZE + 12);
       },
     },
+    // The enum bytes at the end of the first record. 0xff is not a value of any of the four enums.
+    ...[
+      { field: "encoding", at: 48 },
+      { field: "loader", at: 49 },
+      { field: "format", at: 50 },
+      { field: "side", at: 51 },
+    ].map(({ field, at }) => ({
+      label: `an out-of-range module ${field} byte`,
+      files: oneFile,
+      error: `module ${field} is out of range`,
+      corrupt(executable: Buffer, { modulesAt }: ModuleGraphLayout) {
+        executable[modulesAt + at] = 0xff;
+      },
+    })),
   ];
 
   // A damaged graph must surface as an error, not an out-of-bounds panic in


### PR DESCRIPTION
Stacked on #37639: the base branch is that PR's branch, so this diff is only the follow-up its review asked for. When #37639 lands I rebase this onto `main`.

### Problem
- `StandaloneModuleGraph::from_bytes` read each 52-byte `CompiledModuleGraphFile` record out of the executable with `read_unaligned`, so the record's four `#[repr(u8)]` enum bytes (`encoding`, `loader`, `module_format`, `side`, offsets 48..51) became enum values without a check.
- A byte that is not a discriminant of the enum is not a value of that enum. Reading it as one is undefined behavior at the read, before the offset checks from #37639 run. Miri reports it at that line (see the details below).
- Such a byte is not only damage. `bun build --compile --target=bun-<os>-<arch>-v<x.y.z>` and `executablePath` embed a graph written by this Bun into a runtime of another version, so a loader this Bun knows can be a byte the runtime does not.
- In practice the executable ran as if the byte were valid. With 0xff in any of the four bytes, bun 1.4.0 and the debug build both printed the program's output and exited 0. Every other field of the record reports "Corrupted module graph: ..." after #37639.

### Fix
- `CompiledModuleGraphFile::read` decodes a record field by field. The six `StringPointer`s are read at their `offset_of!` positions (any bytes are a valid `StringPointer`). Each enum byte goes through `from_repr` (`strum::FromRepr`, derived on `Encoding`, `ModuleFormat`, `FileSide` and `bun_ast::Loader`). A byte that is not a discriminant returns `Corruption::ModuleEncoding` / `ModuleLoader` / `ModuleFormat` / `ModuleSide`, and the executable exits 1 with "Corrupted module graph: module <field> is out of range".
- `from_bytes` splits the module list with `as_chunks` and builds each `File` from the decoded record, so no enum value is made from an unchecked byte.
- This is correct because `to_bytes` writes these bytes from the enums, so an executable whose runtime matches decodes to the same values as before (the debug round-trip at the end of `to_bytes` now runs the decoder on every record it writes). Any other byte is damage or a version mismatch, and #37639 made a bad field of this record an error rather than something to act on.
- `from_repr` is derived from the variant list, so an appended `Loader` variant keeps the check correct. #37095 adds the same derive to `Loader` for the plugin ABI, in the same position, so either landing order merges to one derive. `bun_errno` uses `from_repr` the same way for untrusted errno values.
- Tests:
  - `test/bundler/bun-build-compile.test.ts`: four new cases in the `corruptedGraphs` table, one per enum byte. Each writes 0xff into the first record and expects exit 1 with the message that names the field. Without the `src/` change all four fail (the executable runs, stdout `should not run`, exit 0). With it the whole file passes.
  - `src/standalone_graph/StandaloneModuleGraph.rs`: a record with a distinct value in every field round-trips through `read`, and every byte value in each enum slot is accepted exactly when it is a discriminant of that slot's enum. The test also asserts that the enum slots are the whole tail of the record, so a later field needs an entry. `bun_standalone_graph` joins the Miri crate set in `scripts/rust-miri.ts` (5 s to run, the whole set still passes), so the sweep runs under Miri, which is the tool that sees this class of bug.
- Also run with the change: `bun-build-compile-sourcemap.test.ts`, `compile-asset-bunfs.test.ts`, `bundler_html_server.test.ts` (client-side records), the bytecode and embedded-file subset of `bundler_compile.test.ts`, `cargo clippy` on both crates, and `bun run rust:miri`.

### Background
- The module graph is the byte section `bun build --compile` appends to a copy of bun. `from_bytes` parses it at startup. Its module list is an array of `#[repr(C)]` `CompiledModuleGraphFile` records: six `StringPointer`s (`{offset: u32, length: u32}` into the section) followed by the four one-byte enums.
- A `#[repr(u8)]` enum is one byte wide, but only its declared discriminants are values of the type. Materializing any other byte as the enum (`read_unaligned`, `transmute`) is undefined behavior at that point, not at a later `match`, so the check has to look at the byte. Nothing at runtime detects it (ASAN does not, Miri does), which is why the unfixed executable appears to work.
- `strum::FromRepr` derives `fn from_repr(u8) -> Option<Self>` from the variant list.
- `Corruption` (`src/standalone_graph/error.rs`, from #37639) has one variant per field of the graph that can be bad. `Error::CorruptedModuleGraph(Corruption)` is what prints "Corrupted module graph: ..." and exits 1.
- The mordant check is red on the base branch too (a finding on `checked_range`, which #37639 adds). This PR adds no finding.

<details>
<summary>Miri on the old shape, and the repro before and after</summary>

The new sweep test, run against a `read` that reads the whole record the way the old loop did (`read_unaligned(record.as_ptr().cast::<Self>())`), under `cargo miri test -p bun_standalone_graph`:

```
error: Undefined Behavior: constructing invalid value of type std::ptr::Unaligned<StandaloneModuleGraph::CompiledModuleGraphFile>:
       at .0.encoding.<enum-tag>, encountered 0x03, but expected a valid enum tag
   --> src/standalone_graph/StandaloneModuleGraph.rs
    |         Ok(unsafe { core::ptr::read_unaligned(record.as_ptr().cast::<Self>()) })
```

A compiled one-file app with 0xff written into each enum byte of its first record. Before (bun 1.4.0 release and the debug build, the same for all four bytes):

```
{ exitCode: 0, stdout: "should not run\n", stderr: "" }
```

After (debug build with this change):

```
error: 'main' returned error.Corrupted module graph: module encoding is out of range   (exit 1)
error: 'main' returned error.Corrupted module graph: module loader is out of range     (exit 1)
error: 'main' returned error.Corrupted module graph: module format is out of range     (exit 1)
error: 'main' returned error.Corrupted module graph: module side is out of range       (exit 1)
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-compile.test.ts

<!-- robobun:evidence:end -->