### PR TITLE
usockets: report a peer reset behind unread data as ECONNRESET, not 'end'

### DIFF
--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -588,6 +588,9 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
             struct us_loop_t* loop = s->group->loop;
             /* Captured before the read loop folds recv()==0 into `eof`; error events keep the error path. */
             const int hangup = (eof & LIBUS_POLL_HANGUP) && !error;
+            /* Set once recv() returns 0 below: the only proof that the peer's stream ended with a FIN. The
+             * eof hint this dispatch was called with (EPOLLHUP, kqueue's EV_EOF) also rides on a reset. */
+            int read_fin = 0;
             if (events & LIBUS_SOCKET_WRITABLE && !error) {
                 s->flags.last_write_failed = 0;
                 #ifdef LIBUS_USE_KQUEUE
@@ -669,9 +672,6 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                 }
 
                 size_t repeat_recv_count = 0;
-                /* Whether this dispatch's read loop delivered any bytes; see the
-                 * hung-up drain and its error handling below. */
-                int read_any = 0;
 
                 do {
                     #ifdef _WIN32
@@ -748,7 +748,6 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                                    : us_dispatch_data(s, loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, length);
                         /* After socket adoption, track the new socket; the old one becomes invalid */
                         s = us_internal_socket_follow_adopted(s);
-                        read_any = 1;
                         // loop->num_ready_polls isn't accessible on Windows.
                         #ifndef WIN32
                         // rare case: we're reading a lot of data, there's more to be read, and either:
@@ -820,21 +819,17 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         #endif
                     } else if (!length) {
                         eof = LIBUS_POLL_EOF; // lets handle EOF in the same place
+                        read_fin = 1;
                         break;
                     } else if (length == LIBUS_SOCKET_ERROR && !bsd_would_block()) {
-                        if (eof && read_any) {
-                            /* The hangup drain above already delivered this
-                             * connection's final data and then hit the error queued
-                             * behind its FIN (an RST from the peer tearing down right
-                             * after, often provoked by our own teardown writes). The
-                             * orderly EOF was announced and nothing readable remains:
-                             * report end-of-stream like a reader that stopped at the
-                             * FIN, not a read error. A hard error on the FIRST read of
-                             * a hung-up event (a pure RST: the kernel discards the
-                             * receive queue) still takes the error path below. */
-                            break;
-                        }
-                        /* Peer-initiated TCP error (RST etc.) — go straight to
+                        /* A read error closes with its errno even when the drain above
+                         * delivered data first, which is what libuv reports to node as
+                         * well: a reset behind unread data (the kernel keeps the receive
+                         * queue, so recv() returns the data and then the error) never
+                         * reached a FIN, so there is no end of stream to report. The eof
+                         * hint this event carried is the reset's own (EPOLLHUP; EV_EOF
+                         * with the error in fflags); a FIN is recv()==0 above.
+                         * Peer-initiated TCP error (RST etc.) — go straight to
                          * raw-close. us_socket_close() would route through
                          * us_internal_ssl_close() now that s->ssl is the
                          * discriminator, and that path fires
@@ -880,6 +875,17 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                  * this batch resumed it: reads are armed again and nothing was read
                  * here, so let the next poll re-report it together with READABLE and
                  * the read loop drain it, instead of closing over the unread tail. */
+                eof = 0;
+            }
+            if (eof && error && !read_fin) {
+                /* An error event whose read loop did not reach a FIN (the socket is
+                 * paused, or on_data paused it mid-drain): the eof hint next to the
+                 * error flag is the reset taking both directions down (EPOLLHUP beside
+                 * EPOLLERR; EV_EOF with the error in fflags), not an end of stream, so
+                 * it must not take the end path below. That path dispatched on_end for
+                 * a reset, and a TLS socket's on_end closes with a clean code itself,
+                 * so the error close never ran. A FIN this dispatch did read still
+                 * delivers its end first; the error close follows either way. */
                 eof = 0;
             }
             if(eof && s) {

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import { readFileSync, realpathSync } from "fs";
-import { bunEnv, bunExe, tls as cert1, isDebug } from "harness";
+import { bunEnv, bunExe, tls as cert1, isDebug, isWindows } from "harness";
 import https from "https";
 import net, { AddressInfo } from "net";
 import { createTest } from "node-harness";
@@ -2455,5 +2455,106 @@ describe("deferred spill-close", () => {
     } finally {
       server.close();
     }
+  });
+});
+
+describe.each(["tls", "net"])("%s server socket whose peer resets the connection behind unread data", transport => {
+  // The peer fills both kernel buffers while the accepted socket is paused, then
+  // resets the connection (RST) instead of ending it. Node reports that as a read
+  // error and never emits 'end'. allowHalfOpen keeps the accepted socket open
+  // after an 'end', so a reset misreported as an orderly end strands it.
+  async function acceptPausedSocketAndFill() {
+    const accepted = Promise.withResolvers<net.Socket>();
+    const onConnection = (socket: net.Socket) => {
+      socket.pause();
+      accepted.resolve(socket);
+    };
+    const server =
+      transport === "tls"
+        ? createServer({ ...COMMON_CERT, allowHalfOpen: true }, onConnection)
+        : net.createServer({ allowHalfOpen: true }, onConnection);
+    await once(server.listen(0, "127.0.0.1"), "listening");
+
+    const peerReady = Promise.withResolvers<void>();
+    const peer = await Bun.connect({
+      hostname: "127.0.0.1",
+      port: (server.address() as AddressInfo).port,
+      tls: transport === "tls" ? { ca: COMMON_CERT.cert } : undefined,
+      socket: {
+        open() {
+          if (transport !== "tls") peerReady.resolve();
+        },
+        handshake(_peer, success, verifyError) {
+          if (success) peerReady.resolve();
+          else peerReady.reject(verifyError ?? new Error("handshake failed"));
+        },
+        data() {},
+        close() {},
+        error(_peer, error) {
+          peerReady.reject(error);
+        },
+        connectError(_peer, error) {
+          peerReady.reject(error);
+        },
+      },
+    });
+    const socket = await accepted.promise;
+    await peerReady.promise;
+
+    const events: string[] = [];
+    let bytes = 0;
+    // Settles on 'close', or on the 'end' that must not happen, so a failure does
+    // not wait for the test timeout on a socket left half-open.
+    const settled = Promise.withResolvers<void>();
+    socket.on("data", chunk => (bytes += chunk.length));
+    socket.on("end", () => {
+      events.push("end");
+      settled.resolve();
+    });
+    socket.on("error", error => events.push(`error ${(error as NodeJS.ErrnoException).code}`));
+    socket.on("close", hadError => {
+      events.push(`close hadError=${hadError}`);
+      settled.resolve();
+    });
+    // Paused again: the 'data' listener above switched the stream to flowing.
+    socket.pause();
+
+    // A short write means the peer's send buffer and the server's receive buffer
+    // are both full: everything written so far is queued ahead of the reset.
+    const chunk = Buffer.alloc(64 * 1024, "r");
+    while (peer.write(chunk) === chunk.length) {}
+
+    return {
+      socket,
+      peer,
+      events,
+      bytesRead: () => bytes,
+      settled: settled.promise,
+      [Symbol.dispose]() {
+        socket.destroy();
+        server.close();
+      },
+    };
+  }
+
+  it("reports the reset that arrives while the socket is paused as ECONNRESET, not 'end'", async () => {
+    using t = await acceptPausedSocketAndFill();
+    t.peer.terminate();
+    await t.settled;
+    expect(t.events).toEqual(["error ECONNRESET", "close hadError=true"]);
+  });
+
+  it("delivers the data queued ahead of the reset and then reports ECONNRESET, not 'end'", async () => {
+    using t = await acceptPausedSocketAndFill();
+    // Both happen before the event loop runs again, so the socket's next read
+    // event carries the queued data and the reset together: the read loop drains
+    // the data and then gets the error from recv().
+    t.socket.resume();
+    t.peer.terminate();
+    await t.settled;
+    expect(t.events).toEqual(["error ECONNRESET", "close hadError=true"]);
+    // Windows discards the receive queue on a reset. Linux and macOS keep it, and
+    // like node, the data is delivered before the error.
+    if (!isWindows) expect(t.bytesRead()).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
### Problem

- A `tls.createServer` socket whose peer resets the connection (RST) while this side still has unread data emits only `'end'`. Node emits `'error'` with `code: 'ECONNRESET'` (`read ECONNRESET`) and never emits `'end'`. With `allowHalfOpen: true` the Bun socket then stays open forever. Found while working on #39548, whose TLS stub had to move into a Node child process because of this.
- A plain `net` server socket in the same situation emits `'end'` first. With the default `allowHalfOpen: false` the `'end'` destroys the socket and the `ECONNRESET` is lost too. With `allowHalfOpen: true` it emits `'end'`, then `'error'`.
- Cause, in `us_internal_dispatch_ready_poll` (`packages/bun-usockets/src/loop.c`):
  - `loop.c:885` (eof block): an event that carries the error flag (EPOLLERR next to EPOLLHUP) still takes the orderly end path first. For node sockets (always `allow_half_open` at this layer) that dispatches `on_end`, and only then does `loop.c:929` close with the socket error. A TLS socket's `on_end` (`us_internal_ssl_on_end`) closes the socket itself with the clean code 0, so the error close at `loop.c:929` finds a closed socket and the error is gone.
  - `loop.c:825` (read loop): a `recv()` error that followed data was folded into an end of stream (`if (eof && read_any) break;`) and went down the same end path. On Linux the kernel keeps the receive queue after a reset, so `recv()` returns the data and then `ECONNRESET`. This is the normal shape of a reset behind unread data.

### Fix

- The read loop closes with the `recv()` errno whether or not it delivered data first. Only `recv() == 0` sets the new `read_fin` flag.
- An error event whose read loop did not read a FIN (`eof && error && !read_fin`) skips the end path and goes straight to the existing error close, which reports `SO_ERROR`.
- A FIN that `recv()` did return on an error event keeps today's behavior: `on_end`, then the error close (`test-net-error-twice` and the `teardownNoise` logic in `net.ts` depend on that order).
- Why this is correct: it is what libuv reports to Node. `read()` returns the data and then the error, Node destroys the socket with `read ECONNRESET`, and `'end'` needs a real EOF. A FIN is the only thing that means end of stream. EPOLLHUP (and kqueue's EV_EOF with a nonzero `fflags`) is also set by a reset, so it cannot stand in for one once the error flag is present. The JS layer already turns a close that carries an errno into `read ECONNRESET` (`SocketEmitEndNT` in `src/js/node/net.ts`), so no JS change is needed.
- Verified with `test/js/node/tls/node-tls-server.test.ts`, "server socket whose peer resets the connection behind unread data": 4 tests (tls and net, reset while paused and reset drained behind data). All 4 fail on main (they observe `["end"]`) and pass with this change, with both the release binary and a debug build of main.
- The same scenario with `allowHalfOpen: false` now also gives `error ECONNRESET, close` for tls and net (script run, not a test: it is the same native path).
- Node v26.3.0 running the same server logic gives `error ECONNRESET (read ECONNRESET)`, `close hadError=true` in all variants.
- No regressions found: the 1026 vendored `test-net-*`, `test-tls-*`, `test-http-*`, `test-https-*` and `test-http2-*` files, `test/js/node/tls`, `test/js/node/net`, `test/js/node/http`, `test/js/bun/net`, `test/js/bun/http`, `test/js/web/fetch`, the nine `test-net-half-open-peer-reset-*` fixtures and `test/js/valkey/reliability/connection-failures.test.ts` were run on a debug build. Every remaining failure also fails on a debug build of main or on the release binary in this container (external network, `localhost` resolution, debug-build timing).

### Background

- usockets event dispatch: `us_internal_dispatch_ready_poll` receives three things per socket event: `events` (readable, writable), `error` (EPOLLERR, or kqueue EV_EOF with a socket error in `fflags`) and an `eof` hint (EPOLLHUP, which Linux sets once both directions are down, or kqueue EV_EOF). The read loop calls `recv()` until it returns 0 (a FIN), an error, or EAGAIN. After the loop, the eof block dispatches `on_end` and handles half-open, and the error block closes the socket with `SO_ERROR`.
- Reset behind unread data: when a peer sends data and then resets, Linux and macOS keep the data that is already in the receive queue. `recv()` returns it and then fails with `ECONNRESET`. The poll reports readable, error and hangup at the same time. Windows discards the queue, so `recv()` fails at once there. The test only asserts that data was delivered on POSIX.
- Half-open at this layer: every node socket, and every uWS HTTP socket, is `allow_half_open` in usockets. `net.ts` implements the JS `allowHalfOpen` option on top. That is why a reset on a node socket went through the half-open branch of the eof block, which is the branch that dispatches `on_end` and then falls through to the error close.
- TLS `on_end`: for node TLS sockets, `us_internal_ssl_on_end` does not dispatch an end event. It closes the socket with code 0 and `net.ts` synthesizes `'end'` from that clean close. That is why the lost error was visible on TLS sockets first: for plain sockets `on_end` only pushes EOF, and the error close that followed still reached JS in the `allowHalfOpen: true` case.
- Close codes: `on_close` receives either a usockets close code (0 clean, 1 reset, 2 fast shutdown) or, for closes driven by the event loop, an errno. `net.ts` destroys the socket with `read ECONNRESET` when the close carries an errno and an `'error'` listener exists.
