### PR TITLE
process.memoryUsage: report heapUsed from the most recent collection

### DIFF
--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -57,6 +57,7 @@ JSVMClientData::JSVMClientData(VM& vm, RefPtr<JSC::SourceProvider> sourceProvide
     , CLIENT_ISO_SUBSPACE_INIT(m_domConstructorSpace)
     , CLIENT_ISO_SUBSPACE_INIT(m_domNamespaceObjectSpace)
     , m_clientSubspaces(makeUnique<ExtendedDOMClientIsoSubspaces>())
+    , m_heapSizeAfterLastCollection(vm.heap)
 {
 }
 

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -67,12 +67,56 @@ class DOMWrapperWorld;
 #include "JSCTaskScheduler.h"
 #include "HTTPHeaderIdentifiers.h"
 #include "DOMURLBaseCache.h"
+#include <JavaScriptCore/HeapObserver.h>
 namespace Zig {
 class GlobalObject;
 }
 
 namespace Bun {
 class StrongRootBlock;
+
+// JSC measures the live size of the heap at the end of each collection, but only
+// publishes it per scope: an eden collection updates
+// Heap::sizeAfterLastEdenCollection() and a full collection updates
+// Heap::sizeAfterLastFullCollection(), so one of the two is always stale. The
+// combined counter (Heap::m_sizeAfterLastCollect) has no accessor. Attached to
+// the heap for the life of the VM, this copies the counter of whichever scope
+// just finished. Unlike Heap::size(), reading it does not walk the heap.
+class HeapSizeAfterLastCollection final : public JSC::HeapObserver {
+    WTF_MAKE_NONCOPYABLE(HeapSizeAfterLastCollection);
+
+public:
+    explicit HeapSizeAfterLastCollection(JSC::Heap& heap)
+        : m_heap(heap)
+    {
+        m_heap.addObserver(this);
+    }
+
+    ~HeapSizeAfterLastCollection() final
+    {
+        m_heap.removeObserver(this);
+    }
+
+    // 0 until the first collection of this heap finishes.
+    size_t get() const { return m_sizeAfterLastCollection; }
+
+private:
+    void willGarbageCollect() final {}
+
+    // Heap::didFinishCollection() notifies observers after updateAllocationLimits()
+    // stored this collection's size, in the end phase of the collection, while
+    // the mutator is stopped. The mutator reads m_sizeAfterLastCollection once
+    // it resumes, the same way it reads JSC's own counters.
+    void didGarbageCollect(JSC::CollectionScope scope) final
+    {
+        m_sizeAfterLastCollection = scope == JSC::CollectionScope::Full
+            ? m_heap.sizeAfterLastFullCollection()
+            : m_heap.sizeAfterLastEdenCollection();
+    }
+
+    JSC::Heap& m_heap;
+    size_t m_sizeAfterLastCollection { 0 };
+};
 }
 
 namespace WebCore {
@@ -173,6 +217,9 @@ public:
 
     WebCore::DOMURLBaseCache& urlBaseCache() { return m_urlBaseCache; }
 
+    // Live size of the heap as measured by the most recent collection, eden or full.
+    size_t heapSizeAfterLastCollection() const { return m_heapSizeAfterLastCollection.get(); }
+
     void* bunVM;
     // Opaque box of the Rust VmHandle for this VM: what any *other* thread uses
     // to post work / ref the loop (never bunVM). Created in create(), released
@@ -238,6 +285,8 @@ private:
     WebCore::HTTPHeaderIdentifiers m_httpHeaderIdentifiers;
 
     WebCore::DOMURLBaseCache m_urlBaseCache;
+
+    Bun::HeapSizeAfterLastCollection m_heapSizeAfterLastCollection;
 
     SentinelLinkedList<JSVMClientDataClient, BasicRawSentinelNode<JSVMClientDataClient>> m_clients;
     bool m_isWorkerVM { false };

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4081,9 +4081,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionMemoryUsage, (JSC::JSGlobalObject * glo
     result->putDirectOffset(vm, 0, JSC::jsNumber(current_rss));
     result->putDirectOffset(vm, 1, JSC::jsNumber(vm.heap.blockBytesAllocated()));
 
-    // heap.size() loops through every cell...
-    // TODO: add a binding for heap.sizeAfterLastCollection()
-    result->putDirectOffset(vm, 2, JSC::jsNumber(vm.heap.sizeAfterLastEdenCollection()));
+    // heap.size() walks every block of the heap, so report the size JSC measured
+    // at the end of the most recent collection instead.
+    result->putDirectOffset(vm, 2, JSC::jsNumber(WebCore::clientData(vm)->heapSizeAfterLastCollection()));
 
     result->putDirectOffset(vm, 3, JSC::jsNumber(vm.heap.extraMemorySize() + vm.heap.externalMemorySize()));
 

--- a/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
+++ b/test/js/node/diagnostics_channel/diagnostics_channel.test.ts
@@ -322,20 +322,35 @@ describe("Channel", () => {
   });
 
   // test-diagnostics-channel-memory-leak.js
+  //
+  // Node's version compares process.memoryUsage().heapUsed before the loop with
+  // the value after a collection. In Bun, heapUsed is the size measured by the
+  // most recent collection, so the first read dates from some earlier point in
+  // this file and the two numbers are not comparable. The entries the module
+  // keeps per channel also go away in FinalizationRegistry callbacks, after the
+  // collection. So check what the node test is after directly: once
+  // unsubscribed, nothing holds the channels.
   test("references are not leaked", () => {
     function noop() {}
 
-    const heapUsedBefore = process.memoryUsage().heapUsed;
+    const refs: WeakRef<Channel>[] = [];
     for (let i = 0; i < 1000; i++) {
       const name = `channel7-${i}`;
+      const dc = channel(name);
       subscribe(name, noop);
       unsubscribe(name, noop);
+      refs.push(new WeakRef(dc));
     }
 
+    // Bun.gc() clears the WeakRef targets this job kept alive before it collects.
     gc(true);
-    const heapUsedAfter = process.memoryUsage().heapUsed;
 
-    expect(heapUsedBefore).toBeGreaterThanOrEqual(heapUsedAfter);
+    // Conservative stack scanning can keep the last few channels the loop
+    // touched alive, so this checks that the channels are collectable rather
+    // than that every one of them was collected. A retained reference keeps
+    // all 1000 alive.
+    const alive = refs.filter(ref => ref.deref() !== undefined).length;
+    expect(alive).toBeLessThan(refs.length / 10);
   });
 });
 

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1018,6 +1018,85 @@ describe.concurrent(() => {
     expect(process.memoryUsage.rss()).toEqual(expect.any(Number));
   });
 
+  // JSC measures the live size of the heap at the end of each collection and
+  // keeps one figure per kind of collection, eden or full. heapUsed used to
+  // report the eden figure only, so it did not change when a full collection
+  // freed memory. Each child disables Bun's GC timer so that the only
+  // collections are the ones it requests. Bun.gc(true) and bun:jsc's edenGC()
+  // return the figure measured by the collection they ran, which is what
+  // heapUsed has to report afterwards.
+  describe("process.memoryUsage().heapUsed reports the most recent collection", () => {
+    async function reportedBy(script, env = {}) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...bunEnv, BUN_GC_TIMER_DISABLE: "1", ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return JSON.parse(stdout);
+    }
+
+    it("after a full collection that follows an eden collection", async () => {
+      const { collections, heapUsed } = await reportedBy(`
+        const { edenGC } = require("bun:jsc");
+        const heapUsed = () => process.memoryUsage().heapUsed;
+
+        // The objects hang off the global object so that the eden collection
+        // counts them whatever the JIT keeps in registers. The array is built in
+        // a function of its own so that no frame that is still on the stack
+        // points at it when the last full collection runs.
+        function fill() {
+          const objects = [];
+          for (let i = 0; i < 50_000; i++) objects.push({ i });
+          globalThis.retained = objects;
+        }
+
+        const full = Bun.gc(true);
+        const heapUsedAfterFull = heapUsed();
+
+        fill();
+        const eden = edenGC();
+        const heapUsedAfterEden = heapUsed();
+
+        globalThis.retained = null;
+        const fullAfterEden = Bun.gc(true);
+        const heapUsedAfterFullAfterEden = heapUsed();
+
+        console.log(JSON.stringify({
+          collections: [full, eden, fullAfterEden],
+          heapUsed: [heapUsedAfterFull, heapUsedAfterEden, heapUsedAfterFullAfterEden],
+        }));
+      `);
+
+      const [full, eden, fullAfterEden] = collections;
+      // The eden collection counted the retained objects and the last full
+      // collection freed them, so a stale figure differs from the current one.
+      expect(full).toBeGreaterThan(0);
+      expect(eden).toBeGreaterThan(full);
+      expect(fullAfterEden).toBeLessThan(eden);
+      expect(heapUsed).toEqual(collections);
+    });
+
+    // Without the JIT, JSC turns off generational collection and runs every
+    // collection as a full one, so the eden figure stays 0 for the life of the
+    // process.
+    it("when every collection is a full collection", async () => {
+      const { full, heapUsed } = await reportedBy(
+        `
+          const full = Bun.gc(true);
+          console.log(JSON.stringify({ full, heapUsed: process.memoryUsage().heapUsed }));
+        `,
+        { BUN_JSC_useJIT: "false" },
+      );
+
+      expect(full).toBeGreaterThan(0);
+      expect(heapUsed).toBe(full);
+    });
+  });
+
   describe("process.cpuUsage", () => {
     it("works", () => {
       expect(process.cpuUsage()).toEqual({


### PR DESCRIPTION
### Problem

- `process.memoryUsage().heapUsed` does not change after a full collection. It keeps the figure of the last eden collection. After `Bun.gc(true)` frees 10 MB, `heapUsed` still reports the 10 MB, and it is larger than `heapTotal`.
- In a process that runs without the JIT (`BUN_JSC_useJIT=0`), `heapUsed` is 0 for the life of the process. JSC turns off generational collection in that mode (`VM::isInMiniMode()`), so every collection is a full one.
- In a fresh process, `heapUsed` is 0 right after `Bun.gc(true)`. The full collection serves the pending startup request, so no eden collection has run.
- Cause: `Process_functionMemoryUsage` in `src/jsc/bindings/BunProcess.cpp` reads `heap.sizeAfterLastEdenCollection()`. `Heap::updateAllocationLimits()` writes that counter after an eden collection only. A full collection writes `m_sizeAfterLastFullCollect`. The counter that is current after both, `m_sizeAfterLastCollect`, has no accessor.

### Fix

- `JSVMClientData` owns a `JSC::HeapObserver` (`Bun::HeapSizeAfterLastCollection`, `src/jsc/bindings/BunClientData.h`). It attaches to the heap when the VM is created and detaches when the VM is destroyed. `didGarbageCollect(scope)` copies the counter of the scope that just ran. `process.memoryUsage()` reports that copy.
- The copy is exact. `Heap::runEndPhase()` calls `updateAllocationLimits()`, which stores the size of the collection in the counter for its scope and in `m_sizeAfterLastCollect`, and then `didFinishCollection()`, which notifies the observers with the same scope. So the copy always equals `m_sizeAfterLastCollect`.
- The read stays O(1), so `process.memoryUsage()` stays usable in a monitoring loop. `heap.size()` would be current too, but it walks every block of the heap.
- The observer runs in the end phase of a collection, while the mutator is stopped. The mutator reads the value after it resumes. This is the same contract under which it reads JSC's own `sizeAfterLast*Collection()` counters today.
- The client data is created right after the VM (`Zig__GlobalObject__create`), before any global object exists, so the observer sees every collection of the heap. Each worker has its own VM and its own copy. `~VM` deletes the client data while the heap is still alive, so the detach is safe.
- `test/js/node/diagnostics_channel/diagnostics_channel.test.ts`, "references are not leaked", compared `heapUsed` from before a loop with `heapUsed` after a full collection. The two numbers were always equal, because `heapUsed` did not move across the full collection. With this change the first number dates from an earlier collection in the file and the comparison fails. The test now checks what the node test is after: once unsubscribed, nothing holds the channels. It holds a `WeakRef` per channel and counts the ones that survive `gc(true)`. Locally 1 or 2 of 1000 survive (conservative stack scanning). A retained reference keeps all 1000 alive.
- Verified with `test/js/node/process/process.test.js`, describe "process.memoryUsage().heapUsed reports the most recent collection". One child runs a full, an eden, and a full collection and checks that `heapUsed` equals the figure each one returned. One child runs with `BUN_JSC_useJIT=false`. Both fail on the released build (`heapUsed` is `[0, eden, eden]` and `0`) and pass with this change.
- Also run with the debug build: `test/js/node/diagnostics_channel/diagnostics_channel.test.ts`, `test/js/bun/globals.test.js` ("cleans up memory" now measures a real drop), `test/js/bun/jsc/bun-jsc.test.ts`, `test/js/node/v8/v8-module.test.ts`, and the node tests `test-memory-usage.js`, `test-sqlite-template-tag.js` (its leak check reads 2.71 MB before and 2.76 MB after, against a 1.5x bound), `test-v8-collect-gc-profile*.js`, `test-v8-stats.js`, `test-worker-heap-statistics.js`, `test-gc-tls-external-memory.js`.

Related PRs. #39541 touches the same line of `BunProcess.cpp`. It adds a fallback to the full counter when the eden counter is 0, for the fresh process case above, and it collects once when both are 0. With this observer in place, that fallback reduces to one check of `heapSizeAfterLastCollection()`. Whichever lands second resolves a small conflict there. #33368 changes what `heapUsed` and `heapTotal` measure (it takes both from the marked space, for #20793). This PR keeps the current measure and only fixes which collection it comes from.

### Background

JSC's collector is generational. An eden collection marks only the objects allocated since the previous collection. A full collection marks the whole heap. At the end of either one, `Heap::updateAllocationLimits()` computes the live size (bytes visited plus the extra memory that live cells reported). It stores it in `m_sizeAfterLastEdenCollect` or `m_sizeAfterLastFullCollect`, depending on the scope of the collection, and always in `m_sizeAfterLastCollect`. Only the first two have accessors.

A `JSC::HeapObserver` is an interface with `willGarbageCollect()` and `didGarbageCollect(CollectionScope)`. `Heap::addObserver()` registers one. The heap calls `didGarbageCollect` from `Heap::didFinishCollection()`, in the end phase of every collection. The end phase runs with the world stopped (`worldShouldBeSuspended()` in `CollectorPhase.cpp`), which can be on the collector thread. `GCProfilerObserver` in `src/jsc/bindings/NodeV8.h` is the existing observer in this codebase. It reads the same counters by scope.

`JSVMClientData` (`src/jsc/bindings/BunClientData.h`) is Bun's per VM data. It is created in `JSVMClientData::create()` right after the VM, and `~VM` deletes it after `heap.lastChanceToFinalize()`, while the heap, a member of the VM, is still alive.

<details>
<summary>Repro on the released build and with this change</summary>

```js
let a = []; for (let i = 0; i < 200000; i++) a.push({ i, s: "x" + i });
console.log(process.memoryUsage().heapUsed);
a = null;
console.log(Bun.gc(true));
console.log(process.memoryUsage());
```

Released build (1.4.0):

```
13324137
156982
{ rss: 66416640, heapTotal: 636928, heapUsed: 13324137, external: 25830, arrayBuffers: 0 }
```

With this change:

```
13438091
156412
{ rss: 389029888, heapTotal: 636928, heapUsed: 156412, external: 28236, arrayBuffers: 0 }
```

Without the JIT, released build, after allocating 300000 objects: `heapUsed` is `0`. With this change: `11833741`.

</details>
