### PR TITLE
Buffer#copy: keep offsets above MAX_SAFE_INTEGER instead of turning them into 0

### DIFF
--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -1175,14 +1175,24 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
     RELEASE_AND_RETURN(throwScope, JSC::JSValue::encode(JSC::jsNumber(normalizeCompareVal(result, sourceLength, targetLength))));
 }
 
-static double toInteger(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value, double defaultVal)
+// Node coerces each Buffer#copy offset with `NumberIsInteger(n) ? n : toInteger(n, 0)`:
+// an integral number is used as is, whatever its magnitude, so 2**53 is still
+// compared against the buffer lengths below (and rejected or clamped there)
+// instead of turning into offset 0. Everything else goes through toInteger():
+// NaN, +-Infinity and values outside the safe-integer range become 0, and
+// fractions round down (-0.5 becomes -1, which the callers reject).
+static double toCopyOffset(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSValue value)
 {
-    auto n = value.toNumber(globalObject);
+    if (value.isNumber()) {
+        double n = value.asNumber();
+        if (std::isfinite(n) && std::trunc(n) == n) return n;
+    }
+    double n = value.toNumber(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
-    if (std::isnan(n)) return defaultVal;
-    if (n < JSC::minSafeInteger()) return defaultVal;
-    if (n > JSC::maxSafeInteger()) return defaultVal;
-    return std::trunc(n);
+    if (std::isnan(n)) return 0;
+    if (n < JSC::minSafeInteger()) return 0;
+    if (n > JSC::maxSafeInteger()) return 0;
+    return std::floor(n);
 }
 
 // https://github.com/nodejs/node/blob/v22.9.0/lib/buffer.js#L825
@@ -1214,22 +1224,27 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_copyBody(JSC::JSGlobalObjec
     // so the memmove stays inside the current logical range, even if
     // valueOf resized the buffer after its own argument was checked.
     //
-    // toInteger() calls toNumber() which invokes user valueOf /
+    // toCopyOffset() calls toNumber() which invokes user valueOf /
     // Symbol.toPrimitive. Those callbacks can transfer() (detach →
     // vector() returns nullptr) or resize() a resizable ArrayBuffer
     // (pointer stays valid, logical length shrinks). The final clamp
     // handles both: a detached buffer has byteLength 0 → sourceStart >=
     // sourceEnd → we return 0 without touching the null vector.
+    //
+    // The offsets stay doubles until the range checks are done: a
+    // coerced offset can be any integral double (2**53, 1e308), and
+    // converting one of those to size_t before comparing it against the
+    // buffer lengths is undefined behavior.
     double targetStartD = 0;
     if (!targetStartValue.isUndefined()) {
-        targetStartD = targetStartValue.isAnyInt() ? targetStartValue.asNumber() : toInteger(throwScope, lexicalGlobalObject, targetStartValue, 0);
+        targetStartD = toCopyOffset(throwScope, lexicalGlobalObject, targetStartValue);
         RETURN_IF_EXCEPTION(throwScope, {});
-        if (targetStartD < 0) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "targetStart"_s, ">= 0"_s, targetStartValue);
+        if (targetStartD < 0) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "targetStart"_s, ">= 0"_s, jsNumber(targetStartD));
     }
 
     double sourceStartD = 0;
     if (!sourceStartValue.isUndefined()) {
-        sourceStartD = sourceStartValue.isAnyInt() ? sourceStartValue.asNumber() : toInteger(throwScope, lexicalGlobalObject, sourceStartValue, 0);
+        sourceStartD = toCopyOffset(throwScope, lexicalGlobalObject, sourceStartValue);
         RETURN_IF_EXCEPTION(throwScope, {});
         // sourceStart is bound-checked against source.length as seen
         // here — BEFORE the later sourceEnd coercion gets a chance to
@@ -1237,15 +1252,15 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_copyBody(JSC::JSGlobalObjec
         // original length must stay valid even if sourceEnd's valueOf
         // resizes mid-call (Node behavior: the call then just copies 0).
         auto sourceLengthAtCheck = source->byteLength();
-        if (sourceStartD < 0 || sourceStartD > sourceLengthAtCheck) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "sourceStart"_s, makeString(">= 0 && <= "_s, sourceLengthAtCheck), sourceStartValue);
+        if (sourceStartD < 0 || sourceStartD > static_cast<double>(sourceLengthAtCheck)) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "sourceStart"_s, makeString(">= 0 && <= "_s, sourceLengthAtCheck), jsNumber(sourceStartD));
     }
 
     bool sourceEndGiven = !sourceEndValue.isUndefined();
     double sourceEndD = 0;
     if (sourceEndGiven) {
-        sourceEndD = sourceEndValue.isAnyInt() ? sourceEndValue.asNumber() : toInteger(throwScope, lexicalGlobalObject, sourceEndValue, 0);
+        sourceEndD = toCopyOffset(throwScope, lexicalGlobalObject, sourceEndValue);
         RETURN_IF_EXCEPTION(throwScope, {});
-        if (sourceEndD < 0) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "sourceEnd"_s, ">= 0"_s, sourceEndValue);
+        if (sourceEndD < 0) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "sourceEnd"_s, ">= 0"_s, jsNumber(sourceEndD));
     }
 
     // Single post-coercion read for the hot path. byteLength is 0 for a
