### PR TITLE
valkey: close the socket on every fail() and mark the client disconnected before onclose runs

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1221,7 +1221,6 @@ impl JSValkeyClient {
                     let error = global_object.take_exception(err);
                     let client = self.client_mut();
                     client.flags.connection_promise_returns_client = false;
-                    client.flags.is_manually_closed = true;
                     let rejected = match Js::connection_promise_get_cached(this_value) {
                         Some(promise) => {
                             Js::connection_promise_set_cached(
@@ -1234,10 +1233,16 @@ impl JSValkeyClient {
                         }
                         None => Ok(()),
                     };
-                    let failed =
-                        rejected.and_then(|()| client.fail_with_js_value(&global_object, error));
-                    let closed = self.client_mut().close();
-                    return failed.and(closed);
+                    // `fail_with_js_value` closes the socket itself; a second close here would
+                    // hit whatever a connect() from `onclose` just opened.
+                    return match rejected {
+                        Ok(()) => client.fail_with_js_value(&global_object, error),
+                        Err(_) => {
+                            client.flags.is_manually_closed = true;
+                            let closed = client.close(uws::CloseCode::Failure);
+                            rejected.and(closed)
+                        }
+                    };
                 }
             };
             Js::hello_set_cached(this_value, &global_object, hello_value);
@@ -1348,6 +1353,10 @@ impl JSValkeyClient {
         // sole releaser. The caller holds its own scoped ref, so count > 0.
         let _socket_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
 
+        // This timer was bounding the attempt that just ended; left armed it
+        // fires during the retry delay, and `fail()` then has no socket to
+        // close and nothing settles connect(). `reconnect()` arms a new one.
+        self.timer.disarm(self);
         self.reconnect_timer
             .arm(self, self.client.get().get_reconnect_delay());
     }
@@ -1853,12 +1862,8 @@ impl<const SSL: bool> SocketHandler<SSL> {
         err_value: JSValue,
     ) -> JsResult<()> {
         let _exit = this.vm().enter_event_loop_scope();
-        this.client_mut().flags.is_manually_closed = true;
-        let failed = this
-            .client_mut()
-            .fail_with_js_value(&this.global_object, err_value);
-        let closed = this.client_mut().close();
-        failed.and(closed)
+        this.client_mut()
+            .fail_with_js_value(&this.global_object, err_value)
     }
 
     pub(crate) const ON_HANDSHAKE: Option<
@@ -1875,10 +1880,10 @@ impl<const SSL: bool> SocketHandler<SSL> {
         let _guard = this.ref_scope();
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
-        let _defer = scopeguard::guard(BackRef::new(this), |p| {
-            p.client_mut().status = valkey::Status::Disconnected;
-            p.update_poll_ref();
-        });
+        // Before `on_close()`: it runs `onclose` and settles the connect()
+        // promise, and a connect() called from either must see Disconnected.
+        this.client_mut().status = valkey::Status::Disconnected;
+        let _defer = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
 
         this.client_mut().on_close()
     }
@@ -1900,10 +1905,8 @@ impl<const SSL: bool> SocketHandler<SSL> {
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
         let _guard = this.ref_scope();
-        let _defer = scopeguard::guard(BackRef::new(this), |p| {
-            p.client_mut().status = valkey::Status::Disconnected;
-            p.update_poll_ref();
-        });
+        this.client_mut().status = valkey::Status::Disconnected;
+        let _defer = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
 
         this.client_mut().on_close()
     }
@@ -2029,7 +2032,7 @@ impl ValkeyDeferredClose {
         let ctx = self.ctx;
         // SAFETY: single-threaded; intrusive ref taken before enqueue guarantees liveness.
         unsafe {
-            crate::dispatch::fold((*ctx).client_mut().close());
+            crate::dispatch::fold((*ctx).client_mut().close(uws::CloseCode::FastShutdown));
             JSValkeyClient::deref(ctx.cast_mut());
         }
     }

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -31,12 +31,14 @@ pub struct ConnectionFlags {
     pub(crate) is_selecting_db_internal: bool,
     pub(crate) enable_offline_queue: bool,
     pub(crate) enable_auto_reconnect: bool,
-    /// Sticky until the next accepted HELLO, so it overlaps `Connecting`
-    /// (`reconnect()` reads it there) and `failed` (`update_poll_ref` reads it
-    /// there); that is why it is not a `Status` variant.
+    /// Set from the close that schedules a retry until the next accepted HELLO
+    /// or `fail()`, so it overlaps `Disconnected` and `Connecting`; that is why
+    /// it is not a `Status` variant.
     pub(crate) is_reconnecting: bool,
-    /// Sticky until `on_open`/`connect()`, and orthogonal to `Status`: `fail()`
-    /// while `Connected` leaves the socket open and `status` unchanged.
+    /// Sticky until `on_open`/`connect()`. `fail()` closes the socket outright
+    /// (see `close()`), so by the time it returns the close callback has run
+    /// (`on_close` reads this to skip the retry policy) and this overlaps
+    /// `Disconnected`.
     pub(crate) failed: bool,
     pub(crate) enable_auto_pipelining: bool,
     pub(crate) finalized: bool,
@@ -604,6 +606,7 @@ impl ValkeyClient {
             return Ok(());
         }
         self.flags.failed = true;
+        self.flags.is_reconnecting = false;
         let val = Self::reject_all_pending_commands(
             &mut self.in_flight,
             &mut self.queue,
@@ -611,17 +614,24 @@ impl ValkeyClient {
             jsvalue,
         );
 
-        if !self.connection_ready() {
-            self.flags.is_manually_closed = true;
-            let closed = self.close(); // unconditionally, whatever `val` is
-            return val.and(closed);
-        }
-        val
+        // A failure the client detected itself (idle timeout, protocol or
+        // handshake error) has always been a deliberate close; `on_close` reads
+        // `failed` and skips the retry policy. It is not `is_manually_closed`:
+        // that flag is copied into `duplicate()`, and a duplicate of a failed
+        // client should still reconnect.
+        let closed = self.close(uws::CloseCode::Failure); // unconditionally, whatever `val` is
+        val.and(closed)
     }
 
+    /// `fail()` passes `Failure`, the one code whose close callback has run by
+    /// the time this returns (see `CloseCode`); everything after a failure
+    /// relies on that, and an RST instead of a FIN costs nothing once the
+    /// connection's commands have been rejected. `disconnect()` and the
+    /// finalizer pass `FastShutdown`, the graceful close.
+    ///
     /// `Err` when the close event left a termination pending, or, for a half-open socket whose `on_close`
     /// runs by hand here, whatever that left.
-    pub fn close(&mut self) -> JsResult<()> {
+    pub fn close(&mut self, code: uws::CloseCode) -> JsResult<()> {
         if self.socket.is_closed() {
             return Ok(());
         }
@@ -643,7 +653,7 @@ impl ValkeyClient {
         let is_semi_socket = matches!(socket.socket(), uws::InternalSocket::Connected(_))
             && !socket.is_established();
         // TODO: make socket.close() return a JsResult.
-        socket.close(uws::CloseCode::Normal);
+        socket.close(code);
         if global.has_exception() {
             return Err(bun_jsc::JsError::Thrown);
         }
@@ -661,9 +671,9 @@ impl ValkeyClient {
         self.unregister_auto_flusher();
         self.write_buffer.clear_and_free();
 
-        // If manually closing, don't attempt to reconnect
-        if self.flags.is_manually_closed {
-            debug!("skip reconnecting since the connection is manually closed");
+        // A manual close or a failure the client detected itself: no retry.
+        if self.flags.is_manually_closed || self.flags.failed {
+            debug!("skip reconnecting since the connection is manually closed or failed");
             self.fail(b"Connection closed", RedisError::ConnectionClosed)?;
             self.on_valkey_close()?;
             return Ok(());
@@ -751,6 +761,10 @@ impl ValkeyClient {
             data.len(),
             bstr::BStr::new(data)
         );
+        // Handling a reply can close this socket and, from `onclose` or a
+        // rejection handler, dial the next one; the remaining replies came from
+        // the closed connection and must not reach the new one.
+        let socket = *self.socket.socket();
         // Path 1: Buffer already has data, append and process from buffer
         if !self.read_buffer.remaining().is_empty() {
             self.read_buffer
@@ -818,7 +832,7 @@ impl ValkeyClient {
                 let mut value_to_handle = value; // Use temp var for defer
                 self.handle_response(&mut value_to_handle)?;
 
-                if self.status == Status::Disconnected || self.flags.failed {
+                if *self.socket.socket() != socket {
                     return Ok(());
                 }
                 self.send_next_command();
@@ -877,8 +891,7 @@ impl ValkeyClient {
             let mut value_to_handle = value; // Use temp var for defer
             self.handle_response(&mut value_to_handle)?;
 
-            // Check connection status after handling
-            if self.status == Status::Disconnected || self.flags.failed {
+            if *self.socket.socket() != socket {
                 return Ok(());
             }
 
@@ -1503,7 +1516,7 @@ impl ValkeyClient {
         self.flags.is_manually_closed = true;
         self.unregister_auto_flusher();
         if self.status == Status::Connected || self.status == Status::Connecting {
-            return self.close();
+            return self.close(uws::CloseCode::FastShutdown);
         }
         Ok(())
     }

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -20,15 +20,26 @@ bun_opaque::opaque_ffi! { pub struct us_socket_t; }
 
 #[repr(i32)]
 #[derive(Copy, Clone, Eq, PartialEq, strum::IntoStaticStr)]
+/// Which of the three codes a close uses decides whether the close callback
+/// has run by the time `close()` returns. Only `failure` guarantees that: for
+/// the other two, `us_internal_ssl_close` (crypto/openssl.c) keeps a TLS
+/// socket open while it still owns the loop's ciphertext spill, i.e. when the
+/// last batch flush hit a full kernel buffer, and finishes the close from the
+/// next writable event or the peer's FIN, which a peer that stopped reading
+/// never produces.
 pub enum CloseCode {
     /// TLS: send close_notify and defer fd close until peer replies. TCP: FIN.
     normal = 0,
-    /// TLS: fast-shutdown (no wait). TCP: SO_LINGER{1,0} → RST, dropping any
-    /// unflushed send buffer. Only for `terminate()` / GC abort.
+    /// Closes now, whatever the peer does: TLS fast-shutdown with no spill
+    /// deferral; TCP SO_LINGER{1,0} → RST, dropping any unflushed send buffer.
+    /// For `terminate()` / GC abort, and for a protocol client that has given
+    /// up on the connection and rejected everything on it (the valkey client's
+    /// `fail()`), whose callers rely on the close callback having run.
     failure = 1,
-    /// TLS: fast-shutdown (no wait). TCP: FIN. For `_handle.close()` where
-    /// the JS wrapper detaches immediately so `.normal`'s deferral would
-    /// orphan the `us_socket_t`, but already-written data must still drain.
+    /// TLS: fast-shutdown, but still deferred while a spill is pending. TCP:
+    /// FIN. For `_handle.close()` where the JS wrapper detaches immediately so
+    /// `.normal`'s deferral would orphan the `us_socket_t`, but already-written
+    /// data must still drain.
     fast_shutdown = 2,
 }
 

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -484,10 +484,6 @@ describe("Valkey: Recovering After fail()", () => {
         await once(server, "listening");
         return (server.address() as net.AddressInfo).port;
       },
-      listenUnix: async (socketPath: string) => {
-        server.listen(socketPath);
-        await once(server, "listening");
-      },
       close: () => new Promise(resolve => server.close(resolve)),
     };
   }

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -1,6 +1,9 @@
 import { RedisClient } from "bun";
 import { describe, expect, mock, test } from "bun:test";
+import { once } from "events";
+import { bunEnv, bunExe, tls as tlsCert } from "harness";
 import net from "net";
+import tls from "tls";
 import { DEFAULT_REDIS_OPTIONS, DEFAULT_REDIS_URL, delay, isEnabled } from "../test-utils";
 
 /**
@@ -439,5 +442,515 @@ describe("Valkey: Auto-Reconnect In-Flight Commands", () => {
         socket.destroy();
       }
     }
+  });
+});
+
+describe("Valkey: Recovering After fail()", () => {
+  // Answers the chunk carrying HELLO with `+OK` and the one carrying PING with
+  // `+PONG` unless `replies` says otherwise for that connection (a hook that
+  // returns null answers nothing). Other commands are never answered.
+  function helloServer(
+    replies: Partial<Record<"HELLO" | "PING", (connection: number, socket: net.Socket) => string | null>> = {},
+    { secure = false, allowHalfOpen = false } = {},
+  ) {
+    const sockets: net.Socket[] = [];
+    const onConnection = (socket: net.Socket) => {
+      sockets.push(socket);
+      const connection = sockets.length;
+      socket.on("data", chunk => {
+        const text = chunk.toString("latin1");
+        for (const command of ["HELLO", "PING"] as const) {
+          if (!text.includes(command)) continue;
+          const reply = replies[command]
+            ? replies[command](connection, socket)
+            : `+${command === "HELLO" ? "OK" : "PONG"}\r\n`;
+          if (reply !== null) socket.write(reply);
+        }
+      });
+      socket.on("error", () => {});
+    };
+    const server: net.Server = secure
+      ? tls.createServer({ key: tlsCert.key, cert: tlsCert.cert, allowHalfOpen }, onConnection)
+      : net.createServer({ allowHalfOpen }, onConnection);
+    return {
+      server,
+      sockets,
+      get connections() {
+        return sockets.length;
+      },
+      // events.once() rejects if the listen fails instead of leaving the test to time out.
+      listen: async () => {
+        server.listen(0, "127.0.0.1");
+        await once(server, "listening");
+        return (server.address() as net.AddressInfo).port;
+      },
+      listenUnix: async (socketPath: string) => {
+        server.listen(socketPath);
+        await once(server, "listening");
+      },
+      close: () => new Promise(resolve => server.close(resolve)),
+    };
+  }
+
+  // The RST a failed client sends makes the stub's socket emit an error before
+  // it closes, which events.once() would turn into a rejection.
+  function closedOnServer(socket: net.Socket): Promise<void> {
+    return socket.destroyed ? Promise.resolve() : new Promise(resolve => socket.once("close", () => resolve()));
+  }
+
+  // Calls connect() from the first onclose and reports how that attempt ended.
+  function connectFromOnclose(client: RedisClient): Promise<string> {
+    const { promise, resolve } = Promise.withResolvers<string>();
+    client.onclose = () => {
+      client.onclose = () => {};
+      resolve(
+        client.connect().then(
+          () => "connected",
+          (err: Error) => `rejected: ${err.message}`,
+        ),
+      );
+    };
+    return promise;
+  }
+
+  // A failure the client detects itself is a deliberate close, not a retry,
+  // even with auto reconnect on (left on here): only closes initiated by the
+  // peer go through the retry policy, as has always been the case and unlike
+  // ioredis. onclose only fires on that terminal path, so it firing is the
+  // assertion.
+  test.each([
+    ["redis", false],
+    ["rediss", true],
+  ])(
+    "a failure while connected over %s:// closes the socket, fires onclose, and connect() reconnects",
+    async (scheme, secure) => {
+      // 0x01 is not a RESP type byte, so the first connection fails after the
+      // handshake, on the same path as an idle timeout or any other protocol error.
+      const fake = helloServer({ PING: connection => (connection === 1 ? "\x01\r\n" : "+PONG\r\n") }, { secure });
+      const port = await fake.listen();
+      const closed = Promise.withResolvers<Error>();
+      const client = new RedisClient(`${scheme}://127.0.0.1:${port}`, secure ? { tls: { ca: tlsCert.cert } } : {});
+      try {
+        client.onclose = err => closed.resolve(err);
+        await client.connect();
+        expect(client.connected).toBe(true);
+        await expect(client.ping()).rejects.toMatchObject({ code: "ERR_REDIS_INVALID_RESPONSE_TYPE" });
+        // Already closed when the rejection is observed. Over TLS a graceful
+        // close would still be waiting for the peer's close_notify at this point.
+        expect(client.connected).toBe(false);
+        expect(await closed.promise).toBeInstanceOf(Error);
+        expect(fake.connections).toBe(1);
+        await client.connect();
+        expect(await client.ping()).toBe("PONG");
+        expect(fake.connections).toBe(2);
+      } finally {
+        client.close();
+        fake.server.close();
+      }
+    },
+  );
+
+  test.each([
+    ["redis", false],
+    ["rediss", true],
+  ])("an idle timeout over %s:// closes the connection and rejects what was in flight", async (scheme, secure) => {
+    const fake = helloServer({}, { secure });
+    const port = await fake.listen();
+    const closed = Promise.withResolvers<{ err: Error & { code: string }; connectedInsideOnclose: boolean }>();
+    // What is pinned here is what happens when the timer fires on an idle
+    // connection. 500ms leaves a debug build ample room to finish connecting.
+    const client = new RedisClient(`${scheme}://127.0.0.1:${port}`, {
+      idleTimeout: 50,
+      connectionTimeout: 500,
+      ...(secure ? { tls: { ca: tlsCert.cert } } : {}),
+    });
+    try {
+      client.onclose = err =>
+        closed.resolve({ err: err as Error & { code: string }, connectedInsideOnclose: client.connected });
+      await client.connect();
+      // GET is never answered by the stub, so it is still in flight when the timeout fires.
+      const inFlight = client.get("key").then(
+        () => "resolved",
+        (err: Error & { code: string }) => err.code,
+      );
+      const { err, connectedInsideOnclose } = await closed.promise;
+      expect({
+        onclose: err.code,
+        connectedInsideOnclose,
+        connectedAfter: client.connected,
+        inFlight: await inFlight,
+        connections: fake.connections,
+      }).toEqual({
+        onclose: "ERR_REDIS_CONNECTION_CLOSED",
+        connectedInsideOnclose: false,
+        connectedAfter: false,
+        inFlight: "ERR_REDIS_IDLE_TIMEOUT",
+        connections: 1,
+      });
+      await closedOnServer(fake.sockets[0]);
+      await client.connect();
+      expect(await client.ping()).toBe("PONG");
+      expect(fake.connections).toBe(2);
+    } finally {
+      client.close();
+      fake.server.close();
+    }
+  });
+  test("connected reads false inside onclose when the server drops an established connection", async () => {
+    // Connection 1 is dropped by the server right after it answers PING.
+    const fake = helloServer({
+      PING: (connection, socket) => {
+        if (connection !== 1) return "+PONG\r\n";
+        socket.end("+PONG\r\n");
+        return null;
+      },
+    });
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: false });
+    try {
+      const closed = Promise.withResolvers<boolean>();
+      client.onclose = () => closed.resolve(client.connected);
+      await client.connect();
+      expect(await client.ping()).toBe("PONG");
+      expect(await closed.promise).toBe(false);
+      await client.connect();
+      expect(await client.ping()).toBe("PONG");
+      expect(fake.connections).toBe(2);
+    } finally {
+      client.close();
+      fake.server.close();
+    }
+  });
+
+  test("close() over rediss:// does not wait for the peer to answer close_notify", async () => {
+    // allowHalfOpen: the server never closes its side in response, which is
+    // what a graceful TLS close would be waiting for.
+    const fake = helloServer({}, { secure: true, allowHalfOpen: true });
+    const port = await fake.listen();
+    const client = new RedisClient(`rediss://127.0.0.1:${port}`, { tls: { ca: tlsCert.cert }, autoReconnect: false });
+    try {
+      let closes = 0;
+      client.onclose = () => closes++;
+      await client.connect();
+      const ended = once(fake.sockets[0], "end");
+      client.close();
+      expect({ connected: client.connected, closes }).toEqual({ connected: false, closes: 1 });
+      await ended;
+    } finally {
+      client.close();
+      fake.sockets[0]?.destroy();
+      fake.server.close();
+    }
+  });
+
+  test("a failure while the peer has stopped reading still closes the TLS socket at once", async () => {
+    // Pins the close code fail() uses: with a fast shutdown, usockets keeps a
+    // TLS socket whose last batch flush could not be handed to the kernel
+    // (packages/bun-usockets/src/crypto/openssl.c, us_internal_ssl_close) until
+    // the peer reads again, which this peer never does.
+    const fake = helloServer(
+      {
+        HELLO: (connection, socket) => {
+          if (connection === 1) socket.pause();
+          return "+OK\r\n";
+        },
+        PING: () => "+PONG\r\n",
+      },
+      { secure: true },
+    );
+    const port = await fake.listen();
+    const closed = Promise.withResolvers<void>();
+    const client = new RedisClient(`rediss://127.0.0.1:${port}`, { tls: { ca: tlsCert.cert }, autoReconnect: false });
+    try {
+      client.onclose = () => closed.resolve();
+      await client.connect();
+      const value = Buffer.alloc(256 * 1024, "x").toString();
+      const pending: Promise<unknown>[] = [];
+      // Each SET is flushed as soon as it is queued; once two flushes in a row
+      // hand nothing at all to the socket, the kernel buffers on both ends are
+      // full and the socket is stuck behind its undelivered ciphertext.
+      let stuckFlushes = 0;
+      while (stuckFlushes < 2 && pending.length < 256) {
+        const before = client.bufferedAmount;
+        pending.push(client.set("key", value).catch(() => {}));
+        await new Promise(resolve => setImmediate(resolve));
+        const added = client.bufferedAmount - before;
+        stuckFlushes = added >= value.length ? stuckFlushes + 1 : 0;
+      }
+      expect(stuckFlushes).toBe(2);
+      const lastSet = client.set("key", "last");
+      fake.sockets[0].write("\x01\r\n");
+      await expect(lastSet).rejects.toMatchObject({ code: "ERR_REDIS_INVALID_RESPONSE_TYPE" });
+      expect(client.connected).toBe(false);
+      await closed.promise;
+      await Promise.all(pending);
+      await client.connect();
+      expect(await client.ping()).toBe("PONG");
+      expect(fake.connections).toBe(2);
+    } finally {
+      client.close();
+      fake.sockets[0]?.destroy();
+      fake.server.close();
+    }
+  });
+
+  test("a connect() issued from onclose after a refused connection rejects instead of hanging", async () => {
+    // Nothing listens on the port a just-closed listener used.
+    const fake = helloServer();
+    const port = await fake.listen();
+    await new Promise(resolve => fake.server.close(resolve));
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: false });
+    try {
+      const secondConnect = connectFromOnclose(client);
+      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      expect(await secondConnect).toBe("rejected: Connection closed");
+    } finally {
+      client.close();
+    }
+  });
+
+  test("a connection timeout shorter than the retry delay does not stop the retries from settling connect()", async () => {
+    const fake = helloServer();
+    const port = await fake.listen();
+    await fake.close();
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        // The refusal comes back within a few milliseconds and the retry is
+        // scheduled 50ms after it, so a 30ms timeout armed for the first attempt
+        // would fire while no socket exists; the retry must still run and give up.
+        // The queued PING is rejected by whichever failure ends the client, so
+        // its message tells the two apart.
+        const client = new Bun.RedisClient("redis://127.0.0.1:${port}", { connectionTimeout: 30, maxRetries: 1 });
+        client.onclose = err => console.log("onclose", err.code);
+        const connected = client.connect().catch(err => console.log("connect rejected", err.code));
+        client.ping().catch(err => console.log("ping rejected:", err.message));
+        await connected;
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: [
+        "onclose ERR_REDIS_CONNECTION_CLOSED",
+        "ping rejected: Max reconnection attempts reached",
+        "connect rejected ERR_REDIS_CONNECTION_CLOSED",
+        "",
+      ].join("\n"),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // The close for a dial that failed before a socket existed runs from the
+  // event loop; until then the client must look like it is dialling, so that
+  // whatever JS runs first neither dials on top of it nor is ignored.
+  test("a connect() issued from onclose is not fed the replies left over from the failed connection", async () => {
+    // With a database in the URL, HELLO and SELECT are written together, so a
+    // server that rejects HELLO delivers both error replies in one read.
+    const fake = helloServer({
+      HELLO: connection =>
+        connection === 1 ? "-WRONGPASS invalid password\r\n-NOAUTH Authentication required.\r\n" : "+OK\r\n+OK\r\n",
+    });
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}/1`, { autoReconnect: false });
+    try {
+      const secondConnect = connectFromOnclose(client);
+      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      expect(await secondConnect).toBe("connected");
+      expect(await client.ping()).toBe("PONG");
+      expect(fake.connections).toBe(2);
+    } finally {
+      client.close();
+      fake.server.close();
+    }
+  });
+
+  test("a rejected SELECT after an accepted HELLO fails the connection once and connect() from onclose dials again", async () => {
+    // HELLO and SELECT are written together, and both replies come back in one
+    // read: connection 1 accepts HELLO and rejects SELECT, connection 2 accepts both.
+    const fake = helloServer({
+      HELLO: connection => (connection === 1 ? "+OK\r\n-ERR DB index is out of range\r\n" : "+OK\r\n+OK\r\n"),
+    });
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}/1`, { autoReconnect: true });
+    try {
+      const closes: { message: string; connected: boolean; connections: number }[] = [];
+      let secondConnect: Promise<string> | undefined;
+      client.onclose = err => {
+        closes.push({ message: err.message, connected: client.connected, connections: fake.connections });
+        secondConnect ??= client.connect().then(
+          () => "connected",
+          (err: Error) => `rejected: ${err.message}`,
+        );
+      };
+      // Queued behind the handshake, so it is still pending when SELECT is rejected.
+      const queued = client.get("key").then(
+        () => "resolved",
+        (err: Error & { code: string }) => `${err.code}: ${err.message}`,
+      );
+      // connect() settles on the accepted HELLO, before the SELECT reply is
+      // read, so it resolves; the failure that follows is reported by onclose.
+      await client.connect();
+      expect(await queued).toBe("ERR_REDIS_INVALID_COMMAND: ERR DB index is out of range");
+      // The rejection is a failure the client detected, so there is no retry
+      // even with autoReconnect on: onclose fires once and the only second
+      // connection is the one dialed from it.
+      expect(closes).toEqual([{ message: "Connection closed", connected: false, connections: 1 }]);
+      expect(await secondConnect).toBe("connected");
+      expect(await client.ping()).toBe("PONG");
+      expect(fake.connections).toBe(2);
+    } finally {
+      client.close();
+      fake.server.close();
+    }
+  });
+
+  test("a duplicate of a failed client still auto-reconnects", async () => {
+    // Connection 1 (the original) fails on a protocol error, connection 2 (the
+    // duplicate) is dropped by the server right after it answers PING.
+    const fake = helloServer({
+      PING: (connection, socket) => {
+        if (connection === 1) return "\x01\r\n";
+        if (connection === 2) {
+          socket.end("+PONG\r\n");
+          return null;
+        }
+        return "+PONG\r\n";
+      },
+    });
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: true });
+    let duplicate: RedisClient | undefined;
+    try {
+      await client.connect();
+      await expect(client.ping()).rejects.toMatchObject({ code: "ERR_REDIS_INVALID_RESPONSE_TYPE" });
+      expect(client.connected).toBe(false);
+      duplicate = await client.duplicate();
+      // A duplicate copies the original's manual-close state; a failure is not
+      // one, so the drop of connection 2 goes through the retry policy: no
+      // onclose, a second onconnect, and the queued PING answered by connection 3.
+      const reconnected = Promise.withResolvers<void>();
+      let connects = 0;
+      duplicate.onconnect = () => {
+        if (++connects === 2) reconnected.resolve();
+      };
+      duplicate.onclose = err => reconnected.reject(err);
+      expect(await duplicate.ping()).toBe("PONG");
+      await reconnected.promise;
+      expect(await duplicate.ping()).toBe("PONG");
+      expect(fake.connections).toBe(3);
+    } finally {
+      duplicate?.close();
+      client.close();
+      fake.server.close();
+    }
+  });
+
+  test("a message listener that closes and reconnects is not fed the pushes buffered behind its message", async () => {
+    // RESP3 push frames as the server writes them for SUBSCRIBE and for messages.
+    const push = (...items: (string | number)[]) =>
+      `>${items.length}\r\n` +
+      items.map(item => (typeof item === "number" ? `:${item}\r\n` : `$${item.length}\r\n${item}\r\n`)).join("");
+    const fake = helloServer();
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`);
+    try {
+      await client.connect();
+      const connection1 = fake.sockets[0];
+      connection1.on("data", chunk => {
+        if (chunk.toString("latin1").includes("SUBSCRIBE")) connection1.write(push("subscribe", "ch", 1));
+      });
+      const delivered: string[] = [];
+      const firstDelivered = Promise.withResolvers<void>();
+      const reconnect = Promise.withResolvers<string>();
+      await client.subscribe("ch", message => {
+        delivered.push(message);
+        if (delivered.length === 1) firstDelivered.resolve();
+        if (delivered.length !== 2) return;
+        client.close();
+        reconnect.resolve(
+          client.connect().then(
+            () => "connected",
+            (err: Error) => `rejected: ${err.message}`,
+          ),
+        );
+      });
+      const [m1, m2] = [push("message", "ch", "m1"), push("message", "ch", "m2")];
+      // m0 is handled straight off this read and the start of m1 is kept in the
+      // read buffer, so everything from here on goes through the buffer path.
+      connection1.write(push("message", "ch", "m0") + m1.slice(0, 10));
+      await firstDelivered.promise;
+      // One read completes m1 and carries m2. The listener closes connection 1
+      // on m1 and dials connection 2; m2 belongs to neither (taken as the next
+      // reply, it would be read as connection 2's HELLO answer and fail it).
+      connection1.write(m1.slice(10) + m2);
+      expect({
+        reconnect: await reconnect.promise,
+        delivered,
+        connected: client.connected,
+        connections: fake.connections,
+      }).toEqual({ reconnect: "connected", delivered: ["m0", "m1"], connected: true, connections: 2 });
+    } finally {
+      client.close();
+      fake.server.close();
+    }
+  });
+
+  test("a connect() issued from onclose after a failed TLS handshake gets to dial again", async () => {
+    let handshakes = 0;
+    const server = net.createServer(socket => {
+      // The first bytes are the ClientHello; dropping the connection there
+      // fails the client's handshake.
+      socket.once("data", () => {
+        handshakes += 1;
+        socket.destroy();
+      });
+      socket.on("error", () => {});
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as net.AddressInfo;
+    const client = new RedisClient(`rediss://127.0.0.1:${port}`, { autoReconnect: false });
+    try {
+      const secondConnect = connectFromOnclose(client);
+      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      expect({ secondConnect: await secondConnect, handshakes }).toEqual({
+        secondConnect: "rejected: Connection closed",
+        handshakes: 2,
+      });
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+  test("the process exits once auto-reconnect gives up", async () => {
+    const fake = helloServer();
+    const port = await fake.listen();
+    await new Promise(resolve => fake.server.close(resolve));
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const client = new Bun.RedisClient("redis://127.0.0.1:${port}", { autoReconnect: true, maxRetries: 1 });
+        client.onclose = err => console.log("onclose", err.code);
+        await client.connect().catch(err => console.log("connect rejected", err.code));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "onclose ERR_REDIS_CONNECTION_CLOSED\nconnect rejected ERR_REDIS_CONNECTION_CLOSED\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });


### PR DESCRIPTION
This is the second PR of a stack split out of #37993. The first is #39513. The third is #38281. This PR does not depend on #39513. #38281 is stacked on this PR.

Part of #18895. The stack as a whole fixes it; #38281 closes it.

The problem

When a RedisClient failed, it did not close the socket. The client was then half alive:

- `failed` was set, but the socket stayed open.
- `client.connected` still read true.
- The `connect()` promise never settled.
- If `onclose` called `connect()`, the new connection could receive replies from the old one.
- Code that was still unwinding from the failure could close the new connection.

The rule this PR sets

After a failure, four things are always true:

- The socket is closed.
- The client reads as disconnected.
- The close path runs exactly once. It settles the `connect()` promise, runs `onclose`, applies the retry policy, and updates the event loop ref.
- A `connect()` called from `onclose` starts a fresh attempt. Nothing from the old attempt touches it.

What changed

`fail()` now always closes the socket. It uses `CloseCode::Failure`. It also clears `is_reconnecting`.

Why `Failure`: it is the only close code that runs the close callback before `close()` returns. `Normal` waits for the peer to answer close_notify. `FastShutdown` waits while the socket still holds unsent TLS data. A peer that stopped reading never lets either finish. On TCP, `Failure` sends RST instead of FIN. That is fine, because every command on the connection is already rejected.

`disconnect()` and the finalizer use `FastShutdown`. So a user `close()` over rediss:// no longer waits for the peer.

The close path reads `failed` to skip the retry policy. It does not use `is_manually_closed` for this. `duplicate()` copies `is_manually_closed`, and a duplicate of a failed client must still reconnect.

The socket close handler and the connect error handler now set the status to disconnected before the close path runs, not after. Before, a `connect()` from `onclose` saw the old status and did not dial. The old code also overwrote the status of the new attempt.

When a retry is scheduled, the connection timer of the failed attempt is disarmed. Before, it fired during the retry delay. With `is_reconnecting` now cleared by `fail()`, that stopped the retry and `connect()` never settled.

A read is dropped as soon as the socket it came from is no longer the client's socket. So replies from a failed connection are not read as the next connection's HELLO reply.

The TLS handshake path and the rejected HELLO path no longer close a second time after `fail()`. The second close hit the socket that `onclose` had just opened.

Visible changes

- `client.connected` is false inside `onclose` when the server drops an established connection. Before, it read true.
- A failure the client detects after HELLO (idle timeout, protocol error) now closes the client and runs `onclose`. As before, it is not retried, even with `autoReconnect` on. Only closes from the peer go through the retry policy. This is one known difference from ioredis. An explicit `connect()` still works after it.
- `close()` or a failure over rediss:// completes at once. Before, it waited for the peer's close_notify.

Tests

The tests are in the "Recovering After fail()" block of connection-failures.test.ts. They run against net and tls stubs and closed ports, over redis:// and rediss://. Two of them use a TLS peer that never answers close_notify, and one that has stopped reading. The rest of test/js/valkey that runs without a container is unchanged.

Not in this PR

- A test for the connection timeout during a TLS handshake.
- Disarming the connection timer on the final close path, not only on the retry path.

Both are follow-ups.

Supersedes #33479. Covers the `is_reconnecting` part of #32779. #39015 (postgres and mysql) shares the CloseCode note.
