### PR TITLE
shell(rm): stop the recursive walk from aborting on entries deeper than PATH_MAX

### DIFF
--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -853,8 +853,7 @@ impl ShellRmTask {
         Ok(())
     }
 
-    /// Join into `buf` (into `spill` when the result does not fit) honoring
-    /// [`join_style`].
+    /// Join into `buf` honoring [`join_style`].
     fn buf_join<'a>(
         &self,
         buf: &'a mut bun_paths::PathBuffer,

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -853,12 +853,19 @@ impl ShellRmTask {
         Ok(())
     }
 
-    /// Join into `buf` honoring [`join_style`].
-    fn buf_join<'a>(&self, buf: &'a mut bun_paths::PathBuffer, parts: &[&[u8]]) -> &'a ZStr {
+    /// Join into `buf` honoring [`join_style`]. A tree can be deeper than
+    /// `buf`, so a result that does not fit goes to `spill` and the syscall
+    /// on it reports `ENAMETOOLONG`.
+    fn buf_join<'a>(
+        &self,
+        buf: &'a mut bun_paths::PathBuffer,
+        spill: &'a mut Vec<u8>,
+        parts: &[&[u8]],
+    ) -> &'a ZStr {
         if self.join_style == JoinStyle::Posix {
-            resolve_path::join_z_buf::<platform::Posix>(buf.as_mut_slice(), parts)
+            resolve_path::join_z_buf_spill::<platform::Posix>(buf.as_mut_slice(), spill, parts)
         } else {
-            resolve_path::join_z_buf::<platform::Windows>(buf.as_mut_slice(), parts)
+            resolve_path::join_z_buf_spill::<platform::Windows>(buf.as_mut_slice(), spill, parts)
         }
     }
 
@@ -892,7 +899,9 @@ impl ShellRmTask {
             }
             return ZBox::from_vec(out);
         }
-        ZBox::from_bytes(resolve_path::join::<platform::Auto>(parts))
+        let mut spill = Vec::new();
+        let joined = resolve_path::join_spill::<platform::Auto>(&mut spill, parts);
+        ZBox::from_bytes(joined)
     }
 
     #[inline]
