### PR TITLE
jsc: keep the out of memory throw out of every host function thunk

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -106,6 +106,8 @@ impl JSGlobalObject {
         JsError::Thrown
     }
 
+    #[cold]
+    #[inline(never)]
     pub fn throw_out_of_memory(&self) -> JsError {
         // See `throw_stack_overflow` for the validation-scope rationale.
         crate::validation_scope!(scope, self);
@@ -118,6 +120,8 @@ impl JSGlobalObject {
         JSGlobalObject__createOutOfMemoryError(self)
     }
 
+    #[cold]
+    #[inline(never)]
     pub fn throw_out_of_memory_value(&self) -> JSValue {
         JSGlobalObject__throwOutOfMemoryError(self);
         JSValue::ZERO

--- a/test/internal/source-lints/oom-throw-outlined.test.ts
+++ b/test/internal/source-lints/oom-throw-outlined.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Every Rust host function thunk converts its body's `JsResult` through
+// `to_js_host_call` (src/jsc/host_fn.rs), which is generic over the body, so
+// its `Err(JsError::OutOfMemory) => global.throw_out_of_memory_value()` arm is
+// instantiated once per thunk (about 1,170 of them). Under the cross-language
+// LTO the release builds use, the C++ body behind that call
+// (`JSGlobalObject__throwOutOfMemoryError`: throw scope, error object, throw)
+// gets inlined into each instantiation unless the Rust helper is kept out of
+// line: about 130 bytes per thunk, roughly 100 KB of binary, for a path that
+// only runs when an allocation fails. A local build has no cross-language LTO,
+// so dropping the attributes changes nothing anyone can see locally, and the
+// CI size check only fails on jumps of 0.5 MB or more.
+const FILE = "src/jsc/JSGlobalObject.rs";
+const REQUIRED = ["#[cold]", "#[inline(never)]"];
+const FUNCTIONS = ["throw_out_of_memory", "throw_out_of_memory_value"];
+
+function attributesOf(lines: string[], fnIndex: number): string[] {
+  const attributes: string[] = [];
+  for (let i = fnIndex - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line.startsWith("//")) continue;
+    if (!line.startsWith("#[")) break;
+    for (const [attribute] of line.matchAll(/#\[[^\]]*\]/g)) {
+      attributes.push(attribute.replace(/\s+/g, ""));
+    }
+  }
+  return attributes;
+}
+
+test("the out of memory throw helpers every host fn thunk instantiates stay out of line", () => {
+  const lines = readFileSync(path.resolve(import.meta.dir, "..", "..", "..", FILE), "utf8").split("\n");
+
+  const missing: Record<string, string[]> = {};
+  for (const name of FUNCTIONS) {
+    const definition = new RegExp(`^\\s*pub fn ${name}\\(`);
+    const fnIndex = lines.findIndex(line => definition.test(line));
+    if (fnIndex === -1) {
+      missing[name] = [`pub fn ${name} not found in ${FILE}`];
+      continue;
+    }
+    const attributes = attributesOf(lines, fnIndex);
+    const absent = REQUIRED.filter(attribute => !attributes.includes(attribute));
+    if (absent.length > 0) missing[name] = absent;
+  }
+
+  expect(missing).toEqual({});
+});


### PR DESCRIPTION
Adopts #39521 by @alii (cherry-picked unchanged, he remains the commit author) and adds a source lint that pins the attributes. Supersedes #39521.

### Problem
- Every Rust host function thunk converts the body's `JsResult` into JSC's return convention through `to_js_host_call` (`src/jsc/host_fn.rs:692`). That function is generic over the body closure, so it is instantiated once per thunk, and with it the `Err(JsError::OutOfMemory) => global.throw_out_of_memory_value()` arm. By @alii's symbol count that is about 1,170 thunks in the linux-x64 binary, 785 of them from the generated class bindings.
- In the release builds CI ships, cross-language LTO inlines the C++ `JSGlobalObject__throwOutOfMemoryError` (`src/jsc/bindings/bindings.cpp:2560`: set up a throw scope, build the OutOfMemoryError object, throw it) through `throw_out_of_memory_value` into each of those instantiations, about 130 bytes per thunk for a path that only runs when an allocation fails.
- `throw_out_of_memory` (the `JsError` returning variant, about 65 direct callers in `src/`) inlines the same body plus its validation scope at every call site.

### Fix
- `throw_out_of_memory` and `throw_out_of_memory_value` in `src/jsc/JSGlobalObject.rs` are now `#[cold] #[inline(never)]`, so each thunk and caller keeps one `call` to a single shared body.
- This is the spelling the codebase already uses for error slow paths (`throw_illegal_constructor` in the same file, `terminated_beneath_script` in `host_fn.rs`, which is what the `Terminated` arm of the same match already goes through, and a couple of hundred other `#[cold] #[inline(never)]` fns in `src/`).
- Behavior is unchanged: same error object, same exception scope handling, the only thing that changes is where the code lives.
- Nothing observable from JS changes, so the test is a source lint, `test/internal/source-lints/oom-throw-outlined.test.ts`: it reads `JSGlobalObject.rs` and checks that both helpers still carry `#[cold]` and `#[inline(never)]`. Dropping them is invisible in a local build (no cross-language LTO) and stays under the 0.5 MB threshold of CI's binary-size check, so nothing else would notice. Fails on main (both attributes reported missing on both fns), passes here; the other 23 files in that directory still pass alongside it.
- Verified:
  - CI's binary-size step on #39521, which is this exact diff on the same base commit (54784dcefd) as the canary baseline it was compared against: darwin-aarch64 -80.6 KB, darwin-x64 -85.4 KB, linux-x64 -128 KB, linux-aarch64 -128 KB, linux-x64-musl -112 KB, linux-aarch64-musl -128 KB, windows-x64 -49.5 KB. The Linux deltas are quantized by alignment padding (the 16 KB aligned `.bun` section on x64, 64 KB segment alignment on aarch64); the darwin and windows figures are closer to the raw code delta.
  - The lanes built without LTO (android, freebsd, windows-aarch64) moved by +64 KB (android-aarch64, one alignment step), 0, 0, 0 and -2 KB. Without cross-language LTO the C++ body was never inlined into the thunks, so no saving was expected there.
  - `cargo check -p bun_jsc` locally; the 13 build-bun jobs passed on the #39521 build.

### Background
- A host function is a native function JSC calls when JS invokes a native method, getter, setter or constructor. On the Rust side each one is wrapped in a small thunk (expanded by `#[bun_jsc::host_fn]` or emitted by `generate-classes.ts`) that turns the Rust `JsResult<JSValue>` into what JSC expects: a value, or an empty value with an exception pending on the VM.
- `JsError::OutOfMemory` is how Rust code reports an allocation failure without touching the VM at the failure site. The thunk is the place that turns it into a real JS exception, which is why every thunk contains a copy of that conversion.
- Cross-language LTO: in CI release builds rustc emits LLVM bitcode and the final link optimizes Rust and C++ together, so a C++ function called from Rust can be inlined into its Rust caller. That is why a one-line extern call in the Rust source costs about 130 bytes per thunk in the shipped binary, and why a local build (no cross-language LTO) shows almost no difference from this change.
- `#[cold]` tells LLVM the function is rarely executed (the call is laid out off the hot path and the inlining threshold for it drops); `#[inline(never)]` additionally guarantees the body is never duplicated into a caller. `#[cold]` alone still lets LLVM inline small bodies, so both are needed to get exactly one copy.
