### PR TITLE
fuzzilli: do not start a second REPRL loop in the same process

### DIFF
--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -6,9 +6,7 @@ const REPRL_CRFD = 100; // Control read FD
 const REPRL_CWFD = 101; // Control write FD
 const REPRL_DRFD = 102; // Data read FD
 
-// A fuzzed script can evaluate this file again, e.g. new Worker(Bun.main) or
-// require(Bun.main + "?x"). A second copy would write its own HELO to REPRL_CWFD,
-// which fuzzilli then reads as the exit status of whatever script runs next.
+// A second copy (new Worker(Bun.main), re-require) would send a HELO that fuzzilli reads as the next script's status.
 const REPRL_RUNNING = Symbol.for("bun.fuzzilli.reprl");
 if (!Bun.isMainThread || globalThis[REPRL_RUNNING]) {
   throw new Error("fuzzilli-reprl: the REPRL loop is already running in this process");

--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -6,6 +6,15 @@ const REPRL_CRFD = 100; // Control read FD
 const REPRL_CWFD = 101; // Control write FD
 const REPRL_DRFD = 102; // Data read FD
 
+// A fuzzed script can evaluate this file again, e.g. new Worker(Bun.main) or
+// require(Bun.main + "?x"). A second copy would write its own HELO to REPRL_CWFD,
+// which fuzzilli then reads as the exit status of whatever script runs next.
+const REPRL_RUNNING = Symbol.for("bun.fuzzilli.reprl");
+if (!Bun.isMainThread || globalThis[REPRL_RUNNING]) {
+  throw new Error("fuzzilli-reprl: the REPRL loop is already running in this process");
+}
+globalThis[REPRL_RUNNING] = true;
+
 const fs = require("node:fs");
 
 // Make common Node modules available

--- a/test/js/bun/util/fuzzilli-reprl.fixture.ts
+++ b/test/js/bun/util/fuzzilli-reprl.fixture.ts
@@ -1,9 +1,8 @@
 // Drives the fuzzilli REPRL loop with in-process mocks for the control/data
 // FDs so the real src/js/eval/fuzzilli-reprl.ts source can be exercised in a
-// normal (non-fuzzilli) build. Feeds a payload that calls process.execve with
-// a nonexistent path: the real implementation prints an error and aborts the
-// process (SIGABRT) when exec fails, so the REPRL wrapper must stub it out
-// before running fuzzed scripts.
+// normal (non-fuzzilli) build. argv[2] selects the fuzzed payload to run first;
+// a second payload then proves the loop is still alive. Every 4-byte write the
+// wrapper makes to the control-write FD is reported on stdout.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -12,8 +11,20 @@ const REPRL_CRFD = 100;
 const REPRL_CWFD = 101;
 const REPRL_DRFD = 102;
 
+const reprlPath = path.join(import.meta.dir, "..", "..", "..", "..", "src", "js", "eval", "fuzzilli-reprl.ts");
+
+const scenarios: Record<string, string> = {
+  // The real process.execve prints an error and aborts the process (SIGABRT)
+  // when exec fails, so the wrapper must stub it out before running payloads.
+  execve: `process.execve("fuzzilli-reprl-execve-does-not-exist", []);`,
+  // Evaluates the wrapper a second time on the main thread, like
+  // require(Bun.main + "?x") does under the fuzzer. The second copy must not
+  // send another HELO or read from the control FD.
+  reenter: `require(${JSON.stringify(reprlPath)});`,
+};
+
 const payloads = [
-  Buffer.from(`process.execve("fuzzilli-reprl-execve-does-not-exist", []);`, "utf8"),
+  Buffer.from(scenarios[process.argv[2]], "utf8"),
   Buffer.from(`globalThis.stillAlive = true;`, "utf8"),
 ];
 
@@ -31,7 +42,9 @@ let controlStream = Buffer.concat(controlChunks);
 // Data-read pipe (fd 102): the payload for each exec cycle.
 let dataStream = Buffer.concat(payloads);
 
-let statusWrites = 0;
+// Control-write pipe (fd 101): "HELO" for a handshake, otherwise the REPRL
+// status word (exit code << 8) written after each payload.
+const controlWrites: string[] = [];
 
 const realFstatSync = fs.fstatSync;
 const realReadSync = fs.readSync;
@@ -60,10 +73,9 @@ const realWriteSync = fs.writeSync;
 
 (fs as any).writeSync = function (fd: any, buffer: any, ...rest: any[]) {
   if (fd === REPRL_CWFD) {
-    if (Buffer.isBuffer(buffer) && buffer.length === 4 && buffer.toString() !== "HELO") {
-      statusWrites++;
-    }
-    return Buffer.isBuffer(buffer) ? buffer.length : String(buffer).length;
+    const bytes = Buffer.from(buffer);
+    controlWrites.push(bytes.toString() === "HELO" ? "HELO" : `status=${bytes.readUInt32LE(0)}`);
+    return bytes.length;
   }
   return (realWriteSync as any).call(fs, fd, buffer, ...rest);
 };
@@ -71,12 +83,11 @@ const realWriteSync = fs.writeSync;
 (globalThis as any).resetCoverage = () => {};
 (globalThis as any).require = require;
 
-const reprlSource = fs.readFileSync(
-  path.join(import.meta.dir, "..", "..", "..", "..", "src", "js", "eval", "fuzzilli-reprl.ts"),
-  "utf8",
-);
-(0, eval)(reprlSource);
+let thrown = "";
+try {
+  (0, eval)(fs.readFileSync(reprlPath, "utf8"));
+} catch (e) {
+  thrown = ` THREW=${(e as Error).message}`;
+}
 
-const liveAfterExecve = (globalThis as any).stillAlive === true;
-realWriteSync.call(fs, 1, `STATUS_WRITES=${statusWrites} LIVE=${liveAfterExecve}\n`);
-process.exit(statusWrites === 2 && liveAfterExecve ? 0 : 1);
+console.log(`CONTROL_WRITES=${controlWrites.join(",")} LIVE=${(globalThis as any).stillAlive === true}${thrown}`);

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -1,23 +1,68 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
 import path from "node:path";
 
 // The fuzzilli REPRL wrapper (src/js/eval/fuzzilli-reprl.ts) executes
-// fuzzer-generated scripts in-process. APIs that intentionally kill the
-// process outside of normal exception handling must be stubbed out before the
-// loop starts, otherwise every fuzz case reaching them is reported as a
-// crash. process.execve is one of those: on success it replaces the process
-// image, which would silently end the REPRL loop.
-test("REPRL loop survives a payload that calls process.execve", async () => {
+// fuzzer-generated scripts in-process. A payload that kills the process, or
+// that gets the wrapper to speak the REPRL protocol a second time, makes
+// fuzzilli report a crash for whatever script happens to run next.
+const reprlPath = path.join(import.meta.dir, "..", "..", "..", "..", "src", "js", "eval", "fuzzilli-reprl.ts");
+
+async function run(cmd: string[]) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), path.join(import.meta.dir, "fuzzilli-reprl-execve.fixture.ts")],
+    cmd,
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });
-
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: normalizeBunSnapshot(stdout), stderr: normalizeBunSnapshot(stderr), exitCode };
+}
 
