### PR TITLE
valkey: reject connect() and call onclose with the real failure reason

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -2066,11 +2066,13 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr,
 
     if (rc != 0) {
         bsd_close_socket(fd);
+        /* bsd_do_connect_raw returned the connect error; re-arm it so the
+         * caller observes the connect failure rather than whatever closing the
+         * socket left behind. */
 #ifdef _WIN32
-        /* bsd_do_connect_raw returned the WSA error; re-arm it so the Rust
-         * caller's WSAGetLastError() observes the connect failure rather than
-         * whatever closesocket() left behind. */
         WSASetLastError(rc);
+#else
+        errno = rc;
 #endif
         return LIBUS_SOCKET_ERROR;
     }
@@ -2091,6 +2093,8 @@ static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_connect_socket_unix(const cha
         bsd_close_socket(fd);
 #ifdef _WIN32
         WSASetLastError(rc);
+#else
+        errno = rc;
 #endif
         return LIBUS_SOCKET_ERROR;
     }
@@ -2127,7 +2131,9 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket_unix(const char *server_path, 
     }
 #elif defined(__linux__)
     if (dirfd_workaround_for_unix_path_len != -1) {
+        int saved_errno = errno;
         close(dirfd_workaround_for_unix_path_len);
+        errno = saved_errno;
     }
 #endif
 

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -304,6 +304,36 @@ pub fn from_errno(errno: i32) -> SystemErrno {
     SystemErrno::init(errno as i64).unwrap_or(SystemErrno::EIO)
 }
 
