### PR TITLE
test(install): cut 46 redundant spawns from bun-add-catalog.test.ts and assert whole files

### DIFF
--- a/test/cli/install/bun-add-catalog.test.ts
+++ b/test/cli/install/bun-add-catalog.test.ts
@@ -15,9 +15,11 @@ afterAll(() => {
   registry.stop();
 });
 
-const PKG1 = JSON.stringify({ name: "pkg1", version: "1.0.0" });
+const pkg1Json = { name: "pkg1", version: "1.0.0" };
+const PKG1 = JSON.stringify(pkg1Json);
 // `bun add` re-prints the package.json it edits; fixtures asserted byte-for-byte afterwards are written in that shape.
 const pretty = (json: Record<string, unknown>) => JSON.stringify(json, null, 2);
+const rootRow = { "": { name: "root" } };
 
 // CI's per-file BUN_INSTALL_CACHE_DIR overrides bunfig's cache; concurrent installs sharing it race on Windows.
 function envFor(packageDir: string) {
@@ -56,6 +58,7 @@ async function createDir(
   const pkg1Path = join(packageDir, "packages", "pkg1", "package.json");
   const pkg2Path = join(packageDir, "packages", "pkg2", "package.json");
   const env = envFor(packageDir);
+  const lockText = () => file(join(packageDir, "bun.lock")).text();
 
   return {
     packageDir,
@@ -74,30 +77,46 @@ async function createDir(
     rootText: () => file(rootPath).text(),
     pkg1Text: () => file(pkg1Path).text(),
     pkg2Text: () => file(pkg2Path).text(),
-    lockText: () => file(join(packageDir, "bun.lock")).text(),
+    lockText,
     lockExists: () => file(join(packageDir, "bun.lock")).exists(),
-    lock: async () => Bun.JSONC.parse(await file(join(packageDir, "bun.lock")).text()) as any,
+    // Everything `bun add --catalog` can change in bun.lock: the catalog sections (present only when the lockfile has
+    // them), every workspace's rows, and the version each non-workspace package resolved to, keyed as bun.lock keys it.
+    lockState: async () => {
+      const { catalog, catalogs, workspaces, packages } = Bun.JSONC.parse(await lockText()) as any;
+      const resolved = Object.fromEntries(
+        Object.entries<[string, ...unknown[]]>(packages)
+          .filter(([, row]) => !row[0].includes("@workspace:"))
+          .map(([key, row]) => [key, row[0]]),
+      );
+      return { ...(catalog && { catalog }), ...(catalogs && { catalogs }), workspaces, resolved };
+    },
     installed: (name: string) => file(join(packageDir, "node_modules", name, "package.json")).json(),
     installedExists: (name: string) => file(join(packageDir, "node_modules", name, "package.json")).exists(),
     memberInstalled: (member: string, name: string) =>
       file(join(packageDir, "packages", member, "node_modules", name, "package.json")).json(),
     store: () => readdirSorted(join(packageDir, "node_modules", ".bun")),
-    frozen: () => spawnBun(packageDir, ["install", "--frozen-lockfile"], env),
-    installSavesNothing: async () => {
-      const { err } = await runBunInstall(env, packageDir, { savesLockfile: false });
+    // The bun.lock the command wrote is what resolving the edited package.json files produces: a plain `bun install`
+    // afterwards has nothing to re-save and nothing to link. Tests whose tree holds a tarball package pass `relinks`,
+    // because bun re-links a tarball package on every install, with or without a catalog.
+    installSavesNothing: async ({ relinks = false } = {}) => {
+      const { out, err } = await runBunInstall(env, packageDir, { savesLockfile: false });
       expect(err).not.toContain("Saved lockfile");
+      if (!relinks) expect(out).toContain("(no changes)");
     },
   };
 }
 
-const PKG2 = JSON.stringify({ name: "pkg2", version: "1.0.0" });
+const pkg2Json = { name: "pkg2", version: "1.0.0" };
+const PKG2 = JSON.stringify(pkg2Json);
 const withPkg2 = (pkg2: Record<string, unknown> | string = PKG2) => ({
   "packages/pkg2/package.json": typeof pkg2 === "string" ? pkg2 : JSON.stringify(pkg2),
 });
 
-function expectOk({ stderr, exitCode }: { stderr: string; exitCode: number }) {
+// `notes` is every `note:` line the command must have printed, in order; by default the command prints none.
+function expectOk({ stderr, exitCode }: { stderr: string; exitCode: number }, ...notes: string[]) {
+  expect(stderr.split("\n").filter(line => line.startsWith("note:"))).toStrictEqual(notes);
   expect(stderr).not.toContain("error:");
-  expect(stderr).not.toContain("panic:");
+  expect(stderr).not.toContain("warn:");
   expect(exitCode).toBe(0);
 }
 
@@ -106,23 +125,34 @@ const workspacesObject = (catalogs: Record<string, unknown> = {}) => ({
   workspaces: { packages: ["packages/*"], ...catalogs },
 });
 
+const pkg1OnCatalog = { ...pkg1Json, dependencies: { "no-deps": "catalog:" } };
+const pkg2OnCatalog = { ...pkg2Json, dependencies: { "no-deps": "catalog:" } };
+// A member fixture, which is also its bun.lock row, whose only dependency is no-deps at `spec`.
+const onCatalog = (name: string, spec = "catalog:") => ({ name, dependencies: { "no-deps": spec } });
+const bothOnCatalog = { ...rootRow, "packages/pkg1": onCatalog("pkg1"), "packages/pkg2": onCatalog("pkg2") };
+// bun.lock after `bun add no-deps --catalog` from pkg1 seeds an empty default catalog.
+const seededLock = {
+  catalog: { "no-deps": "^2.0.0" },
+  workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog },
+  resolved: { "no-deps": "no-deps@2.0.0" },
+};
+// The same add run from the workspace root puts the reference on the root instead.
+const rootOnCatalog = { "": { name: "root", dependencies: { "no-deps": "catalog:" } }, "packages/pkg1": pkg1Json };
+
 describe.concurrent("bun add --catalog", () => {
   test("default catalog from a workspace member", async () => {
     const dir = await createDir(workspacesObject({ catalog: {} }));
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+    const result = await dir.add(dir.pkg1Dir, "no-deps", "--catalog");
+    expectOk(result);
+    expect(result.stdout).toContain("installed no-deps@2.0.0");
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+    expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
+    expect(await dir.lockState()).toStrictEqual(seededLock);
 
-    const lock = await dir.lock();
-    expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-    expect(lock.packages["no-deps"][0]).toBe("no-deps@2.0.0");
-
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   test("named catalog creates the catalogs object", async () => {
@@ -130,17 +160,18 @@ describe.concurrent("bun add --catalog", () => {
 
     expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=testing"));
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:testing" });
-    expect((await dir.root()).workspaces).toStrictEqual({
-      packages: ["packages/*"],
+    const pkg1 = { ...pkg1Json, dependencies: { "a-dep": "catalog:testing" } };
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
+    expect(await dir.root()).toStrictEqual(
+      workspacesObject({ catalog: { "no-deps": "1.0.0" }, catalogs: { testing: { "a-dep": "^1.0.10" } } }),
+    );
+    expect((await dir.installed("a-dep")).version).toBe("1.0.10");
+    expect(await dir.lockState()).toStrictEqual({
       catalog: { "no-deps": "1.0.0" },
       catalogs: { testing: { "a-dep": "^1.0.10" } },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      resolved: { "a-dep": "a-dep@1.0.10" },
     });
-    expect((await dir.installed("a-dep")).version).toBe("1.0.10");
-
-    const lock = await dir.lock();
-    expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "a-dep": "catalog:testing" });
-    expect(lock.catalogs).toStrictEqual({ testing: { "a-dep": "^1.0.10" } });
   });
 
   describe("placement when no catalog is defined yet", () => {
@@ -149,11 +180,9 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-      expect(await dir.root()).toStrictEqual({
-        name: "root",
-        workspaces: { packages: ["packages/*"], catalog: { "no-deps": "^2.0.0" } },
-      });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+      expect(await dir.lockState()).toStrictEqual(seededLock);
     });
 
     test("workspaces array gets a top-level catalog", async () => {
@@ -166,12 +195,14 @@ describe.concurrent("bun add --catalog", () => {
         workspaces: ["packages/*"],
         catalog: { "no-deps": "^2.0.0" },
       });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+      expect(await dir.lockState()).toStrictEqual(seededLock);
     });
   });
 
   describe("existing top-level placement is respected", () => {
     const topLevel = { name: "root", catalog: { "no-deps": "1.0.0" }, workspaces: ["packages/*"] };
+    const pkg1OnADep = { ...pkg1Json, dependencies: { "a-dep": "catalog:" } };
 
     test("default catalog", async () => {
       const dir = await createDir(topLevel);
@@ -185,7 +216,12 @@ describe.concurrent("bun add --catalog", () => {
         workspaces: ["packages/*"],
       });
       expect(Object.keys(root.catalog)).toStrictEqual(["a-dep", "no-deps"]);
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnADep);
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "a-dep": "^1.0.10", "no-deps": "1.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1OnADep },
+        resolved: { "a-dep": "a-dep@1.0.10" },
+      });
     });
 
     test("named catalog", async () => {
@@ -199,7 +235,14 @@ describe.concurrent("bun add --catalog", () => {
         catalogs: { x: { "a-dep": "^1.0.10" } },
         workspaces: ["packages/*"],
       });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:x" });
+      const pkg1 = { ...pkg1Json, dependencies: { "a-dep": "catalog:x" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "1.0.0" },
+        catalogs: { x: { "a-dep": "^1.0.10" } },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+        resolved: { "a-dep": "a-dep@1.0.10" },
+      });
     });
 
     test("workspaces.catalog wins when a top-level catalog also exists", async () => {
@@ -218,9 +261,13 @@ describe.concurrent("bun add --catalog", () => {
         workspaces: { packages: ["packages/*"], catalog: { "a-dep": "^1.0.10", "no-deps": "1.0.0" } },
       });
       expect(Object.keys(root.workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnADep);
       expect((await dir.installed("a-dep")).version).toBe("1.0.10");
-      expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "1.0.0" });
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "a-dep": "^1.0.10", "no-deps": "1.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1OnADep },
+        resolved: { "a-dep": "a-dep@1.0.10" },
+      });
 
       await dir.installSavesNothing();
     });
@@ -238,9 +285,9 @@ describe.concurrent("bun add --catalog", () => {
       expectOk(await dir.add(dir.pkg1Dir, "--catalog", "no-deps"));
 
       expect(await dir.root()).toStrictEqual(seeded);
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+      expect(await dir.lockState()).toStrictEqual(seededLock);
     });
 
     test("a word after --catalog is a package, not the catalog name", async () => {
@@ -249,15 +296,17 @@ describe.concurrent("bun add --catalog", () => {
       expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "a-dep"));
 
       const root = await dir.root();
-      expect(root).toStrictEqual({
-        name: "root",
-        workspaces: { packages: ["packages/*"], catalog: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" } },
-      });
+      expect(root).toStrictEqual(workspacesObject({ catalog: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" } }));
       expect(Object.keys(root.workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:", "no-deps": "catalog:" });
+      const pkg1 = { ...pkg1Json, dependencies: { "a-dep": "catalog:", "no-deps": "catalog:" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
       expect((await dir.installed("a-dep")).version).toBe("1.0.10");
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^2.0.0" });
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+        resolved: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@2.0.0" },
+      });
     });
 
     for (const flag of ["--catalog=", "--catalog= "]) {
@@ -267,13 +316,8 @@ describe.concurrent("bun add --catalog", () => {
         expectOk(await dir.add(dir.pkg1Dir, "no-deps", flag));
 
         expect(await dir.root()).toStrictEqual(seeded);
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        const lock = await dir.lock();
-        expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-        expect(lock.catalogs).toBeUndefined();
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-
-        await dir.installSavesNothing();
+        expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+        expect(await dir.lockState()).toStrictEqual(seededLock);
       });
     }
 
@@ -283,9 +327,13 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--save-catalog"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
+      const pkg1 = { ...pkg1Json, dependencies: { "no-deps": "^2.0.0" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
       expect(await dir.rootText()).toBe(root);
-      expect((await dir.lock()).workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
+      expect(await dir.lockState()).toStrictEqual({
+        workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+        resolved: { "no-deps": "no-deps@2.0.0" },
+      });
     });
   });
 
@@ -300,10 +348,14 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.add(dir.pkg1Dir, ...args));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": entry });
+        expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+        expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": entry } }));
         expect((await dir.installed("no-deps")).version).toBe(installed);
-        expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": entry });
+        expect(await dir.lockState()).toStrictEqual({
+          catalog: { "no-deps": entry },
+          workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog },
+          resolved: { "no-deps": `no-deps@${installed}` },
+        });
       });
     }
   });
@@ -319,13 +371,16 @@ describe.concurrent("bun add --catalog", () => {
 
     expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }));
     expect(await dir.pkg1Text()).toBe(pkg1);
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
+    // Byte-identical to what `bun install` wrote, so a later install has nothing to re-save either.
     expect(await dir.lockText()).toBe(lockBefore);
