### PR TITLE
bundler: don't emit chunks for import() targets referenced only from dead code

### DIFF
--- a/docs/bundler/index.mdx
+++ b/docs/bundler/index.mdx
@@ -555,6 +555,8 @@ Running this build with the JavaScript API results in the following files:
 
 The generated `chunk-dqmx6gc8.js` file contains the shared code. To avoid collisions, the file name includes a content hash by default. The `bun build` CLI names this chunk `entry-a-t268ez5g.js` instead of `chunk-<hash>.js`. Customize this with [`naming`](#naming).
 
+Each `import()` of a bundled JavaScript module also becomes its own chunk. Tree shaking applies to these chunks too: if every `import()` of a module lives in code that tree shaking removes — for example inside a function that is only called behind a [`define`](#define) or [`features`](#features) gate that evaluates to `false` — and nothing else in the live output imports the module, its chunk is not written and the module is absent from the [metafile](#metafile)'s `inputs` and `outputs`. Setting `treeShaking: false` keeps every `import()` chunk. This differs from esbuild, which emits a chunk for every reachable `import()` target.
+
 ### plugins
 
 A list of plugins to use during bundling.

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -901,9 +901,17 @@ impl<'a> LinkerContext<'a> {
                 worklist: Vec::new(),
             };
 
-            // Tree shaking: Each entry point marks all files reachable from itself
+            // Tree shaking: Each entry point marks all files reachable from itself.
+            // `import()` targets are marked live from the live part that holds
+            // the `import()` instead (see `mark_part_live_step`).
+            let root_dynamic_imports = !self.options.tree_shaking;
             for i in 0..entry_points_len {
                 let entry_point = entry_points[i];
+                if !root_dynamic_imports
+                    && entry_point_kinds[entry_point as usize] == EntryPoint::Kind::DynamicImport
+                {
+                    continue;
+                }
                 self.mark_file_live_for_tree_shaking(&mut ctx, entry_point);
             }
         }
@@ -2905,10 +2913,9 @@ impl<'a> LinkerContext<'a> {
             ctx.worklist.push(TreeShakeWork::File(source_index));
         }
 
-        let dependencies =
-            &ctx.parts[source_index as usize].as_slice()[part_index as usize].dependencies;
+        let part = &ctx.parts[source_index as usize].as_slice()[part_index as usize];
 
-        for dependency in dependencies.iter() {
+        for dependency in part.dependencies.iter() {
             let dep_source = dependency.source_index.get();
             let dep_part = dependency.part_index;
             if !ctx.parts_live[dep_source as usize].is_set(dep_part as usize) {
@@ -2916,6 +2923,22 @@ impl<'a> LinkerContext<'a> {
                     part_index: dep_part,
                     source_index: dep_source,
                 });
+            }
+        }
+
+        // `scan_imports_and_exports` adds no wrapper dependency for external `import()`.
+        if self.graph.code_splitting {
+            let records = &ctx.import_records[source_index as usize];
+            for &import_index in part.import_record_indices.iter() {
+                let record = &records[import_index as usize];
+                if record.source_index.is_valid()
+                    && self.is_external_dynamic_import(record, source_index)
+                {
+                    let other = record.source_index.get();
+                    if !self.graph.files_live.is_set(other as usize) {
+                        ctx.worklist.push(TreeShakeWork::File(other));
+                    }
+                }
             }
         }
     }

