### PR TITLE
watcher: keep no descriptor for a watched file outside kqueue

### DIFF
--- a/src/bun_core/feature_flags.rs
+++ b/src/bun_core/feature_flags.rs
@@ -16,8 +16,6 @@ pub const DISABLE_COMPRESSION_IN_HTTP_CLIENT: bool = false;
 
 pub const ENABLE_KEEPALIVE: bool = true;
 
-pub const ATOMIC_FILE_WATCHER: bool = env::IS_LINUX;
-
 pub const HTTP_BUFFER_POOLING: bool = true;
 
 /// React will issue warnings in development if there are multiple children

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -68,7 +68,12 @@ mod EventLoop {
 #[derive(bun_core::EnumTag)]
 #[enum_tag(existing = ContentsOrFdTag)]
 pub enum ContentsOrFd {
-    Fd { dir: Fd, file: Fd },
+    Fd {
+        dir: Fd,
+        file: Fd,
+        /// Opened by this task's read (not the resolver cache); the bundle thread closes it if the watcher does not adopt it.
+        owns_file: bool,
+    },
     // The `'static` is ownership-erased: contents may be arena-owned,
     // plugin-owned, or truly static (runtime source). The producer keeps the
     // backing allocation alive for the duration of the bundle pass.
@@ -160,6 +165,8 @@ impl ResultValue {
 pub(crate) struct WatcherData {
     pub(crate) fd: Fd,
     pub(crate) dir_fd: Fd,
+    /// See `ContentsOrFd::Fd::owns_file`.
+    pub(crate) owns_fd: bool,
 }
 
 impl WatcherData {
@@ -167,6 +174,7 @@ impl WatcherData {
     pub(crate) const NONE: WatcherData = WatcherData {
         fd: Fd::INVALID,
         dir_fd: Fd::INVALID,
+        owns_fd: false,
     };
 }
 
@@ -261,6 +269,7 @@ impl ParseTask {
             contents_or_fd: ContentsOrFd::Fd {
                 dir: resolve_result.dirname_fd,
                 file: resolve_result.file_fd,
+                owns_file: false,
             },
             side_effects: resolve_result.primary_side_effects_data,
             // D042: resolver-side and bundler-side `jsx::Pragma` are the SAME
@@ -1406,7 +1415,7 @@ pub mod parse_worker {
         _loader: Loader,
     ) -> core::result::Result<CacheEntry, AnyError> {
         match &task.contents_or_fd {
-            ContentsOrFd::Fd { dir, file } => 'brk: {
+            ContentsOrFd::Fd { dir, file, .. } => 'brk: {
                 let contents_dir = *dir;
                 let contents_file = *file;
                 let _trace = perf::trace("Bundler.readFile");
@@ -2320,20 +2329,20 @@ pub mod parse_worker {
         // there); closing it leaves a stale fd for the next in-process build.
         let opened_own_fd =
             matches!(task.contents_or_fd, ContentsOrFd::Fd { file, .. } if !file.is_valid());
-        let will_close_file_descriptor = opened_own_fd
-            && entry.fd.is_valid()
-            && entry.fd.stdio_tag().is_none()
-            && worker_ctx.bun_watcher.is_none();
-        if will_close_file_descriptor {
+        let owns_fd = opened_own_fd && entry.fd.is_valid() && entry.fd.stdio_tag().is_none();
+        if owns_fd && worker_ctx.bun_watcher.is_none() {
             let _ = entry.close_fd();
             task.contents_or_fd = ContentsOrFd::Fd {
                 file: Fd::INVALID,
                 dir: Fd::INVALID,
+                owns_file: false,
             };
         } else if matches!(task.contents_or_fd, ContentsOrFd::Fd { .. }) {
+            // With a watcher, `on_parse_task_complete` hands the fd to the watcher or closes it.
             task.contents_or_fd = ContentsOrFd::Fd {
                 file: entry.fd,
                 dir: Fd::INVALID,
+                owns_file: owns_fd,
             };
         }
         *step = Step::Parse;
@@ -2816,9 +2825,14 @@ pub mod parse_worker {
             // doesn't derive `Copy`, so move it out (task is consumed here).
             external: core::mem::take(&mut this.external_free_function),
             watcher_data: match this.contents_or_fd {
-                ContentsOrFd::Fd { file, dir } => WatcherData {
+                ContentsOrFd::Fd {
+                    file,
+                    dir,
+                    owns_file,
+                } => WatcherData {
                     fd: file,
                     dir_fd: dir,
+                    owns_fd: owns_file,
                 },
                 ContentsOrFd::Contents(_) => WatcherData::NONE,
             },

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4943,6 +4943,7 @@ pub mod bv2_impl {
                                 contents_or_fd: parse_task::ContentsOrFd::Fd {
                                     dir: bun_sys::Fd::INVALID,
                                     file: bun_sys::Fd::INVALID,
+                                    owns_file: false,
                                 },
                                 side_effects: bun_ast::SideEffects::HasSideEffects,
                                 jsx: this
@@ -7138,34 +7139,37 @@ pub mod bv2_impl {
             }
 
             // To minimize contention, watchers are appended on the bundle thread.
-            if this.bun_watcher.is_some() {
-                if parse_result.watcher_data.fd != bun_sys::Fd::INVALID {
-                    let source_index = parse_result.value.source_index();
-                    // borrowck — read the source path before
-                    // `should_add_watcher(&self)` so the column borrow is released.
-                    let source_path = this.graph.input_files.items_source()[source_index as usize]
-                        .path
-                        .text;
-                    if this.should_add_watcher(source_path) {
-                        let fd = parse_result.watcher_data.fd;
-                        let dir_fd = parse_result.watcher_data.dir_fd;
-                        let hash = bun_wyhash::hash(source_path) as u32;
-                        let bun_watcher = this.bun_watcher_mut().unwrap();
-                        // The watcher keeps the path past this bundle; borrow it
-                        // only when it is interned for the process lifetime
-                        // (`dupe_alloc` leaves other paths in the bundle arena).
-                        let _ = if Fs::as_interned_path(source_path).is_some() {
-                            bun_watcher.add_file::<{ cfg!(windows) }>(
-                                fd,
-                                source_path,
-                                hash,
-                                dir_fd,
-                                None,
-                            )
-                        } else {
-                            bun_watcher.add_file::<true>(fd, source_path, hash, dir_fd, None)
-                        };
-                    }
+            let watcher_data = &parse_result.watcher_data;
+            if this.bun_watcher.is_some() && watcher_data.fd.is_valid() {
+                let source_index = parse_result.value.source_index();
+                // Read the source path before `should_add_watcher(&self)` so the column borrow is released.
+                let source_path = this.graph.input_files.items_source()[source_index as usize]
+                    .path
+                    .text;
+                let adopted = this.should_add_watcher(source_path) && {
+                    let fd = watcher_data.fd;
+                    let dir_fd = watcher_data.dir_fd;
+                    let hash = bun_wyhash::hash(source_path) as u32;
+                    let bun_watcher = this.bun_watcher_mut().unwrap();
+                    // The watcher keeps the path past this bundle; borrow it
+                    // only when it is interned for the process lifetime
+                    // (`dupe_alloc` leaves other paths in the bundle arena).
+                    let added = if Fs::as_interned_path(source_path).is_some() {
+                        bun_watcher.add_file::<{ cfg!(windows) }>(
+                            fd,
+                            source_path,
+                            hash,
+                            dir_fd,
+                            None,
+                        )
+                    } else {
+                        bun_watcher.add_file::<true>(fd, source_path, hash, dir_fd, None)
+                    };
+                    matches!(added, Ok(bun_watcher::FdOwnership::Watcher))
+                };
+                // Nothing else closes the fd this parse opened.
+                if !adopted && watcher_data.owns_fd {
+                    let _ = bun_sys::close(watcher_data.fd);
                 }
             }
 

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -36,11 +36,10 @@ impl ImportWatcher {
     /// Look up the `package_json` column for `hash` under the watcher's
     /// mutex.
     ///
-    /// Deliberately does NOT hand out the stored fd: the watchlist owns it
-    /// and `flush_evictions` closes it concurrently, so a reader would hit
-    /// `EBADF`/`EISDIR` after the mutex is released (watch-many-dirs.test.ts)
-    /// or read the stale pre-rename inode after an atomic save. Reloads open
-    /// the file by path; `Watcher::add_file` adopts the fresh descriptor.
+    /// Deliberately does NOT hand out a stored fd (kqueue entries hold one):
+    /// the watchlist owns it and `flush_evictions` closes it concurrently, so
+    /// a reader would hit `EBADF`/`EISDIR` after the mutex is released
+    /// (watch-many-dirs.test.ts). Reloads open the file by path.
     pub fn snapshot_package_json(
         &self,
         hash: bun_watcher::HashType,
@@ -1183,32 +1182,27 @@ where
                                             file_hash = Watcher::get_hash(path_string.as_bytes());
                                             for (entry_id, hash) in hashes.iter().enumerate() {
                                                 if *hash == file_hash {
-                                                    if file_descriptors[entry_id].is_valid() {
-                                                        if prev_entry_id != entry_id {
-                                                            record_changed_path(
-                                                                path_string.as_bytes(),
-                                                            );
-                                                            current_task.append(hashes[entry_id]);
-                                                            if self.verbose {
-                                                                Self::debug(format_args!(
-                                                                    "Removing file: {}",
-                                                                    bstr::BStr::new(
-                                                                        path_string.as_bytes()
-                                                                    )
-                                                                ));
-                                                            }
-                                                            // SAFETY: see the
-                                                            // File-arm call
-                                                            // above.
-                                                            unsafe {
-                                                                (*ctx).remove_at_index::<false>(
-                                                                    bun_watcher::Kind::File,
-                                                                    entry_id as u16,
-                                                                    0,
-                                                                    &[],
+                                                    if prev_entry_id != entry_id {
+                                                        record_changed_path(path_string.as_bytes());
+                                                        current_task.append(hashes[entry_id]);
+                                                        if self.verbose {
+                                                            Self::debug(format_args!(
+                                                                "Removing file: {}",
+                                                                bstr::BStr::new(
+                                                                    path_string.as_bytes()
                                                                 )
-                                                            };
+                                                            ));
                                                         }
+                                                        // SAFETY: see the File-arm
+                                                        // call above.
+                                                        unsafe {
+                                                            (*ctx).remove_at_index::<false>(
+                                                                bun_watcher::Kind::File,
+                                                                entry_id as u16,
+                                                                0,
+                                                                &[],
+                                                            )
+                                                        };
                                                     }
 
                                                     prev_entry_id = entry_id;

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -27,6 +27,10 @@ bun_core::define_scoped_log!(log, watcher, visible);
 
 pub const MAX_COUNT: usize = 128;
 
+/// Whether a file is watched through an open descriptor (kqueue) or by path.
+/// Watched by path, a file entry must not hold a descriptor: it would keep the
+/// inode alive after an atomic save replaces it, so its `IN_DELETE_SELF` would
+/// never come and the entry would stay on the old inode.
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 pub const REQUIRES_FILE_DESCRIPTORS: bool = true;
 #[cfg(not(any(target_os = "macos", target_os = "freebsd")))]
@@ -297,10 +301,7 @@ impl Watcher {
                 false
             } else {
                 if close_descriptors && me.running.load() {
-                    let fds = me.watchlist.items_fd();
-                    for &fd in fds {
-                        let _ = bun_sys::close(fd);
-                    }
+                    close_watchlist_fds(&me.watchlist);
                 }
                 true
             }
@@ -366,12 +367,8 @@ impl Watcher {
             Ok(()) => false,
         };
 
-        // deinit and close descriptors if needed
         if self.close_descriptors.load() {
-            let fds = self.watchlist.items_fd();
-            for &fd in fds {
-                let _ = bun_sys::close(fd);
-            }
+            close_watchlist_fds(&self.watchlist);
         }
         owner_still_alive
     }
@@ -569,6 +566,12 @@ impl Watcher {
             self.platform.watch_path(slice)?
         };
 
+        let (fd, ownership) = if REQUIRES_FILE_DESCRIPTORS {
+            (fd, FdOwnership::Watcher)
+        } else {
+            (Fd::INVALID, FdOwnership::Caller)
+        };
+
         self.watchlist.append_assume_capacity(WatchItem {
             file_path: file_path_,
             fd,
@@ -580,7 +583,23 @@ impl Watcher {
             #[cfg(any(target_os = "linux", target_os = "android"))]
             eventlist_index,
         });
-        Ok(FdOwnership::Watcher)
+
+        let cwd_len_with_slash = if self.cwd[self.cwd.len() - 1] == b'/' {
+            self.cwd.len()
+        } else {
+            self.cwd.len() + 1
+        };
+        let display_path =
+            if file_path.len() > cwd_len_with_slash && file_path.starts_with(self.cwd) {
+                &file_path[cwd_len_with_slash..]
+            } else {
+                file_path
+            };
+        log!(
+            "<d>Added <b>{}<r><d> to watch list.<r>",
+            bstr::BStr::new(display_path)
+        );
+        Ok(ownership)
     }
 
     fn append_directory_assume_capacity<const CLONE_FILE_PATH: bool>(
@@ -733,39 +752,14 @@ impl Watcher {
         }
         let _ = parent_watch_item;
 
-        match self.append_file_assume_capacity::<CLONE_FILE_PATH>(
+        self.append_file_assume_capacity::<CLONE_FILE_PATH>(
             fd,
             file_path,
             hash,
             parent_dir_hash,
             package_json,
-        ) {
-            Err(err) => {
-                return Err(err.with_path(file_path));
-            }
-            // Not appended (e.g. outside the project root on Windows); the
-            // caller keeps the descriptor.
-            Ok(FdOwnership::Caller) => return Ok(FdOwnership::Caller),
-            Ok(FdOwnership::Watcher) => {}
-        }
-
-        let cwd_len_with_slash = if self.cwd[self.cwd.len() - 1] == b'/' {
-            self.cwd.len()
-        } else {
-            self.cwd.len() + 1
-        };
-        let display_path =
-            if file_path.len() > cwd_len_with_slash && file_path.starts_with(self.cwd) {
-                &file_path[cwd_len_with_slash..]
-            } else {
-                file_path
-            };
-        log!(
-            "<d>Added <b>{}<r><d> to watch list.<r>",
-            bstr::BStr::new(display_path)
-        );
-
-        Ok(FdOwnership::Watcher)
+        )
+        .map_err(|err| err.with_path(file_path))
     }
 
     #[inline]
@@ -873,22 +867,9 @@ impl Watcher {
         // This must lock due to concurrent transpiler
         self.mutex.lock();
 
-        if let Some(index) = self.index_of(hash) {
-            let mut ownership = FdOwnership::Caller;
-            if feature_flags::ATOMIC_FILE_WATCHER && fd.is_valid() {
-                // Upgrade a path-only entry (`add_file_by_path_slow` inserts
-                // fd-less, e.g. the `--hot` entrypoint) so `hot_reloader`'s
-                // directory-event recovery sees a valid fd. A valid stored fd
-                // is never replaced: the watchlist owns it until eviction,
-                // and the old overwrite leaked it.
-                let fds = self.watchlist.items_fd_mut();
-                if !fds[index as usize].is_valid() {
-                    fds[index as usize] = fd;
-                    ownership = FdOwnership::Watcher;
-                }
-            }
+        if self.index_of(hash).is_some() {
             self.mutex.unlock();
-            return Ok(ownership);
+            return Ok(FdOwnership::Caller);
         }
 
         let r = self.append_file_maybe_lock::<CLONE_FILE_PATH, false>(
@@ -1046,6 +1027,7 @@ pub struct WatchItem {
     pub file_path: Cow<'static, [u8]>,
     // filepath hash for quick comparison
     pub hash: u32,
+    /// Directories always hold one; files only where [`REQUIRES_FILE_DESCRIPTORS`].
     pub fd: Fd,
     pub count: u32,
     pub parent_hash: u32,
@@ -1064,13 +1046,11 @@ pub enum WatchItemKind {
 /// Who owns the `fd` passed to [`Watcher::add_file`] after it returns.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum FdOwnership {
-    /// The watchlist stored the descriptor; `flush_evictions`/shutdown will
-    /// close it. The caller must not use or close it afterwards.
+    /// The watchlist stored the descriptor ([`REQUIRES_FILE_DESCRIPTORS`]) and
+    /// closes it on eviction or shutdown. The caller must not use or close it.
     Watcher,
-    /// The watchlist did not take the descriptor: the file was already
-    /// watched with a valid stored one, or the path is not watchable (e.g.
-    /// outside the project root on Windows). The caller still owns `fd` and
-    /// must close it (or keep using it).
+    /// The watchlist did not take the descriptor. The caller still owns `fd`
+    /// and must close it (or keep using it).
     Caller,
 }
 
@@ -1082,7 +1062,6 @@ pub trait WatchItemColumns {
     fn items_file_path(&self) -> &[Cow<'static, [u8]>];
     fn items_hash(&self) -> &[u32];
     fn items_fd(&self) -> &[Fd];
-    fn items_fd_mut(&mut self) -> &mut [Fd];
     fn items_parent_hash(&self) -> &[u32];
     fn items_kind(&self) -> &[WatchItemKind];
     #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -1098,9 +1077,6 @@ impl WatchItemColumns for WatchList {
     }
     fn items_fd(&self) -> &[Fd] {
         self.items::<"fd", Fd>()
-    }
-    fn items_fd_mut(&mut self) -> &mut [Fd] {
-        self.items_mut::<"fd", Fd>()
     }
     fn items_parent_hash(&self) -> &[u32] {
         self.items::<"parent_hash", u32>()
@@ -1124,9 +1100,6 @@ impl WatchItemColumns for bun_collections::multi_array_list::Slice<WatchItem> {
     fn items_fd(&self) -> &[Fd] {
         self.items::<"fd", Fd>()
     }
-    fn items_fd_mut(&mut self) -> &mut [Fd] {
-        self.items_mut::<"fd", Fd>()
-    }
     fn items_parent_hash(&self) -> &[u32] {
         self.items::<"parent_hash", u32>()
     }
@@ -1136,5 +1109,14 @@ impl WatchItemColumns for bun_collections::multi_array_list::Slice<WatchItem> {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn items_eventlist_index(&self) -> &[platform::EventListIndex] {
         self.items::<"eventlist_index", platform::EventListIndex>()
+    }
+}
+
+/// Directory entries always hold an fd; file entries only with [`REQUIRES_FILE_DESCRIPTORS`].
+fn close_watchlist_fds(watchlist: &WatchList) {
+    for &fd in watchlist.items_fd() {
+        if fd.is_valid() {
+            let _ = sys::close(fd);
+        }
     }
 }

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,6 +1,6 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
 import { expect } from "bun:test";
-import { renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { readdirSync, readlinkSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { devTest, emptyHtmlFile } from "../bake-harness";
 
 devTest("import.meta.hot.accept basic", {
@@ -525,6 +525,77 @@ devTest("hmr forwards every merged inotify sub-path from a directory batch", {
       }
       await c.expectMessage(`atomic ${round}`);
     }
+  },
+});
+devTest("a file replaced by an atomic save keeps being watched", {
+  // An inotify watch follows the inode. An atomic save replaces the inode, and
+  // the kernel reports the old one as deleted (which evicts its entry, and the
+  // re-bundle watches the new one) only once nothing holds it open. So the dev
+  // server must not keep a descriptor for a watched file. kqueue watches
+  // through a descriptor by design and reports the replaced inode as deleted
+  // at rename time; the descriptor check below also needs /proc.
+  skip: ["win32", "darwin"],
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import value from "./dep";
+      import "pkg";
+      console.log(value);
+      import.meta.hot.accept();
+    `,
+    "dep.ts": `
+      export default "initial";
+    `,
+    // Not watched (node_modules), so its descriptor reaches the close in
+    // on_parse_task_complete without going through add_file.
+    "node_modules/pkg/index.js": `export const fromPkg = 1;`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("initial");
+
+    // Save the way editors do: write a temp file and rename it over the
+    // target. dep.ts is a new inode afterwards.
+    {
+      await using _wait = await dev.batchChanges();
+      writeFileSync(dev.join("dep.ts.tmp"), 'export default "atomic";\n');
+      renameSync(dev.join("dep.ts.tmp"), dev.join("dep.ts"));
+    }
+    await c.expectMessage("atomic");
+
+    // Neither the replaced inode ("dep.ts (deleted)"), the new one, nor the
+    // unwatched package file may stay open after the bundles that read them.
+    const fdDir = `/proc/${dev.devProcess.pid}/fd`;
+    const openTargets = readdirSync(fdDir).flatMap(fd => {
+      try {
+        return [readlinkSync(`${fdDir}/${fd}`)];
+      } catch {
+        // A socket or pipe closed between readdir and readlink.
+        return [];
+      }
+    });
+    expect(openTargets).toContain("anon_inode:inotify");
+    const dep = dev.join("dep.ts");
+    const pkg = dev.join("node_modules/pkg/index.js");
+    expect(openTargets.filter(target => [dep, `${dep} (deleted)`, pkg].includes(target))).toEqual([]);
+
+    // Only the watch on the file itself reports a rename away from the path
+    // (the directory watch does not subscribe to IN_MOVED_FROM), so this is
+    // noticed only if the new inode is the one being watched.
+    {
+      await using _wait = await dev.batchChanges({
+        errors: ['index.ts:1:19: error: Could not resolve: "./dep"'],
+      });
+      renameSync(dev.join("dep.ts"), dev.join("dep.moved.ts"));
+    }
+
+    {
+      await using _wait = await dev.batchChanges();
+      renameSync(dev.join("dep.moved.ts"), dev.join("dep.ts"));
+    }
+    await c.expectMessage("atomic");
   },
 });
 devTest("hot update frames are not delivered to application websocket topics", {

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,27 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
-import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, isWindows, tmpdirSync, waitForFileToExist } from "harness";
+import {
+  copyFileSync,
+  cpSync,
+  readdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import {
+  bunEnv,
+  bunExe,
+  forEachLine,
+  isDebug,
+  isLinux,
+  isWindows,
+  tempDir,
+  tmpdirSync,
+  waitForFileToExist,
+} from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -775,4 +795,73 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
     // TODO: bun has a memory leak when --hot is used on very large files
   },
   longTimeout,
+);
+
+// The Windows watcher only covers the working directory tree.
+it.skipIf(isWindows)(
+  "should hot reload an import outside the working directory that is replaced by an atomic save",
+  async () => {
+    // Nothing watches a directory outside the working directory, so the watch on
+    // the file itself is the only signal. An inotify watch follows the inode: the
+    // kernel reports the inode an atomic save replaced as deleted (which makes the
+    // reloader evict and re-import the file) only once nothing holds that inode
+    // open. So the watchlist must not keep the descriptor the file was read
+    // through. kqueue watches through a descriptor and reports the replaced inode
+    // as deleted at rename time.
+    using outside = tempDir("hot-atomic-outside", { "dep.js": "export const value = 1;\n" });
+    const dep = join(String(outside), "dep.js");
+    using project = tempDir("hot-atomic-project", {
+      "entry.js": `import { value } from ${JSON.stringify(dep)};\nconsole.log("value", value);\n`,
+    });
+    await using runner = spawn({
+      cmd: [bunExe(), "--hot", "run", "entry.js"],
+      env: bunEnv,
+      cwd: String(project),
+      stdout: "pipe",
+      stderr: "inherit",
+      stdin: "ignore",
+    });
+    const lines = forEachLine(runner.stdout);
+    const exited: Promise<never> = runner.exited.then(code => {
+      throw new Error(`bun --hot exited with code ${code}`);
+    });
+    // The test kills the process at the end; only the races below should observe this rejection.
+    exited.catch(() => {});
+    async function nextValueLine() {
+      // A reload that never comes (the bug) leaves the process running silently,
+      // so bound the wait instead of relying on the test timeout.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const deadline = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("bun --hot did not print a new value")), 30_000);
+      });
+      try {
+        while (true) {
+          const { value: line, done } = await Promise.race([lines.next(), exited, deadline]);
+          if (done) throw new Error("stdout closed before the next value was printed");
+          if (line.startsWith("value ")) return line;
+        }
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+    expect(await nextValueLine()).toBe("value 1");
+
+    if (isLinux) {
+      const fdDir = `/proc/${runner.pid}/fd`;
+      const openFiles = readdirSync(fdDir).flatMap(fd => {
+        try {
+          return [readlinkSync(`${fdDir}/${fd}`)];
+        } catch {
+          // A descriptor closed between readdir and readlink.
+          return [];
+        }
+      });
+      expect(openFiles).not.toContain(dep);
+    }
+
+    for (const round of [2, 3]) {
+      writeHotFileAtomicSync(dep, `export const value = ${round};\n`);
+      expect(await nextValueLine()).toBe(`value ${round}`);
+    }
+  },
 );

--- a/test/cli/hot/watch-many-dirs.test.ts
+++ b/test/cli/hot/watch-many-dirs.test.ts
@@ -99,11 +99,13 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
     30000,
   ); // 30 second timeout
 
-  // The watchlist owns one descriptor per watched file, closed only when the
-  // entry is evicted or the watcher shuts down. Re-transpiles during a reload
-  // open the file by path and must not stack additional descriptors on top of
-  // the stored one (previously the entrypoint gained one open fd per reload).
-  // /proc/<pid>/fd is Linux-only.
+  // On inotify the watchlist registers paths: it keeps a descriptor for each
+  // watched directory but none for a watched file (an open descriptor would pin
+  // the inode an atomic save replaces). Each transpile opens the file by path,
+  // hands the descriptor to the watcher, and closes it when the watcher
+  // declines it, so no file descriptor may stay open after a reload
+  // (previously the watchlist kept one per file, and the entrypoint gained one
+  // more per reload). /proc/<pid>/fd is Linux-only.
   test.skipIf(!isLinux)(
     "keeps a stable number of file descriptors across reloads",
     async () => {
@@ -121,8 +123,8 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
         stderr: "inherit",
       });
 
-      const countFileFds = () => {
-        const counts = { entry: 0, dep: 0 };
+      const countFds = () => {
+        const counts = { entry: 0, dep: 0, libDir: 0 };
         for (const fd of readdirSync(`/proc/${proc.pid}/fd`)) {
           let target: string;
           try {
@@ -132,6 +134,7 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
           }
           if (target === join(dirReal, "entry.js")) counts.entry++;
           else if (target === join(dirReal, "lib", "dep.js")) counts.dep++;
+          else if (target === join(dirReal, "lib")) counts.libDir++;
         }
         return counts;
       };
@@ -146,39 +149,23 @@ if (globalThis.reloaded++ >= ${maxCount}) process.exit(0);
       };
 
       await waitForReload(0);
-      // Warm up so both files reach their steady state in the watchlist (the
-      // entrypoint is added fd-less before its first transpile; dep's stored
-      // fd settles on its first edited reload).
-      for (let i = 1; i <= 2; i++) {
-        writeFileSync(join(dir, "lib", "dep.js"), `export const value = ${i};`);
-        await waitForReload(i);
-      }
-      const before = countFileFds();
-      // Guard against a vacuous pass: the entrypoint's stored descriptor must
-      // be visible in the baseline. (dep's can be transiently closed by a
-      // directory-event eviction, so it gets no such guard.)
-      expect(before.entry).toBeGreaterThan(0);
+      // A transpile closes its descriptor before it hands the module to the JS
+      // thread, so once RELOAD is printed nothing for either file may be open.
+      // The watch on lib/ holds the directory open; it guards against a
+      // vacuous pass if /proc stops being readable or the paths stop matching.
+      // (The resolver's directory cache holds lib/ too, so only its presence is
+      // checked.)
+      const before = countFds();
+      expect(before).toEqual({ entry: 0, dep: 0, libDir: before.libDir });
+      expect(before.libDir).toBeGreaterThan(0);
 
       const reloads = 15;
-      for (let i = 3; i <= reloads + 2; i++) {
+      for (let i = 1; i <= reloads; i++) {
         writeFileSync(join(dir, "lib", "dep.js"), `export const value = ${i};`);
         await waitForReload(i);
       }
-      const after = countFileFds();
-
-      // One handle's transient presence between samples is not a leak; a
-      // per-reload leak shows up as +reloads.
-      expect({
-        before,
-        after,
-        entryDelta: Math.min(after.entry - before.entry, 1),
-        depDelta: Math.min(after.dep - before.dep, 1),
-      }).toEqual({
-        before,
-        after,
-        entryDelta: after.entry - before.entry,
-        depDelta: after.dep - before.dep,
-      });
+      const after = countFds();
+      expect(after).toEqual({ entry: 0, dep: 0, libDir: after.libDir });
     },
     60000,
   );


### PR DESCRIPTION
### Problem
- Linux dev server: save a bundled file with an atomic save (write `app.ts.tmp`, `rename` it over `app.ts`), then rename `app.ts` out of its path. The server serves the old page for as long as it runs; after an in-place write the same rename shows the build error at once. 1.4.0 and main. `bun --hot` never reloads an atomic save of an import that has no directory watch (one from outside the working directory).
- An inotify watch follows an inode. The watchlist also stored the descriptor each file was read through (`on_parse_task_complete` in `src/bundler/bundle_v2.rs`, the `--hot` transpiler). It keeps the replaced inode alive, so the kernel never reports it as deleted, nothing evicts the entry, and the re-bundle's `Watcher::add_file` finds the entry by path and leaves the new inode unwatched. Only the directory watch still reports the file, and it does not request `IN_MOVED_FROM`.
- Each saved file also pins one unlinked inode plus two descriptors for the life of the server, and the bundler never closed the descriptor of a file it does not watch (everything under `node_modules`), one per parse.
- On Windows the same stored handle blocks the atomic save itself: `rename(target.js.tmp, target.js)` fails with EPERM while `bun --watch` or `bun --hot` runs. Fixes #41045 (verified on this branch on Windows x64, see the comment below).

### Fix
- A file entry stores a descriptor only where the watcher watches through one (`REQUIRES_FILE_DESCRIPTORS`, kqueue). Elsewhere `add_file` returns `FdOwnership::Caller`, which every caller already answers by closing. The bundler records whether the parse opened the descriptor (`owns_file`) and closes it whenever the watcher did not take it (the shape of #39447 / #39488).
- This removes the cause: the kernel now reports `IN_DELETE_SELF` at rename time, and the `DELETE` handling both consumers already have evicts the entry and re-bundles or reloads the file, which watches the new inode. kqueue platforms work this way today. No directory watch is needed, and event order does not matter, because an eviction always comes with a re-bundle. Nothing read the stored descriptor since #37050.
- Removed: `ATOMIC_FILE_WATCHER` and the fd upgrade in `add_file`, the fd check in the hot reloader's directory arm (both only told fd-less entries apart, and every entry is fd-less there now), `items_fd_mut`.
- Not fixed here: under `--hot` / `--watch` the resolver's `store_fd` cache still pins a file resolved through a symlinked directory (#9547, see notes). The dev server does not use that cache.
- Verified: `test/bake/dev/hot.test.ts`, `test/cli/hot/hot.test.ts`, `test/cli/hot/watch-many-dirs.test.ts`, all failing on the unfixed build. Also the `--hot`, `--watch`, bake dev and bundler suites, and darwin and windows `cargo check`.

### Background
- `src/watcher/` keeps one `WatchItem` per file or directory. kqueue needs an open descriptor per watched vnode; inotify and `ReadDirectoryChangesW` register paths. The `fd` column was filled everywhere because the parse had the descriptor at hand. Directory entries keep theirs.
- `IN_DELETE_SELF` is reported when the inode is destroyed. For an unlinked inode that is when its last open descriptor closes.
- `FdOwnership` is `add_file`'s answer on who owns the descriptor afterwards. A `ParseTask` may read through a descriptor the resolver's entry cache owns (symlinked files with `store_fd`); `owns_file` tells that apart from one the parse opened.

<details><summary>Notes</summary>

Trace of the report's repro with the fix. The file's own `delete` arrives with the save and `rename` arrives for the new inode; the unfixed build shows only the directory events:

```
{"/tmp/repro/":{"events":["write","move_to","create"],"changed":["app.ts.tmp","app.ts.tmp","app.ts"]}, ..., "/tmp/repro/app.ts":{"events":["delete"]}}
{"/tmp/repro/":{"events":["move_to"],"changed":["app.ts.moved"]},"/tmp/repro/app.ts":{"events":["rename"]}}
```

`/proc/<pid>/fd` of the unfixed dev server after one atomic save in the new bake test: `dep.ts (deleted)` (stored in the watchlist, pins the inode) and `dep.ts` (the re-parse's descriptor, declined and never closed). The report's repro script detects the rename 4 of 4 times with the fix; the html route variant now logs the re-bundle as the in-place case does (what is served once a route's html file is gone is a separate issue).

The hot reloader's directory arm kept evicting and reloading a matched entry on kqueue (descriptors are always valid there) and, on Linux, every module entry (all had descriptors). Dropping the check keeps that and extends it to the few entries that were fd-less before (entries added by path), whose own `IN_DELETE_SELF` now arrives as well. #33071 rewrites the same block; whichever lands second rebases. `watch-many-dirs.test.ts` previously anchored on the entrypoint's stored descriptor; it now anchors on the `lib/` directory descriptor and asserts both file counts are zero before and after the reloads (a transpile closes its descriptor before the module reaches the JS thread, so the counts are deterministic).

Suites run on the debug build with the fix: `test/cli/hot/` (18), `test/cli/watch/` (12), `test/bake/dev/{hot,bundle,css,html}.test.ts`, `test/bake/deinitialization.test.ts`, `test/bundler/{bun-build-api,bundler_plugin}.test.ts`, `test/cli/test/test-changed.test.ts`. `cargo check` of the touched crates passes for aarch64-apple-darwin and x86_64-pc-windows-msvc, clippy is clean.

Remaining holders and follow-ups. (1) `Resolver` with `store_fd` (`src/resolver/resolver.rs`, the symlink branch around `set_cache_fd`) opens a descriptor for a file resolved through a symlinked directory and hands it out as `Result.file_fd`. The runtime never reads through it, only `ParseTask` does, yet it pins the inode the same way the watchlist did, so under `--hot` an atomic save of `@repo/db` (symlink into `packages/db`) is still not reloaded after this PR, while a direct import of `packages/db/index.js` is. Removing that cache would also remove `owns_file`. This is the `--hot` / `--watch` half of #9547. (2) Watch registration is still gated on the parse having a descriptor (`watcher_data.fd.is_valid()` here, `input_file_fd.is_valid()` in `jsc_hooks.rs` and `RuntimeTranspilerStore.rs`), although outside kqueue the descriptor is only used as a sign that the file was read from disk; `read_file_with_allocator` withholds it when the process is near its descriptor limit, and such files are then not watched. Both predate this PR and are left as they are.

Not covered here: a dev server import from outside the project root. Its watch entry borrows a path from the bundle arena and crashes on any event today (ASAN SEGV on the watcher thread, fixed by #31695 / #39456); once either lands, that scenario works through this change as well.

Rebase on main (c1673e5): #40640 landed in the same `on_parse_task_complete` block. It picks `add_file::<true>` for paths that are not interned for the process lifetime. The merge keeps that choice and feeds its result into `adopted`, so the close of a declined descriptor applies to both branches. `Watcher.rs` only conflicted on the log line that main had restyled and this PR moves into `append_file_assume_capacity`. #40640's new test (`test/bake/dev/html.test.ts`, "editing a file imported from outside the project root hot-reloads") passes on the rebased build, so the out-of-root case described as not covered above now works end to end.

The first version of this PR kept the stored descriptor and re-issued `inotify_add_watch` in `add_file` to move a stale entry to the new inode. Self-review pointed out that this repaired the symptom one layer above its cause and left the pinned inode in place, so it was replaced by this version.

Related: #33071 (`--hot` directory-arm lookup, same cause described in its body), #33073, #36416 (would request `IN_MOVED_FROM`, surfacing the rename through the directory but leaving the pinned inode), #39447 / #39488 (`owns_file` plumbing mirrored here), #31695 / #39456.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/hot/watch-many-dirs.test.ts, test/cli/hot/hot.test.ts, test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->

