### PR TITLE
bun-types: fix the eight open types issues

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
       "name": "bun-types",
       "dependencies": {
         "@types/node": "*",
+        "undici-types": "*",
       },
     },
   },

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4619,7 +4619,7 @@ declare module "bun" {
 
   interface WebSocketEventMap {
     close: CloseEvent;
-    error: Event;
+    error: ErrorEvent;
     message: MessageEvent;
     open: Event;
   }
@@ -4699,9 +4699,10 @@ declare module "bun" {
     onmessage: ((this: WebSocket, ev: MessageEvent) => any) | null;
 
     /**
-     * Event handler for error event
+     * Event handler for error event. Bun dispatches an {@link ErrorEvent}, so
+     * `ev.message` and `ev.error` describe the failure.
      */
-    onerror: ((this: WebSocket, ev: Event) => any) | null;
+    onerror: ((this: WebSocket, ev: ErrorEvent) => any) | null;
 
     /**
      * Event handler for close event
@@ -9337,10 +9338,10 @@ declare module "bun" {
      */
     resize(width: number, height: number): Promise<void>;
 
-    /** Navigate back in session history. */
-    back(): Promise<void>;
-    /** Navigate forward in session history. */
-    forward(): Promise<void>;
+    /** Navigate back in session history. Resolves without navigating when there is no previous entry. */
+    goBack(): Promise<void>;
+    /** Navigate forward in session history. Resolves without navigating when there is no next entry. */
+    goForward(): Promise<void>;
     /** Reload the current page. */
     reload(): Promise<void>;
 

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -66,10 +66,50 @@ declare module "bun" {
     type LibEmptyOrReadableStreamBYOBRequest = LibDomIsLoaded extends true
       ? {}
       : import("node:stream/web").ReadableStreamBYOBRequest;
+
+    /**
+     * Like a `BodyMixin`, but implemented by more types, such as
+     * `Blob`, `ReadableStream`, and `Response`.
+     *
+     * It has no `blob()` method because it's the lowest common
+     * denominator of these objects: a `Blob` in Bun does not have a
+     * `.blob()` method.
+     */
+    interface BunConsumerConvenienceMethods {
+      /**
+       * Consume as text
+       */
+      text(): Promise<string>;
+
+      /**
+       * Consume as a Uint8Array, backed by an ArrayBuffer
+       */
+      bytes(): Promise<Uint8Array<ArrayBuffer>>;
+
+      /**
+       * Consume as JSON
+       */
+      json(): Promise<any>;
+    }
+
+    /**
+     * The methods Bun adds to `ReadableStream`. Both the global `ReadableStream`
+     * interface (whether lib.dom.d.ts declares it or not) and the one exported
+     * by `node:stream/web` (see overrides.d.ts) extend this, so the two stay
+     * assignable to each other.
+     */
+    interface BunReadableStreamConsumerMethods extends BunConsumerConvenienceMethods {
+      /**
+       * Consume as a Blob
+       */
+      blob(): Promise<Blob>;
+    }
   }
 }
 
-interface ReadableStream<R = any> extends Bun.__internal.LibEmptyOrNodeReadableStream<R> {}
+interface ReadableStream<R = any>
+  extends Bun.__internal.LibEmptyOrNodeReadableStream<R>,
+    Bun.__internal.BunReadableStreamConsumerMethods {}
 declare var ReadableStream: Bun.__internal.UseLibDomIfAvailable<
   "ReadableStream",
   {
@@ -1031,6 +1071,20 @@ declare class BuildMessage {
   readonly level: "error" | "warning" | "info" | "debug" | "verbose";
 }
 
+//#region ECMAScript additions
+/*
+ * This region declares ECMAScript features that Bun supports, so that they
+ * type-check regardless of the `lib` compiler option. TypeScript's own lib
+ * files, and libraries such as core-js, declare the same members. Interface
+ * merging turns a signature that differs from the standard one into an extra
+ * overload, and a library that re-declares the standard signature in an
+ * interface that extends the global one then fails with TS2430. So every
+ * signature in this region must stay identical to the one in the TypeScript
+ * lib file named in the comment above it.
+ * test/integration/bun-types/fixture/core-js-types.ts checks that it does.
+ */
+
+// lib.es2022.error.d.ts
 interface ErrorOptions {
   /**
    * The cause of the error.
@@ -1045,16 +1099,19 @@ interface Error {
   cause?: unknown;
 }
 
+// lib.es2022.error.d.ts (constructor), lib.esnext.error.d.ts (`isError`).
+// `captureStackTrace` and `stackTraceLimit` are not in a lib file. @types/node
+// declares them too, with these exact types.
 interface ErrorConstructor {
   new (message?: string, options?: ErrorOptions): Error;
 
   /**
    * Check if a value is an instance of Error
    *
-   * @param value - The value to check
+   * @param error - The value to check
    * @returns True if the value is an instance of Error, false otherwise
    */
-  isError(value: unknown): value is Error;
+  isError(error: unknown): error is Error;
 
   /**
    * Create .stack property on a target object
@@ -1067,38 +1124,37 @@ interface ErrorConstructor {
   stackTraceLimit: number;
 }
 
+// lib.es2024.arraybuffer.d.ts
 interface ArrayBufferConstructor {
-  new (byteLength: number, options: { maxByteLength?: number }): ArrayBuffer;
+  new (byteLength: number, options?: { maxByteLength?: number }): ArrayBuffer;
 }
 
 interface ArrayBuffer {
   /**
-   * The length of the ArrayBuffer in bytes.
+   * Resize an ArrayBuffer in-place. The ArrayBuffer must have been created
+   * with a `maxByteLength`.
    */
-  readonly byteLength: number;
+  resize(newByteLength?: number): void;
+}
 
-  /**
-   * Resize an ArrayBuffer in-place.
-   */
-  resize(byteLength: number): ArrayBuffer;
-
-  /**
-   * Returns a section of an ArrayBuffer.
-   */
-  slice(begin: number, end?: number): ArrayBuffer;
+// lib.es2024.sharedmemory.d.ts
+interface SharedArrayBufferConstructor {
+  new (byteLength: number, options?: { maxByteLength?: number }): SharedArrayBuffer;
 }
 
 interface SharedArrayBuffer {
   /**
-   * Grow the SharedArrayBuffer in-place.
+   * Grow the SharedArrayBuffer in-place. The SharedArrayBuffer must have been
+   * created with a `maxByteLength`.
    */
-  grow(size: number): SharedArrayBuffer;
+  grow(newByteLength?: number): void;
 }
 
+// lib.esnext.array.d.ts
 interface ArrayConstructor {
   /**
    * Create an array from an iterable or async iterable object.
-   * Values from the iterable are awaited.
+   * Values from a sync iterable are awaited.
    *
    * ```ts
    * await Array.fromAsync([1]); // [1]
@@ -1106,34 +1162,209 @@ interface ArrayConstructor {
    * await Array.fromAsync((async function*() { yield 1 })()); // [1]
    * ```
    *
-   * @param arrayLike - The iterable or async iterable to convert to an array.
+   * @param iterableOrArrayLike - The iterable or async iterable to convert to an array.
    * @returns A {@link Promise} that resolves with a new {@link Array} containing the awaited values
    */
-  fromAsync<T>(arrayLike: AsyncIterable<T> | Iterable<T> | ArrayLike<T>): Promise<Awaited<T>[]>;
+  fromAsync<T>(
+    iterableOrArrayLike: AsyncIterable<T> | Iterable<T | PromiseLike<T>> | ArrayLike<T | PromiseLike<T>>,
+  ): Promise<T[]>;
 
   /**
    * Create an array from an iterable or async iterable object.
-   * Values from the iterable are awaited. Results of the map function are also awaited.
+   * Values from a sync iterable are awaited. Results of the map function are also awaited.
    *
    * ```ts
-   * await Array.fromAsync([1]); // [1]
-   * await Array.fromAsync([Promise.resolve(1)]); // [1]
-   * await Array.fromAsync((async function*() { yield 1 })()); // [1]
    * await Array.fromAsync([1], (n) => n + 1); // [2]
    * await Array.fromAsync([1], (n) => Promise.resolve(n + 1)); // [2]
    * ```
    *
-   * @param arrayLike - The iterable or async iterable to convert to an array.
-   * @param mapFn - A mapper function that transforms each element of `arrayLike` after awaiting them.
+   * @param iterableOrArrayLike - The iterable or async iterable to convert to an array.
+   * @param mapFn - A mapper function that transforms each element of `iterableOrArrayLike` after awaiting it.
    * @param thisArg - The `this` to which `mapFn` is bound.
    * @returns A {@link Promise} that resolves with a new {@link Array} containing the awaited values
    */
   fromAsync<T, U>(
-    arrayLike: AsyncIterable<T> | Iterable<T> | ArrayLike<T>,
-    mapFn?: (value: T, index: number) => U,
+    iterableOrArrayLike: AsyncIterable<T> | Iterable<T> | ArrayLike<T>,
+    mapFn: (value: Awaited<T>, index: number) => U,
     thisArg?: any,
   ): Promise<Awaited<U>[]>;
 }
+
+// lib.es2024.promise.d.ts
+interface PromiseWithResolvers<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: any) => void;
+}
+
+// lib.es2024.promise.d.ts (`withResolvers`), lib.es2025.promise.d.ts (`try`)
+interface PromiseConstructor {
+  /**
+   * Create a deferred promise with its `resolve` and `reject` functions exposed,
+   * so code outside the promise can settle it.
+   *
+   * @example
+   * ```ts
+   * const { promise, resolve, reject } = Promise.withResolvers<string>();
+   *
+   * setTimeout(() => {
+   *  resolve("Hello world!");
+   * }, 1000);
+   *
+   * await promise; // "Hello world!"
+   * ```
+   */
+  withResolvers<T>(): PromiseWithResolvers<T>;
+
+  /**
+   * Run a function and return a promise of its result. If the function throws,
+   * the returned promise rejects with the thrown error.
+   *
+   * @param callbackFn - The function to run
+   * @param args - The arguments to pass to the function. This is similar to `setTimeout` and avoids the extra closure.
+   * @returns A promise that resolves with the function's result
+   */
+  try<T, U extends unknown[]>(callbackFn: (...args: U) => T | PromiseLike<T>, ...args: U): Promise<Awaited<T>>;
+}
+
+// lib.esnext.collection.d.ts
+interface Map<K, V> {
+  /**
+   * Returns the value associated with `key`. If there is none, `defaultValue`
+   * is inserted for `key` and returned.
+   *
+   * @example
+   * ```ts
+   * const counts = new Map<string, number[]>();
+   * counts.getOrInsert("a", []).push(1);
+   * ```
+   */
+  getOrInsert(key: K, defaultValue: V): V;
+  /**
+   * Returns the value associated with `key`. If there is none, `callback` is
+   * called with `key`, and its result is inserted for `key` and returned.
+   *
+   * @example
+   * ```ts
+   * const groups = new Map<string, string[]>();
+   * groups.getOrInsertComputed("a", () => []).push("first");
+   * ```
+   */
+  getOrInsertComputed(key: K, callback: (key: K) => V): V;
+}
+
+interface WeakMap<K extends WeakKey, V> {
+  /**
+   * Returns the value associated with `key`. If there is none, `defaultValue`
+   * is inserted for `key` and returned.
+   */
+  getOrInsert(key: K, defaultValue: V): V;
+  /**
+   * Returns the value associated with `key`. If there is none, `callback` is
+   * called with `key`, and its result is inserted for `key` and returned.
+   */
+  getOrInsertComputed(key: K, callback: (key: K) => V): V;
+}
+
+// lib.es2025.regexp.d.ts
+interface RegExpConstructor {
+  /**
+   * Escapes any potential regex syntax characters in a string, and returns a
+   * new string that can be safely used as a literal pattern for the RegExp()
+   * constructor.
+   *
+   * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape)
+   *
+   * @example
+   * ```ts
+   * const re = new RegExp(RegExp.escape("foo.bar"));
+   * re.test("foo.bar"); // true
+   * re.test("foo!bar"); // false
+   * ```
+   */
+  escape(string: string): string;
+}
+
+// lib.esnext.typedarrays.d.ts
+interface Uint8Array {
+  /**
+   * Convert the Uint8Array to a base64 encoded string
+   */
+  toBase64(options?: { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined }): string;
+
+  /**
+   * Decode a base64 encoded string into this Uint8Array, starting at index 0.
+   * Decoding stops when the array is full.
+   *
+   * @param string The base64 encoded string to decode into the array
+   * @param options Options for decoding the base64 string
+   */
+  setFromBase64(
+    string: string,
+    options?: {
+      alphabet?: "base64" | "base64url" | undefined;
+      lastChunkHandling?: "loose" | "strict" | "stop-before-partial" | undefined;
+    },
+  ): {
+    /**
+     * The number of characters read from the base64 string
+     */
+    read: number;
+    /**
+     * The number of bytes written to the Uint8Array.
+     * Never greater than the `.byteLength` of this Uint8Array
+     */
+    written: number;
+  };
+
+  /**
+   * Convert the Uint8Array to a hex encoded string
+   */
+  toHex(): string;
+
+  /**
+   * Decode a hex encoded string into this Uint8Array, starting at index 0.
+   * Decoding stops when the array is full.
+   *
+   * @param string The hex encoded string to decode into the array. The string must have
+   * an even number of characters, contain only hexadecimal characters, and contain no whitespace.
+   */
+  setFromHex(string: string): {
+    /**
+     * The number of characters read from the hex string
+     */
+    read: number;
+    /**
+     * The number of bytes written to the Uint8Array.
+     * Never greater than the `.byteLength` of this Uint8Array
+     */
+    written: number;
+  };
+}
+
+interface Uint8ArrayConstructor {
+  /**
+   * Create a new Uint8Array from a base64 encoded string
+   * @param string The base64 encoded string to convert to a Uint8Array
+   * @param options Options for decoding the base64 string
+   * @returns A new Uint8Array containing the decoded data
+   */
+  fromBase64(
+    string: string,
+    options?: {
+      alphabet?: "base64" | "base64url" | undefined;
+      lastChunkHandling?: "loose" | "strict" | "stop-before-partial" | undefined;
+    },
+  ): Uint8Array<ArrayBuffer>;
+
+  /**
+   * Create a new Uint8Array from a hex encoded string
+   * @param string The hex encoded string to convert to a Uint8Array
+   * @returns A new Uint8Array containing the decoded data
+   */
+  fromHex(string: string): Uint8Array<ArrayBuffer>;
+}
+//#endregion
 
 interface ConsoleOptions {
   stdout: import("stream").Writable;
@@ -1403,39 +1634,6 @@ interface EventSourceInit {
   withCredentials?: boolean;
 }
 
-interface PromiseConstructor {
-  /**
-   * Create a deferred promise with its `resolve` and `reject` functions exposed,
-   * so code outside the promise can settle it.
-   *
-   * @example
-   * ```ts
-   * const { promise, resolve, reject } = Promise.withResolvers();
-   *
-   * setTimeout(() => {
-   *  resolve("Hello world!");
-   * }, 1000);
-   *
-   * await promise; // "Hello world!"
-   * ```
-   */
-  withResolvers<T>(): {
-    promise: Promise<T>;
-    resolve: (value?: T | PromiseLike<T>) => void;
-    reject: (reason?: any) => void;
-  };
-
-  /**
-   * Run a function and return a promise of its result. If the function throws,
-   * the returned promise rejects with the thrown error.
-   *
-   * @param fn - The function to run
-   * @param args - The arguments to pass to the function. This is similar to `setTimeout` and avoids the extra closure.
-   * @returns A promise that resolves with the function's result
-   */
-  try<T, A extends any[] = []>(fn: (...args: A) => T | PromiseLike<T>, ...args: A): Promise<T>;
-}
-
 interface Navigator {
   readonly userAgent: string;
   readonly platform: "MacIntel" | "Win32" | "Linux x86_64";
@@ -1525,78 +1723,6 @@ declare var Blob: Bun.__internal.UseLibDomIfAvailable<
     new (blobParts?: Bun.BlobPart[], options?: BlobPropertyBag): Blob;
   }
 >;
-
-interface Uint8Array {
-  /**
-   * Convert the Uint8Array to a base64 encoded string
-   */
-  toBase64(options?: { alphabet?: "base64" | "base64url"; omitPadding?: boolean }): string;
-
-  /**
-   * Set the contents of the Uint8Array from a base64 encoded string
-   * @param base64 The base64 encoded string to decode into the array
-   * @param offset Optional starting index to begin setting the decoded bytes (default: 0)
-   */
-  setFromBase64(
-    base64: string,
-    offset?: number,
-  ): {
-    /**
-     * The number of bytes read from the base64 string
-     */
-    read: number;
-    /**
-     * The number of bytes written to the Uint8Array.
-     * Never greater than the `.byteLength` of this Uint8Array
-     */
-    written: number;
-  };
-
-  /**
-   * Convert the Uint8Array to a hex encoded string
-   */
-  toHex(): string;
-
-  /**
-   * Set the contents of the Uint8Array from a hex encoded string
-   * @param hex The hex encoded string to decode into the array. The string must have
-   * an even number of characters, contain only hexadecimal characters, and contain no whitespace.
-   */
-  setFromHex(hex: string): {
-    /**
-     * The number of bytes read from the hex string
-     */
-    read: number;
-    /**
-     * The number of bytes written to the Uint8Array.
-     * Never greater than the `.byteLength` of this Uint8Array
-     */
-    written: number;
-  };
-}
-
-interface Uint8ArrayConstructor {
-  /**
-   * Create a new Uint8Array from a base64 encoded string
-   * @param base64 The base64 encoded string to convert to a Uint8Array
-   * @param options Options for decoding the base64 string
-   * @returns A new Uint8Array containing the decoded data
-   */
-  fromBase64(
-    base64: string,
-    options?: {
-      alphabet?: "base64" | "base64url";
-      lastChunkHandling?: "loose" | "strict" | "stop-before-partial";
-    },
-  ): Uint8Array<ArrayBuffer>;
-
-  /**
-   * Create a new Uint8Array from a hex encoded string
-   * @param hex The hex encoded string to convert to a Uint8Array
-   * @returns A new Uint8Array containing the decoded data
-   */
-  fromHex(hex: string): Uint8Array<ArrayBuffer>;
-}
 
 interface BroadcastChannel extends Bun.__internal.LibEmptyOrBroadcastChannel {}
 declare var BroadcastChannel: Bun.__internal.UseLibDomIfAvailable<
@@ -2153,21 +2279,3 @@ declare namespace fetch {
   ): void;
 }
 //#endregion
