### PR TITLE
Restore bun_css dependency of bun_runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,6 +1596,7 @@ dependencies = [
  "bun_core",
  "bun_crash_handler",
  "bun_csrf",
+ "bun_css",
  "bun_css_jsc",
  "bun_dns",
  "bun_dotenv",

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -44,6 +44,7 @@ bun_clap.workspace = true
 bun_collections.workspace = true
 bun_crash_handler.workspace = true
 bun_csrf.workspace = true
+bun_css.workspace = true
 bun_cares_sys.workspace = true
 bun_dns.workspace = true
 bun_dotenv.workspace = true


### PR DESCRIPTION
#37301 dropped `bun_css` from `bun_runtime`'s dependencies, but `src/runtime/cli/pm_diff_normalize.rs` (from #39229) still uses it, so main fails to build. Adds the edge back.