### PR TITLE
watch: configure Output on the reload grace thread before it clears the terminal

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -412,7 +412,7 @@ impl Source {
     ///
     /// Threads that *may* run JS (web workers, debugger, the main VM thread)
     /// must keep using [`configure_thread`] / [`configure_named_thread`].
-    pub(crate) fn configure_thread_no_js() {
+    pub fn configure_thread_no_js() {
         if SOURCE_SET.get() {
             return;
         }
@@ -1077,6 +1077,11 @@ pub fn reset_terminal() {
 }
 
 pub fn reset_terminal_all() {
+    // Reached from `reload_process`, which any thread may call. A thread that
+    // never ran `Source::configure_thread` has zeroed writers, not stdio.
+    if !SOURCE_SET.get() {
+        return;
+    }
     SOURCE.with_borrow_mut(|s| {
         if ENABLE_ANSI_COLORS_STDERR.load(Ordering::Relaxed) {
             let _ = s.error_stream().write_all(b"\x1B[2J\x1B[3J\x1B[H");

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -670,6 +670,9 @@ fn arm_watch_reload_grace_timer() {
     let spawned = std::thread::Builder::new()
         .name("WatchReloadGrace".into())
         .spawn(move || {
+            // `force()` clears the terminal through this thread's `Output`
+            // writers; they are zeroed until the thread is configured.
+            Output::Source::configure_thread_no_js();
             const STEP_MS: u64 = 10;
             // Budget to drain the posted WatchReloadTask; extended once when
             // the kill-signal emit is observed so a bounded synchronous

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -20,6 +20,7 @@ function stdoutWaiter(proc: Subprocess<"ignore", "pipe", any>) {
       }
     },
     release: () => reader.releaseLock(),
+    output: () => output,
   };
 }
 
@@ -284,6 +285,58 @@ it("--watch forces a restart when the kill-signal handler itself never returns",
   release();
   watchee.kill("SIGKILL");
   await watchee.exited;
+}, 30000);
+
+// With colors enabled, a reload also clears the terminal. The forced reload
+// runs on the grace thread, which has its own thread-local Output state; the
+// clear used to write through that thread's never-initialized writers and
+// segfault instead of restarting.
+it("--watch forced restart clears the terminal when colors are enabled", async () => {
+  using dir = tempDir("watch-busy-sigterm-clear-screen", {
+    "busy.js": `
+      process.on("SIGTERM", () => {});
+      console.log("iter first");
+      const end = Date.now() + 30_000;
+      while (Date.now() < end) {}
+      process.exit(1);
+    `,
+  });
+
+  const env = { ...bunEnv, FORCE_COLOR: "1" };
+  delete env.NO_COLOR;
+  // stderr is piped, not inherited: the clear sequence below would otherwise
+  // wipe the terminal running the test suite.
+  const proc = spawn({
+    cmd: [bunExe(), "--watch", "busy.js"],
+    cwd: String(dir),
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  watchee = proc;
+  const stderr = proc.stderr.text();
+
+  const { waitFor, release, output } = stdoutWaiter(proc);
+
+  await waitFor("iter first");
+  await Bun.write(
+    join(String(dir), "busy.js"),
+    `process.on("SIGTERM", () => {});
+     console.log("iter second");
+     process.exit(0);`,
+  );
+  await waitFor("iter second");
+
+  release();
+  proc.kill("SIGKILL");
+  await proc.exited;
+
+  const clearScreen = "\x1b[2J\x1b[3J\x1b[H";
+  expect(output()).toContain(clearScreen);
+  const [beforeReload, afterReload] = output().split(clearScreen);
+  expect(beforeReload).toContain("iter first");
+  expect(afterReload).toContain("iter second");
+  expect(await stderr).toContain(clearScreen);
 }, 30000);
 
 // execve replaces the process without reaching on_exit(), so the compile


### PR DESCRIPTION
### Problem
- `bun --watch` dies with `Segmentation fault at address 0x0` in `bun_core::output::reset_terminal_all` when the grace thread forces a reload (Sentry BUN-4CY2 on Windows, BUN-49T1 on Linux).
- The `WatchReloadGrace` thread (`src/jsc/hot_reloader.rs:672`) calls `reload_process`, which calls `reset_terminal_all` (`src/bun_core/util.rs:4373`). That writes through the thread-local `SOURCE` (`src/bun_core/output.rs:232`), which this thread never configured, so the writer vtable is zeros.
- It needs colors on: then clear screen defaults to on. The existing grace timer tests run with `NO_COLOR=1`.

### Fix
- The grace thread calls `Output::Source::configure_thread_no_js()` when it starts, as every other worker thread does (`Watcher::thread_body`, `ThreadPool`, `HTTPThread`). The function becomes `pub` for this caller.
- `reset_terminal_all` returns early on a thread with no `SOURCE`. `flush` has the same guard, and `reload_process` calls both from any thread. The guard alone reloads without a clear (probe in Notes).
- Verified: `test/cli/watch/watch.test.ts`, new case `--watch forced restart clears the terminal when colors are enabled`. It segfaults on the unfixed build, and it checks that the clear sequence reaches stdout and stderr, so the guard alone fails it too. Also ran `test/cli/watch/` and `test/cli/hot/`.

### Background
- `reload_process` restarts `bun --watch` with an `execve` of itself (a magic exit code on Windows). With clear screen on, it first writes `ESC[2J ESC[3J ESC[H` to stdout and stderr.
- When the script listens for the watch kill signal (default `SIGTERM`), the watcher thread posts the reload to the JS thread and arms a grace timer. If the JS thread is stuck in synchronous code, the grace thread calls `reload_process` itself after 500 ms.
- `bun_core::output` keeps its writers in the thread local `SOURCE`. They work only after `Source::configure_thread*` runs on that thread. Before that the slot holds zeroed adapters.

<details><summary>Notes</summary>

Repro used, with the release build at 4c689909e:

```
process.on("SIGTERM", () => {});
console.log("iter first");
const end = Date.now() + 30_000;
while (Date.now() < end) {}
```

`FORCE_COLOR=1 bun --watch busy.js`, then edit `busy.js`. About 500 ms later: `panic: Segmentation fault at address 0x0`, followed by `RefCell already borrowed` and `panicked during a panic. Aborting.` The second panic is the crash handler trying to print through the same `SOURCE` cell that `reset_terminal_all` still holds borrowed. That is why the Sentry stacks are short. With `BUN_CONFIG_NO_CLEAR_TERMINAL_ON_RELOAD=1`, or with colors off, the same scenario reloads fine.

Windows, canary 32e87032b: the same steps give `panic(WatchReloadGrace): Segmentation fault at address 0x0` 542 ms after the edit, and the watcher manager exits with code 9. With this branch built as a debug binary on Windows, the reload happens 728 ms after the edit, both stdout and stderr receive the clear sequence, and `test/cli/watch/watch.test.ts` passes (6 pass, 3 skipped as Linux or POSIX only). The new test fails there on the canary.

Probe of the guard on its own (hot_reloader.rs change stashed): the process reloads and prints `iter second`, stdout has no clear sequence, and the new test fails at `expect(output()).toContain(clearScreen)`.

The other work the grace thread does before the exec does not depend on `Output`: `node_compile_cache::persist_now` writes its log straight to the stderr fd, `Output::flush` and `disable_buffering` already check `SOURCE_SET`, and `stdio::restore` works on the fds.

The grace window is 500 ms, extended to 2.5 s once the kill signal handlers are seen running.

The new test pipes stderr instead of inheriting it, so the clear sequence does not wipe the terminal of whoever runs the suite. It ran 8 times in a row locally without a failure. The sibling grace timer tests pass a 30 s timeout, the new one matches them.

#35506 (node `--watch` restart semantics) adds the same `configure_thread_no_js` call inside a larger change. This PR is the crash fix on its own.

Suites run with the debug build: `test/cli/watch/` (13 pass), `test/cli/hot/` (17 pass).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->