@@ -1254,16 +1269,20 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_copyBody(JSC::JSGlobalObjec
     auto sourceLength = source->byteLength();
     auto targetLength = target->byteLength();
 
-    size_t targetStart = static_cast<size_t>(targetStartD);
-    size_t sourceStart = static_cast<size_t>(sourceStartD);
     // If valueOf resized the source smaller, don't read past the new end
     // even if the user passed a larger sourceEnd — that would bypass the
     // JS-enforced resize boundary and leak hidden bytes into target.
-    size_t sourceEnd = sourceEndGiven ? std::min<size_t>(static_cast<size_t>(sourceEndD), sourceLength) : sourceLength;
+    if (!sourceEndGiven || sourceEndD > static_cast<double>(sourceLength))
+        sourceEndD = static_cast<double>(sourceLength);
 
-    if (targetStart >= targetLength || sourceStart >= sourceEnd) {
+    if (targetStartD >= static_cast<double>(targetLength) || sourceStartD >= sourceEndD) {
         return JSValue::encode(jsNumber(0));
     }
+
+    // Every offset is now below the length of a live buffer, so it fits a size_t.
+    size_t targetStart = static_cast<size_t>(targetStartD);
+    size_t sourceStart = static_cast<size_t>(sourceStartD);
+    size_t sourceEnd = static_cast<size_t>(sourceEndD);
 
     if (sourceEnd - sourceStart > targetLength - targetStart)
         sourceEnd = sourceStart + (targetLength - targetStart);

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -4739,6 +4739,86 @@ describe("detached buffers in compare, equals, swapNN and as a fill value", () =
   });
 });
 
