### PR TITLE
install: wait for the isolated installer's pool tasks before it is freed

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -37,6 +37,7 @@ use bun_paths::path_options::AssumeOk as _;
 use bun_paths::{self as paths, AutoAbsPath as AbsPath, AutoRelPath, PathBuffer};
 use bun_semver as semver;
 use bun_sys::{self as sys, Fd};
+use bun_threading::WaitGroup;
 use bun_wyhash::{Wyhash, Wyhash11};
 
 use crate::analytics;
@@ -2008,6 +2009,8 @@ pub(crate) fn install_isolated_packages(
         // TODO: delete
         let mut seen_workspace_ids: HashMap<PackageID, ()> = HashMap::default();
 
+        let tasks_in_flight = WaitGroup::init();
+
         // `installer::Task` carries `result: Result` (Drop via `TaskError`
         // payloads) and a non-nullable fn-ptr in `thread_pool::Task`, so
         // `assume_init()` on uninit memory is instant UB and a subsequent
@@ -2026,10 +2029,10 @@ pub(crate) fn install_isolated_packages(
                     installer: bun_ptr::BackRef::from(core::ptr::NonNull::dangling()),
                     result: installer::Result::None,
                     relink: installer::Relink::Off,
-                    task: bun_threading::thread_pool::Task {
-                        callback: installer::Task::callback,
-                        node: Default::default(),
-                    },
+                    task: bun_threading::thread_pool::CountedTask::new(
+                        installer::Task::callback,
+                        &tasks_in_flight,
+                    ),
                     next: bun_threading::Link::new(),
                 });
             }
@@ -2039,6 +2042,7 @@ pub(crate) fn install_isolated_packages(
 
         let show_progress = manager.options.log_level.show_progress();
         let installed = DynamicBitSet::init_empty(lockfile.packages.len())?;
+        let released = DynamicBitSet::init_empty(store.entries.len())?;
         let trusted_dependencies_from_update_requests =
             manager.find_trusted_dependencies_from_update_requests();
         // `Installer.manager` is a BACKREF raw pointer; copying `manager_ptr`
@@ -2057,6 +2061,8 @@ pub(crate) fn install_isolated_packages(
             },
             store: &store,
             tasks,
+            tasks_in_flight: &tasks_in_flight,
+            released,
             waiters_head: vec![store::entry::Id::INVALID; store.entries.len()].into_boxed_slice(),
             next_waiter: vec![store::entry::Id::INVALID; store.entries.len()].into_boxed_slice(),
             trusted_dependencies_mutex: Default::default(),

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -7,7 +7,7 @@ use bun_core::{Environment, Global, Output};
 use bun_core::{ZStr, strings};
 use bun_paths::{self as paths, AbsPath, AutoAbsPath, AutoRelPath};
 use bun_sys::{self as sys, Fd};
-use bun_threading::{Mutex, UnboundedQueue, thread_pool};
+use bun_threading::{Mutex, UnboundedQueue, WaitGroup, thread_pool};
 
 use bun_semver::String as SemverString;
 use bun_sys::{FdDirExt as _, FdExt as _};
@@ -91,6 +91,13 @@ pub struct Installer<'a> {
     pub(crate) task_queue: UnboundedQueue<Task>, // intrusive via .next
     pub(crate) tasks: Box<[Task]>,
 
+    /// Tasks currently on the thread pool: `start_task` adds one, the
+    /// `CountedTask` in `Task::task` finishes it, and `Drop` waits for it.
+    pub(crate) tasks_in_flight: &'a WaitGroup,
+
+    /// Main thread only: entries whose pending-task slot has been released.
+    pub(crate) released: Bitset,
+
     /// Stable Rust has no
     /// generic atomic-enum, so store the `#[repr(u8)]` discriminant and
     /// round-trip via `Method::from_u8` at the load sites below.
@@ -117,6 +124,14 @@ pub struct Installer<'a> {
     /// Main-thread only: `waiters_head[dep]` starts the intrusive list of blocked entries waiting on `dep`, linked through `next_waiter`.
     pub(crate) waiters_head: Box<[StoreEntryId]>,
     pub(crate) next_waiter: Box<[StoreEntryId]>,
+}
+
+impl Drop for Installer<'_> {
+    /// Tasks on the pool read `self` and the store through `Task::installer`, so
+    /// neither may be freed until they have returned.
+    fn drop(&mut self) {
+        self.tasks_in_flight.wait();
+    }
 }
 
 impl<'a> Installer<'a> {
@@ -166,10 +181,36 @@ impl<'a> Installer<'a> {
             | Result::RunScripts(_)
         ));
 
+        if Environment::CI_ASSERT {
+            assert!(
+                !self.released.is_set(entry_id.get() as usize),
+                "isolated install: started entry {} after its pending task was released",
+                entry_id.get()
+            );
+        }
+
         task.result = Result::None;
