### PR TITLE
watch: report a failed watcher init as an error instead of a crash

### DIFF
--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -706,6 +706,24 @@ fn arm_watch_reload_grace_timer() {
     }
 }
 
+/// The watcher could not be created or started. Every caller asked for watch
+/// mode on the command line, so there is nothing to fall back to. The usual
+/// cause is an exhausted descriptor limit in the environment (EMFILE from
+/// `inotify_init1` / `kqueue`), which is a CLI error, not a crash to report.
+#[cold]
+fn exit_on_watcher_error(action: &str, err: bun_watcher::Error) -> ! {
+    bun_core::pretty_errorln!(
+        "<red>error<r><d>:<r> Failed to {} File Watcher: {}",
+        action,
+        err.name()
+    );
+    if let Some(hint) = err.limit_hint() {
+        bun_core::note!("{}", hint);
+    }
+    Output::flush();
+    bun_core::Global::exit(1);
+}
+
 impl<Ctx, EventLoopType, const RELOAD_IMMEDIATELY: bool>
     NewHotReloader<Ctx, EventLoopType, RELOAD_IMMEDIATELY>
 where
@@ -743,13 +761,7 @@ where
         // SAFETY: see above; `watcher_top_level_dir` returns `&'static [u8]`.
         let watcher = match Watcher::init(reloader, unsafe { (*this).watcher_top_level_dir() }) {
             Ok(w) => w,
-            Err(err) => {
-                bun_core::handle_error_return_trace(&err);
-                Output::panic(format_args!(
-                    "Failed to enable File Watcher: {}",
-                    err.name()
-                ));
-            }
+            Err(err) => exit_on_watcher_error("enable", err),
         };
 
         // SAFETY: see above.
@@ -764,13 +776,7 @@ where
 
         // SAFETY: `watcher_ptr` was just installed into the ctx and is live.
         if let Err(err) = unsafe { (*watcher_ptr).start() } {
-            bun_core::handle_error_return_trace(&err);
-            bun_core::pretty_errorln!(
-                "<red>error<r><d>:<r> Failed to start File Watcher: {}",
-                err.name()
-            );
-            Output::flush();
-            bun_core::Global::exit(1);
+            exit_on_watcher_error("start", err);
         }
     }
 

--- a/src/watcher/error.rs
+++ b/src/watcher/error.rs
@@ -19,6 +19,34 @@ impl Error {
             Self::Windows(e) => <&'static str>::from(e),
         }
     }