--- a/src/bundler/linker_context/computeChunks.rs
+++ b/src/bundler/linker_context/computeChunks.rs
@@ -88,6 +88,15 @@ pub(crate) fn compute_chunks(
     for (entry_id_, &source_index) in entry_source_indices.iter().enumerate() {
         let entry_bit = entry_id_ as chunk::EntryPointId;
 
+        // An `import()` target that no live code references gets no chunk.
+        if !this.graph.files_live.is_set(source_index as usize) {
+            debug_assert!(
+                this.graph.files.items_entry_point_kind()[source_index as usize]
+                    == crate::EntryPoint::Kind::DynamicImport
+            );
+            continue;
+        }
+
         // reshaped for borrowck — set the bit through a scoped &mut, then keep an
         // owned clone so the `this.graph.files` borrow does not span the helper calls below
         // that need `&LinkerContext` / `&mut LinkerContext`.

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -3,7 +3,7 @@ import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { SourceMapConsumer } from "source-map";
-import { itBundled } from "./expectBundled";
+import { itBundled, type BundlerTestBundleAPI } from "./expectBundled";
 
 const env = {
   ...bunEnv,
@@ -327,6 +327,172 @@ describe("bundler", () => {
       env,
       stdout: "a.js executed\na loaded from entry\nb.js executed\nb.js imports a {}\nb loaded from entry, value: B",
     },
+  });
+
+  // An `import()` target only referenced from a part that tree shaking removes
+  // must not get a chunk. `define` turns the gate into a compile-time `false`.
+  const deadDynamicImportFiles = {
+    "/main.ts": /* ts */ `
+      import { openSecretDialog } from './launchers.ts'
+      if (FEATURE_SECRET) {
+        openSecretDialog().then(x => console.log(x))
+      }
+      console.log("main")
+    `,
+    "/launchers.ts": /* ts */ `
+      export async function openSecretDialog() {
+        const { SecretDialog } = await import('./secret.ts')
+        return SecretDialog()
+      }
+    `,
+    "/secret.ts": /* ts */ `
+      export function SecretDialog() { return 'internal only' }
+    `,
+  };
+
+  const jsFilesIn = (api: BundlerTestBundleAPI) =>
+    readdirSync(api.outdir)
+      .filter(f => f.endsWith(".js"))
+      .sort();
+
+  // The chunk holding secret.ts, which must be separate from the entry point.
+  const secretChunk = (api: BundlerTestBundleAPI) => {
+    const chunk = jsFilesIn(api).find(f => api.readFile("/out/" + f).includes("internal only"));
+    expect(chunk).toBeDefined();
+    expect(chunk).not.toBe("main.js");
+    return chunk!;
+  };
+
+  for (const backend of ["cli", "api"] as const) {
+    itBundled(`splitting/DeadDynamicImportTargetGetsNoChunk-${backend}`, {
+      files: deadDynamicImportFiles,
+      entryPoints: ["/main.ts"],
+      splitting: true,
+      outdir: "/out",
+      format: "esm",
+      metafile: true,
+      backend,
+      define: { FEATURE_SECRET: "false" },
+      assertNotPresent: { "/out/main.js": "internal only" },
+      onAfterBundle(api) {
+        expect(jsFilesIn(api)).toEqual(["main.js"]);
+        const metafile = JSON.parse(api.readFile("/metafile.json"));
+        expect(Object.keys(metafile.inputs).some(k => k.endsWith("secret.ts"))).toBe(false);
+        expect(Object.keys(metafile.outputs)).toHaveLength(1);
+      },
+      run: { file: "/out/main.js", stdout: "main" },
+    });
+  }
+
+  itBundled("splitting/DeadDynamicImportTargetNoSplittingReference", {
+    files: deadDynamicImportFiles,
+    entryPoints: ["/main.ts"],
+    outdir: "/out",
+    format: "esm",
+    define: { FEATURE_SECRET: "false" },
+    assertNotPresent: { "/out/main.js": "internal only" },
+    onAfterBundle(api) {
+      expect(jsFilesIn(api)).toEqual(["main.js"]);
+    },
+    run: { file: "/out/main.js", stdout: "main" },
+  });
+
+  // With tree shaking off every `import()` target keeps its chunk, as before.
+  itBundled("splitting/DeadDynamicImportTargetKeptWithoutTreeShaking", {
+    files: deadDynamicImportFiles,
+    entryPoints: ["/main.ts"],
+    splitting: true,
+    treeShaking: false,
+    // The CLI has no flag to disable tree shaking.
+    backend: "api",
+    outdir: "/out",
+    format: "esm",
+    define: { FEATURE_SECRET: "false" },
+    onAfterBundle(api) {
+      secretChunk(api);
+    },
+    run: { file: "/out/main.js", stdout: "main" },
+  });
+
+  itBundled("splitting/LiveDynamicImportTargetStillGetsChunk", {
+    files: deadDynamicImportFiles,
+    entryPoints: ["/main.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    define: { FEATURE_SECRET: "true" },
+    onAfterBundle(api) {
+      api.expectFile("/out/main.js").toContain(`import("./${secretChunk(api)}")`);
+    },
+    run: { file: "/out/main.js", stdout: "main\ninternal only" },
+  });
+
+  // live → import() → a → import() → b: liveness has to propagate through the
+  // dynamically imported chunk, not just from the user entry point.
+  itBundled("splitting/DynamicImportChainLiveness", {
+    files: {
+      "/main.ts": /* ts */ `
+        import { loadA, loadDeadA } from './launchers.ts'
+        if (FEATURE) loadDeadA()
+        loadA().then(x => console.log(x))
+        console.log("main")
+      `,
+      "/launchers.ts": /* ts */ `
+        export async function loadA() { return (await import('./a.ts')).a() }
+        export async function loadDeadA() { return (await import('./dead-a.ts')).a() }
+      `,
+      "/a.ts": /* ts */ `
+        export async function a() { return "a:" + (await import('./b.ts')).b() }
+      `,
+      "/b.ts": /* ts */ `
+        export function b() { return "b" }
+      `,
+      "/dead-a.ts": /* ts */ `
+        export async function a() { return "DEAD_A:" + (await import('./dead-b.ts')).b() }
+      `,
+      "/dead-b.ts": /* ts */ `
+        export function b() { return "DEAD_B" }
+      `,
+    },
+    entryPoints: ["/main.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    define: { FEATURE: "false" },
+    onAfterBundle(api) {
+      const contents = jsFilesIn(api).map(f => api.readFile("/out/" + f));
+      expect(contents.filter(c => c.includes('"a:"'))).toHaveLength(1);
+      expect(contents.filter(c => c.includes('return "b"'))).toHaveLength(1);
+      const all = contents.join("\n");
+      expect(all).not.toContain("DEAD_A");
+      expect(all).not.toContain("DEAD_B");
+    },
+    run: { file: "/out/main.js", stdout: "main\na:b" },
+  });
+
+  // A dead `import()` target that live code also imports statically stays in
+  // the output (it is live), and keeps its own chunk because it is an entry point.
+  itBundled("splitting/DeadDynamicImportTargetAlsoStaticallyImported", {
+    files: {
+      ...deadDynamicImportFiles,
+      "/main.ts": /* ts */ `
+        import { openSecretDialog } from './launchers.ts'
+        import { SecretDialog } from './secret.ts'
+        if (FEATURE_SECRET) {
+          openSecretDialog().then(x => console.log(x))
+        }
+        console.log("main", SecretDialog())
+      `,
+    },
+    entryPoints: ["/main.ts"],
+    splitting: true,
+    outdir: "/out",
+    format: "esm",
+    define: { FEATURE_SECRET: "false" },
+    onAfterBundle(api) {
+      api.expectFile("/out/main.js").toContain(`from "./${secretChunk(api)}"`);
+    },
+    run: { file: "/out/main.js", stdout: "main internal only" },
   });
 
   // N same-named cross-chunk exports must get unique aliases in O(N) total

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -817,7 +817,7 @@ function expectBundled(
               jsx.importSource && ["--jsx-import-source", jsx.importSource],
               jsx.sideEffects && ["--jsx-side-effects"],
               dotenv && ["--env", dotenv],
-              // metafile && `--manifest=${metafile}`,
+              metafile && `--metafile=${metafile}`,
               sourceMap && `--sourcemap=${sourceMap}`,
               entryNaming && entryNaming !== "[dir]/[name].[ext]" && [`--entry-naming`, entryNaming],
               chunkNaming && chunkNaming !== "[name]-[hash].[ext]" && [`--chunk-naming`, chunkNaming],


### PR DESCRIPTION
### What does this PR do?

With `--splitting`, every `import()` target reachable in the parse graph was added to `entry_points` as `EntryPoint::Kind::DynamicImport` and then used as a tree-shaking root. A root is never shaken, so a chunk was emitted even when the only `import()` referencing it lived in a part that tree shaking removed. The single-module build does not have this problem: there the target is inlined behind a wrapper dependency of the importing part and dies with it.

```ts
// main.ts
import { openSecretDialog } from './launchers.ts'
if (FEATURE_SECRET) openSecretDialog()   // --define FEATURE_SECRET=false

// launchers.ts
export async function openSecretDialog() {
  const { SecretDialog } = await import('./secret.ts')
  return SecretDialog()
}
```

Before: `bun build main.ts --splitting --define FEATURE_SECRET=false` writes `main.js` and a `chunk-*.js` containing `secret.ts` that nothing references (and lists `secret.ts` in the metafile). Without `--splitting` there is no trace of `secret.ts`. After: only `main.js`, matching the non-splitting build.

Changes:

- `tree_shaking_and_code_splitting`: `DynamicImport` entry points are no longer roots.
- `mark_part_live_step`: when a part becomes live, the targets of its external dynamic imports (`is_external_dynamic_import`, the same predicate `scan_imports_and_exports` uses to skip the wrapper dependency) are pushed onto the existing worklist as live files. Chains (`import()` → A → `import()` → B) fall out of the worklist.
- `compute_chunks`: an entry point whose file is not live gets no chunk (only `DynamicImport` entry points can be dead; asserted in debug builds).
- With `treeShaking: false` dynamic import targets stay roots, so every `import()` chunk is kept as before.

Cost: one scan of `import_record_indices` per part that becomes live (gated on `code_splitting`) and one bit check per entry point. No new pass over the graph.

Behavior notes:

- This differs from esbuild, which roots every dynamic import target and therefore emits these chunks. The docs paragraph under `splitting` describes the new semantics and the difference.
- A target that live code also imports statically stays live and keeps its own entry-point chunk (unchanged).
- Not covered here: CSS reached only through a dead `import('./x.css')` is still bundled into the entry's stylesheet, and file-loader assets behind a dead `import()` are still copied. Both come from passes that run before or without liveness and behave the same before and after this PR.

### How did you verify your code works?

- New tests in `test/bundler/bundler_splitting.test.ts`: dead `import()` target produces no chunk (CLI and API backends, including the metafile), the same fixture without splitting, `treeShaking: false` keeps the chunk, a live `import()` still gets its chunk and runs, a chain (`main → a → b` kept, `dead-a → dead-b` dropped), and a target that is also statically imported. The three "dead" cases fail on the current release; the others guard existing behavior.
- `expectBundled`'s CLI backend now passes `--metafile` so metafile assertions run for both backends.
- `esbuild/splitting`, `esbuild/dce`, `esbuild/metafile`, `bundler_naming`, `bundler_edgecase`, `bundler_regressions`, `bundler_html`, `bundler_html_server`, `bundler_barrel`, `bundler_compile_splitting`, `bun-build-api`, `metafile`, `css-modules` pass locally.
