### PR TITLE
codegen: give JS builtin functions their name (Buffer.prototype.readInt8.name, Glob.prototype.scan.name were empty)

### DIFF
--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -467,9 +467,10 @@ JSC::FunctionExecutable* ${lowerBasename}${cap(fn.name)}CodeGenerator(JSC::VM& v
   // DECLARE_BUILTIN_NAMES (header) declares m_<fn> and m_<fn>PrivateName.
   // DEFINE_BUILTIN_EXECUTABLES passes m_<fn> to createBuiltinExecutable, where it
   // becomes the function's `name` unless $overriddenName is set, so it must be
-  // initialized for every function. m_<fn>PrivateName is only read by
-  // exportNames() for @internal files and must be the symbol BunBuiltinNames
-  // created, since that is what `$<fn>` resolves to in other builtins.
+  // initialized for every function. m_<fn>PrivateName is only used for @internal
+  // files (as the key of the `$<fn>` global in JSBuiltinInternalFunctions::initialize
+  // and in exportNames()) and must be the symbol BunBuiltinNames created, since
+  // that is what `$<fn>` in other builtins resolves to.
   const initializeNames = (fn: BundledBuiltin, internal: boolean) => {
     if (internal) {
       return [`m_${fn.name}(builtinNames.${fn.name}PublicName())`, `m_${fn.name}PrivateName(${privateName(fn.name)})`];

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -464,13 +464,8 @@ JSC::FunctionExecutable* ${lowerBasename}${cap(fn.name)}CodeGenerator(JSC::VM& v
     const name = `${low(basename)}${cap(fn.name)}CodeSource`;
     return `m_${name}(SourceCode(sourceProvider.copyRef(), ${fn.sourceOffset}, ${fn.source.length + fn.sourceOffset}, 1, 1))`;
   };
-  // DECLARE_BUILTIN_NAMES (header) declares m_<fn> and m_<fn>PrivateName.
-  // DEFINE_BUILTIN_EXECUTABLES passes m_<fn> to createBuiltinExecutable, where it
-  // becomes the function's `name` unless $overriddenName is set, so it must be
-  // initialized for every function. m_<fn>PrivateName is only used for @internal
-  // files (as the key of the `$<fn>` global in JSBuiltinInternalFunctions::initialize
-  // and in exportNames()) and must be the symbol BunBuiltinNames created, since
-  // that is what `$<fn>` in other builtins resolves to.
+  // m_<fn> becomes the executable's name (fn.name). m_<fn>PrivateName keys the
+  // `$<fn>` global of @internal files, so it must be the symbol BunBuiltinNames owns.
   const initializeNames = (fn: BundledBuiltin, internal: boolean) => {
     if (internal) {
       return [`m_${fn.name}(builtinNames.${fn.name}PublicName())`, `m_${fn.name}PrivateName(${privateName(fn.name)})`];

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -464,17 +464,29 @@ JSC::FunctionExecutable* ${lowerBasename}${cap(fn.name)}CodeGenerator(JSC::VM& v
     const name = `${low(basename)}${cap(fn.name)}CodeSource`;
     return `m_${name}(SourceCode(sourceProvider.copyRef(), ${fn.sourceOffset}, ${fn.source.length + fn.sourceOffset}, 1, 1))`;
   };
+  // DECLARE_BUILTIN_NAMES (header) declares m_<fn> and m_<fn>PrivateName.
+  // DEFINE_BUILTIN_EXECUTABLES passes m_<fn> to createBuiltinExecutable, where it
+  // becomes the function's `name` unless $overriddenName is set, so it must be
+  // initialized for every function. m_<fn>PrivateName is only read by
+  // exportNames() for @internal files and must be the symbol BunBuiltinNames
+  // created, since that is what `$<fn>` resolves to in other builtins.
+  const initializeNames = (fn: BundledBuiltin, internal: boolean) => {
+    if (internal) {
+      return [`m_${fn.name}(builtinNames.${fn.name}PublicName())`, `m_${fn.name}PrivateName(${privateName(fn.name)})`];
+    }
+    return [`m_${fn.name}(JSC::Identifier::fromString(vm, "${fn.name}"_s))`];
+  };
   for (const { basename, internal, functions } of files) {
+    const initializers = [
+      "m_vm(vm)",
+      ...functions.flatMap(fn => initializeNames(fn, internal)),
+      ...functions.map(fn => initializeSourceCodeFn(fn, basename)),
+    ];
     bundledCPP += `
 #pragma mark ${basename}
 
 ${basename}BuiltinsWrapper::${basename}BuiltinsWrapper(JSC::VM& vm, RefPtr<JSC::SourceProvider> sourceProvider, BunBuiltinNames &builtinNames)
-    : m_vm(vm)`;
-
-    if (internal) {
-      bundledCPP += `, ${functions.map(fn => `m_${fn.name}PrivateName(${privateName(fn.name)})`).join(",\n   ")}`;
-    }
-    bundledCPP += `, ${functions.map(fn => initializeSourceCodeFn(fn, basename)).join(",\n   ")} {}
+    : ${initializers.join(",\n    ")} {}
 `;
   }
 

--- a/src/codegen/bundle-functions.ts
+++ b/src/codegen/bundle-functions.ts
@@ -464,10 +464,9 @@ JSC::FunctionExecutable* ${lowerBasename}${cap(fn.name)}CodeGenerator(JSC::VM& v
     const name = `${low(basename)}${cap(fn.name)}CodeSource`;
     return `m_${name}(SourceCode(sourceProvider.copyRef(), ${fn.sourceOffset}, ${fn.source.length + fn.sourceOffset}, 1, 1))`;
   };
-  // m_<fn> becomes the executable's name (fn.name). m_<fn>PrivateName keys the
-  // `$<fn>` global of @internal files, so it must be the symbol BunBuiltinNames owns.
   const initializeNames = (fn: BundledBuiltin, internal: boolean) => {
     if (internal) {
+      // The private name keys the `$<fn>` global, so it has to be the BunBuiltinNames symbol.
       return [`m_${fn.name}(builtinNames.${fn.name}PublicName())`, `m_${fn.name}PrivateName(${privateName(fn.name)})`];
     }
     return [`m_${fn.name}(JSC::Identifier::fromString(vm, "${fn.name}"_s))`];

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -143,8 +143,7 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
   return mod.exports;
 }
 
-// Installed as RequireFunctionPrototype.resolve; the bound copies on each require
-// function are named "resolve" by JSCommonJSModule.cpp.
+// Exposed as require.resolve
 $overriddenName = "resolve";
 $visibility = "Private";
 export function requireResolve(

--- a/src/js/builtins/CommonJS.ts
+++ b/src/js/builtins/CommonJS.ts
@@ -143,6 +143,9 @@ export function overridableRequire(this: JSCommonJSModule, originalId: string, o
   return mod.exports;
 }
 
+// Installed as RequireFunctionPrototype.resolve; the bound copies on each require
+// function are named "resolve" by JSCommonJSModule.cpp.
+$overriddenName = "resolve";
 $visibility = "Private";
 export function requireResolve(
   this: string | { filename?: string; id?: string },

--- a/src/js/builtins/Peek.ts
+++ b/src/js/builtins/Peek.ts
@@ -2,6 +2,8 @@ export function peek(promise: unknown): unknown {
   return $isPromise(promise) && $peekPromiseStatus(promise) ? $peekPromiseSettledValue(promise) : promise;
 }
 
+// Exposed as Bun.peek.status (BunObject.cpp constructBunPeekObject)
+$overriddenName = "status";
 export function peekStatus(promise: unknown): string {
   return ["pending", "fulfilled", "rejected"][
     $isPromise(promise) //

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -617,6 +617,8 @@ export function getChannel() {
   })();
 }
 
+// Exposed as process._rawDebug (BunProcess.cpp constructRawDebug)
+$overriddenName = "_rawDebug";
 export function rawDebug() {
   // util.format straight to fd 2, bypassing process.stderr (which may be
   // hijacked or broken). os.EOL, not "\n": Node's _rawDebug writes through

--- a/src/js/builtins/UtilInspect.ts
+++ b/src/js/builtins/UtilInspect.ts
@@ -14,8 +14,7 @@ export function getStylizeWithColor(inspect: Inspect) {
   };
 }
 
-// Bun.inspect passes this as `stylize` too. util.inspect (internal/util/inspect.js)
-// and Node name theirs stylizeNoColor.
+// Same name as util.inspect's stylizeNoColor
 $overriddenName = "stylizeNoColor";
 export function stylizeWithNoColor(str: string) {
   return str;

--- a/src/js/builtins/UtilInspect.ts
+++ b/src/js/builtins/UtilInspect.ts
@@ -14,6 +14,9 @@ export function getStylizeWithColor(inspect: Inspect) {
   };
 }
 
+// Bun.inspect passes this as `stylize` too. util.inspect (internal/util/inspect.js)
+// and Node name theirs stylizeNoColor.
+$overriddenName = "stylizeNoColor";
 export function stylizeWithNoColor(str: string) {
   return str;
 }

--- a/test/internal/builtin-function-names.test.ts
+++ b/test/internal/builtin-function-names.test.ts
@@ -1,0 +1,80 @@
+// Guard for the names src/codegen/bundle-functions.ts gives the functions
+// bundled from src/js/builtins/*.ts. The generated <File>BuiltinsWrapper passes
+// the exported function's name (or its $overriddenName) to
+// JSC::createBuiltinExecutable, and JSC reports that name as `fn.name`, in
+// Function.prototype.toString() and in stack frames. This holds no matter how
+// the C++ side attaches the function, so every attachment path is listed here.
+// When the wrapper leaves the name identifier uninitialized, every function
+// without an $overriddenName gets name === "".
+import { describe, expect, test } from "bun:test";
+import Module from "node:module";
+
+describe("functions implemented in src/js/builtins", () => {
+  test("are named after the exported function", () => {
+    expect({
+      // HashTableValue rows of type BuiltinGeneratorType (JSBuffer.cpp)
+      "Buffer.prototype.readInt8": Buffer.prototype.readInt8.name,
+      "Buffer.prototype.writeUInt32LE": Buffer.prototype.writeUInt32LE.name,
+      "Buffer.prototype.toJSON": Buffer.prototype.toJSON.name,
+      // An alias row reuses the executable of the function it points at.
+      "Buffer.prototype.readInt16": Buffer.prototype.readInt16.name,
+      // JSBuiltin rows of a .lut.h table (jsBufferConstructorTable)
+      "Buffer.from": Buffer.from.name,
+      "Buffer.isBuffer": Buffer.isBuffer.name,
+      // `builtin:` in a .classes.ts file (Glob.classes.ts)
+      "Glob.prototype.scan": Bun.Glob.prototype.scan.name,
+      "Glob.prototype.scanSync": Bun.Glob.prototype.scanSync.name,
+      // JSFunction::create(vm, global, <name>CodeGenerator(vm), ...) (BunObject.cpp, BunProcess.cpp)
+      "Bun.peek": Bun.peek.name,
+      "process.loadEnvFile": process.loadEnvFile.name,
+      // putDirectBuiltinFunction (ZigGlobalObject.cpp)
+      "console.write": console.write.name,
+    }).toEqual({
+      "Buffer.prototype.readInt8": "readInt8",
+      "Buffer.prototype.writeUInt32LE": "writeUInt32LE",
+      "Buffer.prototype.toJSON": "toJSON",
+      "Buffer.prototype.readInt16": "readInt16LE",
+      "Buffer.from": "from",
+      "Buffer.isBuffer": "isBuffer",
+      "Glob.prototype.scan": "scan",
+      "Glob.prototype.scanSync": "scanSync",
+      "Bun.peek": "peek",
+      "process.loadEnvFile": "loadEnvFile",
+      "console.write": "write",
+    });
+  });
+
+  test("use $overriddenName when the exported name differs from the exposed one", () => {
+    expect({
+      // Peek.ts peekStatus
+      "Bun.peek.status": Bun.peek.status.name,
+      // ProcessObjectInternals.ts rawDebug
+      "process._rawDebug": process._rawDebug.name,
+      // CommonJS.ts overridableRequire
+      "Module.prototype.require": Module.prototype.require.name,
+      // ConsoleObject.ts asyncIterator
+      "console[Symbol.asyncIterator]": console[Symbol.asyncIterator].name,
+      // JSBufferPrototype.ts offset, a $getter
+      "get Buffer.prototype.offset": Object.getOwnPropertyDescriptor(Buffer.prototype, "offset")!.get!.name,
+    }).toEqual({
+      "Bun.peek.status": "status",
+      "process._rawDebug": "_rawDebug",
+      "Module.prototype.require": "require",
+      "console[Symbol.asyncIterator]": "[Symbol.asyncIterator]",
+      "get Buffer.prototype.offset": "get offset",
+    });
+  });
+
+  test("carry the name into toString(), inspect and stack frames", () => {
+    expect(Buffer.from.toString()).toBe("function from() {\n    [native code]\n}");
+    expect(Bun.inspect(Bun.Glob.prototype.scanSync)).toBe("[Function: scanSync]");
+
+    let error: Error | undefined;
+    try {
+      Buffer.alloc(1).readInt8(5);
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error!.stack).toContain("at readInt8 (");
+  });
+});

--- a/test/internal/builtin-function-names.test.ts
+++ b/test/internal/builtin-function-names.test.ts
@@ -8,6 +8,7 @@
 // without an $overriddenName gets name === "".
 import { describe, expect, test } from "bun:test";
 import Module from "node:module";
+import { inspect } from "node:util";
 
 describe("functions implemented in src/js/builtins", () => {
   test("are named after the exported function", () => {
@@ -45,21 +46,36 @@ describe("functions implemented in src/js/builtins", () => {
   });
 
   test("use $overriddenName when the exported name differs from the exposed one", () => {
+    // UtilInspect.ts stylizeWithNoColor is the `stylize` Bun.inspect hands to inspect.custom.
+    let stylizeName: string | undefined;
+    Bun.inspect({
+      [inspect.custom](_depth: number, options: { stylize: Function }) {
+        stylizeName = options.stylize.name;
+        return "";
+      },
+    });
+
     expect({
+      "Bun.inspect stylize": stylizeName,
       // Peek.ts peekStatus
       "Bun.peek.status": Bun.peek.status.name,
       // ProcessObjectInternals.ts rawDebug
       "process._rawDebug": process._rawDebug.name,
       // CommonJS.ts overridableRequire
       "Module.prototype.require": Module.prototype.require.name,
+      // CommonJS.ts requireResolve. `require.resolve` itself is a bound function that
+      // JSCommonJSModule.cpp names "resolve", so its name is "bound resolve" either way.
+      "Object.getPrototypeOf(require).resolve": Object.getPrototypeOf(require).resolve.name,
       // ConsoleObject.ts asyncIterator
       "console[Symbol.asyncIterator]": console[Symbol.asyncIterator].name,
       // JSBufferPrototype.ts offset, a $getter
       "get Buffer.prototype.offset": Object.getOwnPropertyDescriptor(Buffer.prototype, "offset")!.get!.name,
     }).toEqual({
+      "Bun.inspect stylize": "stylizeNoColor",
       "Bun.peek.status": "status",
       "process._rawDebug": "_rawDebug",
       "Module.prototype.require": "require",
+      "Object.getPrototypeOf(require).resolve": "resolve",
       "console[Symbol.asyncIterator]": "[Symbol.asyncIterator]",
       "get Buffer.prototype.offset": "get offset",
     });


### PR DESCRIPTION
### Problem
- Every function that Bun implements as a JS builtin (`src/js/builtins/*.ts`) has `name === ""`. `Buffer.prototype.readInt8.name`, `Buffer.from.name`, `Bun.Glob.prototype.scan.name`, `Bun.peek.name`, `console.write.name` and `process.loadEnvFile.name` are all `""`. Node reports `"toJSON"`, `"from"`, `"loadEnvFile"` and so on. Native methods on the same objects are named.
- The same functions print as `function () { [native code] }`, inspect as `[Function]`, and their stack frames print as `at <anonymous> (native:1:11)`. JSC's own builtins print `at map (native:1:11)`.
- Cause: the `<File>BuiltinsWrapper` constructors that `src/codegen/bundle-functions.ts` emits do not initialize the `m_<fn>` identifiers that `DECLARE_BUILTIN_NAMES` declares (bundle-functions.ts:471 and :666 before this change). `DEFINE_BUILTIN_EXECUTABLES` passes that null identifier to `JSC::createBuiltinExecutable`, so the executable has no name. Only builtins with an `$overriddenName` (for example the `offset` getter, `"get offset"`) were named, because the macro replaces the identifier for them.
- The constructor lost the `INITIALIZE_BUILTIN_NAMES` call in #12761 (Bun 1.1.21), when it started to take the private names from `BunBuiltinNames` instead.

### Fix
- `bundle-functions.ts` initializes `m_<fn>` for every function. Non-internal files use `JSC::Identifier::fromString(vm, "<fn>"_s)`, which is what JSC's `INITIALIZE_BUILTIN_NAMES` does. The one `@internal` file (`Fifo.ts`) takes both the public and the private name from `BunBuiltinNames`, so `$createFIFO` still resolves to the same private symbol as before.
- This is the right layer: every attachment path (a `HashTableValue` row, a `.lut.h` row, `builtin:` in a `.classes.ts` file, `putDirectBuiltinFunction`, a direct `JSFunction::create`) ends in the same executable, and JSC takes `name`, `toString()` and the stack frame name from it. The private names, `exportNames()`, and the `$overriddenName` path are unchanged.
- Four builtins are exposed under a different name than their exported function. With the name restored they would report the internal name, so they now set `$overriddenName`. I audited every attachment site for this (`grep CodeGenerator(`, the `BuiltinGeneratorType` rows, the `.lut.h` `JSBuiltin` rows, `Glob.classes.ts`, `putDirectBuiltinFunction`):
  - `peekStatus`, exposed as `Bun.peek.status`: `"status"`.
  - `rawDebug`, exposed as `process._rawDebug`: `"_rawDebug"`, the name Node reports.
  - `stylizeWithNoColor`, the `stylize` that `Bun.inspect` passes to `inspect.custom`: `"stylizeNoColor"`, the name `util.inspect` and Node use.
  - `requireResolve`, installed as `resolve` on the prototype of every `require`: `"resolve"`. `require.resolve` itself is a bound function that C++ already names, so it stays `"bound resolve"`, like `require` stays `"bound require"`. That is separate from this change.
  - Not changed: `import.meta.bakeBuiltin` in Bake is the `requireESM` builtin and now reports that name. It is internal to Bake's generated code.
- Visible side effect: a Bun builtin frame now prints in error output the same way a JSC builtin frame does (`at readInt8 (1:11)` instead of no line), because the error printer only drops frames that have neither a name nor a file. The bare position and the code frame's caret column for a builtin frame on top are existing printer behavior, `[1].map(null)` shows both on 1.4.0. #38335 and #38356 change that printer code, so this PR does not touch it or snapshot its output.
- Verified with `test/internal/builtin-function-names.test.ts`. Its three tests fail on Bun 1.4.0, which has the codegen from main (every name is `""`), and pass with this change. One test covers each attachment path, one covers the `$overriddenName` and `$getter` functions, one covers `toString()`, `Bun.inspect` and `error.stack`.
- Also ran `test/js/node/buffer.test.js`, `test/js/node/process/process.test.js`, the glob, peek, inspect (`util` and `Bun.inspect`), `require.resolve`, console, plugin and codegen suites, and every test file that snapshots `at <anonymous> (` frames. No existing expectation changes. The only failures were unrelated to this change: `glob.match` repo scans and one `util-inspect` block that time out under the debug build in this container (CI runs that file in 1.5s), a `process.env.USER` check in a container without `USER`, and one 5s worker test that passes alone.

### Background
- A JS builtin is a function whose body is JavaScript that is compiled into Bun. `bundle-functions.ts` bundles each exported function of `src/js/builtins/*.ts` into one source blob and generates, per file, a `<File>BuiltinsWrapper` C++ class. The wrapper holds one `SourceCode` per function and creates a `<file><Fn>CodeGenerator(vm)` function that C++ code uses to attach the builtin to an object.
- `JSC::createBuiltinExecutable(vm, source, name, ...)` compiles the anonymous `(function (...) {...})` source and stores `name` as the executable's name. For a builtin function JSC reads `fn.name`, `Function.prototype.toString()` and the stack frame name from the executable, not from the property the function is stored under. An empty identifier there means an empty name everywhere.
- `DECLARE_BUILTIN_NAMES(fn)` (JSC `BuiltinUtils.h`) declares two `const JSC::Identifier` members per function: `m_<fn>`, the public name, and `m_<fn>PrivateName`, a private symbol. A `const Identifier` member that is missing from the constructor's initializer list is default constructed, which is a null identifier, so this compiled without a diagnostic.
- `$<fn>` in builtin sources (`@<fn>` after codegen) refers to a private symbol. `BunBuiltinNames` owns those symbols, so a file marked `@internal` must copy its private names from there. That is why the constructor takes `BunBuiltinNames&`, and why this change keeps the private names where they were.
- `$overriddenName = "x"` is a directive that the codegen already supports. `DEFINE_BUILTIN_EXECUTABLES` uses it instead of the function name. `$getter` uses the same path to produce `"get <fn>"`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/builtin-function-names.test.ts
bun test v1.4.0 (8326d1bd3)

test/internal/builtin-function-names.test.ts:
28 |       // JSFunction::create(vm, global, <name>CodeGenerator(vm), ...) (BunObject.cpp, BunProcess.cpp)
29 |       "Bun.peek": Bun.peek.name,
30 |       "process.loadEnvFile": process.loadEnvFile.name,
31 |       // putDirectBuiltinFunction (ZigGlobalObject.cpp)
32 |       "console.write": console.write.name,
33 |     }).toEqual({
            ^
error: expect(received).toEqual(expected)

  {
-   "Buffer.from": "from",
-   "Buffer.isBuffer": "isBuffer",
-   "Buffer.prototype.readInt16": "readInt16LE",
-   "Buffer.prototype.readInt8": "readInt8",
-   "Buffer.prototype.toJSON": "toJSON",
-   "Buffer.prototype.writeUInt32LE": "writeUInt32LE",
-   "Bun.peek": "peek",
-   "Glob.prototype.scan": "scan",
-   "Glob.prototype.scanSync": "scanSync",
-   "console.write": "write",
-   "process.loadEnvFile": "loadEnvFile",
+   "Buffer.from": "",
+   "Buffer.isBuffer": "",
+   "Buffer.prototype.readInt16": "",
+   "Buffer.prototyp
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/internal/builtin-function-names.test.ts:
28 |       // JSFunction::create(vm, global, <name>CodeGenerator(vm), ...) (BunObject.cpp, BunProcess.cpp)
29 |       "Bun.peek": Bun.peek.name,
30 |       "process.loadEnvFile": process.loadEnvFile.name,
31 |       // putDirectBuiltinFunction (ZigGlobalObject.cpp)
32 |       "console.write": console.write.name,
33 |     }).toEqual({
            ^
error: expect(received).toEqual(expected)

  {
-   "Buffer.from": "from",
-   "Buffer.isBuffer": "isBuffer",
-   "Buffer.prototype.readInt16": "readInt16LE",
-   "Buffer.prototype.readInt8": "readInt8",
-   "Buffer.prototype.toJSON": "toJSON",
-   "Buffer.prototype.writeUInt32LE": "writeUInt32LE",
-   "Bun.peek": "peek",
-   "Glob.prototype.scan": "scan",
-   "Glob.prototype.scanSync": "scanSync",
-   "console.write": "write",
-   "process.loadEnvFile": "loadEnvFile",
+   "Buffer.from": "",
+   "Buffer.isBuffer": "",
+   "Buffer.prototype.readInt16": "",
+   "Buffer.prototype.readInt8": "",
+   "Buffer.prototype.toJSON": "",
+   "Buffer.prototype.writeUInt32LE": "",
+   "Bun.peek": "",
+   "Glob.prototype.scan": "",
+   "Glob.prototype.scan
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/builtin-function-names.test.ts
bun test v1.4.0 (8326d1bd3)

test/internal/builtin-function-names.test.ts:
(pass) functions implemented in src/js/builtins > are named after the exported function [20.30ms]
(pass) functions implemented in src/js/builtins > use $overriddenName when the exported name differs from the exposed one [7.59ms]
(pass) functions implemented in src/js/builtins > carry the name into toString(), inspect and stack frames [8.05ms]

 3 pass
 0 fail
 5 expect() calls
Ran 3 tests across 1 file. [2.38s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b889d207f8
  features     baseline

22 deps, 120 codegen, 1144 objects in 720ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1206] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 26 installs across 63 packages (no changes) [12.00ms]
[2/1206] gen bindgenv2
[3/1206] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1206] gen ErrorCode+*.h
[5/1206] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [4.00ms]
[6/1206] fetch zlib
[zlib] up to date
[7/1206] gen .bind.ts → GeneratedBindings.cpp
[8/1206] fetch tinycc
[tinycc] up to date
[9/1205] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1205] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1205] gen ProcessBindingConstants.lut.h
Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/codegen/bundle-functions.ts              | 19 ++++--
 src/js/builtins/CommonJS.ts                  |  2 +
 src/js/builtins/Peek.ts                      |  2 +
 src/js/builtins/ProcessObjectInternals.ts    |  2 +
 src/js/builtins/UtilInspect.ts               |  2 +
 test/internal/builtin-function-names.test.ts | 96 ++++++++++++++++++++++++++++
 6 files changed, 117 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/codegen/bundle-functions.ts                   9      6      0
src/js/builtins/CommonJS.ts                       2      2      0
src/js/builtins/Peek.ts                           1      1      0
src/js/builtins/ProcessObjectInternals.ts         1      1      0
src/js/builtins/UtilInspect.ts                    1      3      0
test/internal/builtin-function-names.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->