### PR TITLE
fix(node:dns): don't expose ARES errno on query errors (fixes #37320)

### DIFF
--- a/src/js/node/dns.ts
+++ b/src/js/node/dns.ts
@@ -57,6 +57,17 @@ function withTranslatedError(error: any) {
   if (code?.startsWith?.("DNS_")) {
     error.code = code.slice(4);
   }
+  // c-ares errors are surfaced with the raw ARES_* number in `errno`, but
+  // Node's DNSException leaves `errno` unset for c-ares query errors; only
+  // getaddrinfo / getnameinfo (libuv) errors carry a numeric errno.
+  const syscall = error?.syscall;
+  if (
+    syscall !== "getaddrinfo" &&
+    syscall !== "getnameinfo" &&
+    typeof error?.errno === "number"
+  ) {
+    delete error.errno;
+  }
   return error;
 }
 

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -609,6 +609,31 @@ describe("test invalid arguments", () => {
     await promise.catch(() => {}); // result depends on the environment's resolver
   });
 
+  // https://github.com/oven-sh/bun/issues/37320
+  describe("DNS error errno matches Node.js", () => {
+    it("dns.promises.resolve errors have no errno", async () => {
+      const error = await dns_promises.resolveAny("invalid.invalid").catch(e => e);
+      expect(error.code).toBe("ENOTFOUND");
+      expect(error.errno).toBeUndefined();
+    });
+
+    it("dns.resolve callback errors have no errno", async () => {
+      const error = await new Promise(resolve => {
+        dns.resolveAny("invalid.invalid", (err, records) => resolve(err));
+      });
+      expect(error.code).toBe("ENOTFOUND");
+      expect(error.errno).toBeUndefined();
+    });
+
+    it("dns.lookup errors keep a numeric errno", async () => {
+      const error = await new Promise(resolve => {
+        dns.lookup("invalid.invalid", err => resolve(err));
+      });
+      expect(error.code).toBe("ENOTFOUND");
+      expect(typeof error.errno).toBe("number");
+    });
+  });
+
   it("dns.lookupService", async () => {
     expect(() => {
       dns.lookupService("", 443, (err, hostname, service) => {});


### PR DESCRIPTION
Fixes #37320

Node's \DNSException\ leaves \rrno\ unset for c-ares query errors (e.g. \dns.resolveAny\): only getaddrinfo / getnameinfo (libuv) errors carry a numeric errno. Bun surfaced the raw ARES_* number (e.g. \rrno: 4\) on all dns errors.

\withTranslatedError\ now removes the numeric \rrno\ for non-getaddrinfo / non-getnameinfo syscalls, so resolve-family errors match Node:

\\\js
// node
dns.promises.resolveAny('invalid.invalid') // -> errno: undefined, code: ENOTFOUND
// bun before
dns.promises.resolveAny('invalid.invalid') // -> errno: 4, code: ENOTFOUND
\\\

\dns.lookup\ errors keep their numeric errno. Added tests: resolve-family errors have no errno (promises + callback), lookup errors keep a numeric errno.

New tests fail pre-fix on 1.3.14 (errno: 4 present); lookup errno test passes either way.