-
-interface RegExpConstructor {
-  /**
-   * Escapes any potential regex syntax characters in a string, and returns a
-   * new string that can be safely used as a literal pattern for the RegExp()
-   * constructor.
-   *
-   * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/escape)
-   *
-   * @example
-   * ```ts
-   * const re = new RegExp(RegExp.escape("foo.bar"));
-   * re.test("foo.bar"); // true
-   * re.test("foo!bar"); // false
-   * ```
-   */
-  escape(string: string): string;
-}

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1830,11 +1830,21 @@ interface FormData {
   set(name: string, value: string): void;
   set(name: string, blobValue: Blob, filename?: string): void;
   forEach(callbackfn: (value: Bun.FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
-  keys(): IterableIterator<string>;
-  values(): IterableIterator<string>;
-  entries(): IterableIterator<[string, string]>;
+  /** Returns an iterator over the `[name, value]` pairs of every entry in the list. Same as {@link FormData.entries}. */
+  [Symbol.iterator](): FormDataIterator<[string, Bun.FormDataEntryValue]>;
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/entries) */
+  entries(): FormDataIterator<[string, Bun.FormDataEntryValue]>;
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/keys) */
+  keys(): FormDataIterator<string>;
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/values) */
+  values(): FormDataIterator<Bun.FormDataEntryValue>;
 }
 declare var FormData: Bun.__internal.UseLibDomIfAvailable<"FormData", { prototype: FormData; new (): FormData }>;
