### PR TITLE
css: fold min(), max() and clamp() over plain numbers

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -996,10 +996,11 @@ impl<V: CalcValue> Calc<V> {
         }
     }
 
-    /// Orders two values when their units allow it.
+    /// Orders two values with compatible units or two numbers, never a number and a value.
     fn partial_cmp_args(a: &Self, b: &Self) -> Option<Ordering> {
         match (a, b) {
             (Calc::Value(a), Calc::Value(b)) => protocol::PartialCmp::partial_cmp(&**a, &**b),
+            (Calc::Number(a), Calc::Number(b)) => protocol::PartialCmp::partial_cmp(a, b),
             _ => None,
         }
     }
@@ -1009,44 +1010,23 @@ impl<V: CalcValue> Calc<V> {
     /// I am pretty sure we could do this reduction in place, or do it as the
     /// arguments are being parsed.
     fn reduce_args(args: &mut Vec<Self>, order: Ordering) {
-        // Reduces the arguments of a min() or max() expression, combining compatible values.
-        // e.g. min(1px, 1em, 2px, 3in) => min(1px, 1em)
+        // Keeps one argument per comparable group: min(1px, 1em, 2px, 3in) => min(1px, 1em).
         let mut reduced: Vec<Self> = Vec::new();
 
-        for arg in args.iter_mut() {
-            let mut found: Option<Option<usize>> = None;
-            if let Calc::Value(val) = &*arg {
-                for (idx, b) in reduced.iter().enumerate() {
-                    if let Calc::Value(v) = b {
-                        let result = protocol::PartialCmp::partial_cmp(&**val, &**v);
-                        if result.is_some() {
-                            if result == Some(order) {
-                                found = Some(Some(idx));
-                                break;
-                            } else {
-                                found = Some(None);
-                                break;
-                            }
-                        }
+        'args: for arg in args.drain(..) {
+            for kept in reduced.iter_mut() {
+                match Self::partial_cmp_args(&arg, kept) {
+                    Some(ord) if ord == order => {
+                        *kept = arg;
+                        continue 'args;
                     }
+                    Some(_) => continue 'args,
+                    None => {}
                 }
             }
-
-            // For borrowck, `found` stores an index rather than a pointer.
-            if let Some(maybe_idx) = found {
-                if let Some(idx) = maybe_idx {
-                    reduced[idx] = core::mem::replace(arg, Calc::Number(420.0));
-                    continue;
-                }
-            } else {
-                reduced.push(core::mem::replace(arg, Calc::Number(420.0)));
-                continue;
-            }
-            // arg dropped here
-            *arg = Calc::Number(420.0);
+            reduced.push(arg);
         }
 
-        // Drop on replace frees the old args.
         *args = reduced;
     }
 

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -187,6 +187,48 @@ describe("css tests", () => {
     minify_test(`a { rotate: calc(NaN * 1deg) }`, `a{rotate:0deg}`);
     minify_test(`a { transition-duration: calc(NaN * 1s) }`, `a{transition-duration:0s}`);
   });
+  describe("min() and max() simplification", () => {
+    minify_test(`a { opacity: min(.5, .2) }`, `a{opacity:.2}`);
+    minify_test(`a { opacity: max(.5, .2) }`, `a{opacity:.5}`);
+    minify_test(`a { line-height: min(1.5, 1.2) }`, `a{line-height:1.2}`);
+    minify_test(`a { flex-grow: max(1, 2, 3) }`, `a{flex-grow:3}`);
+    minify_test(`a { opacity: min(.5, .2, .7) }`, `a{opacity:.2}`);
+    minify_test(`a { opacity: max(.2, .7, .5) }`, `a{opacity:.7}`);
+    minify_test(`a { opacity: min(.5, .5) }`, `a{opacity:.5}`);
+    minify_test(`a { opacity: min(infinity, .5) }`, `a{opacity:.5}`);
+    minify_test(`a { opacity: max(-infinity, .5) }`, `a{opacity:.5}`);
+    minify_test(`a { opacity: min(2 * .2, .5) }`, `a{opacity:.4}`);
+    minify_test(`a { opacity: max(min(.5, .2), .3) }`, `a{opacity:.3}`);
+    minify_test(`a { opacity: calc(1 - min(.5, .2)) }`, `a{opacity:.8}`);
+    minify_test(`a { color: rgb(min(255, 20) 0 0) }`, `a{color:#140000}`);
+    minify_test(`a { color: rgb(max(255, 100), 0, 0) }`, `a{color:red}`);
+    minify_test(`a { color: hsl(max(100, 200) 50% 50%) }`, `a{color:#4095bf}`);
+    minify_test(`a { color: rgb(0 0 0 / min(1, .5)) }`, `a{color:#00000080}`);
+    minify_test(`a { font-weight: max(100, 700) }`, `a{font-weight:700}`);
+    minify_test(`a { font: 12px/min(1.2, 1.5) serif }`, `a{font:12px/1.2 serif}`);
+    minify_test(`a { aspect-ratio: min(1, 2) / 1 }`, `a{aspect-ratio:1}`);
+    // Without the fold, the flex shorthand takes the min() as the <length-percentage> basis and
+    // the numbers after it as grow and shrink.
+    minify_test(`a { flex: min(1, 2) 1 0 }`, `a{flex:1 1 0}`);
+    minify_test(`a { flex: min(1, 2) 2 }`, `a{flex:1 2}`);
+    minify_test(`a { flex: 2 min(1, 2) }`, `a{flex:2}`);
+    // A <ratio> media feature has no unparsed fallback, so without the fold this is an error.
+    minify_test(`@media (aspect-ratio: min(1, 2) / 1) { a { b: c } }`, `@media (aspect-ratio:1){a{b:c}}`);
+    // The alpha channel of a relative color is a number on the same scale as a literal, so these
+    // fold on their own; the other channels are #38553.
+    minify_test(`a { color: rgb(from #336699 r g b / min(alpha, .5)) }`, `a{color:#33669980}`);
+    minify_test(`a { color: rgb(from #336699 r g b / max(alpha, .5)) }`, `a{color:#369}`);
+    // Numbers are only compared with numbers and dimensions with dimensions.
+    minify_test(`a { line-height: max(1.2, 1.5, 1em, 2em) }`, `a{line-height:max(1.5,2em)}`);
+    minify_test(`a { opacity: min(.5, 20%) }`, `a{opacity:min(.5,20%)}`);
+    // NaN compares with nothing, so a NaN argument is never removed.
+    minify_test(`a { opacity: min(NaN, .5) }`, `a{opacity:min(NaN,.5)}`);
+    minify_test(`a { opacity: max(.5, NaN) }`, `a{opacity:max(.5,NaN)}`);
+    // Dimensions keep reducing the way they did: the winner takes the loser's position.
+    minify_test(`a { width: min(1px, 1em, 2px, 3in) }`, `a{width:min(1px,1em)}`);
+    minify_test(`a { width: min(3px, 10%, 2px) }`, `a{width:min(2px,10%)}`);
+    minify_test(`a { width: max(3px, 10%, 2px) }`, `a{width:max(3px,10%)}`);
+  });
   describe("clamp() simplification", () => {
     // The cases lightningcss asserts in its calc tests.
     minify_test(`.foo { border-width: clamp(1px, 2px, 3px) }`, `.foo{border-width:2px}`);
@@ -221,6 +263,20 @@ describe("css tests", () => {
     minify_test(`a { rotate: clamp(0deg, 45deg, 30deg) }`, `a{rotate:30deg}`);
     minify_test(`a { transition-duration: clamp(1s, 500ms, 2s) }`, `a{transition-duration:1s}`);
     minify_test(`a { width: calc(clamp(1px, 2px, 3px) + 1px) }`, `a{width:3px}`);
+    // Plain numbers.
+    minify_test(`a { opacity: clamp(.3, .5, .9) }`, `a{opacity:.5}`);
+    minify_test(`a { opacity: clamp(.3, .1, .9) }`, `a{opacity:.3}`);
+    minify_test(`a { opacity: clamp(0, .5, .2) }`, `a{opacity:.2}`);
+    minify_test(`a { opacity: clamp(.2, .2, .9) }`, `a{opacity:.2}`);
+    minify_test(`a { opacity: clamp(.1, .2, .2) }`, `a{opacity:.2}`);
+    minify_test(`a { line-height: clamp(1, 1.5, 2) }`, `a{line-height:1.5}`);
+    minify_test(`a { flex: clamp(1, 5.20, 20) }`, `a{flex:5.2}`);
+    minify_test(`a { color: rgb(clamp(0, 255, 300), 0, 0) }`, `a{color:red}`);
+    minify_test(`a { color: rgb(from #336699 r g b / clamp(.1, alpha, .5)) }`, `a{color:#33669980}`);
+    minify_test(`a { opacity: calc(1 - clamp(0, .5, .2)) }`, `a{opacity:.8}`);
+    minify_test(`a { width: clamp(1px, 2, 3px) }`, `a{width:clamp(1px,2,3px)}`);
+    minify_test(`a { opacity: clamp(0, .5, 20%) }`, `a{opacity:clamp(0,.5,20%)}`);
+    minify_test(`a { opacity: clamp(0, NaN, 1) }`, `a{opacity:clamp(0,NaN,1)}`);
   });
   describe("calc stack overflow", () => {
     // https://github.com/oven-sh/bun/issues/20128


### PR DESCRIPTION
#39577 (the `clamp()` bound fix and the `partial_cmp_args` helper) has landed; this PR is the number case on top of it, rebased onto main.

Blocked on #38553: this PR makes `min()`/`max()` fold inside relative colors too, and on main the relative color parser resolves channel keywords on the wrong scale (#38553). `rgb(from c min(r, 20) g b)`, which is passed through unchanged today, would print the wrong color until #38553 is in. With #38553 applied on top of this branch the probes below are correct. Merge #38553 first.

### Problem
- The CSS minifier (`bun build` on a `.css` file, `Bun.build`) folds `min()`, `max()` and `clamp()` over dimensions but never over plain numbers. `width: min(3px, 2px)` prints `width:2px`, while `opacity: min(.5, .2)` prints `opacity:min(.5,.2)`, and the same for `line-height`, `flex-grow`, `font-weight`, color channels, and every other `<number>` position. Same on bun 1.4.0 and main.
- This is not only output size. A property parser that wants a `<number>` rejects the unfolded function, and what happens next depends on the property:
  - `flex: min(1, 2) 1 0` (grow 1, shrink 1, basis 0) prints `flex:1 0 min(1,2)`: `Flex::parse` (`src/css/properties/flex.rs:144-152`) fails to read the function as grow, takes it as the `<length-percentage>` basis, and reads the following numbers as grow and shrink. Browsers reject the output. `flex: min(1, 2) 2` prints `flex:2 min(1,2)`, which swaps grow and shrink.
  - `@media (aspect-ratio: min(1, 2) / 1)` is a build error (`error: Invalid media query`), because a media feature has no unparsed fallback.
  - `rgb(from #336699 r g b / min(alpha, .5))` prints `rgb(51 102 153/min(alpha,.5))`, which browsers reject (the `from` is gone, the keyword is not): the alpha falls into the path in `src/css/properties/custom.rs` that keeps an alpha it cannot parse as tokens.
  - `opacity`, `line-height` and the others keep the declaration as the tokens it was written as.
- Cause: `Calc::reduce_args` (the `min()`/`max()` simplifier) and the `clamp()` arm in `src/css/values/calc.rs` only compare arguments that are `Calc::Value`. A bare number inside a math function always parses as `Calc::Number` (`Calc::parse_value`), even for `Calc<CSSNumber>`, so nothing is ever compared. `round()`, `rem()`, `mod()`, `hypot()`, `abs()` and `sign()` already fold numbers, because `apply_op`/`apply_map` handle the `Number` case. Upstream fixed the same two sites in parcel-bundler/lightningcss#1131 (folds in lightningcss 1.33.0, not in the 1.30.2 this repo has in `node_modules`).

### Fix
- `partial_cmp_args` (added in #39577) gets the `(Calc::Number, Calc::Number)` arm, and `reduce_args` goes through it, so `min()`, `max()` and `clamp()` order two numbers the same way they order two values. A number and a value are never compared, so `max(1.2, 1.5, 1em, 2em)` becomes `max(1.5,2em)` and `min(.5, 20%)` or `clamp(1px, 2, 3px)` are left alone. NaN compares with nothing, so a NaN argument is never removed, as before. This is the reduction lightningcss#1131 performs.
- Correct because the value of a parse-time number is exact, so two numbers decide an argument the same way two `px` values already do, and an argument is only dropped when another argument of the same kind is known to be at least as good.
- A single remaining number is returned exactly as a one-argument `min(.5)` is today, so every consumer already handles the shape: `CSSNumber`, color channels, `Flex` and `Ratio` take it, `Percentage`/`Angle`/`Time` reject it and the declaration falls back as it does now, `Length`/`DimensionPercentage` store it and print the number, which is what `width: calc(2)` already prints for that (invalid) input.
- `reduce_args` itself now drains the vector instead of the `iter_mut` plus `mem::replace(.., Calc::Number(420.0))` placeholders. The value path is unchanged, including the winner taking the loser's position (`min(3px, 10%, 2px)` still prints `min(2px,10%)`), which the tests pin.
- `opacity: calc(1 - min(.5, .2))` prints `0` on main. That comes from `Percentage::from_calc` returning NaN for a calc it cannot reduce (fixed in #38513); this PR only stops the input from reaching it, since the `min()` now folds before the subtraction. It is in the tests as a fold inside `calc()`, not claimed as a fix of that arm.
- Relative colors: the alpha keyword is a number on the same scale as a literal on main and in #38553, so `min(alpha, .5)`, `max(alpha, .5)` and `clamp(.1, alpha, .5)` fold to the right color with this PR alone and are tested. The other channels are resolved on the wrong scale on main (#38553), which is why this PR is blocked on it, see the top; they are not tested here, #38553 carries them. Same-basis expressions such as `min(r, g)` print the same bytes before and after.
- Tests: `test/js/bun/css/css.test.ts`. New `min() and max() simplification` block (32 rows: `<number>` properties, three arguments with the winner in each position, equal arguments, `infinity`, a product argument, nested `max(min())`, `min()` inside `calc()`, `rgb()` in both syntaxes, `hsl()`, alpha, `font-weight`, the `font` shorthand, `aspect-ratio`, the three `flex` shorthand forms, the `aspect-ratio` media feature, relative alpha, mixed number/dimension and number/percentage arguments, NaN, and the existing dimension reduction), and 13 number rows added to the `clamp() simplification` block from #39577 (center in range, below, above and equal to each bound, `flex`, `rgb()`, relative alpha, inside `calc()`, a number/dimension mix, a number/percentage mix, NaN). Against a build of main (which has #39577), 36 of these 45 rows fail and the 9 pins pass; with this PR all 69 rows of the two blocks pass.
- Also run: `css.test.ts`, `color.test.ts` and `test/bundler/css/` (2415 pass), `cargo clippy -p bun_css` clean.
- The alpha path in `custom.rs` mentioned above still prints the invalid form for an alpha this PR cannot fold, for example `rgb(from #336699 r g b / min(alpha, var(--x)))` prints `rgb(51 102 153/min(alpha,var(--x)))` before and after. That path needs to keep the whole relative color as written when the alpha uses a keyword; it is a separate fix and not attempted here.

### Background
- `Calc<V>` is the parsed form of a math expression for a value type `V` (`Length`, `Percentage`, `Angle`, `CSSNumber`, ...). `Calc::Value` holds a `V`; `Calc::Number` holds a bare number, which exists for every `V` because numbers are also the multipliers of products. For `V = CSSNumber` the number a property wants therefore arrives as `Calc::Number`, not `Calc::Value`.
- `reduce_args` keeps one argument out of each group of mutually comparable arguments, so `min(1px, 1em, 2px)` becomes `min(1px, 1em)`: `px` compares with `px`, nothing compares with `em` at parse time. If one argument is left, the function disappears.
- Unparsed fallback: when a property's value parser rejects what it was given, bun keeps the declaration as the original tokens and only minifies whitespace. Shorthands and media features do not have it: a shorthand tries its other slots (the `flex` case above) and a media feature fails the stylesheet.

<details>
<summary>Probes: relative colors with this branch alone, and with #38553 applied on top</summary>

```
input                                                 main                         this branch      this branch + #38553
rgb(from #336699 calc(r + 10) g b)                    #f69 (wrong)                 #f69             #3d6699
rgb(from #336699 round(r, 10) g b)                    #069 (wrong)                 #069             #326699
rgb(from #336699 min(r, g) g b)                       #369                         #369             #369
rgb(from #336699 max(r, g) g b)                       #669                         #669             #669
rgb(from #336699 min(r, 20) g b)                      rgb(from #369 min(r,20)g b)  #369 (wrong)     #146699
rgb(from #336699 max(r, 200) g b)                     rgb(from #369 max(r,200)g b) #f69 (wrong)     #c86699
rgb(from #336699 r g b / min(alpha, .5))              rgb(51 102 153/min(alpha,.5)) (invalid)  #33669980   #33669980
rgb(from rgb(200 100 50) min(r, alpha) g b)           -                            -                #016432 (value #38553 asserts)
lab(from lab(50% 20 30) min(l, a) a b)                -                            -                lab(20% 20 30) (value #38553 asserts)
hsl(from #336699 min(h, 100) s l)                     left as written              #593             #593
```

</details>

<details>
<summary>Probes: other inputs whose output changes (bun build --minify, main -> this branch)</summary>

```
flex:min(1,2) 1 0                        flex:1 0 min(1,2)            -> flex:1 1 0
flex:min(1,2) 2                          flex:2 min(1,2)              -> flex:1 2
@media (aspect-ratio:min(1,2)/1){...}    error: Invalid media query   -> @media (aspect-ratio:1){...}
font:12px/min(1.2,1.5) serif             unchanged                    -> font:12px/1.2 serif
opacity:max(.5,sign(-1))                 unchanged                    -> opacity:.5
opacity:calc(1 - min(.5,.2))             opacity:0                    -> opacity:.8
opacity:calc(1 - 2 * min(.5,.2))         opacity:0                    -> opacity:.6
opacity:clamp(0,.5,.2)                   unchanged                    -> opacity:.2

unchanged on purpose:
opacity:min(.5,var(--x),.2)   opacity:min(NaN,.5)   opacity:clamp(0,NaN,1)   width:min(3px,2)
z-index:min(3,2) (<integer> does not parse math functions; lightningcss leaves it too)
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 36 failed, 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [3.70ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.16ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.08ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: w
... (truncated)

release without fix: 36 failed, 67 skipped
bun test v1.4.0-canary.1 (7e15aeb3f)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [0.12ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [0.02ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [0.05ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: white;
        --my-font-size: 16px;
      }
      .element {
        color: var(--my-color);
        background-color: var(--my-bg);
        font-size: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 67 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/css.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/css/css.test.ts:
Output .flexrow {
  flex-direction: row;
}

.flexcol {
  flex-direction: column;
}

.hello {
  flex-wrap: wrap;
}

.world {
  flex-wrap: nowrap;
}

(pass) css tests > .flexrow {
	flex-direction: row;
}

.flexcol {
	flex-direction: column;
}

.hello {
	flex-wrap: wrap;
}

.world {
	flex-wrap: nowrap;
} [20.75ms]
Output .foo {
  content: "+";
}

(pass) css tests > .foo {
  content: "\2b";
} [1.76ms]
Output div {
  --foo: 1 1 1 #0101011a, 2 2 2 #02020233;
  --bar: 1 1 1 #01010116, 2 2 2 #02020233;
}

(pass) css tests > custom property cases > div {
        --foo: 1 1 1 rgba(1, 1, 1, 0.1), 2 2 2 rgba(2, 2, 2, 0.2);
        --bar: 1 1 1 #01010116, 2 2 2 #02020233;
      } [1.77ms]
Output :root {
  --my-color: red;
  --my-bg: white;
  --my-font-size: 16px;
}

.element {
  color: var(--my-color);
  background-color: var(--my-bg);
  font-size: var(--my-font-size);
}

(pass) css tests > custom property cases > :root {
        --my-color: red;
        --my-bg: 
... (truncated)

release with fix: 67 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 755ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[2/22] cxx obj/src/jsc/bindings/BunObject.cpp.o
[3/22] cxx obj/src/jsc/bindings/BunProcess.cpp.o
[4/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[5/22] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[6/22] cxx obj/src/jsc/bindings/bindings.cpp.o
[7/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[8/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[9/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[10/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[11/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[12/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[13/22] cxx obj/codegen/JSSink.cpp.o
[14/22] cxx obj/src/jsc/bindings/napi.cpp.o
[15/22] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[16/22] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[17/22] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/values/calc.rs      | 44 ++++++++++-------------------------
 test/js/bun/css/css.test.ts | 56 +++++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 68 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                         reads  edits  tests
src/css/values/calc.rs          12     10      0
test/js/bun/css/css.test.ts      3      7      0
```

</details>

<!-- robobun:evidence:end -->