### PR TITLE
valkey: add ERR_REDIS_SERVER_ERROR for server error replies

### DIFF
--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -481,6 +481,7 @@ Common error codes:
 - `ERR_REDIS_CONNECTION_CLOSED` - Connection to the server was closed
 - `ERR_REDIS_AUTHENTICATION_FAILED` - Failed to authenticate with the server
 - `ERR_REDIS_INVALID_RESPONSE` - Received an invalid response from the server
+- `ERR_REDIS_SERVER_ERROR` - The server sent an error reply, either rejecting one command or, in subscriber mode, closing the connection
 
 ---
 

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -378,5 +378,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_INSPECTOR_NOT_CONNECTED", Error],
   ["ERR_INSPECTOR_NOT_WORKER", Error],
   ["ERR_INSPECTOR_COMMAND", Error],
+  ["ERR_REDIS_SERVER_ERROR", Error, "RedisError"],
 ];
 export default errors;

--- a/src/runtime/valkey_jsc/protocol_jsc.rs
+++ b/src/runtime/valkey_jsc/protocol_jsc.rs
@@ -43,6 +43,7 @@ pub(crate) fn valkey_error_to_js(
         RedisError::IdleTimeout => JscError::REDIS_IDLE_TIMEOUT,
         RedisError::NestingDepthExceeded => JscError::REDIS_INVALID_RESPONSE,
         RedisError::LineTooLong => JscError::REDIS_INVALID_RESPONSE,
+        RedisError::ServerError => JscError::REDIS_SERVER_ERROR,
         RedisError::JSError => return global.take_exception(JsError::Thrown),
         RedisError::OutOfMemory => {
             let _ = global.throw_out_of_memory();
@@ -91,11 +92,7 @@ pub(crate) fn resp_value_to_js_with_options(
 ) -> JsResult<JSValue> {
     match this {
         RESPValue::SimpleString(str) => valkey_str_to_js_value(global, str, options),
-        RESPValue::Error(str) => Ok(valkey_error_to_js(
-            global,
-            &**str,
-            RedisError::InvalidResponse,
-        )),
+        RESPValue::Error(str) => Ok(valkey_error_to_js(global, &**str, RedisError::ServerError)),
         RESPValue::Integer(int) => Ok(JSValue::js_number(*int as f64)),
         RESPValue::BulkString(maybe_str) => {
             if let Some(str) = maybe_str {

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -1172,7 +1172,7 @@ impl ValkeyClient {
             match value {
                 RESPValue::Error(err) => {
                     if self.parent().is_subscriber() {
-                        self.fail(err, RedisError::InvalidResponse)?;
+                        self.fail(err, RedisError::ServerError)?;
                         return Ok(());
                     }
                     // A raw subscription request from a client that is not (yet) a

--- a/src/valkey/valkey_protocol.rs
+++ b/src/valkey/valkey_protocol.rs
@@ -32,6 +32,8 @@ pub enum RedisError {
     IdleTimeout,
     NestingDepthExceeded,
     LineTooLong,
+    /// The server answered with a `-` or `!` error reply.
+    ServerError,
 }
 
 bun_core::impl_tag_error!(RedisError);

--- a/test/js/valkey/valkey-incremental-scan.test.ts
+++ b/test/js/valkey/valkey-incremental-scan.test.ts
@@ -14,12 +14,13 @@ type PerSocket = { buf: Buffer; replied: boolean };
  * Mock server: answers HELLO, then answers the first GET with `reply`. When
  * `splitAt` is inside the reply it is split there across two event-loop turns
  * so the client's empty-read-buffer stack path sees a partial frame.
- * Subsequent commands get `+OK`.
+ * Subsequent commands get the entry in `replies` for their name, else `+OK`.
  */
 function createReplyServer(
   reply: string,
   splitAt: number = reply.length,
   hello: string = HELLO,
+  replies: Record<string, string> = {},
 ): TCPSocketListener<PerSocket> {
   return Bun.listen<PerSocket>({
     hostname: "127.0.0.1",
@@ -73,7 +74,7 @@ function createReplyServer(
               setImmediate(() => setImmediate(() => s.write(reply.slice(splitAt))));
             }
           } else {
-            s.write(`+OK${CRLF}`);
+            s.write(replies[cmd] ?? `+OK${CRLF}`);
           }
         }
       },
@@ -167,12 +168,13 @@ describe.concurrent("Valkey reply decoding", () => {
       const result = (await client.get("k")) as unknown as [string, Error];
       expect(result[0]).toBe("OK");
       expect(result[1]).toBeInstanceOf(Error);
+      expect((result[1] as Error & { code: string }).code).toBe("ERR_REDIS_SERVER_ERROR");
       expect(result[1].message).toBe("WRONGTYPE wrong kind");
       expect(await client.send("PING", [])).toBe("OK");
     });
   });
 
-  test("simple error (-ERR) rejects with ERR_REDIS_INVALID_RESPONSE", async () => {
+  test("simple error (-ERR) rejects with ERR_REDIS_SERVER_ERROR", async () => {
     const server = createReplyServer(`-ERR unknown command${CRLF}`);
     await withClient(server, async client => {
       const err = await client.get("k").then(
@@ -180,13 +182,34 @@ describe.concurrent("Valkey reply decoding", () => {
         e => e,
       );
       expect(err).toBeInstanceOf(Error);
-      expect(err.code).toBe("ERR_REDIS_INVALID_RESPONSE");
+      expect(err.code).toBe("ERR_REDIS_SERVER_ERROR");
       expect(err.message).toBe("ERR unknown command");
       expect(await client.send("PING", [])).toBe("OK");
     });
   });
 
-  test("blob error (!) rejects with ERR_REDIS_INVALID_RESPONSE and the server text", async () => {
+  test("simple error (-ERR) in subscriber mode fails the connection with ERR_REDIS_SERVER_ERROR", async () => {
+    const server = createReplyServer(`+OK${CRLF}`, undefined, HELLO, {
+      SUBSCRIBE: `>3${CRLF}$9${CRLF}subscribe${CRLF}$2${CRLF}ch${CRLF}:1${CRLF}`,
+      BOGUS: `-ERR unknown command 'BOGUS'${CRLF}`,
+    });
+    await withClient(server, async client => {
+      await client.subscribe("ch", () => {});
+      // The command that drew the error is not awaited: in subscriber mode a
+      // server error fails the whole connection, and every other in-flight
+      // command is rejected with the server's text.
+      client.send("BOGUS", []).catch(() => {});
+      const err = await client.send("PING", []).then(
+        () => null,
+        e => e,
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect(err.code).toBe("ERR_REDIS_SERVER_ERROR");
+      expect(err.message).toBe("ERR unknown command 'BOGUS'");
+    });
+  });
+
+  test("blob error (!) rejects with ERR_REDIS_SERVER_ERROR and the server text", async () => {
     const server = createReplyServer(`!21${CRLF}SYNTAX invalid syntax${CRLF}`);
     await withClient(server, async client => {
       const err = await client.get("k").then(
@@ -194,7 +217,7 @@ describe.concurrent("Valkey reply decoding", () => {
         e => e,
       );
       expect(err).toBeInstanceOf(Error);
-      expect(err.code).toBe("ERR_REDIS_INVALID_RESPONSE");
+      expect(err.code).toBe("ERR_REDIS_SERVER_ERROR");
       expect(err.message).toBe("SYNTAX invalid syntax");
       expect(await client.send("PING", [])).toBe("OK");
     });
@@ -238,7 +261,7 @@ describe.concurrent("Valkey reply torn across socket reads", () => {
         e => e,
       );
       expect(err).toBeInstanceOf(Error);
-      expect(err.code).toBe("ERR_REDIS_INVALID_RESPONSE");
+      expect(err.code).toBe("ERR_REDIS_SERVER_ERROR");
       expect(err.message).toBe("SYNTAX invalid syntax");
       expect(await client.send("PING", [])).toBe("OK");
     });


### PR DESCRIPTION
Breaking

`err.code` for a server error reply changes from ERR_REDIS_INVALID_RESPONSE to ERR_REDIS_SERVER_ERROR. The message text is unchanged. ERR_REDIS_INVALID_RESPONSE stays the code for a reply the client could not parse.

Three public repos match on the old code for server errors. HazelChat/hazel (effect-bun/Redis.ts) maps it to a typed RedisInvalidResponseError. stella/stella (redis-client.ts) branches on it. petarzarkov/dunx (redis/errors.ts) documents that Bun files WRONGTYPE and unknown-command replies under it. The first two will stop matching those replies.

This needs a yes or no from a maintainer.

The problem

A `-ERR` or `!` reply is an answer from the server. Today it carries ERR_REDIS_INVALID_RESPONSE. That code also means the client failed to parse a reply. Users cannot tell the two apart by code.

What changed

ERR_REDIS_SERVER_ERROR is appended at the tail of ErrorCode.ts. The Rust mirror is generated from that file, so existing discriminants do not move.

A `-` or `!` reply that rejects one command carries the new code. So does such a reply nested inside an array reply.

In subscriber mode a `-` or `!` reply still fails the whole connection. The rejection now carries ERR_REDIS_SERVER_ERROR instead of ERR_REDIS_INVALID_RESPONSE.

Handshake failures keep their specific codes. A `-` reply to HELLO stays ERR_REDIS_AUTHENTICATION_FAILED. A `-` reply to the internal SELECT stays ERR_REDIS_INVALID_COMMAND.

The docs list the new code as any error reply the server sent, whether it rejects one command or, in subscriber mode, closes the connection.

Tests

The mock server tests in test/js/valkey/valkey-incremental-scan.test.ts assert the new code for a top level `-ERR`, a top level `!`, the torn `!` frames, and a `-` or `!` element nested in an array.

A new test subscribes a client through the mock server, then sends a command that the server answers with `-ERR`. A second in-flight command rejects with ERR_REDIS_SERVER_ERROR and the server text. Before this change the code was ERR_REDIS_INVALID_RESPONSE.

Not in this PR

The command that drew the error in subscriber mode is not settled today. Its promise pair is consumed before the connection fails. That is pre-existing and belongs with the fail path work in #39542.

Whether a server error should fail a subscriber connection at all is a separate question.
