### PR TITLE
Bump libuv and WebKit for the Windows startup work

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -64,6 +64,15 @@ static void init_debug_logging() {
 extern int Bun__doesMacOSVersionSupportSendRecvMsgX();
 #endif
 
+#if defined(_WIN32)
+/* libuv initializes Winsock on first use; every entry point below that creates
+ * a socket or resolves an address makes sure that has happened first. */
+extern void uv__winsock_ensure(void);
+#define bsd_winsock_ensure() uv__winsock_ensure()
+#else
+#define bsd_winsock_ensure() ((void)0)
+#endif
+
 
 /* We need to emulate sendmmsg, recvmmsg on platform who don't have it */
 int bsd_sendmmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct udp_sendbuf* sendbuf, int flags) {
@@ -718,6 +727,7 @@ void bsd_socket_flush(LIBUS_SOCKET_DESCRIPTOR fd) {
 }
 
 LIBUS_SOCKET_DESCRIPTOR bsd_create_socket(int domain, int type, int protocol, int *err) {
+    bsd_winsock_ensure();
     if (err != NULL) {
         *err = 0;
     }
@@ -1238,6 +1248,7 @@ int bsd_socket_export(LIBUS_SOCKET_DESCRIPTOR fd, unsigned int target_pid, void 
 }
 
 LIBUS_SOCKET_DESCRIPTOR bsd_socket_import(void *info, int *err) {
+    bsd_winsock_ensure();
 #ifdef _WIN32
     SOCKET s = WSASocketW(FROM_PROTOCOL_INFO, FROM_PROTOCOL_INFO, FROM_PROTOCOL_INFO,
                           (WSAPROTOCOL_INFOW *) info, 0, WSA_FLAG_OVERLAPPED);
@@ -1271,6 +1282,7 @@ int bsd_socket_listen_error_is_benign(LIBUS_SOCKET_DESCRIPTOR fd) {
 }
 
 LIBUS_SOCKET_DESCRIPTOR bsd_create_bound_socket(const char *host, int port, int options, int *out_port, int *error) {
+    bsd_winsock_ensure();
     struct addrinfo hints, *result;
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_flags = AI_PASSIVE;
@@ -1352,6 +1364,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_bound_socket(const char *host, int port, int 
 }
 
 LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int options, int* error) {
+    bsd_winsock_ensure();
     struct addrinfo hints, *result;
     memset(&hints, 0, sizeof(struct addrinfo));
 
@@ -1740,6 +1753,7 @@ int bsd_bind_udp_fd(LIBUS_SOCKET_DESCRIPTOR fd, const struct sockaddr *addr, int
 }
 
 LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int options, int *err) {
+    bsd_winsock_ensure();
     if (err != NULL) {
         *err = 0;
     }
@@ -1829,6 +1843,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
 }
 
 int bsd_connect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd, const char *host, int port) {
+    bsd_winsock_ensure();
     struct addrinfo hints, *result;
     memset(&hints, 0, sizeof(struct addrinfo));
 

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -19,7 +19,11 @@ import { LIBC_ALLOCATION_SYMBOLS } from "../source.ts";
 // instead of aborting on AssignProcessToJobObject failure (oven-sh/libuv#12),
 // closes the process/thread handles on that error path (oven-sh/libuv#13), and
 // uv__split_path allocates with uv__malloc instead of _wcsdup so the buffer
-// can be uv__free'd under uv_replace_allocator (oven-sh/libuv#14).
+// can be uv__free'd under uv_replace_allocator (oven-sh/libuv#14), Winsock /
+// console-resize watcher / suspend-resume detection initialized on first use
+// instead of in uv__init, with uv__winsock_ensure() for callers that reach
+// ws2_32 directly (oven-sh/libuv#15), and LoadLibraryExW for those lazy
+// loads (oven-sh/libuv#16).
 // To bump, update `bun`.
 const LIBUV_COMMIT = "8023581113b276e7c1aee3f82da57ca0893faab1";
 

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -21,7 +21,7 @@ import { LIBC_ALLOCATION_SYMBOLS } from "../source.ts";
 // uv__split_path allocates with uv__malloc instead of _wcsdup so the buffer
 // can be uv__free'd under uv_replace_allocator (oven-sh/libuv#14).
 // To bump, update `bun`.
-const LIBUV_COMMIT = "0c89a51e2de5c42cca40e3bccc1e8542e157087c";
+const LIBUV_COMMIT = "8023581113b276e7c1aee3f82da57ca0893faab1";
 
 // prettier-ignore
 const SHARED = [

--- a/scripts/build/deps/mimalloc.ts
+++ b/scripts/build/deps/mimalloc.ts
@@ -12,7 +12,7 @@
 
 import type { Dependency, DirectBuild } from "../source.ts";
 
-const MIMALLOC_COMMIT = "6e891cbe4790982ca9f3f9a60319a72e61b5d725";
+const MIMALLOC_COMMIT = "6a14aee24315e503fa295a1fa90fe8b24ad91774";
 
 export const mimalloc: Dependency = {
   name: "mimalloc",

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "eeab04040fa61fd595695980f9d054b7fc0ed855";
+export const WEBKIT_VERSION = "0f966e81b78c84bb23213e391bc679c4ef83e56b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2719,8 +2719,6 @@ pub mod ffi {
     #[cfg(windows)]
     unsafe impl Zeroable for bun_windows_sys::externs::FILETIME {}
     #[cfg(windows)]
-    unsafe impl Zeroable for bun_windows_sys::externs::ws2_32::WSADATA {}
-    #[cfg(windows)]
     unsafe impl Zeroable for bun_windows_sys::externs::ws2_32::sockaddr_storage {}
     #[cfg(windows)]
     unsafe impl Zeroable for bun_windows_sys::externs::ws2_32::sockaddr_in {}

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -757,6 +757,12 @@ impl Channel {
         let optmask: c_int =
             ARES_OPT_FLAGS | ARES_OPT_TIMEOUTMS | ARES_OPT_SOCK_STATE_CB | ARES_OPT_TRIES;
 
+        // c-ares creates its sockets with ws2_32 directly; Winsock is otherwise
+        // initialized lazily by libuv.
+        #[cfg(windows)]
+        unsafe {
+            bun_libuv_sys::uv__winsock_ensure()
+        };
         // SAFETY: c-ares FFI; opts/channel are valid stack pointers.
         let rc = unsafe { ares_init_options(&raw mut channel, &raw mut opts, optmask) };
         if let Some(err) = Error::get(rc) {

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -757,8 +757,8 @@ impl Channel {
         let optmask: c_int =
             ARES_OPT_FLAGS | ARES_OPT_TIMEOUTMS | ARES_OPT_SOCK_STATE_CB | ARES_OPT_TRIES;
 
-        // c-ares creates its sockets with ws2_32 directly; Winsock is otherwise
-        // initialized lazily by libuv.
+        // SAFETY: idempotent Winsock init (uv_once); c-ares creates its sockets with
+        // ws2_32 directly and libuv otherwise initializes Winsock lazily.
         #[cfg(windows)]
         unsafe {
             bun_libuv_sys::uv__winsock_ensure()

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -288,6 +288,8 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
     // NOLINTBEGIN
     std::call_once(jsc_init_flag, [evalMode, oneShotStartup, shortLivedGlobals, envp, envc, onCrash]() {
         JSC::Config::enableRestrictedOptions();
+        // JSC options come from BUN_JSC_* (applied in the callback below), not JSC_*.
+        JSC::Config::disableEnvironmentOptions();
 
         std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
         WTF::initializeMainThread();

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -2738,6 +2738,11 @@ unsafe extern "C" {
     pub fn uv_timer_stop(handle: *mut Timer) -> c_int;
     pub fn uv_timer_get_due_in(handle: *const Timer) -> u64;
 
+    /// Winsock is initialized on first use inside libuv; anything that calls
+    /// ws2_32 directly (or through c-ares/uSockets) must call this first.
+    /// Thread-safe and idempotent (uv_once).
+    pub fn uv__winsock_ensure();
+
     // dns
     pub fn uv_getaddrinfo(
         loop_: *mut Loop,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -2602,6 +2602,7 @@ pub mod internal {
         #[cfg(windows)]
         unsafe {
             use bun_sys::windows::ws2_32 as wsa;
+            libuv::uv__winsock_ensure();
             let mut wsa_hints: wsa::addrinfo = bun_core::ffi::zeroed();
             wsa_hints.ai_family = wsa::AF_UNSPEC;
             wsa_hints.ai_socktype = wsa::SOCK_STREAM;

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -808,24 +808,13 @@ mod _impl {
         #[cfg(windows)]
         {
             let mut name_buffer: [u16; 130] = [0; 130]; // [129:0]u16 → 130 u16s with NUL at [129]
-            // SAFETY: valid buffer
+            // SAFETY: idempotent Winsock init (libuv defers it to first use); valid buffer.
+            unsafe { windows::libuv::uv__winsock_ensure() };
             if unsafe { windows::GetHostNameW(name_buffer.as_mut_ptr(), 129) } == 0 {
                 let str = BunString::clone_utf16(slice_to_nul_u16(&name_buffer));
                 let js = str.to_js(global);
                 str.deref();
                 return js;
-            }
-
-            let mut result: windows::ws2_32::WSADATA = bun_core::ffi::zeroed();
-            // SAFETY: valid out-pointer
-            if unsafe { windows::ws2_32::WSAStartup(0x202, &mut result) } == 0 {
-                // SAFETY: valid buffer
-                if unsafe { windows::GetHostNameW(name_buffer.as_mut_ptr(), 129) } == 0 {
-                    let y = BunString::clone_utf16(slice_to_nul_u16(&name_buffer));
-                    let js = y.to_js(global);
-                    y.deref();
-                    return js;
-                }
             }
 
             return Ok(ZigString::init(b"unknown").with_encoding().to_js(global));

--- a/src/runtime/node/node_os.rs
+++ b/src/runtime/node/node_os.rs
@@ -808,8 +808,9 @@ mod _impl {
         #[cfg(windows)]
         {
             let mut name_buffer: [u16; 130] = [0; 130]; // [129:0]u16 → 130 u16s with NUL at [129]
-            // SAFETY: idempotent Winsock init (libuv defers it to first use); valid buffer.
+            // SAFETY: idempotent Winsock init (libuv defers it to first use).
             unsafe { windows::libuv::uv__winsock_ensure() };
+            // SAFETY: valid buffer
             if unsafe { windows::GetHostNameW(name_buffer.as_mut_ptr(), 129) } == 0 {
                 let str = BunString::clone_utf16(slice_to_nul_u16(&name_buffer));
                 let js = str.to_js(global);

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -1084,27 +1084,7 @@ pub mod ws2_32 {
             res: *mut *mut addrinfo,
         ) -> c_int;
         pub fn freeaddrinfo(ai: *mut addrinfo);
-        /// `WSAStartup` (`winsock2.h`). 0 on success; non-zero is a `WSAE*`.
-        pub fn WSAStartup(wVersionRequested: u16, lpWSAData: *mut WSADATA) -> c_int;
     }
-
-    /// `WSADATA` (`winsock2.h`, **`_WIN64` layout** — on 64-bit Windows
-    /// `iMaxSockets`/`iMaxUdpDg`/`lpVendorInfo` come *before* the
-    /// `szDescription`/`szSystemStatus` arrays; the 32-bit header swaps that
-    /// order). Only ever read back from `WSAStartup`; callers zero-initialise
-    /// and never project fields beyond `wVersion`.
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    pub struct WSADATA {
-        pub wVersion: u16,
-        pub wHighVersion: u16,
-        pub iMaxSockets: u16,
-        pub iMaxUdpDg: u16,
-        pub lpVendorInfo: *mut u8,
-        pub szDescription: [u8; 257],
-        pub szSystemStatus: [u8; 129],
-    }
-    const _: () = assert!(core::mem::size_of::<WSADATA>() == 408);
 
     /// `SOCKADDR_STORAGE` (`ws2def.h`). 128 bytes, 8-aligned.
     #[repr(C)]

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1247,3 +1247,27 @@ describe("node shim (argv0=node) does not auto-load .env files", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// JSC options come from BUN_JSC_<option>; JSC's own JSC_<option> environment
+// pass is disabled (JSC::Config::disableEnvironmentOptions in JSCInitialize).
+describe("JSC option environment variables", () => {
+  async function dumpsOptions(env: Record<string, string>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "1"],
+      env: { ...bunEnv, ...env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    return stderr.includes("thresholdForJITAfterWarmUp=77");
+  }
+  test.concurrent("BUN_JSC_<option> applies", async () => {
+    expect(await dumpsOptions({ BUN_JSC_dumpOptions: "1", BUN_JSC_thresholdForJITAfterWarmUp: "77" })).toBe(true);
+  });
+  test.concurrent("JSC_<option> is ignored", async () => {
+    // dumpOptions=2 lists every option with its current value, so this would show
+    // the 77 however JSC_* had been applied.
+    expect(await dumpsOptions({ JSC_dumpOptions: "2", JSC_thresholdForJITAfterWarmUp: "77" })).toBe(false);
+  });
+});

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1255,7 +1255,7 @@ describe("JSC option environment variables", () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", "1"],
       env: { ...bunEnv, ...env },
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1263,7 +1263,10 @@ describe("JSC option environment variables", () => {
   }
   test.concurrent("BUN_JSC_<option> applies", async () => {
     // level 1 lists overridden options only
-    const { stderr, exitCode } = await dumpOptions({ BUN_JSC_dumpOptions: "1", BUN_JSC_thresholdForJITAfterWarmUp: "77" });
+    const { stderr, exitCode } = await dumpOptions({
+      BUN_JSC_dumpOptions: "1",
+      BUN_JSC_thresholdForJITAfterWarmUp: "77",
+    });
     expect(stderr).toContain("thresholdForJITAfterWarmUp=77");
     expect(exitCode).toBe(0);
   });

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -1251,7 +1251,7 @@ describe("node shim (argv0=node) does not auto-load .env files", () => {
 // JSC options come from BUN_JSC_<option>; JSC's own JSC_<option> environment
 // pass is disabled (JSC::Config::disableEnvironmentOptions in JSCInitialize).
 describe("JSC option environment variables", () => {
-  async function dumpsOptions(env: Record<string, string>) {
+  async function dumpOptions(env: Record<string, string>) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", "1"],
       env: { ...bunEnv, ...env },
@@ -1259,15 +1259,19 @@ describe("JSC option environment variables", () => {
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(exitCode).toBe(0);
-    return stderr.includes("thresholdForJITAfterWarmUp=77");
+    return { stderr, exitCode };
   }
   test.concurrent("BUN_JSC_<option> applies", async () => {
-    expect(await dumpsOptions({ BUN_JSC_dumpOptions: "1", BUN_JSC_thresholdForJITAfterWarmUp: "77" })).toBe(true);
+    // level 1 lists overridden options only
+    const { stderr, exitCode } = await dumpOptions({ BUN_JSC_dumpOptions: "1", BUN_JSC_thresholdForJITAfterWarmUp: "77" });
+    expect(stderr).toContain("thresholdForJITAfterWarmUp=77");
+    expect(exitCode).toBe(0);
   });
   test.concurrent("JSC_<option> is ignored", async () => {
-    // dumpOptions=2 lists every option with its current value, so this would show
-    // the 77 however JSC_* had been applied.
-    expect(await dumpsOptions({ JSC_dumpOptions: "2", JSC_thresholdForJITAfterWarmUp: "77" })).toBe(false);
+    // level 2 lists every option with its current value, however it was set
+    const { stderr, exitCode } = await dumpOptions({ BUN_JSC_dumpOptions: "2", JSC_thresholdForJITAfterWarmUp: "77" });
+    expect(stderr).toContain("thresholdForJITAfterWarmUp=");
+    expect(stderr).not.toContain("thresholdForJITAfterWarmUp=77");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Bumps libuv and WebKit for the Windows startup work and adds the Bun-side pieces each one needs (the matching mimalloc bump, oven-sh/mimalloc#20, already landed on main via #39602).

**libuv → oven-sh/libuv@8023581** (oven-sh/libuv#15, oven-sh/libuv#16). `uv__init` no longer does `WSAStartup` + the non-IFS LSP probe, `PowerRegisterSuspendResumeNotification`, or the console-resize watcher threads eagerly; each runs on first use. On a plain `bun file.js` that was ~4 ms of a ~30 ms cold start on Windows (13% of main-thread samples in an ETW profile), five DLLs and two threads. Because Winsock is now initialized lazily inside libuv, everything in Bun that reaches ws2_32 without going through libuv calls libuv's idempotent `uv__winsock_ensure()` first: uSockets socket creation and the `getaddrinfo` calls in front of it (`bsd_create_socket`/`listen`/`bound`/`udp`/`connect_udp`/`socket_import`), the internal DNS cache's Windows `getaddrinfo` work-pool path (what `fetch` resolves through), c-ares channel creation, and `os.hostname()` (which used to try `GetHostNameW` and run its own `WSAStartup` on failure). The two `patches/libuv/*.patch` still apply unchanged.

**WebKit → oven-sh/WebKit@0f966e8** (oven-sh/WebKit#467, oven-sh/WebKit#469). `cryptographicallyRandomValues` on Windows calls `ProcessPrng` instead of acquiring a CryptoAPI context per call (advapi32/cryptsp/rsaenh/cryptbase no longer load during VM creation, ~2 ms), and JSC gained `Config::disableEnvironmentOptions()`, which `JSCInitialize` now sets: JSC options come from `BUN_JSC_*` through the options callback as before, and the `JSC_*` environment pass (one `getenv` per option on Windows, ~1.5 ms) is skipped. A bare `JSC_<option>` in the environment therefore no longer affects Bun; `BUN_JSC_<option>` is the supported spelling.

`bun -e '0'` on Windows x64 (Ryzen AI 9 HX 370, Defender on), hyperfine `-N` 200 runs: v1.3.14 37 ms → main 23.6 ms → with these bumps ~18 ms (the rest of the way to ~14 ms is oven-sh/WebKit#468/#470).

### How did you verify your code works?

`bun bd` against the new pins on Windows, then: `JSC_dumpOptions=1` / `JSC_thresholdForJITAfterWarmUp=77` / `JSC_validateOptions=1 JSC_bogus=1` are ignored while `BUN_JSC_dumpOptions` / `BUN_JSC_thresholdForJITAfterWarmUp` apply; `crypto.getRandomValues`/`randomUUID`/`Math.random` behave; and with a WebKit build that has no other `WSAStartup` caller (so a missing `uv__winsock_ensure()` fails loudly rather than being masked): c-ares `dns.resolve4` as the first network user, `Bun.serve` + `fetch`, https `fetch`, `dns.lookup`, `Bun.listen`, `Bun.udpSocket`, `node:net`, `node:dgram`, `WebSocket`, `os.hostname()`/`networkInterfaces()`, spawn IPC and `process.on("SIGWINCH")` all work; ws2_32/mswsock are absent from an idle process and appear once a socket exists.
