### PR TITLE
usockets: report a peer reset on a paused socket on kqueue

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -574,55 +574,62 @@ void us_internal_loop_update_pending_ready_polls(struct us_loop_t *loop, struct 
 /* Poll */
 
 #ifdef LIBUS_USE_KQUEUE
-/* Helper function for setting or updating EVFILT_READ and EVFILT_WRITE */
-int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_data) {
-    struct kevent64_s change_list[2];
+static int kqueue_is_socket_poll(struct us_poll_t *p) {
+    int type = us_internal_poll_type(p);
+    return type == POLL_TYPE_SOCKET || type == POLL_TYPE_SOCKET_SHUT_DOWN;
+}
+
+/* Registers the difference between old_events and new_events for fd.
+ *
+ * With keep_read_knote (us_poll_change passes it for socket polls) the EVFILT_READ knote
+ * stays registered while the socket does not poll for reads (paused, half-open after the
+ * peer's FIN, shut down with reads off, parked as low priority), re-added with EV_CLEAR.
+ * It is kqueue's stand-in for epoll's implicit EPOLLHUP/EPOLLERR: the peer's FIN or RST
+ * still reaches the dispatcher as eof/error (us_poll_events masks the readable bit out),
+ * and EV_CLEAR keeps unread data or a consumed EOF from re-firing every tick. Nothing else
+ * reports them: the one-shot write filter is consumed by the first, immediate, writable
+ * event, so a reset of a paused socket went unreported until resume(), unlike on epoll
+ * and libuv. EV_ADD on an existing knote updates its udata but keeps its flags, so each
+ * switch between the two modes deletes the knote and adds a new one; us_poll_resize relies
+ * on the same rule to move the udata without changing the mode. */
+int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_data, int keep_read_knote) {
+    struct kevent64_s change_list[3];
     int change_length = 0;
 
-    /* Do they differ in readable? */
-    int is_readable =  (new_events & LIBUS_SOCKET_READABLE);
-    int is_writable =  (new_events & LIBUS_SOCKET_WRITABLE);
-    if ((new_events & LIBUS_SOCKET_READABLE) != (old_events & LIBUS_SOCKET_READABLE)) {
-        EV_SET64(&change_list[change_length++], fd, EVFILT_READ, is_readable ? EV_ADD : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
+    int is_readable = (new_events & LIBUS_SOCKET_READABLE);
+    if (is_readable != (old_events & LIBUS_SOCKET_READABLE)) {
+        if (keep_read_knote) {
+            EV_SET64(&change_list[change_length++], fd, EVFILT_READ, EV_DELETE, 0, 0, 0, 0, 0);
+            EV_SET64(&change_list[change_length++], fd, EVFILT_READ, EV_ADD | (is_readable ? 0 : EV_CLEAR), 0, 0, (uint64_t)(void*)user_data, 0, 0);
+        } else {
+            EV_SET64(&change_list[change_length++], fd, EVFILT_READ, is_readable ? EV_ADD : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
+        }
     }
 
-    if(!is_readable && !is_writable) {
-        if(!(old_events & LIBUS_SOCKET_WRITABLE)) {
-            // if we are not reading or writing, we need to add writable to receive FIN
-            EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0, 0, (uint64_t)(void*)user_data, 0, 0);
-        }
-    } else if ((new_events & LIBUS_SOCKET_WRITABLE) != (old_events & LIBUS_SOCKET_WRITABLE)) {
-        /* Do they differ in writable? */
+    if ((new_events & LIBUS_SOCKET_WRITABLE) != (old_events & LIBUS_SOCKET_WRITABLE)) {
         EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, (new_events & LIBUS_SOCKET_WRITABLE) ? EV_ADD | EV_ONESHOT : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
     }
+
     int ret;
     do {
         ret = kevent64(kqfd, change_list, change_length, change_list, change_length, KEVENT_FLAG_ERROR_EVENTS, NULL);
     } while (IS_EINTR(ret));
 
-    // ret should be 0 in most cases (not guaranteed when removing async)
-
-    /* KEVENT_FLAG_ERROR_EVENTS reports per-filter failures as EV_ERROR entries
-     * with the errno in .data; kevent64 itself returns the count and does not
-     * set errno. Mirror epoll's contract so us_poll_start_rc callers can read it. */
-    if (ret > 0) {
-        errno = (int) change_list[0].data;
+    /* KEVENT_FLAG_ERROR_EVENTS reports each failed change as an EV_ERROR entry with the
+     * errno in .data while the other changes still apply; kevent64 itself returns their
+     * count and does not set errno. A delete of a filter that is not registered (a write
+     * one-shot the kernel already consumed) leaves the fd in the state asked for and is not
+     * a failure. Anything else mirrors epoll's contract so us_poll_start_rc callers can
+     * read errno. */
+    for (int i = 0; i < ret; i++) {
+        if ((change_list[i].flags & EV_DELETE) && change_list[i].data == ENOENT) {
+            continue;
+        }
+        errno = (int) change_list[i].data;
+        return 1;
     }
 
-    return ret;
-}
-
-/* Kqueue's stand-in for epoll's implicit EPOLLHUP/EPOLLERR: an EV_CLEAR read
- * filter re-fires on peer FIN/RST but not forever on a consumed EOF; the
- * dispatcher masks its readable bit out via us_poll_events (no reads). */
-void us_internal_kqueue_socket_arm_read_sentinel(struct us_socket_t *s) {
-    struct us_loop_t *loop = s->group->loop;
-    struct kevent64_s event;
-    EV_SET64(&event, us_poll_fd(&s->p), EVFILT_READ, EV_ADD | EV_CLEAR, 0, 0, (uint64_t)(void *)&s->p, 0, 0);
-    int ret;
-    do {
-        ret = kevent64(loop->fd, &event, 1, &event, 1, KEVENT_FLAG_ERROR_EVENTS, NULL);
-    } while (IS_EINTR(ret));
+    return ret < 0 ? ret : 0;
 }
 
 #endif
@@ -646,8 +653,10 @@ struct us_poll_t *us_poll_resize(struct us_poll_t *p, struct us_loop_t *loop, un
     new_p->state.poll_type = us_internal_poll_type(new_p);
     us_poll_change(new_p, loop, events);
 #else
-    /* Forcefully update poll by resetting them with new_p as user data */
-    kqueue_change(loop->fd, new_p->state.fd, 0, LIBUS_SOCKET_WRITABLE | LIBUS_SOCKET_READABLE, new_p);
+    /* Re-add both filters to move their udata to new_p, whether or not they are polled: the
+     * EV_CLEAR read knote of a socket that is not reading (see kqueue_change) has to follow
+     * the relocation too, and EV_ADD keeps the mode of a knote that already exists. */
+    kqueue_change(loop->fd, new_p->state.fd, 0, LIBUS_SOCKET_WRITABLE | LIBUS_SOCKET_READABLE, new_p, 0);
 #endif
     /* This is needed for epoll also (us_change_poll doesn't update the old poll) */
     us_internal_loop_update_pending_ready_polls(loop, p, new_p, events, events);
@@ -685,7 +694,7 @@ int us_poll_start_rc(struct us_poll_t *p, struct us_loop_t *loop, int events) {
     } while (IS_EINTR(ret));
     return ret;
 #else
-    return kqueue_change(loop->fd, p->state.fd, 0, events, p);
+    return kqueue_change(loop->fd, p->state.fd, 0, events, p, 0);
 #endif
 }
 
@@ -720,7 +729,7 @@ int us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
             rc = us_poll_start_rc(p, loop, events);
         }
 #else
-        kqueue_change(loop->fd, p->state.fd, old_events, events, p);
+        kqueue_change(loop->fd, p->state.fd, old_events, events, p, kqueue_is_socket_poll(p));
 #endif
         /* Set all removed events to null-polls in pending ready poll list */
         us_internal_loop_update_pending_ready_polls(loop, p, p, old_events, events);
@@ -738,8 +747,11 @@ void us_poll_stop(struct us_poll_t *p, struct us_loop_t *loop) {
          rc = epoll_ctl(loop->fd, EPOLL_CTL_DEL, p->state.fd, &event);
     } while (IS_EINTR(rc));
 #else
-    if (old_events) {
-        kqueue_change(loop->fd, p->state.fd, old_events, new_events, NULL);
+    /* A socket poll has a read knote in both of its modes (see kqueue_change), so there is
+     * one to delete even when it was not polling for reads. */
+    int registered = kqueue_is_socket_poll(p) ? old_events | LIBUS_SOCKET_READABLE : old_events;
+    if (registered) {
+        kqueue_change(loop->fd, p->state.fd, registered, new_events, NULL, 0);
     }
 #endif
 

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -249,13 +249,6 @@ void us_internal_ssl_ctx_unref(struct ssl_ctx_st *ssl_ctx);
 /* TCP-level FIN, bypassing the SSL layer (used by ssl_on_end). */
 void us_internal_socket_raw_shutdown(us_socket_r s);
 
-#ifdef LIBUS_USE_KQUEUE
-/* Arm an EV_CLEAR read filter on a socket with no readable interest so the
- * peer's FIN/RST still reaches the dispatcher (kqueue's stand-in for epoll's
- * implicit EPOLLHUP/EPOLLERR). See the definition in epoll_kqueue.c. */
-void us_internal_kqueue_socket_arm_read_sentinel(us_socket_r s);
-#endif
-
 int us_internal_handle_dns_results(us_loop_r loop);
 
 /* Sockets are polls */

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -914,12 +914,6 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                      * writable dispatch disables writable polling again once
                      * the buffer is drained, so this does not busy-poll. */
                     us_poll_change(&s->p, loop, LIBUS_SOCKET_WRITABLE);
-#ifdef LIBUS_USE_KQUEUE
-                    /* The change above deleted the read filter; without a sentinel
-                     * the peer's later RST is never reported (the one-shot write
-                     * filter may already be consumed) and the socket strands. */
-                    us_internal_kqueue_socket_arm_read_sentinel(s);
-#endif
                     s = s->ssl ? us_internal_ssl_on_end(s) : us_dispatch_end(s);
                 } else {
                     /* Half-open not allowed, or a hangup (both directions down, level-triggered):

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -731,13 +731,6 @@ void us_internal_socket_raw_shutdown(struct us_socket_t *s) {
         us_internal_poll_set_type(&s->p, POLL_TYPE_SOCKET_SHUT_DOWN);
         us_poll_change(&s->p, s->group->loop, us_poll_events(&s->p) & LIBUS_SOCKET_READABLE);
         bsd_shutdown_socket(us_poll_fd((struct us_poll_t *) s));
-#ifdef LIBUS_USE_KQUEUE
-        if (!(us_poll_events(&s->p) & LIBUS_SOCKET_READABLE)) {
-            /* Shut down with reads off: no filter remains, so a peer FIN/RST
-             * would never be delivered (epoll still reports HUP/ERR). */
-            us_internal_kqueue_socket_arm_read_sentinel(s);
-        }
-#endif
     }
 }
 
@@ -871,13 +864,6 @@ void us_socket_pause(struct us_socket_t *s) {
     // we are readable and writable so we can just pause readable side
     us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_WRITABLE);
     s->flags.is_paused = 1;
-#ifdef LIBUS_USE_KQUEUE
-    if (us_socket_is_shut_down(s)) {
-        /* Pausing dropped a shut-down socket's read filter; same as
-         * us_internal_socket_raw_shutdown. */
-        us_internal_kqueue_socket_arm_read_sentinel(s);
-    }
-#endif
 }
 
 void us_socket_resume(struct us_socket_t *s) {

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4087,66 +4087,64 @@ describe("allowHalfOpen socket whose peer resets behind pending writes", () => {
   });
 });
 