+
+// Declared exactly as in lib.dom.d.ts so that the two declarations merge when lib.dom is loaded.
+interface FormDataIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
+  [Symbol.iterator](): FormDataIterator<T>;
+}
 
 interface EventSource extends Bun.__internal.LibEmptyOrEventSource {}
 declare var EventSource: Bun.__internal.UseLibDomIfAvailable<

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -68,6 +68,18 @@ declare module "bun" {
       : import("node:stream/web").ReadableStreamBYOBRequest;
 
     /**
+     * What the `FormData` iteration methods return. With lib.dom loaded this is
+     * the `FormDataIterator` that lib.dom.d.ts declares for the same methods, so
+     * the two declarations of each method agree. Without it, `Request` and
+     * `Response` come from undici-types, whose `FormData` returns plain
+     * iterators, so `await request.formData()` must stay assignable to the
+     * global `FormData`.
+     */
+    type LibFormDataIteratorOrIterableIterator<T> = LibDomIsLoaded extends true
+      ? FormDataIterator<T>
+      : IterableIterator<T>;
+
+    /**
      * Like a `BodyMixin`, but implemented by more types, such as
      * `Blob`, `ReadableStream`, and `Response`.
      *
@@ -1831,17 +1843,18 @@ interface FormData {
   set(name: string, blobValue: Blob, filename?: string): void;
   forEach(callbackfn: (value: Bun.FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
   /** Returns an iterator over the `[name, value]` pairs of every entry in the list. Same as {@link FormData.entries}. */
-  [Symbol.iterator](): FormDataIterator<[string, Bun.FormDataEntryValue]>;
+  [Symbol.iterator](): Bun.__internal.LibFormDataIteratorOrIterableIterator<[string, Bun.FormDataEntryValue]>;
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/entries) */
-  entries(): FormDataIterator<[string, Bun.FormDataEntryValue]>;
+  entries(): Bun.__internal.LibFormDataIteratorOrIterableIterator<[string, Bun.FormDataEntryValue]>;
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/keys) */
-  keys(): FormDataIterator<string>;
+  keys(): Bun.__internal.LibFormDataIteratorOrIterableIterator<string>;
   /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/values) */
-  values(): FormDataIterator<Bun.FormDataEntryValue>;
+  values(): Bun.__internal.LibFormDataIteratorOrIterableIterator<Bun.FormDataEntryValue>;
 }
 declare var FormData: Bun.__internal.UseLibDomIfAvailable<"FormData", { prototype: FormData; new (): FormData }>;
 
 // Declared exactly as in lib.dom.d.ts so that the two declarations merge when lib.dom is loaded.
+// Without lib.dom, FormData does not use it (see Bun.__internal.LibFormDataIteratorOrIterableIterator).
 interface FormDataIterator<T> extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
   [Symbol.iterator](): FormDataIterator<T>;
 }

--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -1,41 +1,14 @@
 export {};
 
