### PR TITLE
test/bundler: run the bundler_edgecase deep graph cases concurrently and pin more outputs

### DIFF
--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isBroken, isWindows, tempDir } from "harness";
-import { readdirSync, writeFileSync } from "node:fs";
+import { afterAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, bunRun, isBroken, isWindows, tempDir } from "harness";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { decodeSourceMappingsLine, itBundled } from "./expectBundled";
 
@@ -9,10 +9,23 @@ import { decodeSourceMappingsLine, itBundled } from "./expectBundled";
 const CDN_PUBLIC_PATH = "https://cdn.example/app/";
 const cdnUrls = (source: string) => [...source.matchAll(/"(https:\/\/cdn\.example\/[^"]+)"/g)].map(match => match[1]);
 
-describe("bundler", () => {
+// itBundled registers backend=api cases as it.serial, so only the backend=cli
+// cases and the plain test() cases below overlap. Each of them builds in its
+// own directory.
+describe.concurrent("bundler", () => {
   itBundled("edgecase/EmptyFile", {
     files: {
       "/entry.js": "",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toMatchInlineSnapshot(`
+        "// entry.js
+        var entry_default = {};
+        export {
+          entry_default as default
+        };
+        "
+      `);
     },
   });
   itBundled("edgecase/EmptyCommonJSModule", {
@@ -202,6 +215,15 @@ describe("bundler", () => {
       `,
     },
     external: ["*"],
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toMatchInlineSnapshot(`
+        "// entry.js
+        import { foo } from "./foo";
+        import { bar } from "./bar";
+        console.log(foo);
+        "
+      `);
+    },
   });
   itBundled("edgecase/ImportNamespaceAndDefault", {
     files: {
@@ -273,6 +295,13 @@ describe("bundler", () => {
       // ".m": "binary",
       // ".n": "empty",
       // ".o": "copy",
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out/entry.js").toMatchInlineSnapshot(`
+        "// entry.js
+        console.log(1);
+        "
+      `);
     },
   });
   itBundled("edgecase/InvalidLoaderSegfault", {
@@ -383,6 +412,13 @@ describe("bundler", () => {
       "/x.aaaa": `x`,
     },
     outdir: "/out",
+    // An unknown extension gets the file loader: the file is copied into the
+    // output directory and the require() evaluates to its path.
+    onAfterBundle(api) {
+      expect(readdirSync(api.outdir).sort()).toEqual(["entry.js", "x-4my6q98m.aaaa"]);
+      api.expectFile("/out/x-4my6q98m.aaaa").toBe("x");
+      api.expectFile("/out/entry.js").toContain('module.exports = "./x-4my6q98m.aaaa";');
+    },
   });
   itBundled("edgecase/PackageJSONDefaultConditionRequire", {
     files: {
@@ -743,6 +779,17 @@ describe("bundler", () => {
       `,
     },
     target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toMatchInlineSnapshot(`
+        "// @bun
+        // entry.ts
+        var a = 1;
+        export {
+          a
+        };
+        "
+      `);
+    },
   });
   itBundled("edgecase/RuntimeExternalRequire", {
     files: {
@@ -1179,7 +1226,7 @@ describe("bundler", () => {
   itBundled("edgecase/YieldKeyword", {
     files: {
       "/entry.js": /* js */ `
-        function* foo() {
+        export function* foo() {
           yield 1;
           [yield];
           yield yield yield;
@@ -1190,6 +1237,28 @@ describe("bundler", () => {
           yield+1
         }
       `,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toMatchInlineSnapshot(`
+        "// entry.js
+        function* foo() {
+          yield 1;
+          yield;
+          yield yield yield;
+          yield* 2;
+          yield yield;
+          {
+            x:
+              yield;
+          }
+          (yield).hello;
+          yield 1;
+        }
+        export {
+          foo
+        };
+        "
+      `);
     },
   });
   itBundled("edgecase/UsingWithSixImports", {
@@ -1209,6 +1278,18 @@ describe("bundler", () => {
       `,
     },
     target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toMatchInlineSnapshot(`
+        "// @bun
+        // entry.js
+        import { Database } from "bun:sqlite";
+        using a = new Database;
+        export {
+          a
+        };
+        "
+      `);
+    },
   });
   itBundled("edgecase/EmitInvalidSourceMap1", {
     files: {
@@ -2744,90 +2825,100 @@ describe("bundler", () => {
       expect(out).not.toContain("na_ve");
     },
   });
-  // The bundler's per-edge graph walks (reachable files, tree-shaking /
-  // code-splitting liveness, chunk part ordering, CSS discovery, TLA
-  // validation, async propagation, dependency wrapping) used to recurse once
-  // per import-graph edge, overflowing the stack on long linear chains. 7000
-  // reliably crashed the old recursive form under debug+ASAN.
-  const deepChainDepth = 7000;
-  const deepChainFiles = {
-    ...Object.fromEntries(
-      Array.from({ length: deepChainDepth - 1 }, (_, i) => [
-        `/m${i}.js`,
-        `import { v${i + 1} } from "./m${i + 1}.js"; export const v${i} = v${i + 1} + 1;`,
-      ]),
-    ),
-    [`/m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = 1;`,
-  };
-  itBundled("edgecase/DeepImportChain", {
-    files: {
-      "/entry.js": `import { v0 } from "./m0.js"; console.log(v0);`,
-      ...deepChainFiles,
-    },
-    backend: "cli",
-    run: { stdout: String(deepChainDepth) },
-  });
-  // Top-level await in the entry makes `validate_tla` / `propagate_async` walk
-  // the chain; `await import()` of an ESM head without splitting wraps the
-  // whole chain, driving `DependencyWrapper::wrap` through it. The wrapped
-  // output initializes module N by calling module N+1's init, so running it
-  // would recurse at runtime; checking for the deepest wrapper is enough.
-  itBundled("edgecase/DeepImportChainWrappedTLA", {
-    files: {
-      "/entry.js": `await 0; const { v0 } = await import("./m0.js"); console.log(v0);`,
-      ...deepChainFiles,
-    },
-    backend: "cli",
-    onAfterBundle(api) {
-      const out = api.readFile("out.js");
-      expect(out).toContain(`init_m${deepChainDepth - 2}`);
-    },
-  });
+  // The three deep import graph cases below write their modules with plain fs
+  // calls because itBundled's fixture pipeline is too slow at this scale under
+  // debug+ASAN, and they spawn `bun build` so that a stack overflow or a build
+  // that no longer terminates fails the child, not the test runner. They
+  // overlap each other: the DAG case comes first because its fixture is the
+  // largest, so the chain cases write theirs while the DAG build runs.
+
+  /** Bundles `root/entry` into `root/outfile` and returns the outfile's absolute path. */
+  async function buildDeepGraph(root: string, entry: string, outfile: string): Promise<string> {
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", entry, `--outfile=${outfile}`],
+      cwd: root,
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 60_000,
+    });
+    const [, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect({ stderr, exitCode, signalCode: build.signalCode }).toEqual({ stderr: "", exitCode: 0, signalCode: null });
+    return join(root, outfile);
+  }
+
   // Diamond-shaped DAG (half the modules have two importers). The code-
   // splitting reachability pass tracks min distance-from-entry for each file;
   // a LIFO walk with distance relaxation does O(V*E) re-visits here, so this
-  // guards that the pass stays O(V+E). Plain fs writes because itBundled's
-  // fixture pipeline is too slow at this scale under debug+ASAN.
+  // guards that the pass stays O(V+E). m[i] exports i plus the values of the
+  // modules it imports, so the value printed for m[0] covers every module.
   test.concurrent(
     "edgecase/DeepImportDiamondDAG",
     async () => {
       const N = 20000;
       using dir = tempDir("deep-import-dag", {});
       const root = String(dir);
-      for (let i = 0; i < N; i++) {
-        const deps: number[] = [];
-        if (i + 1 < N) deps.push(i + 1);
-        if (2 * i + 3 < N) deps.push(2 * i + 3);
+      const values = new Array<number>(N);
+      for (let i = N - 1; i >= 0; i--) {
+        const deps = [i + 1, 2 * i + 3].filter(d => d < N);
+        values[i] = deps.reduce((sum, d) => sum + values[d], i);
         writeFileSync(
           join(root, `m${i}.js`),
           deps.map(d => `import { v as v${d} } from "./m${d}.js";`).join("\n") +
             `\nexport const v = ${i}${deps.map(d => ` + v${d}`).join("")};\n`,
         );
       }
-      writeFileSync(join(root, "entry.js"), `import { v } from "./m0.js"; console.log(typeof v);\n`);
+      writeFileSync(join(root, "entry.js"), `import { v } from "./m0.js"; console.log(v);\n`);
+      const outfile = await buildDeepGraph(root, "entry.js", "out.js");
+      expect(await bunRun(outfile)).toSpawn(String(values[0]));
+    },
+    120_000,
+  );
+  // The bundler's per-edge graph walks (reachable files, tree-shaking /
+  // code-splitting liveness, chunk part ordering, CSS discovery, TLA
+  // validation, async propagation, dependency wrapping) used to recurse once
+  // per import-graph edge, overflowing the stack on long linear chains. 7000
+  // reliably crashed the old recursive form under debug+ASAN.
+  //
+  // Both chain cases bundle the same modules, written once. They only read
+  // the directory, and each writes its own outfile.
+  const deepChainDepth = 7000;
+  let deepChainDir: ReturnType<typeof tempDir> | undefined;
+  function deepChainRoot(): string {
+    if (!deepChainDir) {
+      const files: Record<string, string> = {
+        "chain.js": `import { v0 } from "./m0.js"; console.log(v0);`,
+        "tla.js": `await 0; const { v0 } = await import("./m0.js"); console.log(v0);`,
+        [`m${deepChainDepth - 1}.js`]: `export const v${deepChainDepth - 1} = 1;`,
+      };
+      for (let i = 0; i < deepChainDepth - 1; i++) {
+        files[`m${i}.js`] = `import { v${i + 1} } from "./m${i + 1}.js"; export const v${i} = v${i + 1} + 1;`;
+      }
+      deepChainDir = tempDir("deep-import-chain", files);
+    }
+    return String(deepChainDir);
+  }
+  afterAll(() => deepChainDir?.[Symbol.dispose]());
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "entry.js", "--outfile=out.js"],
-        cwd: root,
-        env: bunEnv,
-        stdio: ["ignore", "pipe", "pipe"],
-        timeout: 60_000,
-      });
-      const [, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-      expect({ stderr, exitCode, signalCode: build.signalCode }).toEqual({ stderr: "", exitCode: 0, signalCode: null });
-
-      await using run = Bun.spawn({
-        cmd: [bunExe(), "out.js"],
-        cwd: root,
-        env: bunEnv,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-      const [stdout, runStderr, runExit] = await Promise.all([run.stdout.text(), run.stderr.text(), run.exited]);
-      expect({ stdout, stderr: runStderr, exitCode: runExit }).toEqual({
-        stdout: "number\n",
-        stderr: "",
-        exitCode: 0,
-      });
+  test.concurrent(
+    "edgecase/DeepImportChain",
+    async () => {
+      const outfile = await buildDeepGraph(deepChainRoot(), "chain.js", "chain.out.js");
+      expect(await bunRun(outfile)).toSpawn(String(deepChainDepth));
+    },
+    120_000,
+  );
+  // Top-level await in the entry makes `validate_tla` / `propagate_async` walk
+  // the chain; `await import()` of an ESM head without splitting wraps the
+  // whole chain, driving `DependencyWrapper::wrap` through it. The wrapped
+  // output initializes module N by calling module N+1's init, so running it
+  // would recurse at runtime; count the wrappers instead. The last module is
+  // a constant without imports, so it is the one module that gets no wrapper.
+  test.concurrent(
+    "edgecase/DeepImportChainWrappedTLA",
+    async () => {
+      const out = readFileSync(await buildDeepGraph(deepChainRoot(), "tla.js", "tla.out.js"), "utf8");
+      expect(out.match(/^var init_m\d+ = __esm\(/gm)).toHaveLength(deepChainDepth - 1);
+      expect(out).toContain(`var init_m${deepChainDepth - 2} = __esm(`);
     },
     120_000,
   );

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, isBroken, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, bunRun, isASAN, isBroken, isDebug, isWindows, tempDir } from "harness";
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { decodeSourceMappingsLine, itBundled } from "./expectBundled";
@@ -2831,18 +2831,37 @@ describe.concurrent("bundler", () => {
   // that no longer terminates fails the child, not the test runner. They
   // overlap each other: the DAG case comes first because its fixture is the
   // largest, so the chain cases write theirs while the DAG build runs.
+  //
+  // Only debug and ASAN builds can fail these cases at the full sizes. A
+  // release build from before #34554 and #35310 bundles all three graphs: its
+  // stack holds a chain of more than 10000 modules, and the O(V*E) walk took
+  // about 4.5s on the DAG, far below the build cap. Release builds therefore
+  // run the same shapes at a small size.
+  const deepGraphFullSize = isDebug || isASAN;
+  const deepBuildCapMs = 60_000;
 
   /** Bundles `root/entry` into `root/outfile` and returns the outfile's absolute path. */
-  async function buildDeepGraph(root: string, entry: string, outfile: string): Promise<string> {
+  async function buildDeepGraph(root: string, entry: string, outfile: string, graph: string): Promise<string> {
     await using build = Bun.spawn({
       cmd: [bunExe(), "build", entry, `--outfile=${outfile}`],
       cwd: root,
       env: bunEnv,
       stdio: ["ignore", "pipe", "pipe"],
-      timeout: 60_000,
+      timeout: deepBuildCapMs,
     });
-    const [, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
-    expect({ stderr, exitCode, signalCode: build.signalCode }).toEqual({ stderr: "", exitCode: 0, signalCode: null });
+    const [stdout, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    if (build.signalCode !== null) {
+      throw new Error(
+        `bun build of the ${graph} was killed by ${build.signalCode} ` +
+          `(SIGTERM means it did not finish within ${deepBuildCapMs}ms)\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+      );
+    }
+    if (exitCode !== 0 || stderr !== "") {
+      throw new Error(
+        `bun build of the ${graph} exited with ${exitCode} (expected 0 and an empty stderr)` +
+          `\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+      );
+    }
     return join(root, outfile);
   }
 
@@ -2854,7 +2873,7 @@ describe.concurrent("bundler", () => {
   test.concurrent(
     "edgecase/DeepImportDiamondDAG",
     async () => {
-      const N = 20000;
+      const N = deepGraphFullSize ? 20000 : 1000;
       using dir = tempDir("deep-import-dag", {});
       const root = String(dir);
       const values = new Array<number>(N);
@@ -2868,7 +2887,7 @@ describe.concurrent("bundler", () => {
         );
       }
       writeFileSync(join(root, "entry.js"), `import { v } from "./m0.js"; console.log(v);\n`);
-      const outfile = await buildDeepGraph(root, "entry.js", "out.js");
+      const outfile = await buildDeepGraph(root, "entry.js", "out.js", `${N} module DAG`);
       expect(await bunRun(outfile)).toSpawn(String(values[0]));
     },
     120_000,
@@ -2881,7 +2900,7 @@ describe.concurrent("bundler", () => {
   //
   // Both chain cases bundle the same modules, written once. They only read
   // the directory, and each writes its own outfile.
-  const deepChainDepth = 7000;
+  const deepChainDepth = deepGraphFullSize ? 7000 : 500;
   let deepChainDir: ReturnType<typeof tempDir> | undefined;
   function deepChainRoot(): string {
     if (!deepChainDir) {
@@ -2902,7 +2921,12 @@ describe.concurrent("bundler", () => {
   test.concurrent(
     "edgecase/DeepImportChain",
     async () => {
-      const outfile = await buildDeepGraph(deepChainRoot(), "chain.js", "chain.out.js");
+      const outfile = await buildDeepGraph(
+        deepChainRoot(),
+        "chain.js",
+        "chain.out.js",
+        `${deepChainDepth} module chain`,
+      );
       expect(await bunRun(outfile)).toSpawn(String(deepChainDepth));
     },
     120_000,
@@ -2916,7 +2940,13 @@ describe.concurrent("bundler", () => {
   test.concurrent(
     "edgecase/DeepImportChainWrappedTLA",
     async () => {
-      const out = readFileSync(await buildDeepGraph(deepChainRoot(), "tla.js", "tla.out.js"), "utf8");
+      const outfile = await buildDeepGraph(
+        deepChainRoot(),
+        "tla.js",
+        "tla.out.js",
+        `${deepChainDepth} module chain behind await import()`,
+      );
+      const out = readFileSync(outfile, "utf8");
       expect(out.match(/^var init_m\d+ = __esm\(/gm)).toHaveLength(deepChainDepth - 1);
       expect(out).toContain(`var init_m${deepChainDepth - 2} = __esm(`);
     },

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -11,7 +11,8 @@ const cdnUrls = (source: string) => [...source.matchAll(/"(https:\/\/cdn\.exampl
 
 // itBundled registers backend=api cases as it.serial, so only the backend=cli
 // cases and the plain test() cases below overlap. Each of them builds in its
-// own directory.
+// own directory. The exception is todo cases, which itBundled registers with
+// a plain it.todo: adjacent api ones overlap in a `bun test --todo` run.
 describe.concurrent("bundler", () => {
   itBundled("edgecase/EmptyFile", {
     files: {


### PR DESCRIPTION
### Problem
- `bundler_edgecase.test.ts` takes 23s to 31s on the asan lane and up to 42s on darwin (table in Notes). Three cases take most of it: `edgecase/DeepImportChain`, `DeepImportChainWrappedTLA` and `DeepImportDiamondDAG`. They ran in sequence, they wrote the 7000 module chain twice, and release builds cannot fail them.
- Seven cases only checked that the build succeeded (list in Notes). `YieldKeyword` even produced an empty bundle.

### Fix
- The main `describe` becomes `describe.concurrent`. The deep cases write their modules with plain fs calls, share one helper that spawns `bun build`, and overlap. The chain is written once.
- Debug and ASAN builds keep the full sizes and the 60s cap, so the guards from #34554 and #35310 still fire. Release builds run the same shapes with 500 and 1000 modules.
- The seven cases pin the exact bundle. The DAG case checks the value computed through every module, and the TLA case counts the wrappers.
- Verified: `bun bd test test/bundler/bundler_edgecase.test.ts` took 145s and 190s before, 78s to 103s after. Release build: 6.3s to 8.2s before, 1.8s to 2.5s after. Build 101234 passed on every lane.

### Background
- The default `api` backend of `itBundled` calls `process.chdir`, so `expectBundled.ts` registers those cases as `it.serial`. A serial test is a barrier for the concurrent ones, so only the deep cases and five cli cases overlap.
- Depth 7000 overflowed the old walks under debug+ASAN only: a release build's stack holds more than 10000 modules. The old O(V*E) walk took about 4.5s on the 20000 module DAG (#35310), far below the cap. Bun 1.3.14, from before both fixes, passes all three cases at the full sizes.

<details><summary>Notes</summary>

**Per-lane duration of this file as reported by `bun test`, in seconds.** Build 101234 is the first commit of this PR (full sizes on every lane, concurrent). The other builds are main and unrelated PRs from the same day. The second commit (small sizes on release builds) passed CI as build 101410. On the release lanes the three deep cases now take about 0.1s to 0.3s in total (measured locally), so most of the time left there is the 131 serial api cases.

| lane | other builds (n) | 101234 |
|---|---|---|
| debian 13 x64-asan | 23.2 to 31.5 (8) | 19.3 |
| darwin any aarch64 (PR builds, host dependent) | 6.0 to 42.0 (8) | 18.5 |
| darwin 14 / 26 (main builds) | 5.8 to 9.7 (9) | not run on PRs |
| alpine 3.23 aarch64 | 16.2 to 29.8 (10) | 25.1 |
| alpine 3.23 x64 | 17.3 to 27.3 (10) | 23.5 |
| debian 13 aarch64 | 4.8 to 6.8 (10) | 3.4 |
| debian 13 x64 | 3.2 to 6.2 (9) | 4.2 |
| ubuntu 25.04 aarch64 | 4.2 to 6.6 (10) | 4.5 |
| ubuntu 25.04 x64 | 4.0 to 6.6 (10) | 4.0 |
| windows 11 aarch64 | 8.6 to 10.5 (10), 1 test | 14.1, 3 tests |
| windows 2019 x64 | 3.7 to 6.6 (10), 1 test | 6.6, 3 tests |

Windows: every itBundled case is silently dropped on Windows today (#34552 fixes that), so the Windows numbers are the deep cases alone. Before this PR that was the DAG case only. The first commit added the two chain cases there at full size, which is the Windows slowdown in the table. The second commit runs all three at the small sizes there, because those lanes are release builds. The alpine lanes are noisy (29.8s and 27.3s on unrelated builds), so their 101234 numbers are not conclusive either way. The small sizes take that question away, because the three concurrent builds become tiny there.

Why release builds cannot fail the full sizes: with bun 1.3.14 (0d9b296af, before 483fd4204c and 0870c7ca2d) the 7000 module chain bundles in 0.7s and prints 7000, the TLA variant has exactly 6999 wrappers, and the DAG bundles in 0.4s. #35310 reports the regressed DAG walk at 4.4s to 4.6s for 20000 modules on a release build, against the 60s cap. The chain variants need more than 10000 modules to overflow the 8MB main thread stack of a release build on Linux, and the darwin and Windows builds get an 18MB stack. So the full sizes only run where `isDebug || isASAN` is true: local `bun bd` runs and the asan lane. `test/expected-durations.json` has this file's asan median at 15.7s, above the 15s rule of `test/parallel-allowlist.json`, so the file stays in `excludeFiles` after this PR as well. The gain is wall time in the serial part of the run.

Local timings: debug build (`bun bd test`), two runs before (145s, 190s) and three after (78s, 80s, 103s). Release build (`USE_SYSTEM_BUN=1`), four runs before (6.3s to 8.2s) and three after the second commit (1.8s to 2.5s). Slowest cases before, debug build: DeepImportChain 41.1s, DeepImportChainWrappedTLA 35.7s, DeepImportDiamondDAG 35.7s, AssetEntryPoint 2.0s, every other case under 1.3s. Release build: DeepImportDiamondDAG 2.5s, DeepImportChain 1.4s, DeepImportChainWrappedTLA 1.0s, every other case under 85ms. Under the debug build most of the old chain case time was the itBundled pipeline itself: `dedent`, `mkdirSync` and `writeFileSync` per module took about 30s per case, against 2.4s for plain writes of the same files.

Assertion changes:
- `EmptyFile`: pins the bundle. The empty file is CommonJS, so `entry_default = {}` is exported as default.
- `StarExternal`: pins that both relative imports stay as written with `external: ["*"]`.
- `ValidLoaderSeenAsInvalid`: pins the bundle.
- `RequireUnknownExtension`: the output directory holds `entry.js` and `x-4my6q98m.aaaa`, the copied file holds `x`, and the bundle requires the copied path.
- `ExportDefaultUndefined`: pins the bundle, which exports `a` and no default.
- `YieldKeyword`: the generator is exported so that it survives tree shaking, and the printed form of every `yield` is pinned (`yield;`, `yield* 2;`, `yield yield;`, `(yield).hello;`, `yield 1;`). Before, nothing used the generator, so the bundle was empty and only the parse was tested.
- `UsingWithSixImports`: pins the bundle (`using` kept, `bun:sqlite` import kept).
- `DeepImportDiamondDAG`: exact printed value of m[0], computed in the test with the same expression order, instead of `typeof v`.
- `DeepImportChainWrappedTLA`: exactly `deepChainDepth - 1` wrapper definitions (the leaf module is a constant and gets none), and the deepest one is present.
- `buildDeepGraph` throws a message that names the graph, the signal or exit code, the cap, and the build's stdout and stderr. Both paths were exercised with a missing import and with a 1ms cap.

Todo cases: `itBundled` registers a todo case with a plain `it.todo`, not `it.serial.todo`, so under `describe.concurrent` the adjacent api todo cases (`RuntimeExternalImport` and `RuntimeExternalImport2`, and the three `OverwriteInput*` cases) overlap in a `bun test --todo` run and can race on `process.chdir`. CI never passes `--todo`, so CI is not affected. The fix is `it.serial.todo` in the todo branch of `itBundled`, which is inside a hunk of #38655, so this PR only documents it in the comment above the describe.

Diff scope: the three deep cases use `test.concurrent` explicitly, so they also overlap if the describe ever goes back to plain `describe`, and the block keeps the same closing lines as before. The second `describe` at the end of the file (one api case, one cli case) is left as it is. `edgecase/AwsCdkLib` is currently not registered at all because it sets `timeoutScale`, which #34542 fixes. A dry-run merge of ten open PRs that add cases to this file (#38984, #35617, #36122, #38505, #38471, #31667, #33807, #34734, #38757, #38533) gives the same result against this branch as against main. #38629 adds an import line next to the import lines this PR changes, so it gets a conflict on those lines. No `deep-import-*` directories remain in the temp dir after a run.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->