### PR TITLE
ws: let handleUpgrade() run after an await, and fail like the npm package

### DIFF
--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1603,6 +1603,8 @@ class WebSocketServer extends EventEmitter {
    */
   handleUpgrade(req, socket, head, cb) {
     // Stays attached after the upgrade: node:http removed its own listener at the handoff.
+    // One copy, however many WebSocketServers on the http.Server see the same socket.
+    socket.removeListener("error", socketOnError);
     socket.on("error", socketOnError);
 
     const key = req.headers["sec-websocket-key"];

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -932,24 +932,10 @@ function wsEmitClose(server) {
   server.emit("close");
 }
 
-/**
- * Handle socket errors.
- *
- * @private
- */
 function socketOnError() {
   this.destroy();
 }
 
-/**
- * Close the connection when preconditions are not fulfilled.
- *
- * @param {Duplex} socket The socket of the upgrade request
- * @param {Number} code The HTTP response status code
- * @param {String} [message] The HTTP response body
- * @param {Object} [headers] Additional HTTP response headers
- * @private
- */
 function abortHandshake(socket, code, message, headers) {
   const { STATUS_CODES } = lazyHttp();
   message = message || STATUS_CODES[code];

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -933,9 +933,8 @@ function wsEmitClose(server) {
 }
 
 function abortHandshake(socket, code, message, headers = {}) {
-  // node:http does not assign a ServerResponse to the socket of an 'upgrade'
-  // request, so the reply goes through the native response handle instead.
-  // Both are gone once the socket has been closed or destroyed.
+  // An 'upgrade' socket has no ServerResponse, so reply through the native
+  // response handle. A closed socket has neither.
   const response = socket._httpMessage || socket[kBunInternals];
   if (!response) {
     socket.destroy();
@@ -1525,9 +1524,7 @@ class WebSocketServer extends EventEmitter {
    * @private
    */
   completeUpgrade(extensions, key, protocols, request, socket, head, cb) {
-    //
     // Destroy the socket if the client has already sent a FIN packet.
-    //
     if (!socket.readable || !socket.writable) return socket.destroy();
 
     const server = socket.server[kBunInternals];

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1543,7 +1543,6 @@ class WebSocketServer extends EventEmitter {
     // Destroy the socket if the client has already sent a FIN packet.
     if (!socket.readable || !socket.writable) return socket.destroy();
 
-    const server = socket.server[kBunInternals];
     const req = socket[kBunInternals];
 
     if (req?.upgraded) {
@@ -1553,6 +1552,8 @@ class WebSocketServer extends EventEmitter {
     }
 
     if (this._state > RUNNING) return abortHandshake(socket, 503);
+
+    const server = socket.server[kBunInternals];
 
     let protocol = "";
     if (protocols.size) {

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -932,7 +932,16 @@ function wsEmitClose(server) {
   server.emit("close");
 }
 
-function abortHandshake(response, code, message, headers = {}) {
+function abortHandshake(socket, code, message, headers = {}) {
+  // node:http does not assign a ServerResponse to the socket of an 'upgrade'
+  // request, so the reply goes through the native response handle instead.
+  // Both are gone once the socket has been closed or destroyed.
+  const response = socket._httpMessage || socket[kBunInternals];
+  if (!response) {
+    socket.destroy();
+    return;
+  }
+
   message = message || lazyHttp().STATUS_CODES[code];
   headers = {
     Connection: "close",
@@ -946,14 +955,14 @@ function abortHandshake(response, code, message, headers = {}) {
   response.end();
 }
 
-function abortHandshakeOrEmitwsClientError(server, req, response, socket, code, message) {
+function abortHandshakeOrEmitwsClientError(server, req, socket, code, message) {
   if (server.listenerCount("wsClientError")) {
     const err = new Error(message);
     Error.captureStackTrace(err, abortHandshakeOrEmitwsClientError);
 
     server.emit("wsClientError", err, socket, req);
   } else {
-    abortHandshake(response, code, message);
+    abortHandshake(socket, code, message);
   }
 }
 
@@ -1516,11 +1525,21 @@ class WebSocketServer extends EventEmitter {
    * @private
    */
   completeUpgrade(extensions, key, protocols, request, socket, head, cb) {
-    const response = socket._httpMessage;
+    //
+    // Destroy the socket if the client has already sent a FIN packet.
+    //
+    if (!socket.readable || !socket.writable) return socket.destroy();
+
     const server = socket.server[kBunInternals];
     const req = socket[kBunInternals];
 
-    if (this._state > RUNNING) return abortHandshake(response, 503);
+    if (req?.upgraded) {
+      throw new Error(
+        "server.handleUpgrade() was called more than once with the same socket, possibly due to a misconfiguration",
+      );
+    }
+
+    if (this._state > RUNNING) return abortHandshake(socket, 503);
 
     let protocol = "";
     if (protocols.size) {
@@ -1555,7 +1574,7 @@ class WebSocketServer extends EventEmitter {
       }
       cb(ws, request);
     } else {
-      abortHandshake(response, 500);
+      abortHandshake(socket, 500);
     }
   }
   /**
@@ -1569,9 +1588,6 @@ class WebSocketServer extends EventEmitter {
    * @public
    */
   handleUpgrade(req, socket, head, cb) {
-    // socket is actually fake so we use internal http_res
-    const response = socket._httpMessage || socket[kBunInternals];
-
     // socket.on("error", socketOnError);
 
     const key = req.headers["sec-websocket-key"];
@@ -1579,31 +1595,31 @@ class WebSocketServer extends EventEmitter {
 
     if (req.method !== "GET") {
       const message = "Invalid HTTP method";
-      abortHandshakeOrEmitwsClientError(this, req, response, socket, 405, message);
+      abortHandshakeOrEmitwsClientError(this, req, socket, 405, message);
       return;
     }
 
     const upgrade = req.headers.upgrade;
     if (upgrade === undefined || upgrade.toLowerCase() !== "websocket") {
       const message = "Invalid Upgrade header";
-      abortHandshakeOrEmitwsClientError(this, req, response, socket, 400, message);
+      abortHandshakeOrEmitwsClientError(this, req, socket, 400, message);
       return;
     }
 
     if (!key || !wsKeyRegex.test(key)) {
       const message = "Missing or invalid Sec-WebSocket-Key header";
-      abortHandshakeOrEmitwsClientError(this, req, response, socket, 400, message);
+      abortHandshakeOrEmitwsClientError(this, req, socket, 400, message);
       return;
     }
 
     if (version !== 8 && version !== 13) {
       const message = "Missing or invalid Sec-WebSocket-Version header";
-      abortHandshakeOrEmitwsClientError(this, req, response, socket, 400, message);
+      abortHandshakeOrEmitwsClientError(this, req, socket, 400, message);
       return;
     }
 
     if (!this.shouldHandle(req)) {
-      abortHandshake(response, 400);
+      abortHandshake(socket, 400);
       return;
     }
 
@@ -1615,7 +1631,7 @@ class WebSocketServer extends EventEmitter {
         protocols = subprotocolParse(secWebSocketProtocol);
       } catch {
         const message = "Invalid Sec-WebSocket-Protocol header";
-        abortHandshakeOrEmitwsClientError(this, req, response, socket, 400, message);
+        abortHandshakeOrEmitwsClientError(this, req, socket, 400, message);
         return;
       }
     }
@@ -1637,7 +1653,7 @@ class WebSocketServer extends EventEmitter {
       if (this.options.verifyClient.length === 2) {
         this.options.verifyClient(info, (verified, code, message, headers) => {
           if (!verified) {
-            return abortHandshake(response, code || 401, message, headers);
+            return abortHandshake(socket, code || 401, message, headers);
           }
 
           this.completeUpgrade(extensions, key, protocols, req, socket, head, cb);
@@ -1645,7 +1661,7 @@ class WebSocketServer extends EventEmitter {
         return;
       }
 
-      if (!this.options.verifyClient(info)) return abortHandshake(response, 401);
+      if (!this.options.verifyClient(info)) return abortHandshake(socket, 401);
     }
 
     this.completeUpgrade(extensions, key, protocols, req, socket, head, cb);

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -933,8 +933,7 @@ function wsEmitClose(server) {
 }
 
 function abortHandshake(socket, code, message, headers = {}) {
-  // An 'upgrade' socket has no ServerResponse, so reply through the native
-  // response handle. A closed socket has neither.
+  // node:http gives an 'upgrade' socket no ServerResponse, and a closed socket has no native handle.
   const response = socket._httpMessage || socket[kBunInternals];
   if (!response) {
     socket.destroy();

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -932,15 +932,27 @@ function wsEmitClose(server) {
   server.emit("close");
 }
 
-function abortHandshake(socket, code, message, headers = {}) {
-  // node:http gives an 'upgrade' socket no ServerResponse, and a closed socket has no native handle.
-  const response = socket._httpMessage || socket[kBunInternals];
-  if (!response) {
-    socket.destroy();
-    return;
-  }
+/**
+ * Handle socket errors.
+ *
+ * @private
+ */
+function socketOnError() {
+  this.destroy();
+}
 
-  message = message || lazyHttp().STATUS_CODES[code];
+/**
+ * Close the connection when preconditions are not fulfilled.
+ *
+ * @param {Duplex} socket The socket of the upgrade request
+ * @param {Number} code The HTTP response status code
+ * @param {String} [message] The HTTP response body
+ * @param {Object} [headers] Additional HTTP response headers
+ * @private
+ */
+function abortHandshake(socket, code, message, headers) {
+  const { STATUS_CODES } = lazyHttp();
+  message = message || STATUS_CODES[code];
   headers = {
     Connection: "close",
     "Content-Type": "text/html",
@@ -948,19 +960,38 @@ function abortHandshake(socket, code, message, headers = {}) {
     ...headers,
   };
 
-  response.writeHead(code, headers);
-  response.write(message);
-  response.end();
+  // handleUpgrade() was called from a 'request' listener: answer through its ServerResponse.
+  const response = socket._httpMessage;
+  if (response) {
+    response.writeHead(code, headers);
+    response.write(message);
+    response.end();
+    return;
+  }
+
+  // Another WebSocketServer on the same http.Server has already taken this connection.
+  if (socket[kBunInternals]?.upgraded) return;
+
+  socket.once("finish", socket.destroy);
+
+  socket.end(
+    `HTTP/1.1 ${code} ${STATUS_CODES[code]}\r\n` +
+      Object.keys(headers)
+        .map(h => `${h}: ${headers[h]}`)
+        .join("\r\n") +
+      "\r\n\r\n" +
+      message,
+  );
 }
 
-function abortHandshakeOrEmitwsClientError(server, req, socket, code, message) {
+function abortHandshakeOrEmitwsClientError(server, req, socket, code, message, headers) {
   if (server.listenerCount("wsClientError")) {
     const err = new Error(message);
     Error.captureStackTrace(err, abortHandshakeOrEmitwsClientError);
 
     server.emit("wsClientError", err, socket, req);
   } else {
-    abortHandshake(socket, code, message);
+    abortHandshake(socket, code, message, headers);
   }
 }
 
@@ -1584,7 +1615,8 @@ class WebSocketServer extends EventEmitter {
    * @public
    */
   handleUpgrade(req, socket, head, cb) {
-    // socket.on("error", socketOnError);
+    // Stays attached after the upgrade: node:http removed its own listener at the handoff.
+    socket.on("error", socketOnError);
 
     const key = req.headers["sec-websocket-key"];
     const version = +req.headers["sec-websocket-version"];
@@ -1610,7 +1642,9 @@ class WebSocketServer extends EventEmitter {
 
     if (version !== 8 && version !== 13) {
       const message = "Missing or invalid Sec-WebSocket-Version header";
-      abortHandshakeOrEmitwsClientError(this, req, socket, 400, message);
+      abortHandshakeOrEmitwsClientError(this, req, socket, 400, message, {
+        "Sec-WebSocket-Version": "13, 8",
+      });
       return;
     }
 

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -1602,9 +1602,9 @@ class WebSocketServer extends EventEmitter {
    * @public
    */
   handleUpgrade(req, socket, head, cb) {
-    // Stays attached after the upgrade: node:http removed its own listener at the handoff.
-    // One copy, however many WebSocketServers on the http.Server see the same socket.
+    // Every WebSocketServer on the http.Server sees this socket. Keep one copy.
     socket.removeListener("error", socketOnError);
+    // Stays attached after the upgrade: node:http removed its own listener at the handoff.
     socket.on("error", socketOnError);
 
     const key = req.headers["sec-websocket-key"];

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -735,8 +735,7 @@ impl NodeHTTPResponse {
         let vm = vm_get();
         self.clear_on_data_callback(self.get_this_value(), vm.global());
         self.clear_pending_pinned_write(vm.global(), JSValue::ZERO);
-        // A tunneled connection stays open after this release, and its 'upgrade'
-        // listener may still call server.upgrade() on it (upgrade() resets it).
+        // A tunnel stays open, and ws may still upgrade it later. upgrade() resets this itself.
         if !self.flags.get().contains(Flags::TUNNELED) {
             self.upgrade_context.with_mut(|c| c.reset());
         }

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -735,8 +735,7 @@ impl NodeHTTPResponse {
         let vm = vm_get();
         self.clear_on_data_callback(self.get_this_value(), vm.global());
         self.clear_pending_pinned_write(vm.global(), JSValue::ZERO);
-        // A tunnel stays open, and ws may still upgrade it later, so keep a context whose
-        // headers were already copied out of the request. upgrade() resets it itself.
+        // ws may still upgrade an open tunnel: keep a context whose request pointer is detached.
         let tunneled = self.flags.get().contains(Flags::TUNNELED);
         self.upgrade_context.with_mut(|c| {
             if !tunneled || !c.request.is_null() {

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -735,7 +735,11 @@ impl NodeHTTPResponse {
         let vm = vm_get();
         self.clear_on_data_callback(self.get_this_value(), vm.global());
         self.clear_pending_pinned_write(vm.global(), JSValue::ZERO);
-        self.upgrade_context.with_mut(|c| c.reset());
+        // A tunneled connection stays open after this release, and its 'upgrade'
+        // listener may still call server.upgrade() on it (upgrade() resets it).
+        if !self.flags.get().contains(Flags::TUNNELED) {
+            self.upgrade_context.with_mut(|c| c.reset());
+        }
 
         self.buffered_request_body_data_during_pause
             .with_mut(|b| b.clear_and_free());

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -735,10 +735,14 @@ impl NodeHTTPResponse {
         let vm = vm_get();
         self.clear_on_data_callback(self.get_this_value(), vm.global());
         self.clear_pending_pinned_write(vm.global(), JSValue::ZERO);
-        // A tunnel stays open, and ws may still upgrade it later. upgrade() resets this itself.
-        if !self.flags.get().contains(Flags::TUNNELED) {
-            self.upgrade_context.with_mut(|c| c.reset());
-        }
+        // A tunnel stays open, and ws may still upgrade it later, so keep a context whose
+        // headers were already copied out of the request. upgrade() resets it itself.
+        let tunneled = self.flags.get().contains(Flags::TUNNELED);
+        self.upgrade_context.with_mut(|c| {
+            if !tunneled || !c.request.is_null() {
+                c.reset();
+            }
+        });
 
         self.buffered_request_body_data_during_pause
             .with_mut(|b| b.clear_and_free());

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -993,7 +993,8 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
     path = "/",
     key = "dGhlIHNhbXBsZSBub25jZQ==",
     version = "13",
-  }: { path?: string; key?: string; version?: string } = {}) {
+    body = "",
+  }: { path?: string; key?: string; version?: string; body?: string } = {}) {
     return [
       `GET ${path} HTTP/1.1`,
       "Host: localhost",
@@ -1001,8 +1002,22 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
       "Upgrade: websocket",
       `Sec-WebSocket-Version: ${version}`,
       ...(key ? [`Sec-WebSocket-Key: ${key}`] : []),
+      ...(body ? [`Content-Length: ${body.length}`] : []),
       "",
+      body,
+    ].join("\r\n");
+  }
+
+  // The reply the npm package writes for a rejected handshake.
+  function rejection(status: string, body = status.slice(4), headers: string[] = []) {
+    return [
+      `HTTP/1.1 ${status}`,
+      "Connection: close",
+      "Content-Type: text/html",
+      `Content-Length: ${body.length}`,
+      ...headers,
       "",
+      body,
     ].join("\r\n");
   }
 
@@ -1127,17 +1142,8 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
 
     expect(() => wss.handleUpgrade(req, socket, head, ws => connections.push(ws))).not.toThrow();
 
-    const message = "Missing or invalid Sec-WebSocket-Version header";
     expect(await upgrade.received()).toBe(
-      [
-        "HTTP/1.1 400 Bad Request",
-        "Connection: close",
-        "Content-Type: text/html",
-        `Content-Length: ${message.length}`,
-        "Sec-WebSocket-Version: 13, 8",
-        "",
-        message,
-      ].join("\r\n"),
+      rejection("400 Bad Request", "Missing or invalid Sec-WebSocket-Version header", ["Sec-WebSocket-Version: 13, 8"]),
     );
     expect(connections).toEqual([]);
     expect(socket.destroyed).toBe(true);
@@ -1152,18 +1158,44 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
     wss.close();
     expect(() => wss.handleUpgrade(req, socket, head, ws => connections.push(ws))).not.toThrow();
 
-    expect(await upgrade.received()).toBe(
-      [
-        "HTTP/1.1 503 Service Unavailable",
-        "Connection: close",
-        "Content-Type: text/html",
-        "Content-Length: 19",
-        "",
-        "Service Unavailable",
-      ].join("\r\n"),
-    );
+    expect(await upgrade.received()).toBe(rejection("503 Service Unavailable"));
     expect(connections).toEqual([]);
     expect(socket.destroyed).toBe(true);
+  });
+
+  it("answers once when no WebSocketServer on the http.Server serves the path", async () => {
+    const server = createServer();
+    const chat = new WebSocketServer({ server, path: "/chat" });
+    const other = new WebSocketServer({ server, path: "/other" });
+    const connections: unknown[] = [];
+    chat.on("connection", ws => connections.push(ws));
+    other.on("connection", ws => connections.push(ws));
+
+    // Both servers reject the request inside the 'upgrade' event. The first
+    // one ends the socket, so the second one's reply fails with a socket
+    // 'error', which the error handler handleUpgrade() installed absorbs.
+    await using upgrade = await receiveUpgrade(upgradeRequest({ path: "/nope" }), server);
+
+    expect(await upgrade.received()).toBe(rejection("400 Bad Request"));
+    expect(connections).toEqual([]);
+    expect(upgrade.socket.destroyed).toBe(true);
+    chat.close();
+    other.close();
+  });
+
+  it("upgrades a live socket from a later task when the request carried a body", async () => {
+    // node:http releases a request with a body once the body has arrived,
+    // not when the 'upgrade' listener returns. The body is never read here.
+    await using upgrade = await receiveUpgrade(upgradeRequest({ body: "hello" }));
+    const { req, socket, head } = upgrade;
+    const wss = new WebSocketServer({ noServer: true });
+    const connections: unknown[] = [];
+
+    await new Promise(resolve => setImmediate(resolve));
+    expect(() => wss.handleUpgrade(req, socket, head, ws => connections.push(ws))).not.toThrow();
+
+    expect(connections).toHaveLength(1);
+    expect(await upgrade.received("\r\n\r\n")).toStartWith("HTTP/1.1 101 Switching Protocols\r\n");
   });
 
   it("leaves a connection alone that another WebSocketServer on the same http.Server took", async () => {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -2,7 +2,7 @@ import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import crypto from "crypto";
-import { once } from "events";
+import { EventEmitter, once } from "events";
 import { bunEnv, bunExe, isDebug } from "harness";
 import { createServer } from "http";
 import { AddressInfo, connect } from "net";
@@ -929,7 +929,8 @@ describe("handleUpgrade without an Upgrade header", () => {
         written.ended = true;
       },
     };
-    const socket = { _httpMessage: response };
+    // A socket that node:http handed to a 'request' listener, with its ServerResponse attached.
+    const socket = Object.assign(new EventEmitter(), { _httpMessage: response });
     const request = {
       method: "GET",
       headers: {
@@ -956,7 +957,7 @@ describe("handleUpgrade without an Upgrade header", () => {
 
   it("emits wsClientError with the Invalid Upgrade header message", () => {
     const wss = new WebSocketServer({ noServer: true });
-    const socket = {};
+    const socket = new EventEmitter();
     const request = {
       method: "GET",
       headers: {
@@ -982,19 +983,24 @@ describe("handleUpgrade without an Upgrade header", () => {
   });
 });
 
-// Same behavior as the npm "ws" package: on a connection that is gone,
-// handleUpgrade() destroys the socket and returns without calling back. A
-// handshake it rejects itself is answered through the socket the 'upgrade'
-// event handed over, which node:http gives no ServerResponse.
+// Same behavior as the npm "ws" package. node:http hands an 'upgrade' request
+// over as a raw socket with no ServerResponse: a handshake the server rejects
+// is answered by writing to that socket and closing it, a socket whose
+// connection is gone is destroyed without a callback, and a live socket can
+// still be upgraded from a later task (after the app awaited something).
 describe("handleUpgrade on a node:http upgrade socket", () => {
-  function upgradeRequest({ key = true } = {}) {
+  function upgradeRequest({
+    path = "/",
+    key = "dGhlIHNhbXBsZSBub25jZQ==",
+    version = "13",
+  }: { path?: string; key?: string; version?: string } = {}) {
     return [
-      "GET / HTTP/1.1",
+      `GET ${path} HTTP/1.1`,
       "Host: localhost",
       "Connection: Upgrade",
       "Upgrade: websocket",
-      "Sec-WebSocket-Version: 13",
-      ...(key ? ["Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ=="] : []),
+      `Sec-WebSocket-Version: ${version}`,
+      ...(key ? [`Sec-WebSocket-Key: ${key}`] : []),
       "",
       "",
     ].join("\r\n");
@@ -1002,8 +1008,7 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
 
   // Sends `request` to a node:http server over a raw TCP connection and hands
   // back what the server's 'upgrade' listener received.
-  async function receiveUpgrade(request: string) {
-    const server = createServer();
+  async function receiveUpgrade(request: string, server = createServer()) {
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
     const upgrade = once(server, "upgrade");
@@ -1042,6 +1047,22 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
     };
   }
 
+  it("upgrades a live socket from a later task", async () => {
+    await using upgrade = await receiveUpgrade(upgradeRequest());
+    const { req, socket, head } = upgrade;
+    const wss = new WebSocketServer({ noServer: true });
+    const connections: unknown[] = [];
+
+    // The 'upgrade' listener returned without calling handleUpgrade(), as an
+    // app that checks credentials first does.
+    await new Promise(resolve => setImmediate(resolve));
+    expect(() => wss.handleUpgrade(req, socket, head, ws => connections.push(ws))).not.toThrow();
+
+    expect(connections).toHaveLength(1);
+    expect(wss.clients.size).toBe(1);
+    expect(await upgrade.received("\r\n\r\n")).toStartWith("HTTP/1.1 101 Switching Protocols\r\n");
+  });
+
   it("returns without calling back when the socket was destroyed before handleUpgrade()", async () => {
     await using upgrade = await receiveUpgrade(upgradeRequest());
     const { req, socket, head } = upgrade;
@@ -1057,7 +1078,7 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
   });
 
   it("returns without writing when the socket was destroyed and the handshake is invalid", async () => {
-    await using upgrade = await receiveUpgrade(upgradeRequest({ key: false }));
+    await using upgrade = await receiveUpgrade(upgradeRequest({ key: "" }));
     const { req, socket, head } = upgrade;
     const wss = new WebSocketServer({ noServer: true });
     const connections: unknown[] = [];
@@ -1098,7 +1119,31 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
     expect(socket.destroyed).toBe(true);
   });
 
-  it("answers 503 when the WebSocketServer is closing", async () => {
+  it("rejects an unsupported Sec-WebSocket-Version with a 400 and closes the connection", async () => {
+    await using upgrade = await receiveUpgrade(upgradeRequest({ version: "7" }));
+    const { req, socket, head } = upgrade;
+    const wss = new WebSocketServer({ noServer: true });
+    const connections: unknown[] = [];
+
+    expect(() => wss.handleUpgrade(req, socket, head, ws => connections.push(ws))).not.toThrow();
+
+    const message = "Missing or invalid Sec-WebSocket-Version header";
+    expect(await upgrade.received()).toBe(
+      [
+        "HTTP/1.1 400 Bad Request",
+        "Connection: close",
+        "Content-Type: text/html",
+        `Content-Length: ${message.length}`,
+        "Sec-WebSocket-Version: 13, 8",
+        "",
+        message,
+      ].join("\r\n"),
+    );
+    expect(connections).toEqual([]);
+    expect(socket.destroyed).toBe(true);
+  });
+
+  it("answers 503 and closes the connection when the WebSocketServer is closing", async () => {
     await using upgrade = await receiveUpgrade(upgradeRequest());
     const { req, socket, head } = upgrade;
     const wss = new WebSocketServer({ noServer: true });
@@ -1107,8 +1152,37 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
     wss.close();
     expect(() => wss.handleUpgrade(req, socket, head, ws => connections.push(ws))).not.toThrow();
 
-    expect(await upgrade.received("Service Unavailable")).toStartWith("HTTP/1.1 503 ");
+    expect(await upgrade.received()).toBe(
+      [
+        "HTTP/1.1 503 Service Unavailable",
+        "Connection: close",
+        "Content-Type: text/html",
+        "Content-Length: 19",
+        "",
+        "Service Unavailable",
+      ].join("\r\n"),
+    );
     expect(connections).toEqual([]);
+    expect(socket.destroyed).toBe(true);
+  });
+
+  it("leaves a connection alone that another WebSocketServer on the same http.Server took", async () => {
+    const server = createServer();
+    const chat = new WebSocketServer({ server, path: "/chat" });
+    const other = new WebSocketServer({ server, path: "/other" });
+    const connections: unknown[] = [];
+    chat.on("connection", ws => connections.push(ws));
+    other.on("connection", ws => connections.push(ws));
+
+    await using upgrade = await receiveUpgrade(upgradeRequest({ path: "/chat" }), server);
+
+    // Both servers saw the 'upgrade' event: /chat upgraded the connection, and
+    // /other's 400 for the path mismatch must not reach it.
+    expect(connections).toHaveLength(1);
+    expect(await upgrade.received("\r\n\r\n")).toStartWith("HTTP/1.1 101 Switching Protocols\r\n");
+    expect(upgrade.socket.destroyed).toBe(false);
+    chat.close();
+    other.close();
   });
 
   it("throws when called twice with the same socket", async () => {

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -982,6 +982,149 @@ describe("handleUpgrade without an Upgrade header", () => {
   });
 });
 
+// Same behavior as the npm "ws" package: on a connection that is gone,
+// handleUpgrade() destroys the socket and returns without calling back. A
+// handshake it rejects itself is answered through the socket the 'upgrade'
+// event handed over, which node:http gives no ServerResponse.
+describe("handleUpgrade on a node:http upgrade socket", () => {
+  function upgradeRequest({ key = true } = {}) {
+    return [
+      "GET / HTTP/1.1",
+      "Host: localhost",
+      "Connection: Upgrade",
+      "Upgrade: websocket",
+      "Sec-WebSocket-Version: 13",
+      ...(key ? ["Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ=="] : []),
+      "",
+      "",
+    ].join("\r\n");
+  }
+
+  // Sends `request` to a node:http server over a raw TCP connection and hands
+  // back what the server's 'upgrade' listener received.
+  async function receiveUpgrade(request: string) {
+    const server = createServer();
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const upgrade = once(server, "upgrade");
+    const client = connect((server.address() as AddressInfo).port, "127.0.0.1");
+    client.on("error", () => {});
+    let data = "";
+    client.on("data", chunk => (data += chunk.toString("latin1")));
+    const closed = once(client, "close");
+    await once(client, "connect");
+    client.write(request);
+    const [req, socket, head] = await upgrade;
+    return {
+      req,
+      socket,
+      head,
+      client,
+      // What the client received, once `until` has arrived or the server has
+      // closed the connection.
+      received(until?: string) {
+        return new Promise<string>(resolve => {
+          const check = () => {
+            if (until !== undefined && data.includes(until)) resolve(data);
+          };
+          client.on("data", check);
+          closed.then(() => resolve(data));
+          check();
+        });
+      },
+      async [Symbol.asyncDispose]() {
+        client.destroy();
+        server.closeAllConnections();
+        await new Promise(resolve => server.close(resolve));
+      },
+    };
+  }
+
+  it("returns without calling back when the socket was destroyed before handleUpgrade()", async () => {
+    await using upgrade = await receiveUpgrade(upgradeRequest());
+    const { req, socket, head } = upgrade;
+    const wss = new WebSocketServer({ noServer: true });
+    const connections: unknown[] = [];
+
+    socket.destroy();
+    expect(() => wss.handleUpgrade(req, socket, head, ws => connections.push(ws))).not.toThrow();
+
+    expect(connections).toEqual([]);
+    expect(wss.clients.size).toBe(0);
+    expect(await upgrade.received()).toBe("");
+  });
+
+  it("returns without writing when the socket was destroyed and the handshake is invalid", async () => {
+    await using upgrade = await receiveUpgrade(upgradeRequest({ key: false }));
+    const { req, socket, head } = upgrade;
+    const wss = new WebSocketServer({ noServer: true });
+    const connections: unknown[] = [];
+
+    socket.destroy();
+    expect(() => wss.handleUpgrade(req, socket, head, ws => connections.push(ws))).not.toThrow();
+
+    expect(connections).toEqual([]);
+    expect(await upgrade.received()).toBe("");
+  });
+
+  it("destroys the socket when the client went away while verifyClient was pending", async () => {
+    await using upgrade = await receiveUpgrade(upgradeRequest());
+    const { req, socket, head, client } = upgrade;
+    let verified!: (verified: boolean) => void;
+    const wss = new WebSocketServer({
+      noServer: true,
+      verifyClient: (_info: unknown, callback: (verified: boolean) => void) => {
+        verified = callback;
+      },
+    });
+    const connections: unknown[] = [];
+    wss.handleUpgrade(req, socket, head, ws => connections.push(ws));
+
+    // The client's FIN ends the readable side. The socket stays writable
+    // (allowHalfOpen), which is the state the upstream check is written for.
+    const ended = once(socket, "end");
+    client.destroy();
+    await ended;
+    expect({ readable: socket.readable, writable: socket.writable }).toEqual({ readable: false, writable: true });
+
+    const closed = once(socket, "close");
+    expect(() => verified(true)).not.toThrow();
+    await closed;
+
+    expect(connections).toEqual([]);
+    expect(wss.clients.size).toBe(0);
+    expect(socket.destroyed).toBe(true);
+  });
+
+  it("answers 503 when the WebSocketServer is closing", async () => {
+    await using upgrade = await receiveUpgrade(upgradeRequest());
+    const { req, socket, head } = upgrade;
+    const wss = new WebSocketServer({ noServer: true });
+    const connections: unknown[] = [];
+
+    wss.close();
+    expect(() => wss.handleUpgrade(req, socket, head, ws => connections.push(ws))).not.toThrow();
+
+    expect(await upgrade.received("Service Unavailable")).toStartWith("HTTP/1.1 503 ");
+    expect(connections).toEqual([]);
+  });
+
+  it("throws when called twice with the same socket", async () => {
+    await using upgrade = await receiveUpgrade(upgradeRequest());
+    const { req, socket, head } = upgrade;
+    const wss = new WebSocketServer({ noServer: true });
+    const connections: unknown[] = [];
+
+    wss.handleUpgrade(req, socket, head, ws => connections.push(ws));
+    expect(connections).toHaveLength(1);
+
+    expect(() => wss.handleUpgrade(req, socket, head, ws => connections.push(ws))).toThrow(
+      "server.handleUpgrade() was called more than once with the same socket, possibly due to a misconfiguration",
+    );
+    expect(connections).toHaveLength(1);
+  });
+});
+
 describe("module loading", () => {
   it("require('ws') does not load node:http eagerly", async () => {
     // Loading node:http materializes the HTTPParser binding; requiring only

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -1168,6 +1168,9 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
 
   it("leaves a connection alone that another WebSocketServer on the same http.Server took", async () => {
     const server = createServer();
+    // Registered first, so it sees the socket before either WebSocketServer does.
+    let errorListenersBefore = -1;
+    server.on("upgrade", (_req, socket) => (errorListenersBefore = socket.listenerCount("error")));
     const chat = new WebSocketServer({ server, path: "/chat" });
     const other = new WebSocketServer({ server, path: "/other" });
     const connections: unknown[] = [];
@@ -1184,6 +1187,8 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
     expect(received).toStartWith("HTTP/1.1 101 Switching Protocols\r\n");
     expect(received).not.toContain("HTTP/1.1 400");
     expect(upgrade.socket.destroyed).toBe(false);
+    // Both servers installed the error handler. The socket carries one copy.
+    expect(upgrade.socket.listenerCount("error")).toBe(errorListenersBefore + 1);
     chat.close();
     other.close();
   });

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -1011,7 +1011,9 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
     client.on("error", () => {});
     let data = "";
     client.on("data", chunk => (data += chunk.toString("latin1")));
-    const closed = once(client, "close");
+    // Not events.once(): that rejects on 'error', and a reset connection emits
+    // 'error' before 'close'. Whatever happened, 'close' ends the wait.
+    const closed = new Promise<void>(resolve => client.once("close", resolve));
     await once(client, "connect");
     client.write(request);
     const [req, socket, head] = await upgrade;

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -1177,9 +1177,12 @@ describe("handleUpgrade on a node:http upgrade socket", () => {
     await using upgrade = await receiveUpgrade(upgradeRequest({ path: "/chat" }), server);
 
     // Both servers saw the 'upgrade' event: /chat upgraded the connection, and
-    // /other's 400 for the path mismatch must not reach it.
+    // /other's 400 for the path mismatch must not reach it. Writing that 400
+    // ends the socket, so `destroyed` is what detects it.
     expect(connections).toHaveLength(1);
-    expect(await upgrade.received("\r\n\r\n")).toStartWith("HTTP/1.1 101 Switching Protocols\r\n");
+    const received = await upgrade.received("\r\n\r\n");
+    expect(received).toStartWith("HTTP/1.1 101 Switching Protocols\r\n");
+    expect(received).not.toContain("HTTP/1.1 400");
     expect(upgrade.socket.destroyed).toBe(false);
     chat.close();
     other.close();


### PR DESCRIPTION
### Problem
- `handleUpgrade()` from the built-in `ws` throws once it runs after the 'upgrade' listener's tick: `TypeError: undefined is not an object` (live socket) or `TypeError: upgrade requires a Request object` (destroyed socket).
- Live: since #32488 (in 1.4.0, not in 1.3.14) the release of a tunneled request (`NodeHTTPResponse.rs:738`) also resets the upgrade context, so `server.upgrade()` returns false. Fixes #39766.
- Dead: `completeUpgrade()` has no readable/writable check, and failure replies need a response object an upgrade socket lacks. The native one wrote `400 [object Object]` without headers and left the connection open.

### Fix
- The release keeps a tunneled connection's context when its request pointer is already detached (the dispatch tail copies the headers first). `upgrade()` resets it itself.
- `completeUpgrade()` gets the npm package's checks: an unreadable or unwritable socket is destroyed without a callback, and a second call on an upgraded socket throws its "called more than once" Error.
- `abortHandshake()` is the npm package's: write the reply to the socket, close it. `handleUpgrade()` adds its error handler, one per socket, since node:http removed its own at the handoff.
- Verified: `test/js/first_party/ws/ws.test.ts`, 10 new tests, all fail on stock bun. The scenarios in the notes match node with ws 8.18.3 byte for byte.

### Background
- node:http hands an 'upgrade' request over as a raw socket in tunnel mode: writes reach the wire, and no ServerResponse is attached (`_http_server.ts:914`).
- The shim upgrades through `bunServer.upgrade(handle)`. `handle` is `socket[Symbol.for("::bunternal::")]`, the request's native response. Its upgrade context is the uWS route context, which outlives the request.
- After the peer's FIN a socket is unreadable but writable (allowHalfOpen). A destroyed one is neither, and `end()` on it is silent.

<details><summary>Notes</summary>

Scenarios probed with a raw TCP client against a node:http server (probe scripts not committed). Node v26 with ws 8.18.3 gives the "this PR" column in every row, including the reply bytes (Bun's 101 additionally carries a Date header, as before).

| scenario | main | this PR |
| --- | --- | --- |
| live socket, handleUpgrade after setImmediate or setTimeout | throws TypeError | 101, callback |
| live socket, handleUpgrade in the listener, a microtask or nextTick later | 101 | unchanged |
| socket destroyed, valid handshake | throws TypeError | returns, no callback |
| socket destroyed, missing key | throws TypeError | returns, nothing written |
| socket destroyed, missing key, `wsClientError` listener | emits | unchanged |
| peer FIN while async verifyClient pending, then accepted | throws TypeError | socket destroyed, no callback |
| verifyClient pending, socket gone, then rejected | no throw | no throw |
| `wss.close()`, then handleUpgrade on a live socket | throws TypeError | `503 Service Unavailable`, Connection: close, closed |
| live socket: missing key, path mismatch, verifyClient false, bad version | `400 [object Object]`, chunked, connection left open | `400 Bad Request` / `401 Unauthorized` with headers, closed |
| handleUpgrade twice on one socket | throws TypeError | throws the ws Error |
| live socket, Upgrade request with a body, handleUpgrade from a later task (body unread) | throws TypeError | 101. This is the second path into `mark_request_as_done()`, at the body's last chunk |
| two `WebSocketServer({ server, path })` on one http.Server, request matches neither | second reply throws `ERR_STREAM_ALREADY_FINISHED` out of the 'upgrade' emit | one `400 Bad Request`, closed. The second reply fails on the ended socket and the error handler absorbs it |
| two `WebSocketServer({ server, path })` on one http.Server | second server's 400 is swallowed by the dead handle | second server returns (`upgraded` check). Without it, the raw 400 corrupts the WebSocket: client gets 1002, server 1006 |
| `handleUpgrade(req, req.socket)` from a 'request' listener | reply through the ServerResponse | unchanged (`_httpMessage` branch, pinned by the existing fake-socket test) |

Why the live-socket case fails only from a later task: the dispatch tail in `server/mod.rs` (around line 1506) runs right after the listener returns. While the response is still pending it copies the sec-websocket headers and nulls the request pointer (`set_on_aborted_handler`), then calls `mark_request_as_done()`, which reset the context. Microtasks drain before that tail, macrotasks run after it. The fix keeps the context only when that pointer is already null. If the listener ended the response first, the copy was skipped, the pointer is still set, and the context is reset as before, so a kept context never points into the freed request. CONNECT tunnels have no upgrade context, so nothing changes for them.

The readable/writable check runs in `completeUpgrade()`, where the npm package has it, so the async `verifyClient` path is covered and an invalid handshake on a dead socket still emits `wsClientError`.

The error handler stays attached after the upgrade. The npm package moves error handling to its WebSocket object at that point. The shim has no such object, and an 'error' on a listener-less socket is an uncaught exception. handleUpgrade() removes the handler before adding it, so several WebSocketServers on one http.Server leave one copy (the two-server test checks the count).

`BunWebSocketMocked#terminate()` still calls `abortHandshake(this, this._req, msg)` in its CONNECTING branch. A server-side socket is OPEN before user code sees it, so the branch is not reachable. Left as is.

#28152 is a different bug with the same error text (a Proxy that hides the symbol). It edits the same lines of `completeUpgrade()`, so whichever lands second rebases.

A sync upgrade of a request with a body leaves the request's body ref held until the socket closes. That is pre-existing (same on main) and not changed here.

The two existing "handleUpgrade without an Upgrade header" tests now use EventEmitter fakes, because `handleUpgrade()` calls `socket.on()`. Their assertions are unchanged.

Suites run with the debug build: `test/js/first_party/ws/` (the 3 `ws-proxy.test.ts` failures also occur without this change here), `test/js/node/http/{node-http,node-http-with-ws,node-http-connect,node-http-server-abort-events,node-http-uaf}.test.ts` (the proxy test `issue#4295` and the spawned CONNECT sub-suite fail without this change here too: a localhost resolution mismatch and the 5 s timeout on a debug build), the vendored `test-http-upgrade-*` and `test-http-connect*` tests, `test/regression/issue/{32734,3613,03844,012040,26358,29684}`, and three `test/js/web/websocket` client suites.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws.test.ts
bun test v1.4.0 (4c689909e)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:46769/
(pass) WebSocket > url [2912.16ms]
Listening: ws://127.0.0.1:44793/
Received upgrade: {
  host: "127.0.0.1:44793",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "Dv6u1czUCZGkfQmZVNF1gA==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [3233.26ms]
Listening: ws://127.0.0.1:41815/
(pass) WebSocket > binaryType > (default) [2886.31ms]
Listening: ws://127.0.0.1:38705/
(pass) WebSocket > binaryType > (invalid) [2969.16ms]
Listening: ws://127.0.0.1:37251/
Received upgrade: {
  host: "127.0.0.1:37251",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "3dGPjRH6EID2jGq86e8Zbw==",
}
Received connection: 127.0.0.1
Received message: <Buffer
... (truncated)

release without fix: 10 FAILED
bun test v1.4.0-canary.1 (4c689909e)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:39449/
(pass) WebSocket > url [34.05ms]
Listening: ws://127.0.0.1:45923/
Received upgrade: {
  host: "127.0.0.1:45923",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "A+hnc4VCSZBR3HAqrVWIiA==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [36.82ms]
Listening: ws://127.0.0.1:41207/
(pass) WebSocket > binaryType > (default) [31.82ms]
Listening: ws://127.0.0.1:38261/
(pass) WebSocket > binaryType > (invalid) [32.72ms]
Listening: ws://127.0.0.1:37419/
Received upgrade: {
  host: "127.0.0.1:37419",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "CnDCtp2jo6VIip1FiAwBGA==",
}
Received connection: 127.0.0.1
Received message: <Buffer 00>
Received ping: <Buffer >
Received pong: <Buffer >
(pass) WebSocket > binaryType > nodebuffer [36.79ms]
Listening: ws://127.0.0.1:33091/
Received upgrade: {
  hos
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/first_party/ws/ws.test.ts
bun test v1.4.0 (4c689909e)

test/js/first_party/ws/ws.test.ts:
Listening: ws://127.0.0.1:44209/
(pass) WebSocket > url [2901.66ms]
Listening: ws://127.0.0.1:46109/
Received upgrade: {
  host: "127.0.0.1:46109",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "5v4SlAWN+VKcaMn0YG2Xzg==",
}
Received connection: 127.0.0.1
(pass) WebSocket > readyState [3226.98ms]
Listening: ws://127.0.0.1:42465/
(pass) WebSocket > binaryType > (default) [2835.53ms]
Listening: ws://127.0.0.1:46637/
(pass) WebSocket > binaryType > (invalid) [2815.13ms]
Listening: ws://127.0.0.1:34285/
Received upgrade: {
  host: "127.0.0.1:34285",
  connection: "Upgrade",
  upgrade: "websocket",
  "sec-websocket-version": "13",
  "sec-websocket-extensions": "permessage-deflate; client_max_window_bits",
  "sec-websocket-key": "9/csE+7wbaOU8yRDKDwLAA==",
}
Received connection: 127.0.0.1
Received message: <Buffer
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1093ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/95] gen ErrorCode+*.h
[2/41] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/41] gen cpp.rs (cppbind)
[4/41] gen JS modules (bundle-modules)
Preprocess modules (13935ms)
Bundle modules (64ms)
Postprocesss modules (32ms)
Bundle Functions (791ms)
Generate Code (26ms)

[14.87s] Bundled "src/js" for production
  2628 kb
  198 internal modules
  13 native modules
  92 internal functions across 17 files
[4/31] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/thirdparty/ws.js                |  81 +++++++---
 src/runtime/server/NodeHTTPResponse.rs |   8 +-
 test/js/first_party/ws/ws.test.ts      | 265 ++++++++++++++++++++++++++++++++-
 3 files changed, 327 insertions(+), 27 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/js/thirdparty/ws.js                    15     19      0
src/runtime/server/NodeHTTPResponse.rs     11      5      0
test/js/first_party/ws/ws.test.ts          12     17      0
```

</details>

**root cause** · written by the author bot

Bun's built-in ws shim let `handleUpgrade()` proceed on a destroyed node:http socket, so `completeUpgrade()` pulled an undefined upgrade target off the dead socket and passed it to `bunServer.upgrade()`, which threw a TypeError; its rejection paths also relied on `socket._httpMessage`, which node:http never assigns for upgrade requests, and the native side had dropped `upgrade_context` in `mark_request_as_done()` before a delayed tunneled upgrade could use it. The fix adopts the npm ws behavior of destroying unreadable or unwritable sockets and rejecting repeated upgrades, rewrites `abortHa…

<!-- robobun:evidence:end -->
