### PR TITLE
Bun.file().arrayBuffer(): stop panicking at 4 GiB, throw above the ArrayBuffer limit

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -630,14 +630,12 @@ impl JSValue {
     }
     /// `JSValue.createBufferWithCtx` — wrap a foreign-owned byte
     /// range in a Node `Buffer`, transferring ownership to JS. `free(ptr, ctx)`
-    /// runs when the Buffer's backing store is collected, or before this
-    /// returns `Err` (a length above JSC's limit, for example), so the caller
-    /// must not release the bytes again on `Err`.
+    /// runs exactly once: when the Buffer's backing store is collected, or
+    /// before this returns `Err`.
     ///
     /// # Safety
     /// `bytes` must describe a valid allocation whose ownership transfers to
-    /// JSC; `ctx` is forwarded to `free`, on collection or on failure, and must
-    /// remain valid until then.
+    /// JSC; `ctx` must remain valid until `free` runs.
     pub unsafe fn create_buffer_with_ctx(
         global: &JSGlobalObject,
         bytes: core::ptr::NonNull<[u8]>,

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -629,13 +629,15 @@ impl JSValue {
         })
     }
     /// `JSValue.createBufferWithCtx` — wrap a foreign-owned byte
-    /// range in a Node `Buffer`, transferring ownership to JS. `free(ctx, ptr)`
-    /// runs when the Buffer's backing store is collected.
+    /// range in a Node `Buffer`, transferring ownership to JS. `free(ptr, ctx)`
+    /// runs when the Buffer's backing store is collected, or before this
+    /// returns `Err` (a length above JSC's limit, for example), so the caller
+    /// must not release the bytes again on `Err`.
     ///
     /// # Safety
     /// `bytes` must describe a valid allocation whose ownership transfers to
-    /// JSC; `ctx` is forwarded to `free` on collection and must remain valid
-    /// until then.
+    /// JSC; `ctx` is forwarded to `free`, on collection or on failure, and must
+    /// remain valid until then.
     pub unsafe fn create_buffer_with_ctx(
         global: &JSGlobalObject,
         bytes: core::ptr::NonNull<[u8]>,

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -387,8 +387,10 @@ impl ArrayBuffer {
         }
     }
 
