### PR TITLE
Throw instead of aborting when child output does not fit in a Buffer

### DIFF
--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -131,9 +131,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
             res(out);
           }
         };
-        // The interpreter calls this when it cannot build the output buffers
-        // (an output larger than a Buffer can hold, or an allocation failure).
-        // Exit codes go through `resolve`.
+        // Only for a failure to build the output buffers; exit codes go through `resolve`.
         reject = error => {
           potentialError = undefined;
           rej(error);

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -1,7 +1,7 @@
 export function createBunShellTemplateFunction(createShellInterpreter_, createParsedShellScript_) {
   const createShellInterpreter = createShellInterpreter_ as (
     resolve: (code: number, stdout: Buffer, stderr: Buffer) => void,
-    reject: (code: number, stdout: Buffer, stderr: Buffer) => void,
+    reject: (error: unknown) => void,
     args: $ZigGeneratedClasses.ParsedShellScript,
   ) => $ZigGeneratedClasses.ShellInterpreter;
   const createParsedShellScript = createParsedShellScript_ as (
@@ -108,7 +108,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     #hasRun: boolean = false;
     #throws: boolean = true;
     #resolve: (code: number, stdout: Buffer, stderr: Buffer) => void;
-    #reject: (code: number, stdout: Buffer, stderr: Buffer) => void;
+    #reject: (error: unknown) => void;
 
     constructor(args: $ZigGeneratedClasses.ParsedShellScript, throws: boolean) {
       // Create the error immediately so it captures the stacktrace at the point
@@ -131,9 +131,12 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
             res(out);
           }
         };
-        reject = (code, stdout, stderr) => {
-          potentialError!.initialize(new ShellOutput(stdout, stderr, code), code);
-          rej(potentialError);
+        // The interpreter calls this when it cannot build the output buffers
+        // (an output larger than a Buffer can hold, or an allocation failure).
+        // Exit codes go through `resolve`.
+        reject = error => {
+          potentialError = undefined;
+          rej(error);
         };
       });
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -181,18 +181,19 @@ impl ArrayBuffer {
 impl ArrayBuffer {
     /// Only use this when reading from the file descriptor is _very_ cheap. Like, for example, an in-memory file descriptor.
     /// Do not use this for pipes, however tempting it may seem.
-    pub(crate) fn to_js_buffer_from_fd(fd: Fd, size: usize, global: &JSGlobalObject) -> JSValue {
+    pub(crate) fn to_js_buffer_from_fd(
+        fd: Fd,
+        size: usize,
+        global: &JSGlobalObject,
+    ) -> JsResult<JSValue> {
         // SAFETY: FFI — `global` is a live &JSGlobalObject (opaque ZST handle, coerces to
         // *const); fn accepts null ptr with explicit size.
         // Wrapped in `from_js_host_call` so the C++ throw scope opened by
         // `Bun__createUint8ArrayForCopy` is checked before `as_array_buffer` below
         // declares `ASSERT_NO_PENDING_EXCEPTION` (validateExceptionChecks).
-        let buffer_value = match crate::host_fn::from_js_host_call(global, || unsafe {
+        let buffer_value = crate::host_fn::from_js_host_call(global, || unsafe {
             Bun__createUint8ArrayForCopy(global, ptr::null(), size, true)
-        }) {
-            Ok(v) => v,
-            Err(_) => return JSValue::ZERO,
-        };
+        })?;
 
         let mut array_buffer = buffer_value.as_array_buffer(global).expect("Unexpected");
         let mut bytes = array_buffer.byte_slice_mut();
@@ -214,16 +215,14 @@ impl ArrayBuffer {
                     }
                 }
                 bun_sys::Result::Err(err) => {
-                    let err_js = err.to_js(global);
-                    let _ = global.throw_value(err_js);
-                    return JSValue::ZERO;
+                    return Err(global.throw_value(err.to_js(global)));
                 }
             }
         }
 
         buffer_value.ensure_still_alive();
 
-        buffer_value
+        Ok(buffer_value)
     }
 
     #[inline]
@@ -263,7 +262,7 @@ impl ArrayBuffer {
             let result =
                 Self::to_js_buffer_from_fd(fd, usize::try_from(size).expect("int cast"), global);
             fd.close();
-            return Ok(result);
+            return result;
         }
 
         // bun_sys::mmap takes raw i32 prot/flags.
@@ -278,14 +277,13 @@ impl ArrayBuffer {
 
         match result {
             bun_sys::Result::Ok(buf) => {
-                // `buf` is a fresh mmap region whose ownership transfers to JSC.
-                Ok(JSBuffer__fromMmap(global, buf.cast(), map_len))
+                // `buf` is a fresh mmap region whose ownership transfers to JSC, which
+                // also unmaps it when it refuses the length (above `MAX_ARRAY_BUFFER_SIZE`).
+                crate::host_fn::from_js_host_call(global, || {
+                    JSBuffer__fromMmap(global, buf.cast(), map_len)
+                })
             }
-            bun_sys::Result::Err(err) => {
-                let err_js = err.to_js(global);
-                let _ = global.throw_value(err_js);
-                Ok(JSValue::ZERO)
-            }
+            bun_sys::Result::Err(err) => Err(global.throw_value(err.to_js(global))),
         }
     }
 

--- a/src/jsc/array_buffer.rs
+++ b/src/jsc/array_buffer.rs
@@ -277,8 +277,7 @@ impl ArrayBuffer {
 
         match result {
             bun_sys::Result::Ok(buf) => {
-                // `buf` is a fresh mmap region whose ownership transfers to JSC, which
-                // also unmaps it when it refuses the length (above `MAX_ARRAY_BUFFER_SIZE`).
+                // `buf` is a fresh mmap region whose ownership transfers to JSC (on `Err` too).
                 crate::host_fn::from_js_host_call(global, || {
                     JSBuffer__fromMmap(global, buf.cast(), map_len)
                 })

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -380,16 +380,30 @@ public:
 
 }
 
+bool Bun::rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, const void* bytes, size_t length, JSTypedArrayBytesDeallocator deallocator, void* deallocatorContext)
+{
+    if (length <= MAX_ARRAY_BUFFER_SIZE) [[likely]]
+        return false;
+
+    if (deallocator)
+        deallocator(const_cast<void*>(bytes), deallocatorContext);
+    JSC::throwOutOfMemoryError(globalObject, scope);
+    return true;
+}
+
 JSC::EncodedJSValue JSBuffer__bufferFromPointerAndLengthAndDeinit(JSC::JSGlobalObject* lexicalGlobalObject, char* ptr, size_t length, void* ctx, JSTypedArrayBytesDeallocator bytesDeallocator)
 {
     JSC::JSUint8Array* uint8Array = nullptr;
 
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto* subclassStructure = globalObject->JSBufferSubclassStructure();
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(lexicalGlobalObject->vm());
+    auto scope = DECLARE_THROW_SCOPE(lexicalGlobalObject->vm());
 
     if (length > 0) [[likely]] {
         ASSERT(bytesDeallocator);
+        if (Bun::rejectBytesNoCopyAboveArrayBufferLimit(lexicalGlobalObject, scope, ptr, length, bytesDeallocator, ctx)) [[unlikely]]
+            return {};
+
         auto buffer = ArrayBuffer::createFromBytes({ reinterpret_cast<const uint8_t*>(ptr), length }, createSharedTask<void(void*)>([=](void* p) {
             bytesDeallocator(p, ctx);
         }));
@@ -2585,19 +2599,29 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_writeBody(JSC::JSGlobalObje
     RELEASE_AND_RETURN(scope, writeToBuffer(lexicalGlobalObject, castedThis, str, offset, length, encoding));
 }
 
+static void unmapBufferBytes(void* mapping, void* lengthAsContext)
+{
+#if !OS(WINDOWS)
+    munmap(mapping, reinterpret_cast<size_t>(lengthAsContext));
+#else
+    UNUSED_PARAM(lengthAsContext);
+    UnmapViewOfFile(mapping);
+#endif
+}
+
 extern "C" JSC::EncodedJSValue JSBuffer__fromMmap(Zig::GlobalObject* globalObject, void* ptr, size_t length)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    void* lengthAsContext = reinterpret_cast<void*>(length);
+    if (Bun::rejectBytesNoCopyAboveArrayBufferLimit(globalObject, scope, ptr, length, unmapBufferBytes, lengthAsContext)) [[unlikely]]
+        return {};
+
     auto* structure = globalObject->JSBufferSubclassStructure();
 
-    auto buffer = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(ptr), length }, createSharedTask<void(void*)>([length](void* p) {
-#if !OS(WINDOWS)
-        munmap(p, length);
-#else
-        UnmapViewOfFile(p);
-#endif
+    auto buffer = ArrayBuffer::createFromBytes({ static_cast<const uint8_t*>(ptr), length }, createSharedTask<void(void*)>([lengthAsContext](void* p) {
+        unmapBufferBytes(p, lengthAsContext);
     }));
 
     auto* view = JSC::JSUint8Array::create(globalObject, structure, WTF::move(buffer), 0, length);

--- a/src/jsc/bindings/JSBuffer.h
+++ b/src/jsc/bindings/JSBuffer.h
@@ -23,6 +23,7 @@
 #include "root.h"
 
 #include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/ThrowScope.h>
 #include <wtf/NeverDestroyed.h>
 
 #include "BufferEncodingType.h"
@@ -38,6 +39,11 @@ extern "C" bool JSBuffer__isBuffer(JSC::JSGlobalObject*, JSC::EncodedJSValue);
 namespace Bun {
 
 std::optional<size_t> byteLength(JSC::JSString* str, JSC::JSGlobalObject* lexicalGlobalObject, WebCore::BufferEncodingType encoding);
+
+// ArrayBuffer::createFromBytes RELEASE_ASSERTs above MAX_ARRAY_BUFFER_SIZE. Above
+// it, this releases the adopted bytes through the deallocator, throws the
+// RangeError `new ArrayBuffer(length)` would throw, and returns true.
+bool rejectBytesNoCopyAboveArrayBufferLimit(JSC::JSGlobalObject*, JSC::ThrowScope&, const void* bytes, size_t length, JSTypedArrayBytesDeallocator, void* deallocatorContext);
 
 namespace Buffer {
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2038,9 +2038,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
 
     let signal_code = SubprocessT::get_signal_code(subprocess, global_this);
     let exit_code = SubprocessT::get_exit_code(subprocess, global_this);
-    // `to_buffered_value` throws when an output does not fit in a Buffer (or on
-    // OOM). `finalize` runs either way, so that path does not leak the subprocess
-    // and what it still owns (the other stream's buffer, the abort signal ref).
+    // Propagated after `finalize`, which must run even when building the output throws.
     let output = subprocess
         .stdout
         .with_mut(|s| s.to_buffered_value(global_this))

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2031,6 +2031,8 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     }
     if global_this.has_exception() {
         // e.g. a termination exception.
+        // SAFETY: same as the `finalize` below; `subprocess` is not used after this line.
+        SubprocessT::finalize(unsafe { Box::from_raw(subprocess_ptr) });
         return Ok(JSValue::ZERO);
     }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -2038,17 +2038,19 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
 
     let signal_code = SubprocessT::get_signal_code(subprocess, global_this);
     let exit_code = SubprocessT::get_exit_code(subprocess, global_this);
-    let stdout = subprocess
+    // `to_buffered_value` throws when an output does not fit in a Buffer (or on
+    // OOM). `finalize` runs either way, so that path does not leak the subprocess
+    // and what it still owns (the other stream's buffer, the abort signal ref).
+    let output = subprocess
         .stdout
-        .with_mut(|s| s.to_buffered_value(global_this))?;
-    let stderr = subprocess
-        .stderr
-        .with_mut(|s| s.to_buffered_value(global_this))?;
-    let resource_usage: JSValue = if !global_this.has_exception() {
-        subprocess.create_resource_usage_object(global_this)?
-    } else {
-        JSValue::ZERO
-    };
+        .with_mut(|s| s.to_buffered_value(global_this))
+        .and_then(|stdout| {
+            let stderr = subprocess
+                .stderr
+                .with_mut(|s| s.to_buffered_value(global_this))?;
+            let resource_usage = subprocess.create_resource_usage_object(global_this)?;
+            Ok((stdout, stderr, resource_usage))
+        });
     let exited_due_to_timeout = did_timeout;
     let exited_due_to_max_buffer = subprocess.exited_due_to_maxbuf.get();
     let result_pid = JSValue::js_number_from_int32(subprocess.pid());
@@ -2056,6 +2058,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     // above (spawnSync path: never handed to a JS wrapper); reclaim ownership.
     // `subprocess` (`&mut *subprocess_ptr`) is not used after this line.
     SubprocessT::finalize(unsafe { Box::from_raw(subprocess_ptr) });
+    let (stdout, stderr, resource_usage) = output?;
 
     let sync_value = JSValue::create_empty_object(global_this, 0);
     sync_value.put(global_this, b"exitCode", exit_code);

--- a/src/runtime/api/bun/subprocess/Readable.rs
+++ b/src/runtime/api/bun/subprocess/Readable.rs
@@ -1,7 +1,7 @@
 use core::mem;
 use core::ptr::NonNull;
 
-use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult, event_loop::EventLoop};
+use bun_jsc::{JSGlobalObject, JSValue, JsResult, event_loop::EventLoop};
 use bun_sys::{self, Fd, FdExt as _};
 
 use crate::node::types::FdJsc as _;
@@ -280,7 +280,7 @@ impl Readable {
                 {
                     let fd = *fd;
                     *self = Readable::Closed;
-                    jsc::ArrayBuffer::to_js_buffer_from_memfd(fd, global)
+                    bun_jsc::ArrayBuffer::to_js_buffer_from_memfd(fd, global)
                 }
             }
             Readable::Pipe(_) => {
@@ -300,14 +300,7 @@ impl Readable {
                     Err(_) => return Err(global.throw_out_of_memory()),
                 };
 
-                // Ownership of the mimalloc-backed buffer transfers to JSC
-                // (freed via `MarkedArrayBuffer_deallocator`).
-                jsc::MarkedArrayBuffer {
-                    buffer: jsc::ArrayBuffer::from_owned_bytes(own, jsc::JSType::Uint8Array),
-                    owns_buffer: true,
-                    pinned: false,
-                }
-                .to_node_buffer(global)
+                JSValue::create_buffer_from_box(global, own)
             }
             _ => Ok(JSValue::UNDEFINED),
         }

--- a/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
+++ b/src/runtime/api/bun/subprocess/SubprocessPipeReader.rs
@@ -9,7 +9,7 @@ use bun_io::max_buf::MaxBuf;
 #[cfg(unix)]
 use bun_io::pipe_reader::PosixFlags;
 use bun_jsc::event_loop::EventLoop;
-use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult, MarkedArrayBuffer};
+use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 use bun_ptr::ScopedRef;
 use bun_ptr::{IntrusiveRc, ParentRef, RefCount};
 use bun_sys;
@@ -334,14 +334,7 @@ impl PipeReader {
         match &mut self.state {
             State::Done(bytes) => {
                 let bytes = core::mem::take(bytes);
-                // `state.done` is now empty via `take()`.
-                // `MarkedArrayBuffer::from_bytes` takes a borrowed `&mut [u8]`
-                // with `owns_buffer = true` (freed via mimalloc on the JS side); leak the
-                // boxed slice so JS becomes the owner — same pattern as
-                // `MarkedArrayBuffer::from_string`.
-                let slice: &'static mut [u8] = Box::leak(bytes.into_boxed_slice());
-                MarkedArrayBuffer::from_bytes(slice, jsc::JSType::Uint8Array)
-                    .to_node_buffer(global_this)
+                JSValue::create_buffer_from_box(global_this, bytes.into_boxed_slice())
             }
             _ => Ok(JSValue::UNDEFINED),
         }

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1224,8 +1224,6 @@ impl Interpreter {
                             ],
                         ),
                         Err(err) if !global_this.has_pending_termination_exception() => {
-                            // `reject` is called directly, so it needs the thrown
-                            // value, not the `JSC::Exception` that carries it.
                             let error = global_this.take_error(err);
                             if let Some(reject) =
                                 JSShellInterpreter::reject_get_cached(this_jsvalue)

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1224,7 +1224,9 @@ impl Interpreter {
                             ],
                         ),
                         Err(err) if !global_this.has_pending_termination_exception() => {
-                            let error = global_this.take_exception(err);
+                            // `reject` is called directly, so it needs the thrown
+                            // value, not the `JSC::Exception` that carries it.
+                            let error = global_this.take_error(err);
                             if let Some(reject) =
                                 JSShellInterpreter::reject_get_cached(this_jsvalue)
                             {

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -1458,6 +1458,44 @@ describe("toBuffer borrowed-pointer ownership (no bad-free on GC)", () => {
   );
 });
 
+// toBuffer hands an arbitrary (pointer, byteLength) pair straight to the Buffer
+// hand-off that spawnSync, Bun.$ and others use for their output. That makes it
+// the one way to reach the hand-off with a byteLength above kMaxLength (2^32)
+// without 4 GiB of real bytes; the views below never touch the memory they
+// describe. Subprocess because unpatched builds abort inside JSC.
+describe("toBuffer at the Buffer length limit", () => {
+  it.concurrent("throws a RangeError above 2^32 bytes and still creates a view of exactly 2^32 bytes", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { ptr, toBuffer } from "bun:ffi";
+        const backing = new Uint8Array(16);
+        let aboveLimit;
+        try {
+          aboveLimit = { length: toBuffer(ptr(backing), 0, 2 ** 32 + 1).length };
+        } catch (e) {
+          aboveLimit = { isRangeError: e instanceof RangeError };
+        }
+        const atLimit = { length: toBuffer(ptr(backing), 0, 2 ** 32).length };
+        console.log(JSON.stringify({ aboveLimit, atLimit }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ result: JSON.parse(stdout.trim() || "null"), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      result: { aboveLimit: { isRangeError: true }, atLimit: { length: 2 ** 32 } },
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+});
+
 describe.skipIf(!FFI_FIXTURE_PATH)("engine-native FFI (single implementation)", () => {
   const lib = FFI_FIXTURE_PATH;
   it("linkSymbols() binds and calls symbols from raw pointers", () => {

--- a/test/js/bun/shell/shelloutput.test.ts
+++ b/test/js/bun/shell/shelloutput.test.ts
@@ -1,5 +1,7 @@
 import { $, ShellError, ShellPromise } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isPosix } from "harness";
+import { totalmem } from "os";
 
 describe("ShellOutput + ShellError", () => {
   test("output", async () => {
@@ -23,6 +25,41 @@ describe("ShellOutput + ShellError", () => {
     expect(output.stderr.toString()).toEqual("ls: oogabooga: No such file or directory\n");
     expect(output.blob()).toEqual(new Blob([new TextEncoder().encode("hello")]));
   });
+});
+
+// The shell hands its captured stdout to JSC as a Buffer, which holds at most
+// kMaxLength (2^32) bytes. A larger capture used to abort the process at that
+// hand-off, and the rejection path behind it (the interpreter's `reject`
+// callback) had never carried an error. This is the only way to exercise it. The
+// child holds 4 GiB of zeros (8 GiB while its buffer grows), so this runs in a
+// child process, with a long timeout, and only on machines with room.
+describe.skipIf(!isPosix || totalmem() < 16 * 1024 ** 3)("stdout at the Buffer length limit", () => {
+  test("a capture of 2^32 + 1 bytes rejects with the RangeError that new ArrayBuffer(2 ** 32 + 1) throws", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const size = String(2 ** 32 + 1);
+        const result = await Bun.$\`head -c \${size} /dev/zero\`.quiet().then(
+          out => ({ length: out.stdout.length }),
+          e => ({ isRangeError: e instanceof RangeError, message: e.message }),
+        );
+        console.log(JSON.stringify(result));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ result: JSON.parse(stdout.trim() || "null"), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      result: { isRangeError: true, message: "Out of memory" },
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 120_000);
 });
 
 async function withErr(promise: ShellPromise): Promise<ShellError> {

--- a/test/js/bun/spawn/spawnSync.test.ts
+++ b/test/js/bun/spawn/spawnSync.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, bunRun, isLinux, isMusl, isPosix, isWindows } from "harness";
+import { totalmem } from "os";
 import { join } from "path";
 describe("spawnSync", () => {
   it("should throw a RangeError if timeout is less than 0", () => {
@@ -97,6 +98,61 @@ describe("spawnSync", () => {
       expect({ stdout: stdout.toString(), exitedDueToTimeout }).toEqual({ stdout: "A", exitedDueToTimeout: true });
     });
   });
+});
+
+// A Buffer holds at most kMaxLength (2^32) bytes. spawnSync hands the captured
+// output to JSC without a copy, and a larger output used to kill the process at
+// that hand-off instead of throwing the RangeError an allocation of that size
+// throws. An output of exactly 2^32 bytes used to die in a length cast on the
+// same path. Each case makes the child hold 4 GiB of zeros (the read buffer
+// doubles to 8 GiB on the way), so the cases run one at a time, in a child
+// process, with a long timeout, and only on machines with room.
+describe.skipIf(!isPosix || totalmem() < 16 * 1024 ** 3)("spawnSync output at the Buffer length limit", () => {
+  async function captureZeros(size: number) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        let result;
+        try {
+          const { stdout, exitCode } = Bun.spawnSync({
+            cmd: ["head", "-c", ${JSON.stringify(String(size))}, "/dev/zero"],
+            stdout: "pipe",
+            stderr: "pipe",
+          });
+          result = { isBuffer: Buffer.isBuffer(stdout), length: stdout.length, exitCode };
+        } catch (e) {
+          result = { isRangeError: e instanceof RangeError, message: e.message };
+        }
+        console.log(JSON.stringify(result));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { result: JSON.parse(stdout.trim() || "null"), stderr, exitCode, signalCode: proc.signalCode };
+  }
+
+  it("an output of 2^32 + 1 bytes throws the RangeError that new ArrayBuffer(2 ** 32 + 1) throws", async () => {
+    expect(await captureZeros(2 ** 32 + 1)).toEqual({
+      result: { isRangeError: true, message: "Out of memory" },
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 120_000);
+
+  it("an output of exactly 2^32 bytes is returned whole", async () => {
+    expect(await captureZeros(2 ** 32)).toEqual({
+      result: { isBuffer: true, length: 2 ** 32, exitCode: 0 },
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 120_000);
 });
 
 describe("uid/gid", () => {


### PR DESCRIPTION
### Problem
- More than 2^32 bytes of captured child output kill the process instead of throwing. ``await Bun.$`head -c 4294967297 /dev/zero`.quiet()`` dies with `panic(main thread): abort() called` (SIGABRT). `Bun.spawnSync({ cmd: ["head", "-c", "4294967297", "/dev/zero"] })` dies with `panic: int cast: TryFromIntError(PosOverflow)`. So does an output of exactly 2^32 bytes, which is a valid Buffer length.
- `bun:ffi` `toBuffer(ptr, 0, 2 ** 32 + 1)` reaches the same abort with no memory at all.
- Cause 1: `JSBuffer__bufferFromPointerAndLengthAndDeinit` (`src/jsc/bindings/JSBuffer.cpp:383` on main) and `JSBuffer__fromMmap` (`JSBuffer.cpp:2588`) hand their bytes to `ArrayBuffer::createFromBytes` without a length check. JSC RELEASE_ASSERTs there above `MAX_ARRAY_BUFFER_SIZE` (`vendor/WebKit/Source/JavaScriptCore/runtime/ArrayBuffer.cpp:150`).
- Cause 2: the spawnSync output arms (`subprocess/Readable.rs:294`, `SubprocessPipeReader.rs:333`) went through `ArrayBuffer::from_owned_bytes` / `from_bytes`, which convert the length through `u32` with `expect`. That panic fires at 2^32 and above, before the bytes reach JSC.
- Cause 3: once the hand-off throws, two error paths that nothing had reached before misbehave. `spawn_maybe_sync` (`js_bun_spawn_bindings.rs:2041`) returns without `finalize`, which leaks the subprocess. The shell (`interpreter.rs:1227`, added in #37275) rejects with the `JSC::Exception` cell instead of the thrown value, and the JS `reject` callback in `builtins/shell.ts` expects `(code, stdout, stderr)`, so it throws a TypeError and the promise never settles. In a debug build the child dies on an assertion in `JSCell::toStringSlowCase`.

### Fix
- Both entry points in `JSBuffer.cpp` release the bytes (the deallocator, or `munmap`) and throw `RangeError: Out of memory`, the error `new ArrayBuffer(2 ** 32 + 1)` throws, for a length above `MAX_ARRAY_BUFFER_SIZE`. The `JSBuffer.cpp` and `JSBuffer.h` hunks are byte for byte the ones in #39558 (same blobs), which adds the check to the ArrayBuffer and typed array entry points at the same time. The two PRs merge in either order. The rest of this PR is what that check makes reachable.
- The check belongs in the entry points because they are the last step before the assert, and every producer of a Buffer from native bytes uses them: spawnSync, `Bun.$`, `bun:ffi`, `bun:sqlite` serialize, zlib, `Bun.Archive`, `Bun.Image`. A length of exactly 2^32 still passes. JSC accepts it, and `toBuffer(ptr, 0, 2 ** 32)` already works today.
- The bytes are released before the throw because the caller gave them up when it called. The `length == 0` branch of the same function already does this. The repro's RSS drops to about 340 MiB after the catch.
- The two spawnSync output arms call `JSValue::create_buffer_from_box`. It makes the same C++ call as before with the same deallocator, without the `u32` hop. The `u32` conversions themselves stay as they are: #39558 removes them for the `Bun.file()` path, and this PR does not depend on that.
- `spawn_maybe_sync` builds stdout, stderr and the resource usage object first, runs `finalize`, and propagates an error after that. The pre-existing return for an exception that is already pending after the wait (a termination) runs `finalize` too. `finalize` releases the other stream's buffer and the abort signal reference, and it does not run JS, so a pending exception does not affect it.
- `to_js_buffer_from_memfd` and `to_js_buffer_from_fd` return `Err` when they throw. Before, they returned `Ok(JSValue::ZERO)` with the exception pending, and spawnSync would have stored that empty value in the result object. Nothing reaches this path from JS since #33832 (spawnSync no longer uses a memfd for stdout), so it has no test of its own.
- The shell interpreter takes the error with `take_error`, which unwraps the `JSC::Exception`, and the JS `reject` callback forwards the value to the promise. `reject` has exactly one caller, this path. Exit codes still go through `resolve`, which builds the `ShellError`.
- Verified with `test/js/bun/ffi/ffi.test.js` ("toBuffer at the Buffer length limit"): on main the child aborts, with the fix it throws a RangeError and a view of exactly 2^32 bytes is still created. This case costs no memory and runs on every platform. It only checks the error class, so it holds with #33353 too.
- Verified with `test/js/bun/spawn/spawnSync.test.ts` ("spawnSync output at the Buffer length limit"): 2^32 + 1 bytes throw the RangeError, 2^32 bytes come back as a Buffer. On main both cases die with the `int cast` panic. About 11 s per case in a debug build, 8.3 GiB peak RSS in the child, so the block skips below 16 GiB of RAM and is POSIX only (`head -c`). The glibc CI test machines have 8 GB and skip it, the ASAN machines have 64 GB and run it.
- Verified with `test/js/bun/shell/shelloutput.test.ts` ("stdout at the Buffer length limit"): the promise rejects with the RangeError. On main the child aborts. With the entry point check alone the child dies on the `toStringSlowCase` assertion. Same size gate.
- `bun bd test` passes on `spawnSync.test.ts`, `spawn.test.ts`, `spawn-maxbuf.test.ts`, `spawnsync-isolated-event-loop.test.ts`, `spawnsync-no-microtask-drain.test.ts`, `ffi.test.js`, `bunshell.test.ts`, `shelloutput.test.ts`, `throw.test.ts` and `test/internal/source-lints`. The repros are clean under `BUN_JSC_validateExceptionChecks=1`. `cargo check` for `x86_64-pc-windows-msvc` and clippy are clean.
- Related open PRs: #39558 (see above), #33353 (a check in `bun:ffi` in front of the entry point), #37243 (a check in `Buffer.from(string)` in front of it). They apply on top of this change.

### Background
A Buffer is a Uint8Array over a JSC `ArrayBuffer`. JSC stores the byte length as `size_t` but caps it at `MAX_ARRAY_BUFFER_SIZE` (2^32 on 64-bit, `PageCount.h`). Bun exposes the cap as `require("buffer").kMaxLength`. JSC's allocating constructors return null above the cap, and the callers turn that into `RangeError: Out of memory`. The adopting constructor, `createFromBytes`, takes bytes that already exist and asserts instead, so the check has to happen before the hand-off.

Adopting means JSC takes ownership of a byte range that native code allocated, and frees it through a deallocator passed along with the bytes when the object is collected. spawnSync and the shell use this to return their captured output without a copy. `bun:ffi` `toBuffer` uses it with a deallocator that frees nothing, which is why it can describe any length without owning that much memory.

In Rust, `JsResult` is `Result<JSValue, JsError>`, and `Err(Thrown)` means an exception is pending on the VM. `from_js_host_call` turns a C++ call that returns an empty value with an exception pending into that `Err`. `take_exception` removes the pending exception and returns JSC's `Exception` cell, the wrapper that carries the thrown value and its stack. `take_error` returns the thrown value itself, which is what a JS callback has to receive. The promise helpers unwrap the cell themselves, which is why the other `take_exception` callers are fine.

<details>
<summary>Earlier version of this PR</summary>

The first push threw `RangeError` with code `ERR_BUFFER_TOO_LARGE` from the two entry points, with its own helper. #39558 added its check to the same two functions in the meantime, with `RangeError: Out of memory` for all four entry points. This PR now carries that PR's hunks unchanged instead, and the tests expect that error.

</details>
