### PR TITLE
valkey: a duplicate starts with no close history

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -866,9 +866,6 @@ impl JSValkeyClient {
                 tls,
                 database: client.database,
                 flags: valkey::ConnectionFlags {
-                    // If the user manually closed the connection, then duplicating a closed client
-                    // means the new client remains finalized.
-                    is_manually_closed: client.flags.is_manually_closed,
                     enable_offline_queue: if sub_ctx.is_subscriber {
                         sub_ctx.original_enable_offline_queue
                     } else {
@@ -881,8 +878,6 @@ impl JSValkeyClient {
                     } else {
                         client.flags.enable_auto_pipelining
                     },
-                    // Duplicating a finalized client means it stays finalized.
-                    finalized: client.flags.finalized,
                     ..Default::default()
                 },
                 max_retries: client.max_retries,

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -595,9 +595,7 @@ impl ValkeyClient {
 
         // A failure the client detected itself (idle timeout, protocol or
         // handshake error) has always been a deliberate close; `on_close` reads
-        // `failed` and skips the retry policy. It is not `is_manually_closed`:
-        // that flag is copied into `duplicate()`, and a duplicate of a failed
-        // client should still reconnect.
+        // `failed` and skips the retry policy.
         let closed = self.close(uws::CloseCode::Failure); // unconditionally, whatever `val` is
         val.and(closed)
     }

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -898,7 +898,7 @@ describe("Valkey: Recovering After fail()", () => {
       duplicate = await client.duplicate();
       // A duplicate carries no close history from its source, so the drop of
       // connection 2 goes through the retry policy: no onclose, a second
-      // onconnect, and the queued PING answered by connection 3.
+      // onconnect, and the next PING answered by connection 3.
       const reconnected = Promise.withResolvers<void>();
       let connects = 0;
       duplicate.onconnect = () => {

--- a/test/js/valkey/reliability/connection-failures.test.ts
+++ b/test/js/valkey/reliability/connection-failures.test.ts
@@ -896,9 +896,48 @@ describe("Valkey: Recovering After fail()", () => {
       await expect(client.ping()).rejects.toMatchObject({ code: "ERR_REDIS_INVALID_RESPONSE_TYPE" });
       expect(client.connected).toBe(false);
       duplicate = await client.duplicate();
-      // A duplicate copies the original's manual-close state; a failure is not
-      // one, so the drop of connection 2 goes through the retry policy: no
-      // onclose, a second onconnect, and the queued PING answered by connection 3.
+      // A duplicate carries no close history from its source, so the drop of
+      // connection 2 goes through the retry policy: no onclose, a second
+      // onconnect, and the queued PING answered by connection 3.
+      const reconnected = Promise.withResolvers<void>();
+      let connects = 0;
+      duplicate.onconnect = () => {
+        if (++connects === 2) reconnected.resolve();
+      };
+      duplicate.onclose = err => reconnected.reject(err);
+      expect(await duplicate.ping()).toBe("PONG");
+      await reconnected.promise;
+      expect(await duplicate.ping()).toBe("PONG");
+      expect(fake.connections).toBe(3);
+    } finally {
+      duplicate?.close();
+      client.close();
+      fake.server.close();
+    }
+  });
+
+  test("a duplicate of a closed client auto-reconnects", async () => {
+    // Connection 2 (the duplicate's first) is dropped by the server right
+    // after it answers PING.
+    const fake = helloServer({
+      PING: (connection, socket) => {
+        if (connection === 2) {
+          socket.end("+PONG\r\n");
+          return null;
+        }
+        return "+PONG\r\n";
+      },
+    });
+    const port = await fake.listen();
+    const client = new RedisClient(`redis://127.0.0.1:${port}`, { autoReconnect: true });
+    let duplicate: RedisClient | undefined;
+    try {
+      await client.connect();
+      client.close();
+      duplicate = await client.duplicate();
+      // The duplicate has no close history of its own, so the drop of
+      // connection 2 goes through the retry policy: no onclose, a second
+      // onconnect, and the next PING answered by connection 3.
       const reconnected = Promise.withResolvers<void>();
       let connects = 0;
       duplicate.onconnect = () => {


### PR DESCRIPTION
Split out of #39548. One fix in RedisClient.duplicate(), with a test in test/js/valkey/reliability/connection-failures.test.ts that fails on main.

The problem

duplicate() copied the manual-close flag from its source. A duplicate of a close()d client starts out never connected and dials on its first command. Because the copied flag was set, its first dropped connection was treated as a manual close: no retry, even with autoReconnect: true, until the user called connect() explicitly. duplicate() also copied the finalized flag, which is dead: only the finalizer sets it, and duplicate() is only reachable from a live wrapper.

What changed

duplicate() no longer copies either flag. A duplicate starts with no close history; the option flags it does copy are unchanged. A comment in fail() and one in an existing test that described the old copy are reworded.

Visible changes

A duplicate of a closed client reconnects after a dropped connection when autoReconnect is on.

Tests

Against a net stub that answers HELLO and PING: the source is closed, the duplicate's first connection is dropped by the server right after PING, and the duplicate must reconnect and answer the next PING from a third connection.


Rebase

Rebased onto main after #39546 landed. Only the test file conflicted: both sides appended tests to connection-failures.test.ts, and main also opened a new "Offline Queue" describe block at the end of the file. The new test now sits in "Recovering After fail()", directly after "a duplicate of a failed client still auto-reconnects", which defines the helloServer stub it uses. The src change applied unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/valkey/reliability/connection-failures.test.ts

<!-- robobun:evidence:end -->