### PR TITLE
test(os): remove the TMPDIR mutation that leaked into later test files

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1630,7 +1630,8 @@ export function rejectUnauthorizedScope(value: boolean) {
   process.env.NODE_TLS_REJECT_UNAUTHORIZED = value ? "1" : "0";
   return {
     [Symbol.dispose]() {
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = original_rejectUnauthorized;
+      if (original_rejectUnauthorized === undefined) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+      else process.env.NODE_TLS_REJECT_UNAUTHORIZED = original_rejectUnauthorized;
     },
   };
 }

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -72,16 +72,11 @@ it("tmpdir", () => {
       ].includes(os.tmpdir()),
     ).toBeTrue();
   } else {
-    const originalEnv = process.env.TMPDIR;
     let dir = process.env.TMPDIR || process.env.TMP || process.env.TEMP || "/tmp";
     if (dir.length > 1 && dir.endsWith("/")) {
       dir = dir.substring(0, dir.length - 1);
     }
     expect(realpathSync(os.tmpdir())).toBe(realpathSync(dir));
-
-    process.env.TMPDIR = "/boop";
-    expect(os.tmpdir()).toBe("/boop");
-    process.env.TMPDIR = originalEnv;
   }
 });
 


### PR DESCRIPTION
### Problem
- The `tmpdir` test in `test/js/node/os/os.test.js` set `process.env.TMPDIR = "/boop"` and restored it with `process.env.TMPDIR = originalEnv`. When TMPDIR is unset, that stores the string `"undefined"`.
- In a plain multi-file run, `os.tmpdir()` then returns `"undefined"` for every later file. Each test that calls `tmpdirSync()` fails with `ENOENT: no such file or directory, realpath 'undefined'` (`test/harness.ts:1459`). `bun test os.test.js fs.test.ts zlib.test.js` has 69 failures and 5 errors. CI runs `os.test.js` alone (`test/parallel-denylist.txt`) and does not see it.

### Fix
- Remove the mutation. The check of `os.tmpdir()` against the live environment stays. With nothing mutated, there is nothing to restore.
- Replacement for the removed assertion: `test/js/node/test/parallel/test-os.js:42-74` sets TMPDIR, TMP and TEMP through `process.env` and checks precedence, empty values and trailing slashes, in its own process. It runs on every CI lane except macOS x64, and `os.tmpdir()` is platform independent JS.
- `rejectUnauthorizedScope()` in `test/harness.ts` had the same restore bug. It now deletes `NODE_TLS_REJECT_UNAUTHORIZED` when it was unset. A delete resets the native TLS state like any value other than `"0"`, so its one caller in `bun-server.test.ts` behaves the same.
- Verified: the three-file command with `bun bd test` gives 956 pass and 1 unrelated fail (`userInfo`, see Notes). Also ran `test-os.js` and `bun-server.test.ts`.

### Background
- `process.env` coerces every assigned value to a string, in Node and in Bun. `delete process.env.X` is the only way to unset a variable.
- A plain `bun test a b c` runs all files in one process with one shared `process.env`. `--isolate`, which the CI batch gets through `--parallel`, rebuilds it for each file.
- `tmpdirSync()` in `test/harness.ts` builds every temp path from `os.tmpdir()`.

<details><summary>Notes</summary>

- The first version of this PR kept the mutation and restored it in a `finally` block with a delete. The self-review pointed at `test-os.js`, which already covers the same path in its own process, so the mutation is removed instead. The harness hunk is unchanged.
- Reproduced with the released bun as well (`USE_SYSTEM_BUN=1`), so it is a test bug and not a runtime bug. `node -e` with the same save, set, restore sequence also stores `"undefined"`.
- Unfixed three-file run with the released bun: 833 pass, 69 fail, 5 errors, 64 `realpath 'undefined'` messages, plus a stray `undefined/` directory with temp files in the repo root (some tests build relative paths from `os.tmpdir()`).
- Two-file probe: file A assigns the saved `undefined` back, file B reads the variable. Plain `bun test A B` gives `TMPDIR="undefined"` in B. `bun test --isolate A B`, `--parallel=1` and `--parallel=2` give `TMPDIR=undefined` and `os.tmpdir()=/tmp` in B, on the released bun and on this debug build.
- `test-os.js` on this build passes its tmpdir section and fails only at line 238 (`userInfo().shell` is `"unknown"` in this container). It has entries in `test/expected-durations.json` and none in `test/expectations.txt`, so it runs and passes in CI. `scripts/runner.node.mjs` skips the upstream node tests on macOS x64 only. `os.tmpdir()` lives in `src/js/node/os.ts` and has no platform specific native code.
- Survey of `test/` for restores of the form `process.env.X = savedValue`: `os.test.js` and `rejectUnauthorizedScope()` were the only two that do not handle an unset variable. `websocket-proxy.test.ts`, `test-ws-bidir-proxy.test.ts` and `macos-cross-config.test.ts` already delete.
- Delete-then-set of `NODE_TLS_REJECT_UNAUTHORIZED` still applies the native side effect (`JSEnvironmentVariableMap::put` and `deleteProperty` both special-case the key). Probed against a self-signed `Bun.serve`: set `"1"` rejects, delete rejects, set `"0"` after the delete connects, delete again rejects. The released bun behaves the same.
- `bun-server.test.ts` has 3 failures in this container (fixtures cannot connect to localhost). They are identical with and without the harness change. The "handshake failures should not impact future connections" test, the only user of `rejectUnauthorizedScope()`, passes both ways.
- The `userInfo` failure in `os.test.js` is separate: `os.userInfo()` returns `"unknown"` when `USER` is unset in the environment, see #33481.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->