### PR TITLE
share one binary search across large string maps

### DIFF
--- a/src/bun_core/comptime_string_map.rs
+++ b/src/bun_core/comptime_string_map.rs
@@ -526,5 +526,4 @@ mod tests {
             None
         );
     }
-
 }

--- a/src/bun_core/comptime_string_map.rs
+++ b/src/bun_core/comptime_string_map.rs
@@ -3,9 +3,8 @@
 //! Rust port of Zig's `ComptimeStringMap`. Declared via
 //! [`comptime_string_map!`] / [`comptime_string_set!`]; lookups compile to a
 //! `match key.len()` jump table plus constant-length byte compares (word-sized
-//! loads against immediates) — no hashing at runtime. Large maps keep the
-//! length dispatch but store their keys as data and share one binary search
-//! ([`SortedKeys`]) instead of unrolling a compare per key.
+//! loads against immediates) — no hashing at runtime. Large maps binary
+//! search [`SortedKeys`] tables instead.
 //!
 //! ```ignore
 //! bun_core::comptime_string_map! {

--- a/src/bun_core/comptime_string_map.rs
+++ b/src/bun_core/comptime_string_map.rs
@@ -72,6 +72,52 @@ impl HasLength for &crate::String {
     }
 }
 
+/// Key tables of a large map (see `SORTED_LOOKUP_MIN_KEYS` in the macro
+/// crate): the same length-then-bytes dispatch as the small-map compare
+/// tree, but as data plus one shared binary search instead of an unrolled
+/// compare per key.
+#[doc(hidden)]
+pub struct SortedKeys {
+    /// All keys concatenated in declaration order.
+    pub blob: &'static [u8],
+    /// `n + 1` prefix byte offsets into `blob`, declaration order.
+    pub offsets: &'static [u16],
+    /// Declaration indexes ordered by (length, bytes).
+    pub sorted: &'static [u16],
+    /// `MAX_LEN - MIN_LEN + 2` cumulative starts into `sorted`, one per length.
+    pub buckets: &'static [u16],
+    pub min_len: usize,
+}
+
+impl SortedKeys {
+    /// The key declared at index `decl`.
+    #[inline]
+    pub fn key(&self, decl: usize) -> &'static [u8] {
+        &self.blob[self.offsets[decl] as usize..self.offsets[decl + 1] as usize]
+    }
+
+    /// Declaration indexes of all keys of length `len`, sorted by bytes.
+    #[inline]
+    pub fn bucket(&self, len: usize) -> &'static [u16] {
+        let Some(i) = len.checked_sub(self.min_len) else {
+            return &[];
+        };
+        if i + 1 >= self.buckets.len() {
+            return &[];
+        }
+        &self.sorted[self.buckets[i] as usize..self.buckets[i + 1] as usize]
+    }
+
+    /// Declaration index of `key`, or `u32::MAX` for a miss.
+    #[inline(never)]
+    pub fn index_of(&self, key: &[u8]) -> u32 {
+        let bucket = self.bucket(key.len());
+        bucket
+            .binary_search_by(|&i| self.key(i as usize).cmp(key))
+            .map_or(u32::MAX, |pos| bucket[pos] as u32)
+    }
+}
+
 #[macro_export]
 macro_rules! comptime_string_map {
     ($($t:tt)*) => {
@@ -211,4 +257,274 @@ mod tests {
         assert_eq!(COMMANDS.len(), 3);
         assert_eq!(COMMANDS.iter().count(), 3);
     }
+    #[test]
+    fn large_map_uses_sorted_tables() {
+        crate::comptime_string_map! {
+            static BIG: usize = {
+            "k0000x" => 0,
+            "key1" => 1,
+            "key2" => 2,
+            "k0003xyyy" => 3,
+            "key4" => 4,
+            "key5" => 5,
+            "k0006xyyyyyy" => 6,
+            "key7" => 7,
+            "key8" => 8,
+            "k0009xyy" => 9,
+            "key10" => 10,
+            "key11" => 11,
+            "k0012xyyyyy" => 12,
+            "key13" => 13,
+            "key14" => 14,
+            "k0015xy" => 15,
+            "key16" => 16,
+            "key17" => 17,
+            "k0018xyyyy" => 18,
+            "key19" => 19,
+            "key20" => 20,
+            "k0021x" => 21,
+            "key22" => 22,
+            "key23" => 23,
+            "k0024xyyy" => 24,
+            "key25" => 25,
+            "key26" => 26,
+            "k0027xyyyyyy" => 27,
+            "key28" => 28,
+            "key29" => 29,
+            "k0030xyy" => 30,
+            "key31" => 31,
+            "key32" => 32,
+            "k0033xyyyyy" => 33,
+            "key34" => 34,
+            "key35" => 35,
+            "k0036xy" => 36,
+            "key37" => 37,
+            "key38" => 38,
+            "k0039xyyyy" => 39,
+            "key40" => 40,
+            "key41" => 41,
+            "k0042x" => 42,
+            "key43" => 43,
+            "key44" => 44,
+            "k0045xyyy" => 45,
+            "key46" => 46,
+            "key47" => 47,
+            "k0048xyyyyyy" => 48,
+            "key49" => 49,
+            "key50" => 50,
+            "k0051xyy" => 51,
+            "key52" => 52,
+            "key53" => 53,
+            "k0054xyyyyy" => 54,
+            "key55" => 55,
+            "key56" => 56,
+            "k0057xy" => 57,
+            "key58" => 58,
+            "key59" => 59,
+            "k0060xyyyy" => 60,
+            "key61" => 61,
+            "key62" => 62,
+            "k0063x" => 63,
+            "key64" => 64,
+            "key65" => 65,
+            "k0066xyyy" => 66,
+            "key67" => 67,
+            "key68" => 68,
+            "k0069xyyyyyy" => 69,
+            "key70" => 70,
+            "key71" => 71,
+            "k0072xyy" => 72,
+            "key73" => 73,
+            "key74" => 74,
+            "k0075xyyyyy" => 75,
+            "key76" => 76,
+            "key77" => 77,
+            "k0078xy" => 78,
+            "key79" => 79,
+            "key80" => 80,
+            "k0081xyyyy" => 81,
+            "key82" => 82,
+            "key83" => 83,
+            "k0084x" => 84,
+            "key85" => 85,
+            "key86" => 86,
+            "k0087xyyy" => 87,
+            "key88" => 88,
+            "key89" => 89,
+            "k0090xyyyyyy" => 90,
+            "key91" => 91,
+            "key92" => 92,
+            "k0093xyy" => 93,
+            "key94" => 94,
+            "key95" => 95,
+            "k0096xyyyyy" => 96,
+            "key97" => 97,
+            "key98" => 98,
+            "k0099xy" => 99,
+            "key100" => 100,
+            "key101" => 101,
+            "k0102xyyyy" => 102,
+            "key103" => 103,
+            "key104" => 104,
+            "k0105x" => 105,
+            "key106" => 106,
+            "key107" => 107,
+            "k0108xyyy" => 108,
+            "key109" => 109,
+            "key110" => 110,
+            "k0111xyyyyyy" => 111,
+            "key112" => 112,
+            "key113" => 113,
+            "k0114xyy" => 114,
+            "key115" => 115,
+            "key116" => 116,
+            "k0117xyyyyy" => 117,
+            "key118" => 118,
+            "key119" => 119,
+            "k0120xy" => 120,
+            "key121" => 121,
+            "key122" => 122,
+            "k0123xyyyy" => 123,
+            "key124" => 124,
+            "key125" => 125,
+            "k0126x" => 126,
+            "key127" => 127,
+            "key128" => 128,
+            "k0129xyyy" => 129,
+            "key130" => 130,
+            "key131" => 131,
+            "k0132xyyyyyy" => 132,
+            "key133" => 133,
+            "key134" => 134,
+            "k0135xyy" => 135,
+            "key136" => 136,
+            "key137" => 137,
+            "k0138xyyyyy" => 138,
+            "key139" => 139,
+            "key140" => 140,
+            "k0141xy" => 141,
+            "key142" => 142,
+            "key143" => 143,
+            "k0144xyyyy" => 144,
+            "key145" => 145,
+            "key146" => 146,
+            "k0147x" => 147,
+            "key148" => 148,
+            "key149" => 149,
+            "k0150xyyy" => 150,
+            "key151" => 151,
+            "key152" => 152,
+            "k0153xyyyyyy" => 153,
+            "key154" => 154,
+            "key155" => 155,
+            "k0156xyy" => 156,
+            "key157" => 157,
+            "key158" => 158,
+            "k0159xyyyyy" => 159,
+            "key160" => 160,
+            "key161" => 161,
+            "k0162xy" => 162,
+            "key163" => 163,
+            "key164" => 164,
+            "k0165xyyyy" => 165,
+            "key166" => 166,
+            "key167" => 167,
+            "k0168x" => 168,
+            "key169" => 169,
+            "key170" => 170,
+            "k0171xyyy" => 171,
+            "key172" => 172,
+            "key173" => 173,
+            "k0174xyyyyyy" => 174,
+            "key175" => 175,
+            "key176" => 176,
+            "k0177xyy" => 177,
+            "key178" => 178,
+            "key179" => 179,
+            "k0180xyyyyy" => 180,
+            "key181" => 181,
+            "key182" => 182,
+            "k0183xy" => 183,
+            "key184" => 184,
+            "key185" => 185,
+            "k0186xyyyy" => 186,
+            "key187" => 187,
+            "key188" => 188,
+            "k0189x" => 189,
+            "key190" => 190,
+            "key191" => 191,
+            "k0192xyyy" => 192,
+            "key193" => 193,
+            "key194" => 194,
+            "k0195xyyyyyy" => 195,
+            "key196" => 196,
+            "key197" => 197,
+            "k0198xyy" => 198,
+            "key199" => 199,
+            "key200" => 200,
+            "k0201xyyyyy" => 201,
+            "key202" => 202,
+            "key203" => 203,
+            "k0204xy" => 204,
+            "key205" => 205,
+            "key206" => 206,
+            "k0207xyyyy" => 207,
+            "key208" => 208,
+            "key209" => 209,
+            "k0210x" => 210,
+            "key211" => 211,
+            "key212" => 212,
+            "k0213xyyy" => 213,
+            "key214" => 214,
+            "key215" => 215,
+            "k0216xyyyyyy" => 216,
+            "key217" => 217,
+            "key218" => 218,
+            "k0219xyy" => 219,
+            "key220" => 220,
+            "key221" => 221,
+            "k0222xyyyyy" => 222,
+            "key223" => 223,
+            "key224" => 224,
+            "k0225xy" => 225,
+            "key226" => 226,
+            "key227" => 227,
+            "k0228xyyyy" => 228,
+            "key229" => 229,
+            "key230" => 230,
+            "k0231x" => 231,
+            "key232" => 232,
+            "key233" => 233,
+            "k0234xyyy" => 234,
+            "key235" => 235,
+            "key236" => 236,
+            "k0237xyyyyyy" => 237,
+            "key238" => 238,
+            "key239" => 239
+            };
+        }
+        assert_eq!(BIG.len(), 240);
+        for (i, (key, value)) in BIG.entries().enumerate() {
+            assert_eq!(*value, i);
+            assert_eq!(BIG.get(key), Some(&i));
+            let upper = key.to_ascii_uppercase();
+            assert_eq!(BIG.get_ascii_case_insensitive(&upper), Some(&i));
+            assert_eq!(BIG.get(&upper), None, "{}", key.escape_ascii());
+        }
+        assert_eq!(BIG.keys().next(), Some(b"k0000x".as_slice()));
+        assert_eq!(BIG.get(b""), None);
+        assert_eq!(BIG.get(b"key"), None);
+        assert_eq!(BIG.get(b"key1000"), None);
+        assert_eq!(BIG.get(b"k0000xyyyyyyyyyyyyyyyyy"), None);
+        assert_eq!(BIG.get_ascii_case_insensitive(b"KEY"), None);
+        assert_eq!(
+            BIG.get_with_eql(b"key7".as_slice(), |a: &[u8], b| a == b),
+            Some(&7)
+        );
+        assert_eq!(
+            BIG.get_with_eql(b"key0".as_slice(), |a: &[u8], b| a == b),
+            None
+        );
+    }
+
 }

--- a/src/bun_core/comptime_string_map.rs
+++ b/src/bun_core/comptime_string_map.rs
@@ -3,7 +3,9 @@
 //! Rust port of Zig's `ComptimeStringMap`. Declared via
 //! [`comptime_string_map!`] / [`comptime_string_set!`]; lookups compile to a
 //! `match key.len()` jump table plus constant-length byte compares (word-sized
-//! loads against immediates) — no hashing at runtime.
+//! loads against immediates) — no hashing at runtime. Large maps keep the
+//! length dispatch but store their keys as data and share one binary search
+//! ([`SortedKeys`]) instead of unrolling a compare per key.
 //!
 //! ```ignore
 //! bun_core::comptime_string_map! {
@@ -102,10 +104,10 @@ impl SortedKeys {
         let Some(i) = len.checked_sub(self.min_len) else {
             return &[];
         };
-        if i + 1 >= self.buckets.len() {
-            return &[];
+        match self.buckets.get(i..) {
+            Some(&[start, end, ..]) => &self.sorted[start as usize..end as usize],
+            _ => &[],
         }
-        &self.sorted[self.buckets[i] as usize..self.buckets[i + 1] as usize]
     }
 
     /// Declaration index of `key`, or `u32::MAX` for a miss.
@@ -257,6 +259,9 @@ mod tests {
         assert_eq!(COMMANDS.len(), 3);
         assert_eq!(COMMANDS.iter().count(), 3);
     }
+
+    /// 241 keys puts this map over `SORTED_LOOKUP_MIN_KEYS`; the last key is
+    /// the only one longer than 12 bytes, so lengths 13..=15 are empty buckets.
     #[test]
     fn large_map_uses_sorted_tables() {
         crate::comptime_string_map! {
@@ -500,10 +505,13 @@ mod tests {
             "key236" => 236,
             "k0237xyyyyyy" => 237,
             "key238" => 238,
-            "key239" => 239
+            "key239" => 239,
+            "k0240xyyyyyyyyyy" => 240
             };
         }
-        assert_eq!(BIG.len(), 240);
+        assert_eq!(BIG.len(), 241);
+        assert_eq!(<__ComptimeStringMap_BIG>::MIN_LEN, 4);
+        assert_eq!(<__ComptimeStringMap_BIG>::MAX_LEN, 16);
         for (i, (key, value)) in BIG.entries().enumerate() {
             assert_eq!(*value, i);
             assert_eq!(BIG.get(key), Some(&i));
@@ -512,11 +520,15 @@ mod tests {
             assert_eq!(BIG.get(&upper), None, "{}", key.escape_ascii());
         }
         assert_eq!(BIG.keys().next(), Some(b"k0000x".as_slice()));
+        // Below MIN_LEN, in-range lengths, an empty bucket, and past MAX_LEN.
         assert_eq!(BIG.get(b""), None);
         assert_eq!(BIG.get(b"key"), None);
+        assert_eq!(BIG.get(b"key0"), None);
         assert_eq!(BIG.get(b"key1000"), None);
+        assert_eq!(BIG.get(b"k0240xyyyyyyyy"), None);
         assert_eq!(BIG.get(b"k0000xyyyyyyyyyyyyyyyyy"), None);
         assert_eq!(BIG.get_ascii_case_insensitive(b"KEY"), None);
+        assert_eq!(BIG.get_ascii_case_insensitive(b"K0240XYYYYYYYY"), None);
         assert_eq!(
             BIG.get_with_eql(b"key7".as_slice(), |a: &[u8], b| a == b),
             Some(&7)

--- a/src/bun_core/comptime_string_map.rs
+++ b/src/bun_core/comptime_string_map.rs
@@ -3,8 +3,7 @@
 //! Rust port of Zig's `ComptimeStringMap`. Declared via
 //! [`comptime_string_map!`] / [`comptime_string_set!`]; lookups compile to a
 //! `match key.len()` jump table plus constant-length byte compares (word-sized
-//! loads against immediates) — no hashing at runtime. Large maps binary
-//! search [`SortedKeys`] tables instead.
+//! loads against immediates) — no hashing at runtime.
 //!
 //! ```ignore
 //! bun_core::comptime_string_map! {

--- a/src/bun_core_macros/comptime_string_map.rs
+++ b/src/bun_core_macros/comptime_string_map.rs
@@ -5,7 +5,8 @@
 //! table) followed by constant-length byte-slice compares, which LLVM lowers
 //! to word-sized loads compared against immediates — no hashing, no memcmp
 //! calls. See `known_global.rs` in `bun_ast` for the hand-written shape this
-//! automates.
+//! automates. Maps with [`SORTED_LOOKUP_MIN_KEYS`] or more keys instead emit
+//! index tables and share one binary search (`SortedKeys` in `bun_core`).
 
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
@@ -233,6 +234,65 @@ fn eq_check(keys: &[(Vec<u8>, Span)], idx: usize) -> TokenStream {
     }
 }
 
+/// Maps with at least this many keys are looked up through
+/// `bun_core::comptime_string_map::SortedKeys` (index tables + one shared
+/// binary search) instead of an unrolled compare per key, which for a
+/// thousand keys is tens of KB of code per map.
+const SORTED_LOOKUP_MIN_KEYS: usize = 200;
+
+struct SortedTables {
+    sorted: Vec<u16>,
+    offsets: Vec<u16>,
+    buckets: Vec<u16>,
+}
+
+fn sorted_tables(
+    name: &Ident,
+    keys: &[(Vec<u8>, Span)],
+    buckets: &[(usize, Vec<usize>)],
+    blob_total: usize,
+) -> syn::Result<SortedTables> {
+    let too_large = |what: &str| {
+        syn::Error::new(
+            name.span(),
+            format!("comptime string map {what} exceeds u16::MAX"),
+        )
+    };
+    if keys.len() > u16::MAX as usize {
+        return Err(too_large("key count"));
+    }
+    if blob_total > u16::MAX as usize {
+        return Err(too_large("total key bytes"));
+    }
+    let min_len = buckets.first().map(|(l, _)| *l).unwrap_or(0);
+    let max_len = buckets.last().map(|(l, _)| *l).unwrap_or(0);
+    // `starts[len - min_len]..starts[len - min_len + 1]` is the run of
+    // `sorted` holding the keys of length `len`; lengths with no keys get an
+    // empty run.
+    let mut sorted: Vec<u16> = Vec::with_capacity(keys.len());
+    let mut starts: Vec<u16> = Vec::with_capacity(max_len - min_len + 2);
+    let mut buckets = buckets.iter().peekable();
+    for len in min_len..=max_len {
+        starts.push(sorted.len() as u16);
+        if let Some((_, idxs)) = buckets.next_if(|(l, _)| *l == len) {
+            sorted.extend(idxs.iter().map(|&i| i as u16));
+        }
+    }
+    starts.push(sorted.len() as u16);
+    let mut offsets = Vec::with_capacity(keys.len() + 1);
+    let mut off = 0usize;
+    offsets.push(0u16);
+    for (k, _) in keys {
+        off += k.len();
+        offsets.push(off as u16);
+    }
+    Ok(SortedTables {
+        sorted,
+        offsets,
+        buckets: starts,
+    })
+}
+
 pub(crate) fn expand_map(input: TokenStream) -> syn::Result<TokenStream> {
     let MapParse(input) = syn::parse2(input)?;
     let Input {
@@ -297,6 +357,63 @@ pub(crate) fn expand_map(input: TokenStream) -> syn::Result<TokenStream> {
     let decl_values = values.iter();
     let decl_values_again = values.iter();
 
+    let (tables, key_index_body, eql_body) = if n >= SORTED_LOOKUP_MIN_KEYS {
+        let table_name = format_ident!("__COMPTIME_STRING_MAP_TABLE_{}", name);
+        let sorted_name = format_ident!("__COMPTIME_STRING_MAP_SORTED_{}", name);
+        let offsets_name = format_ident!("__COMPTIME_STRING_MAP_OFFSETS_{}", name);
+        let buckets_name = format_ident!("__COMPTIME_STRING_MAP_BUCKETS_{}", name);
+        let SortedTables {
+            sorted,
+            offsets,
+            buckets: bucket_starts,
+        } = sorted_tables(&name, &keys, &buckets, blob_total)?;
+        let (sorted_n, offsets_n, buckets_n) = (sorted.len(), offsets.len(), bucket_starts.len());
+        (
+            quote! {
+                #[doc(hidden)]
+                static #sorted_name: [::core::primitive::u16; #sorted_n] = [ #(#sorted),* ];
+                #[doc(hidden)]
+                static #offsets_name: [::core::primitive::u16; #offsets_n] = [ #(#offsets),* ];
+                #[doc(hidden)]
+                static #buckets_name: [::core::primitive::u16; #buckets_n] = [ #(#bucket_starts),* ];
+                #[doc(hidden)]
+                static #table_name: #crate_path::comptime_string_map::SortedKeys =
+                    #crate_path::comptime_string_map::SortedKeys {
+                        blob: &#blob_name,
+                        offsets: &#offsets_name,
+                        sorted: &#sorted_name,
+                        buckets: &#buckets_name,
+                        min_len: #min_len,
+                    };
+            },
+            quote! { #table_name.index_of(key) },
+            quote! {
+                for &i in #table_name.bucket(len) {
+                    if eql(input, #table_name.key(i as usize)) {
+                        break 'found i as ::core::primitive::u32;
+                    }
+                }
+                ::core::primitive::u32::MAX
+            },
+        )
+    } else {
+        (
+            TokenStream::new(),
+            quote! {
+                match key.len() {
+                    #(#eq_arms)*
+                    _ => ::core::primitive::u32::MAX,
+                }
+            },
+            quote! {
+                match len {
+                    #(#eql_arms)*
+                    _ => ::core::primitive::u32::MAX,
+                }
+            },
+        )
+    };
+
     Ok(quote! {
         #(#attrs)*
         #vis static #name: #ty_name = #ty_name(());
@@ -308,14 +425,16 @@ pub(crate) fn expand_map(input: TokenStream) -> syn::Result<TokenStream> {
         #[doc(hidden)]
         static #values_name: [#value_ty; #n] = [ #(#decl_values),* ];
 
-        // Keys are baked into the lookup's compare instructions; these two
-        // pointer-free tables exist only so `entries()`/`keys()` can hand out
-        // `&'static [u8]` slices without a per-key pointer (and its load-time
-        // relocation) in the data segment.
+        // Small maps bake their keys into the lookup's compare instructions,
+        // so these two pointer-free tables exist only so `entries()`/`keys()`
+        // can hand out `&'static [u8]` slices without a per-key pointer (and
+        // its load-time relocation) in the data segment. Large maps also
+        // look keys up through the blob (see `SORTED_LOOKUP_MIN_KEYS`).
         #[doc(hidden)]
         static #blob_name: [u8; #blob_total] = *#blob_lit;
         #[doc(hidden)]
         static #lens_name: [#len_ty; #n] = [ #(#lens),* ];
+        #tables
 
         #[allow(dead_code)]
         impl #ty_name {
@@ -332,10 +451,7 @@ pub(crate) fn expand_map(input: TokenStream) -> syn::Result<TokenStream> {
             #[doc(hidden)]
             #[inline]
             #vis fn __key_index(key: &[u8]) -> ::core::primitive::u32 {
-                match key.len() {
-                    #(#eq_arms)*
-                    _ => ::core::primitive::u32::MAX,
-                }
+                #key_index_body
             }
 
             #[inline]
@@ -382,12 +498,7 @@ pub(crate) fn expand_map(input: TokenStream) -> syn::Result<TokenStream> {
                 len: usize,
                 eql: impl Fn(I, &'static [u8]) -> bool,
             ) -> ::core::option::Option<&'static #value_ty> {
-                let index = 'found: {
-                    match len {
-                        #(#eql_arms)*
-                        _ => ::core::primitive::u32::MAX,
-                    }
-                };
+                let index = 'found: { #eql_body };
                 #values_name.get(index as usize)
             }
 
@@ -419,7 +530,7 @@ pub(crate) fn expand_map(input: TokenStream) -> syn::Result<TokenStream> {
                 for (dst, src) in buf.iter_mut().zip(key.iter()) {
                     *dst = src.to_ascii_lowercase();
                 }
-                self.get_with_len_and_eql(&*buf, key.len(), |a: &[u8], b| a == b)
+                #values_name.get(Self::__key_index(buf) as usize)
             }
         }
 

--- a/src/bun_core_macros/comptime_string_map.rs
+++ b/src/bun_core_macros/comptime_string_map.rs
@@ -252,17 +252,20 @@ fn sorted_tables(
     buckets: &[(usize, Vec<usize>)],
     blob_total: usize,
 ) -> syn::Result<SortedTables> {
-    let too_large = |what: &str| {
+    let too_large = |what: &str, actual: usize| {
         syn::Error::new(
             name.span(),
-            format!("comptime string map {what} exceeds u16::MAX"),
+            format!(
+                "comptime string map {what} is {actual}; the lookup tables are u16, so the limit is {}",
+                u16::MAX
+            ),
         )
     };
     if keys.len() > u16::MAX as usize {
-        return Err(too_large("key count"));
+        return Err(too_large("key count", keys.len()));
     }
     if blob_total > u16::MAX as usize {
-        return Err(too_large("total key bytes"));
+        return Err(too_large("total key bytes", blob_total));
     }
     let min_len = buckets.first().map(|(l, _)| *l).unwrap_or(0);
     let max_len = buckets.last().map(|(l, _)| *l).unwrap_or(0);

--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -1667,17 +1667,13 @@ pub fn sniff(bytes: &[u8]) -> Option<MimeType> {
 mod tests {
     use super::{EXTENSIONS, Table};
 
-    /// `EXTENSIONS` is by far the largest `comptime_string_map!`, so it is
-    /// looked up through the shared sorted-key tables rather than a compare
-    /// tree. Many extensions share a MIME type, so compare entry addresses:
-    /// value equality would not notice a lookup landing on the wrong entry.
-    ///
-    /// Probes the map rather than `by_extension`: `to_mime_type` reaches the
-    /// highway FFI, which `cargo test -p bun_http_types` does not link.
+    /// Largest map in the tree, so it exercises `SortedKeys`. Entries are
+    /// compared by address because many extensions share a MIME type. Not
+    /// through `by_extension`: `to_mime_type` needs highway, which
+    /// `cargo test -p bun_http_types` does not link.
     #[test]
     fn extensions_resolve_to_their_own_entry() {
-        // Miri interprets every probe of the search; all 1184 extensions take
-        // ~30s there, so it checks every 37th one (32 of assorted lengths).
+        // All 1184 take ~30s under Miri; every 37th is 32 of them.
         let stride = if cfg!(miri) { 37 } else { 1 };
         for (ext, table) in EXTENSIONS.entries().step_by(stride) {
             let ext_str = bstr::BStr::new(ext);

--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -1662,3 +1662,49 @@ pub fn sniff(bytes: &[u8]) -> Option<MimeType> {
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{EXTENSIONS, Table};
+
+    /// `EXTENSIONS` is by far the largest `comptime_string_map!`, so it is
+    /// looked up through the shared sorted-key tables rather than a compare
+    /// tree. Many extensions share a MIME type, so compare entry addresses:
+    /// value equality would not notice a lookup landing on the wrong entry.
+    ///
+    /// Probes the map rather than `by_extension`: `to_mime_type` reaches the
+    /// highway FFI, which `cargo test -p bun_http_types` does not link.
+    #[test]
+    fn extensions_resolve_to_their_own_entry() {
+        // Miri interprets every probe of the search; all 1184 extensions take
+        // ~30s there, so it checks every 37th one (32 of assorted lengths).
+        let stride = if cfg!(miri) { 37 } else { 1 };
+        for (ext, table) in EXTENSIONS.entries().step_by(stride) {
+            let ext_str = bstr::BStr::new(ext);
+            let is_entry = |hit: Option<&Table>| hit.is_some_and(|hit| std::ptr::eq(hit, table));
+            assert!(is_entry(EXTENSIONS.get(ext)), "{ext_str}");
+            let upper = ext.to_ascii_uppercase();
+            assert!(
+                is_entry(EXTENSIONS.get_ascii_case_insensitive(&upper)),
+                "{ext_str}"
+            );
+            if upper != ext {
+                assert!(EXTENSIONS.get(&upper).is_none(), "{ext_str}");
+            }
+        }
+    }
+
+    #[test]
+    fn unknown_extensions_miss() {
+        assert!(EXTENSIONS.get(b"").is_none());
+        assert!(EXTENSIONS.get(b".js").is_none());
+        // Same length as real entries, sorting before, between and after them.
+        assert!(EXTENSIONS.get(b"!!!").is_none());
+        assert!(EXTENSIONS.get(b"jsq").is_none());
+        assert!(EXTENSIONS.get(b"~~~").is_none());
+        assert!(EXTENSIONS.get_ascii_case_insensitive(b"JSQ").is_none());
+        // No extension is 12 bytes long; the longest is 13.
+        assert!(EXTENSIONS.get(b"twelve-bytes").is_none());
+        assert!(EXTENSIONS.get(b"fourteen-bytes").is_none());
+    }
+}

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2530,6 +2530,55 @@ console.log(<div {...obj} key="after" />);`),
     });
   });
 
+  // JSX_ENTITY (src/ast/lexer_tables.rs) has ~250 names, so the lexer looks it
+  // up through the sorted-key tables that comptime_string_map! emits for large
+  // maps instead of a compare tree. Names are case-sensitive and are 2 to 8
+  // characters long ("thetasym" is the only 8-character one). An unknown name
+  // stays in the text as written.
+  describe("named JSX entities", () => {
+    const bun = new Bun.Transpiler({
+      loader: "jsx",
+      define: { "process.env.NODE_ENV": JSON.stringify("development") },
+    });
+    const transpile = entity => bun.transformSync(`export var x = <div>${entity}</div>`);
+    const withChildren = text =>
+      `export var x = jsxDEV_7x81h0kn("div", {\n  children: "${text}"\n}, undefined, false, undefined, this);\n`;
+
+    it.each([
+      ["&lt;", "<"],
+      ["&gt;", ">"],
+      ["&mu;", "\u03BC"],
+      ["&amp;", "&"],
+      ["&ETH;", "\u00D0"],
+      ["&eth;", "\u00F0"],
+      ["&nbsp;", "\u00A0"],
+      ["&copy;", "\u00A9"],
+      ["&euro;", "\u20AC"],
+      ["&laquo;", "\u00AB"],
+      ["&Alpha;", "\u0391"],
+      ["&alpha;", "\u03B1"],
+      ["&hellip;", "\u2026"],
+      ["&forall;", "\u2200"],
+      ["&Lambda;", "\u039B"],
+      ["&lambda;", "\u03BB"],
+      ["&Epsilon;", "\u0395"],
+      ["&epsilon;", "\u03B5"],
+      ["&alefsym;", "\u2135"],
+      ["&thetasym;", "\u03D1"],
+    ])("%s decodes", (entity, decoded) => {
+      expect(transpile(entity)).toBe(withChildren(decoded));
+    });
+
+    // Wrong case, a prefix and an extension of a real name, a miss among the
+    // 7-character names, and a name longer than any entry.
+    it.each(["&NBSP;", "&Nbsp;", "&nbs;", "&nbspx;", "&thetasy;", "&thetasyms;", "&bogus;"])(
+      "%s stays as written",
+      entity => {
+        expect(transpile(entity)).toBe(withChildren(entity));
+      },
+    );
+  });
+
   it("require with a dynamic non-string expression", () => {
     var nodeTranspiler = new Bun.Transpiler({ platform: "node" });
     expect(nodeTranspiler.transformSync("require('hi' + bar)")).toBe('require("hi" + bar);\n');

--- a/test/js/bun/util/file-type.test.ts
+++ b/test/js/bun/util/file-type.test.ts
@@ -16,4 +16,44 @@ describe("util file tests", () => {
     const file = Bun.file("test.css");
     expect(file.type).toBe("text/css;charset=utf-8");
   });
+
+  // The extension table (EXTENSIONS in src/http_types/MimeType.rs) has ~1200
+  // entries, so Bun looks it up through the sorted-key tables that
+  // comptime_string_map! emits for large maps. Its extensions are 1 to 13
+  // characters long; no entry is 12 characters long, and "cryptonote" and
+  // "disposition-n" are the only entries of their lengths. Lookups fold ASCII
+  // case. An unknown extension gives application/octet-stream.
+  describe("mime-type by extension", () => {
+    const typeOf = (ext: string) => Bun.file("test." + ext).type;
+
+    test.each([
+      ["c", "text/x-c"],
+      ["ai", "application/postscript"],
+      ["png", "image/png"],
+      ["htm", "text/html;charset=utf-8"],
+      ["html", "text/html;charset=utf-8"],
+      ["woff2", "font/woff2"],
+      ["coffee", "text/coffeescript"],
+      ["geojson", "application/geo+json"],
+      ["appcache", "text/cache-manifest"],
+      ["emotionml", "application/emotionml+xml"],
+      ["cryptonote", "application/vnd.rig.cryptonote"],
+      ["webmanifest", "application/manifest+json"],
+      ["disposition-n", "message/disposition-notification"],
+    ])("%s", (ext, type) => {
+      expect(typeOf(ext)).toBe(type);
+      expect(typeOf(ext.toUpperCase())).toBe(type);
+    });
+
+    // Misses one character away from an entry, in every bucket shape: a full
+    // bucket (3 characters), a single-entry bucket (10), the empty 12-character
+    // bucket, and a length past the longest entry.
+    test.each(["htn", "pnf", "coffe", "coffees", "geojsom", "cryptonotf", "disposition-", "disposition-nx"])(
+      "%s is unknown",
+      ext => {
+        expect(typeOf(ext)).toBe("application/octet-stream");
+        expect(typeOf(ext.toUpperCase())).toBe("application/octet-stream");
+      },
+    );
+  });
 });


### PR DESCRIPTION
Adopts #39517 at @alii's request. The first two commits are his, unchanged. The commits after them add the review follow-ups and the tests listed below.

### Problem
- `comptime_string_map!` expands every map into its own unrolled compare tree. The tree grows with the key count.
- Four shipped maps have 200 keys or more: `EXTENSIONS` (1184 keys, `src/http_types/MimeType.rs`), `JSX_ENTITY` (253, `src/ast/lexer_tables.rs`), `STRING_MAP` (228, `src/runtime/webcore/EncodingLabel.rs`) and the generated `INTERNAL_MODULE_TAG` (211, `bun_jsc`). Their trees are the same algorithm with different data.
- The `EXTENSIONS` tree alone is 37 KB of text in the `bun_http_types` rlib (58 KB of text in total for that crate).

### Fix
- A map with `SORTED_LOOKUP_MIN_KEYS` (200) keys or more emits its keys as data: the key blob it already had, `u16` offsets into it, the declaration indexes sorted by (length, bytes), and one start index per length. One `#[inline(never)]` function in `bun_core`, `SortedKeys::index_of`, serves every such map: it slices the bucket for the key length and binary searches it. Smaller maps keep the compare tree.
- `get_ascii_case_insensitive` now calls `__key_index` on the lowercased buffer, for maps of every size. Before, it went through the comparator path, which scans the length bucket key by key.
- The macro rejects a large map whose key count or total key bytes do not fit in `u16`. The error reports the offending number.
- `SortedKeys::bucket` slices the start table with a pattern instead of indexing `i + 1`, so no length value can overflow it (review comment on #39517).
- Behavior is unchanged. Both forms return the declaration index, and `get_with_eql` tries the keys of one length in the same order as before.
- Size: with LTO off, `.text` of the `bun_http_types` rlib goes from 57,949 to 19,933 bytes and `.rodata` grows by 610 bytes. #39517 measured about 63 KB less text across all crates before LTO.
- Maps under the threshold keep their machine code: 45 of the 48 functions in the `bun_http_types` rlib are byte for byte identical between main and this branch, including the 72 key method map tree. The other three are the removed 8309 instruction `EXTENSIONS` lookup and the two `by_extension` wrappers it was inlined into. A 24 key map measures 2.2 ns per `get` on both, and 8.8 ns to 8.1 ns per case-insensitive lookup.
- Speed of the four large maps (table below, `EXTENSIONS` is the worst case, 756 of its keys are 3 bytes long): the case-insensitive lookup, which `EXTENSIONS` and `STRING_MAP` use, costs about the same as before (hits 103 ns to 113 ns, misses 135 ns to 101 ns). The exact lookup goes from 11 ns to 91 ns. The two maps that use it, `JSX_ENTITY` and `INTERNAL_MODULE_TAG`, are consulted once per JSX entity and once per builtin module load.
- Tests:
  - `src/bun_core/comptime_string_map.rs`: a 241-key map. It checks every key, its uppercase form, misses below, inside, and above the length range, a miss in an empty length bucket, and `get_with_eql`. `cargo test -p bun_core` does not link (see Background), so I ran this test by copying it into `bun_http_types`. It passes there, and it fails when `bucket` is made to return an empty slice.
  - `src/http_types/MimeType.rs`: each of the 1184 extensions resolves to its own entry (compared by address, because many extensions share a MIME type) through `get` and `get_ascii_case_insensitive`, plus misses next to real keys and in the empty 12-byte bucket. `cargo test -p bun_http_types` runs all of them. Under Miri, the CI lane for this crate, the test checks every 37th extension: 1.6 s instead of 30 s.
  - `test/js/bun/util/file-type.test.ts` and `test/bundler/transpiler/transpiler.test.js`: `Bun.file().type` for an extension of each key length (1 to 13) in both cases, and 20 named JSX entities of each length (2 to 8), plus misses next to real keys in a full bucket, a single-entry bucket, the empty bucket, and past the longest key. Both blocks pass on the released bun (compare tree) and on this branch (sorted tables), which is the behavior claim of this PR. The debug build also agrees with the released bun on 88 ad hoc probes (TextDecoder labels, builtin `require`, Buffer encoding names, CryptoHasher names), and `bun bd test` over the encoding, file-type, bun-file, cryptohasher, which, fetch-redirect, bundler_jsx, transpiler, bun-serve-file, blob and buffer test files passes.
  - `cargo clippy` on the touched crates and `bun run rust:miri -p bun_http_types` pass. CI on #39517, which has the same first two commits, is green, including mordant and the full Buildkite run.
  - No test in this PR fails on main, and none can: the change keeps every lookup result the same and only changes code size. The `robobun/evidence` status expects a failing-before test and stays red for that reason. The tests above pin the results that the new search has to reproduce, and they fail when the search is broken (checked by making `bucket` return an empty slice).

### Background
- `comptime_string_map!` is a proc macro in `src/bun_core_macros/comptime_string_map.rs`. For each map it generates a static with `get`, `get_ascii_case_insensitive`, `get_with_eql` and iterators. A lookup matches on the key length first, then compares the key against each declared key of that length. LLVM lowers those compares to a tree of word loads against constants. The code size of the tree is proportional to the key count, per map.
- `SortedKeys` in `src/bun_core/comptime_string_map.rs` is the data form of the same dispatch. `buckets[len - min_len]..buckets[len - min_len + 1]` is the run of `sorted` that holds the keys of one length, in byte order. `offsets` turns a declaration index back into a slice of the key blob. The macro fills these tables at expansion time.
- The values table is in declaration order in both forms. So `entries()` and the returned `&'static V` do not change.
- `cargo test -p bun_core` fails to link: `bun_core` calls highway and simdutf, and only the full build provides them. A crate such as `bun_http_types` links as a test binary because the linker pulls only the code a test reaches out of the rlibs. That is why the second test lives there, and why it probes the map and not `by_extension` (its `to_mime_type` reaches highway).

<details>
<summary>Lookup cost on EXTENSIONS, ns per lookup</summary>

`cargo test --release -p bun_http_types` with a throwaway timing test, 16 inputs per row, 300k rounds, best of 5. Same machine, same inputs, only the two macro files swapped. A second branch run agreed with the first to within 0.3 ns on every row.

| lookup | main (compare tree) | this PR (sorted tables) |
| --- | ---: | ---: |
| `EXTENSIONS` (1184 keys) `get`, hits | 10.6 | 90.7 |
| `EXTENSIONS` `get`, misses | 13.7 | 75.5 |
| `EXTENSIONS` `get_ascii_case_insensitive`, lowercase hits | 102.5 | 112.9 |
| `EXTENSIONS` `get_ascii_case_insensitive`, uppercase hits | 104.5 | 112.7 |
| `EXTENSIONS` `get_ascii_case_insensitive`, misses | 135.3 | 100.7 |
| 24 key map `get`, hits | 2.2 | 2.2 |
| 24 key map `get`, misses | 1.8 | 1.9 |
| 24 key map `get_ascii_case_insensitive`, hits | 8.8 | 8.1 |
| 24 key map `get_ascii_case_insensitive`, misses | 8.6 | 7.7 |

Extension hits: js, html, png, json, css, woff2, ts, mjs, svg, wasm, jpg, txt, map, ico, webp, md. Misses: 16 strings of 1 to 4 bytes that are not extensions. The 24 key map holds HTTP method names.

Code comparison: `CARGO_PROFILE_RELEASE_LTO=off cargo build --release -p bun_http_types` on main and on this branch, then `llvm-objdump -d` on the rlib, split per function. main: 48 functions, 57,949 bytes of `.text`. This branch: 47 functions, 19,933 bytes. 45 functions are identical. `__ComptimeStringMap_EXTENSIONS::get_ascii_case_insensitive` (8309 instructions) exists only on main. `by_extension` goes from 37 to 79 instructions and `by_extension_no_default` from 19 to 64.

</details>

