### PR TITLE
Don't abort when loading util.inspect for inspect.custom throws

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2301,18 +2301,6 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(JSFunction::create(init.vm, init.owner, 4, "performMicrotaskVariadic"_s, jsFunctionPerformMicrotaskVariadic, ImplementationVisibility::Public));
         });
 
-    m_utilInspectFunction.initLater(
-        [](const Initializer<JSFunction>& init) {
-            auto scope = DECLARE_THROW_SCOPE(init.vm);
-            JSValue nodeUtilValue = uncheckedDowncast<Zig::GlobalObject>(init.owner)->internalModuleRegistry()->requireId(init.owner, init.vm, Bun::InternalModuleRegistry::Field::NodeUtil);
-            RETURN_IF_EXCEPTION(scope, );
-            RELEASE_ASSERT(nodeUtilValue.isObject());
-            auto prop = nodeUtilValue.getObject()->getIfPropertyExists(init.owner, Identifier::fromString(init.vm, "inspect"_s));
-            RETURN_IF_EXCEPTION(scope, );
-            ASSERT(prop);
-            init.set(uncheckedDowncast<JSFunction>(prop));
-        });
-
     m_utilInspectOptionsStructure.initLater(
         [](const Initializer<Structure>& init) {
             init.set(Bun::createUtilInspectOptionsStructure(init.vm, init.owner));
@@ -2325,28 +2313,6 @@ void GlobalObject::finishCreation(VM& vm)
                 init.owner);
 
             init.set(ErrorCodeCache::create(init.vm, structure));
-        });
-
-    m_utilInspectStylizeColorFunction.initLater(
-        [](const Initializer<JSFunction>& init) {
-            auto scope = DECLARE_THROW_SCOPE(init.vm);
-            JSC::MarkedArgumentBuffer args;
-            args.append(uncheckedDowncast<Zig::GlobalObject>(init.owner)->utilInspectFunction());
-            RETURN_IF_EXCEPTION(scope, );
-
-            JSC::JSFunction* getStylize = JSC::JSFunction::create(init.vm, init.owner, utilInspectGetStylizeWithColorCodeGenerator(init.vm), init.owner);
-            RETURN_IF_EXCEPTION(scope, );
-
-            JSC::CallData callData = JSC::getCallData(getStylize);
-            NakedPtr<JSC::Exception> returnedException = nullptr;
-            auto result = JSC::profiledCall(init.owner, ProfilingReason::API, getStylize, callData, jsNull(), args, returnedException);
-            RETURN_IF_EXCEPTION(scope, );
-
-            if (returnedException) {
-                throwException(init.owner, scope, returnedException.get());
-            }
-            RETURN_IF_EXCEPTION(scope, );
-            init.set(uncheckedDowncast<JSFunction>(result));
         });
 
     m_utilInspectStylizeNoColorFunction.initLater(
@@ -2884,6 +2850,44 @@ void GlobalObject::finishCreation(VM& vm)
     addBuiltinGlobals(vm);
 
     ASSERT(classInfo());
+}
+
+JSC::JSFunction* GlobalObject::utilInspectFunction()
+{
+    if (auto* function = m_utilInspectFunction.get())
+        return function;
+
+    auto& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue nodeUtilValue = internalModuleRegistry()->requireId(this, vm, Bun::InternalModuleRegistry::Field::NodeUtil);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    RELEASE_ASSERT(nodeUtilValue.isObject());
+    JSValue inspect = nodeUtilValue.getObject()->getIfPropertyExists(this, Identifier::fromString(vm, "inspect"_s));
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    ASSERT(inspect);
+    auto* function = uncheckedDowncast<JSFunction>(inspect);
+    m_utilInspectFunction.set(vm, this, function);
+    return function;
+}
+
+JSC::JSFunction* GlobalObject::utilInspectStylizeColorFunction()
+{
+    if (auto* function = m_utilInspectStylizeColorFunction.get())
+        return function;
+
+    auto& vm = this->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSFunction* inspect = utilInspectFunction();
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    JSC::MarkedArgumentBuffer args;
+    args.append(inspect);
+    JSC::JSFunction* getStylize = JSC::JSFunction::create(vm, this, utilInspectGetStylizeWithColorCodeGenerator(vm), this);
+    JSValue result = JSC::profiledCall(this, ProfilingReason::API, getStylize, JSC::getCallData(getStylize), jsNull(), args);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+    auto* function = uncheckedDowncast<JSFunction>(result);
+    m_utilInspectStylizeColorFunction.set(vm, this, function);
+    return function;
 }
 
 JSC_DEFINE_CUSTOM_GETTER(JSDOMFileConstructor_getter, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, PropertyName))

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -294,8 +294,10 @@ public:
     JSC::JSFunction* performMicrotaskVariadicFunction() const { return m_performMicrotaskVariadicFunction.getInitializedOnMainThread(this); }
 
     JSC::Structure* utilInspectOptionsStructure() const { return m_utilInspectOptionsStructure.getInitializedOnMainThread(this); }