-/**
- * Like a `BodyMixin`, but implemented by more types, such as
- * `Blob`, `ReadableStream`, and `Response`.
- *
- * It has no `blob()` method because it's the lowest common
- * denominator of these objects: a `Blob` in Bun does not have a
- * `.blob()` method.
- */
-interface BunConsumerConvenienceMethods {
-  /**
-   * Consume as text
-   */
-  text(): Promise<string>;
-
-  /**
-   * Consume as a Uint8Array, backed by an ArrayBuffer
-   */
-  bytes(): Promise<Uint8Array<ArrayBuffer>>;
-
-  /**
-   * Consume as JSON
-   */
-  json(): Promise<any>;
-}
-
 declare module "stream/web" {
-  interface ReadableStream extends BunConsumerConvenienceMethods {
-    /**
-     * Consume as a Blob
-     */
-    blob(): Promise<Blob>;
-  }
+  // The global `ReadableStream` interface (globals.d.ts) extends this same
+  // interface, so streams from `node:stream/web` and global streams stay
+  // assignable to each other.
+  interface ReadableStream extends Bun.__internal.BunReadableStreamConsumerMethods {}
 }
 
 declare module "buffer" {
-  interface Blob extends BunConsumerConvenienceMethods {
+  interface Blob extends Bun.__internal.BunConsumerConvenienceMethods {
     // We have to specify bytes again even though it comes from
     // BunConsumerConvenienceMethods, because inheritance in TypeScript is
     // slightly different from just "copying in the methods" (the difference is

--- a/packages/bun-types/package.json
+++ b/packages/bun-types/package.json
@@ -20,7 +20,8 @@
   ],
   "homepage": "https://bun.com",
   "dependencies": {
-    "@types/node": "*"
+    "@types/node": "*",
+    "undici-types": "*"
   },
   "scripts": {
     "prebuild": "echo $(pwd)",

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -17,8 +17,16 @@ declare module "bun:test" {
   export type Mock<T extends (...args: any[]) => any> = JestMock.Mock<T>;
 
   export const mock: {
+    // Separate overload for the implementation argument: inferring `T` through an
+    // optional parameter (`T | undefined`) instantiates a generic implementation's
+    // type parameters as `unknown`, so its generic call signature would be lost.
     /**
-     * Creates a mock function. The optional `Function` becomes the mock's implementation.
+     * Creates a mock function. `Function` becomes the mock's implementation.
+     */
+    <T extends (...args: any[]) => any>(Function: T): Mock<T>;
+    /**
+     * Creates a mock function with no implementation. Pass a type argument to
+     * give the mock a call signature.
      */
     <T extends (...args: any[]) => any>(Function?: T): Mock<T>;
 
@@ -91,6 +99,8 @@ declare module "bun:test" {
     function restoreAllMocks(): void;
     function clearAllMocks(): void;
     function resetAllMocks(): void;
+    // Same overload pair as `mock()` above, for the same reason.
+    function fn<T extends (...args: any[]) => any>(func: T): Mock<T>;
     function fn<T extends (...args: any[]) => any>(func?: T): Mock<T>;
     function setSystemTime(now?: number | Date): void;
     function setTimeout(milliseconds: number): void;
@@ -2017,9 +2027,13 @@ declare module "bun:test" {
       [K in keyof T as Required<T>[K] extends FunctionLike ? K : never]: T[K];
     };
 
-    export interface Mock<T extends (...args: any[]) => any> extends MockInstance<T> {
-      (...args: Parameters<T>): ReturnType<T>;
-    }
+    /**
+     * The mock is callable exactly like `T`. Intersecting with `T` keeps generic
+     * and overloaded call signatures, which a `(...args: Parameters<T>) =>
+     * ReturnType<T>` call signature would collapse to their `unknown`
+     * instantiation (or to the last overload).
+     */
+    export type Mock<T extends (...args: any[]) => any> = T & MockInstance<T>;
 
     /**
      * All what the internal typings need is to be sure that we have any-function.

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "
 import { bunEnv, bunExe, isDebug, makeTree } from "harness";
 import { existsSync, readFileSync } from "node:fs";
 import { cp, mkdir, mkdtemp, rm } from "node:fs/promises";
+import { builtinModules } from "node:module";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, relative } from "node:path";
 
@@ -324,6 +325,46 @@ describe("@types/bun integration test", () => {
     const claude = Bun.file(join(BASE_FIXTURE_DIR, "node_modules", "bun-types", "CLAUDE.md"));
     expect(await claude.exists()).toBe(true);
     expect((await claude.text()).length).toBeGreaterThan(0);
+  });
+
+  // A hoisted node_modules resolves a package that bun-types imports but does not depend on
+  // (it used to import undici-types through @types/node's dependency on it). Layouts that
+  // only link declared dependencies do not: https://github.com/oven-sh/bun/issues/22805
+  test("every package that bun-types imports from is one of its dependencies", () => {
+    const { dependencies } = JSON.parse(readFileSync(join(BUN_TYPES_PACKAGE_ROOT, "package.json"), "utf8"));
+    const importedPackages = new Map<string, Set<string>>();
+
+    const files = [...new Bun.Glob("**/*.d.ts").scanSync({ cwd: BUN_TYPES_PACKAGE_ROOT })].filter(
+      file => !/^node_modules[\\/]/.test(file),
+    );
+
+    for (const file of files) {
+      const { importedFiles, typeReferenceDirectives } = ts.preProcessFile(
+        readFileSync(join(BUN_TYPES_PACKAGE_ROOT, file), "utf8"),
+      );
+
+      const specifiers = [
+        ...importedFiles.map(({ fileName }) => fileName),
+        // `/// <reference types="node" />` resolves to @types/node
+        ...typeReferenceDirectives.map(({ fileName }) => `@types/${fileName}`),
+      ];
+
+      for (const specifier of specifiers) {
+        if (specifier.startsWith(".") || specifier === "bun" || specifier.startsWith("bun:")) continue;
+        if (builtinModules.includes(specifier.replace(/^node:/, ""))) continue;
+
+        const packageName = specifier.split("/", specifier.startsWith("@") ? 2 : 1).join("/");
+        importedPackages.set(packageName, (importedPackages.get(packageName) ?? new Set()).add(file));
+      }
+    }
+
+    const undeclared = [...importedPackages]
+      .filter(([packageName]) => !(packageName in dependencies))
+      .map(([packageName, files]) => ({ packageName, files: [...files].sort() }));
+
+    expect(undeclared).toEqual([]);
+    // Guards the assertion above against the scan silently finding nothing.
+    expect([...importedPackages.keys()].sort()).toEqual(["@types/node", "undici-types"]);
   });
 
   describe("basic type checks", () => {
@@ -660,19 +701,19 @@ describe("@types/bun integration test", () => {
           code: 2322,
           line: "24154.ts:11:3",
           message:
-            "Type 'Blob' is not assignable to type 'import(\"node:buffer\").Blob'.\nThe types returned by 'stream()' are incompatible between these types.\nType 'ReadableStream<Uint8Array<ArrayBuffer>>' is missing the following properties from type 'ReadableStream<NonSharedUint8Array>': blob, text, bytes, json",
+            "Type 'Blob' is not assignable to type 'import(\"node:buffer\").Blob'.\nThe types of 'stream().pipeThrough' are incompatible between these types.\nType '<T>(transform: ReadableWritablePair<T, Uint8Array<ArrayBuffer>>, options?: StreamPipeOptions | undefined) => ReadableStream<...>' is not assignable to type '<T>(transform: ReadableWritablePair<T, NonSharedUint8Array>, options?: StreamPipeOptions | undefined) => ReadableStream<...>'.\nTypes of parameters 'transform' and 'transform' are incompatible.\nType 'ReadableWritablePair<T, NonSharedUint8Array>' is not assignable to type 'ReadableWritablePair<T | undefined, Uint8Array<ArrayBuffer>>'.\nThe types of 'readable.getReader(...).read' are incompatible between these types.\nType '<T extends NodeJS.NonSharedArrayBufferView>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>' is not assignable to type '<T extends Exclude<BufferSource, ArrayBuffer>>(view: T, options?: ReadableStreamBYOBReaderReadOptions | undefined) => Promise<ReadableStreamReadResult<T>>'.\nTypes of parameters 'view' and 'view' are incompatible.\nType 'T' is not assignable to type 'NonSharedArrayBufferView'.\nType 'ArrayBufferView<ArrayBuffer>' is not assignable to type 'NonSharedArrayBufferView'.\nType 'ArrayBufferView<ArrayBuffer>' is missing the following properties from type 'DataView<ArrayBuffer>': getFloat32, getFloat64, getInt8, getInt16, and 19 more.\nType 'T' is not assignable to type 'DataView<ArrayBuffer>'.\nType 'ArrayBufferView<ArrayBuffer>' is missing the following properties from type 'DataView<ArrayBuffer>': getFloat32, getFloat64, getInt8, getInt16, and 19 more.",
         },
         {
           code: 2769,
           line: "fetch.ts:25:32",
           message:
-            "No overload matches this call.\nOverload 1 of 3, '(input: string | Request | URL, init?: RequestInit | undefined): Promise<Response>', gave the following error.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is not assignable to type 'BodyInit | null | undefined'.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 3 more.\nOverload 2 of 3, '(input: string | Request | URL, init?: BunFetchRequestInit | undefined): Promise<Response>', gave the following error.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is not assignable to type 'BodyInit | null | undefined'.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 3 more.\nOverload 3 of 3, '(input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>', gave the following error.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is not assignable to type 'BodyInit | null | undefined'.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 3 more.",
+            "No overload matches this call.\nOverload 1 of 3, '(input: string | Request | URL, init?: RequestInit | undefined): Promise<Response>', gave the following error.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is not assignable to type 'BodyInit | null | undefined'.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 7 more.\nOverload 2 of 3, '(input: string | Request | URL, init?: BunFetchRequestInit | undefined): Promise<Response>', gave the following error.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is not assignable to type 'BodyInit | null | undefined'.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 7 more.\nOverload 3 of 3, '(input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>', gave the following error.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is not assignable to type 'BodyInit | null | undefined'.\nType 'AsyncGenerator<\"chunk1\" | \"chunk2\", void, unknown>' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 7 more.",
         },
         {
           code: 2769,
           line: "fetch.ts:33:32",
           message:
-            "No overload matches this call.\nOverload 1 of 3, '(input: string | Request | URL, init?: RequestInit | undefined): Promise<Response>', gave the following error.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is not assignable to type 'BodyInit | null | undefined'.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 3 more.\nOverload 2 of 3, '(input: string | Request | URL, init?: BunFetchRequestInit | undefined): Promise<Response>', gave the following error.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is not assignable to type 'BodyInit | null | undefined'.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 3 more.\nOverload 3 of 3, '(input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>', gave the following error.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is not assignable to type 'BodyInit | null | undefined'.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 3 more.",
+            "No overload matches this call.\nOverload 1 of 3, '(input: string | Request | URL, init?: RequestInit | undefined): Promise<Response>', gave the following error.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is not assignable to type 'BodyInit | null | undefined'.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 7 more.\nOverload 2 of 3, '(input: string | Request | URL, init?: BunFetchRequestInit | undefined): Promise<Response>', gave the following error.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is not assignable to type 'BodyInit | null | undefined'.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 7 more.\nOverload 3 of 3, '(input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>', gave the following error.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is not assignable to type 'BodyInit | null | undefined'.\nType '{ [Symbol.asyncIterator](): AsyncGenerator<\"data1\" | \"data2\", void, unknown>; }' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 7 more.",
         },
         {
           code: 2769,
@@ -695,29 +736,19 @@ describe("@types/bun integration test", () => {
           code: 2345,
           line: "http.ts:55:24",
           message:
-            "Argument of type 'AsyncGenerator<Uint8Array<ArrayBuffer> | \"it works!\", void, unknown>' is not assignable to parameter of type 'BodyInit | null | undefined'.\nType 'AsyncGenerator<Uint8Array<ArrayBuffer> | \"it works!\", void, unknown>' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 3 more.",
+            "Argument of type 'AsyncGenerator<Uint8Array<ArrayBuffer> | \"it works!\", void, unknown>' is not assignable to parameter of type 'BodyInit | null | undefined'.\nType 'AsyncGenerator<Uint8Array<ArrayBuffer> | \"it works!\", void, unknown>' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 7 more.",
         },
         {
           code: 2345,
           line: "index.ts:196:14",
           message:
-            "Argument of type 'AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>' is not assignable to parameter of type 'BodyInit | null | undefined'.\nType 'AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 3 more.",
+            "Argument of type 'AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>' is not assignable to parameter of type 'BodyInit | null | undefined'.\nType 'AsyncGenerator<Uint8Array<ArrayBuffer>, void, unknown>' is missing the following properties from type 'ReadableStream<any>': locked, cancel, getReader, pipeThrough, and 7 more.",
         },
         {
           code: 2345,
           line: "index.ts:322:29",
           message:
             "Argument of type '{ headers: { \"x-bun\": string; }; }' is not assignable to parameter of type 'number'.",
-        },
-        {
-          code: 2339,
-          line: "spawn.ts:62:38",
-          message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
-        },
-        {
-          code: 2339,
-          line: "spawn.ts:107:38",
-          message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBuffer>>'.",
         },
         {
           code: 2769,
@@ -729,26 +760,6 @@ describe("@types/bun integration test", () => {
           code: 2339,
           line: "streams.ts:20:16",
           message: "Property 'write' does not exist on type 'ReadableByteStreamController'.",
-        },
-        {
-          code: 2339,
-          line: "streams.ts:46:19",
-          message: "Property 'json' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-        },
-        {
-          code: 2339,
-          line: "streams.ts:47:19",
-          message: "Property 'bytes' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-        },
-        {
-          code: 2339,
-          line: "streams.ts:48:19",
-          message: "Property 'text' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
-        },
-        {
-          code: 2339,
-          line: "streams.ts:49:19",
-          message: "Property 'blob' does not exist on type 'ReadableStream<Uint8Array<ArrayBufferLike>>'.",
         },
         {
           code: 2345,
@@ -798,6 +809,13 @@ describe("@types/bun integration test", () => {
           line: "websocket.ts:51:5",
           message:
             "Object literal may only specify known properties, and 'protocols' does not exist in type 'string[]'.",
+        },
+        // lib.dom.d.ts declares the WebSocket "error" event as a plain Event. Bun's
+        // declaration (an ErrorEvent, which is what Bun dispatches) only applies without it.
+        {
+          code: 2554,
+          line: "websocket.ts:132:23",
+          message: "Expected 2 arguments, but got 0.",
         },
         {
           code: 2551,
@@ -853,6 +871,33 @@ describe("@types/bun integration test", () => {
           code: 2339,
           line: "websocket.ts:270:6",
           message: "Property 'terminate' does not exist on type 'WebSocket'.",
+        },
+        {
+          code: 2554,
+          line: "websocket.ts:279:23",
+          message: "Expected 2 arguments, but got 0.",
+        },
+        {
+          code: 2339,
+          line: "websocket.ts:280:22",
+          message: "Property 'message' does not exist on type 'Event'.",
+        },
+        {
+          code: 2339,
+          line: "websocket.ts:281:22",
+          message: "Property 'error' does not exist on type 'Event'.",
+        },
+        {
+          code: 2769,
+          line: "websocket.ts:288:32",
+          message:
+            "No overload matches this call.\nOverload 1 of 2, '(type: \"error\", listener: (this: WebSocket, ev: Event) => any, options?: boolean | AddEventListenerOptions | undefined): void', gave the following error.\nArgument of type '(event: ErrorEvent) => void' is not assignable to parameter of type '(this: WebSocket, ev: Event) => any'.\nTypes of parameters 'event' and 'ev' are incompatible.\nType 'Event' is missing the following properties from type 'ErrorEvent': colno, error, filename, lineno, message\nOverload 2 of 2, '(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions | undefined): void', gave the following error.\nArgument of type '(event: ErrorEvent) => void' is not assignable to parameter of type 'EventListenerOrEventListenerObject'.\nType '(event: ErrorEvent) => void' is not assignable to type 'EventListener'.\nTypes of parameters 'event' and 'evt' are incompatible.\nType 'Event' is missing the following properties from type 'ErrorEvent': colno, error, filename, lineno, message",
+        },
+        {
+          code: 2322,
+          line: "websocket.ts:289:3",
+          message:
+            "Type '(event: ErrorEvent) => void' is not assignable to type '(this: WebSocket, ev: Event) => any'.\nTypes of parameters 'event' and 'ev' are incompatible.\nType 'Event' is missing the following properties from type 'ErrorEvent': colno, error, filename, lineno, message",
         },
         {
           code: 2339,

--- a/test/integration/bun-types/fixture/core-js-types.ts
+++ b/test/integration/bun-types/fixture/core-js-types.ts
@@ -1,0 +1,163 @@
+import { expectType } from "./utilities";
+
+// https://github.com/oven-sh/bun/issues/26868
+//
+// bun-types declares a few ECMAScript features on the standard global interfaces
+// (ArrayBuffer, PromiseConstructor, Map, Uint8Array, ...) so that they type-check
+// regardless of the `lib` setting. TypeScript's own lib.*.d.ts files and core-js's
+// type definitions declare the same members. Interface merging turns a different
+// signature into an extra overload, so the mismatch is silent until a library such
+// as core-js re-declares the standard signature in an interface that extends the
+// global one: then TS2430 "incorrectly extends" is reported against that library.
+//
+// core-js-types is not published yet, so this file stands in for it: every
+// interface below extends a global interface that bun-types adds members to, and
+// re-declares those members with the signatures from TypeScript's lib files (the
+// file is named above each one), which is what core-js-types does. If a bun-types
+// declaration drifts from the standard one, this file stops compiling. The
+// `lib: []` case in bun-types.test.ts is the one that matters most: there the
+// bun-types declarations are the only ones, like for a user on an older `lib`.
+
+// lib.es2024.arraybuffer.d.ts
+interface CoreJSArrayBuffer extends ArrayBuffer {
+  resize(newByteLength?: number): void;
+}
+
+interface CoreJSArrayBufferConstructor extends ArrayBufferConstructor {
+  new (byteLength: number, options?: { maxByteLength?: number }): ArrayBuffer;
+}
+
+// lib.es2024.sharedmemory.d.ts
+interface CoreJSSharedArrayBuffer extends SharedArrayBuffer {
+  grow(newByteLength?: number): void;
+}
+
+interface CoreJSSharedArrayBufferConstructor extends SharedArrayBufferConstructor {
+  new (byteLength: number, options?: { maxByteLength?: number }): SharedArrayBuffer;
+}
+
+// lib.es2024.promise.d.ts and lib.es2025.promise.d.ts
+declare global {
+  interface PromiseWithResolvers<T> {
+    promise: Promise<T>;
+    resolve: (value: T | PromiseLike<T>) => void;
+    reject: (reason?: any) => void;
+  }
+}
+
+interface CoreJSPromiseConstructor extends PromiseConstructor {
+  withResolvers<T>(): PromiseWithResolvers<T>;
+  try<T, U extends unknown[]>(callbackFn: (...args: U) => T | PromiseLike<T>, ...args: U): Promise<Awaited<T>>;
+}
+
+// lib.esnext.array.d.ts
+interface CoreJSArrayConstructor extends ArrayConstructor {
+  fromAsync<T>(
+    iterableOrArrayLike: AsyncIterable<T> | Iterable<T | PromiseLike<T>> | ArrayLike<T | PromiseLike<T>>,
+  ): Promise<T[]>;
+  fromAsync<T, U>(
+    iterableOrArrayLike: AsyncIterable<T> | Iterable<T> | ArrayLike<T>,
+    mapFn: (value: Awaited<T>, index: number) => U,
+    thisArg?: any,
+  ): Promise<Awaited<U>[]>;
+}
+
+// lib.es2022.error.d.ts and lib.esnext.error.d.ts
+interface CoreJSErrorOptions extends ErrorOptions {
+  cause?: unknown;
+}
+
+interface CoreJSError extends Error {
+  cause?: unknown;
+}
+
+interface CoreJSErrorConstructor extends ErrorConstructor {
+  new (message?: string, options?: ErrorOptions): Error;
+  isError(error: unknown): error is Error;
+}
+
+// lib.esnext.collection.d.ts
+interface CoreJSMap<K, V> extends Map<K, V> {
+  getOrInsert(key: K, defaultValue: V): V;
+  getOrInsertComputed(key: K, callback: (key: K) => V): V;
+}
+
+interface CoreJSWeakMap<K extends WeakKey, V> extends WeakMap<K, V> {
+  getOrInsert(key: K, defaultValue: V): V;
+  getOrInsertComputed(key: K, callback: (key: K) => V): V;
+}
+
+// lib.es2025.regexp.d.ts
+interface CoreJSRegExpConstructor extends RegExpConstructor {
+  escape(string: string): string;
+}
+
+// lib.esnext.typedarrays.d.ts
+interface CoreJSUint8Array extends Uint8Array<ArrayBuffer> {
+  toBase64(options?: { alphabet?: "base64" | "base64url" | undefined; omitPadding?: boolean | undefined }): string;
+  setFromBase64(
+    string: string,
+    options?: {
+      alphabet?: "base64" | "base64url" | undefined;
+      lastChunkHandling?: "loose" | "strict" | "stop-before-partial" | undefined;
+    },
+  ): { read: number; written: number };
+  toHex(): string;
+  setFromHex(string: string): { read: number; written: number };
+}
+
+interface CoreJSUint8ArrayConstructor extends Uint8ArrayConstructor {
+  fromBase64(
+    string: string,
+    options?: {
+      alphabet?: "base64" | "base64url" | undefined;
+      lastChunkHandling?: "loose" | "strict" | "stop-before-partial" | undefined;
+    },
+  ): Uint8Array<ArrayBuffer>;
+  fromHex(string: string): Uint8Array<ArrayBuffer>;
+}
+
+// The merged declarations must also behave like the standard ones at use sites.
+declare const buffer: ArrayBuffer;
+expectType(buffer.resize(16)).is<void>();
+expectType(buffer.resize()).is<void>();
+
+declare const shared: SharedArrayBuffer;
+expectType(shared.grow(16)).is<void>();
+expectType(shared.grow()).is<void>();
+
+new ArrayBuffer(8);
+new ArrayBuffer(8, { maxByteLength: 16 });
+new SharedArrayBuffer(8, { maxByteLength: 16 });
+
+const withResolvers = Promise.withResolvers<number>();
+expectType(withResolvers).is<PromiseWithResolvers<number>>();
+expectType(withResolvers.promise).is<Promise<number>>();
+withResolvers.resolve(1);
+withResolvers.resolve(Promise.resolve(1));
+// @ts-expect-error the value is required when T is not void
+withResolvers.resolve();
+withResolvers.reject(new Error("reason"));
+withResolvers.reject();
+
+// `resolve()` with no argument is the common case for `void` promises.
+const { resolve, reject } = Promise.withResolvers<void>();
+resolve();
+reject();
+
+expectType(Promise.try(() => 1)).is<Promise<number>>();
+expectType(Promise.try(async () => "a")).is<Promise<string>>();
+expectType(Promise.try((a: number, b: string) => `${a}${b}`, 1, "b")).is<Promise<string>>();
+
+const bytes = new Uint8Array(8);
+expectType(bytes.setFromBase64("aGVsbG8=")).is<{ read: number; written: number }>();
+bytes.setFromBase64("aGVsbG8", { alphabet: "base64", lastChunkHandling: "loose" });
+// @ts-expect-error the second argument is an options object, not an offset
+bytes.setFromBase64("aGVsbG8=", 2);
+expectType(bytes.setFromHex("68656c6c6f")).is<{ read: number; written: number }>();
+expectType(bytes.toBase64({ alphabet: "base64url", omitPadding: true })).is<string>();
+expectType(bytes.toHex()).is<string>();
+expectType(Uint8Array.fromBase64("aGVsbG8=", { lastChunkHandling: "strict" })).is<Uint8Array<ArrayBuffer>>();
+expectType(Uint8Array.fromHex("68656c6c6f")).is<Uint8Array<ArrayBuffer>>();
+
+export {};

--- a/test/integration/bun-types/fixture/core-js-types.ts
+++ b/test/integration/bun-types/fixture/core-js-types.ts
@@ -149,6 +149,28 @@ expectType(Promise.try(() => 1)).is<Promise<number>>();
 expectType(Promise.try(async () => "a")).is<Promise<string>>();
 expectType(Promise.try((a: number, b: string) => `${a}${b}`, 1, "b")).is<Promise<string>>();
 
+declare const asyncNumbers: AsyncIterable<number>;
+expectType(Array.fromAsync([1, Promise.resolve(2)])).is<Promise<number[]>>();
+expectType(Array.fromAsync(asyncNumbers)).is<Promise<number[]>>();
+expectType(Array.fromAsync([1, 2], n => `${n}`)).is<Promise<string[]>>();
+expectType(Array.fromAsync(asyncNumbers, async n => n > 1)).is<Promise<boolean[]>>();
+Array.fromAsync(
+  [1, 2],
+  (n, index) => {
+    expectType(n).is<number>();
+    expectType(index).is<number>();
+    return n;
+  },
+  { thisArg: true },
+);
+
+declare const caught: unknown;
+if (Error.isError(caught)) {
+  expectType(caught).is<Error>();
+}
+
+expectType(RegExp.escape("foo.bar")).is<string>();
+
 const bytes = new Uint8Array(8);
 expectType(bytes.setFromBase64("aGVsbG8=")).is<{ read: number; written: number }>();
 bytes.setFromBase64("aGVsbG8", { alphabet: "base64", lastChunkHandling: "loose" });

--- a/test/integration/bun-types/fixture/globals.ts
+++ b/test/integration/bun-types/fixture/globals.ts
@@ -323,11 +323,8 @@ clearImmediate(1);
 {
   const form = new FormData();
 
-  expectType(form.entries()).is<FormDataIterator<[string, Bun.FormDataEntryValue]>>();
-  expectType(form.keys()).is<FormDataIterator<string>>();
-  expectType(form.values()).is<FormDataIterator<Bun.FormDataEntryValue>>();
-  expectType(form[Symbol.iterator]()).is<FormDataIterator<[string, Bun.FormDataEntryValue]>>();
-
+  // The iterator type differs with and without lib.dom (it is lib.dom's FormDataIterator
+  // when that lib is loaded), so only what the iterators yield is checked here.
   for (const [name, value] of form) {
     expectType(name).is<string>();
     expectType(value).is<File | string>();
@@ -337,8 +334,21 @@ clearImmediate(1);
     expectType(value).is<File | string>();
   }
 
+  expectType([...form.keys()]).is<string[]>();
+  expectType([...form.values()]).is<(File | string)[]>();
   expectType([...form.entries()]).is<[string, File | string][]>();
   expectType(Object.fromEntries(form)).is<{ [k: string]: File | string }>();
+}
+
+// Without lib.dom, Request and Response come from undici-types, whose FormData has its own
+// iterator types. What their formData() resolves to must still be a FormData, like the Blob
+// case in 24154.ts. (fetch.ts covers the other direction, a FormData as a request body.)
+async function formDataFromRequest(request: Request): Promise<FormData> {
+  return await request.formData();
+}
+
+async function formDataFromResponse(response: Response): Promise<FormData> {
+  return await response.formData();
 }
 
 const err = new Error("test");

--- a/test/integration/bun-types/fixture/globals.ts
+++ b/test/integration/bun-types/fixture/globals.ts
@@ -336,7 +336,6 @@ new Error("asdf", {
   cause: new Error("asdf"),
 });
 
-// @ts-expect-error this interface is defined top level in globals.d.ts so we
-// are making sure that .d.ts is a module and that anything top level doesn't
-// leak to userland
+// @ts-expect-error this interface lives in Bun.__internal (globals.d.ts), so we
+// are making sure that it does not leak to userland as a global
 expectType<BunConsumerConvenienceMethods>();

--- a/test/integration/bun-types/fixture/globals.ts
+++ b/test/integration/bun-types/fixture/globals.ts
@@ -318,6 +318,29 @@ clearTimeout(1);
 setImmediate(() => {});
 clearImmediate(1);
 
+// FormData iteration yields File | string values, as in lib.dom.d.ts.
+// https://github.com/oven-sh/bun/issues/27194
+{
+  const form = new FormData();
+
+  expectType(form.entries()).is<FormDataIterator<[string, Bun.FormDataEntryValue]>>();
+  expectType(form.keys()).is<FormDataIterator<string>>();
+  expectType(form.values()).is<FormDataIterator<Bun.FormDataEntryValue>>();
+  expectType(form[Symbol.iterator]()).is<FormDataIterator<[string, Bun.FormDataEntryValue]>>();
+
+  for (const [name, value] of form) {
+    expectType(name).is<string>();
+    expectType(value).is<File | string>();
+  }
+
+  for (const value of form.values()) {
+    expectType(value).is<File | string>();
+  }
+
+  expectType([...form.entries()]).is<[string, File | string][]>();
+  expectType(Object.fromEntries(form)).is<{ [k: string]: File | string }>();
+}
+
 const err = new Error("test");
 err.cause = "asdf";
 err.cause = new Error("asdf");

--- a/test/integration/bun-types/fixture/map.ts
+++ b/test/integration/bun-types/fixture/map.ts
@@ -1,0 +1,46 @@
+import { expectType } from "./utilities";
+
+// https://github.com/oven-sh/bun/issues/27380
+// Map.prototype.getOrInsert / getOrInsertComputed and the WeakMap equivalents.
+// The `lib: []` case in bun-types.test.ts checks these without lib.esnext.collection.d.ts,
+// and fixture/core-js-types.ts checks that the declarations match that lib file.
+{
+  const counts = new Map<string, number>();
+
+  expectType(counts.getOrInsert("a", 1)).is<number>();
+  expectType(counts.getOrInsertComputed("a", key => key.length)).is<number>();
+
+  counts.getOrInsertComputed("a", key => {
+    expectType(key).is<string>();
+    return key.length;
+  });
+
+  // @ts-expect-error the default value must be a V
+  counts.getOrInsert("a", "one");
+  // @ts-expect-error the callback must return a V
+  counts.getOrInsertComputed("a", () => "one");
+  // @ts-expect-error the key must be a K
+  counts.getOrInsert(1, 1);
+}
+
+{
+  const themes = new WeakMap<object, string>();
+  const key = {};
+
+  expectType(themes.getOrInsert(key, "light")).is<string>();
+  expectType(themes.getOrInsertComputed(key, k => String(k))).is<string>();
+
+  themes.getOrInsertComputed(key, k => {
+    expectType(k).is<object>();
+    return "dark";
+  });
+
+  // @ts-expect-error the default value must be a V
+  themes.getOrInsert(key, 1);
+  // @ts-expect-error the callback must return a V
+  themes.getOrInsertComputed(key, () => 1);
+  // @ts-expect-error the key must be a K
+  themes.getOrInsert("key", "light");
+}
+
+export {};

--- a/test/integration/bun-types/fixture/mocks.ts
+++ b/test/integration/bun-types/fixture/mocks.ts
@@ -1,4 +1,4 @@
-import { jest, mock } from "bun:test";
+import { jest, mock, type Mock, spyOn, vi } from "bun:test";
 import { expectType } from "./utilities";
 
 const mock1 = mock((arg: string) => {
@@ -29,3 +29,67 @@ jest.fn<() => string>().mockResolvedValue("24");
 jest.fn().mockClear();
 jest.fn().mockReset();
 jest.fn().mockRejectedValueOnce(new Error());
+
+// A mock of a generic function keeps the generic call signature.
+// https://github.com/oven-sh/bun/issues/38037
+{
+  type Run = <T>(callback: () => PromiseLike<T>) => Promise<T>;
+  const run: Run = async callback => callback();
+
+  const mocked = mock(run);
+  const mockedAsRun: Run = mocked;
+  expectType(mocked(async () => 42)).is<Promise<number>>();
+  expectType(mocked.mock.calls).is<[callback: () => PromiseLike<unknown>][]>();
+  mocked.mockClear();
+
+  const jestMocked = jest.fn(run);
+  const jestMockedAsRun: Run = jestMocked;
+  expectType(jestMocked(async () => "a")).is<Promise<string>>();
+
+  const viMocked = vi.fn(run);
+  const viMockedAsRun: Run = viMocked;
+  expectType(viMocked(async () => true)).is<Promise<boolean>>();
+
+  const target = { run };
+  const spied = spyOn(target, "run");
+  const spiedAsRun: Run = spied;
+  expectType(spied(async () => 1n)).is<Promise<bigint>>();
+  spied.mockRestore();
+
+  void [mockedAsRun, jestMockedAsRun, viMockedAsRun, spiedAsRun];
+}
+
+// A mock of an overloaded function keeps every overload.
+{
+  function parse(input: string): number;
+  function parse(input: number): string;
+  function parse(input: string | number) {
+    return typeof input === "string" ? Number(input) : String(input);
+  }
+
+  const mocked = mock(parse);
+  expectType(mocked("1")).is<number>();
+  expectType(mocked(1)).is<string>();
+  // @ts-expect-error no overload accepts a boolean
+  mocked(true);
+}
+
+// Mocks without an implementation, and with an explicit implementation type.
+{
+  const untyped = mock();
+  untyped(1, "two", { three: 3 });
+
+  const typed = mock<(input: number) => string>();
+  expectType(typed(1)).is<string>();
+  // @ts-expect-error the implementation type is (input: number) => string
+  typed("1");
+
+  const declared: Mock<(input: string) => number> = mock((input: string) => input.length);
+  expectType(declared("abc")).is<number>();
+  expectType(declared.mock.calls).is<[input: string][]>();
+  declared.mockReturnValue(1);
+  // @ts-expect-error the return type is number
+  declared.mockReturnValue("1");
+
+  expectType(vi.fn<(input: number) => string>()(1)).is<string>();
+}

--- a/test/integration/bun-types/fixture/streams.ts
+++ b/test/integration/bun-types/fixture/streams.ts
@@ -42,7 +42,7 @@ for await (const chunk of uint8Transform.readable) {
 }
 
 declare const stream: ReadableStream<Uint8Array>;
-
+// These exist with and without lib.dom.d.ts: https://github.com/oven-sh/bun/issues/29401
 expectType(stream.json()).is<Promise<any>>();
 expectType(stream.bytes()).is<Promise<Uint8Array<ArrayBuffer>>>();
 expectType(stream.text()).is<Promise<string>>();

--- a/test/integration/bun-types/fixture/websocket.ts
+++ b/test/integration/bun-types/fixture/websocket.ts
@@ -129,7 +129,7 @@ import { expectType } from "./utilities";
   };
 
   ws.onerror = event => {
-    expectType(event).is<Event>();
+    expectType(event).is<ErrorEvent>();
   };
 
   ws.onclose = event => {
@@ -268,4 +268,23 @@ import { expectType } from "./utilities";
 
   // Terminate the connection immediately
   ws.terminate();
+}
+
+// The "error" event is an ErrorEvent, like the one Bun dispatches at runtime.
+// https://github.com/oven-sh/bun/issues/36329
+{
+  const ws = new WebSocket("wss://dev.local");
+
+  ws.addEventListener("error", event => {
+    expectType(event).is<ErrorEvent>();
+    expectType(event.message).is<string>();
+    expectType(event.error).is<any>();
+  });
+
+  const handleError = (event: ErrorEvent) => {
+    expectType(event.error).is<any>();
+  };
+
+  ws.addEventListener("error", handleError);
+  ws.onerror = handleError;
 }

--- a/test/integration/bun-types/fixture/webview.ts
+++ b/test/integration/bun-types/fixture/webview.ts
@@ -1,0 +1,17 @@
+import { expectType } from "./utilities";
+
+// https://github.com/oven-sh/bun/issues/30754
+// The runtime (src/runtime/webview/JSWebViewPrototype.cpp) names the history
+// methods goBack() and goForward().
+declare const view: Bun.WebView;
+
+expectType(view.goBack()).is<Promise<void>>();
+expectType(view.goForward()).is<Promise<void>>();
+expectType(view.reload()).is<Promise<void>>();
+
+// @ts-expect-error back() does not exist at runtime
+view.back();
+// @ts-expect-error forward() does not exist at runtime
+view.forward();
+
+export {};


### PR DESCRIPTION
One PR for the open `types` issues, except #32576 (a `js_printer` bug, #32577). The notes map each issue to its change. Two of the changes come from earlier PRs by outside contributors, credited as co-authors in the commits (see Related PRs).

Fixes #38037, fixes #36329, fixes #30754, fixes #29401, fixes #27380, fixes #27194, fixes #26868, fixes #22805.

### Problem
- Five declarations do not match the runtime: `Mock<T>`, the WebSocket `error` event, `WebView.back()`, `FormData` iteration (it yields `File | string`), and the global `ReadableStream`, which has no `text()` with lib.dom.
- The ECMAScript members that `globals.d.ts` adds to standard interfaces differ from TypeScript's lib files, so core-js gets TS2430. `Map.getOrInsert` is missing.
- `bun-types` imports from `undici-types` without a dependency on it.

### Fix
- `Mock<T>` is `T & MockInstance<T>`, with a required-parameter overload for `mock()` and `jest.fn()`. The global `ReadableStream` and the `node:stream/web` one extend one shared interface. `FormData` gets `[Symbol.iterator]()`. Its iterators are lib.dom's `FormDataIterator` when that lib is loaded and `IterableIterator` otherwise, so `await request.formData()`, which is undici-types' `FormData` without lib.dom, stays assignable to `FormData`. The other two are one-line fixes.
- The standard members move into one region of `globals.d.ts`, each identical to its lib file. `fixture/core-js-types.ts` re-declares them like core-js does.
- `undici-types` becomes a dependency. A test checks that every package the `.d.ts` files import from is declared.
- To decide on: `Promise.withResolvers()` without a type argument now rejects `resolve()` with no value, like the lib. 139 places in `test/` do this.
- Verified: `bun test test/integration/bun-types/bun-types.test.ts`, 16 pass.

### Related PRs
- #34264 (@0zminDev) fixed #27194 first. Closed in favor of this PR at the maintainer's request, with co-author credit on the `FormData` commit.
- #32484 (@Pablosinyores) fixed the `resize()` return type first. Closed in favor of this PR at the maintainer's request, with co-author credit on the main commit.
- #31757 (@godfengliang) added the same `ReadableStream` extension at the top level of `overrides.d.ts`, which is a module, so it never reached the global interface. Closed in favor of this PR, with co-author credit.

### Background
- The test type-checks the fixtures with and without lib.dom. With it, the DOM declaration of a global wins, so Bun-specific lines are expected diagnostics there.
- Interface merging turns two method declarations into overloads, later one first, so a bun-types signature silently shadowed the lib one. Two property declarations must be identical.

<details><summary>Notes</summary>

Per-issue summary:

| Issue | Change | Fixture |
| --- | --- | --- |
| #38037 | `Mock<T> = T & MockInstance<T>`, required-parameter overloads for `mock()` and `jest.fn()` (`vi.fn` is `typeof jest.fn`). Inference through an optional `T` parameter instantiates a generic implementation with `unknown`, so the required overload comes first. | `mocks.ts` |
| #36329 | `WebSocketEventMap.error: ErrorEvent`, `onerror` | `websocket.ts` |
| #30754 | `goBack()` and `goForward()`, the names in `src/runtime/webview/JSWebViewPrototype.cpp` | `webview.ts` |
| #29401 | `BunReadableStreamConsumerMethods` in `Bun.__internal`, extended by the global interface and by `node:stream/web` | `streams.ts` (its DOM-case diagnostics are gone, also the ones in `spawn.ts`) |
| #27380 | `Map` and `WeakMap` `getOrInsert` and `getOrInsertComputed` | `map.ts`, `core-js-types.ts` |
| #27194 | `entries()`, `values()`, `keys()`, `[Symbol.iterator]()` on `FormData` yield `Bun.FormDataEntryValue` and return `Bun.__internal.LibFormDataIteratorOrIterableIterator` (lib.dom's `FormDataIterator`, declared here too so that the two merge, or `IterableIterator` without lib.dom) | `globals.ts` (iteration, and `formData()` of a `Request` and a `Response` assigned to `FormData`) |
| #26868 | ECMAScript region in `globals.d.ts` | `core-js-types.ts` |
| #22805 | `undici-types` dependency, and a test that every package the `.d.ts` files import from is declared | the "every package" test in `bun-types.test.ts` |

Signatures the ECMAScript region changes: `ArrayBuffer.resize` and `SharedArrayBuffer.grow` return `void` (`newByteLength?: number`), `Promise.withResolvers` returns `PromiseWithResolvers<T>` (copied from lib.es2024.promise.d.ts), `Promise.try`, `Array.fromAsync`, and `Uint8Array.setFromBase64`, whose second parameter was an offset. At runtime `new Uint8Array(8).setFromBase64("aGVsbG8=", 2)` throws `TypeError: Uint8Array.prototype.setFromBase64 requires that options be an object`. `Map.getOrInsert` and `getOrInsertComputed` are added with the lib.esnext.collection.d.ts signatures. `ArrayBuffer.byteLength` and `slice` were duplicates of lib.es5 and are removed. `SharedArrayBufferConstructor` gets the lib.es2024 constructor so that `new SharedArrayBuffer(n, { maxByteLength })` works without that lib. `Array.fromAsync`, `Promise.try`, `Error.isError`, `RegExp.escape` and `Uint8ArrayConstructor` did not conflict. They are aligned anyway so that the region's rule holds for every member in it.

`core-js-types` is not on npm, so a real core-js environment in the test is not possible yet. The fixture does what core-js does: `interface CoreJSPromiseConstructor extends PromiseConstructor { withResolvers<T>(): PromiseWithResolvers<T> }` and so on. Against the current types it reports the TS2430 from the issue on `CoreJSPromiseConstructor` (in the `lib: []` case, where no lib overload hides it), on `CoreJSArrayBuffer`, `CoreJSSharedArrayBuffer` and `CoreJSUint8Array`, and two unused `@ts-expect-error` directives (`resolve()` with no value, `setFromBase64(s, 2)`).

Fail-before detail: without the `packages/` changes, the default case reports 28 diagnostics across `core-js-types.ts`, `mocks.ts`, `websocket.ts` and `webview.ts`. The `lib: []` case adds the 12 `map.ts` lines and the `CoreJSPromiseConstructor` TS2430. The DOM case also reports the six `ReadableStream` lines in `spawn.ts` and `streams.ts` that this PR removes from the expected list. The dependency test reports `undici-types` imported from `bun.d.ts`, `fetch.d.ts` and `globals.d.ts`. With the changes, 16 pass.

Other runtime checks behind the changes (bun 1.4.0): the WebSocket error event is `instanceof ErrorEvent`, `ab.resize(8)` and `sab.grow(8)` return undefined, `Bun.WebView.prototype.goBack` is a function and `.back` is undefined.

Impact probe for the `withResolvers` decision, on this revision and with the same `test/` tree: `tsc --noEmit` in `test/` reports 7282 errors against the bun-types on main and 7397 against this branch. The new errors are 132 TS2554 (`resolve()` with no argument) and 7 callback errors (`resolve` passed where a `() => void` is expected, TS2345 and TS2769), all from `Promise.withResolvers()` without a type argument, plus 4 TS2339 in `js/node/module/require-extensions.test.ts`, where `mock(function (module) { module._compile })` assigned to `require.extensions[".js"]` now gets `module` typed as `Module` instead of implicit `any`: the intersection lets the contextual type reach the implementation. The other line-level differences are the same messages with union members printed in another order, and the fixture diagnostics this PR fixes. `test/` is not type-checked in CI.

The `24154.ts` expected diagnostic in the DOM case changed text: the global `Blob` and `node:buffer`'s `Blob` are still not mutually assignable with lib.dom, but now because lib.dom's and `@types/node`'s `ReadableStream.pipeThrough` differ, not because of the missing consumer methods. The `and 3 more` to `and 7 more` edits are the four new `ReadableStream` members.

`undici-types` uses the `*` range, like `@types/node`. With bun's isolated linker this can install a second copy next to the one `@types/node` pins (`undici-types@8.10.0` for bun-types and `8.3.0` for `@types/node@26.2.0` today). A project with both type-checks cleanly: bun-types' `Request`, `Response`, `Headers` and `EventSource` come from its copy, and `@types/node` only uses its copy for `node:http` exports. A hoisted `node_modules` resolves `undici-types` through `@types/node`, and bun's isolated linker also hoists into `node_modules/.bun/node_modules`, so an install-based test passes with or without the dependency. That is why the test reads the `.d.ts` sources instead. A layout that links only declared dependencies, such as `packages/bun-types` in this repo, gets TS2307 in the three files above.

Found while working on this and handed off separately: the global `EventSource` constructor is declared as `new ()`, and `Bun.Glob.scanSync` returns nothing for a brace pattern whose alternatives contain a `/` (the "every package" test scans `**/*.d.ts` and filters `node_modules` because of it).

Overlap with other PRs. #34264 fixed #27194 with `IterableIterator` return types. The first version of the change here returned a `FormDataIterator` copied from lib.dom.d.ts (`IteratorObject`-based) in every configuration, so that the DOM case agrees with lib.dom and has the iterator helpers. A later self-review found that without lib.dom this breaks `const form: FormData = await request.formData()` with TS2322: `Request` and `Response` are undici-types' classes there, and undici's `FormData` iterators have no `[Symbol.dispose]`. main fails the same assignment for another reason (`values()` yields `string`), and #34264's `IterableIterator` shape passes it. The declaration now returns `FormDataIterator` only when lib.dom is loaded (checked: `new FormData().values().map(...)` type-checks with lib.dom, and does not on main) and `IterableIterator` otherwise, which is #34264's shape. `fixture/globals.ts` assigns the `formData()` of a `Request` and of a `Response` to `FormData`, the way `24154.ts` does for `Blob`: with the first version those two lines fail in every configuration without lib.dom, and `fetch.ts:11` already covers a `FormData` as a request body. The fixture block sits after the line that the DOM case's `globals.ts:307` diagnostic points at, so no expected line numbers move. #32484's `resize()` line and the one here differ only in the parameter (`byteLength: number` there, the lib's `newByteLength?: number` here). #31757 was checked by applying it to main: the types test passes unchanged, still expecting `Property 'text' does not exist on type 'ReadableStream<...>'` in the DOM case, and a file with `declare const s: ReadableStream; s.text()` reports the same TS2339 with and without it. `overrides.d.ts` starts with `export {}`, so its top-level `interface ReadableStream` is local to that module. The existing `fixture/globals.ts` check that `BunConsumerConvenienceMethods` does not leak depends on the same fact. The same hunk inside `declare global` does work, which is what this PR does in `globals.d.ts`, a script file, through a shared interface so that the `node:stream/web` stream stays assignable to the global one.

CI on the final revision (f2e068f, Buildkite build 101270, and 2c83b4a before it, build 101128): 178 of 179 jobs passed in both. The one red job each time is a darwin aarch64 shard where `test/js/node/tls/node-tls-server.test.ts` times out, which also happens on main and is reported there; this PR changes no runtime code. `bun-types.test.ts` and the `TypeScript types` job passed on every lane in both builds.

This PR replaces the single-issue PRs #38048, #36330, #30755, #29105, #36505 (`SharedArrayBuffer.grow()`), #31757, #34264 and #32484.

</details>

<!-- robobun:evidence:begin -->

---

**[decide:dep]** gate passed · iteration 1 · 14 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
ninja: Entering directory `/workspace/bun/build/debug'
[1/61] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/61] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/61] gen cpp.rs (cppbind)
[4/61] gen JS modules (bundle-modules)
Preprocess modules (7945ms)
Bundle modules (81ms)
Postprocesss modules (26ms)
Bundle Functions (602ms)
Generate Code (11ms)

[8.68s] Bundled "src/js" for development
  2822 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[4/53] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[50/53] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
FAILED: obj/src/jsc/bindings/ZigGlobalObject.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem 
... (truncated)

release without fix: 10 FAILED
bun test v1.4.0-canary.1 (4c689909e)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [0.08ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.40ms]
360 | 
361 |     const undeclared = [...importedPackages]
362 |       .filter(([packageName]) => !(packageName in dependencies))
363 |       .map(([packageName, files]) => ({ packageName, files: [...files].sort() }));
364 | 
365 |     expect(undeclared).toEqual([]);
                             ^
error: expect(received).toEqual(expected)

- []
+ [
+   {
+     "files": [
+       "bun.d.ts",
+       "fetch.d.ts",
+       "globals.d.ts",
+     ],
+     "packageName": "undici-types",
+   },
+ ]

- Expected  - 1
+ Received  + 10

      at <anonymous> (/workspace/bun/test/integration/bun-types/bun-types.test.ts:365:24)
(fail) @types/bun integration test > every package that bun-types imports from is one of its dependencies [28.95ms]
132 |     expect(emptyInterfaces).toEqual(config.emptyInterfaces);
133 | 
134 |     if (typeof config.diagnostics === "function") {
135 |       config.diagnostics(diagn
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.0 (4c689909e)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [2.59ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.44ms]
(pass) @types/bun integration test > every package that bun-types imports from is one of its dependencies [1073.75ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [1490.69ms]
(skip) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references
(skip) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation restricts feature() to known 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 703ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/49] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/49] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/49] gen cpp.rs (cppbind)
[4/49] gen JS modules (bundle-modules)
Preprocess modules (11095ms)
Bundle modules (69ms)
Postprocesss modules (26ms)
Bundle Functions (645ms)
Generate Code (20ms)

[11.88s] Bundled "src/js" for production
  2627 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[4/45] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
^[[1m^[[92m   Compiling^[[0m bun_libuv_sys v0.0.0 (/workspace/bun/src/libuv_sys)
^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
bun.lock                                           |   1 +
 packages/bun-types/bun.d.ts                        |  15 +-
 packages/bun-types/globals.d.ts                    | 439 +++++++++++++--------
 packages/bun-types/overrides.d.ts                  |  37 +-
 packages/bun-types/package.json                    |   3 +-
 packages/bun-types/test.d.ts                       |  22 +-
 test/integration/bun-types/bun-types.test.ts       | 115 ++++--
 .../integration/bun-types/fixture/core-js-types.ts | 185 +++++++++
 test/integration/bun-types/fixture/globals.ts      |  38 +-
 test/integration/bun-types/fixture/map.ts          |  46 +++
 test/integration/bun-types/fixture/mocks.ts        |  66 +++-
 test/integration/bun-types/fixture/streams.ts      |   2 +-
 test/integration/bun-types/fixture/websocket.ts    |  21 +-
 test/integration/bun-types/fixture/webview.ts      |  17 +
 14 files changed, 768 insertions(+), 239 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
bun.lock                                                 1      0      0
packages/bun-types/bun.d.ts                              2      3      0
packages/bun-types/globals.d.ts                          9      7      0
packages/bun-types/overrides.d.ts                        1      1      0
packages/bun-types/package.json                          1      2      0
packages/bun-types/test.d.ts                             4      5      0
test/integration/bun-types/bun-types.test.ts             2     13      0
test/integration/bun-types/fixture/core-js-types.ts      2      4      0
test/integration/bun-types/fixture/globals.ts            3      3      0
test/integration/bun-types/fixture/map.ts                0      1      0
test/integration/bun-types/fixture/mocks.ts              1      2      0
test/integration/bun-types/fixture/streams.ts            1      1      0
test/integration/bun-types/fixture/websocket.ts          1      2      0
test/integration/bun-types/fixture/webview.ts            0      1      0
```

</details>

<!-- robobun:evidence:end -->



