### PR TITLE
test(bundler): overlap bundler_compile.test.ts links on release builds and pin more outputs

### DIFF
--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1395,7 +1395,7 @@ main();
 
   // Verify ESM bytecode is actually loaded from the cache at runtime, not just generated.
   // The ESMBytecode matrix above checks the same thing through itBundled; this plain
-  // test() also pins the exact lines: one hit for the entry chunk, one miss for bun:main.
+  // test() is the copy that also runs where itBundled cases are not registered (#34552).
   test("ESM bytecode cache is used at runtime", async () => {
     const ext = isWindows ? ".exe" : "";
     using dir = tempDir("esm-bytecode-cache", {
@@ -1437,10 +1437,9 @@ main();
     const [exeStdout, exeStderr, exeExitCode] = await Promise.all([exe.stdout.text(), exe.stderr.text(), exe.exited]);
 
     expect(exeStdout).toBe("esm bytecode loaded\n");
-    expect(exeStderr.split(/\r?\n/).filter(Boolean)).toEqual([
-      "[Disk Cache] Cache hit for sourceCode",
-      "[Disk Cache] Cache miss for sourceCode",
-    ]);
+    // One chunk, so exactly one module comes from the bytecode (the miss is bun:main).
+    const hits = exeStderr.split(/\r?\n/).filter(line => line.includes("[Disk Cache] Cache hit for sourceCode"));
+    expect(hits).toHaveLength(1);
     expect(exeExitCode).toBe(0);
   }, 30_000);
 

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { rmSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir } from "harness";
 import { join } from "path";
 import { BundlerTestInput, itBundled as itBundledBase } from "./expectBundled";
 
@@ -9,17 +9,27 @@ import { BundlerTestInput, itBundled as itBundledBase } from "./expectBundled";
 // it.serial (the API backend calls process.chdir), so only CLI cases overlap.
 const itBundled = (id: string, opts: BundlerTestInput) => itBundledBase(id, { backend: "cli", ...opts });
 
-// Nearly every case below links a standalone executable. `bun build --compile`
-// reads the whole bun binary and writes a patched copy, so while it runs it holds
-// about twice the binary in memory (~0.6 GB with the 280 MB profile binary CI
-// tests with, ~2 GB with a debug binary). The cases are independent (expectBundled
-// gives each one its own directory), but describe.concurrent alone starts up to
-// 20 of them at once, which exhausted CI memory and IO and made the build
-// subprocesses time out (build #40193). The hooks below let MAX_CONCURRENT_COMPILES
-// cases run at a time. The rest wait in beforeEach, where no per-test timeout is
-// running yet. The wait itself has no timeout: it ends when the cases ahead of it
-// in the queue end, and each of those has its own timeout.
-const MAX_CONCURRENT_COMPILES = 3;
+// Nearly every case below links a standalone executable. On Linux `bun build
+// --compile` copies the bun binary to the output path, reads the copy back and
+// writes it again with the bundle injected, so one link moves about three times
+// the binary through the page cache and holds about twice the binary in memory.
+// The cases are independent (expectBundled gives each one its own directory), but
+// describe.concurrent alone starts up to 20 links at once, which exhausted CI
+// memory and IO and made the build subprocesses time out (build #40193). The hooks
+// below let MAX_CONCURRENT_COMPILES cases run at a time. The rest wait in
+// beforeEach, where no per-test timeout is running yet. The wait itself has no
+// timeout: it ends when the cases ahead of it in the queue end, and each of those
+// has its own timeout.
+//
+// The limit depends on the size of the binary being linked. With the ~280 MB
+// profile binaries of the release lanes, three at a time took this file from
+// 13-59s (by lane and build) to 8-19s (build 101393 against builds 91981 and
+// 94834). The ASAN lane links a far larger binary, and the same gate made the file
+// slower there (170s against 102-107s one at a time): with that much data per link
+// the file is bound by page-cache writeback, and overlapping links only add to it.
+// Debug binaries are in the same size class. Both link one at a time until #33621
+// removes the extra copy.
+const MAX_CONCURRENT_COMPILES = isASAN || isDebug ? 1 : 3;
 let running = 0;
 const waiting: Array<() => void> = [];
 

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -1,18 +1,43 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { rmSync } from "fs";
 import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
 import { BundlerTestInput, itBundled as itBundledBase } from "./expectBundled";
 
-// Default to the CLI backend. We intentionally use plain `describe` here
-// (not `describe.concurrent`): since the ELF-section inject path was added,
-// each `bun build --compile` on Linux reads + rewrites the full executable
-// (~500MB for profile builds). Running 20 of these concurrently exhausts CI
-// memory/IO and causes subprocess timeouts — see build #40193 failures.
+// Default to the CLI backend. expectBundled registers backend:"api" cases with
+// it.serial (the API backend calls process.chdir), so only CLI cases overlap.
 const itBundled = (id: string, opts: BundlerTestInput) => itBundledBase(id, { backend: "cli", ...opts });
 
-describe("bundler", () => {
+// Nearly every case below links a standalone executable. `bun build --compile`
+// reads the whole bun binary and writes a patched copy, so while it runs it holds
+// about twice the binary in memory (~0.6 GB with the 280 MB profile binary CI
+// tests with, ~2 GB with a debug binary). The cases are independent (expectBundled
+// gives each one its own directory), but describe.concurrent alone starts up to
+// 20 of them at once, which exhausted CI memory and IO and made the build
+// subprocesses time out (build #40193). The hooks below let MAX_CONCURRENT_COMPILES
+// cases run at a time. The rest wait in beforeEach, where no per-test timeout is
+// running yet. The wait itself has no timeout: it ends when the cases ahead of it
+// in the queue end, and each of those has its own timeout.
+const MAX_CONCURRENT_COMPILES = 3;
+let running = 0;
+const waiting: Array<() => void> = [];
+
+describe.concurrent("bundler", () => {
+  beforeEach(() => {
+    if (running < MAX_CONCURRENT_COMPILES) {
+      running++;
+      return;
+    }
+    return new Promise<void>(resolve => waiting.push(resolve));
+  }, Infinity);
+  afterEach(() => {
+    // Hand the slot straight to the next case in line, or free it.
+    const next = waiting.shift();
+    if (next) next();
+    else running--;
+  });
+
   itBundled("compile/HelloWorld", {
     compile: true,
     files: {
@@ -22,46 +47,45 @@ describe("bundler", () => {
     },
     run: { stdout: "Hello, world!", stderr: "" },
   });
-  // --footer/--banner are concatenated verbatim (UTF-8). Guard against the
+  // --banner/--footer are concatenated verbatim (UTF-8). Guard against the
   // standalone module graph treating those bytes as Latin-1, which would
   // print "rÃ©sumÃ©" / "ã\x81\x93ã\x82\x93..." (one Latin-1 char per UTF-8
-  // byte) instead of the original codepoints.
-  for (const [where, flag] of [
-    ["Footer", "--footer"],
-    ["Banner", "--banner"],
-  ] as const) {
-    test(`compile/${where}NonAsciiUTF8`, async () => {
-      using dir = tempDir(`compile-${where.toLowerCase()}-nonascii`, {
-        "entry.ts": `export const x = 1;`,
-      });
-      const outfile = join(String(dir), isWindows ? "out.exe" : "out");
-      {
-        await using proc = Bun.spawn({
-          cmd: [
-            bunExe(),
-            "build",
-            "--compile",
-            flag,
-            `console.log("résumé", "こんにちは");`,
-            "./entry.ts",
-            "--outfile",
-            outfile,
-          ],
-          env: bunEnv,
-          cwd: String(dir),
-          stdout: "pipe",
-          stderr: "pipe",
-        });
-        const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect(stderr).not.toContain("error:");
-        expect(exitCode).toBe(0);
-      }
-      await using proc = Bun.spawn({ cmd: [outfile], env: bunEnv, cwd: String(dir), stdout: "pipe", stderr: "pipe" });
-      const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stdout).toBe("résumé こんにちは\n");
-      expect(exitCode).toBe(0);
+  // byte) instead of the original codepoints. One executable carries both: the
+  // banner prints before the (silent) entry point and the footer after it.
+  test("compile/BannerFooterNonAsciiUTF8", async () => {
+    using dir = tempDir("compile-banner-footer-nonascii", {
+      "entry.ts": `export const x = 1;`,
     });
-  }
+    const outfile = join(String(dir), isWindows ? "out.exe" : "out");
+    {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "build",
+          "--compile",
+          "--banner",
+          `console.log("banner", "résumé", "こんにちは");`,
+          "--footer",
+          `console.log("footer", "résumé", "こんにちは");`,
+          "./entry.ts",
+          "--outfile",
+          outfile,
+        ],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }
+    await using proc = Bun.spawn({ cmd: [outfile], env: bunEnv, cwd: String(dir), stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("banner résumé こんにちは\nfooter résumé こんにちは\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  }, 30_000);
   // A chunk with non-ASCII text is embedded as UTF-16; reading it back as a file must still give the UTF-8 text.
   itBundled("compile/NonAsciiChunkReadsBackAsUTF8", {
     compile: true,
@@ -76,6 +100,9 @@ describe("bundler", () => {
     },
     run: { stdout: "true true true" },
   });
+  // The fixture module evaluates to whatever --compile inlined for `process.versions.bun`.
+  // That must be the exact version the embedded runtime reports, "-debug" suffix and all
+  // on debug builds, so the two are compared without normalizing either side.
   itBundled("compile/HelloWorldWithProcessVersionsBun", {
     compile: true,
     files: {
@@ -83,9 +110,9 @@ describe("bundler", () => {
         process.exitCode = 1;
         process.versions.bun = "bun!";
         if (process.versions.bun === "bun!") throw new Error("fail");
-        if (require("./${process.platform}-${process.arch}.js") === "${Bun.version.replaceAll("-debug", "")}") {
-          process.exitCode = 0;
-        }
+        const inlined = require("./${process.platform}-${process.arch}.js");
+        if (inlined !== Bun.version) throw new Error("inlined " + inlined + ", runtime is " + Bun.version);
+        process.exitCode = 0;
       `,
       [`/${process.platform}-${process.arch}.js`]: "module.exports = process.versions.bun;",
     },
@@ -102,10 +129,9 @@ describe("bundler", () => {
         process.exitCode = 1;
         process.versions.bun = "bun!";
         if (process.versions.bun === "bun!") throw new Error("fail");
-        const another = require("./${process.platform}-${process.arch}.js").replaceAll("-debug", "");
-        if (another === "${Bun.version.replaceAll("-debug", "")}") {
-          process.exitCode = 0;
-        }
+        const inlined = require("./${process.platform}-${process.arch}.js");
+        if (inlined !== Bun.version) throw new Error("inlined " + inlined + ", runtime is " + Bun.version);
+        process.exitCode = 0;
       `,
       [`/${process.platform}-${process.arch}.js`]: "module.exports = process.versions.bun;",
     },
@@ -186,8 +212,11 @@ describe("bundler", () => {
     });
   }
   // ESM bytecode test matrix: each scenario × {default, minified} = 2 tests per scenario.
-  // With --compile, static imports are inlined into one chunk, but dynamic imports
-  // create separate modules in the standalone graph — each with its own bytecode + ModuleInfo.
+  // Without --splitting every scenario bundles into one chunk: static imports are
+  // inlined and dynamic imports are lowered to Promise.resolve().then(...). That one
+  // chunk is what gets bytecode and a bundler-built module record, and the run below
+  // checks that the executable really loads it from the bytecode. Multi-chunk graphs
+  // are covered by bundler_compile_splitting.test.ts.
   const esmBytecodeScenarios: Array<{
     name: string;
     files: Record<string, string>;
@@ -224,8 +253,7 @@ describe("bundler", () => {
       stdout: "ok\nok",
     },
     {
-      // Dynamic import creates a separate module in the standalone graph,
-      // exercising per-module bytecode + ModuleInfo.
+      // The lowered dynamic import plus the top-level await that consumes it.
       name: "DynamicImport",
       files: {
         "/entry.ts": `
@@ -237,9 +265,8 @@ describe("bundler", () => {
       stdout: "lazy: 42",
     },
     {
-      // Dynamic import of a module that itself uses top-level await.
-      // The dynamically imported module is a separate chunk with async
-      // evaluation — stresses both ModuleInfo and async bytecode loading.
+      // Dynamic import of a module that itself uses top-level await, so the
+      // inlined module body is async too.
       name: "DynamicImportTLA",
       files: {
         "/entry.ts": `
@@ -251,8 +278,7 @@ describe("bundler", () => {
       stdout: "value: 99",
     },
     {
-      // Multiple dynamic imports: several separate modules in the graph,
-      // each with its own bytecode + ModuleInfo.
+      // Several lowered dynamic imports awaited together.
       name: "MultipleDynamicImports",
       files: {
         "/entry.ts": `
@@ -334,7 +360,16 @@ describe("bundler", () => {
           minifyWhitespace: true,
         }),
         files: scenario.files,
-        run: { stdout: scenario.stdout },
+        run: {
+          stdout: scenario.stdout,
+          env: { BUN_JSC_verboseDiskCache: "1" },
+          validate({ stderr }) {
+            // One chunk, so exactly one module loads from the embedded bytecode.
+            // (Misses are bun:main and any non-JS modules, see HelloWorldBytecode.)
+            const hits = stderr.split("\n").filter(line => line.includes("[Disk Cache] Cache hit for sourceCode"));
+            expect(hits).toHaveLength(1);
+          },
+        },
       });
     }
   }
@@ -365,6 +400,23 @@ describe("bundler", () => {
       stdout: "Hello, world!\nWorker loaded!\n",
       file: "dist/out",
       setCwd: true,
+      env: { BUN_JSC_verboseDiskCache: "1" },
+      // Same shape as WorkerRelativePathTSExtensionBytecode below: each thread
+      // loads its entry from bytecode (hit) and bun:main from source (miss), and
+      // only the multiset of lines is stable because the two threads interleave.
+      validate({ stderr }) {
+        const lines = stderr
+          .split("\n")
+          .map(line => line.trim())
+          .filter(line => line.startsWith("[Disk Cache]"))
+          .sort();
+        expect(lines).toEqual([
+          "[Disk Cache] Cache hit for sourceCode",
+          "[Disk Cache] Cache hit for sourceCode",
+          "[Disk Cache] Cache miss for sourceCode",
+          "[Disk Cache] Cache miss for sourceCode",
+        ]);
+      },
     },
   });
   // A second CommonJS entry point that is only reached through a runtime
@@ -845,8 +897,13 @@ describe("bundler", () => {
       `,
     },
     run: {
-      error: 'Cannot find package "express"',
+      // `error` only makes expectBundled require a failing exit; validate pins the message.
+      error: "Cannot find package 'express'",
+      stdout: "",
       setCwd: true,
+      validate({ stderr }) {
+        expect(stderr).toContain("error: Cannot find package 'express' from '");
+      },
     },
     compile: true,
   });
@@ -1212,8 +1269,11 @@ error: Hello World`,
         stdout: `This is compiled code\n{"isStandaloneExecutable":true}`,
       },
       {
+        // No arguments, so the executable prints bun's own help instead of running the bundle.
         env: { BUN_BE_BUN: "1" },
         validate({ stdout }) {
+          expect(stdout).toStartWith("Bun is a fast JavaScript runtime");
+          expect(stdout).toContain("Usage: bun <command>");
           expect(stdout).not.toContain("This is compiled code");
         },
       },
@@ -1231,7 +1291,10 @@ error: Hello World`,
     ],
   });
 
-  test("does not crash", async () => {
+  // https://github.com/oven-sh/bun/issues/22151: an HTML entry plus --minify --sourcemap
+  // --bytecode tripped an output-file count assertion in the bundler. The build has to
+  // succeed, and the executable has to serve both the embedded HTML and the API route.
+  test("html entry compiled with --minify --sourcemap --bytecode builds and serves", async () => {
     await using dir = tempDir("bundler-compile-shadcn", {
       "frontend.tsx": `console.log("Hello, world!");`,
       "index.html": `<!doctype html>
@@ -1251,6 +1314,7 @@ error: Hello World`,
 import index from "./index.html";
 
 const server = serve({
+  port: 0,
   routes: {
     // Serve index.html for all unmatched routes.
     "/*": index,
@@ -1287,19 +1351,51 @@ const server = serve({
   },
 });
 
+async function main() {
+  const html = await fetch(new URL("/", server.url));
+  console.log(html.status, (await html.text()).includes('<div id="root"></div>'));
+  const api = await fetch(new URL("/api/hello", server.url));
+  console.log(api.status, await api.text());
+  server.stop();
+}
+main();
 `,
     });
+    const outfile = join(String(dir), isWindows ? "app.exe" : "app");
 
-    // Step 2: Run bun build with compile, minify, sourcemap, and bytecode
-    await Bun.$`${bunExe()} build ./index.tsx --compile --minify --sourcemap --bytecode`
-      .cwd(dir)
-      .env(bunEnv)
-      .throws(true);
+    {
+      await using build = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "build",
+          "./index.tsx",
+          "--compile",
+          "--minify",
+          "--sourcemap",
+          "--bytecode",
+          "--outfile",
+          outfile,
+        ],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    }
+
+    await using app = Bun.spawn({ cmd: [outfile], cwd: String(dir), env: bunEnv, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([app.stdout.text(), app.stderr.text(), app.exited]);
+    expect(stdout).toBe('200 true\n200 {"message":"Hello, world!","method":"GET"}\n');
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   }, 30_000);
 
   // Verify ESM bytecode is actually loaded from the cache at runtime, not just generated.
-  // Uses regex matching on stderr (not itBundled) since we don't know the exact
-  // number of cache hit/miss lines for ESM standalone.
+  // The ESMBytecode matrix above checks the same thing through itBundled; this plain
+  // test() also pins the exact lines: one hit for the entry chunk, one miss for bun:main.
   test("ESM bytecode cache is used at runtime", async () => {
     const ext = isWindows ? ".exe" : "";
     using dir = tempDir("esm-bytecode-cache", {
@@ -1340,8 +1436,11 @@ const server = serve({
 
     const [exeStdout, exeStderr, exeExitCode] = await Promise.all([exe.stdout.text(), exe.stderr.text(), exe.exited]);
 
-    expect(exeStdout).toContain("esm bytecode loaded");
-    expect(exeStderr).toMatch(/\[Disk Cache\].*Cache hit/i);
+    expect(exeStdout).toBe("esm bytecode loaded\n");
+    expect(exeStderr.split(/\r?\n/).filter(Boolean)).toEqual([
+      "[Disk Cache] Cache hit for sourceCode",
+      "[Disk Cache] Cache miss for sourceCode",
+    ]);
     expect(exeExitCode).toBe(0);
   }, 30_000);
 
@@ -1362,7 +1461,9 @@ const server = serve({
     await Bun.$`${bunExe()} build --compile app.js assets/* --outfile app`.cwd(dir).env(bunEnv).throws(true);
 
     const result = await Bun.$`./app`.cwd(dir).env(bunEnv).nothrow();
-    expect(result.stdout.toString().trim()).toBe("IT WORKS");
+    expect(result.stdout.toString()).toBe("IT WORKS\n");
+    expect(result.stderr.toString()).toBe("");
+    expect(result.exitCode).toBe(0);
   }, 30_000);
 });
 


### PR DESCRIPTION
### Problem
- `test/bundler/bundler_compile.test.ts` links about 70 executables one after the other: 116s on x64 asan (the slowest file on that lane), 54s on x64 debian, 74s on musl (`test/expected-durations.json`).
- It is serial on purpose: `describe.concurrent` starts up to 20 links at once, which exhausted CI memory (build #40193).

### Fix
- The block is `describe.concurrent` again, and a `beforeEach`/`afterEach` pair caps the links in flight. The rest wait in `beforeEach`, where no per-test timeout runs. `backend: "api"` cases stay serial.
- The cap is 3 for release-sized binaries and 1 (today's behavior) on ASAN and debug builds. A cap of 3 on every lane (build 101393) took the seven release Linux lanes from 13-59s to 8-19s, but x64 asan to 170s, against 102-107s in two serial builds: a link is three passes over the binary (Background), so that lane is bound by writeback. With the final split (build 101408) asan is back to 112.7s (116s expected on main) and the release lanes are at 8-45s, the high end on a shard whose docker services were still starting. That lane stays as it is until #33621 removes the extra copy. Table in the Notes.
- Locally: 35.2s to 13.2s with the 280 MB profile binary, 229s to 218s with the debug build (cap 1), 69 pass. After the rebase onto 5ad6455989 (7 new cases from main): 76 pass with the debug build.
- The gate lives in this file because `itBundled` owns the test body and other test work is changing `expectBundled.ts` now. Moving it there later would also cover `bundler_compile_autoload` (#35416) and `compile-argv` (#35720).
- Banner and footer share one executable. No loop dimension was dropped (Notes). `HelloWorldWithProcessVersionsBun` gets the same debug-build fix as #37373, so the file passes with `bun bd test`.
- Stronger assertions: `ESMBytecode+*` (20 cases), `WorkerBytecodeESM` and `ESM bytecode cache` prove the chunk loads from bytecode. `NoAutoInstall` pins the message (`run.error` never compared it) and an empty stdout. `BunBeBunEnvVar` run 1 pins bun's help. `does not crash` (HTML entry with `--minify --sourcemap --bytecode`) now runs the executable and pins its responses. Banner/footer and `8+ entry points` compare exact stdout, stderr and exit code, in that order.

### Background
- On Linux, `inject()` (`src/standalone_graph/StandaloneModuleGraph.rs`, ~line 1426) copies the bun binary to the output path, reads the copy back and writes it again with the bundle patched in. The binary is 280 MB on the release lanes and far larger on asan (its zip alone is 613 MB).
- `itBundled` registers a plain `it()` per case (`expectBundled.ts:1911`). Bun runs consecutive concurrent tests `--max-concurrency` (20) at a time with no per-describe limit. `afterEach` runs after a failed or timed out test too, so a slot always comes back.
- `BUN_JSC_verboseDiskCache=1` makes JSC print one `[Disk Cache]` hit or miss line per module. A hit is a module loaded from the embedded bytecode. The miss is `bun:main`.

<details><summary>Notes</summary>

**Per-lane wall time of this file**, taken from the shard logs the same way `scripts/update-test-durations.mjs` does (gap between consecutive file headers). All four builds modify this file, so in all of them it ran at the front of its shard, next to the docker prestart. Build 101393 is this branch with a cap of 3 on every lane. Build 101408 is the final branch (cap 3, but 1 on asan). Build 107612 is the same branch rebased onto 5ad6455989, where the file has 76 cases instead of 69 (main added `NonAsciiChunkReadsBackAsUTF8`, `EmbeddedFileNamesPerThread` and the `TextImport*` group). Builds 94834 (#38173) and 91981 (#37373) are serial.

| lane | final, rebased (107612) | final (101408) | cap 3 everywhere (101393) | serial (94834) | serial (91981) |
| --- | ---: | ---: | ---: | ---: | ---: |
| linux-x64-asan-debian-13 | 114.6s (cap 1) | 112.7s (cap 1) | 170.0s | 107.1s | 101.9s |
| linux-x64-debian-13 | 30.9s | 44.9s | 16.8s | 32.2s | 57.8s |
| linux-x64-ubuntu-2504 | 35.9s | 24.0s | 19.0s | 28.6s | 59.0s |
| linux-x64-musl-alpine-323 | 8.4s | 10.9s | 13.9s | 17.8s | 46.1s |
| linux-aarch64-debian-13 | 29.8s | 32.7s | 13.6s | 20.7s | 46.1s |
| linux-aarch64-ubuntu-2504 | 30.7s | 15.7s | 16.9s | 22.2s | 42.8s |
| linux-aarch64-musl-alpine-323 | 5.2s | 8.3s | 8.3s | 12.6s | 25.0s |
| windows-x64-2019 | 2.4s | 2.4s | 2.3s | 3.7s | 4.2s |
| windows-aarch64-11 | 11.1s | 11.4s | 11.4s | 12.5s | 12.2s |

The 170s asan number was not a slow machine: over the 309 files on that lane with an expected duration of 2s or more, build 101393 ran at 0.92 of the expected total (median ratio 1.00), and for example `bundler_compile_autoload.test.ts` took 57s against 73s expected. This file alone went to 1.46 of expected. In its log the first ~40 cases ran at about serial throughput and the rest got progressively slower (the 7 ReactSSR cases took 20s against 7s serial, and one later link took 35s from bundle to output), which is what accumulating dirty pages look like. Build 101408, with the cap of 1 there, ran the lane at the same 0.92 overall and this file at 112.7s. The spread on the release lanes between 101393 and 101408 is the shard, not the code: the x64 debian log of 101408 shows squid, minio and mysql coming up during the first 7s of this file and everything in it running 2-3 times slower than in 101393, where the same services were up before the file started. A third serial build (#37781's 93203) gave 97.9s asan, 45.2s x64 debian, 25.7s x64 musl. Windows only runs the plain `test()` cases today (see below), so it has little to gain.

**Local probes** (this container, 8 cores, much more RAM than any lane). `bun build --compile` of a one-line entry: profile binary (280 MB) 786 ms, 573 MB peak RSS. Debug binary (821 MB) 2.3 s, 1.9 GB peak RSS. Whole file with the profile binary: 35.2s at main, 13.2s and 15.1s on this branch. With the debug build: 229s at main, 218s on this branch (cap 1); a cap of 3 gave 81-91s here, which the asan lane shows does not carry over to a machine with less memory. Lanes (`.buildkite/ci.mjs`): release x64 tests run on c7i.xlarge (4 vCPU, 8 GB), asan on r7i.2xlarge (8 vCPU, 64 GB).

**Hook timeout.** The `beforeEach` wait is passed `Infinity`, the value expectBundled already uses for debug-build tests. The local default hook timeout is 5s, and the last queued case waits for most of the file. A queued case only waits for the cases ahead of it, each of which has its own timeout, and the CI runner still applies its per-file wall clock.

**Same pattern elsewhere.** `bun-install-lifecycle-scripts.test.ts:35`, `bun-workspaces.test.ts:37` and `fetch-http2-client.test.ts:159` each carry their own copy of this slot queue (the last one also keys its cap on `isASAN`). A shared helper in `harness.ts` is the natural follow-up once it can be done without colliding with the test work in flight.

**Loops kept.** `ESMBytecode` x minify: the module record is built from what the printer emits (#37677) and minified identifiers change it. `10344` sourcemap x minify: #10344 was a crash with `--minify --sourcemap` plus embedded files, and each value changes the layout around the two odd-sized files (matrix written with the fix, a78668eb4c). `platform-specific-binary` x minify: `minifySyntax` folds the import template to a constant, without it the import resolves at run time. `ReactSSR` x bytecode x format x minify: bytecode differs per format and minify changes the text it is compiled from; these 7 cases already ran concurrently before #28371. Merging the remaining near-duplicates (for example `ResolveEmbeddedFileOutfile`, covered by `Bun.embeddedFiles`) would save about 1.5s each on asan and would collide with the open PRs that add cases next to them.

**Plain `test()` cases stay plain.** itBundled cases are not registered on Windows at the moment (#34552), so the plain cases are the only ones this file runs there. They keep the 30s ceilings the file already uses: the 5s default is too short for a debug-build link, and the merged banner/footer case hit exactly that in an early 4-wide run. The two `--compile-executable-path` cases outside the block do not copy the binary and are unchanged.

**Pinned strings.** The help text is two constants (`src/bun_core/output.rs:2997`, `src/runtime/cli/mod.rs:651`), and the test pins a prefix of the first line, not the version. Empty build stderr was already asserted by the `ESM bytecode cache` case on every lane. Disk-cache checks count hit lines (one chunk, one hit) instead of pinning the miss lines, so they hold when a scenario adds non-JS modules (#37781) and on lanes where no exact pin has run before. In a compiled executable an HTML import is a manifest object (`{ index, files }`), which `Bun.serve` registers as static routes (`server_body.rs:625`); the dev server only starts for `HTMLBundle` objects (`ServerConfig.rs:1061`), so the `development` option in the fixture does not change the path the test takes.

**Harness follow-up.** `expectBundled.ts:1777` only compares `run.error` when `errorLineMatch` is set, so every `run.error` string in the bundler tests is currently unchecked. Fixing that is a separate `expectBundled` change; `NoAutoInstall` now carries its own check and has the right text for when that lands.

**#37373 and #37781.** The two `HelloWorldWithProcessVersionsBun*` hunks are identical to #37373 (its CI is green), so whichever lands second drops out cleanly. The ESMBytecode loop hunk overlaps #37781's change to the same loop; the resolution is to keep both (its `runtimeFiles` fields plus this `run` block).

**Dynamic imports.** Without `--splitting`, `--compile --format=esm` lowers `import("./lazy.ts")` to `Promise.resolve().then(() => exports_lazy)` inside the entry chunk (checked in the built executable). So every matrix scenario is one chunk and prints exactly one hit, and the scenario comments that described separate modules are corrected. `WorkerBytecodeESM` has two entry points and uses the same multiset check as the CJS worker case (e757183d9d), because the two threads interleave.

**Rebase.** Rebased onto 5ad6455989. The one conflict was `compile/NonAsciiChunkReadsBackAsUTF8` (#40677), which main inserted between the old footer/banner loop and `HelloWorldWithProcessVersionsBun`; it now sits after the merged banner/footer case, unchanged. The other cases main added since the branch point (`EmbeddedFileNamesPerThread`, the `TextImport*` group) applied cleanly and run under the same gate.

**CI.** Build 101393 failed on `test/js/node/tls/node-tls-server.test.ts` (darwin aarch64, also failing on main, reported separately). Every shard that ran this file passed in both builds.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->
