### PR TITLE
lexer: report JSX pragma warnings at the pragma argument

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -891,10 +891,6 @@ impl<'a> Lexer<'a> {
         Ok(())
     }
 
-    fn remaining(&self) -> &[u8] {
-        &self.contents[self.current..]
-    }
-
     /// Note: split into an `#[inline(always)]` ASCII/EOF fast path plus
     /// an outlined multibyte tail. `step()` is called from ~50 sites inside
     /// the giant `next()` switch and inlines into it; with the multibyte
@@ -1952,25 +1948,14 @@ impl<'a> Lexer<'a> {
             return;
         }
 
-        let mut rest = &text[0..end_comment_text];
-
-        while let Some(i) = strings::index_of_any(rest, b"@#") {
-            let c = rest[i];
-            rest = &rest[(i + 1).min(rest.len())..];
-            match c {
-                b'@' | b'#' => {
-                    let chunk = rest;
-                    let offset =
-                        self.scan_pragma(self.start + i + (text.len() - rest.len()), chunk, false);
-
-                    rest = &rest[
-                        // The min is necessary because the file could end
-                        // with a pragma and hasPrefixWithWordBoundary
-                        // returns true when that "word boundary" is EOF
-                        offset.min(rest.len())..];
-                }
-                _ => {}
-            }
+        let body = &text[..end_comment_text];
+        let mut pos = 0;
+        while let Some(i) = strings::index_of_any(&body[pos..], b"@#") {
+            pos += i + 1;
+            let chunk = &body[pos..];
+            pos += self
+                .scan_pragma(self.start + pos, chunk, false)
+                .min(chunk.len());
         }
     }
 
