### PR TITLE
valkey: reject connect() and call onclose with the real failure reason

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -976,8 +976,12 @@ impl JSValkeyClient {
         let promise = promise_ptr.to_js();
         Js::connection_promise_set_cached(this_value, global_object, promise);
 
-        // If was manually closed, reset that flag
+        // If was manually closed, reset that flag. A close() that interrupted
+        // a dial in this same tick is taken back with it: the deferred close
+        // of that dial now settles this connect(), and reports the dial's own
+        // outcome rather than the close.
         self.client_mut().flags.is_manually_closed = false;
+        self.client_mut().flags.close_aborted_dial = false;
         // Explicit connect() should also clear the sticky failure so the
         // client can recover after prior connection attempts exhausted retries.
         // Without this, every subsequent command rejects with "Connection has

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -761,6 +761,7 @@ impl JSValkeyClient {
                 read_buffer: Default::default(),
                 reply_scanner: Default::default(),
                 retry_attempts: 0,
+                failure: None,
                 auto_flusher: Default::default(),
             }),
             global_object,
@@ -873,6 +874,7 @@ impl JSValkeyClient {
                 read_buffer: Default::default(),
                 reply_scanner: Default::default(),
                 retry_attempts: 0,
+                failure: None,
                 auto_flusher: Default::default(),
             }),
             global_object,
