### PR TITLE
Convert scope-object receivers in StringDecoder, node error toString, fs.Stats, Node-API and V8 callbacks

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -52,7 +52,7 @@ JSC_DEFINE_HOST_FUNCTION(NodeError_proto_toString, (JSC::JSGlobalObject * global
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto thisVal = callFrame->thisValue();
+    auto thisVal = callFrame->thisValue().toThis(globalObject, JSC::ECMAMode::strict());
 
     auto name = thisVal.get(globalObject, vm.propertyNames->name);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -591,10 +591,6 @@ JSC::EncodedJSValue JSStringDecoderConstructor::construct(JSC::JSGlobalObject* l
     // This is a hack to make express' body-parser work
     // It does something weird with the prototype
     // Not exactly a subclass
-    //
-    // The this slot holds the receiver of a call and new.target of a construct. A call
-    // resolved through a scope (captured or module-level binding) has that scope object as
-    // its receiver; strict toThis maps it to undefined so it is not decorated and returned.
     JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
     if (thisValue.isObject() && thisValue != constructor) {
         auto clientData = WebCore::clientData(vm);

--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -580,9 +580,7 @@ JSC::EncodedJSValue JSStringDecoderConstructor::construct(JSC::JSGlobalObject* l
             return Bun::ERR::UNKNOWN_ENCODING(throwScope, lexicalGlobalObject, view);
         }
     }
-    JSValue thisValue = callFrame->newTarget();
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
-    JSObject* newTarget = asObject(thisValue);
     auto* constructor = globalObject->JSStringDecoder();
     Structure* structure = globalObject->JSStringDecoderStructure();
 
@@ -593,9 +591,14 @@ JSC::EncodedJSValue JSStringDecoderConstructor::construct(JSC::JSGlobalObject* l
     // This is a hack to make express' body-parser work
     // It does something weird with the prototype
     // Not exactly a subclass
-    if (constructor != newTarget && callFrame->thisValue().isObject()) {
+    //
+    // The this slot holds the receiver of a call and new.target of a construct. A call
+    // resolved through a scope (captured or module-level binding) has that scope object as
+    // its receiver; strict toThis maps it to undefined so it is not decorated and returned.
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
+    if (thisValue.isObject() && thisValue != constructor) {
         auto clientData = WebCore::clientData(vm);
-        JSObject* thisObject = asObject(callFrame->thisValue());
+        JSObject* thisObject = asObject(thisValue);
 
         thisObject->putDirect(vm, clientData->builtinNames().decodePrivateName(), jsObject, JSC::PropertyAttribute::DontEnum | 0);
         thisObject->putDirect(vm, clientData->builtinNames().encodingPublicName(), convertEnumerationToJS<BufferEncodingType>(*lexicalGlobalObject, encoding), JSC::PropertyAttribute::DontEnum | 0);

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -139,8 +139,6 @@ static JSValue modeStatFunction(JSC::JSGlobalObject* globalObject, CallFrame* ca
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    // A bare call through a captured or module binding carries the scope object as its receiver;
-    // strict toThis maps it to undefined so `mode` is not read out of the scope's variable slots.
     auto* thisObject = dynamicDowncast<JSObject>(callFrame->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
     if (!thisObject)
         return JSC::jsUndefined();

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -139,7 +139,9 @@ static JSValue modeStatFunction(JSC::JSGlobalObject* globalObject, CallFrame* ca
 {
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto* thisObject = dynamicDowncast<JSObject>(callFrame->thisValue());
+    // A bare call through a captured or module binding carries the scope object as its receiver;
+    // strict toThis maps it to undefined so `mode` is not read out of the scope's variable slots.
+    auto* thisObject = dynamicDowncast<JSObject>(callFrame->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
     if (!thisObject)
         return JSC::jsUndefined();
 

--- a/src/jsc/bindings/NodeFSStatBinding.cpp
+++ b/src/jsc/bindings/NodeFSStatBinding.cpp
@@ -217,7 +217,7 @@ inline JSC::JSValue getDateField(JSC::JSGlobalObject* globalObject, JSC::Encoded
     auto& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSC::JSObject* thisObject = dynamicDowncast<JSC::JSObject>(JSC::JSValue::decode(thisValue));
+    JSC::JSObject* thisObject = dynamicDowncast<JSC::JSObject>(JSC::JSValue::decode(thisValue).toThis(globalObject, JSC::ECMAMode::strict()));
     if (!thisObject)
         return JSC::jsUndefined();
 
@@ -279,7 +279,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsBigIntStatsPrototypeGetter_atime, (JSGlobalObject * g
 JSC_DEFINE_CUSTOM_SETTER(jsStatsPrototypeFunction_DatePutter, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue encodedValue, JSC::PropertyName propertyName))
 {
     auto& vm = globalObject->vm();
-    JSObject* thisObject = dynamicDowncast<JSObject>(JSValue::decode(thisValue));
+    JSObject* thisObject = dynamicDowncast<JSObject>(JSValue::decode(thisValue).toThis(globalObject, JSC::ECMAMode::strict()));
     if (!thisObject)
         return false;
 

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -980,10 +980,7 @@ public:
         , m_dataPtr(dataPtr)
     {
         // Node-API function calls always run in "sloppy mode," even if the JS side is in strict mode.
-        //
-        // TopExceptionScope: this runs before the addon's callback and its
-        // first NAPI_PREAMBLE; a ThrowScope would simulate a throw on
-        // destruction that the next preamble would see as unchecked.
+        // Not a ThrowScope: its simulated throw would reach the addon's first NAPI_PREAMBLE unchecked.
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(JSC::getVM(globalObject));
         JSValue jscThis = m_callFrame->thisValue().toThis(globalObject, JSC::ECMAMode::sloppy());
         scope.assertNoException();

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -980,20 +980,17 @@ public:
         , m_dataPtr(dataPtr)
     {
         // Node-API function calls always run in "sloppy mode," even if the JS side is in strict
-        // mode. So if `this` is null or undefined, we use globalThis instead; otherwise, we convert
-        // `this` to an object.
-        // TODO change to global? or find another way to avoid JSGlobalProxy
-        JSC::JSObject* jscThis = globalObject->globalThis();
-        if (!m_callFrame->thisValue().isUndefinedOrNull()) {
-            // TopExceptionScope: this runs before the addon's callback and its
-            // first NAPI_PREAMBLE; a ThrowScope would simulate a throw on
-            // destruction that the next preamble would see as unchecked.
-            auto scope = DECLARE_TOP_EXCEPTION_SCOPE(JSC::getVM(globalObject));
-            jscThis = m_callFrame->thisValue().toObject(globalObject);
-            // https://tc39.es/ecma262/#sec-toobject
-            // toObject only throws for undefined and null, which we checked for
-            scope.assertNoException();
-        }
+        // mode: null, undefined and the scope object JSC leaves in the this slot of a call
+        // resolved through a captured or module binding all become globalThis, and primitives
+        // are boxed. Host functions never run op_to_this, so apply it here.
+        //
+        // TopExceptionScope: this runs before the addon's callback and its
+        // first NAPI_PREAMBLE; a ThrowScope would simulate a throw on
+        // destruction that the next preamble would see as unchecked.
+        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(JSC::getVM(globalObject));
+        JSValue jscThis = m_callFrame->thisValue().toThis(globalObject, JSC::ECMAMode::sloppy());
+        // Sloppy toThis only allocates wrapper objects for primitives; it has no throwing path.
+        scope.assertNoException();
         m_callFrame->setThisValue(jscThis);
     }
 

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -979,17 +979,13 @@ public:
         : m_callFrame(callFrame)
         , m_dataPtr(dataPtr)
     {
-        // Node-API function calls always run in "sloppy mode," even if the JS side is in strict
-        // mode: null, undefined and the scope object JSC leaves in the this slot of a call
-        // resolved through a captured or module binding all become globalThis, and primitives
-        // are boxed. Host functions never run op_to_this, so apply it here.
+        // Node-API function calls always run in "sloppy mode," even if the JS side is in strict mode.
         //
         // TopExceptionScope: this runs before the addon's callback and its
         // first NAPI_PREAMBLE; a ThrowScope would simulate a throw on
         // destruction that the next preamble would see as unchecked.
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(JSC::getVM(globalObject));
         JSValue jscThis = m_callFrame->thisValue().toThis(globalObject, JSC::ECMAMode::sloppy());
-        // Sloppy toThis only allocates wrapper objects for primitives; it has no throwing path.
         scope.assertNoException();
         m_callFrame->setThisValue(jscThis);
     }

--- a/src/jsc/bindings/v8/shim/FunctionTemplate.cpp
+++ b/src/jsc/bindings/v8/shim/FunctionTemplate.cpp
@@ -145,9 +145,7 @@ JSC::EncodedJSValue FunctionTemplate::functionCall(JSC::JSGlobalObject* globalOb
 {
     auto* callee = dynamicDowncast<Function>(callFrame->jsCallee());
 
-    // V8 function calls always run in "sloppy mode," even if the JS side is in strict mode: null,
-    // undefined and the scope object JSC leaves in the this slot of a call resolved through a
-    // captured or module binding all become globalThis, and primitives are boxed.
+    // V8 function calls always run in "sloppy mode," even if the JS side is in strict mode.
     JSC::JSObject* jscThis = JSC::asObject(callFrame->thisValue().toThis(globalObject, JSC::ECMAMode::sloppy()));
 
     JSC::ArgList args(callFrame);

--- a/src/jsc/bindings/v8/shim/FunctionTemplate.cpp
+++ b/src/jsc/bindings/v8/shim/FunctionTemplate.cpp
@@ -145,14 +145,10 @@ JSC::EncodedJSValue FunctionTemplate::functionCall(JSC::JSGlobalObject* globalOb
 {
     auto* callee = dynamicDowncast<Function>(callFrame->jsCallee());
 
-    // V8 function calls always run in "sloppy mode," even if the JS side is in strict mode. So if
-    // `this` is null or undefined, we use globalThis instead; otherwise, we convert `this` to an
-    // object.
-    JSC::JSObject* jscThis = globalObject->globalThis();
-    if (!callFrame->thisValue().isUndefinedOrNull()) {
-        // TODO(@190n) throwscope, assert no exception
-        jscThis = callFrame->thisValue().toObject(globalObject);
-    }
+    // V8 function calls always run in "sloppy mode," even if the JS side is in strict mode: null,
+    // undefined and the scope object JSC leaves in the this slot of a call resolved through a
+    // captured or module binding all become globalThis, and primitives are boxed.
+    JSC::JSObject* jscThis = JSC::asObject(callFrame->thisValue().toThis(globalObject, JSC::ECMAMode::sloppy()));
 
     JSC::ArgList args(callFrame);
     return JSValue::encode(invokeCallback(globalObject, callee, jscThis, args, false));

--- a/src/jsc/bindings/v8/shim/TemplateProperty.cpp
+++ b/src/jsc/bindings/v8/shim/TemplateProperty.cpp
@@ -61,8 +61,7 @@ static JSC::JSValue invokeAccessor(
 
     HandleScope hs(isolate);
 
-    // Same sloppy-mode receiver rule as FunctionTemplate::functionCall: null, undefined and a
-    // scope object passed as the receiver of a bare call become globalThis, primitives are boxed.
+    // Sloppy-mode receiver, as in FunctionTemplate::functionCall.
     JSC::JSObject* jscThis = JSC::asObject(thisObject.toThis(globalObject, JSC::ECMAMode::sloppy()));
     Local<v8::Object> holder = hs.createLocal<v8::Object>(vm, jscThis);
     Local<v8::Name> property = hs.createLocal<v8::Name>(vm, name);

--- a/src/jsc/bindings/v8/shim/TemplateProperty.cpp
+++ b/src/jsc/bindings/v8/shim/TemplateProperty.cpp
@@ -61,12 +61,9 @@ static JSC::JSValue invokeAccessor(
 
     HandleScope hs(isolate);
 
-    JSC::JSObject* jscThis = globalObject->globalThis();
-    if (!thisObject.isUndefinedOrNull()) {
-        jscThis = thisObject.toObject(globalObject);
-        if (!jscThis) [[unlikely]]
-            return JSC::jsUndefined();
-    }
+    // Same sloppy-mode receiver rule as FunctionTemplate::functionCall: null, undefined and a
+    // scope object passed as the receiver of a bare call become globalThis, primitives are boxed.
+    JSC::JSObject* jscThis = JSC::asObject(thisObject.toThis(globalObject, JSC::ECMAMode::sloppy()));
     Local<v8::Object> holder = hs.createLocal<v8::Object>(vm, jscThis);
     Local<v8::Name> property = hs.createLocal<v8::Name>(vm, name);
     Local<v8::Value> dataLocal = hs.createLocal<v8::Value>(vm, data);

--- a/test/js/node/errors/error-code-toString-receiver.test.ts
+++ b/test/js/node/errors/error-code-toString-receiver.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { readFileSync } from "node:fs";
+
+// Errors with a Node `code` get their prototype, including `toString`, from the native
+// error table (src/jsc/bindings/ErrorCode.cpp).
+function nodeError(): Error & { code: string } {
+  try {
+    // @ts-expect-error the missing argument is the point
+    readFileSync();
+  } catch (e) {
+    return e as Error & { code: string };
+  }
+  throw new Error("readFileSync() did not throw");
+}
+
+describe("node error toString()", () => {
+  test("formats name, code and message", () => {
+    const err = nodeError();
+    expect({ code: err.code, string: err.toString() }).toEqual({
+      code: "ERR_INVALID_ARG_TYPE",
+      string: `TypeError [ERR_INVALID_ARG_TYPE]: ${err.message}`,
+    });
+  });
+
+  // A call resolved through a binding that a closure captures is compiled with the scope
+  // object itself in the this slot; native functions see it raw. toString() used to read
+  // name/code/message off that scope object and return "undefined [undefined]: undefined".
+  // Node's toString is strict-mode JS, so it throws on the undefined receiver instead.
+  test("called without a receiver through a captured binding throws like Node", () => {
+    const { toString } = nodeError();
+    function keep() {
+      return toString;
+    }
+    expect(() => toString()).toThrow(TypeError);
+    expect(keep()).toBe(toString);
+  });
+
+  // Reading a binding that is still in its temporal dead zone through the scope object yields
+  // an empty value rather than a TDZ error, and toString() crashed the process (SIGSEGV at
+  // address 0x5) when it tried to stringify it.
+  test("called through a scope whose `name` binding is in its TDZ does not crash", async () => {
+    const src = `
+      let toString;
+      try {
+        require("node:fs").readFileSync();
+      } catch (e) {
+        ({ toString } = e);
+      }
+      let result;
+      try {
+        result = toString();
+      } catch (e) {
+        result = e.constructor.name;
+      }
+      console.log(result);
+      let name = "initialized only after the call above";
+      function keep() {
+        return [toString, name];
+      }
+      keep();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "TypeError\n", stderr: "", exitCode: 0 });
+  });
+});

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -57,12 +57,13 @@ test("Stats instances share Stats.prototype", () => {
 });
 
 // A call resolved through a binding that a closure captures is compiled with the scope object
-// itself in the this slot, and native methods see it raw. isFile() and friends used to read
-// `mode` out of that scope object: a missing binding produced a bogus false, and a `mode` binding
-// still in its temporal dead zone crashed the process. Such a receiver now gets the same answer as
-// any other non-object receiver.
-describe("Stats mode methods called without a receiver", () => {
-  test("a call through a captured binding is treated like an undefined receiver", () => {
+// itself in the this slot, and native functions see it raw. isFile() and friends used to read
+// `mode` out of that scope object (the date getters, once pulled out of their property descriptor,
+// `atimeMs` and so on): a missing binding produced a bogus answer, and a binding still in its
+// temporal dead zone crashed the process. Such a receiver now gets the same answer as any other
+// non-object receiver.
+describe("Stats methods and accessors called without a receiver", () => {
+  test("a mode method called through a captured binding is treated like an undefined receiver", () => {
     const stats = statSync(import.meta.path);
     const bigintStats = statSync(import.meta.dir, { bigint: true });
     const { isFile } = stats;
@@ -82,15 +83,37 @@ describe("Stats mode methods called without a receiver", () => {
     expect(keep()).toEqual([isFile, isDirectory]);
   });
 
-  test("a call through a scope whose `mode` binding is in its TDZ does not crash", async () => {
+  test("a date getter called through a captured binding is treated like an undefined receiver", () => {
+    const stats = statSync(import.meta.path);
+    const bigintStats = statSync(import.meta.path, { bigint: true });
+    const atime = Object.getOwnPropertyDescriptor(Stats.prototype, "atime")!.get!;
+    const bigintMtime = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(bigintStats), "mtime")!.get!;
+    function keep() {
+      return [atime, bigintMtime];
+    }
+    expect({
+      bare: [atime(), bigintMtime()],
+      undefinedReceiver: [atime.call(undefined), bigintMtime.call(undefined)],
+      statsReceiver: [atime.call(stats), bigintMtime.call(bigintStats)],
+    }).toEqual({
+      bare: [undefined, undefined],
+      undefinedReceiver: [undefined, undefined],
+      statsReceiver: [stats.atime, bigintStats.mtime],
+    });
+    expect(keep()).toEqual([atime, bigintMtime]);
+  });
+
+  test("calls through a scope whose `mode` and `atimeMs` bindings are in their TDZ do not crash", async () => {
     const src = `
-      const { statSync } = require("node:fs");
+      const { Stats, statSync } = require("node:fs");
       const { isFile } = statSync(${JSON.stringify(import.meta.path)});
       const { isDirectory } = statSync(${JSON.stringify(import.meta.dir)}, { bigint: true });
-      console.log(isFile(), isDirectory());
+      const atime = Object.getOwnPropertyDescriptor(Stats.prototype, "atime").get;
+      console.log(isFile(), isDirectory(), atime());
       let mode = 0;
+      let atimeMs = 0;
       function keep() {
-        return [isFile, isDirectory, mode];
+        return [isFile, isDirectory, atime, mode, atimeMs];
       }
       keep();
     `;
@@ -101,6 +124,10 @@ describe("Stats mode methods called without a receiver", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "undefined undefined\n", stderr: "", exitCode: 0 });
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "undefined undefined undefined\n",
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });

--- a/test/js/node/fs/fs-stats-constructor.test.ts
+++ b/test/js/node/fs/fs-stats-constructor.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { Stats, statSync } from "node:fs";
 
 // Node.js's Stats constructor signature (deprecated, DEP0180):
@@ -53,4 +54,53 @@ test("Stats instances share Stats.prototype", () => {
   const bigint = statSync(import.meta.path, { bigint: true });
   expect(Object.getPrototypeOf(bigint).constructor.name).toBe("BigIntStats");
   expect(bigint instanceof Object.getPrototypeOf(bigint).constructor).toBe(true);
+});
+
+// A call resolved through a binding that a closure captures is compiled with the scope object
+// itself in the this slot, and native methods see it raw. isFile() and friends used to read
+// `mode` out of that scope object: a missing binding produced a bogus false, and a `mode` binding
+// still in its temporal dead zone crashed the process. Such a receiver now gets the same answer as
+// any other non-object receiver.
+describe("Stats mode methods called without a receiver", () => {
+  test("a call through a captured binding is treated like an undefined receiver", () => {
+    const stats = statSync(import.meta.path);
+    const bigintStats = statSync(import.meta.dir, { bigint: true });
+    const { isFile } = stats;
+    const { isDirectory } = bigintStats;
+    function keep() {
+      return [isFile, isDirectory];
+    }
+    expect({
+      bare: [isFile(), isDirectory()],
+      undefinedReceiver: [isFile.call(undefined), isDirectory.call(undefined)],
+      statsReceiver: [isFile.call(stats), isDirectory.call(bigintStats)],
+    }).toEqual({
+      bare: [undefined, undefined],
+      undefinedReceiver: [undefined, undefined],
+      statsReceiver: [true, true],
+    });
+    expect(keep()).toEqual([isFile, isDirectory]);
+  });
+
+  test("a call through a scope whose `mode` binding is in its TDZ does not crash", async () => {
+    const src = `
+      const { statSync } = require("node:fs");
+      const { isFile } = statSync(${JSON.stringify(import.meta.path)});
+      const { isDirectory } = statSync(${JSON.stringify(import.meta.dir)}, { bigint: true });
+      console.log(isFile(), isDirectory());
+      let mode = 0;
+      function keep() {
+        return [isFile, isDirectory, mode];
+      }
+      keep();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "undefined undefined\n", stderr: "", exitCode: 0 });
+  });
 });

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -286,6 +286,26 @@ describe("StringDecoder called without new", () => {
     expect(RealStringDecoder.call(receiver, "latin1")).toBe(receiver);
     expect(receiver.encoding).toBe("latin1");
   });
+
+  // The constructor used to call asObject() on the receiver before checking that it is one, which
+  // aborts a debug build for any non-object receiver. Run it in a child so the abort shows up as a
+  // failed assertion instead of taking the test runner down.
+  it("returns a decoder for an undefined or primitive receiver", async () => {
+    const src = `
+      const { StringDecoder } = require("node:string_decoder");
+      const local = StringDecoder;
+      const results = [local("utf8"), StringDecoder.call(undefined, "utf8"), StringDecoder.call("x", "utf8")];
+      console.log(results.every(d => d instanceof StringDecoder && d.encoding === "utf8"));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "true\n", stderr: "", exitCode: 0 });
+  });
 });
 
 // Node's lastTotal getter is MissingBytes + BufferedBytes; Node clears BufferedBytes when a buffered

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -264,6 +264,30 @@ it("normalizes the encoding name like Node", () => {
   });
 });
 
+// A call resolved through a binding that a closure captures (or through a module binding) is
+// compiled with the scope object itself in the this slot, and native callees see it raw.
+// StringDecoder called without new used to mistake that scope object for a body-parser style
+// receiver: it wrote the decoder state onto it and returned it instead of a decoder.
+describe("StringDecoder called without new", () => {
+  it("returns a decoder when the callee is resolved through a captured binding", () => {
+    const StringDecoder = RealStringDecoder;
+    function keep() {
+      return StringDecoder;
+    }
+    const decoder = StringDecoder("latin1");
+    expect(decoder).toBeInstanceOf(RealStringDecoder);
+    expect(decoder.encoding).toBe("latin1");
+    expect(decoder.write(Buffer.from([0xe9]))).toBe("é");
+    expect(keep()).toBe(RealStringDecoder);
+  });
+
+  it("still initializes an explicit object receiver (body-parser style)", () => {
+    const receiver = {};
+    expect(RealStringDecoder.call(receiver, "latin1")).toBe(receiver);
+    expect(receiver.encoding).toBe("latin1");
+  });
+});
+
 // Node's lastTotal getter is MissingBytes + BufferedBytes; Node clears BufferedBytes when a buffered
 // partial is emitted so lastTotal returns to 0. end() resets lastNeed/lastTotal but leaves lastChar.
 // Decoded output was always correct; this is purely about the observable legacy state triple.

--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -663,7 +663,19 @@ static napi_value test_reference_unref_underflow(const Napi::CallbackInfo &info)
   return result;
 }
 
+// Returns the this_arg that napi_get_cb_info reports for this call, so JS can
+// check what a callback sees as its receiver for different call shapes.
+static napi_value return_this(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  napi_value this_arg;
+  NODE_API_CALL(env,
+                napi_get_cb_info(env, static_cast<napi_callback_info>(info),
+                                 nullptr, nullptr, &this_arg, nullptr));
+  return this_arg;
+}
+
 void register_js_test_helpers(Napi::Env env, Napi::Object exports) {
+  REGISTER_FUNCTION(env, exports, return_this);
   REGISTER_FUNCTION(env, exports, create_ref_with_finalizer);
   REGISTER_FUNCTION(env, exports, was_finalize_called);
   REGISTER_FUNCTION(env, exports, call_and_get_exception);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -766,6 +766,22 @@ nativeTests.test_type_tag = () => {
   console.log("o2 matches o2:", nativeTests.check_tag(o2, 3, 4));
 };
 
+nativeTests.test_this_value_of_bare_call_through_closure = () => {
+  const { return_this } = nativeTests;
+  // return_this is captured by keep, so the bare call below is resolved through the closure's
+  // scope object, which JSC leaves in the call's this slot. A Node-API callback must still see
+  // the sloppy-mode receiver (globalThis), never that scope object.
+  function keep() {
+    return return_this;
+  }
+  console.log("bare call through closure returned globalThis:", return_this() === globalThis);
+  console.log("call(undefined) returned globalThis:", return_this.call(undefined) === globalThis);
+  console.log("call(5) returned a Number object:", return_this.call(5) instanceof Number);
+  const receiver = {};
+  console.log("call(receiver) returned receiver:", return_this.call(receiver) === receiver);
+  keep();
+};
+
 nativeTests.test_napi_class = () => {
   const NapiClass = nativeTests.get_class_with_constructor();
   const instance = new NapiClass();

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -1133,6 +1133,13 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     });
   });
 
+  describe("napi_get_cb_info this_arg", () => {
+    it("is globalThis for a bare call resolved through a closure scope", async () => {
+      const output = await checkSameOutput("test_this_value_of_bare_call_through_closure", []);
+      expect(output).toContain("bare call through closure returned globalThis: true");
+    });
+  });
+
   describe("bigint conversion to int64/uint64", () => {
     it("works", async () => {
       const tests = [-1n, 0n, 1n];

--- a/test/v8/v8-module/main.cpp
+++ b/test/v8/v8-module/main.cpp
@@ -435,6 +435,7 @@ class GlobalTestWrapper {
 public:
   static void set(const FunctionCallbackInfo<Value> &info);
   static void get(const FunctionCallbackInfo<Value> &info);
+  static void store(Isolate *isolate, Local<Value> new_value);
   static void cleanup(void *unused);
 
 private:
@@ -463,7 +464,36 @@ void GlobalTestWrapper::get(const FunctionCallbackInfo<Value> &info) {
   }
 }
 
+void GlobalTestWrapper::store(Isolate *isolate, Local<Value> new_value) {
+  value.Reset(isolate, new_value);
+}
+
 void GlobalTestWrapper::cleanup(void *unused) { value.Reset(); }
+
+// Native data property whose getter returns the holder it was invoked on and
+// whose setter stores it where global_get() can read it, so JS can check what
+// receiver the accessor callbacks see for different ways of reaching them.
+static void holder_getter(Local<Name> property,
+                          const PropertyCallbackInfo<Value> &info) {
+  info.GetReturnValue().Set(info.HolderV2());
+}
+
+static void holder_setter(Local<Name> property, Local<Value> value,
+                          const PropertyCallbackInfo<void> &info) {
+  GlobalTestWrapper::store(info.GetIsolate(), info.HolderV2());
+}
+
+void create_object_with_holder_accessor(
+    const FunctionCallbackInfo<Value> &info) {
+  Isolate *isolate = info.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+
+  Local<ObjectTemplate> obj_t = ObjectTemplate::New(isolate);
+  obj_t->SetNativeDataProperty(String::NewFromUtf8Literal(isolate, "holder"),
+                               holder_getter, holder_setter);
+
+  info.GetReturnValue().Set(obj_t->NewInstance(context).ToLocalChecked());
+}
 
 void test_many_v8_locals(const FunctionCallbackInfo<Value> &info) {
   Isolate *isolate = info.GetIsolate();
@@ -1887,6 +1917,8 @@ void initialize(Local<Object> exports, Local<Value> module,
                   test_v8_function_template_set_class_name);
   NODE_SET_METHOD(exports, "print_values_from_js", print_values_from_js);
   NODE_SET_METHOD(exports, "return_this", return_this);
+  NODE_SET_METHOD(exports, "create_object_with_holder_accessor",
+                  create_object_with_holder_accessor);
   NODE_SET_METHOD(exports, "global_get", GlobalTestWrapper::get);
   NODE_SET_METHOD(exports, "global_set", GlobalTestWrapper::set);
   NODE_SET_METHOD(exports, "test_many_v8_locals", test_many_v8_locals);

--- a/test/v8/v8-module/module.js
+++ b/test/v8/v8-module/module.js
@@ -130,6 +130,49 @@ module.exports = debugMode => {
       keep();
     },
 
+    native_accessor_holder_on_property_access() {
+      const obj = nativeModule.create_object_with_holder_accessor();
+      console.log("getter holder is the object:", obj.holder === obj);
+      obj.holder = 1;
+      console.log("setter holder is the object:", nativeModule.global_get() === obj);
+    },
+
+    // Bun only: V8 itself installs a native data property as a data property, so Bun is the one
+    // runtime where its getter and setter exist as functions that can be called with any receiver.
+    native_accessor_holder_for_weird_receivers() {
+      const obj = nativeModule.create_object_with_holder_accessor();
+      const { get, set } = Object.getOwnPropertyDescriptor(obj, "holder");
+      // get and set are captured by keep, so the bare calls below are resolved through the
+      // closure's scope object, which JSC leaves in the call's this slot.
+      function keep() {
+        return [get, set];
+      }
+      const describe = value => {
+        if (value === globalThis) return "globalThis";
+        if (value === obj) return "the object";
+        if (value instanceof Number) return "a Number object";
+        return typeof value;
+      };
+      const holderSeenBySetter = receiver => {
+        nativeModule.global_set(undefined);
+        set.call(receiver, 1);
+        return nativeModule.global_get();
+      };
+      console.log("bare getter():", describe(get()));
+      console.log("getter.call(undefined):", describe(get.call(undefined)));
+      console.log("getter.call(null):", describe(get.call(null)));
+      console.log("getter.call(5):", describe(get.call(5)));
+      console.log("getter.call(obj):", describe(get.call(obj)));
+      nativeModule.global_set(undefined);
+      set(1);
+      console.log("bare setter():", describe(nativeModule.global_get()));
+      console.log("setter.call(undefined):", describe(holderSeenBySetter(undefined)));
+      console.log("setter.call(null):", describe(holderSeenBySetter(null)));
+      console.log("setter.call(5):", describe(holderSeenBySetter(5)));
+      console.log("setter.call(obj):", describe(holderSeenBySetter(obj)));
+      keep();
+    },
+
     test_v8_object_get_set_exceptions() {
       for (const key of [0, "key"]) {
         for (const access of ["get", "set"]) {

--- a/test/v8/v8-module/module.js
+++ b/test/v8/v8-module/module.js
@@ -118,6 +118,18 @@ module.exports = debugMode => {
       }
     },
 
+    call_function_bare_through_closure() {
+      const { return_this } = nativeModule;
+      // return_this is captured by keep, so the bare call below is resolved through the closure's
+      // scope object, which JSC leaves in the call's this slot. The callback must still see the
+      // sloppy-mode receiver (globalThis), never that scope object.
+      function keep() {
+        return return_this;
+      }
+      console.log("bare call returned globalThis:", return_this() === globalThis);
+      keep();
+    },
+
     test_v8_object_get_set_exceptions() {
       for (const key of [0, "key"]) {
         for (const access of ["get", "set"]) {

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -390,6 +390,36 @@ describe.skipIf(!canBuildNodeAddons()).todoIf(isBroken && isMusl)("node:v8", () 
     it("prototype methods and native accessors are reachable on instances", async () => {
       await checkSameOutput("test_v8_prototype_template");
     });
+
+    it("native accessor callbacks see the object as their holder on property access", async () => {
+      const output = await checkSameOutput("native_accessor_holder_on_property_access");
+      expect(output).toBe(["getter holder is the object: true", "setter holder is the object: true"].join("\n"));
+    });
+
+    // Only Bun exposes a native data property's getter and setter as callable functions, so this
+    // cannot be compared against Node: the receiver has to be converted the way a sloppy-mode
+    // function would, in particular a bare call through a closure must not hand the accessor the
+    // scope object JSC leaves in the this slot.
+    it("native accessor callbacks get a sloppy-mode holder when called as functions", async () => {
+      const expected = [
+        "bare getter(): globalThis",
+        "getter.call(undefined): globalThis",
+        "getter.call(null): globalThis",
+        "getter.call(5): a Number object",
+        "getter.call(obj): the object",
+        "bare setter(): globalThis",
+        "setter.call(undefined): globalThis",
+        "setter.call(null): globalThis",
+        "setter.call(5): a Number object",
+        "setter.call(obj): the object",
+      ].join("\n");
+      for (const buildMode of [BuildMode.release, BuildMode.debug]) {
+        const output = await runOn(Runtime.bun, buildMode, "native_accessor_holder_for_weird_receivers");
+        expect(output.replaceAll(/^\[\w+\].+$/gm, "").trim(), `addon built in ${BuildMode[buildMode]} mode`).toBe(
+          expected,
+        );
+      }
+    });
   });
 
   describe("ArrayBuffer / TypedArray", () => {

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -294,6 +294,11 @@ describe.skipIf(!canBuildNodeAddons()).todoIf(isBroken && isMusl)("node:v8", () 
     it("correctly receives the this value from JS", async () => {
       await checkSameOutput("call_function_with_weird_this_values");
     });
+
+    it("receives globalThis as this when called bare through a closure", async () => {
+      const output = await checkSameOutput("call_function_bare_through_closure");
+      expect(output).toContain("bare call returned globalThis: true");
+    });
   });
 
   describe("error handling", () => {


### PR DESCRIPTION
### Problem

- When JS calls a function with no receiver through a binding that a closure captures (or a module binding), the callee's this slot holds the scope object that the binding was resolved through. This is the normal shape of `const { x } = require(...)` followed by `x()` inside any function. JS callees convert that slot in `op_to_this`; host functions read it raw. The native functions changed in this PR use their receiver generically and so act on the scope object:
  - `NodeError_proto_toString` (`src/jsc/bindings/ErrorCode.cpp:55`) reads `name`/`code`/`message` through it. A binding in the scope that is still in its TDZ reads back as the empty `JSValue`, and the process dies with `panic(main thread): Segmentation fault at address 0x5`. Without a TDZ binding it returns `"undefined [undefined]: undefined"`. Node throws a `TypeError`.
  - `fs.Stats` / `BigIntStats` `isFile()` and the other mode methods (`src/jsc/bindings/NodeFSStatBinding.cpp:142`) read `mode` through it: the same segfault with a TDZ `mode` binding, otherwise a bogus `false` (or a `TypeError` from `toBigInt64` for the BigInt variant). The `atime`/`mtime`/`ctime`/`birthtime` accessors in the same file (`getDateField`, `DatePutter`) have the same shape once their getter is pulled out of the property descriptor: JSC's `JSCustomGetterFunction` wrapper also passes the slot through raw, so a bare call segfaults on a TDZ `atimeMs` binding and otherwise returns an Invalid Date.
  - `StringDecoder(...)` called without `new` (`src/jsc/bindings/JSStringDecoder.cpp:596`) treats it as the body-parser style receiver: it writes the decoder state onto it and returns it, so the caller gets `[native code: JSLexicalEnvironment]` instead of a decoder. The same code also ran `asObject()` on the slot before checking that it holds an object, which aborts debug builds for `StringDecoder.call(undefined, enc)`.
  - `NAPICallFrame` (`src/jsc/bindings/napi.h:986`) and the V8 shim's `FunctionTemplate::functionCall` and `invokeAccessor` (`src/jsc/bindings/v8/shim/FunctionTemplate.cpp:151`, `shim/TemplateProperty.cpp:64`) emulate a sloppy-mode receiver by hand: undefined/null become globalThis, everything else goes through `toObject()`. A scope object is already an object, so the addon receives it as `this_arg` / `info.This()` / `HolderV2()`. Node gives it globalThis.
- All of the above reproduce on the current release build (repros in the details block).
- Root cause: `FunctionCallResolveNode::emitBytecode` (JavaScriptCore bytecompiler) stores the resolve-scope result in the this register and leaves the conversion to the callee. Converting `JSScope` receivers once, where JSC enters a host function, would retire the whole class; that is a change to the WebKit fork. Until then the fix is the one JSC's own host functions use: call `JSValue::toThis` before using the receiver generically. Bun already does this in `JSBuffer.cpp`, `JSDOMOperation.h` and `JSEventTargetCustom.h`.

### Fix

- `NodeError_proto_toString`, the Stats mode methods and date accessors, and the `StringDecoder` constructor convert the receiver with `toThis(globalObject, ECMAMode::strict())` first. Strict `toThis` maps scope objects to `undefined` and returns every other value unchanged, so `err.toString()`, `stats.isFile()`, `stats.atime`, `StringDecoder.call(obj, enc)` and `new StringDecoder()` are unaffected. The scope receiver then takes the path an undefined receiver already took: `toString()` throws the `TypeError` Node throws, `isFile()` and the date getters return `undefined` like they do for `.call(undefined)`, and `StringDecoder()` returns a fresh decoder. The Stats accessors only ever live on the two Stats prototypes, never on the global object, so no legitimate property access can hand them a scope receiver.
- The `StringDecoder` condition compares the converted receiver as a `JSValue` instead of calling `asObject()` on the slot. On a construct call the slot holds `new.target`, which is always a constructor object, so construct calls select the same branch as before.
- `NAPICallFrame`, `FunctionTemplate::functionCall` and `invokeAccessor` replace the hand-rolled logic with `toThis(globalObject, ECMAMode::sloppy())`, which is the engine's definition of a sloppy receiver: undefined, null and scope objects become globalThis, primitives are boxed, other objects pass through. This is what the old code computed for every input except scope objects, and it is what Node hands addons. Every Node-API callable (`napi_create_function`, class constructors, methods, accessors) is a `NapiClass` that builds its frame through this one constructor. Sloppy `toThis` has no throwing path, so the existing `assertNoException()` still holds.
- Verified with the debug build. Each new test fails on the release build as described:
  - `test/js/node/errors/error-code-toString-receiver.test.ts`: bare call throws (release: returns the garbage string), TDZ variant in a child exits 0 (release: exit 139).
  - `test/js/node/fs/fs-stats-constructor.test.ts`: bare `isFile()` / BigInt `isDirectory()` return `undefined` (release: `false` / `TypeError`), the extracted `atime` / BigInt `mtime` getters return `undefined` (release: Invalid Date), TDZ variant in a child exits 0 (release: exit 139). The `DatePutter` hunk has no test of its own: a setter called on a scope object only wrote onto that object, which JS cannot observe.
  - `test/js/node/string_decoder/string-decoder.test.js`: captured bare call returns a decoder (release: `[native code: JSLexicalEnvironment]`), explicit object receiver still initialized, undefined/primitive receivers in a child (unfixed debug build: SIGABRT in `asObject`).
  - `test/napi/napi.test.ts` (new `return_this` helper in the test addon) and `test/v8/v8.test.ts` (existing `return_this`): output compared against node; release prints `false` for the closure line where node prints `true`, the `call(undefined)` / `call(5)` / `call(receiver)` lines already matched.
  - `test/v8/v8.test.ts` accessor coverage (new `create_object_with_holder_accessor` fixture): property access compared against node, plus a Bun-only test that calls the getter and setter functions with bare, undefined, null, primitive and object receivers. Release differs only on the two bare-call lines.
  - Full `napi.test.ts` (175 pass) and `v8.test.ts` (77 pass, 1 pre-existing skip), the js-native-api suites for functions, callbacks, constructors, object wrap, properties and new.target, node's `test-fs-stat*` and `test-string-decoder*`, and the existing string_decoder, stats and error-code tests all pass.
- Known sites of the same shape that this PR leaves alone:
  - `import.meta.resolve` / `resolveSync` (`ImportMetaObject.cpp`): a bare call already throws "must be bound to an import.meta object"; Node resolves it, because its function is bound to the module. That needs a per-module bound function (see #32248), not `toThis`.
  - `NodeVMScript` methods and other typed-receiver sites report the bad receiver as `Received [native code: JSLexicalEnvironment]` in the error message. Cosmetic, no crash.
  - Other custom accessors reached through `Object.getOwnPropertyDescriptor(...).get` get the raw receiver from JSC's `JSCustomGetterFunction` wrapper in the same way. The Stats ones are fixed here because they are in a file this PR already changes; the general fix is in the wrapper, which lives in the WebKit fork and covers every custom accessor at once. Note that `toThis` is not safe to add blindly to a custom accessor that can be installed on the global object, because a bare identifier read resolves on the global object itself, which is also a `JSScope`.
- Relation to the other open PRs for this root cause: #39207 fixes the chaining functions and the `inspect.custom` fallbacks, #39509 the mock functions and `createInvalidThisError`. This PR shares no file with #39207 and touches a different function of `ErrorCode.cpp` than #39509, so the three merge in any order. #32172 was the first attempt; every hunk in it is now in one of these three, and it no longer merges, so it is closed in favor of them.

### Background

- **this slot / `op_to_this`**: every call frame has a slot for the receiver. For `f()` where `f` lives in a scope rather than a local register, JSC stores the scope object it resolved `f` through in that slot and JS function prologues run `op_to_this`, which turns it into `undefined` (strict code) or globalThis (sloppy code). Native functions read the slot directly via `callFrame->thisValue()`.
- **`JSValue::toThis(globalObject, ECMAMode)`**: the runtime form of that conversion. Any object inheriting `JSScope` (`JSLexicalEnvironment` for closures, `JSModuleEnvironment` for ES modules, the global object itself) becomes `undefined` in strict mode or globalThis in sloppy mode. Strict mode returns every other value as is. Sloppy mode also turns undefined/null into globalThis and boxes primitives.
- **Scope objects and the TDZ**: property reads on a scope object go through its symbol table and return the raw variable slot. A `let`/`const` that is not initialized yet holds the empty `JSValue`, which the rest of the engine treats as a cell pointer; touching it is the segfault at address 5 (the offset of the cell type byte).
- **body-parser hack in StringDecoder**: Bun's `StringDecoder` accepts being called as a function on an arbitrary object and initializes that object in place (`RealStringDecoder.apply(this, ...)` from a `util.inherits` subclass). That is why the constructor looks at its receiver at all. The fix keeps that path and only stops scope objects from qualifying.
- **Holder in the V8 shim**: a native data property's callbacks receive the receiver as `HolderV2()`. Bun installs such properties as JS accessors, so their getter and setter can also be extracted from the property descriptor and called like functions; that is the path `invokeAccessor` converts.

<details>
<summary>Release-build repros (bun 1.4.0-canary)</summary>

```js
// exits 139; node prints "result: TypeError"
let toString;
try { require("node:fs").readFileSync(); } catch (e) { ({ toString } = e); }
let out;
try { out = toString(); } catch (e) { out = e.constructor.name; }
console.log("result:", out);
let name = "after";
function keep() { return [toString, name]; }
keep();
```

```js
// exits 139; node throws a TypeError
const { isFile } = require("node:fs").statSync(__filename);
console.log(isFile());
let mode = 0;
function keep() { return [isFile, mode]; }
keep();
```

```js
const { StringDecoder } = require("node:string_decoder");
function keep() { return StringDecoder; }
const d = StringDecoder("utf8");
console.log(Bun.inspect(d));                               // [native code: JSLexicalEnvironment]
console.log(d instanceof StringDecoder, typeof d.write);   // false undefined
```

```js
// addon.c: napi_create_function("returnThis") returning this_arg from napi_get_cb_info
const { returnThis } = require("./addon.node");
function keep() { return returnThis; }
console.log(returnThis() === globalThis);                  // bun: false, node: true
console.log(returnThis.call(undefined) === globalThis);    // both: true
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts test/v8/v8.test.ts

<!-- robobun:evidence:end -->