### PR TITLE
mimalloc: don't nanosleep(0) on the JS thread when waking from epoll

### DIFF
--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "aac01f9c9e195b087f2299b26fa84b6375f90149";
+const MIMALLOC_COMMIT = "6a14aee24315e503fa295a1fa90fe8b24ad91774";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "0b0153b299024baeb48c568ee3e46345238c3407";
+const MIMALLOC_COMMIT = "aac01f9c9e195b087f2299b26fa84b6375f90149";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "6e891cbe4790982ca9f3f9a60319a72e61b5d725";
+const MIMALLOC_COMMIT = "0b0153b299024baeb48c568ee3e46345238c3407";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -576,7 +576,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "2288897e2e716330490893d226b4f079f9da9e0c",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "0b0153b299024baeb48c568ee3e46345238c3407",
+    mimalloc: "aac01f9c9e195b087f2299b26fa84b6375f90149",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -576,7 +576,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "2288897e2e716330490893d226b4f079f9da9e0c",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "6e891cbe4790982ca9f3f9a60319a72e61b5d725",
+    mimalloc: "0b0153b299024baeb48c568ee3e46345238c3407",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -576,7 +576,7 @@ it("process.versions", () => {
   const expectedVersions = {
     boringssl: "2288897e2e716330490893d226b4f079f9da9e0c",
     libarchive: "ded82291ab41d5e355831b96b0e1ff49e24d8939",
-    mimalloc: "aac01f9c9e195b087f2299b26fa84b6375f90149",
+    mimalloc: "6a14aee24315e503fa295a1fa90fe8b24ad91774",
     picohttpparser: "066d2b1e9ab820703db0837a7255d92d30f0c9f5",
     zlib: "12731092979c6d07f42da27da673a9f6c7b13586",
     tinycc: "05f0fafaa3be31e31d7b4b5c17dc60f62c991171",


### PR DESCRIPTION
### What

Bump `oven-sh/mimalloc` to https://github.com/oven-sh/mimalloc/pull/21.

`_mi_prim_thread_yield()` on unix was `sleep(0)`, i.e. `nanosleep({0,0})` — a `clock_nanosleep` syscall that returns without rescheduling. `us_loop_run_bun_tick → mi_on_thread_idle_end → _mi_park_leave` calls it in a loop whenever the event-loop thread wakes while the mimalloc scavenger is mid-sweep of its heaps, so I/O-heavy scripts showed 1–6 `clock_nanosleep(CLOCK_REALTIME, 0, {0,0})` per run on the JS thread (found by diffing `strace -f -c` of 1.3.14 vs canary across ~45 scenarios).

The fork change: `sched_yield()` instead of `sleep(0)`, and `_mi_park_leave` pause-spins (≤256) before ever yielding — the sweeper stops at its next page, so the wake path is syscall-free in practice.

### Verify

`strace -f -c bun fs_promises.mjs` / `node_http.mjs` (200 ops each): canary shows `clock_nanosleep` 1–7; with this bump, 0 across 6 runs. mimalloc standalone ctest unchanged vs `bun-dev3-v2`.