### PR TITLE
error printer: print an uncaught non-Error value at the console depth

### DIFF
--- a/docs/runtime/console.mdx
+++ b/docs/runtime/console.mdx
@@ -27,6 +27,8 @@ console.log(nested);
 
 The CLI flag takes precedence over the configuration file setting.
 
+Bun uses the same depth when it prints an uncaught exception or an unhandled rejection whose value is not an `Error`.
+
 ---
 
 ## Reading from stdin

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -85,8 +85,7 @@ bun_opaque::opaque_ffi! {
 /// Only `--console-depth` CLI flag and `console.depth` bunfig option should modify this.
 const DEFAULT_CONSOLE_LOG_DEPTH: u16 = 2;
 
-/// The `console.log` inspection depth: `--console-depth`, then the bunfig
-/// `console.depth` option, then [`DEFAULT_CONSOLE_LOG_DEPTH`].
+/// `--console-depth`, bunfig `console.depth`, or the default.
 pub(crate) fn console_depth() -> u16 {
     bun_options_types::context::try_get()
         .and_then(|ctx| ctx.runtime_options.console_depth)
@@ -1687,9 +1686,8 @@ pub mod formatter {
             }
         }
 
-        /// Constructor for `VirtualMachine::run_error_handler` (uncaught
-        /// exceptions, unhandled rejections, `reportError`). An uncaught value
-        /// that is not an `Error` is printed whole, at the `console.log` depth.
+        /// For `run_error_handler`: an uncaught value that is not an `Error` is
+        /// printed whole, so it gets the `console.log` depth.
         pub fn for_error_handler(global_this: &'a JSGlobalObject) -> Self {
             let mut formatter = Self::new(global_this);
             formatter.max_depth = console_depth();

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1686,8 +1686,7 @@ pub mod formatter {
             }
         }
 
-        /// For `run_error_handler`: an uncaught value that is not an `Error` is
-        /// printed whole, so it gets the `console.log` depth.
+        /// An uncaught value that is not an `Error` is printed whole, at the console depth.
         pub fn for_error_handler(global_this: &'a JSGlobalObject) -> Self {
             let mut formatter = Self::new(global_this);
             formatter.max_depth = console_depth();

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1686,7 +1686,7 @@ pub mod formatter {
             }
         }
 
-        /// An uncaught value that is not an `Error` is printed whole, at the console depth.
+        /// The error handler prints at the console depth, as `console.error` does.
         pub fn for_error_handler(global_this: &'a JSGlobalObject) -> Self {
             let mut formatter = Self::new(global_this);
             formatter.max_depth = console_depth();

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -85,6 +85,14 @@ bun_opaque::opaque_ffi! {
 /// Only `--console-depth` CLI flag and `console.depth` bunfig option should modify this.
 const DEFAULT_CONSOLE_LOG_DEPTH: u16 = 2;
 
+/// The `console.log` inspection depth: `--console-depth`, then the bunfig
+/// `console.depth` option, then [`DEFAULT_CONSOLE_LOG_DEPTH`].
+pub(crate) fn console_depth() -> u16 {
+    bun_options_types::context::try_get()
+        .and_then(|ctx| ctx.runtime_options.console_depth)
+        .unwrap_or(DEFAULT_CONSOLE_LOG_DEPTH)
+}
+
 type Counter = HashMap<u64, u32>;
 
 pub struct ConsoleObject {
@@ -468,17 +476,13 @@ fn message_with_type_and_level_(
     }
 
     let mut print_length = len;
-    // Get console depth from CLI options or bunfig, fallback to default.
-    let console_depth = bun_options_types::context::try_get()
-        .and_then(|ctx| ctx.runtime_options.console_depth)
-        .unwrap_or(DEFAULT_CONSOLE_LOG_DEPTH);
 
     let mut print_options = FormatOptions {
         enable_colors,
         add_newline: true,
         flush: true,
         default_indent,
-        max_depth: console_depth,
+        max_depth: console_depth(),
         error_display_level: match level {
             MessageLevel::Error => ErrorDisplayLevel::Full,
             MessageLevel::Warning => ErrorDisplayLevel::Warn,
@@ -1681,6 +1685,15 @@ pub mod formatter {
                 error_display_level: ErrorDisplayLevel::Full,
                 format_buffer_as_text: false,
             }
+        }
+
+        /// Constructor for `VirtualMachine::run_error_handler` (uncaught
+        /// exceptions, unhandled rejections, `reportError`). An uncaught value
+        /// that is not an `Error` is printed whole, at the `console.log` depth.
+        pub fn for_error_handler(global_this: &'a JSGlobalObject) -> Self {
+            let mut formatter = Self::new(global_this);
+            formatter.max_depth = console_depth();
+            formatter
         }
 
         /// `Formatter` has a `Drop` impl and owns `map`/`map_node`,
@@ -5924,9 +5937,7 @@ pub(crate) extern "C" fn Bun__ConsoleObject__timeLog(
     // `Formatter` has a `Drop` impl, so struct-update from a
     // temporary is rejected (E0509). Construct via `new()` then mutate.
     let mut fmt = Formatter::new(global);
-    fmt.max_depth = bun_options_types::context::try_get()
-        .and_then(|ctx| ctx.runtime_options.console_depth)
-        .unwrap_or(DEFAULT_CONSOLE_LOG_DEPTH);
+    fmt.max_depth = console_depth();
     fmt.stack_check = StackCheck::init();
     fmt.can_throw_stack_overflow = true;
     let console = vm_console(global);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4803,7 +4803,7 @@ impl VirtualMachine {
         writer: &mut bun_core::io::Writer,
         allow_side_effects: bool,
     ) {
-        let mut formatter = crate::console_object::Formatter::new(self.global());
+        let mut formatter = crate::console_object::Formatter::for_error_handler(self.global());
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         self.print_errorlike_object(
             exception.value(),

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6437,11 +6437,12 @@ impl VirtualMachine {
                 TagOptions::DISABLE_INSPECT_CUSTOM | TagOptions::HIDE_GLOBAL,
             )?;
             if !matches!(tag.tag, TagPayload::NativeCode) {
-                let _ = if allow_ansi_color {
-                    formatter.format::<true>(tag, writer, error_instance, global_ref)
+                // The caller clears the exception a getter or the stack guard left pending.
+                if allow_ansi_color {
+                    formatter.format::<true>(tag, writer, error_instance, global_ref)?;
                 } else {
-                    formatter.format::<false>(tag, writer, error_instance, global_ref)
-                };
+                    formatter.format::<false>(tag, writer, error_instance, global_ref)?;
+                }
                 writer.write_all(b"\n")?;
             }
         }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1250,9 +1250,7 @@ fn print_exception(
         let exception = unsafe { &*exception };
         vm_ref.print_exception(exception, exception_list, writer, true);
     } else {
-        let mut formatter = bun_jsc::console_object::Formatter::new(global);
-        // `Formatter::new` already
-        // defaults `error_display_level` to `Full` (ConsoleObject.rs:1176).
+        let mut formatter = bun_jsc::console_object::Formatter::for_error_handler(global);
         let colors = bun_core::Output::enable_ansi_colors_stderr();
         vm_ref.print_errorlike_object(
             value,

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -213,6 +213,81 @@ Bun v<bun-version>`,
     });
   });
 
+  test.concurrent("--console-depth 0 (unlimited) prints every level", async () => {
+    // 12 levels of `o`, more than the formatter's default depth of 8.
+    const levels = 12;
+    const lines = ["error", "{"];
+    for (let i = 1; i <= levels; i++) lines.push(`${"  ".repeat(i)}o: {`);
+    lines.push(`${"  ".repeat(levels + 1)}leaf: 1,`);
+    for (let i = levels; i >= 1; i--) lines.push(`${"  ".repeat(i)}},`);
+    lines.push("}", "", "Bun v<bun-version>");
+    const code = `let o = { leaf: 1 }; for (let i = 0; i < ${levels}; i++) o = { o }; reportError(o);`;
+    expect(await run(["--console-depth", "0", "-e", code])).toEqual({
+      stdout: "",
+      stderr: lines.join("\n"),
+      exitCode: 1,
+    });
+  });
+
+  test.concurrent("--console-depth 0 on a value deeper than the stack: the script continues", async () => {
+    // The property walk throws a stack overflow RangeError partway down. The
+    // printer has to clear it, or reportError() throws it into the script.
+    // The partial dump is several MB, so stderr is not captured.
+    const code = `
+      let o = { leaf: 1 };
+      for (let i = 0; i < 20000; i++) o = { o };
+      try {
+        reportError(o);
+        console.log("after");
+      } catch (e) {
+        console.log("caught " + e.name);
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--console-depth", "0", "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect(stdout).toBe("after\n");
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(1);
+  });
+
+  // An Error does not read the console depth: its own properties print at
+  // depth 1, and every cause prints. A change that makes more of this output
+  // follow the console depth has to update these on purpose.
+  test.concurrent("an uncaught Error prints its properties and causes as before", async () => {
+    const code = `
+      const e = new Error("root", { cause: new Error("c1", { cause: new Error("c2", { cause: new Error("c3") }) }) });
+      e.deep = { a: { b: { c: 1 } } };
+      throw e;
+    `;
+    const { stdout, stderr, exitCode } = await run(["-e", code]);
+    expect(stderr).toContain("error: root\n deep: {\n  a: [Object ...],\n},\n");
+    expect(stderr.split("\n").filter(line => line.startsWith("error: "))).toEqual([
+      "error: root",
+      "error: c1",
+      "error: c2",
+      "error: c3",
+    ]);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("an uncaught AggregateError prints each Error member as before", async () => {
+    const code = `throw new AggregateError([new Error("m1"), new Error("m2"), new Error("m3")], "agg");`;
+    const { stdout, stderr, exitCode } = await run(["-e", code]);
+    expect(stderr.split("\n").filter(line => line.startsWith("error: "))).toEqual([
+      "error: m1",
+      "error: m2",
+      "error: m3",
+    ]);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
   test.concurrent(
     "bun test: a test that rejects with the value, and an unhandled rejection during a test",
     async () => {

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -140,8 +140,12 @@ describe("an uncaught value that is not an Error is printed at the console depth
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    return { stderr: normalizeBunSnapshot(stderr, String(dir)), exitCode };
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return {
+      stdout: normalizeBunSnapshot(stdout, String(dir)),
+      stderr: normalizeBunSnapshot(stderr, String(dir)),
+      exitCode,
+    };
   }
 
   const atDepth2 = `error
@@ -174,42 +178,45 @@ Bun v<bun-version>`;
     ["uncaught exception", `throw ${value}`],
     ["member of an uncaught AggregateError", `reportError(new AggregateError([${value}]))`],
   ])("%s", async (_, code) => {
-    const { stderr, exitCode } = await run(["-e", code]);
-    expect(stderr).toBe(atDepth2);
-    expect(exitCode).toBe(1);
+    expect(await run(["-e", code])).toEqual({ stdout: "", stderr: atDepth2, exitCode: 1 });
   });
 
   test.concurrent("--console-depth 1 prints one level", async () => {
-    const { stderr, exitCode } = await run(["--console-depth", "1", "-e", `reportError(${value})`]);
-    expect(stderr).toBe(`error
+    expect(await run(["--console-depth", "1", "-e", `reportError(${value})`])).toEqual({
+      stdout: "",
+      stderr: `error
 {
   a: {
     b: [Object ...],
   },
 }
 
-Bun v<bun-version>`);
-    expect(exitCode).toBe(1);
+Bun v<bun-version>`,
+      exitCode: 1,
+    });
   });
 
   test.concurrent("--console-depth 3 prints three levels", async () => {
-    const { stderr, exitCode } = await run(["--console-depth", "3", "-e", `reportError(${value})`]);
-    expect(stderr).toBe(atDepth3);
-    expect(exitCode).toBe(1);
+    expect(await run(["--console-depth", "3", "-e", `reportError(${value})`])).toEqual({
+      stdout: "",
+      stderr: atDepth3,
+      exitCode: 1,
+    });
   });
 
   test.concurrent("bunfig console.depth = 3 prints three levels", async () => {
-    const { stderr, exitCode } = await run(["-e", `reportError(${value})`], {
-      "bunfig.toml": "[console]\ndepth = 3\n",
+    const files = { "bunfig.toml": "[console]\ndepth = 3\n" };
+    expect(await run(["-e", `reportError(${value})`], files)).toEqual({
+      stdout: "",
+      stderr: atDepth3,
+      exitCode: 1,
     });
-    expect(stderr).toBe(atDepth3);
-    expect(exitCode).toBe(1);
   });
 
   test.concurrent(
     "bun test: a test that rejects with the value, and an unhandled rejection during a test",
     async () => {
-      const { stderr, exitCode } = await run(["test", "./depth.test.ts"], {
+      const files = {
         "depth.test.ts": `
         import { test } from "bun:test";
         const value = ${value};
@@ -223,9 +230,10 @@ Bun v<bun-version>`);
           await new Promise(resolve => setTimeout(resolve, 0));
         });
       `,
-      });
-      expect(stderr).toMatchInlineSnapshot(`
-"depth.test.ts:
+      };
+      expect(await run(["test", "./depth.test.ts"], files)).toEqual({
+        stdout: "bun test <version> (<revision>)",
+        stderr: `depth.test.ts:
 error
 {
   a: {
@@ -247,9 +255,9 @@ error
 
  0 pass
  2 fail
-Ran 2 tests across 1 file."
-`);
-      expect(exitCode).toBe(1);
+Ran 2 tests across 1 file.`,
+        exitCode: 1,
+      });
     },
   );
 });

--- a/test/js/bun/util/reportError.test.ts
+++ b/test/js/bun/util/reportError.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { join } from "path";
 
 test("reportError", () => {
@@ -121,4 +121,135 @@ test("native error printer handles lone surrogates in message and stack frame na
   // Printer must not have crashed: normal uncaught-error exit (1), no signal.
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(1);
+});
+
+// The error printer receives these values through `run_error_handler`. A value
+// that is not an `Error` is printed whole, so it follows the `console.log`
+// depth (2 by default, `--console-depth`, bunfig `console.depth`) instead of
+// the formatter's default depth of 8.
+describe("an uncaught value that is not an Error is printed at the console depth", () => {
+  // Four object levels. Depth 2 prints `a` and `b` and elides `c`.
+  const value = "{ a: { b: { c: { d: 1 } } } }";
+
+  async function run(args: string[], files: Record<string, string> = {}) {
+    using dir = tempDir("uncaught-depth", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stderr: normalizeBunSnapshot(stderr, String(dir)), exitCode };
+  }
+
+  const atDepth2 = `error
+{
+  a: {
+    b: {
+      c: [Object ...],
+    },
+  },
+}
+
+Bun v<bun-version>`;
+
+  const atDepth3 = `error
+{
+  a: {
+    b: {
+      c: {
+        d: 1,
+      },
+    },
+  },
+}
+
+Bun v<bun-version>`;
+
+  test.concurrent.each([
+    ["reportError", `reportError(${value})`],
+    ["unhandled rejection", `Promise.reject(${value})`],
+    ["uncaught exception", `throw ${value}`],
+    ["member of an uncaught AggregateError", `reportError(new AggregateError([${value}]))`],
+  ])("%s", async (_, code) => {
+    const { stderr, exitCode } = await run(["-e", code]);
+    expect(stderr).toBe(atDepth2);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("--console-depth 1 prints one level", async () => {
+    const { stderr, exitCode } = await run(["--console-depth", "1", "-e", `reportError(${value})`]);
+    expect(stderr).toBe(`error
+{
+  a: {
+    b: [Object ...],
+  },
+}
+
+Bun v<bun-version>`);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("--console-depth 3 prints three levels", async () => {
+    const { stderr, exitCode } = await run(["--console-depth", "3", "-e", `reportError(${value})`]);
+    expect(stderr).toBe(atDepth3);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent("bunfig console.depth = 3 prints three levels", async () => {
+    const { stderr, exitCode } = await run(["-e", `reportError(${value})`], {
+      "bunfig.toml": "[console]\ndepth = 3\n",
+    });
+    expect(stderr).toBe(atDepth3);
+    expect(exitCode).toBe(1);
+  });
+
+  test.concurrent(
+    "bun test: a test that rejects with the value, and an unhandled rejection during a test",
+    async () => {
+      const { stderr, exitCode } = await run(["test", "./depth.test.ts"], {
+        "depth.test.ts": `
+        import { test } from "bun:test";
+        const value = ${value};
+        test("rejects with the value", async () => {
+          throw value;
+        });
+        test("unhandled rejection while the test runs", async () => {
+          Promise.reject(value);
+          // The rejection is reported at the microtask checkpoint after the
+          // callback returns, before this timer fires.
+          await new Promise(resolve => setTimeout(resolve, 0));
+        });
+      `,
+      });
+      expect(stderr).toMatchInlineSnapshot(`
+"depth.test.ts:
+error
+{
+  a: {
+    b: {
+      c: [Object ...],
+    },
+  },
+}
+(fail) rejects with the value
+error
+{
+  a: {
+    b: {
+      c: [Object ...],
+    },
+  },
+}
+(fail) unhandled rejection while the test runs
+
+ 0 pass
+ 2 fail
+Ran 2 tests across 1 file."
+`);
+      expect(exitCode).toBe(1);
+    },
+  );
 });


### PR DESCRIPTION
### Problem
- An unhandled rejection, uncaught exception, or `reportError()` value that is not an `Error` prints at inspect depth 8. `console.log` uses 2. A happy-dom `Event` rejected by `@monaco-editor/loader` made `bun test` print 145,819 lines (7.2 MB).
- Cause: both entry points of `run_error_handler` build their formatter with `Formatter::new` (`src/jsc/VirtualMachine.rs:4806`, `src/runtime/jsc_hooks.rs:1253`), whose `max_depth` is 8. The non-Error branch of `print_error_instance_body` (`VirtualMachine.rs:6432`) formats the value with it.

### Fix
- Both entry points now call `Formatter::for_error_handler`, which sets `max_depth` to the console depth. The rule: the error handler prints at the depth `console.error(value)` prints at, and `--console-depth` controls both.
- An `Error` prints as before: its properties already print at depth 1, and the cause walk does not read `max_depth`. Two tests pin that, so #35288, which makes the cause walk read it, has to decide that on purpose.
- The non-Error branch now propagates a format error with `?`, so the caller clears it. Under `--console-depth 0` (unlimited) a very deep value makes the property walk throw a stack overflow `RangeError`. Discarded, it stayed pending: `reportError()` threw it into the script, and `bun test` aborted. Same line as #36921.
- Verified: `test/js/bun/util/reportError.test.ts`, 12 new cases. 7 fail on the released bun, and the deep value case fails with the depth change alone. Related suites pass (list in Notes).

### Background
- `run_error_handler` (`VirtualMachine.rs:1387`) is the one funnel for every value Bun reports on its own: uncaught exceptions, rejections, `reportError()`, `bun test` failures.
- `console_object::Formatter` is the native inspector behind `console.log`. `max_depth` is the number of nested object levels it prints before it writes `[Object ...]`. `Formatter::new` sets it to 8.
- The console depth is 2, `--console-depth N`, or bunfig `[console] depth`. `0` means unlimited. `console_depth()` now holds that lookup.

<details><summary>Notes</summary>

Repro with no dependencies:

```ts
// u.test.ts
import { test } from "bun:test";
function build(depth: number, width: number): any {
  if (depth === 0) return { leaf: 1 };
  const o: any = { level: depth };
  for (let j = 0; j < width; j++) o["child" + j] = build(depth - 1, width);
  return o;
}
test("unhandled rejection with a deep non-Error value", async () => {
  Promise.reject(build(12, 2));
  await new Promise(r => setTimeout(r, 10));
});
```

`bun test ./u.test.ts 2>&1 | wc -l` prints 2054 lines before this change and 38 after. Bun 1.2.23 prints the same 2054 lines, so this is not a regression.

This bounds the depth, not the size. A value that is wide at depth 2 still prints every property at those levels. That is enough for the happy-dom case: the `Event` itself is small, and the flood came from the levels below its `[Symbol(target)]`. A byte budget for this output (#37311 adds one for matchers) is a separate change. Depth parity with `console.error` is the right rendering with or without it.

`bun -e 'reportError(x)'`, `bun -e 'Promise.reject(x)'`, `bun -e 'throw x'`, and `reportError(new AggregateError([x]))` all printed depth 8 before. All of them go through `run_error_handler`. The `JSC::Exception` entry point (`VirtualMachine::print_exception`) is changed too, so both halves of the funnel build the same formatter. Today the depth is not observable on that half: the non-Error branch and the `AggregateError` branch do not run for an exception cell.

Test cases: the 4 entry points above at the default depth, `--console-depth 1`, `--console-depth 3`, bunfig `depth = 3`, `--console-depth 0` on a 12 level value, `--console-depth 0` on a 20000 level value (stdout shows that the script continued, stderr is not captured because the partial dump is several MB), an uncaught `Error` with a `deep` property and three causes, an uncaught `AggregateError` with three `Error` members, and a `bun test` file with a test that rejects with the value plus an unhandled rejection during a test. The 7 that fail on the released bun: the 4 entry points, `--console-depth 1`, `--console-depth 0` on 12 levels, and the `bun test` file. The 20000 level case passes on the released bun (depth 8 never reaches the stack guard) and fails with the depth change alone. That is what the `?` is for. It is also clean under `BUN_JSC_validateExceptionChecks=1`.

Interaction with open PRs. #35288 makes the cause walk and the `AggregateError` walk of this printer read `formatter.max_depth`. Combined with this change, an uncaught error would print two causes and then `[Error ...]` by default. The cause pin here (root plus three causes) fails in that combination, so whichever lands second decides: keep the console depth for causes, or bound the cause walk on its own, as the property dump already is. #36921 contains the same `?` change, so whichever lands second drops one line. #34884 seats the formatter's own stack check in `Formatter::new`, which `for_error_handler` inherits. A value whose walk has no JSC guard (a very deep array) is not changed by this PR: `print_array` never read `max_depth`.

Node prints an uncaught thrown value with `inspect(value, { depth: max(defaultDepth, 5) })`, and does not print a non-Error unhandled rejection reason at all (`The promise rejected with the reason "#<Object>"`). This change keeps Bun's behavior of printing the value. Jest prints a thrown non-Error with pretty-format `maxDepth: 3`, which is the same three object levels as depth 2 here.

Out of scope: a non-Error value thrown synchronously inside a test body, or inside a timer callback, reaches the printer as a `JSC::Exception` cell and prints only `error` plus the stack, with none of the value. #38278 and #37524 change how the printer unwraps that cell for `Error` instances. Neither unwraps other values. A value that is unwrapped there later prints through the same bounded branch.

`docs/runtime/console.mdx` gains one sentence about the uncaught value case.

Other suites run with the debug build, all passing: `test/js/bun/test/stack.test.ts`, `test/js/bun/test/bun_test.test.ts`, `test/js/bun/test/test-test.test.ts`, `test/regression/issue/20980.test.ts`, `test/cli/console-depth.test.ts`, `test/js/web/console/`, `test/js/bun/console/`, `test/js/bun/util/inspect.test.js`, `test/js/bun/util/inspect-error.test.js`, `test/cli/test/bun-test.test.ts`. `cargo fmt --all -- --check` is clean.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/reportError.test.ts
bun test v1.4.0 (4c689909e)

test/js/bun/util/reportError.test.ts:
(pass) reportError [324.40ms]
(pass) native error printer handles lone surrogates in message and stack frame name as U+FFFD [294.55ms]
176 |     ["reportError", `reportError(${value})`],
177 |     ["unhandled rejection", `Promise.reject(${value})`],
178 |     ["uncaught exception", `throw ${value}`],
179 |     ["member of an uncaught AggregateError", `reportError(new AggregateError([${value}]))`],
180 |   ])("%s", async (_, code) => {
181 |     expect(await run(["-e", code])).toEqual({ stdout: "", stderr: atDepth2, exitCode: 1 });
                                          ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 1,
    "stderr": 
  "error
  {
    a: {
      b: {
-       c: [Object ...],
+       c: {
+         d: 1,
+       },
      },
    },
  }
  
  Bun v<bun-version>"
  ,
    "stdout": "",
  }

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/util/reportError.test.ts:181:37)

... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (4c689909e)

test/js/bun/util/reportError.test.ts:
(pass) reportError [8.28ms]
(pass) native error printer handles lone surrogates in message and stack frame name as U+FFFD [12.30ms]
176 |     ["reportError", `reportError(${value})`],
177 |     ["unhandled rejection", `Promise.reject(${value})`],
178 |     ["uncaught exception", `throw ${value}`],
179 |     ["member of an uncaught AggregateError", `reportError(new AggregateError([${value}]))`],
180 |   ])("%s", async (_, code) => {
181 |     expect(await run(["-e", code])).toEqual({ stdout: "", stderr: atDepth2, exitCode: 1 });
                                          ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 1,
    "stderr": 
  "error
  {
    a: {
      b: {
-       c: [Object ...],
+       c: {
+         d: 1,
+       },
      },
    },
  }
  
  Bun v<bun-version>"
  ,
    "stdout": "",
  }

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/util/reportError.test.ts:181:37)
176 |     ["reportError", `reportError(${value})`],
177 |     ["unhandled rejection", `Promise.reject(${value})`],
178 |     ["uncaught exception", `throw ${value}`
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/reportError.test.ts
bun test v1.4.0 (4c689909e)

test/js/bun/util/reportError.test.ts:
(pass) reportError [315.36ms]
(pass) native error printer handles lone surrogates in message and stack frame name as U+FFFD [305.74ms]
(pass) an uncaught value that is not an Error is printed at the console depth > reportError [335.56ms]
(pass) an uncaught value that is not an Error is printed at the console depth > unhandled rejection [306.12ms]
(pass) an uncaught value that is not an Error is printed at the console depth > uncaught exception [311.90ms]
(pass) an uncaught value that is not an Error is printed at the console depth > --console-depth 1 prints one level [318.80ms]
(pass) an uncaught value that is not an Error is printed at the console depth > member of an uncaught AggregateError [354.50ms]
(pass) an uncaught value that is not an Error is printed at the console depth > --console-depth 3 prints three levels [275.66ms]
(pass) an uncaught value that is not an Error is printed at the console depth > bunfig console.depth = 3 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 624ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/39] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/39] gen cpp.rs (cppbind)
[3/39] gen JS modules (bundle-modules)
Preprocess modules (7884ms)
Bundle modules (76ms)
Postprocesss modules (64ms)
Bundle Functions (680ms)
Generate Code (29ms)

[8.75s] Bundled "src/js" for production
  2628 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[3/30] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/console.mdx             |   2 +
 src/jsc/ConsoleObject.rs             |  24 ++--
 src/jsc/VirtualMachine.rs            |  11 +-
 src/runtime/jsc_hooks.rs             |   4 +-
 test/js/bun/util/reportError.test.ts | 218 ++++++++++++++++++++++++++++++++++-
 5 files changed, 241 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
docs/runtime/console.mdx                  1      1      0
src/jsc/ConsoleObject.rs                  7      8      0
src/jsc/VirtualMachine.rs                 6      3      0
src/runtime/jsc_hooks.rs                  1      1      0
test/js/bun/util/reportError.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->