### PR TITLE
bun run --filter: stop panicking on workspace paths longer than the path buffer

### DIFF
--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1806,8 +1806,8 @@ pub mod dir_entry_accessor {
     use crate::fs::{DirEntry, EntriesOption, Entry, EntryKind, FileSystem as FS, Implementation};
     use bun_core::ZStr;
     use bun_glob::walk::{Accessor, AccessorDirEntry, AccessorDirIter, AccessorHandle};
-    use bun_paths::{PathBuffer, Platform, resolve_path};
-    use bun_sys::{self as Syscall, Error as SysError, Result as Maybe, Stat};
+    use bun_paths::{MAX_PATH_BYTES, Platform, path_buffer_pool, platform, resolve_path};
+    use bun_sys::{self as Syscall, E, Error as SysError, Result as Maybe, Stat};
 
     pub struct DirEntryAccessor;
 
@@ -1948,56 +1948,46 @@ pub mod dir_entry_accessor {
         }
     }
 
+    impl DirEntryAccessor {
+        /// `path` resolved against the directory `handle` was opened on, as one path
+        /// a syscall can take. The directory and `path` each fit a path buffer, but
+        /// the joined path need not: `spill` holds it then, and whatever takes the
+        /// path reports ENAMETOOLONG for it.
+        fn full_path<'a>(
+            handle: DirEntryHandle,
+            path: &'a ZStr,
+            buf: &'a mut [u8],
+            spill: &'a mut Vec<u8>,
+        ) -> &'a ZStr {
+            match handle.value {
+                Some(entry) if !Platform::AUTO.is_absolute(path.as_bytes()) => {
+                    resolve_path::join_z_buf_spill::<platform::Auto>(
+                        buf,
+                        spill,
+                        &[entry.dir, path.as_bytes()],
+                    )
+                }
+                _ => path,
+            }
+        }
+    }
+
     impl Accessor for DirEntryAccessor {
         const COUNT_FDS: bool = false;
         type Handle = DirEntryHandle;
         type DirIter = DirEntryDirIter;
 
         fn statat(handle: DirEntryHandle, path_: &ZStr) -> Maybe<Stat> {
-            let mut buf = PathBuffer::uninit();
-            let path: &ZStr = if !Platform::AUTO.is_absolute(path_.as_bytes()) {
-                if let Some(entry) = handle.value {
-                    let slice = resolve_path::join_string_buf::<bun_paths::platform::Auto>(
-                        &mut buf,
-                        &[entry.dir, path_.as_bytes()],
-                    );
-                    let len = slice.len();
-                    buf[len] = 0;
-                    // SAFETY: buf[len] == 0 written above
-                    ZStr::from_buf(&buf[..], len)
-                } else {
-                    path_
-                }
-            } else {
-                path_
-            };
-            Syscall::stat(path)
+            let mut buf = path_buffer_pool::get();
+            let mut spill = Vec::new();
+            Syscall::stat(Self::full_path(handle, path_, &mut buf[..], &mut spill))
         }
 
         /// Like statat but does not follow symlinks.
         fn lstatat(handle: DirEntryHandle, path_: &ZStr) -> Maybe<Stat> {
-            let mut buf = PathBuffer::uninit();
-            if let Some(entry) = handle.value {
-                return Syscall::lstatat(entry.fd, path_);
-            }
-
-            let path: &ZStr = if !Platform::AUTO.is_absolute(path_.as_bytes()) {
-                if let Some(entry) = handle.value {
-                    let slice = resolve_path::join_string_buf::<bun_paths::platform::Auto>(
-                        &mut buf,
-                        &[entry.dir, path_.as_bytes()],
-                    );
-                    let len = slice.len();
-                    buf[len] = 0;
-                    // SAFETY: buf[len] == 0 written above
-                    ZStr::from_buf(&buf[..], len)
-                } else {
-                    path_
-                }
-            } else {
-                path_
-            };
-            Syscall::lstat(path)
+            let mut buf = path_buffer_pool::get();
+            let mut spill = Vec::new();
+            Syscall::lstat(Self::full_path(handle, path_, &mut buf[..], &mut spill))
         }
 
         fn open(path: &ZStr) -> Result<Maybe<DirEntryHandle>, bun_core::Error> {
@@ -2008,23 +1998,22 @@ pub mod dir_entry_accessor {
             handle: DirEntryHandle,
             path_: &ZStr,
         ) -> Result<Maybe<DirEntryHandle>, bun_core::Error> {
-            let mut buf = PathBuffer::uninit();
-            let mut path: &[u8] = path_.as_bytes();
-
-            if !Platform::AUTO.is_absolute(path) {
-                if let Some(entry) = handle.value {
-                    path = resolve_path::join_string_buf::<bun_paths::platform::Auto>(
-                        &mut buf,
-                        &[entry.dir, path],
-                    );
-                }
+            let mut buf = path_buffer_pool::get();
+            let mut spill = Vec::new();
+            let path = Self::full_path(handle, path_, &mut buf[..], &mut spill);
+            // A `read_directory` failure ends the whole walk (the `Err` below). A path
+            // that does not fit only fails this directory, like the walker reports
+            // its own paths that do not fit.
+            if path.len() >= MAX_PATH_BYTES {
+                let err = SysError::from_code(E::ENAMETOOLONG, Syscall::Tag::open);
+                return Ok(Err(err.with_path(path.as_bytes())));
             }
             // TODO do we want to propagate ENOTDIR through the 'Maybe' to match the SyscallAccessor?
             // The glob implementation specifically checks for this error when dealing with symlinks
             // return Err(SysError::from_code(E::NOTDIR, Syscall::Tag::open));
             let res = FS::instance()
                 .fs
-                .read_directory(path, None, 0, false)
+                .read_directory(path.as_bytes(), None, 0, false)
                 .map_err(crate::Error::into_core)?;
             match res {
                 EntriesOption::Entries(entry) => {

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1949,10 +1949,7 @@ pub mod dir_entry_accessor {
     }
 
     impl DirEntryAccessor {
-        /// `path` resolved against the directory `handle` was opened on, as one path
-        /// a syscall can take. The directory and `path` each fit a path buffer, but
-        /// the joined path need not: `spill` holds it then, and whatever takes the
-        /// path reports ENAMETOOLONG for it.
+        /// `path` joined onto the handle's directory. Both fit a path buffer, the result need not.
         fn full_path<'a>(
             handle: DirEntryHandle,
             path: &'a ZStr,
@@ -2001,9 +1998,7 @@ pub mod dir_entry_accessor {
             let mut buf = path_buffer_pool::get();
             let mut spill = Vec::new();
             let path = Self::full_path(handle, path_, &mut buf[..], &mut spill);
-            // A `read_directory` failure ends the whole walk (the `Err` below). A path
-            // that does not fit only fails this directory, like the walker reports
-            // its own paths that do not fit.
+            // Fails only this directory: a `read_directory` error below ends the whole walk.
             if path.len() >= MAX_PATH_BYTES {
                 let err = SysError::from_code(E::ENAMETOOLONG, Syscall::Tag::open);
                 return Ok(Err(err.with_path(path.as_bytes())));

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1806,8 +1806,8 @@ pub mod dir_entry_accessor {
     use crate::fs::{DirEntry, EntriesOption, Entry, EntryKind, FileSystem as FS, Implementation};
     use bun_core::ZStr;
     use bun_glob::walk::{Accessor, AccessorDirEntry, AccessorDirIter, AccessorHandle};
-    use bun_paths::{MAX_PATH_BYTES, Platform, path_buffer_pool, platform, resolve_path};
-    use bun_sys::{self as Syscall, E, Error as SysError, Result as Maybe, Stat};
+    use bun_paths::{Platform, path_buffer_pool, platform, resolve_path};
+    use bun_sys::{self as Syscall, Error as SysError, Result as Maybe, Stat};
 
     pub struct DirEntryAccessor;
 
@@ -1998,11 +1998,6 @@ pub mod dir_entry_accessor {
             let mut buf = path_buffer_pool::get();
             let mut spill = Vec::new();
             let path = Self::full_path(handle, path_, &mut buf[..], &mut spill);
-            // Fails only this directory: a `read_directory` error below ends the whole walk.
-            if path.len() >= MAX_PATH_BYTES {
-                let err = SysError::from_code(E::ENAMETOOLONG, Syscall::Tag::open);
-                return Ok(Err(err.with_path(path.as_bytes())));
-            }
             // TODO do we want to propagate ENOTDIR through the 'Maybe' to match the SyscallAccessor?
             // The glob implementation specifically checks for this error when dealing with symlinks
             // return Err(SysError::from_code(E::NOTDIR, Syscall::Tag::open));

--- a/src/runtime/cli/filter_arg.rs
+++ b/src/runtime/cli/filter_arg.rs
@@ -62,11 +62,18 @@ fn get_candidate_package_patterns<'a>(
     'walk: loop {
         'body: {
             let mut name_buf = PathBuffer::uninit();
-            let json_path: &ZStr = resolve_path::join_abs_string_buf_z::<platform::Auto>(
+            let name_buf_len = name_buf.len();
+            // Does not fit: as unreadable as a missing package.json, so try the parent.
+            let Some(json_path) = resolve_path::join_abs_string_buf_checked::<platform::Auto>(
                 workdir,
-                &mut name_buf[..],
+                &mut name_buf[..name_buf_len - 1],
                 &[b"package.json".as_slice()],
-            );
+            ) else {
+                break 'body;
+            };
+            let json_path_len = json_path.len();
+            name_buf[json_path_len] = 0;
+            let json_path: &ZStr = ZStr::from_buf(&name_buf[..], json_path_len);
 
             log.msgs.clear();
             log.errors = 0;

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -1296,11 +1296,12 @@ describe("workspace paths longer than the path buffer", () => {
   const MAX_PATH_BYTES = isMacOS ? 1024 : 4096;
 
   // Creates a chain of directories below `parent` and returns the one whose absolute path is `length` bytes long.
+  // Lengths are counted in bytes, not in characters: the temporary directory may contain non-ASCII characters.
   function makeDirectoryOfLength(parent: string, length: number): string {
     let dir = parent;
-    while (dir.length < length) {
+    while (Buffer.byteLength(dir) < length) {
       // Bytes left after the separator. Unless this is the last component, leave room for "/" and one more byte.
-      const left = length - dir.length - 1;
+      const left = length - Buffer.byteLength(dir) - 1;
       const name = Buffer.alloc(left <= 255 ? left : Math.min(255, left - 2), "d").toString();
       dir = join(dir, name);
       mkdirSync(dir);
@@ -1318,9 +1319,9 @@ describe("workspace paths longer than the path buffer", () => {
       const tooLong = join(
         root,
         "packages",
-        Buffer.alloc(MAX_PATH_BYTES - 6 - root.length - "/packages/".length, "x").toString(),
+        Buffer.alloc(MAX_PATH_BYTES - 6 - Buffer.byteLength(root) - "/packages/".length, "x").toString(),
       );
-      expect(tooLong).toHaveLength(MAX_PATH_BYTES - 6);
+      expect(Buffer.byteLength(tooLong)).toBe(MAX_PATH_BYTES - 6);
       mkdirSync(join(root, "packages", "ok"), { recursive: true });
       mkdirSync(tooLong);
       await Bun.write(join(root, "package.json"), JSON.stringify({ name: "ws-long", workspaces: ["packages/*"] }));

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, makeTreeSync, MAX_PATH_BYTES, tempDir, tempDirWithFiles } from "harness";
 import { existsSync, mkdirSync, symlinkSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 import { join } from "path";
@@ -1290,13 +1290,16 @@ describe("auto-discovered bunfig.toml [run] section", () => {
   });
 });
 
-describe("workspace paths longer than the path buffer", () => {
-  // The size of bun's fixed path buffers (MAX_PATH_BYTES in src/bun_core/util.rs), which is also the longest path
-  // the OS takes. On Windows it is 98302 bytes, longer than any path that can exist there.
-  const MAX_PATH_BYTES = isMacOS ? 1024 : 4096;
+// On Windows MAX_PATH_BYTES (98302) is longer than any path that can exist, so these layouts cannot be created there.
+describe.concurrent.skipIf(isWindows)("workspace paths longer than the path buffer", () => {
+  const workspace = {
+    "package.json": JSON.stringify({ name: "ws", workspaces: ["packages/*"] }),
+    "packages/ok/package.json": JSON.stringify({ name: "ok", scripts: { present: "echo ok-ran" } }),
+  };
 
-  // Creates a chain of directories below `parent` and returns the one whose absolute path is `length` bytes long.
-  // Lengths are counted in bytes, not in characters: the temporary directory may contain non-ASCII characters.
+  // Creates a chain of directories below `parent` and returns the one whose absolute path is exactly `length` bytes
+  // (bytes, not characters: the temporary directory may contain non-ASCII characters). `length` has to stay below
+  // MAX_PATH_BYTES, since every directory is created by its absolute path.
   function makeDirectoryOfLength(parent: string, length: number): string {
     let dir = parent;
     while (Buffer.byteLength(dir) < length) {
@@ -1306,41 +1309,43 @@ describe("workspace paths longer than the path buffer", () => {
       dir = join(dir, name);
       mkdirSync(dir);
     }
+    expect(Buffer.byteLength(dir)).toBe(length);
     return dir;
   }
 
-  test.skipIf(isWindows)(
-    "a member whose package.json path does not fit is reported and the other members still run",
-    async () => {
-      using base = tempDir("filter-long-path", {});
-      const root = makeDirectoryOfLength(String(base), MAX_PATH_BYTES - 196);
-      // The member directory itself fits, so the workspace walk reads it. Only its package.json, 13 bytes further,
-      // does not fit.
-      const tooLong = join(
-        root,
-        "packages",
-        Buffer.alloc(MAX_PATH_BYTES - 6 - Buffer.byteLength(root) - "/packages/".length, "x").toString(),
-      );
-      expect(Buffer.byteLength(tooLong)).toBe(MAX_PATH_BYTES - 6);
-      mkdirSync(join(root, "packages", "ok"), { recursive: true });
-      mkdirSync(tooLong);
-      await Bun.write(join(root, "package.json"), JSON.stringify({ name: "ws-long", workspaces: ["packages/*"] }));
-      await Bun.write(
-        join(root, "packages", "ok", "package.json"),
-        JSON.stringify({ name: "ok", scripts: { present: "echo ok-ran" } }),
-      );
+  async function runFilter(cwd: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "--filter", "*", "present"],
+      env: bunEnv,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "run", "--filter", "*", "present"],
-        env: bunEnv,
-        cwd: root,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr).toContain("ENAMETOOLONG");
-      expect(stdout).toContain("ok present: ok-ran");
-      expect(exitCode).toBe(0);
-    },
-  );
+  test("a member whose package.json path does not fit is reported and the other members still run", async () => {
+    using base = tempDir("filter-long-member", {});
+    const root = makeDirectoryOfLength(String(base), MAX_PATH_BYTES - 196);
+    makeTreeSync(root, workspace);
+    // The member directory itself fits, so the workspace walk reads it. Its package.json, 13 bytes further, does not.
+    const name = Buffer.alloc(MAX_PATH_BYTES - 6 - Buffer.byteLength(`${root}/packages/`), "x").toString();
+    mkdirSync(join(root, "packages", name));
+
+    const { stdout, stderr, exitCode } = await runFilter(root);
+    expect(stderr).toContain("ENAMETOOLONG");
+    expect(stdout).toContain("ok present: ok-ran");
+    expect(exitCode).toBe(0);
+  });
+
+  test("a cwd whose own package.json path does not fit still finds the workspace root above it", async () => {
+    using root = tempDir("filter-long-cwd", workspace);
+    // <cwd>/package.json is MAX_PATH_BYTES bytes, one more than a path may have.
+    const cwd = makeDirectoryOfLength(String(root), MAX_PATH_BYTES - "/package.json".length);
+
+    const { stdout, exitCode } = await runFilter(cwd);
+    expect(stdout).toContain("ok present: ok-ran");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/run/filter-workspace.test.ts
+++ b/test/cli/run/filter-workspace.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
-import { existsSync, symlinkSync } from "node:fs";
+import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { existsSync, mkdirSync, symlinkSync } from "node:fs";
 import { setTimeout as sleep } from "node:timers/promises";
 import { join } from "path";
 
@@ -1288,4 +1288,58 @@ describe("auto-discovered bunfig.toml [run] section", () => {
     expect(r.stdout).not.toContain("Bun is");
     expect(r.exitCode).toBe(1);
   });
+});
+
+describe("workspace paths longer than the path buffer", () => {
+  // The size of bun's fixed path buffers (MAX_PATH_BYTES in src/bun_core/util.rs), which is also the longest path
+  // the OS takes. On Windows it is 98302 bytes, longer than any path that can exist there.
+  const MAX_PATH_BYTES = isMacOS ? 1024 : 4096;
+
+  // Creates a chain of directories below `parent` and returns the one whose absolute path is `length` bytes long.
+  function makeDirectoryOfLength(parent: string, length: number): string {
+    let dir = parent;
+    while (dir.length < length) {
+      // Bytes left after the separator. Unless this is the last component, leave room for "/" and one more byte.
+      const left = length - dir.length - 1;
+      const name = Buffer.alloc(left <= 255 ? left : Math.min(255, left - 2), "d").toString();
+      dir = join(dir, name);
+      mkdirSync(dir);
+    }
+    return dir;
+  }
+
+  test.skipIf(isWindows)(
+    "a member whose package.json path does not fit is reported and the other members still run",
+    async () => {
+      using base = tempDir("filter-long-path", {});
+      const root = makeDirectoryOfLength(String(base), MAX_PATH_BYTES - 196);
+      // The member directory itself fits, so the workspace walk reads it. Only its package.json, 13 bytes further,
+      // does not fit.
+      const tooLong = join(
+        root,
+        "packages",
+        Buffer.alloc(MAX_PATH_BYTES - 6 - root.length - "/packages/".length, "x").toString(),
+      );
+      expect(tooLong).toHaveLength(MAX_PATH_BYTES - 6);
+      mkdirSync(join(root, "packages", "ok"), { recursive: true });
+      mkdirSync(tooLong);
+      await Bun.write(join(root, "package.json"), JSON.stringify({ name: "ws-long", workspaces: ["packages/*"] }));
+      await Bun.write(
+        join(root, "packages", "ok", "package.json"),
+        JSON.stringify({ name: "ok", scripts: { present: "echo ok-ran" } }),
+      );
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "--filter", "*", "present"],
+        env: bunEnv,
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("ENAMETOOLONG");
+      expect(stdout).toContain("ok present: ok-ran");
+      expect(exitCode).toBe(0);
+    },
+  );
 });

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -24,6 +24,11 @@ export const isFreeBSD = process.platform === "freebsd";
 export const isAndroid = process.platform === "android";
 export const isPosix = isMacOS || isLinux || isFreeBSD || isAndroid;
 export const isWindows = process.platform === "win32";
+/**
+ * Size of bun's fixed path buffers (`MAX_PATH_BYTES` in `src/bun_core/util.rs`). A path longer than this does not
+ * fit in one, which code taking a path from the user has to report rather than overflow the buffer.
+ */
+export const MAX_PATH_BYTES = isWindows ? 32767 * 3 + 1 : isLinux || isAndroid ? 4096 : 1024;
 export const isIntelMacOS = isMacOS && process.arch === "x64";
 export const isArm64 = process.arch === "arm64";
 export const isDebug = Bun.version.includes("debug");


### PR DESCRIPTION
### Problem
- `bun run --filter` aborts with `panic: range end index 4102 out of range for slice of length 4095` when a workspace member directory is within 13 bytes of `MAX_PATH_BYTES`. A cwd that deep aborts the same way (Notes).
- Two unchecked `PathBuffer` joins: `DirEntryAccessor::statat` (`src/resolver/lib.rs`) adds `package.json` to the member directory, `filter_arg.rs:65` adds it to the cwd and each parent. `openat` and `lstatat` share the first.

### Fix
- The accessor joins through one helper built on `join_z_buf_spill`. `stat` then reports ENAMETOOLONG. `filter_arg.rs` prints it and runs the other members.
- `filter_arg.rs` uses `join_abs_string_buf_checked` and moves on to the parent when the path does not fit, as for ENOENT. Such a `package.json` cannot be read anyway.
- Correct because a path the OS accepts still reaches the syscall unchanged, and a path it rejects gets the OS's answer. `lstatat` also loses its `entry.fd` shortcut (Notes).
- Verified: two tests in `test/cli/run/filter-workspace.test.ts`, both panic on main. Other suites: Notes.

### Background
- `bun run --filter` walks up from the cwd to the `package.json` with `workspaces`, then finds the members with a `GlobWalker<DirEntryAccessor>`. Entries with `**` reach a third join in `PackageJSON::parse`, fixed by #39626.
- An `Accessor` is the walker's file system interface. Its handle here is a cached `DirEntry`, an absolute path without an fd, so names are joined onto it as strings.
- `MAX_PATH_BYTES` (4096 on Linux) is the size of bun's fixed `PathBuffer` and the longest path the OS takes. The `_spill` and `_checked` joins above are the existing ones for a result that can exceed it.

<details><summary>Notes</summary>

- Sites on the `--filter` path, found by the self-review. (1) `DirEntryAccessor::statat`, this PR. (2) `filter_arg.rs:65`, this PR. On main a cwd of `MAX_PATH_BYTES - 14` bytes works, `- 13` panics at the NUL write (`panic: index out of bounds: the len is 4096 but the index is 4096`), longer ones in the normalizer (`range end index 4100 out of range for slice of length 4095` at `- 8`). With this branch every length up to `- 1` runs the member. (3) `PackageJSON::parse` (`src/resolver/package_json.rs:398`, through `RealFS::abs` at `lib.rs:361`): reached when the pattern still has `**` to match, because the walker then lists the member directory instead of stat'ing its `package.json`, so a member of `MAX_PATH_BYTES - 8` bytes under `packages/**` still panics with this branch (`range end index 4100`). #39626 changes exactly `abs` and `PackageJSON::parse`. The two PRs touch disjoint parts of `lib.rs`.
- The other two accessor joins. `filter_arg.rs` builds the walker with `absolute = true`, so every path it passes to `openat` is absolute (no join) and already checked by the walker. A relative walk, which has no caller today, would now get ENAMETOOLONG from `read_directory`, reported like every other `read_directory` failure of this accessor. `lstatat` is only called for entries of unknown kind, which `DirEntryDirIter` never reports. #36202 makes the literal tail call it.
- The `lstatat` shortcut. This accessor opens directories with `store_fd: false`, so `entry.fd` is always `Fd::INVALID`, which `bun_sys::lstatat` turns into `AT_FDCWD`: it would have stat'd the name against the process cwd. Now `lstatat` is `statat` without following symlinks, as its doc says.
- Test lengths, all measured in bytes. Member test: root `MAX_PATH_BYTES - 196`, member directory `- 6`, so the OS opens it but `<dir>/package.json` is `+ 7`. On main every member directory of `- 13` bytes or more panics. Cwd test: cwd `- 13`, so `<cwd>/package.json` is exactly `MAX_PATH_BYTES` bytes. Every fixture path stays below the limit, so the tests need no chdir. Skipped on Windows, where `MAX_PATH_BYTES` (98302) is longer than any path that can exist. `test/harness.ts` gains `MAX_PATH_BYTES`, the same lines as in #39626, so the second of the two to land merges cleanly.
- Output of the member test with the fix: `Error: ENAMETOOLONG: package.json: File name too long (stat())`, then the other member runs, exit code 0. The message names the component because the walker's literal tail attaches the pattern component to every error it gets there, as for `Bun.Glob`. Unchanged here.
- Suites. `test/cli/run`: `filter-workspace` (82 tests), `workspaces`, `multi-run`, `if-present`, `run-quote`, `no-orphans`, and `test/cli/install/bun-run` pass, except `no-orphans`' root-only uid/gid test, which fails the same way with the release build of main in my container. `test/js/bun/glob/scan.test.ts`: 188 pass, six "recursive search" tests over the repository tree hit their 30 s timeout on the debug ASAN build here. They use `Bun.Glob`, which walks with `SyscallAccessor` and does not touch this code.
- Found while working on #39626. Same family as #35863 (`bun test` scanner, which uses `join_abs_string_buf_checked` the same way) and #37531 (`workspaces` entries in `bun install`).
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/filter-workspace.test.ts

<!-- robobun:evidence:end -->