### PR TITLE
Fix segfault when printing an AggregateError without an errors property

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -378,10 +378,7 @@ impl JSValue {
     /// `JSValue.getErrorsProperty(globalObject)`. Returns the
     /// own `errors` data property via `JSObject::getDirect` — no prototype
     /// walk, no getters invoked, nothrow. Used for `AggregateError.errors`.
-    ///
-    /// `None` when the property is missing (`getDirect` yields the empty
-    /// value), is an accessor (a `GetterSetter` cell), or holds a primitive.
-    /// The C++ side returns `undefined` for all three.
+    /// `None` unless that property holds an object.
     #[inline]
     pub(crate) fn get_errors_property(self, global: &JSGlobalObject) -> Option<JSValue> {
         unsafe extern "C" {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -378,7 +378,7 @@ impl JSValue {
     /// `JSValue.getErrorsProperty(globalObject)`. Returns the
     /// own `errors` data property via `JSObject::getDirect` — no prototype
     /// walk, no getters invoked, nothrow. Used for `AggregateError.errors`.
-    /// `None` unless that property holds an object.
+    /// `None` unless that property holds an object. `self` must be an object.
     #[inline]
     pub(crate) fn get_errors_property(self, global: &JSGlobalObject) -> Option<JSValue> {
         unsafe extern "C" {
@@ -387,6 +387,7 @@ impl JSValue {
                 global: &JSGlobalObject,
             ) -> JSValue;
         }
+        debug_assert!(self.is_object());
         let errors = JSC__JSValue__getErrorsProperty(self, global);
         errors.is_object().then_some(errors)
     }

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -378,15 +378,20 @@ impl JSValue {
     /// `JSValue.getErrorsProperty(globalObject)`. Returns the
     /// own `errors` data property via `JSObject::getDirect` — no prototype
     /// walk, no getters invoked, nothrow. Used for `AggregateError.errors`.
+    ///
+    /// `None` when the property is missing (`getDirect` yields the empty
+    /// value), is an accessor (a `GetterSetter` cell), or holds a primitive.
+    /// The C++ side returns `undefined` for all three.
     #[inline]
-    pub(crate) fn get_errors_property(self, global: &JSGlobalObject) -> JSValue {
+    pub(crate) fn get_errors_property(self, global: &JSGlobalObject) -> Option<JSValue> {
         unsafe extern "C" {
             safe fn JSC__JSValue__getErrorsProperty(
                 this: JSValue,
                 global: &JSGlobalObject,
             ) -> JSValue;
         }
-        JSC__JSValue__getErrorsProperty(self, global)
+        let errors = JSC__JSValue__getErrorsProperty(self, global);
+        errors.is_object().then_some(errors)
     }
     /// `JSValue.isTerminationException()` — true if this
     /// value is the VM's termination-exception sentinel.

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -375,22 +375,6 @@ impl JSValue {
         }
         JSC__JSValue__isAggregateError(self, global)
     }
-    /// `JSValue.getErrorsProperty(globalObject)`. Returns the
-    /// own `errors` data property via `JSObject::getDirect` — no prototype
-    /// walk, no getters invoked, nothrow. Used for `AggregateError.errors`.
-    /// `None` unless that property holds an object. `self` must be an object.
-    #[inline]
-    pub(crate) fn get_errors_property(self, global: &JSGlobalObject) -> Option<JSValue> {
-        unsafe extern "C" {
-            safe fn JSC__JSValue__getErrorsProperty(
-                this: JSValue,
-                global: &JSGlobalObject,
-            ) -> JSValue;
-        }
-        debug_assert!(self.is_object());
-        let errors = JSC__JSValue__getErrorsProperty(self, global);
-        errors.is_object().then_some(errors)
-    }
     /// `JSValue.isTerminationException()` — true if this
     /// value is the VM's termination-exception sentinel.
     #[inline]

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5224,9 +5224,8 @@ impl VirtualMachine {
             if errors
                 .for_each(global_ref, (&raw mut ctx).cast(), agg_iter)
                 .is_err()
-                && !global_ref.clear_exception_except_termination()
             {
-                return;
+                global_ref.clear_exception();
             }
             if ctx.printed_member {
                 return;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5160,12 +5160,8 @@ impl VirtualMachine {
         // once the AggregateError branch is taken).
         let global_ref = self.global();
 
-        // An AggregateError prints its members in place of itself. With no
-        // member to print it falls through and prints like any other error:
-        // no own `errors` object (user code deleted it, or this is the copy
-        // `JSModuleLoader::duplicateError` throws when a module that already
-        // failed to load is imported again), or one that is empty or not
-        // iterable.
+        // Prints the members in place of the AggregateError. `errors` can be missing without
+        // user code: `JSModuleLoader::duplicateError` replays a failed module load without it.
         if value.is_aggregate_error(global_ref)
             && let Some(errors) = value.get_errors_property(global_ref)
         {
@@ -5226,9 +5222,6 @@ impl VirtualMachine {
                 allow_side_effects,
                 printed_member: false,
             };
-            // `for_each` throws when `errors` is not iterable or its iterator
-            // throws. That exception is dropped; a pending termination is left
-            // in place and ends the print.
             if errors
                 .for_each(global_ref, (&raw mut ctx).cast(), agg_iter)
                 .is_err()
@@ -5239,6 +5232,7 @@ impl VirtualMachine {
             if ctx.printed_member {
                 return;
             }
+            // `errors` is empty or not iterable: print the AggregateError itself.
         }
 
         let was_internal = self.print_error_from_maybe_private_data(

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5160,10 +5160,18 @@ impl VirtualMachine {
         // once the AggregateError branch is taken).
         let global_ref = self.global();
 
-        // `errors` is missing on the copies `JSModuleLoader::duplicateError` makes of a load error.
-        if value.is_aggregate_error(global_ref)
-            && let Some(errors) = value.get_errors_property(global_ref)
-        {
+        let errors = if value.is_aggregate_error(global_ref) {
+            match value.fast_get(global_ref, jsc::BuiltinName::errors) {
+                Ok(errors) => errors,
+                Err(_) => {
+                    global_ref.clear_exception();
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        if let Some(errors) = errors {
             // Note: `JSValue::for_each` takes a C-ABI fn
             // pointer + erased ctx, so thread the captures through a struct.
             // The C trampoline erases lifetimes via `*mut c_void`; round-trip

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5160,8 +5160,7 @@ impl VirtualMachine {
         // once the AggregateError branch is taken).
         let global_ref = self.global();
 
-        // Prints the members in place of the AggregateError. `errors` can be missing without
-        // user code: `JSModuleLoader::duplicateError` replays a failed module load without it.
+        // `errors` is missing on the copies `JSModuleLoader::duplicateError` makes of a load error.
         if value.is_aggregate_error(global_ref)
             && let Some(errors) = value.get_errors_property(global_ref)
         {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -5149,7 +5149,7 @@ impl VirtualMachine {
         &mut self,
         value: JSValue,
         exception: Option<&Exception>,
-        exception_list: Option<&mut ExceptionList>,
+        mut exception_list: Option<&mut ExceptionList>,
         formatter: &mut crate::console_object::Formatter,
         writer: &mut bun_core::io::Writer,
         allow_ansi_color: bool,
@@ -5160,7 +5160,15 @@ impl VirtualMachine {
         // once the AggregateError branch is taken).
         let global_ref = self.global();
 
-        if value.is_aggregate_error(global_ref) {
+        // An AggregateError prints its members in place of itself. With no
+        // member to print it falls through and prints like any other error:
+        // no own `errors` object (user code deleted it, or this is the copy
+        // `JSModuleLoader::duplicateError` throws when a module that already
+        // failed to load is imported again), or one that is empty or not
+        // iterable.
+        if value.is_aggregate_error(global_ref)
+            && let Some(errors) = value.get_errors_property(global_ref)
+        {
             // Note: `JSValue::for_each` takes a C-ABI fn
             // pointer + erased ctx, so thread the captures through a struct.
             // The C trampoline erases lifetimes via `*mut c_void`; round-trip
@@ -5172,6 +5180,7 @@ impl VirtualMachine {
                 exception_list: *mut ExceptionList,
                 allow_ansi_color: bool,
                 allow_side_effects: bool,
+                printed_member: bool,
             }
             extern "C" fn agg_iter(
                 _vm: *mut crate::VM,
@@ -5196,6 +5205,7 @@ impl VirtualMachine {
                 // SAFETY: `ctx.writer` borrows the caller's stack local,
                 // live across the synchronous `for_each` call.
                 let writer = unsafe { &mut *ctx.writer };
+                ctx.printed_member = true;
                 vm.print_errorlike_object(
                     next_value,
                     None,
@@ -5207,25 +5217,30 @@ impl VirtualMachine {
                 );
             }
             let mut ctx = AggCtx {
-                formatter: std::ptr::from_mut(formatter),
-                writer: std::ptr::from_mut(writer),
+                formatter: std::ptr::from_mut(&mut *formatter),
+                writer: std::ptr::from_mut(&mut *writer),
                 exception_list: exception_list
-                    .map(std::ptr::from_mut::<ExceptionList>)
-                    .unwrap_or(core::ptr::null_mut()),
+                    .as_deref_mut()
+                    .map_or(core::ptr::null_mut(), std::ptr::from_mut::<ExceptionList>),
                 allow_ansi_color,
                 allow_side_effects,
+                printed_member: false,
             };
-            // `getErrorsProperty` is
-            // `getDirect` (own data prop, nothrow); `for_each` may throw, in
-            // which case the error is swallowed.
-            let errors = value.get_errors_property(global_ref);
-            let _ = errors.for_each(global_ref, (&raw mut ctx).cast(), agg_iter);
-            return;
+            // `for_each` throws when `errors` is not iterable or its iterator
+            // throws. That exception is dropped; a pending termination is left
+            // in place and ends the print.
+            if errors
+                .for_each(global_ref, (&raw mut ctx).cast(), agg_iter)
+                .is_err()
+                && !global_ref.clear_exception_except_termination()
+            {
+                return;
+            }
+            if ctx.printed_member {
+                return;
+            }
         }
 
-        // Note: reborrow so the add-to-error-list tail can still see it after
-        // `print_error_from_maybe_private_data`.
-        let mut exception_list = exception_list;
         let was_internal = self.print_error_from_maybe_private_data(
             value,
             exception_list.as_deref_mut(),

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4857,10 +4857,7 @@ CPP_DECL double Bun__JSValue__toNumber(JSC::EncodedJSValue JSValue0, JSC::JSGlob
     return value.toInt32(arg1);
 }
 
-// The own `errors` data property of an AggregateError when it holds an object,
-// otherwise undefined. `getDirect` returns the empty value when the property is
-// missing and a GetterSetter cell when it was redefined as an accessor; passing
-// either to forEachInIterable reads them as a cell.
+// The own `errors` property of an AggregateError if it holds an object, else undefined.
 JSC::EncodedJSValue JSC__JSValue__getErrorsProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* global)
 {
     JSC::JSObject* obj = JSC::JSValue::decode(JSValue0).getObject();
@@ -4868,6 +4865,7 @@ JSC::EncodedJSValue JSC__JSValue__getErrorsProperty(JSC::EncodedJSValue JSValue0
         return JSC::JSValue::encode(JSC::jsUndefined());
 
     JSC::JSValue errors = obj->getDirect(global->vm(), global->vm().propertyNames->errors);
+    // Empty when the property is missing (isObject() would dereference it), a GetterSetter cell for an accessor.
     if (!errors || !errors.isObject())
         return JSC::JSValue::encode(JSC::jsUndefined());
 

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4860,10 +4860,7 @@ CPP_DECL double Bun__JSValue__toNumber(JSC::EncodedJSValue JSValue0, JSC::JSGlob
 // The own `errors` property of an AggregateError if it holds an object, else undefined.
 JSC::EncodedJSValue JSC__JSValue__getErrorsProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* global)
 {
-    JSC::JSObject* obj = JSC::JSValue::decode(JSValue0).getObject();
-    if (!obj)
-        return JSC::JSValue::encode(JSC::jsUndefined());
-
+    JSC::JSObject* obj = JSC::asObject(JSC::JSValue::decode(JSValue0));
     JSC::JSValue errors = obj->getDirect(global->vm(), global->vm().propertyNames->errors);
     // Empty when the property is missing (isObject() would dereference it), a GetterSetter cell for an accessor.
     if (!errors || !errors.isObject())

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4857,10 +4857,21 @@ CPP_DECL double Bun__JSValue__toNumber(JSC::EncodedJSValue JSValue0, JSC::JSGlob
     return value.toInt32(arg1);
 }
 
+// The own `errors` data property of an AggregateError when it holds an object,
+// otherwise undefined. `getDirect` returns the empty value when the property is
+// missing and a GetterSetter cell when it was redefined as an accessor; passing
+// either to forEachInIterable reads them as a cell.
 JSC::EncodedJSValue JSC__JSValue__getErrorsProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* global)
 {
     JSC::JSObject* obj = JSC::JSValue::decode(JSValue0).getObject();
-    return JSC::JSValue::encode(obj->getDirect(global->vm(), global->vm().propertyNames->errors));
+    if (!obj)
+        return JSC::JSValue::encode(JSC::jsUndefined());
+
+    JSC::JSValue errors = obj->getDirect(global->vm(), global->vm().propertyNames->errors);
+    if (!errors || !errors.isObject())
+        return JSC::JSValue::encode(JSC::jsUndefined());
+
+    return JSC::JSValue::encode(errors);
 }
 
 [[ZIG_EXPORT(nothrow)]] JSC::EncodedJSValue JSC__JSValue__jsTDZValue()

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4857,18 +4857,6 @@ CPP_DECL double Bun__JSValue__toNumber(JSC::EncodedJSValue JSValue0, JSC::JSGlob
     return value.toInt32(arg1);
 }
 
-// The own `errors` property of an AggregateError if it holds an object, else undefined.
-JSC::EncodedJSValue JSC__JSValue__getErrorsProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* global)
-{
-    JSC::JSObject* obj = JSC::asObject(JSC::JSValue::decode(JSValue0));
-    JSC::JSValue errors = obj->getDirect(global->vm(), global->vm().propertyNames->errors);
-    // Empty when the property is missing (isObject() would dereference it), a GetterSetter cell for an accessor.
-    if (!errors || !errors.isObject())
-        return JSC::JSValue::encode(JSC::jsUndefined());
-
-    return JSC::JSValue::encode(errors);
-}
-
 [[ZIG_EXPORT(nothrow)]] JSC::EncodedJSValue JSC__JSValue__jsTDZValue()
 {
     return JSC::JSValue::encode(JSC::jsTDZValue());
@@ -5322,6 +5310,7 @@ enum class BuiltinNamesMap : uint8_t {
     type,
     signal,
     cmd,
+    errors,
     // Private names below: set by builtins via $putByIdDirectPrivate, unreachable from user code.
     internal,
     sharedFd,
@@ -5403,6 +5392,9 @@ static inline const JSC::Identifier& builtinNameMap(JSC::VM& vm, unsigned char n
     }
     case BuiltinNamesMap::cmd: {
         return clientData->builtinNames().cmdPublicName();
+    }
+    case BuiltinNamesMap::errors: {
+        return vm.propertyNames->errors;
     }
     case BuiltinNamesMap::internal: {
         return clientData->builtinNames().internalPrivateName();

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -229,7 +229,6 @@ CPP_DECL JSC::EncodedJSValue JSC__JSValue__bigIntFromLatin1(JSC::JSGlobalObject*
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromTimevalNoTruncate(JSC::JSGlobalObject* arg0, int64_t nsec, int64_t sec);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__bigIntSum(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1);
 CPP_DECL void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString* arg2);
-CPP_DECL JSC::EncodedJSValue JSC__JSValue__getErrorsProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);
 CPP_DECL double JSC__JSValue__getLengthIfPropertyExistsInternal(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL void JSC__JSValue__getNameProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString* arg2);

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -921,6 +921,7 @@ pub enum BuiltinName {
     type_,
     signal,
     cmd,
+    errors,
     /// Private name (`$internal` in builtins); user code cannot set it.
     internal,
     /// Private name (`$sharedFd` in builtins); user code cannot set it.

--- a/test/internal/source-lints/jsresult-swallow.inventory.json
+++ b/test/internal/source-lints/jsresult-swallow.inventory.json
@@ -1,7 +1,7 @@
 {
   "src/jsc/VirtualMachine.rs": {
     "JsResult collapsed on the spot": 1,
-    "discarded result of a call that enters script": 2
+    "discarded result of a call that enters script": 1
   },
   "src/jsc/web_worker.rs": {
     "taken exception discarded": 1

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -327,3 +327,129 @@ describe("source map remapping of the printed stack", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+// The printer replaces an AggregateError with the members of its own `errors`
+// property. When there is nothing to walk it has to print the AggregateError
+// itself. A deleted `errors` used to crash the process (the empty value was
+// passed to the iteration, which read it as a cell at address 0), the other
+// shapes printed nothing, and a non-iterable `errors` made console.error throw.
+describe.concurrent("AggregateError whose errors cannot be walked", () => {
+  async function run(cmd, files) {
+    using dir = tempDir("inspect-aggregate-error", files ?? {});
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...cmd],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const header = "AggregateError: outer message";
+  const make = 'const e = new AggregateError([new Error("inner")], "outer message");';
+  const shapes = {
+    "errors was deleted": "delete e.errors;",
+    "errors is an empty array": "e.errors = [];",
+    "errors is not iterable": "e.errors = {};",
+    "errors is a primitive": "e.errors = 1;",
+    "errors is an accessor": 'Object.defineProperty(e, "errors", { get() { return [new Error("inner")]; } });',
+  };
+
+  for (const [name, shape] of Object.entries(shapes)) {
+    test(`console.error: ${name}`, async () => {
+      const { stdout, stderr, exitCode } = await run([
+        "-e",
+        `${make} ${shape} console.error(e); console.log("after");`,
+      ]);
+      expect(stderr).toContain(header);
+      expect(stdout).toBe("after\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test(`uncaught: ${name}`, async () => {
+      const { stderr, exitCode } = await run(["-e", `${make} ${shape} throw e;`]);
+      expect(stderr).toContain(header);
+      expect(exitCode).toBe(1);
+    });
+  }
+
+  test("Bun.inspect: errors was deleted", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "-e",
+      `${make} delete e.errors; console.log(JSON.stringify(Bun.inspect(e)));`,
+    ]);
+    expect(JSON.parse(stdout)).toContain(header);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("errors is an accessor: the getter is not called", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "-e",
+      `${make}
+       let calls = 0;
+       Object.defineProperty(e, "errors", { get() { calls++; return []; } });
+       console.error(e);
+       console.log(calls);`,
+    ]);
+    expect(stderr).toContain(header);
+    expect(stdout).toBe("0\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("members are still printed in place of the AggregateError", async () => {
+    const { stderr, exitCode } = await run([
+      "-e",
+      'throw new AggregateError([new Error("first member"), new TypeError("second member")], "outer message");',
+    ]);
+    expect(stderr).toContain("error: first member");
+    expect(stderr).toContain("TypeError: second member");
+    expect(exitCode).toBe(1);
+  });
+
+  // Without any user code: a module with two or more build errors rejects its
+  // first load with an AggregateError of BuildMessages. JSC settles every later
+  // load of it from the module registry with a copy made by
+  // JSModuleLoader::duplicateError, which keeps the error type and message but
+  // not the `errors` property.
+  const broken = {
+    "broken.ts": "export function f() {\n  const v = {b: {},),r,};\n}\n",
+  };
+
+  test("the error a second load of a module that failed to build rejects with", async () => {
+    const { stdout, stderr, exitCode } = await run(["main.ts"], {
+      ...broken,
+      "main.ts": `
+        const seen = [];
+        for (let i = 0; i < 2; i++) {
+          try {
+            await import("./broken.ts");
+          } catch (e) {
+            seen.push(e.constructor.name);
+            if (i === 1) console.error(e);
+          }
+        }
+        console.log(JSON.stringify(seen));
+      `,
+    });
+    expect(stdout).toBe('["AggregateError","AggregateError"]\n');
+    expect(stderr).toContain("broken.ts");
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/36963
+  test("bun test: two files import a module that failed to build", async () => {
+    const importer = 'import { f } from "./broken.ts";\nf();\n';
+    const { stderr, exitCode } = await run(["test", "./a.test.ts", "./b.test.ts"], {
+      ...broken,
+      "a.test.ts": importer,
+      "b.test.ts": importer,
+    });
+    expect(stderr).toContain("a.test.ts:");
+    expect(stderr).toContain("b.test.ts:");
+    expect(stderr).toContain("across 2 files");
+    expect(exitCode).toBe(1);
+  });
+});

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -406,6 +406,7 @@ describe.concurrent("AggregateError whose errors cannot be walked", () => {
     ]);
     expect(stderr).toContain("error: first member");
     expect(stderr).toContain("TypeError: second member");
+    expect(stderr).not.toContain(header);
     expect(exitCode).toBe(1);
   });
 

--- a/test/js/bun/util/inspect-error.test.js
+++ b/test/js/bun/util/inspect-error.test.js
@@ -328,11 +328,12 @@ describe("source map remapping of the printed stack", () => {
   });
 });
 
-// The printer replaces an AggregateError with the members of its own `errors`
+// The printer replaces an AggregateError with the members of its `errors`
 // property. When there is nothing to walk it has to print the AggregateError
 // itself. A deleted `errors` used to crash the process (the empty value was
-// passed to the iteration, which read it as a cell at address 0), the other
-// shapes printed nothing, and a non-iterable `errors` made console.error throw.
+// passed to the iteration, which read it as a cell at address 0), an accessor
+// was passed to it as well, the other shapes printed nothing, and a
+// non-iterable `errors` made console.error throw.
 describe.concurrent("AggregateError whose errors cannot be walked", () => {
   async function run(cmd, files) {
     using dir = tempDir("inspect-aggregate-error", files ?? {});
@@ -353,8 +354,9 @@ describe.concurrent("AggregateError whose errors cannot be walked", () => {
     "errors was deleted": "delete e.errors;",
     "errors is an empty array": "e.errors = [];",
     "errors is not iterable": "e.errors = {};",
+    "errors is null": "e.errors = null;",
     "errors is a primitive": "e.errors = 1;",
-    "errors is an accessor": 'Object.defineProperty(e, "errors", { get() { return [new Error("inner")]; } });',
+    "the errors getter throws": 'Object.defineProperty(e, "errors", { get() { throw new Error("getter"); } });',
   };
 
   for (const [name, shape] of Object.entries(shapes)) {
@@ -385,17 +387,17 @@ describe.concurrent("AggregateError whose errors cannot be walked", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("errors is an accessor: the getter is not called", async () => {
+  test("errors is an accessor: the members it returns are printed", async () => {
     const { stdout, stderr, exitCode } = await run([
       "-e",
       `${make}
-       let calls = 0;
-       Object.defineProperty(e, "errors", { get() { calls++; return []; } });
+       Object.defineProperty(e, "errors", { get() { return [new Error("from the getter")]; } });
        console.error(e);
-       console.log(calls);`,
+       console.log("after");`,
     ]);
-    expect(stderr).toContain(header);
-    expect(stdout).toBe("0\n");
+    expect(stderr).toContain("error: from the getter");
+    expect(stderr).not.toContain(header);
+    expect(stdout).toBe("after\n");
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### Problem
- Printing an `AggregateError` with no own `errors` property kills the process: `panic(main thread): Segmentation fault at address 0x5` in `JSC::forEachInIterable` (Sentry BUN-40MQ, 92 events on the 1.4.0 canary, 62 in `bun test`, and BUN-47FF, the same stack as grouped on Windows, 9 events in `bun test`, 1 of them on the public 1.4.0).
- Cause: on main, `JSC__JSValue__getErrorsProperty` (`src/jsc/bindings/bindings.cpp:4860`) returns `getDirect()` as is, which is the empty value for a missing property. `print_errorlike_object` (`src/jsc/VirtualMachine.rs:5221`) passes it to `for_each`, which reads it as a cell at address 0.
- JSC creates such errors itself: `bun test` crashed when a second file imported a module with two or more build errors (#36963).

### Fix
- The binding and `get_errors_property` are deleted. The printer reads `errors` with `fast_get` and a new `BuiltinName::errors`.
- When it printed no member (`errors` missing, empty, or not iterable) it falls through and prints the `AggregateError` like any other error. The normal output, members only, is unchanged.
- An exception from the read or the walk is cleared, as the normal path below already does. Before, it stayed pending and `console.error` threw for a non-iterable `errors`.
- Verified: `test/js/bun/util/inspect-error.test.js`, 17 new tests, 16 fail on bun 1.4.0. Also the build error, inspect, plugin, ipc, cluster and source lint tests.

### Background
- `print_errorlike_object` is the native error printer behind uncaught errors, unhandled rejections, `console.error` and `Bun.inspect`. For an `AggregateError` it prints the members and returns.
- `getDirect` reads an own property slot with no getters. A missing slot gives the empty `JSValue`, which passes JSC's `isCell()`. An accessor slot gives a `GetterSetter` cell.
- `fast_get` is an ordinary `[[Get]]` keyed by a preallocated identifier (`BuiltinNamesMap` in `bindings.cpp`, same order as `BuiltinName` in `src/jsc/lib.rs`). Missing gives `None`, a throwing getter gives `Err`.
- `JSModuleLoader::duplicateError` (`JSModuleLoader.cpp:116`) settles every later load of a module that failed to load with a copy of the stored error, rebuilt from its type and message only.

<details><summary>Notes</summary>

Repro on bun 1.4.0, user code:

```js
const e = new AggregateError([new Error("a")], "agg");
delete e.errors;
console.error(e); // segfault at 0x5. Same for Bun.inspect(e) and throw e.
```

Repro without user code (#36963): `lib.ts` with a syntax error that produces two or more messages, two test files that import it, `bun test`. The second file crashed. It now reports `AggregateError: 4 errors building ".../lib.ts"`. A single build error produces a `BuildMessage`, not an `AggregateError`, and is not affected. Loading the broken module twice with `import()` in one file and printing the second rejection crashes the same way. That is one of the new tests, next to the `bun test` case.

Shapes covered by the tests, each through `console.error` and as an uncaught error: `errors` deleted, `[]`, `{}`, `null`, a number, a getter that throws. Before the fix, the deleted shape crashed (exit 139), `[]` printed nothing (same for `Promise.any([])`), `{}`, `null` and the number made `console.error` throw a `TypeError`, and an accessor (its `GetterSetter` cell was passed to the walk) threw a `TypeError` in release builds and failed `ASSERT(isSymbol())` in `JSValue::synthesizePrototype` in debug builds. All of these now print `AggregateError: <message>` with the source preview and stack. A separate test defines `errors` as an accessor that returns an array: since the read is an ordinary `[[Get]]` now, the getter runs and its members are printed, with no header.

`fast_get` and `for_each` return `Err` with the exception still pending. Both sites call `clear_exception()`, the same call `print_error_from_maybe_private_data` makes when printing an error throws. The removed `let _ = errors.for_each(...)` lowers the count for `VirtualMachine.rs` in `test/internal/source-lints/jsresult-swallow.inventory.json` by one.

`BuiltinName::errors` is inserted before the two private names in both enums, so `internal` and `sharedFd` move by one on both sides. The tests that go through them still pass: `test/js/bun/udp/dgram.test.ts`, `test/js/bun/spawn/spawn.ipc.test.ts`, `bun-ipc-inherit.test.ts`, and the node `test-cluster-basic`, `test-cluster-dgram-1`, `-2` and `-reuse` tests.

Review history: the first revision kept the binding and returned `undefined` unless the slot held an object, the second dropped its null check and a termination special case, and the third (current) replaced it with `fast_get` as asked in review.

Overlapping open PRs, each broader than this one: #36602 reworks the whole AggregateError output and guards this walk. #35816 guards the console formatters and adds an `is_object` check here, but still prints nothing for an `errors`-less AggregateError. #39204 (blocked on a WebKit bump) makes the loader replay the original error with `errors` intact, and #39292 prints replayed build errors again. This PR only makes the printer safe for whatever object it gets, and keeps the normal output unchanged, so it does not change what those PRs do.

Also run: `test/js/bun/resolve/build-error.test.ts`, `test/js/bun/util/reportError.test.ts`, `test/js/bun/util/inspect.test.js`, `test/js/bun/plugin/plugins.test.ts`, `test/js/bun/transpiler/transpiler-error-gc-uaf.test.ts`, `test/regression/issue/hashbang-still-works.test.ts` (130 pass), `rustfmt --check`, `cargo clippy -p bun_jsc`, `clang-format` on `bindings.cpp`, and the repros under `BUN_JSC_validateExceptionChecks=1`. The new tests spawn one process per case because the unfixed binary dies. The file takes about 4 s under the debug build.

</details>

Fixes #36963

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 14 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.0 (4c689909e)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [6.93ms]
(pass) Error [3.37ms]
(pass) BuildMessage [11.73ms]
(pass) Error inside minified file (no color)  [80.80ms]
(pass) Error inside minified file (color)  [46.97ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [123.41ms]
(pass) observable properties > sourceURL is observable [5.71ms]
(pass) observable properties > line is observable [2.61ms]
(pass) observable properties > column is observable [1.85ms]
(pass) error.stack throwing an error doesn't lead to a crash [3.51ms]
(pass) source map remapping of the printed stack > external map whose original source is unavailable [321.92ms]
361 |     test(`console.error: ${name}`, async () => {
362 |       const { stdout, stderr, exitCode } = await run([
363 |         "-e",
364 |         `${make} ${shape} console.error(e); console.log("after");`,
365 |       ]);
366 |       expect(stderr).toContain(header);
                      
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (36c2bd937)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [0.22ms]
(pass) Error [0.08ms]
(pass) BuildMessage [0.93ms]
(pass) Error inside minified file (no color)  [2.25ms]
(pass) Error inside minified file (color)  [0.37ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [2.10ms]
(pass) observable properties > sourceURL is observable [0.15ms]
(pass) observable properties > line is observable [0.06ms]
(pass) observable properties > column is observable [0.05ms]
(pass) error.stack throwing an error doesn't lead to a crash [0.07ms]
(pass) source map remapping of the printed stack > external map whose original source is unavailable [15.36ms]
(pass) AggregateError whose errors cannot be walked > console.error: errors was deleted [12.28ms]
(pass) AggregateError whose errors cannot be walked > uncaught: errors was deleted [11.45ms]
(pass) AggregateError whose errors cannot be walked > console.error: errors is an empty array [11.04ms]
(pass) AggregateError whose errors cannot be walked > uncaught: errors is an empty array [10.43ms]
(pass) AggregateError whose errors cannot be walked > console.error: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/inspect-error.test.js
bun test v1.4.0 (4c689909e)

test/js/bun/util/inspect-error.test.js:
(pass) error.cause [6.87ms]
(pass) Error [3.22ms]
(pass) BuildMessage [11.69ms]
(pass) Error inside minified file (no color)  [82.14ms]
(pass) Error inside minified file (color)  [48.09ms]
(pass) Inserted originalLine and originalColumn do not appear in node:util.inspect [123.36ms]
(pass) observable properties > sourceURL is observable [5.96ms]
(pass) observable properties > line is observable [2.81ms]
(pass) observable properties > column is observable [1.88ms]
(pass) error.stack throwing an error doesn't lead to a crash [3.89ms]
(pass) source map remapping of the printed stack > external map whose original source is unavailable [324.62ms]
(pass) AggregateError whose errors cannot be walked > console.error: errors was deleted [285.43ms]
(pass) AggregateError whose errors cannot be walked > console.error: errors is an empty array [269.00ms]
(pass) AggregateError whose errors cannot be walked > uncaught: errors was deleted [286.79
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 628ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/9] cc obj/packages/bun-usockets/src/loop.c.o
[2/9] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/9] gen cpp.rs (cppbind)
[3/9] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSValue.rs                                 |   6 +-
 src/jsc/VirtualMachine.rs                          |  38 +++---
 src/jsc/bindings/bindings.cpp                      |  11 +-
 .../source-lints/jsresult-swallow.inventory.json   |   2 +-
 test/js/bun/util/inspect-error.test.js             | 127 +++++++++++++++++++++
 5 files changed, 165 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/jsc/JSValue.rs                                            6      3      0
src/jsc/VirtualMachine.rs                                    12     12      0
src/jsc/bindings/bindings.cpp                                 4      3      0
…t/internal/source-lints/jsresult-swallow.inventory.json      1      1      0
test/js/bun/util/inspect-error.test.js                        2      3      0
```

</details>

<!-- robobun:evidence:end -->