@@ -2085,9 +2070,10 @@ impl<'a> Lexer<'a> {
                     } // EOF? Stop.
 
                     0x23 | 0x40 => {
-                        let pragma_trigger_pos = self.end;
-                        let chunk = js_ast::StoreStr::new(self.remaining());
-                        self.current += self.scan_pragma(pragma_trigger_pos, chunk.slice(), true);
+                        // `self.current` is just past the consumed #/@.
+                        let chunk_start = self.current;
+                        self.current +=
+                            self.scan_pragma(chunk_start, &contents[chunk_start..], true);
                         continue;
                     }
                     _ => {
@@ -2109,14 +2095,9 @@ impl<'a> Lexer<'a> {
     }
 
     /// Scans the string for a pragma.
-    /// offset is used when there's an issue with the JSX pragma later on.
+    /// `chunk_start` is the source offset of `chunk[0]`, the byte after the `@` or `#`.
     /// Returns the byte length to advance by if found, otherwise 0.
-    fn scan_pragma(
-        &mut self,
-        offset_for_errors: usize,
-        chunk: &[u8],
-        allow_newline: bool,
-    ) -> usize {
+    fn scan_pragma(&mut self, chunk_start: usize, chunk: &[u8], allow_newline: bool) -> usize {
         if !self.has_pure_comment_before {
             if strings::has_prefix_with_word_boundary(chunk, b"__PURE__") {
                 self.has_pure_comment_before = true;
@@ -2125,9 +2106,7 @@ impl<'a> Lexer<'a> {
         }
 
         if strings::has_prefix_with_word_boundary(chunk, b"jsx") {
-            if let Some(span) =
-                PragmaArg::scan(self.start + offset_for_errors, b"jsx", chunk, allow_newline)
-            {
+            if let Some(span) = PragmaArg::scan(chunk_start, b"jsx", chunk, allow_newline) {
                 self.jsx_pragma._jsx = span;
                 return "jsx".len()
                     + if span.range.len > 0 {
@@ -2137,12 +2116,7 @@ impl<'a> Lexer<'a> {
                     };
             }
         } else if strings::has_prefix_with_word_boundary(chunk, b"jsxFrag") {
-            if let Some(span) = PragmaArg::scan(
-                self.start + offset_for_errors,
-                b"jsxFrag",
-                chunk,
-                allow_newline,
-            ) {
+            if let Some(span) = PragmaArg::scan(chunk_start, b"jsxFrag", chunk, allow_newline) {
                 self.jsx_pragma._jsx_frag = span;
                 return "jsxFrag".len()
                     + if span.range.len > 0 {
@@ -2152,12 +2126,7 @@ impl<'a> Lexer<'a> {
                     };
             }
         } else if strings::has_prefix_with_word_boundary(chunk, b"jsxRuntime") {
-            if let Some(span) = PragmaArg::scan(
-                self.start + offset_for_errors,
-                b"jsxRuntime",
-                chunk,
-                allow_newline,
-            ) {
+            if let Some(span) = PragmaArg::scan(chunk_start, b"jsxRuntime", chunk, allow_newline) {
                 self.jsx_pragma._jsx_runtime = span;
                 return "jsxRuntime".len()
                     + if span.range.len > 0 {
@@ -2167,12 +2136,9 @@ impl<'a> Lexer<'a> {
                     };
             }
         } else if strings::has_prefix_with_word_boundary(chunk, b"jsxImportSource") {
-            if let Some(span) = PragmaArg::scan(
-                self.start + offset_for_errors,
-                b"jsxImportSource",
-                chunk,
-                allow_newline,
-            ) {
+            if let Some(span) =
+                PragmaArg::scan(chunk_start, b"jsxImportSource", chunk, allow_newline)
+            {
                 self.jsx_pragma._jsx_import_source = span;
                 return "jsxImportSource".len()
                     + if span.range.len > 0 {
@@ -2186,8 +2152,7 @@ impl<'a> Lexer<'a> {
         {
             // Check includes space for prefix
             return PragmaArg::scan_source_mapping_url_value(
-                self.start,
-                offset_for_errors,
+                chunk_start,
                 chunk,
                 &mut self.source_mapping_url,
             );
@@ -3428,9 +3393,9 @@ impl PragmaArg {
     // These can be extremely long, so we use SIMD.
     /// "//# sourceMappingURL=data:/adspaoksdpkz"
     ///                       ^^^^^^^^^^^^^^^^^^
+    /// `chunk_start` is the source offset of `chunk[0]`.
     pub(crate) fn scan_source_mapping_url_value(
-        start: usize,
-        offset_for_errors: usize,
+        chunk_start: usize,
         chunk: &[u8],
         result: &mut Option<js_ast::Span>,
     ) -> usize {
@@ -3455,7 +3420,7 @@ impl PragmaArg {
         let url = &url_and_rest_of_code[0..url_len];
 
         // Calculate absolute start location of the argument
-        let absolute_arg_start = start + offset_for_errors + PREFIX as usize;
+        let absolute_arg_start = chunk_start + PREFIX as usize;
 
         *result = Some(js_ast::Span {
             range: Range {
@@ -3471,8 +3436,9 @@ impl PragmaArg {
         PREFIX as usize + url_len // Correct total length
     }
 
+    /// `text_` starts with `pragma` and sits at source offset `chunk_start`.
     pub(crate) fn scan(
-        offset_: usize,
+        chunk_start: usize,
         pragma: &[u8],
         text_: &[u8],
         allow_newline: bool,
@@ -3495,8 +3461,8 @@ impl PragmaArg {
                 break;
             }
         }
-        let start: u32 = cursor.i;
-        text = &text[cursor.i as usize..];
+        let start = cursor.i as usize;
+        text = &text[start..];
         cursor = strings::Cursor::default();
         iter = CodepointIterator::init(text);
         let _ = iter.next(&mut cursor);
@@ -3517,12 +3483,7 @@ impl PragmaArg {
             range: Range {
                 len: i32::try_from(i).expect("int cast"),
                 loc: Loc {
-                    start: i32::try_from(
-                        start
-                            + u32::try_from(offset_).expect("int cast")
-                            + u32::try_from(pragma.len()).expect("int cast"),
-                    )
-                    .unwrap(),
+                    start: i32::try_from(chunk_start + pragma.len() + start).expect("int cast"),
                 },
             },
             text: js_ast::StoreStr::new(&text[0..i]),

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -876,6 +876,56 @@ describe("Bun.build", () => {
     expect(x.logs[0].position).toBeTruthy();
   });
 
+  test.concurrent("JSX pragma warnings point at the pragma argument", async () => {
+    // Each pragma comment comes after other source text, so a location that
+    // counts the comment's own offset twice lands on a later line.
+    const files = {
+      "line-comment.jsx": "const x = 1;\nconst y = 2;\n// @jsxRuntime bogus\nexport default <div />;\n",
+      "block-comment.jsx": "const x = 1;\nconst y = 2;\n/** @jsxRuntime bogus */\nexport default <div />;\n",
+      "doc-comment.jsx": "const x = 1;\n/**\n * @param x The x.\n * @jsxRuntime bogus */\nexport default <div />;\n",
+    };
+    using dir = tempDir("build-api-jsx-pragma-position", files);
+    const x = await Bun.build({
+      entrypoints: Object.keys(files).map(name => join(String(dir), name)),
+      outdir: join(String(dir), "out"),
+      external: ["*"],
+    });
+    expect(x.success).toBe(true);
+
+    const warnings = Object.fromEntries(
+      x.logs.map(log => {
+        const { file, line, column, length, offset, lineText } = log.position!;
+        return [path.basename(file), { message: log.message, line, column, length, offset, lineText }];
+      }),
+    );
+    expect(warnings).toEqual({
+      "line-comment.jsx": {
+        message: 'Unsupported JSX runtime: "bogus"',
+        line: 3,
+        column: 16,
+        length: 5,
+        offset: files["line-comment.jsx"].indexOf("bogus"),
+        lineText: "// @jsxRuntime bogus",
+      },
+      "block-comment.jsx": {
+        message: 'Unsupported JSX runtime: "bogus"',
+        line: 3,
+        column: 17,
+        length: 5,
+        offset: files["block-comment.jsx"].indexOf("bogus"),
+        lineText: "/** @jsxRuntime bogus */",
+      },
+      "doc-comment.jsx": {
+        message: 'Unsupported JSX runtime: "bogus"',
+        line: 4,
+        column: 16,
+        length: 5,
+        offset: files["doc-comment.jsx"].indexOf("bogus"),
+        lineText: " * @jsxRuntime bogus */",
+      },
+    });
+  });
+
   test.concurrent("module() throws error", async () => {
     expect(() =>
       Bun.build({


### PR DESCRIPTION
### Problem
- `Unsupported JSX runtime: "bogus"` for `// @jsxRuntime bogus` on line 3 is reported `at rt.jsx:4:20`. The argument is at `rt.jsx:3:16`. Block comments are off too.
- `Lexer::scan_pragma` (`src/js_parser/lexer.rs:2114` on main) adds `self.start`, the comment start, to an offset that is already absolute. The `//` caller also passes the offset of the `@` itself. The `/* */` caller adds the index of the `@` twice.

### Fix
- `scan_pragma`, `PragmaArg::scan` and `scan_source_mapping_url_value` now take the source offset of the first byte after the `@` or `#` and use it as is.
- The `//` caller passes `self.current` and slices the chunk from its local `contents`, as the rest of that function does. This removes the `StoreStr` copy and the now unused `Lexer::remaining`. The `/* */` caller tracks the chunk offset inside the comment body.
- Correct because `PragmaArg::scan` locates the argument relative to that byte. esbuild 0.25.1 reports the same positions. Only diagnostics change: the parser applies pragmas from the span text and uses the range only in warnings.
- Verified: new test in `test/bundler/bun-build-api.test.ts`. Bun 1.4.0 reports offsets 66, 74 and 84 instead of 41, 42 and 51. The other suites I ran are in the notes.

### Background
- A JSX pragma is a comment such as `// @jsxImportSource preact`. The lexer stores the argument as a `Span`: text plus source `Range`. `prepare_for_visit_pass` (`src/js_parser/p.rs`) applies the text and warns at the range.
- `scan_single_line_comment` calls `scan_pragma` at each `@` or `#` in a `//` comment. `scan_comment_text` does the same for a finished `/* */` comment.
- Lexer offsets are absolute. `self.start` is the start of the current token, here the comment. `self.current` is the offset after the last consumed character.
- #39631 adds warnings at the `@jsx` and `@jsxFrag` spans. They get the right location through this change.

<details><summary>Notes</summary>

Repro on bun 1.4.0:

```
printf 'const x = 1;\nconst y = 2;\n// @jsxRuntime bogus\nconsole.log(<div />);\n' > rt.jsx
bun build --external '*' ./rt.jsx
```

Before: `at rt.jsx:4:20`, with line 4 printed above the caret. After: `at rt.jsx:3:16`, caret under `bogus`. The block comment form `/** @jsxRuntime bogus */` moves from `4:22` (clamped to the end of the file) to `3:17`. A pragma on the second line of a block comment moves from `6:22` to `4:16`. esbuild 0.25.1 prints `3:15`, `3:16` and `4:15` for the same three files (esbuild columns are 0-based).

Arithmetic for the `//` case, comment at offset 26, `@` at 29: main passed 29, `scan_pragma` added `self.start` (26), and `PragmaArg::scan` added the pragma name (10) and the argument index in the text after it (1): 66. The argument is at 30 + 10 + 1 = 41. `Bun.build` exposes the range start as `position.offset`. The new test checks that next to line, column and `lineText`, for a `//` comment, a one line `/** */` comment, and a block comment where the pragma follows another `@` tag on a later line.

`source_mapping_url` gets the same treatment. The lexer writes it and nothing reads it, so there is nothing to test there.

Possible follow-up, kept out of this PR: after this change the `text` of each pragma `Span` is exactly `source` at `range`, so `JSXPragma` could hold plain `Range`s and `prepare_for_visit_pass` could read the text with `Source::text_for_range`, the way it already reads `all_comments`. That would also remove `js_ast::Span` and the unread `source_mapping_url`. It touches the same lines of `p.rs` as #39631, so it is better done once that PR and this one have landed. The offset fix here is needed under either shape.

The same formulas were in `js_lexer.zig` before the port, so this is not a port regression.

The pragma loop in `scan_comment_text` now keeps `pos`, the offset of the chunk inside the comment, so the source offset is `self.start + pos`. The old loop had a `match` on the byte that `index_of_any(rest, b"@#")` found, which can only be one of those two bytes, and a `.min()` on `i + 1`, which is always in bounds. Both are gone. The clamp on the advance after `scan_pragma` stays. Its old comment described a case (pragma at the end of the file) in which `scan_pragma` returns 0 or the exact length, so the comment is gone as well.

Not changed here: in a block comment the argument runs to the next space, so `/**\n * @jsxRuntime classic\n */` still yields `classic\n` and warns. esbuild 0.25.1 does the same. That warning now at least points at the right line.

Rebased on main after #40610, which removed the `IS_JSON` branch around the `//` pragma call. The conflict was in that arm and in the `/* */` loop. Both now carry main's shape plus the offset fix. The test file had no conflict.

Suites run with the debug build: `test/bundler/bundler_jsx.test.ts`, `bundler_comments.test.ts`, `transpiler/transpiler.test.js`, `esbuild/dce.test.ts`, `esbuild/tsconfig.test.ts` and all of `bun-build-api.test.ts`. `cargo fmt` and `cargo clippy -p bun_js_parser` are clean.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bun-build-api.test.ts

<!-- robobun:evidence:end -->
