### PR TITLE
node:http: check the native writeHead through the caller's exception scope (worker-terminate-funnels http)

### DIFF
--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -234,20 +234,6 @@ extern "C" EncodedJSValue Bun__NodeHTTP__buildRawHeadersArray(JSC::JSGlobalObjec
     RELEASE_AND_RETURN(scope, JSValue::encode(array));
 }
 
-// Scope-free VM::exception() read. A callee's ThrowScope destructor
-// simulates a throw so its caller must check; when the caller is Rust
-// (writeHeadAndEnd's write-head phase) there is no ThrowScope to do it, so
-// this acknowledges the check without declaring a scope (declaring one
-// would trip the verifier before the read). The actual success/failure
-// travels through NodeHTTPServer__writeHead's return value.
-extern "C" void Bun__NodeHTTP__acknowledgeThrowScope(JSC::JSGlobalObject* globalObject)
-{
-    // The same sanctioned read RETURN_IF_EXCEPTION performs; it observes
-    // (and under exception-scope verification, acknowledges) any pending
-    // exception without constructing a verifying scope.
-    (void)globalObject->vm().hasExceptionsAfterHandlingTraps();
-}
-
 // Defined in Rust (NodeHTTPResponse.rs): moves the captured raw header bytes
 // onto the native response so takeRawHeaders can materialize them on demand.
 extern "C" void NodeHTTPResponse__adoptRawRequestHeaders(void* nodeHttpResponse, const uint8_t* data, size_t length);
