### PR TITLE
install: percent-decode the credentials written into a registry or tarball URL

### DIFF
--- a/docs/pm/cli/add.mdx
+++ b/docs/pm/cli/add.mdx
@@ -231,7 +231,7 @@ bun add zod@https://registry.npmjs.org/zod/-/zod-3.21.4.tgz
 }
 ```
 
-A tarball URL can carry credentials, such as `https://user:password@example.com/zod-3.21.4.tgz`. Bun sends them as an `Authorization: Basic` header and requests the URL without them, like npm. The URL, credentials included, is written to `package.json` and to the lockfile.
+A tarball URL can carry credentials, such as `https://user:password@example.com/zod-3.21.4.tgz`. Bun sends them as an `Authorization: Basic` header and requests the URL without them, like npm. The URL, credentials included, is written to `package.json` and to the lockfile. Percent-encode a character that cannot be written in a URL: the password `p@ss` is written `p%40ss`. Bun decodes the credentials before it sends them.
 
 ---
 

--- a/docs/pm/scopes-registries.mdx
+++ b/docs/pm/scopes-registries.mdx
@@ -30,6 +30,8 @@ To configure a private registry scoped to a particular organization:
 "@myorg3" = { token = "$npm_token", url = "https://registry.myorg.com/" }
 ```
 
+Credentials written into a URL are percent-encoded, like the rest of the URL: the password `p@ss` is written `p%40ss`. Bun decodes them before it sends them. The `username`, `password` and `token` fields are sent as written.
+
 ### `.npmrc`
 
 Bun also reads [`.npmrc`](/pm/npmrc) files.

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -11,7 +11,7 @@ use bun_http::{
     HeaderBuilder, async_http::Options as AsyncHTTPOptions,
 };
 use bun_threading::thread_pool::Batch;
-use bun_url::URL;
+use bun_url::{PercentEncoding, URL};
 
 use crate::extract_tarball;
 use crate::npm::{self as npm, PackageManifest};
@@ -421,11 +421,11 @@ fn split_url_userinfo(url: &[u8]) -> Option<(&[u8], Box<[u8]>)> {
     Some((&rest[..at], without_userinfo.into_boxed_slice()))
 }
 
-/// `Basic base64(userinfo)` as written (no percent-decoding, `user` means `user:`), matching what npm sends via node's `auth` option.
+/// `Basic base64(user:pass)` with the userinfo percent-decoded, as curl and node's `http.get` send it: the URL
+/// spelling of a password `p@ss` is `p%40ss` (RFC 3986 section 3.2.1). `user` alone means `user:`.
 fn basic_authorization_from_userinfo(userinfo: &[u8]) -> Vec<u8> {
     const SCHEME: &[u8] = b"Basic ";
-    let mut user_pass = Vec::with_capacity(userinfo.len() + 1);
-    user_pass.extend_from_slice(userinfo);
+    let mut user_pass = PercentEncoding::decode_lenient_alloc(userinfo).into_vec();
     if !strings::contains_char(userinfo, b':') {
         user_pass.push(b':');
     }

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -153,16 +153,19 @@ pub mod api {
     }
 
     impl NpmRegistry {
+        /// The credentials in the URL are percent-encoded (RFC 3986 section 3.2.1: a
+        /// password `p@ss` is written `p%40ss`), so they are decoded here. The
+        /// `username`, `password` and `token` config keys are not, and stay as written.
         pub fn from_url(str: &[u8]) -> NpmRegistry {
             let url = bun_url::URL::parse(str);
             let mut registry = NpmRegistry::default();
 
             if url.username.is_empty() && !url.password.is_empty() {
-                registry.token = Box::from(url.password);
+                registry.token = bun_url::PercentEncoding::decode_lenient_alloc(url.password);
                 registry.url = url.href_without_auth();
             } else if !url.username.is_empty() && !url.password.is_empty() {
-                registry.username = Box::from(url.username);
-                registry.password = Box::from(url.password);
+                registry.username = bun_url::PercentEncoding::decode_lenient_alloc(url.username);
+                registry.password = bun_url::PercentEncoding::decode_lenient_alloc(url.password);
                 registry.url = url.href_without_auth();
             } else {
                 // Do not include a trailing slash. There might be parameters at the end.

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -1372,6 +1372,29 @@ impl PercentEncoding {
         Self::decode(&mut w, input)
     }
 
+    /// Decodes each `%XX` and keeps every other byte as written, a `%` that no two
+    /// hex digits follow included (the WHATWG percent-decode algorithm; curl
+    /// reads the userinfo of a URL the same way).
+    pub fn decode_lenient_alloc(input: &[u8]) -> Box<[u8]> {
+        let mut out: Vec<u8> = Vec::with_capacity(input.len());
+        let mut rest = input;
+        while let Some(percent) = strings::index_of_char_usize(rest, b'%') {
+            out.extend_from_slice(&rest[..percent]);
+            rest = &rest[percent..];
+            if let [b'%', hi, lo, ..] = rest
+                && let Some(byte) = bun_fmt::hex_pair_value(*hi, *lo)
+            {
+                out.push(byte);
+                rest = &rest[3..];
+            } else {
+                out.push(b'%');
+                rest = &rest[1..];
+            }
+        }
+        out.extend_from_slice(rest);
+        out.into_boxed_slice()
+    }
+
     pub fn decode_fault_tolerant<W: bun_core::io::Write, const FAULT_TOLERANT: bool>(
         writer: &mut W,
         input: &[u8],

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -915,16 +915,25 @@ describe.concurrent("bun-install", () => {
     }
 
     // Each row is the userinfo of the dependency URL and the `user:pass` the
-    // header must encode. It is sent as written: like npm (checked with npm
-    // 11), a missing password is sent as an empty one and percent-encoding is
-    // left alone. npm would percent-encode the second colon of the last row
-    // because it serializes the URL first.
+    // header must encode. The userinfo is percent-encoded like the rest of the
+    // URL (`p@ss` can only be written as `p%40ss`), so it is decoded the way
+    // curl and node's `http.get` decode it: the username is split off at the
+    // colon written in the URL, every `%XX` is decoded, a `%` that no two hex
+    // digits follow stays, and a missing password is sent as an empty one.
+    // npm 11 sends the userinfo undecoded, which makes such passwords
+    // impossible to use with it; it would also percent-encode the second
+    // colon of the last row because it serializes the URL first.
     it.each([
       ["a username and a password", "carol:s3cret", "carol:s3cret", []],
       ["a username and a password, isolated linker", "carol:s3cret", "carol:s3cret", ["--linker", "isolated"]],
       ["a username only", "carol", "carol:", []],
       ["a password only", ":s3cret", ":s3cret", []],
-      ["a percent-encoded password", "carol:s3%40cret", "carol:s3%40cret", []],
+      ["a percent-encoded password", "carol:s3%40cret", "carol:s3@cret", []],
+      ["a percent-encoded username and password", "us%25er:p%40ss%3Aw", "us%er:p@ss:w", []],
+      ["lowercase hex digits", "carol:s3%2fcret", "carol:s3/cret", []],
+      ["a percent sign that no hex digits follow", "carol:50%off%2F2", "carol:50%off/2", []],
+      ["a trailing percent sign", "carol:s3cret%", "carol:s3cret%", []],
+      ["a percent-encoded colon in the username", "car%3Aol", "car:ol:", []],
       ["a password containing a colon", "carol:s3:cret", "carol:s3:cret", []],
     ])("sends %s as Basic authorization", async (_, userinfo, userPass, args) => {
       const authorization = basic(userPass);

--- a/test/cli/install/config-precedence.test.ts
+++ b/test/cli/install/config-precedence.test.ts
@@ -21,6 +21,7 @@ let authToken: string;
 beforeAll(async () => {
   await registry.start();
   authToken = await registry.generateUser("config-precedence", "verysecure");
+  await registry.generateUser("percent-user", "p@ss:w%rd");
 });
 
 afterAll(() => {
@@ -740,6 +741,56 @@ describe.concurrent("bun install config precedence", () => {
     });
     expect(stderr).not.toContain("error:");
     expect(new Set(capture.authorizations)).toStrictEqual(new Set([basicAuth]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  // Credentials written into a URL are percent-encoded like the rest of it: the
+  // password `p@ss:w%rd` of `percent-user` can only be written as below. Every
+  // way a registry URL reaches bun decodes them before building the header.
+  // (A tarball dependency URL is covered in bun-install.test.ts.)
+  const encodedUserinfo = "percent%2Duser:p%40ss%3Aw%25rd";
+  const percentUserBasicAuth = `Basic ${Buffer.from("percent-user:p@ss:w%rd").toString("base64")}`;
+  type RegistrySetup = { files?: Record<string, string>; args?: string[]; env?: Record<string, string> };
+  const registryEntryPoints: [name: string, setup: (url: string, fallback: string) => RegistrySetup][] = [
+    ["bunfig registry string", url => ({ files: { "project/bunfig.toml": bunfig({ registry: url }) } })],
+    [
+      "bunfig scoped registry object",
+      (url, fallback) => ({
+        files: { "project/bunfig.toml": bunfig({ registry: fallback, scopes: { "needs-auth": { url } } }) },
+      }),
+    ],
+    ["project .npmrc registry=", url => ({ files: { "project/.npmrc": `registry=${url}\n` } })],
+    ["--registry", url => ({ args: ["--registry", url] })],
+    ["BUN_CONFIG_REGISTRY", url => ({ env: { BUN_CONFIG_REGISTRY: url } })],
+  ];
+
+  test.each(registryEntryPoints)("%s percent-decodes the user:password written into the URL", async (_, setup) => {
+    using dead = deadRegistry();
+    using capture = capturingRegistry();
+    const { files, args, env } = setup(withUserinfo(capture, encodedUserinfo), dead.url);
+    using dir = tempDir("config-precedence", {
+      ...files,
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir), args, env);
+    expect(stderr).not.toContain("error:");
+    expect(dead.hits).toBe(0);
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([percentUserBasicAuth]));
+    expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bunfig registry percent-decodes the :token written into its URL", async () => {
+    using capture = capturingRegistry();
+    const encodedToken = Array.from(Buffer.from(authToken), byte => `%${byte.toString(16).padStart(2, "0")}`).join("");
+    using dir = tempDir("config-precedence", {
+      "project/bunfig.toml": bunfig({ registry: withUserinfo(capture, `:${encodedToken}`) }),
+      "project/package.json": packageJson({ "@needs-auth/test-pkg": "1.0.0" }),
+    });
+    const { stderr, exitCode } = await install(String(dir));
+    expect(stderr).not.toContain("error:");
+    expect(new Set(capture.authorizations)).toStrictEqual(new Set([`Bearer ${authToken}`]));
     expect(installed(String(dir), "@needs-auth", "test-pkg")).toBe(true);
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
### Problem
- Credentials in a URL are percent-encoded (RFC 3986 section 3.2.1): a password `p@ss:w` is written `p%40ss%3Aw`. bun sends them as written, `Basic base64("us%25er:p%40ss%3Aw")`, and gets a 401. curl and node's `http.get` send `base64("us%er:p@ss:w")`. A password that needs encoding cannot be used at all.
- Neither builder decodes: `basic_authorization_from_userinfo` (`src/install/NetworkTask.rs`, tarball URLs, #38867) and `NpmRegistry::from_url` (`src/options_types/schema.rs`, registry URLs).

### Fix
- `PercentEncoding::decode_lenient_alloc` (`src/url/lib.rs`) decodes every `%XX` and keeps any other byte, a stray `%` included. That is WHATWG percent-decode and what curl does. A raw `%` keeps working. A password that itself contains `%40` is now written `%2540`, as for curl.
- `from_url` decodes `username`, `password` and the `:token@` form. The config keys of the same names are not URL text and stay as written. The tarball path splits at the colon written in the URL, then decodes, as curl and node do.
- Only the header changes. The lockfile, store names and printed URLs keep the URL as written.
- Verified: 6 new tests in `test/cli/install/config-precedence.test.ts` and 5 rows of the tarball table in `test/cli/install/bun-install.test.ts` fail on main. The other credential suites still pass (Notes).

### Background
- Userinfo is the `user:password@` part of a URL. `@`, `:`, `/` and `%` in it are written as `%XX`. The consumer decodes them. Basic authorization is `base64(user ":" password)` of the real bytes.
- npm 11 sends the userinfo undecoded (`minipass-fetch` passes the encoded WHATWG getters to node's `auth` option). #38867 matched that. Such passwords fail with npm too, so nothing depends on it.
- `from_url` splits a registry URL string (bunfig, `.npmrc`, `--registry`, env vars) into `username`/`password` or `token`, which `Scope::from_api` (`src/install/npm.rs`) sends as Basic or Bearer. A tarball dependency has no scope, so `for_tarball` builds its own header.

<details><summary>Notes</summary>

Request log of a loopback stub for `http://us%25er:p%40ss%3Aw@127.0.0.1:PORT/...`:

