### PR TITLE
test(node-https-checkServerIdentity): spawn one child instead of four

### DIFF
--- a/test/js/node/http/node-https-checkServerIdentity.test.ts
+++ b/test/js/node/http/node-https-checkServerIdentity.test.ts
@@ -1,20 +1,20 @@
-// Regression tests for node-compat group u9sf0l.
+// https.request() checks the peer certificate against the hostname the way
+// tls.checkServerIdentity() does in Node. agent1's certificate is CN=agent1
+// with no subjectAltName, signed by ca1. Every request below trusts ca1, so
+// the identity check alone decides whether the request succeeds.
 //
-// The core bug was an ASAN use-after-poison in
-// src/http/HTTPContext.zig onHandshake: when the native
-// checkServerIdentity() rejected the peer certificate, it called
-// closeAndFail() → fail() → result callback, which destroyed the
-// AsyncHTTP (and its embedded HTTPClient). onHandshake then wrote to
-// client.flags.did_have_handshaking_error on freed memory.
-//
-// Triggering the bug requires `rejectUnauthorized: true`, a trusted
-// CA, and a hostname that does NOT match the certificate's identity.
-// Previously any CN-only cert (no SAN) would hit this, because the
-// native checkX509ServerIdentity never fell back to the Subject CN.
+// The mismatch case runs in a child process. It started as the regression
+// test for a use-after-free when the identity check rejected the peer inside
+// the native handshake callback (#29829). A crash in that path must fail this
+// one test instead of taking down the test runner, so it stays out of process.
+// The other cases only check behavior and run in this process.
 
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
+import { once } from "node:events";
 import { readFileSync } from "node:fs";
+import https, { type RequestOptions, type Server, type ServerOptions } from "node:https";
+import type { AddressInfo } from "node:net";
 import { join } from "node:path";
 
 const keys = join(import.meta.dir, "..", "test", "fixtures", "keys");
@@ -24,10 +24,27 @@ const agent1 = {
   ca: readFileSync(join(keys, "ca1-cert.pem"), "utf8"),
 };
 
