### PR TITLE
test(bake): speed up dev/hot.test.ts and strengthen its assertions

### DIFF
--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,9 +1,17 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
+//
+// Writes whose outcome the next `expectMessage`/`c.js` assertion pins pass
+// `errors: null`. The default (`errors: []`) polls the client for an error
+// overlay for a full second after every write, which is most of a write's
+// cost. Skipping it loses nothing for those steps: a build error sends no
+// update, so the message assertion fails, and a module that throws while it is
+// re-evaluated exits the client, which rejects the write. Steps whose subject
+// is the overlay itself (an error appears or clears) keep the default.
 import { expect } from "bun:test";
 import { renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { devTest, emptyHtmlFile } from "../bake-harness";
 
-devTest("import.meta.hot.accept basic", {
+devTest("import.meta.hot.accept: self-accept callbacks, then accept([deps])", {
   files: {
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
@@ -11,10 +19,18 @@ devTest("import.meta.hot.accept basic", {
     "index.ts": `
       console.log("Hello, world!");
     `,
+    // Only imported by the accept([deps]) half of the test.
+    "counter.ts": `
+      export const count = 1;
+    `,
+    "name.ts": `
+      export const name = "Alice";
+    `,
   },
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage("Hello, world!");
+    // The module does not accept, so editing it reloads the page.
     await c.expectReload(async () => {
       await dev.write(
         "index.ts",
@@ -25,9 +41,12 @@ devTest("import.meta.hot.accept basic", {
             console.log(newModule.method());
           });
         `,
+        { errors: null },
       );
     });
     await c.expectMessage("Hello, Bun!");
+    // The callback registered by the previous version receives the exports of
+    // the new version.
     await dev.write(
       "index.ts",
       `
@@ -38,6 +57,7 @@ devTest("import.meta.hot.accept basic", {
           console.log(Object.keys(newModule));
         });
       `,
+      { errors: null },
     );
     await c.expectMessage(["method"], "Bun");
     await dev.write(
@@ -45,12 +65,83 @@ devTest("import.meta.hot.accept basic", {
       `
         console.log("Without anything.");
       `,
+      { errors: null },
     );
     await c.expectMessage("Without anything.", []);
+    // Saving a non-accepting module without changes still reloads the page.
+    // (`dev.writeNoChanges` cannot skip the error overlay poll.)
     await c.expectReload(async () => {
-      await dev.writeNoChanges("index.ts");
+      await dev.write("index.ts", dev.read("index.ts"), { dedent: false, errors: null });
     });
     await c.expectMessage("Without anything.");
+
+    // accept([deps], cb): the callback receives an array with the updated
+    // module at its index and `undefined` for the other dependencies, and the
+    // importer's live bindings are patched before the callback runs.
+    await c.expectReload(async () => {
+      await dev.write(
+        "index.ts",
+        `
+          import { count } from "./counter.ts";
+          import { name } from "./name.ts";
+          console.log("Initial: " + name + " " + count);
+          globalThis.read = () => name + " " + count;
+
+          import.meta.hot.accept(["./counter.ts", "./name.ts"], ([counter, nameModule]) => {
+            console.log([counter ? counter.count : "unchanged", nameModule ? nameModule.name : "unchanged"]);
+          });
+        `,
+        { errors: null },
+      );
+    });
+    await c.expectMessage("Initial: Alice 1");
+
+    await dev.write(
+      "counter.ts",
+      `
+        export const count = 2;
+      `,
+      { errors: null },
+    );
+    await c.expectMessage([2, "unchanged"]);
+    expect(await c.js<string>`read()`).toBe("Alice 2");
+
+    await dev.write(
+      "name.ts",
+      `
+        export const name = "Bob";
+      `,
+      { errors: null },
+    );
+    await c.expectMessage(["unchanged", "Bob"]);
+    expect(await c.js<string>`read()`).toBe("Bob 2");
+
+    // One hot update that contains both dependencies calls the callback once
+    // per dependency.
+    {
+      await using batch = await dev.batchChanges({ errors: null });
+      await dev.write(
+        "counter.ts",
+        `
+          export const count = 3;
+        `,
+      );
+      await dev.write(
+        "name.ts",
+        `
+          export const name = "Charlie";
+        `,
+      );
+    }
+    await c.expectMessageInAnyOrder([3, "unchanged"], ["unchanged", "Charlie"]);
+    expect(await c.js<string>`read()`).toBe("Charlie 3");
+
+    // Accepting dependencies does not make the module self-accepting: saving
+    // it reloads the page, and the fresh page sees the updated dependencies.
+    await c.expectReload(async () => {
+      await dev.write("index.ts", dev.read("index.ts"), { dedent: false, errors: null });
+    });
+    await c.expectMessage("Initial: Charlie 3");
   },
 });
 devTest("import.meta.hot.accept patches imports", {
@@ -87,26 +178,25 @@ devTest("import.meta.hot.accept patches imports", {
     await c.expectMessage("C", "B", "A");
     expect(await c.js<string>`callFunction()`).toBe("A!0!0");
     expect(await c.js<string>`callFunction()`).toBe("A!1!1");
-    await dev.patch("c.ts", { find: "0", replace: "5" });
+    await dev.patch("c.ts", { find: "0", replace: "5", errors: null });
     await c.expectMessage("C", "B"); // C does not self-accept
     expect(await c.js<string>`callFunction()`).toBe("A!0!5");
     expect(await c.js<string>`callFunction()`).toBe("A!1!6");
-    await dev.patch("b.ts", { find: "A!", replace: "B!" });
+    await dev.patch("b.ts", { find: "A!", replace: "B!", errors: null });
     await c.expectMessage("B"); // B does not cause C to re-evaluate
     expect(await c.js<string>`callFunction()`).toBe("B!0!7");
     expect(await c.js<string>`callFunction()`).toBe("B!1!8");
-    await dev.patch("c.ts", { find: "// ", replace: "" });
+    await dev.patch("c.ts", { find: "// ", replace: "", errors: null });
     await c.expectMessage("C", "B"); // C does not self-accept YET
     expect(await c.js<string>`callFunction()`).toBe("B!0!5");
     expect(await c.js<string>`callFunction()`).toBe("B!1!6");
-    await dev.patch("c.ts", { find: "import.meta.hot.accept();", replace: "" });
+    await dev.patch("c.ts", { find: "import.meta.hot.accept();", replace: "", errors: null });
     await c.expectMessage("C"); // C self accepted even if the new one doesnt
     expect(await c.js<string>`callFunction()`).toBe("B!2!5");
     expect(await c.js<string>`callFunction()`).toBe("B!3!6");
   },
 });
 devTest("import.meta.hot.accept specifier", {
-  timeoutMultiplier: 3,
   files: {
     "index.html": emptyHtmlFile({
       scripts: ["a.ts"],
@@ -156,6 +246,8 @@ devTest("import.meta.hot.accept specifier", {
           "b.ts:3:24: error: Dependencies to `import.meta.hot.accept` must be statically analyzable module specifiers matching direct imports.",
         ],
       });
+      // Fixing the specifier clears the overlay (the default `errors: []`
+      // asserts this) and reloads the page.
       await c.expectReload(async () => {
         await dev.patch("b.ts", { find: "./d.ts", replace: "./d" });
       });
@@ -170,6 +262,7 @@ devTest("import.meta.hot.accept specifier", {
             console.log("D2");
             export default "hey2!";
           `,
+          { errors: null },
         );
       });
       await c.expectMessage("D2", "B", "C", "A");
@@ -192,6 +285,7 @@ devTest("import.meta.hot.accept specifier", {
           console.log("D3");
           export default "hey3!";
         `,
+        { errors: null },
       );
       await c.expectMessage("D3", "C", "B:hey3!");
 
@@ -211,6 +305,7 @@ devTest("import.meta.hot.accept specifier", {
           ],
         },
       );
+      // The default `errors: []` asserts that the overlay is gone again.
       await dev.patch("c.ts", {
         find: "oh no",
         replace: "./d",
@@ -223,6 +318,7 @@ devTest("import.meta.hot.accept specifier", {
           export default "hey4!";
           import.meta.hot.accept();
         `,
+        { errors: null },
       );
       // This order is guaranteed regardless of top-level await if it had existed.
       await c.expectMessage("D4", "B:hey4!", "C:hey4!");
@@ -233,6 +329,7 @@ devTest("import.meta.hot.accept specifier", {
           export default "hey5!";
           import.meta.hot.accept();
         `,
+        { errors: null },
       );
       await c.expectMessage("D5", "B:hey5!", "C:hey5!");
       await c.hardReload();
@@ -244,151 +341,13 @@ devTest("import.meta.hot.accept specifier", {
           export default "hey6!";
           import.meta.hot.accept();
         `,
+        { errors: null },
       );
       await c.expectMessage("D6", "B:hey6!", "C:hey6!");
     }
   },
 });
-devTest("import.meta.hot.accept multiple modules", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import { count } from "./counter.ts";
-      import { name } from "./name.ts";
-      console.log("Initial: " + name + " " + count);
-      
-      import.meta.hot.accept(["./counter.ts", "./name.ts"], (newModules) => {
-        if (newModules[0]) console.log("Counter updated: " + newModules[0].count);
-        if (newModules[1]) console.log("Name updated: " + newModules[1].name);
-      });
-    `,
-    "counter.ts": `
-      export const count = 1;
-    `,
-    "name.ts": `
-      export const name = "Alice";
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("Initial: Alice 1");
-
-    await dev.write(
-      "counter.ts",
-      `
-        export const count = 2;
-      `,
-    );
-
-    await c.expectMessage("Counter updated: 2");
-
-    await dev.write(
-      "name.ts",
-      `
-        export const name = "Bob";
-      `,
-    );
-
-    await c.expectMessage("Name updated: Bob");
-
-    // Test updating both files
-    {
-      await using batch = await dev.batchChanges();
-      await dev.write(
-        "counter.ts",
-        `
-          export const count = 3;
-        `,
-      );
-      await dev.write(
-        "name.ts",
-        `
-          export const name = "Charlie";
-        `,
-      );
-    }
-
-    await c.expectMessageInAnyOrder("Counter updated: 3", "Name updated: Charlie");
-  },
-});
-devTest("import.meta.hot.data persistence", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      // Initialize or retrieve stored value
-      import.meta.hot.data.count ??= 0;
-      console.log("Initial count: " + import.meta.hot.data.count);
-      
-      // Increment the count on each evaluation
-      import.meta.hot.data.count++;
-
-      // By using hot.data, you opt into implicit self-acceptance
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("Initial count: 0");
-    await dev.writeNoChanges("index.ts");
-    await c.expectMessage("Initial count: 1");
-    await dev.writeNoChanges("index.ts");
-    await c.expectMessage("Initial count: 2");
-    await dev.writeNoChanges("index.ts");
-    await c.expectMessage("Initial count: 3");
-  },
-});
-devTest("import.meta.hot.dispose cleanup", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      console.log("Setting up");
-      const id = setInterval(() => {}, 1000);
-      
-      import.meta.hot.dispose(() => {
-        console.log("Cleaning up");
-        clearInterval(id);
-      });
-      
-      import.meta.hot.accept();
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("Setting up");
-
-    await dev.write(
-      "index.ts",
-      `
-        console.log("Setting up again");
-        const id = setInterval(() => {}, 1000);
-        
-        import.meta.hot.dispose(() => {
-          console.log("Cleaning up");
-          clearInterval(id);
-        });
-        
-        import.meta.hot.accept();
-      `,
-    );
-
-    await c.expectMessage("Cleaning up", "Setting up again");
-
-    await dev.write(
-      "index.ts",
-      `
-        console.log("Third setup");
-      `,
-    );
-
-    await c.expectMessage("Cleaning up", "Third setup");
-  },
-});
-devTest("import.meta.hot invalid usage", {
+devTest("import.meta.hot: indirect usage, data, dispose, on/off", {
   files: {
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
@@ -416,6 +375,10 @@ devTest("import.meta.hot invalid usage", {
         console.log(e?.message ?? e);
       }
     `,
+    // Only imported by the on/off section of the test.
+    "dep.ts": `
+      export default "dep 1";
+    `,
   },
   async test(dev) {
     await using c = await dev.client("/");
@@ -424,51 +387,142 @@ devTest("import.meta.hot invalid usage", {
       '"import.meta.hot.accept" must be directly called with string literals for the specifiers. This way, the bundler can pre-process the arguments.',
       "import.meta.hot cannot be used indirectly.",
     );
-  },
-});
-devTest("import.meta.hot on/off events", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      console.log("Initial setup");
-      // Add event listener
-      import.meta.hot.on("vite:beforeUpdate", () => {
-        console.log("Before update event");
-      });
-      import.meta.hot.accept();
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("Initial setup");
+
+    // import.meta.hot.data: the module above does not accept, so replacing it
+    // reloads the page, and the fresh page starts with empty data.
+    await c.expectReload(async () => {
+      await dev.write(
+        "index.ts",
+        `
+          // Initialize or retrieve stored value
+          import.meta.hot.data.count ??= 0;
+          console.log("Initial count: " + import.meta.hot.data.count);
+
+          // Increment the count on each evaluation
+          import.meta.hot.data.count++;
+
+          // By using hot.data, you opt into implicit self-acceptance
+        `,
+        { errors: null },
+      );
+    });
+    await c.expectMessage("Initial count: 0");
+    // Every save re-evaluates the module with the same data object, even when
+    // the contents did not change. (`dev.writeNoChanges` cannot skip the error
+    // overlay poll.)
+    for (let count = 1; count <= 3; count++) {
+      await dev.write("index.ts", dev.read("index.ts"), { dedent: false, errors: null });
+      await c.expectMessage("Initial count: " + count);
+    }
+
+    // import.meta.hot.dispose: the previous version wrote to hot.data, so this
+    // update is applied in place. Dispose callbacks receive the data object
+    // and run before the next version is evaluated.
+    await dev.write(
+      "index.ts",
+      `
+        console.log("Setting up");
+
+        import.meta.hot.dispose(data => {
+          data.disposed = (data.disposed ?? 0) + 1;
+          console.log("Cleaning up");
+        });
+
+        import.meta.hot.accept();
+      `,
+      { errors: null },
+    );
+    await c.expectMessage("Setting up");
+    await dev.write(
+      "index.ts",
+      `
+        console.log("Setting up again, disposed " + import.meta.hot.data.disposed + "x");
+
+        import.meta.hot.dispose(data => {
+          data.disposed++;
+          console.log("Cleaning up again");
+        });
+
+        import.meta.hot.accept();
+      `,
+      { errors: null },
+    );
+    await c.expectMessage("Cleaning up", "Setting up again, disposed 1x");
+    // The replacement does not need to accept for the old version's dispose
+    // callback to run.
+    await dev.write(
+      "index.ts",
+      `
+        console.log("Third setup, disposed " + import.meta.hot.data.disposed + "x");
+      `,
+      { errors: null },
+    );
+    await c.expectMessage("Cleaning up again", "Third setup, disposed 2x");
+
+    // import.meta.hot.on/off: hot.data is still populated, so the module is
+    // still implicitly self-accepting and this update is applied in place too.
+    await dev.write(
+      "index.ts",
+      `
+        import dep from "./dep.ts";
+        console.log("Initial setup: " + dep);
+        import.meta.hot.on("bun:beforeUpdate", () => {
+          console.log("v1 saw bun:beforeUpdate");
+        });
+        import.meta.hot.on("bun:afterUpdate", () => {
+          console.log("v1 saw bun:afterUpdate");
+        });
+        import.meta.hot.accept("./dep.ts", newDep => {
+          console.log("v1 accepted " + newDep.default);
+        });
+      `,
+      { errors: null },
+    );
+    // The listeners exist by the time the update that loaded v1 finishes.
+    await c.expectMessage("Initial setup: dep 1", "v1 saw bun:afterUpdate");
+    // An update that v1 survives fires both events around it.
+    await dev.write(
+      "dep.ts",
+      `
+        export default "dep 2";
+      `,
+      { errors: null },
+    );
+    await c.expectMessage("v1 saw bun:beforeUpdate", "v1 accepted dep 2", "v1 saw bun:afterUpdate");
+    // Replacing v1 removes its listeners. beforeUpdate is emitted before v1 is
+    // disposed, so that listener fires one last time. afterUpdate is emitted
+    // after, so only v2's listener sees it.
     await dev.write(
       "index.ts",
       `
         console.log("Updated setup");
-        // Events implementation is partial according to docs
-        import.meta.hot.on("vite:beforeUpdate", () => {
-          console.log("Before update event 2");
-        });
         const handler = () => {
-          console.log("Another handler");
+          console.log("removed handler");
         };
-        import.meta.hot.on("vite:beforeUpdate", handler);
-        // Remove the handler
-        import.meta.hot.off("vite:beforeUpdate", handler);
+        import.meta.hot.on("bun:beforeUpdate", handler);
+        import.meta.hot.off("bun:beforeUpdate", handler);
+        import.meta.hot.on("bun:beforeUpdate", () => {
+          console.log("v2 saw bun:beforeUpdate");
+        });
+        import.meta.hot.on("bun:afterUpdate", () => {
+          console.log("v2 saw bun:afterUpdate");
+        });
         import.meta.hot.accept();
       `,
+      { errors: null },
     );
-    await c.expectMessage("Updated setup");
+    await c.expectMessage("v1 saw bun:beforeUpdate", "Updated setup", "v2 saw bun:afterUpdate");
+    // The handler that v2 passed to off() never fires, and disposing v2
+    // removes its remaining listeners.
     await dev.write(
       "index.ts",
       `
         console.log("Third update");
         import.meta.hot.accept();
       `,
+      { errors: null },
     );
-    await c.expectMessage("Third update");
+    await c.expectMessage("v2 saw bun:beforeUpdate", "Third update");
   },
 });
 devTest("hmr forwards every merged inotify sub-path from a directory batch", {
@@ -509,7 +563,7 @@ devTest("hmr forwards every merged inotify sub-path from a directory batch", {
       const target = dev.join("dep.ts");
       const content = `export default "atomic ${round}";\n`;
       {
-        await using _wait = await dev.batchChanges();
+        await using _wait = await dev.batchChanges({ errors: null });
         // Remove the direct file watch so only the directory watch can
         // pick up the new dep.ts.
         unlinkSync(target);
@@ -599,6 +653,7 @@ devTest("hot update frames are not delivered to application websocket topics", {
           console.log("updated");
           import.meta.hot.accept();
         `,
+        { errors: null },
       );
       await c.expectMessage("updated");
 
@@ -626,19 +681,38 @@ devTest("dev.write resolves only after the new module body has run", {
     await c.expectMessage("ready");
     expect(await c.js`globalThis.marker`).toBe("initial");
 
-    await dev.write(
+    // The new module body blocks in a top-level await until the test releases
+    // it, so the write has to stay pending for as long as the test wants.
+    const write = dev.write(
       "index.ts",
       `
-        await new Promise(r => setTimeout(r, 500));
+        console.log("blocked");
+        await new Promise(resolve => {
+          globalThis.unblock = resolve;
+        });
         globalThis.marker = "updated";
         import.meta.hot.accept();
       `,
-      // errors: null skips the post-write expectErrorOverlay poll (5 * 200ms),
-      // which would otherwise mask a premature ack.
+      // errors: null also skips the post-write expectErrorOverlay poll, which
+      // would otherwise mask a premature ack.
       { errors: null },
     );
+    let settled = false;
+    write.then(
+      () => (settled = true),
+      () => (settled = true),
+    );
+    // "blocked" proves the client received the update and started evaluating
+    // it. An ack sent on WebSocket receipt would have resolved the write before
+    // that point.
+    await c.expectMessage("blocked");
+    expect(await c.js`globalThis.marker`).toBe("initial");
+    expect(settled).toBe(false);
+
     // dev.write resolves on bun:afterUpdate, i.e. after replaceModules has
-    // awaited the 500ms TLA. Acking on WS receipt would see "initial" here.
+    // awaited the top-level await.
+    await c.js`globalThis.unblock()`;
+    await write;
     expect(await c.js`globalThis.marker`).toBe("updated");
   },
 });


### PR DESCRIPTION
### Problem
- `test/bake/dev/hot.test.ts` took 46s to 55s on all 9 CI lanes (build 101153), ASAN included, so it waits instead of computing.
- The wait is the overlay poll that ends every `dev.write` and `dev.client`: 5 checks 200ms apart (`bake-harness.ts:1051`), one second when nothing is wrong. 31 writes and 12 clients: about 43s of 51s.

### Fix
- Writes whose outcome the next assertion pins pass `errors: null`, which skips the poll. They still fail on a build error (no message) and on a runtime error (the client exits and the write rejects). The 4 steps about the overlay itself keep the poll.
- The six one-entry cases become two sequences that share a server and a client: 7 servers instead of 11, 8 clients instead of 12. Each join asserts a transition.
- New assertions (Notes): the `accept([deps])` array, the data object passed to `dispose`, which update listeners fire and what removes them, and a pending-write check instead of a 500ms timer. The old on/off case tested nothing.
- Verified: `bun bd test` of the file, 80.5s before and 35.5s after (68 expects, was 60). Release: 51.4s to 16.1s. 6 release and 5 debug runs passed.

### Background
- `devTest` boots one dev server per case. `dev.client()` runs the page in happy-dom and forwards each `console.log`. `expectMessage` asserts the exact messages since the previous call.
- `dev.write` waits for the build and for the client's ack (sent from `bun:afterUpdate`), then polls for the overlay unless `errors` is `null`.
- A module that wrote to `import.meta.hot.data` counts as self-accepting later, and the data outlives each version. Later versions in the data sequence are therefore replaced in place.

<details><summary>Notes</summary>

Per case, same machine, back to back. Release is `USE_SYSTEM_BUN=1 bun test`, debug is `bun bd test` (ASAN).

| before | release | debug |
|---|---|---|
| accept basic | 5.7s | 8.3s |
| accept patches imports | 5.7s | 8.1s |
| accept specifier | 10.6s | 13.5s |
| accept multiple modules | 4.6s | 6.9s |
| data persistence | 4.6s | 6.8s |
| dispose cleanup | 3.6s | 5.7s |
| invalid usage | 1.4s | 3.2s |
| on/off events | 3.6s | 5.7s |
| inotify merged sub-paths | 6.7s | 9.5s |
| app websocket topics | 2.5s | 4.7s |
| dev.write synchronization | 2.0s | 4.2s |
| file | 51.2s to 51.6s | 80.3s to 80.7s |

| after | release | debug |
|---|---|---|
| accept: self-accept callbacks, then accept([deps]) | 2.1s | 5.0s |
| accept patches imports | 1.8s | 4.0s |
| accept specifier | 5.7s | 8.4s |
| indirect usage, data, dispose, on/off | 2.1s | 4.8s |
| inotify merged sub-paths | 1.8s | 4.6s |
| app websocket topics | 1.6s | 3.4s |
| dev.write synchronization | 1.6s | 3.6s |
| file | 16.1s to 17.2s (6 runs) | 35.5s to 38.2s (5 runs) |

What is left per case is one server boot, one client (with its own one second poll) and teardown: about 1.5s release and 3.5s debug. The specifier case also keeps 2 client polls, the `hardReload()` poll and 2 overlay-cleared polls. Those are its subject. A harness change (one overlay check after a write, because the write already waited for the client's ack) would remove the remaining write polls from every `test/bake/dev` file. It is not part of this PR because other files in the directory are being changed at the same time.

The inotify case, the app websocket case and the `dev.write` synchronization case keep their own servers. The first is Linux only, the second needs its own `bun.app.ts`, and the third documents a harness guarantee that the other cases rely on.

Transitions that the merged sequences assert and the old cases did not:
- Editing a module that only accepts its dependencies reloads the page, and the fresh page sees the updated dependencies (`Initial: Charlie 3`).
- Replacing a non-accepting module reloads the page, and the new page starts with empty `hot.data` (`Initial count: 0`).
- A version that does not call `accept()` is still replaced in place once an earlier version wrote to `hot.data`, and the replaced version's dispose callback runs first (`Cleaning up again`, `Third setup, disposed 2x`).
- Listeners registered by a version that a hot update loaded exist by the time that update's `bun:afterUpdate` fires.

Other assertion changes:
- `accept([deps])`: the callback logs the whole array (`[2, "unchanged"]`), so the `undefined` slot is asserted too. `read()` asserts the importer's bindings after each update. The batched update still asserts one callback per dependency.
- `dispose`: the callback gets `hot.data`, and the next version reads what it wrote. The old `setInterval` was never asserted and is gone.
- `on` and `off`: the section uses the documented `bun:` names. It asserts the order `beforeUpdate`, accept callback, `afterUpdate` for an update that the listening version survives. It asserts that replacing the version removes its listeners: its `afterUpdate` listener does not fire in the update that replaces it, while the new version's does. A handler passed to `off()` never fires.
- `timeoutMultiplier: 3` on the specifier case dated from when each write also slept. The case now takes 5.7s release and 8.4s debug against a 30s base timeout, which the harness multiplies for debug, ASAN and CI.
- `toMatchInlineSnapshot` was not needed. `expectMessage` already compares the exact message list.

Side finding, not changed here: `import.meta.hot.on("vite:x", cb)` registers for `"bun::x"`. `src/runtime/bake/hmr-module.ts:233` computes `"bun:" + event.slice(4)`, and `"vite:"` has 5 characters. `docs/bundler/hot-reloading.mdx` promises that the `vite:` prefix works. With the listeners of the new on/off section switched to `vite:`, the section fails at its first event assertion. That is why the old case passed. It needs a one-line src fix with its own test.

`test/expected-durations.json` still lists this file at 45s to 52s. #38882 refreshes that file from CI, so this PR does not edit it.

Ran `test/bake/dev/hot.test.ts` 6 times with the release build and 5 times with the debug build, plus the prettier check on the file.
</details>
