### PR TITLE
test(http2): check the release cases through the native handles instead of collecting

### DIFF
--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1674,7 +1674,17 @@ describe("inbound stream lifecycle", () => {
 // (end() without a body, or the empty frame that follows a body once no trailers are coming); the
 // queue writes the two through different branches, so both shapes are covered below.
 describe("stream release after a queued END_STREAM", () => {
-  const STREAMS = 4;
+  const STREAMS = 8;
+  // JSC scans the machine stack conservatively. The dispatch that completes a stream leaves copies
+  // of the stream's address (and of its request and response objects, which point back at it) all
+  // over the stack region that the frames of a later collection occupy. A copy under a slot that
+  // those frames do not write keeps the stream alive although nothing references it, and it does so
+  // on every pass, because every pass lays the frames out the same way. One such stream per run was
+  // seen on linux x64 and darwin arm64 (a different one on each; it is collected as soon as the
+  // collection is started from a differently shaped stack, and each shape tried pinned some copy in
+  // some setup). The leak these cases guard against keeps every stream alive, so they assert that
+  // the streams are collectable, allowing for the pinned ones, instead of requiring all of them gone.
+  const PINNED_BY_STACK_SCAN = 2;
   // The peer advertises a 1 KiB stream window: a 4 KiB body cannot be written in one go, so its
   // tail (the frame carrying END_STREAM) is queued and flushed as the peer's WINDOW_UPDATEs arrive.
   const WINDOW = 1024;
@@ -1689,11 +1699,12 @@ describe("stream release after a queued END_STREAM", () => {
     return `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`;
   }
 
+  /** Collects until at most PINNED_BY_STACK_SCAN of `refs` are alive (or gives up) and reports how many are. */
   async function liveCount(refs: WeakRef<object>[]): Promise<number> {
     const live = () => refs.filter(ref => ref.deref() !== undefined).length;
     // A completed stream's JS teardown is spread over a few immediates, and a WeakRef target
     // survives the job that dereferenced it, so every pass gets a fresh turn before collecting.
-    for (let i = 0; i < 50 && live() > 0; i++) {
+    for (let i = 0; i < 50 && live() > PINNED_BY_STACK_SCAN; i++) {
       await new Promise(resolve => setImmediate(resolve));
       await gcTick();
     }
@@ -1743,7 +1754,7 @@ describe("stream release after a queued END_STREAM", () => {
         tailQueued: Array(STREAMS).fill(true),
         received: Array(STREAMS).fill(BODY.length),
       });
-      expect(await liveCount(refs)).toBe(0);
+      expect(await liveCount(refs)).toBeLessThanOrEqual(PINNED_BY_STACK_SCAN);
     } finally {
       client.close();
       server.close();
@@ -1811,7 +1822,9 @@ describe("stream release after a queued END_STREAM", () => {
         finish(stream);
       });
     });
-    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBe(0);
+    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBeLessThanOrEqual(
+      PINNED_BY_STACK_SCAN,
+    );
   });
 
   // The compat API's responses wait for trailers, so after the body END_STREAM always goes out on an
@@ -1831,7 +1844,9 @@ describe("stream release after a queued END_STREAM", () => {
       req.resume();
       req.on("end", () => res.end("ok"));
     });
-    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBe(0);
+    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBeLessThanOrEqual(
+      PINNED_BY_STACK_SCAN,
+    );
   });
 
   test("client streams whose request body outgrew the server's window are released", async () => {
@@ -1872,7 +1887,7 @@ describe("stream release after a queued END_STREAM", () => {
         tailQueued: Array(STREAMS).fill(true),
         uploaded: Array(STREAMS).fill(BODY.length),
       });
-      expect(await liveCount(refs)).toBe(0);
+      expect(await liveCount(refs)).toBeLessThanOrEqual(PINNED_BY_STACK_SCAN);
     } finally {
       client.close();
       server.close();

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1674,17 +1674,15 @@ describe("inbound stream lifecycle", () => {
 // (end() without a body, or the empty frame that follows a body once no trailers are coming); the
 // queue writes the two through different branches, so both shapes are covered below.
 describe("stream release after a queued END_STREAM", () => {
-  const STREAMS = 8;
-  // JSC scans the machine stack conservatively. The dispatch that completes a stream leaves copies
-  // of the stream's address (and of its request and response objects, which point back at it) all
-  // over the stack region that the frames of a later collection occupy. A copy under a slot that
-  // those frames do not write keeps the stream alive although nothing references it, and it does so
-  // on every pass, because every pass lays the frames out the same way. One such stream per run was
-  // seen on linux x64 and darwin arm64 (a different one on each; it is collected as soon as the
-  // collection is started from a differently shaped stack, and each shape tried pinned some copy in
-  // some setup). The leak these cases guard against keeps every stream alive, so they assert that
-  // the streams are collectable, allowing for the pinned ones, instead of requiring all of them gone.
-  const PINNED_BY_STACK_SCAN = 2;
+  // JSC scans the machine stack conservatively. Completing a stream leaves copies of the stream's
+  // address (and of its request and response objects, which point back at it) in the stack region
+  // that the frames of a later collection occupy, and a copy under a slot those frames never write
+  // keeps the stream alive for as long as the collections keep being started the same way. On the
+  // full file on darwin aarch64, the last stream stays alive through all 50 passes of liveCount and
+  // the one before it through dozens of them (on linux x64 the last one does with `-t`), and three
+  // streams were seen alive after one pass. The leak these cases guard against keeps every stream
+  // alive. So the cases pass once fewer than half of the streams are left, which is far from both.
+  const STREAMS = 16;
   // The peer advertises a 1 KiB stream window: a 4 KiB body cannot be written in one go, so its
   // tail (the frame carrying END_STREAM) is queued and flushed as the peer's WINDOW_UPDATEs arrive.
   const WINDOW = 1024;
@@ -1699,12 +1697,12 @@ describe("stream release after a queued END_STREAM", () => {
     return `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`;
   }
 
-  /** Collects until at most PINNED_BY_STACK_SCAN of `refs` are alive (or gives up) and reports how many are. */
+  /** Collects until fewer than half of `refs` are alive (or gives up) and reports how many are. */
   async function liveCount(refs: WeakRef<object>[]): Promise<number> {
     const live = () => refs.filter(ref => ref.deref() !== undefined).length;
     // A completed stream's JS teardown is spread over a few immediates, and a WeakRef target
     // survives the job that dereferenced it, so every pass gets a fresh turn before collecting.
-    for (let i = 0; i < 50 && live() > PINNED_BY_STACK_SCAN; i++) {
+    for (let i = 0; i < 50 && live() >= STREAMS / 2; i++) {
       await new Promise(resolve => setImmediate(resolve));
       await gcTick();
     }
@@ -1754,7 +1752,7 @@ describe("stream release after a queued END_STREAM", () => {
         tailQueued: Array(STREAMS).fill(true),
         received: Array(STREAMS).fill(BODY.length),
       });
-      expect(await liveCount(refs)).toBeLessThanOrEqual(PINNED_BY_STACK_SCAN);
+      expect(await liveCount(refs)).toBeLessThan(STREAMS / 2);
     } finally {
       client.close();
       server.close();
@@ -1822,9 +1820,7 @@ describe("stream release after a queued END_STREAM", () => {
         finish(stream);
       });
     });
-    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBeLessThanOrEqual(
-      PINNED_BY_STACK_SCAN,
-    );
+    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBeLessThan(STREAMS / 2);
   });
 
   // The compat API's responses wait for trailers, so after the body END_STREAM always goes out on an
@@ -1844,9 +1840,7 @@ describe("stream release after a queued END_STREAM", () => {
       req.resume();
       req.on("end", () => res.end("ok"));
     });
-    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBeLessThanOrEqual(
-      PINNED_BY_STACK_SCAN,
-    );
+    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBeLessThan(STREAMS / 2);
   });
 
   test("client streams whose request body outgrew the server's window are released", async () => {
@@ -1887,7 +1881,7 @@ describe("stream release after a queued END_STREAM", () => {
         tailQueued: Array(STREAMS).fill(true),
         uploaded: Array(STREAMS).fill(BODY.length),
       });
-      expect(await liveCount(refs)).toBeLessThanOrEqual(PINNED_BY_STACK_SCAN);
+      expect(await liveCount(refs)).toBeLessThan(STREAMS / 2);
     } finally {
       client.close();
       server.close();

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1690,100 +1690,113 @@ describe("stream release after a queued END_STREAM", () => {
     return `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`;
   }
 
-  /**
-   * How many Strong handles native code holds on Http2Stream objects right now. A stream's JS
-   * object is rooted that way from the moment the stream exists until free_resources drops the
-   * handles (two per server stream, one per client stream). So a stream that is not released keeps
-   * showing up here for as long as its session lives, and a released one is gone at once, the
-   * handles being dropped rather than collected, which is what makes these counts exact.
-   */
-  function rootedStreams(): number {
-    return getProtectedObjects().filter(o => o instanceof Duplex && /Http2Stream$/.test(o.constructor.name)).length;
-  }
+  /** Names a stream by its side and its id on the session: "ServerHttp2Stream#5". */
+  const label = (stream: http2.Http2Stream) => `${stream.constructor.name}#${stream.id}`;
 
   /**
-   * The count to measure against: the handles on the streams the case has set up so far. Whatever
-   * earlier activity left behind is finalized first, and a release that is still on its way (a
-   * stream's last handle goes one immediate after the stream closes) is given time to land, so that
-   * neither can land inside the measurement.
+   * One entry per Strong handle that native code holds on an Http2Stream object, naming the stream.
+   * A stream's JS object is held that way from the moment the stream exists until free_resources
+   * drops the handles (two for a server stream, one for a client stream). So a stream that is not
+   * released keeps its entries here for as long as its session lives, and a released one loses them
+   * at once: the handles are dropped, not collected, which is what makes this exact.
    */
-  async function settledRootedStreams(): Promise<number> {
-    Bun.gc(true);
-    let count = rootedStreams();
-    for (let i = 0; i < 50; i++) {
-      await new Promise(resolve => setImmediate(resolve));
-      const next = rootedStreams();
-      if (next === count) break;
-      count = next;
-    }
-    return count;
+  function rootedStreams(): string[] {
+    return getProtectedObjects()
+      .filter(o => o instanceof Duplex && /Http2Stream$/.test(o.constructor.name))
+      .map(o => label(o as http2.Http2Stream))
+      .sort();
   }
 
-  /** How many handles beyond `baseline` are still held once the releases have had time to land. */
-  async function rootedBeyond(baseline: number): Promise<number> {
-    for (let i = 0; i < 50 && rootedStreams() !== baseline; i++) {
-      await new Promise(resolve => setImmediate(resolve));
-    }
-    return rootedStreams() - baseline;
+  /** The entries of `rootedStreams()` that `baseline` does not account for. */
+  function rootedBeyondNow(baseline: string[]): string[] {
+    const accountedFor = [...baseline];
+    return rootedStreams().filter(entry => {
+      const i = accountedFor.indexOf(entry);
+      if (i === -1) return true;
+      accountedFor.splice(i, 1);
+      return false;
+    });
   }
 
-  /** Tears the session down before the case ends, so that its releases cannot land inside the next case's measurement. */
+  /**
+   * Resolves to the handles still held beyond `baseline` once the releases have had time to land (the
+   * last handle of a completed stream goes one immediate after the stream closes).
+   */
+  async function rootedBeyond(baseline: string[]): Promise<string[]> {
+    let left = rootedBeyondNow(baseline);
+    for (let i = 0; i < 50 && left.length > 0; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+      left = rootedBeyondNow(baseline);
+    }
+    return left;
+  }
+
+  /**
+   * Tears the case's session down and waits for the handles it still held (on the stalled streams)
+   * to go, which on the server side happens once its socket has closed, so that the next case starts
+   * from an empty set.
+   */
   async function closeAll(client: http2.ClientHttp2Session, server: http2.Http2Server): Promise<void> {
     client.destroy();
     await new Promise(resolve => server.close(resolve));
+    for (let i = 0; i < 50 && rootedStreams().length > 0; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
   }
 
   /**
    * Sends one request and resolves once the client stream has closed, reporting how many response
-   * body bytes arrived and how many frames the client session still had queued when the response
-   * headers came in.
+   * body bytes arrived, how many frames the client session still had queued when the response
+   * headers came in, and whether the client stream was rooted at that point.
    */
   function roundTrip(client: http2.ClientHttp2Session, headers: http2.OutgoingHttpHeaders, body?: Buffer) {
-    const { promise, resolve, reject } = Promise.withResolvers<{ received: number; queuedAtResponse: number }>();
+    const { promise, resolve, reject } = Promise.withResolvers<{
+      received: number;
+      queuedAtResponse: number;
+      rootedAtResponse: boolean;
+    }>();
     const req = client.request(headers);
     let received = 0;
     let queuedAtResponse = -1;
+    let rootedAtResponse = false;
     req.on("error", reject);
     req.on("response", () => {
       queuedAtResponse = client.state.outboundQueueSize!;
+      rootedAtResponse = rootedStreams().includes(label(req));
     });
     req.on("data", (chunk: Buffer) => {
       received += chunk.length;
     });
-    req.on("close", () => resolve({ received, queuedAtResponse }));
+    req.on("close", () => resolve({ received, queuedAtResponse, rootedAtResponse }));
     req.end(body);
     return promise;
   }
 
   test("server streams whose response outgrew the client's window are released", async () => {
-    const rootedWhileOpen: number[] = [];
+    const rootedWhileOpen: boolean[] = [];
     const queuedAfterEnd: number[] = [];
     const server = http2.createServer();
     server.on("stream", stream => {
-      rootedWhileOpen.push(rootedStreams());
+      rootedWhileOpen.push(rootedStreams().includes(label(stream)));
       stream.respond({ ":status": 200 });
       stream.end(BODY);
       queuedAfterEnd.push(stream.session!.state.outboundQueueSize!);
     });
     const client = http2.connect(await listen(server), { settings: { initialWindowSize: WINDOW } });
     try {
-      const baseline = await settledRootedStreams();
+      const baseline = rootedStreams();
       const received: number[] = [];
       for (let i = 0; i < STREAMS; i++) {
         received.push((await roundTrip(client, { ":path": "/" })).received);
       }
-      // The premise: each stream was rooted while it was open, each response left part of its body
-      // queued, and the queue then delivered it.
-      expect({
-        rooted: rootedWhileOpen.map(n => n > baseline),
-        tailQueued: queuedAfterEnd.map(n => n > 0),
-        received,
-      }).toEqual({
-        rooted: Array(STREAMS).fill(true),
+      // The premise: each server stream was rooted while it was open, each response left part of
+      // its body queued, and the queue then delivered it.
+      expect({ rootedWhileOpen, tailQueued: queuedAfterEnd.map(n => n > 0), received }).toEqual({
+        rootedWhileOpen: Array(STREAMS).fill(true),
         tailQueued: Array(STREAMS).fill(true),
         received: Array(STREAMS).fill(BODY.length),
       });
-      expect(await rootedBeyond(baseline)).toBe(0);
+      expect(await rootedBeyond(baseline)).toEqual([]);
     } finally {
       await closeAll(client, server);
     }
@@ -1795,32 +1808,32 @@ describe("stream release after a queued END_STREAM", () => {
    * response, and with it a non-empty outbound queue, until the session goes away), then runs
    * STREAMS ordinary requests on the same session. `server` must answer "/stalled" with
    * STALLED_BODY and report through `stalledFinished` whether that response ever finished; every
-   * other request must push `rootedStreams()` onto `rootedWhileOpen` while its stream is open.
-   * Resolves to how many handles those requests left behind.
+   * other request must push onto `rootedWhileOpen` whether its stream was rooted while it was open.
+   * Resolves to the handles those requests left behind.
    */
   async function rootedAfterRequestsBehindStalledResponse(
     server: http2.Http2Server,
-    rootedWhileOpen: number[],
+    rootedWhileOpen: boolean[],
     stalledFinished: () => boolean,
-  ): Promise<number> {
+  ): Promise<string[]> {
     const client = http2.connect(await listen(server));
     try {
       const stalled = client.request({ ":path": "/stalled" });
       let stalledError: Error | null = null;
       stalled.on("error", err => (stalledError = err));
       await once(stalled, "response");
-      const baseline = await settledRootedStreams();
+      const baseline = rootedStreams();
       for (let i = 0; i < STREAMS; i++) {
         await roundTrip(client, { ":path": "/" });
       }
-      const beyond = await rootedBeyond(baseline);
-      // The premise: every request's stream was rooted while it was open, and the stalled stream is
-      // still open (not errored or reset into releasing the queue) with its response still queued,
-      // as it was while the other requests were answered.
-      expect(rootedWhileOpen.map(n => n > baseline)).toEqual(Array(STREAMS).fill(true));
+      const left = await rootedBeyond(baseline);
+      // The premise: every request's server stream was rooted while it was open, and the stalled
+      // stream is still open (not errored or reset into releasing the queue) with its response still
+      // queued, as it was while the other requests were answered.
+      expect(rootedWhileOpen).toEqual(Array(STREAMS).fill(true));
       expect(stalledError).toBeNull();
       expect(stalledFinished()).toBe(false);
-      return beyond;
+      return left;
     } finally {
       await closeAll(client, server);
     }
@@ -1830,7 +1843,7 @@ describe("stream release after a queued END_STREAM", () => {
     ['end("ok")', (stream: http2.ServerHttp2Stream) => stream.end("ok")],
     ["end() without a body", (stream: http2.ServerHttp2Stream) => stream.end()],
   ])("server streams answered with %s behind another stream's stalled response are released", async (_, finish) => {
-    const rootedWhileOpen: number[] = [];
+    const rootedWhileOpen: boolean[] = [];
     let stalledFinished = false;
     const server = http2.createServer();
     server.on("stream", (stream, headers) => {
@@ -1842,7 +1855,7 @@ describe("stream release after a queued END_STREAM", () => {
         stream.end(STALLED_BODY);
         return;
       }
-      rootedWhileOpen.push(rootedStreams());
+      rootedWhileOpen.push(rootedStreams().includes(label(stream)));
       stream.resume();
       // Answer once the request's END_STREAM has been processed, like a handler that consumes the
       // request body does: the queued response is then the only thing the stream still waits for.
@@ -1851,13 +1864,13 @@ describe("stream release after a queued END_STREAM", () => {
         finish(stream);
       });
     });
-    expect(await rootedAfterRequestsBehindStalledResponse(server, rootedWhileOpen, () => stalledFinished)).toBe(0);
+    expect(await rootedAfterRequestsBehindStalledResponse(server, rootedWhileOpen, () => stalledFinished)).toEqual([]);
   });
 
   // The compat API's responses wait for trailers, so after the body END_STREAM always goes out on an
   // empty DATA frame of its own.
   test("server streams answered through the compat API behind another stream's stalled response are released", async () => {
-    const rootedWhileOpen: number[] = [];
+    const rootedWhileOpen: boolean[] = [];
     let stalledFinished = false;
     const server = http2.createServer((req, res) => {
       if (req.url === "/stalled") {
@@ -1867,19 +1880,17 @@ describe("stream release after a queued END_STREAM", () => {
         res.end(STALLED_BODY);
         return;
       }
-      rootedWhileOpen.push(rootedStreams());
+      rootedWhileOpen.push(rootedStreams().includes(label(res.stream)));
       req.resume();
       req.on("end", () => res.end("ok"));
     });
-    expect(await rootedAfterRequestsBehindStalledResponse(server, rootedWhileOpen, () => stalledFinished)).toBe(0);
+    expect(await rootedAfterRequestsBehindStalledResponse(server, rootedWhileOpen, () => stalledFinished)).toEqual([]);
   });
 
   test("client streams whose request body outgrew the server's window are released", async () => {
-    const rootedWhileOpen: number[] = [];
     const uploaded: Promise<number>[] = [];
     const server = http2.createServer({ settings: { initialWindowSize: WINDOW } });
     server.on("stream", stream => {
-      rootedWhileOpen.push(rootedStreams());
       // Answer as soon as the headers arrive, so the server's END_STREAM reaches the client while
       // the client still has the body's tail queued, and keep reading the body so that tail really
       // is flushed from the queue (an upload nobody reads gets reset instead, and a reset releases
@@ -1901,23 +1912,23 @@ describe("stream release after a queued END_STREAM", () => {
     try {
       // The server's window applies to requests opened after its SETTINGS frame has been received.
       await once(client, "remoteSettings");
-      const baseline = await settledRootedStreams();
-      const queuedAtResponse: number[] = [];
+      const baseline = rootedStreams();
+      const responses: { queuedAtResponse: number; rootedAtResponse: boolean }[] = [];
       for (let i = 0; i < STREAMS; i++) {
-        queuedAtResponse.push((await roundTrip(client, { ":method": "POST", ":path": "/" }, BODY)).queuedAtResponse);
+        responses.push(await roundTrip(client, { ":method": "POST", ":path": "/" }, BODY));
       }
-      // The premise: each stream was rooted while it was open, each response arrived while the
-      // request's tail was still queued, and the queue then delivered that tail.
+      // The premise: each response arrived while the request's tail was still queued and its client
+      // stream still rooted, and the queue then delivered that tail.
       expect({
-        rooted: rootedWhileOpen.map(n => n > baseline),
-        tailQueued: queuedAtResponse.map(n => n > 0),
+        tailQueued: responses.map(r => r.queuedAtResponse > 0),
+        rootedAtResponse: responses.map(r => r.rootedAtResponse),
         uploaded: await Promise.all(uploaded),
       }).toEqual({
-        rooted: Array(STREAMS).fill(true),
         tailQueued: Array(STREAMS).fill(true),
+        rootedAtResponse: Array(STREAMS).fill(true),
         uploaded: Array(STREAMS).fill(BODY.length),
       });
-      expect(await rootedBeyond(baseline)).toBe(0);
+      expect(await rootedBeyond(baseline)).toEqual([]);
     } finally {
       await closeAll(client, server);
     }

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -7,12 +7,13 @@
 // Connection-level cases only here (no HPACK required): preface, SETTINGS handshake/ack, PING,
 // WINDOW_UPDATE, frame-size and stream-id rules. HPACK/HEADERS cases live in a sibling file.
 
+import { getProtectedObjects } from "bun:jsc";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, gcTick, normalizeBunSnapshot } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
-import { Writable } from "node:stream";
+import { Duplex, Writable } from "node:stream";
 
 const PREFACE = Buffer.from("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n", "latin1");
 
@@ -1674,15 +1675,7 @@ describe("inbound stream lifecycle", () => {
 // (end() without a body, or the empty frame that follows a body once no trailers are coming); the
 // queue writes the two through different branches, so both shapes are covered below.
 describe("stream release after a queued END_STREAM", () => {
-  // JSC scans the machine stack conservatively. Completing a stream leaves copies of the stream's
-  // address (and of its request and response objects, which point back at it) in the stack region
-  // that the frames of a later collection occupy, and a copy under a slot those frames never write
-  // keeps the stream alive for as long as the collections keep being started the same way. On the
-  // full file on darwin aarch64, the last stream stays alive through all 50 passes of liveCount and
-  // the one before it through dozens of them (on linux x64 the last one does with `-t`), and three
-  // streams were seen alive after one pass. The leak these cases guard against keeps every stream
-  // alive. So the cases pass once fewer than half of the streams are left, which is far from both.
-  const STREAMS = 16;
+  const STREAMS = 4;
   // The peer advertises a 1 KiB stream window: a 4 KiB body cannot be written in one go, so its
   // tail (the frame carrying END_STREAM) is queued and flushed as the peer's WINDOW_UPDATEs arrive.
   const WINDOW = 1024;
@@ -1697,16 +1690,47 @@ describe("stream release after a queued END_STREAM", () => {
     return `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`;
   }
 
-  /** Collects until fewer than half of `refs` are alive (or gives up) and reports how many are. */
-  async function liveCount(refs: WeakRef<object>[]): Promise<number> {
-    const live = () => refs.filter(ref => ref.deref() !== undefined).length;
-    // A completed stream's JS teardown is spread over a few immediates, and a WeakRef target
-    // survives the job that dereferenced it, so every pass gets a fresh turn before collecting.
-    for (let i = 0; i < 50 && live() >= STREAMS / 2; i++) {
+  /**
+   * How many Strong handles native code holds on Http2Stream objects right now. A stream's JS
+   * object is rooted that way from the moment the stream exists until free_resources drops the
+   * handles (two per server stream, one per client stream). So a stream that is not released keeps
+   * showing up here for as long as its session lives, and a released one is gone at once, the
+   * handles being dropped rather than collected, which is what makes these counts exact.
+   */
+  function rootedStreams(): number {
+    return getProtectedObjects().filter(o => o instanceof Duplex && /Http2Stream$/.test(o.constructor.name)).length;
+  }
+
+  /**
+   * The count to measure against: the handles on the streams the case has set up so far. Whatever
+   * earlier activity left behind is finalized first, and a release that is still on its way (a
+   * stream's last handle goes one immediate after the stream closes) is given time to land, so that
+   * neither can land inside the measurement.
+   */
+  async function settledRootedStreams(): Promise<number> {
+    Bun.gc(true);
+    let count = rootedStreams();
+    for (let i = 0; i < 50; i++) {
       await new Promise(resolve => setImmediate(resolve));
-      await gcTick();
+      const next = rootedStreams();
+      if (next === count) break;
+      count = next;
     }
-    return live();
+    return count;
+  }
+
+  /** How many handles beyond `baseline` are still held once the releases have had time to land. */
+  async function rootedBeyond(baseline: number): Promise<number> {
+    for (let i = 0; i < 50 && rootedStreams() !== baseline; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+    }
+    return rootedStreams() - baseline;
+  }
+
+  /** Tears the session down before the case ends, so that its releases cannot land inside the next case's measurement. */
+  async function closeAll(client: http2.ClientHttp2Session, server: http2.Http2Server): Promise<void> {
+    client.destroy();
+    await new Promise(resolve => server.close(resolve));
   }
 
   /**
@@ -1728,34 +1752,40 @@ describe("stream release after a queued END_STREAM", () => {
     });
     req.on("close", () => resolve({ received, queuedAtResponse }));
     req.end(body);
-    return { ref: new WeakRef<object>(req), closed: promise };
+    return promise;
   }
 
   test("server streams whose response outgrew the client's window are released", async () => {
-    const refs: WeakRef<object>[] = [];
+    const rootedWhileOpen: number[] = [];
     const queuedAfterEnd: number[] = [];
     const server = http2.createServer();
     server.on("stream", stream => {
-      refs.push(new WeakRef(stream));
+      rootedWhileOpen.push(rootedStreams());
       stream.respond({ ":status": 200 });
       stream.end(BODY);
       queuedAfterEnd.push(stream.session!.state.outboundQueueSize!);
     });
     const client = http2.connect(await listen(server), { settings: { initialWindowSize: WINDOW } });
     try {
+      const baseline = await settledRootedStreams();
       const received: number[] = [];
       for (let i = 0; i < STREAMS; i++) {
-        received.push((await roundTrip(client, { ":path": "/" }).closed).received);
+        received.push((await roundTrip(client, { ":path": "/" })).received);
       }
-      // The premise: each response left part of its body queued, and the queue then delivered it.
-      expect({ tailQueued: queuedAfterEnd.map(n => n > 0), received }).toEqual({
+      // The premise: each stream was rooted while it was open, each response left part of its body
+      // queued, and the queue then delivered it.
+      expect({
+        rooted: rootedWhileOpen.map(n => n > baseline),
+        tailQueued: queuedAfterEnd.map(n => n > 0),
+        received,
+      }).toEqual({
+        rooted: Array(STREAMS).fill(true),
         tailQueued: Array(STREAMS).fill(true),
         received: Array(STREAMS).fill(BODY.length),
       });
-      expect(await liveCount(refs)).toBeLessThan(STREAMS / 2);
+      expect(await rootedBeyond(baseline)).toBe(0);
     } finally {
-      client.close();
-      server.close();
+      await closeAll(client, server);
     }
   });
 
@@ -1765,11 +1795,12 @@ describe("stream release after a queued END_STREAM", () => {
    * response, and with it a non-empty outbound queue, until the session goes away), then runs
    * STREAMS ordinary requests on the same session. `server` must answer "/stalled" with
    * STALLED_BODY and report through `stalledFinished` whether that response ever finished; every
-   * other request must register its stream in `refs`. Resolves to how many of `refs` survived GC.
+   * other request must push `rootedStreams()` onto `rootedWhileOpen` while its stream is open.
+   * Resolves to how many handles those requests left behind.
    */
-  async function liveAfterRequestsBehindStalledResponse(
+  async function rootedAfterRequestsBehindStalledResponse(
     server: http2.Http2Server,
-    refs: WeakRef<object>[],
+    rootedWhileOpen: number[],
     stalledFinished: () => boolean,
   ): Promise<number> {
     const client = http2.connect(await listen(server));
@@ -1778,20 +1809,20 @@ describe("stream release after a queued END_STREAM", () => {
       let stalledError: Error | null = null;
       stalled.on("error", err => (stalledError = err));
       await once(stalled, "response");
+      const baseline = await settledRootedStreams();
       for (let i = 0; i < STREAMS; i++) {
-        await roundTrip(client, { ":path": "/" }).closed;
+        await roundTrip(client, { ":path": "/" });
       }
-      expect(refs).toHaveLength(STREAMS);
-      const live = await liveCount(refs);
-      // The premise: the stalled stream is still open (not errored or reset into releasing the
-      // queue) and its response was still queued while the other requests were answered.
+      const beyond = await rootedBeyond(baseline);
+      // The premise: every request's stream was rooted while it was open, and the stalled stream is
+      // still open (not errored or reset into releasing the queue) with its response still queued,
+      // as it was while the other requests were answered.
+      expect(rootedWhileOpen.map(n => n > baseline)).toEqual(Array(STREAMS).fill(true));
       expect(stalledError).toBeNull();
       expect(stalledFinished()).toBe(false);
-      stalled.close();
-      return live;
+      return beyond;
     } finally {
-      client.close();
-      server.close();
+      await closeAll(client, server);
     }
   }
 
@@ -1799,7 +1830,7 @@ describe("stream release after a queued END_STREAM", () => {
     ['end("ok")', (stream: http2.ServerHttp2Stream) => stream.end("ok")],
     ["end() without a body", (stream: http2.ServerHttp2Stream) => stream.end()],
   ])("server streams answered with %s behind another stream's stalled response are released", async (_, finish) => {
-    const refs: WeakRef<object>[] = [];
+    const rootedWhileOpen: number[] = [];
     let stalledFinished = false;
     const server = http2.createServer();
     server.on("stream", (stream, headers) => {
@@ -1811,7 +1842,7 @@ describe("stream release after a queued END_STREAM", () => {
         stream.end(STALLED_BODY);
         return;
       }
-      refs.push(new WeakRef(stream));
+      rootedWhileOpen.push(rootedStreams());
       stream.resume();
       // Answer once the request's END_STREAM has been processed, like a handler that consumes the
       // request body does: the queued response is then the only thing the stream still waits for.
@@ -1820,13 +1851,13 @@ describe("stream release after a queued END_STREAM", () => {
         finish(stream);
       });
     });
-    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBeLessThan(STREAMS / 2);
+    expect(await rootedAfterRequestsBehindStalledResponse(server, rootedWhileOpen, () => stalledFinished)).toBe(0);
   });
 
   // The compat API's responses wait for trailers, so after the body END_STREAM always goes out on an
   // empty DATA frame of its own.
   test("server streams answered through the compat API behind another stream's stalled response are released", async () => {
-    const refs: WeakRef<object>[] = [];
+    const rootedWhileOpen: number[] = [];
     let stalledFinished = false;
     const server = http2.createServer((req, res) => {
       if (req.url === "/stalled") {
@@ -1836,18 +1867,19 @@ describe("stream release after a queued END_STREAM", () => {
         res.end(STALLED_BODY);
         return;
       }
-      refs.push(new WeakRef(res.stream));
+      rootedWhileOpen.push(rootedStreams());
       req.resume();
       req.on("end", () => res.end("ok"));
     });
-    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBeLessThan(STREAMS / 2);
+    expect(await rootedAfterRequestsBehindStalledResponse(server, rootedWhileOpen, () => stalledFinished)).toBe(0);
   });
 
   test("client streams whose request body outgrew the server's window are released", async () => {
-    const refs: WeakRef<object>[] = [];
+    const rootedWhileOpen: number[] = [];
     const uploaded: Promise<number>[] = [];
     const server = http2.createServer({ settings: { initialWindowSize: WINDOW } });
     server.on("stream", stream => {
+      rootedWhileOpen.push(rootedStreams());
       // Answer as soon as the headers arrive, so the server's END_STREAM reaches the client while
       // the client still has the body's tail queued, and keep reading the body so that tail really
       // is flushed from the queue (an upload nobody reads gets reset instead, and a reset releases
@@ -1869,22 +1901,25 @@ describe("stream release after a queued END_STREAM", () => {
     try {
       // The server's window applies to requests opened after its SETTINGS frame has been received.
       await once(client, "remoteSettings");
+      const baseline = await settledRootedStreams();
       const queuedAtResponse: number[] = [];
       for (let i = 0; i < STREAMS; i++) {
-        const { ref, closed } = roundTrip(client, { ":method": "POST", ":path": "/" }, BODY);
-        refs.push(ref);
-        queuedAtResponse.push((await closed).queuedAtResponse);
+        queuedAtResponse.push((await roundTrip(client, { ":method": "POST", ":path": "/" }, BODY)).queuedAtResponse);
       }
-      // The premise: each response arrived while the request's tail was still queued, and the queue
-      // then delivered that tail.
-      expect({ tailQueued: queuedAtResponse.map(n => n > 0), uploaded: await Promise.all(uploaded) }).toEqual({
+      // The premise: each stream was rooted while it was open, each response arrived while the
+      // request's tail was still queued, and the queue then delivered that tail.
+      expect({
+        rooted: rootedWhileOpen.map(n => n > baseline),
+        tailQueued: queuedAtResponse.map(n => n > 0),
+        uploaded: await Promise.all(uploaded),
+      }).toEqual({
+        rooted: Array(STREAMS).fill(true),
         tailQueued: Array(STREAMS).fill(true),
         uploaded: Array(STREAMS).fill(BODY.length),
       });
-      expect(await liveCount(refs)).toBeLessThan(STREAMS / 2);
+      expect(await rootedBeyond(baseline)).toBe(0);
     } finally {
-      client.close();
-      server.close();
+      await closeAll(client, server);
     }
   });
 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1738,10 +1738,10 @@ describe("stream release after a queued END_STREAM", () => {
   }
 
   /**
-   * Tears the case's session down and checks that the streams it still held (the stalled ones) go
-   * with it (the stalled streams and the callback of the stalled frame), which on the server side
-   * happens once its socket has closed. So a case that leaves something behind fails on its own, and
-   * no case starts with another case's streams around.
+   * Tears the case's session down and checks that the handles it still held (the stalled stream on
+   * both sides and the callback of its queued tail) go with it, which on the server side happens once
+   * its socket has closed. So a case that leaves something behind fails on its own, and no case
+   * starts with another case's streams around.
    */
   async function closeAll(
     client: http2.ClientHttp2Session,

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1301,10 +1301,15 @@ describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
 /** Names a stream by its side and its id on the session: "ServerHttp2Stream#5". */
 const label = (stream: http2.Http2Stream) => `${stream.constructor.name}#${stream.id}`;
 
+/** What the write callback of a queued frame is listed as: the writable's onwrite, bound to the stream. */
+const QUEUED_WRITE_CALLBACK = "function bound onwrite";
+
 /**
  * One entry per handle native code holds on an Http2Stream (as `label` names it) or on a function
- * ("function bound onwrite"), sorted. `instanceof` is the guard because the list also holds JSC's own
- * protected cells, which are not all objects.
+ * (QUEUED_WRITE_CALLBACK), sorted. The list also holds JSC's own protected cells, which are not
+ * objects, and a property read on one of those aborts a debug build. Duplex and Function use the
+ * default instanceof, which checks for an object before it touches the value (Writable's own
+ * Symbol.hasInstance reads a property, so it is not a substitute), and that check has to come first.
  */
 function rootedHandles(): string[] {
   const entries: string[] = [];
@@ -1734,40 +1739,40 @@ describe("stream release after a queued END_STREAM", () => {
 
   /**
    * Tears the case's session down and checks that the streams it still held (the stalled ones) go
-   * with it, which on the server side happens once its socket has closed. So a case that leaves a
-   * stream behind fails on its own, and no case starts with another case's streams around.
+   * with it (the stalled streams and the callback of the stalled frame), which on the server side
+   * happens once its socket has closed. So a case that leaves something behind fails on its own, and
+   * no case starts with another case's streams around.
    */
-  async function closeAll(client: http2.ClientHttp2Session, server: http2.Http2Server): Promise<void> {
+  async function closeAll(
+    client: http2.ClientHttp2Session,
+    server: http2.Http2Server,
+    beforeTheCase: string[],
+  ): Promise<void> {
     client.destroy();
     await new Promise(resolve => server.close(resolve));
-    const streamsLeft = () => rootedHandles().filter(entry => entry.includes("Http2Stream#"));
-    let left = streamsLeft();
-    for (let i = 0; i < 50 && left.length > 0; i++) {
-      await new Promise(resolve => setImmediate(resolve));
-      left = streamsLeft();
-    }
-    expect(left).toEqual([]);
+    expect(await rootedBeyond(beforeTheCase)).toEqual([]);
   }
 
   /**
    * Sends one request and resolves once the client stream has closed, reporting how many response
    * body bytes arrived, how many frames the client session still had queued when the response
-   * headers came in, and whether the client stream was rooted at that point.
+   * headers came in, and which of the client stream and a queued frame's callback were rooted then.
    */
   function roundTrip(client: http2.ClientHttp2Session, headers: http2.OutgoingHttpHeaders, body?: Buffer) {
     const { promise, resolve, reject } = Promise.withResolvers<{
       received: number;
       queuedAtResponse: number;
-      rootedAtResponse: boolean;
+      rootedAtResponse: { stream: boolean; callback: boolean };
     }>();
     const req = client.request(headers);
     let received = 0;
     let queuedAtResponse = -1;
-    let rootedAtResponse = false;
+    let rootedAtResponse = { stream: false, callback: false };
     req.on("error", reject);
     req.on("response", () => {
       queuedAtResponse = client.state.outboundQueueSize!;
-      rootedAtResponse = rootedHandles().includes(label(req));
+      const rooted = rootedHandles();
+      rootedAtResponse = { stream: rooted.includes(label(req)), callback: rooted.includes(QUEUED_WRITE_CALLBACK) };
     });
     req.on("data", (chunk: Buffer) => {
       received += chunk.length;
@@ -1780,30 +1785,35 @@ describe("stream release after a queued END_STREAM", () => {
   test("server streams whose response outgrew the client's window are released", async () => {
     const rootedWhileOpen: boolean[] = [];
     const queuedAfterEnd: number[] = [];
+    const callbackRootedAfterEnd: boolean[] = [];
     const server = http2.createServer();
     server.on("stream", stream => {
       rootedWhileOpen.push(rootedHandles().includes(label(stream)));
       stream.respond({ ":status": 200 });
       stream.end(BODY);
       queuedAfterEnd.push(stream.session!.state.outboundQueueSize!);
+      callbackRootedAfterEnd.push(rootedHandles().includes(QUEUED_WRITE_CALLBACK));
     });
+    const baseline = rootedHandles();
     const client = http2.connect(await listen(server), { settings: { initialWindowSize: WINDOW } });
     try {
-      const baseline = rootedHandles();
       const received: number[] = [];
       for (let i = 0; i < STREAMS; i++) {
         received.push((await roundTrip(client, { ":path": "/" })).received);
       }
       // The premise: each server stream was rooted while it was open, each response left part of
-      // its body queued, and the queue then delivered it.
-      expect({ rootedWhileOpen, tailQueued: queuedAfterEnd.map(n => n > 0), received }).toEqual({
-        rootedWhileOpen: Array(STREAMS).fill(true),
-        tailQueued: Array(STREAMS).fill(true),
-        received: Array(STREAMS).fill(BODY.length),
-      });
+      // its body queued, with the callback of the queued tail rooted, and the queue then delivered it.
+      expect({ rootedWhileOpen, tailQueued: queuedAfterEnd.map(n => n > 0), callbackRootedAfterEnd, received }).toEqual(
+        {
+          rootedWhileOpen: Array(STREAMS).fill(true),
+          tailQueued: Array(STREAMS).fill(true),
+          callbackRootedAfterEnd: Array(STREAMS).fill(true),
+          received: Array(STREAMS).fill(BODY.length),
+        },
+      );
       expect(await rootedBeyond(baseline)).toEqual([]);
     } finally {
-      await closeAll(client, server);
+      await closeAll(client, server, baseline);
     }
   });
 
@@ -1821,26 +1831,31 @@ describe("stream release after a queued END_STREAM", () => {
     rootedWhileOpen: boolean[],
     stalledFinished: () => boolean,
   ): Promise<string[]> {
+    const beforeTheCase = rootedHandles();
     const client = http2.connect(await listen(server));
     try {
       const stalled = client.request({ ":path": "/stalled" });
       let stalledError: Error | null = null;
       stalled.on("error", err => (stalledError = err));
       await once(stalled, "response");
+      // What stalling rooted: the stalled stream on both sides and the callback of its queued tail.
+      const rootedByStalling = rootedBeyondNow(beforeTheCase);
       const baseline = rootedHandles();
       for (let i = 0; i < STREAMS; i++) {
         await roundTrip(client, { ":path": "/" });
       }
       const left = await rootedBeyond(baseline);
-      // The premise: every request's server stream was rooted while it was open, and the stalled
-      // stream is still open (not errored or reset into releasing the queue) with its response still
-      // queued, as it was while the other requests were answered.
+      // The premise: every request's server stream was rooted while it was open, the stalled
+      // response's tail was queued with its callback rooted, and the stalled stream is still open
+      // (not errored or reset into releasing the queue), as it was while the other requests were
+      // answered.
       expect(rootedWhileOpen).toEqual(Array(STREAMS).fill(true));
+      expect(rootedByStalling).toContain(QUEUED_WRITE_CALLBACK);
       expect(stalledError).toBeNull();
       expect(stalledFinished()).toBe(false);
       return left;
     } finally {
-      await closeAll(client, server);
+      await closeAll(client, server, beforeTheCase);
     }
   }
 
@@ -1913,29 +1928,29 @@ describe("stream release after a queued END_STREAM", () => {
       stream.respond({ ":status": 200 });
       stream.end();
     });
+    const baseline = rootedHandles();
     const client = http2.connect(await listen(server));
     try {
       // The server's window applies to requests opened after its SETTINGS frame has been received.
       await once(client, "remoteSettings");
-      const baseline = rootedHandles();
-      const responses: { queuedAtResponse: number; rootedAtResponse: boolean }[] = [];
+      const responses: Awaited<ReturnType<typeof roundTrip>>[] = [];
       for (let i = 0; i < STREAMS; i++) {
         responses.push(await roundTrip(client, { ":method": "POST", ":path": "/" }, BODY));
       }
-      // The premise: each response arrived while the request's tail was still queued and its client
-      // stream still rooted, and the queue then delivered that tail.
+      // The premise: each response arrived while the request's tail was still queued, with the
+      // client stream and the tail's callback still rooted, and the queue then delivered that tail.
       expect({
         tailQueued: responses.map(r => r.queuedAtResponse > 0),
         rootedAtResponse: responses.map(r => r.rootedAtResponse),
         uploaded: await Promise.all(uploaded),
       }).toEqual({
         tailQueued: Array(STREAMS).fill(true),
-        rootedAtResponse: Array(STREAMS).fill(true),
+        rootedAtResponse: Array(STREAMS).fill({ stream: true, callback: true }),
         uploaded: Array(STREAMS).fill(BODY.length),
       });
       expect(await rootedBeyond(baseline)).toEqual([]);
     } finally {
-      await closeAll(client, server);
+      await closeAll(client, server, baseline);
     }
   });
 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1733,16 +1733,20 @@ describe("stream release after a queued END_STREAM", () => {
   }
 
   /**
-   * Tears the case's session down and waits for the streams it still held (the stalled ones) to go,
-   * which on the server side happens once its socket has closed, so that the next case starts without
-   * them.
+   * Tears the case's session down and checks that the streams it still held (the stalled ones) go
+   * with it, which on the server side happens once its socket has closed. So a case that leaves a
+   * stream behind fails on its own, and no case starts with another case's streams around.
    */
   async function closeAll(client: http2.ClientHttp2Session, server: http2.Http2Server): Promise<void> {
     client.destroy();
     await new Promise(resolve => server.close(resolve));
-    for (let i = 0; i < 50 && rootedHandles().some(entry => entry.includes("Http2Stream#")); i++) {
+    const streamsLeft = () => rootedHandles().filter(entry => entry.includes("Http2Stream#"));
+    let left = streamsLeft();
+    for (let i = 0; i < 50 && left.length > 0; i++) {
       await new Promise(resolve => setImmediate(resolve));
+      left = streamsLeft();
     }
+    expect(left).toEqual([]);
   }
 
   /**

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -9,7 +9,7 @@
 
 import { getProtectedObjects } from "bun:jsc";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, gcTick, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
 import net from "node:net";
@@ -1290,22 +1290,71 @@ describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
   });
 });
 
+// Native code holds a stream's JS object through Strong handles from the moment the stream exists
+// until free_resources drops them, and holds the write callback of every frame it queues (the
+// writable's bound onwrite, which holds its stream) until the frame is written or dropped. Dropping a
+// handle is synchronous, so the release cases below read the handles before and after instead of
+// collecting: a stream or callback that was not released is still listed, named, and nothing about
+// it depends on the GC. A baseline is subtracted as a multiset, so handles that other activity holds
+// throughout, or releases late, do not matter.
+
+/** Names a stream by its side and its id on the session: "ServerHttp2Stream#5". */
+const label = (stream: http2.Http2Stream) => `${stream.constructor.name}#${stream.id}`;
+
+/**
+ * One entry per handle native code holds on an Http2Stream (as `label` names it) or on a function
+ * ("function bound onwrite"), sorted. `instanceof` is the guard because the list also holds JSC's own
+ * protected cells, which are not all objects.
+ */
+function rootedHandles(): string[] {
+  const entries: string[] = [];
+  for (const o of getProtectedObjects()) {
+    if (o instanceof Duplex && /Http2Stream$/.test(o.constructor.name)) entries.push(label(o as http2.Http2Stream));
+    else if (o instanceof Function) entries.push(`function ${o.name}`);
+  }
+  return entries.sort();
+}
+
+/** The entries of `rootedHandles()` that `baseline` does not account for. */
+function rootedBeyondNow(baseline: string[]): string[] {
+  const accountedFor = [...baseline];
+  return rootedHandles().filter(entry => {
+    const i = accountedFor.indexOf(entry);
+    if (i === -1) return true;
+    accountedFor.splice(i, 1);
+    return false;
+  });
+}
+
+/**
+ * Resolves to the handles still held beyond `baseline` once the releases have had time to land (the
+ * last handle of a completed stream goes one immediate after the stream closes).
+ */
+async function rootedBeyond(baseline: string[]): Promise<string[]> {
+  let left = rootedBeyondNow(baseline);
+  for (let i = 0; i < 50 && left.length > 0; i++) {
+    await new Promise(resolve => setImmediate(resolve));
+    left = rootedBeyondNow(baseline);
+  }
+  return left;
+}
+
 describe("inbound stream lifecycle", () => {
   test("releases server stream objects once the peer resets their streams", async () => {
     const total = 32;
-    const refs: WeakRef<object>[] = [];
+    const rootedWhileOpen: boolean[] = [];
     let closedCount = 0;
     const allOpen = Promise.withResolvers<void>();
     const allClosed = Promise.withResolvers<void>();
     const server = http2.createServer();
-    server.on("stream", (stream: any) => {
-      refs.push(new WeakRef(stream));
+    server.on("stream", stream => {
+      rootedWhileOpen.push(rootedHandles().includes(label(stream)));
       stream.on("error", () => {});
       stream.on("close", () => {
         if (++closedCount === total) allClosed.resolve();
       });
       stream.resume();
-      if (refs.length === total) allOpen.resolve();
+      if (rootedWhileOpen.length === total) allOpen.resolve();
     });
     server.listen(0);
     await once(server, "listening");
@@ -1313,6 +1362,7 @@ describe("inbound stream lifecycle", () => {
     try {
       c.sendPreface();
       c.sendEmptySettings();
+      const baseline = rootedHandles();
       for (let i = 0; i < total; i++) {
         c.sendFrame(FrameType.HEADERS, 0x4, 1 + 2 * i, requestHeaderBlock("POST"));
       }
@@ -1323,16 +1373,8 @@ describe("inbound stream lifecycle", () => {
         c.sendFrame(FrameType.RST_STREAM, 0, 1 + 2 * i, cancel);
       }
       await allClosed.promise;
-      // The streams' native release rides the deferred teardown chain
-      // (setImmediate: rstNextTick / delayed destroy), so drain an immediate
-      // turn before each GC pass - gcTick's Bun.sleep(0) alone leaves the
-      // release pending on slow FinalizationRegistry lanes (alpine/musl
-      // needed a retry at 20 passes; collection is late there, not stuck).
-      for (let i = 0; i < 50 && refs.some(ref => ref.deref() !== undefined); i++) {
-        await new Promise(resolve => setImmediate(resolve));
-        await gcTick();
-      }
-      expect(refs.filter(ref => ref.deref() !== undefined).length).toBe(0);
+      expect(rootedWhileOpen).toEqual(Array(total).fill(true));
+      expect(await rootedBeyond(baseline)).toEqual([]);
     } finally {
       c.destroy();
       server.close();
@@ -1690,56 +1732,15 @@ describe("stream release after a queued END_STREAM", () => {
     return `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`;
   }
 
-  /** Names a stream by its side and its id on the session: "ServerHttp2Stream#5". */
-  const label = (stream: http2.Http2Stream) => `${stream.constructor.name}#${stream.id}`;
-
   /**
-   * One entry per Strong handle that native code holds on an Http2Stream object, naming the stream.
-   * A stream's JS object is held that way from the moment the stream exists until free_resources
-   * drops the handles (two for a server stream, one for a client stream). So a stream that is not
-   * released keeps its entries here for as long as its session lives, and a released one loses them
-   * at once: the handles are dropped, not collected, which is what makes this exact.
-   */
-  function rootedStreams(): string[] {
-    return getProtectedObjects()
-      .filter(o => o instanceof Duplex && /Http2Stream$/.test(o.constructor.name))
-      .map(o => label(o as http2.Http2Stream))
-      .sort();
-  }
-
-  /** The entries of `rootedStreams()` that `baseline` does not account for. */
-  function rootedBeyondNow(baseline: string[]): string[] {
-    const accountedFor = [...baseline];
-    return rootedStreams().filter(entry => {
-      const i = accountedFor.indexOf(entry);
-      if (i === -1) return true;
-      accountedFor.splice(i, 1);
-      return false;
-    });
-  }
-
-  /**
-   * Resolves to the handles still held beyond `baseline` once the releases have had time to land (the
-   * last handle of a completed stream goes one immediate after the stream closes).
-   */
-  async function rootedBeyond(baseline: string[]): Promise<string[]> {
-    let left = rootedBeyondNow(baseline);
-    for (let i = 0; i < 50 && left.length > 0; i++) {
-      await new Promise(resolve => setImmediate(resolve));
-      left = rootedBeyondNow(baseline);
-    }
-    return left;
-  }
-
-  /**
-   * Tears the case's session down and waits for the handles it still held (on the stalled streams)
-   * to go, which on the server side happens once its socket has closed, so that the next case starts
-   * from an empty set.
+   * Tears the case's session down and waits for the streams it still held (the stalled ones) to go,
+   * which on the server side happens once its socket has closed, so that the next case starts without
+   * them.
    */
   async function closeAll(client: http2.ClientHttp2Session, server: http2.Http2Server): Promise<void> {
     client.destroy();
     await new Promise(resolve => server.close(resolve));
-    for (let i = 0; i < 50 && rootedStreams().length > 0; i++) {
+    for (let i = 0; i < 50 && rootedHandles().some(entry => entry.includes("Http2Stream#")); i++) {
       await new Promise(resolve => setImmediate(resolve));
     }
   }
@@ -1762,7 +1763,7 @@ describe("stream release after a queued END_STREAM", () => {
     req.on("error", reject);
     req.on("response", () => {
       queuedAtResponse = client.state.outboundQueueSize!;
-      rootedAtResponse = rootedStreams().includes(label(req));
+      rootedAtResponse = rootedHandles().includes(label(req));
     });
     req.on("data", (chunk: Buffer) => {
       received += chunk.length;
@@ -1777,14 +1778,14 @@ describe("stream release after a queued END_STREAM", () => {
     const queuedAfterEnd: number[] = [];
     const server = http2.createServer();
     server.on("stream", stream => {
-      rootedWhileOpen.push(rootedStreams().includes(label(stream)));
+      rootedWhileOpen.push(rootedHandles().includes(label(stream)));
       stream.respond({ ":status": 200 });
       stream.end(BODY);
       queuedAfterEnd.push(stream.session!.state.outboundQueueSize!);
     });
     const client = http2.connect(await listen(server), { settings: { initialWindowSize: WINDOW } });
     try {
-      const baseline = rootedStreams();
+      const baseline = rootedHandles();
       const received: number[] = [];
       for (let i = 0; i < STREAMS; i++) {
         received.push((await roundTrip(client, { ":path": "/" })).received);
@@ -1822,7 +1823,7 @@ describe("stream release after a queued END_STREAM", () => {
       let stalledError: Error | null = null;
       stalled.on("error", err => (stalledError = err));
       await once(stalled, "response");
-      const baseline = rootedStreams();
+      const baseline = rootedHandles();
       for (let i = 0; i < STREAMS; i++) {
         await roundTrip(client, { ":path": "/" });
       }
@@ -1855,7 +1856,7 @@ describe("stream release after a queued END_STREAM", () => {
         stream.end(STALLED_BODY);
         return;
       }
-      rootedWhileOpen.push(rootedStreams().includes(label(stream)));
+      rootedWhileOpen.push(rootedHandles().includes(label(stream)));
       stream.resume();
       // Answer once the request's END_STREAM has been processed, like a handler that consumes the
       // request body does: the queued response is then the only thing the stream still waits for.
@@ -1880,7 +1881,7 @@ describe("stream release after a queued END_STREAM", () => {
         res.end(STALLED_BODY);
         return;
       }
-      rootedWhileOpen.push(rootedStreams().includes(label(res.stream)));
+      rootedWhileOpen.push(rootedHandles().includes(label(res.stream)));
       req.resume();
       req.on("end", () => res.end("ok"));
     });
@@ -1912,7 +1913,7 @@ describe("stream release after a queued END_STREAM", () => {
     try {
       // The server's window applies to requests opened after its SETTINGS frame has been received.
       await once(client, "remoteSettings");
-      const baseline = rootedStreams();
+      const baseline = rootedHandles();
       const responses: { queuedAtResponse: number; rootedAtResponse: boolean }[] = [];
       for (let i = 0; i < STREAMS; i++) {
         responses.push(await roundTrip(client, { ":method": "POST", ":path": "/" }, BODY));


### PR DESCRIPTION
### Problem
- `h2-conformance.test.ts`, describe "stream release after a queued END_STREAM" (from #38044), fails with `Expected: 0 / Received: 1` on the darwin aarch64 lane (builds 96506, 100498, 100707, 100769, 100996). A darwin bare metal CI machine fails the file 6 of 6.
- The survivor is not leaked. It is destroyed and has no native handle and no reported root. A stale copy of its address on the stack pins it, and every pass of the GC loop pins it again (Notes).

### Fix
- The file's six release cases (these five and the one that resets 32 streams) no longer collect. They list the Strong handles native code holds, through `getProtectedObjects()`, named (`"ServerHttp2Stream#5"`, `"function bound onwrite"`), and require that nothing is left beyond the baseline. The release code is unchanged.
- This is the invariant the cases exist for: the leaks they guard against are `free_resources` not running, and it drops exactly these handles, synchronously. So the check is exact with no collection, and a failure names what was left. Functions are listed because a queued frame holds its write callback, which holds the stream. Each case also checks that its own stream, and the callback of its queued frame, were listed while they were held, so neither branch of the listing can go quiet unnoticed.
- Checked by breaking each path on the debug build (Notes): the five cases list their streams, or their callbacks, and the reset case its 32 streams. Unbroken: `bun bd test` of the file, 20 release runs of the six cases and 10 of the file, 20 runs of the file on the darwin machine above.
- The baseline is subtracted as a multiset, so handles that other activity holds throughout or releases late do not matter. Each case also tears its session down before it ends and checks that everything it rooted (measured against the handles held before the case) is gone.

### Background
- `bun_jsc::Strong` roots a JS value from native code. The handles live in `StrongRootBlock` cells, and `getProtectedObjects()` (`BunJSCModule.h`) returns one entry per occupied slot. `node:http2` holds such handles on each stream's JS object while it exists, and on the callback of each queued frame.
- JSC's conservative scan treats every stack word that looks like a cell pointer as a root and reports nothing for it. A copy under a slot that the collection's frames never write pins the object, and identical passes pin it identically. The old `WeakRef` form measured exactly that.

<details><summary>Notes</summary>

Why the survivor is a pin and not a reference. `generateHeapSnapshotForDebugging()` after the GC loop (with a fresh turn and one more `Bun.gc(true)` first, so the loop's own `deref()` calls keep nothing alive), then a walk of every incoming edge of the survivor: on linux x64 and darwin arm64 the result is a cycle of 12 to 15 nodes (stream, `Http2ServerRequest`, `Http2ServerResponse`, the bound `onwrite`, listeners, the test's closure) with zero root reasons and zero edges from outside the cycle, while the two streams that are alive by design in the same run show `StrongHandles` roots through `StrongRootBlock`. In JSC, `SlotVisitor::append(const ConservativeRoots&)` goes through `appendJSCellOrAuxiliary`, which does not call `analyzeEdge`, so conservative roots are the one kind that leaves no trace. `sanitizeStackForVMImpl` zero-fills the dead stack below the current frame, so it does not reach these words. The stream that the old loop leaves after 50 passes is collected by one `Bun.gc(true)` called inside a `setTimeout` or socket callback (5 of 5), and a version of the test that counted collections with a `FinalizationRegistry`, so without any `WeakRef`, pinned the same stream for 50 passes (6 of 6).

Why not a GC loop of some other shape. Measured in the CI regime (the full file, on an idle darwin bare metal agent of the failing type, canary build, 20 runs per variant, polling to zero and logging each pass): the unmodified file fails 6 of 6 runs. With the file's loop and 8 streams, the last stream stays alive through all 50 passes in 14 of 20 compat runs and 9 of 20 `end("ok")` runs, and the one before it for 20 to 30 passes. With the collection started inside a `setImmediate` callback, one stream stays for 48 or 49 of the 50 passes in 3 of 20 compat runs. The first three pushes of this PR allowed for survivors instead (2 of 8, then fewer than half of 16). They passed in that regime but blurred the assertion. The later pushes replaced the collection with the handle list, then, from review, named the entries and checked the side under test, listed the callbacks, and converted the reset case, which had needed a timing patch of its own in July and is the same invariant.

Leak checks, debug build: with the `free_resources` call in `flush_queue` removed, the five queued cases list their four streams each (server streams twice, client streams once) and the reset case passes. With `flush_queue` leaking its frames instead, the five cases list `"function bound onwrite"` (anonymous callbacks on one path) and the reset case passes. With the `free_resources` call in the reset path removed, the reset case lists its 32 streams and the five pass. With the function branch of `rootedHandles` deleted, the five queued cases fail on their premises and the reset case passes. With the stream branch deleted, all six fail.

Handles measured, identical on release and debug: a server stream holds two entries and a client stream one, a queued frame one function entry, the test runner 71 function entries in the full file (10 with `-t`), and no function entry ever appeared beyond a baseline in any run. At the instant a case's last request closes, that request's last handle is still listed, and it is gone one immediate later, so `rootedBeyond` settles in one turn. At the start of these describes, earlier tests have left no stream handles behind. `getProtectedObjects()` costs about 0.2 ms per call on the debug build. The six cases take 115 to 500 ms on the debug build (the reset case took 1300 ms with the GC loop) and 2 to 4 ms each on darwin release.

At the point where `server.close()` calls back in the stalled cases, the stalled server stream is still listed twice and goes one turn later, which is what the teardown check in `closeAll` observes, together with the stalled frame's callback. The `instanceof Duplex` and `instanceof Function` checks in `rootedHandles` come first because the array also holds JSC internal cells (code blocks), and a property read on one of those aborts a debug build (a release build returns nonsense and passes). Both classes use the default `Symbol.hasInstance`, which checks for an object before it touches the value. `Writable` defines its own, which reads `_writableState`, so it would not do.

Considered and not done: reading the per-session parser through its internal symbol (`forEachStream`, as two other http2 tests do) instead of the process-wide handle list. It would scope each reading to one side by construction, but it depends on an internal API, does not see the callback handles, and the side scoping is already given by the names. `getProtectedObjects()` is documented `bun:jsc` surface and lists the resource that leaks.

The release code ran for every stream in every run, so none of this explains the test-tonic darwin failure that names #38044.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/http2/h2-conformance.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (4c689909e)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [386.15ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [103.95ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [78.17ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [45.43ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [37.34ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [33.21ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [40.48ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [32.62ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [34.00ms]
(pass) WINDOW_UPDATE (checklist §6) > a WINDOW_UPDATE with length != 4 is a FRAME_SIZE_ERROR [74.50ms]
(pass) frame structure (checklist §2,§3) > an unknown frame type is ignored, not an error (§2.4) [36.19ms]
(pass) frame structure (checklist §2,§3) > RST_STREAM on an idle stream is a PROTOCOL_ERROR (§4) [40.05ms]
(pass) stream-id rules (checklist §3) > HEADERS on stream 0 is a PROTOCOL_ERROR (§6.2) [38.85ms]
(pass) stream-id rules (checklist §3) > DATA on stream 0 is a PROTOCOL_ERROR (§6.1) [29.31ms]
(pass) fixed-length frames (checklist §3) > PRIORITY with length != 5 is a FRAME_SIZE_ERROR (§6.3) [28.36ms]
(pass) fixed-length frames (checklist §3) > RST_STREAM with length !
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/node/http2/h2-conformance.test.ts | 217 ++++++++++++++++++++----------
 1 file changed, 146 insertions(+), 71 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
test/js/node/http2/h2-conformance.test.ts     16     22      0
```

</details>

<!-- robobun:evidence:end -->