### PR TITLE
Bun.serve: drop the DevServer before the config that owns its arena when listen fails

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -333,7 +333,9 @@ pub struct UserRoute<const SSL: bool, const DEBUG: bool> {
 
 impl<const SSL: bool, const DEBUG: bool> Drop for NewServer<SSL, DEBUG> {
     fn drop(&mut self) {
-        // The remaining owned fields (config, base_url, h3_alt_svc, dev_server,
+        // Before `config`, which owns the arena the dev server's transpilers and views live in.
+        drop(self.dev_server.take());
+        // The remaining owned fields (config, base_url, h3_alt_svc,
         // user_routes, all_closed_promise) drop automatically.
         if let Some(p) = self.plugins.take() {
             // SAFETY: `plugins` carries the `heap::alloc` provenance from

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -1,4 +1,5 @@
-import { bunEnv, bunExe } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "node:path";
 
 test("dev server deinitializes itself", () => {
@@ -13,3 +14,39 @@ test("dev server deinitializes itself", () => {
   // The child runs a whole `bun test` suite (nine GC-heavy cases plus leak
   // reporting at exit), which takes longer than the 5s default under ASAN.
 }, 60_000);
+
+test("dev server is deinitialized before its arena when listen fails", async () => {
+  using dir = tempDir("dev-server-listen-fails", {
+    "index.html": `<!DOCTYPE html><html><body></body></html>`,
+    "listen-fails-fixture.ts": `
+      import { getDevServerDeinitCount } from "bun:internal-for-testing";
+      import html from "./index.html";
+
+      const taken = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: () => new Response("taken") });
+      const deinitsBefore = getDevServerDeinitCount();
+      let code = "listen succeeded";
+      try {
+        Bun.serve({ development: true, hostname: "127.0.0.1", port: taken.port, routes: { "/": html } }).stop(true);
+      } catch (e) {
+        code = e.code;
+      }
+      const deinits = getDevServerDeinitCount() - deinitsBefore;
+      taken.stop(true);
+      console.log(JSON.stringify({ code, deinits }));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "listen-fails-fixture.ts"],
+    // A read of a freed arena then faults in debug builds instead of seeing stale bytes.
+    env: { ...bunEnv, MIMALLOC_PURGE_DELAY: "0" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe('{"code":"EADDRINUSE","deinits":1}\n');
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `Bun.serve()` with a dev server (HTML routes, `development: true`) crashes when `listen()` fails, for example on `EADDRINUSE`. Sentry BUN-4AWZ, BUN-41MA, BUN-3R52: segfault in `DevServer::drop` under `drop_in_place<bake_types::Framework>`, or in `bun_alloc::dealloc` below it, reached from `NewServer::listen` -> `deinit`.
- The cause is the field order of `NewServer` (`src/runtime/server/mod.rs`): `config` is declared before `dev_server`. `deinit()` drops the box with `dev_server` still set, so `config` destroys `config.bake.arena` first, and `DevServer::drop` then frees the framework views that live in that arena (`DevServer.rs:1196`). The normal teardown takes `dev_server` out first (`deinit_if_we_can`), so only this path crashed.

### Fix
- `Drop for NewServer` drops `dev_server` before the fields drop. The normal path is unchanged: `dev_server` is already `None` there.
- Verified: `test/bake/deinitialization.test.ts` starts a dev server on a port that is in use, with `MIMALLOC_PURGE_DELAY=0`. On main the debug build segfaults with the Sentry stack. With this change the child reports `EADDRINUSE` and one DevServer deinit. Also ran the HTML route tests in `test/js/bun/http`, `test/bake/dev/html.test.ts` and `serve-listen.test.ts`.

### Background
- `config.bake` holds the dev server options and owns an `Arena`, a private mimalloc heap. `DevServer::init` borrows it ("must live until DevServer drops") and allocates one `bake_types::Framework` view per transpiler in it. `DevServer::drop` frees those views.
- `Arena` drop calls `mi_heap_destroy`, which frees the whole heap at once. A later read sees stale or recycled data, so release builds crash only sometimes. `MIMALLOC_PURGE_DELAY=0` purges at once, and debug mimalloc protects purged memory, so the unfixed debug build faults every time.

<details><summary>Notes</summary>

- Earlier revisions of this PR moved the options into the DevServer instead (boxed, then inline with the transpilers built after `assume_init`). The review asked to go back to this version.
- The arena memory is not poisoned after `mi_heap_destroy` (mimalloc marks freed slices as accessible again), so ASAN alone does not report this read. The test relies on the purge. A release build reads zeros after the purge and does not crash, so the test proves the bug on debug builds only.
- `finalize()` reaches `deinit()` only after `schedule_deinit`, which `deinit_if_we_can` calls after it has dropped the dev server. The error path in `NewServer::init` drops the box before `dev_server` is assigned. The listen failure path was the only one that dropped a live DevServer together with the box.
- The three Sentry issues are all Linux x64. The stack walks `built_in_modules` of the view, so the affected projects had `react` installed, which adds the bundled `react-refresh` module to the framework.
- `test/js/bun/http/bun-serve-html-entry.test.ts` has 5 failures in this container with and without the change (the released bun fails them the same way): `fetch("http://localhost:<port>/")` gets `ConnectionRefused`, a name resolution issue of this environment.
- #39488 adds tests to the same test file for dev servers whose `DevServer::init` fails, a different path. The only overlap is the import line.
</details>