+        self.tasks_in_flight.add_one();
+        let task: *mut Task = task;
+        // SAFETY: raw projection through the whole `tasks[entry_id]` slot, so the
+        // pointer `Task::callback` gets back keeps provenance over the whole `Task`.
+        let pool_task = unsafe { &raw mut (*task).task.task };
         manager
             .thread_pool
-            .schedule(thread_pool::Batch::from(&raw mut task.task));
+            .schedule(thread_pool::Batch::from(pool_task));
+    }
+
+    /// Main thread only. Every entry releases its pending-task slot exactly once.
+    fn release_pending_task(&mut self, entry_id: StoreEntryId) {
+        if Environment::CI_ASSERT {
+            assert!(
+                !self.released.is_set(entry_id.get() as usize),
+                "isolated install: released the pending task of entry {} twice",
+                entry_id.get()
+            );
+        }
+        self.released.set(entry_id.get() as usize);
+        self.manager_mut().decrement_pending_tasks();
     }
 
     /// Called from main thread, for an existing project-local store entry.
@@ -434,12 +475,8 @@ impl<'a> Installer<'a> {
 
         self.summary.fail += 1;
 
-        self.decrement_pending_tasks();
+        self.release_pending_task(entry_id);
         self.resume_unblocked_tasks(entry_id);
-    }
-
-    pub(crate) fn decrement_pending_tasks(&mut self) {
-        self.manager_mut().decrement_pending_tasks();
     }
 
     /// Called from main thread
@@ -516,7 +553,7 @@ impl<'a> Installer<'a> {
             );
         }
 
