### PR TITLE
ci: backtrace every thread of a core file

### DIFF
--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -86,6 +86,10 @@ const spawnTimeout = 5_000;
 const spawnBunTimeout = 20_000; // when running with ASAN/LSAN bun can take a bit longer to exit, not a bug.
 const testTimeout = 3 * 60_000;
 const integrationTimeout = 5 * 60_000;
+// Frames gdb prints per thread of a core file. A bun process has 10 to 20
+// threads; idle ones unwind in about 10 frames, so this bounds the annotation
+// without cutting the crashing thread or the JS thread short.
+const gdbFramesPerThread = 64;
 
 const resolutionGatingFlags = new Set([
   "--expose-internals",
@@ -1791,6 +1795,13 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
     BUN_DISABLE_SLOW_FILESYSTEM_WARNING: "1",
     BUN_GARBAGE_COLLECTOR_LEVEL: "1",
     BUN_JSC_randomIntegrityAuditRate: "1.0",
+    // When the marker is handed a cell that the sweeper already freed (a
+    // missing GC root or write barrier somewhere), JSC crashes at once, while
+    // the visitChildren or root constraint that still pointed at the dead cell
+    // is on the stack, with the dead cell's subspace hash, size and block state
+    // in registers. Without it the cell is pushed and a GC helper thread
+    // segfaults later when it pops it. x86_64 only; accepted and inert elsewhere.
+    BUN_JSC_dumpZappedCellCrashData: "1",
     BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
     BUN_INSTALL_CACHE_DIR: tmpdirPath,
     SHELLOPTS: isWindows ? "igncr" : undefined, // ignore "\r" on Windows
@@ -1848,9 +1859,22 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
       for (const coreName of newCores) {
         const corePath = join(coresDir, coreName);
         let out = "";
+        // Every thread, not only the one that crashed: a crash in a GC helper
+        // thread (HeapHelper-*.core) only shows the marker visiting a dead
+        // cell, while the JS thread's stack shows what the process had in
+        // flight. gdb numbers the crashing thread 1 and the main thread next,
+        // so `-ascending` puts the two that matter first. gdb -batch truncates
+        // a deep or corrupt stack silently, hence the frame limit in the
+        // header below.
         const gdb = await spawnSafe({
           command: "gdb",
-          args: ["-batch", `--eval-command=bt`, "--core", corePath, execPath],
+          args: [
+            "-batch",
+            `--eval-command=thread apply all -ascending bt ${gdbFramesPerThread}`,
+            "--core",
+            corePath,
+            execPath,
+          ],
           timeout: 240_000,
           stderr: () => {},
           stdout(text) {
@@ -1860,11 +1884,12 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
         if (!gdb.ok) {
           crashes += `failed to get backtrace from GDB: ${gdb.error}\n`;
         } else {
-          crashes += `======== Stack trace from GDB for ${coreName}: ========\n`;
+          crashes += `======== Stack trace from GDB for ${coreName} (all threads, crashing thread first, up to ${gdbFramesPerThread} frames each): ========\n`;
           for (const line of out.split("\n")) {
             // filter GDB output since it is pretty verbose
             if (
               line.startsWith("Program terminated") ||
+              line.startsWith("Thread ") || // "Thread 2 (Thread 0x... (LWP 123)):" starts each thread's backtrace
               line.startsWith("#") || // gdb backtrace lines start with #0, #1, etc.
               line.startsWith("[Current thread is")
             ) {

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1796,12 +1796,15 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
     BUN_GARBAGE_COLLECTOR_LEVEL: "1",
     BUN_JSC_randomIntegrityAuditRate: "1.0",
     // When the marker is handed a cell that the sweeper already freed (a
-    // missing GC root or write barrier somewhere), JSC crashes at once, while
+    // missing GC root or write barrier somewhere), JSC aborts at once, while
     // the visitChildren or root constraint that still pointed at the dead cell
-    // is on the stack, with the dead cell's subspace hash, size and block state
-    // in registers. Without it the cell is pushed and a GC helper thread
-    // segfaults later when it pops it. x86_64 only; accepted and inert elsewhere.
-    BUN_JSC_dumpZappedCellCrashData: "1",
+    // is on the stack, so the crash report and the core name the owner of the
+    // stale pointer. Without it the cell is pushed and a GC helper thread
+    // segfaults later when it pops it. Checked on x86_64 only; accepted and
+    // inert elsewhere. Not on Windows: the abort there is a __fastfail, which
+    // exits 0xC0000409 with no crash report, and no cores are collected, so it
+    // would only hide the access violation the crash handler reports today.
+    BUN_JSC_dumpZappedCellCrashData: isWindows ? undefined : "1",
     BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
     BUN_INSTALL_CACHE_DIR: tmpdirPath,
     SHELLOPTS: isWindows ? "igncr" : undefined, // ignore "\r" on Windows
@@ -1859,43 +1862,59 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
       for (const coreName of newCores) {
         const corePath = join(coresDir, coreName);
         let out = "";
+        let gdbStderr = "";
         // Every thread, not only the one that crashed: a crash in a GC helper
         // thread (HeapHelper-*.core) only shows the marker visiting a dead
         // cell, while the JS thread's stack shows what the process had in
         // flight. gdb numbers the crashing thread 1 and the main thread next,
-        // so `-ascending` puts the two that matter first. gdb -batch truncates
-        // a deep or corrupt stack silently, hence the frame limit in the
-        // header below.
+        // so `-ascending` puts the two that matter first. Without `-c` an
+        // error in one thread's backtrace abandons the threads after it.
+        // gdb -batch truncates a deep or corrupt stack silently, hence the
+        // frame limit in the header below.
         const gdb = await spawnSafe({
           command: "gdb",
           args: [
             "-batch",
-            `--eval-command=thread apply all -ascending bt ${gdbFramesPerThread}`,
+            `--eval-command=thread apply all -ascending -c bt ${gdbFramesPerThread}`,
             "--core",
             corePath,
             execPath,
           ],
           timeout: 240_000,
-          stderr: () => {},
+          stderr(text) {
+            gdbStderr += text;
+          },
           stdout(text) {
             out += text;
           },
         });
-        if (!gdb.ok) {
-          crashes += `failed to get backtrace from GDB: ${gdb.error}\n`;
-        } else {
-          crashes += `======== Stack trace from GDB for ${coreName} (all threads, crashing thread first, up to ${gdbFramesPerThread} frames each): ========\n`;
-          for (const line of out.split("\n")) {
-            // filter GDB output since it is pretty verbose
-            if (
-              line.startsWith("Program terminated") ||
-              line.startsWith("Thread ") || // "Thread 2 (Thread 0x... (LWP 123)):" starts each thread's backtrace
-              line.startsWith("#") || // gdb backtrace lines start with #0, #1, etc.
-              line.startsWith("[Current thread is")
-            ) {
-              crashes += line + "\n";
-            }
+        crashes += `======== Stack trace from GDB for ${coreName} (all threads, crashing thread first, up to ${gdbFramesPerThread} frames each): ========\n`;
+        let frameCount = 0;
+        for (const line of out.split("\n")) {
+          // filter GDB output since it is pretty verbose
+          if (
+            line.startsWith("Program terminated") ||
+            line.startsWith("Thread ") || // "Thread 2 (Thread 0x... (LWP 123)):" starts each thread's backtrace
+            line.startsWith("#") || // gdb backtrace lines start with #0, #1, etc.
+            line.startsWith("[Current thread is")
+          ) {
+            crashes += line + "\n";
+            if (line.startsWith("#")) frameCount++;
           }
+        }
+        // Whatever gdb did print is kept above. gdb exits 0 when the file is
+        // not a core dump and only says so on stderr, so an empty backtrace is
+        // reported as well as a failing gdb.
+        if (!gdb.ok || frameCount === 0) {
+          const how = gdb.spawnError
+            ? `could not be started (${gdb.spawnError.code || gdb.spawnError.message})`
+            : gdb.signalCode
+              ? `was killed by ${gdb.signalCode}`
+              : gdb.exitCode === undefined
+                ? "timed out"
+                : `exited with code ${gdb.exitCode}`;
+          const why = gdbStderr.trim().split("\n").slice(-3).join(" | ");
+          crashes += `gdb ${how} and printed ${frameCount} frames${why ? `: ${why}` : ""}\n`;
         }
       }
     }

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1880,21 +1880,35 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
         });
         crashes += `======== Stack trace from GDB for ${coreName} (all threads, crashing thread first, up to ${gdbFramesPerThread} frames each): ========\n`;
         let frameCount = 0;
+        let afterThreadHeader = false;
         for (const line of out.split("\n")) {
           // filter GDB output since it is pretty verbose
           if (
             line.startsWith("Program terminated") ||
             line.startsWith("Thread ") || // "Thread 2 (Thread 0x... (LWP 123)):" starts each thread's backtrace
             line.startsWith("#") || // gdb backtrace lines start with #0, #1, etc.
-            line.startsWith("[Current thread is")
+            line.startsWith("Backtrace stopped") || // why a backtrace is short, e.g. a truncated core
+            line.startsWith("[Current thread is") ||
+            // With `-c`, the error for a thread whose backtrace failed is printed
+            // on stdout right under its header, e.g. "Cannot access memory at
+            // address 0x...". Keep it, or the thread shows up with no frames
+            // and no explanation.
+            (afterThreadHeader && line.trim() !== "")
           ) {
             crashes += line + "\n";
             if (line.startsWith("#")) frameCount++;
+            afterThreadHeader = line.startsWith("Thread ");
           }
         }
-        // Whatever gdb did print is kept above. gdb exits 0 when the file is
-        // not a core dump and only says so on stderr, so an empty backtrace is
-        // reported as well as a failing gdb.
+        // gdb's own stderr is mostly "warning:" lines about missing sources
+        // and debug info. Anything else there explains a bad result: a file
+        // that is not a core dump (gdb still exits 0 in that case), or a
+        // truncated core ("BFD: warning: ..."), so it is kept, bounded.
+        const notes = gdbStderr
+          .split("\n")
+          .filter(line => line.trim() !== "" && !line.startsWith("warning:"))
+          .slice(-3)
+          .join(" | ");
         if (!gdb.ok || frameCount === 0) {
           const how = gdb.spawnError
             ? `could not be started (${gdb.spawnError.code || gdb.spawnError.message})`
@@ -1903,8 +1917,9 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
               : gdb.exitCode === undefined
                 ? "timed out"
                 : `exited with code ${gdb.exitCode}`;
-          const why = gdbStderr.trim().split("\n").slice(-3).join(" | ");
-          crashes += `gdb ${how} and printed ${frameCount} frames${why ? `: ${why}` : ""}\n`;
+          crashes += `gdb ${how} and printed ${frameCount} frames${notes ? `: ${notes}` : ""}\n`;
+        } else if (notes) {
+          crashes += `gdb also reported: ${notes}\n`;
         }
       }
     }

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -1795,16 +1795,6 @@ async function spawnBun(execPath, { args, cwd, timeout, gracefulTimeout, idleTim
     BUN_DISABLE_SLOW_FILESYSTEM_WARNING: "1",
     BUN_GARBAGE_COLLECTOR_LEVEL: "1",
     BUN_JSC_randomIntegrityAuditRate: "1.0",
-    // When the marker is handed a cell that the sweeper already freed (a
-    // missing GC root or write barrier somewhere), JSC aborts at once, while
-    // the visitChildren or root constraint that still pointed at the dead cell
-    // is on the stack, so the crash report and the core name the owner of the
-    // stale pointer. Without it the cell is pushed and a GC helper thread
-    // segfaults later when it pops it. Checked on x86_64 only; accepted and
-    // inert elsewhere. Not on Windows: the abort there is a __fastfail, which
-    // exits 0xC0000409 with no crash report, and no cores are collected, so it
-    // would only hide the access violation the crash handler reports today.
-    BUN_JSC_dumpZappedCellCrashData: isWindows ? undefined : "1",
     BUN_RUNTIME_TRANSPILER_CACHE_PATH: "0",
     BUN_INSTALL_CACHE_DIR: tmpdirPath,
     SHELLOPTS: isWindows ? "igncr" : undefined, // ignore "\r" on Windows


### PR DESCRIPTION
### Problem
- Since 2026-08-14 the `:alpine: 3.23 x64` lane has produced three GC helper thread cores (builds 96675, 97509, 100350). Each time the marker visited a cell that an earlier collection had freed: once `Segmentation fault at address 0xD0` in `MethodTable::visitChildren`, twice in `JSObjectWithButterfly::visitButterflyImpl` under `SlotVisitor.cpp:379`, so a dead `JSArray`.
- The runner ran gdb with a plain `bt`, so each annotation holds only the helper thread's `drain` loop. That stack never names the object that still held the pointer, and the JS thread's stack, which shows what the process had in flight, was not captured. The uploaded cores need the age identity, so triage cannot read them.

### Fix
- gdb runs `thread apply all -ascending -c bt 64`. gdb numbers the crashing thread 1 and the main thread next, so the two stacks that matter come first. `-c` keeps going when one thread's backtrace fails. Batch gdb truncates silently, so the header states the frame limit. The filter keeps the `Thread N (...)` lines.
- What gdb printed is kept even when it exits non-zero. With `-c`, gdb prints the error for a thread whose backtrace failed on stdout under that thread's header, so that line and `Backtrace stopped` lines are kept too. An empty result is reported together with gdb's stderr, because gdb exits 0 for a file that is not a core dump and only says so there, and stderr lines other than `warning:` ones (a truncated core, for example) are appended, bounded to three. Before, a failing gdb discarded everything.
- Correct to have because it only changes what the annotation shows after a process has already dumped a core, and every such process has many threads. Verified against a real core, an empty file and a missing file (Notes).

### Background
- JSC marks with several threads: cells are pushed onto mark stacks and helper threads pop and visit them. A crash in a helper thread is one step removed from the bug. The thread that pushed the stale pointer and the JS thread hold the context.
- A core file written by the kernel lists the crashing thread first and the thread group leader next. `-ascending` relies on that order.

<details><summary>Notes</summary>

Verification:
- The gdb block was run as a copy against a core of a bun process made with gdb's `generate-core-file` (gdb 16.3: 10 threads, crashing thread first, `[Current thread is 1 ...]` kept, 0.2 s for the old and the new command), against the same core with `thread apply all -ascending -c frame 40`, which fails for the two short threads and succeeds for the rest (each failing thread keeps its header and `No frame at level 40.`, the others their frame; the error is on stdout and gdb exits 0), against an empty file (`gdb exited with code 0 and printed 0 frames: "..." is not a core dump`) and against a missing file. Threads come from the core's LWP notes, so libthread_db, which musl lacks, is not needed. `node --check` and prettier pass.

Dropped from this PR after review: setting `BUN_JSC_dumpZappedCellCrashData=1` for the spawned processes.
- The option makes `SlotVisitor::appendToMarkStack` crash when it is handed a zapped cell (SlotVisitor.cpp:281-283), with the owner's `visitChildren` on the stack. JSC only zaps cells whose blocks have destructors (MarkedBlockInlines.h:266-270, MarkedBlock.cpp:160-161), so it covers a stale pointer to a swept wrapper or string (the build 96675 shape) and not a freed array or plain object (the other two cores). On Linux `CRASH_WITH_INFO` is `abort()` (WTF Assertions.cpp:757-763), so the location is the whole gain; the cell identity reaches registers on Darwin only. On Windows the abort is a `__fastfail` with no crash report.
- Upstream turns it on in production on Darwin x86_64 (Options.cpp:1129-1131), and bun.report issues with this helper thread signature number about fifty, mostly x86_64 (for example #23823, #28990, #30624, #34476, #37284). If it is worth having, the place is Bun's option defaults in `JSCInitialize` (`src/jsc/bindings/ZigGlobalObject.cpp`) for x86_64 except Windows, where user crash reports gain too and CI inherits it. That is a runtime change with its own cost measurement, left for a separate PR. Measured here on a release build: nothing outside run to run noise on `bun-jsc.test.ts` and `bun-audit.test.ts`, and 1750 ms versus 1748 ms for 40 full collections over 600k objects.

Other follow-ups noted during review, not part of this change:
- `runParallelBucket` writes `crashes` to stderr only (runner.node.mjs near :1019); only the solo re-run produces the annotation.
- The fork could log the payload of `reportZappedCellAndCrash` and drop its two `CPU(X86_64)` guards, so Linux and aarch64 get the cell identity.
- The runner could treat a Windows `__fastfail` exit (`0xC0000409`) as a crash rather than a retryable failure; `randomIntegrityAuditRate` aborts have that problem today.

What was checked for the crash itself (no cause found):
- The three builds are on unrelated branches; merge bases with main are eabb96de72 (08-14 14:10 UTC), 97a4363115 (08-14) and 09f1ca492f (08-17). The third includes 07d38c1716 (08-16), which made `JsRef::Weak` refuse to hand out a wrapper that is dead but not yet swept, so that change covers at most the first two crashes. Remaining bare `JSValue` holders (for example `NodeHTTPResponse.armed_this_value`) stay candidates for the third, although build 97509 had no `node:http` loaded.
- Common to all three processes: module loading in the first seconds, `process.stdout` on a pipe (a `FileSink`), the same builtins. The December 2025 failure on this lane (`blob-write.test.ts`) was an ordinary missing root in `FileSink` that only showed here, so lane specific does not imply a platform specific cause.
- Read for missing roots, barriers and uninitialized arrays: `StrongRootBlock` / `StrongRef` / `Strong.rs` / `JSRef.rs` (store then barrier everywhere, relink and unlink barriered, root constraint re-run at the final fixpoint, unchanged since 07-30 except f598766d67, which is GC equivalent) and the CommonJS and ESM loaders including the 08-11 lazy builtin exports (`materializeLazyExport` writes through `symbolTablePutTouchWatchpointSet`, the source object is a visited `WriteBarrier`). `JSCommonJSExtensions.cpp:215` and `:229` barrier the wrong owner, but that code is unreachable today.
- Soaked on this container's glibc release build (8326d1bd3) with `BUN_JSC_verifyGC=1 BUN_JSC_verboseVerifyGC=1 BUN_GARBAGE_COLLECTOR_LEVEL=1`: 150 runs of `test-http-proxy-request.mjs`, 60 more with `collectContinuously`, 12 runs of `bun-audit.test.ts` and `bun-patch.test.ts` (children inherit the variables through `bunEnv`). Nothing reported. The verifier catches a missing barrier or a collector race, not a missing root.
- Remaining candidates by landing time: WebKit 447082ab (08-09, oven-sh/WebKit#398, conservative scan no longer accepts a pointer to the end of a plain cell), WebKit 09e47774 (08-11, Yarr rework and oven-sh/WebKit#403), mimalloc be7eb3ff / 6e891cbe (08-13, 341 commits; it allocates the MarkedBlocks and the mark stack segments that helper threads free across threads, and the April and May syncs each shipped a rare crash), and any bare `JSValue` holder on the paths above.
- `BUN_JSC_verifyGC=1` works on release builds and is the next lever for the barrier and collector classes. Not enabled here: nothing measurable on ordinary files, but `bun-audit.test.ts` goes from 4.7 s to 9.0 s because every spawned `bun install` pays for it. A time boxed soak on the one lane, or reading the three cores with the age identity, are the remaining steps.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->