+/// The errno a failed `connect(2)` is reported with, as `node:net` reports it.
+/// `raw` is what uSockets hands the connect-error callback (`SO_ERROR`, or the
+/// WSA code on Windows) or what a dial that failed outright left in errno.
+/// Unix-path connect errors keep their real code (a non-socket file is
+/// `ENOTSOCK`, a permission-denied path is `EACCES`, a missing one is
+/// `ENOENT`, an inexpressible path is `EINVAL`); everything else, including
+/// Windows' `ENOTCONN` from the recv probe, is `ECONNREFUSED`.
+pub fn connect_errno(raw: i32) -> SystemErrno {
+    #[cfg(windows)]
+    let raw: i32 = if raw >= 10000 {
+        SystemErrno::init(raw as u32)
+            .map(|e| e as i32)
+            .unwrap_or(SystemErrno::ECONNREFUSED as i32)
+    } else {
+        raw
+    };
+    const KEPT: [SystemErrno; 7] = [
+        SystemErrno::ENOENT,
+        SystemErrno::ENOTSOCK,
+        SystemErrno::EACCES,
+        SystemErrno::EINVAL,
+        SystemErrno::ECONNRESET,
+        SystemErrno::EADDRINUSE,
+        SystemErrno::EADDRNOTAVAIL,
+    ];
+    KEPT.into_iter()
+        .find(|e| *e as i32 == raw)
+        .unwrap_or(SystemErrno::ECONNREFUSED)
+}
+
 #[cfg(not(windows))]
 impl SystemErrno {
     // `i64` covers every concrete call site (errno-range values).

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1128,50 +1128,9 @@ impl<const SSL: bool> NewSocket<SSL> {
             )
         } else {
             debug_assert!(errno >= 0);
-            // uSockets hands us raw WSA codes (SO_ERROR, the recv probe) on
-            // Windows; map those onto the SystemErrno numbering the whitelist
-            // below compares against.
-            #[cfg(windows)]
-            let errno: c_int = if errno >= 10000 {
-                sys::SystemErrno::init(errno as u32)
-                    .map(|e| e as c_int)
-                    .unwrap_or(sys::SystemErrno::ECONNREFUSED as c_int)
-            } else {
-                errno
-            };
-            // Unix-path connect errors keep their real code (a non-socket file
-            // is ENOTSOCK, a permission-denied path is EACCES, a missing one is
-            // ENOENT, an inexpressible path is EINVAL); everything else stays
-            // ECONNREFUSED.
-            let errno_: c_int = if errno == sys::SystemErrno::ENOENT as c_int
-                || errno == sys::SystemErrno::ENOTSOCK as c_int
-                || errno == sys::SystemErrno::EACCES as c_int
-                || errno == sys::SystemErrno::EINVAL as c_int
-                || errno == sys::SystemErrno::ECONNRESET as c_int
-                || errno == sys::SystemErrno::EADDRINUSE as c_int
-                || errno == sys::SystemErrno::EADDRNOTAVAIL as c_int
-            {
-                errno
-            } else {
-                sys::SystemErrno::ECONNREFUSED as c_int
-            };
-            let code_ = if errno == sys::SystemErrno::ENOENT as c_int {
-                BunString::static_("ENOENT")
-            } else if errno == sys::SystemErrno::ENOTSOCK as c_int {
-                BunString::static_("ENOTSOCK")
-            } else if errno == sys::SystemErrno::EACCES as c_int {
-                BunString::static_("EACCES")
-            } else if errno == sys::SystemErrno::EINVAL as c_int {
-                BunString::static_("EINVAL")
-            } else if errno == sys::SystemErrno::ECONNRESET as c_int {
-                BunString::static_("ECONNRESET")
-            } else if errno == sys::SystemErrno::EADDRINUSE as c_int {
-                BunString::static_("EADDRINUSE")
-            } else if errno == sys::SystemErrno::EADDRNOTAVAIL as c_int {
-                BunString::static_("EADDRNOTAVAIL")
-            } else {
-                BunString::static_("ECONNREFUSED")
-            };
+            let errno_enum = bun_errno::connect_errno(errno);
+            let errno_: c_int = errno_enum as c_int;
+            let code_ = BunString::static_(<&'static str>::from(errno_enum));
             #[cfg(windows)]
             let errno_ = -sys::windows::libuv::e_discriminant_to_uv(errno_ as u16)
                 .unwrap_or(sys::windows::libuv::UV_ECONNREFUSED);

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1023,7 +1023,7 @@ impl JSValkeyClient {
                 debug!("first dial failed before a socket was opened: {:?}", err);
                 // Settled by the deferred close like a refused dial: the
                 // promise, onclose and the retry policy all go through on_close().
-                self.close_without_socket_next_tick(self.dial_error_message(err));
+                self.close_without_socket_next_tick(self.dial_error_message(&err));
                 return Ok(promise);
             }
 
@@ -1161,8 +1161,8 @@ impl JSValkeyClient {
     /// before it had a socket, in the shape of `node:net`'s: `connect ENOENT
     /// /run/redis.sock`. `errno` is raw (a WSA code on Windows); `connect_errno`
     /// normalises it the way `Bun.connect` does.
-    fn dial_error_message(&self, err: uws::ConnectError) -> Box<[u8]> {
-        let uws::ConnectError::FailedToOpenSocket { errno } = err;
+    fn dial_error_message(&self, err: &uws::ConnectError) -> Box<[u8]> {
+        let &uws::ConnectError::FailedToOpenSocket { errno } = err;
         Self::connect_error_message(&self.client.get().address, errno)
     }
 
@@ -1228,7 +1228,7 @@ impl JSValkeyClient {
             debug!("reconnect failed before a socket was opened: {:?}", err);
             // Same outcome as a dial that fails asynchronously: another retry,
             // or fail() and a settled connect() promise once retries are used up.
-            self.close_without_socket_next_tick(self.dial_error_message(err));
+            self.close_without_socket_next_tick(self.dial_error_message(&err));
             return Ok(());
         }
 
@@ -1604,7 +1604,7 @@ impl JSValkeyClient {
                 // refused dial.
                 Err(err) => {
                     debug!("first dial failed before a socket was opened: {:?}", err);
-                    self.close_without_socket_next_tick(self.dial_error_message(err));
+                    self.close_without_socket_next_tick(self.dial_error_message(&err));
                 }
                 Ok(()) => self.reset_connection_timeout(),
             }

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -786,6 +786,7 @@ impl JSValkeyClient {
                 read_buffer: Default::default(),
                 reply_scanner: Default::default(),
                 retry_attempts: 0,
+                failure: None,
                 auto_flusher: Default::default(),
             }),
             global_object,
@@ -903,6 +904,7 @@ impl JSValkeyClient {
                 read_buffer: Default::default(),
                 reply_scanner: Default::default(),
                 retry_attempts: 0,
+                failure: None,
                 auto_flusher: Default::default(),
             }),
             global_object,
@@ -1006,11 +1008,11 @@ impl JSValkeyClient {
 
         // If was manually closed, reset that flag
         self.client_mut().flags.is_manually_closed = false;
-        // Explicit connect() should also clear the sticky `failed` flag so the
+        // Explicit connect() should also clear the sticky failure so the
         // client can recover after prior connection attempts exhausted retries.
         // Without this, every subsequent command rejects with "Connection has
         // failed" forever — see https://github.com/oven-sh/bun/issues/29925.
-        self.client_mut().flags.failed = false;
+        self.client_mut().failure = None;
         let self_br = BackRef::new(self);
         let _update = scopeguard::guard(self_br, |p| p.update_poll_ref());
 
@@ -1018,13 +1020,10 @@ impl JSValkeyClient {
             self.poll_ref.with_mut(|r| r.ref_(vm_event_loop_ctx()));
 
             if let Err(err) = self.connect() {
-                debug!(
-                    "first dial failed before a socket was opened: {}",
-                    err.name()
-                );
+                debug!("first dial failed before a socket was opened: {:?}", err);
                 // Settled by the deferred close like a refused dial: the
                 // promise, onclose and the retry policy all go through on_close().
-                self.close_without_socket_next_tick();
+                self.close_without_socket_next_tick(self.dial_error_message(err));
                 return Ok(promise);
             }
 
@@ -1095,7 +1094,7 @@ impl JSValkeyClient {
 
         let _guard = self.ref_scope();
         let _timer_ref = self.timer.take_fire_ref(self);
-        if self.client.get().flags.failed {
+        if self.client.get().failure.is_some() {
             return Ok(());
         }
 
@@ -1152,10 +1151,31 @@ impl JSValkeyClient {
     /// commands queued for the retry or the rejection, and a disconnect()
     /// marks the close as manual for the task to honour. `update_poll_ref`
     /// keeps the wrapper and the event loop alive for it like a dial would.
-    fn close_without_socket_next_tick(&self) {
+    fn close_without_socket_next_tick(&self, reason: Box<[u8]>) {
         self.client_mut().status = valkey::Status::Connecting;
         self.update_poll_ref();
-        self.enqueue_deferred_close(DeferredClose::WithoutSocket);
+        self.enqueue_deferred_close(DeferredClose::WithoutSocket { reason });
+    }
+
+    /// The `CloseReason::DialFailed` text for a dial uSockets turned down
+    /// before it had a socket, in the shape of `node:net`'s: `connect ENOENT
+    /// /run/redis.sock`.
+    fn dial_error_message(&self, err: uws::ConnectError) -> Box<[u8]> {
+        let uws::ConnectError::FailedToOpenSocket { errno } = err;
+        Self::connect_error_message(&self.client.get().address, errno)
+    }
+
+    fn connect_error_message(address: &valkey::Address, errno: i32) -> Box<[u8]> {
+        use std::io::Write;
+        let mut message = Vec::new();
+        let _ = write!(message, "connect {} ", bun_errno::from_errno(errno));
+        match address {
+            valkey::Address::Unix(path) => message.extend_from_slice(path),
+            valkey::Address::Host { host, port } => {
+                let _ = write!(message, "{}:{}", bstr::BStr::new(host), port);
+            }
+        }
+        message.into_boxed_slice()
     }
 
     fn enqueue_deferred_close(&self, what: DeferredClose) {
@@ -1204,13 +1224,10 @@ impl JSValkeyClient {
         });
 
         if let Err(err) = self.connect() {
-            debug!(
-                "reconnect failed before a socket was opened: {}",
-                err.name()
-            );
+            debug!("reconnect failed before a socket was opened: {:?}", err);
             // Same outcome as a dial that fails asynchronously: another retry,
             // or fail() and a settled connect() promise once retries are used up.
-            self.close_without_socket_next_tick();
+            self.close_without_socket_next_tick(self.dial_error_message(err));
             return Ok(());
         }
 
@@ -1412,12 +1429,17 @@ impl JSValkeyClient {
             return Err(bun_jsc::JsError::Thrown);
         }
 
-        // Create an error value
-        let error_value = protocol_jsc::valkey_error_to_js(
-            &global_object,
-            b"Connection closed",
-            protocol::RedisError::ConnectionClosed,
-        );
+        // The error the commands were rejected with. `on_close()` records one
+        // before every call here; the fallback only stands in for a
+        // finalized client, whose `fail()` cannot make JS values.
+        let error_value = match &self.client.get().failure {
+            Some(failure) => failure.get(),
+            None => protocol_jsc::valkey_error_to_js(
+                &global_object,
+                b"Connection closed",
+                protocol::RedisError::ConnectionClosed,
+            ),
+        };
 
         let _exit = self.vm().enter_event_loop_scope();
 
@@ -1477,7 +1499,7 @@ impl JSValkeyClient {
         self.reconnect_timer.disarm(self);
     }
 
-    fn connect(&self) -> Result<(), crate::Error> {
+    fn connect(&self) -> Result<(), uws::ConnectError> {
         if self.client.get().status == valkey::Status::NeverConnected {
             self.client_mut().status = valkey::Status::Disconnected;
         }
@@ -1516,11 +1538,7 @@ impl JSValkeyClient {
         };
         if tls_ctx_failed {
             self.client_mut().flags.enable_auto_reconnect = false;
-            self.client_fail(
-                b"Failed to create TLS context",
-                protocol::RedisError::ConnectionClosed,
-            )?;
-            self.close_without_socket_next_tick();
+            self.close_without_socket_next_tick(Box::from(&b"Failed to create TLS context"[..]));
             return Ok(());
         }
         let ssl_ctx: Option<*mut uws::SslCtx> = match &self.client.get().tls {
@@ -1584,11 +1602,8 @@ impl JSValkeyClient {
                 // deferred close then rejects it or a retry sends it, like a
                 // refused dial.
                 Err(err) => {
-                    debug!(
-                        "first dial failed before a socket was opened: {}",
-                        err.name()
-                    );
-                    self.close_without_socket_next_tick();
+                    debug!("first dial failed before a socket was opened: {:?}", err);
+                    self.close_without_socket_next_tick(self.dial_error_message(err));
                 }
                 Ok(()) => self.reset_connection_timeout(),
             }
@@ -1886,7 +1901,8 @@ impl<const SSL: bool> SocketHandler<SSL> {
         this.client_mut().status = valkey::Status::Disconnected;
         let _defer = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
 
-        this.client_mut().on_close()
+        this.client_mut()
+            .on_close(valkey::CloseReason::SocketClosed)
     }
 
     pub(crate) fn on_end(this: &JSValkeyClient, socket: SocketType<SSL>) {
@@ -1898,18 +1914,42 @@ impl<const SSL: bool> SocketHandler<SSL> {
         // anything here
     }
 
+    /// `code` is the errno the connect ended with, or, when `dns_error` is
+    /// set, the `getaddrinfo(3)` code of the lookup that failed instead.
     pub(crate) fn on_connect_error(
         this: &JSValkeyClient,
-        _socket: SocketType<SSL>,
-        _code: i32,
+        socket: SocketType<SSL>,
+        code: i32,
     ) -> JsResult<()> {
+        // Read before the socket is detached: uSockets keeps the connecting
+        // socket alive for the whole dispatch.
+        let dns_error = socket.dns_error();
         // Ensure the socket pointer is updated.
         this.client_mut().socket = Socket::SocketTcp(uws::SocketTCP::detached());
         let _guard = this.ref_scope();
         this.client_mut().status = valkey::Status::Disconnected;
         let _defer = scopeguard::guard(BackRef::new(this), |p| p.update_poll_ref());
 
-        this.client_mut().on_close()
+        let address = &this.client.get().address;
+        let message =
+            match bun_cares_sys::c_ares::Error::init_eai(dns_error).filter(|_| dns_error != 0) {
+                Some(dns_err) => {
+                    use std::io::Write;
+                    let mut message = Vec::new();
+                    // `code()` is `DNS_ENOTFOUND`; `node:dns` and `Bun.connect`
+                    // report it as `getaddrinfo ENOTFOUND host`.
+                    let _ = write!(
+                        message,
+                        "getaddrinfo {} {}",
+                        &dns_err.code()[4..],
+                        bstr::BStr::new(address.hostname())
+                    );
+                    message.into_boxed_slice()
+                }
+                None => JSValkeyClient::connect_error_message(address, code),
+            };
+        this.client_mut()
+            .on_close(valkey::CloseReason::DialFailed(&message))
     }
 
     pub(crate) fn on_timeout(this: &JSValkeyClient, socket: SocketType<SSL>) {
@@ -2026,13 +2066,12 @@ impl Options {
     }
 }
 
-#[derive(Clone, Copy)]
 enum DeferredClose {
     /// Close the socket the finalized wrapper left behind.
     Socket,
     /// Run the close path for a dial that never produced a socket
-    /// (`close_without_socket_next_tick`).
-    WithoutSocket,
+    /// (`close_without_socket_next_tick`); `reason` is why it did not.
+    WithoutSocket { reason: Box<[u8]> },
 }
 
 pub(crate) struct ValkeyDeferredClose {
@@ -2048,11 +2087,11 @@ impl ValkeyDeferredClose {
         let _enqueue_ref = unsafe { ScopedRef::adopt(self.ctx) };
         // SAFETY: live per the ref above; tasks run on the JS thread.
         let this = unsafe { &*self.ctx };
-        match self.what {
+        match &self.what {
             DeferredClose::Socket => {
                 crate::dispatch::fold(this.client_mut().close(uws::CloseCode::FastShutdown))
             }
-            DeferredClose::WithoutSocket => {
+            DeferredClose::WithoutSocket { reason } => {
                 // Holding Connecting (see `close_without_socket_next_tick`) is
                 // what keeps a dial from starting in between; if one did, its
                 // own callbacks own the close path now, so only drop our ref.
@@ -2063,7 +2102,9 @@ impl ValkeyDeferredClose {
                 // which release the ref the socket would have held.
                 this.ref_();
                 this.client_mut().status = valkey::Status::Disconnected;
-                let closed = this.client_mut().on_close();
+                let closed = this
+                    .client_mut()
+                    .on_close(valkey::CloseReason::DialFailed(reason));
                 this.update_poll_ref();
                 crate::dispatch::fold(closed);
             }
@@ -2081,7 +2122,7 @@ impl bun_event_loop::Taskable for ValkeyDeferredClose {
             DeferredClose::Socket => task.run(),
             // The VM is going away: `on_close()` would run `onclose`, so only
             // give back what `close_without_socket_next_tick` took.
-            DeferredClose::WithoutSocket => {
+            DeferredClose::WithoutSocket { .. } => {
                 // SAFETY: as in `run`.
                 let _enqueue_ref = unsafe { ScopedRef::adopt(task.ctx) };
                 // SAFETY: live per the ref above.

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1159,7 +1159,8 @@ impl JSValkeyClient {
 
     /// The `CloseReason::DialFailed` text for a dial uSockets turned down
     /// before it had a socket, in the shape of `node:net`'s: `connect ENOENT
-    /// /run/redis.sock`.
+    /// /run/redis.sock`. `errno` is raw (a WSA code on Windows); `connect_errno`
+    /// normalises it the way `Bun.connect` does.
     fn dial_error_message(&self, err: uws::ConnectError) -> Box<[u8]> {
         let uws::ConnectError::FailedToOpenSocket { errno } = err;
         Self::connect_error_message(&self.client.get().address, errno)
@@ -1168,7 +1169,7 @@ impl JSValkeyClient {
     fn connect_error_message(address: &valkey::Address, errno: i32) -> Box<[u8]> {
         use std::io::Write;
         let mut message = Vec::new();
-        let _ = write!(message, "connect {} ", bun_errno::from_errno(errno));
+        let _ = write!(message, "connect {} ", bun_errno::connect_errno(errno));
         match address {
             valkey::Address::Unix(path) => message.extend_from_slice(path),
             valkey::Address::Host { host, port } => {

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -35,11 +35,6 @@ pub struct ConnectionFlags {
     /// or `fail()`, so it overlaps `Disconnected` and `Connecting`; that is why
     /// it is not a `Status` variant.
     pub(crate) is_reconnecting: bool,
-    /// Sticky until `on_open`/`connect()`. `fail()` closes the socket outright
-    /// (see `close()`), so by the time it returns the close callback has run
-    /// (`on_close` reads this to skip the retry policy) and this overlaps
-    /// `Disconnected`.
-    pub(crate) failed: bool,
     pub(crate) enable_auto_pipelining: bool,
     pub(crate) finalized: bool,
     // This flag is a slight hack to allow returning the client instance in the
@@ -62,7 +57,6 @@ impl Default for ConnectionFlags {
             enable_offline_queue: true,
             enable_auto_reconnect: true,
             is_reconnecting: false,
-            failed: false,
             enable_auto_pipelining: true,
             finalized: false,
             connection_promise_returns_client: false,
@@ -195,7 +189,7 @@ impl Address {
         group: &mut SocketGroup,
         ssl_ctx: Option<*mut SslCtx>,
         is_tls: bool,
-    ) -> Result<AnySocket, crate::Error> {
+    ) -> Result<AnySocket, uws::ConnectError> {
         if is_tls {
             let kind = SocketKind::ValkeyTls;
             let sock = match self {
@@ -230,6 +224,28 @@ impl Address {
                 )?,
             };
             Ok(AnySocket::SocketTcp(sock))
+        }
+    }
+}
+
+/// Why `on_close` runs. Its message rejects the commands the close leaves
+/// unanswered, and is the failure the connect() promise and `onclose` get
+/// unless `fail()` recorded one first or the retries are used up.
+#[derive(Clone, Copy)]
+pub(crate) enum CloseReason<'a> {
+    /// The socket of a connection went away: closed by the peer, `close()`
+    /// or `fail()`.
+    SocketClosed,
+    /// The dial never produced a connection; the errno/resolver text, e.g.
+    /// `connect ECONNREFUSED 127.0.0.1:6379`.
+    DialFailed(&'a [u8]),
+}
+
+impl<'a> CloseReason<'a> {
+    pub(crate) fn message(self) -> &'a [u8] {
+        match self {
+            Self::SocketClosed => b"Connection closed",
+            Self::DialFailed(message) => message,
         }
     }
 }
@@ -272,6 +288,14 @@ pub struct ValkeyClient {
     pub(crate) max_retries: u32, // Maximum retry attempts
 
     pub(crate) flags: ConnectionFlags,
+
+    /// The error of the failure that closed this connection, `Some` from
+    /// `fail_with_js_value` until the next `connect()`/`on_open`. It is the
+    /// one value the rejected commands, the connect() promise and `onclose`
+    /// all get. `fail()` closes the socket outright (see `close()`), so by the
+    /// time it returns the close callback has run (`on_close` reads this to
+    /// skip the retry policy) and this overlaps `Disconnected`.
+    pub(crate) failure: Option<bun_jsc::Strong>,
 
     // Auto-pipelining
     pub(crate) auto_flusher: AutoFlusher,
@@ -457,7 +481,7 @@ impl ValkeyClient {
 
     /// Get the appropriate timeout interval based on connection state
     pub(crate) fn get_timeout_interval(&self) -> u32 {
-        if self.flags.failed {
+        if self.failure.is_some() {
             return 0;
         }
         match self.status {
@@ -566,7 +590,7 @@ impl ValkeyClient {
     /// Mark the connection as failed with error message
     pub(crate) fn fail(&mut self, message: &[u8], err: RedisError) -> JsResult<()> {
         debug!("failed: {}: {:?}", bstr::BStr::new(message), err);
-        if self.flags.failed {
+        if self.failure.is_some() {
             return Ok(());
         }
 
@@ -602,10 +626,10 @@ impl ValkeyClient {
         global_this: &JSGlobalObject,
         jsvalue: JSValue,
     ) -> JsResult<()> {
-        if self.flags.failed {
+        if self.failure.is_some() {
             return Ok(());
         }
-        self.flags.failed = true;
+        self.failure = Some(bun_jsc::Strong::create(jsvalue, global_this));
         self.flags.is_reconnecting = false;
         let val = Self::reject_all_pending_commands(
             &mut self.in_flight,
@@ -661,13 +685,13 @@ impl ValkeyClient {
             self.status = Status::Disconnected;
             // A half-open socket never gets uSockets' close dispatch, so run the
             // close event here.
-            return self.on_close();
+            return self.on_close(CloseReason::SocketClosed);
         }
         Ok(())
     }
 
     /// Handle connection closed event
-    pub fn on_close(&mut self) -> JsResult<()> {
+    pub(crate) fn on_close(&mut self, reason: CloseReason<'_>) -> JsResult<()> {
         self.unregister_auto_flusher();
         self.write_buffer.clear_and_free();
         // A partial reply can never complete now; left in place it counts as
@@ -675,10 +699,14 @@ impl ValkeyClient {
         self.read_buffer.clear_and_free();
         self.reply_scanner.reset();
 
+        let message = reason.message();
+
         // A manual close or a failure the client detected itself: no retry.
-        if self.flags.is_manually_closed || self.flags.failed {
+        // After `fail()` this `fail` is a no-op and `on_valkey_close` reports
+        // the recorded failure.
+        if self.flags.is_manually_closed || self.failure.is_some() {
             debug!("skip reconnecting since the connection is manually closed or failed");
-            self.fail(b"Connection closed", RedisError::ConnectionClosed)?;
+            self.fail(message, RedisError::ConnectionClosed)?;
             self.on_valkey_close()?;
             return Ok(());
         }
@@ -686,7 +714,7 @@ impl ValkeyClient {
         // If auto reconnect is disabled, just fail
         if !self.flags.enable_auto_reconnect {
             debug!("skip reconnecting since auto reconnect is disabled");
-            self.fail(b"Connection closed", RedisError::ConnectionClosed)?;
+            self.fail(message, RedisError::ConnectionClosed)?;
             self.on_valkey_close()?;
             return Ok(());
         }
@@ -697,6 +725,8 @@ impl ValkeyClient {
 
         if delay_ms == 0 || self.retry_attempts > self.max_retries {
             debug!("Max retries reached or retry strategy returned 0, giving up reconnection");
+            // The last attempt's reason is no more the cause than the attempts
+            // before it; giving up is, so the terminal message replaces it.
             self.fail(
                 b"Max reconnection attempts reached",
                 RedisError::ConnectionClosed,
@@ -713,7 +743,7 @@ impl ValkeyClient {
         self.flags.is_reconnecting = true;
         self.flags.is_selecting_db_internal = false;
 
-        self.reject_in_flight_commands(b"Connection closed", RedisError::ConnectionClosed)?;
+        self.reject_in_flight_commands(message, RedisError::ConnectionClosed)?;
 
         // Signal reconnect timer should be started
         self.on_valkey_reconnect();
@@ -1309,7 +1339,7 @@ impl ValkeyClient {
         // A fresh socket has opened, so reset per-connection state. Without
         // this, `send()` would permanently reject with "Connection has failed"
         // after a previous connection exhausted retries (#29925).
-        self.flags.failed = false;
+        self.failure = None;
         self.flags.is_selecting_db_internal = false;
         if matches!(self.socket, AnySocket::SocketTcp(_)) {
             // if is tcp, we need to start the connection process
@@ -1464,7 +1494,7 @@ impl ValkeyClient {
         let mut promise = command::Promise::create(global_this, checked_command.meta);
 
         let js_promise: *mut JSPromise = std::ptr::from_mut::<JSPromise>(promise.promise.get());
-        if self.flags.failed {
+        if self.failure.is_some() {
             let _ = promise.reject(
                 global_this,
                 Ok(global_this

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -782,7 +782,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         // which would hand the trampoline `1` instead of the owner pointer.
         let ext_size = size_of::<Option<NonNull<Owner>>>() as c_int;
         match g.connect(kind, ssl_ctx, host_z, port, None, opts, ext_size) {
-            ConnectResult::Failed => Err(ConnectError::FailedToOpenSocket),
+            ConnectResult::Failed => Err(ConnectError::failed_to_open_socket()),
             ConnectResult::Socket(s) => {
                 *sock(s).ext::<Option<NonNull<Owner>>>() = NonNull::new(owner);
                 Ok(Self {
@@ -815,7 +815,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         let ext_size = size_of::<Option<NonNull<Owner>>>() as c_int;
         let s = g.connect_unix(kind, ssl_ctx, path, opts, ext_size);
         if s.is_null() {
-            return Err(ConnectError::FailedToOpenSocket);
+            return Err(ConnectError::failed_to_open_socket());
         }
         *sock(s).ext::<Option<NonNull<Owner>>>() = NonNull::new(owner);
         Ok(Self {
@@ -886,7 +886,17 @@ mod sock_c {
 
 #[derive(strum::IntoStaticStr, Debug)]
 pub enum ConnectError {
-    FailedToOpenSocket,
+    /// The dial failed before uSockets had a socket to report on; `errno` is
+    /// what `socket(2)`/`connect(2)` left (uSockets preserves it across its
+    /// own cleanup), e.g. `ENOENT` for a missing unix socket path.
+    FailedToOpenSocket { errno: i32 },
+}
+impl ConnectError {
+    fn failed_to_open_socket() -> Self {
+        Self::FailedToOpenSocket {
+            errno: std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+        }
+    }
 }
 impl From<ConnectError> for crate::Error {
     fn from(_: ConnectError) -> Self {

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -32,7 +32,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Expect an error with connection closed message
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect/i);
+        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|connect E[A-Z]+/i);
       } finally {
         // Cleanup
         await client.close();
@@ -56,7 +56,9 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Should fail with connection error
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|offline queue is disabled/i);
+        expect(error.message).toMatch(
+          /connection closed|socket closed|failed to connect|connect E[A-Z]+|offline queue is disabled/i,
+        );
       }
 
       try {
@@ -64,7 +66,9 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Should fail with connection error
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|offline queue is disabled/i);
+        expect(error.message).toMatch(
+          /connection closed|socket closed|failed to connect|connect E[A-Z]+|offline queue is disabled/i,
+        );
       }
 
       try {
@@ -72,7 +76,9 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Should fail with connection error
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|offline queue is disabled/i);
+        expect(error.message).toMatch(
+          /connection closed|socket closed|failed to connect|connect E[A-Z]+|offline queue is disabled/i,
+        );
       }
 
       try {
@@ -80,7 +86,9 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Should fail with connection error
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|offline queue is disabled/i);
+        expect(error.message).toMatch(
+          /connection closed|socket closed|failed to connect|connect E[A-Z]+|offline queue is disabled/i,
+        );
       }
     });
 
@@ -138,7 +146,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
         expect(false).toBe(true); // Should not reach here
       } catch (error) {
         // Should fail with a connection error
-        expect(error.message).toMatch(/connection closed|socket closed|failed to connect/i);
+        expect(error.message).toMatch(/connection closed|socket closed|failed to connect|connect E[A-Z]+/i);
       }
 
       await client.close();
@@ -281,9 +289,10 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
       await client.close();
 
       expect(client.connected).toBe(false);
+      // The command dials once and gets that dial's errno.
       expect(async () => {
         await client.get("any-key");
-      }).toThrowErrorMatchingInlineSnapshot(`"Connection closed"`);
+      }).toThrow(/connection closed|connect ECONNREFUSED/i);
       // Multiple disconnects should not cause issues
       await client.close();
       await client.close();
@@ -326,7 +335,7 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
       const promises = clients.map(client =>
         client.get("key").catch(err => {
           // We expect errors, but want to make sure they're the right kind
-          expect(err.message).toMatch(/connection closed|socket closed|failed to connect/i);
+          expect(err.message).toMatch(/connection closed|socket closed|failed to connect|connect E[A-Z]+/i);
         }),
       );
 

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -461,6 +461,16 @@ describe("Valkey: connect() error identity", () => {
     });
   });
 
+  test("a hostname that does not resolve rejects connect() with the resolver error", async () => {
+    // A 64 byte DNS label is illegal (RFC 1035 section 2.3.4), so the lookup
+    // fails locally without a query leaving the machine.
+    const host = Buffer.alloc(64, "a").toString() + ".com";
+    expect(await failure(`redis://${host}:6379`, { autoReconnect: false })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: `getaddrinfo ENOTFOUND ${host}`,
+    });
+  });
+
   test("a certificate the client does not trust rejects connect() with the verify error", async () => {
     const server = tls.createServer({ key: tlsCert.key, cert: tlsCert.cert }, socket => {
       socket.on("error", () => {});

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -341,6 +341,187 @@ describe.skipIf(!isEnabled)("Valkey: Connection Failures", () => {
   });
 });
 
+describe("Valkey: connect() error identity", () => {
+  // One failure, one error object: the commands queued behind the dial, the
+  // connect() promise and onclose all get it. Before, connect() and onclose
+  // got ERR_REDIS_CONNECTION_CLOSED "Connection closed" whatever the cause.
+  const CRLF = "\r\n";
+
+  async function stubServer(helloReply: string | null) {
+    const server = net.createServer(sock => {
+      let received = "";
+      let replied = false;
+      sock.on("error", () => {});
+      sock.on("data", d => {
+        if (replied || helloReply === null) return;
+        received += d.toString().toUpperCase();
+        if (received.includes("HELLO") && received.endsWith(CRLF)) {
+          replied = true;
+          sock.write(helloReply);
+        }
+      });
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as net.AddressInfo;
+    return { port, close: () => server.close() };
+  }
+
+  async function closedPort() {
+    const listener = net.createServer();
+    await new Promise<void>(resolve => listener.listen(0, "127.0.0.1", resolve));
+    const { port } = listener.address() as net.AddressInfo;
+    await new Promise<void>(resolve => listener.close(() => resolve()));
+    return port;
+  }
+
+  // Dials with a GET queued behind connect() and returns the error connect()
+  // rejected with, after checking the GET and onclose got the same object.
+  async function failure(url: string, options: any) {
+    const client = new RedisClient(url, options);
+    const closed = Promise.withResolvers<unknown>();
+    client.onclose = err => closed.resolve(err);
+    try {
+      const get = client.get("k").then(
+        () => "<resolved>",
+        e => e,
+      );
+      const err = await client.connect().then(
+        () => "<connected>",
+        e => e,
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect(await get).toBe(err);
+      expect(await closed.promise).toBe(err);
+      return { code: err.code, message: err.message };
+    } finally {
+      client.close();
+    }
+  }
+
+  test("-WRONGPASS reply to HELLO rejects connect() with the server's error text", async () => {
+    const srv = await stubServer(`-WRONGPASS invalid username-password pair or user is disabled.${CRLF}`);
+    try {
+      expect(await failure(`redis://:bad@127.0.0.1:${srv.port}`, { autoReconnect: false })).toEqual({
+        code: "ERR_REDIS_AUTHENTICATION_FAILED",
+        message: "WRONGPASS invalid username-password pair or user is disabled.",
+      });
+    } finally {
+      srv.close();
+    }
+  });
+
+  test("-NOAUTH reply to HELLO rejects connect() with the server's error text", async () => {
+    const srv = await stubServer(`-NOAUTH HELLO must be called with the client already authenticated${CRLF}`);
+    try {
+      expect(await failure(`redis://127.0.0.1:${srv.port}`, { autoReconnect: false })).toEqual({
+        code: "ERR_REDIS_AUTHENTICATION_FAILED",
+        message: "NOAUTH HELLO must be called with the client already authenticated",
+      });
+    } finally {
+      srv.close();
+    }
+  });
+
+  test("connectionTimeout expiry rejects connect() with ERR_REDIS_CONNECTION_TIMEOUT", async () => {
+    const srv = await stubServer(null);
+    try {
+      expect(await failure(`redis://127.0.0.1:${srv.port}`, { autoReconnect: false, connectionTimeout: 200 })).toEqual({
+        code: "ERR_REDIS_CONNECTION_TIMEOUT",
+        message: "Connection timeout reached after 200ms",
+      });
+    } finally {
+      srv.close();
+    }
+  });
+
+  test("a refused TCP connect rejects connect() with the errno", async () => {
+    const port = await closedPort();
+    expect(await failure(`redis://127.0.0.1:${port}`, { autoReconnect: false, connectionTimeout: 2000 })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: `connect ECONNREFUSED 127.0.0.1:${port}`,
+    });
+  });
+
+  test.skipIf(isWindows)("a unix socket path that does not exist rejects connect() with ENOENT", async () => {
+    using dir = tempDir("valkey-unix", {});
+    const socketPath = path.join(String(dir), "missing.sock");
+    // Fails inside the dial itself, before uSockets has a socket to report on.
+    expect(await failure(`redis+unix://${socketPath}`, { autoReconnect: false })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: `connect ENOENT ${socketPath}`,
+    });
+  });
+
+  test("a certificate the client does not trust rejects connect() with the verify error", async () => {
+    const server = tls.createServer({ key: tlsCert.key, cert: tlsCert.cert }, socket => {
+      socket.on("error", () => {});
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      // No `ca`, so the harness cert is self-signed as far as the client knows.
+      const err = await failure(`rediss://localhost:${port}`, {
+        autoReconnect: false,
+        tls: { rejectUnauthorized: true },
+      });
+      expect(err.code).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+      expect(err.message).toContain("self signed certificate");
+    } finally {
+      server.close();
+    }
+  });
+
+  // Giving up is the outcome, so the terminal message replaces the last
+  // attempt's own reason, whether that attempt failed inside the dial (a
+  // missing unix socket path) or from the event loop (a refused port).
+  test("exhausted retries report the terminal reason, not the last refused dial's", async () => {
+    const port = await closedPort();
+    expect(await failure(`redis://127.0.0.1:${port}`, { autoReconnect: true, maxRetries: 1 })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: "Max reconnection attempts reached",
+    });
+  });
+
+  test.skipIf(isWindows)("exhausted retries report the terminal reason, not the last failed dial's", async () => {
+    using dir = tempDir("valkey-unix", {});
+    const socketPath = path.join(String(dir), "missing.sock");
+    expect(await failure(`redis+unix://${socketPath}`, { autoReconnect: true, maxRetries: 1 })).toEqual({
+      code: "ERR_REDIS_CONNECTION_CLOSED",
+      message: "Max reconnection attempts reached",
+    });
+  });
+
+  test("a connect() after an authentication failure gets its own outcome", async () => {
+    let helloReply = `-WRONGPASS invalid username-password pair or user is disabled.${CRLF}`;
+    const server = net.createServer(sock => {
+      sock.on("error", () => {});
+      sock.on("data", () => sock.write(helloReply));
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as net.AddressInfo;
+    const client = new RedisClient(`redis://:bad@127.0.0.1:${port}`, { autoReconnect: false });
+    try {
+      const rejection = (p: Promise<unknown>) =>
+        p.then(
+          () => "<connected>",
+          e => e,
+        );
+      const first = await rejection(client.connect());
+      const second = await rejection(client.connect());
+      expect(second).toMatchObject({ code: "ERR_REDIS_AUTHENTICATION_FAILED" });
+      // The recorded failure is cleared by the dial; the second attempt's
+      // rejection is its own, not the first one's replayed.
+      expect(second).not.toBe(first);
+      helloReply = `+OK${CRLF}`;
+      await client.connect();
+      expect(client.connected).toBe(true);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});
+
 describe("Valkey: Auto-Reconnect In-Flight Commands", () => {
   function readCommands(state: { buffer: Buffer }): string[][] {
     const commands: string[][] = [];
@@ -582,7 +763,7 @@ describe("Valkey: Recovering After fail()", () => {
         inFlight: await inFlight,
         connections: fake.connections,
       }).toEqual({
-        onclose: "ERR_REDIS_CONNECTION_CLOSED",
+        onclose: "ERR_REDIS_IDLE_TIMEOUT",
         connectedInsideOnclose: false,
         connectedAfter: false,
         inFlight: "ERR_REDIS_IDLE_TIMEOUT",
@@ -616,7 +797,7 @@ describe("Valkey: Recovering After fail()", () => {
         client.onclose = err => closed.resolve(err);
         await client.connect();
         expect(client.connected).toBe(true);
-        expect(await closed.promise).toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+        expect(await closed.promise).toMatchObject({ code: "ERR_REDIS_IDLE_TIMEOUT" });
         expect(client.connected).toBe(false);
         expect(fake.connections).toBe(connection);
       }
@@ -763,8 +944,11 @@ describe("Valkey: Recovering After fail()", () => {
     const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: false });
     try {
       const secondConnect = connectFromOnclose(client);
-      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
-      expect(await secondConnect).toBe("rejected: Connection closed");
+      await expect(client.connect()).rejects.toMatchObject({
+        code: "ERR_REDIS_CONNECTION_CLOSED",
+        message: `connect ECONNREFUSED 127.0.0.1:${port}`,
+      });
+      expect(await secondConnect).toBe(`rejected: connect ECONNREFUSED 127.0.0.1:${port}`);
     } finally {
       client.close();
     }
@@ -822,7 +1006,10 @@ describe("Valkey: Recovering After fail()", () => {
     const client = new RedisClient(`redis://127.0.0.1:${port}/1`, { autoReconnect: false });
     try {
       const secondConnect = connectFromOnclose(client);
-      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      await expect(client.connect()).rejects.toMatchObject({
+        code: "ERR_REDIS_AUTHENTICATION_FAILED",
+        message: "WRONGPASS invalid password",
+      });
       expect(await secondConnect).toBe("connected");
       expect(await client.ping()).toBe("PONG");
       expect(fake.connections).toBe(2);
@@ -862,7 +1049,7 @@ describe("Valkey: Recovering After fail()", () => {
       // The rejection is a failure the client detected, so there is no retry
       // even with autoReconnect on: onclose fires once and the only second
       // connection is the one dialed from it.
-      expect(closes).toEqual([{ message: "Connection closed", connected: false, connections: 1 }]);
+      expect(closes).toEqual([{ message: "ERR DB index is out of range", connected: false, connections: 1 }]);
       expect(await secondConnect).toBe("connected");
       expect(await client.ping()).toBe("PONG");
       expect(fake.connections).toBe(2);
@@ -979,9 +1166,12 @@ describe("Valkey: Recovering After fail()", () => {
     const client = new RedisClient(`rediss://127.0.0.1:${port}`, { autoReconnect: false });
     try {
       const secondConnect = connectFromOnclose(client);
-      await expect(client.connect()).rejects.toMatchObject({ code: "ERR_REDIS_CONNECTION_CLOSED" });
+      // The handshake failure is the TLS error the queued commands are
+      // rejected with, not the generic close.
+      const disconnected = "Client network socket disconnected before secure TLS connection was established";
+      await expect(client.connect()).rejects.toMatchObject({ code: "ECONNRESET", message: disconnected });
       expect({ secondConnect: await secondConnect, handshakes }).toEqual({
-        secondConnect: "rejected: Connection closed",
+        secondConnect: `rejected: ${disconnected}`,
         handshakes: 2,
       });
     } finally {


### PR DESCRIPTION
Adopted from #39542 (@alii). The four commits from that branch are unchanged. Two commits are added on top, see "Added in this PR" below. This PR supersedes #39542.

### Problem
- `connect()` rejects with `ERR_REDIS_CONNECTION_CLOSED` "Connection closed" for every failure. `onclose` gets the same generic error. A wrong password, a refused port, a missing unix socket path, a rejected certificate and an idle timeout all look the same (#23467).
- Only the commands queued behind the dial get the real error.
- Cause: `on_valkey_close` (src/runtime/valkey_jsc/js_valkey.rs) builds a new generic error for the promise and for `onclose`. The code that closed the socket already had the real one.

### Fix
- `ConnectionFlags.failed` (a bool) is replaced by `ValkeyClient.failure: Option<Strong>`. It holds the JS error that rejected the queued commands. `fail_with_js_value` sets it once. `connect()` and `on_open` clear it. Every reader of the old bool reads `is_some()`.
- `on_valkey_close` rejects the `connect()` promise and calls `onclose` with that recorded error. The commands, the promise and `onclose` get one object.
- `ValkeyClient::on_close` takes a `CloseReason`. The socket close callback passes `SocketClosed` ("Connection closed"). `on_connect_error` passes the errno or the resolver text in the `node:net` shape: `connect ECONNREFUSED 127.0.0.1:6379`, `getaddrinfo ENOTFOUND host`. A dial that fails inside `connect()` passes the errno it left, for example `connect ENOENT /run/redis.sock`. `uws::ConnectError` now carries that errno.
- The errno normalisation of `Bun.connect` (WSA codes mapped on Windows, unix path errors kept, the rest `ECONNREFUSED`) moves to one function, `bun_errno::connect_errno`. `Bun.connect` and the redis client use it.
- The TLS context failure in `connect()` no longer calls `fail()` early. It hands its reason to the deferred close and goes through `on_close()` like every other dial failure.
- When the retries are used up, "Max reconnection attempts reached" replaces the last attempt's reason. The result is the same when the last dial failed inside `connect()` and when it failed from the event loop.
- The value is a `Strong` because the TLS context failure crosses one event loop turn before `on_valkey_close` runs.
- Error codes do not change. Authentication failures keep `ERR_REDIS_AUTHENTICATION_FAILED`. Timeouts keep `ERR_REDIS_CONNECTION_TIMEOUT` and `ERR_REDIS_IDLE_TIMEOUT`. TLS verify errors keep their OpenSSL code. Every other close keeps `ERR_REDIS_CONNECTION_CLOSED`.

#### Added in this PR
- packages/bun-usockets/src/bsd.c: `bsd_create_connect_socket` and `bsd_create_connect_socket_unix` set `errno` from the connect result after they close the failed socket. The Windows path and the `bind()` failure above them already do this. Before, the POSIX path relied on `close(2)` not touching errno. The Rust side reads errno right after these calls. The Linux close of the long path dirfd keeps errno for the same reason.
- A test for the resolver branch of `on_connect_error`. The host has a 64 byte label, so the lookup fails locally. It expects `getaddrinfo ENOTFOUND <host>` on one object.

#### Verification
- `bun bd test test/js/valkey/reliability/connection-failures.test.ts`: 38 pass, 13 skip (the skipped tests need the redis_unified container, they ran in the CI of #39542).
- `USE_SYSTEM_BUN=1 bun test ...connection-failures.test.ts -t "connect() error identity"`: all 10 tests fail. Nine fail on `expect(await get).toBe(err)` (the objects differ), one hangs on the older binary.
- `bun bd test test/js/valkey/valkey-gc.test.ts` and the redis regression tests (22243, 23621, 24385, 29925): 40 pass.
- `bun bd test test/js/node/net/node-net.test.ts` (it covers the sync dial errnos that the bsd.c change touches): the `ENOENT`, `ENOTSOCK` and `EADDRINUSE` tests pass. The 10 failures in that file are the same with the unmodified binary in this container (localhost resolution).
- CI of #39542 at e99cc42 was green.

#### Visible changes
`connect()` rejections and the `onclose` argument carry the specific reason. Six existing tests in connection-failures.test.ts pinned the generic one and are updated:
- idle timeout over redis:// and rediss://: `onclose` gets `ERR_REDIS_IDLE_TIMEOUT`.
- a refused connection: the message is `connect ECONNREFUSED 127.0.0.1:<port>`.
- `connect()` from `onclose` after WRONGPASS: `ERR_REDIS_AUTHENTICATION_FAILED` with the server text.
- a rejected SELECT: `onclose` gets the server's `ERR DB index is out of range`.
- a failed TLS handshake: `connect()` rejects with the TLS error (`ECONNRESET`).

Not in this PR: a new error code for a refused connection, and a docs change for the error code list.

Note for the merge order: #39546 adds a call to `on_close()` and #39547 reads `flags.failed`. Whichever of those lands after this PR needs a one line update (`on_close(CloseReason::SocketClosed)`, `failure.is_some()`).

### Background
- The redis client has two layers. `ValkeyClient` (valkey.rs) owns the protocol state and the command queues. `JSValkeyClient` (js_valkey.rs) owns the JS wrapper, the `connect()` promise and the `onclose` callback. `ValkeyClient::on_close` runs the retry policy and then calls `JSValkeyClient::on_valkey_close`, which settles the promise and calls `onclose`.
- `fail()` rejects every queued command with one JS error object and closes the socket. It is the place that knows the real reason.
- A `Strong` is a GC root for one JS value. A JS value that is only stored in a native struct field is not seen by the garbage collector. The error must survive from `fail()` until `on_valkey_close` runs, and one path crosses an event loop turn in between, so the field is a `Strong`. The queues in the same struct already hold `JSPromiseStrong` values, so the struct already has to be dropped on the JS thread.
- A dial can fail in three places. Inside `connect()` (for example a unix path that does not exist, errno is read at once). From the event loop through `on_connect_error` (a refused port or a failed lookup, uSockets passes the errno or the resolver code). Or after a socket exists (auth, TLS verify, timeouts), which goes through `fail()`. The first two did not go through `fail()` with a specific message before, which is why `on_close` now takes a `CloseReason`.
- uSockets reports a dial that fails inside `connect(2)` by returning no socket. The only channel for the errno is the thread's errno, which is why bsd.c has to set it after it closes the socket.

Fixes #23467

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/valkey/reliability/connection-failures.test.ts

<!-- robobun:evidence:end -->