### PR TITLE
css: move the skip loop of parse_until_before out of the generic body

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -472,7 +472,9 @@ fn parse_until_before<T, C>(
     result
 }
 
-// FIXME: have a special-purpose tokenizer method for this that does less work.
+/// Tokenizes past whatever a delimited parse left unread, stopping before the
+/// first byte in `delimiters` or at the end of input. A block opened on the
+/// way is skipped whole, so a delimiter inside it does not end the skip.
 #[inline(never)]
 fn skip_until_delimiter(parser: &mut Parser, delimiters: Delimiters) {
     loop {

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -468,8 +468,13 @@ fn parse_until_before<T, C>(
         result
     };
     parser.stop_before = saved_stop_before;
+    skip_until_delimiter(parser, delimiters);
+    result
+}
 
-    // FIXME: have a special-purpose tokenizer method for this that does less work.
+// FIXME: have a special-purpose tokenizer method for this that does less work.
+#[inline(never)]
+fn skip_until_delimiter(parser: &mut Parser, delimiters: Delimiters) {
     loop {
         if delimiters.intersects(Delimiters::from_byte(parser.input.tokenizer.next_byte())) {
             break;
@@ -483,8 +488,6 @@ fn parse_until_before<T, C>(
             _ => break,
         }
     }
-
-    result
 }
 
 pub(crate) fn parse_until_after<T, C>(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7729,6 +7729,44 @@ describe("css tests", () => {
       );
     });
 
+    // After a delimited parse (`parse_until_before` / `parse_until_after`) the
+    // parser skips whatever is left before the delimiter, treating nested
+    // blocks as single units. Two places make that skipping visible without
+    // error recovery: the leading `@charset` rule, whose body is skipped up to
+    // the `;`, and forgiving selector lists, where an invalid selector is
+    // dropped and the rest of it is skipped up to the next top-level comma or
+    // the closing paren of the enclosing block.
+    describe("skipping to a delimiter", () => {
+      describe("@charset", () => {
+        minify_test('@charset "utf-8"; .a { color: red }', ".a{color:red}");
+        // Semicolons inside blocks do not end the skip.
+        minify_test('@charset "utf-8" (a; b); .a { color: red }', ".a{color:red}");
+        minify_test('@charset "utf-8" [a; b] (c; d); .a { color: red }', ".a{color:red}");
+        minify_test('@charset "utf-8" {a; b}; .a { color: red }', ".a{color:red}");
+        minify_test('@charset "utf-8" foo(a; .z { color: green }); .a { color: red }', ".a{color:red}");
+        // `}` is the other delimiter of the @charset skip.
+        minify_test('@charset "utf-8" } .a { color: red }', ".a{color:red}");
+        // End of input, with and without an unclosed block.
+        minify_test('@charset "utf-8"', "");
+        minify_test('@charset "utf-8" (a; b', "");
+      });
+
+      describe("forgiving selector lists", () => {
+        minify_test(".a:is(.b %, .c) { color: red }", ".a.c{color:red}");
+        // Commas inside blocks do not end the skip, even when the block
+        // contains something that would parse as a selector on its own.
+        minify_test(".a:is(.b % (x, .z), .c) { color: red }", ".a.c{color:red}");
+        minify_test(".a:is(.b % foo(x, .z), .c) { color: red }", ".a.c{color:red}");
+        minify_test(".a:is(.b % (x, .z { color: green }), .c) { color: red }", ".a.c{color:red}");
+        minify_test(".a:where(.b % (x, .z), .c) { color: red }", ".a:where(.c){color:red}");
+        // The invalid selector is last: the skip stops at the `)` that closes
+        // the enclosing block, which is a delimiter inherited from it.
+        minify_test(".a:is(.c, .b % (x, .z)) { color: red }", ".a.c{color:red}");
+        minify_test(".a:where(.c, .b % (x, .z)) { color: red }", ".a:where(.c){color:red}");
+        minify_test(".a:is(.b % (x, .z)) { color: red }", ".a:is(){color:red}");
+      });
+    });
+
     describe("unparsed oklab color fallbacks", () => {
       minify_test(".foo { color: var(--x, oklab(40% 0.1 0.1)) }", ".foo{color:var(--x,oklab(40% .1 .1))}");
       minify_test(".foo { color: var(--x, oklch(40% 0.1 30)) }", ".foo{color:var(--x,oklch(40% .1 30))}");


### PR DESCRIPTION
### Problem
- `parse_until_before<T, C>` (`src/css/css_parser.rs:440`) ends with a loop that skips input up to the next delimiter. The loop does not use `T` or `C`, but every instantiation and every caller that inlines one gets a copy.
- `parse_nested_block` had the same problem. #39770 fixed that part on main, so this PR now only carries the `parse_until_before` part.

### Fix
- The loop is now `skip_until_delimiter`, one `#[inline(never)]` function. The body moved as is, and the `Stop` error path still returns before it.
- Two release builds of current main (linux-x64): `.text` shrinks by 9,110 B, all of it in `bun_css`. The stripped `bun` goes from 74,110,128 B to 74,093,744 B.
- Tests: a `skipping to a delimiter` block in `test/js/bun/css/css.test.ts` (16 cases) pins down the moved loop through `@charset` and forgiving selector lists. This is a refactor, so they pass on main too. With the nested block branch of the loop removed, 12 of them fail (see Notes).
- Verified: `bun bd test test/js/bun/css/ test/bundler/css/`. The only failures are 5 s timeouts that a debug build of main hits too on the loaded build box (see Notes).

### Background
- `parse_until_before` runs a closure on the input up to a delimiter such as `{`, then skips what the closure left unread. Every declaration and prelude goes through it.
- Rust compiles one copy of a generic function per set of type arguments, including the code that does not use them. A non-generic `#[inline(never)]` function keeps one copy.
- The release link uses `-icf=safe`, but ICF cannot fold these copies: each one is built around a different closure call.

<details><summary>Notes</summary>

Conflict resolution on rebase: #39770 (main, Aug 20) added `nested_block_enter`, `nested_block_exit` and `NestedBlockState`, which is the same split this PR made under the names `enter_nested_block`, `exit_nested_block` and `NestedBlock`. I kept main's version and dropped this PR's copy. The remaining diff is the `skip_until_delimiter` hunk from the original commit, unchanged.

Measurement of the full original diff against main as of Aug 18 (before #39770), for the record: `.text` 52,938,146 B to 52,835,422 B (-102,724 B), stripped `bun` 76,846,128 B to 76,715,056 B. Before: 164 out-of-line copies of `parse_nested_block` (102,109 B) plus 214 copies of `parse_entirely<closure>` for those blocks (185,074 B). After: 110 plus 20 copies (126,639 B together) plus one copy each of the three helpers. Most of that win is now on main through #39770.

Measurement of the rebased remainder (this PR as it stands): the one out-of-line `parse_until_before` goes from 350 B to 214 B, `skip_until_delimiter` is one 154 B function, and the `parse_nested_block` copies that inline `parse_until_before` shrink from 112,111 B to 109,860 B. Total `.text` delta -9,110 B, bun_css-attributed delta -9,110 B.

Why these tests: bun parses CSS with `error_recovery` off, so an invalid declaration or rule is a fatal error and the skip after it is not visible in the output. Two paths do show it. `@charset` is consumed with `parse_until_after(SEMICOLON | CLOSE_CURLY_BRACKET, parse_empty)` (css_parser.rs, `RuleListParser`), so the skip loop is what consumes the rule. In `:is()` and `:where()`, an invalid selector is dropped and the skip loop advances to the next top-level comma or to the `)` inherited through `stop_before` (`selectors/parser.rs`, `parse_list_with_state`). The 16 cases pass with both a main build and a branch build of the debug binary. Two mutations of the branch as a check on the tests: with the `consume_until_end_of_block` branch removed from `skip_until_delimiter`, 12 of the 16 fail (the other 4 are the plain delimiter and end of input cases). With `parse_until_before` passing the unmerged `delimiters_` instead of the merged set, `css.test.ts` already fails while the file loads, because the last declaration of every block then runs past its `}`.

Test run on the rebased branch: `test/js/bun/css/` and `test/bundler/css/` pass except 5 s timeouts in `css-fuzz.test.ts` (local-only, it runs 1000 `Bun.build` calls per test and times out on a debug build of main too), `nested-selector-expansion.test.ts`, `selector-list-error-recovery.test.ts` and `nested-vendor-prefix-duplication.test.ts`. The build box had a load average of 70 to 80 on 16 cores. I ran those three files alternately with a debug binary built from main and one built from this branch: both binaries hit the same timeouts, and per-test times were within the run-to-run noise (for example 2.1 s vs 2.0 s, 5.8 s vs 7.1 s vs 4.9 s for the same test across runs). The same files passed here on Aug 18 on a quiet box.

Observation, not changed here: `consume_until_end_of_block` is `#[cold]` and allocates a `Vec` per call, but every nested block exit calls it. That is pre-existing and is being handled separately.

</details>
