### PR TITLE
Restore the bun_runtime dependency on bun_css (fixes the main build)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1596,6 +1596,7 @@ dependencies = [
  "bun_core",
  "bun_crash_handler",
  "bun_csrf",
+ "bun_css",
  "bun_css_jsc",
  "bun_dns",
  "bun_dotenv",

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -45,6 +45,7 @@ bun_collections.workspace = true
 bun_crash_handler.workspace = true
 bun_csrf.workspace = true
 bun_cares_sys.workspace = true
+bun_css.workspace = true
 bun_dns.workspace = true
 bun_dotenv.workspace = true
 bun_event_loop.workspace = true


### PR DESCRIPTION
### Problem
- main does not build since a1da88c23d (#37301). `bun bd` and `cargo check -p bun_runtime` stop with five copies of this error:
  ```
  error[E0433]: cannot find module or crate `bun_css` in this scope
     --> src/runtime/cli/pm_diff_normalize.rs:747:20
  ```
  The other four are at pm_diff_normalize.rs:750 (two), 762 and 764.
- `bun pm diff` (#39229, merged first) added these uses of `bun_css` to src/runtime/cli/pm_diff_normalize.rs. #37301 was based on a tree from before #39229. It removed `bun_css` from src/runtime/Cargo.toml as an unused dependency. The edge was in use when #37301 merged.

### Fix
- Put `bun_css.workspace = true` back in src/runtime/Cargo.toml, and the matching `"bun_css"` entry back in the `bun_runtime` block of Cargo.lock. This is the exact reverse of the two hunks that #37301 removed for this edge.
- This is the correct shape of the fix. `bun_css_jsc` (the only CSS crate `bun_runtime` still depended on) does not re-export `ParserOptions`, `StyleSheet` or `PrinterOptions`, so pm_diff_normalize.rs needs `bun_css` itself.
- The other two edges #37301 removed stay removed. `bun_runtime` has no reference to `bun_transpiler`, and `bun_spawn` has no reference to `bstr`.
- Verification: `bun bd` on this branch's parent fails with the errors above. `cargo update -w --offline --locked` accepts the updated Cargo.lock with no changes. Per request, no tests were run and no test is added. The existing CSS cases in test/cli/install/bun-pm-diff.test.ts cover this code once CI builds.
