### PR TITLE
usockets: skip the poll-error close for a socket a handler already closed

### DIFF
--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -921,8 +921,12 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     return;
                 }
             }
-            /* Such as epollerr or EV_ERROR */
-            if (error && s) {
+            /* Such as epollerr or EV_ERROR. A handler above (on_data, on_end, or the
+             * close they triggered) may already have closed this socket: its fd number
+             * is free again, and a socket that handler opened can own it by now, so the
+             * SO_ERROR read below would consume that socket's error (a refused connect
+             * then reports ECONNRESET). Nothing is left to close in that case. */
+            if (error && s && !us_socket_is_closed(s)) {
                 /* Peer-initiated error event — same rationale as the recv-error
                  * branch above: bypass us_internal_ssl_close so on_handshake
                  * isn't fired for a passive close. The poll flag only says THAT

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4284,6 +4284,11 @@ describe.concurrent("close() error after the peer resets the connection", () => 
 // closed the socket, its fd number is free again and a socket opened in the meantime
 // (here: from close()) can own it. Reading SO_ERROR from that number consumed the new
 // socket's error, and its refused connect reported ECONNRESET.
+//
+// The fd arrangement in the fixture is what makes the stale read land on the new socket
+// on POSIX, where a new socket gets the lowest free number. The outcome it checks, a
+// refused connect reports ECONNREFUSED, holds on every platform, so it is not skipped
+// anywhere: on Windows the fixture is only that check.
 describe.concurrent("a socket closed by data() while its peer's reset is being dispatched", () => {
   it("does not consume the connect error of a socket opened from close()", async () => {
     const source = `
@@ -4291,12 +4296,12 @@ describe.concurrent("a socket closed by data() while its peer's reset is being d
 
       // A port nothing listens on. The established connection keeps it bound, so no
       // listener can take it while the test runs.
-      using sink = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+      const sink = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
       const holder = await Bun.connect({ hostname: "127.0.0.1", port: sink.port, socket: { data() {} } });
       const refusedPort = holder.localPort;
 
       const outcome = Promise.withResolvers();
-      using server = Bun.listen({
+      const server = Bun.listen({
         hostname: "127.0.0.1",
         port: 0,
         socket: {
@@ -4319,9 +4324,9 @@ describe.concurrent("a socket closed by data() while its peer's reset is being d
 
       // The connect opened from close() takes the lowest free fd number, and
       // peer.terminate() below frees the peer's number first. So the accepted socket
-      // has to get a lower number than the peer: reserve one before the peer's socket
-      // is created and free it again before the event loop accepts.
-      const reserved = openSync("/dev/null", "r");
+      // has to get a lower number than the peer: reserve one (any file does) before the
+      // peer's socket is created and free it again before the event loop accepts.
+      const reserved = openSync(import.meta.path, "r");
       const connecting = Bun.connect({ hostname: "127.0.0.1", port: server.port, socket: { data() {} } });
       closeSync(reserved);
       const peer = await connecting;
@@ -4332,6 +4337,8 @@ describe.concurrent("a socket closed by data() while its peer's reset is being d
 
       console.log(await outcome.promise);
       holder.terminate();
+      sink.stop(true);
+      server.stop(true);
     `;
     // Its own process: the fd numbers have to line up as described in the fixture.
     using dir = tempDir("socket-close-during-reset", { "fixture.ts": source });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4278,3 +4278,72 @@ describe.concurrent("close() error after the peer resets the connection", () => 
     expect(closeErrorShape(await closedWith.promise)).toEqual(readReset);
   });
 });
+
+// The event that carries a peer's reset is dispatched in two steps: the read loop runs
+// data(), then the dispatcher closes the socket with its SO_ERROR. When data() already
+// closed the socket, its fd number is free again and a socket opened in the meantime
+// (here: from close()) can own it. Reading SO_ERROR from that number consumed the new
+// socket's error, and its refused connect reported ECONNRESET.
+describe.concurrent("a socket closed by data() while its peer's reset is being dispatched", () => {
+  it("does not consume the connect error of a socket opened from close()", async () => {
+    const source = `
+      import { closeSync, openSync } from "node:fs";
+
+      // A port nothing listens on. The established connection keeps it bound, so no
+      // listener can take it while the test runs.
+      using sink = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
+      const holder = await Bun.connect({ hostname: "127.0.0.1", port: sink.port, socket: { data() {} } });
+      const refusedPort = holder.localPort;
+
+      const outcome = Promise.withResolvers();
+      using server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        socket: {
+          data(socket) {
+            socket.terminate();
+          },
+          close() {
+            Bun.connect({
+              hostname: "127.0.0.1",
+              port: refusedPort,
+              socket: {
+                data() {},
+                open: () => outcome.resolve("open"),
+                connectError: (_socket, error) => outcome.resolve(error.code),
+              },
+            }).catch(() => {});
+          },
+        },
+      });
+
+      // The connect opened from close() takes the lowest free fd number, and
+      // peer.terminate() below frees the peer's number first. So the accepted socket
+      // has to get a lower number than the peer: reserve one before the peer's socket
+      // is created and free it again before the event loop accepts.
+      const reserved = openSync("/dev/null", "r");
+      const connecting = Bun.connect({ hostname: "127.0.0.1", port: server.port, socket: { data() {} } });
+      closeSync(reserved);
+      const peer = await connecting;
+      // Both are queued before the event loop runs again, so the accepted socket's next
+      // event carries the data and the reset together.
+      peer.write("x");
+      peer.terminate();
+
+      console.log(await outcome.promise);
+      holder.terminate();
+    `;
+    // Its own process: the fd numbers have to line up as described in the fixture.
+    using dir = tempDir("socket-close-during-reset", { "fixture.ts": source });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: "ECONNREFUSED\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem

- Follow-up to #39600, found in its self-review. When a peer resets the connection behind data and the `data()` handler closes the socket (`terminate()`), a `Bun.connect()` opened from that socket's `close()` handler to a port nothing listens on reports `ECONNRESET` instead of `ECONNREFUSED`. Deterministic on Linux with the fd layout in the new test. Before #39600 it reported `ECONNREFUSED`.
- Cause: the poll-error close in `us_internal_dispatch_ready_poll` (`packages/bun-usockets/src/loop.c:925`) runs for a socket that a handler closed earlier in the same dispatch. `us_socket_get_error()` then reads `SO_ERROR` from the closed socket's fd number. The connect opened from `close()` owns that number by then (it takes the lowest free fd), and `SO_ERROR` is cleared by the read. The connect's own dispatch later finds no error and falls back to `ECONNRESET` (`loop.c:495`).
- Before #39600 the eof block returned early for a closed socket on this path. #39600 routes error events past the eof block on purpose, so the error block is where the check belongs. The same stale read already happened before #39600 when `on_end` closed the socket during an error event, or on an error event without an eof hint.

### Fix

- The poll-error close is skipped when the socket is already closed: `if (error && s && !us_socket_is_closed(s))`. Nothing is left to close for such a socket, and `us_internal_socket_close_raw` was already a no-op for it. The only effect of the block was the stale `SO_ERROR` read.
- The closed socket's memory is still valid here: `close_raw` puts it on the loop's closed list, which is freed after the dispatch. The eof block reads `is_closed` the same way.
- Verified: `test/js/bun/net/socket.test.ts`, "a socket closed by data() while its peer's reset is being dispatched". It fails on a build of main (stdout `ECONNRESET`), passes with this change (25 of 25 runs), and passes on a build from before #39600. Also run: the rest of `socket.test.ts` (the same 9 failures as main in this container: `localhost` resolution and external network), the 4 reset tests in `node-tls-server.test.ts`, the nine `test-net-half-open-peer-reset-*` fixtures, `test-net-error-twice`, `test-net-socket-reset-send`, `test-net-socket-reset-twice`, `test-net-server-reset`, `test-net-connect-reset`, `test-tls-econnreset`.

### Background

- Dispatch of one socket event: the read loop runs `data()` for each `recv()`, then the eof block handles a FIN, then the error block closes the socket with `SO_ERROR` when the event carried the error flag. A handler can close the socket at any point in between. `close()` handlers run synchronously inside that close, so code in them runs in the middle of the dispatch.
- `SO_ERROR` is a destructive read: `getsockopt(SO_ERROR)` returns the pending error and clears it. Reading it through a stale fd number acts on whatever socket owns the number now.
- fd reuse: a closed fd number is handed to the next `socket()` call if it is the lowest free one. The test reserves a number so that the accepted socket gets a lower number than the peer, because `peer.terminate()` frees the peer's number first. It runs in a child process so that nothing else in the process interferes with the numbering.
