### PR TITLE
crash handler: report failed Rust allocations as out of memory

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1738,10 +1738,7 @@ mod draft {
         std::alloc::set_alloc_error_hook(rust_alloc_error_hook);
     }
 
-    /// Reports a failed infallible allocation (`Vec` growth, `Box::new`) as
-    /// out of memory before std aborts, with the allocating frames still on
-    /// the stack. A hook, not a null check in `GlobalAlloc`: a null return is
-    /// also how `try_reserve` reports failure. Must not allocate.
+    /// Not a null check in `GlobalAlloc`: `try_reserve` reports failure with null too. Must not allocate.
     #[cold]
     #[inline(never)]
     fn rust_alloc_error_hook(layout: core::alloc::Layout) {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -644,10 +644,7 @@ mod draft {
         ZigError(&'static [u8]),
 
         OutOfMemory {
-            /// Size of the allocation that failed. Known in `rust_alloc_error_hook`,
-            /// unknown to `bun_alloc::out_of_memory()` callers, which only have an
-            /// `AllocError`. Printed to stderr only: the trace string encodes every
-            /// OOM the same way.
+            /// `None` when the caller only has an `AllocError`.
             requested_bytes: Option<usize>,
         },
     }
@@ -711,8 +708,6 @@ mod draft {
     }
 
     /// ` (failed to allocate N bytes)`, or nothing when the size is unknown.
-    /// Shared by the `CrashReason` `Display` impl and the release-mode
-    /// "oh no" message in `crash_handler`.
     struct RequestedBytes(Option<usize>);
 
     impl fmt::Display for RequestedBytes {
@@ -1743,22 +1738,10 @@ mod draft {
         std::alloc::set_alloc_error_hook(rust_alloc_error_hook);
     }
 
-    /// `std::alloc` error hook: an infallible allocation (`Vec` growth,
-    /// `Box::new`, ...) got null from the global allocator.
-    ///
-    /// Without it std prints `memory allocation of N bytes failed` and calls
-    /// `abort()`. On POSIX the SIGABRT handler then reports `abort() called`
-    /// with the trace seeded inside libc's `abort`/`raise`, which have no
-    /// frame pointers, so the report has one unresolvable frame and neither
-    /// the reason nor the size. On Windows std aborts with `__fastfail`, which
-    /// no exception handler sees. Here the allocating frames are still on the
-    /// stack.
-    ///
-    /// A hook rather than a null check in `GlobalAlloc` because a null return
-    /// is also how `try_reserve` and the other fallible paths report failure.
-    ///
-    /// Must not allocate: a failure inside the report re-enters here and is
-    /// cut short by the `PANIC_STAGE` guard in `crash_handler`.
+    /// Reports a failed infallible allocation (`Vec` growth, `Box::new`) as
+    /// out of memory before std aborts, with the allocating frames still on
+    /// the stack. A hook, not a null check in `GlobalAlloc`: a null return is
+    /// also how `try_reserve` reports failure. Must not allocate.
     #[cold]
     #[inline(never)]
     fn rust_alloc_error_hook(layout: core::alloc::Layout) {

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -20,6 +20,7 @@
 // builds only. Declaring the feature where neither is compiled (Windows
 // release) trips `unused_features`.
 #![cfg_attr(any(not(windows), debug_assertions), feature(core_intrinsics))]
+#![feature(alloc_error_hook)]
 #![allow(internal_features)]
 #![allow(nonstandard_style, static_mut_refs, unexpected_cfgs)]
 #![warn(unused_must_use)]
@@ -41,7 +42,9 @@ pub use error::{Error, Result};
 #[inline(never)]
 fn out_of_memory() -> ! {
     draft::crash_handler(
-        draft::CrashReason::OutOfMemory,
+        draft::CrashReason::OutOfMemory {
+            requested_bytes: None,
+        },
         draft::TraceSeed::BeginAddr(bun_core::return_address()),
     )
 }
@@ -640,7 +643,13 @@ mod draft {
         /// Either `main` returned an error, or somewhere else in the code a trace string is printed.
         ZigError(&'static [u8]),
 
-        OutOfMemory,
+        OutOfMemory {
+            /// Size of the allocation that failed. Known in `rust_alloc_error_hook`,
+            /// unknown to `bun_alloc::out_of_memory()` callers, which only have an
+            /// `AllocError`. Printed to stderr only: the trace string encodes every
+            /// OOM the same way.
+            requested_bytes: Option<usize>,
+        },
     }
 
     impl CrashReason {
@@ -663,7 +672,7 @@ mod draft {
                 | CrashReason::DatatypeMisalignment
                 | CrashReason::StackOverflow
                 | CrashReason::ZigError(_)
-                | CrashReason::OutOfMemory => libc::SIGABRT,
+                | CrashReason::OutOfMemory { .. } => libc::SIGABRT,
             }
         }
     }
@@ -692,7 +701,25 @@ mod draft {
                 CrashReason::ZigError(err_name) => {
                     write!(writer, "error.{}", bstr::BStr::new(err_name))
                 }
-                CrashReason::OutOfMemory => writer.write_str("Bun ran out of memory"),
+                CrashReason::OutOfMemory { requested_bytes } => write!(
+                    writer,
+                    "Bun ran out of memory{}",
+                    RequestedBytes(*requested_bytes)
+                ),
+            }
+        }
+    }
+
+    /// ` (failed to allocate N bytes)`, or nothing when the size is unknown.
+    /// Shared by the `CrashReason` `Display` impl and the release-mode
+    /// "oh no" message in `crash_handler`.
+    struct RequestedBytes(Option<usize>);
+
+    impl fmt::Display for RequestedBytes {
+        fn fmt(&self, writer: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self.0 {
+                Some(bytes) => write!(writer, " (failed to allocate {bytes} bytes)"),
+                None => Ok(()),
             }
         }
     }
@@ -922,7 +949,7 @@ mod draft {
                         }
                     }
 
-                    if !matches!(reason, CrashReason::OutOfMemory) || debug_trace {
+                    if !matches!(reason, CrashReason::OutOfMemory { .. }) || debug_trace {
                         if enable_ansi_colors_stderr() {
                             if writer
                                 .write_all(&Output::pretty_fmt::<true>("<red>"))
@@ -1116,10 +1143,16 @@ mod draft {
                                 {
                                     abort();
                                 }
-                            } else if matches!(reason, CrashReason::OutOfMemory) {
-                                if writer.write_all(
-                                b"Bun has run out of memory.\n\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
-                            ).is_err() { abort(); }
+                            } else if let CrashReason::OutOfMemory { requested_bytes } = reason {
+                                if write!(
+                                    writer,
+                                    "Bun has run out of memory{}.\n\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
+                                    RequestedBytes(requested_bytes)
+                                )
+                                .is_err()
+                                {
+                                    abort();
+                                }
                             } else {
                                 if writer.write_all(
                                 b"Bun has crashed. This indicates a bug in Bun, not your code.\n\nTo send a redacted crash report to Bun's team,\nplease file a GitHub issue using the link below:\n\n",
@@ -1707,6 +1740,34 @@ mod draft {
         // this hook, a bare `panic!` would print the std
         // default hook + unwind with no trace string and no upload.
         std::panic::set_hook(Box::new(rust_panic_hook));
+        std::alloc::set_alloc_error_hook(rust_alloc_error_hook);
+    }
+
+    /// `std::alloc` error hook: an infallible allocation (`Vec` growth,
+    /// `Box::new`, ...) got null from the global allocator.
+    ///
+    /// Without it std prints `memory allocation of N bytes failed` and calls
+    /// `abort()`. On POSIX the SIGABRT handler then reports `abort() called`
+    /// with the trace seeded inside libc's `abort`/`raise`, which have no
+    /// frame pointers, so the report has one unresolvable frame and neither
+    /// the reason nor the size. On Windows std aborts with `__fastfail`, which
+    /// no exception handler sees. Here the allocating frames are still on the
+    /// stack.
+    ///
+    /// A hook rather than a null check in `GlobalAlloc` because a null return
+    /// is also how `try_reserve` and the other fallible paths report failure.
+    ///
+    /// Must not allocate: a failure inside the report re-enters here and is
+    /// cut short by the `PANIC_STAGE` guard in `crash_handler`.
+    #[cold]
+    #[inline(never)]
+    fn rust_alloc_error_hook(layout: core::alloc::Layout) {
+        crash_handler(
+            CrashReason::OutOfMemory {
+                requested_bytes: Some(layout.size()),
+            },
+            TraceSeed::BeginAddr(debug::return_address()),
+        )
     }
 
     /// `std::panic` hook: emit the same trace-string + auto-report as the fatal
@@ -2677,7 +2738,7 @@ mod draft {
                 writer.write_all(err_name)?;
             }
 
-            CrashReason::OutOfMemory => writer.write_byte(b'9')?,
+            CrashReason::OutOfMemory { .. } => writer.write_byte(b'9')?,
 
             CrashReason::Abort => writer.write_byte(b'a')?,
             CrashReason::Trap(addr) => {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -124,6 +124,7 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
   panic: () => void;
   rootError: () => void;
   outOfMemory: () => void;
+  allocError: () => void;
   abort: () => void;
   fastfail: () => void;
   trap: () => void;

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -26,6 +26,7 @@ pub(crate) mod js_bindings {
             ("panic", __jsc_host_js_panic),
             ("rootError", __jsc_host_js_root_error),
             ("outOfMemory", __jsc_host_js_out_of_memory),
+            ("allocError", __jsc_host_js_alloc_error),
             ("abort", __jsc_host_js_abort),
             ("fastfail", __jsc_host_js_fastfail),
             ("trap", __jsc_host_js_trap),
@@ -206,6 +207,29 @@ pub(crate) mod js_bindings {
     fn js_out_of_memory(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
         bun_core::out_of_memory();
+    }
+
+    /// Fails an infallible std allocation (`Vec::with_capacity`), the path a
+    /// `Vec`/`Box`/`String` takes when the global allocator returns null.
+    /// `outOfMemory` above covers the explicit `AllocError` path instead.
+    #[bun_jsc::host_fn]
+    fn js_alloc_error(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        // Larger than any 64-bit address space, so mimalloc returns null no
+        // matter how much memory or overcommit the machine has, and within
+        // `isize::MAX`, so `Vec` reaches the allocator instead of panicking
+        // with a capacity overflow.
+        const SIZE: usize = 1 << 62;
+        // Under ASAN the global allocator is libc's, and ASAN treats a request
+        // this large as an error of its own (allocation-size-too-big) instead
+        // of returning null, so enter std's failure path directly. This is the
+        // same call `Vec` makes below once the allocator has returned null.
+        if Environment::ENABLE_ASAN {
+            std::alloc::handle_alloc_error(core::alloc::Layout::from_size_align(SIZE, 1).unwrap());
+        }
+        let buf: Vec<u8> = Vec::with_capacity(SIZE);
+        core::hint::black_box(buf);
+        Ok(JSValue::UNDEFINED)
     }
 
     #[bun_jsc::host_fn]

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -209,16 +209,13 @@ pub(crate) mod js_bindings {
         bun_core::out_of_memory();
     }
 
-    /// Fails a real infallible allocation. `outOfMemory` covers the explicit
-    /// `AllocError` path.
+    /// Fails a real infallible allocation; `outOfMemory` covers the explicit `AllocError` path.
     #[bun_jsc::host_fn]
     fn js_alloc_error(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
-        // Above any 64-bit address space (mimalloc returns null even with
-        // overcommit), below `isize::MAX` (no capacity overflow panic).
+        // Above any 64-bit address space (null even with overcommit), below `isize::MAX` (no capacity panic).
         const SIZE: usize = 1 << 62;
-        // ASAN's allocator aborts on an oversized request instead of
-        // returning null.
+        // ASAN's allocator aborts on an oversized request instead of returning null.
         if Environment::ENABLE_ASAN {
             std::alloc::handle_alloc_error(core::alloc::Layout::from_size_align(SIZE, 1).unwrap());
         }

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -209,21 +209,16 @@ pub(crate) mod js_bindings {
         bun_core::out_of_memory();
     }
 
-    /// Fails an infallible std allocation (`Vec::with_capacity`), the path a
-    /// `Vec`/`Box`/`String` takes when the global allocator returns null.
-    /// `outOfMemory` above covers the explicit `AllocError` path instead.
+    /// Fails a real infallible allocation. `outOfMemory` covers the explicit
+    /// `AllocError` path.
     #[bun_jsc::host_fn]
     fn js_alloc_error(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
-        // Larger than any 64-bit address space, so mimalloc returns null no
-        // matter how much memory or overcommit the machine has, and within
-        // `isize::MAX`, so `Vec` reaches the allocator instead of panicking
-        // with a capacity overflow.
+        // Above any 64-bit address space (mimalloc returns null even with
+        // overcommit), below `isize::MAX` (no capacity overflow panic).
         const SIZE: usize = 1 << 62;
-        // Under ASAN the global allocator is libc's, and ASAN treats a request
-        // this large as an error of its own (allocation-size-too-big) instead
-        // of returning null, so enter std's failure path directly. This is the
-        // same call `Vec` makes below once the allocator has returned null.
+        // ASAN's allocator aborts on an oversized request instead of
+        // returning null.
         if Environment::ENABLE_ASAN {
             std::alloc::handle_alloc_error(core::alloc::Layout::from_size_align(SIZE, 1).unwrap());
         }

--- a/test/cli/run/fixture-crash.js
+++ b/test/cli/run/fixture-crash.js
@@ -12,6 +12,6 @@ if (approach in crash_handler) {
   crash_handler[approach]();
 } else {
   console.error(
-    "usage: bun fixture-crash.js <segfault|segfaultInDll|panic|rootError|outOfMemory|abort|trap|raiseIgnoringPanicHandler>",
+    "usage: bun fixture-crash.js <segfault|segfaultInDll|panic|rootError|outOfMemory|allocError|abort|trap|raiseIgnoringPanicHandler>",
   );
 }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -15,6 +15,10 @@ const noReportEnv = { ...bunEnv, BUN_CRASH_REPORT_URL: "", BUN_ENABLE_CRASH_REPO
 // without it the fallback printer has no Rust symbol names to assert on.
 const hasSymbolizer = !!(Bun.which("llvm-symbolizer") || Bun.which("llvm-symbolizer-21"));
 
+// The allocation the `allocError` test hook requests (`js_alloc_error` in
+// src/runtime/api/crash_handler_jsc.rs). The crash report prints it.
+const allocErrorSize = 2n ** 62n;
+
 test.if(isDebug && isLinux && hasSymbolizer)(
   "crash trace starts at the crash site, not inside the crash handler",
   async () => {
@@ -39,6 +43,38 @@ test.if(isDebug && isLinux && hasSymbolizer)(
     // ...not the capture machinery. A mismatched trim anchor used to leave
     // `capture_stack_trace` → `crash_handler` → `panic_impl` as the innermost
     // frames of every report, burying the real crash site.
+    expect(stdout).not.toContain("capture_stack_trace");
+  },
+  60_000, // symbolizing the debug binary takes several seconds
+);
+
+// A failed infallible allocation (`Vec` growth, `Box::new`, ...) reaches std's
+// alloc error handler. Without the alloc error hook std prints "memory
+// allocation of N bytes failed" and calls abort(), so the report said
+// "abort() called" and its trace was seeded inside libc, where the frame
+// pointer walk stops after one frame. The hook reports it as out of memory,
+// with the requested size, and captures the trace while the allocating
+// frame is still on the stack.
+test.if(isDebug && isLinux && hasSymbolizer)(
+  "failed Rust allocation is reported as out of memory with the allocating frame in the trace",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "allocError"],
+      env: noReportEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    // Header on stderr, symbolized frames on stdout (see the test above).
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain(`panic(main thread): Bun ran out of memory (failed to allocate ${allocErrorSize} bytes)`);
+    expect(stderr).not.toContain("abort() called");
+    expect(stderr).not.toContain("memory allocation of");
+    expect(exitCode).not.toBe(0);
+
+    // The trace walks from the alloc error hook through std's handler into
+    // the test hook that made the allocation...
+    expect(stdout).toContain("js_alloc_error");
+    // ...and does not include the capture machinery.
     expect(stdout).not.toContain("capture_stack_trace");
   },
   60_000, // symbolizing the debug binary takes several seconds
@@ -99,6 +135,7 @@ describe.if(isPosix)("terminal signal reflects the crash cause", () => {
   test.each([
     ["panic", "SIGABRT"],
     ["outOfMemory", "SIGABRT"],
+    ["allocError", "SIGABRT"],
     ["segfault", "SIGSEGV"],
     ["abort", "SIGABRT"],
     ["trap", "SIGTRAP"],
@@ -119,6 +156,11 @@ describe.if(isPosix)("terminal signal reflects the crash cause", () => {
       expect(stderr).toContain("Segmentation fault at address");
     } else if (approach === "panic") {
       expect(stderr).toContain("invoked crashByPanic() handler");
+    } else if (approach === "outOfMemory") {
+      expect(stderr).toContain("Bun has run out of memory.");
+    } else if (approach === "allocError") {
+      expect(stderr).toContain(`Bun has run out of memory (failed to allocate ${allocErrorSize} bytes).`);
+      expect(stderr).not.toContain("abort() called");
     } else if (approach === "abort") {
       expect(stderr).toContain("abort() called");
     } else if (approach === "trap") {
@@ -562,52 +604,55 @@ describe.if(isPosix)("process.kill() aimed at the process itself is not reported
 });
 
 describe("automatic crash reporter", () => {
-  for (const approach of ["panic", "segfault", "outOfMemory"]) {
-    test(`${approach} should report`, async () => {
-      let sent = false;
-      const resolve_handler = Promise.withResolvers();
+  const crashed = "oh no: Bun has crashed. This indicates a bug in Bun, not your code";
+  // The uploaded URL is the trace string followed by "/ack". The trace string
+  // ends with the reason; both out-of-memory paths encode it as "9" (see
+  // encode_trace_string in src/crash_handler/lib.rs), which is what tells
+  // bun.report to classify the report as out of memory.
+  test.each([
+    ["panic", crashed, "/ack"],
+    ["segfault", crashed, "/ack"],
+    ["outOfMemory", "oh no: Bun has run out of memory.", "9/ack"],
+    ["allocError", `oh no: Bun has run out of memory (failed to allocate ${allocErrorSize} bytes).`, "9/ack"],
+  ])("%s should report", async (approach, expectedMessage, expectedUrlSuffix) => {
+    const reported = Promise.withResolvers<string>();
 
-      // Self host the crash report backend.
-      using server = Bun.serve({
-        port: 0,
-        fetch(request, server) {
-          expect(request.url).toEndWith("/ack");
-          sent = true;
-          resolve_handler.resolve();
-          return new Response("OK");
-        },
-      });
-
-      const proc = Bun.spawn({
-        cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), approach],
-        env: mergeWindowEnvs([
-          bunEnv,
-          {
-            BUN_CRASH_REPORT_URL: server.url.toString(),
-            BUN_ENABLE_CRASH_REPORTING: "1",
-            GITHUB_ACTIONS: undefined,
-            CI: undefined,
-          },
-        ]),
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-      const exitCode = await proc.exited;
-      const stderr = await proc.stderr.text();
-      console.log(stderr);
-
-      await resolve_handler.promise;
-
-      expect(exitCode).not.toBe(0);
-      expect(stderr).toContain(server.url.toString());
-      if (approach !== "outOfMemory") {
-        expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code");
-      } else {
-        expect(stderr.toLowerCase()).toContain("out of memory");
-        expect(stderr.toLowerCase()).not.toContain("panic");
-      }
-      expect(sent).toBe(true);
+    // Self host the crash report backend.
+    using server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        reported.resolve(request.url);
+        return new Response("OK");
+      },
     });
-  }
+
+    const proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), approach],
+      env: mergeWindowEnvs([
+        bunEnv,
+        {
+          BUN_CRASH_REPORT_URL: server.url.toString(),
+          BUN_ENABLE_CRASH_REPORTING: "1",
+          GITHUB_ACTIONS: undefined,
+          CI: undefined,
+        },
+      ]),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const exitCode = await proc.exited;
+    const stderr = await proc.stderr.text();
+    console.log(stderr);
+
+    const reportedUrl = await reported.promise;
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain(server.url.toString());
+    expect(stderr).toContain(expectedMessage);
+    if (approach === "outOfMemory" || approach === "allocError") {
+      expect(stderr.toLowerCase()).not.toContain("panic");
+    }
+    expect(reportedUrl).toEndWith(expectedUrlSuffix);
+  });
 });
 
 test.if(isWindows)(


### PR DESCRIPTION
### Problem
- An infallible Rust allocation that fails (`Vec` growth, `Box::new`) ends in std, which prints `memory allocation of N bytes failed` and aborts. On Linux the report is `abort() called` with one `??` frame (Sentry BUN-2QD1 and siblings). On Windows std uses `__fastfail`, so nothing is reported.
- Cause: nothing hooks std's alloc error path. The SIGABRT handler (`src/crash_handler/lib.rs:1583`) seeds the trace inside libc's `abort`/`raise`, which have no frame pointers, so the walk stops after one frame.

### Fix
- `install_hooks` registers a `std::alloc` error hook next to the panic hook. It calls `crash_handler` with `CrashReason::OutOfMemory` while the allocating frames are still on the stack.
- A hook, not a null check in `GlobalAlloc`: a null return is also how `try_reserve` and the other fallible paths (about 97 sites) report failure.
- `OutOfMemory` carries the requested size, which the stderr message prints. The trace string still encodes every OOM as `9`, so bun.report is unchanged. The hook does not allocate.
- Verified: `test/cli/run/run-crash-handler.test.ts`, with a new `crash_handler.allocError` hook that fails a real `Vec::with_capacity(1 << 62)`. Also `crash-report-command-char.test.ts` and the source lints.

### Background
- The trace string is a URL with the reason and the stack addresses. bun.report decodes it for Sentry: the reason gives the title, the frames give the grouping.
- Bun has two OOM paths. `bun_alloc::out_of_memory()` serves code that holds an `AllocError`. A plain `Vec` or `Box` calls `handle_alloc_error`, which runs std's alloc error hook and then aborts. Bun's Rust code and the rebuilt std keep frame pointers, so a walk from the hook reaches the allocating frame.
- #38888 has the same hook registration inside a large collections refactor. This is the standalone fix. Whichever lands second rebases one hunk.

<details><summary>Notes</summary>

Before, on a debug Linux build (the SIGABRT handler is not installed under ASAN, so this is std's output alone):

```
memory allocation of 4611686018427387904 bytes failed
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After, with `--debug-crash-handler-use-trace-string`:

```
oh no: Bun has run out of memory (failed to allocate 4611686018427387904 bytes).

To send a redacted crash report to Bun's team,
please file a GitHub issue using the link below:

 https://bun.report/1.4.0/la24c68990gGikggC+/2i6S6t338Smlrk6Swm3i6S6g13gTspr3gTmp319M2v8t1Mw3vg3Mio85lNw1zv2M+l/19M_ywnvxT43/lxTq7hzsWA9
```

The symbolized debug trace starts at `std::alloc::rust_oom::{closure#0}` and reaches `js_alloc_error` six frames down (`__rust_end_short_backtrace`, `rust_oom`, `__rust_alloc_error_handler`, `handle_alloc_error::rt_error`, `handle_alloc_error`). The number of std frames differs between debug and release, so the trace is not trimmed past them. Sentry groups on the whole stack, so different allocation sites still become different issues.

Tests. Three new cases: the debug symbolized trace contains `js_alloc_error` and not the capture machinery, the process dies with SIGABRT and prints the OOM message with the size, and the uploaded trace string ends in `9/ack` (the existing `outOfMemory` case now checks that too). Fail-before: with only the `set_alloc_error_hook` line removed, all three fail with std's `memory allocation of ... failed` output. `USE_SYSTEM_BUN=1` fails the two non-debug cases and skips the debug one.

Test hook. Under ASAN the global allocator is libc's and ASAN aborts on an oversized request instead of returning null, so the hook calls `handle_alloc_error` directly there. That is the call `Vec` makes once the allocator has returned null. `1 << 62` as the size: `mi_malloc` of that size returns null on the release mimalloc objects in `build/release` (checked with a small C program linked against `static.c.o`). A merely large size is not reliable, `mi_malloc(1 << 40)` succeeded in the CI container because of overcommit. `isize::MAX` also returns null but is the edge of what `Layout` accepts.

Sentry samples from the `??` group (events 5b525e08, e419f388, 9873e4b3): `1.4.0-canary`, Linux, `Abort` / `abort() called`, one frame at a libc offset (`0x9781b`, `0x969bb`, `0x8aeeb`). The group also holds older Zig era events and single frame Windows segfaults, which this PR does not address.

Not changed here: the SIGABRT walk itself. A real `abort()` from C++ or an addon still yields one libc frame on Linux. Recovering the caller needs a stack scan from the signal context's sp, which is a separate change. Also not changed: on Linux, `StackLine::from_address` encodes an address inside a shared library as an offset with no object name, which is why such a frame shows as `??`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->