### PR TITLE
vscode: launch Run File and Debug File in multi-root windows and in windows without a folder

### DIFF
--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -75,7 +75,7 @@ export function registerDebugger(context: vscode.ExtensionContext, factory?: vsc
 function runFileCommand(resource?: vscode.Uri): void {
   const path = getActivePath(resource);
   if (path) {
-    vscode.debug.startDebugging(undefined, {
+    vscode.debug.startDebugging(getWorkspaceFolder(resource), {
       ...RUN_CONFIGURATION,
       noDebug: true,
       program: path,
@@ -84,17 +84,18 @@ function runFileCommand(resource?: vscode.Uri): void {
   }
 }
 
-export function debugCommand(command: string) {
-  vscode.debug.startDebugging(undefined, {
+export function debugCommand(command: string, folder?: vscode.WorkspaceFolder) {
+  folder ??= getWorkspaceFolder();
+  vscode.debug.startDebugging(folder, {
     ...DEBUG_CONFIGURATION,
     program: command,
-    runtime: getRuntime(),
+    runtime: getRuntime(folder),
   });
 }
 
 function debugFileCommand(resource?: vscode.Uri) {
   const path = getActivePath(resource);
-  if (path) debugCommand(path);
+  if (path) debugCommand(path, getWorkspaceFolder(resource));
 }
 
 async function injectDebugTerminal(terminal: vscode.Terminal): Promise<void> {
@@ -483,6 +484,14 @@ class TerminalDebugSession extends FileDebugSession {
 
 function getActivePath(target?: vscode.Uri): string | undefined {
   return target?.fsPath ?? vscode.window.activeTextEditor?.document?.uri.fsPath;
+}
+
+// In a multi-root workspace, `startDebugging(undefined, ...)` cannot resolve
+// `${workspaceFolder}` and VS Code shows an error instead of launching.
+// Resolve the folder that owns the target file (or the active editor's file).
+function getWorkspaceFolder(resource?: vscode.Uri): vscode.WorkspaceFolder | undefined {
+  const uri = resource ?? vscode.window.activeTextEditor?.document?.uri;
+  return uri ? vscode.workspace.getWorkspaceFolder(uri) : undefined;
 }
 
 function getRuntime(scope?: vscode.ConfigurationScope): string {

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -510,8 +510,11 @@ export async function runUnsavedCode() {
   const startTime = performance.now();
 
   try {
-    // Start debugging
-    await vscode.debug.startDebugging(undefined, {
+    // An untitled document has no owning folder, so fall back to the first
+    // workspace folder (the same fallback FileDebugSession uses for its
+    // [eval] path) to keep ${workspaceFolder} resolvable in a multi-root
+    // workspace.
+    await vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], {
       ...DEBUG_CONFIGURATION,
       program: "-",
       __code: code,

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -488,9 +488,14 @@ function getActivePath(target?: vscode.Uri): string | undefined {
 
 // In a multi-root workspace, `startDebugging(undefined, ...)` cannot resolve
 // `${workspaceFolder}` and VS Code shows an error instead of launching.
-// Resolve the folder that owns the target file (or the active editor's file).
+// Resolve the folder that owns the target file, with a fallback to the
+// active editor's folder, so the run and debug commands stay consistent.
 function getWorkspaceFolder(resource?: vscode.Uri): vscode.WorkspaceFolder | undefined {
-  const uri = resource ?? vscode.window.activeTextEditor?.document?.uri;
+  if (resource) {
+    const folder = vscode.workspace.getWorkspaceFolder(resource);
+    if (folder) return folder;
+  }
+  const uri = vscode.window.activeTextEditor?.document?.uri;
   return uri ? vscode.workspace.getWorkspaceFolder(uri) : undefined;
 }
 

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -75,11 +75,12 @@ export function registerDebugger(context: vscode.ExtensionContext, factory?: vsc
 function runFileCommand(resource?: vscode.Uri): void {
   const path = getActivePath(resource);
   if (path) {
-    vscode.debug.startDebugging(getWorkspaceFolder(resource), {
+    const folder = getWorkspaceFolder(resource);
+    vscode.debug.startDebugging(folder, {
       ...RUN_CONFIGURATION,
       noDebug: true,
       program: path,
-      runtime: getRuntime(resource),
+      runtime: getRuntime(folder ?? resource),
     });
   }
 }

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -1,4 +1,4 @@
-import { DebugSession, OutputEvent } from "@vscode/debugadapter";
+import { DebugSession } from "@vscode/debugadapter";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { join } from "node:path";
@@ -505,76 +505,6 @@ function getRuntime(scope?: vscode.ConfigurationScope): string {
     return value;
   }
   return "bun";
-}
-
-export async function runUnsavedCode() {
-  const editor = vscode.window.activeTextEditor;
-  if (!editor || !editor.document.isUntitled) return;
-
-  const code = editor.document.getText();
-  const startTime = performance.now();
-
-  try {
-    // An untitled document has no owning folder, so fall back to the first
-    // workspace folder (the same fallback FileDebugSession uses for its
-    // [eval] path) to keep ${workspaceFolder} resolvable in a multi-root
-    // workspace.
-    await vscode.debug.startDebugging(vscode.workspace.workspaceFolders?.[0], {
-      ...DEBUG_CONFIGURATION,
-      program: "-",
-      __code: code,
-      __untitledName: editor.document.uri.toString(),
-      console: "debugConsole",
-      internalConsoleOptions: "openOnSessionStart",
-    });
-
-    // Find our debug session instance
-    const debugSession = Array.from(adapters.values()).find(
-      adapter => adapter.sessionId === vscode.debug.activeDebugSession?.id,
-    );
-
-    if (debugSession) {
-      // Wait for both the inspector to connect AND the adapter to be initialized
-      await new Promise<void>(resolve => {
-        let inspectorConnected = false;
-        let adapterInitialized = false;
-
-        const checkDone = () => {
-          if (inspectorConnected && adapterInitialized) {
-            resolve();
-          }
-        };
-
-        debugSession.adapter.once("Inspector.connected", () => {
-          inspectorConnected = true;
-          checkDone();
-        });
-
-        debugSession.adapter.once("Adapter.initialized", () => {
-          adapterInitialized = true;
-          checkDone();
-        });
-      });
-
-      // Now wait for debug session to complete
-      await new Promise<void>(resolve => {
-        const disposable = vscode.debug.onDidTerminateDebugSession(() => {
-          const duration = (performance.now() - startTime).toFixed(1);
-          debugSession.sendEvent(new OutputEvent(`✓ Code execution completed in ${duration}ms\n`));
-          disposable.dispose();
-          resolve();
-        });
-      });
-    }
-  } catch (err) {
-    if (vscode.debug.activeDebugSession) {
-      const duration = (performance.now() - startTime).toFixed(1);
-      const errorSession = adapters.get(vscode.debug.activeDebugSession.id);
-      errorSession?.sendEvent(
-        new OutputEvent(`✕ Error after ${duration}ms: ${err instanceof Error ? err.message : String(err)}\n`),
-      );
-    }
-  }
 }
 
 const languageIds = ["javascript", "typescript", "javascriptreact", "typescriptreact"];

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -101,14 +101,17 @@ function launchFile(configuration: vscode.DebugConfiguration, resource?: vscode.
 }
 
 // `command` is a package.json script, not a path, so the folder comes from the
-// editor that shows the package.json.
+// editor that shows the package.json. Like launchFile, the cwd is concrete:
+// the folder that owns the package.json, else the package.json's own
+// directory, so a package.json that no folder owns still launches.
 export function debugCommand(command: string): void {
   const packageJson = vscode.window.activeTextEditor?.document.uri;
   const folder = packageJson && vscode.workspace.getWorkspaceFolder(packageJson);
   vscode.debug.startDebugging(folder, {
     ...DEBUG_CONFIGURATION,
     program: command,
-    runtime: getRuntime(folder),
+    cwd: folder?.uri.fsPath ?? (packageJson && path.dirname(packageJson.fsPath)),
+    runtime: getRuntime(folder ?? packageJson),
   });
 }
 

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -73,45 +73,36 @@ export function registerDebugger(context: vscode.ExtensionContext, factory?: vsc
 }
 
 function runFileCommand(resource?: vscode.Uri): void {
-  launchFile(RUN_CONFIGURATION, resource);
+  const file = resource ?? vscode.window.activeTextEditor?.document.uri;
+  if (file) launch(RUN_CONFIGURATION, file, file.fsPath);
 }
 
 function debugFileCommand(resource?: vscode.Uri): void {
-  launchFile(DEBUG_CONFIGURATION, resource);
+  const file = resource ?? vscode.window.activeTextEditor?.document.uri;
+  if (file) launch(DEBUG_CONFIGURATION, file, file.fsPath);
 }
 
-// Launches `resource`, or the file in the active editor. The configurations
-// above use `${workspaceFolder}`, which VS Code resolves against the folder
-// passed to `startDebugging`. In a multi-root or empty window a file that no
-// folder owns leaves that variable unresolvable, so the cwd is set here: the
-// folder that owns the file, else the file's own directory (what js-debug does
-// for a file opened without a folder).
-function launchFile(configuration: vscode.DebugConfiguration, resource?: vscode.Uri): void {
-  const uri = resource ?? vscode.window.activeTextEditor?.document.uri;
-  if (!uri) return;
+// Debugs a script of the package.json shown in the active editor (the hover
+// link and the code lens in package.json files call this).
+export function debugCommand(script: string): void {
+  const packageJson = vscode.window.activeTextEditor?.document.uri;
+  if (packageJson) launch(DEBUG_CONFIGURATION, packageJson, script);
+}
 
-  const folder = vscode.workspace.getWorkspaceFolder(uri);
-  const program = uri.fsPath;
+// `document` is the file to run, or the package.json that holds the script.
+// The configurations above set cwd to `${workspaceFolder}`, which VS Code
+// resolves only against the folder passed here, or the single folder of a
+// single-root window. With no such folder (multi-root window, or no folder at
+// all) the cwd is the document's own directory, as js-debug does for a file
+// without a folder. resolveDebugConfiguration below fills in `runtime`,
+// scoped to the same folder.
+function launch(configuration: vscode.DebugConfiguration, document: vscode.Uri, program: string): void {
+  const folders = vscode.workspace.workspaceFolders ?? [];
+  const folder = vscode.workspace.getWorkspaceFolder(document) ?? (folders.length === 1 ? folders[0] : undefined);
   vscode.debug.startDebugging(folder, {
     ...configuration,
     program,
-    cwd: folder?.uri.fsPath ?? path.dirname(program),
-    runtime: getRuntime(folder ?? uri),
-  });
-}
-
-// `command` is a package.json script, not a path, so the folder comes from the
-// editor that shows the package.json. Like launchFile, the cwd is concrete:
-// the folder that owns the package.json, else the package.json's own
-// directory, so a package.json that no folder owns still launches.
-export function debugCommand(command: string): void {
-  const packageJson = vscode.window.activeTextEditor?.document.uri;
-  const folder = packageJson && vscode.workspace.getWorkspaceFolder(packageJson);
-  vscode.debug.startDebugging(folder, {
-    ...DEBUG_CONFIGURATION,
-    program: command,
-    cwd: folder?.uri.fsPath ?? (packageJson && path.dirname(packageJson.fsPath)),
-    runtime: getRuntime(folder ?? packageJson),
+    cwd: folder?.uri.fsPath ?? path.dirname(document.fsPath),
   });
 }
 

--- a/packages/bun-vscode/src/features/debug.ts
+++ b/packages/bun-vscode/src/features/debug.ts
@@ -73,30 +73,43 @@ export function registerDebugger(context: vscode.ExtensionContext, factory?: vsc
 }
 
 function runFileCommand(resource?: vscode.Uri): void {
-  const path = getActivePath(resource);
-  if (path) {
-    const folder = getWorkspaceFolder(resource);
-    vscode.debug.startDebugging(folder, {
-      ...RUN_CONFIGURATION,
-      noDebug: true,
-      program: path,
-      runtime: getRuntime(folder ?? resource),
-    });
-  }
+  launchFile(RUN_CONFIGURATION, resource);
 }
 
-export function debugCommand(command: string, folder?: vscode.WorkspaceFolder) {
-  folder ??= getWorkspaceFolder();
+function debugFileCommand(resource?: vscode.Uri): void {
+  launchFile(DEBUG_CONFIGURATION, resource);
+}
+
+// Launches `resource`, or the file in the active editor. The configurations
+// above use `${workspaceFolder}`, which VS Code resolves against the folder
+// passed to `startDebugging`. In a multi-root or empty window a file that no
+// folder owns leaves that variable unresolvable, so the cwd is set here: the
+// folder that owns the file, else the file's own directory (what js-debug does
+// for a file opened without a folder).
+function launchFile(configuration: vscode.DebugConfiguration, resource?: vscode.Uri): void {
+  const uri = resource ?? vscode.window.activeTextEditor?.document.uri;
+  if (!uri) return;
+
+  const folder = vscode.workspace.getWorkspaceFolder(uri);
+  const program = uri.fsPath;
+  vscode.debug.startDebugging(folder, {
+    ...configuration,
+    program,
+    cwd: folder?.uri.fsPath ?? path.dirname(program),
+    runtime: getRuntime(folder ?? uri),
+  });
+}
+
+// `command` is a package.json script, not a path, so the folder comes from the
+// editor that shows the package.json.
+export function debugCommand(command: string): void {
+  const packageJson = vscode.window.activeTextEditor?.document.uri;
+  const folder = packageJson && vscode.workspace.getWorkspaceFolder(packageJson);
   vscode.debug.startDebugging(folder, {
     ...DEBUG_CONFIGURATION,
     program: command,
     runtime: getRuntime(folder),
   });
-}
-
-function debugFileCommand(resource?: vscode.Uri) {
-  const path = getActivePath(resource);
-  if (path) debugCommand(path, getWorkspaceFolder(resource));
 }
 
 async function injectDebugTerminal(terminal: vscode.Terminal): Promise<void> {
@@ -481,23 +494,6 @@ class TerminalDebugSession extends FileDebugSession {
       iconPath: new vscode.ThemeIcon("debug-console"),
     });
   }
-}
-
-function getActivePath(target?: vscode.Uri): string | undefined {
-  return target?.fsPath ?? vscode.window.activeTextEditor?.document?.uri.fsPath;
-}
-
-// In a multi-root workspace, `startDebugging(undefined, ...)` cannot resolve
-// `${workspaceFolder}` and VS Code shows an error instead of launching.
-// Resolve the folder that owns the target file, with a fallback to the
-// active editor's folder, so the run and debug commands stay consistent.
-function getWorkspaceFolder(resource?: vscode.Uri): vscode.WorkspaceFolder | undefined {
-  if (resource) {
-    const folder = vscode.workspace.getWorkspaceFolder(resource);
-    if (folder) return folder;
-  }
-  const uri = vscode.window.activeTextEditor?.document?.uri;
-  return uri ? vscode.workspace.getWorkspaceFolder(uri) : undefined;
 }
 
 function getRuntime(scope?: vscode.ConfigurationScope): string {

--- a/test/regression/issue/15485.test.ts
+++ b/test/regression/issue/15485.test.ts
@@ -1,10 +1,11 @@
+// https://github.com/oven-sh/bun/issues/15485
 // https://github.com/oven-sh/bun/issues/39612
 // In a multi-root workspace, "Bun: Run File" and "Bun: Debug File" called
 // vscode.debug.startDebugging(undefined, ...) with a config that uses
 // ${workspaceFolder}. VS Code cannot resolve that variable without a folder
 // scope and fails with "Variable workspaceFolder can not be resolved in a
 // multi folder workspace". The extension must pass the workspace folder that
-// owns the target file.
+// owns the target file, and it must read bun.runtime from that folder.
 // This test lives under test/ (not packages/bun-vscode) because CI's test
 // runner only discovers files in the test/ directory. It reuses the
 // extension's shared mock types, but registers its own vscode module mock:
@@ -21,6 +22,20 @@ const folderApp = new MockWorkspaceFolder(MockUri.file("/repo/app"), "app", 0);
 const folderLib = new MockWorkspaceFolder(MockUri.file("/repo/lib"), "lib", 1);
 const workspaceFolders = [folderApp, folderLib];
 
+// Only the "lib" folder sets bun.runtime in its folder settings.
+const libRuntime = "/repo/lib/node_modules/.bin/bun";
+
+function getWorkspaceFolder(uri: MockUri): MockWorkspaceFolder | undefined {
+  return workspaceFolders.find(folder => uri.fsPath.startsWith(folder.uri.fsPath + "/"));
+}
+
+// Like VS Code, a configuration scope that is a folder, or a Uri inside a
+// folder, resolves that folder's settings. No scope resolves no folder value.
+function folderOfScope(scope?: MockWorkspaceFolder | MockUri): MockWorkspaceFolder | undefined {
+  if (!scope) return undefined;
+  return scope instanceof MockWorkspaceFolder ? scope : getWorkspaceFolder(scope);
+}
+
 const startDebugging = mock(async (..._args: unknown[]) => true);
 const registeredCommands = new Map<string, (...args: any[]) => unknown>();
 const disposable = { dispose() {} };
@@ -35,9 +50,10 @@ mock.module("vscode", () => ({
   window: mockWindow,
   workspace: {
     workspaceFolders,
-    getWorkspaceFolder: (uri: MockUri) =>
-      workspaceFolders.find(folder => uri.fsPath.startsWith(folder.uri.fsPath + "/")),
-    getConfiguration: () => ({ get: () => undefined }),
+    getWorkspaceFolder,
+    getConfiguration: (_section: string, scope?: MockWorkspaceFolder | MockUri) => ({
+      get: (key: string) => (key === "runtime" && folderOfScope(scope) === folderLib ? libRuntime : undefined),
+    }),
     onDidOpenTextDocument: () => disposable,
     textDocuments: [],
   },
@@ -106,6 +122,16 @@ registerDebugger({ subscriptions: { push() {} } } as any);
 const runFile = registeredCommands.get("extension.bun.runFile")!;
 const debugFile = registeredCommands.get("extension.bun.debugFile")!;
 
+// One entry per startDebugging call: the folder argument plus the parts of
+// the launch config that depend on the folder.
+function launches() {
+  return startDebugging.mock.calls.map(([folder, config]: any[]) => ({
+    folder,
+    program: config.program,
+    runtime: config.runtime,
+  }));
+}
+
 beforeEach(() => {
   startDebugging.mockClear();
   mockWindow.activeTextEditor = undefined;
@@ -117,50 +143,52 @@ describe("multi-root workspace folder resolution", () => {
     expect(debugFile).toBeInstanceOf(Function);
   });
 
-  test("Bun: Run File passes the folder that owns the file", () => {
+  test("Bun: Run File passes the folder that owns the file and reads bun.runtime from it", () => {
     runFile(MockUri.file("/repo/lib/src/index.ts"));
+    runFile(MockUri.file("/repo/app/main.ts"));
 
-    expect(startDebugging).toHaveBeenCalledTimes(1);
-    const [folder, config] = startDebugging.mock.calls[0] as any[];
-    expect(config.program).toBe("/repo/lib/src/index.ts");
-    expect(folder).toBe(folderLib);
+    expect(launches()).toEqual([
+      { folder: folderLib, program: "/repo/lib/src/index.ts", runtime: libRuntime },
+      { folder: folderApp, program: "/repo/app/main.ts", runtime: "bun" },
+    ]);
   });
 
-  test("Bun: Debug File passes the folder that owns the file", () => {
+  test("Bun: Debug File passes the folder that owns the file and reads bun.runtime from it", () => {
+    debugFile(MockUri.file("/repo/lib/src/index.ts"));
     debugFile(MockUri.file("/repo/app/main.ts"));
 
-    expect(startDebugging).toHaveBeenCalledTimes(1);
-    const [folder, config] = startDebugging.mock.calls[0] as any[];
-    expect(config.program).toBe("/repo/app/main.ts");
-    expect(folder).toBe(folderApp);
+    expect(launches()).toEqual([
+      { folder: folderLib, program: "/repo/lib/src/index.ts", runtime: libRuntime },
+      { folder: folderApp, program: "/repo/app/main.ts", runtime: "bun" },
+    ]);
   });
 
-  test("commands fall back to the active editor's folder", () => {
-    mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/app/server.ts") } };
+  test("without a resource (command palette, keybinding) both commands use the active editor's folder", () => {
+    mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/lib/server.ts") } };
     runFile();
+    debugFile();
 
-    expect(startDebugging).toHaveBeenCalledTimes(1);
-    const [folder, config] = startDebugging.mock.calls[0] as any[];
-    expect(config.program).toBe("/repo/app/server.ts");
-    expect(folder).toBe(folderApp);
+    expect(launches()).toEqual([
+      { folder: folderLib, program: "/repo/lib/server.ts", runtime: libRuntime },
+      { folder: folderLib, program: "/repo/lib/server.ts", runtime: libRuntime },
+    ]);
   });
 
-  test("debugCommand derives the folder from the active editor", () => {
+  test("debugCommand for a package.json script uses the folder of the active editor", () => {
     mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/lib/package.json") } };
     debugCommand("dev");
 
-    expect(startDebugging).toHaveBeenCalledTimes(1);
-    const [folder, config] = startDebugging.mock.calls[0] as any[];
-    expect(config.program).toBe("dev");
-    expect(folder).toBe(folderLib);
+    expect(launches()).toEqual([{ folder: folderLib, program: "dev", runtime: libRuntime }]);
   });
 
   test("a file outside every workspace folder keeps the previous behavior", () => {
     runFile(MockUri.file("/outside/loose.ts"));
+    debugFile(MockUri.file("/outside/loose.ts"));
 
-    expect(startDebugging).toHaveBeenCalledTimes(1);
-    const [folder] = startDebugging.mock.calls[0] as any[];
-    expect(folder).toBeUndefined();
+    expect(launches()).toEqual([
+      { folder: undefined, program: "/outside/loose.ts", runtime: "bun" },
+      { folder: undefined, program: "/outside/loose.ts", runtime: "bun" },
+    ]);
   });
 
   test("run and debug agree on a foreign file: both fall back to the active editor's folder", () => {
@@ -168,10 +196,9 @@ describe("multi-root workspace folder resolution", () => {
     runFile(MockUri.file("/outside/loose.ts"));
     debugFile(MockUri.file("/outside/loose.ts"));
 
-    expect(startDebugging).toHaveBeenCalledTimes(2);
-    const [runFolder] = startDebugging.mock.calls[0] as any[];
-    const [debugFolder] = startDebugging.mock.calls[1] as any[];
-    expect(runFolder).toBe(folderApp);
-    expect(debugFolder).toBe(folderApp);
+    expect(launches()).toEqual([
+      { folder: folderApp, program: "/outside/loose.ts", runtime: "bun" },
+      { folder: folderApp, program: "/outside/loose.ts", runtime: "bun" },
+    ]);
   });
 });

--- a/test/regression/issue/15485.test.ts
+++ b/test/regression/issue/15485.test.ts
@@ -1,5 +1,4 @@
-// https://github.com/oven-sh/bun/issues/15485
-// https://github.com/oven-sh/bun/issues/39612
+// https://github.com/oven-sh/bun/issues/15485 (#39612 is a duplicate)
 // In a multi-root workspace, "Bun: Run File" and "Bun: Debug File" called
 // vscode.debug.startDebugging(undefined, ...) with a config that uses
 // ${workspaceFolder}. VS Code cannot resolve that variable without a folder
@@ -7,10 +6,9 @@
 // multi folder workspace". The extension must pass the workspace folder that
 // owns the target file, and it must read bun.runtime from that folder.
 // This test lives under test/ (not packages/bun-vscode) because CI's test
-// runner only discovers files in the test/ directory. It reuses the
-// extension's shared mock types, but registers its own vscode module mock:
-// the shared one in vscode.mock.ts targets the test controller and lacks
-// command registration and startDebugging capture.
+// runner only discovers files in the test/ directory. It registers its own
+// vscode module mock: the shared one in vscode.mock.ts targets the test
+// controller and lacks command registration and startDebugging capture.
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import path from "node:path";
 import {

--- a/test/regression/issue/15485.test.ts
+++ b/test/regression/issue/15485.test.ts
@@ -1,15 +1,17 @@
-// https://github.com/oven-sh/bun/issues/15485 (#39612 is a duplicate)
-// In a multi-root workspace, "Bun: Run File" and "Bun: Debug File" called
-// vscode.debug.startDebugging(undefined, ...) with a config that uses
-// ${workspaceFolder}. VS Code cannot resolve that variable without a folder
-// scope and fails with "Variable workspaceFolder can not be resolved in a
-// multi folder workspace". The extension must pass the workspace folder that
-// owns the target file, and it must read bun.runtime from that folder.
+// https://github.com/oven-sh/bun/issues/15485 (#39612 is a duplicate, #11925 is the same launch in a window without a folder)
+// "Bun: Run File" and "Bun: Debug File" called vscode.debug.startDebugging(undefined, ...)
+// with a config whose cwd is "${workspaceFolder}". VS Code resolves that variable only
+// against the folder passed to startDebugging, or against the single folder of a
+// single-root window. So the commands failed in a multi-root window ("Variable
+// workspaceFolder can not be resolved in a multi folder workspace") and in a window
+// without a folder ("Please open a folder"). The commands must pass the folder that owns
+// the file, read bun.runtime from it, and set a concrete cwd so that a file that no
+// folder owns still launches.
 // This test lives under test/ (not packages/bun-vscode) because CI's test
 // runner only discovers files in the test/ directory. It registers its own
 // vscode module mock: the shared one in vscode.mock.ts targets the test
 // controller and lacks command registration and startDebugging capture.
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import path from "node:path";
 import {
   MockUri,
@@ -94,12 +96,15 @@ mock.module("vscode", () => ({
   TaskPanelKind: { Shared: 1, Dedicated: 2, New: 3 },
 }));
 
+// The unfixed debug.ts also imports OutputEvent. The stub keeps that version
+// loadable, so that this test fails on its assertions against it, not at import.
 mock.module("@vscode/debugadapter", () => ({
   DebugSession: class {
     sendEvent() {}
     sendResponse() {}
     sendRequest() {}
   },
+  OutputEvent: class {},
 }));
 
 // Stub the adapter package so the test does not pull in its "ws" dependency.
@@ -120,13 +125,22 @@ const runFile = registeredCommands.get("extension.bun.runFile")!;
 const debugFile = registeredCommands.get("extension.bun.debugFile")!;
 
 // One entry per startDebugging call: the folder argument plus the parts of
-// the launch config that depend on the folder.
+// the launch config that depend on the folder or on the command.
 function launches() {
   return startDebugging.mock.calls.map(([folder, config]: any[]) => ({
     folder,
+    noDebug: config.noDebug,
     program: config.program,
+    cwd: config.cwd,
     runtime: config.runtime,
   }));
+}
+
+// VS Code cannot resolve a "${...}" variable in a launch without a folder.
+function unresolvedVariables() {
+  return startDebugging.mock.calls.flatMap(([, config]: any[]) =>
+    Object.values(config).filter(value => typeof value === "string" && value.includes("${")),
+  );
 }
 
 beforeEach(() => {
@@ -134,68 +148,103 @@ beforeEach(() => {
   mockWindow.activeTextEditor = undefined;
 });
 
-describe("multi-root workspace folder resolution", () => {
+describe("multi-root window", () => {
   test("registerDebugger registered the run and debug commands", () => {
     expect(runFile).toBeInstanceOf(Function);
     expect(debugFile).toBeInstanceOf(Function);
   });
 
-  test("Bun: Run File passes the folder that owns the file and reads bun.runtime from it", () => {
+  test("Bun: Run File launches in the folder that owns the file and reads bun.runtime from it", () => {
     runFile(MockUri.file("/repo/lib/src/index.ts"));
     runFile(MockUri.file("/repo/app/main.ts"));
 
     expect(launches()).toEqual([
-      { folder: folderLib, program: "/repo/lib/src/index.ts", runtime: libRuntime },
-      { folder: folderApp, program: "/repo/app/main.ts", runtime: "bun" },
+      { folder: folderLib, noDebug: true, program: "/repo/lib/src/index.ts", cwd: "/repo/lib", runtime: libRuntime },
+      { folder: folderApp, noDebug: true, program: "/repo/app/main.ts", cwd: "/repo/app", runtime: "bun" },
     ]);
   });
 
-  test("Bun: Debug File passes the folder that owns the file and reads bun.runtime from it", () => {
+  test("Bun: Debug File launches in the folder that owns the file and reads bun.runtime from it", () => {
     debugFile(MockUri.file("/repo/lib/src/index.ts"));
     debugFile(MockUri.file("/repo/app/main.ts"));
 
     expect(launches()).toEqual([
-      { folder: folderLib, program: "/repo/lib/src/index.ts", runtime: libRuntime },
-      { folder: folderApp, program: "/repo/app/main.ts", runtime: "bun" },
+      {
+        folder: folderLib,
+        noDebug: undefined,
+        program: "/repo/lib/src/index.ts",
+        cwd: "/repo/lib",
+        runtime: libRuntime,
+      },
+      { folder: folderApp, noDebug: undefined, program: "/repo/app/main.ts", cwd: "/repo/app", runtime: "bun" },
     ]);
   });
 
-  test("without a resource (command palette, keybinding) both commands use the active editor's folder", () => {
+  test("without a resource (command palette, keybinding) both commands launch the file in the active editor", () => {
     mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/lib/server.ts") } };
     runFile();
     debugFile();
 
     expect(launches()).toEqual([
-      { folder: folderLib, program: "/repo/lib/server.ts", runtime: libRuntime },
-      { folder: folderLib, program: "/repo/lib/server.ts", runtime: libRuntime },
+      { folder: folderLib, noDebug: true, program: "/repo/lib/server.ts", cwd: "/repo/lib", runtime: libRuntime },
+      { folder: folderLib, noDebug: undefined, program: "/repo/lib/server.ts", cwd: "/repo/lib", runtime: libRuntime },
     ]);
   });
 
-  test("debugCommand for a package.json script uses the folder of the active editor", () => {
+  test("without a resource and without an active editor nothing launches", () => {
+    runFile();
+    debugFile();
+
+    expect(launches()).toEqual([]);
+  });
+
+  test("debugCommand for a package.json script uses the folder of the package.json in the active editor", () => {
     mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/lib/package.json") } };
     debugCommand("dev");
 
-    expect(launches()).toEqual([{ folder: folderLib, program: "dev", runtime: libRuntime }]);
-  });
-
-  test("a file outside every workspace folder keeps the previous behavior", () => {
-    runFile(MockUri.file("/outside/loose.ts"));
-    debugFile(MockUri.file("/outside/loose.ts"));
-
+    // The script is not a path, so the cwd stays the variable. VS Code resolves
+    // it against the folder that is passed.
     expect(launches()).toEqual([
-      { folder: undefined, program: "/outside/loose.ts", runtime: "bun" },
-      { folder: undefined, program: "/outside/loose.ts", runtime: "bun" },
+      { folder: folderLib, noDebug: undefined, program: "dev", cwd: "${workspaceFolder}", runtime: libRuntime },
     ]);
   });
 
-  test("run and debug agree on a foreign file: both fall back to the active editor's folder", () => {
+  test("a file that no folder owns launches in its own directory", () => {
     mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/app/main.ts") } };
     runFile(MockUri.file("/outside/loose.ts"));
     debugFile(MockUri.file("/outside/loose.ts"));
 
     expect(launches()).toEqual([
-      { folder: folderApp, program: "/outside/loose.ts", runtime: "bun" },
-      { folder: folderApp, program: "/outside/loose.ts", runtime: "bun" },
+      { folder: undefined, noDebug: true, program: "/outside/loose.ts", cwd: "/outside", runtime: "bun" },
+      { folder: undefined, noDebug: undefined, program: "/outside/loose.ts", cwd: "/outside", runtime: "bun" },
     ]);
+    expect(unresolvedVariables()).toEqual([]);
+  });
+});
+
+describe("window without a folder", () => {
+  beforeEach(() => {
+    workspaceFolders.length = 0;
+  });
+  afterEach(() => {
+    workspaceFolders.push(folderApp, folderLib);
+  });
+
+  test("both commands launch the file in its own directory", () => {
+    mockWindow.activeTextEditor = { document: { uri: MockUri.file("/home/me/scripts/222.js") } };
+    runFile();
+    debugFile(MockUri.file("/home/me/scripts/111/111.js"));
+
+    expect(launches()).toEqual([
+      { folder: undefined, noDebug: true, program: "/home/me/scripts/222.js", cwd: "/home/me/scripts", runtime: "bun" },
+      {
+        folder: undefined,
+        noDebug: undefined,
+        program: "/home/me/scripts/111/111.js",
+        cwd: "/home/me/scripts/111",
+        runtime: "bun",
+      },
+    ]);
+    expect(unresolvedVariables()).toEqual([]);
   });
 });

--- a/test/regression/issue/15485.test.ts
+++ b/test/regression/issue/15485.test.ts
@@ -202,11 +202,19 @@ describe("multi-root window", () => {
     mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/lib/package.json") } };
     debugCommand("dev");
 
-    // The script is not a path, so the cwd stays the variable. VS Code resolves
-    // it against the folder that is passed.
     expect(launches()).toEqual([
-      { folder: folderLib, noDebug: undefined, program: "dev", cwd: "${workspaceFolder}", runtime: libRuntime },
+      { folder: folderLib, noDebug: undefined, program: "dev", cwd: "/repo/lib", runtime: libRuntime },
     ]);
+  });
+
+  test("debugCommand for a package.json that no folder owns launches in the package.json's directory", () => {
+    mockWindow.activeTextEditor = { document: { uri: MockUri.file("/outside/package.json") } };
+    debugCommand("dev");
+
+    expect(launches()).toEqual([
+      { folder: undefined, noDebug: undefined, program: "dev", cwd: "/outside", runtime: "bun" },
+    ]);
+    expect(unresolvedVariables()).toEqual([]);
   });
 
   test("a file that no folder owns launches in its own directory", () => {

--- a/test/regression/issue/15485.test.ts
+++ b/test/regression/issue/15485.test.ts
@@ -100,7 +100,6 @@ mock.module("@vscode/debugadapter", () => ({
     sendResponse() {}
     sendRequest() {}
   },
-  OutputEvent: class {},
 }));
 
 // Stub the adapter package so the test does not pull in its "ws" dependency.

--- a/test/regression/issue/15485.test.ts
+++ b/test/regression/issue/15485.test.ts
@@ -1,12 +1,12 @@
-// https://github.com/oven-sh/bun/issues/15485 (#39612 is a duplicate, #11925 is the same launch in a window without a folder)
+// https://github.com/oven-sh/bun/issues/15485 (#39612 is a duplicate; #11925 reports the same commands in a window without a folder)
 // "Bun: Run File" and "Bun: Debug File" called vscode.debug.startDebugging(undefined, ...)
 // with a config whose cwd is "${workspaceFolder}". VS Code resolves that variable only
 // against the folder passed to startDebugging, or against the single folder of a
 // single-root window. So the commands failed in a multi-root window ("Variable
 // workspaceFolder can not be resolved in a multi folder workspace") and in a window
 // without a folder ("Please open a folder"). The commands must pass the folder that owns
-// the file, read bun.runtime from it, and set a concrete cwd so that a file that no
-// folder owns still launches.
+// the file, so that VS Code scopes the launch (and the bun.runtime setting) to it, and
+// must set a concrete cwd, so that a file that no folder owns still launches.
 // This test lives under test/ (not packages/bun-vscode) because CI's test
 // runner only discovers files in the test/ directory. It registers its own
 // vscode module mock: the shared one in vscode.mock.ts targets the test
@@ -20,7 +20,8 @@ import {
 
 const folderApp = new MockWorkspaceFolder(MockUri.file("/repo/app"), "app", 0);
 const folderLib = new MockWorkspaceFolder(MockUri.file("/repo/lib"), "lib", 1);
-const workspaceFolders = [folderApp, folderLib];
+// The folders of the mocked window. The describe blocks below change them.
+const workspaceFolders: MockWorkspaceFolder[] = [];
 
 // Only the "lib" folder sets bun.runtime in its folder settings.
 const libRuntime = "/repo/lib/node_modules/.bin/bun";
@@ -29,15 +30,9 @@ function getWorkspaceFolder(uri: MockUri): MockWorkspaceFolder | undefined {
   return workspaceFolders.find(folder => uri.fsPath.startsWith(folder.uri.fsPath + "/"));
 }
 
-// Like VS Code, a configuration scope that is a folder, or a Uri inside a
-// folder, resolves that folder's settings. No scope resolves no folder value.
-function folderOfScope(scope?: MockWorkspaceFolder | MockUri): MockWorkspaceFolder | undefined {
-  if (!scope) return undefined;
-  return scope instanceof MockWorkspaceFolder ? scope : getWorkspaceFolder(scope);
-}
-
 const startDebugging = mock(async (..._args: unknown[]) => true);
 const registeredCommands = new Map<string, (...args: any[]) => unknown>();
+const configurationProviders: any[] = [];
 const disposable = { dispose() {} };
 
 const mockWindow = {
@@ -51,8 +46,8 @@ mock.module("vscode", () => ({
   workspace: {
     workspaceFolders,
     getWorkspaceFolder,
-    getConfiguration: (_section: string, scope?: MockWorkspaceFolder | MockUri) => ({
-      get: (key: string) => (key === "runtime" && folderOfScope(scope) === folderLib ? libRuntime : undefined),
+    getConfiguration: (_section: string, scope?: unknown) => ({
+      get: (key: string) => (key === "runtime" && scope === folderLib ? libRuntime : undefined),
     }),
     onDidOpenTextDocument: () => disposable,
     textDocuments: [],
@@ -68,7 +63,10 @@ mock.module("vscode", () => ({
   },
   debug: {
     startDebugging,
-    registerDebugConfigurationProvider: () => disposable,
+    registerDebugConfigurationProvider: (_type: string, provider: unknown) => {
+      configurationProviders.push(provider);
+      return disposable;
+    },
     registerDebugAdapterDescriptorFactory: () => disposable,
   },
   DebugConfigurationProviderTriggerKind: { Initial: 1, Dynamic: 2 },
@@ -124,10 +122,21 @@ registerDebugger({ subscriptions: { push() {} } } as any);
 const runFile = registeredCommands.get("extension.bun.runFile")!;
 const debugFile = registeredCommands.get("extension.bun.debugFile")!;
 
-// One entry per startDebugging call: the folder argument plus the parts of
-// the launch config that depend on the folder or on the command.
+// One entry per startDebugging call. Like VS Code, the config first goes
+// through resolveDebugConfiguration of every registered provider, with the
+// folder that was passed to startDebugging. That step fills in the runtime.
+function resolvedLaunches(): Array<{ folder: unknown; config: Record<string, unknown> }> {
+  return startDebugging.mock.calls.map(([folder, launch]: any[]) => {
+    let config = { ...launch };
+    for (const provider of configurationProviders) {
+      config = provider.resolveDebugConfiguration(folder, config);
+    }
+    return { folder, config };
+  });
+}
+
 function launches() {
-  return startDebugging.mock.calls.map(([folder, config]: any[]) => ({
+  return resolvedLaunches().map(({ folder, config }) => ({
     folder,
     noDebug: config.noDebug,
     program: config.program,
@@ -136,11 +145,21 @@ function launches() {
   }));
 }
 
-// VS Code cannot resolve a "${...}" variable in a launch without a folder.
+// VS Code substitutes "${...}" variables after the providers ran, and fails
+// the launch when one of them cannot be resolved without a folder.
 function unresolvedVariables() {
-  return startDebugging.mock.calls.flatMap(([, config]: any[]) =>
+  return resolvedLaunches().flatMap(({ config }) =>
     Object.values(config).filter(value => typeof value === "string" && value.includes("${")),
   );
+}
+
+function useFolders(...folders: MockWorkspaceFolder[]) {
+  beforeEach(() => {
+    workspaceFolders.push(...folders);
+  });
+  afterEach(() => {
+    workspaceFolders.length = 0;
+  });
 }
 
 beforeEach(() => {
@@ -148,13 +167,16 @@ beforeEach(() => {
   mockWindow.activeTextEditor = undefined;
 });
 
-describe("multi-root window", () => {
-  test("registerDebugger registered the run and debug commands", () => {
-    expect(runFile).toBeInstanceOf(Function);
-    expect(debugFile).toBeInstanceOf(Function);
-  });
+test("registerDebugger registered the run and debug commands and a configuration provider", () => {
+  expect(runFile).toBeInstanceOf(Function);
+  expect(debugFile).toBeInstanceOf(Function);
+  expect(configurationProviders.length).toBeGreaterThan(0);
+});
 
-  test("Bun: Run File launches in the folder that owns the file and reads bun.runtime from it", () => {
+describe("multi-root window", () => {
+  useFolders(folderApp, folderLib);
+
+  test("Bun: Run File launches in the folder that owns the file, with that folder's bun.runtime", () => {
     runFile(MockUri.file("/repo/lib/src/index.ts"));
     runFile(MockUri.file("/repo/app/main.ts"));
 
@@ -164,19 +186,13 @@ describe("multi-root window", () => {
     ]);
   });
 
-  test("Bun: Debug File launches in the folder that owns the file and reads bun.runtime from it", () => {
+  test("Bun: Debug File launches in the folder that owns the file, with that folder's bun.runtime", () => {
     debugFile(MockUri.file("/repo/lib/src/index.ts"));
     debugFile(MockUri.file("/repo/app/main.ts"));
 
     expect(launches()).toEqual([
-      {
-        folder: folderLib,
-        noDebug: undefined,
-        program: "/repo/lib/src/index.ts",
-        cwd: "/repo/lib",
-        runtime: libRuntime,
-      },
-      { folder: folderApp, noDebug: undefined, program: "/repo/app/main.ts", cwd: "/repo/app", runtime: "bun" },
+      { folder: folderLib, program: "/repo/lib/src/index.ts", cwd: "/repo/lib", runtime: libRuntime },
+      { folder: folderApp, program: "/repo/app/main.ts", cwd: "/repo/app", runtime: "bun" },
     ]);
   });
 
@@ -187,33 +203,30 @@ describe("multi-root window", () => {
 
     expect(launches()).toEqual([
       { folder: folderLib, noDebug: true, program: "/repo/lib/server.ts", cwd: "/repo/lib", runtime: libRuntime },
-      { folder: folderLib, noDebug: undefined, program: "/repo/lib/server.ts", cwd: "/repo/lib", runtime: libRuntime },
+      { folder: folderLib, program: "/repo/lib/server.ts", cwd: "/repo/lib", runtime: libRuntime },
     ]);
   });
 
   test("without a resource and without an active editor nothing launches", () => {
     runFile();
     debugFile();
+    debugCommand("dev");
 
     expect(launches()).toEqual([]);
   });
 
-  test("debugCommand for a package.json script uses the folder of the package.json in the active editor", () => {
+  test("debugCommand launches a script in the folder of the package.json in the active editor", () => {
     mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/lib/package.json") } };
     debugCommand("dev");
 
-    expect(launches()).toEqual([
-      { folder: folderLib, noDebug: undefined, program: "dev", cwd: "/repo/lib", runtime: libRuntime },
-    ]);
+    expect(launches()).toEqual([{ folder: folderLib, program: "dev", cwd: "/repo/lib", runtime: libRuntime }]);
   });
 
   test("debugCommand for a package.json that no folder owns launches in the package.json's directory", () => {
     mockWindow.activeTextEditor = { document: { uri: MockUri.file("/outside/package.json") } };
     debugCommand("dev");
 
-    expect(launches()).toEqual([
-      { folder: undefined, noDebug: undefined, program: "dev", cwd: "/outside", runtime: "bun" },
-    ]);
+    expect(launches()).toEqual([{ folder: undefined, program: "dev", cwd: "/outside", runtime: "bun" }]);
     expect(unresolvedVariables()).toEqual([]);
   });
 
@@ -224,20 +237,40 @@ describe("multi-root window", () => {
 
     expect(launches()).toEqual([
       { folder: undefined, noDebug: true, program: "/outside/loose.ts", cwd: "/outside", runtime: "bun" },
-      { folder: undefined, noDebug: undefined, program: "/outside/loose.ts", cwd: "/outside", runtime: "bun" },
+      { folder: undefined, program: "/outside/loose.ts", cwd: "/outside", runtime: "bun" },
     ]);
     expect(unresolvedVariables()).toEqual([]);
   });
 });
 
-describe("window without a folder", () => {
-  beforeEach(() => {
-    workspaceFolders.length = 0;
-  });
-  afterEach(() => {
-    workspaceFolders.push(folderApp, folderLib);
+describe("single-root window", () => {
+  useFolders(folderLib);
+
+  test("a file inside the folder launches in the folder", () => {
+    runFile(MockUri.file("/repo/lib/src/index.ts"));
+    debugFile(MockUri.file("/repo/lib/src/index.ts"));
+
+    expect(launches()).toEqual([
+      { folder: folderLib, noDebug: true, program: "/repo/lib/src/index.ts", cwd: "/repo/lib", runtime: libRuntime },
+      { folder: folderLib, program: "/repo/lib/src/index.ts", cwd: "/repo/lib", runtime: libRuntime },
+    ]);
   });
 
+  test("a file outside the folder still launches in the folder, as ${workspaceFolder} resolved before", () => {
+    mockWindow.activeTextEditor = { document: { uri: MockUri.file("/outside/package.json") } };
+    runFile(MockUri.file("/outside/loose.ts"));
+    debugFile(MockUri.file("/outside/loose.ts"));
+    debugCommand("dev");
+
+    expect(launches()).toEqual([
+      { folder: folderLib, noDebug: true, program: "/outside/loose.ts", cwd: "/repo/lib", runtime: libRuntime },
+      { folder: folderLib, program: "/outside/loose.ts", cwd: "/repo/lib", runtime: libRuntime },
+      { folder: folderLib, program: "dev", cwd: "/repo/lib", runtime: libRuntime },
+    ]);
+  });
+});
+
+describe("window without a folder", () => {
   test("both commands launch the file in its own directory", () => {
     mockWindow.activeTextEditor = { document: { uri: MockUri.file("/home/me/scripts/222.js") } };
     runFile();
@@ -245,14 +278,16 @@ describe("window without a folder", () => {
 
     expect(launches()).toEqual([
       { folder: undefined, noDebug: true, program: "/home/me/scripts/222.js", cwd: "/home/me/scripts", runtime: "bun" },
-      {
-        folder: undefined,
-        noDebug: undefined,
-        program: "/home/me/scripts/111/111.js",
-        cwd: "/home/me/scripts/111",
-        runtime: "bun",
-      },
+      { folder: undefined, program: "/home/me/scripts/111/111.js", cwd: "/home/me/scripts/111", runtime: "bun" },
     ]);
+    expect(unresolvedVariables()).toEqual([]);
+  });
+
+  test("debugCommand launches a script in the directory of the package.json", () => {
+    mockWindow.activeTextEditor = { document: { uri: MockUri.file("/home/me/scripts/package.json") } };
+    debugCommand("dev");
+
+    expect(launches()).toEqual([{ folder: undefined, program: "dev", cwd: "/home/me/scripts", runtime: "bun" }]);
     expect(unresolvedVariables()).toEqual([]);
   });
 });

--- a/test/regression/issue/39612.test.ts
+++ b/test/regression/issue/39612.test.ts
@@ -162,4 +162,16 @@ describe("multi-root workspace folder resolution", () => {
     const [folder] = startDebugging.mock.calls[0] as any[];
     expect(folder).toBeUndefined();
   });
+
+  test("run and debug agree on a foreign file: both fall back to the active editor's folder", () => {
+    mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/app/main.ts") } };
+    runFile(MockUri.file("/outside/loose.ts"));
+    debugFile(MockUri.file("/outside/loose.ts"));
+
+    expect(startDebugging).toHaveBeenCalledTimes(2);
+    const [runFolder] = startDebugging.mock.calls[0] as any[];
+    const [debugFolder] = startDebugging.mock.calls[1] as any[];
+    expect(runFolder).toBe(folderApp);
+    expect(debugFolder).toBe(folderApp);
+  });
 });

--- a/test/regression/issue/39612.test.ts
+++ b/test/regression/issue/39612.test.ts
@@ -93,21 +93,16 @@ mock.module("@vscode/debugadapter", () => ({
 }));
 
 // Stub the adapter package so the test does not pull in its "ws" dependency.
-mock.module(
-  path.join(import.meta.dir, "../../../packages/bun-debug-adapter-protocol/index.ts"),
-  () => ({
-    getAvailablePort: async () => 0,
-    getRandomId: () => "id",
-    TCPSocketSignal: class {},
-    UnixSignal: class {},
-    WebSocketDebugAdapter: class {},
-    NodeSocketDebugAdapter: class {},
-  }),
-);
+mock.module(path.join(import.meta.dir, "../../../packages/bun-debug-adapter-protocol/index.ts"), () => ({
+  getAvailablePort: async () => 0,
+  getRandomId: () => "id",
+  TCPSocketSignal: class {},
+  UnixSignal: class {},
+  WebSocketDebugAdapter: class {},
+  NodeSocketDebugAdapter: class {},
+}));
 
-const { registerDebugger, debugCommand } = await import(
-  "../../../packages/bun-vscode/src/features/debug.ts"
-);
+const { registerDebugger, debugCommand } = await import("../../../packages/bun-vscode/src/features/debug.ts");
 
 registerDebugger({ subscriptions: { push() {} } } as any);
 

--- a/test/regression/issue/39612.test.ts
+++ b/test/regression/issue/39612.test.ts
@@ -1,0 +1,173 @@
+// https://github.com/oven-sh/bun/issues/39612
+// In a multi-root workspace, "Bun: Run File" and "Bun: Debug File" called
+// vscode.debug.startDebugging(undefined, ...) with a config that uses
+// ${workspaceFolder}. VS Code cannot resolve that variable without a folder
+// scope and fails with "Variable workspaceFolder can not be resolved in a
+// multi folder workspace". The extension must pass the workspace folder that
+// owns the target file.
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import path from "node:path";
+
+class MockUri {
+  constructor(public fsPath: string) {}
+  static file(p: string): MockUri {
+    return new MockUri(p);
+  }
+  toString(): string {
+    return `file://${this.fsPath}`;
+  }
+}
+
+type MockWorkspaceFolder = { uri: MockUri; name: string; index: number };
+
+const folderApp: MockWorkspaceFolder = { uri: MockUri.file("/repo/app"), name: "app", index: 0 };
+const folderLib: MockWorkspaceFolder = { uri: MockUri.file("/repo/lib"), name: "lib", index: 1 };
+const workspaceFolders = [folderApp, folderLib];
+
+const startDebugging = mock(async (..._args: unknown[]) => true);
+const registeredCommands = new Map<string, (...args: any[]) => unknown>();
+const disposable = { dispose() {} };
+
+const mockWindow = {
+  activeTextEditor: undefined as undefined | { document: { uri: MockUri } },
+  visibleTextEditors: [],
+  createOutputChannel: () => ({ appendLine() {} }),
+};
+
+mock.module("vscode", () => ({
+  window: mockWindow,
+  workspace: {
+    workspaceFolders,
+    getWorkspaceFolder: (uri: MockUri) =>
+      workspaceFolders.find(folder => uri.fsPath.startsWith(folder.uri.fsPath + "/")),
+    getConfiguration: () => ({ get: () => undefined }),
+    onDidOpenTextDocument: () => disposable,
+    textDocuments: [],
+  },
+  commands: {
+    registerCommand: (name: string, callback: (...args: any[]) => unknown) => {
+      registeredCommands.set(name, callback);
+      return disposable;
+    },
+  },
+  languages: {
+    registerCodeLensProvider: () => disposable,
+  },
+  debug: {
+    startDebugging,
+    registerDebugConfigurationProvider: () => disposable,
+    registerDebugAdapterDescriptorFactory: () => disposable,
+  },
+  DebugConfigurationProviderTriggerKind: { Initial: 1, Dynamic: 2 },
+  Uri: MockUri,
+  Range: class {},
+  Position: class {},
+  CodeLens: class {},
+  ThemeIcon: class {},
+  TerminalProfile: class {},
+  MarkdownString: class {},
+  EventEmitter: class {
+    event = () => disposable;
+    fire() {}
+  },
+  TestTag: class {},
+  TestMessage: class {},
+  TestRunProfileKind: { Run: 1, Debug: 2, Coverage: 3 },
+  RelativePattern: class {},
+  Location: class {},
+  DiagnosticSeverity: { Error: 0, Warning: 1, Information: 2, Hint: 3 },
+  Task: class {},
+  TaskScope: { Workspace: 1, Global: 2 },
+  ShellExecution: class {},
+  TaskRevealKind: { Always: 1, Silent: 2, Never: 3 },
+  TaskPanelKind: { Shared: 1, Dedicated: 2, New: 3 },
+}));
+
+mock.module("@vscode/debugadapter", () => ({
+  DebugSession: class {
+    sendEvent() {}
+    sendResponse() {}
+    sendRequest() {}
+  },
+  OutputEvent: class {},
+}));
+
+// Stub the adapter package so the test does not pull in its "ws" dependency.
+mock.module(
+  path.join(import.meta.dir, "../../../packages/bun-debug-adapter-protocol/index.ts"),
+  () => ({
+    getAvailablePort: async () => 0,
+    getRandomId: () => "id",
+    TCPSocketSignal: class {},
+    UnixSignal: class {},
+    WebSocketDebugAdapter: class {},
+    NodeSocketDebugAdapter: class {},
+  }),
+);
+
+const { registerDebugger, debugCommand } = await import(
+  "../../../packages/bun-vscode/src/features/debug.ts"
+);
+
+registerDebugger({ subscriptions: { push() {} } } as any);
+
+const runFile = registeredCommands.get("extension.bun.runFile")!;
+const debugFile = registeredCommands.get("extension.bun.debugFile")!;
+
+beforeEach(() => {
+  startDebugging.mockClear();
+  mockWindow.activeTextEditor = undefined;
+});
+
+describe("multi-root workspace folder resolution", () => {
+  test("registerDebugger registered the run and debug commands", () => {
+    expect(runFile).toBeInstanceOf(Function);
+    expect(debugFile).toBeInstanceOf(Function);
+  });
+
+  test("Bun: Run File passes the folder that owns the file", () => {
+    runFile(MockUri.file("/repo/lib/src/index.ts"));
+
+    expect(startDebugging).toHaveBeenCalledTimes(1);
+    const [folder, config] = startDebugging.mock.calls[0] as any[];
+    expect(config.program).toBe("/repo/lib/src/index.ts");
+    expect(folder).toBe(folderLib);
+  });
+
+  test("Bun: Debug File passes the folder that owns the file", () => {
+    debugFile(MockUri.file("/repo/app/main.ts"));
+
+    expect(startDebugging).toHaveBeenCalledTimes(1);
+    const [folder, config] = startDebugging.mock.calls[0] as any[];
+    expect(config.program).toBe("/repo/app/main.ts");
+    expect(folder).toBe(folderApp);
+  });
+
+  test("commands fall back to the active editor's folder", () => {
+    mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/app/server.ts") } };
+    runFile();
+
+    expect(startDebugging).toHaveBeenCalledTimes(1);
+    const [folder, config] = startDebugging.mock.calls[0] as any[];
+    expect(config.program).toBe("/repo/app/server.ts");
+    expect(folder).toBe(folderApp);
+  });
+
+  test("debugCommand derives the folder from the active editor", () => {
+    mockWindow.activeTextEditor = { document: { uri: MockUri.file("/repo/lib/package.json") } };
+    debugCommand("dev");
+
+    expect(startDebugging).toHaveBeenCalledTimes(1);
+    const [folder, config] = startDebugging.mock.calls[0] as any[];
+    expect(config.program).toBe("dev");
+    expect(folder).toBe(folderLib);
+  });
+
+  test("a file outside every workspace folder keeps the previous behavior", () => {
+    runFile(MockUri.file("/outside/loose.ts"));
+
+    expect(startDebugging).toHaveBeenCalledTimes(1);
+    const [folder] = startDebugging.mock.calls[0] as any[];
+    expect(folder).toBeUndefined();
+  });
+});

--- a/test/regression/issue/39612.test.ts
+++ b/test/regression/issue/39612.test.ts
@@ -5,23 +5,20 @@
 // scope and fails with "Variable workspaceFolder can not be resolved in a
 // multi folder workspace". The extension must pass the workspace folder that
 // owns the target file.
+// This test lives under test/ (not packages/bun-vscode) because CI's test
+// runner only discovers files in the test/ directory. It reuses the
+// extension's shared mock types, but registers its own vscode module mock:
+// the shared one in vscode.mock.ts targets the test controller and lacks
+// command registration and startDebugging capture.
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import path from "node:path";
+import {
+  MockUri,
+  MockWorkspaceFolder,
+} from "../../../packages/bun-vscode/src/features/tests/__tests__/vscode-types.mock";
 
-class MockUri {
-  constructor(public fsPath: string) {}
-  static file(p: string): MockUri {
-    return new MockUri(p);
-  }
-  toString(): string {
-    return `file://${this.fsPath}`;
-  }
-}
-
-type MockWorkspaceFolder = { uri: MockUri; name: string; index: number };
-
-const folderApp: MockWorkspaceFolder = { uri: MockUri.file("/repo/app"), name: "app", index: 0 };
-const folderLib: MockWorkspaceFolder = { uri: MockUri.file("/repo/lib"), name: "lib", index: 1 };
+const folderApp = new MockWorkspaceFolder(MockUri.file("/repo/app"), "app", 0);
+const folderLib = new MockWorkspaceFolder(MockUri.file("/repo/lib"), "lib", 1);
 const workspaceFolders = [folderApp, folderLib];
 
 const startDebugging = mock(async (..._args: unknown[]) => true);


### PR DESCRIPTION
Fixes #15485
Fixes #39612

Supersedes #32053. The same commands now also work in a window without a folder (the command part of #11925).

### Problem

- Run File and Debug File fail in a multi-root window (`Variable workspaceFolder can not be resolved in a multi folder workspace`) and in a window without a folder (`Please open a folder`). The `package.json` Debug link fails the same way.
- The commands call `startDebugging(undefined, ...)` (`packages/bun-vscode/src/features/debug.ts:78`, `:88`) with `cwd: "${workspaceFolder}"`. VS Code resolves it only against the folder passed in, or the one folder of a single-root window.

### Fix

- The three commands share `launch()`. It passes the folder that owns the document (the file, or the `package.json` of the script) to `startDebugging`, else the only folder of a single-root window, and sets `cwd` to it. With no such folder the `cwd` is the document's directory. No variable is left in the config.
- Correct because the folder argument is how VS Code scopes a launch, and the `cwd` fallback is what js-debug uses without a folder. A single-root window keeps every `cwd` it had. `runtime` now comes from the existing `resolveDebugConfiguration`, scoped to the passed folder, as it already does for unsaved code.
- `debugCommand` does nothing without an active editor. The unused `runUnsavedCode` copy in debug.ts is deleted.
- Verified: `test/regression/issue/15485.test.ts` covers two-root, one-root and no-folder windows and runs the registered provider on each launch. Without the fix, 11 of 12 tests fail.

### Background

- `startDebugging(folder, config)`: VS Code hands `folder` to `resolveDebugConfiguration` and resolves `${workspaceFolder}` against it. With one root it uses that root, so the bug needs two roots or none.
- `bun.runtime` names the bun executable. `resolveDebugConfiguration` reads it with the launch's folder as the scope.
- The test is under `test/` because CI discovers tests only there. It mocks `vscode` and records the `startDebugging` calls and the provider.

<details><summary>Notes</summary>

- #32053 by @watanaki fixes the multi-root case with the same folder lookup and a concrete `cwd`, but falls back to the variable when no folder owns the file, and its `debugCommand` change looks the folder up from the script name, so the `package.json` Debug link still fails there. This PR passes the folder itself, adds the directory fallback and a test. The commits that set the `cwd` carry a co-author trailer for @watanaki.
- #39612 is a duplicate of #15485.
- #11925 stays open: F5 with the "Bun" entry in a window without a folder takes the provider path (`provideDebugConfigurations` and the default fill in `resolveDebugConfiguration`), which still hands VS Code `cwd: "${workspaceFolder}"`. The same holds for a user launch config without `cwd` in user settings or in a `.code-workspace` file. Only the three commands change here.
- #28242 (nested `package.json` scripts run from the folder root, and the code lens lists the first root's scripts) is not changed here. The Debug link uses the owning folder as before, and the `package.json` directory only when no folder owns it.
- `extension.ts:21` and `debug.ts:313` still use the first root as the cwd of untitled code. Not changed here.
- #24392 (closed) changed the launch configs to `${fileWorkspaceFolder}`. That resolves from the active editor, not from the file the command was invoked on, and still fails without a folder.
- `bun.runtime` is declared with `window` scope in `packages/bun-vscode/package.json` today, so a folder value does not resolve yet. #33171 raises it to `resource` scope. Passing the folder here is what makes that change reach these commands.
- The window without a folder is verified by the unit test (the config that reaches VS Code holds no variable), not in a live VS Code window.
- Fail-before with the debug.ts from main: the folder argument is `undefined` and the `cwd` is the variable in every launch, and `debugCommand` launches without an editor. The `OutputEvent` stub stays in the test mock because the unfixed debug.ts imports it. Without the stub the test fails at import against that version instead of on its assertions.
- The diff also deletes the `runUnsavedCode` export in debug.ts. Nothing imported it. The live handler is in extension.ts. The test controller already passes its folder to `startDebugging` (`bun-test-controller.ts:1431`).
- Other checks: prettier on both files.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/15485.test.ts"
ninja: Entering directory `/workspace/bun/build/debug'
[1/61] gen JSBuffer.lut.h
Generating /workspace/bun/build/debug/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/61] gen cpp.rs (cppbind)
[3/61] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[4/61] gen JS modules (bundle-modules)
Preprocess modules (7985ms)
Bundle modules (65ms)
Postprocesss modules (235ms)
Bundle Functions (759ms)
Generate Code (18ms)

[9.08s] Bundled "src/js" for development
  2822 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[4/54] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[50/54] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
FAILED: obj/src/jsc/bindings/ZigGlobalObject.cpp.o 
/usr/bin/ccache /usr/lib/llvm-21/bin/clang++ -march=nehalem -O0 -g
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (63b425bae)

test/regression/issue/15485.test.ts:
(pass) registerDebugger registered the run and debug commands and a configuration provider [0.04ms]
178 | 
179 |   test("Bun: Run File launches in the folder that owns the file, with that folder's bun.runtime", () => {
180 |     runFile(MockUri.file("/repo/lib/src/index.ts"));
181 |     runFile(MockUri.file("/repo/app/main.ts"));
182 | 
183 |     expect(launches()).toEqual([
                             ^
error: expect(received).toEqual(expected)

  [
    {
-     "cwd": "/repo/lib",
-     "folder": MockWorkspaceFolder {
-       "index": 1,
-       "name": "lib",
-       "uri": MockUri {
-         "authority": "",
-         "fragment": "",
-         "fsPath": "/repo/lib",
-         "path": "/repo/lib",
-         "query": "",
-         "scheme": "file",
-       },
-     },
+     "cwd": "${workspaceFolder}",
+     "folder": undefined,
      "noDebug": true,
      "program": "/repo/lib/src/index.ts",
-     "runtime": "/repo/lib/node_modules/.bin/bun",
+     "runtime": "bun",
    },
    {
-     "cwd": "/repo/app",
-     "folder": MockWorkspaceFolder {
-       "index": 0,
-       "name": "app",
-  
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/regression/issue/15485.test.ts"
bun test v1.4.0 (4c689909e)

test/regression/issue/15485.test.ts:
(pass) registerDebugger registered the run and debug commands and a configuration provider [3.58ms]
(pass) multi-root window > Bun: Run File launches in the folder that owns the file, with that folder's bun.runtime [27.76ms]
(pass) multi-root window > Bun: Debug File launches in the folder that owns the file, with that folder's bun.runtime [8.62ms]
(pass) multi-root window > without a resource (command palette, keybinding) both commands launch the file in the active editor [7.14ms]
(pass) multi-root window > without a resource and without an active editor nothing launches [3.02ms]
(pass) multi-root window > debugCommand launches a script in the folder of the package.json in the active editor [4.47ms]
(pass) multi-root window > debugCommand for a package.json that no folder owns launches in the package.json's directory [17.77ms]
(pass) multi-root window > a file that no folder owns launches in its own directory [13.58ms]
(pass) single
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 652ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/49] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[2/49] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/49] gen cpp.rs (cppbind)
[4/49] gen JS modules (bundle-modules)
Preprocess modules (7832ms)
Bundle modules (58ms)
Postprocesss modules (289ms)
Bundle Functions (780ms)
Generate Code (37ms)

[9.02s] Bundled "src/js" for production
  2628 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[4/45] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_windows_sys v0.0.0 (/workspace/bun/src/windows_sys)
[1m[92m   Compiling[0m bun_libuv_sys v0.0.0 (/workspace/bun/src/libuv_sys)
[1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-vscode/src/features/debug.ts | 118 +++---------
 test/regression/issue/15485.test.ts       | 293 ++++++++++++++++++++++++++++++
 2 files changed, 321 insertions(+), 90 deletions(-)
```

</details>

**gate history** · 6 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
packages/bun-vscode/src/features/debug.ts      5      8      0
test/regression/issue/15485.test.ts            3      4      0
```

</details>

<!-- robobun:evidence:end -->




