### PR TITLE
keep the out of memory throw out of every host function

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -106,6 +106,8 @@ impl JSGlobalObject {
         JsError::Thrown
     }
 
+    #[cold]
+    #[inline(never)]
     pub fn throw_out_of_memory(&self) -> JsError {
         // See `throw_stack_overflow` for the validation-scope rationale.
         crate::validation_scope!(scope, self);
@@ -118,6 +120,8 @@ impl JSGlobalObject {
         JSGlobalObject__createOutOfMemoryError(self)
     }
 
+    #[cold]
+    #[inline(never)]
     pub fn throw_out_of_memory_value(&self) -> JSValue {
         JSGlobalObject__throwOutOfMemoryError(self);
         JSValue::ZERO


### PR DESCRIPTION
Every Rust host function thunk (about 1,170 of them, 785 from the generated class bindings) inlined the OutOfMemory arm of the error conversion: JSGlobalObject::throw_out_of_memory expands into the C++ createOutOfMemoryError call plus exception setup, about 130 bytes per thunk in the linux-x64 binary.

throw_out_of_memory is now `#[cold] #[inline(never)]`, so each thunk keeps a call to one shared body. The saving is only visible after LTO (the thunks live in many crates), so the local pre-LTO measure shows little; the symbol table estimate is about 100 KB, and CI's size gate has the number.

Behavior is unchanged: same error, same exception scope handling; this is the path that runs when an allocation fails.
