### PR TITLE
sql: keep the reservation's pool slot when reserved.begin() rejects before BEGIN

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -387,10 +387,7 @@ const SQL: typeof Bun.SQL = function SQL(
       finished.resolve();
       settle(value);
     }
-    // reserved_sql.close({ timeout }) waits on reservedTransaction, so it holds a promise per
-    // transaction that only fulfills. No handler may be attached to the caller's promise:
-    // that hides a rejection the caller ignores, and a .finally() chain on it rejects a
-    // second promise that nobody handles when the caller did handle the first one.
+    // Never attach a handler to the caller's promise: it changes which rejections are reported as unhandled.
     function runReservedTransaction(callback: TransactionCallback, options: string | undefined, distributed: boolean) {
       const { promise, resolve, reject } = Promise.withResolvers();
       const finished = Promise.withResolvers<void>();

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -378,8 +378,29 @@ const SQL: typeof Bun.SQL = function SQL(
     reserved_sql.array = sql.array;
     reserved_sql.listen = listen;
     reserved_sql.notify = makeNotify(reserved_sql);
-    function onTransactionFinished(transaction_promise: Promise<any>) {
+    function settleReservedTransaction(transaction_promise: Promise<any>, settle: (value: any) => void, value: any) {
       reservedTransaction.delete(transaction_promise);
+      settle(value);
+    }
+    // reserved_sql.close({ timeout }) waits on reservedTransaction. Entries are removed
+    // from the settle functions, not from a handler on the returned promise: a handler
+    // marks the caller's promise as handled (hiding a rejection the caller ignores), and
+    // a .finally() chain rejects a second promise that nobody handles.
+    function runReservedTransaction(callback: TransactionCallback, options: string | undefined, distributed: boolean) {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      reservedTransaction.add(promise);
+      // lets just reuse the same code path as the transaction begin
+      onTransactionConnected(
+        callback,
+        options,
+        settleReservedTransaction.bind(null, promise, resolve),
+        settleReservedTransaction.bind(null, promise, reject),
+        true,
+        distributed,
+        null,
+        pooledConnection,
+      );
+      return promise;
     }
     reserved_sql.beginDistributed = (name: string, fn: TransactionCallback) => {
       // begin is allowed the difference is that we need to make sure to use the same connection and never release it
@@ -395,12 +416,7 @@ const SQL: typeof Bun.SQL = function SQL(
       if (!$isCallable(callback)) {
         return Promise.$reject($ERR_INVALID_ARG_VALUE("fn", callback, "must be a function"));
       }
-      const { promise, resolve, reject } = Promise.withResolvers();
-      // lets just reuse the same code path as the transaction begin
-      onTransactionConnected(callback, name, resolve, reject, true, true, null, pooledConnection);
-      reservedTransaction.add(promise);
-      promise.finally(onTransactionFinished.bind(null, promise));
-      return promise;
+      return runReservedTransaction(callback, name, true);
     };
     reserved_sql.begin = (options_or_fn: string | TransactionCallback, fn?: TransactionCallback) => {
       // begin is allowed the difference is that we need to make sure to use the same connection and never release it
@@ -421,12 +437,7 @@ const SQL: typeof Bun.SQL = function SQL(
       if (!$isCallable(callback)) {
         return Promise.$reject($ERR_INVALID_ARG_VALUE("fn", callback, "must be a function"));
       }
-      const { promise, resolve, reject } = Promise.withResolvers();
-      // lets just reuse the same code path as the transaction begin
-      onTransactionConnected(callback, options, resolve, reject, true, false, null, pooledConnection);
-      reservedTransaction.add(promise);
-      promise.finally(onTransactionFinished.bind(null, promise));
-      return promise;
+      return runReservedTransaction(callback, options, false);
     };
 
     reserved_sql.flush = () => {
@@ -580,7 +591,9 @@ const SQL: typeof Bun.SQL = function SQL(
       // Get distributed transaction commands from adapter
       const commands = pool.getDistributedTransactionCommands?.(options);
       if (!commands) {
-        pool.release(pooledConnection);
+        if (!dontRelease) {
+          pool.release(pooledConnection);
+        }
         return reject(new Error(`This adapter doesn't support distributed transactions.`));
       }
 
@@ -596,7 +609,9 @@ const SQL: typeof Bun.SQL = function SQL(
       if (options && pool.validateTransactionOptions) {
         const validation = pool.validateTransactionOptions(options);
         if (!validation.valid) {
-          pool.release(pooledConnection);
+          if (!dontRelease) {
+            pool.release(pooledConnection);
+          }
           return reject(new Error(validation.error));
         }
       }
@@ -611,7 +626,9 @@ const SQL: typeof Bun.SQL = function SQL(
         ROLLBACK_TO_SAVEPOINT_COMMAND = commands.ROLLBACK_TO_SAVEPOINT;
         BEFORE_COMMIT_OR_ROLLBACK_COMMAND = commands.BEFORE_COMMIT_OR_ROLLBACK || null;
       } catch (err) {
-        pool.release(pooledConnection);
+        if (!dontRelease) {
+          pool.release(pooledConnection);
+        }
         return reject(err);
       }
     }

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -293,7 +293,7 @@ const SQL: typeof Bun.SQL = function SQL(
       return reject(err);
     }
 
-    let reservedTransaction = new Set();
+    let reservedTransaction = new Set<Promise<void>>();
 
     const state: TransactionState = {
       connectionState: ReservedConnectionState.acceptQueries,
@@ -378,23 +378,29 @@ const SQL: typeof Bun.SQL = function SQL(
     reserved_sql.array = sql.array;
     reserved_sql.listen = listen;
     reserved_sql.notify = makeNotify(reserved_sql);
-    function settleReservedTransaction(transaction_promise: Promise<any>, settle: (value: any) => void, value: any) {
-      reservedTransaction.delete(transaction_promise);
+    function settleReservedTransaction(
+      finished: { promise: Promise<void>; resolve: () => void },
+      settle: (value: any) => void,
+      value: any,
+    ) {
+      reservedTransaction.delete(finished.promise);
+      finished.resolve();
       settle(value);
     }
-    // reserved_sql.close({ timeout }) waits on reservedTransaction. Entries are removed
-    // from the settle functions, not from a handler on the returned promise: a handler
-    // marks the caller's promise as handled (hiding a rejection the caller ignores), and
-    // a .finally() chain rejects a second promise that nobody handles.
+    // reserved_sql.close({ timeout }) waits on reservedTransaction, so it holds a promise per
+    // transaction that only fulfills. No handler may be attached to the caller's promise:
+    // that hides a rejection the caller ignores, and a .finally() chain on it rejects a
+    // second promise that nobody handles when the caller did handle the first one.
     function runReservedTransaction(callback: TransactionCallback, options: string | undefined, distributed: boolean) {
       const { promise, resolve, reject } = Promise.withResolvers();
-      reservedTransaction.add(promise);
+      const finished = Promise.withResolvers<void>();
+      reservedTransaction.add(finished.promise);
       // lets just reuse the same code path as the transaction begin
       onTransactionConnected(
         callback,
         options,
-        settleReservedTransaction.bind(null, promise, resolve),
-        settleReservedTransaction.bind(null, promise, reject),
+        settleReservedTransaction.bind(null, finished, resolve),
+        settleReservedTransaction.bind(null, finished, reject),
         true,
         distributed,
         null,

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -39,6 +39,17 @@ interface ReserveAbortState {
   onAbort: (() => void) | null;
 }
 
+function settleReservedTransaction(
+  reservedTransaction: Set<Promise<void>>,
+  finished: { promise: Promise<void>; resolve: () => void },
+  settle: (value: any) => void,
+  value: any,
+) {
+  reservedTransaction.delete(finished.promise);
+  finished.resolve();
+  settle(value);
+}
+
 function adapterFromOptions(options: Bun.SQL.__internal.DefinedOptions) {
   switch (options.adapter) {
     case "postgres":
@@ -286,6 +297,31 @@ const SQL: typeof Bun.SQL = function SQL(
     };
   }
 
+  // Never attach a handler to the caller's promise: it changes which rejections are reported as unhandled.
+  function runReservedTransaction(
+    reservedTransaction: Set<Promise<void>>,
+    pooledConnection,
+    callback: TransactionCallback,
+    options: string | undefined,
+    distributed: boolean,
+  ) {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const finished = Promise.withResolvers<void>();
+    reservedTransaction.add(finished.promise);
+    // lets just reuse the same code path as the transaction begin
+    onTransactionConnected(
+      callback,
+      options,
+      settleReservedTransaction.bind(null, reservedTransaction, finished, resolve),
+      settleReservedTransaction.bind(null, reservedTransaction, finished, reject),
+      true,
+      distributed,
+      null,
+      pooledConnection,
+    );
+    return promise;
+  }
+
   function onReserveConnected(this: Query<any, any>, err: Error | null, pooledConnection) {
     const { resolve, reject } = this;
 
@@ -378,33 +414,6 @@ const SQL: typeof Bun.SQL = function SQL(
     reserved_sql.array = sql.array;
     reserved_sql.listen = listen;
     reserved_sql.notify = makeNotify(reserved_sql);
-    function settleReservedTransaction(
-      finished: { promise: Promise<void>; resolve: () => void },
-      settle: (value: any) => void,
-      value: any,
-    ) {
-      reservedTransaction.delete(finished.promise);
-      finished.resolve();
-      settle(value);
-    }
-    // Never attach a handler to the caller's promise: it changes which rejections are reported as unhandled.
-    function runReservedTransaction(callback: TransactionCallback, options: string | undefined, distributed: boolean) {
-      const { promise, resolve, reject } = Promise.withResolvers();
-      const finished = Promise.withResolvers<void>();
-      reservedTransaction.add(finished.promise);
-      // lets just reuse the same code path as the transaction begin
-      onTransactionConnected(
-        callback,
-        options,
-        settleReservedTransaction.bind(null, finished, resolve),
-        settleReservedTransaction.bind(null, finished, reject),
-        true,
-        distributed,
-        null,
-        pooledConnection,
-      );
-      return promise;
-    }
     reserved_sql.beginDistributed = (name: string, fn: TransactionCallback) => {
       // begin is allowed the difference is that we need to make sure to use the same connection and never release it
       if (state.connectionState & ReservedConnectionState.closed) {
@@ -419,7 +428,7 @@ const SQL: typeof Bun.SQL = function SQL(
       if (!$isCallable(callback)) {
         return Promise.$reject($ERR_INVALID_ARG_VALUE("fn", callback, "must be a function"));
       }
-      return runReservedTransaction(callback, name, true);
+      return runReservedTransaction(reservedTransaction, pooledConnection, callback, name, true);
     };
     reserved_sql.begin = (options_or_fn: string | TransactionCallback, fn?: TransactionCallback) => {
       // begin is allowed the difference is that we need to make sure to use the same connection and never release it
@@ -440,7 +449,7 @@ const SQL: typeof Bun.SQL = function SQL(
       if (!$isCallable(callback)) {
         return Promise.$reject($ERR_INVALID_ARG_VALUE("fn", callback, "must be a function"));
       }
-      return runReservedTransaction(callback, options, false);
+      return runReservedTransaction(reservedTransaction, pooledConnection, callback, options, false);
     };
 
     reserved_sql.flush = () => {

--- a/test/js/sql/sql-pool-transaction-isolation.test.ts
+++ b/test/js/sql/sql-pool-transaction-isolation.test.ts
@@ -1,7 +1,11 @@
-// Fault-injection test: the mock server drops the socket mid-query, which a real
-// container will not do on demand. Wire bytes come from ./wire-frames.ts.
+// Pool slot accounting across the paths that hand a connection back to the pool.
+// The mock servers record every statement per connection, so a transaction that
+// lands on a connection somebody else still holds shows up in the recorded order.
+// They also drop the socket on demand, which a real container will not do.
+// Wire bytes come from ./wire-frames.ts.
 import { SQL } from "bun";
 import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import type net from "node:net";
 import {
   listeningServer,
@@ -103,12 +107,26 @@ function firstInterleaving(received: Received[]): string | null {
   return null;
 }
 
-const adapters: Array<{ adapter: "postgres" | "mysql"; mockServer: MockServer }> = [
-  { adapter: "postgres", mockServer: pgMockServer },
-  { adapter: "mysql", mockServer: mysqlMockServer },
+const adapters: Array<{ adapter: "postgres" | "mysql"; mockServer: MockServer; beginCommand: string }> = [
+  { adapter: "postgres", mockServer: pgMockServer, beginCommand: "BEGIN" },
+  { adapter: "mysql", mockServer: mysqlMockServer, beginCommand: "START TRANSACTION" },
 ];
 
-describe.each(adapters)("$adapter", ({ adapter, mockServer }) => {
+// reserved.begin() / beginDistributed() calls that reject before anything is sent.
+const rejectedBeforeBegin = [
+  {
+    name: "begin() with invalid options",
+    begin: (reserved: Bun.ReservedSQL) => reserved.begin("read-only", async () => "unreachable"),
+    message: "Transaction options can only contain letters, spaces, and commas.",
+  },
+  {
+    name: "beginDistributed() with an invalid name",
+    begin: (reserved: Bun.ReservedSQL) => reserved.beginDistributed("bad'name", async () => "unreachable"),
+    message: "This adapter doesn't support distributed transactions.",
+  },
+];
+
+describe.each(adapters)("$adapter", ({ adapter, mockServer, beginCommand }) => {
   const options = (port: number): Bun.SQL.Options => ({
     adapter,
     hostname: "127.0.0.1",
@@ -258,6 +276,134 @@ describe.each(adapters)("$adapter", ({ adapter, mockServer }) => {
       expect(firstInterleaving(received)).toBeNull();
     } finally {
       await sql.close({ timeout: 0 }).catch(() => {});
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  // A transaction started on a reserved connection runs on the reservation's own
+  // slot. When it rejects before BEGIN is sent, the slot has to stay with the
+  // reservation. bun:test also fails these tests if the rejected begin() leaves an
+  // unhandled rejection behind.
+  test.each(rejectedBeforeBegin)(
+    "the reservation keeps its pool slot after reserved $name rejects",
+    async ({ begin, message }) => {
+      const received: Received[] = [];
+      const { port, server } = await mockServer(received);
+      const sql = new SQL(options(port));
+      try {
+        const reserved = await sql.reserve();
+        const err = await begin(reserved).then(
+          () => null,
+          e => e,
+        );
+        expect(err?.message).toBe(message);
+
+        // The reservation holds the pool's only slot, so this has to wait for release().
+        const t1 = sql.begin(async tx => {
+          await tx.unsafe("SELECT 'T1a'");
+          return "t1";
+        });
+        await reserved.unsafe("SELECT 'R1'");
+        await reserved.unsafe("SELECT 'R2'");
+        expect(received).toEqual([
+          { conn: 0, sql: "SELECT 'R1'" },
+          { conn: 0, sql: "SELECT 'R2'" },
+        ]);
+
+        reserved.release();
+        expect(await t1).toBe("t1");
+
+        // release() brought the slot back to zero queries, so it can be reserved again.
+        const reservedAgain = await sql.reserve();
+        await reservedAgain.unsafe("SELECT 'R3'");
+        reservedAgain.release();
+
+        expect(received).toEqual([
+          { conn: 0, sql: "SELECT 'R1'" },
+          { conn: 0, sql: "SELECT 'R2'" },
+          { conn: 0, sql: beginCommand },
+          { conn: 0, sql: "SELECT 'T1a'" },
+          { conn: 0, sql: "COMMIT" },
+          { conn: 0, sql: "SELECT 'R3'" },
+        ]);
+      } finally {
+        await sql.close({ timeout: 0 }).catch(() => {});
+        await new Promise<void>(r => server.close(() => r()));
+      }
+    },
+  );
+
+  test("reserved.close({ timeout }) waits for a transaction started on the reservation", async () => {
+    const received: Received[] = [];
+    const { port, server } = await mockServer(received);
+    const sql = new SQL(options(port));
+    try {
+      const reserved = await sql.reserve();
+      const t1 = reserved.begin(async tx => {
+        await tx.unsafe("SELECT 'T1a'");
+        return "t1";
+      });
+      // The timeout is in seconds. close() resolves as soon as t1 settles; without the
+      // transaction being tracked it would close the connection under t1 instead.
+      const closed = reserved.close({ timeout: 60 });
+      expect(await t1).toBe("t1");
+      await closed;
+      reserved.release();
+      expect(received).toEqual([
+        { conn: 0, sql: beginCommand },
+        { conn: 0, sql: "SELECT 'T1a'" },
+        { conn: 0, sql: "COMMIT" },
+      ]);
+    } finally {
+      await sql.close({ timeout: 0 }).catch(() => {});
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  // Runs in a child process: bun:test would turn any unhandled rejection into a test
+  // failure, and the second half of this contract is that one rejection IS reported.
+  test("a rejected reserved begin() is reported as unhandled only when the caller ignores it", async () => {
+    const received: Received[] = [];
+    const { port, server } = await mockServer(received);
+    try {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const reported = [];
+            process.on("unhandledRejection", err => reported.push(err.message));
+            const sql = new Bun.SQL(${JSON.stringify(options(port))});
+            const reserved = await sql.reserve();
+            const handled = await reserved
+              .begin(async () => {
+                throw new Error("handled by the caller");
+              })
+              .catch(err => err.message);
+            reserved.begin("read-only", async () => {});
+            await reserved.unsafe("SELECT 'still reserved'");
+            reserved.release();
+            await sql.close();
+            console.log(JSON.stringify({ handled, reported }));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({
+        handled: "handled by the caller",
+        reported: ["Transaction options can only contain letters, spaces, and commas."],
+      });
+      expect(exitCode).toBe(0);
+      expect(received).toEqual([
+        { conn: 0, sql: beginCommand },
+        { conn: 0, sql: "ROLLBACK" },
+        { conn: 0, sql: "SELECT 'still reserved'" },
+      ]);
+    } finally {
       await new Promise<void>(r => server.close(() => r()));
     }
   });

--- a/test/js/sql/sql-pool-transaction-isolation.test.ts
+++ b/test/js/sql/sql-pool-transaction-isolation.test.ts
@@ -360,6 +360,36 @@ describe.each(adapters)("$adapter", ({ adapter, mockServer, beginCommand }) => {
     }
   });
 
+  // Same overlap with a transaction that fails. close() must wait for the ROLLBACK, and
+  // the failure is the caller's to handle: bun:test fails this test if close()'s wait
+  // reports it as an unhandled rejection as well.
+  test("reserved.close({ timeout }) waits for a failing transaction without reporting its handled error", async () => {
+    const received: Received[] = [];
+    const { port, server } = await mockServer(received);
+    const sql = new SQL(options(port));
+    try {
+      const reserved = await sql.reserve();
+      const failing = reserved
+        .begin(async tx => {
+          await tx.unsafe("SELECT 'T1a'");
+          throw new Error("t1-app-error");
+        })
+        .catch(err => err.message);
+      const closed = reserved.close({ timeout: 60 });
+      expect(await failing).toBe("t1-app-error");
+      await closed;
+      reserved.release();
+      expect(received).toEqual([
+        { conn: 0, sql: beginCommand },
+        { conn: 0, sql: "SELECT 'T1a'" },
+        { conn: 0, sql: "ROLLBACK" },
+      ]);
+    } finally {
+      await sql.close({ timeout: 0 }).catch(() => {});
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
   // Runs in a child process: bun:test would turn any unhandled rejection into a test
   // failure, and the second half of this contract is that one rejection IS reported.
   test("a rejected reserved begin() is reported as unhandled only when the caller ignores it", async () => {


### PR DESCRIPTION
### Problem

- `reserved.begin()` and `reserved.beginDistributed()` return the reservation's pool slot to the pool when they reject before `BEGIN` is sent. The caller still holds the reservation.
- The three early returns in `onTransactionConnected()` call `pool.release(pooledConnection)` without a `dontRelease` check (`src/js/bun/sql.ts:583`, `:599`, `:614` on main). The `finally` block at `:862` has the check. The reserved callers pass `dontRelease = true` and never called `pool.connect()`, so there is no increment for these releases to pair with.
- After the leaked release, a concurrent `sql.begin()` starts on the connection the reservation still uses. The later `reserved.release()` takes `queryCount` to -1. Since #33743, `connect(reserved = true)` treats a slot with `queryCount !== 0` as busy, so with `max: 1` every later `sql.begin()` or `sql.reserve()` waits forever.
- `reserved.begin()` also chained `promise.finally(...)` for the `close({ timeout })` bookkeeping and dropped the chained promise (`:402`, `:428`). When the transaction rejects, that chained promise rejects too, and nobody handles it. Every rejected reserved transaction, for example a callback that throws inside `try/catch`, printed an unhandled rejection and set the exit code to 1.
- `reserved.close({ timeout })` has the same defect one level up (`:473`). It waits with `Promise.all(...).finally(...)` on the promises the caller holds, so a transaction that fails while `close()` waits is reported as unhandled as well.

Repro against a real postgres with `max: 1` (release build): a pool `sql.begin()` starts on the reserved connection while `r` is held, the caught error is printed as unhandled, and on main the final `sql.begin()` never resolves.

```ts
const r = await sql.reserve();
await r.begin("read-only", async () => {}).catch(() => {}); // rejects: invalid options
const t = sql.begin(async () => {});                         // must wait, r holds the only slot
r.release();                                                 // queryCount: 0 -> -1
await t;
await sql.begin(async () => {});                             // hangs on main
```

### Fix

- The three early returns release the connection only when `dontRelease` is false. This is the same rule the `finally` block applies. A reserved connection belongs to the reservation until `reserved.release()`.
- `reserved.begin()` and `beginDistributed()` share a `runReservedTransaction()` helper. For each transaction it creates a second promise that only fulfills, stores that one in `reservedTransaction`, and passes two bound `settleReservedTransaction()` callbacks to `onTransactionConnected()`. Each callback removes the entry, fulfills it, then settles the caller's promise. Nothing is attached to the promise the caller gets, and `close({ timeout })` now waits on promises that cannot reject. Both helpers are defined outside `onReserveConnected()` and get the per-reservation state as arguments, so no function is created per reservation.
- This is correct because any handler attached to the caller's promise changes what the caller observes. `.then()` or `.finally()` marks the promise as handled, so a rejection the caller ignores is never reported. A `.finally()` chain adds a second rejection that the caller cannot handle. With no handler, a rejected reserved transaction is reported exactly when the caller ignores it, which is what `sql.begin()` does today.
- The third early return (`getTransactionCommands()` throws) gets the same check for consistency. No adapter with reserved connections throws there, so it has no test.
- Verified with `test/js/sql/sql-pool-transaction-isolation.test.ts`. It runs against in-process postgres and mysql wire mocks that record each statement per connection. New cases, per adapter:
  - `begin()` with invalid options and `beginDistributed()` with an invalid name: the recorded statements show that a concurrent `sql.begin()` waits for `release()`, and that the slot can be reserved again afterwards.
  - `reserved.close({ timeout })` waits for a reserved transaction that commits. This pins the success path that now resolves through the helper. It passes on main too.
  - `reserved.close({ timeout })` waits for a reserved transaction that fails and the caller catches. The `ROLLBACK` is recorded, and the test fails if `close()` reports the caught error as unhandled. It fails on main and on the first revision of this PR.
  - A child process handles one rejected reserved transaction and ignores another: exactly the ignored one reaches `unhandledRejection`. On main both are reported. A fix that attaches `.then()` to the promise reports neither. I checked both variants against this test.
- On main's `src/`, the eight new rejection tests fail at once (no timeouts) and the eight existing tests pass. With the fix all 18 pass under the debug (ASAN) build.
- The repro above and a script that exercises `reserved.begin()` success, array results, options, savepoints, a throwing callback, and `close({ timeout })` behave correctly against a real postgres with the fixed build.

### Background

- `sql.reserve()` takes one pooled connection out of the pool. The pool marks the slot with `queryCount = 1` and the `reserved` flag. `reserved.release()` calls `pool.release()` once, which brings the count back to 0 and makes the slot available again.
- `onTransactionConnected()` runs a transaction on a pooled connection. `sql.begin()` obtains the connection with `pool.connect()` and passes `dontRelease = false`, so the function releases it when the transaction ends. `reserved.begin()` passes the reservation's own connection and `dontRelease = true`, because the reservation still owns it afterwards.
- `reservedTransaction` is the set of in-flight transactions on a reservation. `reserved.close({ timeout })` waits for them before it closes the connection. On main the set holds the promises returned to the caller. With this change it holds one internal promise per transaction.
- A promise rejection is reported as unhandled when the promise has no reaction handler at the time it rejects. Attaching any handler, including `.finally()` or `Promise.all()`, marks the promise as handled. `.finally()` also returns a new promise that rejects with the same reason, and that one has no handler unless the code keeps it.

### Related

- #33743 fixed `sql.reserve()`'s own release path and left these early returns for a follow-up.
- `reserved.close({ timeout })` and `transaction.close({ timeout })` still wait on the caller's query objects with the same `.finally()` shape (`pending_queries` at `:473` and `:753` on main). A direct query that fails while `close()` waits is still reported as unhandled. The queries are tracked as the caller's objects in `state.queries`, so that needs the same kind of internal signal in the query tracking, which is shared with plain transactions. It is not touched here.

<details>
<summary>Revision history</summary>

- 09a06ca kept the caller's promise in `reservedTransaction` and only moved the removal into the settle wrappers. That fixed `reserved.begin()` itself, but `reserved.close({ timeout })` still produced an unhandled rejection when a caught transaction failed while it waited.
- e63835c switches the set to internal promises and adds the failing-transaction `close({ timeout })` test.
- f55cad2 moves the two helpers out of `onReserveConnected()` after review. The per-reservation state is passed as arguments and bound instead of captured.

</details>
