### PR TITLE
share one body across error text helpers

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -550,32 +550,55 @@ impl JSGlobalObject {
     /// "The {argname} argument must be of type {typename}. Received {value}"
     ///
     /// Accepts `&str`, `&[u8]`, or `b"..."` for `argname`/`typename`.
+    #[inline]
     pub fn throw_invalid_argument_type_value(
         &self,
         argname: impl AsRef<[u8]>,
         typename: impl AsRef<[u8]>,
         value: JSValue,
     ) -> JsError {
-        let actual_string_value = match Self::determine_specific_type(self, value) {
-            Ok(s) => s,
-            Err(e) => return e,
-        };
-        self.err(
-            JscError::INVALID_ARG_TYPE,
-            format_args!(
-                "The \"{}\" argument must be of type {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
-                bstr::BStr::new(typename.as_ref()),
-                actual_string_value
-            ),
+        self.throw_invalid_argument_type_value_impl(
+            argname.as_ref(),
+            "of type ",
+            typename.as_ref(),
+            value,
         )
-        .throw()
     }
 
+    /// "The {argname} argument must be {typename}. Received {value}"
+    #[inline]
     pub fn throw_invalid_argument_type_value2(
         &self,
         argname: impl AsRef<[u8]>,
         typename: impl AsRef<[u8]>,
+        value: JSValue,
+    ) -> JsError {
+        self.throw_invalid_argument_type_value_impl(argname.as_ref(), "", typename.as_ref(), value)
+    }
+
+    /// "The <argname> argument must be one of type <typename>. Received <value>"
+    #[inline]
+    pub fn throw_invalid_argument_type_value_one_of(
+        &self,
+        argname: impl AsRef<[u8]>,
+        typename: impl AsRef<[u8]>,
+        value: JSValue,
+    ) -> JsError {
+        self.throw_invalid_argument_type_value_impl(
+            argname.as_ref(),
+            "one of type ",
+            typename.as_ref(),
+            value,
+        )
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn throw_invalid_argument_type_value_impl(
+        &self,
+        argname: &[u8],
+        of_type: &str,
+        typename: &[u8],
         value: JSValue,
     ) -> JsError {
         let actual_string_value = match Self::determine_specific_type(self, value) {
@@ -585,9 +608,10 @@ impl JSGlobalObject {
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(
-                "The \"{}\" argument must be {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
-                bstr::BStr::new(typename.as_ref()),
+                "The \"{}\" argument must be {}{}. Received {}",
+                bstr::BStr::new(argname),
+                of_type,
+                bstr::BStr::new(typename),
                 actual_string_value
             ),
         )
@@ -597,9 +621,11 @@ impl JSGlobalObject {
     /// `validators.throwErrInvalidArgType` —
     /// `The "<name>" property must be of type <expected>, got <actual>`
     /// where `<actual>` is the JS `typeof` (or `"array"` for arrays).
+    #[cold]
+    #[inline(never)]
     pub(crate) fn throw_invalid_property_type(
         &self,
-        name: impl AsRef<[u8]>,
+        name: &[u8],
         expected_type: &str,
         value: JSValue,
     ) -> JsError {
@@ -608,32 +634,9 @@ impl JSGlobalObject {
             JscError::INVALID_ARG_TYPE,
             format_args!(
                 "The \"{}\" property must be of type {}, got {}",
-                bstr::BStr::new(name.as_ref()),
+                bstr::BStr::new(name),
                 expected_type,
                 actual_type,
-            ),
-        )
-        .throw()
-    }
-
-    /// "The <argname> argument must be one of type <typename>. Received <value>"
-    pub fn throw_invalid_argument_type_value_one_of(
-        &self,
-        argname: impl AsRef<[u8]>,
-        typename: impl AsRef<[u8]>,
-        value: JSValue,
-    ) -> JsError {
-        let actual_string_value = match Self::determine_specific_type(self, value) {
-            Ok(s) => s,
-            Err(e) => return e,
-        };
-        self.err(
-            JscError::INVALID_ARG_TYPE,
-            format_args!(
-                "The \"{}\" argument must be one of type {}. Received {}",
-                bstr::BStr::new(argname.as_ref()),
-                bstr::BStr::new(typename.as_ref()),
-                actual_string_value
             ),
         )
         .throw()

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1205,12 +1205,21 @@ impl JSValue {
     /// Own/prototype lookup,
     /// `null`/`undefined` → `None`, non-string → `ERR_INVALID_ARG_TYPE`,
     /// otherwise return the UTF-8 slice.
+    #[inline]
     pub fn get_optional_slice(
         self,
         global: &JSGlobalObject,
         property: impl AsRef<[u8]>,
     ) -> JsResult<Option<bun_core::Utf8Bytes<'static>>> {
-        let property = property.as_ref();
+        self.get_optional_slice_impl(global, property.as_ref())
+    }
+
+    #[inline(never)]
+    fn get_optional_slice_impl(
+        self,
+        global: &JSGlobalObject,
+        property: &[u8],
+    ) -> JsResult<Option<bun_core::Utf8Bytes<'static>>> {
         match self.get(global, property)? {
             Some(v) if !v.is_undefined_or_null() => {
                 if !v.is_string() {

--- a/test/js/node/errors/error-code-messages.test.ts
+++ b/test/js/node/errors/error-code-messages.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import child_process from "node:child_process";
+import crypto from "node:crypto";
 import http from "node:http";
 import { Readable } from "node:stream";
 import tls from "node:tls";
@@ -34,4 +36,50 @@ test("table-driven ERR_* codes keep their exact messages", () => {
   expect(capture(() => Readable.prototype._read.call(new Readable()))).toBe(
     "ERR_METHOD_NOT_IMPLEMENTED | Error | The _read() method is not implemented",
   );
+});
+
+// ERR_INVALID_ARG_TYPE messages that the native side formats through one shared body
+// (JSGlobalObject::throw_invalid_argument_type_value* and throw_invalid_property_type).
+// The callers below pass argument names and type names of different lengths, and the
+// three `must be ...` variants differ only in the words inserted before the type name.
+test("native ERR_INVALID_ARG_TYPE variants keep their exact messages", async () => {
+  // "must be of type <type>"
+  expect(capture(() => crypto.pbkdf2Sync("pw", "salt", "x" as any, 16, "sha256"))).toBe(
+    `ERR_INVALID_ARG_TYPE | TypeError | The "iterations" argument must be of type number. Received type string ('x')`,
+  );
+  expect(capture(() => crypto.pbkdf2Sync("pw", "salt", 1, 16, 42 as any))).toBe(
+    `ERR_INVALID_ARG_TYPE | TypeError | The "digest" argument must be of type string. Received type number (42)`,
+  );
+  expect(capture(() => crypto.randomInt(0, 10, "x" as any))).toBe(
+    `ERR_INVALID_ARG_TYPE | TypeError | The "callback" argument must be of type function. Received type string ('x')`,
+  );
+
+  // "must be <description>"
+  expect(capture(() => crypto.randomInt(1.5, 10))).toBe(
+    `ERR_INVALID_ARG_TYPE | TypeError | The "min" argument must be a safe integer. Received type number (1.5)`,
+  );
+  expect(capture(() => crypto.randomInt(0, 2 ** 53))).toBe(
+    `ERR_INVALID_ARG_TYPE | TypeError | The "max" argument must be a safe integer. Received type number (9007199254740992)`,
+  );
+
+  // "must be one of type <types>"
+  await using child = Bun.spawn({
+    cmd: [bunExe(), "-e", "setTimeout(() => {}, 60_000)"],
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "ignore",
+    ipc() {},
+  });
+  expect(capture(() => child.send(Symbol()))).toBe(
+    `ERR_INVALID_ARG_TYPE | TypeError | The "message" argument must be one of type string, object, number, or boolean. Received type symbol (Symbol())`,
+  );
+
+  // Optional string properties read through JSValue::get_optional_slice.
+  expect(capture(() => Bun.CSRF.generate("secret", { sessionId: 1 as any }))).toBe(
+    `ERR_INVALID_ARG_TYPE | TypeError | The "sessionId" property must be of type string, got number`,
+  );
+  expect(capture(() => Bun.CSRF.verify("token", { secret: ["x"] as any }))).toBe(
+    `ERR_INVALID_ARG_TYPE | TypeError | The "secret" property must be of type string, got array`,
+  );
+  expect(capture(() => Bun.CSRF.generate("secret", { sessionId: "abc" }))).toBe("no throw");
 });


### PR DESCRIPTION
Two error-text helpers take `impl AsRef<[u8]>` parameters, so every caller stamps out its own copy of the body: `JSGlobalObject::throw_invalid_argument_type_value` (with its `2` and `_one_of` variants) and `JSValue::get_optional_slice`. The bodies do the same formatting and allocation each time. Only the argument conversion differs.

Each public function now converts its arguments at the boundary and calls one `#[inline(never)]` body. The three `throw_invalid_argument_type_value*` variants share `throw_invalid_argument_type_value_impl`. Each variant passes the words between `must be ` and the type name (`of type `, nothing, `one of type `), so every message stays byte for byte the same. `throw_invalid_property_type` is `pub(crate)` and both callers already pass `&[u8]`, so it now takes `&[u8]` directly. All of these are error paths. The pre-LTO measurement from the first version of this PR attributes about 13 KB of rlib text to these two helpers (`throw_invalid_*` 9 KB, `get_optional_slice` 4 KB).

Rebase notes: the first version of this PR also split `Log::add_error` and `Log::add_range_error_with_notes` in `src/ast/lib.rs`. #39770 landed the same split on main (same shape, same names), so the rebase keeps main's version of that file and this PR no longer touches it. The numbers for that part (tracked range data 15.5 KB, `add_error` 6 KB) now belong to #39770. The second rebase picked up #40374, which changed the return type of `get_optional_slice` from `ZigStringSlice` to `Utf8Bytes<'static>`. The shim and `get_optional_slice_impl` now return that type. The body is main's body, moved as is.

Test: `test/js/node/errors/error-code-messages.test.ts` gets a second block. It pins the exact message of each variant (`of type` through three callers with different name and type lengths, the bare variant, `one of type` through `Subprocess.send`), and the property error and success path of `get_optional_slice` through `Bun.CSRF`. This is a code size refactor with no behavior change, so no test can fail before it: the block passes on main and on this branch by design. It guards the contract of the shared body. A one character change to the format string in `throw_invalid_argument_type_value_impl` makes the block fail.

Also verified on a debug build of the rebased branch: `test/js/bun/util/inspect-error.test.js`, `test/js/bun/util/error-code-mirror.test.ts`, `test/js/web/fetch/wasm-streaming.test.ts`, `test/bundler/cli.test.ts`, and the node scripts `test-crypto-random.js`, `test-fs-mkdir.js` and `test-child-process-fork.js` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/errors/error-code-messages.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/168] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[2/168] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/debug/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[3/168] gen BunObject.lut.h
Generating /workspace/bun/build/debug/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[4/168] gen cpp.rs (cppbind)
[5/168] gen JS modules (bundle-modules)
Preprocess modules (10566ms)
Bundle modules (66ms)
Postprocesss modules (135ms)
Bundle Functions (879ms)
Generate Code (14ms)

[11.68s] Bundled "src/js" for development
  2822 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[5/167] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6e906e468)

test/js/node/errors/error-code-messages.test.ts:
(pass) table-driven ERR_* codes keep their exact messages [2.23ms]
(pass) native ERR_INVALID_ARG_TYPE variants keep their exact messages [2.88ms]

 2 pass
 0 fail
 15 expect() calls
Ran 2 tests across 1 file. [625.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/errors/error-code-messages.test.ts
bun test v1.4.0 (6e906e468)

test/js/node/errors/error-code-messages.test.ts:
(pass) table-driven ERR_* codes keep their exact messages [183.27ms]
(pass) native ERR_INVALID_ARG_TYPE variants keep their exact messages [79.42ms]

 2 pass
 0 fail
 15 expect() calls
Ran 2 tests across 1 file. [4.72s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     3d760bd8dc
  features     baseline

23 deps, 129 codegen, 1172 objects in 943ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] gen ErrorCode+*.h
[2/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [15.00ms]
[3/1244] gen bindgenv2
[4/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [3.00ms]
[5/1244] gen .bind.ts → GeneratedBindings.cpp
[6/1244] fetch zlib
[zlib] up to date
[7/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [11.00ms]
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSGlobalObject.rs                       | 85 +++++++++++++------------
 src/jsc/JSValue.rs                              | 11 +++-
 test/js/node/errors/error-code-messages.test.ts | 48 ++++++++++++++
 3 files changed, 102 insertions(+), 42 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
src/jsc/JSGlobalObject.rs                            1      0      0
src/jsc/JSValue.rs                                   1      0      0
test/js/node/errors/error-code-messages.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->

