### PR TITLE
Remove orphaned extern C comment lines in InspectorHTTPServerAgent.cpp

### DIFF
--- a/src/jsc/bindings/InspectorHTTPServerAgent.cpp
+++ b/src/jsc/bindings/InspectorHTTPServerAgent.cpp
@@ -16,11 +16,6 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(InspectorHTTPServerAgent);
 // Rust bindings implementation
 extern "C" {
 void Bun__HTTPServerAgent__setEnabled(Inspector::InspectorHTTPServerAgent* agent);
-
-// void Bun__HTTPServerAgentStartListening(Inspector::InspectorHTTPServerAgent* agent, int serverId);
-// void Bun__HTTPServerAgentStopListening(Inspector::InspectorHTTPServerAgent* agent, int serverId);
-// void Bun__HTTPServerAgentGetRequestBody(Inspector::InspectorHTTPServerAgent* agent, int requestId, int serverId);
-// void Bun__HTTPServerAgentGetResponseBody(Inspector::InspectorHTTPServerAgent* agent, int requestId, int serverId);
 }
 
 InspectorHTTPServerAgent::InspectorHTTPServerAgent(JSC::JSGlobalObject& globalObject)


### PR DESCRIPTION
### Problem
- PR #38900 removed the `startListening`, `stopListening`, `getRequestBody`, and `getResponseBody` stub methods from `InspectorHTTPServerAgent`.
- The four commented-out `extern "C"` declarations for `Bun__HTTPServerAgentStartListening`, `StopListening`, `GetRequestBody`, and `GetResponseBody` stayed behind at `src/jsc/bindings/InspectorHTTPServerAgent.cpp:20-23`.
- Nothing names these four symbols anywhere in the repository now.

### Fix
- Delete the four comment lines and the blank line before them.
- The `extern "C"` block now contains only the live declaration, `Bun__HTTPServerAgent__setEnabled`.
- The change removes comments only. It does not change any compiled code.