-describe("https.request checkServerIdentity", () => {
-  // Direct repro of the ASAN crash: trusted CA + servername that does not
-  // match the cert. Before the fix this hit use-after-poison in
-  // HTTPContext.onHandshake on ASAN builds instead of emitting 'error'.
+async function listen(options: ServerOptions): Promise<Server> {
+  const server = https.createServer(options, (_req, res) => {
+    res.writeHead(200);
+    res.end("ok");
+  });
+  await once(server.listen(0), "listening");
+  return server;
+}
+
+async function request(options: RequestOptions): Promise<{ statusCode: number | undefined; body: string }> {
+  const req = https.request(options);
+  req.end();
+  const [res] = await once(req, "response");
+  res.setEncoding("utf8");
+  let body = "";
+  res.on("data", (chunk: string) => (body += chunk));
+  await once(res, "end");
+  return { statusCode: res.statusCode, body };
+}
+
+describe.concurrent("https.request checkServerIdentity", () => {
   test("hostname mismatch emits error without crashing", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -45,12 +62,19 @@ describe("https.request checkServerIdentity", () => {
               rejectUnauthorized: true,
               ca: ${JSON.stringify(agent1.ca)},
               servername: "not-agent1",
-            }, () => {
-              console.log("UNEXPECTED_RESPONSE");
+            }, res => {
+              console.log(JSON.stringify({ unexpectedResponse: res.statusCode }));
+              res.resume();
               server.close();
             });
             req.on("error", err => {
-              console.log("ERROR_CODE=" + err.code);
+              console.log(JSON.stringify({
+                code: err.code,
+                reason: err.reason,
+                host: err.host,
+                certCN: err.cert?.subject?.CN,
+                message: err.message,
+              }));
               server.close();
             });
             req.end();
@@ -63,151 +87,52 @@ describe("https.request checkServerIdentity", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("ERROR_CODE=ERR_TLS_CERT_ALTNAME_INVALID");
+    expect(JSON.parse(stdout)).toEqual({
+      code: "ERR_TLS_CERT_ALTNAME_INVALID",
+      reason: "Host: not-agent1. is not cert's CN: agent1",
+      host: "not-agent1",
+      certCN: "agent1",
+      message: "Hostname/IP does not match certificate's altnames: Host: not-agent1. is not cert's CN: agent1",
+    });
     expect(exitCode).toBe(0);
   });
 
-  // Node's tls.checkServerIdentity falls back to the Subject CN when the
-  // certificate carries no DNS/IP/URI SANs. agent1's cert is CN=agent1 with
-  // no SAN. With `servername: "agent1"` the request must succeed.
   test("falls back to Subject CN when no SAN is present", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const https = require("https");
-          const server = https.createServer({
-            key: ${JSON.stringify(agent1.key)},
-            cert: ${JSON.stringify(agent1.cert)},
-          }, (req, res) => { res.writeHead(200); res.end("ok"); });
-          server.listen(0, () => {
-            const req = https.request({
-              port: server.address().port,
-              rejectUnauthorized: true,
-              ca: ${JSON.stringify(agent1.ca)},
-              servername: "agent1",
-            }, res => {
-              let body = "";
-              res.on("data", d => body += d);
-              res.on("end", () => {
-                console.log("BODY=" + body);
-                server.close();
-              });
-            });
-            req.on("error", err => {
-              console.log("UNEXPECTED_ERROR=" + (err.code || err.message));
-              server.close();
-            });
-            req.end();
-          });
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+    await using server = await listen({ key: agent1.key, cert: agent1.cert });
+    const { port } = server.address() as AddressInfo;
+    expect(await request({ port, rejectUnauthorized: true, ca: agent1.ca, servername: "agent1" })).toEqual({
+      statusCode: 200,
+      body: "ok",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("BODY=ok");
-    expect(exitCode).toBe(0);
   });
 
-  // A user-supplied `checkServerIdentity` must override the native check.
-  // agent1's CN is "agent1" so the native check for hostname "localhost"
-  // would fail; the custom callback makes the request succeed and must
-  // actually be invoked.
+  // https.request() defaults the host to "localhost", which does not match
+  // CN=agent1, so only the custom callback can let this request through.
   test("custom checkServerIdentity overrides the native check", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const https = require("https");
-          const server = https.createServer({
-            key: ${JSON.stringify(agent1.key)},
-            cert: ${JSON.stringify(agent1.cert)},
-          }, (req, res) => { res.writeHead(200); res.end("ok"); });
-          server.listen(0, () => {
-            let called = false;
-            const req = https.request({
-              port: server.address().port,
-              rejectUnauthorized: true,
-              ca: ${JSON.stringify(agent1.ca)},
-              checkServerIdentity: (host, cert) => {
-                called = true;
-                return undefined;
-              },
-            }, res => {
-              let body = "";
-              res.on("data", d => body += d);
-              res.on("end", () => {
-                console.log("CALLED=" + called + " BODY=" + body);
-                server.close();
-              });
-            });
-            req.on("error", err => {
-              console.log("UNEXPECTED_ERROR=" + (err.code || err.message));
-              server.close();
-            });
-            req.end();
-          });
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+    await using server = await listen({ key: agent1.key, cert: agent1.cert });
+    const { port } = server.address() as AddressInfo;
+    const calls: { hostname: string; subjectCN: string; issuerCN: string }[] = [];
+    const response = await request({
+      port,
+      rejectUnauthorized: true,
+      ca: agent1.ca,
+      checkServerIdentity(hostname, cert) {
+        calls.push({ hostname, subjectCN: cert.subject.CN, issuerCN: cert.issuer.CN });
+        return undefined;
+      },
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("CALLED=true BODY=ok");
-    expect(exitCode).toBe(0);
+    expect(response).toEqual({ statusCode: 200, body: "ok" });
+    expect(calls).toEqual([{ hostname: "localhost", subjectCN: "agent1", issuerCN: "ca1" }]);
   });
 
-  // Node.js only requests a client certificate when `requestCert: true`.
-  // Passing `ca` alone must not make the server reject clients that don't
-  // present one.
+  // Node only asks the client for a certificate when requestCert is set.
+  // A server `ca` on its own must not reject a client without one.
   test("https.Server with ca but no requestCert accepts clients without a cert", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const https = require("https");
-          const server = https.createServer({
-            key: ${JSON.stringify(agent1.key)},
-            cert: ${JSON.stringify(agent1.cert)},
-            ca: ${JSON.stringify(agent1.ca)},
-          }, (req, res) => { res.writeHead(200); res.end("ok"); });
-          server.listen(0, () => {
-            const req = https.request({
-              port: server.address().port,
-              rejectUnauthorized: true,
-              ca: ${JSON.stringify(agent1.ca)},
-              servername: "agent1",
-            }, res => {
-              let body = "";
-              res.on("data", d => body += d);
-              res.on("end", () => {
-                console.log("BODY=" + body);
-                server.close();
-              });
-            });
-            req.on("error", err => {
-              console.log("UNEXPECTED_ERROR=" + (err.code || err.message));
-              server.close();
-            });
-            req.end();
-          });
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+    await using server = await listen({ key: agent1.key, cert: agent1.cert, ca: agent1.ca });
+    const { port } = server.address() as AddressInfo;
+    expect(await request({ port, rejectUnauthorized: true, ca: agent1.ca, servername: "agent1" })).toEqual({
+      statusCode: 200,
+      body: "ok",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("BODY=ok");
-    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/http/node-https-checkServerIdentity.test.ts
+++ b/test/js/node/http/node-https-checkServerIdentity.test.ts
@@ -3,11 +3,13 @@
 // with no subjectAltName, signed by ca1. Every request below trusts ca1, so
 // the identity check alone decides whether the request succeeds.
 //
-// The mismatch case runs in a child process. It started as the regression
-// test for a use-after-free when the identity check rejected the peer inside
-// the native handshake callback (#29829). A crash in that path must fail this
-// one test instead of taking down the test runner, so it stays out of process.
-// The other cases only check behavior and run in this process.
+// The mismatch case runs in a child process on purpose. The child makes one
+// rejected request, closes the server as soon as the request emits "error",
+// and exits. The test requires an empty stderr and exit code 0. On the ASAN
+// lane the child also runs with leak detection. A crash or a leak on the
+// reject path fails this one test instead of the test runner. This child is
+// how the close_notify leak fixed in #30368 was found, and that fix has no
+// other test. The other cases only check behavior and run in this process.
 
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";


### PR DESCRIPTION
### Problem
- `test/js/node/http/node-https-checkServerIdentity.test.ts` takes 20 to 25 s on the debian x64-asan lane (`expected-durations.json` has `asan: 25420`). On every other lane it takes 0.2 to 0.4 s.
- The file spawned one bun child per test and ran the four children one after another. Each child starts a debug ASAN process, loads `node:https`, and does one TLS handshake. On a local debug build one child costs about 3.4 s: about 1.4 s for `require("https")`, about 0.8 s for the TLS round trip, the rest is process start.
- Because of the 25 s median, `parallel-allowlist.json` lists the file in `excludeFiles`. It runs alone in the serial phase of each shard.

### Fix
- The hostname mismatch case still runs in a child, with the same sequence as before: the request emits `error`, the child closes the server and exits, and the test requires an empty `stderr` and exit code 0. On the ASAN lane the child inherits `detect_leaks=1` (`scripts/runner.node.mjs:2003-2007`), so a crash or a leak on the reject path fails this one test. This child is how the close_notify leak of #30368 was found (`packages/bun-usockets/src/crypto/openssl.c:1878`), and that fix has no other test.
- The other three cases start their `https` server and make their request in the test process. They check behavior only, so they do not need their own process. This removes three spawns. With one spawn left, there is no script template to share.
- The describe block is `describe.concurrent`. Each case owns its server on port 0. The cases share no state.
- Stronger assertions:
  - mismatch: the child prints one JSON object. The test compares `code`, `reason`, `host`, the `subject.CN` of `err.cert`, and `message` with `toEqual`. Node v26.3.0 produces the same five values for this certificate (checked with the same script). The `stderr` check stays first and the exit code check stays last.
  - custom `checkServerIdentity`: the test records each call and expects exactly one call with hostname `"localhost"` (the `https.request()` default host), subject CN `agent1`, and issuer CN `ca1`. Before, it only checked that the callback ran.
  - CN fallback, and server with `ca` but no `requestCert`: the tests compare `{ statusCode: 200, body: "ok" }` with `toEqual`. Before, they checked the body only.
- The old header described the client path of #29829. `https.request()` connects through `tls.connect()` since #31587 (`src/js/node/https.ts:277`), so the header now gives the reason above for the child.
- Overlap, for the record: the vendored `test-https-client-checkServerIdentity.js`, `test-https-agent-servername.js`, and `test/js/node/tls/node-tls-connect-hostname-verification.test.ts` cover the outcome of each of the four scenarios. What only this file pins at the `https` layer: `reason`, `host`, `cert`, and `message` of the error, the arguments of a custom `checkServerIdentity`, and the clean exit of the child. The task for this PR is to make the file faster without removing tests, so it keeps the file. Deleting it is a separate decision.
- `parallel-allowlist.json` and `expected-durations.json` are generated from CI data by their scripts, so this PR does not edit them. The file leaves `excludeFiles` on the next regeneration once its asan median is under 15 s.
- Verification on one machine with the same debug build, `bun bd test test/js/node/http/node-https-checkServerIdentity.test.ts`, three runs each, best run:
  - before: 16994 ms wall (bun reports 16.20 s), tests 3.4 to 3.7 s each, in series
  - after: 7190 ms wall (bun reports 6.40 s), the child takes 3.3 s and the three in-process cases take 1.2 to 1.4 s and overlap with it
  - the file still has the same four tests with the same names
  - a mutation run (wrong expected `reason`, a callback that returns an error, a wrong `servername`) fails the three cases it touches
- #33704 is a 53-file sweep that only changes the `describe` of this file to `describe.concurrent`. It has conflicts and does not change the assertions.

### Background
- `tls.checkServerIdentity(hostname, cert)` is the Node function that compares a hostname with the peer certificate. When the certificate has no subjectAltName, it compares against the subject CN. On a mismatch it returns an error with `code: "ERR_TLS_CERT_ALTNAME_INVALID"`, `reason`, `host`, and `cert`. A `checkServerIdentity` option on the request replaces this function.
- The fixture `agent1-cert.pem` (in `test/js/node/test/fixtures/keys`) has CN `agent1`, no subjectAltName, and is signed by `ca1`. Every request in the file trusts `ca1`, so the identity check alone decides the result.
- On the ASAN lane the runner sets `ASAN_OPTIONS=detect_leaks=1` and `BUN_DESTRUCT_VM_ON_EXIT=1` for the test process. `bunEnv` copies `process.env`, so a spawned child gets them too, and a leak prints a report to its `stderr` at exit.
- The CI runner runs a test file in the parallel bucket (next to other files on the same 8 vCPU box) only when its slowest lane median is at or under 15 s. This is why one child is better than four concurrent children here: both give about the same wall time on an idle machine, but one child uses about a quarter of the CPU when the file shares the box.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/http/node-https-checkServerIdentity.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/http/node-https-checkServerIdentity.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/node/http/node-https-checkServerIdentity.test.ts:
(pass) https.request checkServerIdentity > falls back to Subject CN when no SAN is present [1471.64ms]
(pass) https.request checkServerIdentity > custom checkServerIdentity overrides the native check [1296.33ms]
(pass) https.request checkServerIdentity > https.Server with ca but no requestCert accepts clients without a cert [1265.60ms]
(pass) https.request checkServerIdentity > hostname mismatch emits error without crashing [3413.53ms]

 4 pass
 0 fail
 7 expect() calls
Ran 4 tests across 1 file. [6.62s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../http/node-https-checkServerIdentity.test.ts    | 231 +++++++--------------
 1 file changed, 79 insertions(+), 152 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
test/js/node/http/node-https-checkServerIdentity.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->