@@ -586,8 +572,12 @@ static void writeAutoHeaders(uWS::HttpResponse<isSSL>* response, uint32_t autoHe
 
 // Returns false when a JS exception is pending (header conversion or
 // validation threw). The exception check happens here, inside the owning
-// ThrowScope; callers on the Rust side branch on the return value instead
-// of probing VM exception state through another scope.
+// scope; callers on the Rust side branch on the return value instead of
+// probing VM exception state through another scope. TopExceptionScope rather
+// than ThrowScope because this returns to Rust, not to JS: a ThrowScope
+// destructor simulates a throw for its caller under validateExceptionChecks,
+// and the scope-less Rust caller has nothing to satisfy it with (same reason
+// as NAPI_PREAMBLE in napi.cpp).
 template<bool isSSL>
 static bool NodeHTTPServer__writeHead(
     JSC::JSGlobalObject* globalObject,
@@ -599,7 +589,7 @@ static bool NodeHTTPServer__writeHead(
     uWS::HttpResponse<isSSL>* response)
 {
     auto& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     JSObject* headersObject = headersObjectValue.getObject();
     if (!response->uWS::template AsyncSocket<isSSL>::isCorked() && response->getBufferedAmount() == 0) {

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -570,8 +570,6 @@ static void writeAutoHeaders(uWS::HttpResponse<isSSL>* response, uint32_t autoHe
     }
 }
 
-// Throws when header conversion or validation fails; the Rust caller checks
-// through its own scope (from_js_host_call_generic in write_head_internal).
 template<bool isSSL>
 static void NodeHTTPServer__writeHead(
     JSC::JSGlobalObject* globalObject,

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -570,10 +570,10 @@ static void writeAutoHeaders(uWS::HttpResponse<isSSL>* response, uint32_t autoHe
     }
 }
 
-// Returns false when a JS exception is pending (header conversion or
-// validation threw); the Rust callers branch on the return value.
+// Throws when header conversion or validation fails; the Rust caller checks
+// through its own scope (from_js_host_call_generic in write_head_internal).
 template<bool isSSL>
-static bool NodeHTTPServer__writeHead(
+static void NodeHTTPServer__writeHead(
     JSC::JSGlobalObject* globalObject,
     const char* statusMessage,
     size_t statusMessageLength,
@@ -583,8 +583,7 @@ static bool NodeHTTPServer__writeHead(
     uWS::HttpResponse<isSSL>* response)
 {
     auto& vm = globalObject->vm();
-    // Not a ThrowScope: the Rust caller has no scope to acknowledge its simulated throw with (see NAPI_PREAMBLE).
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSObject* headersObject = headersObjectValue.getObject();
     if (!response->uWS::template AsyncSocket<isSSL>::isCorked() && response->getBufferedAmount() == 0) {
@@ -608,9 +607,9 @@ static bool NodeHTTPServer__writeHead(
     if (headersObject) {
         if (auto* fetchHeaders = dynamicDowncast<WebCore::JSFetchHeaders>(headersObject)) {
             writeFetchHeadersToUWSResponse<isSSL>(fetchHeaders->wrapped(), response);
-            RETURN_IF_EXCEPTION(scope, false);
+            RETURN_IF_EXCEPTION(scope, void());
             if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
-            return true;
+            return;
         }
 
         // A flat [name, value, name, value, ...] array. Used by node:http's
@@ -622,14 +621,14 @@ static bool NodeHTTPServer__writeHead(
             unsigned length = pairsArray->length();
             for (unsigned i = 0; i + 1 < length; i += 2) {
                 JSValue nameValue = pairsArray->getIndex(globalObject, i);
-                RETURN_IF_EXCEPTION(scope, false);
+                RETURN_IF_EXCEPTION(scope, void());
                 JSValue headerValue = pairsArray->getIndex(globalObject, i + 1);
-                RETURN_IF_EXCEPTION(scope, false);
+                RETURN_IF_EXCEPTION(scope, void());
 
                 String name = nameValue.toWTFString(globalObject);
-                RETURN_IF_EXCEPTION(scope, false);
+                RETURN_IF_EXCEPTION(scope, void());
                 String value = headerValue.toWTFString(globalObject);
-                RETURN_IF_EXCEPTION(scope, false);
+                RETURN_IF_EXCEPTION(scope, void());
 
                 // node:http marks framing decisions with a NUL-named sentinel
                 // pair instead of a real header: value "1" = close-delimited
@@ -660,14 +659,14 @@ static bool NodeHTTPServer__writeHead(
 
                 writeResponseHeader<isSSL>(response, name, value);
             }
-            RETURN_IF_EXCEPTION(scope, false);
+            RETURN_IF_EXCEPTION(scope, void());
             if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
-            return true;
+            return;
         }
 
         if (headersObject->hasNonReifiedStaticProperties()) [[unlikely]] {
             headersObject->reifyAllStaticProperties(globalObject);
-            RETURN_IF_EXCEPTION(scope, false);
+            RETURN_IF_EXCEPTION(scope, void());
         }
 
         auto* structure = headersObject->structure();
@@ -691,31 +690,29 @@ static bool NodeHTTPServer__writeHead(
         } else {
             PropertyNameArrayBuilder propertyNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
             headersObject->getOwnPropertyNames(headersObject, globalObject, propertyNames, DontEnumPropertiesMode::Exclude);
-            RETURN_IF_EXCEPTION(scope, false);
+            RETURN_IF_EXCEPTION(scope, void());
 
             for (unsigned i = 0; i < propertyNames.size(); ++i) {
                 JSValue headerValue = headersObject->getIfPropertyExists(globalObject, propertyNames[i]);
-                RETURN_IF_EXCEPTION(scope, false);
+                RETURN_IF_EXCEPTION(scope, void());
                 if (!headerValue.isString()) {
                     continue;
                 }
 
                 String key = propertyNames[i].string();
                 String value = headerValue.toWTFString(globalObject);
-                RETURN_IF_EXCEPTION(scope, false);
+                RETURN_IF_EXCEPTION(scope, void());
 
                 writeResponseHeader<isSSL>(response, key, value);
             }
         }
     }
 
-    RETURN_IF_EXCEPTION(scope, false);
+    RETURN_IF_EXCEPTION(scope, void());
     if (autoHeaderBits) writeAutoHeaders<isSSL>(response, autoHeaderBits, keepAliveTimeoutSecs);
-
-    return true;
 }
 
-extern "C" bool NodeHTTPServer__writeHead_http(
+extern "C" void NodeHTTPServer__writeHead_http(
     JSC::JSGlobalObject* globalObject,
     const char* statusMessage,
     size_t statusMessageLength,
@@ -724,10 +721,10 @@ extern "C" bool NodeHTTPServer__writeHead_http(
     uint32_t keepAliveTimeoutSecs,
     uWS::HttpResponse<false>* response)
 {
-    return NodeHTTPServer__writeHead<false>(globalObject, statusMessage, statusMessageLength, headersObjectValue, autoHeaderBits, keepAliveTimeoutSecs, response);
+    NodeHTTPServer__writeHead<false>(globalObject, statusMessage, statusMessageLength, headersObjectValue, autoHeaderBits, keepAliveTimeoutSecs, response);
 }
 
-extern "C" bool NodeHTTPServer__writeHead_https(
+extern "C" void NodeHTTPServer__writeHead_https(
     JSC::JSGlobalObject* globalObject,
     const char* statusMessage,
     size_t statusMessageLength,
@@ -736,7 +733,7 @@ extern "C" bool NodeHTTPServer__writeHead_https(
     uint32_t keepAliveTimeoutSecs,
     uWS::HttpResponse<true>* response)
 {
-    return NodeHTTPServer__writeHead<true>(globalObject, statusMessage, statusMessageLength, headersObjectValue, autoHeaderBits, keepAliveTimeoutSecs, response);
+    NodeHTTPServer__writeHead<true>(globalObject, statusMessage, statusMessageLength, headersObjectValue, autoHeaderBits, keepAliveTimeoutSecs, response);
 }
 
 extern "C" EncodedJSValue NodeHTTPServer__onRequest_http(

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -571,13 +571,9 @@ static void writeAutoHeaders(uWS::HttpResponse<isSSL>* response, uint32_t autoHe
 }
 
 // Returns false when a JS exception is pending (header conversion or
-// validation threw). The exception check happens here, inside the owning
-// scope; callers on the Rust side branch on the return value instead of
-// probing VM exception state through another scope. TopExceptionScope rather
-// than ThrowScope because this returns to Rust, not to JS: a ThrowScope
-// destructor simulates a throw for its caller under validateExceptionChecks,
-// and the scope-less Rust caller has nothing to satisfy it with (same reason
-// as NAPI_PREAMBLE in napi.cpp).
+// validation threw); the Rust callers branch on that. TopExceptionScope, not
+// ThrowScope: this returns to scope-less Rust, which could not acknowledge the
+// simulated throw a ThrowScope destructor leaves behind (as in NAPI_PREAMBLE).
 template<bool isSSL>
 static bool NodeHTTPServer__writeHead(
     JSC::JSGlobalObject* globalObject,

--- a/src/jsc/bindings/NodeHTTP.cpp
+++ b/src/jsc/bindings/NodeHTTP.cpp
@@ -571,9 +571,7 @@ static void writeAutoHeaders(uWS::HttpResponse<isSSL>* response, uint32_t autoHe
 }
 
 // Returns false when a JS exception is pending (header conversion or
-// validation threw); the Rust callers branch on that. TopExceptionScope, not
-// ThrowScope: this returns to scope-less Rust, which could not acknowledge the
-// simulated throw a ThrowScope destructor leaves behind (as in NAPI_PREAMBLE).
+// validation threw); the Rust callers branch on the return value.
 template<bool isSSL>
 static bool NodeHTTPServer__writeHead(
     JSC::JSGlobalObject* globalObject,
@@ -585,6 +583,7 @@ static bool NodeHTTPServer__writeHead(
     uWS::HttpResponse<isSSL>* response)
 {
     auto& vm = globalObject->vm();
+    // Not a ThrowScope: the Rust caller has no scope to acknowledge its simulated throw with (see NAPI_PREAMBLE).
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     JSObject* headersObject = headersObjectValue.getObject();

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -230,8 +230,8 @@ unsafe extern "C" {
     // `&JSGlobalObject` encodes non-null/aligned; `status_message` is the
     // ptr/len of a Rust `&[u8]` and `response` is a live `uws::Response<SSL>*`
     // from the matched `AnyResponse` arm. Module-private with one call site.
-    // Returns false when the C++ header writer left a JS exception pending
-    // (checked inside its own scope; nothing to acknowledge here).
+    // May throw (header conversion or validation); `write_head_internal`
+    // calls it through `from_js_host_call_generic`.
     safe fn NodeHTTPServer__writeHead_http(
         global_object: &JSGlobalObject,
         status_message: *const u8,
@@ -240,7 +240,7 @@ unsafe extern "C" {
         auto_header_bits: u32,
         keep_alive_timeout_secs: u32,
         response: *mut c_void,
-    ) -> bool;
+    );
 
     safe fn NodeHTTPServer__writeHead_https(
         global_object: &JSGlobalObject,
@@ -250,7 +250,7 @@ unsafe extern "C" {
         auto_header_bits: u32,
         keep_alive_timeout_secs: u32,
         response: *mut c_void,
-    ) -> bool;
+    );
 }
 
 /// `VirtualMachine::get()` returns `*mut`; deref once for callers that need `&mut`.
@@ -992,20 +992,19 @@ impl NodeHTTPResponse {
             }
         }
 
-        let wrote_head_ok;
         'do_it: {
             if status_message_bytes.is_empty() {
                 if let Some(status_message) =
                     HTTPStatusText::get(u16::try_from(status_code).expect("int cast"))
                 {
-                    wrote_head_ok = write_head_internal(
+                    write_head_internal(
                         &raw_response,
                         global_object,
                         status_message,
                         headers_object_value,
                         auto_header_bits,
                         keep_alive_timeout_secs,
-                    );
+                    )?;
                     break 'do_it;
                 }
             }
@@ -1028,33 +1027,29 @@ impl NodeHTTPResponse {
                 stack_buf[..code.len()].copy_from_slice(code);
                 stack_buf[code.len()] = b' ';
                 stack_buf[code.len() + 1..n].copy_from_slice(message);
-                wrote_head_ok = write_head_internal(
+                write_head_internal(
                     &raw_response,
                     global_object,
                     &stack_buf[..n],
                     headers_object_value,
                     auto_header_bits,
                     keep_alive_timeout_secs,
-                );
+                )?;
             } else {
                 // Heap fallback for absurdly long status messages (> 252 bytes).
                 let mut heap = Vec::with_capacity(n);
                 heap.extend_from_slice(code);
                 heap.push(b' ');
                 heap.extend_from_slice(message);
-                wrote_head_ok = write_head_internal(
+                write_head_internal(
                     &raw_response,
                     global_object,
                     &heap,
                     headers_object_value,
                     auto_header_bits,
                     keep_alive_timeout_secs,
-                );
+                )?;
             }
-        }
-
-        if !wrote_head_ok {
-            return Err(jsc::JsError::Thrown);
         }
 
         Ok(JSValue::UNDEFINED)
@@ -1151,35 +1146,32 @@ fn write_head_internal(
     headers: JSValue,
     auto_header_bits: u32,
     keep_alive_timeout_secs: u32,
-) -> bool {
+) -> JsResult<()> {
     scoped_log!(
         NodeHTTPResponse,
         "writeHeadInternal({})",
         BStr::new(status_message)
     );
-    match response {
-        uws::AnyResponse::TCP(tcp) => NodeHTTPServer__writeHead_http(
-            global_object,
-            status_message.as_ptr(),
-            status_message.len(),
-            headers,
-            auto_header_bits,
-            keep_alive_timeout_secs,
-            (*tcp).cast::<c_void>(),
-        ),
-        uws::AnyResponse::SSL(ssl) => NodeHTTPServer__writeHead_https(
-            global_object,
-            status_message.as_ptr(),
-            status_message.len(),
-            headers,
-            auto_header_bits,
-            keep_alive_timeout_secs,
-            (*ssl).cast::<c_void>(),
-        ),
+    type WriteHead =
+        extern "C" fn(&JSGlobalObject, *const u8, usize, JSValue, u32, u32, *mut c_void);
+    let (write_head, response): (WriteHead, *mut c_void) = match response {
+        uws::AnyResponse::TCP(tcp) => (NodeHTTPServer__writeHead_http, (*tcp).cast::<c_void>()),
+        uws::AnyResponse::SSL(ssl) => (NodeHTTPServer__writeHead_https, (*ssl).cast::<c_void>()),
         uws::AnyResponse::H3(_) => {
             bun_core::Output::panic(format_args!("node:http does not support HTTP/3 responses"));
         }
-    }
+    };
+    bun_jsc::from_js_host_call_generic(global_object, || {
+        write_head(
+            global_object,
+            status_message.as_ptr(),
+            status_message.len(),
+            headers,
+            auto_header_bits,
+            keep_alive_timeout_secs,
+            response,
+        )
+    })
 }
 
 impl NodeHTTPResponse {

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -230,9 +230,8 @@ unsafe extern "C" {
     // `&JSGlobalObject` encodes non-null/aligned; `status_message` is the
     // ptr/len of a Rust `&[u8]` and `response` is a live `uws::Response<SSL>*`
     // from the matched `AnyResponse` arm. Module-private with one call site.
-    // Returns false when the C++ header writer left a JS exception pending.
-    // It checks that inside its own (Top)ExceptionScope and leaves nothing
-    // for this scope-less caller to acknowledge.
+    // Returns false when the C++ header writer left a JS exception pending
+    // (checked inside its own scope; nothing to acknowledge here).
     safe fn NodeHTTPServer__writeHead_http(
         global_object: &JSGlobalObject,
         status_message: *const u8,
@@ -1054,9 +1053,6 @@ impl NodeHTTPResponse {
             }
         }
 
-        // Propagate the failure that traveled through the return value;
-        // otherwise writeHeadAndEnd's end phase would run with an exception
-        // pending.
         if !wrote_head_ok {
             return Err(jsc::JsError::Thrown);
         }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -230,8 +230,6 @@ unsafe extern "C" {
     // `&JSGlobalObject` encodes non-null/aligned; `status_message` is the
     // ptr/len of a Rust `&[u8]` and `response` is a live `uws::Response<SSL>*`
     // from the matched `AnyResponse` arm. Module-private with one call site.
-    // May throw (header conversion or validation); `write_head_internal`
-    // calls it through `from_js_host_call_generic`.
     safe fn NodeHTTPServer__writeHead_http(
         global_object: &JSGlobalObject,
         status_message: *const u8,

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -219,10 +219,6 @@ unsafe extern "C" {
         length: usize,
         use_insecure_http_parser: bool,
     ) -> JSValue;
-    // Scope-free exception read: satisfies the exception-check verifier
-    // after a callee ThrowScope destructor simulated a throw for this
-    // (scope-less native) caller. A single traps check in release builds.
-    safe fn Bun__NodeHTTP__acknowledgeThrowScope(global_object: &JSGlobalObject);
     // Builds req.rawHeaders' flat [name, value, ...] JSArray from the header
     // bytes captured at dispatch ([u32 nameLen][u32 valueLen][name][value]...).
     safe fn Bun__NodeHTTP__buildRawHeadersArray(
@@ -234,8 +230,9 @@ unsafe extern "C" {
     // `&JSGlobalObject` encodes non-null/aligned; `status_message` is the
     // ptr/len of a Rust `&[u8]` and `response` is a live `uws::Response<SSL>*`
     // from the matched `AnyResponse` arm. Module-private with one call site.
-    // Returns false when the C++ header writer left a JS exception pending
-    // (checked inside its own ThrowScope).
+    // Returns false when the C++ header writer left a JS exception pending.
+    // It checks that inside its own (Top)ExceptionScope and leaves nothing
+    // for this scope-less caller to acknowledge.
     safe fn NodeHTTPServer__writeHead_http(
         global_object: &JSGlobalObject,
         status_message: *const u8,
@@ -1057,12 +1054,9 @@ impl NodeHTTPResponse {
             }
         }
 
-        // The writeHead ThrowScope's destructor simulates a throw so its
-        // caller must check; acknowledge it scope-free (we are that caller
-        // when running inside writeHeadAndEnd), then propagate the result
-        // that traveled through the return value - otherwise the end phase
-        // would run with an exception pending.
-        Bun__NodeHTTP__acknowledgeThrowScope(global_object);
+        // Propagate the failure that traveled through the return value;
+        // otherwise writeHeadAndEnd's end phase would run with an exception
+        // pending.
         if !wrote_head_ok {
             return Err(jsc::JsError::Thrown);
         }

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -20,6 +20,38 @@ const slow = isASAN || isDebug;
 uafTest("node-http-uaf-fixture.ts", { REQUESTS: slow ? "2000" : "10000" });
 uafTest("node-http-uaf-fixture-2.ts", { ROUNDS: "200" });
 
+// A termination request (worker.terminate(), a node:vm timeout) that landed on
+// the native writeHead of a response used to be taken in a stretch of native
+// code that had no exception scope. JSC's exception-check validator reports
+// that as "Unchecked JS exception ... NodeHTTPServer__writeHead" and aborts.
+// The validator only exists in debug and ASAN builds; release has nothing to
+// observe. The fixture steers node:vm deadlines onto that call. Against the
+// unfixed build, all 20 calibration runs (five at a time on a 16-core
+// debug+ASAN box) aborted, between attempt 350 and 1060. The fixed build
+// survived 20/20 runs of the full 3000 attempts, in 17 to 19 s each.
+test.concurrent.skipIf(!slow)(
+  "a termination request landing on the native writeHead passes the exception-check validator",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "node-http-writehead-termination-fixture.ts")],
+      env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // On a failure stdout stays empty and stderr carries the validator's report.
+    const summary = stdout.startsWith("ok ") ? JSON.parse(stdout.slice(3)) : stdout;
+    expect({ summary, stderr, exitCode }).toEqual({
+      summary: expect.objectContaining({ attempts: expect.any(Number) }),
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(summary.attempts).toBeGreaterThan(100);
+  },
+  60_000,
+);
+
 function uafTest(fixture: string, extraEnv: Record<string, string>) {
   test.concurrent(
     `should not crash on abort (${fixture})`,

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -42,12 +42,34 @@ test.concurrent.skipIf(!slow)(
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // On a failure stdout stays empty and stderr carries the validator's report.
     const summary = stdout.startsWith("ok ") ? JSON.parse(stdout.slice(3)) : stdout;
+    const counts = {
+      early: expect.any(Number),
+      inCall: expect.any(Number),
+      late: expect.any(Number),
+      cutAfterHead: expect.any(Number),
+    };
     expect({ summary, stderr, exitCode }).toEqual({
-      summary: expect.objectContaining({ attempts: expect.any(Number) }),
+      summary: {
+        attempts: expect.any(Number),
+        timeout: expect.any(Number),
+        paths: [
+          { name: "end", ...counts },
+          { name: "flushHeaders", ...counts },
+        ],
+      },
       stderr: "",
       exitCode: 0,
     });
     expect(summary.attempts).toBeGreaterThan(100);
+    // The deadlines did land inside both calls (about 45% of them do here), and
+    // on the end() path some were taken right after the native writeHead had
+    // put the head out (20 to 30% of that path's attempts here).
+    const [end, flushHeaders] = summary.paths;
+    expect({ end: end.inCall > 0, flushHeaders: flushHeaders.inCall > 0, cutAfterHead: end.cutAfterHead > 0 }).toEqual({
+      end: true,
+      flushHeaders: true,
+      cutAfterHead: true,
+    });
   },
   60_000,
 );

--- a/test/js/node/http/node-http-writehead-termination-fixture.ts
+++ b/test/js/node/http/node-http-writehead-termination-fixture.ts
@@ -38,7 +38,7 @@ const run = (call: string) =>
 const paths = [
   { name: "end", script: run("end") },
   { name: "flushHeaders", script: run("flushHeaders") },
-].map(path => ({ ...path, target: 0, step: 0.1, lastDirection: 0, early: 0, inCall: 0, late: 0 }));
+].map(path => ({ ...path, target: 0, step: 0.1, lastDirection: 0, early: 0, inCall: 0, late: 0, cutAfterHead: 0 }));
 
 let timeout = 2;
 let firedBeforeScript = 0;
@@ -56,8 +56,10 @@ const server = http.createServer((req, res) => {
   ctx.armedAt = performance.now();
   try {
     path.script.runInContext(ctx, { timeout });
-  } catch {
-    // ERR_SCRIPT_EXECUTION_TIMEOUT: the deadline cut the run short.
+  } catch (e) {
+    // The deadline cut the run short. Anything else is a real failure of the
+    // call under test: let it take the process down.
+    if ((e as NodeJS.ErrnoException)?.code !== "ERR_SCRIPT_EXECUTION_TIMEOUT") throw e;
   }
   ctx.res = null;
 
@@ -85,13 +87,17 @@ const server = http.createServer((req, res) => {
   }
 
   // Whatever state the run left the response in, complete it outside the
-  // deadline. When that is impossible (the head went out natively but the run
-  // was cut before JS learned about it), drop the connection instead; the
-  // client reconnects.
+  // deadline. The one state in which that fails is a cut that landed after the
+  // native writeHead had put the head on the wire but before JS recorded it:
+  // end() then reports the head as already sent. Drop that connection, the
+  // client reconnects. Any other error is a real failure.
   if (!res.finished) {
     try {
       res.end();
-    } catch {
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException)?.code;
+      if (code !== "ERR_HTTP_HEADERS_SENT" && code !== "ERR_STREAM_ALREADY_FINISHED") throw e;
+      path.cutAfterHead++;
       req.socket.destroy();
     }
   }
@@ -105,7 +111,7 @@ server.listen(0, "127.0.0.1", () => {
     const summary = {
       attempts,
       timeout,
-      paths: paths.map(({ name, early, inCall, late }) => ({ name, early, inCall, late })),
+      paths: paths.map(({ name, early, inCall, late, cutAfterHead }) => ({ name, early, inCall, late, cutAfterHead })),
     };
     console.log("ok " + JSON.stringify(summary));
     process.exit(0);

--- a/test/js/node/http/node-http-writehead-termination-fixture.ts
+++ b/test/js/node/http/node-http-writehead-termination-fixture.ts
@@ -1,0 +1,145 @@
+// Lands a termination request on the native writeHead of node:http responses as
+// often as it can. Spawned by node-http-uaf.test.ts with
+// BUN_JSC_validateExceptionChecks=1.
+//
+// node:vm's `timeout` is a JSC termination deadline: a timer thread requests the
+// VM's termination exactly like worker.terminate() does, and the request is
+// taken at the next exception check. Native code that returns to a caller with
+// no exception scope of its own, right after such a check, is where the
+// validator catches a request taken in the wrong place (it aborts the
+// process). Each request below is one attempt: the handler makes the call that
+// writes the head under a deadline, notes whether the deadline landed before
+// or after the call returned, and moves the call so that the deadline keeps
+// landing around the moment the native writeHead returns. Attempts alternate
+// between res.end() (handle.writeHeadAndEnd) and res.flushHeaders()
+// (handle.writeHead), the two entry points of the native writeHead.
+import http from "node:http";
+import net from "node:net";
+import vm from "node:vm";
+
+const ATTEMPTS = Number(process.env.ATTEMPTS ?? 3000);
+const BUDGET_MS = Number(process.env.BUDGET_MS ?? 30_000);
+
+// The run spins until `armedAt + target` (the deadline is armed shortly after
+// `armedAt` is taken, so however long entering the context takes, the call
+// starts a fixed time before the deadline) and then makes the call. `t`
+// records how far it got: [] the deadline fired before the script started,
+// [1] while spinning, [1, 2] inside the call, [1, 2, 3] the call returned
+// first (the deadline is cancelled when the run completes).
+const ctx = vm.createContext({
+  now: () => performance.now(),
+  res: null as http.ServerResponse | null,
+  armedAt: 0,
+  target: 0,
+  t: [] as number[],
+});
+const run = (call: string) =>
+  new vm.Script(`t.push(1); { const u = armedAt + target; while (now() < u); } t.push(2); res.${call}(); t.push(3);`);
+const paths = [
+  { name: "end", script: run("end") },
+  { name: "flushHeaders", script: run("flushHeaders") },
+].map(path => ({ ...path, target: 0, step: 0.1, lastDirection: 0, early: 0, inCall: 0, late: 0 }));
+
+let timeout = 2;
+let firedBeforeScript = 0;
+let attempts = 0;
+const started = performance.now();
+
+const server = http.createServer((req, res) => {
+  const path = paths[attempts++ % paths.length];
+  // Every response is a bare header block, so the client can tell where one
+  // response ends whichever of the two calls wrote it.
+  res.setHeader("content-length", "0");
+  ctx.res = res;
+  ctx.target = path.target;
+  ctx.t.length = 0;
+  ctx.armedAt = performance.now();
+  try {
+    path.script.runInContext(ctx, { timeout });
+  } catch {
+    // ERR_SCRIPT_EXECUTION_TIMEOUT: the deadline cut the run short.
+  }
+  ctx.res = null;
+
+  if (ctx.t.length === 0) {
+    // Entering the context alone outlived the deadline: a slow machine. Give
+    // the runs more time.
+    if (++firedBeforeScript % 20 === 0 && timeout < 20) {
+      timeout++;
+      for (const p of paths) p.target++;
+    }
+  } else {
+    // end() sets `finished` right after its native call returns, so it tells
+    // "after the call" more precisely than the script's own last marker.
+    const late = ctx.t.length === 3 || res.finished;
+    if (late) path.late++;
+    else if (ctx.t.length === 2) path.inCall++;
+    else path.early++;
+    // The call returned before the deadline: start it later next time, and
+    // the other way round. Once the target has crossed the deadline for the
+    // first time, hunt around it in small steps.
+    const direction = late ? 1 : -1;
+    if (path.lastDirection !== 0 && direction !== path.lastDirection) path.step = 0.02;
+    path.lastDirection = direction;
+    path.target = Math.max(0, path.target + direction * path.step);
+  }
+
+  // Whatever state the run left the response in, complete it outside the
+  // deadline. When that is impossible (the head went out natively but the run
+  // was cut before JS learned about it), drop the connection instead; the
+  // client reconnects.
+  if (!res.finished) {
+    try {
+      res.end();
+    } catch {
+      req.socket.destroy();
+    }
+  }
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const port = (server.address() as net.AddressInfo).port;
+  const request = "GET / HTTP/1.1\r\nHost: a\r\n\r\n";
+
+  function done() {
+    const summary = {
+      attempts,
+      timeout,
+      paths: paths.map(({ name, early, inCall, late }) => ({ name, early, inCall, late })),
+    };
+    console.log("ok " + JSON.stringify(summary));
+    process.exit(0);
+  }
+
+  function connect() {
+    if (attempts >= ATTEMPTS || performance.now() - started > BUDGET_MS) return done();
+    const socket = net.connect(port, "127.0.0.1");
+    let buffered = "";
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    const send = () => {
+      socket.write(request);
+      // A response that never comes (the server dropped this connection, or a
+      // cut run left it half written) must not stall the loop.
+      watchdog = setTimeout(() => socket.destroy(), 2_000);
+    };
+    socket.setEncoding("latin1");
+    socket.on("connect", send);
+    socket.on("data", chunk => {
+      buffered += chunk;
+      // One request is in flight at a time, so a status line followed by the
+      // end of a header block is the whole response to it; anything else that
+      // trickles in is discarded along with it.
+      if (!buffered.includes("HTTP/1.") || !buffered.includes("\r\n\r\n")) return;
+      buffered = "";
+      clearTimeout(watchdog);
+      if (attempts >= ATTEMPTS || performance.now() - started > BUDGET_MS) return done();
+      send();
+    });
+    socket.on("error", () => {});
+    socket.on("close", () => {
+      clearTimeout(watchdog);
+      connect();
+    });
+  }
+  connect();
+});


### PR DESCRIPTION
### Problem
- `worker-terminate-funnels.test.ts` (http) goes red on x64-asan (builds 100863, 100211): `Unchecked JS exception: This scope can throw a JS exception: NodeHTTPServer__writeHead @ NodeHTTP.cpp:602 ... unchecked as of this scope: handleTraps @ VMTraps.cpp:444`, then `ASSERTION FAILED: exception check validation failed`.
- Cause: `Bun__NodeHTTP__acknowledgeThrowScope` (`src/jsc/bindings/NodeHTTP.cpp:243`, #32488) acknowledged writeHead's simulated throw through `vm.hasExceptionsAfterHandlingTraps()`. With a termination trap pending, that runs `handleTraps()` first, and its ThrowScope constructor fails the check. `RETURN_IF_EXCEPTION` reads `exception()` before it services traps.
- The trap must land in the few microseconds between writeHead's last internal check and that read: about two hits in 650 builds.

### Fix
- `write_head_internal` calls `NodeHTTPServer__writeHead_{http,https}` through `from_js_host_call_generic` and returns `JsResult`. The helper, its FFI call and the bool return value go away; the C++ keeps its ThrowScope and returns void again.
- Correct because this is the convention for a C++ callee that owns a ThrowScope: the Rust scope is declared before the call, and its `return_if_exception()` reads the exception first and services traps second, like a C++ caller's `RETURN_IF_EXCEPTION`. The edge stays under verification. A termination that lands in the old window now comes back as `Err`, so `writeHeadAndEnd` skips its end phase.
- In release builds the check is one `Bun__RETURN_IF_EXCEPTION` call, the same cost as the deleted helper.
- Verified: new test in `test/js/node/http/node-http-uaf.test.ts`. Unfixed, 20 of 20 runs abort within 1060 attempts. Fixed, 10 of 10 runs survive 3000 (30 of 30 on the first version). Also the funnel test, `node-http.test.ts` and 18 vendored writeHead tests under validation.

### Background
- Exception-check validation (`BUN_JSC_validateExceptionChecks=1`, on for the asan lanes): a `ThrowScope` destructor marks the VM "caller must check". Reading `vm.exception()` clears the mark. Constructing a scope while it is set aborts with the message above.
- `from_js_host_call_generic` (`call_check_slow`) is the Rust side of that protocol for a callee whose return value says nothing about exceptions: a scope around the call, then `return_if_exception()`.
- A VM trap is a bit another thread sets (`worker.terminate()`, node:vm `timeout`). `handleTraps()` turns it into a TerminationException.

<details><summary>Notes</summary>

**History of this PR.** The first version replaced the ThrowScope with a `TopExceptionScope`, which leaves no mark and so needs no caller-side check. Review (dylan-conway) pointed out that this opts the call edge out of verification, which is the right trade only when the caller genuinely cannot check (napi's C callers); this caller can, so the current version keeps the ThrowScope and checks from Rust. The test did not change between the two versions.

**Culprit.** The helper landed in 4bbe0751a2 (#32488, July 16). The funnel test that observes it landed in #37075 (August 8). The two CI hits are on unrelated branches (build 100211 touches H2 header identifiers, build 100863 touches the fuzzilli script), so this is main's. #37267 (`ensureTerminationExceptionPending`) and #39410 (`getErrorMap`) are other sites of the same family and do not cover this one.

**Other scope-free callers of `hasExceptionsAfterHandlingTraps()`** in `src/` (blast radius of the same mistake): `RELEASE_RETURN_IF_EXCEPTION` (ErrorCode.h) and `ConversionResult::hasException` (JSDOMConvertResult.h) read `exception()` first, like `RETURN_IF_EXCEPTION`. `dispatchExitInternal` (BunProcess.cpp:302) calls it with no ThrowScope callee in between, so nothing is left unacknowledged when it runs. The sqlite authorizer (NodeSqlite.cpp:1912) acknowledges with a plain `scope.exception()`. The deleted helper was the only one that serviced traps as its way of acknowledging.

**Why it is rare.** Every `RETURN_IF_EXCEPTION` inside writeHead takes a pending trap itself and makes the function return early, which the old helper handled fine. Only a trap that fired after the last of those checks (during `writeAutoHeaders`, the scope destructor, and the return through `write_head_internal`) reached the helper with the bit still set. The funnel's only worker-side writeHead is `http.Server request [after]`, where `terminate()` races the worker's own `res.end("x")`.

**Probes against the unfixed build at HEAD** (`681a49bee1`, the same debug+ASAN build type as `bun bd`, `BUN_JSC_validateExceptionChecks=1`):
- 320 worker lifecycles that `terminate()` a worker saturated with pipelined node:http responses: 0 hits. The window is too small for an untargeted race.
- node:vm `timeout` (a `TerminationDeadline`, which calls `notifyNeedTermination()` from a timer thread exactly like `terminate()`) aimed at the response head: 8 of 8 processes aborted within 16 s, every one with the exact CI message (`NodeHTTPServer__writeHead @ NodeHTTP.cpp:602` / `handleTraps @ VMTraps.cpp:444`). The same probe against the first fixed build: 34481 attempts, 0 aborts, no other signature.
- The committed fixture, unfixed build, 20 runs five at a time, aborted at attempts 1040 1060 660 840 810 950 750 740 810 700 390 740 350 680 490 560 770 640 530 440. Hits cluster once the JIT has warmed the header path up, which is why the fixture runs 3000 attempts (17 s alone, 18 to 20 s inside the test file, whose existing fixtures already take 22 to 28 s). Sweeps at 150, 300 and 600 attempts aborted in 1, 0 to 3, and 5 to 6 of 10 runs. 1500 and 3000 attempts aborted in 20 of 20 and 30 of 30.
- The fixture alternates `res.end()` (`handle.writeHeadAndEnd`, the CI path) and `res.flushHeaders()` (`handle.writeHead`). Both reach `write_head_impl`, which held the deleted call. Over 9000 fixed-build attempts the run's catch saw only `ERR_SCRIPT_EXECUTION_TIMEOUT`, and the fallback `end()` saw only `ERR_HTTP_HEADERS_SENT`, on the end() path only; the fixture rethrows anything else.

**Suites run on the current version under validation:** `node-http-uaf.test.ts` (9 of 9), the funnel http family (all 10 families on the first version), `node-http.test.ts` (144 pass, 1 skip, and `request via http proxy`, which fails the same way on the unfixed build in this container, where `localhost` resolves to `::1` for the listener and `127.0.0.1` for the client), `node-http-transfer-encoding.test.ts`, `numeric-header.test.ts`, `early-hints-crlf-injection.test.ts` (35 of 35), and these vendored tests: `test-http-write-head{,-2,-after-set-header}`, `test-http-response-{multiheaders,multi-content-length,no-headers,setheaders,splitting,status-message,statuscode,writehead-returns-this,add-header-after-sent,remove-header-after-sent,cork}`, `test-http-head-{request,response-has-no-body,response-has-no-body-end,response-has-no-body-end-implicit-headers}` (18 of 18). They cover the header array path with duplicates and invalid characters (the throwing path through the new `JsResult`), the no-headers path, 204/304 and HEAD. `cargo clippy -p bun_runtime` is clean.

</details>
