### PR TITLE
valkey: add ERR_REDIS_SERVER_ERROR for server error replies

### DIFF
--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -481,6 +481,7 @@ Common error codes:
 - `ERR_REDIS_CONNECTION_CLOSED` - Connection to the server was closed
 - `ERR_REDIS_AUTHENTICATION_FAILED` - Failed to authenticate with the server
 - `ERR_REDIS_INVALID_RESPONSE` - Received an invalid response from the server
+- `ERR_REDIS_SERVER_ERROR` - The server replied to a command with an error
 
 ---
 

--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -481,7 +481,7 @@ Common error codes:
 - `ERR_REDIS_CONNECTION_CLOSED` - Connection to the server was closed
 - `ERR_REDIS_AUTHENTICATION_FAILED` - Failed to authenticate with the server
 - `ERR_REDIS_INVALID_RESPONSE` - Received an invalid response from the server
-- `ERR_REDIS_SERVER_ERROR` - The server replied to a command with an error
+- `ERR_REDIS_SERVER_ERROR` - The server sent an error reply, either rejecting one command or, in subscriber mode, closing the connection
 
 ---
 

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -122,7 +122,7 @@ declare module "bun" {
      * - An array becomes an array.
      * - A set becomes an array.
      * - A map becomes a plain object with a null prototype.
-     * - An error reply (`-` or `!`) rejects the promise with code ERR_REDIS_INVALID_RESPONSE.
+     * - An error reply (`-` or `!`) rejects the promise with code ERR_REDIS_SERVER_ERROR.
      */
     send(command: string, args: string[]): Promise<any>;
 

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -378,5 +378,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_INSPECTOR_NOT_CONNECTED", Error],
   ["ERR_INSPECTOR_NOT_WORKER", Error],
   ["ERR_INSPECTOR_COMMAND", Error],
+  ["ERR_REDIS_SERVER_ERROR", Error, "RedisError"],
 ];
 export default errors;