```
main, tarball dependency:            Basic dXMlMjVlcjpwJTQwc3MlM0F3   = us%25er:p%40ss%3Aw
main, [install.scopes] url:          Basic dXMlMjVlcjpwJTQwc3MlM0F3
curl 8.14, node http.get:            Basic dXMlZXI6cEBzczp3           = us%er:p@ss:w
this branch, both:                   Basic dXMlZXI6cEBzczp3
```

curl edge cases, checked against the same stub and encoded in the test table: `carol:50%off%2F2` sends `carol:50%off/2`, `carol:s3cret%` sends `carol:s3cret%`, `car%3Aol` sends `car:ol:` (the username is split off before decoding), lowercase hex decodes. The trailing `%` row passes on main too. It documents the lenient rule. node's `urlToHttpOptions` uses `decodeURIComponent` and throws on a stray `%`. curl keeps it. This change follows curl, which keeps today's behavior for such input.

Compatibility: the only input whose header changes is a userinfo that contains a valid `%XX` sequence. On main it was sent literally. Now it decodes, and the literal spelling is `%25XX`. That is the same rule every other client applies to the same URL, and the same URL did not work with npm 11 either (it sends the text undecoded, like main), so no URL that works today across tools changes meaning.

The new config-precedence tests cover the bunfig string form, a `[install.scopes]` object with a `url` (the reported registry case), `.npmrc` `registry=`, `--registry` and `BUN_CONFIG_REGISTRY`, all with `percent%2Duser:p%40ss%3Aw%25rd` against a verdaccio user whose password is `p@ss:w%rd`, plus a `:token@` whose every byte is written as `%xx`. On main each fails with `error: GET http://localhost:PORT//@needs-auth%2ftest-pkg - 401`.