-describe.concurrent("paused socket whose peer resets the connection", () => {
-  // A paused socket polls for nothing. epoll reports the reset anyway (EPOLLERR cannot be
-  // masked); kqueue only reports it through the read knote that epoll_kqueue.c keeps
-  // registered while reads are off. Before that, the pause left a one-shot writable event
-  // behind and nothing else: a reset that landed after it was consumed was never reported,
-  // and the socket stayed paused for good. The greeting round trip below guarantees the
-  // one-shot has been consumed before the reset is sent. The node:net and node:tls shapes
-  // of this scenario are in test/js/node/tls/node-tls-server.test.ts.
-  for (const transport of ["tcp", "tls"] as const) {
-    it(`${transport}: closes with read ECONNRESET while still paused and delivers none of the unread data`, async () => {
-      const closedWith = Promise.withResolvers<Error | undefined>();
-      let dataCalls = 0;
-      const pauseAndGreet = (socket: Socket) => {
-        socket.pause();
-        socket.write("greeting");
-      };
-      using server = Bun.listen({
-        hostname: "127.0.0.1",
-        port: 0,
-        tls: transport === "tls" ? tls : undefined,
-        socket: {
-          open(socket) {
-            // A TLS socket cannot be paused before its handshake has been read.
-            if (transport === "tcp") pauseAndGreet(socket);
-          },
-          handshake(socket, success, authorizationError) {
-            if (success) pauseAndGreet(socket);
-            else closedWith.reject(authorizationError ?? new Error("server handshake failed"));
-          },
-          data() {
-            dataCalls++;
-          },
-          close(_socket, error) {
-            closedWith.resolve(error);
-          },
+// A paused socket polls for nothing. epoll reports the reset anyway (EPOLLERR cannot be
+// masked); kqueue only reports it through the read knote that epoll_kqueue.c keeps
+// registered while reads are off. Before that, the pause left a one-shot writable event
+// behind and nothing else: a reset that landed after it was consumed was never reported,
+// and the socket stayed paused for good. The greeting round trip below guarantees the
+// one-shot has been consumed before the reset is sent. The node:net and node:tls shapes
+// of this scenario are in test/js/node/tls/node-tls-server.test.ts.
+describe.concurrent.each(["tcp", "tls"] as const)("%s socket paused when its peer resets the connection", transport => {
+  it("closes with read ECONNRESET while still paused and delivers none of the unread data", async () => {
+    const closedWith = Promise.withResolvers<Error | undefined>();
+    let dataCalls = 0;
+    const pauseAndGreet = (socket: Socket) => {
+      socket.pause();
+      socket.write("greeting");
+    };
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      tls: transport === "tls" ? tls : undefined,
+      socket: {
+        open(socket) {
+          // A TLS socket cannot be paused before its handshake has been read.
+          if (transport === "tcp") pauseAndGreet(socket);
         },
-      });
-
-      const greeted = Promise.withResolvers<Socket>();
-      await Bun.connect({
-        hostname: "127.0.0.1",
-        port: server.port,
-        tls: transport === "tls" ? { ca: tls.cert } : undefined,
-        socket: {
-          data: socket => greeted.resolve(socket),
-          error: (_socket, error) => greeted.reject(error),
-          connectError: (_socket, error) => greeted.reject(error),
-          close: () => greeted.reject(new Error("peer closed before the greeting arrived")),
+        handshake(socket, success, authorizationError) {
+          if (success) pauseAndGreet(socket);
+          else closedWith.reject(authorizationError ?? new Error("server handshake failed"));
         },
-      });
-      const peer = await greeted.promise;
-      peer.write("queued behind the pause");
-      peer.terminate();
-
-      const error = (await closedWith.promise) as NodeJS.ErrnoException | undefined;
-      expect({ code: error?.code, syscall: error?.syscall, dataCalls }).toEqual({
-        code: "ECONNRESET",
-        syscall: "read",
-        dataCalls: 0,
-      });
+        data() {
+          dataCalls++;
+        },
+        close(_socket, error) {
+          closedWith.resolve(error);
+        },
+      },
     });
-  }
+
+    const greeted = Promise.withResolvers<Socket>();
+    await Bun.connect({
+      hostname: "127.0.0.1",
+      port: server.port,
+      tls: transport === "tls" ? { ca: tls.cert } : undefined,
+      socket: {
+        data: socket => greeted.resolve(socket),
+        error: (_socket, error) => greeted.reject(error),
+        connectError: (_socket, error) => greeted.reject(error),
+        close: () => greeted.reject(new Error("peer closed before the greeting arrived")),
+      },
+    });
+    const peer = await greeted.promise;
+    peer.write("queued behind the pause");
+    peer.terminate();
+
+    const error = (await closedWith.promise) as NodeJS.ErrnoException | undefined;
+    expect({ code: error?.code, syscall: error?.syscall, dataCalls }).toEqual({
+      code: "ECONNRESET",
+      syscall: "read",
+      dataCalls: 0,
+    });
+  });
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4141,10 +4141,19 @@ describe.concurrent.each(["tcp", "tls"] as const)("%s socket paused when its pee
     peer.terminate();
 
     const error = (await closedWith.promise) as NodeJS.ErrnoException | undefined;
-    expect({ code: error?.code, syscall: error?.syscall, dataCalls }).toEqual({
-      code: "ECONNRESET",
+    // On Windows the close reports the reset too, but the error it carries has no code: the
+    // raw WSA code reaches on_close unmapped (node:net papers over it, see SocketEmitEndNT).
+    // That is a separate bug. Until it is fixed only POSIX can check the code.
+    expect({
+      reported: error instanceof Error,
+      syscall: error?.syscall,
+      dataCalls,
+      code: isWindows ? null : error?.code,
+    }).toEqual({
+      reported: true,
       syscall: "read",
       dataCalls: 0,
+      code: isWindows ? null : "ECONNRESET",
     });
   });
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4086,3 +4086,67 @@ describe("allowHalfOpen socket whose peer resets behind pending writes", () => {
     expect(endCount).toBe(1);
   });
 });
+
+describe.concurrent("paused socket whose peer resets the connection", () => {
+  // A paused socket polls for nothing. epoll reports the reset anyway (EPOLLERR cannot be
+  // masked); kqueue only reports it through the read knote that epoll_kqueue.c keeps
+  // registered while reads are off. Before that, the pause left a one-shot writable event
+  // behind and nothing else: a reset that landed after it was consumed was never reported,
+  // and the socket stayed paused for good. The greeting round trip below guarantees the
+  // one-shot has been consumed before the reset is sent. The node:net and node:tls shapes
+  // of this scenario are in test/js/node/tls/node-tls-server.test.ts.
+  for (const transport of ["tcp", "tls"] as const) {
+    it(`${transport}: closes with read ECONNRESET while still paused and delivers none of the unread data`, async () => {
+      const closedWith = Promise.withResolvers<Error | undefined>();
+      let dataCalls = 0;
+      const pauseAndGreet = (socket: Socket) => {
+        socket.pause();
+        socket.write("greeting");
+      };
+      using server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls: transport === "tls" ? tls : undefined,
+        socket: {
+          open(socket) {
+            // A TLS socket cannot be paused before its handshake has been read.
+            if (transport === "tcp") pauseAndGreet(socket);
+          },
+          handshake(socket, success, authorizationError) {
+            if (success) pauseAndGreet(socket);
+            else closedWith.reject(authorizationError ?? new Error("server handshake failed"));
+          },
+          data() {
+            dataCalls++;
+          },
+          close(_socket, error) {
+            closedWith.resolve(error);
+          },
+        },
+      });
+
+      const greeted = Promise.withResolvers<Socket>();
+      await Bun.connect({
+        hostname: "127.0.0.1",
+        port: server.port,
+        tls: transport === "tls" ? { ca: tls.cert } : undefined,
+        socket: {
+          data: socket => greeted.resolve(socket),
+          error: (_socket, error) => greeted.reject(error),
+          connectError: (_socket, error) => greeted.reject(error),
+          close: () => greeted.reject(new Error("peer closed before the greeting arrived")),
+        },
+      });
+      const peer = await greeted.promise;
+      peer.write("queued behind the pause");
+      peer.terminate();
+
+      const error = (await closedWith.promise) as NodeJS.ErrnoException | undefined;
+      expect({ code: error?.code, syscall: error?.syscall, dataCalls }).toEqual({
+        code: "ECONNRESET",
+        syscall: "read",
+        dataCalls: 0,
+      });
+    });
+  }
+});


### PR DESCRIPTION
### Problem
- `test/js/node/tls/node-tls-server.test.ts` is red on every darwin lane since #39600: "reports the reset that arrives while the socket is paused as ECONNRESET, not 'end'" hangs to the timeout. Linux passes.
- Cause: on kqueue a paused socket has no filter. `us_socket_pause` (`socket.c:864`) deletes the read filter, and the one-shot write filter it adds is consumed at once. The peer's RST is reported only after `resume()`.
- Also found: `EV_ADD` on an existing knote keeps its flags (macOS 14 and 26). The read sentinel from #37077 stayed edge-triggered after the re-add on resume.

### Fix
- `kqueue_change` (`epoll_kqueue.c`) keeps the read knote of a socket poll in both modes: level-triggered while the socket reads, `EV_CLEAR` while it does not. A mode switch deletes the knote and adds a new one. `us_poll_stop` deletes it in either mode.
- The three hand-armed sentinel sites and the write filter added at zero events are removed. A delete of an unregistered filter is not a failure.
- Correct because the dispatcher already handles these events: it masks the readable bit, defers a FIN while paused, and closes on a reset. After resume the knote is level-triggered again, so a partial drain cannot stall.
- Verified: a six-scenario harness of the real `kqueue_change` on both macs (notes), the related suites on Linux, and new `Bun.listen` tcp/tls tests in `test/js/bun/net/socket.test.ts`. Linux behavior does not change, so this PR's darwin lanes prove the red test.

### Background
- epoll reports HUP and ERR for a socket that polls nothing. libuv probes for a reset. kqueue reports nothing without a knote, and its write filter is one-shot since #25475.
- An `EV_CLEAR` knote fires once per activation (data, FIN, RST). The dispatcher sees a FIN as eof and a reset as error (`fflags == ECONNRESET`).
- `us_poll_resize` re-adds both filters only to move the udata. `EV_ADD` keeps the mode of an existing knote, so that still works.

<details><summary>Notes</summary>

Culprit: #39600 added the tests. The kqueue gap predates it: the write filter became one-shot in #25475, and the sentinel from #37077 covered shutdown and half-open but not pause. The rare darwin pass in CI was the RST landing before the one-shot write filter was consumed.

kqueue probes, run as small C programs on darwin-arm64 (macOS 26.6, xnu 12377) and darwin-x64 (macOS 14.8, xnu 10063), identical results:
- read filter deleted + one-shot write consumed, then RST: no event (the bug). RST while the one-shot is still armed: `EVFILT_WRITE` with `EV_EOF fflags=54` (the flaky pass).
- `EV_ADD|EV_CLEAR` knote, then plain `EV_ADD`: still edge-triggered, udata updated. `EV_ADD|EV_CLEAR` over a level knote: still level. `EV_DELETE` + `EV_ADD` in one changelist: level again.
- `EV_CLEAR` knote, RST behind 10 unread bytes: one event, `EV_EOF fflags=ECONNRESET`, `SO_ERROR=ECONNRESET`, no re-fire. FIN behind data: one event, `fflags=0`, no re-fire. More data while not reading: one wakeup per arrival.
- `EV_CLEAR` knote registered before our own `SHUT_WR` still reports the peer's later FIN and RST, fresh or already cleared once. So dropping the post-shutdown re-arm in `raw_shutdown` is safe.
- `KEVENT_FLAG_ERROR_EVENTS` with a failing delete first: the error entry keeps `EV_DELETE` in flags and `ENOENT` in data, and the following add still applies.

The real `kqueue_change` body, compiled into a harness on both machines: pause then RST (reported, no spin), pause then FIN then resume (FIN deferred once, level-triggered after resume), stop on a paused socket (nothing left), resize touch (udata moved, mode kept), plain changes on a reading socket, EBADF still reported. The changed files also compile with `-fsyntax-only` in the kqueue configuration.

Linux, debug build: `node-tls-server.test.ts` (73 pass, the SNICallback failure is pre-existing in this container), `node-net.test.ts`, `node-net-allowHalfOpen.test.js`, `fetch-backpressure.test.ts`, `node-http-backpressure.test.ts` (the same 15 pre-existing failures as unmodified main: localhost resolution and h3), `socket.test.ts` (the same 9 pre-existing failures as main, the 2 new tests pass), the nine `test-net-half-open-peer-reset-*.mjs` fixtures, `node-http-server-socket-end-drain`, `node-http-connect`, `tls-syscall-fault`, `net-syscall-fault`.

The new `socket.test.ts` variants also fail on a release binary from before #39600 (the close carried no error), so they pin that contract for the Bun socket API on Linux as well. On macOS without this diff they hang like the node ones.

Node itself does not report a reset while a socket is paused. libuv removes the fd from the poll set, and node v26.3.0 reports `ECONNRESET` after the resume (checked with the same server logic). Bun's epoll and libuv backends have reported it at once for a long time, and #39600 made that the tested contract. This PR only brings kqueue to the same contract.

Related open PRs: #37098 rewrites the kqueue branch of `us_poll_resize` and would delete the read knote of a non-reading socket, which this rule keeps. #37099 touches the same pause code against an older base. `JSNodeHTTPServerSocketPrototype.cpp:226` pauses and resumes around a shutdown to work around the same gap. It still works and is left alone here.

kqueue on FreeBSD (shimmed, not a CI target) stops a changelist at the first failing entry. The delete in a mode switch always finds a knote, because every socket poll starts with a level read filter, so the add after it is not affected.

Windows lanes on the first CI run: the new tests reached the close with `syscall: "read"` but no `code`. The libuv backend reports the reset on a paused socket as intended, but on Windows the close carries the raw WSA code, which `on_close` stores unmapped (node:net accepts `code === undefined` as a reset, which is why the node tests pass there). That is a pre-existing bug in a different layer and is handed off separately. The tests check the code on POSIX only until it is fixed.
</details>
