### PR TITLE
sql: drop preReserved marks that outlive their reservation

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1005,12 +1005,42 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
       return false;
     }
     this.reservedQueue.splice(index, 1);
+    this.#dropExcessPreReservations();
     // the cancelled reservation may have been the last pending work; a
     // graceful close() is waiting on this callback
     if (this.onAllQueriesFinished && !this.hasPendingQueries()) {
       this.onAllQueriesFinished();
     }
     return true;
+  }
+
+  /// preReserved marks are not tied to a specific reservation. When a
+  /// reservation leaves reservedQueue without taking a marked connection
+  /// (cancelled, or an unmarked connection went idle first), the mark would
+  /// keep queries off that connection until it happens to go idle, which is
+  /// the only point where release() clears it. Keep at most one mark per
+  /// reservation still queued.
+  #dropExcessPreReservations() {
+    const preReserved: PooledConnection[] = [];
+    const pollSize = this.connections.length;
+    for (let i = 0; i < pollSize; i++) {
+      const connection = this.connections[i];
+      // unassigned holes while the pool is starting, null once it is closed
+      if (connection && connection.flags & PooledConnectionFlags.preReserved) {
+        preReserved.push(connection);
+      }
+    }
+    const excess = preReserved.length - this.reservedQueue.length;
+    if (excess <= 0) {
+      return;
+    }
+    // the connections closest to idle serve the remaining reservations
+    // soonest, so give up the busiest marks first
+    preReserved.sort((a, b) => b.queryCount - a.queryCount);
+    for (let i = 0; i < excess; i++) {
+      preReserved[i].flags &= ~PooledConnectionFlags.preReserved;
+    }
+    this.flushConcurrentQueries();
   }
 
   getConnectionForQuery(pooledConnection: PooledConnection) {
@@ -1150,6 +1180,8 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
         this.readyConnections.delete(connection);
         // we have a connection waiting for a reserved connection lets prioritize it
         pendingReserved(connection.storedError, connection);
+        // the reservation may have been draining a different connection
+        this.#dropExcessPreReservations();
         return;
       }
     }

--- a/test/js/sql/sql-reserve-abort.test.ts
+++ b/test/js/sql/sql-reserve-abort.test.ts
@@ -4,11 +4,14 @@
 // frees up; nobody releases it, so the pool permanently shrinks and
 // sql.end() never resolves (issue #39451).
 import { SQL } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { describeWithContainer } from "harness";
 
 describeWithContainer("postgres", { image: "postgres_plain" }, container => {
-  const connect = () => new SQL(`postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`, { max: 1 });
+  const connect = (max = 1) =>
+    new SQL(`postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`, { max });
+  // pg_advisory_lock key; no other test takes it
+  const LOCK_KEY = 39454;
 
   test("aborting a queued reserve() keeps the pool intact and lets end() resolve", async () => {
     await container.ready;
@@ -118,5 +121,98 @@ describeWithContainer("postgres", { image: "postgres_plain" }, container => {
       code: "ERR_INVALID_ARG_TYPE",
     });
     await sql.end();
+  });
+
+  // A reserve() that finds every connection busy picks one of them and stops
+  // the pool from pipelining more queries onto it, so that it drains toward the
+  // reservation. Once the reservation is gone, that hold has no purpose and
+  // queries must be pipelined onto the connection again.
+  //
+  // The tests observe the hold through ordering, not timing. A query issued
+  // while a stale hold is in place is parked until the connection goes idle,
+  // and at that moment a pending reserve() takes the connection first. A query
+  // pipelined onto the connection finishes before the connection goes idle, so
+  // it resolves before that reserve() does.
+  describe("a connection held for a reservation that no longer exists", () => {
+    test("aborting the reservation gives the connection back to queries", async () => {
+      await container.ready;
+      await using sql = connect();
+      await sql`select 1`;
+
+      // execute() binds a query to the pool's only connection synchronously.
+      // Nothing yields before the `await` below, so the connection is busy
+      // during the whole reserve / abort / query / reserve sequence.
+      const inflight = sql`select 1`.execute();
+
+      const controller = new AbortController();
+      const reason = new Error("gave up waiting");
+      const aborted = sql.reserve({ signal: controller.signal });
+      controller.abort(reason);
+
+      const order: string[] = [];
+      const queryDone = sql`select 2 as x`.execute().then(() => {
+        order.push("query");
+      });
+      const secondReserve = sql.reserve();
+      await expect(aborted).rejects.toBe(reason);
+
+      const reserved = await secondReserve;
+      order.push("reserve");
+      reserved.release();
+
+      await queryDone;
+      await inflight;
+      expect(order).toEqual(["query", "reserve"]);
+      await sql.end();
+    });
+
+    test("serving the reservation from another connection gives the held one back to queries", async () => {
+      await container.ready;
+      // A separate single-connection pool (one session) holds the advisory
+      // lock, so a query for it in the pool below stays in flight until this
+      // test unlocks through the same session.
+      await using locker = connect();
+      await locker`select pg_advisory_lock(${LOCK_KEY}::bigint)`;
+
+      // reserving both connections brings both up; releasing them puts both
+      // back into the idle set
+      await using sql = connect(2);
+      const first = await sql.reserve();
+      const second = await sql.reserve();
+      first.release();
+      second.release();
+
+      // Each connection gets one query. reserve() holds the first busy
+      // connection it sees, which is the one the blocked query went to.
+      const blocked = sql`select pg_advisory_lock(${LOCK_KEY}::bigint)`.execute();
+      const quick = sql`select 1`.execute();
+      const firstReserve = sql.reserve();
+
+      // only the quick connection can go idle, so it serves the reservation
+      const reserved = await firstReserve;
+      await quick;
+
+      // No reservation is pending, so this query belongs on the blocked
+      // connection at once, ahead of the reserve() issued right after it.
+      const order: string[] = [];
+      const queryDone = sql`select 2 as x`.execute().then(() => {
+        order.push("query");
+      });
+      const secondReserve = sql.reserve();
+
+      await locker`select pg_advisory_unlock(${LOCK_KEY}::bigint)`;
+      await blocked;
+
+      const reservedAgain = await secondReserve;
+      order.push("reserve");
+      reservedAgain.release();
+      reserved.release();
+
+      await queryDone;
+      expect(order).toEqual(["query", "reserve"]);
+      // closing the pool ends the session that now holds the lock
+      await sql.end();
+      await locker.end();
+    });
   });
 });