-    /// The length is not range-checked here: `to_js*` hands it to
-    /// `Bun__make*WithBytesNoCopy`, which throws a RangeError for anything
+    /// The length is not range-checked here. The C++ side that adopts the bytes
+    /// (`Bun__make*WithBytesNoCopy` behind `to_js*`,
+    /// `JSBuffer__bufferFromPointerAndLengthAndDeinit` behind
+    /// `MarkedArrayBuffer::to_node_buffer`) throws a RangeError for anything
     /// above JSC's `MAX_ARRAY_BUFFER_SIZE` (2^32 bytes on 64-bit targets).
     pub fn from_bytes(bytes: &mut [u8], typed_array_type: JSType) -> ArrayBuffer {
         ArrayBuffer {
@@ -522,7 +524,10 @@ impl ArrayBuffer {
 
     /// Hand this descriptor's bytes to JSC with a caller-supplied finalizer:
     /// `callback(self.ptr, deallocator)` runs on the JS thread when the
-    /// returned object is collected (never, if `callback` is `None`).
+    /// returned object is collected, or before this returns `Err` (never, if
+    /// `callback` is `None`). Fails like [`make_array_buffer_with_bytes_no_copy`]
+    /// when `self.byte_len` is above JSC's limit: the bytes are consumed either
+    /// way, so the caller must not release them again on `Err`.
     ///
     /// # Safety
     ///
@@ -530,8 +535,8 @@ impl ArrayBuffer {
     /// bytes and stay valid (including for writes) for the returned object's
     /// entire lifetime: until `callback` runs, or indefinitely when
     /// `callback` is `None`. `callback`, if `Some`, must be sound to invoke
-    /// exactly once with `(self.ptr, deallocator)` at GC time, and
-    /// `deallocator` must remain valid until then.
+    /// exactly once with `(self.ptr, deallocator)`, either at GC time or when
+    /// this call fails, and `deallocator` must remain valid until then.
     pub unsafe fn to_js_with_context(
         self,
         ctx: &JSGlobalObject,

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -387,11 +387,8 @@ impl ArrayBuffer {
         }
     }
 
-    /// The length is not range-checked here. The C++ side that adopts the bytes
-    /// (`Bun__make*WithBytesNoCopy` behind `to_js*`,
-    /// `JSBuffer__bufferFromPointerAndLengthAndDeinit` behind
-    /// `MarkedArrayBuffer::to_node_buffer`) throws a RangeError for anything
-    /// above JSC's `MAX_ARRAY_BUFFER_SIZE` (2^32 bytes on 64-bit targets).
+    /// Any length is accepted here; the C++ side that adopts the bytes throws a
+    /// RangeError above JSC's `MAX_ARRAY_BUFFER_SIZE`.
     pub fn from_bytes(bytes: &mut [u8], typed_array_type: JSType) -> ArrayBuffer {
         ArrayBuffer {
             len: bytes.len(),
@@ -523,11 +520,9 @@ impl ArrayBuffer {
     }
 
     /// Hand this descriptor's bytes to JSC with a caller-supplied finalizer:
-    /// `callback(self.ptr, deallocator)` runs on the JS thread when the
-    /// returned object is collected, or before this returns `Err` (never, if
-    /// `callback` is `None`). Fails like [`make_array_buffer_with_bytes_no_copy`]
-    /// when `self.byte_len` is above JSC's limit: the bytes are consumed either
-    /// way, so the caller must not release them again on `Err`.
+    /// `callback(self.ptr, deallocator)` runs exactly once on the JS thread,
+    /// when the returned object is collected or before this returns `Err`
+    /// (never, if `callback` is `None`).
     ///
     /// # Safety
     ///
@@ -535,8 +530,8 @@ impl ArrayBuffer {
     /// bytes and stay valid (including for writes) for the returned object's
     /// entire lifetime: until `callback` runs, or indefinitely when
     /// `callback` is `None`. `callback`, if `Some`, must be sound to invoke
-    /// exactly once with `(self.ptr, deallocator)`, either at GC time or when
-    /// this call fails, and `deallocator` must remain valid until then.
+    /// once with `(self.ptr, deallocator)`, and `deallocator` must remain
+    /// valid until then.
     pub unsafe fn to_js_with_context(
         self,
         ctx: &JSGlobalObject,
@@ -951,13 +946,10 @@ pub use bun_alloc::c_thunks::mi_free_bytes as MarkedArrayBuffer_deallocator;
 
 /// Wrap caller-provided bytes in a JS `ArrayBuffer` without copying. JSC
 /// adopts `ptr..ptr+len` as the backing store of the returned object and
-/// calls `deallocator(ptr, deallocator_context)` on the JS thread when it is
-/// collected (never, if `deallocator` is `None`).
-///
-/// Fails with a RangeError when `len` is above JSC's `MAX_ARRAY_BUFFER_SIZE`
-/// (2^32 bytes on 64-bit targets). The bytes are still consumed: the
-/// deallocator runs before the error is returned, so the caller must not
-/// release them again on `Err`.
+/// calls `deallocator(ptr, deallocator_context)` exactly once on the JS
+/// thread: when the object is collected, or before this returns `Err`
+/// (a `len` above `MAX_ARRAY_BUFFER_SIZE` is a RangeError). Never, if
+/// `deallocator` is `None`.
 ///
 /// # Safety
 ///
@@ -965,10 +957,9 @@ pub use bun_alloc::c_thunks::mi_free_bytes as MarkedArrayBuffer_deallocator;
 ///   both through the returned object) for the returned object's entire
 ///   lifetime: until the deallocator runs, or indefinitely when `deallocator`
 ///   is `None`. `ptr` may be null only when `len == 0`.
-/// - `deallocator`, if `Some`, must be sound to call exactly once with
-///   `(ptr, deallocator_context)` on the JS thread, either at GC time or
-///   when this call fails, and `deallocator_context` must remain valid
-///   until then.
+/// - `deallocator`, if `Some`, must be sound to call once with
+///   `(ptr, deallocator_context)` on the JS thread, and `deallocator_context`
+///   must remain valid until then.
 pub(crate) unsafe fn make_array_buffer_with_bytes_no_copy(
     global: &JSGlobalObject,
     ptr: *mut c_void,

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -387,10 +387,13 @@ impl ArrayBuffer {
         }
     }
 
+    /// The length is not range-checked here: `to_js*` hands it to
+    /// `Bun__make*WithBytesNoCopy`, which throws a RangeError for anything
+    /// above JSC's `MAX_ARRAY_BUFFER_SIZE` (2^32 bytes on 64-bit targets).
     pub fn from_bytes(bytes: &mut [u8], typed_array_type: JSType) -> ArrayBuffer {
         ArrayBuffer {
-            len: u32::try_from(bytes.len()).expect("int cast") as usize,
-            byte_len: u32::try_from(bytes.len()).expect("int cast") as usize,
+            len: bytes.len(),
+            byte_len: bytes.len(),
             typed_array_type,
             ptr: bytes.as_mut_ptr(),
             ..Default::default()
@@ -411,8 +414,8 @@ impl ArrayBuffer {
         // this is an FFI hand-off, not a leak.
         let ptr = bun_core::heap::into_raw(bytes).cast::<u8>();
         ArrayBuffer {
-            len: u32::try_from(len).expect("int cast") as usize,
-            byte_len: u32::try_from(len).expect("int cast") as usize,
+            len,
+            byte_len: len,
             typed_array_type,
             ptr,
             ..Default::default()
@@ -946,6 +949,11 @@ pub use bun_alloc::c_thunks::mi_free_bytes as MarkedArrayBuffer_deallocator;
 /// calls `deallocator(ptr, deallocator_context)` on the JS thread when it is
 /// collected (never, if `deallocator` is `None`).
 ///
+/// Fails with a RangeError when `len` is above JSC's `MAX_ARRAY_BUFFER_SIZE`
+/// (2^32 bytes on 64-bit targets). The bytes are still consumed: the
+/// deallocator runs before the error is returned, so the caller must not
+/// release them again on `Err`.
+///
 /// # Safety
 ///
 /// - `ptr` must be valid for reads and writes of `len` bytes (JS code can do
@@ -953,8 +961,9 @@ pub use bun_alloc::c_thunks::mi_free_bytes as MarkedArrayBuffer_deallocator;
 ///   lifetime: until the deallocator runs, or indefinitely when `deallocator`
 ///   is `None`. `ptr` may be null only when `len == 0`.
 /// - `deallocator`, if `Some`, must be sound to call exactly once with
-///   `(ptr, deallocator_context)` on the JS thread at GC time, and
-///   `deallocator_context` must remain valid until then.
+///   `(ptr, deallocator_context)` on the JS thread, either at GC time or
+///   when this call fails, and `deallocator_context` must remain valid
+///   until then.
 pub(crate) unsafe fn make_array_buffer_with_bytes_no_copy(
     global: &JSGlobalObject,
     ptr: *mut c_void,

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -2599,8 +2599,6 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObje
     RELEASE_AND_RETURN(scope, writeToBuffer(lexicalGlobalObject, castedThis, str, offset, length, encoding));
 }
 
-// The mapping's length travels in the deallocator context, which is the shape
-// rejectBytesNoCopyAboveArrayBufferLimit and the collection path share.
 static void unmapBufferBytes(void* mapping, void* lengthAsContext)
 {
 #if !OS(WINDOWS)

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -380,16 +380,30 @@ public:
 
 }
 
+bool Bun::rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, const void* bytes, size_t length, JSTypedArrayBytesDeallocator deallocator, void* deallocatorContext)
+{
+    if (length <= MAX_ARRAY_BUFFER_SIZE) [[likely]]
+        return false;
+
+    if (deallocator)
+        deallocator(const_cast<void*>(bytes), deallocatorContext);
+    JSC::throwOutOfMemoryError(globalObject, scope);
+    return true;
+}
+
 JSC::EncodedJSValue JSBuffer__bufferFromPointerAndLengthAndDeinit(JSC::JSGlobalObject* lexicalGlobalObject, char* ptr, size_t length, void* ctx, JSTypedArrayBytesDeallocator bytesDeallocator)
 {
     JSC::JSUint8Array* uint8Array = nullptr;
 
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto* subclassStructure = globalObject->JSBufferSubclassStructure();
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(lexicalGlobalObject->vm());
+    auto scope = DECLARE_THROW_SCOPE(lexicalGlobalObject->vm());
 
     if (length > 0) [[likely]] {
         ASSERT(bytesDeallocator);
+        if (Bun::rejectBytesNoCopyAboveArrayBufferLimit(lexicalGlobalObject, scope, ptr, length, bytesDeallocator, ctx)) [[unlikely]]
+            return {};
+
         auto buffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(ptr), length }, createSharedTask<void(void*)>([=](void* p) {
             bytesDeallocator(p, ctx);
         }));
@@ -2585,19 +2599,31 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObje
     RELEASE_AND_RETURN(scope, writeToBuffer(lexicalGlobalObject, castedThis, str, offset, length, encoding));
 }
 
+// The mapping's length travels in the deallocator context, which is the shape
+// rejectBytesNoCopyAboveArrayBufferLimit and the collection path share.
+static void unmapBufferBytes(void* mapping, void* lengthAsContext)
+{
+#if !OS(WINDOWS)
+    munmap(mapping, reinterpret_cast<size_t>(lengthAsContext));
+#else
+    UNUSED_PARAM(lengthAsContext);
+    UnmapViewOfFile(mapping);
+#endif
+}
+
 extern "C" JSC::EncodedJSValue JSBuffer__fromMmap(Zig::GlobalObject* globalObject, void* ptr, size_t length)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    void* lengthAsContext = reinterpret_cast<void*>(length);
+    if (Bun::rejectBytesNoCopyAboveArrayBufferLimit(globalObject, scope, ptr, length, unmapBufferBytes, lengthAsContext)) [[unlikely]]
+        return {};
+
     auto* structure = globalObject->JSBufferSubclassStructure();
 
-    auto buffer = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(ptr), length }, createSharedTask<void(void*)>([length](void* p) {
-#if !OS(WINDOWS)
-        munmap(p, length);
-#else
-        UnmapViewOfFile(p);
-#endif
+    auto buffer = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(ptr), length }, createSharedTask<void(void*)>([lengthAsContext](void* p) {
+        unmapBufferBytes(p, lengthAsContext);
     }));
 
     auto* view = JSC::JSUint8Array::create(globalObject, structure, WTF::move(buffer), 0, length);

--- a/src/jsc/bindings/JSBuffer.h
+++ b/src/jsc/bindings/JSBuffer.h
@@ -40,12 +40,9 @@ namespace Bun {
 
 std::optional<size_t> byteLength(JSC::JSString* str, JSC::JSGlobalObject* lexicalGlobalObject, WebCore::BufferEncodingType encoding);
 
-// For the functions that adopt caller-owned bytes as the backing store of a new
-// ArrayBuffer or view. JSC::ArrayBuffer::createFromBytes RELEASE_ASSERTs above
-// MAX_ARRAY_BUFFER_SIZE, so such a length has to become the RangeError that
-// `new ArrayBuffer(length)` throws before the bytes reach it. The caller already
-// gave the bytes up, so they are released through the deallocator here, the same
-// as when the object would have been collected. Returns true once it has thrown.
+// ArrayBuffer::createFromBytes RELEASE_ASSERTs above MAX_ARRAY_BUFFER_SIZE. Above
+// it, this releases the adopted bytes through the deallocator, throws the
+// RangeError `new ArrayBuffer(length)` would throw, and returns true.
 bool rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject*, JSC::ThrowScope&, const void* bytes, size_t length, JSTypedArrayBytesDeallocator, void* deallocatorContext);
 
 namespace Buffer {

--- a/src/jsc/bindings/JSBuffer.h
+++ b/src/jsc/bindings/JSBuffer.h
@@ -23,6 +23,7 @@
 #include "root.h"
 
 #include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/ThrowScope.h>
 #include <wtf/NeverDestroyed.h>
 
 #include "BufferEncodingType.h"
@@ -38,6 +39,14 @@ extern "C" bool JSBuffer__isBuffer(JSC::JSGlobalObject*, JSC::EncodedJSValue);
 namespace Bun {
 
 std::optional<size_t> byteLength(JSC::JSString* str, JSC::JSGlobalObject* lexicalGlobalObject, WebCore::BufferEncodingType encoding);
+
+// For the functions that adopt caller-owned bytes as the backing store of a new
+// ArrayBuffer or view. JSC::ArrayBuffer::createFromBytes RELEASE_ASSERTs above
+// MAX_ARRAY_BUFFER_SIZE, so such a length has to become the RangeError that
+// `new ArrayBuffer(length)` throws before the bytes reach it. The caller already
+// gave the bytes up, so they are released through the deallocator here, the same
+// as when the object would have been collected. Returns true once it has thrown.
+bool rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject*, JSC::ThrowScope&, const void* bytes, size_t length, JSTypedArrayBytesDeallocator, void* deallocatorContext);
 
 namespace Buffer {
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1431,8 +1431,7 @@ extern "C" JSC::EncodedJSValue ArrayBuffer__fromSharedMemfd(int64_t fd, JSC::JSG
 // Windows doesn't have mmap
 // This code should pretty much only be called on Linux.
 #if !OS(WINDOWS)
-    // An empty result makes the caller fall back to a copying allocation, which
-    // throws for this length. createFromBytes below would RELEASE_ASSERT instead.
+    // Empty makes the caller fall back to the copying path, which throws for this length.
     if (byteLength > MAX_ARRAY_BUFFER_SIZE) [[unlikely]] {
         return JSC::JSValue::encode(JSC::JSValue {});
     }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1431,6 +1431,12 @@ extern "C" JSC::EncodedJSValue ArrayBuffer__fromSharedMemfd(int64_t fd, JSC::JSG
 // Windows doesn't have mmap
 // This code should pretty much only be called on Linux.
 #if !OS(WINDOWS)
+    // An empty result makes the caller fall back to a copying allocation, which
+    // throws for this length. createFromBytes below would RELEASE_ASSERT instead.
+    if (byteLength > MAX_ARRAY_BUFFER_SIZE) [[unlikely]] {
+        return JSC::JSValue::encode(JSC::JSValue {});
+    }
+
     auto ptr = mmap(nullptr, totalLength, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
 
     if (ptr == MAP_FAILED) {
@@ -1521,10 +1527,29 @@ extern "C" JSC::EncodedJSValue Bun__createUint8ArrayForCopy(JSC::JSGlobalObject*
     RELEASE_AND_RETURN(scope, JSValue::encode(array));
 }
 
+// ArrayBuffer::createFromBytes RELEASE_ASSERTs above MAX_ARRAY_BUFFER_SIZE, so an
+// oversized length has to be turned into the RangeError `new ArrayBuffer(len)`
+// throws before the bytes reach it. The caller already gave the bytes up, so
+// they are released through the deallocator here, the same as when the
+// returned object is collected.
+static bool rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, const void* ptr, size_t len, JSTypedArrayBytesDeallocator deallocator, void* deallocatorContext)
+{
+    if (len <= MAX_ARRAY_BUFFER_SIZE) [[likely]]
+        return false;
+
+    if (deallocator)
+        deallocator(const_cast<void*>(ptr), deallocatorContext);
+    throwOutOfMemoryError(globalObject, scope);
+    return true;
+}
+
 extern "C" JSC::EncodedJSValue Bun__makeArrayBufferWithBytesNoCopy(JSC::JSGlobalObject* globalObject, const void* ptr, size_t len, JSTypedArrayBytesDeallocator deallocator, void* deallocatorContext)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (rejectBytesNoCopyAboveArrayBufferLimit(globalObject, scope, ptr, len, deallocator, deallocatorContext)) [[unlikely]]
+        return {};
 
     auto buffer = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(ptr), len }, createSharedTask<void(void*)>([=](void* p) {
         if (deallocator) deallocator(p, deallocatorContext);
@@ -1539,6 +1564,9 @@ extern "C" JSC::EncodedJSValue Bun__makeTypedArrayWithBytesNoCopy(JSC::JSGlobalO
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (rejectBytesNoCopyAboveArrayBufferLimit(globalObject, scope, ptr, len, deallocator, deallocatorContext)) [[unlikely]]
+        return {};
 
     auto buffer_ = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(ptr), len }, createSharedTask<void(void*)>([=](void* p) {
         if (deallocator) deallocator(p, deallocatorContext);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1527,28 +1527,12 @@ extern "C" JSC::EncodedJSValue Bun__createUint8ArrayForCopy(JSC::JSGlobalObject*
     RELEASE_AND_RETURN(scope, JSValue::encode(array));
 }
 
-// ArrayBuffer::createFromBytes RELEASE_ASSERTs above MAX_ARRAY_BUFFER_SIZE, so an
-// oversized length has to be turned into the RangeError `new ArrayBuffer(len)`
-// throws before the bytes reach it. The caller already gave the bytes up, so
-// they are released through the deallocator here, the same as when the
-// returned object is collected.
-static bool rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, const void* ptr, size_t len, JSTypedArrayBytesDeallocator deallocator, void* deallocatorContext)
-{
-    if (len <= MAX_ARRAY_BUFFER_SIZE) [[likely]]
-        return false;
-
-    if (deallocator)
-        deallocator(const_cast<void*>(ptr), deallocatorContext);
-    throwOutOfMemoryError(globalObject, scope);
-    return true;
-}
-
 extern "C" JSC::EncodedJSValue Bun__makeArrayBufferWithBytesNoCopy(JSC::JSGlobalObject* globalObject, const void* ptr, size_t len, JSTypedArrayBytesDeallocator deallocator, void* deallocatorContext)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (rejectBytesNoCopyAboveArrayBufferLimit(globalObject, scope, ptr, len, deallocator, deallocatorContext)) [[unlikely]]
+    if (Bun::rejectBytesNoCopyAboveArrayBufferLimit(globalObject, scope, ptr, len, deallocator, deallocatorContext)) [[unlikely]]
         return {};
 
     auto buffer = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(ptr), len }, createSharedTask<void(void*)>([=](void* p) {
@@ -1565,7 +1549,7 @@ extern "C" JSC::EncodedJSValue Bun__makeTypedArrayWithBytesNoCopy(JSC::JSGlobalO
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    if (rejectBytesNoCopyAboveArrayBufferLimit(globalObject, scope, ptr, len, deallocator, deallocatorContext)) [[unlikely]]
+    if (Bun::rejectBytesNoCopyAboveArrayBufferLimit(globalObject, scope, ptr, len, deallocator, deallocatorContext)) [[unlikely]]
         return {};
 
     auto buffer_ = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(ptr), len }, createSharedTask<void(void*)>([=](void* p) {

--- a/test/js/bun/util/mmap.test.js
+++ b/test/js/bun/util/mmap.test.js
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, gcTick, isWindows, tempDir, tmpdirSync } from "harness";
-import { writeFileSync } from "node:fs";
+import { truncateSync, writeFileSync } from "node:fs";
 import { join } from "path";
 
 // TODO: We do not support mmap() on Windows. Maybe we can add it later.
@@ -151,6 +151,51 @@ try {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("Path too long\n");
     expect(exitCode).toBe(0);
+  });
+
+  it("mmap of more than 2^32 bytes throws a RangeError instead of aborting", async () => {
+    using dir = tempDir("mmap-4gib", {});
+    const file = join(String(dir), "big.bin");
+    // Sparse: the mappings below cost address space, not memory or disk.
+    writeFileSync(file, "");
+    truncateSync(file, 2 ** 32 + 4096);
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const file = ${JSON.stringify(file)};
+const out = {};
+try {
+  out.wholeFile = Bun.mmap(file).length;
+} catch (e) {
+  out.wholeFile = e.name;
+}
+try {
+  out.sizeAboveLimit = Bun.mmap(file, { size: 2 ** 32 + 1 }).length;
+} catch (e) {
+  out.sizeAboveLimit = e.name;
+}
+out.sizeAtLimit = Bun.mmap(file, { size: 2 ** 32 }).length;
+out.smallWindow = Bun.mmap(file, { size: 4096 }).length;
+console.log(JSON.stringify(out));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim() || "null"), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      out: {
+        wholeFile: "RangeError",
+        sizeAboveLimit: "RangeError",
+        sizeAtLimit: 2 ** 32,
+        smallWindow: 4096,
+      },
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
   });
 
   it("mmap rejects negative offset", () => {

--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -222,3 +222,54 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB strin
     expect(exitCode).toBe(0);
   });
 });
+
+// An ArrayBuffer can hold at most 2^32 bytes (JSC's MAX_ARRAY_BUFFER_SIZE). The
+// file path hands the bytes it read to JSC without a copy; converting the
+// length through u32 on the way panicked at exactly 2^32, and JSC aborts when
+// it is asked to adopt more than that. The file is sparse, but each case still
+// reads a real 4 GiB into the child (about 6 seconds in a debug build, all of
+// it page faults), so it runs in a subprocess, gets a long timeout, and skips
+// on small machines like the 2 GiB cases above.
+describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("Bun.file().arrayBuffer() at the 4 GiB ArrayBuffer limit", () => {
+  async function readSparseFileAsArrayBuffer(size: number) {
+    using dir = tempDir("blob-4gib", {});
+    const file = path.join(String(dir), "big.bin");
+    // 'x' followed by a hole, which reads back as NUL bytes. Nothing is written
+    // after the truncate: on NTFS that would zero-fill the whole file on disk.
+    writeFileSync(file, "x");
+    truncateSync(file, size);
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const report = buf => {
+            const view = new DataView(buf);
+            return { byteLength: buf.byteLength, first: view.getUint8(0), last: view.getUint8(buf.byteLength - 1) };
+          };
+          const result = await Bun.file(${JSON.stringify(file)}).arrayBuffer().then(report, e => ({ error: { name: e.name, message: e.message } }));
+          console.log(JSON.stringify(result));
+          `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode, signalCode: proc.signalCode }));
+  }
+
+  test("a file of exactly 2^32 bytes is returned whole", async () => {
+    expect(await readSparseFileAsArrayBuffer(2 ** 32)).toEqual({
+      byteLength: 2 ** 32,
+      first: "x".charCodeAt(0),
+      last: 0,
+    });
+  }, 120_000);
+
+  test("a file of 2^32 + 1 bytes rejects with the RangeError that new ArrayBuffer() throws for that size", async () => {
+    expect(await readSparseFileAsArrayBuffer(2 ** 32 + 1)).toEqual({
+      error: { name: "RangeError", message: "Out of memory" },
+    });
+  }, 120_000);
+});

--- a/test/js/web/fetch/blob-oom.test.ts
+++ b/test/js/web/fetch/blob-oom.test.ts
@@ -1,7 +1,7 @@
 import { setSyntheticAllocationLimitForTesting } from "bun:internal-for-testing";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { truncateSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
 import os from "node:os";
 import path from "path";
 describe("Memory", () => {
@@ -188,7 +188,7 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB strin
       },
     ]);
     expect(exitCode).toBe(0);
-  });
+  }, 90_000);
 
   test("Bun.file().text() at 2^31 bytes throws ERR_STRING_TOO_LONG instead of aborting", async () => {
     using dir = tempDir("blob-2gib", {});
@@ -220,7 +220,9 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB strin
       },
     ]);
     expect(exitCode).toBe(0);
-  });
+    // Reads 2 GiB through the page cache; measured right at the default 5s
+    // ceiling under load.
+  }, 90_000);
 });
 
 // An ArrayBuffer can hold at most 2^32 bytes (JSC's MAX_ARRAY_BUFFER_SIZE). The
@@ -229,20 +231,24 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("byte sources at the 2 GiB strin
 // it is asked to adopt more than that. The file is sparse, but each case still
 // reads a real 4 GiB into the child (about 6 seconds in a debug build, all of
 // it page faults), so it runs in a subprocess, gets a long timeout, and skips
-// on small machines like the 2 GiB cases above.
-describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("Bun.file().arrayBuffer() at the 4 GiB ArrayBuffer limit", () => {
-  async function readSparseFileAsArrayBuffer(size: number) {
-    using dir = tempDir("blob-4gib", {});
-    const file = path.join(String(dir), "big.bin");
-    // 'x' followed by a hole, which reads back as NUL bytes. Nothing is written
-    // after the truncate: on NTFS that would zero-fill the whole file on disk.
-    writeFileSync(file, "x");
-    truncateSync(file, size);
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
+// on small machines like the 2 GiB cases above. On Windows the file reader
+// itself rejects files of 2^32 bytes or more with ENOMEM (read_file.rs,
+// ReadFileUV), so neither case reaches the ArrayBuffer hand-off there.
+describe.skipIf(isWindows || os.totalmem() < 10 * 1024 ** 3)(
+  "Bun.file().arrayBuffer() at the 4 GiB ArrayBuffer limit",
+  () => {
+    async function readSparseFileAsArrayBuffer(size: number) {
+      using dir = tempDir("blob-4gib", {});
+      const file = path.join(String(dir), "big.bin");
+      // 'x' followed by a hole, which reads back as NUL bytes. Nothing is written
+      // after the truncate: on NTFS that would zero-fill the whole file on disk.
+      writeFileSync(file, "x");
+      truncateSync(file, size);
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
           const report = buf => {
             const view = new DataView(buf);
             return { byteLength: buf.byteLength, first: view.getUint8(0), last: view.getUint8(buf.byteLength - 1) };
@@ -250,26 +256,27 @@ describe.skipIf(os.totalmem() < 10 * 1024 ** 3)("Bun.file().arrayBuffer() at the
           const result = await Bun.file(${JSON.stringify(file)}).arrayBuffer().then(report, e => ({ error: { name: e.name, message: e.message } }));
           console.log(JSON.stringify(result));
           `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode, signalCode: proc.signalCode }));
-  }
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return JSON.parse(stdout.trim() || JSON.stringify({ stdout, stderr, exitCode, signalCode: proc.signalCode }));
+    }
 
-  test("a file of exactly 2^32 bytes is returned whole", async () => {
-    expect(await readSparseFileAsArrayBuffer(2 ** 32)).toEqual({
-      byteLength: 2 ** 32,
-      first: "x".charCodeAt(0),
-      last: 0,
-    });
-  }, 120_000);
+    test("a file of exactly 2^32 bytes is returned whole", async () => {
+      expect(await readSparseFileAsArrayBuffer(2 ** 32)).toEqual({
+        byteLength: 2 ** 32,
+        first: "x".charCodeAt(0),
+        last: 0,
+      });
+    }, 120_000);
 
-  test("a file of 2^32 + 1 bytes rejects with the RangeError that new ArrayBuffer() throws for that size", async () => {
-    expect(await readSparseFileAsArrayBuffer(2 ** 32 + 1)).toEqual({
-      error: { name: "RangeError", message: "Out of memory" },
-    });
-  }, 120_000);
-});
+    test("a file of 2^32 + 1 bytes rejects with the RangeError that new ArrayBuffer() throws for that size", async () => {
+      expect(await readSparseFileAsArrayBuffer(2 ** 32 + 1)).toEqual({
+        error: { name: "RangeError", message: "Out of memory" },
+      });
+    }, 120_000);
+  },
+);


### PR DESCRIPTION
### Problem
- `await Bun.file(path).arrayBuffer()` on a file of exactly 2^32 bytes reads the whole file and then crashes with `panic: int cast: TryFromIntError(PosOverflow)`. The same happens through `new Response(Bun.file(path)).arrayBuffer()`. Bun 1.3.14 returns the 4294967296-byte ArrayBuffer, so this is a regression of the Rust port.
- Cause: `ArrayBuffer::from_bytes` and `from_owned_bytes` (`src/jsc/array_buffer.rs:392`) convert the length through `u32` with `expect` before they store it in a `usize` field. The read path reaches them from `Blob.rs:3074` with the bytes it read.
- Behind that panic sits a second failure. JSC's `ArrayBuffer::createFromBytes` RELEASE_ASSERTs when it is given more than `MAX_ARRAY_BUFFER_SIZE` (2^32) bytes. `Bun.mmap()` of a file larger than 4 GiB aborts there today, and a file of 2^32 + 1 bytes would abort there once the panic is gone.

### Fix
- `from_bytes` and `from_owned_bytes` store the length as is. A file of exactly 2^32 bytes is returned whole again.
- `Bun::rejectBytesNoCopyAboveArrayBufferLimit` (`JSBuffer.cpp`) rejects a length above `MAX_ARRAY_BUFFER_SIZE` with the `RangeError: Out of memory` that `new ArrayBuffer(2 ** 32 + 1)` throws. The four functions that adopt bytes from Rust call it before `createFromBytes`: `Bun__makeArrayBufferWithBytesNoCopy` and `Bun__makeTypedArrayWithBytesNoCopy` (every `ArrayBuffer::to_js*` call, and `Bun.mmap`), `JSBuffer__bufferFromPointerAndLengthAndDeinit` (`create_buffer*`, `to_node_buffer`) and `JSBuffer__fromMmap` (`to_js_buffer_from_memfd`).
- The caller has already handed the bytes over, so the helper runs the deallocator before it throws. That frees the read buffer, unmaps the mapping, or drops the Blob store reference, exactly as a collection would. The typed array function already ran the deallocator when creation failed after `createFromBytes`, and the Buffer function already runs it for an empty length, so no caller releases the bytes twice. The doc comments on the Rust wrappers state this.
- `ArrayBuffer__fromSharedMemfd` returns an empty value for such a length. Its only caller (`Blob.rs`, the `Clone` arm) then falls back to the copying allocation, which already throws the same RangeError.
- Verified with `test/js/web/fetch/blob-oom.test.ts` ("at the 4 GiB ArrayBuffer limit"): a sparse file of 2^32 bytes comes back whole, and a file of 2^32 + 1 bytes rejects with the RangeError. On main both cases die with the panic above after reading 4 GiB. The block skips below 10 GiB of RAM and on Windows, where the file reader itself rejects files of 2^32 bytes or more with ENOMEM (`read_file.rs`, `ReadFileUV`). Each case has a 120 s timeout, like the 2 GiB cases in the same file (about 6 s each in a debug build here). The two existing 2 GiB cases get the 90 s timeout they already needed on loaded debug builds.
- Verified with `test/js/bun/util/mmap.test.js`: a sparse file of 2^32 + 4096 bytes throws a RangeError from `Bun.mmap(file)` and from `{ size: 2 ** 32 + 1 }`, while `{ size: 2 ** 32 }` still maps. On main the first call aborts with SIGABRT. This case costs address space only.
- The two Buffer entry points have no test of their own. The only way to reach them with such a length is more than 4 GiB of piped subprocess output (`to_js_buffer_from_memfd` is not reachable from JS today: a buffer or blob is not accepted as stdout). They call the same helper the two tests above exercise.
- `bun bd test` on `blob.test.ts`, `blob-cow.test.ts`, `body.test.ts`, `zstd.test.ts`, `ffi.test.js`, `spawn.test.ts` and `buffer.test.js`: all pass.
- Related open PRs. #33353 removes the same `u32` conversion for `bun:ffi` and adds a check in the FFI layer. #34119 adds a `Bun.mmap` message with the byte count in `BunObject.rs`. #37243 covers in-memory string and `InternalBlob` bodies, which take the separate `fromDefaultAllocator` path. All three still apply on top of this change. The mmap test here only checks the error name, so it holds with or without #34119.

### Background
A Blob that is backed by a file is read on a thread into a Rust buffer. To return it as an `ArrayBuffer` without a copy, Bun builds an `ArrayBuffer` descriptor (`ptr`, `len`) and hands it to JSC through `Bun__makeArrayBufferWithBytesNoCopy`. JSC then owns the bytes and calls the deallocator that was passed along when the object is collected. JSC stores the size of an ArrayBuffer as a `size_t`, but caps it at `MAX_ARRAY_BUFFER_SIZE` (`PageCount.h`, 2^32 on 64-bit). Its allocating constructors return null above the cap, and Bun turns that into `RangeError: Out of memory`. The adopting constructor used for zero-copy hand-offs asserts instead, so the check has to happen in Bun before the hand-off. The `u32` conversion is the port of a `@as(u32, @intCast(len))` in the Zig version, which had the same `usize` fields. In a release build that cast was unchecked, and in practice the value passed through, which is why 1.3.14 returned the buffer. The port made it a checked conversion, so the same input now panics.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/mmap.test.js test/js/web/fetch/blob-oom.test.ts

<!-- robobun:evidence:end -->