@@ -1032,6 +1041,7 @@ impl ShellRmTask {
         // `delete_after_waiting_for_children` on this dir and the owning
         // `ShellRmTask` would never be freed.
         let mut i: usize = 0;
+        let mut join_spill = Vec::new();
         let loop_result: bun_sys::Maybe<()> = loop {
             let current = match iterator.next() {
                 Err(e) => break Err(self.error_with_path(&e, path.as_bytes())),
@@ -1057,7 +1067,7 @@ impl ShellRmTask {
                     // Copy the join into an owned ZBox so `buf` is free to
                     // be re-borrowed by the vtable callback.
                     let file_path = {
-                        let joined = self.buf_join(buf, &[path.as_bytes(), name]);
+                        let joined = self.buf_join(buf, &mut join_spill, &[path.as_bytes(), name]);
                         ZBox::from_bytes(joined.as_bytes())
                     };
                     if let Err(e) = self.remove_entry_file(

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -853,9 +853,8 @@ impl ShellRmTask {
         Ok(())
     }
 
-    /// Join into `buf` honoring [`join_style`]. A tree can be deeper than
-    /// `buf`, so a result that does not fit goes to `spill` and the syscall
-    /// on it reports `ENAMETOOLONG`.
+    /// Join into `buf` (into `spill` when the result does not fit) honoring
+    /// [`join_style`].
     fn buf_join<'a>(
         &self,
         buf: &'a mut bun_paths::PathBuffer,

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -316,8 +316,8 @@ test.skipIf(process.platform === "win32")(
       // <base>/<tag>/ddd.../ddd... with an absolute path of deepLength bytes.
       function deepDir(tag: string): string {
         let dir = join(base, tag);
-        while (dir.length + 1 + component.length <= deepLength) dir = join(dir, component);
-        const rest = deepLength - dir.length - 1;
+        while (Buffer.byteLength(dir) + 1 + component.length <= deepLength) dir = join(dir, component);
+        const rest = deepLength - Buffer.byteLength(dir) - 1;
         if (rest > 0) dir = join(dir, Buffer.alloc(rest, "e").toString());
         mkdirSync(dir, { recursive: true });
         return dir;
@@ -362,8 +362,8 @@ test.skipIf(process.platform === "win32")(
     const results = JSON.parse(stdout);
     // The entries are what rm could not remove, and this is why: a path of
     // PATH_MAX bytes has no room left for its NUL.
-    expect(results.file.entry.length).toBeGreaterThanOrEqual(PATH_MAX);
-    expect(results.dir.entry.length).toBeGreaterThanOrEqual(PATH_MAX);
+    expect(Buffer.byteLength(results.file.entry)).toBeGreaterThanOrEqual(PATH_MAX);
+    expect(Buffer.byteLength(results.dir.entry)).toBeGreaterThanOrEqual(PATH_MAX);
     expect(results).toEqual({
       file: {
         exitCode: 1,

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -299,6 +299,8 @@ test.skipIf(process.platform === "win32")(
 test.skipIf(process.platform === "win32")(
   "recursive rm reports an entry deeper than PATH_MAX instead of crashing",
   async () => {
+    // Linux PATH_MAX is 4096, every other POSIX platform Bun runs on has 1024.
+    const PATH_MAX = process.platform === "linux" ? 4096 : 1024;
     using base = tempDir("rm-deep-walk", {});
     const fixture = /* ts */ `
       import { $ } from "bun";
@@ -307,13 +309,15 @@ test.skipIf(process.platform === "win32")(
       $.nothrow();
 
       const base = process.env.BASE!;
-      const component = Buffer.alloc(200, "d").toString();
-      // <base>/<tag>/ddd.../ddd... with an absolute path of about 4060 bytes:
-      // it still fits a path buffer, an entry inside it no longer does.
+      // Long enough that a 100 byte entry inside the directory is past
+      // PATH_MAX, short enough that the directory itself is still well inside.
+      const deepLength = Number(process.env.PATH_MAX) - 64;
+      const component = Buffer.alloc(100, "d").toString();
+      // <base>/<tag>/ddd.../ddd... with an absolute path of deepLength bytes.
       function deepDir(tag: string): string {
         let dir = join(base, tag);
-        while (dir.length + 1 + component.length <= 4060) dir = join(dir, component);
-        const rest = 4060 - dir.length - 1;
+        while (dir.length + 1 + component.length <= deepLength) dir = join(dir, component);
+        const rest = deepLength - dir.length - 1;
         if (rest > 0) dir = join(dir, Buffer.alloc(rest, "e").toString());
         mkdirSync(dir, { recursive: true });
         return dir;
@@ -348,7 +352,7 @@ test.skipIf(process.platform === "win32")(
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: { ...bunEnv, BASE: String(base) },
+      env: { ...bunEnv, BASE: String(base), PATH_MAX: String(PATH_MAX) },
       cwd: String(base),
       stdout: "pipe",
       stderr: "pipe",
@@ -356,10 +360,10 @@ test.skipIf(process.platform === "win32")(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     const results = JSON.parse(stdout);
-    // The entries are what rm could not remove, and they are the reason: each
-    // of their paths is longer than PATH_MAX.
-    expect(results.file.entry.length).toBeGreaterThan(4095);
-    expect(results.dir.entry.length).toBeGreaterThan(4095);
+    // The entries are what rm could not remove, and this is why: a path of
+    // PATH_MAX bytes has no room left for its NUL.
+    expect(results.file.entry.length).toBeGreaterThanOrEqual(PATH_MAX);
+    expect(results.dir.entry.length).toBeGreaterThanOrEqual(PATH_MAX);
     expect(results).toEqual({
       file: {
         exitCode: 1,

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -290,6 +290,95 @@ test.skipIf(process.platform === "win32")(
   },
 );
 
+// The recursive walk joined every entry onto its directory's path inside a
+// fixed-size path buffer on the worker thread, so a tree deeper than PATH_MAX
+// aborted the whole process instead of failing that entry. Files and
+// directories take different joins, so one tree of each. Runs in a child
+// process so the abort shows up as a failed assertion. Windows has a
+// different path limit, and its shell rm is bounded differently.
+test.skipIf(process.platform === "win32")(
+  "recursive rm reports an entry deeper than PATH_MAX instead of crashing",
+  async () => {
+    using base = tempDir("rm-deep-walk", {});
+    const fixture = /* ts */ `
+      import { $ } from "bun";
+      import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+      import { join } from "node:path";
+      $.nothrow();
+
+      const base = process.env.BASE!;
+      const component = Buffer.alloc(200, "d").toString();
+      // <base>/<tag>/ddd.../ddd... with an absolute path of about 4060 bytes:
+      // it still fits a path buffer, an entry inside it no longer does.
+      function deepDir(tag: string): string {
+        let dir = join(base, tag);
+        while (dir.length + 1 + component.length <= 4060) dir = join(dir, component);
+        const rest = 4060 - dir.length - 1;
+        if (rest > 0) dir = join(dir, Buffer.alloc(rest, "e").toString());
+        mkdirSync(dir, { recursive: true });
+        return dir;
+      }
+
+      // An entry whose full path is longer than PATH_MAX can only be created
+      // relative to its directory.
+      const fileDir = deepDir("file");
+      const fileName = Buffer.alloc(100, "f").toString();
+      process.chdir(fileDir);
+      writeFileSync(fileName, "");
+
+      const dirDir = deepDir("dir");
+      const dirName = Buffer.alloc(100, "s").toString();
+      process.chdir(dirDir);
+      mkdirSync(dirName);
+
+      process.chdir(base);
+      mkdirSync(join(base, "plain", "sub"), { recursive: true });
+
+      const run = async (operand: string) => {
+        const { exitCode, stderr } = await $\`rm -rf \${operand}\`.cwd(base).quiet();
+        return { exitCode, stderr: stderr.toString() };
+      };
+      console.log(
+        JSON.stringify({
+          file: { ...(await run(join(base, "file"))), entry: join(fileDir, fileName), dirKept: existsSync(fileDir) },
+          dir: { ...(await run(join(base, "dir"))), entry: join(dirDir, dirName), dirKept: existsSync(dirDir) },
+          plain: { ...(await run(join(base, "plain"))), removed: !existsSync(join(base, "plain")) },
+        }),
+      );
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, BASE: String(base) },
+      cwd: String(base),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const results = JSON.parse(stdout);
+    // The entries are what rm could not remove, and they are the reason: each
+    // of their paths is longer than PATH_MAX.
+    expect(results.file.entry.length).toBeGreaterThan(4095);
+    expect(results.dir.entry.length).toBeGreaterThan(4095);
+    expect(results).toEqual({
+      file: {
+        exitCode: 1,
+        stderr: `rm: ${results.file.entry}: File name too long\n`,
+        entry: expect.stringMatching(/\/f{100}$/),
+        dirKept: true,
+      },
+      dir: {
+        exitCode: 1,
+        stderr: `rm: ${results.dir.entry}: File name too long\n`,
+        entry: expect.stringMatching(/\/s{100}$/),
+        dirKept: true,
+      },
+      plain: { exitCode: 0, stderr: "", removed: true },
+    });
+    expect(exitCode).toBe(0);
+  },
+);
+
 test.skipIf(process.platform === "win32")(
   "relative operands are resolved against the shell cwd, not the process cwd",
   async () => {


### PR DESCRIPTION
### Problem
- `Bun.$` `rm -rf <dir>` aborts the whole process when the tree under `<dir>` has an entry whose path is longer than the path buffer: `panic: range end index 4160 out of range for slice of length 4094` (exit 134). With an absolute operand the message reads `... out of range for slice of length 4095`.
- The panic happens on a thread pool thread. No JS code can catch it, and `.nothrow()` does not help.
- Cause, files: `ShellRmTask::buf_join` (`src/runtime/shell/builtin/rm.rs`) joins the directory path and the entry name with `join_z_buf` into a stack `PathBuffer`. The join writes the result with plain slice indexing, so a result longer than the buffer panics.
- Cause, directories: `ShellRmTask::join` does the same for an absolute operand with `resolve_path::join`, which writes into a 4096 byte thread-local buffer. (For a relative operand this branch already builds a `Vec`.)
- A directory path that still fits the buffer can hold an entry that does not. The walk reaches such an entry on every tree deeper than `PATH_MAX`. Such trees are legal. `mkdir` relative to an open directory creates them, and so do `tar` and `git`.

### Fix
- `buf_join` joins through `join_z_buf_spill`. It uses the `PathBuffer` as before when the result fits, and a `Vec` owned by the readdir loop when it does not.
- The absolute branch of `join` uses `join_spill` the same way.
- The result for every path that used to work is unchanged. A path that does not fit now reaches `unlinkat` or `openat` whole, and the OS rejects it with `ENAMETOOLONG`. `rm` reports that as `rm: <path>: File name too long` and exits 1, like every other failed entry.
- `join_z_buf_spill` and `join_spill` are the existing helpers that `fs.readdir`, `Bun.Glob` and `fs.watch` use for the same problem. #37521 (the preserve-root check in `rm`) and #38379 (`mkdir`, `touch`) use them for the other shell sites.
- Test: `test/js/bun/shell/commands/rm.test.ts`, "recursive rm reports an entry deeper than PATH_MAX instead of crashing". It builds two trees whose deepest directory is `PATH_MAX - 64` bytes long (`PATH_MAX` is 4096 on Linux and 1024 on the other POSIX platforms, the same split as `MAX_PATH_BYTES`), one with a 100 byte file and one with a 100 byte directory inside, so both joins are exercised. It runs `rm -rf` on each in a child process and expects exit 1 and the `File name too long` line for the entry, then a normal `rm -rf` that still succeeds. Skipped on Windows, where the path limit is different.
- `USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/rm.test.ts -t "deeper than PATH_MAX"`: fails with the panic above.
- `bun bd test test/js/bun/shell/commands/rm.test.ts`: 8 pass.
- `cargo fmt --all -- --check`: clean.

### Background
`rm -r` in the Bun shell is a tree of `DirTask`s. The root task holds the operand as written. When a task reads a directory, it removes each file entry itself and creates a child task for each directory entry. Every task stores the full path of its entry, relative to the shell cwd when the operand was relative, and passes that path to `unlinkat`, `openat` or `rmdirat` with the shell cwd fd. The two joins in this PR are where those full paths are built.

`PATH_MAX` (4096 on Linux) bounds one path string that the kernel accepts in a syscall. It does not bound how deep a tree can be, because a process can always create an entry relative to an open directory. So a walker that builds full paths has to expect paths longer than its buffers. The OS then rejects the syscall with `ENAMETOOLONG`, which is the error coreutils also shows for such an entry when it cannot use `*at` calls.

`resolve_path::join_z_buf` and `resolve_path::join` normalize the joined parts (collapse `//`, resolve `.` and `..`) into a caller buffer or a thread-local buffer. Neither checks the buffer length. The `_spill` variants take an extra `Vec`, compute an upper bound of the result from the input lengths, and grow the `Vec` and write there when the bound exceeds the buffer.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/rm.test.ts

<!-- robobun:evidence:end -->