### PR TITLE
valkey: run a dial that fails before there is a socket through the deferred close

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1018,16 +1018,13 @@ impl JSValkeyClient {
             self.poll_ref.with_mut(|r| r.ref_(vm_event_loop_ctx()));
 
             if let Err(err) = self.connect() {
-                self.poll_ref.with_mut(|r| r.unref(vm_event_loop_ctx()));
-                self.client_mut().status = valkey::Status::NeverConnected;
-                let err_value = global_object
-                    .err(
-                        jsc::ErrorCode::SOCKET_CLOSED_BEFORE_CONNECTION,
-                        format_args!(" {} connecting to Valkey", err.name()),
-                    )
-                    .to_js();
-                let _exit = self.vm().enter_event_loop_scope();
-                promise_ptr.reject(global_object, Ok(err_value))?;
+                debug!(
+                    "first dial failed before a socket was opened: {}",
+                    err.name()
+                );
+                // Settled by the deferred close like a refused dial: the
+                // promise, onclose and the retry policy all go through on_close().
+                self.close_without_socket_next_tick();
                 return Ok(promise);
             }
 
@@ -1142,6 +1139,38 @@ impl JSValkeyClient {
         }
     }
 
+    /// Runs `ValkeyClient::on_close()` for a dial that failed before there was
+    /// a socket, so the connect() promise, `onclose`, the retry policy and the
+    /// poll ref are handled as for a dial that failed asynchronously. Deferred
+    /// because `onclose` may call connect(), and a dial that fails the same way
+    /// from in there would otherwise re-enter `on_close()` on the same stack.
+    ///
+    /// Until the task runs the client is `Connecting`, as it would be with a
+    /// dial in flight: JS that runs in between (timers due in the same tick,
+    /// or the caller of connect() or of the command that dialled) then gets
+    /// the cached promise from connect() instead of a second dial, has its
+    /// commands queued for the retry or the rejection, and a disconnect()
+    /// marks the close as manual for the task to honour. `update_poll_ref`
+    /// keeps the wrapper and the event loop alive for it like a dial would.
+    fn close_without_socket_next_tick(&self) {
+        self.client_mut().status = valkey::Status::Connecting;
+        self.update_poll_ref();
+        self.enqueue_deferred_close(DeferredClose::WithoutSocket);
+    }
+
+    fn enqueue_deferred_close(&self, what: DeferredClose) {
+        // Released by the task, whether it runs or the VM tears down first.
+        self.ref_();
+        let task = jsc::Task::from_boxed(Box::new(ValkeyDeferredClose {
+            ctx: self.as_ctx_ptr(),
+            what,
+        }));
+        // SAFETY: VM-owned event loop pointer; uniquely accessed on the JS thread.
+        unsafe {
+            (*self.vm().event_loop()).enqueue_task(task);
+        }
+    }
+
     pub(crate) fn on_reconnect_timer(&self) -> JsResult<()> {
         debug!("Reconnect timer fired, attempting to reconnect");
 
@@ -1175,15 +1204,14 @@ impl JSValkeyClient {
         });
 
         if let Err(err) = self.connect() {
-            self.poll_ref.with_mut(|r| r.disable());
-            return self.fail_with_js_value(
-                self.global_object
-                    .err(
-                        jsc::ErrorCode::SOCKET_CLOSED_BEFORE_CONNECTION,
-                        format_args!("{} reconnecting", err.name()),
-                    )
-                    .to_js(),
+            debug!(
+                "reconnect failed before a socket was opened: {}",
+                err.name()
             );
+            // Same outcome as a dial that fails asynchronously: another retry,
+            // or fail() and a settled connect() promise once retries are used up.
+            self.close_without_socket_next_tick();
+            return Ok(());
         }
 
         // Reset the socket timeout
@@ -1348,9 +1376,10 @@ impl JSValkeyClient {
     // Callback for when Valkey client needs to reconnect
     pub(crate) fn on_valkey_reconnect(&self) {
         // SAFETY: adopts connect()'s socket keep-alive ref for the just-closed
-        // socket. Reached only from `ValkeyClient::on_close()`'s reconnect
-        // branch, which never calls `on_valkey_close()`, so this scope is the
-        // sole releaser. The caller holds its own scoped ref, so count > 0.
+        // socket (or the one `ValkeyDeferredClose::run` took in its place).
+        // Reached only from `ValkeyClient::on_close()`'s reconnect branch,
+        // which never calls `on_valkey_close()`, so this scope is the sole
+        // releaser. The caller holds its own scoped ref, so count > 0.
         let _socket_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
 
         // This timer was bounding the attempt that just ended; left armed it
@@ -1365,8 +1394,9 @@ impl JSValkeyClient {
     pub(crate) fn on_valkey_close(&self) -> JsResult<()> {
         let global_object = self.global_object;
 
-        // SAFETY: adopts connect()'s socket keep-alive ref; the caller holds
-        // its own scoped ref so count stays > 0 until this drops.
+        // SAFETY: adopts connect()'s socket keep-alive ref (or the one
+        // `ValkeyDeferredClose::run` took in its place); the caller holds its
+        // own scoped ref so count stays > 0 until this drops.
         let _socket_ref = unsafe { ScopedRef::adopt(self.as_ctx_ptr()) };
         let _defer = scopeguard::guard(BackRef::new(self), |p| p.update_poll_ref());
 
@@ -1375,7 +1405,8 @@ impl JSValkeyClient {
         };
         this_jsvalue.ensure_still_alive();
         if global_object.has_exception() {
-            // As in `fail_with_js_value`: an exception already unwinding keeps propagating.
+            // Already unwinding an exception (a caller's, or the worker's termination): it keeps
+            // propagating; `onclose` cannot be entered on top of it.
             return Err(bun_jsc::JsError::Thrown);
         }
 
@@ -1411,37 +1442,13 @@ impl JSValkeyClient {
         self.client_mut().fail(message, err)
     }
 
-    pub(crate) fn fail_with_js_value(&self, value: JSValue) -> JsResult<()> {
-        let Some(this_value) = self.this_value.get().try_get() else {
-            return Ok(());
-        };
-        let global_object = self.global_object;
-        if global_object.has_exception() {
-            // Already unwinding an exception (a caller's, or the worker's termination): it keeps
-            // propagating; `onclose` cannot be entered on top of it.
-            return Err(bun_jsc::JsError::Thrown);
-        }
-        if let Some(on_close) = Js::onclose_get_cached(this_value) {
-            let _exit = self.vm().enter_event_loop_scope();
-            on_close.call(&global_object, this_value, &[value])?;
-        }
-        Ok(())
-    }
-
     fn close_socket_next_tick(&self) {
         if self.client.get().socket.is_closed() {
             return;
         }
 
-        self.ref_();
         // socket close can potentially call JS so we need to enqueue the deinit
-        let task = jsc::Task::from_boxed(Box::new(ValkeyDeferredClose {
-            ctx: self.as_ctx_ptr(),
-        }));
-        // SAFETY: VM-owned event loop pointer; uniquely accessed on the JS thread.
-        unsafe {
-            (*self.vm().event_loop()).enqueue_task(task);
-        }
+        self.enqueue_deferred_close(DeferredClose::Socket);
     }
 
     pub fn finalize(self: Box<Self>) {
@@ -1474,12 +1481,6 @@ impl JSValkeyClient {
         }
 
         let _guard = self.ref_scope();
-
-        // Socket keep-alive ref, released by on_valkey_close/on_valkey_reconnect.
-        // Taken before the TLS-context check so the `tls_ctx_failed` branch's
-        // `on_valkey_close()` has a ref to consume instead of over-releasing.
-        // Forgotten on success (the socket adopts it).
-        let socket_ref = self.ref_scope();
 
         let is_tls = self.client.get().tls != valkey::TLS::None;
         let vm = self.client.get().vm.as_mut();
@@ -1517,11 +1518,7 @@ impl JSValkeyClient {
                 b"Failed to create TLS context",
                 protocol::RedisError::ConnectionClosed,
             )?;
-            // `on_valkey_close()` consumes the socket ref; hand it over so it
-            // isn't released twice.
-            socket_ref.forget();
-            self.client_mut().on_valkey_close()?;
-            self.client_mut().status = valkey::Status::Disconnected;
+            self.close_without_socket_next_tick();
             return Ok(());
         }
         let ssl_ctx: Option<*mut uws::SslCtx> = match &self.client.get().tls {
@@ -1549,6 +1546,9 @@ impl JSValkeyClient {
         // `owner_ptr` opaquely (no overlapping write).
         let owner_ptr: *mut JSValkeyClient = std::ptr::from_ref::<JSValkeyClient>(self).cast_mut();
         let client_ptr: *mut valkey::ValkeyClient = self.client.as_ptr();
+        // Socket keep-alive ref, released by on_valkey_close/on_valkey_reconnect.
+        // Forgotten once there is a socket to own it.
+        let socket_ref = self.ref_scope();
         // SAFETY: `client_ptr` is live; `group` is the lazy-initialised per-VM
         // `SocketGroup` (stable for the VM's lifetime). `ssl_ctx` is a +1-ref
         // BoringSSL `SSL_CTX*` (or None) forwarded opaquely to usockets.
@@ -1577,20 +1577,19 @@ impl JSValkeyClient {
         if self.client.get().status == valkey::Status::NeverConnected {
             bun_core::hint::cold();
 
-            if let Err(err) = self.connect() {
-                self.client_mut().status = valkey::Status::NeverConnected;
-                let err_value = global_this
-                    .err(
-                        jsc::ErrorCode::SOCKET_CLOSED_BEFORE_CONNECTION,
-                        format_args!(" {} connecting to Valkey", err.name()),
-                    )
-                    .to_js();
-                let promise = JSPromise::create(global_this);
-                let _exit = self.vm().enter_event_loop_scope();
-                promise.reject(global_this, Ok(err_value))?;
-                return Ok(promise);
+            match self.connect() {
+                // The command is queued below as for a dial in flight; the
+                // deferred close then rejects it or a retry sends it, like a
+                // refused dial.
+                Err(err) => {
+                    debug!(
+                        "first dial failed before a socket was opened: {}",
+                        err.name()
+                    );
+                    self.close_without_socket_next_tick();
+                }
+                Ok(()) => self.reset_connection_timeout(),
             }
-            self.reset_connection_timeout();
         }
 
         let self_br = BackRef::new(self);
@@ -2022,27 +2021,67 @@ impl Options {
     }
 }
 
+#[derive(Clone, Copy)]
+enum DeferredClose {
+    /// Close the socket the finalized wrapper left behind.
+    Socket,
+    /// Run the close path for a dial that never produced a socket
+    /// (`close_without_socket_next_tick`).
+    WithoutSocket,
+}
+
 pub(crate) struct ValkeyDeferredClose {
-    ctx: *const JSValkeyClient,
+    ctx: *mut JSValkeyClient,
+    what: DeferredClose,
 }
 
 impl ValkeyDeferredClose {
     #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
     pub(crate) fn run(self: Box<Self>) {
-        let ctx = self.ctx;
-        // SAFETY: single-threaded; intrusive ref taken before enqueue guarantees liveness.
-        unsafe {
-            crate::dispatch::fold((*ctx).client_mut().close(uws::CloseCode::FastShutdown));
-            JSValkeyClient::deref(ctx.cast_mut());
+        // SAFETY: adopts the ref `enqueue_deferred_close` took, which kept the
+        // client alive until now; released when this scope ends.
+        let _enqueue_ref = unsafe { ScopedRef::adopt(self.ctx) };
+        // SAFETY: live per the ref above; tasks run on the JS thread.
+        let this = unsafe { &*self.ctx };
+        match self.what {
+            DeferredClose::Socket => {
+                crate::dispatch::fold(this.client_mut().close(uws::CloseCode::FastShutdown))
+            }
+            DeferredClose::WithoutSocket => {
+                // Holding Connecting (see `close_without_socket_next_tick`) is
+                // what keeps a dial from starting in between; if one did, its
+                // own callbacks own the close path now, so only drop our ref.
+                if !this.client.get().socket.is_closed() {
+                    return;
+                }
+                // `on_close()` ends in `on_valkey_close`/`on_valkey_reconnect`,
+                // which release the ref the socket would have held.
+                this.ref_();
+                this.client_mut().status = valkey::Status::Disconnected;
+                let closed = this.client_mut().on_close();
+                this.update_poll_ref();
+                crate::dispatch::fold(closed);
+            }
         }
     }
 }
 
 impl bun_event_loop::Taskable for ValkeyDeferredClose {
     const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ValkeyDeferredClose;
-    /// The deferred close is script-free bookkeeping; do it.
     unsafe fn release_unrun(this: *mut Self) {
         // SAFETY: fn contract — boxed at the enqueue site.
-        unsafe { bun_core::heap::take(this) }.run();
+        let task = unsafe { bun_core::heap::take(this) };
+        match task.what {
+            // Script-free bookkeeping; do it.
+            DeferredClose::Socket => task.run(),
+            // The VM is going away: `on_close()` would run `onclose`, so only
+            // give back what `close_without_socket_next_tick` took.
+            DeferredClose::WithoutSocket => {
+                // SAFETY: as in `run`.
+                let _enqueue_ref = unsafe { ScopedRef::adopt(task.ctx) };
+                // SAFETY: live per the ref above.
+                unsafe { &*task.ctx }.poll_ref.with_mut(|r| r.disable());
+            }
+        }
     }
 }

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -670,6 +670,10 @@ impl ValkeyClient {
     pub fn on_close(&mut self) -> JsResult<()> {
         self.unregister_auto_flusher();
         self.write_buffer.clear_and_free();
+        // A partial reply can never complete now; left in place it counts as
+        // pending activity in `update_poll_ref` and keeps the event loop alive.
+        self.read_buffer.clear_and_free();
+        self.reply_scanner.reset();
 
         // A manual close or a failure the client detected itself: no retry.
         if self.flags.is_manually_closed || self.flags.failed {

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -1,8 +1,9 @@
 import { RedisClient } from "bun";
 import { describe, expect, mock, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tls as tlsCert } from "harness";
 import net from "net";
+import path from "path";
 import tls from "tls";
 import { DEFAULT_REDIS_OPTIONS, DEFAULT_REDIS_URL, delay, isEnabled } from "../test-utils";
 
@@ -484,6 +485,10 @@ describe("Valkey: Recovering After fail()", () => {
         await once(server, "listening");
         return (server.address() as net.AddressInfo).port;
       },
+      listenUnix: async (socketPath: string) => {
+        server.listen(socketPath);
+        await once(server, "listening");
+      },
       close: () => new Promise(resolve => server.close(resolve)),
     };
   }
@@ -948,5 +953,314 @@ describe("Valkey: Recovering After fail()", () => {
       stderr: "",
       exitCode: 0,
     });
+  });
+
+  // The close for a dial that failed before a socket existed runs from the
+  // event loop; until then the client must look like it is dialling, so that
+  // whatever JS runs first neither dials on top of it nor is ignored.
+  test.skipIf(isWindows)(
+    "a close() issued right after a dial failed outright is honoured by the deferred close",
+    async () => {
+      using dir = tempDir("valkey-unix", {});
+      const socketPath = path.join(String(dir), "r.sock");
+      const first = helloServer();
+      const second = helloServer();
+      await first.listenUnix(socketPath);
+      const client = new RedisClient(`redis+unix://${socketPath}`);
+      try {
+        await client.connect();
+        client.close();
+        await first.close();
+        let closes = 0;
+        client.onclose = () => closes++;
+        const outcome = client.connect().then(
+          () => "connected",
+          (err: Error & { code: string }) => err.code,
+        );
+        client.close();
+        await second.listenUnix(socketPath);
+        expect({ outcome: await outcome, closes, connected: client.connected, redialled: second.connections }).toEqual({
+          outcome: "ERR_REDIS_CONNECTION_CLOSED",
+          closes: 1,
+          connected: false,
+          redialled: 0,
+        });
+      } finally {
+        client.close();
+        await first.close();
+        await second.close();
+      }
+    },
+  );
+
+  test.skipIf(isWindows)(
+    "a connect() that runs in the same tick as a retry that failed outright does not dial on top of it",
+    async () => {
+      using dir = tempDir("valkey-unix", {});
+      const socketPath = path.join(String(dir), "r.sock");
+      // Connection 1 is dropped by the server instead of answering PING.
+      const first = helloServer({
+        PING: (_connection, socket) => {
+          socket.end();
+          return null;
+        },
+      });
+      // The listener that comes back holds its HELLO reply, so a second dial on
+      // top of the first one would show up as a second connection here.
+      const second = helloServer({ HELLO: () => null });
+      await first.listenUnix(socketPath);
+      const client = new RedisClient(`redis+unix://${socketPath}`);
+      // Settled by the connect() made in the window; the handler is attached
+      // right away so that a failure elsewhere is not reported as its rejection.
+      const fromTimer = Promise.withResolvers<string>();
+      try {
+        await client.connect();
+        // Stops accepting at once while connection 1 stays up, so the retry
+        // scheduled when it drops fails outright.
+        void first.close();
+        const ping = await client.ping().then(
+          () => "answered",
+          (err: Error & { code: string }) => err.code,
+        );
+        expect(ping).toBe("ERR_REDIS_CONNECTION_CLOSED");
+        // The close that rejected the PING also armed the retry, 50ms out, and
+        // this continuation runs in its microtask checkpoint, before the loop
+        // turns again. Blocking past the retry and the timer armed here makes
+        // the loop fire both in one pass, in due order: the retry fails
+        // outright, then the callback runs in the window before the deferred
+        // close, brings the listener back and calls connect().
+        setTimeout(() => {
+          void second.listenUnix(socketPath);
+          fromTimer.resolve(
+            client.connect().then(
+              () => "connected",
+              (err: Error & { code: string }) => err.code,
+            ),
+          );
+        }, 150);
+        Bun.sleepSync(250);
+        // The deferred close schedules the next retry, which is what connects.
+        while (second.connections === 0) await Bun.sleep(1);
+        // Had the callback's connect() dialled on top, the deferred close would
+        // still have scheduled its retry, so a second connection would follow
+        // within one retry delay (at most 100ms at this point); this is the
+        // bound on asserting that it never comes.
+        await Bun.sleep(250);
+        expect(second.connections).toBe(1);
+        second.sockets[0].write("+OK\r\n");
+        expect({
+          fromTimer: await fromTimer.promise,
+          connected: client.connected,
+          connections: second.connections,
+        }).toEqual({ fromTimer: "connected", connected: true, connections: 1 });
+      } finally {
+        client.close();
+        await first.close();
+        await second.close();
+      }
+    },
+  );
+
+  test.skipIf(isWindows)("a reconnect whose dial fails outright is retried like a refused one", async () => {
+    using dir = tempDir("valkey-unix", {});
+    const socketPath = path.join(String(dir), "r.sock");
+    const first = helloServer();
+    const second = helloServer();
+    await first.listenUnix(socketPath);
+    const client = new RedisClient(`redis+unix://${socketPath}`);
+    try {
+      await client.connect();
+      client.close();
+      await first.close();
+      // connect(2) on a path nobody listens on fails before a socket exists.
+      const reconnected = client.connect();
+      await second.listenUnix(socketPath);
+      await reconnected;
+      expect(await client.ping()).toBe("PONG");
+      expect({ first: first.connections, second: second.connections }).toEqual({ first: 1, second: 1 });
+    } finally {
+      client.close();
+      await first.close();
+      await second.close();
+    }
+  });
+
+  test.skipIf(isWindows)(
+    "a reconnect whose dial fails outright rejects connect() when auto-reconnect is off",
+    async () => {
+      using dir = tempDir("valkey-unix", {});
+      const socketPath = path.join(String(dir), "r.sock");
+      const fake = helloServer();
+      await fake.listenUnix(socketPath);
+      const client = new RedisClient(`redis+unix://${socketPath}`, { autoReconnect: false });
+      try {
+        await client.connect();
+        client.close();
+        await fake.close();
+        let closes = 0;
+        client.onclose = () => closes++;
+        const attempt = client.connect();
+        // Reported from the event loop like a refused connection, not from
+        // inside connect(), so an onclose that calls connect() cannot recurse.
+        expect(closes).toBe(0);
+        const outcome = await attempt.then(
+          () => "connected",
+          (err: Error & { code: string }) => `rejected: ${err.code}`,
+        );
+        expect({ outcome, closes }).toEqual({ outcome: "rejected: ERR_REDIS_CONNECTION_CLOSED", closes: 1 });
+        await expect(client.ping()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      } finally {
+        client.close();
+        await fake.close();
+      }
+    },
+  );
+
+  // A fresh client's first dial can fail the same way, whether connect() or the
+  // first command makes it; it goes through the same close as a refused dial.
+  const firstDialFrom: [string, (client: RedisClient) => Promise<unknown>][] = [
+    ["connect()", client => client.connect()],
+    ["a command", client => client.ping()],
+  ];
+
+  test.skipIf(isWindows).each(firstDialFrom)(
+    "a first dial that fails outright, made by %s, rejects and runs onclose once when auto-reconnect is off",
+    async (_entry, dial) => {
+      using dir = tempDir("valkey-unix", {});
+      const socketPath = path.join(String(dir), "r.sock");
+      const fake = helloServer();
+      const client = new RedisClient(`redis+unix://${socketPath}`, { autoReconnect: false });
+      try {
+        let closes = 0;
+        client.onclose = () => closes++;
+        const attempt = dial(client).then(
+          () => "resolved",
+          (err: Error & { code: string }) => `rejected: ${err.code}`,
+        );
+        expect(closes).toBe(0);
+        expect({ outcome: await attempt, closes, connected: client.connected }).toEqual({
+          outcome: "rejected: ERR_REDIS_CONNECTION_CLOSED",
+          closes: 1,
+          connected: false,
+        });
+        // The failed attempt is settled and forgotten: a connect() once a
+        // listener is there dials rather than handing the same promise back.
+        await fake.listenUnix(socketPath);
+        await client.connect();
+        expect({ ping: await client.ping(), connections: fake.connections }).toEqual({ ping: "PONG", connections: 1 });
+      } finally {
+        client.close();
+        await fake.close();
+      }
+    },
+  );
+
+  test.skipIf(isWindows).each(firstDialFrom)(
+    "a first dial that fails outright, made by %s, is retried until a listener is there",
+    async (_entry, dial) => {
+      using dir = tempDir("valkey-unix", {});
+      const socketPath = path.join(String(dir), "r.sock");
+      const fake = helloServer();
+      const client = new RedisClient(`redis+unix://${socketPath}`);
+      try {
+        let closes = 0;
+        client.onclose = () => closes++;
+        const attempt = dial(client);
+        // Listening well before the first retry is due; a later retry would
+        // connect just the same, the retries are not terminal either way.
+        await fake.listenUnix(socketPath);
+        await attempt;
+        expect({ ping: await client.ping(), closes, connections: fake.connections }).toEqual({
+          ping: "PONG",
+          closes: 0,
+          connections: 1,
+        });
+      } finally {
+        client.close();
+        await fake.close();
+      }
+    },
+  );
+
+  test("a connect() issued from onclose after the TLS context cannot be built dials again from the event loop", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        // Neither key nor cert parses, so no attempt ever gets as far as a socket.
+        const client = new Bun.RedisClient("rediss://127.0.0.1:1", {
+          tls: { key: "not a key", cert: "not a cert" },
+          autoReconnect: false,
+        });
+        const attempts = [];
+        const done = Promise.withResolvers();
+        let closes = 0, depth = 0, nested = false;
+        client.onclose = () => {
+          closes += 1;
+          nested ||= depth > 0;
+          depth += 1;
+          if (closes < 3) attempts.push(client.connect());
+          else done.resolve();
+          depth -= 1;
+        };
+        attempts.push(client.connect());
+        const closesInsideConnect = closes;
+        await done.promise;
+        const outcomes = await Promise.all(attempts.map(p => p.then(() => "connected", err => err.code)));
+        console.log(JSON.stringify({ closesInsideConnect, nested, closes, outcomes, connected: client.connected }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({
+        closesInsideConnect: 0,
+        nested: false,
+        closes: 3,
+        outcomes: ["ERR_REDIS_CONNECTION_CLOSED", "ERR_REDIS_CONNECTION_CLOSED", "ERR_REDIS_CONNECTION_CLOSED"],
+        connected: false,
+      }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("close() discards a half-received reply instead of letting it keep the process alive", async () => {
+    // Announces a 4 byte bulk string and stops halfway through it.
+    const fake = helloServer({ PING: () => "$4\r\nPO" });
+    const port = await fake.listen();
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const client = new Bun.RedisClient("redis://127.0.0.1:${port}", { autoReconnect: false });
+          await client.connect();
+          const ping = client.ping().catch(err => console.log("ping rejected", err.code));
+          while (client.bufferedAmount === 0) await Bun.sleep(1);
+          console.log("buffered before close", client.bufferedAmount);
+          client.close();
+          await ping;
+          console.log("buffered after close", client.bufferedAmount);
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "buffered before close 6\nping rejected ERR_REDIS_CONNECTION_CLOSED\nbuffered after close 0\n",
+        stderr: "",
+        exitCode: 0,
+      });
+    } finally {
+      fake.server.close();
+    }
   });
 });

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, tempDir, tls } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir, tls } from "harness";
 import { join } from "path";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
@@ -725,6 +725,48 @@ test(
   timeout,
 );
 
+// Spawns workers that each start `connectExpr` in one immediate and call
+// process.exit(0) in the next, so whatever that connect attempt left behind is
+// still pending when the worker's VM tears down.
+async function exitRightAfterConnecting(connectExpr: string) {
+  const workers = slow ? 8 : 24;
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const { Worker } = require("node:worker_threads");
+      const src =
+        "const { parentPort } = require('node:worker_threads');" +
+        "Bun.file(process.execPath).slice(0, 100).json().catch(() => {});" +
+        ${JSON.stringify(`setImmediate(() => ${connectExpr}.catch(() => {}));`)} +
+        "parentPort.postMessage('up');" +
+        "setImmediate(() => process.exit(0));";
+      let started = 0, exited = 0;
+      function again() {
+        if (started >= ${workers}) {
+          if (exited === ${workers}) console.log("PASS");
+          return;
+        }
+        started++;
+        const w = new Worker(src, { eval: true });
+        w.on("error", (e) => { console.error(e); process.exit(1); });
+        w.on("exit", () => { exited++; again(); });
+      }
+      again(); again();
+    `,
+    ],
+    env: { ...bunEnv, UV_THREADPOOL_SIZE: "4" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("PASS\n");
+  expect(exitCode).toBe(0);
+}
+
 // For a debug build: host code that runs after the worker's own process.exit()
 // unwound script — here a redis connect started in the same immediate tick as
 // the exit, whose ECONNREFUSED then lands in that loop tick — builds JS error
@@ -735,43 +777,62 @@ test(
 // for as long as it keeps the exception.
 test.skipIf(!isDebug)(
   "process.exit() with native error completions landing in the same tick does not trip DeferTermination",
+  () =>
+    exitRightAfterConnecting(
+      "new Bun.RedisClient('redis://127.0.0.1:9', { connectionTimeout: 100, autoReconnect: false }).connect()",
+    ),
+  timeout,
+);
+
+// A TLS context that cannot be built fails the dial before there is a socket;
+// the redis client then settles that from a task it queues on the event loop,
+// holding a ref to itself and the loop. The exit in the next immediate tears
+// the VM down with that task still queued, so it has to be released without
+// running (a debug build asserts on the refcount if either ref is mishandled;
+// the ASAN build reports the leak).
+test.skipIf(!isDebug && !isASAN)(
+  "process.exit() with a redis client's deferred close still queued releases it cleanly",
+  () =>
+    exitRightAfterConnecting(
+      "new Bun.RedisClient('rediss://127.0.0.1:9', { tls: { key: 'x', cert: 'x' }, autoReconnect: false }).connect()",
+    ),
+  timeout,
+);
+
+// The same task, queued by a first command whose dial failed outright (a unix
+// socket path nobody listens on), with the command itself still queued behind it.
+test.skipIf((!isDebug && !isASAN) || isWindows)(
+  "process.exit() with a redis client's deferred close and a queued command releases both cleanly",
+  () => exitRightAfterConnecting("new Bun.RedisClient('redis+unix:///nonexistent/redis.sock').ping()"),
+  timeout,
+);
+
+// The same deferred close on the main thread, left to run: it settles the
+// connect and drops its refs, so nothing keeps the event loop alive and the
+// process exits on its own.
+test(
+  "a redis client whose TLS context cannot be built does not keep the process alive",
   async () => {
-    const workers = slow ? 8 : 24;
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
         "-e",
         `
-        const { Worker } = require("node:worker_threads");
-        const src =
-          "const { parentPort } = require('node:worker_threads');" +
-          "Bun.file(process.execPath).slice(0, 100).json().catch(() => {});" +
-          "setImmediate(() => new Bun.RedisClient('redis://127.0.0.1:9', { connectionTimeout: 100, autoReconnect: false }).connect().catch(() => {}));" +
-          "parentPort.postMessage('up');" +
-          "setImmediate(() => process.exit(0));";
-        let started = 0, exited = 0;
-        function again() {
-          if (started >= ${workers}) {
-            if (exited === ${workers}) console.log("PASS");
-            return;
-          }
-          started++;
-          const w = new Worker(src, { eval: true });
-          w.on("error", (e) => { console.error(e); process.exit(1); });
-          w.on("exit", () => { exited++; again(); });
-        }
-        again(); again();
-      `,
+        new Bun.RedisClient("rediss://127.0.0.1:1", { tls: { key: "x", cert: "x" }, autoReconnect: false })
+          .connect()
+          .catch(err => console.log("connect rejected", err.code));
+        `,
       ],
-      env: { ...bunEnv, UV_THREADPOOL_SIZE: "4" },
+      env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
-
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout).toBe("PASS\n");
-    expect(exitCode).toBe(0);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "connect rejected ERR_REDIS_CONNECTION_CLOSED\n",
+      stderr: "",
+      exitCode: 0,
+    });
   },
   timeout,
 );


### PR DESCRIPTION
This is the first PR of a stack split out of #37993. The second is #39511. The third is #38281. Each PR stands on its own.

Part of #18895. The stack as a whole fixes it; #38281 closes it.

The problem

Some dials fail before a socket exists:

- `connect(2)` fails at once, for example a unix socket path that does not exist.
- The TLS context cannot be built.

Each entry point had its own close path for this case. None of them behaved like a dial that fails later, with a socket.

- A retry that failed this way called `onclose` from inside the timer callback. If `onclose` dialled again and that failed too, the code recursed. Nothing settled.
- A first dial that failed this way rejected at once with ERR_SOCKET_CLOSED_BEFORE_CONNECTION. It did not run `onclose`. It ignored the retry policy. It left the rejected promise cached, so a later dial that succeeded settled it a second time.
- A TLS context failure ran the close callback from inside `connect()`.

Separately, a half-received reply stayed in the read buffer after `close()`. It counted as pending activity and kept the process alive.

The rule this PR sets

A dial that fails before there is a socket takes the same close path as a dial that fails with one. The close path settles the `connect()` promise, runs `onclose`, applies the retry policy, and updates the event loop ref.

What changed

All four cases now queue one task on the event loop. The task is a second mode of the existing `ValkeyDeferredClose`. It runs the close path for the failed dial.

Until the task runs, the client stays in the `Connecting` state, as it would with a real dial in flight. So a `connect()` or `close()` called in the meantime joins or cancels the attempt. It does not dial on top of it, and it is not ignored.

If `onclose` calls `connect()` and that dial fails the same way, it queues another task. It does not re-enter the close path on the same stack.

If the VM tears down while the task is still queued, the task releases the client ref and the event loop ref. It does not run script.

The close path now frees the read buffer. A half-received reply cannot outlive its connection.

Visible change

A first dial that fails at once now rejects from the event loop with ERR_REDIS_CONNECTION_CLOSED. It runs `onclose` and follows the retry policy, like a refused dial. Before, it rejected synchronously with ERR_SOCKET_CLOSED_BEFORE_CONNECTION.

Tests

The tests are in the "Recovering After fail()" block of connection-failures.test.ts. They use unix socket paths that nobody listens on, closed ports, and a net stub. All ten fail on Bun 1.3.14.

worker-terminate-lifetime.test.ts tears a VM down with the task still queued, once with a command queued behind it. It also runs the same close on the main thread, where the process then exits on its own.

Not in this PR

The old synchronous path put the errno in the error message. This path only logs it. Carrying it into the rejection is a follow-up.

Supersedes #32768.