-    JSC::JSFunction* utilInspectFunction() const { return m_utilInspectFunction.getInitializedOnMainThread(this); }
-    JSC::JSFunction* utilInspectStylizeColorFunction() const { return m_utilInspectStylizeColorFunction.getInitializedOnMainThread(this); }
+    // Loading node:util can throw (stack overflow, termination). These return
+    // nullptr with an exception pending in that case.
+    JSC::JSFunction* utilInspectFunction();
+    JSC::JSFunction* utilInspectStylizeColorFunction();
     JSC::JSFunction* utilInspectStylizeNoColorFunction() const { return m_utilInspectStylizeNoColorFunction.getInitializedOnMainThread(this); }
 
     JSC::JSFunction* wasmStreamingConsumeStreamFunction() const { return m_wasmStreamingConsumeStreamFunction.getInitializedOnMainThread(this); }
@@ -632,9 +634,9 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_JSSocketHandlersStructure)                           \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_nativeMicrotaskTrampoline)                          \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_performMicrotaskVariadicFunction)                   \
-    V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectFunction)                                \
+    V(private, WriteBarrier<JSFunction>, m_utilInspectFunction)                                              \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_utilInspectOptionsStructure)                         \
-    V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectStylizeColorFunction)                    \
+    V(private, WriteBarrier<JSFunction>, m_utilInspectStylizeColorFunction)                                  \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_utilInspectStylizeNoColorFunction)                  \
     V(private, LazyPropertyOfGlobalObject<JSFunction>, m_wasmStreamingConsumeStreamFunction)                 \
     V(private, WebCore::JSStreamsRuntime, m_streamsRuntime)                                                  \

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -294,8 +294,6 @@ public:
     JSC::JSFunction* performMicrotaskVariadicFunction() const { return m_performMicrotaskVariadicFunction.getInitializedOnMainThread(this); }
 
     JSC::Structure* utilInspectOptionsStructure() const { return m_utilInspectOptionsStructure.getInitializedOnMainThread(this); }
