### PR TITLE
jsx: keep the default factory when a tsconfig or pragma factory has no members

### DIFF
--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -1762,7 +1762,7 @@ impl<'a> BundleOptions<'a> {
         }
 
         if let Some(jsx_opts) = &transform.jsx {
-            opts.jsx = jsx::Pragma::from_api(jsx_opts.clone())?;
+            opts.jsx = jsx::Pragma::from_api(jsx_opts.clone());
         }
 
         if !transform.extension_order.is_empty() {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2656,23 +2656,33 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if let Some(factory) = self.lexer.jsx_pragma.jsx() {
             // `Span.text` is a `StoreStr` into lexer-owned source; valid for 'a.
             let text = factory.text.slice();
-            self.options.jsx.factory =
-                options::JSX::Pragma::member_list_to_components_if_different(
-                    core::mem::take(&mut self.options.jsx.factory),
-                    text,
-                )
-                .expect("unreachable");
+            match options::JSX::Pragma::member_list_to_components_if_different(
+                &self.options.jsx.factory,
+                text,
+            ) {
+                Some(members) => self.options.jsx.factory = members,
+                None => self.log().add_range_warning_fmt(
+                    Some(self.source),
+                    factory.range,
+                    format_args!("Invalid JSX factory: \"{}\"", bstr::BStr::new(text)),
+                ),
+            }
         }
 
         if let Some(fragment) = self.lexer.jsx_pragma.jsx_frag() {
             // SAFETY: Span.text is `ArenaStr` valid for 'a.
             let text = fragment.text.slice();
-            self.options.jsx.fragment =
-                options::JSX::Pragma::member_list_to_components_if_different(
-                    core::mem::take(&mut self.options.jsx.fragment),
-                    text,
-                )
-                .expect("unreachable");
+            match options::JSX::Pragma::member_list_to_components_if_different(
+                &self.options.jsx.fragment,
+                text,
+            ) {
+                Some(members) => self.options.jsx.fragment = members,
+                None => self.log().add_range_warning_fmt(
+                    Some(self.source),
+                    fragment.range,
+                    format_args!("Invalid JSX fragment: \"{}\"", bstr::BStr::new(text)),
+                ),
+            }
         }
 
         if let Some(import_source) = self.lexer.jsx_pragma.jsx_import_source() {

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -65,11 +65,7 @@ bun_core::comptime_string_map! {
 /// pointer copy; only an explicit override (`/** @jsx foo */`, tsconfig
 /// `jsxFactory`, …) materialises an `Owned` boxed slice.
 ///
-/// A list always has at least one member: the parser turns `factory[0]` into
-/// an identifier without checking. Every producer of an override
-/// (`Pragma::member_list_to_components_if_different`, tsconfig's
-/// `parse_member_expression_for_jsx`) keeps the previous list when the
-/// override text has no members.
+/// Never empty: the parser reads `factory[0]` without a check.
 #[derive(Debug, Clone)]
 pub enum MemberList {
     Static(&'static [&'static [u8]]),
@@ -254,15 +250,9 @@ impl Pragma {
         Cow::Owned(out)
     }
 
-    /// `"React.createElement"` => `["React", "createElement"]`.
-    ///
-    /// Returns a copy of `original` when `new` names the same members, so an
-    /// override that spells out the default keeps the allocation-free
-    /// `Static` list.
-    ///
-    /// Returns `None` when `new` has no members (`""`, `"."`, `".."`). The
-    /// parser reads the first member of the list unconditionally, so the
-    /// caller keeps `original` in that case instead of storing an empty list.
+    /// `"React.createElement"` => `["React", "createElement"]`, or a copy of
+    /// `original` (no allocation for `Static`) when `new` names the same
+    /// members. `None` when `new` has no members, for example `"."`.
     pub fn member_list_to_components_if_different(
         original: &MemberList,
         new: &[u8],

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -278,7 +278,7 @@ impl Pragma {
         ))
     }
 
-    pub fn from_api(jsx: api::Jsx) -> Result<Pragma, crate::Error> {
+    pub fn from_api(jsx: api::Jsx) -> Pragma {
         let mut pragma = Pragma::default();
 
         if let Some(fragment) =
@@ -304,7 +304,7 @@ impl Pragma {
 
         pragma.development = jsx.development;
         pragma.parse = true;
-        Ok(pragma)
+        pragma
     }
 }
 

--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -64,19 +64,16 @@ bun_core::comptime_string_map! {
 /// (`Static`) borrows a `&'static [&'static [u8]]` so default+clone are a
 /// pointer copy; only an explicit override (`/** @jsx foo */`, tsconfig
 /// `jsxFactory`, …) materialises an `Owned` boxed slice.
+///
+/// A list always has at least one member: the parser turns `factory[0]` into
+/// an identifier without checking. Every producer of an override
+/// (`Pragma::member_list_to_components_if_different`, tsconfig's
+/// `parse_member_expression_for_jsx`) keeps the previous list when the
+/// override text has no members.
 #[derive(Debug, Clone)]
 pub enum MemberList {
     Static(&'static [&'static [u8]]),
     Owned(Box<[Box<[u8]>]>),
-}
-
-impl Default for MemberList {
-    /// Empty static slice — used by `core::mem::take`. `Pragma::default()`
-    /// sets the real `defaults::FACTORY`/`FRAGMENT` explicitly.
-    #[inline]
-    fn default() -> Self {
-        MemberList::Static(&[])
-    }
 }
 
 impl From<Box<[Box<[u8]>]>> for MemberList {
@@ -257,59 +254,43 @@ impl Pragma {
         Cow::Owned(out)
     }
 
-    // "React.createElement" => ["React", "createElement"]
-    // ...unless new is "React.createElement" and original is ["React", "createElement"]
-    // saves an allocation for the majority case
+    /// `"React.createElement"` => `["React", "createElement"]`.
+    ///
+    /// Returns a copy of `original` when `new` names the same members, so an
+    /// override that spells out the default keeps the allocation-free
+    /// `Static` list.
+    ///
+    /// Returns `None` when `new` has no members (`""`, `"."`, `".."`). The
+    /// parser reads the first member of the list unconditionally, so the
+    /// caller keeps `original` in that case instead of storing an empty list.
     pub fn member_list_to_components_if_different(
-        original: MemberList,
+        original: &MemberList,
         new: &[u8],
-    ) -> Result<MemberList, crate::Error> {
-        let count = strings::count_char(new, b'.') + 1;
+    ) -> Option<MemberList> {
+        strings::tokenize(new, b".").next()?;
 
-        let mut needs_alloc = false;
-        let mut current_i: usize = 0;
-        for str in strings::split(new, b".") {
-            if str.is_empty() {
-                continue;
-            }
-            match original.get(current_i) {
-                Some(part) if part == str => current_i += 1,
-                _ => {
-                    needs_alloc = true;
-                    break;
-                }
-            }
+        if strings::tokenize(new, b".").eq(original.iter()) {
+            return Some(original.clone());
         }
 
-        if !needs_alloc {
-            return Ok(original);
-        }
-
-        let mut out: Vec<Box<[u8]>> = Vec::with_capacity(count);
-        for str in strings::split(new, b".") {
-            if str.is_empty() {
-                continue;
-            }
-            out.push(Box::from(str));
-        }
-        Ok(MemberList::Owned(out.into_boxed_slice()))
+        Some(MemberList::Owned(
+            strings::tokenize(new, b".").map(Box::from).collect(),
+        ))
     }
 
     pub fn from_api(jsx: api::Jsx) -> Result<Pragma, crate::Error> {
         let mut pragma = Pragma::default();
 
-        if !jsx.fragment.is_empty() {
-            pragma.fragment = Self::member_list_to_components_if_different(
-                core::mem::take(&mut pragma.fragment),
-                &jsx.fragment,
-            )?;
+        if let Some(fragment) =
+            Self::member_list_to_components_if_different(&pragma.fragment, &jsx.fragment)
+        {
+            pragma.fragment = fragment;
         }
 
-        if !jsx.factory.is_empty() {
-            pragma.factory = Self::member_list_to_components_if_different(
-                core::mem::take(&mut pragma.factory),
-                &jsx.factory,
-            )?;
+        if let Some(factory) =
+            Self::member_list_to_components_if_different(&pragma.factory, &jsx.factory)
+        {
+            pragma.factory = factory;
         }
 
         pragma.runtime = Runtime::from(jsx.runtime);

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -449,18 +449,22 @@ impl TSConfigJSON {
 
             // Parse "jsxFactory"
             if let Some((jsx_prop, loc)) = jsx_factory_v {
-                if let Some(str) = jsx_prop.as_str() {
-                    result.jsx.factory =
-                        Self::parse_member_expression_for_jsx(log, source, loc, str)?.into();
+                if let Some(factory) = jsx_prop
+                    .as_str()
+                    .and_then(|str| Self::parse_member_expression_for_jsx(log, source, loc, str))
+                {
+                    result.jsx.factory = factory.into();
                     result.jsx_flags.insert(JsxField::Factory);
                 }
             }
 
             // Parse "jsxFragmentFactory"
             if let Some((jsx_prop, loc)) = jsx_fragment_factory_v {
-                if let Some(str) = jsx_prop.as_str() {
-                    result.jsx.fragment =
-                        Self::parse_member_expression_for_jsx(log, source, loc, str)?.into();
+                if let Some(fragment) = jsx_prop
+                    .as_str()
+                    .and_then(|str| Self::parse_member_expression_for_jsx(log, source, loc, str))
+                {
+                    result.jsx.fragment = fragment.into();
                     result.jsx_flags.insert(JsxField::Fragment);
                 }
             }
@@ -697,61 +701,44 @@ impl TSConfigJSON {
         true
     }
 
+    /// `"React.createElement"` => `["React", "createElement"]`.
+    ///
+    /// Returns `None` when `text` is not a dotted chain of identifiers. The
+    /// caller then leaves the factory (or fragment) unset, so the default
+    /// stays in effect: the parser needs at least one member. An empty
+    /// `text` is treated as unset without a warning.
     pub(crate) fn parse_member_expression_for_jsx(
         log: &mut bun_ast::Log,
         source: &bun_ast::Source,
         loc: bun_ast::Loc,
         text: &[u8],
-    ) -> Result<Box<[Box<[u8]>]>, crate::Error> {
+    ) -> Option<Box<[Box<[u8]>]>> {
         if text.is_empty() {
-            return Ok(Box::default());
-        }
-        // foo.bar == 2
-        // foo.bar. == 2
-        // foo == 1
-        // foo.bar.baz == 3
-        // foo.bar.baz.bun == 4
-        let parts_count =
-            strings::count_char(text, b'.') + usize::from(text[text.len() - 1] != b'.');
-        let mut parts: Vec<Box<[u8]>> = Vec::with_capacity(parts_count);
-
-        if parts_count == 1 {
-            if !js_lexer::is_identifier(text) {
-                let warn = source.range_of_string(loc);
-                let _ = log.add_range_warning_fmt(
-                    Some(source),
-                    warn,
-                    format_args!(
-                        "Invalid JSX member expression: \"{}\"",
-                        bstr::BStr::new(text)
-                    ),
-                );
-                return Ok(Box::default());
-            }
-
-            parts.push(Box::from(text));
-            return Ok(parts.into_boxed_slice());
+            return None;
         }
 
-        let iter = strings::tokenize(text, b".");
+        let mut parts = strings::tokenize(text, b".").peekable();
+        // Text made of dots only ("." or "..") has no parts; report the whole text.
+        let invalid = if parts.peek().is_none() {
+            Some(text)
+        } else {
+            parts.find(|part| !js_lexer::is_identifier(part))
+        };
 
-        for part in iter {
-            if !js_lexer::is_identifier(part) {
-                let warn = source.range_of_string(loc);
-                let _ = log.add_range_warning_fmt(
-                    Some(source),
-                    warn,
-                    format_args!(
-                        "Invalid JSX member expression: \"{}\"",
-                        bstr::BStr::new(part)
-                    ),
-                );
-                return Ok(Box::default());
-            }
-            parts.push(Box::from(part));
+        if let Some(invalid) = invalid {
+            let warn = source.range_of_string(loc);
+            let _ = log.add_range_warning_fmt(
+                Some(source),
+                warn,
+                format_args!(
+                    "Invalid JSX member expression: \"{}\"",
+                    bstr::BStr::new(invalid)
+                ),
+            );
+            return None;
         }
 
-        Ok(parts.into_boxed_slice())
+        Some(strings::tokenize(text, b".").map(Box::from).collect())
     }
 
     pub(crate) fn is_valid_tsconfig_path_no_base_url_pattern(

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -701,12 +701,9 @@ impl TSConfigJSON {
         true
     }
 
-    /// `"React.createElement"` => `["React", "createElement"]`.
-    ///
-    /// Returns `None` when `text` is not a dotted chain of identifiers. The
-    /// caller then leaves the factory (or fragment) unset, so the default
-    /// stays in effect: the parser needs at least one member. An empty
-    /// `text` is treated as unset without a warning.
+    /// `"React.createElement"` => `["React", "createElement"]`. `None` (after
+    /// a warning, unless `text` is empty) when `text` is not a dotted chain
+    /// of identifiers.
     pub(crate) fn parse_member_expression_for_jsx(
         log: &mut bun_ast::Log,
         source: &bun_ast::Source,

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -938,23 +938,19 @@ impl CompletionStruct for JSBundleCompletionTask {
         transpiler.options.entry_points = config.entry_points.keys().to_vec().into_boxed_slice();
         // Convert API JSX config back to options.JSX.Pragma
         let jsx_import = &config.jsx.import_source;
+        let default_factory = options::jsx::MemberList::Static(options::jsx::defaults::FACTORY);
+        let default_fragment = options::jsx::MemberList::Static(options::jsx::defaults::FRAGMENT);
         transpiler.options.jsx = options::jsx::Pragma {
-            factory: if !config.jsx.factory.is_empty() {
-                options::jsx::Pragma::member_list_to_components_if_different(
-                    options::jsx::MemberList::Static(options::jsx::defaults::FACTORY),
-                    &config.jsx.factory,
-                )?
-            } else {
-                options::jsx::MemberList::Static(options::jsx::defaults::FACTORY)
-            },
-            fragment: if !config.jsx.fragment.is_empty() {
-                options::jsx::Pragma::member_list_to_components_if_different(
-                    options::jsx::MemberList::Static(options::jsx::defaults::FRAGMENT),
-                    &config.jsx.fragment,
-                )?
-            } else {
-                options::jsx::MemberList::Static(options::jsx::defaults::FRAGMENT)
-            },
+            factory: options::jsx::Pragma::member_list_to_components_if_different(
+                &default_factory,
+                &config.jsx.factory,
+            )
+            .unwrap_or(default_factory),
+            fragment: options::jsx::Pragma::member_list_to_components_if_different(
+                &default_fragment,
+                &config.jsx.fragment,
+            )
+            .unwrap_or(default_fragment),
             runtime: options::jsx::Runtime::from(config.jsx.runtime),
             development: config.jsx.development,
             package_name: if !jsx_import.is_empty() {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect } from "bun:test";
-import { normalizeBunSnapshot } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { BundlerTestInput, itBundled } from "./expectBundled";
 
 const helpers = {
@@ -523,6 +523,175 @@ describe("bundler", () => {
     run: {
       stdout: `{\n  $$typeof: Symbol(hello_jsxDEV),\n  type: \"div\",\n  props: {\n    children: \"Hello World\",\n  },\n  key: undefined,\n}`,
     },
+  });
+
+  // The classic transform reads the first member of the factory and fragment
+  // member lists. A factory or fragment option whose text has no identifier
+  // in it ("." or "..") must keep the list that was configured before it,
+  // instead of reaching the parser as an empty list (which crashed it with
+  // "index out of bounds: the len is 0 but the index is 0").
+  describe("factoryMemberList", () => {
+    // Defines the default factory and fragment (React.createElement and
+    // React.Fragment), so the output shows which factory the transform used.
+    const defaultFactoryPrelude = /* js */ `
+      const React = {
+        createElement: (tag, props) => ["default factory", tag, props],
+        Fragment: "default fragment",
+      };
+    `;
+    const defaultFactoryStdout = `[["default factory","a",null],["default factory","default fragment",null]]`;
+
+    itBundled("jsx/TsconfigFactoryWithoutIdentifierKeepsDefault", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          ${defaultFactoryPrelude}
+          console.log(JSON.stringify([<a></a>, <></>]));
+        `,
+        "/tsconfig.json": /* json */ `{
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": ".",
+            "jsxFragmentFactory": ".."
+          }
+        }`,
+      },
+      target: "bun",
+      bundleWarnings: {
+        "/tsconfig.json": ['Invalid JSX member expression: "."', 'Invalid JSX member expression: ".."'],
+      },
+      run: { stdout: defaultFactoryStdout },
+    });
+
+    itBundled("jsx/TsconfigFactoryNotAnIdentifierKeepsDefault", {
+      files: {
+        "/index.tsx": /* tsx */ `
+          ${defaultFactoryPrelude}
+          console.log(JSON.stringify([<a></a>, <></>]));
+        `,
+        "/tsconfig.json": /* json */ `{
+          "compilerOptions": {
+            "jsx": "react",
+            "jsxFactory": "foo-bar",
+            "jsxFragmentFactory": ""
+          }
+        }`,
+      },
+      target: "bun",
+      // An empty string is treated as unset and does not warn.
+      bundleWarnings: {
+        "/tsconfig.json": ['Invalid JSX member expression: "foo-bar"'],
+      },
+      run: { stdout: defaultFactoryStdout },
+    });
+
+    test("bun run keeps the default factory when tsconfig jsxFactory has no identifier", async () => {
+      using dir = tempDir("jsx-factory-without-identifier", {
+        "tsconfig.json": JSON.stringify({
+          compilerOptions: { jsx: "react", jsxFactory: ".", jsxFragmentFactory: "." },
+        }),
+        "index.tsx": `
+          ${defaultFactoryPrelude}
+          console.log(JSON.stringify([<a></a>, <></>]));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "index.tsx"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe(defaultFactoryStdout + "\n");
+      expect(stderr).toContain('Invalid JSX member expression: "."');
+      expect(exitCode).toBe(0);
+    });
+
+    test("Bun.Transpiler keeps the default factory when tsconfig jsxFactory is empty", async () => {
+      const tsconfig = JSON.stringify({
+        compilerOptions: { jsx: "react", jsxFactory: "", jsxFragmentFactory: "" },
+      });
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const transpiler = new Bun.Transpiler({ loader: "jsx", tsconfig: ${JSON.stringify(tsconfig)} });
+           console.log(transpiler.transformSync("export default [<a></a>, <></>];"));`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe(
+        'export default [React.createElement("a", null), React.createElement(React.Fragment, null)];\n\n',
+      );
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
+    itBundled("jsx/PragmaFactoryWithoutIdentifierKeepsDefault", {
+      files: {
+        "/index.jsx": /* jsx */ `
+          // @jsx .
+          // @jsxFrag ..
+          ${defaultFactoryPrelude}
+          console.log(JSON.stringify([<a></a>, <></>]));
+        `,
+      },
+      target: "bun",
+      jsx: { runtime: "classic" },
+      bundleWarnings: {
+        "/index.jsx": ['Invalid JSX factory: "."', 'Invalid JSX fragment: ".."'],
+      },
+      run: { stdout: defaultFactoryStdout },
+    });
+
+    // "React" is a prefix of the default "React.createElement" / "React.Fragment".
+    // It used to compare equal to the default, which left the default in place.
+    const prefixPrelude = /* js */ `
+      function React(tag, props) {
+        return [tag === React ? "fragment" : tag, props];
+      }
+    `;
+    const prefixStdout = `[["a",null],["fragment",null]]`;
+
+    // "cli" passes the option as --jsx-factory, "api" as Bun.build({ jsx: { factory } }).
+    for (const backend of ["cli", "api"] as const) {
+      itBundled(`jsx/FactoryPrefixOfDefault-${backend}`, {
+        files: {
+          "/index.jsx": /* jsx */ `
+            ${prefixPrelude}
+            console.log(JSON.stringify([<a></a>, <></>]));
+          `,
+        },
+        backend,
+        target: "bun",
+        jsx: { runtime: "classic", factory: "React", fragment: "React" },
+        run: { stdout: prefixStdout },
+        onAfterBundle(api) {
+          expect(api.readFile("out.js")).toContain("React(React, null)");
+        },
+      });
+    }
+
+    itBundled("jsx/PragmaFactoryPrefixOfDefault", {
+      files: {
+        "/index.jsx": /* jsx */ `
+          // @jsx React
+          // @jsxFrag React
+          ${prefixPrelude}
+          console.log(JSON.stringify([<a></a>, <></>]));
+        `,
+      },
+      target: "bun",
+      jsx: { runtime: "classic" },
+      run: { stdout: prefixStdout },
+      onAfterBundle(api) {
+        expect(api.readFile("out.js")).toContain("React(React, null)");
+      },
+    });
   });
 
   // Test for jsxSideEffects option - equivalent to esbuild's TestJSXSideEffects


### PR DESCRIPTION
### Problem
- A tsconfig `jsxFactory` or `jsxFragmentFactory` with no identifier in it (`""`, `"."`, `"foo-bar"`) crashes on the first JSX element: `panic: index out of bounds: the len is 0 but the index is 0` in `jsx_strings_to_member_expression` (`src/js_parser/p.rs:4777`, `parts[0]`). Sentry BUN-3KR0 has one event with this stack.
- `parse_member_expression_for_jsx` (`src/resolver/tsconfig_json.rs`) returns an empty list for such a value, and the caller stores it as the factory.
- `member_list_to_components_if_different` (`src/options_types/jsx.rs`) compares only the members present in the override. `--jsx-factory=React` counts as equal to `React.createElement` and is ignored.

### Fix
- `parse_member_expression_for_jsx` returns `Option`. An invalid value leaves the field unset, so the default applies. The existing warning now also covers text made of dots only.
- `member_list_to_components_if_different` returns `None` for an override with no members. CLI, bunfig and `Bun.build` keep the default. The `@jsx` and `@jsxFrag` pragmas warn and keep the current list. The equal check compares the whole list.
- `MemberList::default()` was an empty list for the old `mem::take` callers. Removed.
- Verified: `test/bundler/bundler_jsx.test.ts`, `factoryMemberList`. 8 new tests fail on bun 1.4.0, 3 by the crash. Other suites: see the notes.

### Background
- `factory` and `fragment` in `jsx::Pragma` are `MemberList`s, for example `["React", "createElement"]`. The classic transform resolves the first member as an identifier and appends the rest as property accesses.
- `MemberList::Static` borrows the default, so the per module `Pragma` clone does not allocate. An override allocates only when it differs from the current list.
- The lists come from `Pragma::from_api` (CLI, bunfig), `configure_bundler` (`Bun.build`), the `@jsx` pragma, and tsconfig. tsconfig has its own parser because it validates identifiers and warns with a location.

<details><summary>Notes</summary>

Repro on bun 1.4.0:

```
printf '{"compilerOptions": {"jsx": "react", "jsxFactory": "."}}' > tsconfig.json
printf 'console.log(<div />)\n' > index.tsx
bun index.tsx   # or: bun build index.tsx
```

`""`, `".."` and `"foo-bar"` crash the same way, as does `jsxFragmentFactory` with `<></>`. `new Bun.Transpiler({ tsconfig })` with `jsxFactory: ""` crashes on `transformSync`. With a non empty invalid value the `Bun.Transpiler` constructor already threw, because it turns tsconfig warnings into errors.

The pragma, `--jsx-factory=.` and `Bun.build({ jsx: { factory: "." } })` did not crash before this change. They start from the non empty default, and an override with no segments left it untouched. The crash needed tsconfig to produce the empty list first. After this change the same inputs give the same result, now on purpose, and the pragma also warns. `member_list_to_components_if_different` now takes the current list by reference, so a caller still has it when the override is rejected.

The pragma warnings (the new ones and the existing `Unsupported JSX runtime`) point at the wrong line. The lexer adds the comment start to an offset that is already absolute when it builds the pragma spans. That is a separate lexer bug and is handled separately.

`parse_member_expression_for_jsx` used to reject `"h."` and accept `"foo.bar."`. It now tokenizes in both cases, so `"h."` means `h`, which matches how the other producers split the text. An empty string stays silent, as before.

Sentry BUN-3KR0 and BUN-3RAS group every `index out of bounds: the len is 0 but the index is 0` panic together. Of the 34 events fetched, one has this JSX stack (tagged `tsconfig`, `RunCommand`). The others are in the linker (`append_isolated_hashes_for_imported_chunks`, `generate_chunks_in_parallel`), the shell brace expansion and the YAML parser. This change does not touch them.

Suites run with the debug build: `test/bundler/bundler_jsx.test.ts` (55 pass, 4 todo), `test/bundler/esbuild/tsconfig.test.ts`, `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts`, `test/js/bun/transpiler/transpiler-tsconfig-uaf.test.ts`. `cargo clippy` on `bun_options_types`, `bun_resolver`, `bun_js_parser` and `bun_runtime` reports nothing for the changed files.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts
bun test v1.4.0 (4c689909e)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1050.30ms]
(pass) bundler > jsx/AutomaticProd [683.03ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [630.34ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [656.38ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [785.77ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [728.64ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [368.67ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [311.69ms]
(pass) bundler > jsx/ClassicDev [694.53ms]
(pass) bundler > jsx/ClassicProd [759.72ms]
(pass) bundler > jsx/ClassicPragmaDev [730.67ms]
(pass) bundler > jsx/ClassicPragmaProd [696.84ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [686.73ms]
(pass) bundler > jsx/FactoryProd [744.67ms]
(pass) bundler > jsx/FactoryImportDev
... (truncated)

release without fix: 4 skipped
bun test v1.4.0-canary.1 (f85b329af)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [32.58ms]
(pass) bundler > jsx/AutomaticProd [16.93ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [19.52ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [18.22ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [18.29ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [20.15ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [13.19ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [13.33ms]
(pass) bundler > jsx/ClassicDev [16.08ms]
(pass) bundler > jsx/ClassicProd [19.47ms]
(pass) bundler > jsx/ClassicPragmaDev [20.68ms]
(pass) bundler > jsx/ClassicPragmaProd [16.76ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [14.06ms]
(pass) bundler > jsx/FactoryProd [19.23ms]
(pass) bundler > jsx/FactoryImportDev [23.34ms]
(pass) bundler > jsx/FactoryImportProd [16.66ms]
(pass) bundler > jsx/FactoryImportExplicitReactDefaultDev [11.10ms]
(pass) bundler > jsx/FactoryImportExplicitRe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 4 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_jsx.test.ts
bun test v1.4.0 (4c689909e)

test/bundler/bundler_jsx.test.ts:
(pass) bundler > jsx/AutomaticDev [1311.97ms]
(pass) bundler > jsx/AutomaticProd [784.92ms]
(todo) bundler > jsx/AutomaticFragmentDev
(todo) bundler > jsx/AutomaticFragmentProd
(pass) bundler > jsx/AutomaticFragmentNamedImportDev [783.08ms]
(pass) bundler > jsx/AutomaticFragmentNamedImportProd [710.86ms]
(pass) bundler > jsx/AutomaticLocalShadowDev [791.26ms]
(pass) bundler > jsx/AutomaticLocalShadowProd [784.18ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersProd [356.20ms]
(pass) bundler > jsx/AutomaticLocalShadowMinifyIdentifiersDev [378.02ms]
(pass) bundler > jsx/ClassicDev [734.39ms]
(pass) bundler > jsx/ClassicProd [678.26ms]
(pass) bundler > jsx/ClassicPragmaDev [746.37ms]
(pass) bundler > jsx/ClassicPragmaProd [693.79ms]
(todo) bundler > jsx/PragmaMultipleDev
(todo) bundler > jsx/PragmaMultipleProd
(pass) bundler > jsx/FactoryDev [707.00ms]
(pass) bundler > jsx/FactoryProd [742.73ms]
(pass) bundler > jsx/FactoryImportDev
... (truncated)

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 629ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cc obj/packages/bun-usockets/src/loop.c.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/options.rs                       |   2 +-
 src/js_parser/p.rs                           |  34 ++++--
 src/options_types/jsx.rs                     |  75 ++++--------
 src/resolver/tsconfig_json.rs                |  84 ++++++-------
 src/runtime/api/js_bundle_completion_task.rs |  28 ++---
 test/bundler/bundler_jsx.test.ts             | 173 ++++++++++++++++++++++++++-
 6 files changed, 263 insertions(+), 133 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/bundler/options.rs                            2      1      0
src/js_parser/p.rs                                2      1      0
src/options_types/jsx.rs                          5      6      0
src/resolver/tsconfig_json.rs                     4      4      0
src/runtime/api/js_bundle_completion_task.rs      1      1      0
test/bundler/bundler_jsx.test.ts                  5      3      0
```

</details>

<!-- robobun:evidence:end -->