### PR TITLE
node:module: non-enumerable Module.prototype; setting Module.wrapper to its default is not an override (unblocks jest under --bun)

### DIFF
--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -426,8 +426,8 @@ export function createRequireCache() {
 }
 
 type WrapperMutate = (start: string, end: string) => void;
-export function getWrapperArrayProxy(onMutate: WrapperMutate) {
-  const wrapper = ["(function(exports,require,module,__filename,__dirname){", "})"];
+export function getWrapperArrayProxy(onMutate: WrapperMutate, start: string, end: string) {
+  const wrapper = [start, end];
   return new Proxy(wrapper, {
     set(_target, prop, value, receiver) {
       Reflect.set(wrapper, prop, value, receiver);

--- a/src/jsc/bindings/JSCommonJSModule.cpp
+++ b/src/jsc/bindings/JSCommonJSModule.cpp
@@ -745,10 +745,7 @@ JSC_DEFINE_HOST_FUNCTION(functionJSCommonJSModule_compile, (JSGlobalObject * glo
             sourceString,
             zigGlobalObject->m_moduleWrapperEnd);
     } else {
-        wrappedString = makeString(
-            "(function(exports,require,module,__filename,__dirname){"_s,
-            sourceString,
-            "\n})"_s);
+        wrappedString = makeString(commonJSDefaultWrapperStart, sourceString, "\n"_s, commonJSDefaultWrapperEnd);
     }
 
     moduleObject->sourceCode = makeSource(

--- a/src/jsc/bindings/JSCommonJSModule.h
+++ b/src/jsc/bindings/JSCommonJSModule.h
@@ -21,6 +21,10 @@ namespace Bun {
 
 using namespace JSC;
 
+// What `require("module").wrapper` reports and every CommonJS module body is wrapped in unless that is overridden.
+static constexpr ASCIILiteral commonJSDefaultWrapperStart = "(function(exports,require,module,__filename,__dirname){"_s;
+static constexpr ASCIILiteral commonJSDefaultWrapperEnd = "})"_s;
+
 JSC_DECLARE_HOST_FUNCTION(jsFunctionCreateCommonJSModule);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionEvaluateCommonJSModule);
 JSC_DECLARE_HOST_FUNCTION(functionJSCommonJSModule_compile);

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -964,7 +964,7 @@ flushCompileCache       jsFunctionFlushCompileCache       Function 0
 getCompileCacheDir      jsFunctionGetCompileCacheDir      Function 0
 globalPaths             getGlobalPathsObject              PropertyCallback
 isBuiltin               jsFunctionIsBuiltinModule         Function 1
-prototype               getModulePrototypeObject          PropertyCallback
+prototype               getModulePrototypeObject          DontEnum|DontDelete|PropertyCallback
 register                jsFunctionRegister                Function 1
 runMain                 moduleRunMain                        CustomAccessor
 SourceMap               getSourceMapFunction              PropertyCallback

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -686,7 +686,7 @@ static JSValue getGlobalPathsObject(VM& vm, JSObject* moduleObject)
 // subclass, as jest-runtime does) is not an override.
 static void setModuleWrapper(Zig::GlobalObject* global, String&& start, String&& end)
 {
-    global->hasOverriddenModuleWrapper = start != "(function(exports,require,module,__filename,__dirname){"_s || end != "})"_s;
+    global->hasOverriddenModuleWrapper = start != commonJSDefaultWrapperStart || end != commonJSDefaultWrapperEnd;
     global->m_moduleWrapperStart = WTF::move(start);
     global->m_moduleWrapperEnd = WTF::move(end);
 }
@@ -720,6 +720,8 @@ JSC_DEFINE_CUSTOM_GETTER(nodeModuleWrapper,
         vm, global, 1, "onMutate"_s,
         jsFunctionSetCJSWrapperItem, JSC::ImplementationVisibility::Public,
         JSC::NoIntrinsic));
+    args.append(jsString(vm, String(commonJSDefaultWrapperStart)));
+    args.append(jsString(vm, String(commonJSDefaultWrapperEnd)));
 
     auto scope = DECLARE_THROW_SCOPE(vm);
     NakedPtr<JSC::Exception> returnedException = nullptr;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -682,6 +682,15 @@ static JSValue getGlobalPathsObject(VM& vm, JSObject* moduleObject)
         static_cast<ArrayAllocationProfile*>(nullptr), 0);
 }
 
+// Like the _resolveFilename / runMain setters: writing back the default (e.g. copying Module's statics onto a
+// subclass, as jest-runtime does) is not an override.
+static void setModuleWrapper(Zig::GlobalObject* global, String&& start, String&& end)
+{
+    global->hasOverriddenModuleWrapper = start != "(function(exports,require,module,__filename,__dirname){"_s || end != "})"_s;
+    global->m_moduleWrapperStart = WTF::move(start);
+    global->m_moduleWrapperEnd = WTF::move(end);
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionSetCJSWrapperItem, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
@@ -692,9 +701,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionSetCJSWrapperItem, (JSGlobalObject * globalOb
     RETURN_IF_EXCEPTION(scope, {});
     String bString = b.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    global->m_moduleWrapperStart = aString;
-    global->m_moduleWrapperEnd = bString;
-    global->hasOverriddenModuleWrapper = true;
+    setModuleWrapper(global, WTF::move(aString), WTF::move(bString));
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 
@@ -749,10 +756,7 @@ JSC_DEFINE_CUSTOM_SETTER(setNodeModuleWrapper,
     auto bstring = b.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, false);
 
-    globalObject->m_moduleWrapperStart = astring;
-    globalObject->m_moduleWrapperEnd = bstring;
-    globalObject->hasOverriddenModuleWrapper = true;
-
+    setModuleWrapper(globalObject, WTF::move(astring), WTF::move(bstring));
     return true;
 }
 

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -1216,11 +1216,14 @@ JSC::JSObject* generateNativeModule_NodeModule(JSC::JSGlobalObject* lexicalGloba
     auto& vm = JSC::getVM(globalObject);
     auto* constructor = globalObject->m_nodeModuleConstructor.getInitializedOnMainThread(globalObject);
 
-    // The exports are the static table's entries, not the constructor's own properties (`length`, `name`,
-    // whatever user code assigned onto Module).
+    // The exports are the static table's enumerable entries, not the constructor's own properties (`length`,
+    // `name`, `prototype`, whatever user code assigned onto Module).
     PropertyNameArrayBuilder properties(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-    for (const auto& entry : Bun::nodeModuleObjectTableValues)
+    for (const auto& entry : Bun::nodeModuleObjectTableValues) {
+        if (entry.attributes() & PropertyAttribute::DontEnum)
+            continue;
         properties.add(Identifier::fromString(vm, entry.m_key));
+    }
 
     return exportObjectProperties(vm, constructor, properties, exportNames, exportValues);
 }

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -29,6 +29,18 @@ describe.concurrent("node-module-module", () => {
     expect(Array.isArray(require("module").globalPaths)).toBe(true);
   });
 
+  test("Module.prototype is not enumerable, so its enumerable statics can be copied onto a subclass", () => {
+    const Module = require("module");
+    const { value, ...descriptor } = Object.getOwnPropertyDescriptor(Module, "prototype");
+    expect(descriptor).toEqual({ writable: true, enumerable: false, configurable: false });
+    expect(Object.keys(Module)).not.toContain("prototype");
+    // jest-runtime builds its `Module` this way; assigning `prototype` on a class throws.
+    class Sub extends Module.Module {}
+    for (const [key, val] of Object.entries(Module.Module)) Sub[key] = val;
+    expect(Sub.prototype).toBeInstanceOf(Module);
+    expect(Sub._extensions).toBe(Module._extensions);
+  });
+
   test("module.enableCompileCache validates its argument", () => {
     expect(Module.enableCompileCache.length).toBe(1);
     for (const invalid of [0, null, false, 1, NaN, true, Symbol(0)]) {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -29,16 +29,54 @@ describe.concurrent("node-module-module", () => {
     expect(Array.isArray(require("module").globalPaths)).toBe(true);
   });
 
-  test("Module.prototype is not enumerable, so its enumerable statics can be copied onto a subclass", () => {
+  test("Module.prototype is not enumerable", () => {
     const Module = require("module");
     const { value, ...descriptor } = Object.getOwnPropertyDescriptor(Module, "prototype");
     expect(descriptor).toEqual({ writable: true, enumerable: false, configurable: false });
+    expect(value).toBe(Module.prototype);
     expect(Object.keys(Module)).not.toContain("prototype");
-    // jest-runtime builds its `Module` this way; assigning `prototype` on a class throws.
-    class Sub extends Module.Module {}
-    for (const [key, val] of Object.entries(Module.Module)) Sub[key] = val;
-    expect(Sub.prototype).toBeInstanceOf(Module);
-    expect(Sub._extensions).toBe(Module._extensions);
+  });
+
+  // jest-runtime builds the `Module` it hands to tests this way. Assigning a class's `prototype` throws, so this
+  // needs `prototype` to be non-enumerable; and the copy goes through the inherited `wrapper` / `_resolveFilename`
+  // / `runMain` setters with their current values, which must not count as overriding them (an overridden wrapper
+  // re-wraps every CommonJS module from source and bypasses the --isolate SourceProvider cache).
+  test("Module's enumerable statics can be copied onto a subclass without overriding the CJS wrapper", async () => {
+    using dir = tempDir("module-statics-copy", {
+      "dep.cjs": `module.exports = "dep";`,
+      "dep2.cjs": `module.exports = "dep2";`,
+      "copy.test.js": `
+        const { test, expect } = require("bun:test");
+        const { isolatedModuleCacheSourceType } = require("bun:internal-for-testing");
+        const Module = require("node:module");
+        test("copy statics", () => {
+          class Sub extends Module.Module {}
+          for (const [key, value] of Object.entries(Module.Module)) Sub[key] = value;
+          expect(Sub.prototype).toBeInstanceOf(Module);
+          expect(Sub._extensions).toBe(Module._extensions);
+          expect(Sub.wrapper[0]).toBe(Module.wrapper[0]);
+
+          expect(require("./dep.cjs")).toBe("dep");
+          expect(isolatedModuleCacheSourceType(require.resolve("./dep.cjs"))).toBe("Program");
+
+          // A real override still takes effect (and such modules are not cached).
+          Module.wrapper = ["(function(exports,require,module,__filename,__dirname){module.wrapped = true;", "})"];
+          expect(require("./dep2.cjs")).toBe("dep2");
+          expect(require.cache[require.resolve("./dep2.cjs")].wrapped).toBe(true);
+          expect(isolatedModuleCacheSourceType(require.resolve("./dep2.cjs"))).toBe(null);
+        });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "./copy.test.js"],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout + stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
   });
 
   test("module.enableCompileCache validates its argument", () => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -29,12 +29,16 @@ describe.concurrent("node-module-module", () => {
     expect(Array.isArray(require("module").globalPaths)).toBe(true);
   });
 
-  test("Module.prototype is not enumerable", () => {
+  test("Module.prototype is not enumerable", async () => {
     const Module = require("module");
     const { value, ...descriptor } = Object.getOwnPropertyDescriptor(Module, "prototype");
     expect(descriptor).toEqual({ writable: true, enumerable: false, configurable: false });
     expect(value).toBe(Module.prototype);
     expect(Object.keys(Module)).not.toContain("prototype");
+    // and so, as in Node, it is not a named export of the ES module either
+    const ns = await import("node:module");
+    expect(Object.keys(ns)).not.toContain("prototype");
+    expect(ns.default.prototype).toBe(Module.prototype);
   });
 
   // jest-runtime builds the `Module` it hands to tests this way. Assigning a class's `prototype` throws, so this


### PR DESCRIPTION
### What does this PR do?

`require("module").prototype` was defined as an enumerable, configurable property. In Node it is an ordinary function `prototype`: `{ writable: true, enumerable: false, configurable: false }`.

Because it was enumerable, code that copies `Module`'s enumerable statics onto a subclass:

```js
class Module extends require("module").Module {}
Object.entries(require("module").Module).forEach(([key, value]) => { Module[key] = value; });
```

hit `key === "prototype"`, tried to assign the class's read-only `prototype`, and threw `TypeError: Attempted to assign to readonly property`. That snippet is how `jest-runtime` builds the `Module` it hands to test code, so `bun --bun jest` failed every suite with "Test suite failed to run" before any test executed. The fix is the attribute on the `prototype` entry of the `node:module` static property table (`DontEnum|DontDelete`).

With that fixed the same loop runs to completion, and one of the statics it copies is `wrapper`, an accessor: `Sub.wrapper = Module.wrapper` runs the inherited setter with the default wrapper strings. The setter treated any write as an override, and an overridden wrapper makes every later CommonJS load re-wrap its source and skip the `--isolate` SourceProvider cache for the rest of the process. The setter (and the per-index one behind `Module.wrapper[i] = …`) now only flags an override when the strings differ from the defaults — the same "writing back the original is not an override" rule the `_resolveFilename` and `runMain` setters next to it already apply.

### How did you verify your code works?

- `test/js/node/module/node-module-module.test.js`: descriptor / `Object.keys` check for `prototype`; and, in a `bun test --isolate` subprocess, the jest-style static copy followed by a CJS `require` that must still be served from the isolate cache (`isolatedModuleCacheSourceType(...) === "Program"`), plus a real `Module.wrapper = [...]` override that must still take effect and not be cached. Both fail on current bun.
- A jest 29.7 project (6 node-env suites + 1 jsdom suite, 37 tests) run with `bun --bun jest`: before, `Test Suites: 7 failed` (all "failed to run" with the readonly-property error at `jest-runtime/build/index.js:1638`); after, `7 passed, 37 passed`, both in-band and with workers.
