### PR TITLE
usockets: report an out-of-descriptors event loop init as an error, not a crash

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -230,6 +230,9 @@ struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(struct us_loop_t 
 
 #ifdef LIBUS_USE_EPOLL
     loop->fd = epoll_create1(EPOLL_CLOEXEC);
+    if (loop->fd == -1) {
+        Bun__loopInitFailed("epoll_create1", errno);
+    }
 
     if (has_epoll_pwait2 == -1) {
         if (Bun__isEpollPwait2SupportedOnLinuxKernel() == 0) {
@@ -239,6 +242,9 @@ struct us_loop_t *us_create_loop(void *hint, void (*wakeup_cb)(struct us_loop_t 
 
 #else
     loop->fd = kqueue();
+    if (loop->fd == -1) {
+        Bun__loopInitFailed("kqueue", errno);
+    }
 #endif
 
     us_internal_loop_data_init(loop, wakeup_cb, pre_cb, post_cb);
@@ -786,10 +792,7 @@ struct us_internal_async *us_internal_create_async(struct us_loop_t *loop, int f
 
     int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
     if (efd == -1) {
-        // eventfd only fails on EMFILE/ENFILE — the loop is unusable without
-        // wakeup_async, and the sole caller doesn't NULL-check. Crash loudly
-        // rather than NULL-deref or store -1 as a poll fd.
-        BUN_PANIC("eventfd() failed during loop init (out of file descriptors?)");
+        Bun__loopInitFailed("eventfd", errno);
     }
     us_poll_init(p, efd, POLL_TYPE_CALLBACK);
 

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -75,6 +75,10 @@ extern void __attribute__((__noreturn__)) Bun__panic(const char *message, size_t
  * allocations this library has no way to fail gracefully from. */
 extern void __attribute__((__noreturn__)) Bun__outOfMemory(void);
 
+/* us_create_loop could not get a descriptor the loop needs. Exits with the
+ * file descriptor limit error for EMFILE/ENFILE, crashes for anything else. */
+extern void __attribute__((__noreturn__)) Bun__loopInitFailed(const char *syscall_name, int err);
+
 /* The error code a loop-driven close carries (recv()'s error, SO_ERROR, or
  * the fallback where those report nothing) is in LIBUS_ERR's numbering: errno
  * on POSIX, a WSA code on Windows, which on_close maps (socket_body.rs). The

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1286,7 +1286,7 @@ mod draft {
             err_generic!(
                 "The current working directory was deleted, so that command didn't work. Please cd into a different directory and try again.",
             );
-        } else if name == b"SystemFdQuotaExceeded" {
+        } else if matches!(name, b"SystemFdQuotaExceeded" | b"ENFILE") {
             #[cfg(unix)]
             {
                 let limit = getrlimit_nofile().map(|l| l.rlim_cur);
@@ -1329,7 +1329,7 @@ mod draft {
                     "<r><red>error<r>: Your computer ran out of file descriptors <d>(<red>SystemFdQuotaExceeded<r><d>)<r>",
                 );
             }
-        } else if name == b"ProcessFdQuotaExceeded" {
+        } else if matches!(name, b"ProcessFdQuotaExceeded" | b"EMFILE") {
             #[cfg(unix)]
             {
                 let limit = getrlimit_nofile().map(|l| l.rlim_cur);

--- a/src/runtime/bin_entry/c_abi_exports.rs
+++ b/src/runtime/bin_entry/c_abi_exports.rs
@@ -1,5 +1,5 @@
 //! C-ABI entry points that belong to the final binary rather than any
-//! library crate: the process-level panic hook and the OOM crash handler.
+//! library crate: the process-level panic hook and the fatal-exit hooks.
 //!
 //! Everything else that used to live here has a real home in `bun_jsc` /
 //! `bun_runtime` and is exported via `generate-host-exports.ts`.
@@ -26,4 +26,31 @@ extern "C" fn Bun__panic(msg: *const u8, len: usize) -> ! {
 #[unsafe(no_mangle)]
 extern "C" fn Bun__outOfMemory() -> ! {
     bun_core::out_of_memory()
+}
+
+/// Exit for bun-usockets when `us_create_loop` cannot get a descriptor.
+/// `syscall_name` must be NUL-terminated.
+#[cfg(unix)]
+#[unsafe(no_mangle)]
+unsafe extern "C" fn Bun__loopInitFailed(
+    syscall_name: *const core::ffi::c_char,
+    err: core::ffi::c_int,
+) -> ! {
+    use bun_sys::{E, SystemErrno};
+
+    let errno = SystemErrno::init(i64::from(err));
+    if let Some(errno @ (E::EMFILE | E::ENFILE)) = errno {
+        bun_crash_handler::handle_root_error(errno, None);
+    }
+    // SAFETY: the caller passes a NUL-terminated string literal.
+    let syscall_name =
+        bstr::BStr::new(unsafe { core::ffi::CStr::from_ptr(syscall_name) }.to_bytes());
+    match errno {
+        Some(errno) => bun_core::output::panic(format_args!(
+            "{syscall_name}() failed while creating the event loop: {errno}"
+        )),
+        None => bun_core::output::panic(format_args!(
+            "{syscall_name}() failed while creating the event loop: errno {err}"
+        )),
+    }
 }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isGlibc, isLinux, isPosix, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import { rmSync } from "node:fs";
 import { constants as osConstants } from "node:os";
 import path from "path";
@@ -558,6 +558,145 @@ describe.if(isPosix)("process.kill() aimed at the process itself is not reported
     expect(stderr).toContain("abort() called");
     expect(stderr).toContain("oh no: Bun has crashed");
     expect({ exitCode, exited }).toEqual({ exitCode: null, exited: diedFrom("SIGABRT") });
+  });
+});
+
+// The event loop is created before the entry point is read. On Linux that
+// takes two descriptors, an epoll instance and the wakeup eventfd, so a process
+// that starts out of descriptors (`ulimit -n 4`) fails right there. That is the
+// environment's limit, not a bug in Bun: it must print the file descriptor
+// error and exit 1 instead of aborting with a crash report.
+//
+// An LD_PRELOAD shim fails the syscall instead of a real `ulimit -n` because
+// the limit at which the loop's syscall is the first one to fail depends on
+// how many descriptors the build holds by then (debug builds hold one more).
+// bun-musl is statically linked, so LD_PRELOAD cannot interpose there.
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+describe.skipIf(!isGlibc || !cc)("out of file descriptors while creating the event loop", () => {
+  // FAIL_LOOP_SYSCALL names the function that fails, FAIL_LOOP_ERRNO the errno
+  // it fails with. The other function passes through to libc.
+  const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/resource.h>
+
+/* A build without the fix aborts. Keep its core file off the CI runner, which
+ * flags leaked core files. RLIMIT_CORE survives exec. */
+__attribute__((constructor)) static void no_core(void) {
+  struct rlimit rl = {0, 0};
+  setrlimit(RLIMIT_CORE, &rl);
+}
+
+static int should_fail(const char *name) {
+  const char *target = getenv("FAIL_LOOP_SYSCALL");
+  if (!target || strcmp(target, name) != 0) return 0;
+  const char *err = getenv("FAIL_LOOP_ERRNO");
+  errno = err && strcmp(err, "ENFILE") == 0 ? ENFILE : err && strcmp(err, "ENOMEM") == 0 ? ENOMEM : EMFILE;
+  return 1;
+}
+
+int epoll_create1(int flags) {
+  if (should_fail("epoll_create1")) return -1;
+  return ((int (*)(int)) dlsym(RTLD_NEXT, "epoll_create1"))(flags);
+}
+
+int eventfd(unsigned int initval, int flags) {
+  if (should_fail("eventfd")) return -1;
+  return ((int (*)(unsigned int, int)) dlsym(RTLD_NEXT, "eventfd"))(initval, flags);
+}
+`;
+
+  async function runWithFailingSyscall(syscall: string, errno: string, env: Record<string, string | undefined>) {
+    using dir = tempDir("loop-init-fd-limit", {
+      "shim.c": SHIM_C,
+      "app.js": "console.log('entry point ran');\n",
+    });
+    const shimPath = path.join(String(dir), "shim.so");
+    await using ccProc = Bun.spawn({
+      cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, path.join(String(dir), "shim.c"), "-ldl"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+    if (ccExit !== 0) throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+
+    await using proc = Bun.spawn({
+      // The flag only matters when the child crashes: it makes debug builds
+      // print the trace string instead of spawning llvm-symbolizer.
+      cmd: [bunExe(), "app.js", "--debug-crash-handler-use-trace-string"],
+      cwd: String(dir),
+      env: {
+        ...env,
+        LD_PRELOAD: env.LD_PRELOAD ? `${shimPath}:${env.LD_PRELOAD}` : shimPath,
+        FAIL_LOOP_SYSCALL: syscall,
+        FAIL_LOOP_ERRNO: errno,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+  }
+
+  test.concurrent.each([
+    ["epoll_create1", "EMFILE", "bun ran out of file descriptors (ProcessFdQuotaExceeded)"],
+    ["eventfd", "EMFILE", "bun ran out of file descriptors (ProcessFdQuotaExceeded)"],
+    ["eventfd", "ENFILE", "Your computer ran out of file descriptors (SystemFdQuotaExceeded)"],
+  ])(
+    "%s failing with %s exits 1 with the file descriptor error and no crash report",
+    async (syscall, errno, message) => {
+      let sent = false;
+      using server = Bun.serve({
+        port: 0,
+        fetch() {
+          sent = true;
+          return new Response("OK");
+        },
+      });
+
+      const result = await runWithFailingSyscall(
+        syscall,
+        errno,
+        mergeWindowEnvs([
+          bunEnv,
+          {
+            BUN_CRASH_REPORT_URL: server.url.toString(),
+            BUN_ENABLE_CRASH_REPORTING: "1",
+            GITHUB_ACTIONS: undefined,
+            CI: undefined,
+          },
+        ]),
+      );
+
+      expect(result).toEqual({
+        stdout: "",
+        stderr: expect.stringContaining(message),
+        exitCode: 1,
+        signalCode: null,
+      });
+      expect(result.stderr).toContain("ulimit -n");
+      expect(result.stderr).not.toContain("Bun has crashed");
+      expect(result.stderr).not.toContain(server.url.toString());
+      expect(sent).toBe(false);
+    },
+  );
+
+  // Only the descriptor limit is the environment's problem. Any other failure
+  // of the same syscalls is still a bug and still gets a crash report that
+  // names the syscall and the errno.
+  test.concurrent("eventfd failing with another errno is still reported as a crash", async () => {
+    const result = await runWithFailingSyscall("eventfd", "ENOMEM", noReportEnv);
+
+    expect(result).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining("panic: eventfd() failed while creating the event loop: ENOMEM"),
+      exitCode: 134,
+      signalCode: "SIGABRT",
+    });
+    expect(result.stderr).toContain("Bun has crashed");
   });
 });
 


### PR DESCRIPTION
### Problem
- `bun app.js` with no free file descriptors (`ulimit -n 4`) dies in the crash handler: `panic: eventfd() failed during loop init (out of file descriptors?)`, then a crash report. The limit is the environment's, not a bug. No user has reported this site. It was found next to the reported watcher site that #39629 fixes.
- `us_create_loop` (`packages/bun-usockets/src/eventing/epoll_kqueue.c:235`) does not check `epoll_create1()` or `kqueue()`. `us_internal_create_async` (`epoll_kqueue.c:788`) turns an `eventfd()` failure into `BUN_PANIC`.

### Fix
- The three sites call the new `Bun__loopInitFailed(syscall, errno)` in `src/runtime/bin_entry/c_abi_exports.rs`. For EMFILE and ENFILE it passes the errno to `handle_root_error`: the existing `ulimit -n` advice, exit 1, no crash report. Any other errno still panics, and the message names the syscall and the errno.
- `handle_root_error` keyed its two descriptor branches on the Zig names `ProcessFdQuotaExceeded` / `SystemFdQuotaExceeded`. Errno errors are named `EMFILE` / `ENFILE`, so the branches now accept those names too.
- The failure stays fatal. Every caller dereferences the new loop. #33850 made loop creation fallible and was rejected for that reason. This change only changes the report.
- Verified: `test/cli/run/run-crash-handler.test.ts`, block "out of file descriptors while creating the event loop" (4 tests, all fail on the current build).

### Background
- `us_create_loop` creates the uSockets loop of a thread. On Linux it needs an epoll instance and an `eventfd` that other threads write to wake the loop. On macOS and FreeBSD it needs a kqueue. The main thread creates its loop in `VirtualMachine::init`, before the entry point is read.
- `handle_root_error` (`src/crash_handler/lib.rs`) is what `main` calls when a command returns an error. It maps some error names to advice and exits 1. It accepts a `SystemErrno` directly.
- `Bun__panic` and `Bun__outOfMemory` are the entry points uSockets already uses to end the process. The new export sits next to them.

<details><summary>Notes</summary>

**Second site, not fixed here.** With one more free descriptor (`ulimit -n 5`) startup gets past the loop and into `JSC::VM::VM`, which calls `WTF::cryptographicallyRandomNumber`. `WTF::RandomDevice::RandomDevice` (`Source/WTF/wtf/RandomDevice.cpp:75` in the WebKit fork) opens `/dev/urandom` and calls `CRASH()` when that fails. Bun then prints `panic(main thread): abort() called` with a crash report. Found with gdb on the debug build. The fix belongs in the WebKit fork, for example `getrandom(2)` on Linux. That needs no descriptor, and it would also free a descriptor that every bun process holds for its whole lifetime today. This site is also the one behind the `--watch` restart loop from the report: the signal path of the crash handler honors auto reload on crash, the Rust panic hook path does not. So the `eventfd` panic never restarted, and the WebKit abort still does.

**Related PRs.**
- #37339 rewrites the advice text of the two descriptor branches (it fixes #37337). This PR does not touch those strings, so the two merge cleanly in either order (checked with `git merge-tree`). The only overlap is the `harness` import line of the test file. On current main the Linux advice still prints `sudo echo ... /etc/sysctl.conf` without the `>>`, because the `<tag>` formatter drops a bare `>`. #37339 replaces that line.
- #35033 edits the same three usockets sites the other way round (`us_create_loop` returns NULL) for the private `spawnSync` loop, and also fixes a Windows `uv_loop_new()` NULL dereference in `libuv.c` that this PR does not touch. If this PR lands, the three usockets hunks of #35033 are superseded and its Windows hunk still stands. Left a note there.
- #33845 is about the lazily created `IoRequestLoop`, a different loop. #39629 fixes the watcher site from the same report (`ulimit -n 6` with `--watch`).

**Descriptor budget at startup** (Linux, release build, in order): epoll, eventfd, `/dev/urandom` (WTF, kept open), `/proc/self/statm` (kept open), then the entry point is read. `ulimit -n 6` and `7` give the normal `error: EMFILE reading "app.js"`. `8` runs. The debug build opens `/dev/urandom` once more before the loop, so every site fires one limit higher there. That is why the test injects the failure with an LD_PRELOAD shim instead of a real `ulimit -n`. The shim exercises the same code path: the kernel fails the same call with the same errno. With the debug build, a real `ulimit -n 5` prints the descriptor error and exits 1.

**Unchecked `epoll_create1` before this change.** The `epoll_create1` test case runs `app.js` and exits 0 on the current build. Every `epoll_ctl` on fd -1 fails silently and `epoll_wait` returns EBADF at once, so the loop spins, timers still fire, and no socket can ever be registered.

**Who creates loops.** `uWS::Loop::get()` creates the loop of the main thread (from `VirtualMachine::init`), of the HTTP client thread, and of each worker. `SpawnSyncEventLoop` creates a private one for `spawnSync`. All of them dereference the result. For the lazily created loops this change also turns the crash report into the descriptor error: the process still exits.

**Earlier shape of this PR.** The first push kept `handle_root_error` keyed on the Zig names, mapped the errno to those names in the export, and escaped the `>>` in the two Linux messages. The self-review pointed out the escape hunks conflict with #37339 and that the Zig-name branches were unreachable for every errno error in the Rust port. The branches now accept the errno names and the message text is left to #37339.

**Rebase.** Main added a describe block at the same place in `run-crash-handler.test.ts` (#39953) and dropped `isASAN` from its imports. Both blocks are kept, main's first. No other conflicts.

**Runs.** New block: 4 pass with `bun bd`, 4 fail with the released build (two SIGABRT crash reports, one exit 0 with the entry point run, one with the old panic text). Whole `run-crash-handler.test.ts`: 21 pass. `test/js/bun/http/serve-epoll-add-fail.test.ts`: 6 pass. A fetch + Worker + spawnSync smoke run with the debug build. `cargo fmt --check`. `cargo clippy` on the export's crate and `bun_crash_handler`: clean. After the rebase onto #39895 (which moved the export's file from `src/bun_bin/` to `src/runtime/bin_entry/`) the whole file reports 31 pass, 7 skip with `bun bd`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->