-    expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-
-    await dir.installSavesNothing();
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": "^1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog },
+      resolved: { "no-deps": "no-deps@1.1.0" },
+    });
   });
 
   test("an existing entry is reused by a new consumer without touching the other members", async () => {
@@ -334,24 +389,19 @@ describe.concurrent("bun add --catalog", () => {
     await dir.install();
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-    const result = await dir.add(dir.pkg2Dir, "no-deps", "--catalog");
-    expectOk(result);
-    expect(result.stderr).not.toContain("note:");
+    expectOk(await dir.add(dir.pkg2Dir, "no-deps", "--catalog"));
 
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-    expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }));
+    expect(await dir.pkg2()).toStrictEqual(pkg2OnCatalog);
     expect(await dir.pkg1Text()).toBe(pkg1);
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-
-    const lock = await dir.lock();
-    expect(lock.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-    expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": "^1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": JSON.parse(pkg1), "packages/pkg2": pkg2OnCatalog },
+      resolved: { "no-deps": "no-deps@1.1.0" },
+    });
 
     await dir.installSavesNothing();
-    const { stderr, exitCode } = await dir.frozen();
-    expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
   });
 
   test("an existing entry wins over the range the target declares directly", async () => {
@@ -363,17 +413,21 @@ describe.concurrent("bun add --catalog", () => {
     );
     await dir.install();
 
-    const result = await dir.add(dir.pkg1Dir, "no-deps", "--catalog");
-    expectOk(result);
-    expect(result.stderr).toContain('note: no-deps in pkg1 now follows the catalog entry "1.0.0" instead of "^1.0.0"');
+    expectOk(
+      await dir.add(dir.pkg1Dir, "no-deps", "--catalog"),
+      'note: no-deps in pkg1 now follows the catalog entry "1.0.0" instead of "^1.0.0"',
+    );
 
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "1.0.0" } }));
+    const pkg1 = onCatalog("pkg1");
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
     expect(await dir.pkg2Text()).toBe(pkg2);
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    const lockText = await dir.lockText();
-    expect(lockText).not.toContain("no-deps@1.1.0");
-    expect(lockText).not.toContain("no-deps@2.0.0");
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": "1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1, "packages/pkg2": JSON.parse(pkg2) },
+      resolved: { "no-deps": "no-deps@1.0.0" },
+    });
 
     await dir.installSavesNothing();
   });
@@ -385,13 +439,19 @@ describe.concurrent("bun add --catalog", () => {
     });
 
     const { stdout, stderr, exitCode } = await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--silent");
-    expect(stderr).not.toContain("note:");
+    expect(stderr).toBe("");
     expect(stdout).toBe("");
     expect(exitCode).toBe(0);
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+    const pkg1 = onCatalog("pkg1");
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }));
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": "^1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      resolved: { "no-deps": "no-deps@1.1.0" },
+    });
   });
 
   test("the note names package.json when the target has no name", async () => {
@@ -400,9 +460,8 @@ describe.concurrent("bun add --catalog", () => {
       workspaces: { packages: ["packages/*"], catalog: { "no-deps": "1.0.0" } },
     });
 
-    const result = await dir.add(dir.packageDir, "no-deps", "--catalog");
-    expectOk(result);
-    expect(result.stderr).toContain(
+    expectOk(
+      await dir.add(dir.packageDir, "no-deps", "--catalog"),
       'note: no-deps in package.json now follows the catalog entry "1.0.0" instead of "^1.0.0"',
     );
 
@@ -410,8 +469,13 @@ describe.concurrent("bun add --catalog", () => {
       dependencies: { "no-deps": "catalog:" },
       workspaces: { packages: ["packages/*"], catalog: { "no-deps": "1.0.0" } },
     });
+    expect(await dir.pkg1Text()).toBe(PKG1);
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    expect((await dir.lock()).workspaces[""].dependencies).toStrictEqual({ "no-deps": "catalog:" });
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": "1.0.0" },
+      workspaces: { "": { dependencies: { "no-deps": "catalog:" } }, "packages/pkg1": pkg1Json },
+      resolved: { "no-deps": "no-deps@1.0.0" },
+    });
   });
 
   test("a tarball url the target declares is cataloged verbatim", async () => {
@@ -423,19 +487,19 @@ describe.concurrent("bun add --catalog", () => {
     await dir.install();
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-    const result = await dir.add(dir.pkg1Dir, "no-deps", "--catalog");
-    expectOk(result);
-    expect(result.stderr).not.toContain("note:");
+    expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect(await dir.pkg1()).toStrictEqual({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": tarball });
+    const pkg1 = onCatalog("pkg1");
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": tarball } }));
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    const lock = await dir.lock();
-    expect(lock.catalog).toStrictEqual({ "no-deps": tarball });
-    expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": tarball },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      resolved: { "no-deps": `no-deps@${tarball}` },
+    });
 
-    await dir.installSavesNothing();
+    await dir.installSavesNothing({ relinks: true });
   });
 
   test("an explicit version equal to the existing entry leaves the root as it was", async () => {
@@ -445,15 +509,19 @@ describe.concurrent("bun add --catalog", () => {
     expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog"));
 
     expect(await dir.rootText()).toBe(root);
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+    expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "1.0.1", "no-deps": "1.0.0" });
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "a-dep": "1.0.1", "no-deps": "1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog },
+      resolved: { "no-deps": "no-deps@1.0.0" },
+    });
   });
 
   describe("explicit version inside an existing range", () => {
     for (const linker of ["hoisted", "isolated"] as const) {
       test(`keeps the range and moves the installed version (${linker})`, async () => {
-        const member = (name: string) => pretty({ name, dependencies: { "no-deps": "catalog:" } });
+        const member = (name: string) => pretty(onCatalog(name));
         const dir = await createDir(
           workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
           member("pkg1"),
@@ -472,29 +540,27 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog"));
 
-        expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+        expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }));
         expect(await dir.pkg1Text()).toBe(member("pkg1"));
         expect(await dir.pkg2Text()).toBe(member("pkg2"));
         expect(await installedVersions()).toStrictEqual(linker === "isolated" ? ["1.0.0", "1.0.0"] : ["1.0.0"]);
         if (linker === "isolated") {
           expect(await dir.store()).toContain("no-deps@1.0.0");
         }
+        expect(await dir.lockState()).toStrictEqual({
+          catalog: { "no-deps": "^1.0.0" },
+          workspaces: bothOnCatalog,
+          resolved: { "no-deps": "no-deps@1.0.0" },
+        });
 
-        const lock = await dir.lock();
-        expect(lock.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-        expect(lock.packages["no-deps"][0]).toBe("no-deps@1.0.0");
-        expect(await dir.lockText()).not.toContain("no-deps@1.1.0");
-
+        // The range still allows 1.1.0; only the lockfile pins 1.0.0, and a plain install must honor that pin.
         await dir.installSavesNothing();
         expect(await installedVersions()).toStrictEqual(linker === "isolated" ? ["1.0.0", "1.0.0"] : ["1.0.0"]);
-        const { stderr, exitCode } = await dir.frozen();
-        expect(stderr).not.toContain("error:");
-        expect(exitCode).toBe(0);
       });
     }
 
     test("a range that differs replaces the entry", async () => {
-      const member = (name: string) => JSON.stringify({ name, dependencies: { "no-deps": "catalog:" } });
+      const member = (name: string) => JSON.stringify(onCatalog(name));
       const dir = await createDir(
         workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
         member("pkg1"),
@@ -502,12 +568,20 @@ describe.concurrent("bun add --catalog", () => {
       );
       await dir.install();
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@^2.0.0", "--catalog"));
+      expectOk(
+        await dir.add(dir.pkg1Dir, "no-deps@^2.0.0", "--catalog"),
+        'note: catalog entry no-deps changed from "^1.0.0" to "^2.0.0" (also used by pkg2)',
+      );
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
+      expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1"));
       expect(await dir.pkg2Text()).toBe(member("pkg2"));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "^2.0.0" },
+        workspaces: bothOnCatalog,
+        resolved: { "no-deps": "no-deps@2.0.0" },
+      });
     });
   });
 
@@ -519,10 +593,15 @@ describe.concurrent("bun add --catalog", () => {
 
     expectOk(await dir.add(dir.pkg1Dir, "dep-with-tags", "--catalog"));
 
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "dep-with-tags": "^1.0.1" });
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "dep-with-tags": "catalog:" });
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "dep-with-tags": "^1.0.1" } }));
+    const pkg1 = { name: "pkg1", dependencies: { "dep-with-tags": "catalog:" } };
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
     expect((await dir.installed("dep-with-tags")).version).toBe("1.0.1");
-    expect((await dir.lock()).catalog).toStrictEqual({ "dep-with-tags": "^1.0.1" });
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "dep-with-tags": "^1.0.1" },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      resolved: { "dep-with-tags": "dep-with-tags@1.0.1" },
+    });
 
     await dir.installSavesNothing();
   });
