### PR TITLE
css: keep the block skip stack inline and off the cold path

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -290,11 +290,8 @@ pub trait EnumProperty: Sized + Copy + Into<&'static str> {
 /// Skips to the end of the current block. Returns `true` if the matching
 /// closing token was found, `false` if the end of input was reached first
 /// (the block is unclosed).
-///
-/// Hot: `parse_nested_block` calls this on every block exit, so the common
-/// case (already at the closing token) must not allocate. `inline(never)`
-/// keeps one copy of it instead of one per `parse_nested_block` instantiation.
-#[inline(never)]
+/// Hot: `parse_nested_block` calls this on every block exit, so it must not allocate.
+#[inline(never)] // one copy, not one per `parse_nested_block` instantiation
 fn consume_until_end_of_block(block_type: BlockType, tokenizer: &mut Tokenizer) -> bool {
     let mut innermost = block_type;
     let mut outer = SmallList::<BlockType, 16>::default();

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -291,13 +291,9 @@ pub trait EnumProperty: Sized + Copy + Into<&'static str> {
 /// closing token was found, `false` if the end of input was reached first
 /// (the block is unclosed).
 ///
-/// This is not an error path: `parse_nested_block` calls it on every block
-/// exit, where the tokenizer is usually already at the closing token. So the
-/// common case must not touch the heap. `outer` only receives the blocks that
-/// a skipped region opens, and that region is not bounded by
-/// `MAX_NESTING_DEPTH`, so it still spills to the heap past 16 levels.
-/// `inline(never)` keeps the loop out of the many `parse_nested_block`
-/// instantiations.
+/// Hot: `parse_nested_block` calls this on every block exit, so the common
+/// case (already at the closing token) must not allocate. `inline(never)`
+/// keeps one copy of it instead of one per `parse_nested_block` instantiation.
 #[inline(never)]
 fn consume_until_end_of_block(block_type: BlockType, tokenizer: &mut Tokenizer) -> bool {
     let mut innermost = block_type;

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -290,23 +290,28 @@ pub trait EnumProperty: Sized + Copy + Into<&'static str> {
 /// Skips to the end of the current block. Returns `true` if the matching
 /// closing token was found, `false` if the end of input was reached first
 /// (the block is unclosed).
-#[cold]
+///
+/// This is not an error path: `parse_nested_block` calls it on every block
+/// exit, where the tokenizer is usually already at the closing token. So the
+/// common case must not touch the heap. `outer` only receives the blocks that
+/// a skipped region opens, and that region is not bounded by
+/// `MAX_NESTING_DEPTH`, so it still spills to the heap past 16 levels.
+/// `inline(never)` keeps the loop out of the many `parse_nested_block`
+/// instantiations.
+#[inline(never)]
 fn consume_until_end_of_block(block_type: BlockType, tokenizer: &mut Tokenizer) -> bool {
-    // Vec is fine for the cold path.
-    let mut stack: Vec<BlockType> = Vec::with_capacity(16);
-    stack.push(block_type);
+    let mut innermost = block_type;
+    let mut outer = SmallList::<BlockType, 16>::default();
 
     while let Ok(tok) = tokenizer.next() {
-        if let Some(b) = BlockType::closing(&tok) {
-            if *stack.last().unwrap() == b {
-                let _ = stack.pop();
-                if stack.is_empty() {
-                    return true;
-                }
+        if BlockType::closing(&tok) == Some(innermost) {
+            match outer.pop() {
+                Some(enclosing) => innermost = enclosing,
+                None => return true,
             }
-        }
-        if let Some(bt) = BlockType::opening(&tok) {
-            stack.push(bt);
+        } else if let Some(opened) = BlockType::opening(&tok) {
+            outer.append(innermost);
+            innermost = opened;
         }
     }
     false

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -8005,13 +8005,12 @@ describe("css tests", () => {
     // When a block fails to parse, the parser skips to its closing token by
     // walking the raw tokens and keeping a stack of the blocks opened on the
     // way (`consume_until_end_of_block` in css_parser.rs). The stack holds 16
-    // blocks inline and moves to the heap past that, so each case runs at a
-    // depth on both sides of that limit. Nothing from inside the skipped
-    // region may survive, and parsing must resume right after it.
-    describe.each([
-      ["skipped blocks nested within the inline stack", 3],
-      ["skipped blocks nested past the inline stack", 64],
-    ])("%s", (_, depth) => {
+    // blocks inline and moves to the heap past that. Each skipped block below
+    // has `depth` more blocks nested inside it, so 16 fills the inline stack,
+    // 17 is the first depth that moves to the heap, and 3 and 64 sit on either
+    // side. Nothing from inside the skipped region may survive, and parsing
+    // must resume right after it.
+    describe.each([3, 16, 17, 64])("skipping a block with %d blocks nested inside it", depth => {
       const unclosed = Buffer.alloc(depth, "(").toString();
       const closers = Buffer.alloc(depth, ")").toString();
       const parens = unclosed + closers;
@@ -8071,8 +8070,14 @@ describe("css tests", () => {
         `.a { color: rgb(1 2 3 ${mixed}); background: blue }`,
         `.a{color:rgb(1 2 3 ${mixed});background:#00f}`,
       );
-      // Reaching the end of input while skipping.
-      skips("an @charset rule that is never closed", `@charset "utf-8" (${unclosed}; .x { color: red }`, "");
+      // Reaching the end of input instead of a closing token. The skip of the
+      // @charset block gives up silently. The custom property parses, so its
+      // open blocks are closed on output. The failed rgb() is reported.
+      skips(
+        "an @charset rule that is never closed swallows the rest of the input",
+        `@charset "utf-8" (${unclosed}; .b`,
+        "",
+      );
       skips("an unclosed value that parses is closed on output", `.a { --x: ${unclosed}`, `.a{--x:${parens}}`);
       test("an unclosed value that fails to parse reports the end of input", () => {
         expect(() => minify_test_with_options(`.a { color: red } .b { color: rgb(1 2 3 ${unclosed}`, "")).toThrow(

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -8001,6 +8001,85 @@ describe("css tests", () => {
       const output = await Bun.file(join(__dirname, "unicode_expected.css")).text();
       cssTest(input, output);
     });
+
+    // When a block fails to parse, the parser skips to its closing token by
+    // walking the raw tokens and keeping a stack of the blocks opened on the
+    // way (`consume_until_end_of_block` in css_parser.rs). The stack holds 16
+    // blocks inline and moves to the heap past that, so each case runs at a
+    // depth on both sides of that limit. Nothing from inside the skipped
+    // region may survive, and parsing must resume right after it.
+    describe.each([
+      ["skipped blocks nested within the inline stack", 3],
+      ["skipped blocks nested past the inline stack", 64],
+    ])("%s", (_, depth) => {
+      const unclosed = Buffer.alloc(depth, "(").toString();
+      const closers = Buffer.alloc(depth, ")").toString();
+      const parens = unclosed + closers;
+      // Every kind of block the tokenizer knows, one per level: a parenthesis,
+      // a square bracket, a curly bracket and a function.
+      const opens = ["(", "[", "{", "fn("];
+      const closes = [")", "]", "}", ")"];
+      let mixed = "";
+      for (let i = 0; i < depth; i++) mixed += opens[i % opens.length];
+      for (let i = depth - 1; i >= 0; i--) mixed += closes[i % closes.length];
+
+      function skips(name: string, source: string, expected: string) {
+        test(name, () => {
+          expect(minify_test_with_options(source, expected)).toBe(expected);
+        });
+      }
+
+      // A forgiving selector list drops the invalid selector and resumes at
+      // the comma that follows its block.
+      skips(
+        "an invalid selector made of parentheses",
+        `.a:where((${parens}, .x), .b) { color: red }`,
+        ".a:where(.b){color:red}",
+      );
+      skips(
+        "an invalid selector made of mixed blocks",
+        `.a:where((${mixed}, .x), .b) { color: red }`,
+        ".a:where(.b){color:red}",
+      );
+      skips(
+        "an invalid selector made of a function",
+        `.a:where(fn(${mixed}, .x), .b) { color: red }`,
+        ".a:where(.b){color:red}",
+      );
+      skips(
+        "closing tokens of other block kinds do not end the skipped block",
+        `.a:where(( ] } ${parens} ] }, .x), .b) { color: red }`,
+        ".a:where(.b){color:red}",
+      );
+      // A leading @charset rule is skipped up to its semicolon. The blocks in
+      // between are skipped whole, including the semicolons and rules inside them.
+      skips(
+        "the blocks in an @charset rule",
+        `@charset "utf-8" (${mixed}; .x { color: red }); .b { color: blue }`,
+        ".b{color:#00f}",
+      );
+      skips(
+        "a curly bracket block in an @charset rule",
+        `@charset "utf-8" {${mixed}; .x { color: red }}; .b { color: blue }`,
+        ".b{color:#00f}",
+      );
+      // rgb() fails to parse as a color at the first nested block. The rest of
+      // the function block is skipped on the way out, then the declaration is
+      // kept as an unparsed value.
+      skips(
+        "the rest of a function whose value failed to parse",
+        `.a { color: rgb(1 2 3 ${mixed}); background: blue }`,
+        `.a{color:rgb(1 2 3 ${mixed});background:#00f}`,
+      );
+      // Reaching the end of input while skipping.
+      skips("an @charset rule that is never closed", `@charset "utf-8" (${unclosed}; .x { color: red }`, "");
+      skips("an unclosed value that parses is closed on output", `.a { --x: ${unclosed}`, `.a{--x:${parens}}`);
+      test("an unclosed value that fails to parse reports the end of input", () => {
+        expect(() => minify_test_with_options(`.a { color: red } .b { color: rgb(1 2 3 ${unclosed}`, "")).toThrow(
+          "Unexpected end of input",
+        );
+      });
+    });
   });
 
   test("deeply nested rules keep two spaces of indentation per level", async () => {


### PR DESCRIPTION
### Problem
- `consume_until_end_of_block` (`src/css/css_parser.rs:293` on main) allocates a `Vec<BlockType>` with capacity 16 on every call and is marked `#[cold]`.
- It is called on every block exit: `parse_nested_block` calls it unconditionally after the block's content is parsed (`css_parser.rs:593`), once per rule body and once per function, parenthesis or bracket block. In the common case the tokenizer is already at the closing token, so the call does one malloc, one free and one `tokenizer.next()`.
- The `Vec` is a port regression. Upstream rust-cssparser uses a `SmallVec<[BlockType; 16]>` here and the Zig parser used `SmallList(BlockType, 16)`. The port replaced it with a `Vec` and left the note `PERF(port): was SmallList<BlockType, 16> ... profile in Phase B` (23427dbc12). 85534281c6 removed the note without a change to the code.
- The `#[cold]` attribute places the function in `.text.unlikely`. #39520 notes that its new `exit_nested_block` helper also lands in `.text.unlikely` because every function it calls is cold, and leaves the removal of the attribute and of the `Vec` to a separate change. This is that change.

### Fix
- The innermost open block lives in a local. The enclosing blocks live in a `SmallList<BlockType, 16>`, the crate's newtype over `smallvec`, so this is the container upstream and the Zig parser use. The common case, where the first token is the closing token, never touches the list. The list still spills to the heap past 16 levels, because the skipped region is not subject to `MAX_NESTING_DEPTH`.
- The token handling is unchanged: a closing token of the innermost block pops, a closing token of another kind is ignored, an opening token pushes, and the end of input returns `false` so `record_unclosed_block_at_eof` still works.
- `#[cold]` becomes `#[inline(never)]`. Upstream and the Zig parser keep the cold hint, so this part is a deliberate difference: the function runs on every block exit, and with #39520 the hint also moves the whole exit path into `.text.unlikely`. The attribute does not change the code of the function (the body is 0x17f bytes with or without it, see details). It only changes where the linker puts it. `inline(never)` keeps one copy of the function instead of one per `parse_nested_block` instantiation (about 190 in the linux-x64 binary). The linker map of the release build shows one copy, in `.text`.
- What this does and does not buy: on a debug build, `bun build` of a 20,000 rule file makes exactly one malloc less per block exit (60,000 less on the file with functions, 20,000 less on the file without, table in details). On release builds of the same tree with and without this change, parse, minify and print of nine real stylesheets (bulma, bootstrap 4, tailwind, uikit, pico, foundation, materialize, animate, tachyons) differ by under 2 percent in both directions, which is the run-to-run noise. Only the synthetic file that consists of three block exits per rule is measurably faster, by 2 to 5 percent, and that is the upper bound of the effect. mimalloc serves a 16 byte malloc and free pair in a few nanoseconds, and bulma, the densest of the nine, has about 20,000 block exits in a 19 ms parse. So this PR removes a recorded port regression and a wrong hint. Do not read it as a speedup for real stylesheets.
- The hunks of this PR (lines 290 to 311) do not overlap with #39520 (lines 468 and later), so the two can land in either order.
- Tests: `test/js/bun/css/css.test.ts`, new `describe.each` block "skipping a block with N blocks nested inside it" for N = 3, 16, 17 and 64. 16 fills the inline list, 17 is the first depth that spills, and temporary instrumentation confirmed that the list reaches exactly N in every skipping case. The cases: an invalid argument of `:where()` made of parentheses, of mixed block kinds, of a function, and one with stray `]` and `}` closers inside; an `@charset` rule with blocks that contain semicolons and rules; an `rgb()` that fails to parse after nested blocks; and three cases that reach the end of input instead of a closing token. The behavior is unchanged, so these tests pass before and after this change. They cover the inline and spill paths of the skip stack, which had no tests of their own. No test can fail on main and pass here: the only differences are the allocation and the section the function is placed in, and neither is visible to a test. The malloc counts and the linker maps in the details below are the before and after evidence for those two things.
- `bun bd test test/js/bun/css/ test/bundler/css/`: 2525 pass. The only failures are the four timeouts in `css-fuzz.test.ts`, which is skipped in CI and times out the same way on the unfixed debug build. `css.test.ts` was run again after each later commit (1197 pass).

### Background
- The CSS parser handles `{...}`, `(...)`, `[...]` and `fn(...)` through `parse_nested_block`. It runs the caller's closure on the content, and then skips to the block's closing token. That skip is `consume_until_end_of_block`. When the closure consumed the whole content, the skip consumes one token. When the closure failed part of the way in, the skip walks the remaining tokens and has to track the blocks that open and close inside them. That is what the stack is for.
- `#[cold]` tells LLVM that a function is rarely called. LLVM puts it in the `.text.unlikely` section and treats each call to it as an unlikely branch. A function whose callees are all cold can be placed there as well, which is the `exit_nested_block` observation in #39520.
- `parse_nested_block<T>` is generic over the closure, so it is compiled once per call site. Without an attribute, LLVM may inline a small helper into each copy. `#[inline(never)]` keeps one copy of the helper, which is the same shape #39520 uses for its helpers.

<details>
<summary>Malloc counts (debug build)</summary>

A preloaded library counts calls through `__sanitizer_install_malloc_and_free_hooks` in the ASan debug build, installed from gdb at `main`, and read back when the process calls `exit_group`. The rust side of the debug build uses the system allocator, so every `Vec` allocation passes through the hook. The inputs are 20,000 copies of `.cN{color:rgb(1,2,3);width:calc(1px + 2px)}` (60,000 block exits), 20,000 copies of `.cN{color:red;width:3px}` (20,000 block exits), and a one rule file.

| input | block exits | before | after |
| --- | ---: | ---: | ---: |
| with functions | 60,000 | 127,051 | 67,051 |
| without functions | 20,000 | 27,051 | 7,051 |
| one rule | 1 | | 7,010 |

The counts are stable across runs except for a 925 malloc difference in process startup that shows up now and then, in the one rule runs as well as in the 20,000 rule runs.
</details>

<details>
<summary>Wall-clock and code size (release builds)</summary>

Three release builds of the same tree: main's function, this PR, and a variant with the `SmallList` but with `#[cold]` kept. Each stylesheet was parsed, minified and printed in process through the test internals, 40 iterations per process, with the builds interleaved over six to eight rounds. Averages of the per-round minimums:

| input | main | this PR | `SmallList`, `#[cold]` kept |
| --- | ---: | ---: | ---: |
| bulma.css (763 KB, about 20,000 block exits) | 19.27 ms | 19.11 ms | 19.17 ms |
| animate.css | 1.760 ms | 1.773 ms | 1.750 ms |
| synthetic, 20,000 rules without functions (20,000 exits) | 24.38 ms | 24.53 ms | 24.71 ms |
| synthetic, 20,000 rules with functions (60,000 exits) | 41.53 ms | 40.70 ms | 41.21 ms |

A separate six round run of main against this PR gave 43.47 ms against 41.47 ms for the file with functions and 25.94 ms against 25.85 ms for the file without. Bootstrap 4, tailwind, uikit, pico, foundation, materialize and tachyons were run the same way and differ by under 2 percent in both directions. The variant that keeps `#[cold]` is not distinguishable from this PR, so the attribute has no measurable runtime effect of its own. In the linker maps the `SmallList` body is 0x17f bytes in both variants. Main's `Vec` body is 0x12a bytes in `.text.unlikely`. This PR's body is in `.text`, once.
</details>