-  expect(stdout).toContain("STATUS_WRITES=2 LIVE=true");
-  expect(exitCode).toBe(0);
+function runFixture(scenario: string) {
+  return run([bunExe(), path.join(import.meta.dir, "fuzzilli-reprl.fixture.ts"), scenario]);
+}
+
+// process.execve either replaces the process image or aborts, so the wrapper
+// stubs it out before the loop starts.
+test.concurrent("REPRL loop survives a payload that calls process.execve", async () => {
+  expect(await runFixture("execve")).toEqual({
+    stdout: "CONTROL_WRITES=HELO,status=0,status=0 LIVE=true",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// require(Bun.main + "?x") evaluates the wrapper again on the main thread. The
+// second copy must throw before it writes its own HELO to the control FD.
+test.concurrent("REPRL loop survives a payload that evaluates the wrapper again", async () => {
+  expect(await runFixture("reenter")).toEqual({
+    stdout: [
+      "uncaught:Error: fuzzilli-reprl: the REPRL loop is already running in this process",
+      "CONTROL_WRITES=HELO,status=256,status=0 LIVE=true",
+    ].join("\n"),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// new Worker(Bun.main) evaluates the wrapper on a second thread, with its own
+// globals but the same FDs. That copy must stop before the handshake.
+test.concurrent("wrapper evaluated in a Worker does not start a second REPRL loop", async () => {
+  const result = await run([
+    bunExe(),
+    "-e",
+    `
+      const worker = new Worker(${JSON.stringify(reprlPath)});
+      worker.addEventListener("error", event => {
+        console.log(event.message.split("\\n").find(line => line.startsWith("error:")));
+      });
+      worker.addEventListener("close", event => console.log("close:", event.code));
+    `,
+  ]);
+  expect(result).toEqual({
+    stdout: ["error: fuzzilli-reprl: the REPRL loop is already running in this process", "close: 1"].join("\n"),
+    stderr: "",
+    exitCode: 0,
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fuzzilli reported a flaky crash (fingerprint `7d6dfc49112c594f`) with `TERMSIG: 72` and empty stdout and stderr. Signal 72 does not exist on Linux. 72 is the byte `H`. libreprl reads 4 bytes from the control pipe and uses the low byte as the signal number (`libreprl-posix.c`, `reprl_execute`). So the REPRL child wrote `HELO` to fd 101 while an unrelated script ran.

The wrapper in `src/js/eval/fuzzilli-reprl.ts` writes `HELO` once, at startup. A fuzzed script can evaluate the wrapper a second time. In the REPRL child, `Bun.main` and `process.argv[1]` are `/tmp/bun-fuzzilli-reprl.js`.

- `new Worker(Bun.main)` runs the wrapper on a second thread. That copy passes the `fstat(100)` check and writes `HELO` to fd 101 some time later, while a later script runs. Fuzzilli reports that later script as a crash with signal 72. After that, both threads read from fd 100 and the child dies. This matches the report: flaky, no output, and the reported script is inert (it throws at `new BigInt64Array(v23)` because the explore step called `v23.transfer()`).
- `require(Bun.main + "?x")` does the same thing on the main thread. The script that does this is reported as a deterministic crash with signal 72, and the results of the next scripts are shifted by one.

I reproduced both with a small REPRL driver over real fds 100 to 103, on the unmodified wrapper. `raw` is the 4 bytes libreprl reads as the status:

```
t_worker_main.js -> STATUS exit=0 (55ms)      // new Worker(Bun.main);
t_ok.js          -> STATUS exit=0 (4ms)       // 42
t_ok.js          -> STATUS exit=0 (2ms)
t_ok.js          -> STATUS exit=0 (3ms)
t_ok.js          -> STATUS CRASH termsig=72 raw=b'HELO' (0ms)
t_ok.js          -> STATUS exit=0 (0ms)       // the status of the previous script
BrokenPipeError: [Errno 32] Broken pipe       // the child is dead
```

The fix is in the wrapper. It throws before the handshake when `Bun.isMainThread` is false, or when a `Symbol.for` marker on `globalThis` shows that this global already started the loop. A second copy in a Worker ends with an error event that nobody reads. A second copy on the main thread makes the `require()` in the fuzzed script throw. Neither copy touches the REPRL fds. This follows the `process.execve` stub from #31759.

Nothing changes outside `bun fuzzilli`. The wrapper is embedded with `include_bytes!`, so the fix takes effect in the next fuzzilli build.

### How did you verify your code works?

`test/js/bun/util/fuzzilli-reprl.test.ts` drives the real wrapper source with mocked fds, as before. The fixture (renamed from `fuzzilli-reprl-execve.fixture.ts`) now takes the scenario as an argument and reports every 4-byte write to fd 101, so the tests assert the exact list of writes.

- `execve`: the existing case. It expects `HELO,status=0,status=0` and a live loop.
- `reenter`: a payload requires the wrapper again. With the fix it reports `HELO,status=256,status=0 LIVE=true`. With the fix reverted it reports `HELO,HELO,status=256 LIVE=false THREW=Invalid REPRL command`.
- Worker: `bun -e` starts the wrapper in a `Worker` and prints the error event. With the fix reverted, the worker copy reaches the fd check and prints `ERROR: REPRL file descriptors not available` instead.

The tests read the wrapper from `src/`, so they pass or fail with the source change, not with the binary. All three pass with `bun bd test test/js/bun/util/fuzzilli-reprl.test.ts`. The two new cases fail when the wrapper change is reverted.

I also rebuilt `build/debug-fuzz` and ran `bun-debug fuzzilli` under the REPRL driver. `new Worker(Bun.main)`, then the reported script, then 10 more scripts: 12 normal results. `require(Bun.main + "?x")`: the require throws `fuzzilli-reprl: the REPRL loop is already running in this process` and the loop continues. The reported script itself is a normal failed execution (exit 1) in every run, before and after the change. Fuzzilli's `REPRLRun` tool gives the same results as before the change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/fuzzilli-reprl.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/util/fuzzilli-reprl.test.ts:
(pass) REPRL loop survives a payload that calls process.execve [875.71ms]
34 | });
35 | 
36 | // require(Bun.main + "?x") evaluates the wrapper again on the main thread. The
37 | // second copy must throw before it writes its own HELO to the control FD.
38 | test.concurrent("REPRL loop survives a payload that evaluates the wrapper again", async () => {
39 |   expect(await runFixture("reenter")).toEqual({
                                           ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
    "stdout": 
- "uncaught:Error: fuzzilli-reprl: the REPRL loop is already running in this process
- CONTROL_WRITES=HELO,status=256,status=0 LIVE=true"
+ "uncaught:Error: Invalid REPRL command: expected 'exec', got 
+ CONTROL_WRITES=HELO,HELO,status=256 LIVE=false THREW=Invalid REPRL command: expected 'exec', got "
  ,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (cfeab43a8)

test/js/bun/util/fuzzilli-reprl.test.ts:
34 | });
35 | 
36 | // require(Bun.main + "?x") evaluates the wrapper again on the main thread. The
37 | // second copy must throw before it writes its own HELO to the control FD.
38 | test.concurrent("REPRL loop survives a payload that evaluates the wrapper again", async () => {
39 |   expect(await runFixture("reenter")).toEqual({
                                           ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "stderr": "",
    "stdout": 
- "uncaught:Error: fuzzilli-reprl: the REPRL loop is already running in this process
- CONTROL_WRITES=HELO,status=256,status=0 LIVE=true"
+ "uncaught:Error: Invalid REPRL command: expected 'exec', got 
+ CONTROL_WRITES=HELO,HELO,status=256 LIVE=false THREW=Invalid REPRL command: expected 'exec', got "
  ,
  }

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/bun/util/fuzzilli-reprl.test.ts:39:39)
(fail) REPRL loop survives a payload that evaluates the wrapper again [16.85ms]
(pass) REPRL loop survives a payload that calls process.execve [21.23ms]
58 |         console.log(event.messag
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/fuzzilli-reprl.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/util/fuzzilli-reprl.test.ts:
(pass) wrapper evaluated in a Worker does not start a second REPRL loop [535.46ms]
(pass) REPRL loop survives a payload that calls process.execve [860.09ms]
(pass) REPRL loop survives a payload that evaluates the wrapper again [925.72ms]

 3 pass
 0 fail
 3 expect() calls
Ran 3 tests across 1 file. [3.27s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 675ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/126] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/126] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/126] gen cpp.rs (cppbind)
[4/126] gen JS modules (bundle-modules)
Preprocess modules (8055ms)
Bundle modules (61ms)
Postprocesss modules (106ms)
Bundle Functions (854ms)
Generate Code (23ms)

[9.13s] Bundled "src/js" for production
  2626 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[4/125] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Comp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/eval/fuzzilli-reprl.ts                      |  7 +++
 ...execve.fixture.ts => fuzzilli-reprl.fixture.ts} | 47 +++++++++------
 test/js/bun/util/fuzzilli-reprl.test.ts            | 67 ++++++++++++++++++----
 3 files changed, 92 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/eval/fuzzilli-reprl.ts                   4      2      0
test/js/bun/util/fuzzilli-reprl.fixture.ts      1      2      0
test/js/bun/util/fuzzilli-reprl.test.ts         1      2      0
```

</details>

<!-- robobun:evidence:end -->