### PR TITLE
net: report the real connect errno

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1980,9 +1980,7 @@ static int is_loopback(struct sockaddr_storage *sockaddr) {
 }
 #endif
 
-/* The OS error of the call that just failed; never 0, so a caller that gets
- * LIBUS_SOCKET_ERROR always has a code to report. */
-static int bsd_last_error_or_refused(void) {
+int bsd_last_error_or_refused(void) {
     int err = LIBUS_ERR;
     return err ? err : ECONNREFUSED;
 }

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1986,9 +1986,10 @@ int bsd_last_error_or_refused(void) {
 }
 
 LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr, struct sockaddr_storage *local_addr, int options, int *error) {
-    LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_socket(addr->ss_family, SOCK_STREAM, 0, NULL);
+    int socket_error = 0;
+    LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_socket(addr->ss_family, SOCK_STREAM, 0, &socket_error);
     if (fd == LIBUS_SOCKET_ERROR) {
-        *error = bsd_last_error_or_refused();
+        *error = socket_error ? socket_error : LIBUS_ECONNREFUSED;
         return LIBUS_SOCKET_ERROR;
     }
 
@@ -2056,10 +2057,11 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr,
 }
 
 static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_connect_socket_unix(const char *server_path, size_t len, int options, struct sockaddr_un* server_address, const size_t addrlen, int *error) {
-    LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_socket(AF_UNIX, SOCK_STREAM, 0, NULL);
+    int socket_error = 0;
+    LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_socket(AF_UNIX, SOCK_STREAM, 0, &socket_error);
 
     if (fd == LIBUS_SOCKET_ERROR) {
-        *error = bsd_last_error_or_refused();
+        *error = socket_error ? socket_error : LIBUS_ECONNREFUSED;
         return LIBUS_SOCKET_ERROR;
     }
 

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -746,6 +746,12 @@ void bsd_close_socket(LIBUS_SOCKET_DESCRIPTOR fd) {
 #else
     close(fd);
 #endif
+    /* After the real close (no fd leak): an armed "close" rule leaves errno,
+     * and WSAGetLastError on Windows, set the way a failed close would, so a
+     * caller that reads them after its cleanup is caught. */
+    ssize_t injected = 0; int unused = 0;
+    (void)US_FAULT_CHECK(US_FAULT_CLOSE, fd, injected, unused);
+    (void)injected; (void)unused;
 }
 
 void bsd_shutdown_socket(LIBUS_SOCKET_DESCRIPTOR fd) {

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1982,7 +1982,7 @@ static int is_loopback(struct sockaddr_storage *sockaddr) {
 
 int bsd_last_error_or_refused(void) {
     int err = LIBUS_ERR;
-    return err ? err : ECONNREFUSED;
+    return err ? err : LIBUS_ECONNREFUSED;
 }
 
 LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr, struct sockaddr_storage *local_addr, int options, int *error) {

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1974,9 +1974,17 @@ static int is_loopback(struct sockaddr_storage *sockaddr) {
 }
 #endif
 
-LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr, struct sockaddr_storage *local_addr, int options) {
+/* The OS error of the call that just failed; never 0, so a caller that gets
+ * LIBUS_SOCKET_ERROR always has a code to report. */
+static int bsd_last_error_or_refused(void) {
+    int err = LIBUS_ERR;
+    return err ? err : ECONNREFUSED;
+}
+
+LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr, struct sockaddr_storage *local_addr, int options, int *error) {
     LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_socket(addr->ss_family, SOCK_STREAM, 0, NULL);
     if (fd == LIBUS_SOCKET_ERROR) {
+        *error = bsd_last_error_or_refused();
         return LIBUS_SOCKET_ERROR;
     }
 
@@ -1994,15 +2002,8 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr,
 #endif
         socklen_t local_len = local_addr->ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
         if (bind(fd, (struct sockaddr *) local_addr, local_len)) {
-#ifdef _WIN32
-            int bind_err = WSAGetLastError();
+            *error = bsd_last_error_or_refused();
             bsd_close_socket(fd);
-            WSASetLastError(bind_err);
-#else
-            int bind_err = errno;
-            bsd_close_socket(fd);
-            errno = bind_err;
-#endif
             return LIBUS_SOCKET_ERROR;
         }
     }
@@ -2042,22 +2043,19 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr,
     int rc = bsd_do_connect_raw(fd, (struct sockaddr*) addr, addr->ss_family == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
 
     if (rc != 0) {
+        /* The connect error itself, not what closing the socket leaves behind. */
+        *error = rc;
         bsd_close_socket(fd);
-#ifdef _WIN32
-        /* bsd_do_connect_raw returned the WSA error; re-arm it so the Rust
-         * caller's WSAGetLastError() observes the connect failure rather than
-         * whatever closesocket() left behind. */
-        WSASetLastError(rc);
-#endif
         return LIBUS_SOCKET_ERROR;
     }
     return fd;
 }
 
-static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_connect_socket_unix(const char *server_path, size_t len, int options, struct sockaddr_un* server_address, const size_t addrlen) {
+static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_connect_socket_unix(const char *server_path, size_t len, int options, struct sockaddr_un* server_address, const size_t addrlen, int *error) {
     LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_socket(AF_UNIX, SOCK_STREAM, 0, NULL);
 
     if (fd == LIBUS_SOCKET_ERROR) {
+        *error = bsd_last_error_or_refused();
         return LIBUS_SOCKET_ERROR;
     }
 
@@ -2065,21 +2063,22 @@ static LIBUS_SOCKET_DESCRIPTOR internal_bsd_create_connect_socket_unix(const cha
 
     int rc = bsd_do_connect_raw(fd, (struct sockaddr *)server_address, addrlen);
     if (rc != 0) {
+        *error = rc;
         bsd_close_socket(fd);
-#ifdef _WIN32
-        WSASetLastError(rc);
-#endif
         return LIBUS_SOCKET_ERROR;
     }
 
     return fd;
 }
 
-LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket_unix(const char *server_path, size_t len, int options) {
+LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket_unix(const char *server_path, size_t len, int options, int *error) {
     struct sockaddr_un server_address;
     size_t addrlen = 0;
     int dirfd_workaround_for_unix_path_len = -1;
     if (bsd_create_unix_socket_address(server_path, len, &dirfd_workaround_for_unix_path_len, &server_address, &addrlen)) {
+        /* ENOENT for an empty path (ERROR_PATH_NOT_FOUND on Windows),
+         * ENAMETOOLONG for one sun_path cannot hold. */
+        *error = bsd_last_error_or_refused();
         return LIBUS_SOCKET_ERROR;
     }
 
@@ -2087,20 +2086,18 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket_unix(const char *server_path, 
     if (dirfd_workaround_for_unix_path_len != -1) {
         if (__pthread_fchdir(dirfd_workaround_for_unix_path_len) != 0) {
             close(dirfd_workaround_for_unix_path_len);
-            errno = ENAMETOOLONG;
+            *error = ENAMETOOLONG;
             return LIBUS_SOCKET_ERROR;
         }
     }
 #endif
 
-    LIBUS_SOCKET_DESCRIPTOR fd = internal_bsd_create_connect_socket_unix(server_path, len, options, &server_address, addrlen);
+    LIBUS_SOCKET_DESCRIPTOR fd = internal_bsd_create_connect_socket_unix(server_path, len, options, &server_address, addrlen, error);
 
 #if defined(__APPLE__)
     if (dirfd_workaround_for_unix_path_len != -1) {
-        int saved_errno = errno;
         __pthread_fchdir(-1);
         close(dirfd_workaround_for_unix_path_len);
-        errno = saved_errno;
     }
 #elif defined(__linux__)
     if (dirfd_workaround_for_unix_path_len != -1) {

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -549,10 +549,16 @@ static inline void us_internal_init_connect_socket(struct us_socket_t *s,
     s->connect_next = NULL;
 }
 
+/* The OS error of the call that just failed; never 0. */
+static int last_error_or_refused(void) {
+    int err = LIBUS_ERR;
+    return err ? err : ECONNREFUSED;
+}
+
 struct us_socket_t *us_socket_group_connect_resolved_dns(struct us_socket_group_t *group,
         unsigned char kind, struct ssl_ctx_st *ssl_ctx,
-        struct sockaddr_storage *addr, struct sockaddr_storage *local_addr, int options, int socket_ext_size) {
-    LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(addr, local_addr, options);
+        struct sockaddr_storage *addr, struct sockaddr_storage *local_addr, int options, int socket_ext_size, int *error) {
+    LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(addr, local_addr, options, error);
     if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
         return NULL;
     }
@@ -562,10 +568,9 @@ struct us_socket_t *us_socket_group_connect_resolved_dns(struct us_socket_group_
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_socket_t) + socket_ext_size);
     us_poll_init(p, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
     if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_WRITABLE) != 0) {
-        int saved_errno = errno;
+        *error = last_error_or_refused();
         bsd_close_socket(connect_socket_fd);
         us_poll_free(p, group->loop);
-        errno = saved_errno;
         return NULL;
     }
 
@@ -602,7 +607,7 @@ static bool try_parse_ip(const char *ip_str, int port, struct sockaddr_storage *
 void *us_socket_group_connect(struct us_socket_group_t *group, unsigned char kind,
         struct ssl_ctx_st *ssl_ctx, const char *host, int port,
         const char *local_host, int local_port, int options,
-        int socket_ext_size, int *has_dns_resolved) {
+        int socket_ext_size, int *has_dns_resolved, int *error) {
     struct us_loop_t *loop = group->loop;
 
     /* The local address is always a literal IP (Node validates it as one). */
@@ -615,7 +620,7 @@ void *us_socket_group_connect(struct us_socket_group_t *group, unsigned char kin
     struct sockaddr_storage addr;
     if (try_parse_ip(host, port, &addr)) {
         *has_dns_resolved = 1;
-        return us_socket_group_connect_resolved_dns(group, kind, ssl_ctx, &addr, local_addr, options, socket_ext_size);
+        return us_socket_group_connect_resolved_dns(group, kind, ssl_ctx, &addr, local_addr, options, socket_ext_size, error);
     }
 
     struct addrinfo_request *ai_req;
@@ -632,7 +637,7 @@ void *us_socket_group_connect(struct us_socket_group_t *group, unsigned char kin
                 struct sockaddr_storage a;
                 init_addr_with_port(&entries->info, port, &a);
                 *has_dns_resolved = 1;
-                struct us_socket_t *s = us_socket_group_connect_resolved_dns(group, kind, ssl_ctx, &a, local_addr, options, socket_ext_size);
+                struct us_socket_t *s = us_socket_group_connect_resolved_dns(group, kind, ssl_ctx, &a, local_addr, options, socket_ext_size, error);
                 Bun__addrinfo_freeRequest(ai_req, s == NULL);
                 return s;
             }
@@ -670,8 +675,8 @@ void *us_socket_group_connect(struct us_socket_group_t *group, unsigned char kin
 
 struct us_socket_t *us_socket_group_connect_unix(struct us_socket_group_t *group,
         unsigned char kind, struct ssl_ctx_st *ssl_ctx,
-        const char *server_path, size_t pathlen, int options, int socket_ext_size) {
-    LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket_unix(server_path, pathlen, options);
+        const char *server_path, size_t pathlen, int options, int socket_ext_size, int *error) {
+    LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket_unix(server_path, pathlen, options, error);
     if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
         return 0;
     }
@@ -679,10 +684,9 @@ struct us_socket_t *us_socket_group_connect_unix(struct us_socket_group_t *group
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_socket_t) + socket_ext_size);
     us_poll_init(p, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
     if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_WRITABLE) != 0) {
-        int saved_errno = errno;
+        *error = last_error_or_refused();
         bsd_close_socket(connect_socket_fd);
         us_poll_free(p, group->loop);
-        errno = saved_errno;
         return 0;
     }
 
@@ -705,7 +709,8 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         struct sockaddr_storage addr;
         init_addr_with_port(c->addrinfo_head, c->port, &addr);
         /* The deferred-DNS path does not carry a local binding. */
-        LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(&addr, NULL, c->options);
+        int unused_error = 0;
+        LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(&addr, NULL, c->options, &unused_error);
         if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
             continue;
         }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -702,14 +702,14 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
     for (; c->addrinfo_head != NULL && opened < count; c->addrinfo_head = c->addrinfo_head->ai_next) {
         struct sockaddr_storage addr;
         init_addr_with_port(c->addrinfo_head, c->port, &addr);
-        /* The deferred-DNS path does not carry a local binding. */
-        /* Why this candidate failed. Not reported: the dial goes on with the
-         * next address, and when none connects after_open/after_resolve report
-         * LIBUS_ECONNREFUSED. Read it here, not LIBUS_ERR after the call: the
+        /* The deferred-DNS path does not carry a local binding. The dial goes
+         * on with the next address; the error is kept for the case none
+         * connects. Read from the out-param, not LIBUS_ERR after the call: the
          * failed socket has been closed by then. */
         int candidate_error = 0;
         LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(&addr, NULL, c->options, &candidate_error);
         if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
+            c->last_candidate_error = candidate_error;
             continue;
         }
         bsd_socket_nodelay(connect_socket_fd, 1);
@@ -717,6 +717,7 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         struct us_poll_t *poll = &s->p;
         us_poll_init(poll, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
         if (us_poll_start_rc(poll, loop, LIBUS_SOCKET_WRITABLE) != 0) {
+            c->last_candidate_error = bsd_last_error_or_refused();
             bsd_close_socket(connect_socket_fd);
             us_poll_free(poll, loop);
             continue;
@@ -776,8 +777,9 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
     int opened = start_connections(c, CONCURRENT_CONNECTIONS);
     if (opened == 0) {
         /* Same as the exhausted path in us_internal_socket_after_open: a
-         * real connect failure must not be reported as a caller abort. */
-        c->error = LIBUS_ECONNREFUSED;
+         * real connect failure must not be reported as a caller abort, and
+         * the last address's own error beats a blanket LIBUS_ECONNREFUSED. */
+        c->error = c->last_candidate_error ? c->last_candidate_error : LIBUS_ECONNREFUSED;
         us_connecting_socket_close(c);
     }
 }
@@ -814,6 +816,7 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
     #endif
     if (error) {
         if (c) {
+            c->last_candidate_error = error;
             for (struct us_socket_t **next = &c->connecting_head; *next; next = &(*next)->connect_next) {
                 if (*next == s) {
                     *next = s->connect_next;
@@ -828,8 +831,10 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
                     /* Every resolved address failed to connect. Without this,
                      * us_connecting_socket_close defaults c->error to
                      * ECONNABORTED (caller abort) and never invalidates the
-                     * DNS cache entry for the dead host. */
-                    c->error = LIBUS_ECONNREFUSED;
+                     * DNS cache entry for the dead host. The last address's
+                     * own error is reported; several addresses failing
+                     * differently is last-wins. */
+                    c->error = c->last_candidate_error ? c->last_candidate_error : LIBUS_ECONNREFUSED;
                     us_connecting_socket_close(c);
                 }
             }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -792,6 +792,17 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
                     break;
                 }
                 default: {
+                    /* The probe only says the socket never connected
+                     * (WSAENOTCONN); why the connect failed (WSAECONNREFUSED,
+                     * WSAETIMEDOUT, ...) is in SO_ERROR. A probe error other
+                     * than WSAENOTCONN (WSAECONNRESET, WSAEADDRINUSE) is the
+                     * reason itself. */
+                    int connect_error = us_socket_get_error(s);
+                    if (connect_error != 0) {
+                        error = connect_error;
+                    } else if (error == WSAENOTCONN) {
+                        error = WSAECONNREFUSED;
+                    }
                     break;
                 }
             }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -113,7 +113,7 @@ void us_socket_group_close_all_ex(struct us_socket_group_t *group, int also_list
              * the natural failure path would have, which detaches the
              * wrapper. The handler then closes; if it doesn't, the
              * force-drain below catches it. */
-            us_dispatch_connect_error(s, ECONNABORTED);
+            us_dispatch_connect_error(s, LIBUS_ECONNABORTED);
             if (!us_socket_is_closed(s)) {
                 us_internal_socket_close_raw(s, LIBUS_SOCKET_CLOSE_CODE_CONNECTION_RESET, 0);
             }
@@ -703,8 +703,12 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         struct sockaddr_storage addr;
         init_addr_with_port(c->addrinfo_head, c->port, &addr);
         /* The deferred-DNS path does not carry a local binding. */
-        int unused_error = 0;
-        LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(&addr, NULL, c->options, &unused_error);
+        /* Why this candidate failed. Not reported: the dial goes on with the
+         * next address, and when none connects after_open/after_resolve report
+         * LIBUS_ECONNREFUSED. Read it here, not LIBUS_ERR after the call: the
+         * failed socket has been closed by then. */
+        int candidate_error = 0;
+        LIBUS_SOCKET_DESCRIPTOR connect_socket_fd = bsd_create_connect_socket(&addr, NULL, c->options, &candidate_error);
         if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
             continue;
         }
@@ -773,7 +777,7 @@ void us_internal_socket_after_resolve(struct us_connecting_socket_t *c) {
     if (opened == 0) {
         /* Same as the exhausted path in us_internal_socket_after_open: a
          * real connect failure must not be reported as a caller abort. */
-        c->error = ECONNREFUSED;
+        c->error = LIBUS_ECONNREFUSED;
         us_connecting_socket_close(c);
     }
 }
@@ -800,7 +804,7 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
                     if (connect_error != 0) {
                         error = connect_error;
                     } else if (error == WSAENOTCONN) {
-                        error = WSAECONNREFUSED;
+                        error = LIBUS_ECONNREFUSED;
                     }
                     break;
                 }
@@ -825,7 +829,7 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
                      * us_connecting_socket_close defaults c->error to
                      * ECONNABORTED (caller abort) and never invalidates the
                      * DNS cache entry for the dead host. */
-                    c->error = ECONNREFUSED;
+                    c->error = LIBUS_ECONNREFUSED;
                     us_connecting_socket_close(c);
                 }
             }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -549,12 +549,6 @@ static inline void us_internal_init_connect_socket(struct us_socket_t *s,
     s->connect_next = NULL;
 }
 
-/* The OS error of the call that just failed; never 0. */
-static int last_error_or_refused(void) {
-    int err = LIBUS_ERR;
-    return err ? err : ECONNREFUSED;
-}
-
 struct us_socket_t *us_socket_group_connect_resolved_dns(struct us_socket_group_t *group,
         unsigned char kind, struct ssl_ctx_st *ssl_ctx,
         struct sockaddr_storage *addr, struct sockaddr_storage *local_addr, int options, int socket_ext_size, int *error) {
@@ -568,7 +562,7 @@ struct us_socket_t *us_socket_group_connect_resolved_dns(struct us_socket_group_
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_socket_t) + socket_ext_size);
     us_poll_init(p, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
     if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_WRITABLE) != 0) {
-        *error = last_error_or_refused();
+        *error = bsd_last_error_or_refused();
         bsd_close_socket(connect_socket_fd);
         us_poll_free(p, group->loop);
         return NULL;
@@ -684,7 +678,7 @@ struct us_socket_t *us_socket_group_connect_unix(struct us_socket_group_t *group
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_socket_t) + socket_ext_size);
     us_poll_init(p, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
     if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_WRITABLE) != 0) {
-        *error = last_error_or_refused();
+        *error = bsd_last_error_or_refused();
         bsd_close_socket(connect_socket_fd);
         us_poll_free(p, group->loop);
         return 0;

--- a/packages/bun-usockets/src/internal/fault_inject.h
+++ b/packages/bun-usockets/src/internal/fault_inject.h
@@ -37,7 +37,10 @@ enum us_fault_syscall {
     US_FAULT_ACCEPT,
     /* Reserved: no bsd.c hooks yet, so the JS setter does not accept them. */
     US_FAULT_SOCKET,
+    /* Runs after the real close in bsd_close_socket. Only US_FAULT_ERRNO
+     * applies: the close still happens, the rule only sets errno afterwards. */
     US_FAULT_CLOSE,
+    /* Reserved, as US_FAULT_SOCKET. */
     US_FAULT_SHUTDOWN,
     /* Not a syscall: the per-loop TLS plaintext buffer allocated once by
      * us_internal_init_loop_ssl_data. Only US_FAULT_ERRNO applies — there is

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -84,11 +84,18 @@ extern void __attribute__((__noreturn__)) Bun__outOfMemory(void);
 #define IS_EINTR(rc) (rc == SOCKET_ERROR && WSAGetLastError() == WSAEINTR)
 #define LIBUS_ERR WSAGetLastError()
 #define LIBUS_ECONNRESET WSAECONNRESET
+/* The codes uSockets fills in itself for a connect it ended or gave up on,
+ * in that same numbering, so a caller can treat every connect error code
+ * alike. */
+#define LIBUS_ECONNABORTED WSAECONNABORTED
+#define LIBUS_ECONNREFUSED WSAECONNREFUSED
 #else
 #include <errno.h>
 #define IS_EINTR(rc) (rc == -1 && errno == EINTR)
 #define LIBUS_ERR errno
 #define LIBUS_ECONNRESET ECONNRESET
+#define LIBUS_ECONNABORTED ECONNABORTED
+#define LIBUS_ECONNREFUSED ECONNREFUSED
 #endif
 #include <stdbool.h>
 /* Poll type and what it polls for */

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -387,6 +387,11 @@ struct us_connecting_socket_t {
     unsigned char kind;
     uint16_t port;
     int error;
+    /* The error of the last address that failed (the out-param of a dial
+     * that failed outright, or the SO_ERROR reported through after_open).
+     * When every address is exhausted this is what `error` becomes, in
+     * place of a blanket LIBUS_ECONNREFUSED. */
+    int last_candidate_error;
     struct addrinfo *addrinfo_head;
     // this is used to track pending connecting sockets in the context
     struct us_connecting_socket_t* next_pending;

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -226,6 +226,9 @@ ssize_t bsd_writev(LIBUS_SOCKET_DESCRIPTOR fd, const struct us_iovec_t *iov, int
 ssize_t bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length, const char *payload, int payload_length);
 int bsd_would_block();
 int bsd_send_is_transient_error();
+/* The OS error of the call that just failed; never 0, so a caller that got
+ * LIBUS_SOCKET_ERROR always has a code to report. */
+int bsd_last_error_or_refused(void);
 
 // return LIBUS_SOCKET_ERROR or the fd that represents listen socket
 // listen both on ipv6 and ipv4

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -238,9 +238,11 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
 int bsd_connect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd, const char *host, int port);
 int bsd_disconnect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd);
 
-LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr, struct sockaddr_storage *local_addr, int options);
+/* On LIBUS_SOCKET_ERROR, *error is the OS error of the call that failed
+ * (socket, bind, connect, or building the unix address); never 0. */
+LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket(struct sockaddr_storage *addr, struct sockaddr_storage *local_addr, int options, int *error);
 
-LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket_unix(const char *server_path, size_t pathlen, int options);
+LIBUS_SOCKET_DESCRIPTOR bsd_create_connect_socket_unix(const char *server_path, size_t pathlen, int options, int *error);
 
 int bsd_socket_export_size(void);
 int bsd_socket_export(LIBUS_SOCKET_DESCRIPTOR fd, unsigned int target_pid, void *info_out);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -450,16 +450,19 @@ void us_socket_on_server_name(us_socket_r s, us_socket_server_name_cb cb);
 /* ── Connect ──────────────────────────────────────────────────────────────
  * Returns either us_socket_t* (fast path, *is_connecting=1) or
  * us_connecting_socket_t* (DNS / happy-eyeballs in flight, *is_connecting=0).
- * ssl_ctx may be NULL for plain TCP. */
+ * ssl_ctx may be NULL for plain TCP. NULL when the dial failed outright, with
+ * the OS error (errno, or the WSA/Win32 code on Windows) in *error; a dial
+ * that fails later reports through the connect error callback instead. */
 void *us_socket_group_connect(us_socket_group_r group, unsigned char kind,
     struct ssl_ctx_st *ssl_ctx, const char *host, int port,
     const char *local_host, int local_port, int options,
-    int socket_ext_size, int *is_connecting)
-    __attribute__((nonnull(1, 4, 10)));  /* ssl_ctx, local_host nullable */
+    int socket_ext_size, int *is_connecting, int *error)
+    __attribute__((nonnull(1, 4, 10, 11)));  /* ssl_ctx, local_host nullable */
 struct us_socket_t *us_socket_group_connect_unix(us_socket_group_r group,
     unsigned char kind, struct ssl_ctx_st *ssl_ctx,
-    const char *server_path, size_t pathlen, int options, int socket_ext_size)
-    __attribute__((nonnull(1, 4)));  /* ssl_ctx nullable */
+    const char *server_path, size_t pathlen, int options, int socket_ext_size,
+    int *error)
+    __attribute__((nonnull(1, 4, 8)));  /* ssl_ctx nullable */
 
 int us_socket_is_established(us_socket_r s) nonnull_fn_decl;
 void us_connecting_socket_free(struct us_connecting_socket_t *c) nonnull_fn_decl;

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -210,7 +210,7 @@ void us_connecting_socket_close(struct us_connecting_socket_t *c) {
     }
     if (!c->error) {
         // if we have no error, we have to set that we were aborted aka we called close
-        c->error = ECONNABORTED;
+        c->error = LIBUS_ECONNABORTED;
     }
     struct us_socket_group_t *group = c->group;
 
@@ -250,7 +250,7 @@ void us_connecting_socket_close(struct us_connecting_socket_t *c) {
     if (c->addrinfo_req) {
         /* Invalidate the cache entry for a refused connect (addresses may be
          * stale) and for a resolver failure (never cache a negative result). */
-        Bun__addrinfo_freeRequest(c->addrinfo_req, c->error == ECONNREFUSED || c->error_is_dns);
+        Bun__addrinfo_freeRequest(c->addrinfo_req, c->error == LIBUS_ECONNREFUSED || c->error_is_dns);
         c->addrinfo_req = 0;
     }
     us_dispatch_connecting_error(c, c->error);

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -248,9 +248,11 @@ void us_connecting_socket_close(struct us_connecting_socket_t *c) {
     }
 
     if (c->addrinfo_req) {
-        /* Invalidate the cache entry for a refused connect (addresses may be
-         * stale) and for a resolver failure (never cache a negative result). */
-        Bun__addrinfo_freeRequest(c->addrinfo_req, c->error == LIBUS_ECONNREFUSED || c->error_is_dns);
+        /* Invalidate the cache entry for a failed connect (the addresses may
+         * be stale) and for a resolver failure (never cache a negative
+         * result). LIBUS_ECONNABORTED is the caller aborting, not the
+         * addresses failing. */
+        Bun__addrinfo_freeRequest(c->addrinfo_req, (c->error && c->error != LIBUS_ECONNABORTED) || c->error_is_dns);
         c->addrinfo_req = 0;
     }
     us_dispatch_connecting_error(c, c->error);

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -306,11 +306,11 @@ pub fn from_errno(errno: i32) -> SystemErrno {
 
 /// The error of a failed `connect(2)`, in `SystemErrno` numbering. `raw` is
 /// the code as uSockets reports it: the socket's `SO_ERROR` in the connect
-/// error callback, or what a dial that failed outright left in errno. On
-/// Windows that is a WSA or Win32 code (`WSAETIMEDOUT`, `ERROR_PATH_NOT_FOUND`
-/// for an empty unix path), so it goes through the Win32 table there. A code
-/// the table does not know, and the `ECONNREFUSED` uSockets fills in itself
-/// when no address reported a code (a CRT errno on Windows), come out as
+/// error callback, the error out-param of a dial that failed outright, or the
+/// code uSockets fills in itself (`LIBUS_ECONNABORTED`, `LIBUS_ECONNREFUSED`).
+/// On Windows all of those are WSA or Win32 codes (`WSAETIMEDOUT`,
+/// `ERROR_PATH_NOT_FOUND` for an empty unix path), so it goes through the
+/// Win32 table there. A code the table does not know comes out as
 /// `ECONNREFUSED`.
 pub fn connect_errno(raw: i32) -> SystemErrno {
     #[cfg(windows)]
@@ -590,9 +590,12 @@ mod errno_name_tests {
                 connect_errno(i32::from(W::PATH_NOT_FOUND.0)),
                 SystemErrno::ENOENT
             );
-            // The CRT's ECONNREFUSED, which uSockets fills in itself when no
-            // address reported a code. It is not a Win32 code.
-            assert_eq!(connect_errno(107), SystemErrno::ECONNREFUSED);
+            // What uSockets fills in itself for a dial the caller aborted
+            // (LIBUS_ECONNABORTED, a WSA code on Windows).
+            assert_eq!(
+                connect_errno(i32::from(W::WSAECONNABORTED.0)),
+                SystemErrno::ECONNABORTED
+            );
             assert_eq!(connect_errno(-1), SystemErrno::ECONNREFUSED);
         }
         #[cfg(not(windows))]

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -310,13 +310,16 @@ pub fn from_errno(errno: i32) -> SystemErrno {
 /// code uSockets fills in itself (`LIBUS_ECONNABORTED`, `LIBUS_ECONNREFUSED`).
 /// On Windows all of those are WSA or Win32 codes (`WSAETIMEDOUT`,
 /// `ERROR_PATH_NOT_FOUND` for an empty unix path), so it goes through the
-/// Win32 table there. A code the table does not know comes out as
-/// `ECONNREFUSED`.
+/// Win32 table there. A code the table does not know, and a value that is not
+/// a code at all (0, or a negative number), come out as `ECONNREFUSED`.
 pub fn connect_errno(raw: i32) -> SystemErrno {
+    let Ok(code) = u32::try_from(raw) else {
+        return SystemErrno::ECONNREFUSED;
+    };
     #[cfg(windows)]
-    let errno = u32::try_from(raw).ok().and_then(SystemErrno::init);
+    let errno = SystemErrno::init(code);
     #[cfg(not(windows))]
-    let errno = SystemErrno::init(i64::from(raw));
+    let errno = SystemErrno::init(i64::from(code));
     match errno {
         None | Some(SystemErrno::SUCCESS) => SystemErrno::ECONNREFUSED,
         Some(errno) => errno,
@@ -596,7 +599,6 @@ mod errno_name_tests {
                 connect_errno(i32::from(W::WSAECONNABORTED.0)),
                 SystemErrno::ECONNABORTED
             );
-            assert_eq!(connect_errno(-1), SystemErrno::ECONNREFUSED);
         }
         #[cfg(not(windows))]
         {
@@ -611,6 +613,12 @@ mod errno_name_tests {
         }
         assert_eq!(connect_errno(0), SystemErrno::ECONNREFUSED);
         assert_eq!(connect_errno(i32::MAX), SystemErrno::ECONNREFUSED);
+        // Not codes: connect errors are never reported negated.
+        assert_eq!(connect_errno(-1), SystemErrno::ECONNREFUSED);
+        assert_eq!(
+            connect_errno(-(SystemErrno::ENOENT as i32)),
+            SystemErrno::ECONNREFUSED
+        );
     }
 
     #[test]

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -304,6 +304,48 @@ pub fn from_errno(errno: i32) -> SystemErrno {
     SystemErrno::init(errno as i64).unwrap_or(SystemErrno::EIO)
 }
 
+/// The error of a failed `connect(2)`, in `SystemErrno` numbering. `raw` is
+/// the code as uSockets reports it: the socket's `SO_ERROR` in the connect
+/// error callback, or what a dial that failed outright left in errno. On
+/// Windows that is a WSA or Win32 code (`WSAETIMEDOUT`, `ERROR_PATH_NOT_FOUND`
+/// for an empty unix path), so it goes through the Win32 table there. A code
+/// the table does not know, and the `ECONNREFUSED` uSockets fills in itself
+/// when no address reported a code (a CRT errno on Windows), come out as
+/// `ECONNREFUSED`.
+pub fn connect_errno(raw: i32) -> SystemErrno {
+    #[cfg(windows)]
+    let errno = u32::try_from(raw).ok().and_then(SystemErrno::init);
+    #[cfg(not(windows))]
+    let errno = SystemErrno::init(i64::from(raw));
+    match errno {
+        None | Some(SystemErrno::SUCCESS) => SystemErrno::ECONNREFUSED,
+        Some(errno) => errno,
+    }
+}
+
+/// The `.code` of the error `Bun.connect` reports for a failed `connect(2)`.
+/// `errno` is in `SystemErrno` numbering: the result of `connect_errno`, or a
+/// code the caller picked itself (`ENOENT` for a named pipe that does not
+/// exist). The codes a unix path produces (`ENOENT`, `ENOTSOCK`, `EACCES`,
+/// `EINVAL`), the codes a local bind produces (`EADDRINUSE`, `EADDRNOTAVAIL`)
+/// and `ECONNRESET` are reported as they are. Every other code is reported as
+/// `ECONNREFUSED`. Callers that print the error use `connect_errno` instead,
+/// so that an unreachable host prints `EHOSTUNREACH`.
+pub fn connect_errno_code(errno: i32) -> SystemErrno {
+    const KEPT: [SystemErrno; 7] = [
+        SystemErrno::ENOENT,
+        SystemErrno::ENOTSOCK,
+        SystemErrno::EACCES,
+        SystemErrno::EINVAL,
+        SystemErrno::ECONNRESET,
+        SystemErrno::EADDRINUSE,
+        SystemErrno::EADDRNOTAVAIL,
+    ];
+    KEPT.into_iter()
+        .find(|e| *e as i32 == errno)
+        .unwrap_or(SystemErrno::ECONNREFUSED)
+}
+
 #[cfg(not(windows))]
 impl SystemErrno {
     // `i64` covers every concrete call site (errno-range values).
@@ -525,5 +567,71 @@ mod errno_name_tests {
             Some("Resource deadlock avoided")
         );
         assert_eq!(coreutils_error_map::get(0), None);
+    }
+
+    #[test]
+    fn connect_errno_reports_the_os_code() {
+        #[cfg(windows)]
+        {
+            use windows_errno::Win32Error as W;
+            assert_eq!(
+                connect_errno(i32::from(W::WSAEHOSTUNREACH.0)),
+                SystemErrno::EHOSTUNREACH
+            );
+            assert_eq!(
+                connect_errno(i32::from(W::WSAETIMEDOUT.0)),
+                SystemErrno::ETIMEDOUT
+            );
+            assert_eq!(
+                connect_errno(i32::from(W::WSAECONNREFUSED.0)),
+                SystemErrno::ECONNREFUSED
+            );
+            assert_eq!(
+                connect_errno(i32::from(W::PATH_NOT_FOUND.0)),
+                SystemErrno::ENOENT
+            );
+            // The CRT's ECONNREFUSED, which uSockets fills in itself when no
+            // address reported a code. It is not a Win32 code.
+            assert_eq!(connect_errno(107), SystemErrno::ECONNREFUSED);
+            assert_eq!(connect_errno(-1), SystemErrno::ECONNREFUSED);
+        }
+        #[cfg(not(windows))]
+        {
+            for errno in [
+                SystemErrno::EHOSTUNREACH,
+                SystemErrno::ETIMEDOUT,
+                SystemErrno::ECONNREFUSED,
+                SystemErrno::ENOENT,
+            ] {
+                assert_eq!(connect_errno(errno as i32), errno);
+            }
+        }
+        assert_eq!(connect_errno(0), SystemErrno::ECONNREFUSED);
+        assert_eq!(connect_errno(i32::MAX), SystemErrno::ECONNREFUSED);
+    }
+
+    #[test]
+    fn connect_errno_code_keeps_the_listed_codes_only() {
+        for errno in [
+            SystemErrno::ENOENT,
+            SystemErrno::ENOTSOCK,
+            SystemErrno::EACCES,
+            SystemErrno::EINVAL,
+            SystemErrno::ECONNRESET,
+            SystemErrno::EADDRINUSE,
+            SystemErrno::EADDRNOTAVAIL,
+            SystemErrno::ECONNREFUSED,
+        ] {
+            assert_eq!(connect_errno_code(errno as i32), errno);
+        }
+        for errno in [
+            SystemErrno::ETIMEDOUT,
+            SystemErrno::EHOSTUNREACH,
+            SystemErrno::ENETUNREACH,
+            SystemErrno::ECONNABORTED,
+            SystemErrno::SUCCESS,
+        ] {
+            assert_eq!(connect_errno_code(errno as i32), SystemErrno::ECONNREFUSED);
+        }
     }
 }

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -591,6 +591,7 @@ export type SocketFaultSyscall =
   | "recvmsg"
   | "connect"
   | "accept"
+  | "close"
   | "ssl_loop_buffer"
   | "poll_start"
   | "session_buffer";

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -30,10 +30,10 @@ pub enum Error {
     ERR_TLS_CERT_ALTNAME_INVALID,
     #[error("ConnectionClosed")]
     ConnectionClosed,
-    /// A dial that failed before there was a socket; `errno` is the OS
-    /// error uSockets returned for it (see `bun_uws::ConnectResult::Failed`).
+    /// A dial that failed before there was a socket; `errno` is its error
+    /// (see `bun_uws::ConnectResult::Failed`).
     #[error("FailedToOpenSocket")]
-    FailedToOpenSocket { errno: i32 },
+    FailedToOpenSocket { errno: bun_errno::SystemErrno },
     #[error("MissingCredentials")]
     MissingCredentials,
     #[error("InvalidMethod")]

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -30,8 +30,10 @@ pub enum Error {
     ERR_TLS_CERT_ALTNAME_INVALID,
     #[error("ConnectionClosed")]
     ConnectionClosed,
+    /// A dial that failed before there was a socket; `errno` is the OS
+    /// error uSockets returned for it (see `bun_uws::ConnectResult::Failed`).
     #[error("FailedToOpenSocket")]
-    FailedToOpenSocket,
+    FailedToOpenSocket { errno: i32 },
     #[error("MissingCredentials")]
     MissingCredentials,
     #[error("InvalidMethod")]
@@ -299,8 +301,9 @@ impl From<bun_sys::Error> for Error {
 
 impl From<bun_uws::ConnectError> for Error {
     #[inline]
-    fn from(_: bun_uws::ConnectError) -> Self {
-        Self::FailedToOpenSocket
+    fn from(err: bun_uws::ConnectError) -> Self {
+        let bun_uws::ConnectError::FailedToOpenSocket { errno } = err;
+        Self::FailedToOpenSocket { errno }
     }
 }
 
@@ -409,7 +412,7 @@ impl Error {
             Self::JSError => "JSError",
             Self::ERR_TLS_CERT_ALTNAME_INVALID => "ERR_TLS_CERT_ALTNAME_INVALID",
             Self::ConnectionClosed => "ConnectionClosed",
-            Self::FailedToOpenSocket => "FailedToOpenSocket",
+            Self::FailedToOpenSocket { .. } => "FailedToOpenSocket",
             Self::MissingCredentials => "MissingCredentials",
             Self::InvalidMethod => "InvalidMethod",
             Self::InvalidPath => "InvalidPath",

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1652,25 +1652,19 @@ fn connect_finish<const IS_SSL: bool>(
     let opened_err = match socket_ref.do_connect() {
         Ok(()) => None,
         Err(crate::Error::Js(err)) => Some(err),
-        Err(_) => {
-            // Winsock sets WSAGetLastError, not the CRT `_errno()` that
-            // `last_errno()` reads.
-            #[cfg(windows)]
-            let os_errno = {
-                let mut e = bun_sys::windows::WSAGetLastError().map_or(0, |err| err as c_int);
-                // Winsock AF_UNIX returns WSAECONNREFUSED whether the path exists
-                // or not; Node distinguishes ENOENT via `CreateFile`.
-                if port.is_none() && e == bun_sys::SystemErrno::ECONNREFUSED as c_int {
-                    if let Some(UnixOrHost::Unix(path)) = socket_ref.connection.get() {
-                        if !bun_sys::exists(path) {
-                            e = bun_sys::SystemErrno::ENOENT as c_int;
-                        }
-                    }
-                }
-                e
+        Err(err) => {
+            // The OS error uSockets returned for the dial, in SystemErrno
+            // numbering; a failure that is not a dial has no code.
+            let raw = match err {
+                crate::Error::FailedToOpenSocket { errno } => errno,
+                _ => 0,
             };
-            #[cfg(not(windows))]
-            let os_errno = bun_sys::last_errno();
+            let mut os_errno = bun_errno::connect_errno(raw) as c_int;
+            if port.is_none() {
+                if let Some(UnixOrHost::Unix(path)) = socket_ref.connection.get() {
+                    os_errno = bun_sys::unix_connect_errno(os_errno, path);
+                }
+            }
             let errno = if port.is_none() {
                 // Preserve the real errno from the failed connect(2) on a unix path:
                 // connecting to an existing non-socket file is ENOTSOCK, a
@@ -1678,10 +1672,8 @@ fn connect_finish<const IS_SSL: bool>(
                 if os_errno == bun_sys::SystemErrno::ENAMETOOLONG as c_int {
                     // libuv reports UV_EINVAL for a pipe path it cannot express.
                     bun_sys::SystemErrno::EINVAL as c_int
-                } else if os_errno != 0 {
-                    os_errno
                 } else {
-                    bun_sys::SystemErrno::ENOENT as c_int
+                    os_errno
                 }
             } else {
                 // A synchronous TCP connect failure is almost always the local

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1463,7 +1463,6 @@ impl Listener {
                 default_data,
                 allow_half_open,
                 pause_on_connect,
-                port,
                 promise_value,
             )
         } else {
@@ -1478,7 +1477,6 @@ impl Listener {
                 default_data,
                 allow_half_open,
                 pause_on_connect,
-                port,
                 promise_value,
             )
         }
@@ -1560,7 +1558,6 @@ fn connect_finish<const IS_SSL: bool>(
     default_data: JSValue,
     allow_half_open: bool,
     pause_on_connect: bool,
-    port: Option<u16>,
     promise_value: JSValue,
 ) -> JsResult<JSValue> {
     let vm = handlers.vm;
@@ -1653,45 +1650,17 @@ fn connect_finish<const IS_SSL: bool>(
         Ok(()) => None,
         Err(crate::Error::Js(err)) => Some(err),
         Err(err) => {
-            // The OS error uSockets returned for the dial, in SystemErrno
-            // numbering; a failure that is not a dial has no code.
-            let raw = match err {
-                crate::Error::FailedToOpenSocket { errno } => errno,
-                _ => 0,
+            // The dial's error; a failure that is not a dial has none and is
+            // reported as a refused connect. `handle_connect_error` applies
+            // the same `.code` rule to it as to a connect that failed later,
+            // so a sync and an async failure report alike.
+            let mut errno = match err {
+                crate::Error::FailedToOpenSocket { errno } => errno as c_int,
+                _ => bun_sys::SystemErrno::ECONNREFUSED as c_int,
             };
-            let mut os_errno = bun_errno::connect_errno(raw) as c_int;
-            if port.is_none() {
-                if let Some(UnixOrHost::Unix(path)) = socket_ref.connection.get() {
-                    os_errno = bun_sys::unix_connect_errno(os_errno, path);
-                }
+            if let Some(UnixOrHost::Unix(path)) = socket_ref.connection.get() {
+                errno = bun_sys::unix_connect_errno(errno, path);
             }
-            let errno = if port.is_none() {
-                // Preserve the real errno from the failed connect(2) on a unix path:
-                // connecting to an existing non-socket file is ENOTSOCK, a
-                // permission-denied path is EACCES, a missing one is ENOENT.
-                if os_errno == bun_sys::SystemErrno::ENAMETOOLONG as c_int {
-                    // libuv reports UV_EINVAL for a pipe path it cannot express.
-                    bun_sys::SystemErrno::EINVAL as c_int
-                } else {
-                    os_errno
-                }
-            } else {
-                // A synchronous TCP connect failure is almost always the local
-                // bind() (localAddress/localPort) failing - preserve the errnos a
-                // bind() meaningfully produces (EADDRINUSE: port busy,
-                // EADDRNOTAVAIL: address not local, EACCES: privileged port,
-                // EINVAL: address family mismatch); everything else stays
-                // ECONNREFUSED. Mirrors handle_connect_error's whitelist.
-                if os_errno == bun_sys::SystemErrno::EADDRINUSE as c_int
-                    || os_errno == bun_sys::SystemErrno::EADDRNOTAVAIL as c_int
-                    || os_errno == bun_sys::SystemErrno::EACCES as c_int
-                    || os_errno == bun_sys::SystemErrno::EINVAL as c_int
-                {
-                    os_errno
-                } else {
-                    bun_sys::SystemErrno::ECONNREFUSED as c_int
-                }
-            };
             {
                 let this = socket;
                 let handled = NewSocket::<IS_SSL>::handle_connect_error(this, errno, 0);

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -5079,6 +5079,8 @@ pub mod testing_apis {
                 fi::CONNECT
             } else if syscall_str.eq_ascii(b"accept") {
                 fi::ACCEPT
+            } else if syscall_str.eq_ascii(b"close") {
+                fi::CLOSE
             } else if syscall_str.eq_ascii(b"ssl_loop_buffer") {
                 fi::SSL_LOOP_BUFFER
             } else if syscall_str.eq_ascii(b"poll_start") {
@@ -5086,10 +5088,10 @@ pub mod testing_apis {
             } else if syscall_str.eq_ascii(b"session_buffer") {
                 fi::SESSION_BUFFER
             } else {
-                // socket/close/shutdown have enum slots but no bsd.c hooks;
+                // socket/shutdown have enum slots but no bsd.c hooks;
                 // accepting them would arm rules that can never fire.
                 return Err(global.throw(format_args!(
-                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, ssl_loop_buffer, poll_start, session_buffer"
+                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, close, ssl_loop_buffer, poll_start, session_buffer"
                 )));
             };
 

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -634,8 +634,8 @@ impl<const SSL: bool> NewSocket<SSL> {
                         flags,
                         core::mem::size_of::<*mut c_void>() as c_int,
                     ) {
-                        uws::ConnectResult::Failed => {
-                            return Err(crate::Error::FailedToOpenSocket);
+                        uws::ConnectResult::Failed { errno } => {
+                            return Err(crate::Error::FailedToOpenSocket { errno });
                         }
                         uws::ConnectResult::Socket(s) => {
                             *uws::us_socket_t::opaque_mut(s).ext() = Some(this);
@@ -649,16 +649,15 @@ impl<const SSL: bool> NewSocket<SSL> {
                 );
             }
             Some(UnixOrHost::Unix(u)) => {
-                let s = group.connect_unix(
-                    kind,
-                    ssl_ctx,
-                    u,
-                    flags,
-                    core::mem::size_of::<*mut c_void>() as c_int,
-                );
-                if s.is_null() {
-                    return Err(crate::Error::FailedToOpenSocket);
-                }
+                let s = group
+                    .connect_unix(
+                        kind,
+                        ssl_ctx,
+                        u,
+                        flags,
+                        core::mem::size_of::<*mut c_void>() as c_int,
+                    )
+                    .map_err(|errno| crate::Error::FailedToOpenSocket { errno })?;
                 *uws::us_socket_t::opaque_mut(s).ext() = Some(this);
                 self.socket.set(SocketHandler::<SSL>::from(s));
             }
@@ -1097,7 +1096,9 @@ impl<const SSL: bool> NewSocket<SSL> {
     ///
     /// `dns_error` is the raw `getaddrinfo(3)` return code when the name
     /// lookup itself failed; 0 for a connect failure past name resolution
-    /// (then `errno` carries the connect error).
+    /// (then `errno` carries the connect error, in `SystemErrno` numbering:
+    /// every caller either maps the OS code with `connect_errno` first, as
+    /// `on_connect_error` does, or picks the errno itself).
     /// `Err` is what the `connectError`/`error` handler or a promise
     /// rejection left pending; the socket is released either way (guards).
     pub(crate) fn handle_connect_error(
@@ -1154,8 +1155,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         // A failed name lookup is reported as the resolver error
         // (`getaddrinfo ENOTFOUND <hostname>`, `syscall`/`hostname` set),
         // matching `node:dns` — never collapsed into ECONNREFUSED. On that
-        // path `errno` carries the same (possibly negative) getaddrinfo code
-        // as `dns_error`, so it is only treated as an errno in the else arm.
+        // path there is no connect error and `errno` is ignored; it is only
+        // read in the else arm.
         let dns_err = c_ares::Error::init_eai(dns_error).filter(|_| dns_error != 0);
         let err = if let Some(dns_err) = dns_err {
             let hostname: &[u8] = match this.connection.get() {
@@ -1169,50 +1170,9 @@ impl<const SSL: bool> NewSocket<SSL> {
             )
         } else {
             debug_assert!(errno >= 0);
-            // uSockets hands us raw WSA codes (SO_ERROR, the recv probe) on
-            // Windows; map those onto the SystemErrno numbering the whitelist
-            // below compares against.
-            #[cfg(windows)]
-            let errno: c_int = if errno >= 10000 {
-                sys::SystemErrno::init(errno as u32)
-                    .map(|e| e as c_int)
-                    .unwrap_or(sys::SystemErrno::ECONNREFUSED as c_int)
-            } else {
-                errno
-            };
-            // Unix-path connect errors keep their real code (a non-socket file
-            // is ENOTSOCK, a permission-denied path is EACCES, a missing one is
-            // ENOENT, an inexpressible path is EINVAL); everything else stays
-            // ECONNREFUSED.
-            let errno_: c_int = if errno == sys::SystemErrno::ENOENT as c_int
-                || errno == sys::SystemErrno::ENOTSOCK as c_int
-                || errno == sys::SystemErrno::EACCES as c_int
-                || errno == sys::SystemErrno::EINVAL as c_int
-                || errno == sys::SystemErrno::ECONNRESET as c_int
-                || errno == sys::SystemErrno::EADDRINUSE as c_int
-                || errno == sys::SystemErrno::EADDRNOTAVAIL as c_int
-            {
-                errno
-            } else {
-                sys::SystemErrno::ECONNREFUSED as c_int
-            };
-            let code_ = if errno == sys::SystemErrno::ENOENT as c_int {
-                BunString::static_("ENOENT")
-            } else if errno == sys::SystemErrno::ENOTSOCK as c_int {
-                BunString::static_("ENOTSOCK")
-            } else if errno == sys::SystemErrno::EACCES as c_int {
-                BunString::static_("EACCES")
-            } else if errno == sys::SystemErrno::EINVAL as c_int {
-                BunString::static_("EINVAL")
-            } else if errno == sys::SystemErrno::ECONNRESET as c_int {
-                BunString::static_("ECONNRESET")
-            } else if errno == sys::SystemErrno::EADDRINUSE as c_int {
-                BunString::static_("EADDRINUSE")
-            } else if errno == sys::SystemErrno::EADDRNOTAVAIL as c_int {
-                BunString::static_("EADDRNOTAVAIL")
-            } else {
-                BunString::static_("ECONNREFUSED")
-            };
+            let errno_enum = bun_errno::connect_errno_code(errno);
+            let errno_: c_int = errno_enum as c_int;
+            let code_ = BunString::static_(<&'static str>::from(errno_enum));
             #[cfg(windows)]
             let errno_ = -sys::windows::libuv::e_discriminant_to_uv(errno_ as u16)
                 .unwrap_or(sys::windows::libuv::UV_ECONNREFUSED);
@@ -1288,7 +1248,9 @@ impl<const SSL: bool> NewSocket<SSL> {
     }
 
     /// Takes `ThisPtr<Self>` for the same re-entrancy reason as
-    /// `handle_connect_error`.
+    /// `handle_connect_error`. `errno` is in `SystemErrno` numbering (the
+    /// uSockets trampoline maps the OS code), or the resolver code when the
+    /// lookup failed, which `dns_error` reports too.
     pub(crate) fn on_connect_error(
         this: bun_ptr::ThisPtr<Self>,
         socket: SocketHandler<SSL>,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8887,6 +8887,17 @@ pub fn renameat_concurrently_a(
 pub fn iterate_dir(dir: Fd) -> dir_iterator::WrappedIterator {
     dir_iterator::iterate(dir)
 }
+/// `errno` (`SystemErrno` numbering) is what a `connect(2)` to the unix socket
+/// `path` failed with. Winsock reports `WSAECONNREFUSED` for an AF_UNIX path
+/// that does not exist; node checks the path and reports `ENOENT` for it, and
+/// so does this. Every other OS already reports `ENOENT` itself.
+pub fn unix_connect_errno(errno: core::ffi::c_int, path: &[u8]) -> core::ffi::c_int {
+    if cfg!(windows) && errno == SystemErrno::ECONNREFUSED as core::ffi::c_int && !exists(path) {
+        return SystemErrno::ENOENT as core::ffi::c_int;
+    }
+    errno
+}
+
 /// `bun.sys.exists`. Non-NUL-terminated convenience over
 /// [`exists_z`]: copies into a stack `PathBuffer`, NUL-terminates, then
 /// `access(path, F_OK)` (POSIX) / `GetFileAttributesW` (Windows).

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8888,12 +8888,17 @@ pub fn iterate_dir(dir: Fd) -> dir_iterator::WrappedIterator {
     dir_iterator::iterate(dir)
 }
 /// `errno` (`SystemErrno` numbering) is what a `connect(2)` to the unix socket
-/// `path` failed with. Winsock reports `WSAECONNREFUSED` for an AF_UNIX path
-/// that does not exist; node checks the path and reports `ENOENT` for it, and
-/// so does this. Every other OS already reports `ENOENT` itself.
+/// `path` failed with, as node reports it. Winsock reports `WSAECONNREFUSED`
+/// for an AF_UNIX path that does not exist; node checks the path and reports
+/// `ENOENT` for it, and so does this (every other OS reports `ENOENT` itself).
+/// A path `sun_path` cannot hold is `ENAMETOOLONG` from the OS and `EINVAL`
+/// from libuv.
 pub fn unix_connect_errno(errno: core::ffi::c_int, path: &[u8]) -> core::ffi::c_int {
     if cfg!(windows) && errno == SystemErrno::ECONNREFUSED as core::ffi::c_int && !exists(path) {
         return SystemErrno::ENOENT as core::ffi::c_int;
+    }
+    if errno == SystemErrno::ENAMETOOLONG as core::ffi::c_int {
+        return SystemErrno::EINVAL as core::ffi::c_int;
     }
     errno
 }

--- a/src/uws_sys/SocketGroup.rs
+++ b/src/uws_sys/SocketGroup.rs
@@ -7,6 +7,7 @@
 //! read/written directly by C (loop.c walks `head_sockets`/`iterator`,
 //! context.c flips `linked`).
 
+use bun_errno::SystemErrno;
 use core::ffi::{c_char, c_int, c_void};
 use core::ptr;
 
@@ -85,11 +86,12 @@ pub enum ConnectResult {
     Socket(*mut us_socket_t),
     Connecting(*mut ConnectingSocket),
     /// The dial failed before there was a socket to report on; `errno` is the
-    /// OS error of the call that failed (`socket`, `bind`, `connect`, or
-    /// building the unix address), as uSockets read it: errno on POSIX, a
-    /// WSA/Win32 code on Windows. Never 0.
+    /// error of the call that failed (`socket`, `bind`, `connect`, or building
+    /// the unix address), mapped from the OS code with
+    /// [`bun_errno::connect_errno`] like the code the connect error callback
+    /// receives, so both exits report in one numbering.
     Failed {
-        errno: c_int,
+        errno: SystemErrno,
     },
 }
 
@@ -253,7 +255,9 @@ impl SocketGroup {
             )
         };
         if ptr.is_null() {
-            return ConnectResult::Failed { errno };
+            return ConnectResult::Failed {
+                errno: bun_errno::connect_errno(errno),
+            };
         }
         if has_dns_resolved != 0 {
             ConnectResult::Socket(ptr.cast::<us_socket_t>())
@@ -262,7 +266,7 @@ impl SocketGroup {
         }
     }
 
-    /// `Err` is the OS error of a dial that failed outright, as for
+    /// `Err` is the error of a dial that failed outright, as for
     /// [`ConnectResult::Failed`].
     pub fn connect_unix(
         &mut self,
@@ -271,7 +275,7 @@ impl SocketGroup {
         path: &[u8],
         options: c_int,
         socket_ext_size: c_int,
-    ) -> Result<*mut us_socket_t, c_int> {
+    ) -> Result<*mut us_socket_t, SystemErrno> {
         let mut errno: c_int = 0;
         // SAFETY: forwarding to C; `path` ptr+len derived from a valid slice.
         let s = unsafe {
@@ -286,7 +290,11 @@ impl SocketGroup {
                 &raw mut errno,
             )
         };
-        if s.is_null() { Err(errno) } else { Ok(s) }
+        if s.is_null() {
+            Err(bun_errno::connect_errno(errno))
+        } else {
+            Ok(s)
+        }
     }
 
     pub fn from_fd(

--- a/src/uws_sys/SocketGroup.rs
+++ b/src/uws_sys/SocketGroup.rs
@@ -84,7 +84,13 @@ impl Default for SocketGroup {
 pub enum ConnectResult {
     Socket(*mut us_socket_t),
     Connecting(*mut ConnectingSocket),
-    Failed,
+    /// The dial failed before there was a socket to report on; `errno` is the
+    /// OS error of the call that failed (`socket`, `bind`, `connect`, or
+    /// building the unix address), as uSockets read it: errno on POSIX, a
+    /// WSA/Win32 code on Windows. Never 0.
+    Failed {
+        errno: c_int,
+    },
 }
 
 impl SocketGroup {
@@ -229,6 +235,7 @@ impl SocketGroup {
         // `us_connecting_socket_t*` placeholder. Named to match the C side so
         // the branches read the right way round — see PR review #3161005603.
         let mut has_dns_resolved: c_int = 0;
+        let mut errno: c_int = 0;
         // SAFETY: forwarding to C; `host` is a valid NUL-terminated C string.
         let ptr = unsafe {
             us_socket_group_connect(
@@ -242,10 +249,11 @@ impl SocketGroup {
                 options,
                 socket_ext_size,
                 &raw mut has_dns_resolved,
+                &raw mut errno,
             )
         };
         if ptr.is_null() {
-            return ConnectResult::Failed;
+            return ConnectResult::Failed { errno };
         }
         if has_dns_resolved != 0 {
             ConnectResult::Socket(ptr.cast::<us_socket_t>())
@@ -254,6 +262,8 @@ impl SocketGroup {
         }
     }
 
+    /// `Err` is the OS error of a dial that failed outright, as for
+    /// [`ConnectResult::Failed`].
     pub fn connect_unix(
         &mut self,
         kind: SocketKind,
@@ -261,9 +271,10 @@ impl SocketGroup {
         path: &[u8],
         options: c_int,
         socket_ext_size: c_int,
-    ) -> *mut us_socket_t {
+    ) -> Result<*mut us_socket_t, c_int> {
+        let mut errno: c_int = 0;
         // SAFETY: forwarding to C; `path` ptr+len derived from a valid slice.
-        unsafe {
+        let s = unsafe {
             us_socket_group_connect_unix(
                 self,
                 kind as u8,
@@ -272,8 +283,10 @@ impl SocketGroup {
                 path.len(),
                 options,
                 socket_ext_size,
+                &raw mut errno,
             )
-        }
+        };
+        if s.is_null() { Err(errno) } else { Ok(s) }
     }
 
     pub fn from_fd(
@@ -367,6 +380,7 @@ unsafe extern "C" {
         options: c_int,
         socket_ext_size: c_int,
         is_connecting: *mut c_int,
+        error: *mut c_int,
     ) -> *mut c_void;
     fn us_socket_group_connect_unix(
         group: *mut SocketGroup,
@@ -376,6 +390,7 @@ unsafe extern "C" {
         pathlen: usize,
         options: c_int,
         socket_ext_size: c_int,
+        error: *mut c_int,
     ) -> *mut us_socket_t;
     fn us_socket_from_fd(
         group: *mut SocketGroup,

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -435,6 +435,9 @@ pub mod fault_inject {
     pub const RECVMSG: c_int = 4;
     pub const CONNECT: c_int = 5;
     pub const ACCEPT: c_int = 6;
+    /// Runs after the real close in `bsd_close_socket`; only `ACTION_ERRNO`
+    /// applies, and it sets errno the way a failed close would.
+    pub const CLOSE: c_int = 8;
     pub const SHUTDOWN: c_int = 9;
     /// Not a syscall: the per-loop TLS plaintext buffer allocation in
     /// `us_internal_init_loop_ssl_data`.

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -909,9 +909,9 @@ mod sock_c {
 #[derive(strum::IntoStaticStr, Debug)]
 pub enum ConnectError {
     /// The dial failed before uSockets had a socket to report on; `errno` is
-    /// the OS error uSockets returned for the call that failed, as for
-    /// [`ConnectResult::Failed`], e.g. `ENOENT` for a missing unix socket path.
-    FailedToOpenSocket { errno: i32 },
+    /// the error of the call that failed, as for [`ConnectResult::Failed`],
+    /// e.g. `ENOENT` for a missing unix socket path.
+    FailedToOpenSocket { errno: bun_errno::SystemErrno },
 }
 impl From<ConnectError> for crate::Error {
     fn from(_: ConnectError) -> Self {

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -805,7 +805,7 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         // which would hand the trampoline `1` instead of the owner pointer.
         let ext_size = size_of::<Option<NonNull<Owner>>>() as c_int;
         match g.connect(kind, ssl_ctx, host_z, port, None, opts, ext_size) {
-            ConnectResult::Failed => Err(ConnectError::FailedToOpenSocket),
+            ConnectResult::Failed { errno } => Err(ConnectError::FailedToOpenSocket { errno }),
             ConnectResult::Socket(s) => {
                 *sock(s).ext::<Option<NonNull<Owner>>>() = NonNull::new(owner);
                 Ok(Self {
@@ -836,10 +836,9 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         };
         // See connect_group above for the ext-slot layout rationale.
         let ext_size = size_of::<Option<NonNull<Owner>>>() as c_int;
-        let s = g.connect_unix(kind, ssl_ctx, path, opts, ext_size);
-        if s.is_null() {
-            return Err(ConnectError::FailedToOpenSocket);
-        }
+        let s = g
+            .connect_unix(kind, ssl_ctx, path, opts, ext_size)
+            .map_err(|errno| ConnectError::FailedToOpenSocket { errno })?;
         *sock(s).ext::<Option<NonNull<Owner>>>() = NonNull::new(owner);
         Ok(Self {
             socket: InternalSocket::Connected(s),
@@ -909,7 +908,10 @@ mod sock_c {
 
 #[derive(strum::IntoStaticStr, Debug)]
 pub enum ConnectError {
-    FailedToOpenSocket,
+    /// The dial failed before uSockets had a socket to report on; `errno` is
+    /// the OS error uSockets returned for the call that failed, as for
+    /// [`ConnectResult::Failed`], e.g. `ENOENT` for a missing unix socket path.
+    FailedToOpenSocket { errno: i32 },
 }
 impl From<ConnectError> for crate::Error {
     fn from(_: ConnectError) -> Self {

--- a/src/uws_sys/vtable.rs
+++ b/src/uws_sys/vtable.rs
@@ -305,7 +305,12 @@ impl<H: Handler> Trampolines<H> {
         s
     }
 
+    /// `code` reaches every handler in `SystemErrno` numbering: uSockets
+    /// hands over the OS code (`SO_ERROR`; a WSA code on Windows) and this is
+    /// the one place it is mapped. A failed lookup passes its resolver code
+    /// through untouched; the handler reads `dns_error` for that case.
     extern "C" fn on_connect_error(s: *mut us_socket_t, code: c_int) -> *mut us_socket_t {
+        let code = bun_errno::connect_errno(code) as c_int;
         if H::HAS_EXT {
             H::on_connect_error(Self::ext(s), s, code);
         } else {
@@ -318,6 +323,11 @@ impl<H: Handler> Trampolines<H> {
         cs: *mut ConnectingSocket,
         code: c_int,
     ) -> *mut ConnectingSocket {
+        let code = if ConnectingSocket::opaque_mut(cs).get_dns_error() != 0 {
+            code
+        } else {
+            bun_errno::connect_errno(code) as c_int
+        };
         H::on_connecting_error(cs, code);
         cs
     }

--- a/src/uws_sys/vtable.rs
+++ b/src/uws_sys/vtable.rs
@@ -307,8 +307,11 @@ impl<H: Handler> Trampolines<H> {
 
     /// `code` reaches every handler in `SystemErrno` numbering: uSockets
     /// hands over the OS code (`SO_ERROR`; a WSA code on Windows) and this is
-    /// the one place it is mapped. A failed lookup passes its resolver code
-    /// through untouched; the handler reads `dns_error` for that case.
+    /// the one place it is mapped, as `SocketGroup::connect` maps the error of
+    /// a dial that failed outright, so both exits of this crate agree. A failed
+    /// lookup passes its resolver code through untouched; the handler reads
+    /// `dns_error` for that case, which is why the parameter stays a `c_int`
+    /// rather than a `SystemErrno`.
     extern "C" fn on_connect_error(s: *mut us_socket_t, code: c_int) -> *mut us_socket_t {
         let code = bun_errno::connect_errno(code) as c_int;
         if H::HAS_EXT {

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -1,9 +1,10 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { afterEach, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isWindows } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
+import { constants as osConstants } from "node:os";
 import { join } from "node:path";
 
 const skip = !fault.available() || isWindows;
@@ -398,5 +399,119 @@ describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOT
       new Promise<void>(resolve => h.req.once("close", () => resolve())),
     ]);
     expect(h.client.closed || h.client.destroyed).toBe(true);
+  });
+});
+
+// The error Bun.connect() reports for a dial that fails. handle_connect_error
+// builds it from one table (bun_errno::connect_errno_code): the codes a unix
+// path or a local bind can produce keep their name, every other errno is
+// reported as ECONNREFUSED. The errno itself comes from connect(2) and has to
+// survive the close of the failed socket (bsd.c restores it after
+// bsd_close_socket), which is what the rows with a close rule check.
+describe.skipIf(skip)("connect() reports the errno the failed dial left", () => {
+  type ErrnoName = keyof typeof osConstants.errno;
+  // [dial, errno connect(2) fails with (null: the real connect(2) runs, and the
+  //  path does not exist), errno the close of the failed socket leaves behind,
+  //  code Bun.connect() reports]
+  type Case = ["unix" | "tcp", ErrnoName | null, ErrnoName | null, ErrnoName];
+
+  function reported(code: ErrnoName) {
+    return { code, errno: -osConstants.errno[code], syscall: "connect", message: "Failed to connect", callback: code };
+  }
+
+  // One child per table: a fault rule is process wide, and the test runner's
+  // own sockets would consume it. The unix dial uses a relative path in an
+  // empty directory, so it is short on every platform and never exists.
+  async function dial(cases: readonly Case[]) {
+    using dir = tempDir("connect-errno", {});
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+        const { errno } = require("node:os").constants;
+        // Gives the tcp dials a port. No dial reaches it: connect(2) fails first.
+        const listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+        const dials = {
+          unix: { unix: "missing.sock" },
+          tcp: { hostname: "127.0.0.1", port: listener.port },
+        };
+        const results = [];
+        for (const [dial, connectErrno, closeErrno] of ${JSON.stringify(cases)}) {
+          let callback = "connectError not called";
+          try {
+            if (connectErrno !== null) fault.set({ syscall: "connect", action: "errno", errno: errno[connectErrno] });
+            if (closeErrno !== null) fault.set({ syscall: "close", action: "errno", errno: errno[closeErrno] });
+            await Bun.connect({ ...dials[dial], socket: { data() {}, connectError(_s, e) { callback = e.code; } } });
+            results.push("connected");
+          } catch (e) {
+            results.push({ code: e.code, errno: e.errno, syscall: e.syscall, message: e.message, callback });
+          } finally {
+            fault.clear();
+          }
+        }
+        listener.stop(true);
+        console.log(JSON.stringify(results));
+        `,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    return JSON.parse(stdout);
+  }
+
+  test.concurrent("a code in the table keeps its name, any other errno is reported as ECONNREFUSED", async () => {
+    const cases: Case[] = [
+      ["unix", "ENOENT", null, "ENOENT"],
+      ["unix", "ENOTSOCK", null, "ENOTSOCK"],
+      ["unix", "EACCES", null, "EACCES"],
+      // libuv reports a pipe path it cannot express as EINVAL.
+      ["unix", "ENAMETOOLONG", null, "EINVAL"],
+      ["unix", "EPERM", null, "ECONNREFUSED"],
+      ["tcp", "EADDRINUSE", null, "EADDRINUSE"],
+      ["tcp", "EADDRNOTAVAIL", null, "EADDRNOTAVAIL"],
+      ["tcp", "ENETUNREACH", null, "ECONNREFUSED"],
+      ["tcp", "ETIMEDOUT", null, "ECONNREFUSED"],
+    ];
+    expect(await dial(cases)).toEqual(cases.map(([, , , code]) => reported(code)));
+  });
+
+  test.concurrent("the errno of connect(2) survives a close that fails", async () => {
+    const cases: Case[] = [
+      ["unix", null, "EINTR", "ENOENT"],
+      ["tcp", "EADDRNOTAVAIL", "EINTR", "EADDRNOTAVAIL"],
+    ];
+    expect(await dial(cases)).toEqual(cases.map(([, , , code]) => reported(code)));
+  });
+
+  // A real refusal, no rule. The kernel reports it either from connect(2) or
+  // later through SO_ERROR (on_connect_error); both end in the same table.
+  test.concurrent("a refused connect is reported with the platform's ECONNREFUSED errno", async () => {
+    const probe = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+    const port = probe.port;
+    probe.stop(true);
+
+    let callback = "connectError not called";
+    const e: any = await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        data() {},
+        connectError(_s, err: any) {
+          callback = err.code;
+        },
+      },
+    }).then(
+      () => new Error("connected"),
+      err => err,
+    );
+    expect({ code: e.code, errno: e.errno, syscall: e.syscall, message: e.message, callback }).toEqual(
+      reported("ECONNREFUSED"),
+    );
   });
 });

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -494,6 +494,41 @@ describe.skipIf(skip)("connect() reports the errno the failed dial left", () => 
     expect(await dial(cases)).toEqual(cases.map(([, , , code]) => reported(code)));
   });
 
+  // A hostname is resolved from the event loop, and its addresses are dialed
+  // one after the other. When none connects, the error reported is the last
+  // address's own, not a blanket ECONNREFUSED. The rule fires for every
+  // address; EINVAL is one of the codes the table keeps.
+  test.concurrent("a hostname whose every address fails reports the last address's error", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+        const { errno } = require("node:os").constants;
+        const listener = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+        fault.set({ syscall: "connect", action: "errno", errno: errno.EINVAL, repeat: 8 });
+        let callback = "connectError not called";
+        try {
+          await Bun.connect({ hostname: "localhost", port: listener.port, socket: { data() {}, connectError(_s, e) { callback = e.code; } } });
+          console.log("connected");
+        } catch (e) {
+          console.log(JSON.stringify({ code: e.code, errno: e.errno, syscall: e.syscall, message: e.message, callback }));
+        } finally {
+          fault.clear();
+          listener.stop(true);
+        }
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+    expect(JSON.parse(stdout)).toEqual(reported("EINVAL"));
+  });
+
   // A real refusal, no rule. The kernel reports it either from connect(2) or
   // later through SO_ERROR (on_connect_error); both end in the same table.
   test.concurrent("a refused connect is reported with the platform's ECONNREFUSED errno", async () => {

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -406,8 +406,8 @@ describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOT
 // builds it from one table (bun_errno::connect_errno_code): the codes a unix
 // path or a local bind can produce keep their name, every other errno is
 // reported as ECONNREFUSED. The errno itself comes from connect(2) and has to
-// survive the close of the failed socket (bsd.c restores it after
-// bsd_close_socket), which is what the rows with a close rule check.
+// survive the close of the failed socket (bsd.c stores it in *error before
+// bsd_close_socket runs), which is what the rows with a close rule check.
 describe.skipIf(skip)("connect() reports the errno the failed dial left", () => {
   type ErrnoName = keyof typeof osConstants.errno;
   // [dial, errno connect(2) fails with (null: the real connect(2) runs, and the

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -403,11 +403,13 @@ describe.skipIf(skip)("h2 client under injected unclassified send errno (EPROTOT
 });
 
 // The error Bun.connect() reports for a dial that fails. handle_connect_error
-// builds it from one table (bun_errno::connect_errno_code): the codes a unix
-// path or a local bind can produce keep their name, every other errno is
-// reported as ECONNREFUSED. The errno itself comes from connect(2) and has to
-// survive the close of the failed socket (bsd.c stores it in *error before
-// bsd_close_socket runs), which is what the rows with a close rule check.
+// builds it from one table (bun_errno::connect_errno_code), whether the dial
+// failed inside connect(2) or later: the codes a unix path or a local bind
+// can produce, and ECONNRESET, keep their name, every other errno is reported
+// as ECONNREFUSED. The errno itself comes from connect(2);
+// bsd_create_connect_socket hands it back through its error out-param before
+// it closes the failed socket, so what that close leaves in errno is never
+// read. The rows with a close rule check that.
 describe.skipIf(skip)("connect() reports the errno the failed dial left", () => {
   type ErrnoName = keyof typeof osConstants.errno;
   // [dial, errno connect(2) fails with (null: the real connect(2) runs, and the
@@ -475,6 +477,9 @@ describe.skipIf(skip)("connect() reports the errno the failed dial left", () => 
       ["unix", "EPERM", null, "ECONNREFUSED"],
       ["tcp", "EADDRINUSE", null, "EADDRINUSE"],
       ["tcp", "EADDRNOTAVAIL", null, "EADDRNOTAVAIL"],
+      // Kept by the table; before, a dial that failed inside connect(2) went
+      // through a narrower list and reported ECONNREFUSED for it.
+      ["tcp", "ECONNRESET", null, "ECONNRESET"],
       ["tcp", "ENETUNREACH", null, "ECONNREFUSED"],
       ["tcp", "ETIMEDOUT", null, "ECONNREFUSED"],
     ];

--- a/test/js/bun/util/socket-fault-injection.test.ts
+++ b/test/js/bun/util/socket-fault-injection.test.ts
@@ -24,7 +24,7 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   // syscall used to succeed silently and never fire. ssl_loop_buffer is an
   // allocation, so it has no byte count either.
   test("set() rejects 'short' for syscalls that cannot clamp a byte count", () => {
-    for (const syscall of ["writev", "sendmsg", "recvmsg", "connect", "accept", "ssl_loop_buffer"] as const) {
+    for (const syscall of ["writev", "sendmsg", "recvmsg", "connect", "accept", "close", "ssl_loop_buffer"] as const) {
       expect(() => fault.set({ syscall, action: "short", bytes: 1 })).toThrow(/only supported for syscall/);
     }
     expect(fault.set({ syscall: "recv", action: "short", bytes: 1 })).toBe(true);
@@ -32,9 +32,10 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   });
 
   // A zero return only means something for the data syscalls (EOF on the read
-  // side, backpressure on the write side); connect's wrapper returns errno.
+  // side, backpressure on the write side); connect's wrapper returns errno and
+  // close's returns nothing.
   test("set() rejects 'zero' for syscalls with no zero-return semantics", () => {
-    for (const syscall of ["connect", "accept", "ssl_loop_buffer"] as const) {
+    for (const syscall of ["connect", "accept", "close", "ssl_loop_buffer"] as const) {
       expect(() => fault.set({ syscall, action: "zero" })).toThrow(/only supported for syscall/);
     }
     for (const syscall of ["recv", "send", "writev", "sendmsg", "recvmsg"] as const) {
@@ -103,7 +104,7 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   });
 
   test("rules can target each hooked syscall", () => {
-    for (const sc of ["recv", "send", "writev", "sendmsg", "recvmsg", "connect", "accept"] as const) {
+    for (const sc of ["recv", "send", "writev", "sendmsg", "recvmsg", "connect", "accept", "close"] as const) {
       expect(fault.set({ syscall: sc, action: "none" })).toBe(true);
     }
   });
@@ -111,7 +112,7 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   // These have enum slots but no bsd.c hooks; arming them used to "succeed"
   // and then never fire.
   test("set() rejects syscalls that have no fault hook", () => {
-    for (const sc of ["socket", "close", "shutdown"]) {
+    for (const sc of ["socket", "shutdown"]) {
       expect(() => fault.set({ syscall: sc as any, action: "none" })).toThrow(/rule\.syscall must be one of/);
     }
   });

--- a/test/js/node/net/net-syscall-fault.test.ts
+++ b/test/js/node/net/net-syscall-fault.test.ts
@@ -244,6 +244,37 @@ describe.skipIf(skip)("node:net under injected syscall faults", () => {
     }
   });
 
+  // A dial that fails inside connect(2) closes its socket before reporting.
+  // The code reported must be the connect's, not what that close left in
+  // errno; the "close" rule sets errno the way a failed close would.
+  test("the errno of a failed connect survives the close that follows it", async () => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    try {
+      // EINVAL is one of the codes a synchronous TCP failure keeps.
+      fault.set({ syscall: "connect", action: "errno", errno: "EINVAL", repeat: 1 });
+      fault.set({ syscall: "close", action: "errno", errno: "EBADF", repeat: 1 });
+      const client = net.connect({ port, host: "127.0.0.1" });
+      const [err] = (await once(client, "error")) as [NodeJS.ErrnoException];
+      expect(err.code).toBe("EINVAL");
+    } finally {
+      fault.clear();
+      server.close();
+    }
+  });
+
+  test("the errno of a failed unix connect survives the close that follows it", async () => {
+    fault.set({ syscall: "connect", action: "errno", errno: "ECONNRESET", repeat: 1 });
+    fault.set({ syscall: "close", action: "errno", errno: "EBADF", repeat: 1 });
+    // The path is not looked at: the injected connect fails first.
+    const client = net.connect({ path: "/nonexistent-dir/r.sock" });
+    const [err] = (await once(client, "error")) as [NodeJS.ErrnoException];
+    fault.clear();
+    expect(err.code).toBe("ECONNRESET");
+  });
+
   test("fd targeting: rule on the server fd does not affect the client", async () => {
     using p = await connectedPair();
     // The server socket's recv should error; the client should still receive


### PR DESCRIPTION
The problem

The errno of a failed connect(2) did not reach the code that reports it in one piece.

- uSockets returned NULL for a dial that failed outright and left the reason in thread-local errno. The caller in Rust read errno again after the C code had closed the socket, freed the poll, and on the cached resolver path taken a lock and freed the request. bsd.c had per-site errno saves and restores to keep that working; the listen and udp constructors in the same file return their error through an out-parameter instead.
- On Windows a failed non-blocking connect is detected with a recv() probe. The probe fails with WSAENOTCONN whatever the reason, so the connect error callback got ENOTCONN for a refused port and for a timed out one alike. The real error is in SO_ERROR.
- The mapping from the OS code to a SystemErrno lived inline in Bun.connect, next to Bun.connect's own rule for which codes its connectError keeps. Every other client of the callback (fetch, WebSocket, postgres, mysql, redis) would have to copy that mapping to report the code.

What changed

- packages/bun-usockets/src/context.c: on Windows, when the recv() probe fails, the connect error is read from SO_ERROR. A probe error other than WSAENOTCONN (WSAECONNRESET) is kept, and WSAENOTCONN with no SO_ERROR is reported as WSAECONNREFUSED.
- bsd_create_connect_socket and bsd_create_connect_socket_unix take an int *error, like bsd_create_listen_socket. Every failure exit sets it to a non-zero code before any cleanup: socket(), bind(), connect(), and building the unix address (ENOENT for an empty path, ENAMETOOLONG for one sun_path cannot hold). us_socket_group_connect and us_socket_group_connect_unix pass it through, and the errno saves and restores in bsd.c and context.c are gone.
- src/uws_sys: ConnectResult::Failed { errno } and ConnectError::FailedToOpenSocket { errno } carry that value as a SystemErrno, mapped with bun_errno::connect_errno right where the out-param is read. The trampoline that dispatches the connect error callback maps the OS code the same way, so both exits of the crate report in one numbering and no caller maps again; a failed lookup keeps its resolver code, which the handler reads through dns_error, and that is why the callback parameter stays a c_int.
- packages/bun-usockets: a hostname dial keeps the error of the last address that failed (last_candidate_error, from the out-param of a dial that failed outright or from SO_ERROR through after_open). When every address is exhausted, both places that used to fill in ECONNREFUSED report that error instead, and fall back to LIBUS_ECONNREFUSED only when no address reported one. Several addresses failing differently is last-wins, as #37093 proposes. The DNS cache entry is invalidated for any connect failure that is not the caller aborting, since a real error in that slot is as stale-address-suspect as a refusal.
- packages/bun-usockets: the codes uSockets fills in itself for a connect it ended or gave up on are LIBUS_ECONNABORTED and LIBUS_ECONNREFUSED, WSAECONNABORTED and WSAECONNREFUSED on Windows and the errno values elsewhere, so on Windows every connect error code is a WSA or Win32 code. Before, the CRT constants were used there and mapped to ECONNREFUSED only because their values are absent from the Win32 table.
- src/errno/lib.rs: connect_errno(raw) turns the OS code (SO_ERROR, or a WSA or Win32 code on Windows) into a SystemErrno. connect_errno_code(errno) is Bun.connect's rule for the .code of its connectError: ENOENT, ENOTSOCK, EACCES, EINVAL, ECONNRESET, EADDRINUSE and EADDRNOTAVAIL are reported as they are, every other code as ECONNREFUSED. That rule is unchanged, and this function is now the only place it exists. Unit tests pin both helpers.
- src/sys/lib.rs: unix_connect_errno holds the two unix path rules: ENOENT for a path that does not exist where Winsock says WSAECONNREFUSED, and EINVAL for a path sun_path cannot hold, as libuv reports it.
- src/runtime/socket: Bun.connect's synchronous failure path reads the errno from the FailedToOpenSocket it got back instead of calling last_errno or WSAGetLastError after the fact, and hands it to handle_connect_error like a connect that failed later. Its own list of four codes for that path is gone; connect_errno_code is the only place the .code is decided, for a synchronous and an asynchronous failure alike.
- A "close" fault rule is accepted by the socket fault layer. It runs after the real close in bsd_close_socket and sets errno the way a failed close would, so a caller that reads errno after its cleanup can be caught by a test.

Visible changes

- Bun.connect's connectError .code is unchanged for every code the tests pinned before, with one addition: a TCP dial that fails inside connect(2) with ECONNRESET now reports ECONNRESET, as one that fails later already did; before it reported ECONNREFUSED. On its own this PR changes nothing else a Bun.connect or node:net user sees; the redis client, in a follow-up stacked on this branch, is the first caller that prints the code.
- A first dial to a hostname the resolver has not cached now reports the last address's own error when every address failed. With connect_errno_code unchanged, that is visible for the codes it keeps (EADDRNOTAVAIL, EACCES, EINVAL, ECONNRESET); ETIMEDOUT, EHOSTUNREACH and ENETUNREACH still come out as ECONNREFUSED by that rule, which #37093 changes.
- node:net on Windows: ECONNREFUSED and ECONNRESET now come from SO_ERROR instead of the recv() probe, with the same values as before. EADDRINUSE for a localPort in use is a synchronous bind() failure and never reaches the probe; it is pinned by "localPort in use reports EADDRINUSE".

Tests

Two new tests in test/js/node/net/net-syscall-fault.test.ts fail on main and pass here. Both arm a connect fault and a close fault together:

- "the errno of a failed connect survives the close that follows it": connect fails with EINVAL, the close that follows leaves EBADF. Expected EINVAL. On main the code is read from errno after the close and comes out as ECONNREFUSED.
- "the errno of a failed unix connect survives the close that follows it": connect fails with ECONNRESET, close leaves EBADF. Expected ECONNRESET. On main it is EBADF.
- "a hostname whose every address fails reports the last address's error" (socket-syscall-fault.test.ts): a child dials localhost with a connect fault of EINVAL armed for every address. Expected EINVAL; on the previous head it was ECONNREFUSED. It runs on the first, uncached dial, so it takes the deferred resolver path on every platform whatever localhost resolves to.
- The table in test/js/bun/net/socket-syscall-fault.test.ts has a new row: a TCP dial that fails inside connect(2) with ECONNRESET reports ECONNRESET. On main it is ECONNREFUSED. An asynchronous ECONNRESET at connect time is not something a POSIX host produces (a reset after connect completes is a read error), so the asynchronous side of the same table is pinned by the refused connect test only.

On main the fault setter also rejects "close", so both fail there before the assertion.

test/js/bun/net/socket-syscall-fault.test.ts adds a table over Bun.connect: every code connect_errno_code keeps for a unix path or a local bind, two errnos outside the table reported as ECONNREFUSED, a missing unix path and an injected EADDRNOTAVAIL each followed by a close that reports EINTR (ECONNREFUSED on main), and a real refused connect with the platform's errno number. test/js/bun/util/socket-fault-injection.test.ts pins that "close" is accepted with action errno or none and rejected with short and zero.

No test pins a Windows SO_ERROR value other than a refused port. A code such as WSAETIMEDOUT or WSAEHOSTUNREACH needs a black-holed address, and there is no fault hook for SO_ERROR, so that is not something CI can produce on demand. The unit tests in src/errno/lib.rs pin that WSAETIMEDOUT and WSAEHOSTUNREACH map to ETIMEDOUT and EHOSTUNREACH.

Existing tests that cover the same paths, run locally: test/js/bun/net/socket.test.ts ("a synchronous unix connect failure rejects the promise and fires connectError"), test/js/node/net/node-net.test.ts ("should handle connection error (unix)" and the Windows-only "connect() error codes on Windows" block), socket-dns-error.test.ts, node-net-server.test.ts, server.spec.ts, and test/js/valkey. cargo check passes for x86_64-pc-windows-msvc and x86_64-unknown-linux-gnu; the C is compiled only by the full build, which was run on macOS.

Related

- #37093 wants ETIMEDOUT, EHOSTUNREACH and ENETUNREACH to reach Bun.connect's .code, with a repro and a test that fails on main. This PR does not change that policy. connect_errno_code is now the one place it is decided, for the synchronous and the asynchronous path, so #37093's change to it becomes three entries in that list. Its last_candidate_error plumbing (both exhaustion sites in context.c, start_connections, the cache invalidation in socket.c) is here now, reading each candidate's error from the out-param, so #37093 shrinks to the policy change and its loop.c hunk. It is sequenced after this PR.
- The uSockets Rust rewrite, #34037, deletes every C file this PR touches. Today it fills in ECONNREFUSED and ECONNABORTED again in src/usockets/connecting.rs and reads last_os_error() in neterr.rs. To keep this behaviour it has to port: the error out-param through the group connect (no read of the OS error after the failed socket is closed), the last address's real error at both exhaustion sites, SO_ERROR after the recv() probe on Windows, the LIBUS_ECONNABORTED and LIBUS_ECONNREFUSED constants in the platform's numbering, and the "close" fault rule so net-syscall-fault and socket-syscall-fault keep passing.
- fetch, postgres and mysql still ignore the code the callback delivers. fetch's fixed "Unable to connect" message is the obvious next caller.
- #36140 (EMFILE) touches bsd.c and context.c too.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/net-syscall-fault.test.ts, test/js/bun/net/socket-syscall-fault.test.ts

<!-- robobun:evidence:end -->