@@ -535,12 +614,15 @@ describe.concurrent("bun add --catalog", () => {
 
     expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--dev"));
 
-    expect(await dir.pkg1()).toStrictEqual({ name: "pkg1", devDependencies: { "no-deps": "catalog:" } });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
+    const pkg1 = { name: "pkg1", devDependencies: { "no-deps": "catalog:" } };
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "1.0.0" } }));
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "1.0.0" });
-
-    await dir.installSavesNothing();
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": "1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      resolved: { "no-deps": "no-deps@1.0.0" },
+    });
   });
 
   test("run from the workspace root", async () => {
@@ -555,13 +637,9 @@ describe.concurrent("bun add --catalog", () => {
     });
     expect(await dir.pkg1Text()).toBe(PKG1);
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
+    expect(await dir.lockState()).toStrictEqual({ ...seededLock, workspaces: rootOnCatalog });
 
-    const lock = await dir.lock();
-    expect(lock.workspaces[""].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   test("bun install <pkg> --catalog --dev", async () => {
@@ -569,11 +647,11 @@ describe.concurrent("bun add --catalog", () => {
 
     expectOk(await dir.run(dir.pkg1Dir, ["install", "no-deps", "--catalog", "--dev"]));
 
-    const pkg1 = await dir.pkg1();
-    expect(pkg1.devDependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect(pkg1.dependencies).toBeUndefined();
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+    const pkg1 = { ...pkg1Json, devDependencies: { "no-deps": "catalog:" } };
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
+    expect(await dir.lockState()).toStrictEqual({ ...seededLock, workspaces: { ...rootRow, "packages/pkg1": pkg1 } });
   });
 
   test("several packages into a named catalog", async () => {
@@ -581,13 +659,18 @@ describe.concurrent("bun add --catalog", () => {
 
     expectOk(await dir.add(dir.pkg1Dir, "no-deps", "a-dep", "--catalog=libs"));
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:libs", "no-deps": "catalog:libs" });
+    const pkg1 = { ...pkg1Json, dependencies: { "a-dep": "catalog:libs", "no-deps": "catalog:libs" } };
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
     const root = await dir.root();
-    expect(root.workspaces.catalogs.libs).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^2.0.0" });
+    expect(root).toStrictEqual(workspacesObject({ catalogs: { libs: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" } } }));
     expect(Object.keys(root.workspaces.catalogs.libs)).toStrictEqual(["a-dep", "no-deps"]);
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
     expect((await dir.installed("a-dep")).version).toBe("1.0.10");
-    expect((await dir.lock()).catalogs).toStrictEqual({ libs: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" } });
+    expect(await dir.lockState()).toStrictEqual({
+      catalogs: { libs: { "a-dep": "^1.0.10", "no-deps": "^2.0.0" } },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      resolved: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@2.0.0" },
+    });
   });
 
   for (const from of ["member", "root"] as const) {
@@ -596,43 +679,42 @@ describe.concurrent("bun add --catalog", () => {
       const [rootBefore, pkg1Before] = await Promise.all([dir.rootText(), dir.pkg1Text()]);
 
       const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
-      const { stderr, exitCode } = await dir.add(cwd, "no-deps", "--catalog", "--dry-run");
+      const result = await dir.add(cwd, "no-deps", "--catalog", "--dry-run");
 
-      expect(stderr).not.toContain("error:");
+      expectOk(result);
+      expect(result.stdout).toContain("installed no-deps@2.0.0");
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
       expect(await dir.lockExists()).toBeFalse();
-      expect(exitCode).toBe(0);
+      expect(existsSync(join(dir.packageDir, "node_modules"))).toBeFalse();
     });
 
     test(`--lockfile-only writes both files and bun.lock but installs nothing (from ${from})`, async () => {
       const dir = await createDir(workspacesObject({ catalog: {} }));
 
       const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
-      expectOk(await dir.add(cwd, "no-deps", "--catalog", "--lockfile-only"));
+      const result = await dir.add(cwd, "no-deps", "--catalog", "--lockfile-only");
+      expectOk(result);
+      expect(result.stdout).toContain("Saved bun.lock (3 packages)");
 
-      const root = await dir.root();
-      expect(root.workspaces).toStrictEqual({ packages: ["packages/*"], catalog: { "no-deps": "^2.0.0" } });
       if (from === "member") {
-        expect(root.dependencies).toBeUndefined();
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+        expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
+        expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+        expect(await dir.lockState()).toStrictEqual(seededLock);
       } else {
-        expect(root.dependencies).toStrictEqual({ "no-deps": "catalog:" });
+        expect(await dir.root()).toStrictEqual({
+          ...workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
+          dependencies: { "no-deps": "catalog:" },
+        });
         expect(await dir.pkg1Text()).toBe(PKG1);
+        expect(await dir.lockState()).toStrictEqual({ ...seededLock, workspaces: rootOnCatalog });
       }
-
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-      expect(lock.workspaces[from === "member" ? "packages/pkg1" : ""].dependencies).toStrictEqual({
-        "no-deps": "catalog:",
-      });
-      expect(lock.packages["no-deps"][0]).toBe("no-deps@2.0.0");
       expect(existsSync(join(dir.packageDir, "node_modules"))).toBeFalse();
       expect(existsSync(join(dir.pkg1Dir, "node_modules"))).toBeFalse();
 
-      const { stderr, exitCode } = await dir.frozen();
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      const frozen = await dir.run(dir.packageDir, ["install", "--frozen-lockfile"]);
+      expectOk(frozen);
+      expect(frozen.stdout).toContain("2 packages installed");
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
     });
   }
@@ -643,16 +725,11 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--optional"));
 
-      expect(await dir.pkg1()).toStrictEqual({
-        name: "pkg1",
-        version: "1.0.0",
-        optionalDependencies: { "no-deps": "catalog:" },
-      });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+      const pkg1 = { ...pkg1Json, optionalDependencies: { "no-deps": "catalog:" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-      expect(lock.workspaces["packages/pkg1"].optionalDependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.lockState()).toStrictEqual({ ...seededLock, workspaces: { ...rootRow, "packages/pkg1": pkg1 } });
 
       await dir.installSavesNothing();
     });
@@ -666,19 +743,18 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--dev"));
 
-      expect(await dir.pkg1()).toStrictEqual({
+      const pkg1 = {
         name: "pkg1",
         devDependencies: { "no-deps": "catalog:" },
         peerDependencies: { "no-deps": ">=1" },
-      });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
+      };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "1.0.0" } }));
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect(lock.workspaces["packages/pkg1"]).toStrictEqual({
-        name: "pkg1",
-        devDependencies: { "no-deps": "catalog:" },
-        peerDependencies: { "no-deps": ">=1" },
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "1.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+        resolved: { "no-deps": "no-deps@1.0.0" },
       });
     });
 
@@ -708,45 +784,45 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog", "--peer"));
 
-      expect(await dir.pkg1()).toStrictEqual({
-        name: "pkg1",
-        version: "1.0.0",
-        peerDependencies: { "no-deps": "catalog:" },
-      });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+      const pkg1 = { ...pkg1Json, peerDependencies: { "no-deps": "catalog:" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
+      expect((await dir.installed("no-deps")).version).toBe("2.0.0");
+      expect(await dir.lockState()).toStrictEqual({ ...seededLock, workspaces: { ...rootRow, "packages/pkg1": pkg1 } });
     });
   });
 
   // pnpm: a dependency already on `catalog:<name>` stays in that catalog; the flag only picks the catalog for new references.
   describe("target already on a named catalog reference stays in that catalog", () => {
-    const pkg1 = pretty({ name: "pkg1", dependencies: { "no-deps": "catalog:testing" } });
+    const pkg1Row = onCatalog("pkg1", "catalog:testing");
+    const pkg1 = pretty(pkg1Row);
     const testingRoot = workspacesObject({ catalogs: { testing: { "no-deps": "1.0.0" } } });
 
-    for (const { args, entry, installed } of [
-      { args: ["no-deps", "--catalog"], entry: "1.0.0", installed: "1.0.0" },
-      { args: ["no-deps", "--catalog=other"], entry: "1.0.0", installed: "1.0.0" },
-      { args: ["no-deps@1.1.0", "--catalog"], entry: "1.1.0", installed: "1.1.0" },
+    for (const { args, entry, installed, notes } of [
+      { args: ["no-deps", "--catalog"], entry: "1.0.0", installed: "1.0.0", notes: [] },
+      { args: ["no-deps", "--catalog=other"], entry: "1.0.0", installed: "1.0.0", notes: [] },
+      {
+        args: ["no-deps@1.1.0", "--catalog"],
+        entry: "1.1.0",
+        installed: "1.1.0",
+        notes: ['note: catalog entry no-deps changed from "1.0.0" to "1.1.0"'],
+      },
     ]) {
       test(`bun add ${args.join(" ")}`, async () => {
         const dir = await createDir(testingRoot, pkg1);
         await dir.install();
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-        expectOk(await dir.add(dir.pkg1Dir, ...args));
+        expectOk(await dir.add(dir.pkg1Dir, ...args), ...notes);
 
-        expect((await dir.root()).workspaces).toStrictEqual({
-          packages: ["packages/*"],
-          catalogs: { testing: { "no-deps": entry } },
-        });
+        expect(await dir.root()).toStrictEqual(workspacesObject({ catalogs: { testing: { "no-deps": entry } } }));
         expect(await dir.pkg1Text()).toBe(pkg1);
         expect((await dir.installed("no-deps")).version).toBe(installed);
-
-        const lock = await dir.lock();
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:testing" });
-        expect(lock.catalog).toBeUndefined();
-        expect(lock.catalogs).toStrictEqual({ testing: { "no-deps": entry } });
-
-        await dir.installSavesNothing();
+        expect(await dir.lockState()).toStrictEqual({
+          catalogs: { testing: { "no-deps": entry } },
+          workspaces: { ...rootRow, "packages/pkg1": pkg1Row },
+          resolved: { "no-deps": `no-deps@${installed}` },
+        });
       });
     }
 
@@ -757,24 +833,28 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.0.1", "--catalog"));
 
-      expect((await dir.root()).workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalogs: { testing: { "no-deps": "^1.0.0" } },
-      });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalogs: { testing: { "no-deps": "^1.0.0" } } }));
       expect(await dir.pkg1Text()).toBe(pkg1);
       expect((await dir.installed("no-deps")).version).toBe("1.0.1");
-
-      const lock = await dir.lock();
-      expect(lock.catalog).toBeUndefined();
-      expect(lock.catalogs).toStrictEqual({ testing: { "no-deps": "^1.0.0" } });
-      expect(lock.packages["no-deps"][0]).toBe("no-deps@1.0.1");
+      expect(await dir.lockState()).toStrictEqual({
+        catalogs: { testing: { "no-deps": "^1.0.0" } },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1Row },
+        resolved: { "no-deps": "no-deps@1.0.1" },
+      });
 
       await dir.installSavesNothing();
+      expect((await dir.installed("no-deps")).version).toBe("1.0.1");
     });
   });
 
   describe("target on a named reference whose catalog has no entry", () => {
-    const pkg1 = pretty({ name: "pkg1", dependencies: { "no-deps": "catalog:legacy" } });
+    const pkg1Row = onCatalog("pkg1", "catalog:legacy");
+    const pkg1 = pretty(pkg1Row);
+    const legacyLock = {
+      catalogs: { legacy: { "no-deps": "^2.0.0" } },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1Row },
+      resolved: { "no-deps": "no-deps@2.0.0" },
+    };
 
     for (const { flag, root } of [
       { flag: "--catalog", root: { catalog: {} } },
@@ -783,27 +863,16 @@ describe.concurrent("bun add --catalog", () => {
       test(`bun add no-deps ${flag} seeds that catalog and keeps the reference`, async () => {
         const dir = await createDir(workspacesObject(root), pkg1);
 
-        const result = await dir.add(dir.pkg1Dir, "no-deps", flag);
-        expectOk(result);
-        expect(result.stderr).not.toContain("note:");
+        expectOk(await dir.add(dir.pkg1Dir, "no-deps", flag));
 
         expect(await dir.pkg1Text()).toBe(pkg1);
-        expect((await dir.root()).workspaces).toStrictEqual({
-          packages: ["packages/*"],
-          ...root,
-          catalogs: { legacy: { "no-deps": "^2.0.0" } },
-        });
+        expect(await dir.root()).toStrictEqual(
+          workspacesObject({ ...root, catalogs: { legacy: { "no-deps": "^2.0.0" } } }),
+        );
         expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-
-        const lock = await dir.lock();
-        expect(lock.catalog).toBeUndefined();
-        expect(lock.catalogs).toStrictEqual({ legacy: { "no-deps": "^2.0.0" } });
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:legacy" });
+        expect(await dir.lockState()).toStrictEqual(legacyLock);
 
         await dir.installSavesNothing();
-        const { stderr, exitCode } = await dir.frozen();
-        expect(stderr).not.toContain("error:");
-        expect(exitCode).toBe(0);
       });
     }
 
@@ -813,31 +882,36 @@ describe.concurrent("bun add --catalog", () => {
       expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog=other"));
 
       expect(await dir.pkg1Text()).toBe(pkg1);
-      expect((await dir.root()).workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalog: {},
-        catalogs: { legacy: { "no-deps": "1.0.0" } },
-      });
+      expect(await dir.root()).toStrictEqual(
+        workspacesObject({ catalog: {}, catalogs: { legacy: { "no-deps": "1.0.0" } } }),
+      );
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-      expect((await dir.lock()).catalogs).toStrictEqual({ legacy: { "no-deps": "1.0.0" } });
-
-      await dir.installSavesNothing();
+      expect(await dir.lockState()).toStrictEqual({
+        catalogs: { legacy: { "no-deps": "1.0.0" } },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1Row },
+        resolved: { "no-deps": "no-deps@1.0.0" },
+      });
     });
   });
 
   describe("literals other than a bare name", () => {
+    const pkg1OnFoo = { ...pkg1Json, dependencies: { foo: "catalog:" } };
+
     test("alias@npm:pkg is written verbatim, like plain add", async () => {
       const dir = await createDir(workspacesObject({ catalog: {} }));
 
       expectOk(await dir.add(dir.pkg1Dir, "foo@npm:no-deps", "--catalog"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ foo: "catalog:" });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ foo: "npm:no-deps" });
-      expect((await dir.lock()).catalog).toStrictEqual({ foo: "npm:no-deps" });
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnFoo);
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { foo: "npm:no-deps" } }));
       expect(await dir.installed("foo")).toMatchObject({ name: "no-deps", version: "2.0.0" });
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { foo: "npm:no-deps" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1OnFoo },
+        resolved: { foo: "no-deps@2.0.0" },
+      });
 
-      const { err } = await dir.install({ savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      await dir.installSavesNothing();
     });
 
     test("alias@npm:pkg@dist-tag gets the resolved range", async () => {
@@ -845,13 +919,16 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "foo@npm:no-deps@latest", "--catalog"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ foo: "catalog:" });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ foo: "npm:no-deps@^2.0.0" });
-      expect((await dir.lock()).catalog).toStrictEqual({ foo: "npm:no-deps@^2.0.0" });
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnFoo);
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { foo: "npm:no-deps@^2.0.0" } }));
       expect(await dir.installed("foo")).toMatchObject({ name: "no-deps", version: "2.0.0" });
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { foo: "npm:no-deps@^2.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1OnFoo },
+        resolved: { foo: "no-deps@2.0.0" },
+      });
 
-      const { err } = await dir.install({ savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      await dir.installSavesNothing();
     });
 
     test("name@tarball-url is written verbatim, dist-tags become a range", async () => {
@@ -860,15 +937,17 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, `no-deps@${tarball}`, "dep-with-tags@pre-1", "--catalog"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "dep-with-tags": "catalog:", "no-deps": "catalog:" });
+      const pkg1 = { ...pkg1Json, dependencies: { "dep-with-tags": "catalog:", "no-deps": "catalog:" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
       const catalog = { "dep-with-tags": "^1.0.1", "no-deps": tarball };
-      expect((await dir.root()).workspaces.catalog).toStrictEqual(catalog);
-      expect((await dir.lock()).catalog).toStrictEqual(catalog);
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog }));
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
       expect((await dir.installed("dep-with-tags")).version).toBe("1.0.1");
-
-      const { err } = await dir.install({ savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      expect(await dir.lockState()).toStrictEqual({
+        catalog,
+        workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+        resolved: { "dep-with-tags": "dep-with-tags@1.0.1", "no-deps": `no-deps@${tarball}` },
+      });
     });
 
     test("scoped package into a named catalog", async () => {
@@ -876,45 +955,47 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "@types/no-deps", "--catalog=types"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "@types/no-deps": "catalog:types" });
-      expect((await dir.root()).workspaces.catalogs).toStrictEqual({ types: { "@types/no-deps": "^2.0.0" } });
-      expect((await dir.lock()).catalogs).toStrictEqual({ types: { "@types/no-deps": "^2.0.0" } });
+      const pkg1 = { ...pkg1Json, dependencies: { "@types/no-deps": "catalog:types" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalogs: { types: { "@types/no-deps": "^2.0.0" } } }));
       expect((await dir.installed("@types/no-deps")).version).toBe("2.0.0");
