### PR TITLE
css: resolve relative color keywords inside nested math functions

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -629,9 +629,7 @@ impl<V: CalcValue> Calc<V> {
         input: &mut css::Parser,
         parse_ident: ParseIdent<'_, V>,
     ) -> CssResult<Self> {
-        // Parse nested calc() and other math functions. They resolve the same
-        // identifiers as the enclosing function: `calc(r + abs(g))` in a
-        // relative color.
+        // Parse nested calc() and other math functions.
         match input.try_parse(|i| Self::parse_with(i, parse_ident)) {
             Ok(calc) => match calc {
                 Calc::Function(f) => {

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -629,8 +629,10 @@ impl<V: CalcValue> Calc<V> {
         input: &mut css::Parser,
         parse_ident: ParseIdent<'_, V>,
     ) -> CssResult<Self> {
-        // Parse nested calc() and other math functions.
-        match input.try_parse(Self::parse) {
+        // Parse nested calc() and other math functions. They resolve the same
+        // identifiers as the enclosing function: `calc(r + abs(g))` in a
+        // relative color.
+        match input.try_parse(|i| Self::parse_with(i, parse_ident)) {
             Ok(calc) => match calc {
                 Calc::Function(f) => {
                     return match *f {
@@ -641,7 +643,7 @@ impl<V: CalcValue> Calc<V> {
                 other => return Ok(other),
             },
             Err(e) => {
-                // A math function token can only be parsed by `Self::parse`.
+                // A math function token can only be parsed by `Self::parse_with`.
                 // If that failed, none of the alternatives below can succeed
                 // either, so return the error rather than falling through:
                 // `V::parse` would re-enter the same nested block through

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -197,6 +197,68 @@ describe("css tests", () => {
     ); // ideally -400% - 8vh + 3ic
     minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
   });
+  describe("relative color keywords inside nested math functions", () => {
+    // https://drafts.csswg.org/css-color-5/#relative-colors: a channel keyword
+    // may appear anywhere in a channel's math, including inside a math function
+    // nested in another one. #336699 is r 51, g 102, b 153, hsl(210 50% 40%),
+    // alpha 1. Every expression below is homogeneous in its keywords, so the
+    // expected colors hold whatever number a keyword stands for.
+    minify_test(".foo { color: rgb(from #336699 calc(calc(r)) g b) }", ".foo{color:#369}");
+    minify_test(".foo { color: rgb(from #336699 calc(r + calc(g)) b b) }", ".foo{color:#999}");
+    minify_test(".foo { color: rgb(from #336699 r g calc(abs(r - b))) }", ".foo{color:#366}");
+    minify_test(".foo { color: rgb(from #336699 calc(b * sign(g)) g b) }", ".foo{color:#969}");
+    minify_test(".foo { color: rgb(from #336699 r g calc(rem(b, g))) }", ".foo{color:#363}");
+    minify_test(".foo { color: rgb(from #336699 calc(max(r, g)) g calc(min(r, b))) }", ".foo{color:#663}");
+    minify_test(".foo { color: rgb(from #336699 r g calc(b + min(r, g))) }", ".foo{color:#36c}");
+    // sqrt() parses its argument as a plain number; the pow() inside it still sees the keywords.
+    minify_test(".foo { color: rgb(from #336699 r g sqrt(pow(r, 2))) }", ".foo{color:#363}");
+    minify_test(".foo { color: rgb(from #336699 r calc(sqrt(pow(b, 2))) b) }", ".foo{color:#399}");
+    // An alpha that did not resolve was not left as written: rgb() and hsl()
+    // were re-parsed as a color with an unresolved alpha and printed without
+    // their `from`, as rgb(51 102 153/calc(alpha - calc(alpha/2))), which
+    // browsers reject.
+    minify_test(".foo { color: rgb(from #336699 r g b / calc(alpha - calc(alpha / 2))) }", ".foo{color:#33669980}");
+    minify_test(".foo { color: hsl(from #336699 h s l / calc(alpha - calc(alpha / 2))) }", ".foo{color:#33669980}");
+    minify_test(
+      ".foo { color: rgb(from light-dark(#336699, #996633) calc(r + calc(g)) b b) }",
+      ".foo{color:light-dark(#999,#f33)}",
+    );
+    minify_test(
+      ".foo { color: rgb(from #336699 calc(r + calc(g)) b b / var(--a)) }",
+      ".foo{color:rgb(153 153 153/var(--a))}",
+    );
+    // Hues: as a number, and as an angle once a unit is involved.
+    minify_test(".foo { color: hsl(from #336699 calc(h + calc(h)) s l) }", ".foo{color:#993}");
+    minify_test(".foo { color: hsl(from #336699 calc(calc(h) + 30deg) s l) }", ".foo{color:#339}");
+    minify_test(".foo { color: lch(from lch(50% 30 120) l c calc(h + calc(h))) }", ".foo{color:lch(50% 30 240)}");
+    // Channels written as percentages.
+    minify_test(".foo { color: hsl(from #336699 h calc(s + calc(s)) l) }", ".foo{color:#06c}");
+    minify_test(".foo { color: hsl(from #336699 h calc(min(s, l)) l) }", ".foo{color:#3d668f}");
+    minify_test(".foo { color: lab(from lab(50% 20 30) calc(l + calc(l)) a b) }", ".foo{color:lab(100% 20 30)}");
+    // Channels written as numbers.
+    minify_test(".foo { color: lab(from lab(50% 20 30) l calc(a + calc(b)) b) }", ".foo{color:lab(50% 50 30)}");
+    minify_test(
+      ".foo { color: color(from color(srgb 0.8 0.4 0.2) srgb calc(r - calc(g)) g b) }",
+      ".foo{color:color(srgb .4 .4 .2)}",
+    );
+    minify_test(
+      ".foo { color: color(from color(display-p3 0.8 0.4 0.2) display-p3 r g calc(max(g, b))) }",
+      ".foo{color:color(display-p3 .8 .4 .4)}",
+    );
+    // The nested function sees exactly the keywords of the function it is
+    // written in: an unknown identifier, another color space's keyword, and a
+    // keyword outside relative syntax are still invalid, and the declaration
+    // is left as written.
+    minify_test(
+      ".foo { color: rgb(from #336699 calc(r + calc(x)) g b) }",
+      ".foo{color:rgb(from #369 calc(r + calc(x))g b)}",
+    );
+    minify_test(
+      ".foo { color: rgb(from #336699 calc(r + calc(h)) g b) }",
+      ".foo{color:rgb(from #369 calc(r + calc(h))g b)}",
+    );
+    minify_test(".foo { color: rgb(calc(1 + calc(r)) 0 0) }", ".foo{color:rgb(calc(1 + calc(r))0 0)}");
+  });
   describe("border_spacing", () => {
     minify_test(
       `


### PR DESCRIPTION
Merge order: after #38553 (the relative color keyword scale fix). The reason is under Fix. This PR needs no code change when #38553 lands, it only touches `calc.rs` and `calc.rs` is not in #38553.

### Problem
- In relative color syntax a channel keyword resolves directly inside a math function, but not inside a math function nested in another one. Two things happen then:
  ```
  rgb(from #336699 calc(r * 2) g b)                        -> #669                                          (works)
  rgb(from #336699 calc(r + calc(g)) b b)                  -> rgb(from #369 calc(r + calc(g))b b)           (left as written, browsers show #999)
  rgb(from #336699 r g b / calc(alpha - calc(alpha / 2)))  -> rgb(51 102 153/calc(alpha - calc(alpha/2)))   (invalid: the from is gone, browsers drop the declaration)
  hsl(from #336699 h s l / calc(alpha - calc(alpha / 2)))  -> hsl(210 50% 40%/calc(alpha - calc(alpha/2)))  (same)
  ```
  A channel position (`calc(r + calc(g))`, `calc(abs(r - b))`, `sqrt(pow(r, 2))`, `calc(h + calc(h))`, ...) is left as written. That is valid CSS, so it only costs the fold. An alpha position in `rgb()` or `hsl()` is worse: the declaration is re-parsed as a color with an unresolved alpha (`UnresolvedColor` in `src/css/properties/custom.rs`), the channels resolve, the alpha is kept as tokens, and the printed color has no `from`, so the keyword in it is invalid. Same output on bun 1.4.0 and main. CSS Color 5 allows the keywords anywhere in the channel's math. Found in review of #39501.
- Cause: `Calc::parse_value` (`src/css/values/calc.rs`) parses a nested math function with `input.try_parse(Self::parse)`, and `Calc::parse` installs the empty identifier resolver. The resolver the relative color parser passed in (`RelativeComponentParser`, `src/css/values/color.rs`) is only consulted for identifiers written directly in the outermost function.

### Fix
- `parse_value` parses the nested function with `Self::parse_with(i, parse_ident)`, the resolver it was itself given. The `Err` branch (math function failure bookkeeping) is unchanged.
- Correct because the keywords are defined for the whole channel value, not for one nesting level. The sub-parsers that project the resolver (`number_ident`, used by trig, `atan2()`, `pow()`, `log()`, `sqrt()`, `exp()`) forward their projection the same way, so a nested function sees exactly what its enclosing function sees. Non-relative `calc()` is unaffected: `Calc::parse` still passes the empty resolver, and the four closures in `color.rs` are the only non-empty resolvers in the crate.
- Why the bug existed, and why this waited for #39501 (merged): with the generic `(ctx, parse_ident)` pair the forward did not compile. `parse_trig`, `parse_atan2` and `parse_numeric` each wrap the resolver in a new closure type, so every nesting level was a new instantiation and rustc stopped with `reached the recursion limit while instantiating Parser::try_parse::<Calc<f32>, ...>` (7 errors, `cargo build -p bun_css` on the old code with this line). `Self::parse` was what bounded that recursion. #39501 made the resolver a `&dyn Fn`, so the forward is a plain call. `nm` on the debug binary shows one `parse`, `parse_with`, `parse_sum`, `parse_product` and `parse_value` per value type, as before.
- Why after #38553: on main a keyword is the stored unit value (`r` is 0.2) while a literal is in CSS units, and that mismatch (#38553's subject) already mis-folds top level mixes such as `calc(r + 10)`. Nested mixes are left as written today because of this bug. With this change alone they fold on the wrong scale too: `rgb(from #336699 r g calc(abs(r - 100)))` goes from left as written to `#36f` (browsers `#336631`), `calc(round(b, 10))` to `#360` (browsers `#336696`). After #38553 those fold to the browser values and this change is additive. The tests in this PR are chosen so that they hold on either side of #38553 (below), the two rows above are worth adding once it is in.
- Not changed by this PR, kept here so nobody looks for it in this diff: the `UnresolvedColor` path drops the `from` whenever it keeps an alpha as tokens. `rgb(from #336699 r g b / calc(alpha * var(--a)))` prints `rgb(51 102 153/calc(alpha*var(--a)))` before and after. With this change the variant with nested channel math (`calc(r + calc(g)) b b / calc(alpha * var(--a))`) moves from left as written into that same output, because its channels now resolve. The fix for that class is in `custom.rs` (reject, or keep the input, when `from` is set and the alpha tokens are not a bare `var()`), separate from this PR. `clamp()` and `atan2()` over keywords are also unchanged, at the top level too, and independent of nesting.
- Tests: `test/js/bun/css/css.test.ts`, block "relative color keywords inside nested math functions", 25 cases: nested `calc()`, `abs()`, `sign()`, `rem()`, `min()`/`max()` (the second, percentage-typed pass), `pow()` inside `sqrt()` (the projected resolver), the `rgb()` and `hsl()` alpha slot, a `light-dark()` origin, the `/ var(--a)` path, hues as numbers and as angles, percentage channels (`hsl()`, `lab()` lightness), number channels (`lab()` a/b, `color()`), and 3 cases that pin that an unknown identifier, another space's keyword and a keyword outside relative syntax stay rejected inside a nested function. Every expression is homogeneous in its keywords, so the expected colors do not depend on the keyword scale. `USE_SYSTEM_BUN=1`: 22 of 25 fail (the 3 rejection cases pass, as intended). `bun bd test`: 25 pass. The block sits next to the calc tests because #38553 and #38513 both add blocks elsewhere in the file.
- Also run with the debug build: all of `css.test.ts`, `color.test.ts`, `nested-function-backtracking.test.ts`, `atan2-backtracking-hang.test.ts`, `token-list-backtracking.test.ts`, `doesnt_crash.test.ts`, and `test/bundler/css/`. All pass.

### Background
- Relative color syntax: `rgb(from <origin> r g b / alpha)` converts the origin into the function's color space and lets each channel be written as a keyword naming one of the converted channels, a literal, or a math function over them (https://drafts.csswg.org/css-color-5/#relative-colors).
- `Calc<V>` (`calc.rs`) parses one math function into a value of type `V` (`f32`, `Percentage`, `Angle`, ...). `parse_with` dispatches on the function name, `parse_sum`, `parse_product` and `parse_value` parse the arguments, and `parse_value` is where a nested function, a parenthesis, a number or an identifier is recognised. It is the one place a nested function is entered from.
- Identifier resolver (`ParseIdent`, from #39501): the callback `parse_value` asks about a bare identifier. Ordinary CSS passes one that always answers "unknown". The relative color parser passes one that maps `r`, `g`, `b`, `alpha`, ... to the origin's channels. It tries up to three typed passes per channel (`Calc<f32>`, then `Calc<Percentage>`, then `Calc<Angle>` for hues), each with its own resolver, which is why the tests cover each kind of channel.
- Number projection (`number_ident`): `sin()`, `atan2()`, `pow()` and friends parse their arguments as plain numbers or angles, so they wrap the resolver in one that only passes numeric answers through. A function nested inside them now receives that wrapped resolver.
- `UnresolvedColor` (`custom.rs`): when a color function cannot be parsed as a color, the declaration is kept as a token list. Inside that list an `rgb()` or `hsl()` whose channels parse is stored as resolved channels plus the alpha tokens, so that `rgb(1 2 3 / var(--a))` can still be printed in legacy syntax. It does not store the origin, hence the missing `from` above.

<details>
<summary>Probes on released bun 1.4.0 (same as main here) and on this branch</summary>

Every case in the test block:

```
input                                                                          1.4.0                                          this branch
rgb(from #336699 calc(calc(r)) g b)                                            rgb(from #369 calc(calc(r))g b)                #369
rgb(from #336699 calc(r + calc(g)) b b)                                        rgb(from #369 calc(r + calc(g))b b)            #999
rgb(from #336699 r g calc(abs(r - b)))                                         left as written                                #366
rgb(from #336699 calc(b * sign(g)) g b)                                        left as written                                #969
rgb(from #336699 r g calc(rem(b, g)))                                          left as written                                #363
rgb(from #336699 calc(max(r, g)) g calc(min(r, b)))                            left as written                                #663
rgb(from #336699 r g calc(b + min(r, g)))                                      left as written                                #36c
rgb(from #336699 r g sqrt(pow(r, 2)))                                          left as written                                #363
rgb(from #336699 r calc(sqrt(pow(b, 2))) b)                                    left as written                                #399
rgb(from #336699 r g b / calc(alpha - calc(alpha / 2)))                        rgb(51 102 153/calc(alpha - calc(alpha/2)))    #33669980
hsl(from #336699 h s l / calc(alpha - calc(alpha / 2)))                        hsl(210 50% 40%/calc(alpha - calc(alpha/2)))   #33669980
rgb(from light-dark(#336699, #996633) calc(r + calc(g)) b b)                   left as written                                light-dark(#999,#f33)
rgb(from #336699 calc(r + calc(g)) b b / var(--a))                             left as written                                rgb(153 153 153/var(--a))
hsl(from #336699 calc(h + calc(h)) s l)                                        left as written                                #993
hsl(from #336699 calc(calc(h) + 30deg) s l)                                    left as written                                #339
lch(from lch(50% 30 120) l c calc(h + calc(h)))                                left as written                                lch(50% 30 240)
hsl(from #336699 h calc(s + calc(s)) l)                                        left as written                                #06c
hsl(from #336699 h calc(min(s, l)) l)                                          left as written                                #3d668f
lab(from lab(50% 20 30) calc(l + calc(l)) a b)                                 left as written                                lab(100% 20 30)
lab(from lab(50% 20 30) l calc(a + calc(b)) b)                                 left as written                                lab(50% 50 30)
color(from color(srgb 0.8 0.4 0.2) srgb calc(r - calc(g)) g b)                 left as written                                color(srgb .4 .4 .2)
color(from color(display-p3 0.8 0.4 0.2) display-p3 r g calc(max(g, b)))       left as written                                color(display-p3 .8 .4 .4)
rgb(from #336699 calc(r + calc(x)) g b)                                        left as written                                left as written
rgb(from #336699 calc(r + calc(h)) g b)                                        left as written                                left as written
rgb(calc(1 + calc(r)) 0 0)                                                     left as written                                left as written
```

Keyword and literal mixes, the reason for the merge order (browser values in the last column):

```
rgb(from #336699 calc(r + 10) g b)                                             #f69                                           #f69             (#3d6699, top level, #38553)
rgb(from #336699 r g calc(abs(r - 100)))                                       left as written                                #36f             (#336631)
rgb(from #336699 r g calc(round(b, 10)))                                       left as written                                #360             (#336696)
rgb(from #336699 r g calc(b + max(g, 10)))                                     left as written                                #360             (#3366ff, also needs the min()/max() number folding)
```

The `UnresolvedColor` class that this PR does not touch:

```
rgb(from #336699 r g b / calc(alpha * var(--a)))                               rgb(51 102 153/calc(alpha*var(--a)))           same
hsl(from #336699 h s l / calc(alpha * var(--a)))                               hsl(210 50% 40%/calc(alpha*var(--a)))          same
rgb(from #336699 calc(r + calc(g)) b b / calc(alpha * var(--a)))               left as written                                rgb(153 153 153/calc(alpha*var(--a)))
```

</details>

<details>
<summary>History</summary>

Opened against #39501's branch while that PR was open, because the change only compiles on its type-erased resolver. #39501 merged as 81e9ec5691 without the `calc-parser-monomorphization.test.ts` its branch had carried for a while, and GitHub retargeted this PR to main, which would have brought that file back. The branch was rebased onto main so the diff is `calc.rs` and `css.test.ts` only. A self-review of the diff produced the merge order note, the `hsl()` alpha test and the `UnresolvedColor` paragraph above.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 22 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.08ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.01ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.00ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: w
... (truncated)

release without fix: 22 failed, 67 skipped
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.11ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.02ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.04ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.26ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.04ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.02ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: w
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     44111de374
  features     baseline

22 deps, 120 codegen, 1144 objects in 780ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1206] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 26 installs across 63 packages (no changes) [6.00ms]
[2/1206] gen ErrorCode+*.h
[3/1206] gen bindgenv2
[4/1206] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1206] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[6/1206] fetch zlib
[zlib] up to date
[7/1206] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [16.00ms]
[8/1206] gen .bind.ts → GeneratedBindings.cpp
[9/1206] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /work
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/values/calc.rs      |  4 +--
 test/js/bun/css/css.test.ts | 62 +++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 64 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/css/values/calc.rs           8      3      0
test/js/bun/css/css.test.ts      4      2      0
```

</details>

<!-- robobun:evidence:end -->