### PR TITLE
fetch: drop the upload and drain hop refs at VM teardown

### DIFF
--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -74,6 +74,7 @@ pub mod task_tag {
         DuplexUpgradeContext,
         FetchTasklet,
         FetchTaskletDeinit,
+        FetchTaskletDrain,
         FetchTaskletPromiseSettle,
         FSWatchTask,
         GetAddrInfoLibuvComplete,

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -346,6 +346,14 @@ pub(crate) fn run_task(
                 ))
             };
         }
+        task_tag::FetchTaskletDrain => {
+            // SAFETY: posted by `on_write_request_data_drain` with a ref held.
+            unsafe {
+                crate::webcore::fetch::FetchTaskletDrainHop::run(cast_ptr!(
+                    crate::webcore::fetch::FetchTaskletDrainHop
+                ))
+            }?;
+        }
         // `cast_ptr!` yields the heap-allocated S3 task; JS-thread dispatch
         // is the sole owner here.
         task_tag::S3HttpSimpleTask => {
@@ -591,7 +599,7 @@ fn run_task_cold(task: Task) {
 /// `release_task_unrun` track `bun_event_loop::task_tag::COUNT`. Bump when
 /// adding a variant — and give it an arm in both.
 const _: () = assert!(
-    task_tag::COUNT == 61,
+    task_tag::COUNT == 62,
     "dispatch::run_task / release_task_unrun arm count out of sync with bun_event_loop::task_tag",
 );
 
@@ -1238,6 +1246,7 @@ fn __bun_release_task_unrun(task: bun_event_loop::Task) {
         task_tag::DuplexUpgradeContext => release!(crate::socket::DuplexUpgradeContext),
         task_tag::FetchTasklet => release!(FetchTasklet),
         task_tag::FetchTaskletDeinit => release!(crate::webcore::fetch::FetchTaskletDeinitHop),
+        task_tag::FetchTaskletDrain => release!(crate::webcore::fetch::FetchTaskletDrainHop),
         task_tag::FetchTaskletPromiseSettle => {
             release!(crate::webcore::fetch::fetch_tasklet::FetchTaskletPromiseSettle)
         }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1811,6 +1811,10 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
                 crate::socket::WindowsNamedPipeContext::stop_for_vm_teardown(c.as_ptr())
             },
             // SAFETY: live until it unregisters in `deinit`.
+            ActiveHandle::Fetch(t) if reason == StopReason::TestIsolation => unsafe {
+                crate::webcore::fetch::FetchTasklet::abort_for_test_isolation(t.as_ptr())
+            },
+            // SAFETY: as above.
             ActiveHandle::Fetch(t) => unsafe {
                 crate::webcore::fetch::FetchTasklet::stop_for_vm_teardown(t.as_ptr())
             },

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -83,7 +83,7 @@ use bun_url::PercentEncoding;
 use bun_url::URL as ZigURL;
 
 use self::fetch_tasklet::{FetchOptions, HTTPRequestBody};
-pub use self::fetch_tasklet::{FetchTasklet, FetchTaskletDeinitHop};
+pub use self::fetch_tasklet::{FetchTasklet, FetchTaskletDeinitHop, FetchTaskletDrainHop};
 
 // ──────────────────────────────────────────────────────────────────────────
 // Local extension shims (upstream methods not yet ported / not in scope)

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -70,9 +70,8 @@ impl FetchTaskletDeinitHop {
     }
 }
 
-/// The "request body buffer drained → resume the body stream" hop
-/// (`on_write_request_data_drain`): same pointer, its own tag, carrying the
-/// +1 that `resume_request_data_stream` drops.
+/// The "request body buffer drained" hop (`on_write_request_data_drain`):
+/// same pointer, its own tag, carrying a ref that running or releasing it drops.
 #[repr(transparent)]
 pub struct FetchTaskletDrainHop(FetchTasklet);
 impl Taskable for FetchTaskletDrainHop {
@@ -2302,8 +2301,7 @@ impl FetchTasklet {
     /// This is ALWAYS called from the http thread and we cannot touch the buffer here because is locked
     fn on_write_request_data_drain(this: *mut FetchTasklet) {
         let this_ref = Self::from_raw_ref(this);
-        // Held by the hop until `resume_request_data_stream` (or its release
-        // unrun) drops it.
+        // The hop's ref.
         this_ref.ref_();
         let task = ConcurrentTask::create_from(this.cast::<FetchTaskletDrainHop>());
         this_ref

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -537,8 +537,7 @@ impl FetchTasklet {
     /// VM teardown's stop phase (JS thread): abort the transport. The HTTP
     /// thread then fails the request promptly — started or still queued — and
     /// hands the tasklet back through its final callback, which teardown
-    /// waits for before the handle closes. A request body still streaming in
-    /// from a native source is ended here as well.
+    /// waits for before the handle closes.
     ///
     /// # Safety
     /// `this` is live (registered ⇒ not yet deinit'd); JS thread. May free it.
@@ -2482,11 +2481,9 @@ impl FetchTasklet {
         }
     }
 
-    /// Stop-phase [`Self::cancel_request_body_sink`] for a `ByteStream` /
-    /// `FileReader` body: unpipes the source without running script. At
-    /// teardown nothing else ends such a sink (a JS pump's controller cell
-    /// runs the sink's `finalize` instead). Returns whether the caller took
-    /// over the sink's ref on the tasklet and must release it.
+    /// Stop phase: nothing else ends a `ByteStream` / `FileReader` sink at
+    /// teardown (a JS pump's controller cell runs the sink's `finalize`).
+    /// Returns whether the caller must release the sink's ref on the tasklet.
     fn detach_native_request_body_sink(&mut self) -> bool {
         let global_this = self.global_this;
         let Some(sink) = self.sink_mut() else {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -537,13 +537,28 @@ impl FetchTasklet {
     /// VM teardown's stop phase (JS thread): abort the transport. The HTTP
     /// thread then fails the request promptly — started or still queued — and
     /// hands the tasklet back through its final callback, which teardown
-    /// waits for before the handle closes.
+    /// waits for before the handle closes. A request body still streaming in
+    /// from a native source is ended here too: the progress update that would
+    /// otherwise cancel it is released unrun, so nothing else drops its ref.
     ///
     /// # Safety
-    /// `this` is live (registered ⇒ not yet deinit'd); JS thread.
+    /// `this` is live (registered ⇒ not yet deinit'd); JS thread. May free
+    /// `*this`; not touched afterwards.
     pub(crate) unsafe fn stop_for_vm_teardown(this: *mut FetchTasklet) {
-        // SAFETY: fn contract.
-        unsafe { (*this).abort_task() };
+        // SAFETY: fn contract. Neither call drops a ref, so the borrow is over
+        // before the release below.
+        let owes_body_ref = unsafe {
+            let tasklet = &mut *this;
+            tasklet.abort_task();
+            tasklet.detach_native_request_body_sink()
+        };
+        if owes_body_ref {
+            // The `+1` from `start_request_stream`. It can be the last ref (a
+            // final progress update that ran once script was forbidden has
+            // already dropped the JS-side one), so release through the
+            // allocation pointer, as the sink's `finalize` does.
+            FetchTasklet::deref(this);
+        }
     }
 
     /// `HTTPClientResultCallback::release_at_shutdown` for `FetchTasklet`.
@@ -2471,6 +2486,38 @@ impl FetchTasklet {
             // `write_end_request(Some(_))` is just the balancing deref.
             self.write_end_request(Some(reason));
         }
+    }
+
+    /// The stop phase's form of [`Self::cancel_request_body_sink`] for a body
+    /// streaming in from a native source (`ByteStream` / `FileReader`). The
+    /// `+1` from `start_request_stream` is otherwise released only by the
+    /// source ending the sink or by a progress update cancelling it; at
+    /// teardown the source is destroyed with the heap without ending its sink
+    /// and the progress update is released unrun, so the tasklet would leak.
+    /// Runs no script: the source is unpiped, not cancelled. A JS pump's ref
+    /// is left to its controller cell, whose destructor runs the sink's
+    /// `finalize`.
+    ///
+    /// Returns whether the sink's hold on the tasklet was taken over, i.e.
+    /// whether the caller now has to release that `+1`.
+    fn detach_native_request_body_sink(&mut self) -> bool {
+        let global_this = self.global_this;
+        let Some(sink) = self.sink_mut() else {
+            return false;
+        };
+        if sink.ended
+            || !matches!(
+                sink.source,
+                SourceHandle::ByteStream(_) | SourceHandle::FileReader(_)
+            )
+        {
+            return false;
+        }
+        sink.ended = true;
+        sink.done = true;
+        let owes_ref = sink.task.take().is_some();
+        JSSink::<FetchRequestBodySink>::detach(&mut sink.source, &global_this);
+        owes_ref
     }
 
     pub(crate) fn queue(

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -538,25 +538,19 @@ impl FetchTasklet {
     /// thread then fails the request promptly — started or still queued — and
     /// hands the tasklet back through its final callback, which teardown
     /// waits for before the handle closes. A request body still streaming in
-    /// from a native source is ended here too: the progress update that would
-    /// otherwise cancel it is released unrun, so nothing else drops its ref.
+    /// from a native source is ended here as well.
     ///
     /// # Safety
-    /// `this` is live (registered ⇒ not yet deinit'd); JS thread. May free
-    /// `*this`; not touched afterwards.
+    /// `this` is live (registered ⇒ not yet deinit'd); JS thread. May free it.
     pub(crate) unsafe fn stop_for_vm_teardown(this: *mut FetchTasklet) {
-        // SAFETY: fn contract. Neither call drops a ref, so the borrow is over
-        // before the release below.
+        // SAFETY: fn contract; neither call drops a ref.
         let owes_body_ref = unsafe {
             let tasklet = &mut *this;
             tasklet.abort_task();
             tasklet.detach_native_request_body_sink()
         };
         if owes_body_ref {
-            // The `+1` from `start_request_stream`. It can be the last ref (a
-            // final progress update that ran once script was forbidden has
-            // already dropped the JS-side one), so release through the
-            // allocation pointer, as the sink's `finalize` does.
+            // The upload's ref; it can be the last one.
             FetchTasklet::deref(this);
         }
     }
@@ -2488,18 +2482,11 @@ impl FetchTasklet {
         }
     }
 
-    /// The stop phase's form of [`Self::cancel_request_body_sink`] for a body
-    /// streaming in from a native source (`ByteStream` / `FileReader`). The
-    /// `+1` from `start_request_stream` is otherwise released only by the
-    /// source ending the sink or by a progress update cancelling it; at
-    /// teardown the source is destroyed with the heap without ending its sink
-    /// and the progress update is released unrun, so the tasklet would leak.
-    /// Runs no script: the source is unpiped, not cancelled. A JS pump's ref
-    /// is left to its controller cell, whose destructor runs the sink's
-    /// `finalize`.
-    ///
-    /// Returns whether the sink's hold on the tasklet was taken over, i.e.
-    /// whether the caller now has to release that `+1`.
+    /// Stop-phase [`Self::cancel_request_body_sink`] for a `ByteStream` /
+    /// `FileReader` body: unpipes the source without running script. At
+    /// teardown nothing else ends such a sink (a JS pump's controller cell
+    /// runs the sink's `finalize` instead). Returns whether the caller took
+    /// over the sink's ref on the tasklet and must release it.
     fn detach_native_request_body_sink(&mut self) -> bool {
         let global_this = self.global_this;
         let Some(sink) = self.sink_mut() else {

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -70,6 +70,25 @@ impl FetchTaskletDeinitHop {
     }
 }
 
+/// The "request body buffer drained → resume the body stream" hop
+/// (`on_write_request_data_drain`): same pointer, its own tag, carrying the
+/// +1 that `resume_request_data_stream` drops.
+#[repr(transparent)]
+pub struct FetchTaskletDrainHop(FetchTasklet);
+impl Taskable for FetchTaskletDrainHop {
+    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::FetchTaskletDrain;
+    unsafe fn release_unrun(this: *mut Self) {
+        FetchTasklet::deref(this.cast());
+    }
+}
+impl FetchTaskletDrainHop {
+    /// # Safety
+    /// `this` is the tasklet the hop was posted for, with the hop's ref held; JS thread.
+    pub(crate) unsafe fn run(this: *mut Self) -> ElJsResult<()> {
+        FetchTasklet::resume_request_data_stream(this.cast())
+    }
+}
+
 impl Taskable for FetchTasklet {
     const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::FetchTasklet;
     /// A progress hop the HTTP thread posted: it carries the +1 that
@@ -552,6 +571,16 @@ impl FetchTasklet {
             // The upload's ref; it can be the last one.
             FetchTasklet::deref(this);
         }
+    }
+
+    /// `bun test --isolate` swap (JS thread): only abort. The VM keeps
+    /// running, so the final progress update still cancels the body sink.
+    ///
+    /// # Safety
+    /// `this` is live (registered ⇒ not yet deinit'd); JS thread.
+    pub(crate) unsafe fn abort_for_test_isolation(this: *mut FetchTasklet) {
+        // SAFETY: fn contract.
+        unsafe { (*this).abort_task() };
     }
 
     /// `HTTPClientResultCallback::release_at_shutdown` for `FetchTasklet`.
@@ -2273,10 +2302,10 @@ impl FetchTasklet {
     /// This is ALWAYS called from the http thread and we cannot touch the buffer here because is locked
     fn on_write_request_data_drain(this: *mut FetchTasklet) {
         let this_ref = Self::from_raw_ref(this);
-        // ref until the main thread callback is called
+        // Held by the hop until `resume_request_data_stream` (or its release
+        // unrun) drops it.
         this_ref.ref_();
-        // `from_callback` heap-allocates a fresh `ConcurrentTaskItem`.
-        let task = ConcurrentTask::from_callback(this, FetchTasklet::resume_request_data_stream);
+        let task = ConcurrentTask::create_from(this.cast::<FetchTaskletDrainHop>());
         this_ref
             .http_ticket
             .as_ref()
@@ -2285,7 +2314,6 @@ impl FetchTasklet {
     }
 
     /// This is ALWAYS called from the main thread
-    // ConcurrentTask::from_callback expects `fn(*mut T) -> bun_event_loop::JsResult<()>`.
     fn resume_request_data_stream(this: *mut FetchTasklet) -> ElJsResult<()> {
         let this_ref = Self::from_raw_mut(this);
         bun_output::scoped_log!(FetchTasklet, "resumeRequestDataStream");

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import fs from "node:fs";
 import net from "node:net";
 import { join } from "node:path";
@@ -944,6 +944,12 @@ test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next fil
 // - monitorEventLoopDelay().enable(): the per-thread monitor holds the file's
 //   histogram. It is disabled at the swap and only ever holds the histogram
 //   weakly, so an enabled monitor must not keep the file's global alive.
+// - fetch() still uploading a Bun.file() body: the swap only aborts the
+//   transport. The VM keeps running, so the fetch's final progress update
+//   cancels the body sink, which closes the file reader and drops the ref
+//   that roots the stream (and through it the global). The stop used by VM
+//   teardown must not be used here: it unpipes the reader without closing
+//   it, and the progress update then finds nothing left to cancel.
 //
 // Each fixture runs 8 isolated files that leak one handle apiece, forces a
 // full GC, and counts live GlobalObject cells. Pinned globals accumulate
@@ -1078,6 +1084,34 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
       makeLeakFixture(`
         import { monitorEventLoopDelay } from "node:perf_hooks";
         monitorEventLoopDelay({ resolution: 1 }).enable();
+      `),
+    );
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+  });
+
+  // The file holds its FIFO open read-write, so the reader gets the bytes but
+  // never EOF, and waits until the target has the first chunk, so the upload
+  // is mid-flight when the file ends.
+  test.skipIf(isWindows)("fetch() left uploading a Bun.file() body", async () => {
+    using dir = tempDir(
+      "isolate-leak-fetch-upload",
+      makeLeakFixture(`
+        import { execFileSync } from "node:child_process";
+        import fs from "node:fs";
+        const fifo = import.meta.path + ".fifo";
+        execFileSync("mkfifo", [fifo]);
+        fs.writeSync(fs.openSync(fifo, "r+"), Buffer.alloc(64, 1));
+        const firstChunk = Promise.withResolvers();
+        const target = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            await req.body.getReader().read();
+            firstChunk.resolve();
+            return new Promise(() => {});
+          },
+        });
+        fetch(target.url, { method: "POST", body: Bun.file(fifo).stream() }).catch(() => {});
+        await firstChunk.promise;
       `),
     );
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);

--- a/test/js/web/workers/worker-late-completion.test.ts
+++ b/test/js/web/workers/worker-late-completion.test.ts
@@ -415,3 +415,89 @@ describe.skipIf(isWindows)("terminate() waits for work that cannot be cancelled"
     expect(await proc.exited).toBe(0);
   });
 });
+
+// A fetch() whose request body is still uploading when its worker goes holds
+// one more reference than the "fetch in flight" row above: the one
+// start_request_stream takes for the upload. A body pumped by JS (a pull or
+// direct stream) releases it when the JSC heap destroys the pump's controller
+// cell. A body streaming in from a native source (another response's body, a
+// file) has no such cell, and the progress update that would cancel the sink
+// is released unrun at teardown, so the stop phase has to end the sink itself
+// or the whole request (tasklet, AsyncHTTP, sink, stream buffer) outlives the
+// worker. The target server terminates the worker once the first body chunk
+// has arrived, so the upload is mid-flight every time. LSan reports a request
+// that was never released; ASAN reports one released once too often as a
+// use-after-free when the HTTP thread hands it back during the wait.
+describe.skipIf(!isASAN || isWindows)("terminate() while a request body is still uploading", () => {
+  const BODIES = {
+    "a JS pull stream": `new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(16)); return new Promise(() => {}); } })`,
+    "a direct stream": `new ReadableStream({ type: "direct", pull(c) { c.write(new Uint8Array(16)); return new Promise(() => {}); } })`,
+    "another response's body": `(await fetch(workerData.upstream)).body`,
+    "Bun.file(fifo).stream()": `Bun.file(workerData.fifo).stream()`,
+  };
+  // Runs in the host process: two servers (the target, which never answers,
+  // and an upstream whose body never ends), a FIFO the host keeps open so the
+  // worker's reader gets bytes but never EOF, and one worker that starts the
+  // upload. The host terminates the worker when the target has the first chunk.
+  const host = (body: string) => `
+    const { Worker } = require("node:worker_threads");
+    const { execFileSync } = require("node:child_process");
+    const fs = require("node:fs");
+    execFileSync("mkfifo", ["fifo"]);
+    const fifoFd = fs.openSync("fifo", "r+");
+    fs.writeSync(fifoFd, Buffer.alloc(64, 1));
+    const firstChunk = Promise.withResolvers();
+    const target = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        await req.body.getReader().read();
+        firstChunk.resolve();
+        return new Promise(() => {});
+      },
+    });
+    const upstream = Bun.serve({
+      port: 0,
+      fetch: () => new Response(new ReadableStream({
+        start(c) { c.enqueue(new Uint8Array(1024)); },
+        pull() { return new Promise(() => {}); },
+      })),
+    });
+    const worker = new Worker(
+      'const { workerData } = require("node:worker_threads");' +
+      '(async () => { const body = ' + ${JSON.stringify(body)} + '; fetch(workerData.target, { method: "POST", body }).catch(() => {}); })();',
+      { eval: true, workerData: { target: target.url.href, upstream: upstream.url.href, fifo: "fifo" } },
+    );
+    worker.on("error", e => { console.error("worker error:", e); process.exit(1); });
+    await firstChunk.promise;
+    console.log("terminated:", await worker.terminate());
+    fs.closeSync(fifoFd);
+    target.stop(true);
+    upstream.stop(true);
+  `;
+
+  for (const [name, body] of Object.entries(BODIES)) {
+    test.concurrent(
+      name,
+      async () => {
+        using dir = tempDir("worker-terminate-upload", {});
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", host(body)],
+          cwd: String(dir),
+          env: {
+            ...bunEnv,
+            BUN_DESTRUCT_VM_ON_EXIT: "1",
+            ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+            LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../../leaksan.supp")}`,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "terminated: 1\n", stderr: "", exitCode: 0 });
+      },
+      // LSan symbolizes its report against the debug binary on failure, which
+      // alone can take tens of seconds.
+      90_000,
+    );
+  }
+});

--- a/test/js/web/workers/worker-late-completion.test.ts
+++ b/test/js/web/workers/worker-late-completion.test.ts
@@ -439,12 +439,13 @@ describe.skipIf(!isASAN || isWindows)("terminate() while a request body is still
   // and an upstream whose body never ends), a FIFO the host keeps open so the
   // worker's reader gets bytes but never EOF, and one worker that starts the
   // upload. The host terminates the worker when the target has the first chunk.
-  const host = (body: string) => `
+  const host = (body: string, fifo: string) => `
     const { Worker } = require("node:worker_threads");
     const { execFileSync } = require("node:child_process");
     const fs = require("node:fs");
-    execFileSync("mkfifo", ["fifo"]);
-    const fifoFd = fs.openSync("fifo", "r+");
+    const fifo = ${JSON.stringify(fifo)};
+    execFileSync("mkfifo", [fifo]);
+    const fifoFd = fs.openSync(fifo, "r+");
     fs.writeSync(fifoFd, Buffer.alloc(64, 1));
     const firstChunk = Promise.withResolvers();
     const target = Bun.serve({
@@ -465,7 +466,7 @@ describe.skipIf(!isASAN || isWindows)("terminate() while a request body is still
     const worker = new Worker(
       'const { workerData } = require("node:worker_threads");' +
       '(async () => { const body = ' + ${JSON.stringify(body)} + '; fetch(workerData.target, { method: "POST", body }).catch(() => {}); })();',
-      { eval: true, workerData: { target: target.url.href, upstream: upstream.url.href, fifo: "fifo" } },
+      { eval: true, workerData: { target: target.url.href, upstream: upstream.url.href, fifo } },
     );
     worker.on("error", e => { console.error("worker error:", e); process.exit(1); });
     await firstChunk.promise;
@@ -481,8 +482,7 @@ describe.skipIf(!isASAN || isWindows)("terminate() while a request body is still
       async () => {
         using dir = tempDir("worker-terminate-upload", {});
         await using proc = Bun.spawn({
-          cmd: [bunExe(), "-e", host(body)],
-          cwd: String(dir),
+          cmd: [bunExe(), "-e", host(body, path.join(String(dir), "fifo"))],
           env: {
             ...bunEnv,
             BUN_DESTRUCT_VM_ON_EXIT: "1",

--- a/test/js/web/workers/worker-late-completion.test.ts
+++ b/test/js/web/workers/worker-late-completion.test.ts
@@ -417,29 +417,62 @@ describe.skipIf(isWindows)("terminate() waits for work that cannot be cancelled"
 });
 
 // A fetch() whose request body is still uploading when its worker goes holds
-// one more reference than the "fetch in flight" row above: the one
-// start_request_stream takes for the upload. A body pumped by JS (a pull or
-// direct stream) releases it when the JSC heap destroys the pump's controller
-// cell. A body streaming in from a native source (another response's body, a
-// file) has no such cell, and the progress update that would cancel the sink
-// is released unrun at teardown, so the stop phase has to end the sink itself
-// or the whole request (tasklet, AsyncHTTP, sink, stream buffer) outlives the
-// worker. The target server terminates the worker once the first body chunk
-// has arrived, so the upload is mid-flight every time. LSan reports a request
-// that was never released; ASAN reports one released once too often as a
-// use-after-free when the HTTP thread hands it back during the wait.
-describe.skipIf(!isASAN || isWindows)("terminate() while a request body is still uploading", () => {
-  const BODIES = {
-    "a JS pull stream": `new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(16)); return new Promise(() => {}); } })`,
-    "a direct stream": `new ReadableStream({ type: "direct", pull(c) { c.write(new Uint8Array(16)); return new Promise(() => {}); } })`,
-    "another response's body": `(await fetch(workerData.upstream)).body`,
-    "Bun.file(fifo).stream()": `Bun.file(workerData.fifo).stream()`,
-  };
-  // Runs in the host process: two servers (the target, which never answers,
-  // and an upstream whose body never ends), a FIFO the host keeps open so the
-  // worker's reader gets bytes but never EOF, and one worker that starts the
-  // upload. The host terminates the worker when the target has the first chunk.
-  const host = (body: string, fifo: string) => `
+// references the "fetch in flight" row above never takes: the one
+// start_request_stream holds for the upload, and one per "buffer drained" hop
+// the HTTP thread has posted back. Every one of them has to be dropped by the
+// teardown itself. The upload's ref is dropped by the JSC heap destroying the
+// pump's controller cell for a JS-pumped body (a pull or direct stream), and
+// by the stop phase for a body streaming in from a native source (another
+// response's body, a file), because the progress update that would otherwise
+// cancel that sink is released unrun. A drain hop still queued when the worker
+// goes is released unrun too, and has to drop its ref then. A ref that is not
+// dropped leaves the whole request behind (tasklet, AsyncHTTP, sink, stream
+// buffer); one dropped twice frees it while the HTTP thread still hands it
+// back. The oracle is the tasklet's own teardown log line: one `deinit` per
+// fetch the worker made (debug builds only), plus LSan and ASAN on that build.
+//
+// Each row's upload is mid-flight by construction: the target server holds
+// the request open and the host terminates the worker once the first body
+// chunk has arrived, or (drain row) the body's pull() exits the worker right
+// after handing the chunk over, so the drain hop for it comes back to a
+// worker that is already tearing down.
+describe.skipIf((!isDebug && !isASAN) || isWindows)("a worker goes while a request body is still uploading", () => {
+  const ROWS: { name: string; body: string; fetches: number; terminate: boolean }[] = [
+    {
+      name: "a JS pull stream, terminated",
+      body: `new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(16)); return new Promise(() => {}); } })`,
+      fetches: 1,
+      terminate: true,
+    },
+    {
+      name: "a direct stream, terminated",
+      body: `new ReadableStream({ type: "direct", pull(c) { c.write(new Uint8Array(16)); return new Promise(() => {}); } })`,
+      fetches: 1,
+      terminate: true,
+    },
+    {
+      name: "another response's body, terminated",
+      body: `(await fetch(workerData.upstream)).body`,
+      fetches: 2,
+      terminate: true,
+    },
+    {
+      name: "Bun.file(fifo).stream(), terminated",
+      body: `Bun.file(workerData.fifo).stream()`,
+      fetches: 1,
+      terminate: true,
+    },
+    {
+      name: "a direct stream whose pull() exits the worker after a write",
+      body: `new ReadableStream({ type: "direct", pull(c) { c.write(new Uint8Array(16)); process.exit(0); } })`,
+      fetches: 1,
+      terminate: false,
+    },
+  ];
+  // The host process: the target server (never answers), an upstream whose
+  // body never ends, a FIFO the host keeps open so the worker's reader gets
+  // bytes but never EOF, and the one worker that starts the upload.
+  const host = (row: (typeof ROWS)[number], fifo: string) => `
     const { Worker } = require("node:worker_threads");
     const { execFileSync } = require("node:child_process");
     const fs = require("node:fs");
@@ -465,26 +498,31 @@ describe.skipIf(!isASAN || isWindows)("terminate() while a request body is still
     });
     const worker = new Worker(
       'const { workerData } = require("node:worker_threads");' +
-      '(async () => { const body = ' + ${JSON.stringify(body)} + '; fetch(workerData.target, { method: "POST", body }).catch(() => {}); })();',
+      '(async () => { const body = ' + ${JSON.stringify(row.body)} + '; fetch(workerData.target, { method: "POST", body }).catch(() => {}); })();',
       { eval: true, workerData: { target: target.url.href, upstream: upstream.url.href, fifo } },
     );
     worker.on("error", e => { console.error("worker error:", e); process.exit(1); });
-    await firstChunk.promise;
-    console.log("terminated:", await worker.terminate());
+    const exited = new Promise(resolve => worker.on("exit", resolve));
+    if (${row.terminate}) {
+      await firstChunk.promise;
+      worker.terminate();
+    }
+    console.log("worker exit code:", await exited);
     fs.closeSync(fifoFd);
     target.stop(true);
     upstream.stop(true);
   `;
 
-  for (const [name, body] of Object.entries(BODIES)) {
+  for (const row of ROWS) {
     test.concurrent(
-      name,
+      row.name,
       async () => {
-        using dir = tempDir("worker-terminate-upload", {});
+        using dir = tempDir("worker-upload-teardown", {});
         await using proc = Bun.spawn({
-          cmd: [bunExe(), "-e", host(body, path.join(String(dir), "fifo"))],
+          cmd: [bunExe(), "-e", host(row, path.join(String(dir), "fifo"))],
           env: {
             ...bunEnv,
+            BUN_DEBUG_FetchTasklet: "1",
             BUN_DESTRUCT_VM_ON_EXIT: "1",
             ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
             LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../../leaksan.supp")}`,
@@ -493,7 +531,22 @@ describe.skipIf(!isASAN || isWindows)("terminate() while a request body is still
           stderr: "pipe",
         });
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "terminated: 1\n", stderr: "", exitCode: 0 });
+        // The debug log lines share stdout with the host's own line.
+        const output = stdout + stderr;
+        expect({
+          workerExit: output.match(/^worker exit code: (\d+)$/m)?.[1],
+          deinits: output.match(/^\[fetchtasklet\] deinit$/gm)?.length ?? 0,
+          sanitizer: output.includes("Sanitizer"),
+          exitCode,
+          // On a failure, everything the host printed.
+          detail: exitCode === 0 ? "" : output,
+        }).toEqual({
+          workerExit: row.terminate ? "1" : "0",
+          deinits: row.fetches,
+          sanitizer: false,
+          exitCode: 0,
+          detail: "",
+        });
       },
       // LSan symbolizes its report against the debug binary on failure, which
       // alone can take tens of seconds.

--- a/test/js/web/workers/worker-late-completion.test.ts
+++ b/test/js/web/workers/worker-late-completion.test.ts
@@ -517,45 +517,39 @@ describe.skipIf((!isDebug && !isASAN) || isWindows)("a worker goes while a reque
   `;
 
   for (const row of ROWS) {
-    test.concurrent(
-      row.name,
-      async () => {
-        using dir = tempDir("worker-upload-teardown", {});
-        await using proc = Bun.spawn({
-          cmd: [bunExe(), "-e", host(row, path.join(String(dir), "fifo"))],
-          env: {
-            ...bunEnv,
-            BUN_DEBUG_FetchTasklet: "1",
-            BUN_DESTRUCT_VM_ON_EXIT: "1",
-            ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
-            LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../../leaksan.supp")}`,
-          },
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        // The debug log lines share stdout with the host's own line.
-        const output = stdout + stderr;
-        const deinits = isDebug ? (output.match(/^\[fetchtasklet\] deinit$/gm)?.length ?? 0) : "release build";
-        const expectedDeinits = isDebug ? row.fetches : "release build";
-        expect({
-          workerExit: output.match(/^worker exit code: (\d+)$/m)?.[1],
-          deinits,
-          sanitizer: output.includes("Sanitizer"),
-          exitCode,
-          // On a failure, everything the host printed.
-          detail: exitCode === 0 && deinits === expectedDeinits ? "" : output,
-        }).toEqual({
-          workerExit: row.terminate ? "1" : "0",
-          deinits: expectedDeinits,
-          sanitizer: false,
-          exitCode: 0,
-          detail: "",
-        });
-      },
-      // LSan symbolizes its report against the debug binary on failure, which
-      // alone can take tens of seconds.
-      90_000,
-    );
+    test.concurrent(row.name, async () => {
+      using dir = tempDir("worker-upload-teardown", {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", host(row, path.join(String(dir), "fifo"))],
+        env: {
+          ...bunEnv,
+          BUN_DEBUG_FetchTasklet: "1",
+          BUN_DESTRUCT_VM_ON_EXIT: "1",
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+          LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dirname, "../../../leaksan.supp")}`,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // The debug log lines share stdout with the host's own line.
+      const output = stdout + stderr;
+      const deinits = isDebug ? (output.match(/^\[fetchtasklet\] deinit$/gm)?.length ?? 0) : "release build";
+      const expectedDeinits = isDebug ? row.fetches : "release build";
+      expect({
+        workerExit: output.match(/^worker exit code: (\d+)$/m)?.[1],
+        deinits,
+        sanitizer: output.includes("Sanitizer"),
+        exitCode,
+        // On a failure, everything the host printed.
+        detail: exitCode === 0 && deinits === expectedDeinits ? "" : output,
+      }).toEqual({
+        workerExit: row.terminate ? "1" : "0",
+        deinits: expectedDeinits,
+        sanitizer: false,
+        exitCode: 0,
+        detail: "",
+      });
+    });
   }
 });

--- a/test/js/web/workers/worker-late-completion.test.ts
+++ b/test/js/web/workers/worker-late-completion.test.ts
@@ -428,8 +428,11 @@ describe.skipIf(isWindows)("terminate() waits for work that cannot be cancelled"
 // goes is released unrun too, and has to drop its ref then. A ref that is not
 // dropped leaves the whole request behind (tasklet, AsyncHTTP, sink, stream
 // buffer); one dropped twice frees it while the HTTP thread still hands it
-// back. The oracle is the tasklet's own teardown log line: one `deinit` per
-// fetch the worker made (debug builds only), plus LSan and ASAN on that build.
+// back. The oracle on a debug build is the tasklet's own teardown log line:
+// one `deinit` per fetch the worker made. The ASAN build is a release build
+// without that log; there the rows run for ASAN itself and for LSan, which
+// reports the response-body row's leak (the others stay reachable to it
+// through stale JS heap memory).
 //
 // Each row's upload is mid-flight by construction: the target server holds
 // the request open and the host terminates the worker once the first body
@@ -533,16 +536,18 @@ describe.skipIf((!isDebug && !isASAN) || isWindows)("a worker goes while a reque
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
         // The debug log lines share stdout with the host's own line.
         const output = stdout + stderr;
+        const deinits = isDebug ? (output.match(/^\[fetchtasklet\] deinit$/gm)?.length ?? 0) : "release build";
+        const expectedDeinits = isDebug ? row.fetches : "release build";
         expect({
           workerExit: output.match(/^worker exit code: (\d+)$/m)?.[1],
-          deinits: output.match(/^\[fetchtasklet\] deinit$/gm)?.length ?? 0,
+          deinits,
           sanitizer: output.includes("Sanitizer"),
           exitCode,
           // On a failure, everything the host printed.
-          detail: exitCode === 0 ? "" : output,
+          detail: exitCode === 0 && deinits === expectedDeinits ? "" : output,
         }).toEqual({
           workerExit: row.terminate ? "1" : "0",
-          deinits: row.fetches,
+          deinits: expectedDeinits,
           sanitizer: false,
           exitCode: 0,
           detail: "",


### PR DESCRIPTION
### Problem
- A fetch with a streaming request body holds refs on its `FetchTasklet` that a plain fetch never takes. VM teardown (a worker ending or terminated) dropped none of them, so the whole request outlived the VM.
- The upload ref (`FetchTasklet.rs:684`): for a body from a native source (another response's body, `Bun.file().stream()`) only the source ending the sink or a progress update cancelling it drops it. Teardown destroys the source without ending the sink and releases the progress update unrun. A JS-pumped body is fine: its controller cell's destructor runs the sink's `finalize`.
- The drain hop ref: the hop was a `ManagedTask` without cleanup, so one still queued at teardown was freed with its ref.

### Fix
- `stop_for_vm_teardown` also ends a live native sink: mark it ended, unpipe the source (no script), drop its ref through the allocation pointer, as `finalize` does, since it can be the last one.
- The drain hop is a tagged task of its own (`FetchTaskletDrainHop`, like the deinit hop): run resumes the stream as before, `release_unrun` drops the ref. One allocation less per drain.
- `bun test --isolate` reaches the same stop. Its VM lives on and the progress update still cancels the sink, so that path only aborts, as before. A new row in `isolation.test.ts` pins that: with the teardown stop used there, a `Bun.file()` upload left in flight keeps its file's global alive (8 of 8 globals live instead of 2).
- Verified: `worker-late-completion.test.ts`, block "a worker goes while a request body is still uploading", 5 rows, 3 of them failing on main, and the isolation row above. Other suites in the notes.

### Background
- `FetchTasklet` is the per-`fetch()` object shared by the JS and HTTP threads: one ref for the JS side, one for the HTTP thread, one per upload, one per queued drain hop (what the HTTP thread posts when the upload buffer empties).
- `FetchRequestBodySink` receives the body chunks; its `task` back-pointer is the token for the upload ref. A native source calls the sink directly, a JS source goes through a controller cell.
- Teardown stops every handle without script, waits for the HTTP thread to hand its requests back, releases the tasks still queued unrun, then destroys the heap.

<details><summary>Notes</summary>

Origin: the HTTP-thread crashes BUN-3BR3 and BUN-3EX4 (`FetchTasklet::callback` enqueueing on a freed tasklet or loop), suspected to be an over-release of the upload ref. They are not, and main does not reproduce them:

- 61 of the 64 events have `workers_spawned` and `workers_terminated`, including every event on a build that contains #36939 (45ee9556a, 52bf09cb1). On those builds a worker's shutdown freed the `VirtualMachine` while its fetches were still out on the HTTP thread, so `callback` read `javascript_vm.event_loop` from freed memory. #38299 makes teardown wait for them. There are no events on a build after it.
- The other 3 events (Claude Code builds, `abort_signal`, no workers) belong to the same family as the `assert_no_refs` panics BUN-3KDD and BUN-3PM8 and the BUN-3BZF unwrap: the HTTP thread hit zero while the JS side still held a ref. Every affected build is based on upstream from before #32015 (the client delivered a second final result after `fail()`, so the HTTP-side ref was dropped twice). The two newer stable builds (eb835313a, 939d4325b) show none of these signatures over 5 days while having the most traffic.
- `write_end_request` and `finalize` are exclusive on main: the promise handlers clear `sink.task` before releasing, and the controller cell can only die still attached once the pump promise is unreachable or the heap is going down. A refcount trace of a terminate during a JS-pumped upload shows `finalize` as the single release of that ref.

The drain hop leak and the `--isolate` point came out of review of the first version of this PR. The drain hop case is deterministic: a direct stream's `pull()` writes a chunk and exits the worker, so the hop for that chunk is still queued when teardown releases the queue (refcount trace: the tasklet ends at 1 with no `deinit`).

On main the rows fail as: FIFO body 0 of 1 tasklets torn down, drain hop 0 of 1, response body 1 of 2 (plus an LSan report). The JS pull and direct rows pass on main and guard against a release too many.

Test oracles: the worker rows count the tasklet's `deinit` debug log line (`BUN_DEBUG_FetchTasklet=1`) on debug builds; on the ASAN build (a release build, no such log) they run for ASAN and LSan. LSan only reports the response-body row: a leaked tasklet that stale JS heap memory still points at (the FIFO and drain rows) counts as reachable for it. The isolation row uses the existing 8-file live-globals fixture: the file reader's pending read roots the stream, so a reader that is unpiped instead of cancelled pins the file's global. Measured: 1, 2, 2, ... at head; 1, 2, 3, ... 8 with the teardown stop wired to the isolate path.

Out of scope, same pattern elsewhere: a native source's `finalize` never ends the sink piped from it, so every consumer holding a ref for the length of a native pipe has to drop it at teardown itself. `Bun.serve` already does (`RequestContext`, abort path). The S3 streaming upload (`S3UploadStreamWrapper`, pump ref released only by `NetworkSink::end_from_stream` or the failure path, and not an `ActiveHandle`) does not; that is handed off separately, and its fix shares no code with this diff. `FileSink` fed by a native source holds a similar keep-alive ref; not verified here.

Probes on the ASAN debug build, all clean: a worker terminated, exited or aborted during a JS, direct and native upload (12 modes, 20 to 60 iterations each); 400 iterations of aborting a fetch with each body kind at different points against a parking, an answering and a closing server, with GC in between; `bun test --isolate` with a native upload and with a FIFO upload left in flight.

Suites run: all of `worker-late-completion`, `body-stream` (9086 tests, exercises the drain hop), `fetch-abort-stream-body`, `fetch-stream-cancel-leak`, `fetch.stream`, `stream-fast-path`, `exiting`, all of `cli/test/isolation`, and the 23 source lint files.

Unrelated leak found on the way, handed off and now #39660: `Bun.serve` keeps a pending request's buffered body bytes when the handler never settles.

The `fetch.stream.test.ts` failures seen locally are the 5 s local default timeout on the ASAN build; they pass with the CI timeout.

CI on the current head (e612c1c, build 102971): the test lanes fail on `test/cli/install/bun-audit.test.ts`, whose snapshot contains the literal version range `<1.4.1` that `normalizeBunSnapshot` now rewrites after main's version bump to 1.4.1. That fails on main as well and is reported to main-break triage; it does not involve this PR. The previous build on the earlier rebase (102155) had every lane green apart from one unrelated node:http2 GC-liveness test, also reported.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/workers/worker-late-completion.test.ts, test/cli/test/isolation.test.ts

<!-- robobun:evidence:end -->