+      expect(await dir.lockState()).toStrictEqual({
+        catalogs: { types: { "@types/no-deps": "^2.0.0" } },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+        resolved: { "@types/no-deps": "@types/no-deps@2.0.0" },
+      });
     });
 
     describe("positionals without a name", () => {
       const tarball = () => `${registry.registryUrl()}no-deps/-/no-deps-1.0.0.tgz`;
+      const tarballResolved = { "no-deps": `no-deps@${tarball()}` };
 
       for (const from of ["member", "root"] as const) {
         test(`a tarball url is cataloged under the resolved name (from ${from})`, async () => {
           const dir = await createDir(workspacesObject({ catalog: {} }));
 
           const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
-          const result = await dir.add(cwd, tarball(), "--catalog");
-          expectOk(result);
-          expect(result.stderr).not.toContain("note:");
+          expectOk(await dir.add(cwd, tarball(), "--catalog"));
 
-          const root = await dir.root();
+          const catalog = { "no-deps": tarball() };
           if (from === "member") {
-            expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-            expect(root.dependencies).toBeUndefined();
+            expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+            expect(await dir.root()).toStrictEqual(workspacesObject({ catalog }));
           } else {
-            expect(root.dependencies).toStrictEqual({ "no-deps": "catalog:" });
+            expect(await dir.root()).toStrictEqual({
+              ...workspacesObject({ catalog }),
+              dependencies: { "no-deps": "catalog:" },
+            });
             expect(await dir.pkg1Text()).toBe(PKG1);
           }
-          expect(root.workspaces.catalog).toStrictEqual({ "no-deps": tarball() });
           expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-
-          const lock = await dir.lock();
-          expect(lock.catalog).toStrictEqual({ "no-deps": tarball() });
-          expect(lock.workspaces[from === "member" ? "packages/pkg1" : ""].dependencies).toStrictEqual({
-            "no-deps": "catalog:",
+          expect(await dir.lockState()).toStrictEqual({
+            catalog,
+            workspaces: from === "member" ? seededLock.workspaces : rootOnCatalog,
+            resolved: tarballResolved,
           });
 
-          await dir.installSavesNothing();
-          const { stderr, exitCode } = await dir.frozen();
-          expect(stderr).not.toContain("error:");
-          expect(exitCode).toBe(0);
+          await dir.installSavesNothing({ relinks: true });
         });
       }
 
@@ -923,18 +1004,16 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.add(dir.packageDir, tarball(), "--catalog", "--filter", "pkg1", "--filter", "pkg2"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        const root = await dir.root();
-        expect(root.dependencies).toBeUndefined();
-        expect(root.workspaces.catalog).toStrictEqual({ "no-deps": tarball() });
+        expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+        expect(await dir.pkg2()).toStrictEqual(pkg2OnCatalog);
+        expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": tarball() } }));
+        expect(await dir.lockState()).toStrictEqual({
+          catalog: { "no-deps": tarball() },
+          workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog, "packages/pkg2": pkg2OnCatalog },
+          resolved: tarballResolved,
+        });
 
-        const lock = await dir.lock();
-        expect(lock.catalog).toStrictEqual({ "no-deps": tarball() });
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-
-        await dir.installSavesNothing();
+        await dir.installSavesNothing({ relinks: true });
       });
 
       test("mixed with a named package", async () => {
@@ -942,15 +1021,21 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.add(dir.pkg1Dir, tarball(), "a-dep", "--catalog"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:", "no-deps": "catalog:" });
-        const catalog = (await dir.root()).workspaces.catalog;
-        expect(catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": tarball() });
-        expect(Object.keys(catalog)).toStrictEqual(["a-dep", "no-deps"]);
-        expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": tarball() });
+        const pkg1 = { ...pkg1Json, dependencies: { "a-dep": "catalog:", "no-deps": "catalog:" } };
+        expect(await dir.pkg1()).toStrictEqual(pkg1);
+        const catalog = { "a-dep": "^1.0.10", "no-deps": tarball() };
+        const root = await dir.root();
+        expect(root).toStrictEqual(workspacesObject({ catalog }));
+        expect(Object.keys(root.workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
         expect((await dir.installed("a-dep")).version).toBe("1.0.10");
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
+        expect(await dir.lockState()).toStrictEqual({
+          catalog,
+          workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+          resolved: { "a-dep": "a-dep@1.0.10", ...tarballResolved },
+        });
 
-        await dir.installSavesNothing();
+        await dir.installSavesNothing({ relinks: true });
       });
 
       test("the entry is inserted in alphabetical order", async () => {
@@ -958,13 +1043,16 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
 
-        const catalog = (await dir.root()).workspaces.catalog;
-        expect(catalog).toStrictEqual({ "no-deps": tarball(), zzz: "1.0.0" });
-        expect(Object.keys(catalog)).toStrictEqual(["no-deps", "zzz"]);
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": tarball(), zzz: "1.0.0" });
-
-        await dir.installSavesNothing();
+        const catalog = { "no-deps": tarball(), zzz: "1.0.0" };
+        const root = await dir.root();
+        expect(root).toStrictEqual(workspacesObject({ catalog }));
+        expect(Object.keys(root.workspaces.catalog)).toStrictEqual(["no-deps", "zzz"]);
+        expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+        expect(await dir.lockState()).toStrictEqual({
+          catalog,
+          workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog },
+          resolved: tarballResolved,
+        });
       });
 
       test("into a named catalog", async () => {
@@ -972,40 +1060,41 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.add(dir.pkg1Dir, tarball(), "--catalog=vendored"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:vendored" });
-        expect((await dir.root()).workspaces.catalogs).toStrictEqual({ vendored: { "no-deps": tarball() } });
-        expect((await dir.lock()).catalogs).toStrictEqual({ vendored: { "no-deps": tarball() } });
+        const pkg1 = { ...pkg1Json, dependencies: { "no-deps": "catalog:vendored" } };
+        expect(await dir.pkg1()).toStrictEqual(pkg1);
+        expect(await dir.root()).toStrictEqual(workspacesObject({ catalogs: { vendored: { "no-deps": tarball() } } }));
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-
-        await dir.installSavesNothing();
+        expect(await dir.lockState()).toStrictEqual({
+          catalogs: { vendored: { "no-deps": tarball() } },
+          workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+          resolved: tarballResolved,
+        });
       });
 
       test("an identical entry is reused", async () => {
         const root = workspacesObject({ catalog: { "no-deps": tarball() } });
-        const pkg2 = JSON.stringify({ name: "pkg2", dependencies: { "no-deps": "catalog:" } });
+        const pkg2 = JSON.stringify(onCatalog("pkg2"));
         const dir = await createDir(root, PKG1, withPkg2(pkg2));
         await dir.install();
 
-        const result = await dir.add(dir.pkg1Dir, tarball(), "--catalog");
-        expectOk(result);
-        expect(result.stderr).not.toContain("note:");
+        expectOk(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+        expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
         expect(await dir.root()).toStrictEqual(root);
         expect(await dir.pkg2Text()).toBe(pkg2);
-        expect((await dir.lock()).workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-
-        await dir.installSavesNothing();
-        const { stderr, exitCode } = await dir.frozen();
-        expect(stderr).not.toContain("error:");
-        expect(exitCode).toBe(0);
+        expect(await dir.lockState()).toStrictEqual({
+          catalog: { "no-deps": tarball() },
+          workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog, "packages/pkg2": onCatalog("pkg2") },
+          resolved: tarballResolved,
+        });
       });
 
       test("re-running is a no-op", async () => {
         const dir = await createDir(workspacesObject({ catalog: {} }));
 
         expectOk(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
-        expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": tarball() });
+        expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": tarball() } }));
+        expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
         const [rootAfter, pkg1After, lockAfter] = await Promise.all([dir.rootText(), dir.pkg1Text(), dir.lockText()]);
 
         expectOk(await dir.add(dir.pkg1Dir, tarball(), "--catalog"));
@@ -1017,24 +1106,26 @@ describe.concurrent("bun add --catalog", () => {
 
       test("a different existing entry keeps the package direct", async () => {
         const root = workspacesObject({ catalog: { "no-deps": "^1.0.0" } });
-        const dir = await createDir(root, PKG1, withPkg2({ name: "pkg2", dependencies: { "no-deps": "catalog:" } }));
+        const dir = await createDir(root, PKG1, withPkg2(onCatalog("pkg2")));
         await dir.install();
 
-        const result = await dir.add(dir.pkg1Dir, tarball(), "--catalog");
-        expectOk(result);
-        expect(result.stderr).toContain(
+        expectOk(
+          await dir.add(dir.pkg1Dir, tarball(), "--catalog"),
           `note: no-deps in pkg1 keeps "${tarball()}" because the catalog entry is "^1.0.0"`,
         );
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": tarball() });
+        const pkg1 = { ...pkg1Json, dependencies: { "no-deps": tarball() } };
+        expect(await dir.pkg1()).toStrictEqual(pkg1);
         expect(await dir.root()).toStrictEqual(root);
+        expect(await dir.pkg2()).toStrictEqual(onCatalog("pkg2"));
+        expect(await dir.lockState()).toStrictEqual({
+          catalog: { "no-deps": "^1.0.0" },
+          workspaces: { ...rootRow, "packages/pkg1": pkg1, "packages/pkg2": onCatalog("pkg2") },
+          // Both resolutions stay: the tarball is hoisted and pkg2's catalog resolution is nested under pkg2.
+          resolved: { ...tarballResolved, "pkg2/no-deps": "no-deps@1.1.0" },
+        });
 
-        const lock = await dir.lock();
-        expect(lock.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": tarball() });
-        expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-
-        await dir.installSavesNothing();
+        await dir.installSavesNothing({ relinks: true });
       });
 
       // The name is only known after both rows resolved, so this is refused before anything is written; `name@url` binds the declaration instead.
@@ -1086,15 +1177,16 @@ describe.concurrent("bun add --catalog", () => {
 
           expectOk(await dir.add(dir.pkg1Dir, `no-deps@${tarball()}`, "--catalog"));
 
-          expect(await dir.pkg1()).toStrictEqual({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
+          const moved = onCatalog("pkg1");
+          expect(await dir.pkg1()).toStrictEqual(moved);
           expect((await dir.pkg1Text()).match(/"no-deps"/g)).toHaveLength(1);
-          expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": tarball() });
-          const lock = await dir.lock();
-          expect(lock.catalog).toStrictEqual({ "no-deps": tarball() });
-          expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
+          expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": tarball() } }));
           expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-
-          await dir.installSavesNothing();
+          expect(await dir.lockState()).toStrictEqual({
+            catalog: { "no-deps": tarball() },
+            workspaces: { ...rootRow, "packages/pkg1": moved },
+            resolved: tarballResolved,
+          });
         });
       });
 
@@ -1105,29 +1197,32 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.add(dir.pkg1Dir, literal, "--catalog"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ baz: "catalog:" });
-        expect((await dir.root()).workspaces.catalog).toStrictEqual({ baz: literal });
-        expect((await dir.lock()).catalog).toStrictEqual({ baz: literal });
+        const pkg1 = { ...pkg1Json, dependencies: { baz: "catalog:" } };
+        expect(await dir.pkg1()).toStrictEqual(pkg1);
+        expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { baz: literal } }));
         expect((await dir.installed("baz")).version).toBe("0.0.3");
+        expect(await dir.lockState()).toStrictEqual({
+          catalog: { baz: literal },
+          workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+          resolved: { baz: `baz@${literal}` },
+        });
 
-        await dir.installSavesNothing();
+        await dir.installSavesNothing({ relinks: true });
       });
 
       test("a url that fails to resolve writes nothing", async () => {
         const dir = await createDir(workspacesObject({ catalog: {} }));
         const [rootBefore, pkg1Before] = await Promise.all([dir.rootText(), dir.pkg1Text()]);
+        const url = `${registry.registryUrl()}no-deps/-/no-deps-9.9.9.tgz`;
 
-        const { stderr, exitCode } = await dir.add(
-          dir.pkg1Dir,
-          `${registry.registryUrl()}no-deps/-/no-deps-9.9.9.tgz`,
-          "--catalog",
-        );
+        const { stderr, exitCode } = await dir.add(dir.pkg1Dir, url, "--catalog");
 
-        expect(stderr).toContain("error:");
+        expect(stderr).toContain(`error: GET ${url} - 404`);
+        expect(stderr).toContain(`error: ${url} failed to resolve`);
         expect(await dir.rootText()).toBe(rootBefore);
         expect(await dir.pkg1Text()).toBe(pkg1Before);
         expect(await dir.lockExists()).toBeFalse();
-        expect(exitCode).not.toBe(0);
+        expect(exitCode).toBe(1);
       });
     });
   });
@@ -1302,47 +1397,65 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, `foo@${literal}`, "--catalog"));
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ foo: literal });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ foo: "catalog:" });
-      expect((await dir.lock()).catalog).toStrictEqual({ foo: literal });
-      // Folder dependencies of a workspace are linked under that workspace's node_modules, not hoisted.
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { foo: literal } }));
+      const pkg1 = { ...pkg1Json, dependencies: { foo: "catalog:" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
+      // Folder dependencies of a workspace are linked under that workspace's node_modules, not hoisted, and bun.lock
+      // records the folder relative to the workspace root.
       expect(await dir.memberInstalled("pkg1", "foo")).toMatchObject({ name: "foo", version: "1.0.0" });
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { foo: literal },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+        resolved: { "pkg1/foo": "foo@file:vendor/foo" },
+      });
     });
   });
 
   describe("--filter", () => {
+    // pkg1's "1.0.0" seeded the entry; pkg2 kept its own "1.0.1", which bun.lock nests under pkg2.
+    const seededAndKept = {
+      catalog: { "no-deps": "1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": onCatalog("pkg1"), "packages/pkg2": onCatalog("pkg2", "1.0.1") },
+      resolved: { "no-deps": "no-deps@1.0.0", "pkg2/no-deps": "no-deps@1.0.1" },
+    };
+
     test("'*' alone edits the members and the root catalog, not the root's dependencies", async () => {
-      const pkg1 = JSON.stringify({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
-      const dir = await createDir(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }), pkg1, withPkg2());
-      await dir.install();
+      const dir = await createDir(
+        workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
+        onCatalog("pkg1"),
+        withPkg2(),
+      );
 
       expectOk(await dir.add(dir.packageDir, "a-dep", "--catalog", "--filter", "*"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:", "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
-      const root = await dir.root();
-      expect(root.dependencies).toBeUndefined();
-      expect(root.workspaces.catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
-      expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
-
-      await dir.installSavesNothing();
+      const pkg1After = { name: "pkg1", dependencies: { "a-dep": "catalog:", "no-deps": "catalog:" } };
+      const pkg2After = { ...pkg2Json, dependencies: { "a-dep": "catalog:" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1After);
+      expect(await dir.pkg2()).toStrictEqual(pkg2After);
+      const catalog = { "a-dep": "^1.0.10", "no-deps": "^1.0.0" };
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog }));
+      expect(await dir.lockState()).toStrictEqual({
+        catalog,
+        workspaces: { ...rootRow, "packages/pkg1": pkg1After, "packages/pkg2": pkg2After },
+        resolved: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@1.1.0" },
+      });
     });
 
     test("an existing entry is reused for every selected member", async () => {
-      const dir = await createDir(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }), PKG1, withPkg2());
+      const root = workspacesObject({ catalog: { "no-deps": "^1.0.0" } });
+      const dir = await createDir(root, PKG1, withPkg2());
 
       expectOk(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "*"));
 
-      const root = await dir.root();
-      expect(root.workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect(root.dependencies).toBeUndefined();
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(root);
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+      expect(await dir.pkg2()).toStrictEqual(pkg2OnCatalog);
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
-
-      await dir.installSavesNothing();
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "^1.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog, "packages/pkg2": pkg2OnCatalog },
+        resolved: { "no-deps": "no-deps@1.1.0" },
+      });
     });
 
     test("a range declared by any selected member is what gets cataloged", async () => {
@@ -1354,13 +1467,16 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg1", "--filter", "pkg2"));
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }));
+      const pkg1 = onCatalog("pkg1");
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
+      expect(await dir.pkg2()).toStrictEqual(pkg2OnCatalog);
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-
-      await dir.installSavesNothing();
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "^1.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1, "packages/pkg2": pkg2OnCatalog },
+        resolved: { "no-deps": "no-deps@1.1.0" },
+      });
     });
 
     // pnpm's rule: the first member declaring a range seeds the entry; later members switch only when equal or an exact version inside it, otherwise they are kept with a note.