### PR DESCRIPTION
### Problem

- After `reserve({ signal })` is aborted, the pool keeps one busy connection out of rotation. Plain queries skip that connection until every query already on it finishes. With `max: 1` this means a query issued right after the abort waits for the whole connection to go idle instead of being pipelined at once.
- `connect(reserved)` sets `preReserved` on a busy connection when it queues a reservation (`src/js/internal/sql/shared.ts:1425` on main). `flushConcurrentQueries()` skips marked connections (`shared.ts:1076`). The only code that cleared the mark was `release()`, and only when that same connection reached `queryCount == 0` (`shared.ts:1103`).
- `cancelReserve()` removed the callback from `reservedQueue` and left the mark in place (`shared.ts:1002`).
- `release()` has the same gap without an abort. It hands a pending reservation whichever connection goes idle first (`shared.ts:1145`). When that is not the marked connection, the marked one stays marked.
- Postgres and MySQL share this code. SQLite has its own adapter and is not affected.

### Fix

- Add `BaseSQLAdapter.#dropExcessPreReservations()`. It counts the marked connections, un-marks those beyond `reservedQueue.length`, busiest first, and calls `flushConcurrentQueries()` so the waiting queries use them.
- Call it from `cancelReserve()` after the splice, and from `release()` after it hands a connection to a reservation.
- Why this is correct: a mark exists only to let a connection drain toward a queued reservation, and marks are not tied to one reservation. So the pool needs at most one marked connection per queued reservation. The two call sites are the two places where a reservation leaves the queue without taking a marked connection. Pool close and connection failure already clear the marks on their own paths.
- Un-marking the busiest connections first keeps the ones closest to idle draining for the reservations that are still queued.
- When nothing is in excess the helper returns before it flushes, so the existing paths behave as before.
- Tests: `test/js/sql/sql-reserve-abort.test.ts`, one test per call site. Both fail on main with the order `["reserve", "query"]` (10 of 10 runs) and pass with the fix (30 of 30 runs). The tests observe ordering, not time: a query issued after the reservation is gone must resolve before a `reserve()` issued after it. A parked query resolves after that `reserve()`, because the reservation takes the connection the moment it goes idle.
- `test/js/sql/sql.test.ts` against a local Postgres: 831 pass with and without the fix, with the same 20 failures both ways (server configuration and wall-clock timing in a debug build).
- `test/js/sql/sql-mysql.transactions.test.ts` and the pool tests of `sql-mysql.test.ts` pass against a local MariaDB. The remaining failures there are MariaDB error message wording.

### Background

- `reserve()` gives the caller exclusive use of one pooled connection. `BaseSQLAdapter.connect(onConnected, reserved)` serves it at once when an idle connection exists. Otherwise it pushes the callback onto `reservedQueue`.
- Plain queries are pipelined: `flushConcurrentQueries()` can bind several queries to one connection at a time. `queryCount` is the number of queries bound to a connection. `release()` runs when one of them finishes.
- `preReserved` is a flag on a pooled connection. While it is set, `flushConcurrentQueries()` binds no new queries to the connection, so its `queryCount` can reach 0. At that point `release()` clears the flag and hands the connection to the first entry in `reservedQueue`.
- `release()` hands over any connection that reaches 0, marked or not. The flag only guarantees that some connection drains while reservations are queued.
- The second test uses `pg_advisory_lock` from a second pool to keep one connection busy until the test unlocks. This makes the drain order deterministic without sleeps.
