### PR TITLE
verify-baseline-static: allowlist llint_op_wide16_wide16 decode false positive

### DIFF
--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -1036,6 +1036,7 @@ _ZN9bun_image9N_AVX3_DLL9HorizPassEPKhmmPhmPKNS_4SpanEPKsm  [AVX, AVX2, AVX512DQ
 # single-digit hit here is decode noise. Ceiling [AVX] so a multi-feature leak
 # still fails. On ELF each opcode handler has its own symbol, so layout shifts
 # can move the desync between llint_op_* siblings; add them here as they trip.
-# (1 symbol)
+# (2 symbols)
 # ----------------------------------------------------------------------------
 llint_op_enter_wide32  [AVX]
+llint_op_wide16_wide16  [AVX]


### PR DESCRIPTION
The x64 baseline static scan on main flags one \`Vphaddsw\` in \`llint_op_wide16_wide16\`.

This is the documented LLInt data-in-.text false positive (\`ENABLE(LLINT_EMBEDDED_OPCODE_ID)\` puts a raw \`.int\` at the start of every handler; the linear sweep desyncs on it). The .text layout shift from the libjpeg-turbo SIMD change moved the desync from \`llint_op_enter_wide32\` to this sibling. Same \`[AVX]\` ceiling, so a real multi-feature leak still fails.