@@ -1372,20 +1488,15 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2(pkg2),
       );
 
-      const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*");
-      expectOk(result);
-      expect(result.stderr).toContain('note: no-deps in pkg2 keeps "1.0.1" because the catalog entry is "1.0.0"');
+      expectOk(
+        await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*"),
+        'note: no-deps in pkg2 keeps "1.0.1" because the catalog entry is "1.0.0"',
+      );
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "1.0.0" } }));
+      expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1"));
       expect(await dir.pkg2Text()).toBe(pkg2);
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "1.0.1" });
-      const lockText = await dir.lockText();
-      expect(lockText).toContain("no-deps@1.0.0");
-      expect(lockText).toContain("no-deps@1.0.1");
+      expect(await dir.lockState()).toStrictEqual(seededAndKept);
 
       await dir.installSavesNothing();
     });
@@ -1397,20 +1508,20 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2({ name: "pkg2", dependencies: { "no-deps": "1.0.0" } }),
       );
 
-      const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*");
-      expectOk(result);
-      expect(result.stderr).toContain(
+      expectOk(
+        await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*"),
         'note: no-deps in pkg2 now follows the catalog entry "^1.0.0" instead of "1.0.0"',
       );
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }));
+      expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1"));
+      expect(await dir.pkg2()).toStrictEqual(onCatalog("pkg2"));
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect(await dir.lockText()).not.toContain('no-deps@1.0.0"');
-
-      await dir.installSavesNothing();
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "^1.0.0" },
+        workspaces: bothOnCatalog,
+        resolved: { "no-deps": "no-deps@1.1.0" },
+      });
     });
 
     test("members declaring the same range are all switched without a note", async () => {
@@ -1420,16 +1531,16 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2({ name: "pkg2", dependencies: { "no-deps": "^1.0.0" } }),
       );
 
-      const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*");
-      expectOk(result);
-      expect(result.stderr).not.toContain("note:");
+      expectOk(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*"));
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-
-      await dir.installSavesNothing();
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }));
+      expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1"));
+      expect(await dir.pkg2()).toStrictEqual(onCatalog("pkg2"));
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "^1.0.0" },
+        workspaces: bothOnCatalog,
+        resolved: { "no-deps": "no-deps@1.1.0" },
+      });
     });
 
     test("a member declaring nothing does not block a later member's range from seeding", async () => {
@@ -1439,17 +1550,17 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2({ name: "pkg2", dependencies: { "no-deps": "^1.0.0" } }),
       );
 
-      const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*");
-      expectOk(result);
-      expect(result.stderr).not.toContain("note:");
+      expectOk(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*"));
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }));
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+      expect(await dir.pkg2()).toStrictEqual(onCatalog("pkg2"));
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-
-      await dir.installSavesNothing();
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "^1.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog, "packages/pkg2": onCatalog("pkg2") },
+        resolved: { "no-deps": "no-deps@1.1.0" },
+      });
     });
 
     test("an entry the root already has is used by every selected member, with a note per member that declared something else", async () => {
@@ -1459,21 +1570,21 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2({ name: "pkg2", dependencies: { "no-deps": "2.0.0" } }),
       );
 
-      const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*");
-      expectOk(result);
-      expect(result.stderr).toContain(
+      expectOk(
+        await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*"),
         'note: no-deps in pkg1 now follows the catalog entry "1.0.0" instead of "^1.0.0"',
+        'note: no-deps in pkg2 now follows the catalog entry "1.0.0" instead of "2.0.0"',
       );
-      expect(result.stderr).toContain('note: no-deps in pkg2 now follows the catalog entry "1.0.0" instead of "2.0.0"');
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "1.0.0" } }));
+      expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1"));
+      expect(await dir.pkg2()).toStrictEqual(onCatalog("pkg2"));
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
-
-      await dir.installSavesNothing();
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "1.0.0" },
+        workspaces: bothOnCatalog,
+        resolved: { "no-deps": "no-deps@1.0.0" },
+      });
     });
 
     test("--silent prints no notes", async () => {
@@ -1484,23 +1595,27 @@ describe.concurrent("bun add --catalog", () => {
         withPkg2(pkg2),
       );
 
-      const result = await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg*", "--silent");
-      expectOk(result);
-      expect(result.stderr).not.toContain("note:");
+      const { stdout, stderr, exitCode } = await dir.add(
+        dir.packageDir,
+        "no-deps",
+        "--catalog",
+        "--filter",
+        "pkg*",
+        "--silent",
+      );
+      expect(stderr).toBe("");
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(0);
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "1.0.0" } }));
+      expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1"));
       expect(await dir.pkg2Text()).toBe(pkg2);
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "1.0.1" });
-
-      await dir.installSavesNothing();
+      expect(await dir.lockState()).toStrictEqual(seededAndKept);
     });
 
     test("each member keeps its own catalog", async () => {
-      const pkg1 = pretty({ name: "pkg1", dependencies: { "no-deps": "catalog:legacy" } });
+      const pkg1Row = onCatalog("pkg1", "catalog:legacy");
+      const pkg1 = pretty(pkg1Row);
       const dir = await createDir(
         workspacesObject({ catalogs: { legacy: { "no-deps": "1.0.0" } } }),
         pkg1,
@@ -1510,23 +1625,16 @@ describe.concurrent("bun add --catalog", () => {
       expectOk(await dir.add(dir.packageDir, "no-deps", "--catalog", "--filter", "pkg1", "--filter", "pkg2"));
 
       expect(await dir.pkg1Text()).toBe(pkg1);
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      const root = await dir.root();
-      expect(root.dependencies).toBeUndefined();
-      expect(root.workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalogs: { legacy: { "no-deps": "1.0.0" } },
+      expect(await dir.pkg2()).toStrictEqual(onCatalog("pkg2"));
+      expect(await dir.root()).toStrictEqual(
+        workspacesObject({ catalogs: { legacy: { "no-deps": "1.0.0" } }, catalog: { "no-deps": "^2.0.0" } }),
+      );
+      expect(await dir.lockState()).toStrictEqual({
         catalog: { "no-deps": "^2.0.0" },
+        catalogs: { legacy: { "no-deps": "1.0.0" } },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1Row, "packages/pkg2": onCatalog("pkg2") },
+        resolved: { "no-deps": "no-deps@1.0.0", "pkg2/no-deps": "no-deps@2.0.0" },
       });
-
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-      expect(lock.catalogs).toStrictEqual({ legacy: { "no-deps": "1.0.0" } });
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:legacy" });
-      expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      const lockText = await dir.lockText();
-      expect(lockText).toContain("no-deps@1.0.0");
-      expect(lockText).toContain("no-deps@2.0.0");
 
       await dir.installSavesNothing();
     });
@@ -1534,28 +1642,39 @@ describe.concurrent("bun add --catalog", () => {
     test("edits only the filtered member and the root catalog", async () => {
       const pkg1 = JSON.stringify({ name: "pkg1", dependencies: { "no-deps": "catalog:" } });
       const dir = await createDir(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }), pkg1, withPkg2());
-      await dir.install();
 
       expectOk(await dir.add(dir.packageDir, "a-dep", "--catalog", "--filter", "pkg2"));
 
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
+      const catalog = { "a-dep": "^1.0.10", "no-deps": "^1.0.0" };
+      const pkg2 = { ...pkg2Json, dependencies: { "a-dep": "catalog:" } };
+      expect(await dir.pkg2()).toStrictEqual(pkg2);
       expect(await dir.pkg1Text()).toBe(pkg1);
       const root = await dir.root();
-      expect(root.dependencies).toBeUndefined();
-      expect(root.workspaces.catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
+      expect(root).toStrictEqual(workspacesObject({ catalog }));
       expect(Object.keys(root.workspaces.catalog)).toStrictEqual(["a-dep", "no-deps"]);
-      expect((await dir.lock()).catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
       expect((await dir.installed("a-dep")).version).toBe("1.0.10");
+      expect(await dir.lockState()).toStrictEqual({
+        catalog,
+        workspaces: { ...rootRow, "packages/pkg1": JSON.parse(pkg1), "packages/pkg2": pkg2 },
+        resolved: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@1.1.0" },
+      });
 
       expectOk(await dir.add(dir.packageDir, "a-dep", "--catalog", "--filter", "*", "--filter", "root"));
 
-      expect((await dir.root()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:", "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "a-dep": "catalog:" });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
-
-      const { err } = await dir.install({ savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      const rootAfter = { ...workspacesObject({ catalog }), dependencies: { "a-dep": "catalog:" } };
+      const pkg1After = { name: "pkg1", dependencies: { "a-dep": "catalog:", "no-deps": "catalog:" } };
+      expect(await dir.root()).toStrictEqual(rootAfter);
+      expect(await dir.pkg1()).toStrictEqual(pkg1After);
+      expect(await dir.pkg2()).toStrictEqual(pkg2);
+      expect(await dir.lockState()).toStrictEqual({
+        catalog,
+        workspaces: {
+          "": { name: "root", dependencies: { "a-dep": "catalog:" } },
+          "packages/pkg1": pkg1After,
+          "packages/pkg2": pkg2,
+        },
+        resolved: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@1.1.0" },
+      });
     });
 
     test("--only-missing skips members that already have the package", async () => {
@@ -1567,8 +1686,13 @@ describe.concurrent("bun add --catalog", () => {
       );
 
       expect(await dir.pkg1()).toStrictEqual(pkg1);
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+      expect(await dir.pkg2()).toStrictEqual(pkg2OnCatalog);
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "^2.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1, "packages/pkg2": pkg2OnCatalog },
+        resolved: { "no-deps": "no-deps@1.1.0", "pkg2/no-deps": "no-deps@2.0.0" },
+      });
     });
 
     test("--only-missing with every member already having the package leaves the catalog empty", async () => {
@@ -1579,6 +1703,10 @@ describe.concurrent("bun add --catalog", () => {
 
       expect(await dir.pkg1()).toStrictEqual(pkg1);
       expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: {} }));
+      expect(await dir.lockState()).toStrictEqual({
+        workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+        resolved: { "no-deps": "no-deps@1.1.0" },
+      });
     });
   });
 
@@ -1592,11 +1720,15 @@ describe.concurrent("bun add --catalog", () => {
     expect(await dir.pkg1()).toStrictEqual(pkg1);
     expect(await dir.rootText()).toBe(rootBefore);
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
+    expect(await dir.lockState()).toStrictEqual({
+      workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      resolved: { "no-deps": "no-deps@1.1.0" },
+    });
   });
 
   // pnpm #9647: an existing entry is moved to the version given on the command line.
   test("explicit version replaces an entry other members reference", async () => {
-    const member = (name: string) => JSON.stringify({ name, dependencies: { "no-deps": "catalog:" } });
+    const member = (name: string) => JSON.stringify(onCatalog(name));
     const dir = await createDir(
       workspacesObject({ catalog: { "no-deps": "^2.0.0" } }),
       member("pkg1"),
@@ -1605,24 +1737,28 @@ describe.concurrent("bun add --catalog", () => {
     await dir.install();
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
 
-    expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog"));
+    expectOk(
+      await dir.add(dir.pkg1Dir, "no-deps@1.0.0", "--catalog"),
+      'note: catalog entry no-deps changed from "^2.0.0" to "1.0.0" (also used by pkg2)',
+    );
 
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "1.0.0" });
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "1.0.0" } }));
+    expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1"));
     expect(await dir.pkg2Text()).toBe(member("pkg2"));
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-    const lockText = await dir.lockText();
-    expect(lockText).not.toContain("no-deps@2.0.0");
-    expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "1.0.0" });
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": "1.0.0" },
+      workspaces: bothOnCatalog,
+      resolved: { "no-deps": "no-deps@1.0.0" },
+    });
 
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   // Bun deviates from pnpm here: pnpm keeps the entry and writes the version directly into the member.
   describe("an explicit version the entry or the target's range does not cover replaces the entry", () => {
     test("entry other members reference", async () => {
-      const member = (name: string) => JSON.stringify({ name, dependencies: { "no-deps": "catalog:" } });
+      const member = (name: string) => JSON.stringify(onCatalog(name));
       const dir = await createDir(
         workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
         member("pkg1"),
@@ -1631,26 +1767,37 @@ describe.concurrent("bun add --catalog", () => {
       await dir.install();
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"));
+      expectOk(
+        await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"),
+        'note: catalog entry no-deps changed from "^1.0.0" to "2.0.0" (also used by pkg2)',
+      );
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "2.0.0" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "2.0.0" } }));
+      expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1"));
       expect(await dir.pkg2Text()).toBe(member("pkg2"));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      expect(await dir.lockText()).not.toContain("no-deps@1.1.0");
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "2.0.0" },
+        workspaces: bothOnCatalog,
+        resolved: { "no-deps": "no-deps@2.0.0" },
+      });
     });
 
     test("range declared directly by the target", async () => {
-      const dir = await createDir(workspacesObject({ catalog: {} }), {
-        name: "pkg1",
-        dependencies: { "no-deps": "^1.0.0" },
-      });
+      const dir = await createDir(workspacesObject({ catalog: {} }), onCatalog("pkg1", "^1.0.0"));
       await dir.install();
+      expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"));
 
-      expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "2.0.0" });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "2.0.0" } }));
+      expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1"));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "2.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": onCatalog("pkg1") },
+        resolved: { "no-deps": "no-deps@2.0.0" },
+      });
     });
   });
 
