### PR TITLE
bun:test: convert scope receivers to undefined in mock host functions

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1806,6 +1806,9 @@ JSC::JSObject* Bun::createInvalidThisError(JSC::JSGlobalObject* globalObject, co
 
 JSC::JSObject* Bun::createInvalidThisError(JSC::JSGlobalObject* globalObject, JSC::JSValue thisValue, const ASCIILiteral typeName)
 {
+    if (!thisValue.isEmpty())
+        thisValue = thisValue.toThis(globalObject, JSC::ECMAMode::strict());
+
     if (thisValue.isEmpty() || thisValue.isUndefined()) {
         return Bun::createError(globalObject, Bun::ErrorCode::ERR_INVALID_THIS, makeString("Expected this to be instanceof "_s, typeName));
     }

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -810,7 +810,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
+    JSValue thisValue = callframe->thisValue().toThis(globalObject, ECMAMode::strict());
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -1248,7 +1248,7 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall, (JSC::JSGlobalObj
 {
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    JSValue thisObject = callframe->thisValue();
+    JSValue thisObject = callframe->thisValue().toThis(globalObject, ECMAMode::strict());
     if (!thisObject.isObject()) [[unlikely]] {
         return JSValue::encode(jsUndefined());
     }

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -38,6 +38,22 @@ it("ERR_INVALID_THIS", () => {
     expect(e.name).toBe("TypeError");
     expect(e.message).toBe(`Expected this to be instanceof Request, but received type string ('hellooo')`);
   }
+
+  // A bare call through a closure-captured binding hands the native function
+  // the scope object as `this`; it must be reported like an undefined receiver.
+  const { formData } = Request.prototype;
+  function keep() {
+    return formData;
+  }
+  try {
+    formData();
+    expect.unreachable();
+  } catch (e) {
+    expect(e.code).toBe("ERR_INVALID_THIS");
+    expect(e.name).toBe("TypeError");
+    expect(e.message).toBe("Expected this to be instanceof Request");
+  }
+  expect(keep()).toBe(formData);
 });
 
 it("extendable", () => {

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -515,6 +515,37 @@ describe("mock()", () => {
       value: 44,
     });
   });
+  test("this is undefined when called without a receiver from a closure", () => {
+    const fn = jest.fn().mockReturnThis();
+    // Referencing `fn` from an inner function moves it into the closure's
+    // scope, so the bare call below resolves it through that scope object.
+    function keep() {
+      return fn;
+    }
+    expect(fn()).toBeUndefined();
+    expect(fn.mock.contexts).toEqual([undefined]);
+    expect(fn.mock.results).toEqual([{ type: "return", value: undefined }]);
+    expect(keep()).toBe(fn);
+  });
+  if (isBun) {
+    test("mock.lastCall getter ignores the closure scope it is called through", () => {
+      const calls = [["from the enclosing scope"]];
+      const lastCall = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(jest.fn().mock), "lastCall").get;
+      function keep() {
+        return [calls, lastCall];
+      }
+      expect(lastCall()).toBeUndefined();
+      expect(keep()).toEqual([calls, lastCall]);
+    });
+    test("mock methods called without a receiver from a closure throw the invalid this error", () => {
+      const { mockName } = jest.fn();
+      function keep() {
+        return mockName;
+      }
+      expect(() => mockName("name")).toThrow(/^Expected this to be instanceof Mock$/);
+      expect(keep()).toBe(mockName);
+    });
+  }
   test("looks like a function", () => {
     const fn = jest.fn(function nameHere(a, b, c) {
       return [a, b, c];


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found segfault in `bun:test` mock functions (fingerprint `93132250f39961d6`). Reduced repro:

```js
const { spyOn } = Bun.jest();
const mock = spyOn({}, "foo").mockReturnThis();
const ret = mock();        // `mock` is captured below, so this is a bare call through the closure scope
ret.later;                 // reads a TDZ binding through the leaked scope object: SIGSEGV at address 0x5
const later = 1;
function keep() { return [mock, later]; }
```

Root cause: when JS calls a function without a receiver through a captured variable or a module binding, JSC puts the resolving scope object (`JSLexicalEnvironment`, `JSModuleEnvironment`) in the `this` slot and relies on the callee's `op_to_this` to turn it into `undefined` (see `FunctionCallResolveNode::emitBytecode` and `JSValue::toThis`). Host functions never run `op_to_this`, so they see the raw scope object. JSC's own host functions deal with this by calling `thisValue().toThis(globalObject, ECMAMode::strict())` before doing anything generic with the receiver; `jsMockFunctionCall` did not, so:

* `mock.contexts` and `mock.results` recorded the scope object and `mockReturnThis()` returned it to user code. Property reads on a scope object go through `symbolTableGet`, which hands back the raw slot, and a binding still in its temporal dead zone is the empty `JSValue`. The fuzzer then hit `typeof` on that empty value in the interpreter.
* The `mock.lastCall` getter read `calls` through the receiver, so calling it through a scope that has a TDZ `calls` binding crashes the same way without any leak first.
* Every `CHECK_IS_MOCK_FUNCTION` method (`mockName`, `mockClear`, ...) reports the bad receiver through `createInvalidThisError`, whose `determineSpecificType` reads `constructor` through it; a TDZ `constructor` binding crashes the same way. The same overload is what `generate-classes.ts` emits for the invalid-this path of every generated class method (`Request.prototype.formData`, `Blob.prototype.text`, ...), so those had the same crash and the same `[native code: JSLexicalEnvironment]` text in their error messages. Both TDZ cases reproduce on the current release build with `bun test` (segfault at address `0x5`).

The fix is the `toThis(..., ECMAMode::strict())` call in three places: the receiver read at the top of `jsMockFunctionCall`, the receiver read in `jsMockFunctionGetter_mockGetLastCall`, and `createInvalidThisError` before it formats the receiver. Strict mode `toThis` only changes scope objects (to `undefined`); primitives and ordinary objects pass through unchanged, so `fn.call(123)`, `obj.fn()` and `new fn()` (where the slot holds `new.target`) behave exactly as before. This also makes a bare call of a module level mock from inside a test callback record `undefined` in `mock.contexts`, which is what Jest and Vitest record; before this change Bun recorded the module environment.

Other host functions return or read their raw receiver in the same way (the fake timer and `setSystemTime` chaining functions, the `Bun.plugin` builder methods, `StringDecoder` called without `new`, the `inspect.custom` fallbacks, and `NAPICallFrame`'s sloppy `this` emulation). They are not touched here; the crash this PR fixes is the mock receiver handling, and those are being tracked separately since the clean fix for them is a shared helper or a conversion at the native call boundary.

### How did you verify your code works?

Three new tests in `test/js/bun/test/mock-fn.test.js` and one more case in the existing `ERR_INVALID_THIS` test in `test/js/bun/globals.test.js`, which exercises the `createInvalidThisError` change through a generated class (`Request.prototype.formData`) rather than through the mock macro. On an unfixed build (1.3.14 and the 8326d1bd3 canary) all four fail: they receive the `JSLexicalEnvironment`, the enclosing scope's `calls` array, and the `..., but received [native code: JSLexicalEnvironment]` message (mock and Request) respectively. With `bun bd test` both files pass (83 and 20 tests). The first mock test is also valid under Jest and Vitest, which record `undefined` there.

With the debug build, the original fuzzer script and the two TDZ repros above (for `lastCall` and for `mockName`) exit cleanly. Also ran `spyMatchers`, `mock-disposable`, `toHaveReturnedWith`, `mock-module`, `expect`, `describe`, the MIME and `node:sqlite` tests, `globals.test.js` and `bun-serve-routes` (the other callers of the changed `createInvalidThisError` overload are the generated classes, MIME, `node:sqlite` and `BunRequest`); all green.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/globals.test.js test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (8326d1bd3)

test/js/bun/globals.test.js:
49 |     formData();
50 |     expect.unreachable();
51 |   } catch (e) {
52 |     expect(e.code).toBe("ERR_INVALID_THIS");
53 |     expect(e.name).toBe("TypeError");
54 |     expect(e.message).toBe("Expected this to be instanceof Request");
                           ^
error: expect(received).toBe(expected)

Expected: "Expected this to be instanceof Request"
Received: "Expected this to be instanceof Request, but received [native code: JSLexicalEnvironment]"

      at <anonymous> (/workspace/bun/test/js/bun/globals.test.js:54:23)
(fail) ERR_INVALID_THIS [21.36ms]
(pass) extendable [19.32ms]
(pass) writable [11.48ms]
(pass) name [5.48ms]
(pass) File > constructor [9.67ms]
(pass) File > constructor with empty array [2.55ms]
(pass) File > constructor with lastModified [2.97ms]
(pass) File > constructor with undefined name [2.73ms]
(pass) File > constructor throws invalid args [6.96ms]
(pass) File > constructor without new 
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (b614f0a9b)

test/js/bun/globals.test.js:
(pass) ERR_INVALID_THIS [0.26ms]
(pass) extendable [0.27ms]
(pass) writable [0.12ms]
(pass) name [0.05ms]
(pass) File > constructor [0.16ms]
(pass) File > constructor with empty array [0.03ms]
(pass) File > constructor with lastModified [0.03ms]
(pass) File > constructor with undefined name [0.02ms]
(pass) File > constructor throws invalid args [0.19ms]
(pass) File > constructor without new [0.03ms]
(pass) File > instanceof [0.05ms]
(pass) File > extendable [0.18ms]
(pass) globals are deletable [25.24ms]
(pass) self is a getter [0.06ms]
(pass) errors thrown by native code should be TypeError [0.20ms]
(pass) globalThis.gc > when --expose-gc is not passed > globalThis.gc === undefined [6.41ms]
(pass) globalThis.gc > when --expose-gc is not passed > .gc does not take up a property slot [5.31ms]
(pass) globalThis.gc > when --expose-gc is passed > is a function [4.83ms]
(pass) globalThis.gc > when --expose-gc is passed > gc is the same as globalThis.gc [5.12ms]
(pass) globalThis.gc > when --expose-gc is passed > cleans up memory [45.14ms]

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.f
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/globals.test.js test/js/bun/test/mock-fn.test.js
bun test v1.4.0 (8326d1bd3)

test/js/bun/globals.test.js:
(pass) ERR_INVALID_THIS [19.76ms]
(pass) extendable [18.91ms]
(pass) writable [11.06ms]
(pass) name [5.39ms]
(pass) File > constructor [9.74ms]
(pass) File > constructor with empty array [2.75ms]
(pass) File > constructor with lastModified [2.67ms]
(pass) File > constructor with undefined name [2.67ms]
(pass) File > constructor throws invalid args [6.76ms]
(pass) File > constructor without new [2.95ms]
(pass) File > instanceof [4.14ms]
(pass) File > extendable [13.60ms]
(pass) globals are deletable [1474.47ms]
(pass) self is a getter [3.60ms]
(pass) errors thrown by native code should be TypeError [9.61ms]
(pass) globalThis.gc > when --expose-gc is not passed > globalThis.gc === undefined [261.54ms]
(pass) globalThis.gc > when --expose-gc is not passed > .gc does not take up a property slot [263.34ms]
(pass) globalThis.gc > when --expose-gc is passed > is a function [262.69ms]
(pass) globalThis.gc > when --expose-gc is
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 634ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/76] gen ErrorCode+*.h
[2/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[3/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[4/10] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[5/10] gen cpp.rs (cppbind)
[5/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Com
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ErrorCode.cpp      |  3 +++
 src/jsc/bindings/JSMockFunction.cpp |  4 ++--
 test/js/bun/globals.test.js         | 16 ++++++++++++++++
 test/js/bun/test/mock-fn.test.js    | 31 +++++++++++++++++++++++++++++++
 4 files changed, 52 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/bindings/ErrorCode.cpp           2      1      0
src/jsc/bindings/JSMockFunction.cpp      7      4      0
test/js/bun/globals.test.js              1      1      0
test/js/bun/test/mock-fn.test.js         3      3      0
```

</details>

<!-- robobun:evidence:end -->