-    // Loading node:util can throw (stack overflow, termination). These return
-    // nullptr with an exception pending in that case.
     JSC::JSFunction* utilInspectFunction();
     JSC::JSFunction* utilInspectStylizeColorFunction();
     JSC::JSFunction* utilInspectStylizeNoColorFunction() const { return m_utilInspectStylizeNoColorFunction.getInitializedOnMainThread(this); }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -7051,6 +7051,7 @@ extern "C" JSC::EncodedJSValue Bun__REPL__formatValue(
     // Get the util.inspect function from the global object
     auto* bunGlobal = uncheckedDowncast<Zig::GlobalObject>(globalObject);
     JSC::JSValue inspectFn = bunGlobal->utilInspectFunction();
+    RETURN_IF_EXCEPTION(scope, JSC::JSValue::encode(JSC::jsUndefined()));
 
     if (!inspectFn || !inspectFn.isCallable()) {
         // Fallback to toString if util.inspect is not available

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -672,13 +672,12 @@ describe.concurrent("Bun.inspect when a property lookup throws", () => {
 });
 
 // Formatting an object with [util.inspect.custom] loads node:util on first use. When that load
-// throws (here: the stack is exhausted), the error has to propagate to the caller and the next
-// call has to retry the load. It used to abort the process in the lazy property initializer.
+// throws (the stack is exhausted, or a global that the internal modules read while loading has
+// been replaced), the error has to propagate to the caller and the next call has to retry the
+// load. It used to abort the process in the lazy property initializer. Each case runs in a fresh
+// child so that nothing has loaded node:util yet.
 describe.concurrent("Bun.inspect when loading util.inspect for inspect.custom throws", () => {
-  it.each([
-    ["without colors", "Bun.inspect(obj)", '"custom"'],
-    ["with colors", "Bun.inspect(obj, { colors: true })", '"\\u001b[36mcustom\\u001b[39m"'],
-  ])("%s", async (_, call, expected) => {
+  async function inspectInChild(code) {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -687,22 +686,7 @@ describe.concurrent("Bun.inspect when loading util.inspect for inspect.custom th
           const obj = {
             [Symbol.for("nodejs.util.inspect.custom")]: (depth, options) => options.stylize("custom", "special"),
           };
-          let deep;
-          function recurse() {
-            try {
-              recurse();
-            } catch {
-              // Only the frame whose call overflowed gets here.
-              try {
-                deep = ${call};
-              } catch (e) {
-                deep = e;
-              }
-            }
-          }
-          recurse();
-          console.log(String(deep));
-          console.log(JSON.stringify(${call}));
+          ${code}
         `,
       ],
       env: bunEnv,
@@ -710,11 +694,52 @@ describe.concurrent("Bun.inspect when loading util.inspect for inspect.custom th
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({
+    return { stdout, stderr, exitCode };
+  }
+
+  it.each([
+    ["without colors", "Bun.inspect(obj)", '"custom"'],
+    ["with colors", "Bun.inspect(obj, { colors: true })", '"\\u001b[36mcustom\\u001b[39m"'],
+  ])("with the stack exhausted, %s", async (_, call, expected) => {
+    const result = await inspectInChild(`
+      let deep;
+      function recurse() {
+        try {
+          recurse();
+        } catch {
+          // Only the frame whose call overflowed gets here.
+          try {
+            deep = ${call};
+          } catch (e) {
+            deep = e;
+          }
+        }
+      }
+      recurse();
+      console.log(String(deep));
+      console.log(JSON.stringify(${call}));
+    `);
+    expect(result).toEqual({
       stdout: `RangeError: Maximum call stack size exceeded.\n${expected}\n`,
       stderr: "",
       exitCode: 0,
     });
+  });
+
+  // internal/primordials reads the global Reflect when it loads.
+  it("with a global used by the internal modules replaced", async () => {
+    const result = await inspectInChild(`
+      const realReflect = Reflect;
+      globalThis.Reflect = new Proxy({}, { get() { throw new Error("tampered Reflect"); } });
+      try {
+        console.log(Bun.inspect(obj));
+      } catch (e) {
+        console.log(String(e));
+      }
+      globalThis.Reflect = realReflect;
+      console.log(Bun.inspect(obj));
+    `);
+    expect(result).toEqual({ stdout: "Error: tampered Reflect\ncustom\n", stderr: "", exitCode: 0 });
   });
 });
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -671,6 +671,53 @@ describe.concurrent("Bun.inspect when a property lookup throws", () => {
   });
 });
 
+// Formatting an object with [util.inspect.custom] loads node:util on first use. When that load
+// throws (here: the stack is exhausted), the error has to propagate to the caller and the next
+// call has to retry the load. It used to abort the process in the lazy property initializer.
+describe.concurrent("Bun.inspect when loading util.inspect for inspect.custom throws", () => {
+  it.each([
+    ["without colors", "Bun.inspect(obj)", '"custom"'],
+    ["with colors", "Bun.inspect(obj, { colors: true })", '"\\u001b[36mcustom\\u001b[39m"'],
+  ])("%s", async (_, call, expected) => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const obj = {
+            [Symbol.for("nodejs.util.inspect.custom")]: (depth, options) => options.stylize("custom", "special"),
+          };
+          let deep;
+          function recurse() {
+            try {
+              recurse();
+            } catch {
+              // Only the frame whose call overflowed gets here.
+              try {
+                deep = ${call};
+              } catch (e) {
+                deep = e;
+              }
+            }
+          }
+          recurse();
+          console.log(String(deep));
+          console.log(JSON.stringify(${call}));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: `RangeError: Maximum call stack size exceeded.\n${expected}\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 describe("console.logging function displays async and generator names", async () => {
   const cases = [
     function () {},


### PR DESCRIPTION
### What does this PR do?

Fixes an abort (`RELEASE_ASSERT` in `LazyProperty::callFunc`, `LazyPropertyInlines.h:105`) found by fuzzing. It reproduces on release builds too. The shortest trigger replaces a global that the internal modules read while they load, then formats something with a `[util.inspect.custom]` method, in a process that has not loaded `node:util` yet:

```js
globalThis.Reflect = {};
Bun.inspect({ [Symbol.for("nodejs.util.inspect.custom")]: () => "custom" });
```

The same thing happens without any tampering when the stack is nearly exhausted:

```js
const obj = { [Symbol.for("nodejs.util.inspect.custom")]: () => "custom" };
function recurse() {
  try {
    recurse();
  } catch {
    try { Bun.inspect(obj); } catch {}
  }
}
recurse();
```

```
panic(main thread): abort() called
```

Formatting anything that has a `[util.inspect.custom]` method (including `Buffer`, so also error messages like the `ERR_INVALID_ARG_VALUE` thrown by `new DecompressionStream(buffer)`, and the failure message of `expect(Bun).toBeString()`, which is what the fuzzer samples hit) calls `globalObject->utilInspectFunction()`. That was a `LazyProperty` whose initializer loads `node:util` with `requireId`. Loading a module can throw (`internal/primordials` reads `Reflect` at load time, or the stack is exhausted), and the initializer then returned without calling `init.set()`. `LazyProperty::callFunc` release-asserts when that happens, so the JS exception turned into a process abort. `utilInspectStylizeColorFunction()` had the same problem through the same initializer (it calls `utilInspectFunction()` and then runs a builtin), which is the `colors: true` path.

This also explains why the fuzzer reports the crash as flaky: the load only fails if `node:util` and its dependencies are not loaded yet, which depends on what ran earlier in the same process.

All callers of these two getters already do `RETURN_IF_EXCEPTION` right after calling them, so the getters were always meant to be able to fail. This PR stores the two functions in `WriteBarrier`s instead and moves the loading into the getters, which now return `nullptr` with the exception pending when the load throws. Nothing is cached on failure, so the next call retries the load. The unused REPL helper `Bun__REPL__formatValue` gets the missing exception check.

After the change the first snippet throws the error from the module load (`TypeError: Reflect.getPrototypeOf is not a function ...`), the second one throws `RangeError: Maximum call stack size exceeded.` at the deep call, and `Bun.inspect(obj)` works normally afterwards in both cases.

### How did you verify your code works?

- The snippets above and the fuzzer's scripts abort on the current build and run to completion with this change, also with `BUN_JSC_validateExceptionChecks=1`.
- Added three cases to `test/js/bun/util/inspect.test.js`: stack exhausted with and without colors, and a replaced `Reflect` followed by a successful call once it is restored. All three exit with code 134 on the current build and pass with `bun bd test`.
- `test/js/bun/util/inspect.test.js`, `test/js/node/util/custom-inspect.test.js` (covers the stylize functions and the web streams inspect path), `test/js/web/url/url.test.ts` and `test/js/web/broadcastchannel/broadcast-channel.test.ts` (the other callers of `utilInspectFunction()`) pass with the debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->