### PR TITLE
dev server: report a route whose html file cannot be read instead of crashing

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4952,7 +4952,7 @@ impl DevServer {
         log: &Log,
         bv2: &mut BundleV2,
     ) -> Result<(), AllocError> {
-        let _g = self.graph_safety_lock.guard();
+        let graph_lock = self.graph_safety_lock.guard();
 
         debug_log!(
             "handleParseTaskFailure({}, .{}, {}, {} messages)",
@@ -4962,13 +4962,35 @@ impl DevServer {
             log.msgs.len(),
         );
 
+        let mut watch_for_route_file = false;
         if matches!(err.name(), "ENOENT" | "FileNotFound" | "ModuleNotFound") {
-            // Special-case files being deleted.
+            // Special-case files being deleted: the importers are re-bundled
+            // and report the missing file.
             match graph {
                 bake::Graph::Server | bake::Graph::Ssr => {
                     self.server_graph.on_file_deleted(abs_path, bv2)?
                 }
-                bake::Graph::Client => self.client_graph.on_file_deleted(abs_path, bv2)?,
+                bake::Graph::Client => {
+                    self.client_graph.on_file_deleted(abs_path, bv2)?;
+                    // Nothing imports the html file of a route. Without a
+                    // failure of its own, `finalize_bundle` marks the route
+                    // loaded and serves it without any bundled html.
+                    if let Some(file) = self
+                        .client_graph
+                        .bundled_files
+                        .get(abs_path)
+                        .filter(|file| file.html_route_bundle_index.is_some())
+                    {
+                        // The failure stays set until the file is bundled again,
+                        // so a route that keeps failing registers one watch.
+                        watch_for_route_file = !file.failed;
+                        self.client_graph.insert_failure(
+                            incremental_graph::InsertFailureKey::AbsPath(abs_path),
+                            log,
+                            false,
+                        )?;
+                    }
+                }
             }
         } else {
             match graph {
@@ -4988,6 +5010,19 @@ impl DevServer {
                     false,
                 )?,
             }
+        }
+        drop(graph_lock);
+
+        if watch_for_route_file {
+            // The same directory watch that retries a failed import re-bundles
+            // the route once its html file exists again. It takes the graph
+            // lock itself.
+            self.directory_watchers.track_resolution_failure(
+                abs_path,
+                paths::basename(abs_path),
+                bake::Graph::Client,
+                Loader::Html,
+            )?;
         }
         Ok(())
     }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4964,25 +4964,21 @@ impl DevServer {
 
         let mut watch_for_route_file = false;
         if matches!(err.name(), "ENOENT" | "FileNotFound" | "ModuleNotFound") {
-            // Special-case files being deleted: the importers are re-bundled
-            // and report the missing file.
+            // Special-case files being deleted: the importers report them.
             match graph {
                 bake::Graph::Server | bake::Graph::Ssr => {
                     self.server_graph.on_file_deleted(abs_path, bv2)?
                 }
                 bake::Graph::Client => {
                     self.client_graph.on_file_deleted(abs_path, bv2)?;
-                    // Nothing imports the html file of a route. Without a
-                    // failure of its own, `finalize_bundle` marks the route
-                    // loaded and serves it without any bundled html.
+                    // The html file of a route has no importer.
                     if let Some(file) = self
                         .client_graph
                         .bundled_files
                         .get(abs_path)
                         .filter(|file| file.html_route_bundle_index.is_some())
                     {
-                        // The failure stays set until the file is bundled again,
-                        // so a route that keeps failing registers one watch.
+                        // `failed` is cleared by the next successful bundle.
                         watch_for_route_file = !file.failed;
                         self.client_graph.insert_failure(
                             incremental_graph::InsertFailureKey::AbsPath(abs_path),
@@ -5011,12 +5007,11 @@ impl DevServer {
                 )?,
             }
         }
+        // `track_resolution_failure` takes the graph lock itself.
         drop(graph_lock);
 
         if watch_for_route_file {
-            // The same directory watch that retries a failed import re-bundles
-            // the route once its html file exists again. It takes the graph
-            // lock itself.
+            // Bundles the route again once its html file exists, like a failed import.
             self.directory_watchers.track_resolution_failure(
                 abs_path,
                 paths::basename(abs_path),

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -691,7 +691,11 @@ test("serve html whose file is deleted before its first bundle", async () => {
     "app.ts": `console.log("app");`,
     "serve.ts": /*ts*/ `
       import { renameSync } from "node:fs";
+      import { join } from "node:path";
       import html from "./index.html";
+
+      const htmlPath = join(import.meta.dir, "index.html");
+      const movedPath = htmlPath + ".moved";
 
       const server = Bun.serve({ port: 0, development: true, routes: { "/": html } });
       async function page() {
@@ -700,11 +704,11 @@ test("serve html whose file is deleted before its first bundle", async () => {
         return { status: response.status, title: text.match(/<title>(.*?)<\\/title>/)?.[1] };
       }
 
-      renameSync("index.html", "index.html.moved");
+      renameSync(htmlPath, movedPath);
       // The second request hits the route while it is already marked as failed.
       const missing = [await page(), await page()];
 
-      renameSync("index.html.moved", "index.html");
+      renameSync(movedPath, htmlPath);
       let restored = await page();
       const deadline = Date.now() + 30_000;
       while (restored.status !== 200 && Date.now() < deadline) {

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -678,6 +678,60 @@ test("serve html error handling", async () => {
   Bun.gc(true);
 });
 
+// The dev server treats a file that fails to load with ENOENT as deleted and
+// leaves it to the importers to report. The html file of a route has no
+// importer, so the route used to reach the loaded state without any bundled
+// html and crash the process while it rendered the page. Now the route reports
+// the missing file and watches its directory, so the page comes back with the
+// file. Nothing else in the directory was ever bundled, so nothing else
+// watches it.
+test("serve html whose file is deleted before its first bundle", async () => {
+  using dir = tempDir("bun-serve-html-deleted-route-file", {
+    "index.html": `<!DOCTYPE html><html><head><title>restored page</title></head><body><script type="module" src="./app.ts"></script></body></html>`,
+    "app.ts": `console.log("app");`,
+    "serve.ts": /*ts*/ `
+      import { renameSync } from "node:fs";
+      import html from "./index.html";
+
+      const server = Bun.serve({ port: 0, development: true, routes: { "/": html } });
+      async function page() {
+        const response = await fetch(server.url);
+        const text = await response.text();
+        return { status: response.status, title: text.match(/<title>(.*?)<\\/title>/)?.[1] };
+      }
+
+      renameSync("index.html", "index.html.moved");
+      // The second request hits the route while it is already marked as failed.
+      const missing = [await page(), await page()];
+
+      renameSync("index.html.moved", "index.html");
+      let restored = await page();
+      const deadline = Date.now() + 30_000;
+      while (restored.status !== 200 && Date.now() < deadline) {
+        await Bun.sleep(10);
+        restored = await page();
+      }
+
+      console.log(JSON.stringify({ missing, restored }));
+      server.stop(true);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "serve.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const failed = { status: 500, title: "Bun - Build Failed" };
+  expect({ stdout: stdout.trim(), exitCode }, stderr).toEqual({
+    stdout: JSON.stringify({ missing: [failed, failed], restored: { status: 200, title: "restored page" } }),
+    exitCode: 0,
+  });
+});
+
 test("wildcard static routes", async () => {
   await using dir = tempDir("bun-serve-html-error-handling", {
     "index.html": /*html*/ `


### PR DESCRIPTION
### Problem
- A dev server whose html route file is missing when the route is first requested aborts the process: `panic: called Option::unwrap() on a None value` in `DevServer::generate_html_payload` (`src/runtime/bake/DevServer.rs:2770`, `html.script_injection_offset.unwrap()`), reached from `finalize_bundle` when it replays the deferred request. Release builds abort too ("Bun has crashed"). This reproduces 1/1 on 1.4.0 with `Bun.serve({ development: true, routes: { "/": html } })`, `unlinkSync("index.html")`, `fetch("/")`. A rename or delete of the file while the first bundle is in flight reaches the same panic through the same path.
- A route that was served before and whose file is then deleted does not crash, because the route bundle still holds the old html. It keeps serving the old page and never reports the missing file.
- Cause: `handle_parse_task_failure` (`DevServer.rs:4965`) treats `ENOENT` as a deleted file and records no failure. That is correct for an imported file, because its importers are bundled again and report the failed import. The html file of a route has no importer. So the bundle finishes with no failure, `finalize_bundle` marks the route `Loaded` (`DevServer.rs:4799`), and the route bundle has no html text and no injection offset.
- #37929 fixes a different door to the same panic (`server.reload()` creates a second route bundle). It does not change this path.

### Fix
- In the `ENOENT` branch of `handle_parse_task_failure`, when the file is the html file of a route (its client graph entry has an `html_route_bundle_index`), also call `insert_failure` with the bundler's log. The request then gets the normal build failure page (500), the same as for any other failed file. The failure is inserted on every failed attempt because `finalize_bundle` chooses the failure path from the failures added during that bundle.
- On the first failure, register the directory of the file in `DirectoryWatchStore` through `track_resolution_failure`, with the file name as the specifier. A missing file is not in the file watcher, and on a fresh server nothing else in that directory is bundled yet, so without this the route would stay failed. When the file appears, the store resolves the name, invalidates the html file, and the route is bundled again. `File.failed` stays set until a bundle succeeds, so a route that keeps failing registers one watch. This is the same mechanism a failed import uses.
- The directory watch store takes the graph lock itself, so the function now drops its own lock before that call. `ThreadLock` panics on a second lock in debug builds.
- Verified with the new test in `test/js/bun/http/bun-serve-html.test.ts` ("serve html whose file is deleted before its first bundle"): two requests while the file is missing get the build failure page, and the page is served again after the file is moved back. `USE_SYSTEM_BUN=1`: the child exits with 134 (the panic). `bun bd`: passes, also with `BUN_ASSUME_PERFECT_INCREMENTAL=0` (the release default, where every request bundles again; the second request then fails through the entry point resolution path instead of the read path). 5 repeated runs pass.
- Also green on the debug build: the rest of `bun-serve-html.test.ts`, `test/bake/dev/{html,bundle,hot,css,incremental-graph-edge-deletion}.test.ts`.
- A deleted route file of a served page now shows the build failure page and comes back with the file (probed with rename and unlink on the debug build). On 1.4.0 both are ignored.
- #38041 (also in #39488) adds a `loader` argument to `insert_failure`. The new call here needs `Some(Loader::Html)` when the two meet. Nothing else overlaps.

### Background
- With `development: true`, each imported html file served as a route gets a `RouteBundle` in the dev server. The first request for the route starts a bundle with the html file as the entry point and defers the request. `finalize_bundle` stores the bundled html text and the offset where the dev server injects its script tags into the route bundle, sets the route `Loaded`, and replays the deferred requests. `generate_html_payload` renders the page from that text and offset.
- The incremental graph has one `File` per bundled path. `File.failed` plus an entry in `dev.bundling_failures` is how a file with an error is represented. `finalize_bundle` sends the failures added during the bundle to the deferred requests as the build failure page, and a later successful `receive_chunk` for the file clears the flag.
- `DirectoryWatchStore` (`src/runtime/bake/dev_server/mod.rs`) holds, per watched directory, a list of (source file, specifier) pairs for imports that failed to resolve. When the directory changes, it resolves each specifier again from the source file's directory and invalidates the source files whose specifier now resolves. With the source file set to the html file and the specifier set to its own name, a recreated file invalidates the route's html file.
- `graph_safety_lock` is a `ThreadLock`: a debug-only assertion that one code path at a time touches the graphs. It is not re-entrant.

<details>
<summary>Stack without the fix (debug build)</summary>

```
panic: called `Option::unwrap()` on a `None` value
<bun_runtime::bake::dev_server_body::DevServer>::generate_html_payload         src/runtime/bake/DevServer.rs:2770
<bun_runtime::bake::dev_server_body::DevServer>::on_html_request_with_bundle   src/runtime/bake/DevServer.rs:2718
bun_runtime::bake::dev_server_body::finalize_bundle                            src/runtime/bake/DevServer.rs:4859
```

Repro (1.4.0 aborts, this branch answers 500 and then 200 after the file is restored):

```js
import html from "./index.html";
import { unlinkSync } from "node:fs";
const srv = Bun.serve({ routes: { "/": html }, development: true, port: 0 });
unlinkSync("index.html");
console.log((await fetch(srv.url)).status);
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_INdOgL {
  "/": "/tmp/html-css-js_INdOgL/index.html",
  "/dashboard": "/tmp/html-css-js_INdOgL/dashboard.html",
}
[0.10ms] bundle index.html 1.09 KB
[0.06ms] bundle dashboard.html 1.27 KB
(pass) serve html [680.33ms]
waitForServer /tmp/bun-serve-html-txt_RbwOXF {
  "/": "/tmp/bun-serve-html-txt_RbwOXF/index.html",
}
[0.18ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [689.49ms]
waitForServer /tmp/html-css-js-failing-plugin_Fq2vaY {
  "/": "/tmp/html-css-js-failing-plugin_Fq2vaY/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_Fq2vaY/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_Fq2vaY/styles.css:0
(pass) serve plugins > serve html with failing plugin [633.00ms]
waitForServer /tmp/html-css-js-empty-plugins_WLMYMH {
  "/": "/tmp/html-css-js-empty-plugins_WLMYMH/index.html",
}
[0.16ms] bu
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_1wj9nd {
  "/": "/tmp/html-css-js_1wj9nd/index.html",
  "/dashboard": "/tmp/html-css-js_1wj9nd/dashboard.html",
}
[0.00ms] bundle index.html 1.09 KB
[0.00ms] bundle dashboard.html 1.27 KB
(pass) serve html [23.81ms]
waitForServer /tmp/bun-serve-html-txt_6o0Rss {
  "/": "/tmp/bun-serve-html-txt_6o0Rss/index.html",
}
[0.00ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [17.21ms]
waitForServer /tmp/html-css-js-failing-plugin_KzhTvv {
  "/": "/tmp/html-css-js-failing-plugin_KzhTvv/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_KzhTvv/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_KzhTvv/styles.css:0
(pass) serve plugins > serve html with failing plugin [16.45ms]
waitForServer /tmp/html-css-js-empty-plugins_xlOGmM {
  "/": "/tmp/html-css-js-empty-plugins_xlOGmM/index.html",
}
[0.00ms] bundle index.html 0.71 KB
(pass) serve plugins > empty plugin array [13.58ms]
Waiting for server
waitForServer /tmp/html-css-js-concurrent-plugins_HEInNp {
  "/": "/tmp/
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_tbUteS {
  "/": "/tmp/html-css-js_tbUteS/index.html",
  "/dashboard": "/tmp/html-css-js_tbUteS/dashboard.html",
}
[0.09ms] bundle index.html 1.09 KB
[0.06ms] bundle dashboard.html 1.27 KB
(pass) serve html [644.89ms]
waitForServer /tmp/bun-serve-html-txt_X1Cxyq {
  "/": "/tmp/bun-serve-html-txt_X1Cxyq/index.html",
}
[0.16ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [616.03ms]
waitForServer /tmp/html-css-js-failing-plugin_jYZafQ {
  "/": "/tmp/html-css-js-failing-plugin_jYZafQ/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_jYZafQ/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_jYZafQ/styles.css:0
(pass) serve plugins > serve html with failing plugin [549.81ms]
waitForServer /tmp/html-css-js-empty-plugins_w0aF6w {
  "/": "/tmp/html-css-js-empty-plugins_w0aF6w/index.html",
}
[0.09ms] bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 600ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 242 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/DevServer.rs           | 36 ++++++++++++++++++--
 test/js/bun/http/bun-serve-html.test.ts | 58 +++++++++++++++++++++++++++++++++
 2 files changed, 91 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/bake/DevServer.rs               19      6      0
test/js/bun/http/bun-serve-html.test.ts      6      8      0
```

</details>

<!-- robobun:evidence:end -->