### PR TITLE
valkey: cancel the retry timer on close() and connect()

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1067,10 +1067,11 @@ impl JSValkeyClient {
     /// close path for it, since no socket exists to dispatch a close event.
     pub(crate) fn cancel_reconnect(&self) -> JsResult<()> {
         debug_assert!(self.client.get().status == valkey::Status::Disconnected);
+        // The timer's ref goes back with the disarm; there is no socket ref
+        // to give back (`connect()` forgets it only once it has a socket) and
+        // `on_valkey_close` adopts none. The caller's scoped ref covers the
+        // call.
         self.reconnect_timer.disarm(self);
-        // `on_close()` ends in `on_valkey_close`, which adopts the ref the
-        // socket of a dial would have held.
-        self.ref_();
         self.client_mut().on_close()
     }
 
@@ -2059,12 +2060,9 @@ impl ValkeyDeferredClose {
                 crate::dispatch::fold(this.client_mut().close(uws::CloseCode::FastShutdown))
             }
             DeferredClose::WithoutSocket => {
-                // Holding Connecting (see `close_without_socket_next_tick`) is
-                // what keeps a dial from starting in between; if one did, its
-                // own callbacks own the close path now, so only drop our ref.
-                if !this.client.get().socket.is_closed() {
-                    return;
-                }
+                // Holding Connecting (see `close_without_socket_next_tick`)
+                // and the gate in `reconnect()` keep every dial entry out.
+                debug_assert!(this.client.get().socket.is_closed());
                 // No socket ref to give back: `connect()` forgets it only once
                 // it has a socket, and this task exists because it never did.
                 this.client_mut().status = valkey::Status::Disconnected;

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1052,14 +1052,26 @@ impl JSValkeyClient {
         // which derefs. Hold a ref so `&self` stays live across the call.
         let _guard = self.ref_scope();
 
-        if matches!(
-            self.client.get().status,
-            valkey::Status::NeverConnected | valkey::Status::Disconnected
-        ) {
-            return Ok(JSValue::UNDEFINED);
+        match self.client.get().status {
+            valkey::Status::NeverConnected => return Ok(JSValue::UNDEFINED),
+            valkey::Status::Disconnected if !self.client.get().flags.is_reconnecting => {
+                return Ok(JSValue::UNDEFINED);
+            }
+            _ => {}
         }
         self.client_mut().disconnect()?;
         Ok(JSValue::UNDEFINED)
+    }
+
+    /// Cancels the retry a `Disconnected` client is waiting on and runs the
+    /// close path for it, since no socket exists to dispatch a close event.
+    pub(crate) fn cancel_reconnect(&self) -> JsResult<()> {
+        debug_assert!(self.client.get().status == valkey::Status::Disconnected);
+        self.reconnect_timer.disarm(self);
+        // `on_close()` ends in `on_valkey_close`, which adopts the ref the
+        // socket of a dial would have held.
+        self.ref_();
+        self.client_mut().on_close()
     }
 
     // `onconnect`/`onclose` are declared with `this: true` in
@@ -1171,7 +1183,17 @@ impl JSValkeyClient {
     }
 
     pub(crate) fn reconnect(&self) -> JsResult<()> {
+        // Whether the retry timer fired or connect() got here first, this is
+        // the one dial: a retry still armed would open a second socket.
+        self.reconnect_timer.disarm(self);
         if !self.client.get().flags.is_reconnecting {
+            return Ok(());
+        }
+        // A dial (or the deferred close of one that failed outright) is
+        // already in flight and owns the retry policy from here.
+        if self.client.get().status != valkey::Status::Disconnected
+            || !self.client.get().socket.is_closed()
+        {
             return Ok(());
         }
 
@@ -1379,6 +1401,10 @@ impl JSValkeyClient {
         let global_object = self.global_object;
         let _defer = scopeguard::guard(BackRef::new(self), |p| p.update_poll_ref());
 
+        // Bounded the attempt that just ended; a dial that fails outright
+        // arms no timer of its own, so left armed this one would fire into it.
+        self.timer.disarm(self);
+
         let Some(this_jsvalue) = self.this_value.get().try_get() else {
             return Ok(());
         };
@@ -1455,6 +1481,9 @@ impl JSValkeyClient {
     }
 
     fn connect(&self) -> Result<(), crate::Error> {
+        // Overwriting a live socket below would leave its callbacks driving
+        // this client alongside the new one's.
+        debug_assert!(self.client.get().socket.is_closed());
         if self.client.get().status == valkey::Status::NeverConnected {
             self.client_mut().status = valkey::Status::Disconnected;
         }

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -1491,10 +1491,12 @@ impl ValkeyClient {
     pub(crate) fn disconnect(&mut self) -> JsResult<()> {
         self.flags.is_manually_closed = true;
         self.unregister_auto_flusher();
-        if self.status == Status::Connected || self.status == Status::Connecting {
-            return self.close(uws::CloseCode::FastShutdown);
+        match self.status {
+            Status::Connected | Status::Connecting => self.close(uws::CloseCode::FastShutdown),
+            // Between retries: the manual flag makes the close terminal.
+            Status::Disconnected if self.flags.is_reconnecting => self.parent().cancel_reconnect(),
+            Status::NeverConnected | Status::Disconnected => Ok(()),
         }
-        Ok(())
     }
 
     /// Get a writer for the connected socket

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -1496,6 +1496,46 @@ describe("Valkey: Recovering After fail()", () => {
     }
   });
 
+  test("connect() during the retry delay starts the retry budget over", async () => {
+    // Connection 1 is dropped on PING; every later connection is dropped as
+    // soon as it sends HELLO, so each dial ends in another retry.
+    const fake = helloServer({
+      PING: (_connection, socket) => {
+        socket.end();
+        return null;
+      },
+      HELLO: (connection, socket) => {
+        if (connection === 1) return "+OK\r\n";
+        socket.destroy();
+        return null;
+      },
+    });
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { maxRetries: 2 });
+    let closes = 0;
+    client.onclose = () => closes++;
+    try {
+      // Attempt 1 of 2 is pending here. Waiting for it would leave one more
+      // attempt; connect() dials now instead and counts from zero again, so
+      // three more connections are dropped before the client gives up.
+      await dropAndAwaitRetryDelay(client);
+      const outcome = await client.connect().then(
+        () => "connected",
+        (err: Error & { code: string }) => err.code,
+      );
+      expect({ outcome, connections: fake.connections, closes, connected: client.connected }).toEqual({
+        outcome: "ERR_REDIS_CONNECTION_CLOSED",
+        connections: 4,
+        closes: 1,
+        connected: false,
+      });
+    } finally {
+      client.close();
+      for (const socket of fake.sockets) socket.destroy();
+      await fake.close();
+    }
+  });
+
   test("close() during a reconnect attempt reports the close exactly once", async () => {
     const fake = droppingServer();
     const port = await fake.listen();
@@ -1534,11 +1574,16 @@ describe("Valkey: Recovering After fail()", () => {
       const first = helloServer({ HELLO: () => null });
       const second = helloServer();
       await first.listenUnix(socketPath);
-      const client = new RedisClient(`redis+unix://${socketPath}`, { connectionTimeout: 300 });
+      const connectionTimeout = 1000;
+      const client = new RedisClient(`redis+unix://${socketPath}`, { connectionTimeout });
       let closes = 0;
       client.onclose = () => closes++;
       // Settled by the connect() made from the socket callback below.
-      const fromCallback = Promise.withResolvers<{ outcome: Promise<string>; ping: Promise<string> }>();
+      const fromCallback = Promise.withResolvers<{
+        outcome: Promise<string>;
+        ping: Promise<string>;
+        beforeStaleDeadline: boolean;
+      }>();
       // A dial made from a socket callback runs before the timers of that
       // loop iteration are checked, and blocking there makes them due.
       using control = Bun.listen({
@@ -1548,6 +1593,7 @@ describe("Valkey: Recovering After fail()", () => {
           data(_socket, chunk) {
             const staleDeadline = Number(chunk.toString());
             fromCallback.resolve({
+              beforeStaleDeadline: performance.now() < staleDeadline,
               outcome: client.connect().then(
                 () => "connected",
                 (err: Error & { code: string }) => `rejected: ${err.code}`,
@@ -1557,7 +1603,7 @@ describe("Valkey: Recovering After fail()", () => {
                 (err: Error) => `rejected: ${err.message}`,
               ),
             });
-            Bun.sleepSync(Math.max(0, staleDeadline - performance.now()));
+            Bun.sleepSync(Math.max(0, staleDeadline + 100 - performance.now()));
           },
           open() {},
           close() {},
@@ -1570,13 +1616,15 @@ describe("Valkey: Recovering After fail()", () => {
         socket: { data() {}, open() {}, close() {}, error() {} },
       });
       try {
+        // connect() arms the connect timer before it returns; the deadline
+        // measured from here is at or after the real one.
+        const armedAt = performance.now();
         const attempt = client.connect().then(
           () => "connected",
           (err: Error & { code: string }) => `rejected: ${err.code}`,
         );
+        const staleDeadline = armedAt + connectionTimeout;
         expect(await until(() => first.connections === 1, 1000)).toBe(true);
-        // The dial's 300ms connect timer was armed just before this.
-        const staleDeadline = performance.now() + 300;
         client.close();
         expect({ attempt: await attempt, closes }).toEqual({
           attempt: "rejected: ERR_REDIS_CONNECTION_CLOSED",
@@ -1587,8 +1635,11 @@ describe("Valkey: Recovering After fail()", () => {
         // event loop, after the timers of the iteration are checked. Blocking
         // in the callback past the stale deadline makes that timer due first.
         await first.close();
-        sender.write(String(staleDeadline + 100));
-        const { outcome, ping } = await fromCallback.promise;
+        sender.write(String(staleDeadline));
+        const { outcome, ping, beforeStaleDeadline } = await fromCallback.promise;
+        // Had the timer been left armed, it was still pending when the
+        // callback dialled; otherwise the test proved nothing.
+        expect(beforeStaleDeadline).toBe(true);
         // The hold's close schedules a retry, which is what connects.
         await second.listenUnix(socketPath);
         expect(await until(() => second.connections >= 1, 3000)).toBe(true);

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -1326,6 +1326,286 @@ describe("Valkey: Recovering After fail()", () => {
       fake.server.close();
     }
   });
+
+  // Polls `condition` until it holds or `timeoutMs` passes; reports whether it held.
+  async function until(condition: () => boolean, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (!condition() && Date.now() < deadline) await Bun.sleep(1);
+    return condition();
+  }
+
+  // Answers HELLO on connection 1 and drops it on PING, so the client is left
+  // between retries with the reconnect timer armed and no socket. Later
+  // connections hold their HELLO reply until `release` is called for them.
+  function droppingServer() {
+    const held = new Map<number, net.Socket>();
+    const fake = helloServer({
+      PING: (connection, socket) => {
+        if (connection !== 1) return "+PONG\r\n";
+        socket.end();
+        return null;
+      },
+      HELLO: (connection, socket) => {
+        if (connection === 1) return "+OK\r\n";
+        held.set(connection, socket);
+        return null;
+      },
+    });
+    return {
+      ...fake,
+      get connections() {
+        return fake.connections;
+      },
+      release: (connection: number) => held.get(connection)!.write("+OK\r\n"),
+    };
+  }
+
+  // Connects `client`, has the server drop the connection, and returns once the
+  // client has scheduled its first retry (50ms out).
+  async function dropAndAwaitRetryDelay(client: RedisClient) {
+    await client.connect();
+    const ping = await client.ping().then(
+      () => "answered",
+      (err: Error & { code: string }) => err.code,
+    );
+    expect(ping).toBe("ERR_REDIS_CONNECTION_CLOSED");
+    expect(client.connected).toBe(false);
+  }
+
+  test("close() during the retry delay cancels the retry and fires onclose once", async () => {
+    const fake = droppingServer();
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`);
+    const closes: string[] = [];
+    client.onclose = err => closes.push(`${err.code}: ${err.message}`);
+    try {
+      await dropAndAwaitRetryDelay(client);
+      // Queued for the retry; only close() is left to settle it.
+      const queued = client.get("k").then(
+        () => "answered",
+        (err: Error & { code: string }) => err.code,
+      );
+      client.close();
+      expect({ queued: await queued, closes }).toEqual({
+        queued: "ERR_REDIS_CONNECTION_CLOSED",
+        closes: ["ERR_REDIS_CONNECTION_CLOSED: Connection closed"],
+      });
+      // The retry was due 50ms after the drop; a second connection within a
+      // few multiples of that would be the cancelled timer dialling anyway.
+      await until(() => fake.connections >= 2, 300);
+      expect({ connections: fake.connections, closes: closes.length, connected: client.connected }).toEqual({
+        connections: 1,
+        closes: 1,
+        connected: false,
+      });
+    } finally {
+      client.close();
+      for (const socket of fake.sockets) socket.destroy();
+      await fake.close();
+    }
+  });
+
+  test("close() after the retries are exhausted does not report a second close", async () => {
+    const fake = helloServer();
+    const port = await fake.listen();
+    await fake.close();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { maxRetries: 1 });
+    let closes = 0;
+    client.onclose = () => closes++;
+    try {
+      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      expect(closes).toBe(1);
+      client.close();
+      await until(() => closes >= 2, 100);
+      expect(closes).toBe(1);
+    } finally {
+      client.close();
+    }
+  });
+
+  test("the process exits once close() cancels a pending retry", async () => {
+    const fake = droppingServer();
+    const port = await fake.listen();
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const client = new Bun.RedisClient("redis://127.0.0.1:${port}");
+          let connects = 0;
+          client.onconnect = () => console.log("onconnect", ++connects);
+          client.onclose = err => console.log("onclose", err.code);
+          await client.connect();
+          await client.ping().catch(err => console.log("ping rejected", err.code));
+          while (client.connected) await Bun.sleep(1);
+          client.close();
+          console.log("closed");
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: [
+          "onconnect 1",
+          "ping rejected ERR_REDIS_CONNECTION_CLOSED",
+          "onclose ERR_REDIS_CONNECTION_CLOSED",
+          "closed",
+          "",
+        ].join("\n"),
+        stderr: "",
+        exitCode: 0,
+      });
+      expect(fake.connections).toBe(1);
+    } finally {
+      await fake.close();
+    }
+  });
+
+  test("connect() during the retry delay dials once and the retry timer does not dial on top of it", async () => {
+    const fake = droppingServer();
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`);
+    let closes = 0;
+    client.onclose = () => closes++;
+    try {
+      await dropAndAwaitRetryDelay(client);
+      const reconnected = client.connect().then(
+        () => "connected",
+        (err: Error & { code: string }) => err.code,
+      );
+      expect(await until(() => fake.connections === 2, 1000)).toBe(true);
+      // Connection 2 holds its HELLO reply past the 50ms the retry was due
+      // in; a third connection would be that retry dialling on top of it.
+      await until(() => fake.connections >= 3, 300);
+      expect(fake.connections).toBe(2);
+      fake.release(2);
+      expect({ reconnected: await reconnected, connected: client.connected, closes }).toEqual({
+        reconnected: "connected",
+        connected: true,
+        closes: 0,
+      });
+      expect(await client.ping()).toBe("PONG");
+    } finally {
+      client.close();
+      for (const socket of fake.sockets) socket.destroy();
+      await fake.close();
+    }
+  });
+
+  test("close() during a reconnect attempt reports the close exactly once", async () => {
+    const fake = droppingServer();
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`);
+    let closes = 0;
+    client.onclose = () => closes++;
+    try {
+      await dropAndAwaitRetryDelay(client);
+      // The explicit dial is left connecting on a held HELLO reply.
+      const reconnected = client.connect().then(
+        () => "connected",
+        (err: Error & { code: string }) => err.code,
+      );
+      expect(await until(() => fake.connections === 2, 1000)).toBe(true);
+      client.close();
+      expect(await reconnected).toBe("ERR_REDIS_CONNECTION_CLOSED");
+      await until(() => closes >= 2, 300);
+      expect({ closes, connections: fake.connections, connected: client.connected }).toEqual({
+        closes: 1,
+        connections: 2,
+        connected: false,
+      });
+    } finally {
+      client.close();
+      for (const socket of fake.sockets) socket.destroy();
+      await fake.close();
+    }
+  });
+
+  test.skipIf(isWindows)(
+    "the connect timer of an attempt ended by close() does not fire into the next attempt",
+    async () => {
+      using dir = tempDir("valkey-unix", {});
+      const socketPath = path.join(String(dir), "r.sock");
+      // Holds every HELLO reply, so the first dial stays connecting until close().
+      const first = helloServer({ HELLO: () => null });
+      const second = helloServer();
+      await first.listenUnix(socketPath);
+      const client = new RedisClient(`redis+unix://${socketPath}`, { connectionTimeout: 300 });
+      let closes = 0;
+      client.onclose = () => closes++;
+      // Settled by the connect() made from the socket callback below.
+      const fromCallback = Promise.withResolvers<{ outcome: Promise<string>; ping: Promise<string> }>();
+      // A dial made from a socket callback runs before the timers of that
+      // loop iteration are checked, and blocking there makes them due.
+      using control = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: {
+          data(_socket, chunk) {
+            const staleDeadline = Number(chunk.toString());
+            fromCallback.resolve({
+              outcome: client.connect().then(
+                () => "connected",
+                (err: Error & { code: string }) => `rejected: ${err.code}`,
+              ),
+              ping: client.ping().then(
+                () => "PONG",
+                (err: Error) => `rejected: ${err.message}`,
+              ),
+            });
+            Bun.sleepSync(Math.max(0, staleDeadline - performance.now()));
+          },
+          open() {},
+          close() {},
+          error() {},
+        },
+      });
+      const sender = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: control.port,
+        socket: { data() {}, open() {}, close() {}, error() {} },
+      });
+      try {
+        const attempt = client.connect().then(
+          () => "connected",
+          (err: Error & { code: string }) => `rejected: ${err.code}`,
+        );
+        expect(await until(() => first.connections === 1, 1000)).toBe(true);
+        // The dial's 300ms connect timer was armed just before this.
+        const staleDeadline = performance.now() + 300;
+        client.close();
+        expect({ attempt: await attempt, closes }).toEqual({
+          attempt: "rejected: ERR_REDIS_CONNECTION_CLOSED",
+          closes: 1,
+        });
+        // With the path gone the next dial fails outright, so it arms no
+        // connect timer of its own; the hold it leaves is settled from the
+        // event loop, after the timers of the iteration are checked. Blocking
+        // in the callback past the stale deadline makes that timer due first.
+        await first.close();
+        sender.write(String(staleDeadline + 100));
+        const { outcome, ping } = await fromCallback.promise;
+        // The hold's close schedules a retry, which is what connects.
+        await second.listenUnix(socketPath);
+        expect(await until(() => second.connections >= 1, 3000)).toBe(true);
+        expect({ outcome: await outcome, ping: await ping, closes }).toEqual({
+          outcome: "connected",
+          ping: "PONG",
+          closes: 1,
+        });
+      } finally {
+        client.close();
+        sender.end();
+        for (const socket of first.sockets) socket.destroy();
+        await first.close();
+        await second.close();
+      }
+    },
+  );
 });
 
 describe("Valkey: Offline Queue", () => {

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -1616,8 +1616,10 @@ describe("Valkey: Recovering After fail()", () => {
         socket: { data() {}, open() {}, close() {}, error() {} },
       });
       try {
-        // connect() arms the connect timer before it returns; the deadline
-        // measured from here is at or after the real one.
+        // connect() arms the connect timer before it returns, so the real
+        // deadline is at or shortly after the one computed from here: a dial
+        // before this one is before the real one too, and the callback sleeps
+        // 100ms past it to be past the real one as well.
         const armedAt = performance.now();
         const attempt = client.connect().then(
           () => "connected",

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -158,7 +158,10 @@ describe.skipIf(!isASAN)("VM teardown with commands owed to a RedisClient leaks 
 
   // close() during the retry delay has no socket close event to run through:
   // it disarms the retry timer and runs the close path by hand, so it must
-  // take no ref of its own for that path to release.
+  // take no ref of its own for that path to release. After close() nothing
+  // else keeps the worker alive, and terminate() on a worker that has already
+  // exited reports that exit instead; the timer keeps it running until
+  // terminate() ends it like the other cases.
   test.concurrent(
     "worker.terminate(): after close() during the retry delay",
     () =>
@@ -168,6 +171,7 @@ describe.skipIf(!isASAN)("VM teardown with commands owed to a RedisClient leaks 
           client.incr("k").catch(() => {});
           while (client.connected) await Bun.sleep(1);
           client.close();
+          setTimeout(() => {}, 1 << 30);
           parentPort.postMessage("closed");
         });`,
         true,

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -63,7 +63,9 @@ describe.skipIf(!isASAN)("VM teardown with commands owed to a RedisClient leaks 
   const CRLF = "\\r\\n";
   // Answers HELLO, never replies to a command, and resolves `ready` once the
   // first INCR has arrived, so the commands it owes are in flight from then on.
-  const server = `
+  // With `endAtIncr` it ends the connection at that INCR instead, which leaves
+  // the client in its retry delay.
+  const server = (endAtIncr: boolean) => `
     const HELLO = "%1${CRLF}$5${CRLF}proto${CRLF}:3${CRLF}";
     const { promise: ready, resolve: onReady } = Promise.withResolvers();
     const server = Bun.listen({
@@ -77,7 +79,10 @@ describe.skipIf(!isASAN)("VM teardown with commands owed to a RedisClient leaks 
             s.data.hello = true;
             s.write(HELLO);
           }
-          if (s.data.buf.includes("INCR")) onReady();
+          if (s.data.buf.includes("INCR")) {
+            onReady();
+            if (${endAtIncr}) s.end();
+          }
         },
         close() {},
         error() {},
@@ -114,19 +119,23 @@ describe.skipIf(!isASAN)("VM teardown with commands owed to a RedisClient leaks 
   `;
 
   // Terminates the worker once the server reports `ready`, with whatever the
-  // client still owes.
-  function terminateWorker(options: object, worker: string) {
+  // client still owes. With `closedDuringRetryDelay` the server ends the
+  // connection instead, and the worker is terminated once it has posted that
+  // it called close() during the retry delay.
+  function terminateWorker(options: object, worker: string, closedDuringRetryDelay = false) {
     return expectCleanExit(
       `
       const { Worker } = require("node:worker_threads");
-      ${server}
+      ${server(closedDuringRetryDelay)}
       const worker = new Worker(${JSON.stringify(workerSrc(worker))}, {
         eval: true,
         workerData: { url: "redis://127.0.0.1:" + server.port, options: ${JSON.stringify(options)} },
       });
+      const { promise: closed, resolve: onClosed } = Promise.withResolvers();
+      worker.on("message", onClosed);
       worker.on("error", (err) => { console.error(err); process.exit(2); });
       worker.on("exit", (code) => { console.error("worker exited on its own with " + code); process.exit(3); });
-      await ready;
+      await ${closedDuringRetryDelay ? "closed" : "ready"};
       worker.removeAllListeners("exit");
       console.log("terminated", await worker.terminate());
       server.stop(true);
@@ -146,6 +155,25 @@ describe.skipIf(!isASAN)("VM teardown with commands owed to a RedisClient leaks 
     timeout,
   );
   test.concurrent("worker.terminate(): retries exhausted", () => terminateWorker({ maxRetries: 0 }, inFlight), timeout);
+
+  // close() during the retry delay has no socket close event to run through:
+  // it disarms the retry timer and runs the close path by hand, so it must
+  // take no ref of its own for that path to release.
+  test.concurrent(
+    "worker.terminate(): after close() during the retry delay",
+    () =>
+      terminateWorker(
+        {},
+        `client.connect().then(async () => {
+          client.incr("k").catch(() => {});
+          while (client.connected) await Bun.sleep(1);
+          client.close();
+          parentPort.postMessage("closed");
+        });`,
+        true,
+      ),
+    timeout,
+  );
 
   // WATCH is not auto-pipelined, so it waits in the offline queue while the
   // INCRs are in flight, and the INCRs sent after it queue up behind it. The


### PR DESCRIPTION
Stacks on #39543 (the socket keep-alive ref moves to the close event's entry); this PR is based on that branch and its diff shows only the timer changes.

The problem

The RedisClient has two timers. `reconnect_timer` schedules the next retry. `timer` bounds one attempt (connect timeout) or one idle period. Only the retry path and the finalizer disarmed them. Three things went wrong because of that.

1. `close()` during a retry delay did nothing. The client was `Disconnected`, so `close()` returned early. The retry timer stayed armed. It dialled a closed client, fired `onconnect` on it, and kept the process alive for the whole retry schedule.

2. `connect()` during a retry delay dialled at once but left the retry timer armed. The timer fired into the in-flight dial and opened a second socket on the same client. Both sockets then drove one state machine.

3. The connect timer of an attempt that ended in a terminal close stayed armed. A dial that fails outright arms no timer of its own, so the stale one fired "Connection timeout" into the next attempt.

What changed

`close()` during a retry delay cancels the retry. It disarms `reconnect_timer`, marks the close as manual, and runs the close path once: the cached `connect()` promise rejects, `onclose` runs once, and the event loop ref is released. Nothing dials again. This path takes no ref of its own: the timer's ref goes back with the disarm, and there was never a socket ref to release, which is the accounting #39543 established for a dial that never got a socket.

`reconnect()` disarms `reconnect_timer` before it dials. It only dials from `Disconnected` with no socket. A `connect()` that takes over a pending retry is now the one dial. A retry timer that fires while a dial is in flight does nothing.

`on_valkey_close` disarms `timer`, as `on_valkey_reconnect` already did. No attempt's timer outlives it.

`connect()` asserts in debug builds that the client has no live socket, and the deferred close of a dial that failed outright asserts the same instead of returning early on a live socket, since no dial can start during its hold.

Visible changes

`close()` between retries is honoured. `onclose` receives `ERR_REDIS_CONNECTION_CLOSED` with the message "Connection closed". A `connect()` promise still pending from before the retries rejects with the same error. Queued commands reject with it too. The process can exit.

`connect()` between retries: if a `connect()` promise is still pending (the client has not connected yet and its first dial is being retried), it is returned and the retry schedule is left alone. Otherwise the pending retry is cancelled, the client dials at once, and retry counting starts over from zero, so a client one retry from giving up gets a full `maxRetries` budget again. Before, the dial happened too, but on top of the retry, which then opened a second socket.

Tests

New tests in `test/js/valkey/reliability/connection-failures.test.ts`:

- `close()` during the retry delay fires `onclose` once, rejects the queued command, and the stub sees no second connection.
- A spawned process that calls `close()` during the retry delay exits with one `onclose` and no second `onconnect`.
- `close()` after the retries are exhausted does not report a second close.
- `connect()` during the retry delay opens one connection while HELLO is held past the retry deadline, then resolves.
- `connect()` during the retry delay starts the retry budget over: with `maxRetries: 2` and a stub that drops every later connection, the client is dropped three more times before it gives up.
- `close()` during that in-flight dial reports the close once.
- The connect timer of an attempt ended by `close()` does not fire into a next attempt whose dial fails outright in the same loop iteration. The stale deadline is measured from before the first `connect()`, and the test asserts the callback ran before it, so a slow machine fails the test rather than passing it vacuously.

New case in the ASAN block of `test/js/valkey/valkey-gc.test.ts`: a worker calls `close()` during the retry delay and is then terminated; LSan reports nothing, which pins the ref accounting above.

The first, second, fourth and seventh fail on main. The third, fifth and sixth pin behaviour that already held (the fifth passes without the fix too: the stub drops each connection within the 50ms retry delay, so the stale retry timer is re-armed before it can fire). The valkey-gc case fails with the `cancel_reconnect` of the first commit, which took a ref of its own: LSan reports the `Box<JSValkeyClient>`.

This supersedes #33306 and #32803. Their tests are kept in adapted form here.

Not in this PR

The failure reason reported to `connect()` and `onclose` (#39542). The `Connection` state enum.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/valkey/reliability/connection-failures.test.ts test/js/valkey/valkey-gc.test.ts

<!-- robobun:evidence:end -->