### PR TITLE
share the constructor-called-without-new throw across generated classes

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -455,7 +455,7 @@ class ${proto} ${final ? "final" : ""} : public JSC::JSNonFinalObject {
 `;
 }
 
-function generateConstructorHeader(typeName) {
+function generateConstructorHeader(typeName, obj: ClassDefinition) {
   const name = constructorName(typeName);
 
   // we use a single shared isosubspace for constructors since they will rarely
@@ -488,7 +488,7 @@ class ${name} final : public JSC::InternalFunction {
 
       // Must be defined for each specialization class.
       static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES construct(JSC::JSGlobalObject*, JSC::CallFrame*);
-      static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES call(JSC::JSGlobalObject*, JSC::CallFrame*);
+      ${obj.call ? "" : "static JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES call(JSC::JSGlobalObject*, JSC::CallFrame*);"}
 
       DECLARE_EXPORT_INFO;
   protected:
@@ -535,62 +535,15 @@ ${name}* ${name}::create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::St
     return ptr;
 }
 
-JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES ${name}::call(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
+${
+  obj.call
+    ? ""
+    : `JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES ${name}::call(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame*)
 {
-${
-  obj.call
-    ? `    Zig::GlobalObject *globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
-    JSC::VM &vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-`
-    : ""
-}
-${
-  obj.call
-    ? !obj.constructNeedsThis
-      ? `
-    void* ptr = ${classSymbolName(typeName, "construct")}(globalObject, callFrame);
-
-    if (!ptr || scope.exception()) [[unlikely]] {
-      return JSValue::encode(JSC::jsUndefined());
-    }
-
-    Structure* structure = globalObject->${className(typeName)}Structure();
-    ${className(typeName)}* instance = ${className(typeName)}::create(vm, globalObject, structure, ptr);
-`
-      : `
-    Structure* structure = globalObject->${className(typeName)}Structure();
-    ${className(typeName)}* instance = ${className(typeName)}::create(vm, globalObject, structure, nullptr);
-
-    void* ptr = ${classSymbolName(typeName, "construct")}(globalObject, callFrame, JSValue::encode(instance));
-    if (scope.exception()) [[unlikely]] {
-      ASSERT_WITH_MESSAGE(!ptr, "Memory leak detected: new ${typeName}() allocated memory without checking for exceptions.");
-      return JSValue::encode(JSC::jsUndefined());
-    }
-
-    instance->m_ctx = ptr;
-`
-    : `
     return Bun::throwConstructorCalledWithoutNewError(lexicalGlobalObject, "${typeName}"_s);
+}
 `
 }
-
-${
-  obj.call
-    ? `    RETURN_IF_EXCEPTION(scope, {});
-  ${
-    obj.estimatedSize
-      ? `
-      auto size = ${symbolName(typeName, "estimatedSize")}(ptr);
-      vm.heap.reportExtraMemoryAllocated(instance, size);`
-      : ""
-  }
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(instance));`
-    : ""
-}
-}
-
 JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES ${name}::construct(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
 {
     Zig::GlobalObject *globalObject = defaultGlobalObject(lexicalGlobalObject);
@@ -1621,7 +1574,7 @@ function generateImpl(typeName, obj: ClassDefinition) {
   const proto = obj.proto;
   return [
     (obj.final ?? true) ? generatePrototypeHeader(typeName, true) : null,
-    !obj.noConstructor ? generateConstructorHeader(typeName).trim() + "\n" : null,
+    !obj.noConstructor ? generateConstructorHeader(typeName, obj).trim() + "\n" : null,
     generatePrototype(typeName, obj).trim(),
     !obj.noConstructor ? generateConstructorImpl(typeName, obj).trim() : null,
     generateClassImpl(typeName, obj).trim(),

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -537,10 +537,14 @@ ${name}* ${name}::create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::St
 
 JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES ${name}::call(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame)
 {
-    Zig::GlobalObject *globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
+${
+  obj.call
+    ? `    Zig::GlobalObject *globalObject = reinterpret_cast<Zig::GlobalObject*>(lexicalGlobalObject);
     JSC::VM &vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-
+`
+    : ""
+}
 ${
   obj.call
     ? !obj.constructNeedsThis
@@ -567,8 +571,7 @@ ${
     instance->m_ctx = ptr;
 `
     : `
-    Bun::throwError(lexicalGlobalObject, scope, Bun::ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, "${typeName} constructor cannot be invoked without 'new'"_s);
-    return JSValue::encode(JSC::jsUndefined());
+    return Bun::throwConstructorCalledWithoutNewError(lexicalGlobalObject, "${typeName}"_s);
 `
 }
 

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1798,6 +1798,13 @@ JSC::EncodedJSValue Bun::throwInvalidThisCallError(JSC::JSGlobalObject* globalOb
     return {};
 }
 
+JSC::EncodedJSValue Bun::throwConstructorCalledWithoutNewError(JSC::JSGlobalObject* globalObject, const ASCIILiteral typeName)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    return Bun::throwError(globalObject, scope, Bun::ErrorCode::ERR_ILLEGAL_CONSTRUCTOR, makeString(typeName, " constructor cannot be invoked without 'new'"_s));
+}
+
 JSC::JSObject* Bun::createInvalidThisError(JSC::JSGlobalObject* globalObject, JSC::JSValue thisValue, const ASCIILiteral typeName)
 {
     if (!thisValue.isEmpty())

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -63,6 +63,8 @@ JSC::JSObject* createError(VM& vm, Zig::GlobalObject* globalObject, ErrorCode co
 JSObject* createInvalidThisError(JSGlobalObject* globalObject, JSValue thisValue, const ASCIILiteral typeName);
 // Throws createInvalidThisError(callFrame->thisValue()) and returns the empty value; one call at each generated host-function's invalid-this branch.
 JSC::EncodedJSValue throwInvalidThisCallError(JSGlobalObject* globalObject, JSC::CallFrame* callFrame, const ASCIILiteral typeName);
+// Throws ERR_ILLEGAL_CONSTRUCTOR "<typeName> constructor cannot be invoked without 'new'" and returns the empty value; the call() of every generated constructor that is not callable.
+JSC::EncodedJSValue throwConstructorCalledWithoutNewError(JSGlobalObject* globalObject, const ASCIILiteral typeName);
 JSObject* createInvalidThisError(JSGlobalObject* globalObject, const String& message);
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionMakeErrorWithCode);

--- a/test/js/bun/generated-class-heap-snapshot-fixture.js
+++ b/test/js/bun/generated-class-heap-snapshot-fixture.js
@@ -1,0 +1,36 @@
+// Prints the class names each "Property" edge out of a Request node points at.
+// Request.prototype shares the "Request" class name with instances, so every
+// accessor on the prototype also shows up under its property name; the test
+// asserts on edge targets, not on names.
+const request = new Request("https://example.com/", { method: "POST", body: "body" });
+request.headers; // fills the cached headers slot
+request.signal; // fills the cached signal slot
+// request.body and request.url are never read, so their cached slots stay empty.
+globalThis.request = request;
+
+const snapshot = Bun.generateHeapSnapshot();
+const { nodes, edges, nodeClassNames, edgeNames, edgeTypes, type } = snapshot;
+
+const nodeStride = type === "GCDebugging" ? 7 : 4;
+const requestClassIndex = nodeClassNames.indexOf("Request");
+if (requestClassIndex === -1) throw new Error("no Request class in snapshot");
+
+// Edges reference node identifiers (nodes[i + 0]), not node indices.
+const classNameOfId = new Map();
+const requestIds = new Set();
+for (let i = 0; i < nodes.length; i += nodeStride) {
+  classNameOfId.set(nodes[i], nodeClassNames[nodes[i + 2]]);
+  if (nodes[i + 2] === requestClassIndex) requestIds.add(nodes[i]);
+}
+
+const propertyEdgeType = edgeTypes.indexOf("Property");
+// Request.prototype has a "constructor" edge, which would collide with Object.prototype.constructor.
+const targetsByName = { __proto__: null };
+for (let i = 0; i < edges.length; i += 4) {
+  if (edges[i + 2] !== propertyEdgeType) continue;
+  if (!requestIds.has(edges[i])) continue;
+  const name = edgeNames[edges[i + 3]];
+  (targetsByName[name] ??= []).push(classNameOfId.get(edges[i + 1]));
+}
+
+console.log(JSON.stringify(targetsByName));

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -109,6 +109,75 @@ it("name", () => {
   }
 });
 
+// These classes come out of generate-classes.ts, which installs the same
+// prototype and constructor boilerplate on every class it emits.
+describe.each([
+  ["Blob", Blob, Object.prototype],
+  ["Request", Request, Object.prototype],
+  ["Response", Response, Object.prototype],
+  ["TextDecoder", TextDecoder, Object.prototype],
+  ["HTMLRewriter", HTMLRewriter, Object.prototype],
+  ["BuildMessage", BuildMessage, Error.prototype],
+  ["ResolveMessage", ResolveMessage, Error.prototype],
+  ["Transpiler", Bun.Transpiler, Object.prototype],
+  ["CryptoHasher", Bun.CryptoHasher, Object.prototype],
+  ["Glob", Bun.Glob, Object.prototype],
+])("generated class %s", (name, Class, prototypeParent) => {
+  it("prototype has a read-only, non-enumerable Symbol.toStringTag", () => {
+    expect(Object.getOwnPropertyDescriptor(Class.prototype, Symbol.toStringTag)).toEqual({
+      value: name,
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
+  it("prototype chain starts at the configured base", () => {
+    expect(Object.getPrototypeOf(Class.prototype)).toBe(prototypeParent);
+  });
+
+  it("constructor.prototype is frozen in place", () => {
+    expect(Object.getOwnPropertyDescriptor(Class, "prototype")).toEqual({
+      value: Class.prototype,
+      writable: false,
+      enumerable: false,
+      configurable: false,
+    });
+  });
+
+  it("calling the constructor without new throws ERR_ILLEGAL_CONSTRUCTOR", () => {
+    expect(() => Class()).toThrow(
+      expect.objectContaining({
+        name: "TypeError",
+        code: "ERR_ILLEGAL_CONSTRUCTOR",
+        message: `${name} constructor cannot be invoked without 'new'`,
+      }),
+    );
+  });
+});
+
+it("generated class cached slots show up in heap snapshots", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "generated-class-heap-snapshot-fixture.js")],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  const targetsByName = JSON.parse(stdout);
+  // The fixture read request.headers and request.signal, so those cached
+  // slots hold cells. The accessor targets come from Request.prototype.
+  expect(targetsByName["headers"]).toContain("Headers");
+  expect(targetsByName["signal"]).toContain("AbortSignal");
+  // request.body and request.url were never read, so only the prototype
+  // accessors show up under those names.
+  expect(targetsByName["body"]).not.toContain("ReadableStream");
+  expect(targetsByName["url"]).not.toContain("string");
+  expect(exitCode).toBe(0);
+});
+
 describe("File", () => {
   it("constructor", () => {
     const file = new File(["foo"], "bar.txt", { type: "text/plain;charset=utf-8" });


### PR DESCRIPTION
### Problem
- `generate-classes.ts` emitted, for each generated class, its own copy of several once-per-class setup bodies that differ only in a class-info pointer or a string. #39770 has since landed the structure creation, the static property tables, the `toStringTag` put and the `analyzeHeap` loop as shared bodies. This PR is rebased on top of it and keeps the one part that did not land.
- Each generated constructor's `call()` (43 classes) still builds the `ERR_ILLEGAL_CONSTRUCTOR` error inline: its own throw scope, a full per-class message literal, and the throw (`src/codegen/generate-classes.ts:538` on main).
- For the two `call: true` classes that have a constructor (`Expect`, `ExpectTypeOf`), the generator also emitted an instance-constructing `call()` body that nothing referenced. The `InternalFunction` is constructed with the class's own call symbol (`generate-classes.ts:529`). The other seven `call: true` classes are `noConstructor`, so they get no constructor code at all.

### Fix
- `Bun::throwConstructorCalledWithoutNewError(globalObject, typeName)` in `ErrorCode.cpp`, next to `throwInvalidThisCallError` from #39770, builds the same message from the type name and throws. The generated `call()` is one call with the type name.
- The generator emits `call()` (declaration and body) only for classes without `call: true`. That deletes the unreferenced instance-constructing body and the three `obj.call` ternaries that kept it compiling.
- Behavior is unchanged: same error code, same message, same `TypeError`. The throwing host function now returns the empty value instead of `undefined` after the throw, which is what `throwInvalidThisCallError` and the rest of `ErrorCode.cpp` do. A probe of the descriptors and errors of 12 generated classes gives identical output on bun 1.4.0 and on this branch.
- Verified: `test/js/bun/globals.test.js` (new tests below, plus the existing file), `test/regression/issue/22243.test.ts` (asserts the message), and the expect, expect-type and expect-extend suites for the two `call: true` classes.
- Size, from the CI size step against main at the base commit (3d3016e), stripped release binaries: windows-x64 -5.5 KB, windows-aarch64 -6.0 KB, darwin-x64 -16.0 KB, darwin-aarch64 -16.2 KB, freebsd-x64 -16.0 KB, linux-aarch64-android -64.0 KB, the other Linux and FreeBSD targets +0.0 KB. The Windows numbers are the unrounded ones. The others are rounded by segment alignment, so about 6 KB of code is what this change removes. It is small. Closing this in favor of #39770 and keeping only the tests is a fine outcome too.

Tests (`test/js/bun/globals.test.js`, with `generated-class-heap-snapshot-fixture.js`):
- For ten generated classes, two of them with `Error.prototype` as the base: the `Symbol.toStringTag` descriptor on the prototype, the `prototype` descriptor on the constructor, the prototype parent, and the `ERR_ILLEGAL_CONSTRUCTOR` error from a call without `new`. These pin the contracts of the bodies that #39770 and this PR share.
- A heap snapshot of a `Request` with two cached slots filled and two left empty. Only the filled slots produce property edges. This exercises the table-driven `analyzeHeap` from #39770. Removing its empty-slot check makes the fixture abort in `HeapSnapshotBuilder::analyzePropertyNameEdge`.
- The tests also pass on the unmodified binary. The change is a refactor, so that is expected.

### Background
- A generated class is a class declared in a `*.classes.ts` file. `generate-classes.ts` emits three C++ classes for it: the instance class, `JS*Prototype` and `JS*Constructor`.
- A `JS*Constructor` is a JSC `InternalFunction`. It holds two native function pointers: one for `f()` and one for `new f()`. For a class without `call: true` the first one is the generated `call()`, which throws. For a class with `call: true` it is a function exported by the class itself.
- `ERR_ILLEGAL_CONSTRUCTOR` is the Node error code for calling a constructor the wrong way. `Bun::throwError` creates the error with that code and throws it.

<details><summary>Notes</summary>

The first version of this PR (8954728, then 9dda9dd and 7b7fe6c) moved seven bodies into a new `GeneratedClassSupport.{h,cpp}` and measured 64 KB to 166 KB per target against its base commit (for example linux-x64 -128.0 KB, darwin-aarch64 -145.3 KB, windows-x64 -166.5 KB). #39770 landed `Bun::createClassStructure`, `Bun::reifyStaticPropertyTable`, `Bun::putToStringTagWithoutTransition` and a table-driven `analyzeHeap` in `BunClientData.{h,cpp}` and the generator, so the rebase drops those parts here. The `setMayBePrototype` call in `createPrototype` and the `prototype` put in the constructor's `finishCreation` stay inline, which matches the hand-written classes on main after #39770.

While running the suites for the first version I found that `Headers` iteration is quadratic in the number of headers (`FetchHeaders::Iterator::next` looks each key up again). That is unrelated and tracked separately.

Original description:

generate-classes.ts emits, per generated class, its own copy of createStructure, createPrototypeStructure, reifyStaticProperties, the toStringTag put, the cached-value heap-edge analysis and the "constructor cannot be called" throw. In the linux-x64 binary these are 192, 143 and 174 near-identical copies respectively (from the near-duplicate body scan), differing only in a class-info pointer or a string.

The bodies move to GeneratedClassSupport.{h,cpp} as NEVER_INLINE functions taking those values as arguments; the generated code per class is a call. The second commit guards an empty cached value in the heap-edge analysis, which the first commit's shared body had exposed. This is C++ only, so the local Rust size measure cannot see it; CI's size gate has the number.

Behavior is unchanged: same structures, same prototype properties, same errors. Streams, serve, blob, worker and the generated-class heavy suites pass on the debug build.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/globals.test.js
ninja: Entering directory `/workspace/bun/build/debug'
[1/170] gen ErrorCode+*.h
[2/170] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/debug/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[3/170] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[4/170] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSyst
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (6e906e468)

test/js/bun/globals.test.js:
(pass) ERR_INVALID_THIS [0.31ms]
(pass) extendable [0.27ms]
(pass) writable [0.19ms]
(pass) name [0.08ms]
(pass) generated class Blob > prototype has a read-only, non-enumerable Symbol.toStringTag [0.05ms]
(pass) generated class Blob > prototype chain starts at the configured base [0.02ms]
(pass) generated class Blob > constructor.prototype is frozen in place [0.02ms]
(pass) generated class Blob > calling the constructor without new throws ERR_ILLEGAL_CONSTRUCTOR [0.08ms]
(pass) generated class Request > prototype has a read-only, non-enumerable Symbol.toStringTag
(pass) generated class Request > prototype chain starts at the configured base
(pass) generated class Request > constructor.prototype is frozen in place
(pass) generated class Request > calling the constructor without new throws ERR_ILLEGAL_CONSTRUCTOR
(pass) generated class Response > prototype has a read-only, non-enumerable Symbol.toStringTag
(pass) generated class Response > prototype chain starts at the configured base
(pass) generated class Response > constructor.prototype is frozen in place
(pass) generated class Response > calling t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/globals.test.js
bun test v1.4.0 (6e906e468)

test/js/bun/globals.test.js:
(pass) ERR_INVALID_THIS [33.61ms]
(pass) extendable [26.69ms]
(pass) writable [16.57ms]
(pass) name [9.00ms]
(pass) generated class Blob > prototype has a read-only, non-enumerable Symbol.toStringTag [3.41ms]
(pass) generated class Blob > prototype chain starts at the configured base [2.26ms]
(pass) generated class Blob > constructor.prototype is frozen in place [2.12ms]
(pass) generated class Blob > calling the constructor without new throws ERR_ILLEGAL_CONSTRUCTOR [6.28ms]
(pass) generated class Request > prototype has a read-only, non-enumerable Symbol.toStringTag [1.21ms]
(pass) generated class Request > prototype chain starts at the configured base [0.51ms]
(pass) generated class Request > constructor.prototype is frozen in place [0.53ms]
(pass) generated class Request > calling the constructor without new throws ERR_ILLEGAL_CONSTRUCTOR [1.10ms]
(pass) generated class Response > prototype has a read-only, non-enumerable Symbol.toStringTag [0.38ms
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 840ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/129] gen ErrorCode+*.h
[2/129] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[3/129] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 240 extern-C blocks audited
[4/129] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Fou
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/codegen/generate-classes.ts                    | 60 +++----------------
 src/jsc/bindings/ErrorCode.cpp                     |  7 +++
 src/jsc/bindings/ErrorCode.h                       |  2 +
 .../bun/generated-class-heap-snapshot-fixture.js   | 36 +++++++++++
 test/js/bun/globals.test.js                        | 69 ++++++++++++++++++++++
 5 files changed, 122 insertions(+), 52 deletions(-)
```

</details>

**gate history** · 1 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/codegen/generate-classes.ts                          10     11      0
src/jsc/bindings/ErrorCode.cpp                            2      1      0
src/jsc/bindings/ErrorCode.h                              1      1      0
test/js/bun/generated-class-heap-snapshot-fixture.js      0      0      0
test/js/bun/globals.test.js                               2      2      0
```

</details>

<!-- robobun:evidence:end -->