--- a/src/runtime/valkey_jsc/protocol_jsc.rs
+++ b/src/runtime/valkey_jsc/protocol_jsc.rs
@@ -43,6 +43,7 @@ pub(crate) fn valkey_error_to_js(
         RedisError::IdleTimeout => JscError::REDIS_IDLE_TIMEOUT,
         RedisError::NestingDepthExceeded => JscError::REDIS_INVALID_RESPONSE,
         RedisError::LineTooLong => JscError::REDIS_INVALID_RESPONSE,
+        RedisError::ServerError => JscError::REDIS_SERVER_ERROR,
         RedisError::JSError => return global.take_exception(JsError::Thrown),
         RedisError::OutOfMemory => {
             let _ = global.throw_out_of_memory();
@@ -91,11 +92,7 @@ pub(crate) fn resp_value_to_js_with_options(
 ) -> JsResult<JSValue> {
     match this {
         RESPValue::SimpleString(str) => valkey_str_to_js_value(global, str, options),
-        RESPValue::Error(str) => Ok(valkey_error_to_js(
-            global,
-            &**str,
-            RedisError::InvalidResponse,
-        )),
+        RESPValue::Error(str) => Ok(valkey_error_to_js(global, &**str, RedisError::ServerError)),
         RESPValue::Integer(int) => Ok(JSValue::js_number(*int as f64)),
         RESPValue::BulkString(maybe_str) => {
             if let Some(str) = maybe_str {

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -1161,7 +1161,7 @@ impl ValkeyClient {
             match value {
                 RESPValue::Error(err) => {
                     if self.parent().is_subscriber() {
-                        self.fail(err, RedisError::InvalidResponse)?;
+                        self.fail(err, RedisError::ServerError)?;
                         return Ok(());
                     }
                     // A raw subscription request from a client that is not (yet) a

--- a/src/valkey/valkey_protocol.rs
+++ b/src/valkey/valkey_protocol.rs
@@ -32,6 +32,8 @@ pub enum RedisError {
     IdleTimeout,
     NestingDepthExceeded,
     LineTooLong,
+    /// The server answered with a `-` or `!` error reply.
+    ServerError,
 }
 
 bun_core::impl_tag_error!(RedisError);

--- a/test/js/valkey/valkey-incremental-scan.test.ts
+++ b/test/js/valkey/valkey-incremental-scan.test.ts
@@ -1,4 +1,4 @@
-import { RedisClient, type TCPSocketListener } from "bun";
+import { RedisClient, type Socket, type TCPSocketListener } from "bun";
 import { describe, expect, test } from "bun:test";
 import net from "node:net";
 
@@ -11,16 +11,11 @@ const HELLO =
 type PerSocket = { buf: Buffer; replied: boolean };
 
 /**
- * Mock server: answers HELLO, then answers the first GET with `reply`. When
- * `splitAt` is inside the reply it is split there across two event-loop turns
- * so the client's empty-read-buffer stack path sees a partial frame; "bytes"
- * sends one byte per turn so the reply scanner resumes at every offset.
- * Subsequent commands get `+OK`.
+ * Mock server: parses the client's RESP command frames
+ * (`*N\r\n($len\r\n...\r\n){N}`) and hands each complete one to `onCommand`.
  */
-function createReplyServer(
-  reply: string,
-  splitAt: number | "bytes" = reply.length,
-  hello: string = HELLO,
+function createCommandServer(
+  onCommand: (fields: string[], s: Socket<PerSocket>) => void,
 ): TCPSocketListener<PerSocket> {
   return Bun.listen<PerSocket>({
     hostname: "127.0.0.1",
@@ -34,7 +29,6 @@ function createReplyServer(
       data(s, raw) {
         const st = s.data;
         st.buf = Buffer.concat([st.buf, raw]);
-        // Parse complete client RESP command frames (`*N\r\n($len\r\n...\r\n){N}`).
         for (;;) {
           const b = st.buf;
           if (!b.length || b[0] !== 0x2a) break;
@@ -61,35 +55,52 @@ function createReplyServer(
           }
           if (!complete) break;
           st.buf = b.subarray(pos);
-          const cmd = fields[0]?.toUpperCase();
-          if (cmd === "HELLO") {
-            s.write(hello);
-          } else if (cmd === "GET" && !st.replied) {
-            st.replied = true;
-            if (splitAt === "bytes") {
-              const bytes = Buffer.from(reply, "latin1");
-              const writeByte = (i: number) => {
-                if (i >= bytes.length) return;
-                s.write(bytes.subarray(i, i + 1));
-                s.flush();
-                setImmediate(() => setImmediate(() => writeByte(i + 1)));
-              };
-              writeByte(0);
-            } else {
-              s.write(reply.slice(0, splitAt));
-              s.flush();
-              if (splitAt < reply.length) {
-                // Yield twice so the first write reaches the client's `on_data`
-                // before the second is sent.
-                setImmediate(() => setImmediate(() => s.write(reply.slice(splitAt))));
-              }
-            }
-          } else {
-            s.write(`+OK${CRLF}`);
-          }
+          onCommand(fields, s);
         }
       },
     },
+  });
+}
+
+/**
+ * Mock server: answers HELLO, then answers the first GET with `reply`. When
+ * `splitAt` is inside the reply it is split there across two event-loop turns
+ * so the client's empty-read-buffer stack path sees a partial frame; "bytes"
+ * sends one byte per turn so the reply scanner resumes at every offset.
+ * Subsequent commands get `+OK`.
+ */
+function createReplyServer(
+  reply: string,
+  splitAt: number | "bytes" = reply.length,
+  hello: string = HELLO,
+): TCPSocketListener<PerSocket> {
+  return createCommandServer((fields, s) => {
+    const cmd = fields[0]?.toUpperCase();
+    if (cmd === "HELLO") {
+      s.write(hello);
+    } else if (cmd === "GET" && !s.data.replied) {
+      s.data.replied = true;
+      if (splitAt === "bytes") {
+        const bytes = Buffer.from(reply, "latin1");
+        const writeByte = (i: number) => {
+          if (i >= bytes.length) return;
+          s.write(bytes.subarray(i, i + 1));
+          s.flush();
+          setImmediate(() => setImmediate(() => writeByte(i + 1)));
+        };
+        writeByte(0);
+      } else {
+        s.write(reply.slice(0, splitAt));
+        s.flush();
+        if (splitAt < reply.length) {
+          // Yield twice so the first write reaches the client's `on_data`
+          // before the second is sent.
+          setImmediate(() => setImmediate(() => s.write(reply.slice(splitAt))));
+        }
+      }
+    } else {
+      s.write(`+OK${CRLF}`);
+    }
   });
 }
 
@@ -201,14 +212,49 @@ describe.concurrent("Valkey reply decoding", () => {
   test.each([
     ["-", `-WRONGTYPE wrong kind${CRLF}`],
     ["!", `!20${CRLF}WRONGTYPE wrong kind${CRLF}`],
-  ])("error reply (%s) nested in an array resolves as an Error element", async (_kind, element) => {
+  ])("error reply (%s) nested in an array resolves as an ERR_REDIS_SERVER_ERROR element", async (_kind, element) => {
     const server = createReplyServer(`*2${CRLF}+OK${CRLF}${element}`);
     await withClient(server, async client => {
-      const result = (await client.get("k")) as unknown as [string, Error];
+      const result = (await client.get("k")) as unknown as [string, Error & { code: string }];
       expect(result[0]).toBe("OK");
       expect(result[1]).toBeInstanceOf(Error);
-      expect(result[1].message).toBe("WRONGTYPE wrong kind");
+      expect({ code: result[1].code, message: result[1].message }).toEqual({
+        code: "ERR_REDIS_SERVER_ERROR",
+        message: "WRONGTYPE wrong kind",
+      });
       expect(await client.send("PING", [])).toBe("OK");
+    });
+  });
+
+  test("error reply in subscriber mode fails the connection with ERR_REDIS_SERVER_ERROR", async () => {
+    const server = createCommandServer((fields, s) => {
+      switch (fields[0]?.toUpperCase()) {
+        case "HELLO":
+          s.write(HELLO);
+          break;
+        case "SUBSCRIBE":
+          s.write(`>3${CRLF}` + bulk("subscribe") + bulk(fields[1]) + `:1${CRLF}`);
+          break;
+        default:
+          s.write(`-NOPERM no permissions${CRLF}`);
+      }
+    });
+    await withClient(server, async client => {
+      await client.subscribe("ch", () => {});
+      // A subscriber fails the whole connection on an error reply. The PING
+      // that drew the reply is left unsettled (#32858 changes that), so the
+      // code is read from the second PING, which is still in flight when the
+      // connection fails.
+      client.send("PING", []).catch(() => {});
+      const err = await client.send("PING", []).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect({ code: err.code, message: err.message }).toEqual({
+        code: "ERR_REDIS_SERVER_ERROR",
+        message: "NOPERM no permissions",
+      });
     });
   });
 });

--- a/test/js/valkey/valkey-incremental-scan.test.ts
+++ b/test/js/valkey/valkey-incremental-scan.test.ts
@@ -127,12 +127,12 @@ const FRAMES: [name: string, frame: string, expected: Decoded][] = [
   [
     "simple error (-ERR)",
     `-ERR unknown command${CRLF}`,
-    { rejects: { code: "ERR_REDIS_INVALID_RESPONSE", message: "ERR unknown command" } },
+    { rejects: { code: "ERR_REDIS_SERVER_ERROR", message: "ERR unknown command" } },
   ],
   [
     "blob error (!)",
     `!21${CRLF}SYNTAX invalid syntax${CRLF}`,
-    { rejects: { code: "ERR_REDIS_INVALID_RESPONSE", message: "SYNTAX invalid syntax" } },
+    { rejects: { code: "ERR_REDIS_SERVER_ERROR", message: "SYNTAX invalid syntax" } },
   ],
 ];
 
@@ -250,7 +250,7 @@ describe.concurrent("Valkey reply torn across socket reads", () => {
         e => e,
       );
       expect(err).toBeInstanceOf(Error);
-      expect(err.code).toBe("ERR_REDIS_INVALID_RESPONSE");
+      expect(err.code).toBe("ERR_REDIS_SERVER_ERROR");
       expect(err.message).toBe("SYNTAX invalid syntax");
       expect(await client.send("PING", [])).toBe("OK");
     });


### PR DESCRIPTION
### Problem
- A server error reply (`-WRONGTYPE ...` or a `!` blob error) rejects with `err.code === "ERR_REDIS_INVALID_RESPONSE"`. `src/runtime/valkey_jsc/protocol_jsc.rs:94` passes `RedisError::InvalidResponse` for `RESPValue::Error`.
- The same code means a reply the client cannot parse (`_junk`, nesting depth). A caller cannot tell them apart.
- The subscriber arm at `src/runtime/valkey_jsc/valkey.rs:1164` passes `InvalidResponse` too.

### Fix
- `ERR_REDIS_SERVER_ERROR` goes at the tail of `ErrorCode.ts`, so no discriminant moves. The new `RedisError::ServerError` maps to it.
- Both `RESPValue::Error` sites now pass `ServerError`: the top-level rejection, an Error element nested in an array (the `EXEC` shape), and the subscriber arm. The message text is unchanged.
- Breaking: `err.code` for a server error reply changes. Three public repos compare against the old code (see Notes). The docs and the `send()` JSDoc name the new code.
- Verified: `test/js/valkey/valkey-incremental-scan.test.ts`, 41 pass here, 11 fail with the `src/` of main. Also `reliability/resp-nesting-depth.test.ts` and a real redis 8.0.2.

### Background
- RESP is the Redis wire protocol. A `-` reply is a simple error, a `!` reply is a blob error. Since #39544 both parse to `RESPValue::Error`.
- `resp_value_to_js_with_options` (`protocol_jsc.rs`) turns a reply into a JS value. For `RESPValue::Error` it calls `valkey_error_to_js`, which maps a `RedisError` variant to an `ERR_*` code.
- A subscriber is a client that sent `SUBSCRIBE`. On an error reply `handle_response` (`valkey.rs`) calls `fail`. `fail` rejects every pending command with the given variant and closes the connection.
- The build generates the C++ and Rust `ERR_*` tables from `ErrorCode.ts` in file order.

<details><summary>Notes</summary>

- The 11 tests that fail without the `src/` change: the `-ERR` and `!` frames in both send modes, the two nested element tests, the subscriber-mode test, and the four torn blob error tests. They all assert the new code. The subscriber-mode test also fails with only the `valkey.rs` line removed.
- Public repos that compare against `ERR_REDIS_INVALID_RESPONSE` for a server error: HazelChat/hazel, stella/stella, petarzarkov/dunx.
- Real redis 8.0.2: `LPUSH` on a string key rejects with `ERR_REDIS_SERVER_ERROR` and the unchanged `WRONGTYPE` message. An error inside an `EXEC` reply resolves as an Error element with the same code.
- `ERR_REDIS_INVALID_RESPONSE` is still used for a reply the client could not parse (`_junk`, nesting depth, line too long, a bad type byte). Those paths are not changed.
- Not changed: a subscriber still fails the whole connection on an error reply, and the command that reply answers is left unsettled. #32858 changes that path. The subscriber test here reads the code from the command still in flight behind it, which holds before and after #32858.
- Docs: the bullet in `docs/runtime/redis.mdx` says that the reply rejects one command or, in subscriber mode, closes the connection. #39576 asked for the subscriber part. It was lost when the branch was rebuilt on the reduced #39544, and commit 4 restores it. `packages/bun-types/redis.d.ts` names the code in the `send()` JSDoc.
- History: this PR was stacked on #39544 and at first carried the decoder fix too. #39544 is merged as 24c0063. The branch is now rebased onto main. The rebase did not change the diff. Commit 1 is @alii's commit from the earlier version of #39544, with its test hunks redone on top of the table-driven tests. Commits 2 to 4 were added during adoption.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 11 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-incremental-scan.test.ts
bun test v1.4.0 (4c689909e)

test/js/valkey/valkey-incremental-scan.test.ts:
(pass) Valkey reply decoding, frame sent whole > RESP3 null with trailing bytes (_junk) [45.87ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null array (*-1) [78.52ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null array nested in an array [62.81ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null bulk string ($-1) [62.40ms]
(pass) Valkey reply decoding, frame sent whole > RESP3 null (_) [62.22ms]
162 |         expect(typeof (outcome as { value: unknown }).value).toBe(typeof expected.value);
163 |       } else {
164 |         expect(outcome).toHaveProperty("error");
165 |         const { error } = outcome as { error: Error & { code: string } };
166 |         expect(error).toBeInstanceOf(Error);
167 |         expect(error.code).toBe(expected.rejects.code);
                                 ^
error: expect(received).toBe(expected)

Expected: "ERR_REDIS_SERVER_ERROR"
Received: "ERR_
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (4c6ff0c53)

test/js/valkey/valkey-incremental-scan.test.ts:
(pass) Valkey reply decoding, frame sent whole > RESP3 null with trailing bytes (_junk) [2.45ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null array (*-1) [3.60ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null array nested in an array [3.31ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null bulk string ($-1) [3.38ms]
(pass) Valkey reply decoding, frame sent whole > RESP3 null (_) [3.56ms]
(pass) Valkey reply decoding, frame sent whole > big number above 2^53 [3.52ms]
(pass) Valkey reply decoding, frame sent whole > negative big number [3.64ms]
(pass) Valkey reply decoding, frame sent whole > big number above 2^64 [3.66ms]
(pass) Valkey reply decoding, frame sent whole > big number with a non-integer payload [3.76ms]
(pass) Valkey reply decoding, frame sent whole > simple error (-ERR) [3.87ms]
(pass) Valkey reply decoding, frame sent whole > blob error (!) [3.90ms]
(pass) Valkey reply decoding > error reply (-) to HELLO rejects queued commands with the server text [1.96ms]
(pass) Valkey reply decoding > error reply (!) to HELLO rejects queued 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-incremental-scan.test.ts
bun test v1.4.0 (4c689909e)

test/js/valkey/valkey-incremental-scan.test.ts:
(pass) Valkey reply decoding, frame sent whole > RESP3 null with trailing bytes (_junk) [49.15ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null array (*-1) [84.60ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null array nested in an array [67.49ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null bulk string ($-1) [66.94ms]
(pass) Valkey reply decoding, frame sent whole > RESP3 null (_) [66.75ms]
(pass) Valkey reply decoding, frame sent whole > big number above 2^53 [41.64ms]
(pass) Valkey reply decoding, frame sent whole > negative big number [43.01ms]
(pass) Valkey reply decoding, frame sent whole > big number above 2^64 [44.06ms]
(pass) Valkey reply decoding, frame sent whole > big number with a non-integer payload [44.02ms]
(pass) Valkey reply decoding, frame sent whole > simple error (-ERR) [43.74ms]
(pass) Valkey reply decoding, frame sent whole > blob error (!) [40.86ms]
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 647ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/80] gen ErrorCode+*.h
[2/24] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/24] gen JS modules (bundle-modules)
Preprocess modules (7828ms)
Bundle modules (54ms)
Postprocesss modules (33ms)
Bundle Functions (734ms)
Generate Code (26ms)

[8.69s] Bundled "src/js" for production
  2628 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   C
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/redis.mdx                         |   1 +
 packages/bun-types/redis.d.ts                  |   2 +-
 src/jsc/bindings/ErrorCode.ts                  |   1 +
 src/runtime/valkey_jsc/protocol_jsc.rs         |   7 +-
 src/runtime/valkey_jsc/valkey.rs               |   2 +-
 src/valkey/valkey_protocol.rs                  |   2 +
 test/js/valkey/valkey-incremental-scan.test.ts | 132 +++++++++++++++++--------
 7 files changed, 97 insertions(+), 50 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
docs/runtime/redis.mdx                              1      1      0
packages/bun-types/redis.d.ts                       0      0      0
src/jsc/bindings/ErrorCode.ts                       0      0      0
src/runtime/valkey_jsc/protocol_jsc.rs              0      0      0
src/runtime/valkey_jsc/valkey.rs                    0      0      0
src/valkey/valkey_protocol.rs                       0      0      0
test/js/valkey/valkey-incremental-scan.test.ts      0      0      0
```

</details>

<!-- robobun:evidence:end -->