@@ -976,11 +978,11 @@ impl JSValkeyClient {
 
         // If was manually closed, reset that flag
         self.client_mut().flags.is_manually_closed = false;
-        // Explicit connect() should also clear the sticky `failed` flag so the
+        // Explicit connect() should also clear the sticky failure so the
         // client can recover after prior connection attempts exhausted retries.
         // Without this, every subsequent command rejects with "Connection has
         // failed" forever — see https://github.com/oven-sh/bun/issues/29925.
-        self.client_mut().flags.failed = false;
+        self.client_mut().failure = None;
         let self_br = BackRef::new(self);
         let _update = scopeguard::guard(self_br, |p| p.update_poll_ref());
 
@@ -988,13 +990,10 @@ impl JSValkeyClient {
             self.poll_ref.with_mut(|r| r.ref_(vm_event_loop_ctx()));
 
             if let Err(err) = self.connect() {
-                debug!(
-                    "first dial failed before a socket was opened: {}",
-                    err.name()
-                );
+                debug!("first dial failed before a socket was opened: {:?}", err);
                 // Settled by the deferred close like a refused dial: the
                 // promise, onclose and the retry policy all go through on_close().
-                self.close_without_socket_next_tick();
+                self.close_without_socket_next_tick(self.dial_error_message(&err), false);
                 return Ok(promise);
             }
 
@@ -1053,7 +1052,8 @@ impl JSValkeyClient {
         // `on_valkey_close` adopts none. The caller's scoped ref covers the
         // call.
         self.reconnect_timer.disarm(self);
-        self.client_mut().on_close()
+        self.client_mut()
+            .on_close(valkey::CloseReason::SocketClosed)
     }
 
     // `onconnect`/`onclose` are declared with `this: true` in
@@ -1078,7 +1078,7 @@ impl JSValkeyClient {
 
         let _guard = self.ref_guard();
         let _timer_ref = self.timer.take_fire_ref(self);
-        if self.client.get().flags.failed {
+        if self.client.get().failure.is_some() {
             return Ok(());
         }
 
@@ -1135,10 +1135,43 @@ impl JSValkeyClient {
     /// commands queued for the retry or the rejection, and a disconnect()
     /// marks the close as manual for the task to honour. `update_poll_ref`
     /// keeps the wrapper and the event loop alive for it like a dial would.
-    fn close_without_socket_next_tick(&self) {
+    fn close_without_socket_next_tick(&self, reason: Box<[u8]>, terminal: bool) {
         self.client_mut().status = valkey::Status::Connecting;
         self.update_poll_ref();
-        self.enqueue_deferred_close(DeferredClose::WithoutSocket);
+        self.enqueue_deferred_close(DeferredClose::WithoutSocket { reason, terminal });
+    }
+
+    /// The `CloseReason::DialFailed` text for a dial uSockets turned down
+    /// before it had a socket, in the shape of `node:net`'s: `connect ENOENT
+    /// /run/redis.sock`.
+    fn dial_error_message(&self, err: &uws::ConnectError) -> Box<[u8]> {
+        let &uws::ConnectError::FailedToOpenSocket { mut errno } = err;
+        let address = &self.client.get().address;
+        if let valkey::Address::Unix(path) = address {
+            errno = bun_errno::from_errno(bun_sys::unix_connect_errno(errno as i32, path));
+        }
+        Self::connect_error_message(address, errno)
+    }
+
+    fn connect_error_message(
+        address: &valkey::Address,
+        errno: bun_errno::SystemErrno,
+    ) -> Box<[u8]> {
+        use std::io::Write;
+        let mut message = Vec::new();
+        let _ = write!(message, "connect {} ", errno);
+        match address {
+            valkey::Address::Unix(path) => message.extend_from_slice(path),
+            valkey::Address::Host { host, port } => {
+                // `URL.host()` keeps an IPv6 literal's brackets; node prints `::1:6379`.
+                let host = host
+                    .strip_prefix(b"[")
+                    .and_then(|h| h.strip_suffix(b"]"))
+                    .unwrap_or(host);
+                let _ = write!(message, "{}:{}", bstr::BStr::new(host), port);
+            }
+        }
+        message.into_boxed_slice()
     }
 
     fn enqueue_deferred_close(&self, what: DeferredClose) {
@@ -1197,13 +1230,10 @@ impl JSValkeyClient {
         });
 
         if let Err(err) = self.connect() {
-            debug!(
-                "reconnect failed before a socket was opened: {}",
-                err.name()
-            );
+            debug!("reconnect failed before a socket was opened: {:?}", err);
             // Same outcome as a dial that fails asynchronously: another retry,
             // or fail() and a settled connect() promise once retries are used up.
-            self.close_without_socket_next_tick();
+            self.close_without_socket_next_tick(self.dial_error_message(&err), false);
             return Ok(());
         }
 
@@ -1397,12 +1427,17 @@ impl JSValkeyClient {
             return Err(bun_jsc::JsError::Thrown);
         }
 
-        // Create an error value
-        let error_value = protocol_jsc::valkey_error_to_js(
-            &global_object,
-            b"Connection closed",
-            protocol::RedisError::ConnectionClosed,
-        );
+        // The error the commands were rejected with. Every arm of `on_close()`
+        // calls `fail()` first, and the one `fail()` that cannot record (a
+        // finalized client) never gets past the `this_value` guard above.
+        let Some(failure) = &self.client.get().failure else {
+            debug_assert!(
+                false,
+                "on_close() records a failure before on_valkey_close()"
+            );
+            return Ok(());
+        };
+        let error_value = failure.get();
 
         let _exit = self.vm().enter_event_loop_scope();
 
@@ -1462,7 +1497,7 @@ impl JSValkeyClient {
         self.reconnect_timer.disarm(self);
     }
 
-    fn connect(&self) -> Result<(), crate::Error> {
+    fn connect(&self) -> Result<(), uws::ConnectError> {
         // Overwriting a live socket below would leave its callbacks driving
         // this client alongside the new one's.
         debug_assert!(self.client.get().socket.is_closed());
@@ -1503,12 +1538,11 @@ impl JSValkeyClient {
             false
         };
         if tls_ctx_failed {
-            self.client_mut().flags.enable_auto_reconnect = false;
-            self.client_fail(
-                b"Failed to create TLS context",
-                protocol::RedisError::ConnectionClosed,
-            )?;
-            self.close_without_socket_next_tick();
+            // Terminal: no retry could build the context either.
+            self.close_without_socket_next_tick(
+                Box::from(&b"Failed to create TLS context"[..]),
+                true,
+            );
             return Ok(());
         }
         let ssl_ctx: Option<*mut uws::SslCtx> = match &self.client.get().tls {
@@ -1586,11 +1620,8 @@ impl JSValkeyClient {
             // The command is queued as for a dial in flight; the deferred
             // close then rejects it or a retry sends it, like a refused dial.
             Err(err) => {
-                debug!(
-                    "first dial failed before a socket was opened: {}",
-                    err.name()
-                );
-                self.close_without_socket_next_tick();
+                debug!("first dial failed before a socket was opened: {:?}", err);
+                self.close_without_socket_next_tick(self.dial_error_message(&err), false);
             }
             Ok(()) => self.reset_connection_timeout(),
         }
@@ -1878,7 +1909,8 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.client_mut().status = valkey::Status::Disconnected;
         let _defer = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
 
-        this.client_mut().on_close()
+        this.client_mut()
+            .on_close(valkey::CloseReason::SocketClosed)
     }
 
     pub(crate) fn on_end(this: &JSValkeyClient, socket: SocketType<SSL>) {
@@ -1890,11 +1922,17 @@ impl<const SSL: bool> SocketHandler<SSL> {
         // anything here
     }
 
+    /// `errno` is the connect's error in `SystemErrno` numbering (the uSockets
+    /// trampoline maps the OS code), or, when `dns_error` is set, the
+    /// `getaddrinfo(3)` code of the lookup that failed instead.
     pub(crate) fn on_connect_error(
         this: &JSValkeyClient,
-        _socket: SocketType<SSL>,
-        _code: i32,
+        socket: SocketType<SSL>,
+        errno: i32,
     ) -> JsResult<()> {
+        // Read before the socket is detached: uSockets keeps the connecting
+        // socket alive for the whole dispatch.
+        let dns_error = socket.dns_error();
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
         let _guard = this.ref_guard();
@@ -1903,7 +1941,29 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.client_mut().status = valkey::Status::Disconnected;
         let _defer = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
 
-        this.client_mut().on_close()
+        let address = &this.client.get().address;
+        let message = match bun_cares_sys::c_ares::Error::init_eai(dns_error)
+            .filter(|_| dns_error != 0)
+        {
+            Some(dns_err) => {
+                use std::io::Write;
+                let mut message = Vec::new();
+                // `code()` is `DNS_ENOTFOUND`; `node:dns` and `Bun.connect`
+                // report it as `getaddrinfo ENOTFOUND host`.
+                let _ = write!(
+                    message,
+                    "getaddrinfo {} {}",
+                    &dns_err.code()[4..],
+                    bstr::BStr::new(address.hostname())
+                );
+                message.into_boxed_slice()
+            }
+            None => JSValkeyClient::connect_error_message(address, bun_errno::from_errno(errno)),
+        };
+        this.client_mut().on_close(valkey::CloseReason::DialFailed {
+            message: &message,
+            terminal: false,
+        })
     }
 
     pub(crate) fn on_timeout(this: &JSValkeyClient, socket: SocketType<SSL>) {
@@ -2020,13 +2080,13 @@ impl Options {
     }
 }
 
-#[derive(Clone, Copy)]
 enum DeferredClose {
     /// Close the socket the finalized wrapper left behind.
     Socket,
     /// Run the close path for a dial that never produced a socket
-    /// (`close_without_socket_next_tick`).
-    WithoutSocket,
+    /// (`close_without_socket_next_tick`); `reason` and `terminal` are the
+    /// `CloseReason::DialFailed` it runs with.
+    WithoutSocket { reason: Box<[u8]>, terminal: bool },
 }
 
 pub(crate) struct ValkeyDeferredClose {
@@ -2042,18 +2102,21 @@ impl ValkeyDeferredClose {
         let _enqueue_ref = unsafe { RefPtr::from_raw(self.ctx) };
         // SAFETY: live per the ref above; tasks run on the JS thread.
         let this = unsafe { &*self.ctx };
-        match self.what {
+        match &self.what {
             DeferredClose::Socket => {
                 crate::dispatch::fold(this.client_mut().close(uws::CloseCode::FastShutdown))
             }
-            DeferredClose::WithoutSocket => {
+            DeferredClose::WithoutSocket { reason, terminal } => {
                 // Holding Connecting (see `close_without_socket_next_tick`)
                 // and the gate in `reconnect()` keep every dial entry out.
                 debug_assert!(this.client.get().socket.is_closed());
                 // No socket ref to give back: `connect()` forgets it only once
                 // it has a socket, and this task exists because it never did.
                 this.client_mut().status = valkey::Status::Disconnected;
-                let closed = this.client_mut().on_close();
+                let closed = this.client_mut().on_close(valkey::CloseReason::DialFailed {
+                    message: reason,
+                    terminal: *terminal,
+                });
                 this.update_poll_ref();
                 crate::dispatch::fold(closed);
             }
@@ -2071,7 +2134,7 @@ impl bun_event_loop::Taskable for ValkeyDeferredClose {
             DeferredClose::Socket => task.run(),
             // The VM is going away: `on_close()` would run `onclose`, so only
             // give back what `close_without_socket_next_tick` took.
-            DeferredClose::WithoutSocket => {
+            DeferredClose::WithoutSocket { .. } => {
                 // SAFETY: as in `run`.
                 let _enqueue_ref = unsafe { RefPtr::from_raw(task.ctx) };
                 // SAFETY: live per the ref above.

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -30,6 +30,10 @@ bun_output::define_scoped_log!(debug, Redis, visible);
 /// Connection flags to track Valkey client state
 pub struct ConnectionFlags {
     pub(crate) is_manually_closed: bool,
+    /// Set by `disconnect()` while a dial is in flight and taken by that
+    /// dial's `on_close`: uSockets reports the aborted dial as a connect
+    /// error (`ECONNABORTED`), and the user asked for that close.
+    pub(crate) close_aborted_dial: bool,
     pub(crate) is_selecting_db_internal: bool,
     pub(crate) enable_offline_queue: bool,
     pub(crate) enable_auto_reconnect: bool,
@@ -37,11 +41,6 @@ pub struct ConnectionFlags {
     /// or `fail()`, so it overlaps `Disconnected` and `Connecting`; that is why
     /// it is not a `Status` variant.
     pub(crate) is_reconnecting: bool,
-    /// Sticky until `on_open`/`connect()`. `fail()` closes the socket outright
-    /// (see `close()`), so by the time it returns the close callback has run
-    /// (`on_close` reads this to skip the retry policy) and this overlaps
-    /// `Disconnected`.
-    pub(crate) failed: bool,
     pub(crate) enable_auto_pipelining: bool,
     pub(crate) finalized: bool,
     // This flag is a slight hack to allow returning the client instance in the
@@ -60,11 +59,11 @@ impl Default for ConnectionFlags {
     fn default() -> Self {
         Self {
             is_manually_closed: false,
+            close_aborted_dial: false,
             is_selecting_db_internal: false,
             enable_offline_queue: true,
             enable_auto_reconnect: true,
             is_reconnecting: false,
-            failed: false,
             enable_auto_pipelining: true,
             finalized: false,
             connection_promise_returns_client: false,
@@ -197,7 +196,7 @@ impl Address {
         group: &mut SocketGroup,
         ssl_ctx: Option<*mut SslCtx>,
         is_tls: bool,
-    ) -> Result<AnySocket, crate::Error> {
+    ) -> Result<AnySocket, uws::ConnectError> {
         if is_tls {
             let kind = SocketKind::ValkeyTls;
             let sock = match self {
@@ -233,6 +232,34 @@ impl Address {
             };
             Ok(AnySocket::SocketTcp(sock))
         }
+    }
+}
+
+/// Why `on_close` runs. Its message rejects the commands the close leaves
+/// unanswered, and is the failure the connect() promise and `onclose` get
+/// unless `fail()` recorded one first or the retries are used up.
+#[derive(Clone, Copy)]
+pub(crate) enum CloseReason<'a> {
+    /// The socket of a connection went away: closed by the peer, `close()`
+    /// or `fail()`.
+    SocketClosed,
+    /// The dial never produced a connection; `message` is the errno/resolver
+    /// text, e.g. `connect ECONNREFUSED 127.0.0.1:6379`. A `terminal` dial is
+    /// one no retry can make succeed (the TLS context cannot be built), so
+    /// the retry policy is skipped whatever `autoReconnect` says.
+    DialFailed { message: &'a [u8], terminal: bool },
+}
+
+impl<'a> CloseReason<'a> {
+    pub(crate) fn message(self) -> &'a [u8] {
+        match self {
+            Self::SocketClosed => b"Connection closed",
+            Self::DialFailed { message, .. } => message,
+        }
+    }
+
+    fn is_terminal(self) -> bool {
+        matches!(self, Self::DialFailed { terminal: true, .. })
     }
 }
 
@@ -274,6 +301,21 @@ pub struct ValkeyClient {
     pub(crate) max_retries: u32, // Maximum retry attempts
 
     pub(crate) flags: ConnectionFlags,
+
+    /// The error of the failure that closed this connection, `Some` from
+    /// `fail_with_js_value` until the next `connect()`/`on_open`. It is the
+    /// one value the rejected commands, the connect() promise and `onclose`
+    /// all get. `fail()` closes the socket outright (see `close()`), so by the
+    /// time it returns the close callback has run (`on_close` reads this to
+    /// skip the retry policy) and this overlaps `Disconnected`.
+    ///
+    /// A `Strong` because the value has to live from `fail_with_js_value`
+    /// through the socket close dispatch to `on_valkey_close`, a chain that
+    /// allocates and can collect, while it may have no other referent (no
+    /// command was queued) and a `JSValue` in this boxed client is not
+    /// scanned. Dropped with the client; cleared on the next dial so a
+    /// client that failed once does not root its error for good.
+    pub(crate) failure: Option<bun_jsc::Strong>,
 
     // Auto-pipelining
     pub(crate) auto_flusher: AutoFlusher,
@@ -438,7 +480,7 @@ impl ValkeyClient {
 
     /// Get the appropriate timeout interval based on connection state
     pub(crate) fn get_timeout_interval(&self) -> u32 {
-        if self.flags.failed {
+        if self.failure.is_some() {
             return 0;
         }
         match self.status {
@@ -548,7 +590,7 @@ impl ValkeyClient {
     /// Mark the connection as failed with error message
     pub(crate) fn fail(&mut self, message: &[u8], err: RedisError) -> JsResult<()> {
         debug!("failed: {}: {:?}", bstr::BStr::new(message), err);
-        if self.flags.failed {
+        if self.failure.is_some() {
             return Ok(());
         }
 
@@ -581,10 +623,10 @@ impl ValkeyClient {
         global_this: &JSGlobalObject,
         jsvalue: JSValue,
     ) -> JsResult<()> {
-        if self.flags.failed {
+        if self.failure.is_some() {
             return Ok(());
         }
-        self.flags.failed = true;
+        self.failure = Some(bun_jsc::Strong::create(jsvalue, global_this));
         self.flags.is_reconnecting = false;
         let val = Self::reject_all_pending_commands(
             &mut self.in_flight,
@@ -595,7 +637,7 @@ impl ValkeyClient {
 
         // A failure the client detected itself (idle timeout, protocol or
         // handshake error) has always been a deliberate close; `on_close` reads
-        // `failed` and skips the retry policy.
+        // `failure` and skips the retry policy.
         let closed = self.close(uws::CloseCode::Failure); // unconditionally, whatever `val` is
         val.and(closed)
     }
@@ -655,12 +697,12 @@ impl ValkeyClient {
         // client outlives this scope.
         let _socket_ref = unsafe { RefPtr::from_raw(self.parent_ptr()) };
         self.status = Status::Disconnected;
-        let closed = self.on_close();
+        let closed = self.on_close(CloseReason::SocketClosed);
         thrown.and(closed)
     }
 
     /// Handle connection closed event
-    pub fn on_close(&mut self) -> JsResult<()> {
+    pub(crate) fn on_close(&mut self, reason: CloseReason<'_>) -> JsResult<()> {
         self.unregister_auto_flusher();
         self.write_buffer.clear_and_free();
         // A partial reply can never complete now; left in place it counts as
@@ -668,10 +710,19 @@ impl ValkeyClient {
         self.read_buffer.clear_and_free();
         self.reply_scanner.reset();
 
-        // A manual close or a failure the client detected itself: no retry.
-        if self.flags.is_manually_closed || self.flags.failed {
+        // A dial `close()` aborted did not fail; see `close_aborted_dial`.
+        let message = if core::mem::take(&mut self.flags.close_aborted_dial) {
+            CloseReason::SocketClosed.message()
+        } else {
+            reason.message()
+        };
+
+        // A manual close, a failure the client detected itself or a dial no
+        // retry can fix: no retry. After `fail()` this `fail` is a no-op and
+        // `on_valkey_close` reports the recorded failure.
+        if self.flags.is_manually_closed || self.failure.is_some() || reason.is_terminal() {
             debug!("skip reconnecting since the connection is manually closed or failed");
-            self.fail(b"Connection closed", RedisError::ConnectionClosed)?;
+            self.fail(message, RedisError::ConnectionClosed)?;
             self.on_valkey_close()?;
             return Ok(());
         }
@@ -679,7 +730,7 @@ impl ValkeyClient {
         // If auto reconnect is disabled, just fail
         if !self.flags.enable_auto_reconnect {
             debug!("skip reconnecting since auto reconnect is disabled");
-            self.fail(b"Connection closed", RedisError::ConnectionClosed)?;
+            self.fail(message, RedisError::ConnectionClosed)?;
             self.on_valkey_close()?;
             return Ok(());
         }
@@ -690,10 +741,23 @@ impl ValkeyClient {
 
         if delay_ms == 0 || self.retry_attempts > self.max_retries {
             debug!("Max retries reached or retry strategy returned 0, giving up reconnection");
-            self.fail(
-                b"Max reconnection attempts reached",
-                RedisError::ConnectionClosed,
-            )?;
+            // Giving up is the outcome, so it is the message; the last attempt's
+            // reason, the only one anybody could still ask about, is its `cause`.
+            const GAVE_UP: &[u8] = b"Max reconnection attempts reached";
+            if self.flags.finalized {
+                // `fail()` cannot make JS values here and defers the rejections.
+                self.fail(GAVE_UP, RedisError::ConnectionClosed)?;
+            } else {
+                let global_this = self.global_object();
+                let err = valkey_error_to_js(&global_this, GAVE_UP, RedisError::ConnectionClosed);
+                // Non-enumerable, as `new Error(message, { cause })` makes it.
+                err.put_non_enumerable(
+                    &global_this,
+                    b"cause",
+                    valkey_error_to_js(&global_this, message, RedisError::ConnectionClosed),
+                );
+                self.fail_with_js_value(&global_this, err)?;
+            }
             self.on_valkey_close()?;
             return Ok(());
         }
@@ -706,7 +770,7 @@ impl ValkeyClient {
         self.flags.is_reconnecting = true;
         self.flags.is_selecting_db_internal = false;
 
-        self.reject_in_flight_commands(b"Connection closed", RedisError::ConnectionClosed)?;
+        self.reject_in_flight_commands(message, RedisError::ConnectionClosed)?;
 
         // Signal reconnect timer should be started
         self.on_valkey_reconnect();
@@ -1298,7 +1362,7 @@ impl ValkeyClient {
         // A fresh socket has opened, so reset per-connection state. Without
         // this, `send()` would permanently reject with "Connection has failed"
         // after a previous connection exhausted retries (#29925).
-        self.flags.failed = false;
+        self.failure = None;
         self.flags.is_selecting_db_internal = false;
         if matches!(self.socket, AnySocket::SocketTcp(_)) {
             // if is tcp, we need to start the connection process
@@ -1473,7 +1537,7 @@ impl ValkeyClient {
     /// Why `send()` would reject a command outright instead of sending or
     /// queueing it in the current state, or `None` when it would be accepted.
     pub(crate) fn send_rejection(&self) -> Option<&'static str> {
-        if self.flags.failed {
+        if self.failure.is_some() {
             return Some("Connection has failed");
         }
         if self.status != Status::Connected && !self.flags.enable_offline_queue {
@@ -1498,6 +1562,9 @@ impl ValkeyClient {
     pub(crate) fn disconnect(&mut self) -> JsResult<()> {
         self.flags.is_manually_closed = true;
         self.unregister_auto_flusher();
+        if self.status == Status::Connecting {
+            self.flags.close_aborted_dial = true;
+        }
         match self.status {
             Status::Connected | Status::Connecting => self.close(uws::CloseCode::FastShutdown),
             // Between retries: the manual flag makes the close terminal.

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -32,7 +32,8 @@ pub struct ConnectionFlags {
     pub(crate) is_manually_closed: bool,
     /// Set by `disconnect()` while a dial is in flight and taken by that
     /// dial's `on_close`: uSockets reports the aborted dial as a connect
-    /// error (`ECONNABORTED`), and the user asked for that close.
+    /// error (`ECONNABORTED`), and the user asked for that close. A
+    /// `connect()` before that `on_close` clears it with `is_manually_closed`.
     pub(crate) close_aborted_dial: bool,
     pub(crate) is_selecting_db_internal: bool,
     pub(crate) enable_offline_queue: bool,

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -535,6 +535,42 @@ describe("Valkey: connect() error identity", () => {
     },
   );
 
+  test.skipIf(isWindows)(
+    "a connect() that follows a close() in the tick of a failed first dial reports the dial's errno",
+    async () => {
+      using dir = tempDir("valkey-unix", {});
+      const { url, seen } = missingUnixSocket(String(dir));
+      const client = new RedisClient(url, { autoReconnect: false });
+      const closed = Promise.withResolvers<unknown>();
+      let closes = 0;
+      client.onclose = err => {
+        closes++;
+        closed.resolve(err);
+      };
+      try {
+        // The command's dial fails inside connect() and its close is deferred.
+        // close() marks that dial as aborted by the user; the connect() in the
+        // same tick takes the close back, so the dial's own outcome is what
+        // the deferred close reports.
+        const get = client.get("k").then(
+          () => "<resolved>",
+          e => e,
+        );
+        client.close();
+        const err = await client.connect().then(
+          () => "<connected>",
+          e => e,
+        );
+        expect(err).toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED", message: `connect ENOENT ${seen}` });
+        expect(await get).toBe(err);
+        expect(await closed.promise).toBe(err);
+        expect(closes).toBe(1);
+      } finally {
+        client.close();
+      }
+    },
+  );
+
   test("a connect() after an authentication failure gets its own outcome", async () => {
     let helloReply = `-WRONGPASS invalid username-password pair or user is disabled.${CRLF}`;
     const server = net.createServer(sock => {

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -3,7 +3,7 @@ import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { describe, expect, mock, test } from "bun:test";
 import { once } from "events";
 import { existsSync, readFileSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isASAN, isDebug, isWindows, nodeExe, tempDir, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isIPv6, isWindows, nodeExe, tempDir, tls as tlsCert } from "harness";
 import net from "net";
 import path from "path";
 import tls from "tls";
@@ -34,7 +34,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Expect an error with connection closed message
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect/i);
+        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|connect E[A-Z]+/i);
       } finally {
         // Cleanup
         await client.close();
@@ -58,7 +58,9 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Should fail with connection error
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|offline queue is disabled/i);
+        expect(error.message).toMatch(
+          /connection closed|socket closed|failed to connect|connect E[A-Z]+|offline queue is disabled/i,
+        );
       }
 
       try {
@@ -66,7 +68,9 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Should fail with connection error
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|offline queue is disabled/i);
+        expect(error.message).toMatch(
+          /connection closed|socket closed|failed to connect|connect E[A-Z]+|offline queue is disabled/i,
+        );
       }
 
       try {
@@ -74,7 +78,9 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Should fail with connection error
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|offline queue is disabled/i);
+        expect(error.message).toMatch(
+          /connection closed|socket closed|failed to connect|connect E[A-Z]+|offline queue is disabled/i,
+        );
       }
 
       try {
@@ -82,7 +88,9 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Should fail with connection error
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|offline queue is disabled/i);
+        expect(error.message).toMatch(
+          /connection closed|socket closed|failed to connect|connect E[A-Z]+|offline queue is disabled/i,
+        );
       }
     });
 
@@ -140,7 +148,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Should fail with a connection error
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect/i);
+        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|connect E[A-Z]+/i);
       }
 
       await client.close();
@@ -283,9 +291,11 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
       await client.close();
 
       expect(client.connected).toBe(false);
+      // close() on a client that never dialed is a no-op; the command dials
+      // once and gets that dial's errno.
       expect(async () => {
         await client.get("any-key");
-      }).toThrowErrorMatchingInlineSnapshot(`"Connection closed"`);
+      }).toThrow("connect ECONNREFUSED localhost:12345");
       // Multiple disconnects should not cause issues
       await client.close();
       await client.close();
@@ -328,7 +338,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
       const promises = clients.map(client =>
         client.get("key").catch(err => {
           // We expect errors, but want to make sure they're the right kind
-          expect(err.message).toMatch(/connection closed|socket closed|failed to connect/i);
+          expect(err.message).toMatch(/connection closed|socket closed|failed to connect|connect E[A-Z]+/i);
         }),
       );
 
@@ -340,6 +350,289 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         await client.close();
       }
     });
+  });
+});
+
+describe("Valkey: connect() error identity", () => {
+  // One failure, one error object: the commands queued behind the dial, the
+  // connect() promise and onclose all get it. Before, connect() and onclose
+  // got ERR_REDIS_CONNECTION_CLOSED "Connection closed" whatever the cause.
+  const CRLF = "\r\n";
+
+  async function stubServer(helloReply: string | null) {
+    const server = net.createServer(sock => {
+      let received = "";
+      let replied = false;
+      sock.on("error", () => {});
+      sock.on("data", d => {
+        if (replied || helloReply === null) return;
+        received += d.toString().toUpperCase();
+        if (received.includes("HELLO") && received.endsWith(CRLF)) {
+          replied = true;
+          sock.write(helloReply);
+        }
+      });
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as net.AddressInfo;
+    return { port, close: () => server.close() };
+  }
+
+  async function closedPort() {
+    const listener = net.createServer();
+    await new Promise<void>(resolve => listener.listen(0, "127.0.0.1", resolve));
+    const { port } = listener.address() as net.AddressInfo;
+    await new Promise<void>(resolve => listener.close(() => resolve()));
+    return port;
+  }
+
+  // `redis+unix://` takes the path from the URL's pathname. A Windows path
+  // cannot be spelled that way: `redis+unix:///C:/dir/r.sock` reaches
+  // connect(2) as `/C:/dir/r.sock`, which Winsock rejects with EINVAL.
+  function missingUnixSocket(dir: string) {
+    const socketPath = path.join(dir, "missing.sock");
+    return { url: `redis+unix://${socketPath}`, seen: socketPath };
+  }
+
+  // Dials with a GET queued behind connect() and returns the error connect()
+  // rejected with, after checking the GET and onclose got the same object.
+  async function failure(url: string, options: any) {
+    const client = new RedisClient(url, options);
+    const closed = Promise.withResolvers<unknown>();
+    let closes = 0;
+    client.onclose = err => {
+      closes++;
+      closed.resolve(err);
+    };
+    try {
+      const get = client.get("k").then(
+        () => "<resolved>",
+        e => e,
+      );
+      const err = await client.connect().then(
+        () => "<connected>",
+        e => e,
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect(await get).toBe(err);
+      expect(await closed.promise).toBe(err);
+      expect(closes).toBe(1);
+      if (!("cause" in err)) return { code: err.code, message: err.message };
+      // The same shape as `new Error(message, { cause })`.
+      expect(Object.getOwnPropertyDescriptor(err, "cause")!.enumerable).toBe(false);
+      return { code: err.code, message: err.message, cause: err.cause.message };
+    } finally {
+      client.close();
+    }
+  }
+
+  test("-WRONGPASS reply to HELLO rejects connect() with the server's error text", async () => {
+    const srv = await stubServer(`-WRONGPASS invalid username-password pair or user is disabled.${CRLF}`);
+    try {
+      expect(await failure(`redis://:bad@127.0.0.1:${srv.port}`, { autoReconnect: false })).toEqual({
+        code: "ERR_REDIS_AUTHENTICATION_FAILED",
+        message: "WRONGPASS invalid username-password pair or user is disabled.",
+      });
+    } finally {
+      srv.close();
+    }
+  });
+
+  test("-NOAUTH reply to HELLO rejects connect() with the server's error text", async () => {
+    const srv = await stubServer(`-NOAUTH HELLO must be called with the client already authenticated${CRLF}`);
+    try {
+      expect(await failure(`redis://127.0.0.1:${srv.port}`, { autoReconnect: false })).toEqual({
+        code: "ERR_REDIS_AUTHENTICATION_FAILED",
+        message: "NOAUTH HELLO must be called with the client already authenticated",
+      });
+    } finally {
+      srv.close();
+    }
+  });
+
+  test("connectionTimeout expiry rejects connect() with ERR_REDIS_CONNECTION_TIMEOUT", async () => {
+    const srv = await stubServer(null);
+    try {
+      expect(await failure(`redis://127.0.0.1:${srv.port}`, { autoReconnect: false, connectionTimeout: 200 })).toEqual({
+        code: "ERR_REDIS_CONNECTION_TIMEOUT",
+        message: "Connection timeout reached after 200ms",
+      });
+    } finally {
+      srv.close();
+    }
+  });
+
+  test("a refused TCP connect rejects connect() with the errno", async () => {
+    const port = await closedPort();
+    expect(await failure(`redis://127.0.0.1:${port}`, { autoReconnect: false, connectionTimeout: 2000 })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: `connect ECONNREFUSED 127.0.0.1:${port}`,
+    });
+  });
+
+  test.skipIf(isWindows)("a unix socket path that does not exist rejects connect() with ENOENT", async () => {
+    using dir = tempDir("valkey-unix", {});
+    const { url, seen } = missingUnixSocket(String(dir));
+    // Fails inside the dial itself, before uSockets has a socket to report on.
+    expect(await failure(url, { autoReconnect: false })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: `connect ENOENT ${seen}`,
+    });
+  });
+
+  test("a hostname that does not resolve rejects connect() with the resolver error", async () => {
+    // A 64 byte DNS label is illegal (RFC 1035 section 2.3.4), so the lookup
+    // fails locally without a query leaving the machine.
+    const host = Buffer.alloc(64, "a").toString() + ".com";
+    expect(await failure(`redis://${host}:6379`, { autoReconnect: false })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: `getaddrinfo ENOTFOUND ${host}`,
+    });
+  });
+
+  test("a certificate the client does not trust rejects connect() with the verify error", async () => {
+    const server = tls.createServer({ key: tlsCert.key, cert: tlsCert.cert }, socket => {
+      socket.on("error", () => {});
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      // No `ca`, so the harness cert is self-signed as far as the client knows.
+      const err = await failure(`rediss://localhost:${port}`, {
+        autoReconnect: false,
+        tls: { rejectUnauthorized: true },
+      });
+      expect(err.code).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+      expect(err.message).toContain("self signed certificate");
+    } finally {
+      server.close();
+    }
+  });
+
+  // Giving up is the outcome, so the terminal message replaces the last
+  // attempt's own reason, whether that attempt failed inside the dial (a
+  // missing unix socket path) or from the event loop (a refused port); that
+  // reason is kept as the error's cause.
+  test("exhausted retries report the terminal reason with the last refused dial's as cause", async () => {
+    const port = await closedPort();
+    expect(await failure(`redis://127.0.0.1:${port}`, { autoReconnect: true, maxRetries: 1 })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: "Max reconnection attempts reached",
+      cause: `connect ECONNREFUSED 127.0.0.1:${port}`,
+    });
+  });
+
+  test.skipIf(isWindows)(
+    "exhausted retries report the terminal reason with the last failed dial's as cause",
+    async () => {
+      using dir = tempDir("valkey-unix", {});
+      const { url, seen } = missingUnixSocket(String(dir));
+      expect(await failure(url, { autoReconnect: true, maxRetries: 1 })).toEqual({
+        code: "ERR_REDIS_CONNECTION_CLOSED",
+        message: "Max reconnection attempts reached",
+        cause: `connect ENOENT ${seen}`,
+      });
+    },
+  );
+
+  test("a connect() after an authentication failure gets its own outcome", async () => {
+    let helloReply = `-WRONGPASS invalid username-password pair or user is disabled.${CRLF}`;
+    const server = net.createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("data", () => sock.write(helloReply));
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as net.AddressInfo;
+    const client = new RedisClient(`redis://:bad@127.0.0.1:${port}`, { autoReconnect: false });
+    try {
+      const rejection = (p: Promise<unknown>) =>
+        p.then(
+          () => "<connected>",
+          e => e,
+        );
+      const first = await rejection(client.connect());
+      const second = await rejection(client.connect());
+      expect(second).toMatchObject({ code: "ERR_REDIS_AUTHENTICATION_FAILED" });
+      // The recorded failure is cleared by the dial; the second attempt's
+      // rejection is its own, not the first one's replayed.
+      expect(second).not.toBe(first);
+      helloReply = `+OK${CRLF}`;
+      await client.connect();
+      expect(client.connected).toBe(true);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  test.skipIf(!isIPv6())("a refused IPv6 literal is reported without its URL brackets", async () => {
+    const listener = net.createServer();
+    await new Promise<void>(resolve => listener.listen(0, "::1", resolve));
+    const { port } = listener.address() as net.AddressInfo;
+    await new Promise<void>(resolve => listener.close(() => resolve()));
+    expect(await failure(`redis://[::1]:${port}`, { autoReconnect: false })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: `connect ECONNREFUSED ::1:${port}`,
+    });
+  });
+
+  test("a TLS context that cannot be built is terminal even with autoReconnect on", async () => {
+    // Neither key nor cert parses, so no attempt gets as far as a socket, and
+    // no retry could do better: one onclose, whatever autoReconnect says.
+    expect(await failure("rediss://127.0.0.1:1", { tls: { key: "not a key", cert: "not a cert" } })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: "Failed to create TLS context",
+    });
+  });
+
+  // close() while the dial is pending. A hostname in a fresh process is
+  // resolved from the event loop, so its dial is a connecting socket that
+  // uSockets aborts with a connect error (ECONNABORTED); a literal IP is a
+  // half-open socket the client closes by hand. Both are the user's close.
+  test.each([
+    ["a hostname", "localhost"],
+    ["a literal IP", "127.0.0.1"],
+  ])("close() during a dial to %s reports the close, not a connect error", async (_kind, host) => {
+    const srv = await stubServer(`+OK${CRLF}`);
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const client = new Bun.RedisClient("redis://${host}:${srv.port}", { autoReconnect: false });
+          let closes = 0;
+          const closed = Promise.withResolvers();
+          client.onclose = err => { closes++; closed.resolve(err); };
+          const get = client.get("k").then(() => "<resolved>", e => e);
+          const connect = client.connect().then(() => "<connected>", e => e);
+          client.close();
+          const err = await connect;
+          console.log(JSON.stringify({
+            code: err.code, message: err.message, closes,
+            sameForGet: (await get) === err, sameForOnclose: (await closed.promise) === err,
+          }));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: JSON.stringify({
+          code: "ERR_REDIS_CONNECTION_CLOSED",
+          message: "Connection closed",
+          closes: 1,
+          sameForGet: true,
+          sameForOnclose: true,
+        }),
+        stderr: "",
+        exitCode: 0,
+      });
+    } finally {
+      srv.close();
+    }
   });
 });
 
@@ -642,7 +935,7 @@ describe("Valkey: Recovering After fail()", () => {
         inFlight: await inFlight,
         connections: fake.connections,
       }).toEqual({
-        onclose: "ERR_REDIS_CONNECTION_CLOSED",
+        onclose: "ERR_REDIS_IDLE_TIMEOUT",
         connectedInsideOnclose: false,
         connectedAfter: false,
         inFlight: "ERR_REDIS_IDLE_TIMEOUT",
@@ -676,7 +969,7 @@ describe("Valkey: Recovering After fail()", () => {
         client.onclose = err => closed.resolve(err);
         await client.connect();
         expect(client.connected).toBe(true);
-        expect(await closed.promise).toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+        expect(await closed.promise).toMatchObject({ code: "ERR_REDIS_IDLE_TIMEOUT" });
         expect(client.connected).toBe(false);
         expect(fake.connections).toBe(connection);
       }
@@ -711,6 +1004,105 @@ describe("Valkey: Recovering After fail()", () => {
       await expect(client.ping()).rejects.toMatchObject({ code: "ERR_REDIS_IDLE_TIMEOUT" });
       expect(pushes).toBe(30);
       expect(client.connected).toBe(false);
+    } finally {
+      client.close();
+      fake.server.close();
+    }
+  });
+
+  test("the peer dropping an established connection reports the close to onclose and the in-flight command", async () => {
+    // PING is left unanswered and the socket is dropped instead.
+    const fake = helloServer({
+      PING: (_, socket) => {
+        socket.destroy();
+        return null;
+      },
+    });
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: false });
+    try {
+      const closed = Promise.withResolvers<unknown>();
+      client.onclose = err => closed.resolve(err);
+      await client.connect();
+      const err = await client.ping().then(
+        () => "<resolved>",
+        e => e,
+      );
+      expect(err).toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED", message: "Connection closed" });
+      expect(await closed.promise).toBe(err);
+    } finally {
+      client.close();
+      fake.server.close();
+    }
+  });
+
+  test("close() on a connected client reports the close to onclose and the in-flight command", async () => {
+    const fake = helloServer({ PING: () => null });
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`);
+    try {
+      const closed = Promise.withResolvers<unknown>();
+      client.onclose = err => closed.resolve(err);
+      await client.connect();
+      const ping = client.ping().then(
+        () => "<resolved>",
+        e => e,
+      );
+      client.close();
+      const err = await ping;
+      expect(err).toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED", message: "Connection closed" });
+      expect(await closed.promise).toBe(err);
+    } finally {
+      client.close();
+      fake.server.close();
+    }
+  });
+
+  test("a TLS context that could not be built does not turn off autoReconnect for later connections", async () => {
+    // Connection 1 is dropped by the server right after it answers PING.
+    const fake = helloServer(
+      {
+        PING: (connection, socket) => {
+          if (connection === 1) {
+            socket.end("+PONG\r\n");
+            return null;
+          }
+          return "+PONG\r\n";
+        },
+      },
+      { secure: true },
+    );
+    const port = await fake.listen();
+    // The files exist, so the constructor accepts them; their content is read
+    // when a connection is dialed, and neither parses.
+    using dir = tempDir("valkey-tls", { "key.pem": "not a key", "cert.pem": "not a cert" });
+    const client = new RedisClient(`rediss://127.0.0.1:${port}`, {
+      tls: {
+        ca: tlsCert.cert,
+        keyFile: path.join(String(dir), "key.pem"),
+        certFile: path.join(String(dir), "cert.pem"),
+      },
+      autoReconnect: true,
+    });
+    try {
+      let closes = 0;
+      client.onclose = () => closes++;
+      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      expect({ closes, connections: fake.connections }).toEqual({ closes: 1, connections: 0 });
+
+      await Bun.write(path.join(String(dir), "key.pem"), tlsCert.key);
+      await Bun.write(path.join(String(dir), "cert.pem"), tlsCert.cert);
+      const reconnected = Promise.withResolvers<void>();
+      let connects = 0;
+      client.onconnect = () => {
+        if (++connects === 2) reconnected.resolve();
+      };
+      client.onclose = err => reconnected.reject(err);
+      await client.connect();
+      expect(await client.ping()).toBe("PONG");
+      await reconnected.promise;
+      expect(await client.ping()).toBe("PONG");
+      expect(fake.connections).toBe(2);
     } finally {
       client.close();
       fake.server.close();
@@ -810,8 +1202,11 @@ describe("Valkey: Recovering After fail()", () => {
     const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: false });
     try {
       const secondConnect = connectFromOnclose(client);
-      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
-      expect(await secondConnect).toBe("rejected: Connection closed");
+      await expect(client.connect()).rejects.toMatchObject({
+        code: "ERR_REDIS_CONNECTION_CLOSED",
+        message: `connect ECONNREFUSED 127.0.0.1:${port}`,
+      });
+      expect(await secondConnect).toBe(`rejected: connect ECONNREFUSED 127.0.0.1:${port}`);
     } finally {
       client.close();
     }
@@ -869,7 +1264,10 @@ describe("Valkey: Recovering After fail()", () => {
     const client = new RedisClient(`redis://127.0.0.1:${port}/1`, { autoReconnect: false });
     try {
       const secondConnect = connectFromOnclose(client);
-      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      await expect(client.connect()).rejects.toMatchObject({
+        code: "ERR_REDIS_AUTHENTICATION_FAILED",
+        message: "WRONGPASS invalid password",
+      });
       expect(await secondConnect).toBe("connected");
       expect(await client.ping()).toBe("PONG");
       expect(fake.connections).toBe(2);
@@ -909,7 +1307,7 @@ describe("Valkey: Recovering After fail()", () => {
       // The rejection is a failure the client detected, so there is no retry
       // even with autoReconnect on: onclose fires once and the only second
       // connection is the one dialed from it.
-      expect(closes).toEqual([{ message: "Connection closed", connected: false, connections: 1 }]);
+      expect(closes).toEqual([{ message: "ERR DB index is out of range", connected: false, connections: 1 }]);
       expect(await secondConnect).toBe("connected");
       expect(await client.ping()).toBe("PONG");
       expect(fake.connections).toBe(2);
@@ -1061,9 +1459,12 @@ describe("Valkey: Recovering After fail()", () => {
     const client = new RedisClient(`rediss://127.0.0.1:${port}`, { autoReconnect: false });
     try {
       const secondConnect = connectFromOnclose(client);
-      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      // The handshake failure is the TLS error the queued commands are
+      // rejected with, not the generic close.
+      const disconnected = "Client network socket disconnected before secure TLS connection was established";
+      await expect(client.connect()).rejects.toMatchObject({ code: "ECONNRESET", message: disconnected });
       expect({ secondConnect: await secondConnect, handshakes }).toEqual({
-        secondConnect: "rejected: Connection closed",
+        secondConnect: `rejected: ${disconnected}`,
         handshakes: 2,
       });
     } finally {
@@ -1114,19 +1515,31 @@ describe("Valkey: Recovering After fail()", () => {
         client.close();
         await first.close();
         let closes = 0;
-        client.onclose = () => closes++;
+        const closed = Promise.withResolvers<unknown>();
+        client.onclose = err => {
+          closes++;
+          closed.resolve(err);
+        };
         const outcome = client.connect().then(
           () => "connected",
-          (err: Error & { code: string }) => err.code,
+          (err: Error) => err,
+        );
+        const get = client.get("k").then(
+          () => "resolved",
+          (err: Error) => err,
         );
         client.close();
         await second.listenUnix(socketPath);
-        expect({ outcome: await outcome, closes, connected: client.connected, redialled: second.connections }).toEqual({
-          outcome: "ERR_REDIS_CONNECTION_CLOSED",
+        const err = await outcome;
+        // The close is what is reported, not the ENOENT the dial hit.
+        expect(err).toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED", message: "Connection closed" });
+        expect({ closes, connected: client.connected, redialled: second.connections }).toEqual({
           closes: 1,
           connected: false,
           redialled: 0,
         });
+        expect(await get).toBe(err);
+        expect(await closed.promise).toBe(err);
       } finally {
         client.close();
         await first.close();

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -265,8 +265,8 @@ describe.skipIf(!isASAN)("VM teardown with commands owed to a RedisClient leaks 
   // ValkeyClient::close() releases connect()'s keep-alive ref and runs the
   // close event by hand. One case per entry into that branch: close() while
   // the dial is pending, and the connection timeout firing during it. The
-  // command in the offline queue tells the two apart: connect() itself is
-  // always rejected as connection-closed. The client is created from a
+  // connect() promise and the command in the offline queue are rejected with
+  // the same error, which tells the two apart. The client is created from a
   // macrotask for the same reason as the workers'.
   function closePendingDial(options: object, body: string, stdout: string) {
     return expectCleanExit(
@@ -308,7 +308,7 @@ describe.skipIf(!isASAN)("VM teardown with commands owed to a RedisClient leaks 
       closePendingDial(
         { connectionTimeout: 1 },
         "",
-        "ERR_REDIS_CONNECTION_CLOSED ERR_REDIS_CONNECTION_TIMEOUT 1 false",
+        "ERR_REDIS_CONNECTION_TIMEOUT ERR_REDIS_CONNECTION_TIMEOUT 1 false",
       ),
     timeout,
   );

--- a/test/js/valkey/valkey-incremental-scan.test.ts
+++ b/test/js/valkey/valkey-incremental-scan.test.ts
@@ -193,13 +193,17 @@ describe.concurrent("Valkey reply decoding", () => {
     client.onconnect = client.onclose = () => {};
     try {
       // Queued before the handshake finishes, so the rejection carries the
-      // HELLO error. connect() itself rejects with a generic "Connection closed".
+      // HELLO error; connect() rejects with the same error object.
       const queued = client.get("k").then(
         () => null,
         e => e,
       );
-      await client.connect().catch(() => {});
+      const connected = await client.connect().then(
+        () => null,
+        e => e,
+      );
       const err = await queued;
+      expect(connected).toBe(err);
       expect(err).toBeInstanceOf(Error);
       expect(err.code).toBe("ERR_REDIS_AUTHENTICATION_FAILED");
       expect(err.message).toBe("NOAUTH nope!");


### PR DESCRIPTION
Stacked on #39579, which carries the uSockets and errno changes this client uses.

The problem

connect() and onclose always got ERR_REDIS_CONNECTION_CLOSED with the message "Connection closed". This was true for every failure. A wrong password, a refused port, a missing unix socket path, a rejected TLS certificate and an idle timeout all looked the same to the caller. Only the commands queued behind the dial were rejected with the real error. Users could not tell WRONGPASS from a server that is down (#23467).

The cause is in on_valkey_close. It built a new generic error for the promise and for onclose, even though the code that closed the socket already had the real one.

What changed

- flags.failed (a bool) is gone. ValkeyClient now has failure: Option<Strong>. It holds the JS error the queued commands were rejected with. fail_with_js_value sets it once. connect() and on_open clear it. Every reader of the old bool reads is_some() instead.
- on_valkey_close rejects the connect() promise and calls onclose with that recorded error. The same object reaches the commands, the promise and onclose.
- ValkeyClient::on_close now takes a CloseReason. Every close origin supplies one. The socket close callback passes SocketClosed ("Connection closed"). on_connect_error passes the errno or resolver text, in the shape of node:net: "connect ECONNREFUSED 127.0.0.1:6379" or "getaddrinfo ENOTFOUND host". A dial that fails inside connect() passes the errno it left, for example "connect ENOENT /run/redis.sock". The errno comes from #39579: uSockets returns it, and both ConnectError and the connect error callback carry it already mapped.
- The message prints the real errno (mapped once in #39579), so an unreachable host prints EHOSTUNREACH, not ECONNREFUSED. On Windows a refused connect prints ECONNREFUSED because #39579 reads SO_ERROR instead of the recv() probe's WSAENOTCONN.
- IPv6 literals are printed without the URL brackets: "connect ECONNREFUSED ::1:6379".
- A Strong holds the error because it must stay alive from fail_with_js_value, through the socket close dispatch, to on_valkey_close. That chain allocates and can collect, the error may have no other referent when no command was queued, and a plain JSValue in the boxed client is not scanned. It is dropped with the client and cleared on the next connect() or on_open, so a client that failed once does not root its error for good.
- The TLS context failure in connect() no longer calls fail() early and no longer turns off the client's autoReconnect option. It hands the deferred close a terminal CloseReason::DialFailed. on_close() skips the retry policy for a terminal dial, so the message is "Failed to create TLS context", there is no retry, and a later connect() keeps autoReconnect.
- A close() while a dial is pending is reported as "Connection closed". uSockets reports an aborted dial as a connect error (ECONNABORTED). disconnect() marks the dial it interrupted and that dial's on_close() drops the errno text. A dial started later, for example by a duplicate() of a closed client, reports its own errno. A connect() in the same tick as that close() takes the close back, mark included, so the dial's own errno is what it reports (a test covers a command, close() and connect() in one tick against a missing unix socket path).
- When retries are used up, "Max reconnection attempts reached" is the message and the last attempt's error is its cause, non-enumerable like new Error(message, { cause }), so err.cause.message is "connect ECONNREFUSED host:port" under the default options. The outcome is the same whether the last dial failed inside connect() or from the event loop.

Error codes are unchanged. Authentication failures keep ERR_REDIS_AUTHENTICATION_FAILED, timeouts keep ERR_REDIS_CONNECTION_TIMEOUT and ERR_REDIS_IDLE_TIMEOUT, TLS verify errors keep their OpenSSL code, and every other close keeps ERR_REDIS_CONNECTION_CLOSED.

Visible changes

connect() rejections and the onclose argument now carry the specific reason. Existing tests that pinned the generic one were updated on purpose:

- "an idle timeout over redis:// (rediss://) closes the connection and rejects what was in flight": onclose code is ERR_REDIS_IDLE_TIMEOUT, not ERR_REDIS_CONNECTION_CLOSED.
- "a connection that stays silent after the handshake is closed by its idle timeout": onclose code is ERR_REDIS_IDLE_TIMEOUT.
- "a connect() issued from onclose after a refused connection rejects instead of hanging": the message is "connect ECONNREFUSED 127.0.0.1:<port>", not "Connection closed".
- "a connect() issued from onclose is not fed the replies left over from the failed connection": connect() rejects with ERR_REDIS_AUTHENTICATION_FAILED and the WRONGPASS text.
- "a rejected SELECT after an accepted HELLO fails the connection once": onclose gets the server's "ERR DB index is out of range".
- "a connect() issued from onclose after a failed TLS handshake gets to dial again": connect() rejects with the TLS error (code ECONNRESET, "Client network socket disconnected before secure TLS connection was established").
- valkey-gc.test.ts, "connection timeout while a dial to an IP literal is pending" (from #39543, which landed while this was open): connect() now rejects with the same ERR_REDIS_CONNECTION_TIMEOUT error as the queued command, not ERR_REDIS_CONNECTION_CLOSED.
- valkey-incremental-scan.test.ts, "error reply to HELLO rejects queued commands with the server text" (from #39544): its comment said connect() rejects with a generic "Connection closed"; it now asserts connect() rejects with the same error object as the queued command.

Tests

All in test/js/valkey/reliability/connection-failures.test.ts, against net and tls stubs on port 0. Each one asserts that the queued command, connect() and onclose received the same error object.

- WRONGPASS and NOAUTH replies to HELLO.
- connectionTimeout expiry.
- A refused TCP port.
- A unix socket path that does not exist (ENOENT, not on Windows).
- A self signed certificate with rejectUnauthorized.
- Retries used up, with the last dial refused (async) and with the last dial failing inside connect() (sync); the cause carries the errno text.
- A second connect() after an authentication failure gets its own rejection, and a third one connects once the stub accepts.
- A refused IPv6 literal prints "::1:<port>" (skipped without IPv6).
- A TLS context that cannot be built, with autoReconnect on: one onclose, "Failed to create TLS context".
- close() while a dial is pending, to a hostname (connecting socket, run in a fresh process so the resolver cache is cold) and to a literal IP (half-open socket): "Connection closed" to connect(), the queued command and onclose, one onclose. The same for close() right after a dial failed inside connect().
- The peer dropping an established connection, and close() on a connected client: onclose and the in-flight command get the same "Connection closed" error.
- A later connect() keeps autoReconnect after a TLS context failure.

The first four tests come from #35509. This PR supersedes that one. It fixes the same bug without a second field next to flags.failed, and it covers the failures that never went through fail(): TLS verify errors, dial errors and the terminal retry message.

Not in this PR

- No new error code for a refused connection. postgres has ERR_POSTGRES_CONNECTION_REFUSED; redis keeps ERR_REDIS_CONNECTION_CLOSED with the errno in the message.
- The docs list of error codes is unchanged.
- redis+unix:// cannot dial a Windows path. The path comes from the URL pathname, so redis+unix:///C:/dir/r.sock reaches connect(2) as /C:/dir/r.sock and Winsock rejects it with EINVAL (that EINVAL is now what connect() reports; before it was "Connection closed"). The unix socket tests stay skipped on Windows for that reason. The ENOENT check in bun_sys::unix_connect_errno (#39579) is still reached through Bun.connect, whose Windows test pins it.

Rebased onto the current #39579 (f2e2fb2)

- #39579 is rebased onto newer mains regularly; the latest adds #40478 (RefPtr releases on Drop). Each time the commits here applied without conflicts and the patch content is unchanged. test/js/valkey/ on the rebased tree: 200 pass, 1 fail. The failing one is "RESP map keys are not leaked" in valkey-gc.test.ts, which times out the same way on plain main in the same container (a debug build over a 5s budget), so it is not from this PR.

Fixes #23467

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 11 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/valkey/valkey-gc.test.ts, test/js/valkey/reliability/connection-failures.test.ts

<!-- robobun:evidence:end -->




