### PR TITLE
test(bundler): speed up bundler_splitting.test.ts and tighten its assertions

### DIFF
--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -11,7 +11,37 @@ const env = {
   BUN_FEATURE_FLAG_DISABLE_ASYNC_TRANSPILER: "1",
 };
 
-describe("bundler", () => {
+// Chunks are named `[name]-[hash].[ext]` with an 8 character hash. The helpers
+// below refer to them as `name-[hash].ext` so a case can pin its whole output
+// directory with one toEqual.
+const unhashed = (file: string) => file.replace(/-[a-z0-9]{8}(?=\.\w+$)/, "-[hash]");
+
+const outputFiles = (api: BundlerTestBundleAPI) => readdirSync(api.outdir).map(unhashed).sort();
+
+function readOutput(api: BundlerTestBundleAPI, file: string) {
+  const matches = readdirSync(api.outdir).filter(f => unhashed(f) === file);
+  expect(matches).toHaveLength(1);
+  return api.readFile("/out/" + matches[0]);
+}
+
+// The import() specifiers in an output file. Each of them must name a file in
+// the output directory: with splitting they used to be rewritten to the
+// importee's CSS output instead of its JS chunk.
+function dynamicImportsIn(api: BundlerTestBundleAPI, file: string) {
+  const specifiers = Array.from(readOutput(api, file).matchAll(/\bimport\("\.\/([^"]+)"\)/g), m => m[1]);
+  for (const specifier of specifiers) api.assertFileExists("/out/" + specifier);
+  return specifiers.map(unhashed);
+}
+
+// The source files bundled into an output CSS file, in order, from the
+// `/* name.css */` comment the bundler prints above each of them.
+const cssSourcesIn = (api: BundlerTestBundleAPI, file: string) =>
+  Array.from(readOutput(api, file).matchAll(/^\/\* (\S+\.css) \*\/$/gm), m => m[1]);
+
+// Every case builds into its own directory under expectBundled's temp root and
+// spawns its own processes, so they can overlap. expectBundled registers the
+// backend: "api" cases with it.serial because that backend chdirs.
+describe.concurrent("bundler", () => {
   itBundled("splitting/DynamicImportCSSFile", {
     files: {
       "/client.tsx": `import('./test')`,
@@ -27,6 +57,13 @@ describe("bundler", () => {
     target: "browser",
     env: "inline",
     format: "esm",
+    onAfterBundle(api) {
+      // test.ts imports the same CSS as the entry point reaches, so the two
+      // share one CSS output.
+      expect(outputFiles(api)).toEqual(["client.css", "client.js", "test-[hash].js"]);
+      expect(dynamicImportsIn(api, "client.js")).toEqual(["test-[hash].js"]);
+      expect(cssSourcesIn(api, "client.css")).toEqual(["test.css"]);
+    },
     run: {
       file: "/out/client.js",
       env,
@@ -57,6 +94,20 @@ describe("bundler", () => {
     target: "browser",
     env: "inline",
     format: "esm",
+    onAfterBundle(api) {
+      expect(outputFiles(api)).toEqual([
+        "entry.css",
+        "entry.js",
+        "module1-[hash].css",
+        "module1-[hash].js",
+        "module2-[hash].css",
+        "module2-[hash].js",
+      ]);
+      expect(dynamicImportsIn(api, "entry.js")).toEqual(["module1-[hash].js", "module2-[hash].js"]);
+      expect(cssSourcesIn(api, "entry.css")).toEqual(["styles1.css", "styles2.css"]);
+      expect(cssSourcesIn(api, "module1-[hash].css")).toEqual(["styles1.css"]);
+      expect(cssSourcesIn(api, "module2-[hash].css")).toEqual(["styles2.css"]);
+    },
     run: {
       file: "/out/entry.js",
       env,
@@ -83,6 +134,12 @@ describe("bundler", () => {
     target: "browser",
     env: "inline",
     format: "esm",
+    onAfterBundle(api) {
+      expect(outputFiles(api)).toEqual(["dynamic-[hash].css", "dynamic-[hash].js", "entry.css", "entry.js"]);
+      expect(dynamicImportsIn(api, "entry.js")).toEqual(["dynamic-[hash].js"]);
+      expect(cssSourcesIn(api, "entry.css")).toEqual(["static.css", "dynamic.css"]);
+      expect(cssSourcesIn(api, "dynamic-[hash].css")).toEqual(["dynamic.css"]);
+    },
     run: {
       file: "/out/entry.js",
       env,
@@ -113,6 +170,23 @@ describe("bundler", () => {
     target: "browser",
     env: "inline",
     format: "esm",
+    onAfterBundle(api) {
+      // entry-[hash].js holds the runtime helpers that entry.js and level1's
+      // chunk share. level1 reaches the same CSS as the entry point, so it
+      // shares entry.css instead of getting a CSS output of its own.
+      expect(outputFiles(api)).toEqual([
+        "entry-[hash].js",
+        "entry.css",
+        "entry.js",
+        "level1-[hash].js",
+        "level2-[hash].css",
+        "level2-[hash].js",
+      ]);
+      expect(dynamicImportsIn(api, "entry.js")).toEqual(["level1-[hash].js"]);
+      expect(dynamicImportsIn(api, "level1-[hash].js")).toEqual(["level2-[hash].js"]);
+      expect(cssSourcesIn(api, "entry.css")).toEqual(["level1.css", "level2.css"]);
+      expect(cssSourcesIn(api, "level2-[hash].css")).toEqual(["level2.css"]);
+    },
     run: {
       file: "/out/entry.js",
       env,
@@ -148,6 +222,20 @@ describe("bundler", () => {
     target: "browser",
     env: "inline",
     format: "esm",
+    onAfterBundle(api) {
+      expect(outputFiles(api)).toEqual([
+        "entry.css",
+        "entry.js",
+        "moduleA-[hash].css",
+        "moduleA-[hash].js",
+        "moduleB-[hash].css",
+        "moduleB-[hash].js",
+      ]);
+      expect(dynamicImportsIn(api, "entry.js")).toEqual(["moduleA-[hash].js", "moduleB-[hash].js"]);
+      expect(cssSourcesIn(api, "entry.css")).toEqual(["shared.css", "moduleA.css", "moduleB.css"]);
+      expect(cssSourcesIn(api, "moduleA-[hash].css")).toEqual(["shared.css", "moduleA.css"]);
+      expect(cssSourcesIn(api, "moduleB-[hash].css")).toEqual(["shared.css", "moduleB.css"]);
+    },
     run: {
       file: "/out/entry.js",
       env,
@@ -194,6 +282,20 @@ describe("bundler", () => {
     target: "browser",
     env: "inline",
     format: "esm",
+    onAfterBundle(api) {
+      expect(outputFiles(api)).toEqual([
+        "chain1-[hash].css",
+        "chain1-[hash].js",
+        "chain2-[hash].css",
+        "chain2-[hash].js",
+        "chain3-[hash].css",
+        "chain3-[hash].js",
+        "entry.css",
+        "entry.js",
+      ]);
+      expect(dynamicImportsIn(api, "entry.js")).toEqual(["chain1-[hash].js", "chain2-[hash].js", "chain3-[hash].js"]);
+      expect(cssSourcesIn(api, "entry.css")).toEqual(["chain1.css", "chain2.css", "chain3.css"]);
+    },
     run: {
       file: "/out/entry.js",
       env,
@@ -228,6 +330,19 @@ describe("bundler", () => {
     target: "browser",
     env: "inline",
     format: "esm",
+    onAfterBundle(api) {
+      // Both branches get a chunk: `condition` is only folded with minifySyntax.
+      expect(outputFiles(api)).toEqual([
+        "entry.css",
+        "entry.js",
+        "moduleFalse-[hash].css",
+        "moduleFalse-[hash].js",
+        "moduleTrue-[hash].css",
+        "moduleTrue-[hash].js",
+      ]);
+      expect(dynamicImportsIn(api, "entry.js")).toEqual(["moduleTrue-[hash].js", "moduleFalse-[hash].js"]);
+      expect(cssSourcesIn(api, "entry.css")).toEqual(["true.css", "false.css"]);
+    },
     run: {
       file: "/out/entry.js",
       env,
@@ -257,6 +372,13 @@ describe("bundler", () => {
     target: "browser",
     env: "inline",
     format: "esm",
+    onAfterBundle(api) {
+      // The entry points share no JS, so there is no shared chunk. Each one
+      // gets its own CSS output that starts with the shared stylesheet.
+      expect(outputFiles(api)).toEqual(["entry1.css", "entry1.js", "entry2.css", "entry2.js"]);
+      expect(cssSourcesIn(api, "entry1.css")).toEqual(["shared.css", "entry1.css"]);
+      expect(cssSourcesIn(api, "entry2.css")).toEqual(["shared.css", "entry2.css"]);
+    },
     run: [
       {
         file: "/out/entry1.js",
@@ -284,6 +406,14 @@ describe("bundler", () => {
     target: "browser",
     env: "inline",
     format: "esm",
+    onAfterBundle(api) {
+      // A stylesheet has no JS chunk, so the import() is rewritten to the
+      // stylesheet's own CSS output.
+      expect(outputFiles(api)).toEqual(["entry.css", "entry.js", "styles-[hash].css"]);
+      expect(dynamicImportsIn(api, "entry.js")).toEqual(["styles-[hash].css"]);
+      expect(cssSourcesIn(api, "entry.css")).toEqual(["styles.css"]);
+      expect(cssSourcesIn(api, "styles-[hash].css")).toEqual(["styles.css"]);
+    },
     run: {
       file: "/out/entry.js",
       env,
@@ -322,6 +452,25 @@ describe("bundler", () => {
     target: "browser",
     env: "inline",
     format: "esm",
+    onAfterBundle(api) {
+      // a.js is reached from both import() targets, so its code moves into a
+      // shared chunk; the second shared chunk holds the runtime helpers. Both
+      // are named after the entry point.
+      expect(outputFiles(api)).toEqual([
+        "a-[hash].css",
+        "a-[hash].js",
+        "b-[hash].css",
+        "b-[hash].js",
+        "entry-[hash].js",
+        "entry-[hash].js",
+        "entry.css",
+        "entry.js",
+      ]);
+      expect(dynamicImportsIn(api, "entry.js")).toEqual(["a-[hash].js", "b-[hash].js"]);
+      expect(cssSourcesIn(api, "entry.css")).toEqual(["a.css", "b.css"]);
+      expect(cssSourcesIn(api, "a-[hash].css")).toEqual(["a.css"]);
+      expect(cssSourcesIn(api, "b-[hash].css")).toEqual(["b.css", "a.css"]);
+    },
     run: {
       file: "/out/entry.js",
       env,
@@ -496,79 +645,80 @@ describe("bundler", () => {
   });
 
   // N same-named cross-chunk exports must get unique aliases in O(N) total
-  // (ExportRenamer::next_renamed_name). Debug/ASAN builds blow past the 15s
-  // cap with far fewer files than release, hence the scaled N.
-  test("splitting/ManyCrossChunkExportAliasCollisions", async () => {
-    const N = isDebug || isASAN ? 2500 : 20000;
-    const THRESHOLD_MS = 15000;
+  // (ExportRenamer::next_renamed_name). The O(N^2) renamer that #34529 replaced
+  // needs about 16s for N=2500 in a debug/ASAN build, and in release 17s for
+  // N=20000, so about 39s for N=30000. The O(N) one needs about 3s and 0.5s.
+  //
+  // A plugin supplies the N modules: creating, reading and deleting N files
+  // costs many times more than the build itself on the macOS and Alpine lanes.
+  // Serial so that the other cases do not run while the build is timed.
+  test.serial(
+    "splitting/ManyCrossChunkExportAliasCollisions",
+    async () => {
+      const N = isDebug || isASAN ? 2500 : 30000;
+      const THRESHOLD_MS = 15000;
 
-    const files: Record<string, string> = {};
-    let imports = "";
-    let uses = "";
-    for (let i = 0; i < N; i++) {
-      files[`s${i}.js`] = `export const shared = ${i};\n`;
-      imports += `import { shared as s${i} } from "./s${i}.js";\n`;
-      uses += `t += s${i};\n`;
-    }
-    // Flat statement list keeps every import live without building a deep AST.
-    const entryBody = imports + "let t = 0;\n" + uses + `console.log(t, s0, s${N - 1});\n`;
-    files["e1.js"] = entryBody;
-    files["e2.js"] = entryBody;
+      let imports = "";
+      let uses = "";
+      for (let i = 0; i < N; i++) {
+        imports += `import { shared as s${i} } from "shared:${i}";\n`;
+        uses += `t += s${i};\n`;
+      }
+      // Flat statement list keeps every import live without building a deep AST.
+      // Two identical entry points put all N modules into one shared chunk.
+      const entryBody = imports + "let t = 0;\n" + uses + `console.log(t, s0, s${N - 1});\n`;
+      using dir = tempDir("splitting-export-alias-collisions", { "e1.js": entryBody, "e2.js": entryBody });
+      const root = String(dir);
+      const outDir = join(root, "out");
 
-    using dir = tempDir("splitting-export-alias-collisions", files);
-    const root = String(dir);
+      const start = performance.now();
+      const build = await Bun.build({
+        entrypoints: [join(root, "e1.js"), join(root, "e2.js")],
+        outdir: outDir,
+        splitting: true,
+        format: "esm",
+        plugins: [
+          {
+            name: "shared modules",
+            setup(builder) {
+              builder.onResolve({ filter: /^shared:\d+$/ }, ({ path }) => ({
+                path: path.slice("shared:".length),
+                namespace: "shared",
+              }));
+              builder.onLoad({ filter: /.*/, namespace: "shared" }, ({ path }) => ({
+                contents: `export const shared = ${path};\n`,
+                loader: "js",
+              }));
+            },
+          },
+        ],
+      });
+      const buildMs = performance.now() - start;
+      expect(build.logs).toBeEmpty();
+      expect(buildMs).toBeLessThan(THRESHOLD_MS);
 
-    await using build = Bun.spawn({
-      cmd: [bunExe(), "build", "--splitting", "--format=esm", "--outdir", "out", "./e1.js", "./e2.js"],
-      env: bunEnv,
-      cwd: root,
-      stdout: "pipe",
-      stderr: "pipe",
-      timeout: THRESHOLD_MS,
-      killSignal: "SIGKILL",
-    });
-    const [buildOut, buildErr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    if (build.signalCode !== null) {
-      throw new Error(
-        `bun build did not finish within ${THRESHOLD_MS}ms for ${N} colliding cross-chunk export names ` +
-          `(signal ${build.signalCode})\nstdout:\n${buildOut}\nstderr:\n${buildErr}`,
-      );
-    }
-    if (buildExit !== 0) {
-      throw new Error(`bun build exited ${buildExit}\nstdout:\n${buildOut}\nstderr:\n${buildErr}`);
-    }
+      // The shared chunk's export clause hands out `shared`, `shared1`, ... in
+      // module order. Running an entry point checks that its imports use the
+      // same aliases.
+      const outputs = readdirSync(outDir).sort();
+      expect(outputs.map(unhashed)).toEqual(["chunk-[hash].js", "e1.js", "e2.js"]);
+      const clause = readFileSync(join(outDir, outputs[0]), "utf8").match(/export\s*\{([^}]*)\}/)![1];
+      const aliases = clause.split(",").map(item => item.trim().split(" as ").pop());
+      expect(aliases).toEqual(Array.from({ length: N }, (_, i) => (i === 0 ? "shared" : `shared${i}`)));
 
-    // The shared chunk's export clause must hand out a unique alias for every
-    // `shared` symbol; verify by inspecting the generated chunk and by running
-    // the output.
-    const outDir = join(root, "out");
-    const chunkName = readdirSync(outDir).find(f => f !== "e1.js" && f !== "e2.js" && f.endsWith(".js"));
-    expect(chunkName).toBeDefined();
-    const chunk = readFileSync(join(outDir, chunkName!), "utf8");
-    const clause = chunk.match(/export\s*\{([^}]*)\}/)?.[1] ?? "";
-    const aliases = clause
-      .split(",")
-      .map(part => {
-        const bits = part.trim().split(/\s+as\s+/);
-        return bits[bits.length - 1];
-      })
-      .filter(Boolean);
-    expect(aliases.length).toBe(N);
-    expect(new Set(aliases).size).toBe(N);
-    for (const a of aliases) expect(a).toMatch(/^shared\d*$/);
-
-    await using run = Bun.spawn({
-      cmd: [bunExe(), join(outDir, "e1.js")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [runOut, runErr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
-    if (runExit !== 0) {
-      throw new Error(`running e1.js exited ${runExit}\nstdout:\n${runOut}\nstderr:\n${runErr}`);
-    }
-    expect(runOut.trim()).toBe(`${(N * (N - 1)) / 2} 0 ${N - 1}`);
-  }, 60_000);
+      await using run = Bun.spawn({
+        cmd: [bunExe(), join(outDir, "e1.js")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
+      expect(stdout).toBe(`${(N * (N - 1)) / 2} 0 ${N - 1}\n`);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+    60_000,
+  );
 
   // Chunks are printed with placeholders where they refer to other chunks and
   // assets; the placeholders are replaced once every output path is known.

--- a/test/bundler/bundler_splitting.test.ts
+++ b/test/bundler/bundler_splitting.test.ts
@@ -25,8 +25,8 @@ function readOutput(api: BundlerTestBundleAPI, file: string) {
 }
 
 // The import() specifiers in an output file. Each of them must name a file in
-// the output directory: with splitting they used to be rewritten to the
-// importee's CSS output instead of its JS chunk.
+// the output directory: the import() of a module that imports CSS used to be
+// rewritten to the module's CSS output instead of its JS chunk.
 function dynamicImportsIn(api: BundlerTestBundleAPI, file: string) {
   const specifiers = Array.from(readOutput(api, file).matchAll(/\bimport\("\.\/([^"]+)"\)/g), m => m[1]);
   for (const specifier of specifiers) api.assertFileExists("/out/" + specifier);
@@ -40,7 +40,8 @@ const cssSourcesIn = (api: BundlerTestBundleAPI, file: string) =>
 
 // Every case builds into its own directory under expectBundled's temp root and
 // spawns its own processes, so they can overlap. expectBundled registers the
-// backend: "api" cases with it.serial because that backend chdirs.
+// backend: "api" cases with it.serial because that backend chdirs. Each of
+// those waits for the cases declared before it and blocks the ones after it.
 describe.concurrent("bundler", () => {
   itBundled("splitting/DynamicImportCSSFile", {
     files: {
@@ -171,17 +172,11 @@ describe.concurrent("bundler", () => {
     env: "inline",
     format: "esm",
     onAfterBundle(api) {
-      // entry-[hash].js holds the runtime helpers that entry.js and level1's
-      // chunk share. level1 reaches the same CSS as the entry point, so it
-      // shares entry.css instead of getting a CSS output of its own.
-      expect(outputFiles(api)).toEqual([
-        "entry-[hash].js",
-        "entry.css",
-        "entry.js",
-        "level1-[hash].js",
-        "level2-[hash].css",
-        "level2-[hash].js",
-      ]);
+      // level1 reaches the same CSS as the entry point, so it shares entry.css
+      // instead of getting a CSS output of its own. Only the CSS outputs are
+      // pinned: the JS side also has a chunk of unused runtime helpers, whose
+      // presence and name this case does not cover.
+      expect(outputFiles(api).filter(file => file.endsWith(".css"))).toEqual(["entry.css", "level2-[hash].css"]);
       expect(dynamicImportsIn(api, "entry.js")).toEqual(["level1-[hash].js"]);
       expect(dynamicImportsIn(api, "level1-[hash].js")).toEqual(["level2-[hash].js"]);
       expect(cssSourcesIn(api, "entry.css")).toEqual(["level1.css", "level2.css"]);
@@ -407,8 +402,9 @@ describe.concurrent("bundler", () => {
     env: "inline",
     format: "esm",
     onAfterBundle(api) {
-      // A stylesheet has no JS chunk, so the import() is rewritten to the
-      // stylesheet's own CSS output.
+      // Current behavior: the stylesheet gets no JS chunk, so the import() is
+      // rewritten to the stylesheet's own CSS output. A build that gives an
+      // import()ed stylesheet a JS chunk has to update these two lists.
       expect(outputFiles(api)).toEqual(["entry.css", "entry.js", "styles-[hash].css"]);
       expect(dynamicImportsIn(api, "entry.js")).toEqual(["styles-[hash].css"]);
       expect(cssSourcesIn(api, "entry.css")).toEqual(["styles.css"]);
@@ -453,18 +449,13 @@ describe.concurrent("bundler", () => {
     env: "inline",
     format: "esm",
     onAfterBundle(api) {
-      // a.js is reached from both import() targets, so its code moves into a
-      // shared chunk; the second shared chunk holds the runtime helpers. Both
-      // are named after the entry point.
-      expect(outputFiles(api)).toEqual([
+      // b reaches a's CSS too. Only the CSS outputs are pinned: a.js itself
+      // moves into a shared chunk, next to a chunk of unused runtime helpers,
+      // and the names of those two chunks are not what this case covers.
+      expect(outputFiles(api).filter(file => file.endsWith(".css"))).toEqual([
         "a-[hash].css",
-        "a-[hash].js",
         "b-[hash].css",
-        "b-[hash].js",
-        "entry-[hash].js",
-        "entry-[hash].js",
         "entry.css",
-        "entry.js",
       ]);
       expect(dynamicImportsIn(api, "entry.js")).toEqual(["a-[hash].js", "b-[hash].js"]);
       expect(cssSourcesIn(api, "entry.css")).toEqual(["a.css", "b.css"]);
@@ -646,22 +637,22 @@ describe.concurrent("bundler", () => {
 
   // N same-named cross-chunk exports must get unique aliases in O(N) total
   // (ExportRenamer::next_renamed_name). The O(N^2) renamer that #34529 replaced
-  // needs about 16s for N=2500 in a debug/ASAN build, and in release 17s for
-  // N=20000, so about 39s for N=30000. The O(N) one needs about 3s and 0.5s.
+  // needs about 15s for N=2500 in a debug/ASAN build, and in release 17s for
+  // N=20000, so about 39s for N=30000. The O(N) one needs about 1.6s and 0.6s.
   //
-  // A plugin supplies the N modules: creating, reading and deleting N files
+  // The N modules are passed in memory: creating, reading and deleting N files
   // costs many times more than the build itself on the macOS and Alpine lanes.
   // Serial so that the other cases do not run while the build is timed.
   test.serial(
     "splitting/ManyCrossChunkExportAliasCollisions",
     async () => {
       const N = isDebug || isASAN ? 2500 : 30000;
-      const THRESHOLD_MS = 15000;
+      const THRESHOLD_MS = 10_000;
 
       let imports = "";
       let uses = "";
       for (let i = 0; i < N; i++) {
-        imports += `import { shared as s${i} } from "shared:${i}";\n`;
+        imports += `import { shared as s${i} } from "./s${i}.js";\n`;
         uses += `t += s${i};\n`;
       }
       // Flat statement list keeps every import live without building a deep AST.
@@ -670,6 +661,8 @@ describe.concurrent("bundler", () => {
       using dir = tempDir("splitting-export-alias-collisions", { "e1.js": entryBody, "e2.js": entryBody });
       const root = String(dir);
       const outDir = join(root, "out");
+      const files: Record<string, string> = {};
+      for (let i = 0; i < N; i++) files[`${root}/s${i}.js`] = `export const shared = ${i};\n`;
 
       const start = performance.now();
       const build = await Bun.build({
@@ -677,21 +670,7 @@ describe.concurrent("bundler", () => {
         outdir: outDir,
         splitting: true,
         format: "esm",
-        plugins: [
-          {
-            name: "shared modules",
-            setup(builder) {
-              builder.onResolve({ filter: /^shared:\d+$/ }, ({ path }) => ({
-                path: path.slice("shared:".length),
-                namespace: "shared",
-              }));
-              builder.onLoad({ filter: /.*/, namespace: "shared" }, ({ path }) => ({
-                contents: `export const shared = ${path};\n`,
-                loader: "js",
-              }));
-            },
-          },
-        ],
+        files,
       });
       const buildMs = performance.now() - start;
       expect(build.logs).toBeEmpty();


### PR DESCRIPTION
### Problem
- The file takes 40s on darwin aarch64 and 26s on alpine aarch64 in CI (build 101153). The lane logs put all of it in `splitting/ManyCrossChunkExportAliasCollisions`, which writes 20000 modules to disk, builds them and deletes them. The slow lanes pay for the file I/O.
- The 17 `itBundled` cases run in sequence. The 10 CSS cases assert only the run output.

### Fix
- The big case passes its N modules to `Bun.build()` through the `files` option and times the build call. `test.serial` keeps the other cases out of the timed window. The cap goes from 15s to 10s, see Background.
- The outer `describe` is `describe.concurrent`. Each case builds into its own directory, and `expectBundled` already makes the `backend: "api"` cases serial.
- Each CSS case pins its output file list, its `import()` targets (each has to exist) and the source order of its CSS outputs. The two cases whose output also holds a chunk of unused runtime helpers pin only their CSS outputs.
- Verified: `bun bd test test/bundler/bundler_splitting.test.ts` goes from 21.2s to 23.0s down to 11.9s. In CI the file passed on all ten platforms of both PR builds, in 1.0s to 2.9s: darwin aarch64 39.6s to 2.5s and 2.9s, alpine aarch64 25.7s to 1.2s and 2.3s (table in Notes).

### Background
- The big case is the timing guard from #34529: N modules that all export `shared` land in one chunk, and `ExportRenamer::next_renamed_name` has to give them distinct aliases. The old renamer cost N^2.
- N cannot shrink: with that fix reverted, the debug build takes 15.0s at N=2500, the fixed one 1.6s. The old 15s cap had no margin, 10s sits between the two. Release N goes from 20000 (17s when quadratic, per #34529) to 30000 (about 39s, 0.55s fixed).
- `unhashed` replaces the chunk hash before the file names are sorted, so the hashes do not decide the order of the pinned lists.

<details><summary>Notes</summary>

Per-test times from `bun bd test` (debug, ASAN) before the change. About 3.3s of the file total is loading the file and its imports.

| test | before | after |
| --- | --- | --- |
| ManyCrossChunkExportAliasCollisions | 6.7s to 7.6s | 4.2s, serial |
| DynamicImportCSSFile | 0.95s | 0.96s, overlapped with the other cli cases |
| MultipleEntryPointsWithSharedCSS | 0.86s | overlapped |
| 14 other itBundled cases | 0.4s to 0.7s each, 8.4s in sequence | overlapped, except the two `backend: "api"` cases |
| ChunkReferencePaths (4, already concurrent) | 0.8s | unchanged |

CI times of this file: before (build 101153 on main), first revision (build 101232) and second revision (build 101318). In each before log the first 17 dots arrive together and the 18th (this case) arrives 8s to 39s later. The file passed on every lane of both PR builds.

| lane | before | revision 1 | revision 2 |
| --- | --- | --- | --- |
| darwin aarch64 | 39.6s | 2.45s | 2.87s |
| alpine 3.23 aarch64 | 25.7s | 1.24s | 2.32s |
| alpine 3.23 x64 | about 25s | 2.02s | |
| windows 11 aarch64 | about 25s | 1.05s | 1.44s |
| windows 2019 x64 | | 1.17s | |
| debian 13 x64 | 8.6s | 1.20s | |
| debian 13 x64-asan | 6.3s | 2.49s | 2.21s |
| debian 13 aarch64, ubuntu 25.04 x64 and aarch64 | | 1.04s to 1.35s | |

Where the big case spent its time (release, this container, N=20000): writing 20002 files 725ms, `bun build` 430ms, running e1.js 160ms to 210ms, deleting the directory 300ms. With the modules in memory there is no per-module file I/O. `Bun.build()` takes 360ms for N=20000 and 552ms for N=30000 with the released bun. Debug/ASAN: 1.6s for N=2500 (2.8s with the onResolve/onLoad plugin the first revision used, which is why the second revision switched to `files`).

Unfixed renamer (the `src/js_printer/renamer.rs` change of #34529 reverted, debug/ASAN): N=2500 takes 15.05s with the `files` shape (15.26s with the old on-disk shape, 16.3s with the plugin shape; N=500, 1000 and 1500 take 1.4s, 3.5s and 6.7s with the plugin shape, which shows the N^2 growth). The rewritten test fails with `Expected: < 10000, Received: 15063`. Against the old 15s cap the unfixed build passed or failed by a few percent depending on the machine.

Assertion changes:
- All 10 CSS cases: `outputFiles` (CSS outputs only in `NestedDynamicImportWithCSS` and `CircularDynamicImportsWithCSS`, see below), `dynamicImportsIn` of the entry (every target must exist in the output directory, which is the #20784 bug these cases come from) and `cssSourcesIn` of the CSS outputs. This pins the CSS chunk dedupe of `computeChunks` (a chunk whose CSS order equals the entry's shares the entry's CSS file: `DynamicImportCSSFile`, `NestedDynamicImportWithCSS`), the CSS of a chunk that imports another module with CSS (`CircularDynamicImportsWithCSS`: `b.css, a.css`), and that `DynamicImportWithOnlyCSSNoJS` rewrites the `import()` to the CSS output.
- `NestedDynamicImportWithCSS` also checks the `import()` inside `level1-[hash].js`.
- `ManyCrossChunkExportAliasCollisions`: exact output list, exact alias sequence, empty `build.logs`, exact stdout, empty stderr, exit code.
- The count `bun test` reports drops from 2564 to 137 assertions because the 2500 per-alias `toMatch` calls became one `toEqual`. The other cases gain 70.
- The `DeadDynamicImport*` cases (#39591) already pin their file lists and the metafile. Unchanged.

The new assertions also pass on the released bun 1.4.0, so they pin behavior that is not new. `NestedDynamicImportWithCSS` and `CircularDynamicImportsWithCSS` also emit an `entry-[hash].js` chunk that only holds the unused `__require` shim (#12615). The first revision pinned it; since #35579 removes that chunk and #36326 renames shared chunks, these two cases now pin their CSS outputs only, and their JS side is covered by the `import()` target checks. Of the open PRs, only #38319 (a JS chunk for an `import()`ed stylesheet) still has to update pinned lines: the two in `DynamicImportWithOnlyCSSNoJS`, whose comment says so.

Also ran prettier (with the repo's organize-imports plugin) and oxlint on the file. The `tsc` errors for the file (`env: "inline"`, the `source-map` types) are the same before and after.
</details>