-        self.decrement_pending_tasks();
+        self.release_pending_task(entry_id);
         self.resume_unblocked_tasks(entry_id);
 
         if let Some(node) = self.install_node.as_mut() {
@@ -651,7 +688,8 @@ pub struct Task {
     /// any `start_task` call — see `isolated_install.rs`.
     pub(crate) installer: bun_ptr::BackRef<Installer<'static>>,
 
-    pub(crate) task: thread_pool::Task,
+    /// Counted on `Installer::tasks_in_flight`; runs `Task::callback`.
+    pub(crate) task: thread_pool::CountedTask,
     pub(crate) next: bun_threading::Link<Task>, // INTRUSIVE: bun.UnboundedQueue(Task, .next) link
 
     pub(crate) result: Result,
@@ -1947,15 +1985,17 @@ impl Task {
             Err(_oom) => bun_core::out_of_memory(),
         };
 
-        // SAFETY: installer outlives all tasks (BACKREF). `callback` runs on the
-        // thread pool concurrently across many `Task`s sharing the same
-        // `*mut Installer` — never materialize `&mut Installer`. `task_queue.push`
-        // takes `&self` (lock-free); `store.entries` columns are atomic / per-entry;
-        // both are reached through a shared `&Installer`. `manager.wake()` is the
-        // cross-thread wakeup: route through `PackageManager::wake_raw` which never
-        // forms `&mut PackageManager`, so two threads finishing simultaneously do
-        // not hold aliased exclusive borrows ("deref it fresh per call" alone
-        // would not prevent the `&mut` lifetimes from overlapping).
+        // SAFETY: the installer is alive until this fn returns: `Task::task` counts
+        // on `Installer::tasks_in_flight` until then, and `Installer::drop` waits
+        // for that count. `callback` runs on the thread pool concurrently across
+        // many `Task`s sharing the same `*mut Installer` — never materialize
+        // `&mut Installer`. `task_queue.push` takes `&self` (lock-free);
+        // `store.entries` columns are atomic / per-entry; both are reached through
+        // a shared `&Installer`. `manager.wake()` is the cross-thread wakeup: route
+        // through `PackageManager::wake_raw` which never forms
+        // `&mut PackageManager`, so two threads finishing simultaneously do not
+        // hold aliased exclusive borrows ("deref it fresh per call" alone would
+        // not prevent the `&mut` lifetimes from overlapping).
         let installer_ptr = this.installer;
         let installer = installer_ptr.get();
         let manager_ptr: *mut PackageManager = installer.manager;

--- a/src/install/isolated_install/Store.rs
+++ b/src/install/isolated_install/Store.rs
@@ -99,7 +99,7 @@ impl Drop for Store {
         use entry::EntryColumns as _;
         for slot in self.entries.items_scripts() {
             if let Some(list) = slot.take() {
-                // SAFETY: the installer returned only after every task finished, so nothing else references the list boxed in Installer's RunPreinstall step.
+                // SAFETY: `Installer::drop` waited for every task on the pool, so nothing else references the list boxed in Installer's RunPreinstall step.
                 unsafe { bun_core::heap::destroy(list) };
             }
         }


### PR DESCRIPTION
### Problem
- BUN-4960: `bun install --linker=isolated` segfaults in `Installer::is_task_blocked` (`Segmentation fault at address 0x807`). The report's feature bits show `Global::exit` never ran, so `install_isolated_packages` returned while a pool task still read the installer.
- `Installer` and `Store` are locals of that function (`src/install/isolated_install.rs`) and every task reads them through `Task::installer`. No return path waited for the tasks. An early return under ASAN gives a `heap-use-after-free` in a pool thread (Notes).
- The exact way the released build left the function is still unknown. The candidates are a pending-task slot released twice and the `?` returns after tasks were started.

### Fix
- Each `Task` embeds a `thread_pool::CountedTask` on a `WaitGroup` that the function owns. `start_task` adds one, the pool finishes it when `Task::callback` returns, and `Installer::drop` waits for it. Every way out of the function now drains the pool before the installer and the store are freed. On the normal path the wait returns at once.
- Under `CI_ASSERT` (on in canary) `Installer.released` records each entry whose slot was released. A second release, or a start after it, panics with the entry id instead of leaving a later segfault. This names the unknown trigger if it happens again.
- Verified by fault injection only (Notes). The drain has no behavior a test can observe from outside: a release build reaches it only through the unknown trigger or an allocation failure. The hang that an earlier version of this PR also fixed is now #39672, with its tests.
- Touches the same `start_task` lines as #37894. Whichever lands second needs a trivial rebase.

### Background
- The isolated installer builds one `Store` entry per package variant and one `Task` per entry. Tasks run on the shared thread pool and report back through `Installer.task_queue`.
- The main thread holds one pending-task slot per entry and leaves the loop when the count is zero. A slot released twice lets it leave while a task still runs.
- `CountedTask` (`src/threading/ThreadPool.rs`) wraps a task callback and finishes a `WaitGroup` after the callback returns. `WaitGroup::wait` returns only after that finish is done with the group, so the waiter may free everything afterwards.
- `Store::drop` already assumed that no task was running. `Installer::drop` makes it true. The installer borrows both the store and the group, so it is dropped before them.

<details><summary>Notes</summary>

**What the report says.** Trace string `li252bf09c...`: one frame, `is_task_blocked`, fault address `0x807`. The packed features decode to binlinks, bunfig, extracted_packages, text_lockfile, isolated_bun_install. Bit 50 (`exited`, set by `Global::exit`) is clear, and so are `lifecycle_scripts` and `git_dependencies`. On Linux `Global::exit` is `quick_exit`, which keeps the stack intact, so the exit paths cannot free the store either way. The `dependencies` column of a store entry is always a built `Vec` (`build_store` appends whole entries, `Dependencies::EMPTY` is `Vec::new()`), so a lazily initialised list is not the cause. What remains is the driver leaving the function. Every `?` return after the start loop is reachable only on allocation failure (`get_or_put`, `package_patch_info`, and `build_url`, whose string store falls back to the heap for long URLs), which is also why no test can reach the drain from outside. I did not find a double release by reading, or by running the install suites and a download failure stress with a per-entry state assertion, which is why the assertion ships in canary builds.

**Fault injection.** I temporarily added `return Err(AllocError)` after the start loop and ran a 53 package isolated install with a warm cache on the ASAN build. Without the drain: `AddressSanitizer: heap-use-after-free ... READ of size 8 ... thread T5 (Bun Pool 1)` at `ThreadPool.rs:1249` (the task callback), freed by `drop_glue::<Installer>` in `install_isolated_packages`, in 4 of 5 runs (one of them a 4 byte read, a step load). With the `CountedTask` drain: nothing in 6 of 6 runs. The injection is not part of this PR.

**Re-scheduling.** A task that reports `Blocked` or `RunScripts` is scheduled again later by `start_task`, which adds to the group before the previous finish may have run. That is an add racing a finish on a count of at least one, which `WaitGroup` supports. `wait()` is only called from `drop`, after the last `start_task`. The `Yield::Yield` arm (the unreachable `Blocked` step) returns from the callback like every other arm, so its count is finished too.

**Possible follow-up, not in this PR.** A check in `Wait::is_done` that fails entries whose download callbacks can no longer arrive would turn the next accounting drift into an exit 1 instead of a hang.

**Suites run** with the debug build: `isolated-install` (82), `isolated-relink`, `public-hoist-pattern`, `bun-workspaces`, `bun-install-lifecycle-scripts` (3 failures that need `node` on PATH, same before the change), `test/internal/source-lints`. `cargo clippy -p bun_install` and `cargo fmt` are clean. A stress of 53 entries with 404, 500 and dropped tarball downloads found no crash or assertion.
</details>
