### PR TITLE
node:dns: accept "NAPTR" as an rrtype in resolve()

### DIFF
--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3849,6 +3849,7 @@ pub enum RecordType {
     CAA = 257,
     CNAME = 5,
     MX = 15,
+    NAPTR = 35,
     NS = 2,
     PTR = 12,
     SOA = 6,
@@ -3861,12 +3862,12 @@ bun_core::comptime_string_map! {
     pub(super) static RECORD_TYPE_MAP: RecordType = {
         b"A" => RecordType::A, b"AAAA" => RecordType::AAAA, b"ANY" => RecordType::ANY,
         b"CAA" => RecordType::CAA, b"CNAME" => RecordType::CNAME, b"MX" => RecordType::MX,
-        b"NS" => RecordType::NS, b"PTR" => RecordType::PTR, b"SOA" => RecordType::SOA,
-        b"SRV" => RecordType::SRV, b"TXT" => RecordType::TXT,
+        b"NAPTR" => RecordType::NAPTR, b"NS" => RecordType::NS, b"PTR" => RecordType::PTR,
+        b"SOA" => RecordType::SOA, b"SRV" => RecordType::SRV, b"TXT" => RecordType::TXT,
         b"a" => RecordType::A, b"aaaa" => RecordType::AAAA, b"any" => RecordType::ANY,
         b"caa" => RecordType::CAA, b"cname" => RecordType::CNAME, b"mx" => RecordType::MX,
-        b"ns" => RecordType::NS, b"ptr" => RecordType::PTR, b"soa" => RecordType::SOA,
-        b"srv" => RecordType::SRV, b"txt" => RecordType::TXT,
+        b"naptr" => RecordType::NAPTR, b"ns" => RecordType::NS, b"ptr" => RecordType::PTR,
+        b"soa" => RecordType::SOA, b"srv" => RecordType::SRV, b"txt" => RecordType::TXT,
     };
 }
 
@@ -4950,7 +4951,9 @@ impl Resolver {
                     None => {
                         return Err(global_this.throw_invalid_argument_property_value(
                             b"record",
-                            Some("one of: A, AAAA, ANY, CAA, CNAME, MX, NS, PTR, SOA, SRV, TXT"),
+                            Some(
+                                "one of: A, AAAA, ANY, CAA, CNAME, MX, NAPTR, NS, PTR, SOA, SRV, TXT",
+                            ),
                             record_type_value,
                         ));
                     }
@@ -4987,6 +4990,9 @@ impl Resolver {
             RecordType::CNAME => self.do_resolve_cares::<CnameHostent>(name.slice(), global_this),
             RecordType::MX => {
                 self.do_resolve_cares::<c_ares::struct_ares_mx_reply>(name.slice(), global_this)
+            }
+            RecordType::NAPTR => {
+                self.do_resolve_cares::<c_ares::struct_ares_naptr_reply>(name.slice(), global_this)
             }
             RecordType::NS => self.do_resolve_cares::<NsHostent>(name.slice(), global_this),
             RecordType::PTR => self.do_resolve_cares::<PtrHostent>(name.slice(), global_this),

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -287,7 +287,7 @@ describe("dns", () => {
     test("resolve() with a UTF-16 invalid record type throws TypeError", () => {
       // @ts-expect-error
       expect(() => Bun.dns.resolve("localhost", utf16("BOGUS"))).toThrow(
-        `The property "record" is invalid. Expected one of: A, AAAA, ANY, CAA, CNAME, MX, NS, PTR, SOA, SRV, TXT, received type string ('BOGUS')`,
+        `The property "record" is invalid. Expected one of: A, AAAA, ANY, CAA, CNAME, MX, NAPTR, NS, PTR, SOA, SRV, TXT, received type string ('BOGUS')`,
       );
     });
   });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1006,9 +1006,8 @@ test.concurrent.each(["NAPTR", "naptr"])("resolve(hostname, %p) issues a NAPTR q
     const received = once(socket, "message");
     const promise = resolver.resolve("naptr.example.test", rrtype);
     const [query] = await received;
-    let off = 12;
-    while (query[off] !== 0) off += query[off] + 1;
-    expect(query.readUInt16BE(off + 1)).toBe(35);
+    // QNAME ends at the first zero byte after the 12-byte header; QTYPE follows it.
+    expect(query.readUInt16BE(query.indexOf(0, 12) + 1)).toBe(35);
     resolver.cancel();
     expect(await promise.catch(err => err)).toMatchObject({ code: "ECANCELLED", syscall: "queryNaptr" });
   } finally {

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -874,13 +874,6 @@ describe("dns.lookupService with a numeric-string port", () => {
   });
 });
 
-function encodeName(name) {
-  return Buffer.concat([
-    ...name.split(".").map(label => Buffer.concat([Buffer.from([label.length]), Buffer.from(label)])),
-    Buffer.from([0]),
-  ]);
-}
-
 // A resolver keeps a 32-slot pending cache per query kind. The first in-flight
 // query for a name owns a slot; identical queries issued while it is in flight
 // are chained onto it and settled together when it completes, so the server
@@ -890,6 +883,13 @@ function encodeName(name) {
 // 10.0.0.<n>, so a promise settled from the wrong slot shows up as the wrong
 // address.
 describe("pending cache", () => {
+  function encodeName(name) {
+    return Buffer.concat([
+      ...name.split(".").map(label => Buffer.concat([Buffer.from([label.length]), Buffer.from(label)])),
+      Buffer.from([0]),
+    ]);
+  }
+
   async function startFakeServer() {
     const socket = dgram.createSocket("udp4");
     const queries = [];
@@ -993,150 +993,25 @@ describe("pending cache", () => {
   });
 });
 
-// resolve(hostname, rrtype) maps the rrtype string onto the same per-type
-// queries the resolveXxx() functions issue. The fake server below records the
-// QTYPE of every query it receives (as "<qtype> <first label>") and answers
-// NAPTR queries with NAPTR_RECORD and everything else with an empty NOERROR
-// response, so these stay off the network.
-describe("resolve() rrtype", () => {
-  const QTYPES = {
-    A: 1,
-    AAAA: 28,
-    ANY: 255,
-    CAA: 257,
-    CNAME: 5,
-    MX: 15,
-    NAPTR: 35,
-    NS: 2,
-    PTR: 12,
-    SOA: 6,
-    SRV: 33,
-    TXT: 16,
-  };
-
-  const NAPTR_RECORD = {
-    order: 10,
-    preference: 20,
-    flags: "S",
-    service: "SIP+D2U",
-    regexp: "",
-    replacement: "_sip._udp.example.test",
-  };
-
-  function characterString(value) {
-    return Buffer.concat([Buffer.from([value.length]), Buffer.from(value)]);
-  }
-
-  function naptrAnswer() {
-    const rdata = Buffer.concat([
-      Buffer.from([0, NAPTR_RECORD.order, 0, NAPTR_RECORD.preference]),
-      characterString(NAPTR_RECORD.flags),
-      characterString(NAPTR_RECORD.service),
-      characterString(NAPTR_RECORD.regexp),
-      encodeName(NAPTR_RECORD.replacement),
-    ]);
-    // NAME = pointer to QNAME, TYPE NAPTR, CLASS IN, TTL 60, RDLENGTH
-    return Buffer.concat([
-      Buffer.from([0xc0, 0x0c, 0, QTYPES.NAPTR, 0, 1, 0, 0, 0, 60, rdata.length >> 8, rdata.length & 0xff]),
-      rdata,
-    ]);
-  }
-
-  async function startFakeServer() {
-    const socket = dgram.createSocket("udp4");
-    const queries = [];
-    socket.on("message", (query, rinfo) => {
-      let off = 12;
-      while (query[off] !== 0) off += query[off] + 1;
-      const qtype = query.readUInt16BE(off + 1);
-      const question = query.subarray(12, off + 5);
-      queries.push(`${qtype} ${query.toString("latin1", 13, 13 + query[12])}`);
-      const answer = qtype === QTYPES.NAPTR ? naptrAnswer() : Buffer.alloc(0);
-      const header = Buffer.from([query[0], query[1], 0x81, 0x80, 0, 1, 0, answer.length ? 1 : 0, 0, 0, 0, 0]);
-      socket.send(Buffer.concat([header, question, answer]), rinfo.port, rinfo.address);
-    });
+// The socket never answers. The QTYPE that reaches it and the syscall the
+// cancelled query reports pin resolve()'s rrtype dispatch to the query that
+// resolveNaptr() issues; decoding is covered by the resolveNaptr() tests.
+test.concurrent.each(["NAPTR", "naptr"])("resolve(hostname, %p) issues a NAPTR query", async rrtype => {
+  const socket = dgram.createSocket("udp4");
+  try {
     socket.bind(0, "127.0.0.1");
     await once(socket, "listening");
-    return { socket, queries, server: "127.0.0.1:" + socket.address().port };
+    const resolver = new dns_promises.Resolver();
+    resolver.setServers(["127.0.0.1:" + socket.address().port]);
+    const received = once(socket, "message");
+    const promise = resolver.resolve("naptr.example.test", rrtype);
+    const [query] = await received;
+    let off = 12;
+    while (query[off] !== 0) off += query[off] + 1;
+    expect(query.readUInt16BE(off + 1)).toBe(35);
+    resolver.cancel();
+    expect(await promise.catch(err => err)).toMatchObject({ code: "ECANCELLED", syscall: "queryNaptr" });
+  } finally {
+    socket.close();
   }
-
-  test.concurrent("Resolver#resolve() queries the QTYPE named by the rrtype, in either case", async () => {
-    const { socket, queries, server } = await startFakeServer();
-    try {
-      const resolver = new dns_promises.Resolver({ timeout: 5000, tries: 1 });
-      resolver.setServers([server]);
-      // Distinct names per case: identical (name, type) queries in flight at
-      // the same time are coalesced onto one wire query by the pending cache.
-      await Promise.allSettled(
-        Object.keys(QTYPES).flatMap(rrtype => [
-          resolver.resolve("upper.example.test", rrtype),
-          resolver.resolve("lower.example.test", rrtype.toLowerCase()),
-        ]),
-      );
-      expect(queries.sort()).toEqual(
-        Object.values(QTYPES)
-          .flatMap(qtype => [`${qtype} upper`, `${qtype} lower`])
-          .sort(),
-      );
-    } finally {
-      socket.close();
-    }
-  });
-
-  test.concurrent("Resolver#resolve(hostname, 'NAPTR') returns what resolveNaptr() returns", async () => {
-    const { socket, queries, server } = await startFakeServer();
-    try {
-      const promisesResolver = new dns_promises.Resolver({ timeout: 5000, tries: 1 });
-      promisesResolver.setServers([server]);
-      const callbackResolver = new dns.Resolver({ timeout: 5000, tries: 1 });
-      callbackResolver.setServers([server]);
-
-      const results = await Promise.all([
-        promisesResolver.resolve("promises.example.test", "NAPTR"),
-        promisesResolver.resolveNaptr("naptr.example.test"),
-        new Promise((resolve, reject) =>
-          callbackResolver.resolve("callback.example.test", "NAPTR", (err, records) =>
-            err ? reject(err) : resolve(records),
-          ),
-        ),
-      ]);
-      expect(results).toEqual(Array(3).fill([NAPTR_RECORD]));
-      expect(queries.sort()).toEqual(["35 callback", "35 naptr", "35 promises"]);
-    } finally {
-      socket.close();
-    }
-  });
-
-  // The module-level functions use the process-wide resolver, so point that one
-  // at the fake server in a child process.
-  test.concurrent("dns.resolve(), dns.promises.resolve() and Bun.dns.resolve() accept 'NAPTR'", async () => {
-    const { socket, queries, server } = await startFakeServer();
-    try {
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `const dns = require("node:dns");
-           dns.setServers([process.argv[1]]);
-           Promise.all([
-             new Promise((resolve, reject) =>
-               dns.resolve("callback.example.test", "NAPTR", (err, records) => (err ? reject(err) : resolve(records))),
-             ),
-             dns.promises.resolve("promises.example.test", "NAPTR"),
-             Bun.dns.resolve("bun.example.test", "NAPTR"),
-           ]).then(results => console.log(JSON.stringify(results)));`,
-          server,
-        ],
-        env: bunEnv,
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual(Array(3).fill([NAPTR_RECORD]));
-      expect(exitCode).toBe(0);
-      expect(queries.sort()).toEqual(["35 bun", "35 callback", "35 promises"]);
-    } finally {
-      socket.close();
-    }
-  });
 });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -874,6 +874,13 @@ describe("dns.lookupService with a numeric-string port", () => {
   });
 });
 
+function encodeName(name) {
+  return Buffer.concat([
+    ...name.split(".").map(label => Buffer.concat([Buffer.from([label.length]), Buffer.from(label)])),
+    Buffer.from([0]),
+  ]);
+}
+
 // A resolver keeps a 32-slot pending cache per query kind. The first in-flight
 // query for a name owns a slot; identical queries issued while it is in flight
 // are chained onto it and settled together when it completes, so the server
@@ -883,13 +890,6 @@ describe("dns.lookupService with a numeric-string port", () => {
 // 10.0.0.<n>, so a promise settled from the wrong slot shows up as the wrong
 // address.
 describe("pending cache", () => {
-  function encodeName(name) {
-    return Buffer.concat([
-      ...name.split(".").map(label => Buffer.concat([Buffer.from([label.length]), Buffer.from(label)])),
-      Buffer.from([0]),
-    ]);
-  }
-
   async function startFakeServer() {
     const socket = dgram.createSocket("udp4");
     const queries = [];
@@ -990,5 +990,153 @@ describe("pending cache", () => {
   test.concurrent("concurrent lookup() of the same name all settle", async () => {
     const results = await Promise.all(Array.from({ length: 8 }, () => dns_promises.lookup("localhost", { family: 4 })));
     expect(results).toEqual(Array(8).fill({ address: "127.0.0.1", family: 4 }));
+  });
+});
+
+// resolve(hostname, rrtype) maps the rrtype string onto the same per-type
+// queries the resolveXxx() functions issue. The fake server below records the
+// QTYPE of every query it receives (as "<qtype> <first label>") and answers
+// NAPTR queries with NAPTR_RECORD and everything else with an empty NOERROR
+// response, so these stay off the network.
+describe("resolve() rrtype", () => {
+  const QTYPES = {
+    A: 1,
+    AAAA: 28,
+    ANY: 255,
+    CAA: 257,
+    CNAME: 5,
+    MX: 15,
+    NAPTR: 35,
+    NS: 2,
+    PTR: 12,
+    SOA: 6,
+    SRV: 33,
+    TXT: 16,
+  };
+
+  const NAPTR_RECORD = {
+    order: 10,
+    preference: 20,
+    flags: "S",
+    service: "SIP+D2U",
+    regexp: "",
+    replacement: "_sip._udp.example.test",
+  };
+
+  function characterString(value) {
+    return Buffer.concat([Buffer.from([value.length]), Buffer.from(value)]);
+  }
+
+  function naptrAnswer() {
+    const rdata = Buffer.concat([
+      Buffer.from([0, NAPTR_RECORD.order, 0, NAPTR_RECORD.preference]),
+      characterString(NAPTR_RECORD.flags),
+      characterString(NAPTR_RECORD.service),
+      characterString(NAPTR_RECORD.regexp),
+      encodeName(NAPTR_RECORD.replacement),
+    ]);
+    // NAME = pointer to QNAME, TYPE NAPTR, CLASS IN, TTL 60, RDLENGTH
+    return Buffer.concat([
+      Buffer.from([0xc0, 0x0c, 0, QTYPES.NAPTR, 0, 1, 0, 0, 0, 60, rdata.length >> 8, rdata.length & 0xff]),
+      rdata,
+    ]);
+  }
+
+  async function startFakeServer() {
+    const socket = dgram.createSocket("udp4");
+    const queries = [];
+    socket.on("message", (query, rinfo) => {
+      let off = 12;
+      while (query[off] !== 0) off += query[off] + 1;
+      const qtype = query.readUInt16BE(off + 1);
+      const question = query.subarray(12, off + 5);
+      queries.push(`${qtype} ${query.toString("latin1", 13, 13 + query[12])}`);
+      const answer = qtype === QTYPES.NAPTR ? naptrAnswer() : Buffer.alloc(0);
+      const header = Buffer.from([query[0], query[1], 0x81, 0x80, 0, 1, 0, answer.length ? 1 : 0, 0, 0, 0, 0]);
+      socket.send(Buffer.concat([header, question, answer]), rinfo.port, rinfo.address);
+    });
+    socket.bind(0, "127.0.0.1");
+    await once(socket, "listening");
+    return { socket, queries, server: "127.0.0.1:" + socket.address().port };
+  }
+
+  test.concurrent("Resolver#resolve() queries the QTYPE named by the rrtype, in either case", async () => {
+    const { socket, queries, server } = await startFakeServer();
+    try {
+      const resolver = new dns_promises.Resolver({ timeout: 5000, tries: 1 });
+      resolver.setServers([server]);
+      // Distinct names per case: identical (name, type) queries in flight at
+      // the same time are coalesced onto one wire query by the pending cache.
+      await Promise.allSettled(
+        Object.keys(QTYPES).flatMap(rrtype => [
+          resolver.resolve("upper.example.test", rrtype),
+          resolver.resolve("lower.example.test", rrtype.toLowerCase()),
+        ]),
+      );
+      expect(queries.sort()).toEqual(
+        Object.values(QTYPES)
+          .flatMap(qtype => [`${qtype} upper`, `${qtype} lower`])
+          .sort(),
+      );
+    } finally {
+      socket.close();
+    }
+  });
+
+  test.concurrent("Resolver#resolve(hostname, 'NAPTR') returns what resolveNaptr() returns", async () => {
+    const { socket, queries, server } = await startFakeServer();
+    try {
+      const promisesResolver = new dns_promises.Resolver({ timeout: 5000, tries: 1 });
+      promisesResolver.setServers([server]);
+      const callbackResolver = new dns.Resolver({ timeout: 5000, tries: 1 });
+      callbackResolver.setServers([server]);
+
+      const results = await Promise.all([
+        promisesResolver.resolve("promises.example.test", "NAPTR"),
+        promisesResolver.resolveNaptr("naptr.example.test"),
+        new Promise((resolve, reject) =>
+          callbackResolver.resolve("callback.example.test", "NAPTR", (err, records) =>
+            err ? reject(err) : resolve(records),
+          ),
+        ),
+      ]);
+      expect(results).toEqual(Array(3).fill([NAPTR_RECORD]));
+      expect(queries.sort()).toEqual(["35 callback", "35 naptr", "35 promises"]);
+    } finally {
+      socket.close();
+    }
+  });
+
+  // The module-level functions use the process-wide resolver, so point that one
+  // at the fake server in a child process.
+  test.concurrent("dns.resolve(), dns.promises.resolve() and Bun.dns.resolve() accept 'NAPTR'", async () => {
+    const { socket, queries, server } = await startFakeServer();
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const dns = require("node:dns");
+           dns.setServers([process.argv[1]]);
+           Promise.all([
+             new Promise((resolve, reject) =>
+               dns.resolve("callback.example.test", "NAPTR", (err, records) => (err ? reject(err) : resolve(records))),
+             ),
+             dns.promises.resolve("promises.example.test", "NAPTR"),
+             Bun.dns.resolve("bun.example.test", "NAPTR"),
+           ]).then(results => console.log(JSON.stringify(results)));`,
+          server,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual(Array(3).fill([NAPTR_RECORD]));
+      expect(exitCode).toBe(0);
+      expect(queries.sort()).toEqual(["35 bun", "35 callback", "35 promises"]);
+    } finally {
+      socket.close();
+    }
   });
 });


### PR DESCRIPTION
### Problem
- `dns.resolve(host, "NAPTR", cb)`, `dns.promises.resolve(host, "NAPTR")` and `Resolver#resolve(host, "NAPTR")` (both APIs) throw synchronously:
  `TypeError: The property "record" is invalid. Expected one of: A, AAAA, ANY, CAA, CNAME, MX, NS, PTR, SOA, SRV, TXT, received type string ('NAPTR')` (`code: ERR_INVALID_ARG_VALUE`).
- Node documents `'NAPTR'` as a valid `rrtype` for `dns.resolve()` and sends a NAPTR query (node v26.3.0 output below). `dns.resolveNaptr()` already works in Bun.
- Cause: every entry point above calls the one native `Resolver::resolve` in `src/runtime/dns_jsc/dns.rs`. Its rrtype table (`RecordType`, `RECORD_TYPE_MAP`, the `match record_type`) has no NAPTR row, although the NAPTR reply type that `resolveNaptr()` uses exists.

### Fix
- Add `RecordType::NAPTR`, the `"NAPTR"` and `"naptr"` map rows, and a match arm that calls `do_resolve_cares::<c_ares::struct_ares_naptr_reply>`, the call `resolveNaptr()` makes. The match arm is the fix. The other rows make it reachable.
- List NAPTR in the invalid-rrtype message. The assertion on that message in `test/js/bun/dns/resolve-dns.test.ts` is updated.
- Correct because `resolve(host, T)` is, in Node and for the 11 other rows of this table, the query `resolveT(host)` makes, and the new arm is that query. Against one fake server, Node and this branch return the same record from the same QTYPE 35 query (details below). Invalid rrtypes still throw `ERR_INVALID_ARG_VALUE`.
- The `"naptr"` row follows the table, which has a lowercase row for every type. Node accepts uppercase only, for every type. This PR does not change that.
- `src/js/node/dns.ts` is not changed. Its `resolve()` implementations pass the rrtype through to the native function and only post-process A and AAAA results, so one native test covers the callback, promises and `Bun.dns` entry points.
- Test: `test/js/node/dns/node-dns.test.js`, `resolve(hostname, "NAPTR") issues a NAPTR query`, for `"NAPTR"` and `"naptr"`. A UDP socket on 127.0.0.1 that never answers receives the query. The test checks the QTYPE on the wire (35) and then cancels the resolver and checks the rejection (`code: "ECANCELLED"`, `syscall: "queryNaptr"`). Node produces the same rejection. Decoding of NAPTR answers is the existing `resolveNaptr()` coverage, and #39504 adds a table test that compares `resolve(name, T)` with each `resolveT(name)`. Its NAPTR row currently skips `resolve()`. After this lands, that skip can go.
- Verified: both rows of the new test and the updated `resolve-dns.test.ts` assertion fail on the unfixed binary (`USE_SYSTEM_BUN=1`, the synchronous `ERR_INVALID_ARG_VALUE` above) and pass with `bun bd test` (5 runs). The other failures in both files in this sandbox are the tests that need outside DNS. They fail the same way on the unfixed binary.
- #39504 rewrites the same `match`. Whichever PR lands second adds this one arm back in the other PR's shape.

### Background
- `node:dns` in Bun is `src/js/node/dns.ts` over the native `Bun.dns` object. The `resolve*()` functions call into `src/runtime/dns_jsc/dns.rs`, which sends the query with c-ares.
- `resolve(hostname, rrtype)` is one native function. It maps the rrtype string to a record type, then calls `do_resolve_cares::<ReplyType>`. Each `resolveXxx()` function calls the same generic with its reply type directly. The reply type carries the c-ares QTYPE, the result conversion and the pending cache for that record type.
- The `syscall` property of a `node:dns` error names the query kind (`queryA`, `queryNaptr`, ...). It comes from the reply type, so it identifies which arm of the table a call took.
- NAPTR (RFC 3403, QTYPE 35) is the record type that ENUM and SIP service discovery use.

<details>
<summary>Node vs Bun</summary>

Cancelled query against a silent socket (the shape the test asserts):

```
node v26.3.0:        NAPTR qtype: 35 rejection: {"code":"ECANCELLED","syscall":"queryNaptr","hostname":"naptr.example.test","message":"queryNaptr ECANCELLED naptr.example.test"}
                     naptr threw sync: ERR_INVALID_ARG_VALUE
bun, this branch:    NAPTR qtype: 35 rejection: {"code":"ECANCELLED","syscall":"queryNaptr","hostname":"naptr.example.test","message":"queryNaptr ECANCELLED naptr.example.test"}
                     naptr qtype: 35 rejection: (same)
bun 1.4.0-canary:    NAPTR threw sync: ERR_INVALID_ARG_VALUE
                     naptr threw sync: ERR_INVALID_ARG_VALUE
```

Fake server that answers QTYPE 35 with one record (order 10, preference 20, flags "S", service "SIP+D2U", empty regexp, replacement `_sip._udp.example.test`): node v26.3.0 and this branch both return

```
[{ flags: "S", service: "SIP+D2U", regexp: "", replacement: "_sip._udp.example.test", order: 10, preference: 20 }]
```

from `promises.Resolver#resolve`, callback `Resolver#resolve`, `dns.resolve`, `dns.promises.resolve` and `resolveNaptr` (this branch also from `Bun.dns.resolve`), with one QTYPE 35 query per call. The unfixed binary throws the `ERR_INVALID_ARG_VALUE` above at the first `resolve()` call.

</details>

<details>
<summary>Earlier revision</summary>

The first push had a 150-line block with its own fake server: a 12-rrtype QTYPE matrix, a NAPTR decode comparison with `resolveNaptr()`, and a child process for the module-level entry points. A review pass found that #39504's table test already covers the matrix and the decode comparison once its NAPTR skip is removed, and that the module-level entry points reach the same native function. The block is replaced by the one test described above.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/dns/resolve-dns.test.ts test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->