### PR TITLE
sql: close the reserved connection when close({ timeout }) drains before the timeout

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -39,9 +39,7 @@ interface ReserveAbortState {
   onAbort: (() => void) | null;
 }
 
-/// Bound as `this` to the one callback that both the timer and the pending work of a
-/// reserved.close({ timeout }) call settle through, so whichever comes first closes
-/// and the other one is a no-op.
+/// Bound as `this` to the callback shared by the timer and the pending work of reserved.close({ timeout }).
 interface ReservedCloseState {
   state: TransactionState;
   pooledConnection: { close(): void };
@@ -60,10 +58,8 @@ function settleReservedTransaction(
   settle(value);
 }
 
-/// Every reserved.close() path ends here. The closed bit is already set when the
-/// connection dropped on its own or when release() handed it back to the pool, where
-/// it may be serving other queries by now, so then there is nothing for us to close.
 function closeReservedConnection(state: TransactionState, pooledConnection: { close(): void }) {
+  // already closed, or release() gave the connection back to the pool in the meantime
   if (state.connectionState & ReservedConnectionState.closed) return;
   state.connectionState |= ReservedConnectionState.closed;
   for (const query of state.queries) {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -39,14 +39,6 @@ interface ReserveAbortState {
   onAbort: (() => void) | null;
 }
 
-/// Bound as `this` to the callback shared by the timer and the pending work of reserved.close({ timeout }).
-interface ReservedCloseState {
-  state: TransactionState;
-  pooledConnection: { close(): void };
-  timer: ReturnType<typeof setTimeout> | null;
-  resolve: () => void;
-}
-
 function settleReservedTransaction(
   reservedTransaction: Set<Promise<void>>,
   finished: { promise: Promise<void>; resolve: () => void },
@@ -58,21 +50,19 @@ function settleReservedTransaction(
   settle(value);
 }
 
-function closeReservedConnection(state: TransactionState, pooledConnection: { close(): void }) {
-  // already closed, or release() gave the connection back to the pool in the meantime
-  if (state.connectionState & ReservedConnectionState.closed) return;
-  state.connectionState |= ReservedConnectionState.closed;
-  for (const query of state.queries) {
-    query.cancel();
-  }
-  // the close handler attached in onReserveConnected returns the pool slot
-  pooledConnection.close();
+function onPendingWorkSettled(timer: ReturnType<typeof setTimeout>, resolve: () => void) {
+  clearTimeout(timer);
+  resolve();
 }
 
-function settleReservedClose(this: ReservedCloseState) {
-  clearTimeout(this.timer!);
-  closeReservedConnection(this.state, this.pooledConnection);
-  this.resolve();
+/// The grace period of close({ timeout }): resolves once `pending` has settled or after `timeout` seconds.
+function waitForPendingWork(pending: PromiseLike<unknown>[], timeout: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const timer = setTimeout(resolve, timeout * 1000);
+  timer.unref(); // dont block the event loop
+  // allSettled: one rejected query must not cut the grace period short for the rest
+  Promise.allSettled(pending).then(onPendingWorkSettled.bind(null, timer, resolve));
+  return promise;
 }
 
 function adapterFromOptions(options: Bun.SQL.__internal.DefinedOptions) {
@@ -503,18 +493,18 @@ const SQL: typeof Bun.SQL = function SQL(
           throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
         }
         if (timeout > 0 && (reserveQueries.size > 0 || reservedTransaction.size > 0)) {
-          const { promise, resolve } = Promise.withResolvers<void>();
-          const closeState: ReservedCloseState = { state, pooledConnection, timer: null, resolve };
-          const settle = settleReservedClose.bind(closeState);
-          // the timeout is a ceiling: close as soon as the pending work settles, or when it fires
-          closeState.timer = setTimeout(settle, timeout * 1000);
-          closeState.timer.unref(); // dont block the event loop
-          // allSettled: one failing query must not close the connection under the others
-          Promise.allSettled([...reserveQueries, ...reservedTransaction]).then(settle);
-          return promise;
+          await waitForPendingWork([...reserveQueries, ...reservedTransaction], timeout);
+          // release() or a disconnect may have ended the reservation while we waited
+          if (state.connectionState & ReservedConnectionState.closed) return;
         }
       }
-      closeReservedConnection(state, pooledConnection);
+      state.connectionState |= ReservedConnectionState.closed;
+      for (const query of reserveQueries) {
+        (query as Query<any, any>).cancel();
+      }
+      // the close handler attached above returns the pool slot
+      pooledConnection.close();
+
       return Promise.$resolve(undefined);
     };
     reserved_sql.release = () => {

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -39,6 +39,16 @@ interface ReserveAbortState {
   onAbort: (() => void) | null;
 }
 
+/// Bound as `this` to the one callback that both the timer and the pending work of a
+/// reserved.close({ timeout }) call settle through, so whichever comes first closes
+/// and the other one is a no-op.
+interface ReservedCloseState {
+  state: TransactionState;
+  pooledConnection: { close(): void };
+  timer: ReturnType<typeof setTimeout> | null;
+  resolve: () => void;
+}
+
 function settleReservedTransaction(
   reservedTransaction: Set<Promise<void>>,
   finished: { promise: Promise<void>; resolve: () => void },
@@ -48,6 +58,25 @@ function settleReservedTransaction(
   reservedTransaction.delete(finished.promise);
   finished.resolve();
   settle(value);
+}
+
+/// Every reserved.close() path ends here. The closed bit is already set when the
+/// connection dropped on its own or when release() handed it back to the pool, where
+/// it may be serving other queries by now, so then there is nothing for us to close.
+function closeReservedConnection(state: TransactionState, pooledConnection: { close(): void }) {
+  if (state.connectionState & ReservedConnectionState.closed) return;
+  state.connectionState |= ReservedConnectionState.closed;
+  for (const query of state.queries) {
+    query.cancel();
+  }
+  // the close handler attached in onReserveConnected returns the pool slot
+  pooledConnection.close();
+}
+
+function settleReservedClose(this: ReservedCloseState) {
+  clearTimeout(this.timer!);
+  closeReservedConnection(this.state, this.pooledConnection);
+  this.resolve();
 }
 
 function adapterFromOptions(options: Bun.SQL.__internal.DefinedOptions) {
@@ -478,35 +507,18 @@ const SQL: typeof Bun.SQL = function SQL(
           throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
         }
         if (timeout > 0 && (reserveQueries.size > 0 || reservedTransaction.size > 0)) {
-          const { promise, resolve } = Promise.withResolvers();
-          // race all queries vs timeout
-          const pending_queries = Array.from(reserveQueries);
-          const pending_transactions = Array.from(reservedTransaction);
-          const timer = setTimeout(() => {
-            state.connectionState |= ReservedConnectionState.closed;
-            for (const query of reserveQueries) {
-              (query as Query<any, any>).cancel();
-            }
-            state.connectionState |= ReservedConnectionState.closed;
-            pooledConnection.close();
-
-            resolve();
-          }, timeout * 1000);
-          timer.unref(); // dont block the event loop
-          Promise.all([Promise.all(pending_queries), Promise.all(pending_transactions)]).finally(() => {
-            clearTimeout(timer);
-            resolve();
-          });
+          const { promise, resolve } = Promise.withResolvers<void>();
+          const closeState: ReservedCloseState = { state, pooledConnection, timer: null, resolve };
+          const settle = settleReservedClose.bind(closeState);
+          // the timeout is a ceiling: close as soon as the pending work settles, or when it fires
+          closeState.timer = setTimeout(settle, timeout * 1000);
+          closeState.timer.unref(); // dont block the event loop
+          // allSettled: one failing query must not close the connection under the others
+          Promise.allSettled([...reserveQueries, ...reservedTransaction]).then(settle);
           return promise;
         }
       }
-      state.connectionState |= ReservedConnectionState.closed;
-      for (const query of reserveQueries) {
-        (query as Query<any, any>).cancel();
-      }
-
-      pooledConnection.close();
-
+      closeReservedConnection(state, pooledConnection);
       return Promise.$resolve(undefined);
     };
     reserved_sql.release = () => {

--- a/test/js/sql/sql-pool-transaction-isolation.test.ts
+++ b/test/js/sql/sql-pool-transaction-isolation.test.ts
@@ -287,6 +287,8 @@ describe.each(adapters)("$adapter", ({ adapter, mockServer, beginCommand, connec
         return "t1";
       });
       expect(t1).toBe("t1");
+      // A graceful close waits for pending work. It hangs if the pool still counts the reservation.
+      await sql.close();
     } finally {
       await sql.close({ timeout: 0 }).catch(() => {});
       await new Promise<void>(r => server.close(() => r()));

--- a/test/js/sql/sql-pool-transaction-isolation.test.ts
+++ b/test/js/sql/sql-pool-transaction-isolation.test.ts
@@ -129,10 +129,39 @@ function firstInterleaving(received: Received[]): string | null {
   return null;
 }
 
-const adapters: Array<{ adapter: "postgres" | "mysql"; mockServer: MockServer; beginCommand: string }> = [
-  { adapter: "postgres", mockServer: pgMockServer, beginCommand: "BEGIN" },
-  { adapter: "mysql", mockServer: mysqlMockServer, beginCommand: "START TRANSACTION" },
+const adapters: Array<{
+  adapter: "postgres" | "mysql";
+  mockServer: MockServer;
+  beginCommand: string;
+  connectionClosedCode: string;
+}> = [
+  {
+    adapter: "postgres",
+    mockServer: pgMockServer,
+    beginCommand: "BEGIN",
+    connectionClosedCode: "ERR_POSTGRES_CONNECTION_CLOSED",
+  },
+  {
+    adapter: "mysql",
+    mockServer: mysqlMockServer,
+    beginCommand: "START TRANSACTION",
+    connectionClosedCode: "ERR_MYSQL_CONNECTION_CLOSED",
+  },
 ];
+
+// A transaction on the reservation whose callback parks after its first statement until
+// finish() is called, so a test controls when the transaction settles.
+function parkedTransaction(reserved: Bun.ReservedSQL, statement: string) {
+  const started = Promise.withResolvers<void>();
+  const gate = Promise.withResolvers<void>();
+  const promise = reserved.begin(async tx => {
+    await tx.unsafe(statement);
+    started.resolve();
+    await gate.promise;
+    return "committed";
+  });
+  return { promise, started: started.promise, finish: gate.resolve };
+}
 
 // reserved.begin() / beginDistributed() calls that reject before anything is sent.
 const rejectedBeforeBegin = [
@@ -148,7 +177,7 @@ const rejectedBeforeBegin = [
   },
 ];
 
-describe.each(adapters)("$adapter", ({ adapter, mockServer, beginCommand }) => {
+describe.each(adapters)("$adapter", ({ adapter, mockServer, beginCommand, connectionClosedCode }) => {
   const options = (port: number): Bun.SQL.Options => ({
     adapter,
     hostname: "127.0.0.1",
@@ -355,175 +384,221 @@ describe.each(adapters)("$adapter", ({ adapter, mockServer, beginCommand }) => {
     },
   );
 
-  test("reserved.close({ timeout }) waits for a transaction started on the reservation", async () => {
+  // reserved.close({ timeout }) waits, up to the timeout (in seconds), for the queries and
+  // transactions that are pending on the reservation, then closes the connection. The
+  // connection's close handler returns the pool slot. The tests below use a pool whose
+  // onclose callback counts the connections the pool has closed so far.
+  type CloseTestPool = {
+    sql: SQL;
+    received: Received[];
+    closes: () => number;
+    firstClose: Promise<void>;
+    [Symbol.asyncDispose](): Promise<void>;
+  };
+  async function closeTestPool(onReceived?: () => void): Promise<CloseTestPool> {
     const received: Received[] = [];
-    const { port, server } = await mockServer(received);
-    const sql = new SQL(options(port));
-    try {
-      const reserved = await sql.reserve();
-      const t1 = reserved.begin(async tx => {
-        await tx.unsafe("SELECT 'T1a'");
-        return "t1";
-      });
-      // The timeout is in seconds. close() resolves as soon as t1 settles; without the
-      // transaction being tracked it would close the connection under t1 instead.
-      const closed = reserved.close({ timeout: 60 });
-      expect(await t1).toBe("t1");
-      await closed;
-      reserved.release();
-      expect(received).toEqual([
-        { conn: 0, sql: beginCommand },
-        { conn: 0, sql: "SELECT 'T1a'" },
-        { conn: 0, sql: "COMMIT" },
-      ]);
-    } finally {
-      await sql.close({ timeout: 0 }).catch(() => {});
-      await new Promise<void>(r => server.close(() => r()));
-    }
+    const { port, server } = await mockServer(received, onReceived);
+    const firstClose = Promise.withResolvers<void>();
+    let closes = 0;
+    const sql = new SQL({
+      ...options(port),
+      onclose: () => {
+        closes++;
+        firstClose.resolve();
+      },
+    });
+    return {
+      sql,
+      received,
+      closes: () => closes,
+      firstClose: firstClose.promise,
+      async [Symbol.asyncDispose]() {
+        await sql.close({ timeout: 0 }).catch(() => {});
+        await new Promise<void>(r => server.close(() => r()));
+      },
+    };
+  }
+
+  // The statements of the transaction that expectSlotReturned / expectConnectionKept run.
+  const afterTransaction = (conn: number): Received[] => [
+    { conn, sql: beginCommand },
+    { conn, sql: "SELECT 'after'" },
+    { conn, sql: "COMMIT" },
+  ];
+  const runAfterTransaction = (sql: SQL) =>
+    sql.begin(async tx => {
+      await tx.unsafe("SELECT 'after'");
+      return "after";
+    });
+
+  // close() closed the reservation's connection and gave its slot back: the pool's only
+  // slot reconnects (conn 1) for the next transaction, and a graceful sql.close() resolves
+  // because the pool no longer counts the reservation.
+  async function expectSlotReturned(pool: CloseTestPool) {
+    await pool.firstClose;
+    expect(await runAfterTransaction(pool.sql)).toBe("after");
+    await pool.sql.close();
+  }
+
+  // close() left the connection alone: nothing was closed, and the next transaction runs
+  // on the same connection (conn 0).
+  async function expectConnectionKept(pool: CloseTestPool) {
+    expect(pool.closes()).toBe(0);
+    expect(await runAfterTransaction(pool.sql)).toBe("after");
+    await pool.sql.close();
+  }
+
+  test("reserved.close({ timeout }) waits for a transaction started on the reservation", async () => {
+    await using pool = await closeTestPool();
+    const reserved = await pool.sql.reserve();
+    const t1 = reserved.begin(async tx => {
+      await tx.unsafe("SELECT 'T1a'");
+      return "t1";
+    });
+    // close() resolves as soon as t1 settles; without the transaction being tracked it
+    // would close the connection under t1 instead.
+    const closed = reserved.close({ timeout: 60 });
+    expect(await t1).toBe("t1");
+    await closed;
+    // The slot already went back when close() closed the connection, so this is a no-op.
+    // `await using reserved` ends the same way.
+    reserved.release();
+    await expectSlotReturned(pool);
+    expect(pool.received).toEqual([
+      { conn: 0, sql: beginCommand },
+      { conn: 0, sql: "SELECT 'T1a'" },
+      { conn: 0, sql: "COMMIT" },
+      ...afterTransaction(1),
+    ]);
   });
 
   // Same overlap with a transaction that fails. close() must wait for the ROLLBACK, and
   // the failure is the caller's to handle: bun:test fails this test if close()'s wait
   // reports it as an unhandled rejection as well.
   test("reserved.close({ timeout }) waits for a failing transaction without reporting its handled error", async () => {
-    const received: Received[] = [];
-    const { port, server } = await mockServer(received);
-    const sql = new SQL(options(port));
-    try {
-      const reserved = await sql.reserve();
-      const failing = reserved
-        .begin(async tx => {
-          await tx.unsafe("SELECT 'T1a'");
-          throw new Error("t1-app-error");
-        })
-        .catch(err => err.message);
-      const closed = reserved.close({ timeout: 60 });
-      expect(await failing).toBe("t1-app-error");
-      await closed;
-      reserved.release();
-      expect(received).toEqual([
-        { conn: 0, sql: beginCommand },
-        { conn: 0, sql: "SELECT 'T1a'" },
-        { conn: 0, sql: "ROLLBACK" },
-      ]);
-    } finally {
-      await sql.close({ timeout: 0 }).catch(() => {});
-      await new Promise<void>(r => server.close(() => r()));
-    }
+    await using pool = await closeTestPool();
+    const reserved = await pool.sql.reserve();
+    const failing = reserved
+      .begin(async tx => {
+        await tx.unsafe("SELECT 'T1a'");
+        throw new Error("t1-app-error");
+      })
+      .catch(err => err.message);
+    const closed = reserved.close({ timeout: 60 });
+    expect(await failing).toBe("t1-app-error");
+    await closed;
+    reserved.release();
+    await expectSlotReturned(pool);
+    expect(pool.received).toEqual([
+      { conn: 0, sql: beginCommand },
+      { conn: 0, sql: "SELECT 'T1a'" },
+      { conn: 0, sql: "ROLLBACK" },
+      ...afterTransaction(1),
+    ]);
   });
 
-  // The three tests below end the same way: the connection the reservation held gets
-  // closed, so the pool's only slot reconnects (conn 1) for the next transaction, and a
-  // graceful sql.close() resolves because the pool no longer counts the reservation.
-  // Nothing calls reserved.release(); close() alone has to return the slot.
-  async function expectSlotReturned(sql: SQL, connectionClosed: Promise<void>) {
-    await connectionClosed;
-    const t = await sql.begin(async tx => {
-      await tx.unsafe("SELECT 'after'");
-      return "after";
-    });
-    expect(t).toBe("after");
-    await sql.close();
-  }
-
   test("reserved.close({ timeout }) closes the connection once the pending query finishes", async () => {
-    const received: Received[] = [];
-    const { port, server } = await mockServer(received);
-    const connectionClosed = Promise.withResolvers<void>();
-    const sql = new SQL({ ...options(port), onclose: () => connectionClosed.resolve() });
-    try {
-      const reserved = await sql.reserve();
-      const inFlight = reserved.unsafe("SELECT 'in flight'").execute();
-      const closed = reserved.close({ timeout: 60 });
-      await inFlight;
-      await closed;
-      await expectSlotReturned(sql, connectionClosed.promise);
-      expect(received).toEqual([
-        { conn: 0, sql: "SELECT 'in flight'" },
-        { conn: 1, sql: beginCommand },
-        { conn: 1, sql: "SELECT 'after'" },
-        { conn: 1, sql: "COMMIT" },
-      ]);
-    } finally {
-      await sql.close({ timeout: 0 }).catch(() => {});
-      await new Promise<void>(r => server.close(() => r()));
-    }
+    await using pool = await closeTestPool();
+    const reserved = await pool.sql.reserve();
+    const inFlight = reserved.unsafe("SELECT 'in flight'").execute();
+    const closed = reserved.close({ timeout: 60 });
+    await inFlight;
+    await closed;
+    await expectSlotReturned(pool);
+    expect(pool.received).toEqual([{ conn: 0, sql: "SELECT 'in flight'" }, ...afterTransaction(1)]);
   });
 
   // A query that fails while close() waits does not end the wait: the transaction that is
   // still open on the same reservation must get to COMMIT before the connection closes.
   // bun:test also fails this test if close()'s wait reports the handled failure as unhandled.
   test("reserved.close({ timeout }) keeps waiting for the other pending work when one query fails", async () => {
-    const received: Received[] = [];
-    const { port, server } = await mockServer(received);
-    const connectionClosed = Promise.withResolvers<void>();
-    const sql = new SQL({ ...options(port), onclose: () => connectionClosed.resolve() });
-    try {
-      const reserved = await sql.reserve();
-      const inTransaction = Promise.withResolvers<void>();
-      const finishTransaction = Promise.withResolvers<void>();
-      const t1 = reserved.begin(async tx => {
-        await tx.unsafe("SELECT 'T1a'");
-        inTransaction.resolve();
-        await finishTransaction.promise;
-        return "t1";
-      });
-      await inTransaction.promise;
-      const failed = reserved.unsafe("SELECT 'FAIL'").then(
-        () => null,
-        e => e.message,
-      );
-      const closed = reserved.close({ timeout: 60 });
-      expect(await failed).toBe("mock failure");
-      finishTransaction.resolve();
-      expect(await t1).toBe("t1");
-      await closed;
-      await expectSlotReturned(sql, connectionClosed.promise);
-      expect(received).toEqual([
-        { conn: 0, sql: beginCommand },
-        { conn: 0, sql: "SELECT 'T1a'" },
-        { conn: 0, sql: "SELECT 'FAIL'" },
-        { conn: 0, sql: "COMMIT" },
-        { conn: 1, sql: beginCommand },
-        { conn: 1, sql: "SELECT 'after'" },
-        { conn: 1, sql: "COMMIT" },
-      ]);
-    } finally {
-      await sql.close({ timeout: 0 }).catch(() => {});
-      await new Promise<void>(r => server.close(() => r()));
-    }
+    await using pool = await closeTestPool();
+    const reserved = await pool.sql.reserve();
+    const t1 = parkedTransaction(reserved, "SELECT 'T1a'");
+    await t1.started;
+    const failed = reserved.unsafe("SELECT 'FAIL'").then(
+      () => null,
+      e => e.message,
+    );
+    const closed = reserved.close({ timeout: 60 });
+    expect(await failed).toBe("mock failure");
+    t1.finish();
+    expect(await t1.promise).toBe("committed");
+    await closed;
+    await expectSlotReturned(pool);
+    expect(pool.received).toEqual([
+      { conn: 0, sql: beginCommand },
+      { conn: 0, sql: "SELECT 'T1a'" },
+      { conn: 0, sql: "SELECT 'FAIL'" },
+      { conn: 0, sql: "COMMIT" },
+      ...afterTransaction(1),
+    ]);
   });
 
-  // The query that close() cancels here rejects, and that rejection belongs to its caller.
+  // The query that close() cuts off here rejects, and that rejection belongs to its caller.
   // bun:test fails this test if close()'s own wait reports it as unhandled as well.
   test("reserved.close({ timeout }) closes the connection under a query that outlives the timeout", async () => {
-    const received: Received[] = [];
     const held = Promise.withResolvers<void>();
-    const { port, server } = await mockServer(received, () => held.resolve());
-    const connectionClosed = Promise.withResolvers<void>();
-    const sql = new SQL({ ...options(port), onclose: () => connectionClosed.resolve() });
-    try {
-      const reserved = await sql.reserve();
-      const neverAnswered = reserved.unsafe("SELECT 'HOLD'").then(
-        () => null,
-        e => e,
-      );
-      // The server has the query and will not answer it, so only the timer can end close().
-      await held.promise;
-      await reserved.close({ timeout: 0.05 });
-      expect(await neverAnswered).toBeInstanceOf(Error);
-      await expectSlotReturned(sql, connectionClosed.promise);
-      expect(received).toEqual([
-        { conn: 0, sql: "SELECT 'HOLD'" },
-        { conn: 1, sql: beginCommand },
-        { conn: 1, sql: "SELECT 'after'" },
-        { conn: 1, sql: "COMMIT" },
-      ]);
-    } finally {
-      await sql.close({ timeout: 0 }).catch(() => {});
-      await new Promise<void>(r => server.close(() => r()));
-    }
+    await using pool = await closeTestPool(() => held.resolve());
+    const reserved = await pool.sql.reserve();
+    const neverAnswered = reserved.unsafe("SELECT 'HOLD'").then(
+      () => null,
+      e => e.code,
+    );
+    // The server has the query and will not answer it, so only the timer can end close().
+    await held.promise;
+    await reserved.close({ timeout: 0.05 });
+    expect(await neverAnswered).toBe(connectionClosedCode);
+    await expectSlotReturned(pool);
+    expect(pool.received).toEqual([{ conn: 0, sql: "SELECT 'HOLD'" }, ...afterTransaction(1)]);
   });
+
+  // bun:test fails this test if the queries the server took down are reported as unhandled
+  // by close()'s wait. The close handler already returned the slot when the server dropped
+  // the connection, so close() has nothing left to do but resolve.
+  test("reserved.close({ timeout }) resolves when the server drops the connection while it waits", async () => {
+    await using pool = await closeTestPool();
+    const reserved = await pool.sql.reserve();
+    const dropped = reserved.unsafe("SELECT 'KILL'").then(
+      () => null,
+      e => e,
+    );
+    const closed = reserved.close({ timeout: 60 });
+    expect(await dropped).toBeInstanceOf(Error);
+    await closed;
+    await expectSlotReturned(pool);
+    expect(pool.received).toEqual([{ conn: 0, sql: "SELECT 'KILL'" }, ...afterTransaction(1)]);
+  });
+
+  // release() during the wait gives the connection back to the pool, where it may already
+  // serve other callers, so neither way of ending the wait may close it. The transaction
+  // still open on it is the probe: it can only commit if the connection stayed open.
+  test.each([
+    { ending: "the pending transaction finishes", timeout: 60, timerEndsTheWait: false },
+    { ending: "the timer fires", timeout: 0.05, timerEndsTheWait: true },
+  ])(
+    "reserved.close({ timeout }) leaves a connection alone that release() gave back before $ending",
+    async ({ timeout, timerEndsTheWait }) => {
+      await using pool = await closeTestPool();
+      const reserved = await pool.sql.reserve();
+      const t1 = parkedTransaction(reserved, "SELECT 'T1a'");
+      await t1.started;
+      const closed = reserved.close({ timeout });
+      reserved.release();
+      // While t1 is parked, only the timer can end the wait.
+      if (timerEndsTheWait) await closed;
+      t1.finish();
+      expect(await t1.promise).toBe("committed");
+      await closed;
+      await expectConnectionKept(pool);
+      expect(pool.received).toEqual([
+        { conn: 0, sql: beginCommand },
+        { conn: 0, sql: "SELECT 'T1a'" },
+        { conn: 0, sql: "COMMIT" },
+        ...afterTransaction(0),
+      ]);
+    },
+  );
 
   // Runs in a child process: bun:test would turn any unhandled rejection into a test
   // failure, and the second half of this contract is that one rejection IS reported.

--- a/test/js/sql/sql-pool-transaction-isolation.test.ts
+++ b/test/js/sql/sql-pool-transaction-isolation.test.ts
@@ -10,19 +10,25 @@ import type net from "node:net";
 import {
   listeningServer,
   mysqlAckSessionSetup,
+  mysqlErrPacket,
   mysqlHandshakeV10,
   mysqlOkPacket,
   mysqlReadPackets,
   pgAuthenticationOk,
   pgCommandComplete,
+  pgErrorResponse,
   pgReadyForQuery,
 } from "./wire-frames";
 
 type Received = { conn: number; sql: string };
-type MockServer = (received: Received[]) => Promise<{ port: number; server: net.Server }>;
+// `onReceived` runs after each statement is recorded.
+type MockServer = (received: Received[], onReceived?: () => void) => Promise<{ port: number; server: net.Server }>;
 
-// Query text containing "KILL" destroys the socket without answering.
-const pgMockServer: MockServer = received => {
+// Both mocks answer every statement at once, except for these markers in the query text:
+//   KILL destroys the socket without answering,
+//   FAIL answers with an error,
+//   HOLD never answers.
+const pgMockServer: MockServer = (received, onReceived) => {
   let nextConn = 0;
   return listeningServer(socket => {
     const connId = nextConn++;
@@ -47,9 +53,17 @@ const pgMockServer: MockServer = received => {
         if (type !== "Q") continue;
         const sql = body.subarray(0, body.indexOf(0)).toString("utf8");
         received.push({ conn: connId, sql });
+        onReceived?.();
         if (sql.includes("KILL")) {
           socket.destroy();
           return;
+        }
+        if (sql.includes("HOLD")) continue;
+        if (sql.includes("FAIL")) {
+          socket.write(
+            Buffer.concat([pgErrorResponse({ S: "ERROR", C: "XX000", M: "mock failure" }), pgReadyForQuery()]),
+          );
+          continue;
         }
         socket.write(Buffer.concat([pgCommandComplete("SELECT 0"), pgReadyForQuery()]));
       }
@@ -58,7 +72,7 @@ const pgMockServer: MockServer = received => {
   });
 };
 
-const mysqlMockServer: MockServer = received => {
+const mysqlMockServer: MockServer = (received, onReceived) => {
   const COM_QUIT = 0x01;
   const COM_QUERY = 0x03;
   let nextConn = 0;
@@ -78,8 +92,14 @@ const mysqlMockServer: MockServer = received => {
         if (payload[0] === COM_QUERY) {
           const sql = payload.subarray(1).toString("utf8");
           received.push({ conn: connId, sql });
+          onReceived?.();
           if (sql.includes("KILL")) {
             socket.destroy();
+            return;
+          }
+          if (sql.includes("HOLD")) return;
+          if (sql.includes("FAIL")) {
+            socket.write(mysqlErrPacket(1, 1105, "HY000", "mock failure"));
             return;
           }
           socket.write(mysqlOkPacket(1));
@@ -385,6 +405,119 @@ describe.each(adapters)("$adapter", ({ adapter, mockServer, beginCommand }) => {
         { conn: 0, sql: beginCommand },
         { conn: 0, sql: "SELECT 'T1a'" },
         { conn: 0, sql: "ROLLBACK" },
+      ]);
+    } finally {
+      await sql.close({ timeout: 0 }).catch(() => {});
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  // The three tests below end the same way: the connection the reservation held gets
+  // closed, so the pool's only slot reconnects (conn 1) for the next transaction, and a
+  // graceful sql.close() resolves because the pool no longer counts the reservation.
+  // Nothing calls reserved.release(); close() alone has to return the slot.
+  async function expectSlotReturned(sql: SQL, connectionClosed: Promise<void>) {
+    await connectionClosed;
+    const t = await sql.begin(async tx => {
+      await tx.unsafe("SELECT 'after'");
+      return "after";
+    });
+    expect(t).toBe("after");
+    await sql.close();
+  }
+
+  test("reserved.close({ timeout }) closes the connection once the pending query finishes", async () => {
+    const received: Received[] = [];
+    const { port, server } = await mockServer(received);
+    const connectionClosed = Promise.withResolvers<void>();
+    const sql = new SQL({ ...options(port), onclose: () => connectionClosed.resolve() });
+    try {
+      const reserved = await sql.reserve();
+      const inFlight = reserved.unsafe("SELECT 'in flight'").execute();
+      const closed = reserved.close({ timeout: 60 });
+      await inFlight;
+      await closed;
+      await expectSlotReturned(sql, connectionClosed.promise);
+      expect(received).toEqual([
+        { conn: 0, sql: "SELECT 'in flight'" },
+        { conn: 1, sql: beginCommand },
+        { conn: 1, sql: "SELECT 'after'" },
+        { conn: 1, sql: "COMMIT" },
+      ]);
+    } finally {
+      await sql.close({ timeout: 0 }).catch(() => {});
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  // A query that fails while close() waits does not end the wait: the transaction that is
+  // still open on the same reservation must get to COMMIT before the connection closes.
+  // bun:test also fails this test if close()'s wait reports the handled failure as unhandled.
+  test("reserved.close({ timeout }) keeps waiting for the other pending work when one query fails", async () => {
+    const received: Received[] = [];
+    const { port, server } = await mockServer(received);
+    const connectionClosed = Promise.withResolvers<void>();
+    const sql = new SQL({ ...options(port), onclose: () => connectionClosed.resolve() });
+    try {
+      const reserved = await sql.reserve();
+      const inTransaction = Promise.withResolvers<void>();
+      const finishTransaction = Promise.withResolvers<void>();
+      const t1 = reserved.begin(async tx => {
+        await tx.unsafe("SELECT 'T1a'");
+        inTransaction.resolve();
+        await finishTransaction.promise;
+        return "t1";
+      });
+      await inTransaction.promise;
+      const failed = reserved.unsafe("SELECT 'FAIL'").then(
+        () => null,
+        e => e.message,
+      );
+      const closed = reserved.close({ timeout: 60 });
+      expect(await failed).toBe("mock failure");
+      finishTransaction.resolve();
+      expect(await t1).toBe("t1");
+      await closed;
+      await expectSlotReturned(sql, connectionClosed.promise);
+      expect(received).toEqual([
+        { conn: 0, sql: beginCommand },
+        { conn: 0, sql: "SELECT 'T1a'" },
+        { conn: 0, sql: "SELECT 'FAIL'" },
+        { conn: 0, sql: "COMMIT" },
+        { conn: 1, sql: beginCommand },
+        { conn: 1, sql: "SELECT 'after'" },
+        { conn: 1, sql: "COMMIT" },
+      ]);
+    } finally {
+      await sql.close({ timeout: 0 }).catch(() => {});
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+
+  // The query that close() cancels here rejects, and that rejection belongs to its caller.
+  // bun:test fails this test if close()'s own wait reports it as unhandled as well.
+  test("reserved.close({ timeout }) closes the connection under a query that outlives the timeout", async () => {
+    const received: Received[] = [];
+    const held = Promise.withResolvers<void>();
+    const { port, server } = await mockServer(received, () => held.resolve());
+    const connectionClosed = Promise.withResolvers<void>();
+    const sql = new SQL({ ...options(port), onclose: () => connectionClosed.resolve() });
+    try {
+      const reserved = await sql.reserve();
+      const neverAnswered = reserved.unsafe("SELECT 'HOLD'").then(
+        () => null,
+        e => e,
+      );
+      // The server has the query and will not answer it, so only the timer can end close().
+      await held.promise;
+      await reserved.close({ timeout: 0.05 });
+      expect(await neverAnswered).toBeInstanceOf(Error);
+      await expectSlotReturned(sql, connectionClosed.promise);
+      expect(received).toEqual([
+        { conn: 0, sql: "SELECT 'HOLD'" },
+        { conn: 1, sql: beginCommand },
+        { conn: 1, sql: "SELECT 'after'" },
+        { conn: 1, sql: "COMMIT" },
       ]);
     } finally {
       await sql.close({ timeout: 0 }).catch(() => {});

--- a/test/js/sql/wire-frames.test.ts
+++ b/test/js/sql/wire-frames.test.ts
@@ -8,6 +8,7 @@ import { expect, test } from "bun:test";
 import {
   listeningServer,
   mysqlAckSessionSetup,
+  mysqlErrPacket,
   mysqlHandshakeV10,
   mysqlLenencInt,
   mysqlOkPacket,
@@ -32,6 +33,11 @@ test("mysqlLenencInt encodes per page_protocol_basic_dt_integers.html", () => {
   expect(mysqlLenencInt(0x1_0000)).toEqual(Buffer.from([0xfd, 0x00, 0x00, 0x01]));
   expect(mysqlLenencInt(0xff_ffffn)).toEqual(Buffer.from([0xfd, 0xff, 0xff, 0xff]));
   expect(mysqlLenencInt(0x1_00_0000n)).toEqual(Buffer.from([0xfe, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00]));
+});
+
+test("mysqlErrPacket encodes per page_protocol_basic_err_packet.html", () => {
+  // error_code 1064 = 0x0428, little-endian; the 3-byte packet length counts the payload only
+  expect(mysqlErrPacket(1, 1064, "42000", "x")).toEqual(Buffer.from("\x0a\x00\x00\x01\xff\x28\x04#42000x", "binary"));
 });
 
 test("pgErrorResponse encodes per §55.7", () => {


### PR DESCRIPTION
### Problem
- `reserved.close({ timeout })` resolves without closing or releasing the connection when the pending work finishes before the timeout. With `max: 1` every later query hangs, and a graceful `sql.close()` never resolves.
- Cause: the race in `reserved_sql.close()` (`src/js/bun/sql.ts:480` to `:500` on main). Only the timer arm closes the connection. The drained arm (`:496`) only calls `resolve()`. An identifier helper such as `reserved("users")` stays in the tracked set, so this path is also taken with nothing in flight.
- That arm is a dropped `Promise.all(...).finally(...)` chain. A pending query that rejects during the wait, also one the timer arm cancels, is reported as unhandled (noted in #39598).

### Fix
- The grace period becomes `waitForPendingWork()`: it resolves when the pending work has settled or when the timer fires. `close()` awaits it and falls through to the close body it already had for the no-timeout case, which closes the pooled connection. The close handler returns the slot (#33743).
- After the await, `close()` returns if the closed bit is set. `release()` sets it, and then the connection serves other callers, so a timer that fires later must not close it. On main it does. A disconnect during the wait sets it too.
- The helper waits with `Promise.allSettled()`. One failing query no longer ends the wait under an open transaction, and the wait itself no longer rejects. The query tracking already marks the caller's queries handled.
- Verified: `test/js/sql/sql-pool-transaction-isolation.test.ts`, eight `close({ timeout })` cases per adapter, seven fail on main. Also `wire-frames.test.ts`, `sql-reserve-abort.test.ts`, the repro on real servers.

### Background
- `sql.reserve()` checks one connection out of the pool. `releaseReservation()` returns it with exactly one `pool.release()`, from `reserved.release()` or from the connection's close handler.
- `reserved.close({ timeout })` waits up to `timeout` seconds for the tracked queries and transactions, then closes the socket.
- A graceful `sql.close()` waits for `totalQueries` to reach 0. An unreleased reservation holds it at 1.

<details><summary>Notes</summary>

Repro from the report, against a real postgres, `max: 1`:

```ts
const c = await sql.reserve();
const q = c`select pg_sleep(0.01)`;
await c.close({ timeout: 5 });   // resolves once q finishes
await q;
await sql`select 1`;             // hangs on main
await sql.close();               // also hangs on main
```

On main's `src/` this hangs with both the postgres and the mysql adapter. With this change both complete. The timer arm (`select pg_sleep(5)` plus `close({ timeout: 0.1 })`) recovers the slot on main too, but on main it reports the cancelled query's `ERR_POSTGRES_CONNECTION_CLOSED` (`ERR_MYSQL_CONNECTION_CLOSED` on MariaDB) as an unhandled rejection coming from `close()`'s own wait.

The `close({ timeout })` cases, per adapter, and how each fails with main's `src/js/bun/sql.ts`:

- "waits for a transaction started on the reservation" and "waits for a failing transaction ..." (from #39598) now also check that the slot came back from `close()` alone, and keep the `reserved.release()` they called afterwards, which pins it as a no-op (`await using reserved` ends the same way). Main: hang, the connection never closes.
- "closes the connection once the pending query finishes": the report's case. Main: hang.
- "keeps waiting for the other pending work when one query fails": a parked reserved transaction plus a direct query the mock answers with an error (new `FAIL` marker, answered with `mysqlErrPacket` from `wire-frames.ts`, which gets a byte-layout check in `wire-frames.test.ts`). A variant of this change with `Promise.all()` closes the connection under the transaction and fails here. Main: unhandled `mock failure`.
- "closes the connection under a query that outlives the timeout": new `HOLD` marker (never answered), `timeout: 0.05`. Nothing races the timer, the held query cannot settle. Main: unhandled `ERR_*_CONNECTION_CLOSED`.
- "resolves when the server drops the connection while it waits" (`KILL`). Main: unhandled rejection.
- "leaves a connection alone that release() gave back", ended by the transaction and ended by the timer. These pin the check after the await: with that line deleted, exactly these four cases (two per adapter) fail. The timer variant fails on main, which closes the connection the pool already reuses. The drain variant passes on main and guards the new arm.

The two `release()` cases and the server-drop case are the observable uses of the check after the await. A server-side drop rejects the tracked queries and transactions at once, so the wait ends right away and the check is what keeps `close()` from touching the slot again.

The existing no-timeout case "a pool slot is reusable after sql.reserve() is closed explicitly" now ends with a graceful `sql.close()`, the #32099 symptom, as suggested in the comments. It passes on main, it only pins the arm that now also runs through the helper.

Each case observes the close through the `onclose` option and then proves the slot's state: the next transaction runs on the reconnected slot (`conn: 1` in the mocks' record) or on the same connection (`conn: 0`), and a graceful `sql.close()` resolves. The native close runs the close handler synchronously for both adapters, but the tests do not rely on it.

Identifier helpers: `queryFromTransaction()` adds every object it creates to the tracked set, and a helper like `reserved("users")` never executes, so it is never removed. On main, a reservation that used one helper strands its slot on any later `close({ timeout })`, even with nothing in flight (checked against the postgres mock: the next pool query and a graceful `sql.close()` hang, plus an unhandled `ERR_POSTGRES_NOT_TAGGED_CALL` from the dropped chain). With this change that `close({ timeout })` closes, returns the slot and reports nothing. Unchanged by this PR: a plain `reserved.close()`, or a server-side drop, rejects such a lingering helper with `ERR_*_CONNECTION_CLOSED` and nothing handles it. The same happens to a helper created inside a plain `sql.begin()` when the server drops the connection. That comes from the tracking in `queryFromTransaction()`, which is shared with plain transactions, and is left for a separate change.

Unhandled rejection semantics: `Promise.all()` on main and `Promise.allSettled()` here both attach handlers to the pending queries. That changes nothing for the caller, because `queryFromTransactionHandler()` attaches a `.finally()` to every query that runs on a reserved or transaction connection, so such a query counts as handled as soon as it runs. The only difference is that the wait no longer creates a rejected promise of its own. A per-query internal signal, as #39598 did for transactions, would need changes in the query tracking shared with plain transactions, and would stop executing queries that were created but not yet awaited when `close()` was called. It is not needed here.

Left as is: `transaction.close({ timeout })` has the same drained arm shape (#32149 is open for it). `options.timeout` is still validated after `acceptQueries` is cleared (#32100 is open for the timeout range).

Related: #32101 listed this drained arm as a secondary item and was closed in favor of this PR. Its headline symptom, `sql.close()` hanging after a plain `reserved.close()`, was fixed by #33743. #35117 moves the reservation's close handler into a module-level object and does not touch this block, so the two compose.

`tsc` on `src/js` and on `test/` reports the same pre-existing errors with and without this change.

Revision history: f284a32 fix plus the first three cases per adapter. b308743 adds the `release()` and server-drop cases and the slot checks in the two #39598 cases, after a self-review found the check for `release()` during the wait untested. 223bf45 shortens two comments and adds the graceful close pin. 25edb8d restructures the production change after a second self-review: the first shape had a close step that both the timer and the settled work called, memoized by the closed bit. `transaction.close({ timeout })` (#32149) has the same race but an awaited ROLLBACK, which that shape cannot host, so it would have landed a second, different copy. The current shape awaits a wait helper and runs the one close body once. The twin can await the same helper before its ROLLBACK. The tests did not change between the two shapes, and both mutation checks (check deleted, `allSettled` replaced by `all`) still fail the same cases. cd51df6 is the rebase onto main after #40439, which added its own `mysqlErrPacket` to `wire-frames.ts`: this PR now uses that one, and the mysql mock acknowledges the driver's session setup query.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-pool-transaction-isolation.test.ts test/js/sql/wire-frames.test.ts
bun test v1.4.1 (861e9ae04)

test/js/sql/sql-pool-transaction-isolation.test.ts:
(pass) postgres > concurrent sql.begin() stays serialized after a server-side disconnect with queries in flight [781.18ms]
(pass) postgres > a pool slot is reusable after a server-side disconnect during sql.reserve() [120.59ms]
(pass) postgres > a pool slot is reusable after sql.reserve() is closed explicitly [71.55ms]
(pass) postgres > concurrent sql.begin() stays serialized after a server-side disconnect during a transaction [119.19ms]
(pass) postgres > the reservation keeps its pool slot after reserved begin() with invalid options rejects [72.30ms]
(pass) postgres > the reservation keeps its pool slot after reserved beginDistributed() with an invalid name rejects [43.44ms]
(fail) postgres > reserved.close({ timeout }) waits for a transaction started on the reservation [5007.33ms]
  ^ this test timed out after 5000ms.
(fail) postgres > reserved.close({ timeout }) waits for
... (truncated)

release without fix: 14 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/js/sql/sql-pool-transaction-isolation.test.ts:
(pass) postgres > concurrent sql.begin() stays serialized after a server-side disconnect with queries in flight [13.77ms]
(pass) postgres > a pool slot is reusable after a server-side disconnect during sql.reserve() [2.63ms]
(pass) postgres > a pool slot is reusable after sql.reserve() is closed explicitly [1.75ms]
(pass) postgres > concurrent sql.begin() stays serialized after a server-side disconnect during a transaction [2.73ms]
(pass) postgres > the reservation keeps its pool slot after reserved begin() with invalid options rejects [1.77ms]
(pass) postgres > the reservation keeps its pool slot after reserved beginDistributed() with an invalid name rejects [1.04ms]
(fail) postgres > reserved.close({ timeout }) waits for a transaction started on the reservation [5000.08ms]
  ^ this test timed out after 5000ms.
(fail) postgres > reserved.close({ timeout }) waits for a failing transaction without reporting its handled error [5000.08ms]
  ^ this test timed out after 5000ms.
(fail) postgres > reserved.close({ timeout }) closes the connection once the pending query finishes [5000.
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/sql-pool-transaction-isolation.test.ts test/js/sql/wire-frames.test.ts
bun test v1.4.1 (861e9ae04)

test/js/sql/sql-pool-transaction-isolation.test.ts:
(pass) postgres > concurrent sql.begin() stays serialized after a server-side disconnect with queries in flight [841.23ms]
(pass) postgres > a pool slot is reusable after a server-side disconnect during sql.reserve() [127.85ms]
(pass) postgres > a pool slot is reusable after sql.reserve() is closed explicitly [85.70ms]
(pass) postgres > concurrent sql.begin() stays serialized after a server-side disconnect during a transaction [137.28ms]
(pass) postgres > the reservation keeps its pool slot after reserved begin() with invalid options rejects [115.24ms]
(pass) postgres > the reservation keeps its pool slot after reserved beginDistributed() with an invalid name rejects [52.81ms]
(pass) postgres > reserved.close({ timeout }) waits for a transaction started on the reservation [100.44ms]
(pass) postgres > reserved.close({ timeout }) waits for a failing transaction without reporti
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 561ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (8210ms)
Bundle modules (73ms)
Postprocesss modules (40ms)
Bundle Functions (404ms)
Generate Code (28ms)

[8.76s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/bun/sql.ts                                  |  40 ++-
 test/js/sql/sql-pool-transaction-isolation.test.ts | 318 +++++++++++++++++----
 test/js/sql/wire-frames.test.ts                    |   6 +
 3 files changed, 289 insertions(+), 75 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/js/bun/sql.ts                                       9      9      0
test/js/sql/sql-pool-transaction-isolation.test.ts      8     12      0
test/js/sql/wire-frames.test.ts                         2      2      0
```

</details>

<!-- robobun:evidence:end -->
