### PR TITLE
share one run tasks body across install callbacks

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -927,9 +927,9 @@ impl<'a> PackageInstaller<'a> {
                     self.current_tree_id = context.tree_id;
 
                     // Re-verify: a parent reinstall may have deleted a deferred entry.
-                    const NEEDS_VERIFY: bool = true;
-                    const IS_PENDING_PACKAGE_INSTALL: bool = true;
-                    self.install_package_with_name_and_resolution::<NEEDS_VERIFY, IS_PENDING_PACKAGE_INSTALL>(
+                    self.install_package_with_name_and_resolution(
+                        /* needs_verify */ true,
+                        /* is_pending_package_install */ true,
                         // This id might be different from the id used to enqueue the task. Important
                         // to use the correct one because the package might be aliased with a different
                         // name
@@ -1163,9 +1163,9 @@ impl<'a> PackageInstaller<'a> {
                 // `DependencyInstallContext.path: Vec<u8>` — clone since `cb` is `&`.
                 self.node_modules.path.clone_from(&context.path);
                 self.current_tree_id = context.tree_id;
-                const NEEDS_VERIFY: bool = false;
-                const IS_PENDING_PACKAGE_INSTALL: bool = false;
-                self.install_package_with_name_and_resolution::<NEEDS_VERIFY, IS_PENDING_PACKAGE_INSTALL>(
+                self.install_package_with_name_and_resolution(
+                    /* needs_verify */ false,
+                    /* is_pending_package_install */ false,
                     // This id might be different from the id used to enqueue the task. Important
                     // to use the correct one because the package might be aliased with a different
                     // name
@@ -1259,15 +1259,14 @@ impl<'a> PackageInstaller<'a> {
         count
     }
 
-    pub(crate) fn install_package_with_name_and_resolution<
+    pub(crate) fn install_package_with_name_and_resolution(
+        &mut self,
         // false when coming from download. if the package was downloaded
         // it was already determined to need an install
-        const NEEDS_VERIFY: bool,
+        needs_verify: bool,
         // we don't want to allow more package installs through
         // pending packages if we're already draining them.
-        const IS_PENDING_PACKAGE_INSTALL: bool,
-    >(
-        &mut self,
+        is_pending_package_install: bool,
         dependency_id: DependencyID,
         package_id: PackageID,
         log_level: Options::LogLevel,
@@ -1300,7 +1299,7 @@ impl<'a> PackageInstaller<'a> {
             }
             self.summary.fail += 1;
             self.increment_tree_install_count(
-                !IS_PENDING_PACKAGE_INSTALL,
+                !is_pending_package_install,
                 self.current_tree_id,
                 log_level,
             );
@@ -1506,7 +1505,7 @@ impl<'a> PackageInstaller<'a> {
                         }
                         self.summary.fail += 1;
                         self.increment_tree_install_count(
-                            !IS_PENDING_PACKAGE_INSTALL,
+                            !is_pending_package_install,
                             self.current_tree_id,
                             log_level,
                         );
@@ -1589,7 +1588,7 @@ impl<'a> PackageInstaller<'a> {
                     panic!("Internal assertion failure: unexpected resolution tag");
                 }
                 self.increment_tree_install_count(
-                    !IS_PENDING_PACKAGE_INSTALL,
+                    !is_pending_package_install,
                     self.current_tree_id,
                     log_level,
                 );
@@ -1599,7 +1598,7 @@ impl<'a> PackageInstaller<'a> {
 
         let needs_install = self.force_install
             || self.skip_verify_installed_version_number
-            || !NEEDS_VERIFY
+            || !needs_verify
             || remove_patch
             || !installer.verify(resolution, &self.root_node_modules_folder);
 
@@ -1653,11 +1652,11 @@ impl<'a> PackageInstaller<'a> {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
                             Err(ForTarballError::InvalidURL) => {
-                                self.fail_with_invalid_url::<IS_PENDING_PACKAGE_INSTALL>(log_level)
+                                self.fail_with_invalid_url(is_pending_package_install, log_level)
                             }
                             Err(ForTarballError::AlreadyFailed) => self
                                 .increment_tree_install_count(
-                                    !IS_PENDING_PACKAGE_INSTALL,
+                                    !is_pending_package_install,
                                     self.current_tree_id,
                                     log_level,
                                 ),
@@ -1685,11 +1684,11 @@ impl<'a> PackageInstaller<'a> {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
                             Err(ForTarballError::InvalidURL) => {
-                                self.fail_with_invalid_url::<IS_PENDING_PACKAGE_INSTALL>(log_level)
+                                self.fail_with_invalid_url(is_pending_package_install, log_level)
                             }
                             Err(ForTarballError::AlreadyFailed) => self
                                 .increment_tree_install_count(
-                                    !IS_PENDING_PACKAGE_INSTALL,
+                                    !is_pending_package_install,
                                     self.current_tree_id,
                                     log_level,
                                 ),
@@ -1723,11 +1722,11 @@ impl<'a> PackageInstaller<'a> {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
                             Err(ForTarballError::InvalidURL) => {
-                                self.fail_with_invalid_url::<IS_PENDING_PACKAGE_INSTALL>(log_level)
+                                self.fail_with_invalid_url(is_pending_package_install, log_level)
                             }
                             Err(ForTarballError::AlreadyFailed) => self
                                 .increment_tree_install_count(
-                                    !IS_PENDING_PACKAGE_INSTALL,
+                                    !is_pending_package_install,
                                     self.current_tree_id,
                                     log_level,
                                 ),
@@ -1738,7 +1737,7 @@ impl<'a> PackageInstaller<'a> {
                             panic!("unreachable, handled above");
                         }
                         self.increment_tree_install_count(
-                            !IS_PENDING_PACKAGE_INSTALL,
+                            !is_pending_package_install,
                             self.current_tree_id,
                             log_level,
                         );
@@ -1771,7 +1770,7 @@ impl<'a> PackageInstaller<'a> {
                 }
             }
 
-            if !IS_PENDING_PACKAGE_INSTALL
+            if !is_pending_package_install
                 && !Self::can_install_package_for_tree(
                     &self.completed_trees,
                     self.lockfile().buffers.trees.as_slice(),
@@ -1810,7 +1809,7 @@ impl<'a> PackageInstaller<'a> {
                     }
                     self.summary.fail += 1;
                     self.increment_tree_install_count(
-                        !IS_PENDING_PACKAGE_INSTALL,
+                        !is_pending_package_install,
                         self.current_tree_id,
                         log_level,
                     );
@@ -2075,7 +2074,7 @@ impl<'a> PackageInstaller<'a> {
                     }
 
                     self.increment_tree_install_count(
-                        !IS_PENDING_PACKAGE_INSTALL,
+                        !is_pending_package_install,
                         self.current_tree_id,
                         log_level,
                     );
@@ -2090,7 +2089,7 @@ impl<'a> PackageInstaller<'a> {
                     // even if the package failed to install, we still need to increment the install
                     // counter for this tree
                     self.increment_tree_install_count(
-                        !IS_PENDING_PACKAGE_INSTALL,
+                        !is_pending_package_install,
                         self.current_tree_id,
                         log_level,
                     );
@@ -2222,7 +2221,7 @@ impl<'a> PackageInstaller<'a> {
         } else {
             // Same gate as the `needs_install` branch: a pending parent's
             // `uninstall_before_install` would delete this verified package.
-            if !IS_PENDING_PACKAGE_INSTALL
+            if !is_pending_package_install
                 && !Self::can_install_package_for_tree(
                     &self.completed_trees,
                     self.lockfile().buffers.trees.as_slice(),
@@ -2378,20 +2377,21 @@ impl<'a> PackageInstaller<'a> {
             // only used in the `needs_install` branch's EACCES handler).
             destination_dir.close();
             self.increment_tree_install_count(
-                !IS_PENDING_PACKAGE_INSTALL,
+                !is_pending_package_install,
                 self.current_tree_id,
                 log_level,
             );
         }
     }
 
-    fn fail_with_invalid_url<const IS_PENDING_PACKAGE_INSTALL: bool>(
+    fn fail_with_invalid_url(
         &mut self,
+        is_pending_package_install: bool,
         log_level: Options::LogLevel,
     ) {
         self.summary.fail += 1;
         self.increment_tree_install_count(
-            !IS_PENDING_PACKAGE_INSTALL,
+            !is_pending_package_install,
             self.current_tree_id,
             log_level,
         );
@@ -2511,9 +2511,9 @@ impl<'a> PackageInstaller<'a> {
         // `&mut self` call.
         let resolutions = self.resolutions;
 
-        const NEEDS_VERIFY: bool = true;
-        const IS_PENDING_PACKAGE_INSTALL: bool = false;
-        self.install_package_with_name_and_resolution::<NEEDS_VERIFY, IS_PENDING_PACKAGE_INSTALL>(
+        self.install_package_with_name_and_resolution(
+            /* needs_verify */ true,
+            /* is_pending_package_install */ false,
             dep_id,
             package_id,
             log_level,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -487,12 +487,10 @@ pub fn enqueue_dependency_to_root(
                     // this callback, so this is the unique live borrow.
                     let manager = unsafe { &mut *self.manager };
                     if manager.pending_task_count() > 0 {
-                        // All callbacks void: `VoidRunTasksCallbacks` (below)
-                        // has `Ctx = ()` and every `HAS_* = false`.
                         let log_level = manager.options.log_level;
-                        if let Err(err) = run_tasks::run_tasks::<VoidRunTasksCallbacks>(
+                        if let Err(err) = run_tasks::run_tasks(
                             manager,
-                            &mut (),
+                            &mut VoidRunTasksCallbacks,
                             false,
                             log_level,
                         ) {
@@ -554,12 +552,12 @@ pub fn enqueue_dependency_to_root(
     }
 }
 
-/// All-void callback set used by `enqueueDependencyToRoot` and `runAndWaitFn`:
-/// `Ctx = ()`, no callbacks, so the `HAS_*` const-gates compile out the
-/// callback paths.
+/// All-void callback set used by `enqueueDependencyToRoot`.
 struct VoidRunTasksCallbacks;
-impl run_tasks::RunTasksCallbacks for VoidRunTasksCallbacks {
-    type Ctx = ();
+impl run_tasks::RunTasksCallbacks<'_> for VoidRunTasksCallbacks {
+    fn flags(&self) -> run_tasks::RunTasksFlags {
+        run_tasks::RunTasksFlags::default()
+    }
 }
 
 pub fn enqueue_network_task(this: &mut PackageManager, task: *mut NetworkTask) {

--- a/src/install/PackageManager/PopulateManifestCache.rs
+++ b/src/install/PackageManager/PopulateManifestCache.rs
@@ -13,7 +13,7 @@ use crate::invalid_package_id;
 // `runTasks.rs` / `PackageManagerEnqueue.rs`).
 use super::PackageManager;
 use super::enqueue;
-use super::run_tasks::{self, RunTasksCallbacks};
+use super::run_tasks::{self, RunTasksCallbacks, RunTasksFlags};
 use crate::package_manager_task as Task;
 use crate::resolution::Tag as ResolutionTag;
 
@@ -104,10 +104,14 @@ pub enum Packages<'a> {
 /// `RunTasksCallbacks` impl for the void-callback `runTasks` call in
 /// `populateManifestCache`.
 struct ManifestsOnlyCallbacks;
-impl RunTasksCallbacks for ManifestsOnlyCallbacks {
-    type Ctx = ();
-    const PROGRESS_BAR: bool = true;
-    const MANIFESTS_ONLY: bool = true;
+impl RunTasksCallbacks<'_> for ManifestsOnlyCallbacks {
+    fn flags(&self) -> RunTasksFlags {
+        RunTasksFlags {
+            progress_bar: true,
+            manifests_only: true,
+            ..Default::default()
+        }
+    }
 }
 
 /// Populate the manifest cache for packages included from `root_pkg_ids`. Only manifests of
@@ -320,15 +324,9 @@ pub fn populate_manifest_cache(
                 // callback, so this is the unique live borrow.
                 let manager = unsafe { &mut *closure.manager };
                 let log_level = manager.options.log_level;
-                // void RunTasksCallbacks — `extract_ctx` is unit. Do NOT pass
-                // `manager` as both receiver and ctx (aliased &mut); the generic
-                // context collapses to `&mut ()`.
-                if let Err(err) = run_tasks::run_tasks::<ManifestsOnlyCallbacks>(
-                    manager,
-                    &mut (),
-                    true,
-                    log_level,
-                ) {
+                if let Err(err) =
+                    run_tasks::run_tasks(manager, &mut ManifestsOnlyCallbacks, true, log_level)
+                {
                     closure.err = Some(err);
                     return true;
                 }

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -39,7 +39,7 @@ use bun_install_types::NodeLinker::NodeLinker;
 
 // Free-function "methods" on `PackageManager` hosted in sibling modules
 // to avoid one giant `impl PackageManager` block.
-use crate::package_manager_real::run_tasks::{RunTasksCallbacks, run_tasks};
+use crate::package_manager_real::run_tasks::{RunTasksCallbacks, RunTasksFlags, run_tasks};
 use crate::package_manager_real::{
     UpdateRequest, enqueue_dependency_list, enqueue_dependency_with_main, enqueue_patch_task_pre,
     save_lockfile, setup_global_dir, update_lockfile_if_needed, write_yarn_lock,
@@ -998,9 +998,13 @@ pub fn install_with_manager(
 /// `runAndWaitFn::isDone` (no hooks, `progress_bar = true`). Only these
 /// flags differ from the default.
 struct InstallWaitCallbacks;
-impl RunTasksCallbacks for InstallWaitCallbacks {
-    type Ctx = ();
-    const PROGRESS_BAR: bool = true;
+impl RunTasksCallbacks<'_> for InstallWaitCallbacks {
+    fn flags(&self) -> RunTasksFlags {
+        RunTasksFlags {
+            progress_bar: true,
+            ..Default::default()
+        }
+    }
 }
 
 struct RunAndWaitClosure<const CHECK_PEERS: bool, const ONLY_PRE_PATCH: bool> {
@@ -1034,11 +1038,8 @@ impl<const CHECK_PEERS: bool, const ONLY_PRE_PATCH: bool>
 
         this.drain_dependency_list();
 
-        // void RunTasksCallbacks — the trait dispatch needs a
-        // concrete `RunTasksCallbacks` impl; `extract_ctx` collapses to `()` so we
-        // do NOT pass `this` as both receiver and ctx (would alias `&mut`).
         let log_level = this.options.log_level;
-        if let Err(err) = run_tasks::<InstallWaitCallbacks>(this, &mut (), CHECK_PEERS, log_level) {
+        if let Err(err) = run_tasks(this, &mut InstallWaitCallbacks, CHECK_PEERS, log_level) {
             closure.err = Some(err);
             return true;
         }

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -41,47 +41,38 @@ use crate::isolated_install::store as Store;
 // Callbacks trait
 // ──────────────────────────────────────────────────────────────────────────
 //
-// A single trait with associated consts gating the
-// optional hooks (default-unreachable bodies), plus associated-const tags for
-// the `Ctx` identity checks. The trait branches on three `Ctx` identities
-// (`PackageInstaller`, `Store.Installer`, neither), but there are six impls
-// across four `Ctx` shapes: `PackageInstaller` (`HoistedRunTasksCallbacks`),
-// `Store::Installer` (`StoreRunTasksCallbacks`), unit
-// (`VoidRunTasksCallbacks`, `ManifestsOnlyCallbacks`, `InstallWaitCallbacks`),
-// and `Queue` (`QueueRunTasksCallbacks` in `src/jsc/AsyncModule.rs`).
-pub trait RunTasksCallbacks {
-    /// Mirrors `Ctx` (the `extract_ctx` value type).
-    type Ctx;
+// Dyn-compatible so `run_tasks` is compiled once: the impls are the ctx
+// types themselves (`PackageInstaller`, `Store::Installer`, `Queue`) or unit
+// markers, and `flags()` says which optional hooks are live. Hook defaults
+// are unreachable and only called when the matching flag is set.
 
-    const PROGRESS_BAR: bool = false;
-    const MANIFESTS_ONLY: bool = false;
+#[derive(Clone, Copy, Default)]
+pub struct RunTasksFlags {
+    pub progress_bar: bool,
+    pub manifests_only: bool,
+    pub has_on_extract: bool,
+    pub has_on_package_manifest_error: bool,
+    pub has_on_package_download_error: bool,
+    pub has_on_resolve: bool,
+    /// ctx is a `PackageInstaller`
+    pub is_package_installer: bool,
+    /// ctx is a `Store::Installer`
+    pub is_store_installer: bool,
+}
 
-    const HAS_ON_EXTRACT: bool = false;
-    const HAS_ON_PACKAGE_MANIFEST_ERROR: bool = false;
-    const HAS_ON_PACKAGE_DOWNLOAD_ERROR: bool = false;
-    const HAS_ON_RESOLVE: bool = false;
+/// `'a` is the installer's inner lifetime; only the two `as_*` downcasts use it.
+pub trait RunTasksCallbacks<'a> {
+    fn flags(&self) -> RunTasksFlags;
 
-    /// `Ctx == *PackageInstaller`
-    const IS_PACKAGE_INSTALLER: bool = false;
-    /// `Ctx == *Store.Installer`
-    const IS_STORE_INSTALLER: bool = false;
-
-    fn on_package_manifest_error(
-        _ctx: &mut Self::Ctx,
-        _name: &[u8],
-        _err: crate::Error,
-        _url: &[u8],
-    ) {
+    fn on_package_manifest_error(&mut self, _name: &[u8], _err: crate::Error, _url: &[u8]) {
         unreachable!()
     }
 
     // `onPackageDownloadError` is called with two distinct shapes depending
-    // on the `Ctx`: `task.task_id: Task::Id` for the store installer,
-    // `package_id: PackageID` otherwise. Static dispatch via two trait
-    // methods lets impls receive the correctly-typed id without a
-    // `Task::Id` round-trip pun.
+    // on the ctx: `task.task_id: Task::Id` for the store installer,
+    // `package_id: PackageID` otherwise.
     fn on_package_download_error_store(
-        _ctx: &mut Self::Ctx,
+        &mut self,
         _task_id: Task::Id,
         _name: &[u8],
         _resolution: &bun_install::Resolution,
@@ -91,7 +82,7 @@ pub trait RunTasksCallbacks {
         unreachable!()
     }
     fn on_package_download_error_pkg(
-        _ctx: &mut Self::Ctx,
+        &mut self,
         _package_id: PackageID,
         _name: &[u8],
         _resolution: &bun_install::Resolution,
@@ -102,7 +93,7 @@ pub trait RunTasksCallbacks {
     }
 
     fn on_extract_package_installer(
-        _ctx: &mut Self::Ctx,
+        &mut self,
         _task_id: Task::Id,
         _dependency_id: DependencyID,
         _data: &mut bun_install::ExtractData,
@@ -110,36 +101,34 @@ pub trait RunTasksCallbacks {
     ) {
         unreachable!()
     }
-    fn on_extract_store_installer(_ctx: &mut Self::Ctx, _task_id: Task::Id) {
+    fn on_extract_store_installer(&mut self, _task_id: Task::Id) {
         unreachable!()
     }
 
-    fn on_resolve(_ctx: &mut Self::Ctx) {
+    fn on_resolve(&mut self) {
         unreachable!()
     }
 
-    /// Reinterpret `&mut Self::Ctx` as `&mut PackageInstaller` — only valid
-    /// when `IS_PACKAGE_INSTALLER` is true. Default body is unreachable; the `PackageInstaller`
-    /// impl overrides it with an identity cast.
-    fn as_package_installer<'a>(_ctx: &'a mut Self::Ctx) -> &'a mut PackageInstaller<'a> {
+    /// Only valid when `flags().is_package_installer`.
+    fn as_package_installer(&mut self) -> &mut PackageInstaller<'a> {
         unreachable!()
     }
 
-    /// Reinterpret `&mut Self::Ctx` as `&mut Store::Installer` — only valid
-    /// when `IS_STORE_INSTALLER` is true. Default body is unreachable; the `Store::Installer`
-    /// impl overrides it with an identity cast.
-    fn as_store_installer<'a>(_ctx: &'a mut Self::Ctx) -> &'a mut Store::Installer<'a> {
+    /// Only valid when `flags().is_store_installer`.
+    fn as_store_installer(&mut self) -> &mut Store::Installer<'a> {
         unreachable!()
     }
 }
 
 /// Called from isolated_install on the main thread.
-pub fn run_tasks<C: RunTasksCallbacks>(
+#[inline(never)]
+pub fn run_tasks(
     manager: &mut PackageManager,
-    extract_ctx: &mut C::Ctx,
+    extract_ctx: &mut dyn RunTasksCallbacks<'_>,
     install_peer: bool,
     log_level: Options::LogLevel,
 ) -> crate::Result<()> {
+    let flags = extract_ctx.flags();
     // `Cell<bool>` so the `scopeguard::defer!` below can read it via `&self`
     // while the loop body sets it — no raw-ptr provenance dance needed.
     let has_updated_this_run = Cell::new(false);
@@ -159,7 +148,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
     // use of `manager`/`extract_ctx` below is a child of `*_ptr`, so the
     // pointers stay valid until the guards fire.
     let manager_ptr: *mut PackageManager = manager;
-    let extract_ctx_ptr: *mut C::Ctx = extract_ctx;
+    let extract_ctx_ptr: *mut dyn RunTasksCallbacks<'_> = extract_ctx;
     // SAFETY: `manager_ptr`/`extract_ctx_ptr` were just derived from unique
     // `&mut` fn params; reborrowing here yields the sole live `&mut` to each
     // for the body. Dropped before the guards reborrow the same pointers.
@@ -174,7 +163,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
         if log_level.show_progress() {
             manager.start_progress_bar_if_none();
 
-            if C::PROGRESS_BAR {
+            if flags.progress_bar {
                 let completed_items = (manager.total_tasks - manager.pending_task_count()) as usize;
                 // SAFETY: `downloads_node` set by `start_progress_bar_if_none`;
                 // points into `manager.progress` which is live.
@@ -209,14 +198,14 @@ pub fn run_tasks<C: RunTasksCallbacks>(
         ptask.run_from_main_thread(manager, log_level)?;
         if let PatchTaskCallback::Apply(apply) = &mut ptask.callback {
             if apply.logger.errors == 0 {
-                if C::HAS_ON_EXTRACT {
+                if flags.has_on_extract {
                     if let Some(_task_id) = apply.task_id {
                         // autofix
-                    } else if C::IS_PACKAGE_INSTALLER {
+                    } else if flags.is_package_installer {
                         if let Some(ctx) = apply.install_context.as_mut() {
                             // `extract_ctx` *is* the installer here.
                             let installer: &mut PackageInstaller =
-                                C::as_package_installer(extract_ctx);
+                                extract_ctx.as_package_installer();
                             let path = core::mem::take(&mut ctx.path);
                             installer.node_modules.path = path;
                             installer.current_tree_id = ctx.tree_id;
@@ -224,7 +213,9 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             let resolution =
                                 &manager.lockfile.packages.items_resolution()[pkg_id as usize];
 
-                            installer.install_package_with_name_and_resolution::<false, false>(
+                            installer.install_package_with_name_and_resolution(
+                                false,
+                                false,
                                 ctx.dependency_id,
                                 pkg_id,
                                 log_level,
@@ -241,13 +232,13 @@ pub fn run_tasks<C: RunTasksCallbacks>(
         }
     }
 
-    if C::IS_STORE_INSTALLER {
+    if flags.is_store_installer {
         // We obtain the
         // installer via the trait downcast and access PackageManager only
         // through `installer.manager` for the duration of this block, never
         // via the function-scope `manager` shadow, so the two `&mut` do not
         // overlap in use.
-        let installer: &mut Store::Installer<'_> = C::as_store_installer(extract_ctx);
+        let installer: &mut Store::Installer<'_> = extract_ctx.as_store_installer();
         let installer_ptr: *mut Store::Installer<'_> = installer;
         let batch = installer.task_queue.pop_batch();
         let mut iter = batch.iterator();
@@ -421,8 +412,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         .map(crate::Error::from)
                         .unwrap_or(crate::Error::HTTPError);
 
-                    if C::HAS_ON_PACKAGE_MANIFEST_ERROR {
-                        C::on_package_manifest_error(extract_ctx, name, err, &task.url_buf);
+                    if flags.has_on_package_manifest_error {
+                        extract_ctx.on_package_manifest_error(name, err, &task.url_buf);
                     } else {
                         let fmt_args = (err.name(), name);
                         if manager.is_network_task_required(task.task_id) {
@@ -462,7 +453,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 let response = &metadata.response;
 
                 if response.status_code > 399 {
-                    if C::HAS_ON_PACKAGE_MANIFEST_ERROR {
+                    if flags.has_on_package_manifest_error {
                         let err: PackageManifestError = match response.status_code {
                             400 => PackageManifestError::PackageManifestHTTP400,
                             401 => PackageManifestError::PackageManifestHTTP401,
@@ -473,7 +464,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             _ => PackageManifestError::PackageManifestHTTP5xx,
                         };
 
-                        C::on_package_manifest_error(extract_ctx, name, err.into(), &task.url_buf);
+                        extract_ctx.on_package_manifest_error(name, err.into(), &task.url_buf);
 
                         continue;
                     }
@@ -575,7 +566,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             );
                         }
 
-                        if C::MANIFESTS_ONLY {
+                        if flags.manifests_only {
                             continue;
                         }
 
@@ -586,7 +577,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
 
                         let dependency_list = core::mem::take(dependency_list_entry);
 
-                        process_dependency_list_for_ctx::<C>(
+                        process_dependency_list_for_ctx(
                             manager,
                             dependency_list,
                             extract_ctx,
@@ -714,10 +705,9 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let is_required = manager.is_network_task_required(task.task_id);
                     manager.mark_network_task_failed(task.task_id);
 
-                    if C::HAS_ON_PACKAGE_DOWNLOAD_ERROR {
-                        if C::IS_STORE_INSTALLER {
-                            C::on_package_download_error_store(
-                                extract_ctx,
+                    if flags.has_on_package_download_error {
+                        if flags.is_store_installer {
+                            extract_ctx.on_package_download_error_store(
                                 task.task_id,
                                 extract.name.slice(),
                                 &extract.resolution,
@@ -727,8 +717,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         } else {
                             let package_id = manager.lockfile.buffers.resolutions
                                 [extract.dependency_id as usize];
-                            C::on_package_download_error_pkg(
-                                extract_ctx,
+                            extract_ctx.on_package_download_error_pkg(
                                 package_id,
                                 extract.name.slice(),
                                 &extract.resolution,
@@ -793,7 +782,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let is_required = manager.is_network_task_required(task.task_id);
                     manager.mark_network_task_failed(task.task_id);
 
-                    if C::HAS_ON_PACKAGE_DOWNLOAD_ERROR {
+                    if flags.has_on_package_download_error {
                         let err = match response.status_code {
                             400 => crate::Error::TarballHTTP400,
                             401 => crate::Error::TarballHTTP401,
@@ -804,9 +793,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             _ => crate::Error::TarballHTTP5xx,
                         };
 
-                        if C::IS_STORE_INSTALLER {
-                            C::on_package_download_error_store(
-                                extract_ctx,
+                        if flags.is_store_installer {
+                            extract_ctx.on_package_download_error_store(
                                 task.task_id,
                                 extract.name.slice(),
                                 &extract.resolution,
@@ -816,8 +804,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         } else {
                             let package_id = manager.lockfile.buffers.resolutions
                                 [extract.dependency_id as usize];
-                            C::on_package_download_error_pkg(
-                                extract_ctx,
+                            extract_ctx.on_package_download_error_pkg(
                                 package_id,
                                 extract.name.slice(),
                                 &extract.resolution,
@@ -968,8 +955,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let name = req.name.slice();
                     let err = task.err.unwrap_or(crate::Error::Failed);
 
-                    if C::HAS_ON_PACKAGE_MANIFEST_ERROR {
-                        C::on_package_manifest_error(extract_ctx, name, err, &req.network.url_buf);
+                    if flags.has_on_package_manifest_error {
+                        extract_ctx.on_package_manifest_error(name, err, &req.network.url_buf);
                     } else {
                         bun_ast::add_error_pretty!(
                             manager.log_mut(),
@@ -992,14 +979,14 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     m
                 };
                 let name_hash = manifest.pkg.name.hash;
-                let progress_name: Option<Vec<u8>> = (!C::MANIFESTS_ONLY
+                let progress_name: Option<Vec<u8>> = (!flags.manifests_only
                     && log_level.show_progress()
                     && !has_updated_this_run.get())
                 .then(|| manifest.name().to_vec());
 
                 manager.manifests.insert(name_hash, manifest)?;
 
-                if C::MANIFESTS_ONLY {
+                if flags.manifests_only {
                     continue;
                 }
 
@@ -1009,7 +996,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     .expect("infallible: task queued");
                 let dependency_list = core::mem::take(dependency_list_entry);
 
-                process_dependency_list_for_ctx::<C>(
+                process_dependency_list_for_ctx(
                     manager,
                     dependency_list,
                     extract_ctx,
@@ -1078,7 +1065,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     // `local_tarball` tasks (they never populate the map).
                     manager.mark_network_task_failed(task.id);
 
-                    if C::HAS_ON_PACKAGE_DOWNLOAD_ERROR {
+                    if flags.has_on_package_download_error {
                         // SAFETY: `task.tag` selects the active `task.request` union arm.
                         let fail_url: &[u8] = unsafe {
                             match task.tag {
@@ -1089,23 +1076,13 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                 _ => unreachable!(),
                             }
                         };
-                        if C::IS_STORE_INSTALLER {
-                            C::on_package_download_error_store(
-                                extract_ctx,
-                                task.id,
-                                alias,
-                                resolution,
-                                err,
-                                fail_url,
+                        if flags.is_store_installer {
+                            extract_ctx.on_package_download_error_store(
+                                task.id, alias, resolution, err, fail_url,
                             );
                         } else {
-                            C::on_package_download_error_pkg(
-                                extract_ctx,
-                                package_id,
-                                alias,
-                                resolution,
-                                err,
-                                fail_url,
+                            extract_ctx.on_package_download_error_pkg(
+                                package_id, alias, resolution, err, fail_url,
                             );
                         }
                         continue;
@@ -1133,11 +1110,12 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 manager.extracted_count += 1;
                 bun_core::analytics::Features::extracted_packages_inc();
 
-                if C::HAS_ON_EXTRACT {
-                    if C::IS_PACKAGE_INSTALLER {
-                        C::as_package_installer(extract_ctx).fix_cached_lockfile_package_slices();
-                        C::on_extract_package_installer(
-                            extract_ctx,
+                if flags.has_on_extract {
+                    if flags.is_package_installer {
+                        extract_ctx
+                            .as_package_installer()
+                            .fix_cached_lockfile_package_slices();
+                        extract_ctx.on_extract_package_installer(
                             task.id,
                             dependency_id,
                             // SAFETY: `task.tag` is Extract/LocalTarball — `data.extract`
@@ -1145,8 +1123,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             unsafe { &mut task.data.extract },
                             log_level,
                         );
-                    } else if C::IS_STORE_INSTALLER {
-                        C::on_extract_store_installer(extract_ctx, task.id);
+                    } else if flags.is_store_installer {
+                        extract_ctx.on_extract_store_installer(task.id);
                     } else {
                         unreachable!("unexpected context type");
                     }
@@ -1176,10 +1154,10 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         };
 
                         scopeguard::defer! {
-                            if C::HAS_ON_RESOLVE && any_root.get() {
+                            if flags.has_on_resolve && any_root.get() {
                                 // SAFETY: `extract_ctx_ptr` is the function-scope provenance
                                 // root for `extract_ctx`; the body shadow is dead at guard time.
-                                C::on_resolve(unsafe { &mut *extract_ctx_ptr });
+                                unsafe { &mut *extract_ctx_ptr }.on_resolve();
                             }
                         };
 
@@ -1258,9 +1236,9 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 if task.status == Task::Status::Fail {
                     let err = task.err.unwrap_or(crate::Error::Failed);
 
-                    if C::HAS_ON_PACKAGE_MANIFEST_ERROR {
-                        C::on_package_manifest_error(extract_ctx, name, err, url);
-                    } else if C::HAS_ON_PACKAGE_DOWNLOAD_ERROR && C::IS_STORE_INSTALLER {
+                    if flags.has_on_package_manifest_error {
+                        extract_ctx.on_package_manifest_error(name, err, url);
+                    } else if flags.has_on_package_download_error && flags.is_store_installer {
                         // The isolated installer queued its entry contexts
                         // under `checkout_id`, not `clone_id`. A failed clone
                         // never reaches checkout, so drain every waiting
@@ -1290,8 +1268,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                                     manager.lockfile.str(&res_git.resolved),
                                 );
                                 drained_any = true;
-                                C::on_package_download_error_store(
-                                    extract_ctx,
+                                extract_ctx.on_package_download_error_store(
                                     checkout_id,
                                     name,
                                     res,
@@ -1311,8 +1288,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             let resolved = &clone.res.git().resolved;
                             let checkout_id =
                                 Task::Id::for_git_checkout(url, manager.lockfile.str(resolved));
-                            C::on_package_download_error_store(
-                                extract_ctx,
+                            extract_ctx.on_package_download_error_store(
                                 checkout_id,
                                 name,
                                 &clone.res,
@@ -1335,7 +1311,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
 
                 manager.git_repositories.insert(task.id, repo_fd);
 
-                if C::HAS_ON_EXTRACT && C::IS_PACKAGE_INSTALLER {
+                if flags.has_on_extract && flags.is_package_installer {
                     // Installing! The clone task is shared by every dependency on
                     // this repo URL; enqueue a checkout per waiter, not just one.
                     let Some(waiters) = manager.task_queue.remove(&task.id) else {
@@ -1401,7 +1377,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         .remove(&task.id)
                         .expect("infallible: task queued");
 
-                    process_dependency_list_for_ctx::<C>(
+                    process_dependency_list_for_ctx(
                         manager,
                         dependency_list,
                         extract_ctx,
@@ -1430,13 +1406,12 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 if task.status == Task::Status::Fail {
                     let err = task.err.unwrap_or(crate::Error::Failed);
 
-                    if C::HAS_ON_PACKAGE_DOWNLOAD_ERROR && C::IS_STORE_INSTALLER {
+                    if flags.has_on_package_download_error && flags.is_store_installer {
                         // SAFETY: `resolution.tag == Git` — git-checkout tasks are
                         // only enqueued for git resolutions; `value.git` is the
                         // active union arm.
                         let repo = &resolution.git().repo;
-                        C::on_package_download_error_store(
-                            extract_ctx,
+                        extract_ctx.on_package_download_error_store(
                             task.id,
                             alias.slice(),
                             resolution,
@@ -1457,16 +1432,17 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     continue;
                 }
 
-                if C::HAS_ON_EXTRACT {
+                if flags.has_on_extract {
                     // We've populated the cache, package already exists in memory. Call the package installer callback
                     // and don't enqueue dependencies
-                    if C::IS_PACKAGE_INSTALLER {
+                    if flags.is_package_installer {
                         // TODO(dylan-conway) most likely don't need to call this now that the package isn't appended, but
                         // keeping just in case for now
-                        C::as_package_installer(extract_ctx).fix_cached_lockfile_package_slices();
+                        extract_ctx
+                            .as_package_installer()
+                            .fix_cached_lockfile_package_slices();
 
-                        C::on_extract_package_installer(
-                            extract_ctx,
+                        extract_ctx.on_extract_package_installer(
                             task.id,
                             git_checkout.dependency_id,
                             // SAFETY: `task.tag == GitCheckout` — `data.git_checkout`
@@ -1474,8 +1450,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                             unsafe { &mut task.data.git_checkout },
                             log_level,
                         );
-                    } else if C::IS_STORE_INSTALLER {
-                        C::on_extract_store_installer(extract_ctx, task.id);
+                    } else if flags.is_store_installer {
+                        extract_ctx.on_extract_store_installer(task.id);
                     } else {
                         unreachable!("unexpected context type");
                     }
@@ -1502,10 +1478,10 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         };
 
                         scopeguard::defer! {
-                            if C::HAS_ON_RESOLVE && any_root.get() {
+                            if flags.has_on_resolve && any_root.get() {
                                 // SAFETY: `extract_ctx_ptr` is the function-scope provenance
                                 // root for `extract_ctx`; the body shadow is dead at guard time.
-                                C::on_resolve(unsafe { &mut *extract_ctx_ptr });
+                                unsafe { &mut *extract_ctx_ptr }.on_resolve();
                             }
                         };
 
@@ -1540,7 +1516,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                         }
 
                         // Invariant: this branch only reachable when !HAS_ON_EXTRACT.
-                        debug_assert!(!C::HAS_ON_EXTRACT, "ctx should be void");
+                        debug_assert!(!flags.has_on_extract, "ctx should be void");
                     }
                 }
 
@@ -1956,21 +1932,21 @@ impl PackageManager {
 /// Adapter wrapping the existing `PackageManager::process_dependency_list` so
 /// it can be driven by a `RunTasksCallbacks` impl, dispatching `on_resolve`
 /// if any root dep changed.
-fn process_dependency_list_for_ctx<C: RunTasksCallbacks>(
+fn process_dependency_list_for_ctx(
     manager: &mut PackageManager,
     dependency_list: TaskCallbackList,
-    extract_ctx: &mut C::Ctx,
+    extract_ctx: &mut dyn RunTasksCallbacks<'_>,
     install_peer: bool,
 ) -> crate::Result<()> {
-    let ctx_ptr: *mut C::Ctx = extract_ctx;
+    let ctx_ptr: *mut dyn RunTasksCallbacks<'_> = extract_ctx;
     manager.process_dependency_list(
         dependency_list,
         (),
-        if C::HAS_ON_RESOLVE {
+        if extract_ctx.flags().has_on_resolve {
             Some(move |()| {
                 // SAFETY: `ctx_ptr` derived from a unique `&mut` that outlives
                 // this closure; `process_dependency_list` does not alias it.
-                C::on_resolve(unsafe { &mut *ctx_ptr });
+                unsafe { &mut *ctx_ptr }.on_resolve();
             })
         } else {
             None

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -42,9 +42,10 @@ use crate::isolated_install::store as Store;
 // ──────────────────────────────────────────────────────────────────────────
 //
 // Dyn-compatible so `run_tasks` is compiled once: the impls are the ctx
-// types themselves (`PackageInstaller`, `Store::Installer`, `Queue`) or unit
-// markers, and `flags()` says which optional hooks are live. Hook defaults
-// are unreachable and only called when the matching flag is set.
+// types themselves (`PackageInstaller`, `Store::Installer`), a wrapper around
+// the auto-install `Queue`, or unit markers, and `flags()` says which optional
+// hooks are live. Hook defaults are unreachable and only called when the
+// matching flag is set.
 
 #[derive(Clone, Copy, Default)]
 pub struct RunTasksFlags {
@@ -1515,7 +1516,6 @@ pub fn run_tasks(
                             }
                         }
 
-                        // Invariant: this branch only reachable when !HAS_ON_EXTRACT.
                         debug_assert!(!flags.has_on_extract, "ctx should be void");
                     }
                 }
@@ -1938,19 +1938,9 @@ fn process_dependency_list_for_ctx(
     extract_ctx: &mut dyn RunTasksCallbacks<'_>,
     install_peer: bool,
 ) -> crate::Result<()> {
-    let ctx_ptr: *mut dyn RunTasksCallbacks<'_> = extract_ctx;
-    manager.process_dependency_list(
-        dependency_list,
-        (),
-        if extract_ctx.flags().has_on_resolve {
-            Some(move |()| {
-                // SAFETY: `ctx_ptr` derived from a unique `&mut` that outlives
-                // this closure; `process_dependency_list` does not alias it.
-                unsafe { &mut *ctx_ptr }.on_resolve();
-            })
-        } else {
-            None
-        },
-        install_peer,
-    )
+    let on_resolve = extract_ctx
+        .flags()
+        .has_on_resolve
+        .then_some(|ctx: &mut dyn RunTasksCallbacks<'_>| ctx.on_resolve());
+    manager.process_dependency_list(dependency_list, extract_ctx, on_resolve, install_peer)
 }

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -215,8 +215,8 @@ pub fn run_tasks(
                                 &manager.lockfile.packages.items_resolution()[pkg_id as usize];
 
                             installer.install_package_with_name_and_resolution(
-                                false,
-                                false,
+                                /* needs_verify */ false,
+                                /* is_pending_package_install */ false,
                                 ctx.dependency_id,
                                 pkg_id,
                                 log_level,

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -26,32 +26,27 @@ use crate::package_manager_real::ProgressStrings;
 use crate::package_manager_real::run_tasks;
 use crate::package_manager_task as Task;
 
-/// `RunTasksCallbacks` impl for the hoisted-install loop, with
-/// `Ctx == PackageInstaller`.
-pub(crate) struct HoistedRunTasksCallbacks<'a>(core::marker::PhantomData<&'a mut ()>);
-
-impl<'a> run_tasks::RunTasksCallbacks for HoistedRunTasksCallbacks<'a> {
-    type Ctx = PackageInstaller<'a>;
-
-    const HAS_ON_EXTRACT: bool = true;
-    const IS_PACKAGE_INSTALLER: bool = true;
+impl<'a> run_tasks::RunTasksCallbacks<'a> for PackageInstaller<'a> {
+    fn flags(&self) -> run_tasks::RunTasksFlags {
+        run_tasks::RunTasksFlags {
+            has_on_extract: true,
+            is_package_installer: true,
+            ..Default::default()
+        }
+    }
 
     fn on_extract_package_installer(
-        ctx: &mut Self::Ctx,
+        &mut self,
         task_id: Task::Id,
         dependency_id: DependencyID,
         data: &mut ExtractData,
         log_level: package_manager::Options::LogLevel,
     ) {
-        ctx.install_enqueued_packages_after_extraction(task_id, dependency_id, &*data, log_level);
+        self.install_enqueued_packages_after_extraction(task_id, dependency_id, &*data, log_level);
     }
 
-    fn as_package_installer<'x>(ctx: &'x mut Self::Ctx) -> &'x mut PackageInstaller<'x> {
-        // SAFETY: identity cast — narrows the invariant `'a` param to the
-        // borrow-local `'x` (`'a: 'x` is implied by `&'x mut PackageInstaller<'a>`).
-        // The returned reference cannot outlive `'x`, so all inner `'a` borrows
-        // remain valid. Inner-lifetime variance cast via raw pointer.
-        unsafe { &mut *core::ptr::from_mut(ctx).cast::<PackageInstaller<'x>>() }
+    fn as_package_installer(&mut self) -> &mut PackageInstaller<'a> {
+        self
     }
 }
 
@@ -451,12 +446,7 @@ pub(crate) fn install_hoisted_packages(
                 // We want to minimize how often we call this function
                 // That's part of why we unroll this loop
                 if this.pending_task_count() > 0 {
-                    run_tasks::run_tasks::<HoistedRunTasksCallbacks>(
-                        this,
-                        &mut installer,
-                        true,
-                        log_level,
-                    )?;
+                    run_tasks::run_tasks(this, &mut installer, true, log_level)?;
                     if !this.options.do_.install_packages() {
                         return Err(crate::Error::InstallFailed);
                     }
@@ -469,12 +459,7 @@ pub(crate) fn install_hoisted_packages(
                 installer.install_package(*dependency_id, log_level);
             }
 
-            run_tasks::run_tasks::<HoistedRunTasksCallbacks>(
-                this,
-                &mut installer,
-                true,
-                log_level,
-            )?;
+            run_tasks::run_tasks(this, &mut installer, true, log_level)?;
             if !this.options.do_.install_packages() {
                 return Err(crate::Error::InstallFailed);
             }
@@ -499,12 +484,9 @@ pub(crate) fn install_hoisted_packages(
                     // this callback, so this is the unique live borrow.
                     let manager = unsafe { &mut *closure.manager };
                     let log_level = manager.options.log_level;
-                    if let Err(err) = run_tasks::run_tasks::<HoistedRunTasksCallbacks>(
-                        manager,
-                        closure.installer,
-                        true,
-                        log_level,
-                    ) {
+                    if let Err(err) =
+                        run_tasks::run_tasks(manager, closure.installer, true, log_level)
+                    {
                         closure.err = Some(err);
                     }
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -133,38 +133,33 @@ impl<'a> std::io::Write for WyhashWriter<'a> {
     }
 }
 
-/// `RunTasksCallbacks` impl for the isolated-install loop, with
-/// `Ctx == store::Installer`.
-pub(crate) struct StoreRunTasksCallbacks<'a>(core::marker::PhantomData<&'a mut ()>);
+impl<'a> run_tasks::RunTasksCallbacks<'a> for store::Installer<'a> {
+    fn flags(&self) -> run_tasks::RunTasksFlags {
+        run_tasks::RunTasksFlags {
+            has_on_extract: true,
+            has_on_package_download_error: true,
+            is_store_installer: true,
+            ..Default::default()
+        }
+    }
 
-impl<'a> run_tasks::RunTasksCallbacks for StoreRunTasksCallbacks<'a> {
-    type Ctx = store::Installer<'a>;
-
-    const HAS_ON_EXTRACT: bool = true;
-    const HAS_ON_PACKAGE_DOWNLOAD_ERROR: bool = true;
-    const IS_STORE_INSTALLER: bool = true;
-
-    fn on_extract_store_installer(ctx: &mut Self::Ctx, task_id: Task::Id) {
-        ctx.on_package_extracted(task_id);
+    fn on_extract_store_installer(&mut self, task_id: Task::Id) {
+        self.on_package_extracted(task_id);
     }
 
     fn on_package_download_error_store(
-        ctx: &mut Self::Ctx,
+        &mut self,
         id: Task::Id,
         name: &[u8],
         resolution: &Resolution,
         err: crate::Error,
         url: &[u8],
     ) {
-        ctx.on_package_download_error(id, name, resolution, err, url);
+        self.on_package_download_error(id, name, resolution, err, url);
     }
 
-    fn as_store_installer<'x>(ctx: &'x mut Self::Ctx) -> &'x mut store::Installer<'x> {
-        // SAFETY: identity cast — narrows the invariant `'a` param to the
-        // borrow-local `'x` (`'a: 'x` is implied by `&'x mut Installer<'a>`).
-        // The returned reference cannot outlive `'x`, so all inner `'a`
-        // borrows remain valid. Inner-lifetime variance cast via raw pointer.
-        unsafe { &mut *core::ptr::from_mut(ctx).cast::<store::Installer<'x>>() }
+    fn as_store_installer(&mut self) -> &mut store::Installer<'a> {
+        self
     }
 }
 
@@ -182,12 +177,7 @@ impl<'a, 'b> Wait<'a, 'b> {
         let log_level = pkg_manager.options.log_level;
         // `run_tasks` must not call `installer.manager_mut()` — `pkg_manager`
         // is the live `&mut PackageManager` for this call.
-        if let Err(err) = run_tasks::run_tasks::<StoreRunTasksCallbacks>(
-            pkg_manager,
-            self.installer,
-            true,
-            log_level,
-        ) {
+        if let Err(err) = run_tasks::run_tasks(pkg_manager, self.installer, true, log_level) {
             self.err = Some(err);
             return true;
         }

--- a/src/jsc/AsyncModule.rs
+++ b/src/jsc/AsyncModule.rs
@@ -273,40 +273,41 @@ use crate::event_loop::{ConcurrentTaskItem, Task};
 
 /// `RunTasksCallbacks` impl for the auto-install module queue. `onResolve` /
 /// `onPackageManifestError` / `onPackageDownloadError` forward to the `Queue`
-/// methods, `progress_bar` selected via const generic to match the
-/// `enable_ansi_colors_stderr` branch.
-struct QueueRunTasksCallbacks<const PROGRESS: bool>;
+/// methods; `progress` matches the `enable_ansi_colors_stderr` branch.
+struct QueueRunTasksCallbacks<'a> {
+    queue: &'a mut Queue,
+    progress: bool,
+}
 
-impl<const PROGRESS: bool> run_tasks::RunTasksCallbacks for QueueRunTasksCallbacks<PROGRESS> {
-    type Ctx = Queue;
-
-    const PROGRESS_BAR: bool = PROGRESS;
-    const HAS_ON_PACKAGE_MANIFEST_ERROR: bool = true;
-    const HAS_ON_PACKAGE_DOWNLOAD_ERROR: bool = true;
-    const HAS_ON_RESOLVE: bool = true;
-
-    fn on_resolve(ctx: &mut Queue) {
-        Queue::on_resolve(ctx)
+impl run_tasks::RunTasksCallbacks<'_> for QueueRunTasksCallbacks<'_> {
+    fn flags(&self) -> run_tasks::RunTasksFlags {
+        run_tasks::RunTasksFlags {
+            progress_bar: self.progress,
+            has_on_package_manifest_error: true,
+            has_on_package_download_error: true,
+            has_on_resolve: true,
+            ..Default::default()
+        }
     }
 
-    fn on_package_manifest_error(
-        ctx: &mut Queue,
-        name: &[u8],
-        err: bun_install::Error,
-        url: &[u8],
-    ) {
-        ctx.on_package_manifest_error(name, err.name(), url)
+    fn on_resolve(&mut self) {
+        Queue::on_resolve(self.queue)
+    }
+
+    fn on_package_manifest_error(&mut self, name: &[u8], err: bun_install::Error, url: &[u8]) {
+        self.queue.on_package_manifest_error(name, err.name(), url)
     }
 
     fn on_package_download_error_pkg(
-        ctx: &mut Queue,
+        &mut self,
         package_id: PackageID,
         name: &[u8],
         resolution: &Resolution,
         err: bun_install::Error,
         url: &[u8],
     ) {
-        ctx.on_package_download_error(package_id, name, resolution, err.name(), url)
+        self.queue
+            .on_package_download_error(package_id, name, resolution, err.name(), url)
     }
 }
 
@@ -415,19 +416,23 @@ impl Queue {
         // `container_of`-derived `*mut` reborrow.
         let pm = VirtualMachine::get().as_mut().package_manager();
 
-        if bun_core::output::enable_ansi_colors_stderr() {
+        let progress = bun_core::output::enable_ansi_colors_stderr();
+        let log_level = if progress {
             pm.start_progress_bar_if_none();
-            run_tasks::run_tasks::<QueueRunTasksCallbacks<true>>(pm, self, true, LogLevel::Default)
-                .expect("unreachable");
+            LogLevel::Default
         } else {
-            run_tasks::run_tasks::<QueueRunTasksCallbacks<false>>(
-                pm,
-                self,
-                true,
-                LogLevel::DefaultNoProgress,
-            )
-            .expect("unreachable");
-        }
+            LogLevel::DefaultNoProgress
+        };
+        run_tasks::run_tasks(
+            pm,
+            &mut QueueRunTasksCallbacks {
+                queue: self,
+                progress,
+            },
+            true,
+            log_level,
+        )
+        .expect("unreachable");
     }
 
     pub(crate) fn on_package_manifest_error(&mut self, name: &[u8], err: &'static str, url: &[u8]) {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -2105,6 +2105,67 @@ test("tarball URL with query string resolves at runtime", async () => {
   expect(exitCode).toBe(0);
 });
 
+// With a lockfile present, the store installer itself downloads the tarballs
+// missing from the cache. A failed download reaches it through
+// `on_package_download_error` (src/install/isolated_install/Installer.rs),
+// which fails the store entries waiting on that tarball; without it the
+// pending task count never reaches zero. A download that fails during
+// resolution (no lockfile yet) is reported as `GET <url> - 404` by the package
+// manager's log instead, which is why the first install below has to succeed.
+test("tarball download failure is reported by the store installer", async () => {
+  const tarball = file(join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz"));
+  let serveTarball = true;
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (pathname === "/no-deps") {
+        return Response.json({
+          "name": "no-deps",
+          "dist-tags": { latest: "1.0.0" },
+          "versions": {
+            "1.0.0": {
+              name: "no-deps",
+              version: "1.0.0",
+              dist: { tarball: `http://localhost:${server.port}/no-deps/-/no-deps-1.0.0.tgz` },
+            },
+          },
+        });
+      }
+      if (pathname === "/no-deps/-/no-deps-1.0.0.tgz" && serveTarball) {
+        return new Response(tarball, { headers: { "Content-Type": "application/octet-stream" } });
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  using packageDir = tempDir("isolated-tarball-404-", {
+    "bunfig.toml": `[install]\nlinker = "isolated"\nregistry = "http://localhost:${server.port}/"\n`,
+    "package.json": JSON.stringify({
+      name: "test-tarball-404",
+      dependencies: {
+        "no-deps": "1.0.0",
+      },
+    }),
+  });
+  const cacheDir = join(String(packageDir), ".bun-cache");
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir };
+
+  await runBunInstall(env, String(packageDir));
+
+  serveTarball = false;
+  await rm(cacheDir, { recursive: true, force: true });
+  await rm(join(String(packageDir), "node_modules"), { recursive: true, force: true });
+
+  const { err } = await runBunInstall(env, String(packageDir), {
+    allowErrors: true,
+    expectedExitCode: 1,
+    savesLockfile: false,
+  });
+  expect(err).toContain("failed to download no-deps@1.0.0: 404 Not Found");
+  expect(err).toContain(`http://localhost:${server.port}/no-deps/-/no-deps-1.0.0.tgz`);
+});
+
 // The resolution part of a store entry name (`<name>@<resolution>`) embeds
 // folder paths, tarball URLs and git URLs verbatim. `write_resolution` in
 // src/install/isolated_install/Store.rs bounds it: a resolution longer than


### PR DESCRIPTION
bun install's run_tasks loop is generic over a callbacks trait, so the whole 20 KB task-drain body was compiled once per caller: 5 copies in bun_install and 2 in bun_jsc, and install_package_with_name_and_resolution was further stamped per pair of const bool flags. The bodies are the same code with different callback targets.

The loop now takes the callbacks as a `&mut dyn` object and the two verify flags are plain arguments, so one body exists. Pre-LTO the rlib text drops by about 105 KB (run_tasks −108 KB and the flag pairs −44 KB, minus the shared bodies). The dyn calls sit at the per-task boundary (one per finished network or extract task), not inside any per-byte or per-file loop; the extract and manifest paths themselves are unchanged.

Behavior is unchanged. bun-install, bun-add, streaming-extract, tarball-integrity and the workspace tests pass on the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->