@@ -1662,27 +1809,33 @@ describe.concurrent("bun add --catalog", () => {
 
     expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "1.0.1", "no-deps": "catalog:" });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+    const pkg1 = { name: "pkg1", dependencies: { "a-dep": "1.0.1", "no-deps": "catalog:" } };
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
     expect((await dir.installed("a-dep")).version).toBe("1.0.1");
     expect((await dir.installed("no-deps")).version).toBe("2.0.0");
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": "^2.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      resolved: { "a-dep": "a-dep@1.0.1", "no-deps": "no-deps@2.0.0" },
+    });
   });
 
   test("existing direct range is converted in place", async () => {
-    const dir = await createDir(workspacesObject({ catalog: {} }), {
-      name: "pkg1",
-      dependencies: { "no-deps": "^1.0.0" },
-    });
+    const dir = await createDir(workspacesObject({ catalog: {} }), onCatalog("pkg1", "^1.0.0"));
     await dir.install();
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
     expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect(await dir.pkg1Text()).toBe(pretty({ name: "pkg1", dependencies: { "no-deps": "catalog:" } }));
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+    expect(await dir.pkg1Text()).toBe(pretty(onCatalog("pkg1")));
+    expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^1.0.0" } }));
     expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-    expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-    expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": "^1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": onCatalog("pkg1") },
+      resolved: { "no-deps": "no-deps@1.1.0" },
+    });
 
     await dir.installSavesNothing();
   });
