### PR TITLE
Bun.serve: arm the streaming response's uWS callbacks before attaching the stream

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1923,10 +1923,16 @@ where
         );
     }
 
-    /// `do_render_stream` found the request aborted (or the server stopped)
-    /// once the user code it ran returned. `on_abort` has already aborted the
-    /// sink and detached `resp`, and whoever detaches `resp` also releases the
-    /// base ref, so all that is left here is dropping the sink and the stream.
+    /// `do_render_stream` found `resp` detached once the user code it ran
+    /// returned: `on_abort` ran from inside it (`server.stop(true)` in `pull()`
+    /// closes this request's socket), aborted the sink and took over the base
+    /// ref, so all that is left is dropping the sink and the stream.
+    ///
+    /// Not for a stop that did not reach `on_abort` because the stream had
+    /// already completed the response (uWS `markDone()` dropped the callback):
+    /// `resp` is still set then, the request still owns its base ref, and the
+    /// regular arms release it (`end_stream()` right away, or the settle paths
+    /// once `pull()` finishes).
     fn discard_stream_after_abort(
         &self,
         stream: &WebCore::ReadableStream,
@@ -2027,7 +2033,8 @@ where
         let aborted = this.flags.aborted() || response_stream.sink.is_aborted();
         this.flags.set_aborted(aborted);
 
-        if this.is_aborted_or_ended() {
+        // Deliberately not `is_aborted_or_ended()`; see the helper.
+        if this.resp.get().is_none() {
             this.discard_stream_after_abort(stream, global_this);
             return;
         }
@@ -2086,9 +2093,11 @@ where
                 if this.drain_microtasks().is_err() {
                     return;
                 }
-                // The drained microtasks ran user code too (`server.stop(true)`
-                // from one of them reaches `on_abort` just like from `pull()`).
-                if this.is_aborted_or_ended() {
+                // The drained microtasks ran user code too: a `server.stop(true)`
+                // in one of them reaches `on_abort` just like one in `pull()`
+                // (unless the drain completed the response first; then the
+                // request stays owned and the settle paths release it).
+                if this.resp.get().is_none() {
                     this.discard_stream_after_abort(stream, global_this);
                     return;
                 }

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1175,11 +1175,9 @@ where
     /// (`us_internal_free_closed_sockets`) or recycled it onto the next
     /// keep-alive request. Release the handle without dereferencing it. The
     /// `clear_on_data()`/`clear_aborted()`/`clear_timeout()` calls
-    /// `detach_response()` would make are already covered by `markDone()`
-    /// (`do_render_stream` arms them before the sink can end the response, and
-    /// nothing arms them afterwards). For the same reason a later
-    /// `server.stop(true)` does not reach `on_abort`, so callers get here even
-    /// when the server is already terminated: nothing else releases the ref.
+    /// `detach_response()` would make are already covered by `markDone()`,
+    /// which is also why a later `server.stop(true)` cannot reach `on_abort`:
+    /// callers come here even once the server is terminated.
     ///
     /// HTTP/3 must never reach this. `Http3Response::markDone()` deliberately
     /// leaves `onAborted` armed so `on_stream_close` can notify the holder,
@@ -1990,11 +1988,10 @@ where
             this.render_metadata();
         }
 
-        // Armed before `pull()` can run, not in `to_async()`: a `server.stop(true)`
-        // inside `pull()` must reach `on_abort` before the sink uses the freed
-        // socket, and if the stream completes the response within this frame,
-        // uWS `markDone()` drops both callbacks for good (`to_async()` then
-        // finds `has_abort_handler` set); see `end_already_responded_stream`.
+        // Before `pull()` runs, not in `to_async()`: a `server.stop(true)` inside
+        // `pull()` has to reach `on_abort`, and once the stream has completed the
+        // response, uWS `markDone()` must have dropped these for good (the flag
+        // makes the later `to_async()` a no-op); see `end_already_responded_stream`.
         this.set_abort_handler();
         resp.on_writable(
             |this, off, resp| Self::on_writable_response_stream(this, off, resp),

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1175,7 +1175,16 @@ where
     /// (`us_internal_free_closed_sockets`) or recycled it onto the next
     /// keep-alive request. Release the handle without dereferencing it. The
     /// `clear_on_data()`/`clear_aborted()`/`clear_timeout()` calls
-    /// `detach_response()` would make are already covered by `markDone()`.
+    /// `detach_response()` would make are already covered by `markDone()`:
+    /// `do_render_stream` arms the callbacks before the sink can end the
+    /// response, and nothing arms them after (`to_async()` finds
+    /// `has_abort_handler` set), so uWS never points at this context again
+    /// once it is back in the pool.
+    ///
+    /// The same `markDone()` means a `server.stop(true)` issued after the end
+    /// closes the socket without reaching `on_abort`, so the callers must get
+    /// here even when `is_aborted_or_ended()` already reports the server as
+    /// terminated: this is the only remaining release of the base ref.
     ///
     /// HTTP/3 must never reach this. `Http3Response::markDone()` deliberately
     /// leaves `onAborted` armed so `on_stream_close` can notify the holder,
@@ -1513,11 +1522,12 @@ where
     /// Forward uWS's drain notification to the streaming response sink so it
     /// can resend any `try_end` tail and signal the JS writer to resume.
     ///
-    /// Registered once in `do_render_stream` (pending-promise branch) for the
-    /// lifetime of the streaming response, so the sink itself never touches
-    /// uWS callback registration — it only tracks `has_backpressure`. uWS only
-    /// invokes the handler once its own send buffer has fully drained, so an
-    /// always-armed registration costs nothing on the no-backpressure path.
+    /// Registered once in `do_render_stream` (before the stream is attached)
+    /// for the lifetime of the streaming response, so the sink itself never
+    /// touches uWS callback registration — it only tracks `has_backpressure`.
+    /// uWS only invokes the handler once its own send buffer has fully
+    /// drained, so an always-armed registration costs nothing on the
+    /// no-backpressure path.
     fn on_writable_response_stream(
         this: *mut Self,
         write_offset: u64,
@@ -1913,6 +1923,36 @@ where
         );
     }
 
+    /// `do_render_stream` found the request aborted (or the server stopped)
+    /// once the user code it ran returned. `on_abort` has already aborted the
+    /// sink and detached `resp`, and whoever detaches `resp` also releases the
+    /// base ref, so all that is left here is dropping the sink and the stream.
+    fn discard_stream_after_abort(
+        &self,
+        stream: &WebCore::ReadableStream,
+        global_this: &JSGlobalObject,
+    ) {
+        stream_log!("aborted while attaching the stream");
+        let mut readable_ref = self
+            .response_body_readable_stream_ref
+            .replace(readable_stream::Strong::default());
+        if let Some(wrapper_ptr) = self.sink.take() {
+            // SAFETY: this context is the sink's sole owner until `destroy_sink`
+            // below (see the `sink` field); `on_abort` leaves it allocated.
+            let wrapper = unsafe { &mut *wrapper_ptr.as_ptr() };
+            ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
+                &mut wrapper.sink.source,
+                global_this,
+            );
+            crate::dispatch::fold(stream.cancel(global_this));
+            wrapper.sink.mark_done();
+            wrapper.sink.on_first_write = None;
+            wrapper.sink.finalize();
+            Self::destroy_sink(wrapper_ptr);
+        }
+        readable_ref.deinit();
+    }
+
     fn do_render_stream(pair: *mut StreamPair<'_, ThisServer, SSL_ENABLED, DEBUG_MODE, HTTP3>) {
         ctx_log!("doRenderStream");
         // SAFETY: pair is a stack local threaded through cork user-data.
@@ -1954,6 +1994,23 @@ where
             this.render_metadata();
         }
 
+        // Armed here, before the sink gets to run user code, rather than in
+        // `to_async()` once the handler has returned: `server.stop(true)` from
+        // inside `pull()` closes the socket right there, and `on_abort` is what
+        // stops the sink from using the freed socket later. Conversely, if the
+        // stream already completes the response inside this frame (an
+        // auto-flush in the drain below), uWS `markDone()` drops both
+        // callbacks, and nothing may arm them again: the context is released
+        // to the pool by `end_already_responded_stream()` while the keep-alive
+        // socket lives on (`set_abort_handler()` is a no-op once armed).
+        // The drain callback stays armed for the whole response; the sink only
+        // tracks `has_backpressure` (see `on_writable_response_stream`).
+        this.set_abort_handler();
+        resp.on_writable(
+            |this, off, resp| Self::on_writable_response_stream(this, off, resp),
+            this.as_ctx_ptr(),
+        );
+
         // We are already corked!
         let assignment_result: JSValue =
             ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::assign_to_stream(
@@ -1967,13 +2024,18 @@ where
         // assignToStream stored the controller in `sink.source`; a sync-finished stream's
         // `__controllerDetached` may already have cleared it again (handled below).
 
+        let aborted = this.flags.aborted() || response_stream.sink.is_aborted();
+        this.flags.set_aborted(aborted);
+
+        if this.is_aborted_or_ended() {
+            this.discard_stream_after_abort(stream, global_this);
+            return;
+        }
+
         #[cfg(debug_assertions)]
         if resp.has_responded() {
             stream_log!("responded");
         }
-
-        let aborted = this.flags.aborted() || response_stream.sink.is_aborted();
-        this.flags.set_aborted(aborted);
 
         if let Some(err_value) = assignment_result.to_error() {
             stream_log!("returned an error");
@@ -2006,8 +2068,8 @@ where
         // hits transport backpressure (common on QUIC right after the
         // HEADERS frame), the sink parks a pending_flush promise, but
         // assignToStream() itself returns undefined. Surface that promise
-        // here so the request waits for the drain (the Pending branch below
-        // arms on_writable) instead of falling through to the cancel path.
+        // here so the request waits for the drain (the on_writable armed
+        // above resolves it) instead of falling through to the cancel path.
         let mut effective_result = assignment_result;
         if effective_result.is_empty_or_undefined_or_null() {
             if let Some(flush) = response_stream.sink.pending_flush {
@@ -2022,6 +2084,12 @@ where
             if let Some(promise) = effective_result.as_any_promise() {
                 stream_log!("returned a promise");
                 if this.drain_microtasks().is_err() {
+                    return;
+                }
+                // The drained microtasks ran user code too (`server.stop(true)`
+                // from one of them reaches `on_abort` just like from `pull()`).
+                if this.is_aborted_or_ended() {
+                    this.discard_stream_after_abort(stream, global_this);
                     return;
                 }
 
@@ -2042,15 +2110,6 @@ where
                             response_stream.sink.ctx = None;
                             this.render_metadata();
                         }
-
-                        // The sink only tracks `has_backpressure`; the
-                        // on_writable registration lives here so it is armed
-                        // once for the response's lifetime instead of toggled
-                        // on every write — see `on_writable_response_stream`.
-                        resp.on_writable(
-                            |this, off, resp| Self::on_writable_response_stream(this, off, resp),
-                            this.as_ctx_ptr(),
-                        );
 
                         // TODO: should this timeout?
                         let body_value = this.response_mut().unwrap().get_body_value();
@@ -2113,25 +2172,6 @@ where
             }
         }
 
-        if this.is_aborted_or_ended() {
-            ResponseStreamJSSink::<SSL_ENABLED, HTTP3>::detach(
-                &mut response_stream.sink.source,
-                global_this,
-            );
-            crate::dispatch::fold(stream.cancel(global_this));
-            let mut readable_ref = this
-                .response_body_readable_stream_ref
-                .replace(readable_stream::Strong::default());
-
-            response_stream.sink.mark_done();
-            response_stream.sink.on_first_write = None;
-
-            response_stream.sink.finalize();
-            this.sink.set(None);
-            Self::destroy_sink(response_stream_ptr);
-            readable_ref.deinit();
-            return;
-        }
         let mut readable_ref = this
             .response_body_readable_stream_ref
             .replace(readable_stream::Strong::default());
@@ -2683,24 +2723,17 @@ where
         if let Some(wrapper) = self.sink_mut() {
             if !self.flags.aborted() && !wrapper.sink.is_aborted() {
                 // Only defer when there is still a live response to drain the
-                // flush through: on_writable (which resolves the flush via
-                // flush_promise) is armed on `resp`. With no response the flush
-                // can never settle, so taking a ref and attaching here would
-                // leak the ref and hang the request; fall through to teardown.
-                if let (Some(flush), Some(resp)) = (wrapper.sink.pending_flush, self.resp.get()) {
+                // flush through: the on_writable `do_render_stream` armed on
+                // `resp` is what resolves the flush (via flush_promise). With
+                // no response the flush can never settle, so taking a ref and
+                // attaching here would leak the ref and hang the request; fall
+                // through to teardown.
+                if let Some(flush) = wrapper.sink.pending_flush
+                    && self.resp.get().is_some()
+                {
                     stream_log!("handleResolveStream: waiting for pending flush");
                     debug_assert!(self.server.get().is_some());
                     let global_this = self.server().global_this();
-                    // The sink no longer registers its own drain callback;
-                    // RequestContext owns it (see on_writable_response_stream).
-                    // do_render_stream only arms it on the Pending branch, but
-                    // a fulfilled pull() reaches here directly, so arm it now
-                    // or the parked flush never drains. Re-arming with the same
-                    // handler is idempotent in uWS.
-                    resp.on_writable(
-                        |this, off, resp| Self::on_writable_response_stream(this, off, resp),
-                        self.as_ctx_ptr(),
-                    );
                     self.ref_();
                     let cell = NativePromiseContext::create(global_this, self.as_ctx_ptr());
                     // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
@@ -2762,6 +2795,11 @@ where
         }
 
         if self.is_aborted_or_ended() {
+            // A `server.stop(true)` in the meantime did not reach `on_abort`
+            // (see `end_already_responded_stream`), so the release is still ours.
+            if !HTTP3 && ended_response {
+                self.end_already_responded_stream();
+            }
             return;
         }
 
@@ -2868,6 +2906,11 @@ where
 
         // aborted so call finalizeForAbort
         if self.is_aborted_or_ended() {
+            // A `server.stop(true)` in the meantime did not reach `on_abort`
+            // (see `end_already_responded_stream`), so the release is still ours.
+            if !HTTP3 && ended_response {
+                self.end_already_responded_stream();
+            }
             return;
         }
 
@@ -4132,24 +4175,28 @@ where
         }
         ctx_log!("resumeRequestBodySocket");
         self.flags.set_request_body_paused(false);
-        if self.resp_may_be_freed() {
-            return;
-        }
-        if let Some(resp) = self.resp.get() {
+        if let Some(resp) = self.live_resp() {
             resp.resume();
         }
     }
 
-    /// After a streaming-response sink has set `ended_response`, `markDone()`
-    /// dropped `onAborted` and `resp` may point at a freed `us_socket_t` (see
-    /// `end_already_responded_stream`). The sink already resumed the socket.
+    /// `resp` for the uses that can come in from JS at any time while the
+    /// request is pending (`server.requestIP()`, `server.timeout()`, resuming
+    /// the request body): `None` once a streaming sink has set
+    /// `ended_response`. From then on `markDone()` has dropped `onAborted` and
+    /// `resp` may point at a freed `us_socket_t` (see
+    /// `end_already_responded_stream`); the sink already resumed the socket.
+    /// The end/abort paths read `resp` directly: they learn the same thing
+    /// from the sink they tear down.
     #[inline]
-    fn resp_may_be_freed(&self) -> bool {
+    fn live_resp(&self) -> Option<uws::AnyResponse> {
         if let Some(sink) = self.sink.get() {
             // SAFETY: `sink` is owned by this context and freed in `handle_resolve_stream`/`deinit`.
-            return unsafe { (*sink.as_ptr()).sink.ended_response };
+            if unsafe { (*sink.as_ptr()).sink.ended_response } {
+                return None;
+            }
         }
-        false
+        self.resp.get()
     }
 
     /// Detach the body ByteStream's producer back-pointer (the stream can outlive this ctx in JS).
@@ -4177,10 +4224,7 @@ where
         {
             return;
         }
-        if this.resp_may_be_freed() {
-            return;
-        }
-        if let Some(resp) = this.resp.get() {
+        if let Some(resp) = this.live_resp() {
             resp.resume();
         }
     }
@@ -4273,7 +4317,7 @@ where
     }
 
     pub(crate) fn get_remote_socket_info(&self) -> Option<uws::SocketAddress> {
-        let resp = self.resp.get()?;
+        let resp = self.live_resp()?;
         // `AnyResponse::get_remote_socket_info` returns the uws_sys
         // variant; convert to the owned `bun_uws::SocketAddress`.
         // SAFETY: FFI handle
@@ -4286,7 +4330,7 @@ where
     }
 
     pub(crate) fn set_timeout(&self, seconds: c_uint) -> bool {
-        if let Some(resp) = self.resp.get() {
+        if let Some(resp) = self.live_resp() {
             // SAFETY: FFI handle
             resp.timeout(seconds.min(255) as u8);
             if seconds == 0 {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1175,16 +1175,11 @@ where
     /// (`us_internal_free_closed_sockets`) or recycled it onto the next
     /// keep-alive request. Release the handle without dereferencing it. The
     /// `clear_on_data()`/`clear_aborted()`/`clear_timeout()` calls
-    /// `detach_response()` would make are already covered by `markDone()`:
-    /// `do_render_stream` arms the callbacks before the sink can end the
-    /// response, and nothing arms them after (`to_async()` finds
-    /// `has_abort_handler` set), so uWS never points at this context again
-    /// once it is back in the pool.
-    ///
-    /// The same `markDone()` means a `server.stop(true)` issued after the end
-    /// closes the socket without reaching `on_abort`, so the callers must get
-    /// here even when `is_aborted_or_ended()` already reports the server as
-    /// terminated: this is the only remaining release of the base ref.
+    /// `detach_response()` would make are already covered by `markDone()`
+    /// (`do_render_stream` arms them before the sink can end the response, and
+    /// nothing arms them afterwards). For the same reason a later
+    /// `server.stop(true)` does not reach `on_abort`, so callers get here even
+    /// when the server is already terminated: nothing else releases the ref.
     ///
     /// HTTP/3 must never reach this. `Http3Response::markDone()` deliberately
     /// leaves `onAborted` armed so `on_stream_close` can notify the holder,
@@ -1522,12 +1517,11 @@ where
     /// Forward uWS's drain notification to the streaming response sink so it
     /// can resend any `try_end` tail and signal the JS writer to resume.
     ///
-    /// Registered once in `do_render_stream` (before the stream is attached)
-    /// for the lifetime of the streaming response, so the sink itself never
-    /// touches uWS callback registration — it only tracks `has_backpressure`.
-    /// uWS only invokes the handler once its own send buffer has fully
-    /// drained, so an always-armed registration costs nothing on the
-    /// no-backpressure path.
+    /// Registered once in `do_render_stream` (before assign_to_stream) for the
+    /// lifetime of the streaming response, so the sink itself never touches
+    /// uWS callback registration — it only tracks `has_backpressure`. uWS only
+    /// invokes the handler once its own send buffer has fully drained, so an
+    /// always-armed registration costs nothing on the no-backpressure path.
     fn on_writable_response_stream(
         this: *mut Self,
         write_offset: u64,
@@ -1923,16 +1917,12 @@ where
         );
     }
 
-    /// `do_render_stream` found `resp` detached once the user code it ran
-    /// returned: `on_abort` ran from inside it (`server.stop(true)` in `pull()`
-    /// closes this request's socket), aborted the sink and took over the base
-    /// ref, so all that is left is dropping the sink and the stream.
-    ///
-    /// Not for a stop that did not reach `on_abort` because the stream had
-    /// already completed the response (uWS `markDone()` dropped the callback):
-    /// `resp` is still set then, the request still owns its base ref, and the
-    /// regular arms release it (`end_stream()` right away, or the settle paths
-    /// once `pull()` finishes).
+    /// `on_abort` ran from inside the user code `do_render_stream` invoked
+    /// (`server.stop(true)` in `pull()`): it aborted the sink, detached `resp`
+    /// and took over the base ref, leaving only the sink and stream to drop.
+    /// Keyed on `resp` being gone, not on `is_aborted_or_ended()`: a stop that
+    /// found the response already complete never reaches `on_abort`, and that
+    /// request still owns its ref, which the regular arms release.
     fn discard_stream_after_abort(
         &self,
         stream: &WebCore::ReadableStream,
@@ -2000,17 +1990,11 @@ where
             this.render_metadata();
         }
 
-        // Armed here, before the sink gets to run user code, rather than in
-        // `to_async()` once the handler has returned: `server.stop(true)` from
-        // inside `pull()` closes the socket right there, and `on_abort` is what
-        // stops the sink from using the freed socket later. Conversely, if the
-        // stream already completes the response inside this frame (an
-        // auto-flush in the drain below), uWS `markDone()` drops both
-        // callbacks, and nothing may arm them again: the context is released
-        // to the pool by `end_already_responded_stream()` while the keep-alive
-        // socket lives on (`set_abort_handler()` is a no-op once armed).
-        // The drain callback stays armed for the whole response; the sink only
-        // tracks `has_backpressure` (see `on_writable_response_stream`).
+        // Armed before `pull()` can run, not in `to_async()`: a `server.stop(true)`
+        // inside `pull()` must reach `on_abort` before the sink uses the freed
+        // socket, and if the stream completes the response within this frame,
+        // uWS `markDone()` drops both callbacks for good (`to_async()` then
+        // finds `has_abort_handler` set); see `end_already_responded_stream`.
         this.set_abort_handler();
         resp.on_writable(
             |this, off, resp| Self::on_writable_response_stream(this, off, resp),
@@ -2033,7 +2017,6 @@ where
         let aborted = this.flags.aborted() || response_stream.sink.is_aborted();
         this.flags.set_aborted(aborted);
 
-        // Deliberately not `is_aborted_or_ended()`; see the helper.
         if this.resp.get().is_none() {
             this.discard_stream_after_abort(stream, global_this);
             return;
@@ -2093,10 +2076,7 @@ where
                 if this.drain_microtasks().is_err() {
                     return;
                 }
-                // The drained microtasks ran user code too: a `server.stop(true)`
-                // in one of them reaches `on_abort` just like one in `pull()`
-                // (unless the drain completed the response first; then the
-                // request stays owned and the settle paths release it).
+                // The drain ran user code too (same as right after assign_to_stream).
                 if this.resp.get().is_none() {
                     this.discard_stream_after_abort(stream, global_this);
                     return;
@@ -2732,11 +2712,10 @@ where
         if let Some(wrapper) = self.sink_mut() {
             if !self.flags.aborted() && !wrapper.sink.is_aborted() {
                 // Only defer when there is still a live response to drain the
-                // flush through: the on_writable `do_render_stream` armed on
-                // `resp` is what resolves the flush (via flush_promise). With
-                // no response the flush can never settle, so taking a ref and
-                // attaching here would leak the ref and hang the request; fall
-                // through to teardown.
+                // flush through: on_writable (which resolves the flush via
+                // flush_promise) is armed on `resp`. With no response the flush
+                // can never settle, so taking a ref and attaching here would
+                // leak the ref and hang the request; fall through to teardown.
                 if let Some(flush) = wrapper.sink.pending_flush
                     && self.resp.get().is_some()
                 {
@@ -2804,8 +2783,7 @@ where
         }
 
         if self.is_aborted_or_ended() {
-            // A `server.stop(true)` in the meantime did not reach `on_abort`
-            // (see `end_already_responded_stream`), so the release is still ours.
+            // Still ours to release after a stop; see `end_already_responded_stream`.
             if !HTTP3 && ended_response {
                 self.end_already_responded_stream();
             }
@@ -2915,8 +2893,7 @@ where
 
         // aborted so call finalizeForAbort
         if self.is_aborted_or_ended() {
-            // A `server.stop(true)` in the meantime did not reach `on_abort`
-            // (see `end_already_responded_stream`), so the release is still ours.
+            // Still ours to release after a stop; see `end_already_responded_stream`.
             if !HTTP3 && ended_response {
                 self.end_already_responded_stream();
             }
@@ -4189,14 +4166,10 @@ where
         }
     }
 
-    /// `resp` for the uses that can come in from JS at any time while the
-    /// request is pending (`server.requestIP()`, `server.timeout()`, resuming
-    /// the request body): `None` once a streaming sink has set
-    /// `ended_response`. From then on `markDone()` has dropped `onAborted` and
-    /// `resp` may point at a freed `us_socket_t` (see
-    /// `end_already_responded_stream`); the sink already resumed the socket.
-    /// The end/abort paths read `resp` directly: they learn the same thing
-    /// from the sink they tear down.
+    /// `resp` for everything outside the end/abort paths (`server.requestIP()`,
+    /// `server.timeout()`, request-body resume): `None` once a streaming sink
+    /// has set `ended_response`, after which `resp` may point at a freed
+    /// `us_socket_t` (see `end_already_responded_stream`; the sink resumed it).
     #[inline]
     fn live_resp(&self) -> Option<uws::AnyResponse> {
         if let Some(sink) = self.sink.get() {

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -386,6 +386,232 @@ test.concurrent(
   60_000,
 );
 
+// The request context used to arm its uWS onAborted callback only once the
+// fetch handler had returned (toAsync). A direct stream runs pull() before
+// that, while the request is still being dispatched, which left two gaps:
+//
+// - pull() writes and close()s: the auto-flusher completes the response before
+//   the dispatch returns, uWS markDone() drops its callbacks, and toAsync then
+//   armed onAborted anyway. The keep-alive socket outlives the request, so the
+//   callback pointed at a context already returned to the pool; closing the
+//   connection later (server.stop(true) here, a client disconnect in general)
+//   invoked it on the freed slot:
+//     panic: infallible: server bound            (RequestContext::server)
+//     AddressSanitizer: use-after-poison          RequestContext::ref_ <- on_abort
+//                                                 <- uWS::HttpContext::onClose
+// - pull() calls server.stop(true): the socket is closed on the spot, but with
+//   nothing armed neither the context nor its sink heard about it. uSockets
+//   frees the socket at the end of the tick and the sink's next write()/end()
+//   used it:
+//     AddressSanitizer: heap-use-after-free       uws_res_has_responded
+//                                                 <- HTTPServerWritable::end_from_js
+//
+// The callbacks are now armed before the stream is attached, so markDone()
+// disarming them is final and a stop() from inside pull() aborts the sink.
+// The remaining tests pin down what follows from markDone() being final: while
+// pull() is still parked after the response completed, nothing tells the
+// request when its socket goes away, so both a later stop() and the Request
+// based APIs have to cope with that on their own.
+describe("direct stream whose pull() runs while the request is still being dispatched", () => {
+  // Raw socket so the test decides when the connection goes away (it stays
+  // open after the response until the test or server.stop(true) closes it).
+  const client = `
+    const net = require("node:net");
+    const socket = net.connect(server.port, "127.0.0.1", () => {
+      socket.write("GET / HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+    });
+    socket.on("error", () => {});
+    const closed = new Promise(resolve => socket.once("close", resolve));
+    const responseBody = () =>
+      new Promise(resolve => {
+        let buf = "";
+        socket.on("data", chunk => {
+          buf += chunk.toString("latin1");
+          // Content-Length: 4, so the response is complete once "seed" is in.
+          if (buf.endsWith("seed")) resolve(buf.slice(buf.indexOf("\\r\\n\\r\\n") + 4));
+        });
+      });
+  `;
+
+  // pull() parks after close(): the response completes inside the dispatch,
+  // the request itself stays pending until the gate opens.
+  const closeThenPark = `
+    const gate = Promise.withResolvers();
+    let request;
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      idleTimeout: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname === "/probe") return new Response("probe");
+        request = req;
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            async pull(controller) {
+              controller.write("seed");
+              controller.close();
+              await gate.promise;
+            },
+          }),
+        );
+      },
+    });
+  `;
+
+  async function run(fixture: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.concurrent("closing the connection after the request was released does not reach the request", async () => {
+    const result = await run(`
+      ${closeThenPark}
+      ${client}
+      const body = await responseBody();
+      gate.resolve();
+      // The parked pull() settles and the request is released; the keep-alive
+      // connection is still open.
+      while (server.pendingRequests > 0) await Bun.sleep(0);
+      server.stop(true);
+      await closed;
+      console.log(JSON.stringify({ body, pendingRequests: server.pendingRequests }));
+    `);
+    expect(result).toEqual({
+      stdout: JSON.stringify({ body: "seed", pendingRequests: 0 }) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Companion to the above: once the response has completed, closing the
+  // connection no longer notifies the request, so a server.stop(true) issued
+  // while pull() is still parked must not keep the request (and so the stop()
+  // promise) pending forever once pull() settles.
+  test.concurrent("stop(true) after the response completed still releases the parked request", async () => {
+    const result = await run(`
+      ${closeThenPark}
+      ${client}
+      const body = await responseBody();
+      const stopped = server.stop(true);
+      await closed;
+      const pendingWhileParked = server.pendingRequests;
+      gate.resolve();
+      await stopped;
+      console.log(JSON.stringify({ body, pendingWhileParked, pendingRequests: server.pendingRequests }));
+    `);
+    expect(result).toEqual({
+      stdout: JSON.stringify({ body: "seed", pendingWhileParked: 1, pendingRequests: 0 }) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Same window, reached through the Request object: the client is gone and
+  // uSockets has freed the socket, but pull() still holds the request, so the
+  // APIs that look at its socket must treat it as gone instead of reading it
+  // (heap-use-after-free in us_get_remote_address_info <- requestIP).
+  test.concurrent("requestIP()/timeout() after the response completed and the client left", async () => {
+    const result = await run(`
+      ${closeThenPark}
+      ${client}
+      const body = await responseBody();
+      socket.destroy();
+      await closed;
+      // A round trip through the server proves it has run the event loop turn
+      // that processed the close above; uSockets frees the socket at the end
+      // of that turn.
+      const probe = await (await fetch(new URL("/probe", server.url))).text();
+      const requestIP = server.requestIP(request);
+      server.timeout(request, 1);
+      const pendingWhileParked = server.pendingRequests;
+      gate.resolve();
+      while (server.pendingRequests > 0) await Bun.sleep(0);
+      server.stop(true);
+      console.log(JSON.stringify({ body, probe, requestIP, pendingWhileParked }));
+    `);
+    expect(result).toEqual({
+      stdout: JSON.stringify({ body: "seed", probe: "probe", requestIP: null, pendingWhileParked: 1 }) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // A sync handler's Response is attached inside the request's dispatch (the
+  // context is kept alive by the dispatch frame); an async handler's from its
+  // promise reaction (kept alive by the reaction's ref). Both must survive the
+  // request being aborted out from under them while pull() runs.
+  test.concurrent.each(["fetch()", "async fetch()"])(
+    "server.stop(true) from inside pull() aborts the stream before the socket is freed (%s)",
+    async handler => {
+      const result = await run(`
+      const events = [];
+      const pulled = Promise.withResolvers();
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        idleTimeout: 0,
+        ${handler} {
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              async pull(controller) {
+                controller.write("seed");
+                events.push("stop(true)");
+                server.stop(true);
+                events.push("stop(true) returned");
+                // uSockets frees the closed socket at the end of this event
+                // loop turn; the calls below must not be able to reach it.
+                await Bun.sleep(0);
+                try {
+                  controller.write("late");
+                  events.push("write() returned");
+                } catch (error) {
+                  events.push("write() threw: " + error.message);
+                }
+                controller.end();
+                events.push("end() returned");
+                pulled.resolve();
+              },
+              cancel() {
+                events.push("cancel()");
+              },
+            }),
+          );
+        },
+      });
+      ${client}
+      await closed;
+      // The request was released as soon as the Response had been attached,
+      // i.e. before the timer above resumed pull().
+      await pulled.promise;
+      console.log(JSON.stringify({ events, pendingRequests: server.pendingRequests }));
+    `);
+      expect(result).toEqual({
+        stdout:
+          JSON.stringify({
+            events: [
+              "stop(true)",
+              "cancel()",
+              "stop(true) returned",
+              'write() threw: This HTTPResponseSink has already been closed. A "direct" ReadableStream terminates its underlying socket once `async pull()` returns.',
+              "end() returned",
+            ],
+            pendingRequests: 0,
+          }) + "\n",
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+  );
+});
+
 // The HTTP/3 sibling must NOT take the ended_response short-circuit.
 // Http3Response::markDone() deliberately leaves onAborted armed (unlike
 // HTTP/1's markDone()) so that Http3Context's on_stream_close can notify the

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -412,9 +412,10 @@ test.concurrent(
 // pull() is still parked after the response completed, nothing tells the
 // request when its socket goes away, so both a later stop() and the Request
 // based APIs have to cope with that on their own.
-describe("direct stream whose pull() runs while the request is still being dispatched", () => {
+describe("direct stream whose pull() runs while its Response is being attached", () => {
   // Raw socket so the test decides when the connection goes away (it stays
   // open after the response until the test or server.stop(true) closes it).
+  // Always reading, so a close that arrives behind response bytes is seen too.
   const client = `
     const net = require("node:net");
     const socket = net.connect(server.port, "127.0.0.1", () => {
@@ -422,15 +423,14 @@ describe("direct stream whose pull() runs while the request is still being dispa
     });
     socket.on("error", () => {});
     const closed = new Promise(resolve => socket.once("close", resolve));
-    const responseBody = () =>
-      new Promise(resolve => {
-        let buf = "";
-        socket.on("data", chunk => {
-          buf += chunk.toString("latin1");
-          // Content-Length: 4, so the response is complete once "seed" is in.
-          if (buf.endsWith("seed")) resolve(buf.slice(buf.indexOf("\\r\\n\\r\\n") + 4));
-        });
-      });
+    const responded = Promise.withResolvers();
+    let received = "";
+    socket.on("data", chunk => {
+      received += chunk.toString("latin1");
+      // Content-Length: 4, so the response is complete once "seed" is in.
+      if (received.endsWith("seed")) responded.resolve(received.slice(received.indexOf("\\r\\n\\r\\n") + 4));
+    });
+    const responseBody = () => responded.promise;
   `;
 
   // pull() parks after close(): the response completes inside the dispatch,
@@ -543,40 +543,44 @@ describe("direct stream whose pull() runs while the request is still being dispa
     });
   });
 
-  // A sync handler's Response is attached inside the request's dispatch (the
-  // context is kept alive by the dispatch frame); an async handler's from its
-  // promise reaction (kept alive by the reaction's ref). Both must survive the
-  // request being aborted out from under them while pull() runs.
-  test.concurrent.each(["fetch()", "async fetch()"])(
-    "server.stop(true) from inside pull() aborts the stream before the socket is freed (%s)",
-    async handler => {
-      const result = await run(`
+  // A handler that returns (or whose promise is already settled once the
+  // dispatch drains microtasks) has its Response attached inside the request's
+  // dispatch, which keeps the context alive; one that is still pending when the
+  // dispatch returns has it attached later from the promise reaction, which
+  // holds its own ref and has already armed the request's callbacks (toAsync).
+  // Both have to cope with whatever pull() does to the request while it runs.
+  const handlers = [
+    ["fetch()", "fetch() {"],
+    ["async fetch()", "async fetch() { await Bun.sleep(0);"],
+  ];
+
+  // pull() runs `body` with "seed" buffered, yields one event loop turn
+  // (uSockets frees a closed socket at the end of the turn that closed it),
+  // runs `afterwards` and finishes. The request count is sampled one more turn
+  // later, once the microtasks queued by pull() finishing (the stream
+  // settling) have run as well.
+  function stopFromPull(handler: string, body: string, afterwards = "") {
+    return `
       const events = [];
       const pulled = Promise.withResolvers();
+      const stop = () => {
+        events.push("stop(true)");
+        server.stop(true);
+        events.push("stop(true) returned");
+      };
       const server = Bun.serve({
         port: 0,
         hostname: "127.0.0.1",
         idleTimeout: 0,
-        ${handler} {
+        ${handler}
           return new Response(
             new ReadableStream({
               type: "direct",
               async pull(controller) {
                 controller.write("seed");
-                events.push("stop(true)");
-                server.stop(true);
-                events.push("stop(true) returned");
-                // uSockets frees the closed socket at the end of this event
-                // loop turn; the calls below must not be able to reach it.
+                ${body}
                 await Bun.sleep(0);
-                try {
-                  controller.write("late");
-                  events.push("write() returned");
-                } catch (error) {
-                  events.push("write() threw: " + error.message);
-                }
-                controller.end();
-                events.push("end() returned");
+                ${afterwards}
                 pulled.resolve();
               },
               cancel() {
@@ -588,23 +592,61 @@ describe("direct stream whose pull() runs while the request is still being dispa
       });
       ${client}
       await closed;
-      // The request was released as soon as the Response had been attached,
-      // i.e. before the timer above resumed pull().
       await pulled.promise;
+      await Bun.sleep(0);
       console.log(JSON.stringify({ events, pendingRequests: server.pendingRequests }));
-    `);
+    `;
+  }
+
+  const lateWrites = `
+    try {
+      controller.write("late");
+      events.push("write() returned");
+    } catch (error) {
+      events.push("write() threw: " + error.message);
+    }
+    controller.end();
+    events.push("end() returned");
+  `;
+  const abortedEvents = [
+    "stop(true)",
+    "cancel()",
+    "stop(true) returned",
+    'write() threw: This HTTPResponseSink has already been closed. A "direct" ReadableStream terminates its underlying socket once `async pull()` returns.',
+    "end() returned",
+  ];
+
+  // Called directly, the stop runs while the stream is being attached. From a
+  // microtask it runs inside the microtask drain that follows the attach (sync
+  // handler) or once the stream's promise reactions are in place (async one).
+  test.concurrent.each(
+    handlers.flatMap(([label, handler]) => [
+      [label, "directly", handler, "stop();"],
+      [label, "from a microtask", handler, "queueMicrotask(stop);"],
+    ]),
+  )(
+    "server.stop(true) from inside pull() (%s, %s) aborts the stream before the socket is freed",
+    async (_label, _where, handler, body) => {
+      const result = await run(stopFromPull(handler, body, lateWrites));
+      expect(result).toEqual({
+        stdout: JSON.stringify({ events: abortedEvents, pendingRequests: 0 }) + "\n",
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+  );
+
+  // end() completes the response, so uWS has already dropped the abort
+  // callback when the stop closes the socket: nothing aborts the request, and
+  // it has to be released the way a completed response normally is.
+  test.concurrent.each(handlers)(
+    "server.stop(true) from inside pull() after end() still releases the request (%s)",
+    async (_label, handler) => {
+      const result = await run(stopFromPull(handler, `events.push("end()"); controller.end(); stop();`));
       expect(result).toEqual({
         stdout:
-          JSON.stringify({
-            events: [
-              "stop(true)",
-              "cancel()",
-              "stop(true) returned",
-              'write() threw: This HTTPResponseSink has already been closed. A "direct" ReadableStream terminates its underlying socket once `async pull()` returns.',
-              "end() returned",
-            ],
-            pendingRequests: 0,
-          }) + "\n",
+          JSON.stringify({ events: ["end()", "cancel()", "stop(true)", "stop(true) returned"], pendingRequests: 0 }) +
+          "\n",
         stderr: "",
         exitCode: 0,
       });


### PR DESCRIPTION
### Problem

Two crashes with a `type: "direct"` response body and `server.stop(true)`. Both come from one ordering problem: the request context armed its uWS `onAborted` callback in `to_async()`, after the fetch handler returned, but a direct stream runs the user's `pull()` earlier, inside `do_render_stream`, while the request is still being dispatched.

- `pull()` does `controller.write(); controller.close()` and awaits. The unflushed bytes go out via the auto-flusher during the microtask drain in `do_render_stream`, which completes the response: uWS `markDone()` drops its callbacks, and `to_async()` then armed `onAborted` anyway. Once `pull()` settles, `handle_resolve_stream` releases the context to the pool (`end_already_responded_stream`), but the keep-alive socket lives on with `onAborted` still pointing at the slot. Closing that connection later (`server.stop(true)`, or just the client disconnecting) ran `on_abort` on the released context:
  - release: `panic: infallible: server bound` (`RequestContext::server`, `RequestContext.rs:551`)
  - ASAN: `use-after-poison` in `RequestContext::ref_` <- `RequestContextRef::pin` <- `on_abort` <- `uWS::HttpContext::onClose` <- `us_socket_group_close_all` <- `NewServer::stop`
  - Regression from the change that introduced `end_already_responded_stream()`: before it, the settle path happened to clear the stale callback through `detach_response()`.
- `pull()` calls `server.stop(true)`. `app.close()` closes the request's own socket right there, but nothing was armed on it, so neither the context nor its `HTTPServerWritable` heard about it. uSockets frees the socket at the end of the tick and the sink's next `controller.end()`/`write()` used it:
  - ASAN: `heap-use-after-free` in `uws_res_has_responded` <- `HTTPServerWritable::end_from_js` (`streams.rs:1853`; `write_latin1` for `write()`). Pre-existing, only visible under ASAN.

### Fix

- `do_render_stream` arms `onAborted` and `onWritable` before `assign_to_stream`, i.e. before the sink can run user code or complete the response. `markDone()` disarming them is then final (`to_async()` -> `set_abort_handler()` is a no-op once `has_abort_handler` is set, as `do_sendfile` already relies on), and a `stop(true)` from inside `pull()` reaches `on_abort`, which aborts the sink and releases the context. The Pending-arm `onWritable` registration and the re-arm in `handle_resolve_stream` are superseded and removed.
- After `assign_to_stream`, and again after the microtask drain (which also runs user code), `do_render_stream` checks whether `on_abort` ran in the meantime and then only drops the sink (`discard_stream_after_abort`): the abort already released the context, and in the synchronous dispatch it has already run `finalize_without_deinit`, so continuing into the Pending arm would hit `response_mut().unwrap()` (in the async-handler case the reaction's ref keeps the context alive and this merely tears down earlier). The check is "`resp` is detached", not `is_aborted_or_ended()`: a `stop(true)` issued after `pull()` already completed the response with `end()` never reaches `on_abort` (uWS dropped the callback at `markDone()`), and that request still owns its ref, which the existing `has_responded()` arm releases as before. The `is_aborted_or_ended()` block that sat after the promise handling is unreachable now and is folded into the helper.
- Because the callback is no longer re-armed, a `server.stop(true)` issued after the response completed but before `pull()` settles no longer reaches the context at all, so `handle_resolve_stream`/`handle_reject_stream` call `end_already_responded_stream()` even when `is_aborted_or_ended()` reports the server as terminated. Otherwise the context, `server.pendingRequests` and the `stop()` promise would stay pending forever (that case used to work only through the stale callback).
- Same window reached from JS: `server.requestIP(req)` and `server.timeout(req, n)` dereferenced `resp` while `pull()` was parked after the response completed and the peer had gone (ASAN `heap-use-after-free` in `us_get_remote_address_info`). They now use the `ended_response` check the request-body resume paths already had (`resp_may_be_freed`, renamed `live_resp()` so the four sites share it); `requestIP()` returns `null` there.
- Non-streaming responses are untouched: the uWS request is still only copied out in `to_async()` when the request turns out to be asynchronous, and the blob path registers nothing new. For streaming responses both registrations were already being made; they now happen before `pull()` instead of after.
- Tests: new `describe` block in `test/js/bun/http/serve-direct-readable-stream.test.ts` (9 spawned fixtures). On an unmodified build, the stale-callback test dies with `panic: infallible: server bound`; the `stop(true)`-inside-`pull()` matrix (handler whose Response is attached from the dispatch vs. from its promise reaction, stop called directly vs. from a microtask) sees `cancel()` only at `end()` time, `write()` succeeding and `pendingRequests: 1` (the `end_from_js` UAF under ASAN); the `requestIP()` test, run against a build with only the arming change, reported the `us_get_remote_address_info` UAF. The `end()`-then-`stop(true)` test with the promise-reaction handler is the leak the first revision of this PR had (it reported `pendingRequests: 1` against it); it and the "stop(true) after the response completed" test also pass on main and guard the arming change against becoming a leak.
- Also run on this build: the rest of that file (including the HTTP/3 cases), `serve.test.ts`, `bun-server.test.ts`, `serve-body-leak`, `serve-http3`, and the other `serve-*stream*`/abort/leak files in `test/js/bun/http`; the only failures are `localhost`/IPv6 ones that fail identically with the unmodified binary in this environment.

### Background

- `RequestContext` is the per-request state, allocated from a per-server pool and returned to it in `deinit()`. It is intrusively ref-counted; the base ref is released by whichever path ends the response (`end()`, `end_stream()`, `end_already_responded_stream()`) or adopted by `on_abort`. `resp` being `Some` marks that the base ref is still held, which is why the settle paths are gated on it.
- uWS keeps one `HttpResponseData` per connection with raw `onAborted`/`onWritable`/`onData` function pointers and a user-data pointer. `HttpContext::onClose` invokes `onAborted` whenever the socket closes, for any reason. `markDone()` (a fully ended response) clears the callbacks; a new request on the same keep-alive connection does not, so a callback armed after `markDone()` survives until something closes the socket or overwrites it.
- `HTTPServerWritable` (`streams.rs`) is the sink a streaming `Response` body writes into. It holds a raw copy of the uWS response and is owned by the `RequestContext`, which frees it when the stream's promise settles. `ended_response` means the sink itself fully ended the response; after that, on HTTP/1, nothing tells the context if the socket goes away, so the context must not dereference `resp` again. `end_already_responded_stream()` is the settle path for that state.
- A `type: "direct"` stream calls the user's `pull(controller)` synchronously from `assign_to_stream` (`readDirectStream`, `BunStreamSource.cpp`). If `pull()` returns a promise, the stream's completion promise settles when that one does, so the request stays pending while `pull()` is parked even if the HTTP response was already completed through the controller.
- `server.stop(true)` is `stop_listening(abrupt)` -> `app.close()`: every socket of the app is closed synchronously, running `HttpContext::onClose` (and so `on_abort`, where armed) for each, including the socket of the request whose handler is currently on the stack.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-direct-readable-stream.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [49.82ms]
(pass) controller.end() after pull() resolved does not use the sink after free [375.85ms]
(pass) client disconnect after controller.end() with a parked pull() does not use the socket after free [1287.33ms]
(pass) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free [1295.17ms]
(pass) pull() rejecting after the client aborted releases the request without reporting the error [1240.00ms]
(pass) direct stream whose pull() runs while its Response is being attached > stop(true) after the response completed still releases the parked request [1273.76ms]
(pass) direct stream whose pull() runs while its Response is being attached > requestIP()/timeout() after the response completed and the client left [1614.48ms]
(pass) direct stream whose pull() runs while its Response is being attached > server.st
... (truncated)

release without fix: 1 failed, 4 skipped
bun test v1.4.0-canary.1 (583bb688a)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [12.56ms]
(skip) controller.end() after pull() resolved does not use the sink after free
(skip) client disconnect after controller.end() with a parked pull() does not use the socket after free
(skip) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free
(pass) direct stream whose pull() runs while its Response is being attached > requestIP()/timeout() after the response completed and the client left [22.33ms]
(pass) direct stream whose pull() runs while its Response is being attached > server.stop(true) from inside pull() (fetch(), from a microtask) aborts the stream before the socket is freed [22.56ms]
(pass) direct stream whose pull() runs while its Response is being attached > closing the connection after the request was released does not reach the request [34.76ms]
(pass) pull() rejecting after the client aborted releases the request without reporting the error [37.17ms]
(pass) direct stream whose pull() runs while its Response is being attached > server.stop(true) from 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-direct-readable-stream.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [60.85ms]
(pass) controller.end() after pull() resolved does not use the sink after free [380.17ms]
(pass) client disconnect after controller.end() with a parked pull() does not use the socket after free [1305.98ms]
(pass) client disconnect after controller.end() with a parked rejecting pull() does not use the socket after free [1318.42ms]
(pass) direct stream whose pull() runs while its Response is being attached > stop(true) after the response completed still releases the parked request [1202.62ms]
(pass) direct stream whose pull() runs while its Response is being attached > closing the connection after the request was released does not reach the request [1229.34ms]
(pass) pull() rejecting after the client aborted releases the request without reporting the error [1258.00ms]
(pass) direct stream whose pull() runs while its Response is being attached >
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 958ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 242 extern-C blocks audited
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 17s
[4/7] link bun-profile
[6/7] strip bun
[6/7] bun-profile --revision
1.4.0-canary.1+52ec203e3
[build] done
bun test v1.4.0-canary.1 (52ec203e3)

test/js/bun/http/serve-direct-readable-stream.test.ts:
(pass) HTTPResponseSink displays correct message [12.66ms]
(skip) controller.end() after pull() resolved does not use the sink after free
(skip) client disconnect after controller.end
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/server/RequestContext.rs               | 147 ++++++-----
 .../bun/http/serve-direct-readable-stream.test.ts  | 268 +++++++++++++++++++++
 2 files changed, 353 insertions(+), 62 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                   reads  edits  tests
src/runtime/server/RequestContext.rs                      33     38      0
test/js/bun/http/serve-direct-readable-stream.test.ts     11     13      0
```

</details>

<!-- robobun:evidence:end -->