### PR TITLE
FileSink, ByteStream: do not end a native sink while its last bytes are still buffered

### DIFF
--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -219,6 +219,15 @@ impl ByteStream {
 
         self.signal_drained();
 
+        // A synchronous producer (RewriterPipe) may have pushed its remaining
+        // output through `on_data` just now. If one of those writes hit
+        // backpressure, the chunks after it (and the end) were buffered; the
+        // sink's next drain ack comes back here and delivers them. Ending now
+        // would drop them.
+        if self.sink_paused.get() {
+            return;
+        }
+
         if self.has_received_last_chunk.get() && self.sink.get().is_some() {
             self.sink.set(SinkHandle::None);
             sink.end(None);

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -446,10 +446,18 @@ impl FileSink {
 
             // `end()`'s Pending flush branch leaves the writer running; finish the
             // teardown here regardless of `pending.state` (native path has no promise).
-            if (*this).done.get() && status == WriteStatus::Drained {
-                (*this).writer.with_mut(|w| w.end());
-            } else if (*this).done.get() && status == WriteStatus::EndOfFile && !has_pending_data {
-                (*this).writer.with_mut(|w| w.close());
+            //
+            // Not on `status`: `run_pending`/`src.ready()` above can re-enter
+            // `write()` (a short write buffers the tail) and then `end()` (flush
+            // Pending, sets `done`). `status` predates that, so a close on a stale
+            // `Drained` drops the tail. Re-read the buffer instead; draining the
+            // tail calls back here and finishes the teardown.
+            if (*this).done.get() && !(*this).writer.get().has_pending_data() {
+                if status == WriteStatus::EndOfFile {
+                    (*this).writer.with_mut(|w| w.close());
+                } else {
+                    (*this).writer.with_mut(|w| w.end());
+                }
             }
 
             if status == WriteStatus::EndOfFile {

--- a/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
+++ b/test/js/bun/spawn/spawn-stdin-readable-stream.test.ts
@@ -10,7 +10,9 @@ import {
   isDebug,
   isWindows,
   runFixtureMaxRSS,
+  tempDir,
 } from "harness";
+import path from "node:path";
 
 describe("spawn stdin ReadableStream", () => {
   test("basic ReadableStream as stdin", async () => {
@@ -892,6 +894,61 @@ describe("spawn stdin ReadableStream", () => {
     // iteration leaks one native FileSink (delta == iterations). Allow one
     // straggler whose wrapper has not yet been finalized.
     expect(fileSinkInternals.liveCount()).toBeLessThanOrEqual(baseline + 1);
+  });
+
+  // An HTMLRewriter body piped into a child's stdin is a native ByteStream →
+  // FileSink pump with a synchronous producer: the FileSink's drain callback
+  // resumes the ByteStream, which makes the rewriter feed the next file chunk
+  // and, at EOF, end the sink, all before the drain callback returns. The
+  // child reads slowly, so each chunk's output overfills the pipe and its
+  // tail stays buffered in the sink when the sink is ended from inside that
+  // callback. Every byte must still reach the child before its stdin closes:
+  // the buffered tail, and whatever the document-end handler emits after the
+  // last chunk's write reported backpressure.
+  describe("HTMLRewriter body as stdin while the child reads slowly", () => {
+    // Two file reads (256 KiB + the rest); each element's output grows by
+    // `appended`, so each chunk's output is about 1 MiB, more than a stdin
+    // pipe holds on any platform.
+    const piece = `<p>${Buffer.alloc(8192, "a").toString()}</p>`;
+    const count = 56;
+    const input = Buffer.alloc(piece.length * count, piece).toString();
+    const appended = Buffer.alloc(32 * 1024, "b").toString();
+    const footer = "<!-- end -->";
+
+    const slowChild = `
+      const fs = require("node:fs");
+      const buf = Buffer.allocUnsafe(4 * 1024 * 1024);
+      let total = 0;
+      for (;;) {
+        const n = fs.readSync(0, buf);
+        if (n === 0) break;
+        total += n;
+        Bun.sleepSync(10);
+      }
+      process.stdout.write(String(total));
+    `;
+
+    test.each([
+      ["no document-end output", false],
+      ["output appended at document end", true],
+    ])("every byte reaches the child: %s", async (_, appendAtEnd) => {
+      using dir = tempDir("hr-stdin-slow-child", { "in.html": input });
+      let rewriter = new HTMLRewriter().on("p", { element: e => void e.append(appended) });
+      if (appendAtEnd) rewriter = rewriter.onDocument({ end: e => void e.append(footer, { html: true }) });
+      const res = rewriter.transform(new Response(Bun.file(path.join(String(dir), "in.html"))));
+
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", slowChild],
+        env: bunEnv,
+        stdin: res,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(Number(stdout)).toBe(input.length + count * appended.length + (appendAtEnd ? footer.length : 0));
+      expect(exitCode).toBe(0);
+    });
   });
 
   // A fetch response body piped into a child's stdin is a native ByteStream →


### PR DESCRIPTION
### Problem
- An HTMLRewriter body piped into `Bun.spawn` stdin sometimes loses its tail (the flaky "held file input completes via Bun.spawn stdin" case in `html-rewriter.test.js`).
- Cause 1: `FileSink::on_write` (`src/runtime/webcore/FileSink.rs:449`) ends the writer on `status == Drained`. Its `src.ready()` call lets the rewriter write the last chunk (a short write buffers the tail) and end the sink, which sets `done`. The stale status then closes the fd under the tail.
- Cause 2: `ByteStream::resume` (`src/runtime/webcore/ByteStream.rs:220`) ends the sink after `signal_drained()` and drops chunks buffered during that call (document-end output after a backpressured write).

### Fix
- `on_write` re-reads `writer.has_pending_data()` after the re-entrant calls and ends the writer only when the buffer is empty. The tail has a poll registered, so its drain calls `on_write` again.
- `resume` returns when `sink_paused` is set after `signal_drained()`, as `on_data` already does. The next drain ack writes the buffered chunks, then ends.
- Correct because a sink may end only once its buffer is empty, which is what both sites now check. The Windows writer already defers the close in `end()`.
- Verified: two new cases in `test/js/bun/spawn/spawn-stdin-readable-stream.test.ts`. Unfixed, the child gets 1497216 of 2294152 bytes. Other suites: see notes.

### Background
- A `ByteStream` is the native source behind a producer-fed body. Piped into a native sink, it writes each chunk directly. On `Backpressure` it pauses until the sink calls `ready()`, which is `resume()`.
- `FileSink` is the sink for a child's stdin pipe. Its writer buffers what the fd does not accept. If `end()` cannot flush, it sets `done` and the poll callback `on_write` ends the writer after the drain.
- `RewriterPipe` (HTMLRewriter) is the one producer whose `ready()` handler emits synchronously, so a chunk and the document end can arrive inside one drain callback.

<details><summary>Notes</summary>

Handoff from another session. Buildkite flaky annotations on builds 100135, 99842, 99759, 99240, 99115, 100886: always this one test, always green on retry.

Repro on main: the test's chain with `cat` as the child, 6 loops of 400 runs in parallel, release build: 12 to 17 truncated runs per loop. The loss is almost always exactly 12970 bytes, sometimes 12970 + k * 36544: the remainder of the last 159146 byte output chunk after the stdin socketpair accepted a whole number of 36544 byte skbs. Debug log of a failing run (`BUN_DEBUG_FileSink=1`, printed on stdout):

```
[filesink] onWrite(95308, 1)          <- Drained: previous chunk's tail. src.ready() runs everything below.
[filereader] onReadChunk() = 158204 (eof)
[filesink] onWrite(146176, 2)         <- last chunk, short write, 12970 bytes stay buffered
[bytestream] ByteStream.onData sink paused -> buffer   <- Done arrives while paused
[filereader] onReaderDone()
[filesink] onClose()                  <- closed by the outer onWrite. No onWrite(12970, ...) ever comes.
```

History: before #36087 the `done && Drained` check ran only after `run_pending`, and a JS pump cannot write after `end()`. #36087 added the native `src.ready()` call to the same callback, and that source can.

The `EndOfFile` arm keeps its old condition: the writer already closed the fd without reporting, and nothing can buffer after that, so the fresh `has_pending_data()` equals the value captured at the top there.

The new test makes the race deterministic. The child reads stdin with one large `readSync` every 10 ms, so the pipe is full at each drain, every chunk write is short, and the last chunk is always produced inside a drain callback. Each chunk's output is about 1 MiB (32 KiB appended per `<p>`), more than the stdin socketpair holds on Linux (about 213 KiB) or macOS (512 KiB buffers). Second case: with only the FileSink change it is short by the 12 byte document-end footer, which is cause 2.

Cause 2 is not what the flaky test hits (its document has no end output), but it is the same drop in the same flow. It also applies to `Bun.serve` responses (`ServerResponse` sink) whose document-end handler appends content while the client is slow.

Suites run with the debug build: `spawn-stdin-readable-stream.test.ts` (36 pass), `spawn-stdin-readable-stream-integration`, `-edge-cases`, `spawn-streaming-stdin`, `spawn-stream-serve`, `proxy.test.ts`, `html-rewriter.test.js` (171 pass), `filesink.test.ts`, `streams.test.js`, `body-stream.test.ts`, `fetch.stream.test.ts`, `fetch-backpressure.test.ts`, `native-source-onclose-leak.test.ts`, the serve response sink and proxy memory tests. The original repro loop, 480 runs with the fixed debug build: 0 truncated.

Unrelated timeouts on this loaded machine (load average above 20, debug ASAN build): `bun-write.test.js` "copyFileRange is not available > on large files" (256 MB synchronous copy, 5 s budget), six `fetch.stream.test.ts` "Content-Length (multiple parts)" cases and the four `fetch-backpressure.test.ts` h3 cases when run together. All pass when run alone. None of them use a native sink.

Observed, not changed: `FileSink::on_auto_flush` unrefs the poll once `done` is set, so a `Bun.file(fifo).writer()` whose `end()` promise is not awaited lets the process exit with bytes still buffered. Separate behavior.
</details>