@@ -1691,6 +1844,7 @@ describe.concurrent("bun add --catalog", () => {
     const dir = await createDir(workspacesObject({ catalog: {} }));
 
     expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
+    expect(await dir.lockState()).toStrictEqual(seededLock);
     const [rootAfter, pkg1After, lockAfter] = await Promise.all([dir.rootText(), dir.pkg1Text(), dir.lockText()]);
 
     expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
@@ -1709,14 +1863,18 @@ describe.concurrent("bun add --catalog", () => {
 
     const catalogs = { other: { "a-dep": "1.0.1" }, testing: { "a-dep": "^1.0.10", "no-deps": "1.0.0" } };
     const root = await dir.root();
-    expect(root.workspaces.catalogs).toStrictEqual(catalogs);
+    expect(root).toStrictEqual(workspacesObject({ catalogs }));
     expect(Object.keys(root.workspaces.catalogs.testing)).toStrictEqual(["a-dep", "no-deps"]);
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:testing" });
-    expect((await dir.lock()).catalogs).toStrictEqual(catalogs);
+    const pkg1 = { ...pkg1Json, dependencies: { "a-dep": "catalog:testing" } };
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
     expect((await dir.installed("a-dep")).version).toBe("1.0.10");
+    expect(await dir.lockState()).toStrictEqual({
+      catalogs,
+      workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      resolved: { "a-dep": "a-dep@1.0.10" },
+    });
 
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   test("one package failing to resolve writes nothing", async () => {
@@ -1725,11 +1883,12 @@ describe.concurrent("bun add --catalog", () => {
 
     const { stderr, exitCode } = await dir.add(dir.pkg1Dir, "no-deps", "this-package-does-not-exist-xyz", "--catalog");
 
-    expect(stderr).toContain("error:");
+    expect(stderr).toContain(`error: GET ${registry.registryUrl()}this-package-does-not-exist-xyz - 404`);
     expect(await dir.rootText()).toBe(rootBefore);
     expect(await dir.pkg1Text()).toBe(pkg1Before);
     expect(await dir.lockExists()).toBeFalse();
-    expect(exitCode).not.toBe(0);
+    expect(await dir.installedExists("no-deps")).toBeFalse();
+    expect(exitCode).toBe(1);
   });
 
   for (const from of ["member", "root"] as const) {
@@ -1738,8 +1897,10 @@ describe.concurrent("bun add --catalog", () => {
       const [rootBefore, pkg1Before] = await Promise.all([dir.rootText(), dir.pkg1Text()]);
 
       const cwd = from === "member" ? dir.pkg1Dir : dir.packageDir;
-      expectOk(await dir.add(cwd, "no-deps", "--catalog", "--no-save"));
+      const result = await dir.add(cwd, "no-deps", "--catalog", "--no-save");
 
+      expectOk(result);
+      expect(result.stdout).toContain("installed no-deps@2.0.0");
       expect(await dir.rootText()).toBe(rootBefore);
       expect(await dir.pkg1Text()).toBe(pkg1Before);
       expect(await dir.lockExists()).toBeFalse();
@@ -1770,7 +1931,7 @@ describe.concurrent("bun add --catalog", () => {
 
   // pnpm #7072: `catalog:` and `catalog:default` are one catalog, whether it is spelled `catalog` or `catalogs.default`.
   describe("default catalog alias", () => {
-    const member = (name: string, ref = "catalog:") => JSON.stringify({ name, dependencies: { "no-deps": ref } });
+    const member = (name: string, ref = "catalog:") => JSON.stringify(onCatalog(name, ref));
 
     const reuseRows: { flag: string; root: { catalog?: object; catalogs?: object }; reference: string }[] = [
       { flag: "--catalog", root: { catalogs: { default: { "no-deps": "1.0.0" } } }, reference: "catalog:" },
@@ -1785,15 +1946,16 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.add(dir.pkg1Dir, "no-deps", flag));
 
-        expect((await dir.root()).workspaces).toStrictEqual({ packages: ["packages/*"], ...root });
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": reference });
+        expect(await dir.root()).toStrictEqual(workspacesObject(root));
+        const pkg1 = { ...pkg1Json, dependencies: { "no-deps": reference } };
+        expect(await dir.pkg1()).toStrictEqual(pkg1);
         expect(await dir.pkg2Text()).toBe(member("pkg2", otherReference));
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-
-        const lock = await dir.lock();
-        expect(lock.catalog).toStrictEqual(root.catalog);
-        expect(lock.catalogs).toStrictEqual(root.catalogs);
-        expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
+        expect(await dir.lockState()).toStrictEqual({
+          ...root,
+          workspaces: { ...rootRow, "packages/pkg1": pkg1, "packages/pkg2": onCatalog("pkg2", otherReference) },
+          resolved: { "no-deps": "no-deps@1.0.0" },
+        });
 
         await dir.installSavesNothing();
       });
@@ -1811,9 +1973,16 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-      expect((await dir.root()).workspaces).toStrictEqual(bothObjects.workspaces);
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(bothObjects);
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+      expect(await dir.pkg2Text()).toBe(member("pkg2"));
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "a-dep": "1.0.1" },
+        catalogs: { default: { "no-deps": "1.0.0" } },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog, "packages/pkg2": onCatalog("pkg2") },
+        resolved: { "no-deps": "no-deps@1.0.0" },
+      });
 
       await dir.installSavesNothing();
     });
@@ -1823,19 +1992,23 @@ describe.concurrent("bun add --catalog", () => {
       await dir.install();
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"));
+      expectOk(
+        await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"),
+        'note: catalog entry no-deps changed from "1.0.0" to "2.0.0" (also used by pkg2)',
+      );
 
-      expect((await dir.root()).workspaces).toStrictEqual({
-        packages: ["packages/*"],
+      expect(await dir.root()).toStrictEqual(
+        workspacesObject({ catalog: { "a-dep": "1.0.1" }, catalogs: { default: { "no-deps": "2.0.0" } } }),
+      );
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+      expect(await dir.pkg2Text()).toBe(member("pkg2"));
+      expect((await dir.installed("no-deps")).version).toBe("2.0.0");
+      expect(await dir.lockState()).toStrictEqual({
         catalog: { "a-dep": "1.0.1" },
         catalogs: { default: { "no-deps": "2.0.0" } },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog, "packages/pkg2": onCatalog("pkg2") },
+        resolved: { "no-deps": "no-deps@2.0.0" },
       });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-
-      const { stderr, exitCode } = await dir.frozen();
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
     });
 
     test("--catalog with an explicit version replaces the catalogs.default entry instead of adding a second catalog", async () => {
@@ -1847,24 +2020,24 @@ describe.concurrent("bun add --catalog", () => {
       await dir.install();
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"));
+      expectOk(
+        await dir.add(dir.pkg1Dir, "no-deps@2.0.0", "--catalog"),
+        'note: catalog entry no-deps changed from "1.0.0" to "2.0.0" (also used by pkg2)',
+      );
 
-      expect((await dir.root()).workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalogs: { default: { "no-deps": "2.0.0" } },
-      });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalogs: { default: { "no-deps": "2.0.0" } } }));
+      expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1"));
       expect(await dir.pkg2Text()).toBe(member("pkg2", "catalog:default"));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-
-      const lock = await dir.lock();
-      expect(lock.catalog).toBeUndefined();
-      expect(lock.catalogs).toStrictEqual({ default: { "no-deps": "2.0.0" } });
-      expect(lock.packages["no-deps"][0]).toBe("no-deps@2.0.0");
-
-      const { stderr, exitCode } = await dir.frozen();
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      expect(await dir.lockState()).toStrictEqual({
+        catalogs: { default: { "no-deps": "2.0.0" } },
+        workspaces: {
+          ...rootRow,
+          "packages/pkg1": onCatalog("pkg1"),
+          "packages/pkg2": onCatalog("pkg2", "catalog:default"),
+        },
+        resolved: { "no-deps": "no-deps@2.0.0" },
+      });
     });
 
     test("--catalog=default with an explicit range replaces the singular catalog every catalog: reference resolves through", async () => {
@@ -1876,22 +2049,21 @@ describe.concurrent("bun add --catalog", () => {
       await dir.install();
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
 
-      expectOk(await dir.add(dir.pkg1Dir, "no-deps@^2.0.0", "--catalog=default"));
+      expectOk(
+        await dir.add(dir.pkg1Dir, "no-deps@^2.0.0", "--catalog=default"),
+        'note: catalog entry no-deps changed from "^1.0.0" to "^2.0.0" (also used by pkg2)',
+      );
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:default" });
-      expect((await dir.root()).workspaces).toStrictEqual({
-        packages: ["packages/*"],
-        catalog: { "no-deps": "^2.0.0" },
-      });
+      const pkg1 = { ...pkg1Json, dependencies: { "no-deps": "catalog:default" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
+      expect(await dir.pkg2Text()).toBe(member("pkg2"));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-
-      const lock = await dir.lock();
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^2.0.0" });
-      expect(lock.catalogs).toBeUndefined();
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:default" });
-      expect(await dir.lockText()).not.toContain("no-deps@1.1.0");
-
-      await dir.installSavesNothing();
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "no-deps": "^2.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1, "packages/pkg2": onCatalog("pkg2") },
+        resolved: { "no-deps": "no-deps@2.0.0" },
+      });
     });
 
     test("--catalog=default with no catalog defined creates the singular catalog", async () => {
@@ -1899,13 +2071,11 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog=default"));
 
-      expect(await dir.root()).toStrictEqual({
-        name: "root",
-        workspaces: { packages: ["packages/*"], catalog: { "no-deps": "^2.0.0" } },
-      });
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:default" });
-      expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^2.0.0" });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalog: { "no-deps": "^2.0.0" } }));
+      const pkg1 = { ...pkg1Json, dependencies: { "no-deps": "catalog:default" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
+      expect(await dir.lockState()).toStrictEqual({ ...seededLock, workspaces: { ...rootRow, "packages/pkg1": pkg1 } });
     });
 
     test("bun update --latest refreshes a catalogs.default entry referenced as catalog:", async () => {
@@ -1915,13 +2085,16 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.run(dir.packageDir, ["update", "--latest"]));
 
-      expect((await dir.root()).workspaces.catalogs).toStrictEqual({ default: { "no-deps": "^2.0.0" } });
+      expect(await dir.root()).toStrictEqual(workspacesObject({ catalogs: { default: { "no-deps": "^2.0.0" } } }));
       expect(await dir.pkg1Text()).toBe(member("pkg1"));
       expect((await dir.installed("no-deps")).version).toBe("2.0.0");
-      expect((await dir.lock()).catalogs).toStrictEqual({ default: { "no-deps": "^2.0.0" } });
+      expect(await dir.lockState()).toStrictEqual({
+        catalogs: { default: { "no-deps": "^2.0.0" } },
+        workspaces: { ...rootRow, "packages/pkg1": onCatalog("pkg1") },
+        resolved: { "no-deps": "no-deps@2.0.0" },
+      });
 
-      const { err } = await dir.install({ savesLockfile: false });
-      expect(err).not.toContain("Saved lockfile");
+      await dir.installSavesNothing();
     });
 
     test("bun pm pack substitutes a catalogs.default entry referenced as catalog:", async () => {
@@ -1930,11 +2103,10 @@ describe.concurrent("bun add --catalog", () => {
         version: "1.0.0",
         peerDependencies: { "no-deps": "catalog:" },
       });
+      // pack reads the catalog through bun.lock, so the workspace has to be installed first.
       await dir.install();
 
-      const { stderr, exitCode } = await dir.run(dir.pkg1Dir, ["pm", "pack"]);
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      expectOk(await dir.run(dir.pkg1Dir, ["pm", "pack"]));
 
       const tarball = readTarball(join(dir.pkg1Dir, "pkg1-1.0.0.tgz"));
       expect(JSON.parse(tarball.entries[0].contents)).toStrictEqual({
@@ -1952,14 +2124,16 @@ describe.concurrent("bun add --catalog", () => {
       version: "1.0.0",
       peerDependencies: { "no-deps": "catalog:" },
     });
-    await dir.install();
 
+    // pack reads the catalog through bun.lock, which this add writes.
     expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=x"));
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:x" });
+    expect(await dir.pkg1()).toStrictEqual({
+      ...pkg1Json,
+      peerDependencies: { "no-deps": "catalog:" },
+      dependencies: { "a-dep": "catalog:x" },
+    });
 
-    const { stderr, exitCode } = await dir.run(dir.pkg1Dir, ["pm", "pack"]);
-    expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
+    expectOk(await dir.run(dir.pkg1Dir, ["pm", "pack"]));
 
     const tarball = readTarball(join(dir.pkg1Dir, "pkg1-1.0.0.tgz"));
     expect(JSON.parse(tarball.entries[0].contents)).toStrictEqual({
@@ -1972,30 +2146,34 @@ describe.concurrent("bun add --catalog", () => {
 
   // pnpm #10456: removing the last reference to an entry does not drop the catalog from bun.lock.
   test("bun remove from members keeps the catalog definitions", async () => {
-    const member = (name: string) => JSON.stringify({ name, dependencies: { "no-deps": "catalog:" } });
     const dir = await createDir(
       workspacesObject({ catalog: { "no-deps": "1.0.0" } }),
-      member("pkg1"),
-      withPkg2(member("pkg2")),
+      onCatalog("pkg1"),
+      withPkg2(onCatalog("pkg2")),
     );
 
     expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog=libs"));
-    expectOk(await dir.run(dir.pkg1Dir, ["remove", "no-deps"]));
-    expectOk(await dir.run(dir.pkg2Dir, ["remove", "no-deps"]));
+    for (const cwd of [dir.pkg1Dir, dir.pkg2Dir]) {
+      const removed = await dir.run(cwd, ["remove", "no-deps"]);
+      expectOk(removed);
+      expect(removed.stdout).toContain("- no-deps");
+    }
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:libs" });
-    expect((await dir.pkg2()).dependencies).toBeUndefined();
-    expect((await dir.root()).workspaces).toStrictEqual({
-      packages: ["packages/*"],
+    const pkg1 = { name: "pkg1", dependencies: { "a-dep": "catalog:libs" } };
+    const pkg2 = { name: "pkg2" };
+    expect(await dir.pkg1()).toStrictEqual(pkg1);
+    expect(await dir.pkg2()).toStrictEqual(pkg2);
+    expect(await dir.root()).toStrictEqual(
+      workspacesObject({ catalog: { "no-deps": "1.0.0" }, catalogs: { libs: { "a-dep": "^1.0.10" } } }),
+    );
+    expect(await dir.lockState()).toStrictEqual({
       catalog: { "no-deps": "1.0.0" },
       catalogs: { libs: { "a-dep": "^1.0.10" } },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1, "packages/pkg2": pkg2 },
+      resolved: { "a-dep": "a-dep@1.0.10" },
     });
-    const lock = await dir.lock();
-    expect(lock.catalog).toStrictEqual({ "no-deps": "1.0.0" });
-    expect(lock.catalogs).toStrictEqual({ libs: { "a-dep": "^1.0.10" } });
 
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   // pnpm #8795: --frozen-lockfile notices a changed catalog entry.
@@ -2006,26 +2184,32 @@ describe.concurrent("bun add --catalog", () => {
       expectOk(await dir.add(from === "member" ? dir.pkg1Dir : dir.packageDir, "no-deps", "--catalog"));
 
       const frozen = await dir.run(dir.packageDir, ["install", "--frozen-lockfile"]);
-      expect(frozen.stderr).not.toContain("error:");
-      expect(frozen.exitCode).toBe(0);
+      expectOk(frozen);
+      expect(frozen.stdout).toContain("(no changes)");
 
       const root = await dir.root();
       root.workspaces.catalog["no-deps"] = "1.0.0";
       await write(dir.rootPath, JSON.stringify(root));
 
       const { stderr, exitCode } = await dir.run(dir.packageDir, ["install", "--frozen-lockfile"]);
-      expect(stderr).toContain("error:");
-      expect(stderr).toContain("frozen-lockfile");
+      expect(stderr).toContain("error: lockfile had changes, but lockfile is frozen");
+      expect(stderr).toContain("note: the catalog in package.json changed since bun.lock was saved");
+      expect((await dir.lockState()).catalog).toStrictEqual({ "no-deps": "^2.0.0" });
       expect(exitCode).toBe(1);
     });
   }
 
   // pnpm #12115 / #11591: update never replaces a `catalog:` reference, even with an override or an explicit spec.
   describe("catalog: references with an override", () => {
-    const pkg1 = { name: "pkg1", dependencies: { "no-deps": "catalog:" } };
+    const pkg1 = onCatalog("pkg1");
     const overriddenRoot = {
       ...workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
       overrides: { "no-deps": "1.0.0" },
+    };
+    const overriddenLock = {
+      catalog: { "no-deps": "^1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      resolved: { "no-deps": "no-deps@1.0.0" },
     };
 
     for (const args of [["update"], ["update", "--recursive"], ["update", "no-deps"], ["update", "no-deps@1.1.0"]]) {
@@ -2034,10 +2218,14 @@ describe.concurrent("bun add --catalog", () => {
         await dir.install();
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
 
-        expectOk(await dir.run(dir.pkg1Dir, args));
+        const result = await dir.run(dir.pkg1Dir, args);
+        expectOk(result);
+        expect(result.stdout).toContain("(no changes)");
 
         expect(await dir.pkg1()).toStrictEqual(pkg1);
+        expect(await dir.root()).toStrictEqual(overriddenRoot);
         expect((await dir.installed("no-deps")).version).toBe("1.0.0");
+        expect(await dir.lockState()).toStrictEqual(overriddenLock);
       });
     }
 
@@ -2046,18 +2234,18 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "a-dep", "--catalog"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "a-dep": "catalog:", "no-deps": "catalog:" });
-      const lock = await dir.lock();
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({
-        "a-dep": "catalog:",
-        "no-deps": "catalog:",
+      const pkg1After = { name: "pkg1", dependencies: { "a-dep": "catalog:", "no-deps": "catalog:" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1After);
+      expect(await dir.root()).toStrictEqual({
+        ...overriddenRoot,
+        ...workspacesObject({ catalog: { "a-dep": "^1.0.10", "no-deps": "^1.0.0" } }),
       });
-      expect(lock.catalog).toStrictEqual({ "a-dep": "^1.0.10", "no-deps": "^1.0.0" });
       expect((await dir.installed("no-deps")).version).toBe("1.0.0");
-
-      const { stderr, exitCode } = await dir.frozen();
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
+      expect(await dir.lockState()).toStrictEqual({
+        catalog: { "a-dep": "^1.0.10", "no-deps": "^1.0.0" },
+        workspaces: { ...rootRow, "packages/pkg1": pkg1After },
+        resolved: { "a-dep": "a-dep@1.0.10", "no-deps": "no-deps@1.0.0" },
+      });
     });
   });
 
@@ -2067,18 +2255,30 @@ describe.concurrent("bun add --catalog", () => {
 
     expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--catalog"));
 
-    expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-    expect((await dir.root()).workspaces.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-    expect((await dir.lock()).catalog).toStrictEqual({ "no-deps": "^1.0.0" });
+    expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+    expect(await dir.root()).toStrictEqual({
+      ...workspacesObject({ catalog: { "no-deps": "^1.0.0" } }),
+      overrides: { "no-deps": "1.0.0" },
+    });
     expect((await dir.installed("no-deps")).version).toBe("1.0.0");
+    expect(await dir.lockState()).toStrictEqual({
+      catalog: { "no-deps": "^1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog },
+      resolved: { "no-deps": "no-deps@1.0.0" },
+    });
 
-    const { err } = await dir.install({ savesLockfile: false });
-    expect(err).not.toContain("Saved lockfile");
+    await dir.installSavesNothing();
   });
 
   // pnpm: a bare `add <name>` in a workspace whose default catalog lists <name> writes `catalog:`.
   describe("plain bun add uses the default catalog", () => {
     const defaultRoot = workspacesObject({ catalog: { "no-deps": "^1.0.0" } });
+    // bun.lock after pkg1 was put on the existing default entry.
+    const referencedLock = {
+      catalog: { "no-deps": "^1.0.0" },
+      workspaces: { ...rootRow, "packages/pkg1": pkg1OnCatalog },
+      resolved: { "no-deps": "no-deps@1.1.0" },
+    };
 
     test("bare name from a member", async () => {
       const dir = await createDir(defaultRoot);
@@ -2086,19 +2286,12 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
       expect(await dir.rootText()).toBe(rootBefore);
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-
-      const lock = await dir.lock();
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-      expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
+      expect(await dir.lockState()).toStrictEqual(referencedLock);
 
       await dir.installSavesNothing();
-      const { stderr, exitCode } = await dir.frozen();
-      expect(stderr).not.toContain("error:");
-      expect(exitCode).toBe(0);
     });
 
     test("bare name from the root", async () => {
@@ -2106,17 +2299,10 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.packageDir, "no-deps"));
 
-      const root = await dir.root();
-      expect(root.dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(root.workspaces).toStrictEqual(defaultRoot.workspaces);
+      expect(await dir.root()).toStrictEqual({ ...defaultRoot, dependencies: { "no-deps": "catalog:" } });
       expect(await dir.pkg1Text()).toBe(PKG1);
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-
-      const lock = await dir.lock();
-      expect(lock.workspaces[""].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(lock.catalog).toStrictEqual({ "no-deps": "^1.0.0" });
-
-      await dir.installSavesNothing();
+      expect(await dir.lockState()).toStrictEqual({ ...referencedLock, workspaces: rootOnCatalog });
     });
 
     for (const { title, args } of [
@@ -2129,17 +2315,14 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.add(dir.pkg1Dir, ...args));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+        expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
         expect(await dir.rootText()).toBe(root);
         expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-
-        const lock = await dir.lock();
-        expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-        expect(lock.catalog).toBeUndefined();
-        expect(lock.catalogs).toStrictEqual({ default: { "no-deps": "^1.0.0" } });
-        expect(await dir.lockText()).not.toContain("no-deps@2.0.0");
-
-        await dir.installSavesNothing();
+        expect(await dir.lockState()).toStrictEqual({
+          catalogs: { default: { "no-deps": "^1.0.0" } },
+          workspaces: referencedLock.workspaces,
+          resolved: referencedLock.resolved,
+        });
       });
     }
 
@@ -2149,12 +2332,14 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.pkg1Dir, "no-deps", "--dev"));
 
-      const pkg1 = await dir.pkg1();
-      expect(pkg1.devDependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(pkg1.dependencies).toBeUndefined();
+      const pkg1 = { ...pkg1Json, devDependencies: { "no-deps": "catalog:" } };
+      expect(await dir.pkg1()).toStrictEqual(pkg1);
       expect(await dir.rootText()).toBe(rootBefore);
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-      expect((await dir.lock()).workspaces["packages/pkg1"].devDependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.lockState()).toStrictEqual({
+        ...referencedLock,
+        workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+      });
     });
 
     for (const { title, args } of [
@@ -2169,12 +2354,10 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.run(dir.pkg1Dir, args));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+        expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
         expect(await dir.rootText()).toBe(rootBefore);
         expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-        expect((await dir.lock()).workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-
-        await dir.installSavesNothing();
+        expect(await dir.lockState()).toStrictEqual(referencedLock);
       });
     }
 
@@ -2184,16 +2367,14 @@ describe.concurrent("bun add --catalog", () => {
 
       expectOk(await dir.add(dir.packageDir, "no-deps", "--filter", "pkg1", "--filter", "pkg2"));
 
-      expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect((await dir.pkg2()).dependencies).toStrictEqual({ "no-deps": "catalog:" });
+      expect(await dir.pkg1()).toStrictEqual(pkg1OnCatalog);
+      expect(await dir.pkg2()).toStrictEqual(pkg2OnCatalog);
       expect(await dir.rootText()).toBe(rootBefore);
       expect((await dir.installed("no-deps")).version).toBe("1.1.0");
-
-      const lock = await dir.lock();
-      expect(lock.workspaces["packages/pkg1"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-      expect(lock.workspaces["packages/pkg2"].dependencies).toStrictEqual({ "no-deps": "catalog:" });
-
-      await dir.installSavesNothing();
+      expect(await dir.lockState()).toStrictEqual({
+        ...referencedLock,
+        workspaces: { ...referencedLock.workspaces, "packages/pkg2": pkg2OnCatalog },
+      });
     });
 
     test("re-adding a package already on catalog: keeps the reference", async () => {
@@ -2225,13 +2406,38 @@ describe.concurrent("bun add --catalog", () => {
     });
 
     describe("explicit versions and unlisted names are added normally", () => {
-      for (const { spec, written, installed } of [
-        { spec: "no-deps@1.0.0", written: { "no-deps": "1.0.0" }, installed: "1.0.0" },
-        { spec: "no-deps@latest", written: { "no-deps": "^2.0.0" }, installed: "2.0.0" },
-        { spec: "no-deps@^2.0.0", written: { "no-deps": "^2.0.0" }, installed: "2.0.0" },
-        { spec: "a-dep", written: { "a-dep": "^1.0.10" }, installed: "1.0.10" },
-        { spec: "@types/no-deps", written: { "@types/no-deps": "^2.0.0" }, installed: "2.0.0" },
-        { spec: "foo@npm:no-deps", written: { foo: "npm:no-deps@^2.0.0" }, installed: "2.0.0" },
+      for (const { spec, written, installed, resolved } of [
+        {
+          spec: "no-deps@1.0.0",
+          written: { "no-deps": "1.0.0" },
+          installed: "1.0.0",
+          resolved: { "no-deps": "no-deps@1.0.0" },
+        },
+        {
+          spec: "no-deps@latest",
+          written: { "no-deps": "^2.0.0" },
+          installed: "2.0.0",
+          resolved: { "no-deps": "no-deps@2.0.0" },
+        },
+        {
+          spec: "no-deps@^2.0.0",
+          written: { "no-deps": "^2.0.0" },
+          installed: "2.0.0",
+          resolved: { "no-deps": "no-deps@2.0.0" },
+        },
+        { spec: "a-dep", written: { "a-dep": "^1.0.10" }, installed: "1.0.10", resolved: { "a-dep": "a-dep@1.0.10" } },
+        {
+          spec: "@types/no-deps",
+          written: { "@types/no-deps": "^2.0.0" },
+          installed: "2.0.0",
+          resolved: { "@types/no-deps": "@types/no-deps@2.0.0" },
+        },
+        {
+          spec: "foo@npm:no-deps",
+          written: { foo: "npm:no-deps@^2.0.0" },
+          installed: "2.0.0",
+          resolved: { foo: "no-deps@2.0.0" },
+        },
       ]) {
         test(`bun add ${spec}`, async () => {
           const dir = await createDir(defaultRoot);
@@ -2239,24 +2445,35 @@ describe.concurrent("bun add --catalog", () => {
 
           expectOk(await dir.add(dir.pkg1Dir, spec));
 
-          expect((await dir.pkg1()).dependencies).toStrictEqual(written);
+          const pkg1 = { ...pkg1Json, dependencies: written };
+          expect(await dir.pkg1()).toStrictEqual(pkg1);
           expect(await dir.rootText()).toBe(rootBefore);
           expect((await dir.installed(Object.keys(written)[0])).version).toBe(installed);
+          expect(await dir.lockState()).toStrictEqual({
+            catalog: { "no-deps": "^1.0.0" },
+            workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+            resolved,
+          });
         });
       }
 
       test("an explicit version replaces a named reference", async () => {
-        const dir = await createDir(workspacesObject({ catalogs: { libs: { "no-deps": "1.0.0" } } }), {
-          name: "pkg1",
-          dependencies: { "no-deps": "catalog:libs" },
-        });
+        const dir = await createDir(
+          workspacesObject({ catalogs: { libs: { "no-deps": "1.0.0" } } }),
+          onCatalog("pkg1", "catalog:libs"),
+        );
         const rootBefore = await dir.rootText();
 
         expectOk(await dir.add(dir.pkg1Dir, "no-deps@1.1.0"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "1.1.0" });
+        expect(await dir.pkg1()).toStrictEqual(onCatalog("pkg1", "1.1.0"));
         expect(await dir.rootText()).toBe(rootBefore);
         expect((await dir.installed("no-deps")).version).toBe("1.1.0");
+        expect(await dir.lockState()).toStrictEqual({
+          catalogs: { libs: { "no-deps": "1.0.0" } },
+          workspaces: { ...rootRow, "packages/pkg1": onCatalog("pkg1", "1.1.0") },
+          resolved: { "no-deps": "no-deps@1.1.0" },
+        });
       });
 
       test("named catalogs are not used without the flag", async () => {
@@ -2265,9 +2482,15 @@ describe.concurrent("bun add --catalog", () => {
 
         expectOk(await dir.add(dir.pkg1Dir, "no-deps"));
 
-        expect((await dir.pkg1()).dependencies).toStrictEqual({ "no-deps": "^2.0.0" });
+        const pkg1 = { ...pkg1Json, dependencies: { "no-deps": "^2.0.0" } };
+        expect(await dir.pkg1()).toStrictEqual(pkg1);
         expect(await dir.rootText()).toBe(rootBefore);
         expect((await dir.installed("no-deps")).version).toBe("2.0.0");
+        expect(await dir.lockState()).toStrictEqual({
+          catalogs: { libs: { "no-deps": "1.0.0" } },
+          workspaces: { ...rootRow, "packages/pkg1": pkg1 },
+          resolved: { "no-deps": "no-deps@2.0.0" },
+        });
       });
     });
   });


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-add-catalog.test.ts` is the slowest install test file without a speed pass: 16 s on debian 13 x64-asan (build 100495), 1.3 s with a release build.
- The file spawns 272 bun processes for 149 tests. On a sanitized build a spawn costs about 145 ms, and about 105 ms of that is process startup (`bun --version` alone). The asan runner also caps `describe.concurrent` at 5 tests (`src/options_types/context.rs:506`). So the wall time of this file is about the spawn count divided by 5.
- 82 of the spawns are a `bun install` or `bun install --frozen-lockfile` run after the command under test. All 82 prove the same property: the bun.lock the command wrote is in sync with the package.json files it edited. Three more spawns are setup installs whose result no assertion used.
- Most tests asserted one field of each file (`pkg1().dependencies`, `root().workspaces.catalog`, `lock.catalog`) and proved the absence of a version with `lockText().not.toContain("no-deps@2.0.0")`. 16 tests checked only `stderr not.toContain("error:")` plus the exit code. Two error tests checked only that stderr contains `error:`.

### Fix
- Keep the re-install check in 29 tests (33 runs, four of them are loop rows), one or two per bun.lock write path: a seeded entry (default catalog, named catalog, root target, `--optional`, a dist-tag the target already declared, a seed into the catalog that a `catalog:name` reference points at, an override, `workspaces.catalog` winning over a top-level `catalog`), a reused entry (a new consumer, a declared range, a tarball the target declared, `catalogs.default` spelled both ways, both objects present), a moved resolution (hoisted, isolated, named catalog), a replaced entry other members use, a converted direct range, nameless tarball positionals (member, root, `--filter`, mixed with a name, kept direct next to a different entry, local tarball), `npm:` aliases, `--filter` with mixed outcomes and with two catalogs, a plain `bun add` that uses the default entry, `bun update --latest`, `bun remove`. Drop the other 31 runs.
- Keep `--frozen-lockfile` where it is the subject (pnpm #8795, two tests) or the install step of the `--lockfile-only` tests. Drop the 12 runs that followed a re-install check or replaced one.
- Drop the setup install in three tests where nothing read its result: `'*' alone edits the members...`, `edits only the filtered member...`, and the `bun pm pack` test whose `bun add` writes the bun.lock that pack needs.
- Result: 272 spawns become 226 (144 `add`, 31 setup installs, 33 re-installs, 6 frozen installs, 12 update, pack, remove and `install <pkg>` runs). 149 tests before and after. No test was removed or merged.
- Every test that dropped a spawn, and most others, now assert more than before:
  - `lockState()` returns the catalog sections, every workspace row, and the resolved version of every non-workspace package from bun.lock. 92 call sites compare it with `toStrictEqual`. This replaces the single-field checks and the `not.toContain` version checks, and adds bun.lock coverage to tests that did not read it (placement, `--peer`, `--only-missing`, the override `update` rows, the plain-add rows).
  - `root()`, `pkg1()` and `pkg2()` are compared as whole objects.
  - `expectOk` compares the exact list of `note:` lines the command printed (none by default) and rejects `warn:`. This asserts the `catalog entry X changed from A to B (also used by pkg2)` note in six tests and its form without the suffix in one. This file never asserted that note before.
  - `installSavesNothing` also asserts the install reported `(no changes)`. Tests with a tarball package pass `relinks`, because bun re-links a tarball package on every install, with or without a catalog (see details).
  - The 16 bare exit-code sites are gone. `--silent` tests assert stdout and stderr are empty. `--dry-run` and `--no-save` assert stdout reports `installed no-deps@2.0.0`. `--lockfile-only` asserts `Saved bun.lock (3 packages)` and that the frozen install reports `2 packages installed`. The override `update` rows assert `(no changes)` and an unchanged root. `bun remove` asserts its `- no-deps` rows, that no-deps left the packages section, and that both catalog sections stayed.
  - The two unresolvable-package tests assert the exact `error: GET <url> - 404` line and exit code 1. The pnpm #8795 tests assert `error: lockfile had changes, but lockfile is frozen`, the note that names the catalog, and that bun.lock kept the old entry.
- The `name only in peerDependencies` test is byte for byte unchanged, so #36284 still applies on top of this branch (checked with `git apply --check`). No test was renamed or reordered.
- Verified with `bun bd test test/cli/install/bun-add-catalog.test.ts`, 149 pass. Timing, three interleaved rounds on one machine, before then after: 14.31 s / 13.44 s, 15.05 s / 14.08 s, 14.72 s / 13.60 s. Best of each: 14.31 s before, 13.44 s after. About 3.7 s of both numbers is fixed: the debug runner starts in 2.75 s and verdaccio in 1 s. `USE_SYSTEM_BUN=1 bun test` also passes, in 1.25 s.

### Background
- `bun add <pkg> --catalog` writes the catalog entry into the root package.json and a `catalog:` reference into the target. After the install it derives the catalog sections of bun.lock from the final package.json files. The re-install check proves that derivation matched: a second `bun install` finds nothing to save.
- A re-install check costs one spawn and does not touch the registry, so it costs the same as the command under test. That is why the count of these checks, and not the work each `bun add` does, decides the wall time of this file.
- bun.lock keys a package by its name when it is hoisted and by `<workspace>/<name>` when it is nested under a workspace. `lockState().resolved` uses those keys, so a test with two resolutions of one name shows both.

<details>
<summary>Measurements and levers that did not pay</summary>

Spawns before (counted by wrapping `Bun.spawn`): 144 `add`, 34 setup installs, 64 re-installs, 18 `--frozen-lockfile`, 3 `install <pkg>`, 5 `update`, 2 `pm pack`, 2 `remove`. After: 144, 31, 33, 6, 3, 5, 2, 2.

Per spawn on the debug asan build, uncontended: `bun --version` 106 ms, `bun add --catalog` with a fresh cache 145 to 180 ms, no-op `bun install` 148 ms, `bun add --dry-run` 190 ms, `--lockfile-only` 183 ms. So flags that skip the install work do not save anything.

In-flight spawns during the file never exceeded 5, which is the asan default for `--max-concurrency`. The nested plain describes do inherit the concurrency. Completion order interleaves across describes.

A warm cache copied into every test dir (one `bun install` in `beforeAll`, `cpSync` per test) makes every `bun add` resolve without a registry request, because a cached manifest is fresh for 300 s (`src/install/npm.rs:578`). It still lost about 3 s here: the `cpSync` runs in the sanitized runner process and costs more than the downloads it saves. Not included.

With `CI` set, the harness runs verdaccio on the build under test. On the debug build that start takes 32 s here. The 149 tests take the same 13 to 14 s either way, so request serving is not the bottleneck on the asan lane either. That start time belongs to the harness and is out of scope for this file.

`test.each` tables were not introduced. They would not remove a spawn, and they rename tests, which #36284 and the slow-test tracking key on.

Observation, unrelated to catalogs: after a package was installed from a tarball url or a local tarball, every later `bun install` prints `1 package installed` for it again (reproduced with plain `bun add <url>` in a project without workspaces, released build). The lockfile is not re-saved. The `relinks` option in `installSavesNothing` only skips the `(no changes)` check for the six tests with such a package.
</details>