+
+    /// Names the exhausted limit when `inotify_init1(2)` / `kqueue(2)` failed
+    /// with `EMFILE` or `ENFILE`, so the caller can print it as advice next to
+    /// the errno. `None` for every other error.
+    pub fn limit_hint(self) -> Option<&'static str> {
+        #[cfg(not(unix))]
+        {
+            None
+        }
+        #[cfg(unix)]
+        {
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            const EMFILE: &str = "this process is out of file descriptors (ulimit -n), or this user is out of inotify instances (sysctl fs.inotify.max_user_instances). Raise the limit or close other file watchers.";
+            #[cfg(not(any(target_os = "linux", target_os = "android")))]
+            const EMFILE: &str =
+                "this process is out of file descriptors. Raise the limit with \"ulimit -n\".";
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            const ENFILE: &str = "the system is out of file descriptors. Close other programs or raise sysctl fs.file-max.";
+            #[cfg(not(any(target_os = "linux", target_os = "android")))]
+            const ENFILE: &str = "the system is out of file descriptors. Close other programs or raise sysctl kern.maxfiles.";
+
+            match self {
+                Self::Sys(bun_errno::SystemErrno::EMFILE) => Some(EMFILE),
+                Self::Sys(bun_errno::SystemErrno::ENFILE) => Some(ENFILE),
+                _ => None,
+            }
+        }
+    }
 }
 
 impl bun_core::output::ErrName for Error {

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
-import { afterEach, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isBroken, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
 import { readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
@@ -128,29 +128,61 @@ setInterval(() => {}, 1000);
   10000,
 );
 
-// Watcher::start() must propagate a failed thread spawn as an Err through its
-// Result return instead of aborting inside start() with `.expect()`. An
-// LD_PRELOAD shim arms on inotify_init1 (which Watcher::init() calls on Linux
-// immediately before start()) and fails the very next pthread_create.
+// The watcher fault-injection tests below build an LD_PRELOAD shim around the
+// libc calls Watcher::init()/start() make on Linux. The shims zero RLIMIT_CORE
+// because the unfixed binaries these tests guard against abort, and a core file
+// would make CI's runner flag the child as a crash. RLIMIT_CORE survives execvp.
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+const NO_CORE_C = /* c */ `
+#include <sys/resource.h>
+__attribute__((constructor)) static void no_core(void) {
+  struct rlimit rl = {0, 0};
+  setrlimit(RLIMIT_CORE, &rl);
+}
+`;
+
+async function compileShim(dir: string): Promise<string> {
+  const shimPath = join(dir, "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(dir, "shim.c"), "-ldl", "-lpthread"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  return shimPath;
+}
+
+async function runWatcheeWithShim(dir: string, shimPath: string, args: string[]) {
+  const existing = bunEnv.LD_PRELOAD;
+  await using proc = Bun.spawn({
+    // --debug-crash-handler-use-trace-string skips the debug build's slow
+    // backtrace symbolication so an aborting child exits promptly.
+    cmd: [bunExe(), "--debug-crash-handler-use-trace-string", ...args],
+    cwd: dir,
+    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
+// Watcher::start() must propagate a failed thread spawn as an Err through its
+// Result return instead of aborting inside start() with `.expect()`. The shim
+// arms on inotify_init1 (which Watcher::init() calls on Linux immediately
+// before start()) and fails the very next pthread_create.
 it.skipIf(!isLinux || !cc)("propagates FileWatcher thread spawn failure instead of panicking in start()", async () => {
   const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>
 #include <pthread.h>
-#include <sys/resource.h>
-
+${NO_CORE_C}
 static int (*real_inotify_init1)(int);
 static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
 static volatile int armed = 0;
-
-/* The child is expected to abort; suppress the core file so CI's runner does
- * not flag it as a crash. RLIMIT_CORE survives execvp. */
-__attribute__((constructor)) static void no_core(void) {
-  struct rlimit rl = {0, 0};
-  setrlimit(RLIMIT_CORE, &rl);
-}
 
 int inotify_init1(int flags) {
   if (!real_inotify_init1) real_inotify_init1 = dlsym(RTLD_NEXT, "inotify_init1");
@@ -172,27 +204,8 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
     "shim.c": SHIM_C,
     "watchee.js": "console.log('unreachable');\n",
   });
-  const shimPath = join(String(dir), "shim.so");
-  await using ccProc = Bun.spawn({
-    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl", "-lpthread"],
-    env: bunEnv,
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
-  if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
-
-  const existing = bunEnv.LD_PRELOAD;
-  await using proc = Bun.spawn({
-    // --debug-crash-handler-use-trace-string skips the debug build's slow
-    // backtrace symbolication so the child exits promptly.
-    cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "--watch", "watchee.js"],
-    cwd: String(dir),
-    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const shimPath = await compileShim(String(dir));
+  const { stdout, stderr, exitCode } = await runWatcheeWithShim(String(dir), shimPath, ["--watch", "watchee.js"]);
 
   // The .expect("spawn FileWatcher thread") panic inside start() must be gone;
   // the error now reaches the caller, which reports it by errno name.
@@ -200,6 +213,46 @@ int pthread_create(pthread_t *t, const pthread_attr_t *a, void *(*f)(void *), vo
   expect(stderr).toContain("Failed to start File Watcher: EAGAIN");
   expect(stdout).not.toContain("unreachable");
   expect(exitCode).not.toBe(0);
+});
+
+// inotify_init1 fails with EMFILE when the process is out of file descriptors
+// or the user is out of inotify instances (fs.inotify.max_user_instances). That
+// is the environment's limit, not a bug: watch mode must report it like any
+// other CLI error and exit 1 instead of aborting with a crash report.
+describe.skipIf(!isLinux || !cc)("watcher init failure", () => {
+  const SHIM_C = /* c */ `
+#include <errno.h>
+${NO_CORE_C}
+int inotify_init1(int flags) {
+  (void)flags;
+  errno = EMFILE;
+  return -1;
+}
+`;
+
+  const commands: [name: string, args: string[]][] = [
+    ["bun --watch", ["--watch", "watchee.js"]],
+    ["bun --hot", ["--hot", "watchee.js"]],
+    ["bun test --watch", ["test", "--watch", "watchee.test.js"]],
+    ["bun build --watch", ["build", "--watch", "watchee.js", "--outdir", "out"]],
+  ];
+
+  it.concurrent.each(commands)("%s reports EMFILE from inotify_init1 as an error and exits 1", async (_, args) => {
+    using dir = tempDir("watch-init-emfile", {
+      "shim.c": SHIM_C,
+      "watchee.js": "console.log('unreachable');\n",
+      "watchee.test.js": "import { test } from 'bun:test';\ntest('unreachable', () => console.log('unreachable'));\n",
+    });
+    const shimPath = await compileShim(String(dir));
+    const { stdout, stderr, exitCode, signalCode } = await runWatcheeWithShim(String(dir), shimPath, args);
+
+    expect(stderr).toContain("error: Failed to enable File Watcher: EMFILE");
+    expect(stderr).toContain("note: ");
+    expect(stderr).toContain("fs.inotify.max_user_instances");
+    expect(stdout).not.toContain("unreachable");
+    expect(signalCode).toBeNull();
+    expect(exitCode).toBe(1);
+  });
 });
 
 // A script that registers a SIGTERM handler and then spins in synchronous


### PR DESCRIPTION
### Problem
- Watch mode (`--watch`, `--hot`, `bun test --watch`, `bun build --watch`) aborts with `panic: Failed to enable File Watcher: EMFILE` when the watcher cannot be created. That files a crash report (Sentry BUN-402B) for an environment limit: `ulimit -n` or `fs.inotify.max_user_instances`.
- The `Err` arm of `Watcher::init` in `enable_hot_module_reloading` (`src/jsc/hot_reloader.rs:744`) calls `Output::panic`. The `start()` arm below it already prints an error and exits.

### Fix
- The arm now prints `error: Failed to enable File Watcher: EMFILE` and exits with code 1. The `start()` arm shares the new helper and keeps its message.
- New `bun_watcher::Error::limit_hint` adds a `note:` for `EMFILE` and `ENFILE`. On Linux it names `ulimit -n` and `sysctl fs.inotify.max_user_instances`. On macOS and FreeBSD it names `ulimit -n` and `kern.maxfiles`.
- Exit is correct for every caller. Each asked for watch mode, and `bun test --watch` and `bun build --watch` wait on the watcher.
- Verified: `test/cli/watch/watch.test.ts`. An `LD_PRELOAD` shim makes `inotify_init1` return `EMFILE`. The new block checks the error, the note and exit code 1 for all four commands. All four fail on the release build.

Supersedes #34070, which no longer applies to main.

Fixes #15329

### Background
- `Watcher` (`src/watcher/`) is the thread behind watch mode. `Watcher::init` calls `inotify_init1` (Linux) or `kqueue` (macOS, FreeBSD). `start` spawns the thread.
- Both calls take a file descriptor, so both return `EMFILE` at the process limit. `inotify_init1` also returns `EMFILE` when the user is out of inotify instances (often 128, shared with editors).
- `Output::panic` goes through the crash handler, which prints the banner and sends a report.

<details><summary>Notes</summary>

- Repro on the release build without the shim: `(ulimit -n 7; bun --watch app.js)` prints the panic and the crash report. The exact number depends on how many descriptors are open before the watcher starts, which is why the test injects the errno instead.
- Smaller limits crash earlier, before the watcher: `ulimit -n 4` panics in `us_loop` init (`eventfd()`), `ulimit -n 5` hits a bare `abort()`. Those are separate sites and are reported separately.
- The dev server (`src/runtime/bake/DevServer.rs`) creates its own watcher and already throws a JS error on this failure. It is not affected.
- The `reloader` box allocated before `Watcher::init` is not freed on this path. The process exits in the same frame. LSAN with the CI settings (`detect_leaks=1:abort_on_error=1`) reports nothing on the debug build, because the pointer is still live on the stack.
- The rest of `test/cli/watch/watch.test.ts` passes. The existing `start()` test now shares the shim build and spawn helpers with the new block. Its assertions did not change.
- `cargo check -p bun_watcher` passes for `aarch64-apple-darwin`, `x86_64-pc-windows-msvc` and `x86_64-unknown-freebsd`. `cargo clippy` is clean for `bun_jsc` and `bun_watcher`. `cargo fmt --check` and `test/internal/source-lints` pass.
- The Windows watcher returns its own error names (`CreateFileFailed`, `IocpFailed`). Those now print as `error: Failed to enable File Watcher: CreateFileFailed` with no note.
- `Global::exit(1)` flushes stdout and stderr before it exits, so the note is never lost.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->