### PR TITLE
expect: drop the exception when a value throws while a failure message is formatted

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -44,23 +44,20 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 flush: false,
                 quote_strings: true,
             };
-            let _ = JestPrettyFormat::format(
-                MessageLevel::Debug,
-                global_this,
-                core::slice::from_ref(&received),
-                1,
-                &mut received_buf,
-                fmt_options,
-            ); // TODO:
-
-            let _ = JestPrettyFormat::format(
-                MessageLevel::Debug,
-                global_this,
-                core::slice::from_ref(&expected),
-                1,
-                &mut expected_buf,
-                fmt_options,
-            ); // TODO:
+            for (value, buf) in [(received, &mut received_buf), (expected, &mut expected_buf)] {
+                if JestPrettyFormat::format(
+                    MessageLevel::Debug,
+                    global_this,
+                    core::slice::from_ref(&value),
+                    1,
+                    buf,
+                    fmt_options,
+                )
+                .is_err()
+                {
+                    let _ = global_this.clear_exception_except_termination();
+                }
+            }
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();

--- a/test/js/bun/test/expect-stack-overflow-crash.test.ts
+++ b/test/js/bun/test/expect-stack-overflow-crash.test.ts
@@ -125,11 +125,11 @@ describe.concurrent("failing matcher when formatting a value throws", () => {
         console.log(JSON.stringify(e.message));
       }
     `);
+    expect(result).toMatchObject({ stderr: "", exitCode: 0 });
     const message = JSON.parse(result.stdout);
     expect(message).toStartWith("expect(received).toEqual(expected)\n\n");
     expect(message).toContain('"a": 1');
     expect(message).not.toContain("boom");
-    expect(result).toMatchObject({ stderr: "", exitCode: 0 });
   });
 
   test("a getter that overflows the stack while the message is formatted", async () => {

--- a/test/js/bun/test/expect-stack-overflow-crash.test.ts
+++ b/test/js/bun/test/expect-stack-overflow-crash.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 // Regression test: calling expect matchers after catching a stack overflow
@@ -55,4 +55,166 @@ try {
   expect(stdout).toBe("true Maximum call stack size exceeded.\n");
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
+});
+
+// A failing matcher formats the received and the expected value for its message.
+// The formatter reads `$$typeof` from every object, so a `$$typeof` getter that
+// throws makes formatting that object throw. The exception used to stay pending
+// while the remaining properties and the other value were formatted. Debug builds
+// asserted on the next native call. Release builds dropped the property, or threw
+// the getter's error instead of the matcher's error.
+describe.concurrent("failing matcher when formatting a value throws", () => {
+  // Properties are formatted in code point order. On the Bun object, "A0" comes
+  // right before "Archive", which is initialized lazily by native code, and "B0"
+  // comes after it.
+  const marker = "formatted-after-the-throwing-property";
+
+  async function run(script: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("the property that throws ends the walk of that object", async () => {
+    const result = await run(`
+      Bun.A0 = { get $$typeof() { throw new Error("boom"); } };
+      Bun.B0 = ${JSON.stringify(marker)};
+      try {
+        Bun.jest().expect({}).toStrictEqual(Bun);
+      } catch (e) {
+        console.log(e.message.split("\\n")[0], e.message.includes(${JSON.stringify(marker)}));
+      }
+    `);
+    expect(result).toEqual({
+      stdout: "expect(received).toStrictEqual(expected) false\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("the exception also ends the walk of the enclosing object", async () => {
+    const result = await run(`
+      const a = {};
+      Object.defineProperty(a, "$$typeof", { get() { throw new Error("boom"); } });
+      const received = { x: { a, b: ${JSON.stringify(marker)} }, y: ${JSON.stringify(marker)} };
+      try {
+        Bun.jest().expect(received).toEqual({});
+      } catch (e) {
+        console.log(e.message.split("\\n")[0], e.message.includes(${JSON.stringify(marker)}));
+      }
+    `);
+    expect(result).toEqual({
+      stdout: "expect(received).toEqual(expected) false\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("the matcher throws its own error when the received value itself cannot be formatted", async () => {
+    const result = await run(`
+      const received = {};
+      Object.defineProperty(received, "$$typeof", { get() { throw new Error("boom"); } });
+      try {
+        Bun.jest().expect(received).toEqual({ a: 1 });
+      } catch (e) {
+        console.log(JSON.stringify(e.message));
+      }
+    `);
+    const message = JSON.parse(result.stdout);
+    expect(message).toStartWith("expect(received).toEqual(expected)\n\n");
+    expect(message).toContain('"a": 1');
+    expect(message).not.toContain("boom");
+    expect(result).toMatchObject({ stderr: "", exitCode: 0 });
+  });
+
+  test("a getter that overflows the stack while the message is formatted", async () => {
+    // The getter is plain JavaScript, so it only throws once the stack is
+    // exhausted. The matcher runs in the three deepest frames that caught the
+    // overflow, like the fuzzer-generated program this test comes from.
+    const result = await run(`
+      function helper() { return undefined; }
+      Bun.A0 = { get $$typeof() { return helper(); } };
+      Bun.B0 = ${JSON.stringify(marker)};
+      const errors = [];
+      function F() {
+        try { new F(); } catch {}
+        if (errors.length < 3) {
+          const jest = Bun.jest();
+          try { jest.expect(jest).toStrictEqual(Bun); } catch (e) { errors.push(e); }
+        }
+      }
+      new F();
+      for (const e of errors) {
+        console.log(e.constructor.name, e.message.split("\\n")[0], e.message.includes(${JSON.stringify(marker)}));
+      }
+    `);
+    expect(result).toEqual({
+      stdout: Array(3).fill("Error expect(received).toStrictEqual(expected) false\n").join(""),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // Other places where the formatter runs user code. None of them is reached by
+  // the comparison itself, so only the message formatting throws.
+  const throwingValues = {
+    "a RegExp whose toString throws": `
+      const value = /abc/;
+      Object.defineProperty(value, "toString", { value() { throw new Error("boom"); } });
+    `,
+    "an array Proxy whose get trap throws": `
+      const value = new Proxy([1], { get() { throw new Error("boom"); } });
+    `,
+    "an object whose Symbol.toStringTag getter throws": `
+      const value = { a: 1 };
+      Object.defineProperty(value, Symbol.toStringTag, { get() { throw new Error("boom"); } });
+    `,
+  };
+
+  test.each(Object.entries(throwingValues))("%s on either side of the diff", async (_, makeValue) => {
+    const result = await run(`
+      ${makeValue}
+      const { expect } = Bun.jest();
+      for (const assertion of [() => expect(value).toEqual({ z: 9 }), () => expect({ z: 9 }).toEqual(value)]) {
+        try {
+          assertion();
+        } catch (e) {
+          console.log(e.message.split("\\n")[0]);
+        }
+      }
+    `);
+    expect(result).toEqual({
+      stdout: "expect(received).toEqual(expected)\nexpect(received).toEqual(expected)\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("matcherHint renders the same diff for a custom matcher", async () => {
+    const result = await run(`
+      ${throwingValues["an object whose Symbol.toStringTag getter throws"]}
+      const { expect } = Bun.jest();
+      expect.extend({
+        toBeHinted() {
+          console.log(this.utils.matcherHint("toBeHinted", value, { z: 9 }).split("\\n")[0]);
+          return { pass: true, message: () => "" };
+        },
+      });
+      try {
+        expect(value).toBeHinted();
+      } catch (e) {
+        console.log(e.message.split("\\n")[0]);
+      }
+    `);
+    expect(result).toEqual({
+      stdout: "expect(received).toBeHinted(expected)\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes the rest of a fuzzer crash in the failure path of `expect()` matchers. Fingerprint `c5d217fcf09dae60`:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Maximum call stack size exceeded.
!exception()
ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

The fuzzer program recursed until the stack overflowed. In the frames that caught the overflow it ran `expect(jestObject).toStrictEqual(Bun)`. The matcher fails and formats both values for its message. At that stack depth every call from native code into JavaScript throws a `RangeError`. One of these throws happened inside the formatter's property callback, and two places let the pending exception through.

The first place was `JSC__JSValue__forEachPropertyOrdered`. It went on to the next key with the callback's exception pending, and the native initializer of the next `Bun` property asserted. That is the line 62 assertion in the report. #39804 fixed it on main while this PR was open (the walk now returns after a callback throws), so this PR no longer touches `bindings.cpp`. The rebase dropped that hunk, which was the same line.

The second place is `DiffFormatter::fmt` (`src/runtime/test_runner/diff_format.rs`), and it is what this PR fixes. It ignored the result of both `JestPrettyFormat::format` calls. On main today:

- When the received value throws while it is formatted, the expected value is formatted with the exception pending. The first native call of that pass asserts in a debug build: `ASSERT_NO_PENDING_EXCEPTION` in `JSC__JSValue__getOwn`, reached from `Tag::get`. This is the `ExceptionScope.h(63)` form of the same assertion.
- When either value throws, `throw_value` sees the pending exception and returns without throwing the matcher's error. The matcher throws the getter's error (or the `RangeError`) instead of `expect(received).toEqual(expected)`.

The fix is the `clear_exception_except_termination()` after a `format` call fails. The two calls are now one loop, so the same branch runs for both values. The message is built from what was formatted before the throw, and the matcher throws its own error. This is the policy `create_error_instance` (`src/jsc/JSGlobalObject.rs:749`) already applies to every other matcher message when a `Display` impl fails. `DiffFormatter` cannot return `fmt::Error` instead: `matcher_hint` (`src/runtime/test_runner/expect.rs:2917`) renders it with `format!`, which panics on a `Display` error, and `matcher_hint` reaches the same assertion today. A termination exception stays pending, as in `create_error_instance`.

Behavior change, in release builds too: a value that cannot be formatted no longer turns the failure into the getter's error. The matcher reports its own failure, and the side that threw is printed as far as it got (empty when the value itself threw). #34649 proposes the opposite policy for the same crash: keep the getter's error, which is what a release build prints today and what Jest does, by changing `create_error_instance`, `DiffFormatter` and `matcher_hint` to propagate, among other changes. The two PRs need one decision. If propagate is chosen, this PR should be closed and the tests below need the matcher's error replaced by the getter's error in their expected output.

This PR consolidates #28538 and #29784. Both contain this `diff_format.rs` change and nothing else. Their triggers (a RegExp whose `toString` throws, a Proxy that throws while it is formatted) are tests here now.

### How did you verify your code works?

`test/js/bun/test/expect-stack-overflow-crash.test.ts` gets eight subprocess tests. The first four use a `$$typeof` getter, which the formatter reads from every object:

- A throwing property on `Bun` that sorts right before `Bun.Archive`, and a marker property that sorts after it. The marker must not be in the message.
- The same, nested one level down in a plain object.
- The received value itself cannot be formatted. The expected value is still in the message, the getter's error is not.
- The fuzzer's shape. The getter is plain JavaScript and only throws once the stack is exhausted. The matcher runs in the three deepest frames that caught the overflow. On the unfixed build before #39804 this aborted with the exact text of the report, `Error Exception: Maximum call stack size exceeded.` at `ExceptionScope.h(62)`, with `DiffFormatter::fmt` > `JSC__JSValue__forEachPropertyOrdered` > `getPropertySlot` > `BunObject_lazyPropCb_Archive` > `to_js_host_call` on the stack.

The other four run a RegExp whose `toString` throws, an array Proxy whose `get` trap throws, and an object whose `Symbol.toStringTag` getter throws on both sides of `toEqual`, and the `toStringTag` case through `matcherHint` in an `expect.extend` matcher. None of these values is touched by the comparison, only by the message.

On a debug build of main (`025570f4b6`, which includes #39804) all eight fail: the cases where the received value throws abort with the line 63 assertion, the others print the getter's error. All eight also fail with `USE_SYSTEM_BUN=1 bun test` (1.4.0-canary.1). They pass with `bun bd test`, in about 4 seconds for the file. The original test in the file is unchanged.

Also run with the fix on the rebased branch: `test/js/bun/test/expect.test.js`, `test/js/bun/test/printing/diffexample.test.ts`, `test/js/bun/util/inspect.test.js`. A local probe of ten value types (arrays, Maps, Errors, Dates, class instances, Proxies, nested objects) through `toEqual`, `toStrictEqual` and `toMatchSnapshot` with a throwing `$$typeof` getter runs clean on the debug build.

The fuzzer program itself does not crash on main in a fresh process. It needed state left behind by earlier programs in the same long-lived fuzzing process, which is why the report calls it flaky. The tests above set up that state directly.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-stack-overflow-crash.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/expect-stack-overflow-crash.test.ts:
(pass) expect does not crash when called after catching stack overflow [913.59ms]
88 |         Bun.jest().expect({}).toStrictEqual(Bun);
89 |       } catch (e) {
90 |         console.log(e.message.split("\\n")[0], e.message.includes(${JSON.stringify(marker)}));
91 |       }
92 |     `);
93 |     expect(result).toEqual({
                        ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
    "stdout": 
- "expect(received).toStrictEqual(expected) false
+ "boom false
  "
  ,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/test/expect-stack-overflow-crash.test.ts:93:20)
(fail) failing matcher when formatting a value throws > the property that throws ends the walk of that object [385.30ms]
123 |         Bun.jest().expect(received).toEqual({ a: 1 });
124 |       } catch (e) {
125 |         console.log(JSON.stringify(e.message));
... (truncated)

release without fix: 10 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/bun/test/expect-stack-overflow-crash.test.ts:
(pass) expect does not crash when called after catching stack overflow [16.37ms]
88 |         Bun.jest().expect({}).toStrictEqual(Bun);
89 |       } catch (e) {
90 |         console.log(e.message.split("\\n")[0], e.message.includes(${JSON.stringify(marker)}));
91 |       }
92 |     `);
93 |     expect(result).toEqual({
                        ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
    "stdout": 
- "expect(received).toStrictEqual(expected) false
+ "boom false
  "
  ,
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/test/expect-stack-overflow-crash.test.ts:93:20)
(fail) failing matcher when formatting a value throws > the property that throws ends the walk of that object [8.47ms]
106 |         Bun.jest().expect(received).toEqual({});
107 |       } catch (e) {
108 |         console.log(e.message.split("\\n")[0], e.message.includes(${JSON.stringify(marker)}));
109 |       }
110 |     `);
111 |     expect(result).toEqual({
                         ^
error: expect(received).toEqual(expected)

  {
 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/expect-stack-overflow-crash.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/expect-stack-overflow-crash.test.ts:
(pass) expect does not crash when called after catching stack overflow [800.00ms]
(pass) failing matcher when formatting a value throws > the exception also ends the walk of the enclosing object [309.85ms]
(pass) failing matcher when formatting a value throws > the matcher throws its own error when the received value itself cannot be formatted [315.58ms]
(pass) failing matcher when formatting a value throws > the property that throws ends the walk of that object [556.34ms]
(pass) failing matcher when formatting a value throws > a RegExp whose toString throws on either side of the diff [391.46ms]
(pass) failing matcher when formatting a value throws > an array Proxy whose get trap throws on either side of the diff [307.40ms]
(pass) failing matcher when formatting a value throws > a getter that overflows the stack while the message is formatted [641.25ms]
(pass) failing matcher when formatting a value th
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 671ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 120 exports (host=5, lazy=10, generic=105, rust=0); 244 extern-C blocks audited
[1/5] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 26s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.1-canary.1+884ca9afc
[build] done
bun test v1.4.1-canary.1 (884ca9afc)

test/js/bun/test/expect-stack-overflow-crash.test.ts:
(pass) expect does not crash when called after catching stack overflow [13.54ms]
(pass) failing matcher when formatting a value throws > the property that throws ends the walk of that object [6.74ms]
(pass) failing matcher when formatting a value throws > the exception also ends the walk of the enclosing object [7.03ms]
(pass) fail
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/diff_format.rs             |  31 ++--
 .../bun/test/expect-stack-overflow-crash.test.ts   | 164 ++++++++++++++++++++-
 2 files changed, 177 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/runtime/test_runner/diff_format.rs                    2      2      0
test/js/bun/test/expect-stack-overflow-crash.test.ts      5      7      0
```

</details>

<!-- robobun:evidence:end -->