### PR TITLE
fetch: set TCP keepalive once per connection instead of once per request

### DIFF
--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1133,9 +1133,6 @@ impl<const SSL: bool> Drop for HTTPContext<SSL> {
 pub struct Handler<const SSL: bool>;
 
 impl<const SSL: bool> Handler<SSL> {
-    /// Fires once per connection, when a socket opened by `connect` /
-    /// `connect_socket` is established. Pooled sockets are re-attached in
-    /// `connect` without passing through here.
     pub fn on_open(ptr: *mut c_void, socket: HTTPSocket<SSL>) {
         let active = HTTPContext::<SSL>::get_tagged(ptr);
         if let Some(client) = active.client_mut() {

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1133,10 +1133,13 @@ impl<const SSL: bool> Drop for HTTPContext<SSL> {
 pub struct Handler<const SSL: bool>;
 
 impl<const SSL: bool> Handler<SSL> {
+    /// Fires once per connection, when a socket opened by `connect` /
+    /// `connect_socket` is established. Pooled sockets are re-attached in
+    /// `connect` without passing through here.
     pub fn on_open(ptr: *mut c_void, socket: HTTPSocket<SSL>) {
         let active = HTTPContext::<SSL>::get_tagged(ptr);
         if let Some(client) = active.client_mut() {
-            match client.on_open::<SSL>(socket) {
+            match client.on_connect::<SSL>(socket) {
                 Ok(_) => return,
                 Err(_) => {
                     bun_core::scoped_log!(HTTPContext, "Unable to open socket");

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1768,6 +1768,10 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
+    /// Attaches this client to an established socket and starts the request
+    /// on it. Called for a fresh connection from [`Self::on_connect`] and for
+    /// a socket taken from the keep-alive pool from `HTTPContext::connect`.
+    /// Per-connection setup does not belong here; see `on_connect`.
     pub(crate) fn on_open<const IS_SSL: bool>(
         &mut self,
         socket: HttpSocket<IS_SSL>,
@@ -1790,28 +1794,6 @@ impl<'a> HTTPClient<'a> {
         // was inside `on_writable`, which only runs *after* the handshake
         // completes. See https://github.com/oven-sh/bun/issues/30325.
         self.set_timeout(&socket);
-
-        // Enable TCP keepalive so a half-open connection (peer closed but the
-        // FIN/RST never reached us — NAT timeout, wifi/cellular handoff,
-        // middlebox state eviction, VPN disconnect) is detected in ~70s instead
-        // of hanging until an application-level timeout. Without this, a
-        // streaming `reader.read()` on a half-open socket blocks indefinitely.
-        // Matches Node/undici, which calls `socket.setKeepAlive(true, 60e3)` in
-        // buildConnector:
-        // https://github.com/nodejs/undici/blob/f33a6cb615e1/lib/core/connect.js#L121-L124
-        // TCP_KEEPIDLE=60, KEEPINTVL=1, KEEPCNT=10 — the latter two are hardcoded
-        // in bsd_socket_keepalive. The kernel default TCP_KEEPIDLE is 7200s, so
-        // bare SO_KEEPALIVE without the delay would be ineffective; 60 here sets
-        // TCP_KEEPIDLE=60s.
-        //
-        // `disable_keepalive` is set when fetch is called with `keepalive: false`,
-        // which is what `node:http`/`node:https` pass through from
-        // `agent.keepAlive` (see _http_client.ts) — so requests through
-        // `http.globalAgent` (`keepAlive: true`) get TCP keepalive and requests
-        // through a non-keepalive Agent or `agent: false` skip it, matching Node.
-        if !self.flags.disable_keepalive {
-            let _ = socket.set_keep_alive(true, 60);
-        }
 
         if self.signals.get(signals::Field::Aborted) {
             self.close_and_abort::<IS_SSL>(socket);
@@ -1889,6 +1871,47 @@ impl<'a> HTTPClient<'a> {
             self.first_call::<IS_SSL>(socket);
         }
         Ok(())
+    }
+
+    /// The uSockets open callback (`http_context::Handler::on_open`) for a
+    /// socket this client just connected. A socket taken from the keep-alive
+    /// pool does not come through here: `HTTPContext::connect` hands it to
+    /// [`Self::on_open`] directly. Socket options set here stay on the fd for
+    /// the life of the connection, so they are applied once per connection
+    /// rather than once per request.
+    pub(crate) fn on_connect<const IS_SSL: bool>(
+        &mut self,
+        socket: HttpSocket<IS_SSL>,
+    ) -> crate::Result<()> {
+        // Enable TCP keepalive so a half-open connection (peer closed but the
+        // FIN/RST never reached us — NAT timeout, wifi/cellular handoff,
+        // middlebox state eviction, VPN disconnect) is detected in ~70s instead
+        // of hanging until an application-level timeout. Without this, a
+        // streaming `reader.read()` on a half-open socket blocks indefinitely.
+        // Matches Node/undici, which calls `socket.setKeepAlive(true, 60e3)` in
+        // buildConnector:
+        // https://github.com/nodejs/undici/blob/f33a6cb615e1/lib/core/connect.js#L121-L124
+        // TCP_KEEPIDLE=60, KEEPINTVL=1, KEEPCNT=10 — the latter two are hardcoded
+        // in bsd_socket_keepalive. The kernel default TCP_KEEPIDLE is 7200s, so
+        // bare SO_KEEPALIVE without the delay would be ineffective; 60 here sets
+        // TCP_KEEPIDLE=60s.
+        //
+        // `disable_keepalive` is set when fetch is called with `keepalive: false`,
+        // which is what `node:http`/`node:https` pass through from
+        // `agent.keepAlive` (see _http_client.ts) — so requests through
+        // `http.globalAgent` (`keepAlive: true`) get TCP keepalive and requests
+        // through a non-keepalive Agent or `agent: false` skip it, matching Node.
+        // Like undici, this is decided once by the request that opens the
+        // connection; a `keepalive: false` request never takes a socket from
+        // the pool (`is_keep_alive_possible`), so reuse has nothing to undo.
+        //
+        // A unix socket has no TCP keepalive (Node's `setKeepAlive` is a no-op
+        // on a pipe handle too).
+        if !self.flags.disable_keepalive && self.unix_socket_path.slice().is_empty() {
+            let _ = socket.set_keep_alive(true, 60);
+        }
+
+        self.on_open::<IS_SSL>(socket)
     }
 
     /// Whether to advertise "h2" in the TLS ALPN list. Restricted to request

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1768,10 +1768,8 @@ impl<'a> HTTPClient<'a> {
         }
     }
 
-    /// Attaches this client to an established socket and starts the request
-    /// on it. Called for a fresh connection from [`Self::on_connect`] and for
-    /// a socket taken from the keep-alive pool from `HTTPContext::connect`.
-    /// Per-connection setup does not belong here; see `on_connect`.
+    /// Runs once per request: for a new connection via [`Self::on_connect`],
+    /// and for a socket reused from the pool via `HTTPContext::connect`.
     pub(crate) fn on_open<const IS_SSL: bool>(
         &mut self,
         socket: HttpSocket<IS_SSL>,
@@ -1873,12 +1871,9 @@ impl<'a> HTTPClient<'a> {
         Ok(())
     }
 
-    /// The uSockets open callback (`http_context::Handler::on_open`) for a
-    /// socket this client just connected. A socket taken from the keep-alive
-    /// pool does not come through here: `HTTPContext::connect` hands it to
-    /// [`Self::on_open`] directly. Socket options set here stay on the fd for
-    /// the life of the connection, so they are applied once per connection
-    /// rather than once per request.
+    /// Runs once per connection, from the uSockets open callback. A socket
+    /// reused from the pool skips this and goes straight to [`Self::on_open`],
+    /// so socket options belong here, not there.
     pub(crate) fn on_connect<const IS_SSL: bool>(
         &mut self,
         socket: HttpSocket<IS_SSL>,
@@ -1901,15 +1896,8 @@ impl<'a> HTTPClient<'a> {
         // `agent.keepAlive` (see _http_client.ts) — so requests through
         // `http.globalAgent` (`keepAlive: true`) get TCP keepalive and requests
         // through a non-keepalive Agent or `agent: false` skip it, matching Node.
-        // Like undici, the request that opens the connection decides this for
-        // the connection's whole life. A `keepalive: false` request does not
-        // take a socket from the pool (`is_keep_alive_possible`), so reuse has
-        // nothing to undo. It can still donate one: `build_request` clears
-        // `disable_keepalive` again for an explicit `Connection: keep-alive`
-        // header, and that socket is pooled without TCP keepalive.
         //
-        // A unix socket has no TCP keepalive (Node's `setKeepAlive` is a no-op
-        // on a pipe handle too).
+        // TCP options do not apply to a unix socket.
         if !self.flags.disable_keepalive && self.unix_socket_path.slice().is_empty() {
             let _ = socket.set_keep_alive(true, 60);
         }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1901,9 +1901,12 @@ impl<'a> HTTPClient<'a> {
         // `agent.keepAlive` (see _http_client.ts) — so requests through
         // `http.globalAgent` (`keepAlive: true`) get TCP keepalive and requests
         // through a non-keepalive Agent or `agent: false` skip it, matching Node.
-        // Like undici, this is decided once by the request that opens the
-        // connection; a `keepalive: false` request never takes a socket from
-        // the pool (`is_keep_alive_possible`), so reuse has nothing to undo.
+        // Like undici, the request that opens the connection decides this for
+        // the connection's whole life. A `keepalive: false` request does not
+        // take a socket from the pool (`is_keep_alive_possible`), so reuse has
+        // nothing to undo. It can still donate one: `build_request` clears
+        // `disable_keepalive` again for an explicit `Connection: keep-alive`
+        // header, and that socket is pooled without TCP keepalive.
         //
         // A unix socket has no TCP keepalive (Node's `setKeepAlive` is a no-op
         // on a pipe handle too).

--- a/test/js/web/fetch/fetch-tcp-keepalive.test.ts
+++ b/test/js/web/fetch/fetch-tcp-keepalive.test.ts
@@ -4,12 +4,19 @@
 // HTTP connection pooling) skips it. node:http forwards `agent.keepAlive`
 // to fetch's `keepalive`, so the same gate covers Node compat.
 //
+// The option lives on the fd, so it must be set once per connection: the
+// second half of the file counts the setsockopt(SO_KEEPALIVE) calls with an
+// LD_PRELOAD shim and checks that a request served by a pooled connection
+// does not set it again, and that a unix socket never sets it.
+//
 // Linux-only: reads /proc/<pid>/net/tcp for the kernel's view of the
-// socket's keepalive timer. Other platforms skip.
-import { expect, test } from "bun:test";
+// socket's keepalive timer, and uses LD_PRELOAD. Other platforms skip.
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import http from "node:http";
+import { join } from "node:path";
 
-const linuxOnly = test.skipIf(process.platform !== "linux");
+const linuxOnly = test.skipIf(!isLinux);
 
 // Spin up a server that holds the response open, run the request via
 // `startRequest`, and return the kernel timer field for the client
@@ -20,7 +27,13 @@ async function probeClientSocket(startRequest: (url: string) => Promise<{ drain:
   // ESTABLISHED long enough to inspect.
   await using server = Bun.serve({
     port: 0,
-    async fetch(req) {
+    async fetch(req, server) {
+      // The client's ephemeral port identifies the TCP connection that
+      // carried the request: a reused keep-alive socket keeps its port.
+      const headers = { "x-client-port": String(server.requestIP(req)?.port) };
+      if (new URL(req.url).pathname === "/warmup") {
+        return new Response("ok", { headers });
+      }
       // Keep the response streaming so the client socket stays open
       // while we inspect /proc/net/tcp from the client side.
       return new Response(
@@ -31,6 +44,7 @@ async function probeClientSocket(startRequest: (url: string) => Promise<{ drain:
             controller.close();
           },
         }),
+        { headers },
       );
     },
   });
@@ -90,6 +104,23 @@ linuxOnly("fetch keepalive: false skips SO_KEEPALIVE (matches undici options.kee
   expect(timerActive).toBe("00");
 });
 
+linuxOnly("a connection reused from the keep-alive pool still has TCP keepalive enabled", async () => {
+  const timerActive = await probeClientSocket(async url => {
+    // The first request opens the connection and, once its body is
+    // consumed, returns the socket to the pool.
+    const warmup = await fetch(new URL("/warmup", url));
+    await warmup.text();
+    // The second request must be served by that same connection, on which
+    // SO_KEEPALIVE was set only when it was opened.
+    const resp = await fetch(url);
+    expect(resp.headers.get("x-client-port")).toBe(warmup.headers.get("x-client-port"));
+    const reader = resp.body!.getReader();
+    await reader.read();
+    return { drain: () => reader.cancel() };
+  });
+  expect(timerActive).toBe("02");
+});
+
 linuxOnly("node:http with non-keepalive Agent skips SO_KEEPALIVE", async () => {
   // `agent: false` constructs a fresh `new Agent()` whose `keepAlive`
   // defaults to false; _http_client.ts forwards that as fetch
@@ -125,4 +156,143 @@ linuxOnly("node:http globalAgent (keepAlive: true) enables SO_KEEPALIVE", async 
     };
   });
   expect(timerActive).toBe("02");
+});
+
+// ---------------------------------------------------------------------------
+// setsockopt(SO_KEEPALIVE) call counting.
+//
+// The kernel exposes whether keepalive is on, not how many times it was set,
+// so the client runs in a child process with an LD_PRELOAD shim that logs one
+// "SO_KEEPALIVE fd=N" line to stderr per setsockopt(SOL_SOCKET, SO_KEEPALIVE)
+// call. The server runs in this process, so the child's only sockets are the
+// fetch client sockets.
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+const shimTests = test.skipIf(!isLinux || !cc);
+
+const SHIM_C = String.raw`
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int (*real_setsockopt)(int, int, int, const void *, socklen_t);
+
+int setsockopt(int fd, int level, int optname, const void *optval, socklen_t optlen) {
+    if (!real_setsockopt) {
+        real_setsockopt = (int (*)(int, int, int, const void *, socklen_t)) dlsym(RTLD_NEXT, "setsockopt");
+    }
+    if (level == SOL_SOCKET && optname == SO_KEEPALIVE) {
+        char line[64];
+        int n = snprintf(line, sizeof line, "SO_KEEPALIVE fd=%d\n", fd);
+        if (n > 0) {
+            ssize_t unused = write(2, line, (size_t) n);
+            (void) unused;
+        }
+    }
+    return real_setsockopt(fd, level, optname, optval, optlen);
+}
+`;
+
+// Sequential requests to one origin. Each response body is the client port
+// the server saw, so the output proves how many connections were used.
+const POOLED_FIXTURE = /* js */ `
+const ports = [];
+for (let i = 0; i < Number(process.env.REQUEST_COUNT); i++) {
+  const res = await fetch(process.env.SERVER_URL);
+  ports.push(await res.text());
+}
+console.log(JSON.stringify(ports));
+`;
+
+const UNIX_FIXTURE = /* js */ `
+const bodies = [];
+for (let i = 0; i < Number(process.env.REQUEST_COUNT); i++) {
+  const res = await fetch("http://localhost/", { unix: process.env.UNIX_PATH });
+  bodies.push(await res.text());
+}
+console.log(JSON.stringify(bodies));
+`;
+
+let shimDir: ReturnType<typeof tempDir> | undefined;
+let shimPath: string;
+
+beforeAll(async () => {
+  if (!isLinux || !cc) return;
+  shimDir = tempDir("fetch-so-keepalive-count", {
+    "shim.c": SHIM_C,
+    "pooled.js": POOLED_FIXTURE,
+    "unix.js": UNIX_FIXTURE,
+  });
+  shimPath = join(String(shimDir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(shimDir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) {
+    throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  }
+});
+
+afterAll(() => {
+  shimDir?.[Symbol.dispose]();
+});
+
+async function runWithShim(fixture: string, env: Record<string, string>) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), fixture],
+    cwd: String(shimDir),
+    env: {
+      ...bunEnv,
+      ...env,
+      LD_PRELOAD: bunEnv.LD_PRELOAD ? `${shimPath}:${bunEnv.LD_PRELOAD}` : shimPath,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const keepaliveCalls = stderr.match(/SO_KEEPALIVE fd=\d+/g) ?? [];
+  return { stdout, stderr, exitCode, keepaliveCalls };
+}
+
+shimTests("SO_KEEPALIVE is set once per connection, not once per request on a pooled connection", async () => {
+  await using server = Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch: (req, server) => new Response(String(server.requestIP(req)?.port)),
+  });
+
+  const { stdout, stderr, exitCode, keepaliveCalls } = await runWithShim("pooled.js", {
+    SERVER_URL: server.url.href,
+    REQUEST_COUNT: "5",
+  });
+
+  const ports: string[] = JSON.parse(stdout.trim());
+  // All five requests went over one connection...
+  expect(ports).toHaveLength(5);
+  expect(new Set(ports).size).toBe(1);
+  // ...so keepalive was set up exactly once.
+  expect(keepaliveCalls, stderr).toHaveLength(1);
+  expect(exitCode).toBe(0);
+});
+
+shimTests("fetch over a unix socket does not set SO_KEEPALIVE", async () => {
+  const unix = join(String(shimDir), "server.sock");
+  await using server = Bun.serve({
+    unix,
+    fetch: () => new Response("ok"),
+  });
+
+  const { stdout, stderr, exitCode, keepaliveCalls } = await runWithShim("unix.js", {
+    UNIX_PATH: unix,
+    REQUEST_COUNT: "2",
+  });
+
+  expect(JSON.parse(stdout.trim())).toEqual(["ok", "ok"]);
+  expect(keepaliveCalls, stderr).toHaveLength(0);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- `fetch` sets TCP keepalive on every request instead of once per connection. `HTTPClient::on_open` (`src/http/lib.rs`, added in #30733) calls `socket.set_keep_alive(true, 60)`, and `HTTPContext::connect` also calls `on_open` for a socket taken from the keep-alive pool.
- One `set_keep_alive` is four `setsockopt` calls on Linux (`SO_KEEPALIVE`, `TCP_KEEPIDLE`, `TCP_KEEPINTVL`, `TCP_KEEPCNT`). 200 sequential fetches to a local server make about 1000 `setsockopt` calls on the same fd. Version 1.3.14 made about 200.

### Fix
- Add `HTTPClient::on_connect`. It sets the option, then calls `on_open`. `Handler::on_open` in `src/http/HTTPContext.rs` now calls it. The pool reuse path still calls `on_open`, which no longer touches the option.
- Correct because the option lives on the fd: a pooled socket keeps what its first request set. The `keepalive: false` gate is unchanged, and such a request never takes a socket from the pool (`is_keep_alive_possible`).
- `on_connect` also skips unix sockets. `TCP_KEEPIDLE` fails on them and they are never pooled, so each unix request paid two wasted calls.
- Verified: `test/js/web/fetch/fetch-tcp-keepalive.test.ts`. The two new tests fail on the current canary (5 and 2 calls) and pass here (1 and 0). The four tests from #30733 still pass. Other suites are listed in the notes.

### Background
- The HTTP client keeps an idle connection in a pool (`HTTPContext::release_socket`). The next request to the same host takes it back in `HTTPContext::connect`, which calls `client.on_open` on it directly.
- `Handler::on_open` is the callback uSockets fires when a socket opened by `connect` or `connect_socket` becomes established. It runs once per connection, and a pooled socket does not pass through it.
- The kernel does not report how often an option was set. The test runs the client in a child process with an `LD_PRELOAD` shim that logs each `setsockopt(SO_KEEPALIVE)`. The server returns the client port of each request, which proves all requests used one connection. `serve-epoll-add-fail.test.ts` uses the same pattern.

<details><summary>Notes</summary>

- Shim output on the current canary, five requests over one connection: `SO_KEEPALIVE fd=9` five times. With this change: once.
- The new tests skip when the platform is not Linux or there is no C compiler, like the other shim tests.
- The file also gets a `/proc/self/net/tcp` test that checks a request served by a pooled connection still has the keepalive timer armed (`timer_active` = 02). It passes before and after. It guards the claim that the option survives pool reuse.
- A redirect to the same host also goes through the pool path, so it used to set the option again as well.
- Other suites run with this change: `fetch-keepalive`, `fetch-preconnect`, `fetch-connection-header`, `fetch.unix`, `fetch-redirect`, `fetch-retry-chunked`, `fetch-http2-client`, `tls-keepalive`, `proxy`, `proxy-stress-lifecycle`, `fetch-proxy-connect-tunnel-split-envelope`, `node-http-agent-tls-options`, `node-http`.
- `fetch-preconnect.test.ts` and the `issue#4295` proxy test in `node-http.test.ts` fail in my environment with and without this change. There, `localhost` resolves to `::1` first, so a server bound to `localhost` listens on `[::1]` while the client connects to `127.0.0.1`. That is a separate problem and is reported separately.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/fetch-tcp-keepalive.test.ts

<!-- robobun:evidence:end -->