+// Expected values are Node's (v26). Node uses an integral number as the offset as
+// is, whatever its magnitude, and only sends other values through toInteger()
+// (NaN, +-Infinity and anything outside the safe-integer range become 0,
+// fractions round down). An offset >= 2**53 used to take the toInteger() path
+// here and silently become 0.
+describe("Buffer.prototype.copy offset coercion", () => {
+  function copyInto(...args) {
+    const target = Buffer.alloc(8, ".");
+    try {
+      const copied = Buffer.from("ABCDEFGH").copy(target, ...args);
+      return { copied, target: target.toString("latin1") };
+    } catch (e) {
+      return { code: e.code, message: e.message };
+    }
+  }
+
+  const untouched = { copied: 0, target: "........" };
+  const whole = { copied: 8, target: "ABCDEFGH" };
+
+  it.each([
+    [2 ** 53, untouched],
+    [2 ** 52 + 3, untouched],
+    [1e308, untouched],
+    [Infinity, whole],
+    [-Infinity, whole],
+    [NaN, whole],
+    ["2", { copied: 6, target: "..ABCDEF" }],
+    [1.5, { copied: 7, target: ".ABCDEFG" }],
+    [
+      -0.5,
+      { code: "ERR_OUT_OF_RANGE", message: 'The value of "targetStart" is out of range. It must be >= 0. Received -1' },
+    ],
+  ])("targetStart %p", (targetStart, expected) => {
+    expect(copyInto(targetStart)).toEqual(expected);
+  });
+
+  it.each([
+    [
+      2 ** 53,
+      {
+        code: "ERR_OUT_OF_RANGE",
+        message: 'The value of "sourceStart" is out of range. It must be >= 0 && <= 8. Received 9_007_199_254_740_992',
+      },
+    ],
+    [1e308, { code: "ERR_OUT_OF_RANGE", message: expect.stringContaining('"sourceStart" is out of range') }],
+    [Infinity, whole],
+    [2.9, { copied: 6, target: "CDEFGH.." }],
+    [
+      -0.5,
+      {
+        code: "ERR_OUT_OF_RANGE",
+        message: 'The value of "sourceStart" is out of range. It must be >= 0 && <= 8. Received -1',
+      },
+    ],
+  ])("sourceStart %p", (sourceStart, expected) => {
+    expect(copyInto(0, sourceStart)).toEqual(expected);
+  });
+
+  it.each([
+    [2 ** 53, whole],
+    [1e308, whole],
+    [Infinity, untouched],
+    [-Infinity, untouched],
+    [2.9, { copied: 2, target: "AB......" }],
+    [
+      -0.5,
+      { code: "ERR_OUT_OF_RANGE", message: 'The value of "sourceEnd" is out of range. It must be >= 0. Received -1' },
+    ],
+  ])("sourceEnd %p", (sourceEnd, expected) => {
+    expect(copyInto(0, 0, sourceEnd)).toEqual(expected);
+  });
+
+  it("checks sourceStart even when targetStart is already past the target", () => {
+    expect(copyInto(2 ** 53, 2 ** 53)).toEqual({
+      code: "ERR_OUT_OF_RANGE",
+      message: 'The value of "sourceStart" is out of range. It must be >= 0 && <= 8. Received 9_007_199_254_740_992',
+    });
+  });
+});
+
 describe("Buffer.copyBytesFrom", () => {
   it("copies the correct bytes from a Uint8Array view with a non-zero byteOffset", () => {
     const ab = new ArrayBuffer(10);


### PR DESCRIPTION
### Problem
- `Buffer.prototype.copy` turns any offset at or above 2^53 into 0. `src.copy(target, 2 ** 53)` overwrites `target[0..]` and returns 8. `src.copy(target, 0, 2 ** 53)` copies from offset 0. `src.copy(target, 0, 0, 2 ** 53)` copies nothing. Node returns 0, throws `ERR_OUT_OF_RANGE`, and copies the whole source, in that order.
- Cause: `toInteger()` in `src/jsc/bindings/JSBuffer.cpp:1178` returns the default value 0 for every number outside the safe-integer range. The `isAnyInt()` fast path in front of it only covers values that fit 52 bits, so 2^53 and 1e308 take the `toInteger()` path.
- A second, smaller difference has the same cause: `toInteger()` truncates, Node rounds down. So `src.copy(target, -0.5)` copies in Bun and throws in Node.
- Not a regression. Bun 1.3.14 has the same behavior.

### Fix
- `toCopyOffset()` follows Node's `copyImpl`: an integral number is used as is, whatever its magnitude. Other values are coerced, NaN, +-Infinity and values outside the safe-integer range become 0, and fractions round down.
- The three offsets stay doubles until the range checks are done. A check of 2^53 against the buffer length is exact in a double. Converting such a double to `size_t` first is undefined behavior. After the early return every offset is below a buffer length, so the conversion is safe.
- The `ERR_OUT_OF_RANGE` messages now report the coerced value, as Node does (`Received -1` for `-0.5`).
- Verified with `test/js/node/buffer.test.js` ("Buffer.prototype.copy offset coercion", 21 cases, expected values taken from Node v26.3.0). 10 cases fail on main and pass with this change.
- `bun bd test test/js/node/buffer.test.js`: 666 pass.
- `bun bd test/js/node/test/parallel/test-buffer-copy.js` and `test-buffer-alloc.js`: exit 0.

### Background
`Buffer#copy(target, targetStart, sourceStart, sourceEnd)` is implemented in C++ in `jsBufferPrototypeFunction_copyBody`. Node's version (`copyImpl` in `lib/buffer.js`) coerces each offset with `NumberIsInteger(n) ? n : toInteger(n, 0)`. `toInteger()` is Node's helper that maps NaN, infinities and unsafe integers to a default and rounds everything else down. The bug was that Bun applied the `toInteger()` half to integral numbers too, once they were too large for the `isAnyInt()` fast path. The large offsets matter because the bounds checks that follow are what reject or clamp them. Turning them into 0 skips those checks and writes to the wrong place with a success return.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/buffer.test.js

<!-- robobun:evidence:end -->