### PR TITLE
types: WebSocket error events are ErrorEvent (fixes #36329)

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4619,7 +4619,7 @@ declare module "bun" {
 
   interface WebSocketEventMap {
     close: CloseEvent;
-    error: Event;
+    error: ErrorEvent;
     message: MessageEvent;
     open: Event;
   }


### PR DESCRIPTION
Fixes #36329

The runtime fires an `ErrorEvent` for WebSocket `error` events (with `.error`, `.message`, `.type`), but `WebSocketEventMap` typed it as `Event`, so `event.error` failed to typecheck:

```ts
webSocket.addEventListener("error", (event) => console.log(event.error));
// Property 'error' does not exist on type 'Event'.
```

Change `WebSocketEventMap["error"]` from `Event` to `ErrorEvent` (the WHATWG spec's fail-the-WebSocket-connection steps fire an `ErrorEvent`, and browsers expose the same shape). `ErrorEvent` is already a global in bun-types with `.error` and `.message`.