### PR TITLE
node:vm: fix crash creating a ShadowRealm inside a context

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -989,7 +989,7 @@ const JSC::GlobalObjectMethodTable& NodeVMGlobalObject::globalObjectMethodTable(
         nullptr, // defaultLanguage
         nullptr, // compileStreaming
         nullptr, // instantiateStreaming
-        nullptr,
+        &Zig::GlobalObject::deriveShadowRealmGlobalObject,
         &codeForEval,
         &canCompileStrings,
         &trustedScriptStructure,

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -946,7 +946,7 @@ namespace Zig {
 
 using namespace WebCore;
 
-static JSGlobalObject* deriveShadowRealmGlobalObject(JSGlobalObject* globalObject)
+JSGlobalObject* GlobalObject::deriveShadowRealmGlobalObject(JSGlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
     // Same reasoning as Zig__GlobalObject__createForTestIsolation: keep the
@@ -1000,7 +1000,7 @@ const JSC::GlobalObjectMethodTable& GlobalObject::globalObjectMethodTable()
         nullptr, // defaultLanguage
         &compileStreaming,
         &instantiateStreaming,
-        &Zig::deriveShadowRealmGlobalObject,
+        &deriveShadowRealmGlobalObject,
         &codeForEval, // codeForEval
         &canCompileStrings, // canCompileStrings
         &trustedScriptStructure, // trustedScriptStructure
@@ -1028,7 +1028,7 @@ const JSC::GlobalObjectMethodTable& EvalGlobalObject::globalObjectMethodTable()
         nullptr, // defaultLanguage
         &compileStreaming,
         &instantiateStreaming,
-        &Zig::deriveShadowRealmGlobalObject,
+        &deriveShadowRealmGlobalObject,
         &codeForEval, // codeForEval
         &canCompileStrings, // canCompileStrings
         &trustedScriptStructure, // trustedScriptStructure

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -65,6 +65,24 @@ describe("vm", () => {
       );
       expect(result).toBe(2);
     });
+    test("ShadowRealm can be created and used inside a context", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const vm = require("node:vm");
+          const realm = vm.runInNewContext("new ShadowRealm()");
+          const wrapped = vm.runInNewContext("new ShadowRealm().evaluate('(a, b) => a + b')");
+          console.log(typeof realm.evaluate, realm.evaluate("6 * 7"), wrapped(20, 22));`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("function 42 42\n");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("runInThisContext()", () => {


### PR DESCRIPTION
### What does this PR do?

`new ShadowRealm()` inside a `node:vm` context (`vm.runInNewContext("new ShadowRealm()")`, or any script run in a `createContext()` global) segfaulted at address 0. JSC's `ShadowRealmObject::create` calls the global's `deriveShadowRealmGlobalObject` method-table hook unconditionally, and the vm context global (`NodeVMGlobalObject`) had `nullptr` in that slot.

The vm context table now uses the same hook as the main global, so a ShadowRealm created inside a context is a fresh realm exactly like one created in the main realm. The hook was a file-static function while `ZigGlobalObject.h` already declared it as a `Zig::GlobalObject` static member with no definition; it is now that member, which is what lets `NodeVM.cpp` reference it.

### How did you verify your code works?

- New test in `test/js/node/vm/vm.test.ts` spawns bun, creates a ShadowRealm inside a context, evaluates in it and calls a wrapped function returned from it. With the current release the child segfaults; with this change it prints `function 42 42`.
- Ran test262's `built-ins/ShadowRealm` tests (67 files) through `vm.Script` in fresh contexts on a debug+ASAN build: no crashes (previously 11 of them segfaulted); remaining failures are unrelated (`$262.createRealm`, non-configurable `Bun` global).
- JSC's `stress/proxy-all-the-parameters.js` run inside a vm context (calls every global function, including `ShadowRealm`, with throwing proxies) no longer crashes.