`bun-install.test.ts` as a whole has 14 failures in this sandbox with and without the change: 13 tests that fetch from bitbucket, gitlab or some.url, and `should support --registry CLI flag`, whose listener binds `localhost` to `::1` here while the client connects to `127.0.0.1` (node behaves the same in this sandbox). `config-precedence.test.ts` passes completely (57 tests).

The proxy header already decodes (`build_proxy_authorization`, `src/http/AsyncHTTP.rs`, strict `decode_alloc`). `decode_lenient_alloc` is a separate function rather than a third mode of `decode_fault_tolerant`, whose fault tolerant mode is the `%PUBLIC_URL%` special case used by `URLPath`. The strict callers (`DirectoryRoute`, `fetch`, `package_json`, the proxy header) are unchanged.

`$VAR` expansion: `Scope::from_api` still expands a username, password or token that is exactly `$NAME`, as it did with the undecoded text. A registry URL that itself comes from a `$VAR` bunfig value is still not split at all (noted in #38796, unchanged here). `pm whoami` prints the decoded username, since it reads `Scope.user`.

Overlap: #39063 rewrites the same three assignments in `from_url` (username without a password). Whichever lands second keeps the decode calls on the same lines. #33617 (fetch) also decodes, so the Authorization builders agree once both land.

Also run with the fix: the rest of both test files, `npmrc.test.ts`, `redacted-config-logs.test.ts`, and the credential tests of `bun-publish`, `bun-audit`, `isolated-install` and `pm whoami`. `cargo clippy` and `cargo fmt --check` on `bun_url`, `bun_options_types` and `bun_install` are clean, as are prettier and the byte-search source lint. Docs: one sentence each in `docs/pm/cli/add.mdx` and `docs/pm/scopes-registries.mdx`.

</details>
