### PR TITLE
performance: keep the user timing entry counts exact after clearMarks(name) and clearMeasures(name)

### DIFF
--- a/src/jsc/bindings/webcore/PerformanceUserTiming.cpp
+++ b/src/jsc/bindings/webcore/PerformanceUserTiming.cpp
@@ -63,12 +63,13 @@ size_t PerformanceUserTiming::memoryCost() const
     return size;
 }
 
-static void clearPerformanceEntries(PerformanceEntryMap& map, const String& name)
+static void clearPerformanceEntries(PerformanceEntryMap& map, const String& name, int64_t& counter)
 {
-    if (name.isNull())
+    if (name.isNull()) {
         map.clear();
-    else
-        map.remove(name);
+        counter = 0;
+    } else
+        counter -= static_cast<int64_t>(map.take(name).size());
 }
 
 static void addPerformanceEntry(PerformanceEntryMap& map, const String& name, PerformanceEntry& entry)
@@ -98,8 +99,7 @@ ExceptionOr<Ref<PerformanceMark>> PerformanceUserTiming::mark(JSC::JSGlobalObjec
 
 void PerformanceUserTiming::clearMarks(const String& markName)
 {
-    clearPerformanceEntries(m_marksMap, markName);
-    m_markCounter = 0;
+    clearPerformanceEntries(m_marksMap, markName, m_markCounter);
 }
 
 ExceptionOr<double> PerformanceUserTiming::convertMarkToTimestamp(const std::variant<String, double>& mark) const
@@ -263,8 +263,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(JSC::JSGloba
 
 void PerformanceUserTiming::clearMeasures(const String& measureName)
 {
-    clearPerformanceEntries(m_measuresMap, measureName);
-    m_measureCounter = 0;
+    clearPerformanceEntries(m_measuresMap, measureName, m_measureCounter);
 }
 
 static Vector<RefPtr<PerformanceEntry>> convertToEntrySequence(const PerformanceEntryMap& map, int64_t initialCapacity)

--- a/test/js/web/timers/performance-entries.test.ts
+++ b/test/js/web/timers/performance-entries.test.ts
@@ -15,3 +15,38 @@ test("memory usage of Performance", () => {
   expect(final2).toBeGreaterThan(final);
   expect(final).toBeGreaterThan(initial);
 });
+
+test("getEntries() after clearMarks(name) and clearMeasures(name)", () => {
+  performance.clearMarks();
+  performance.clearMeasures();
+
+  performance.mark("kept-mark");
+  performance.mark("dropped-mark");
+  performance.mark("dropped-mark");
+  performance.clearMarks("dropped-mark");
+  performance.clearMarks("missing-mark");
+
+  performance.measure("kept-measure");
+  performance.measure("dropped-measure");
+  performance.measure("dropped-measure");
+  performance.clearMeasures("dropped-measure");
+  performance.clearMeasures("missing-measure");
+
+  const names = (entries: PerformanceEntryList) => entries.map(entry => `${entry.entryType}:${entry.name}`).sort();
+  expect(names(performance.getEntries())).toEqual(["mark:kept-mark", "measure:kept-measure"]);
+  expect(names(performance.getEntriesByType("mark"))).toEqual(["mark:kept-mark"]);
+  expect(names(performance.getEntriesByType("measure"))).toEqual(["measure:kept-measure"]);
+
+  performance.mark("kept-mark");
+  performance.measure("kept-measure");
+  expect(names(performance.getEntries())).toEqual([
+    "mark:kept-mark",
+    "mark:kept-mark",
+    "measure:kept-measure",
+    "measure:kept-measure",
+  ]);
+
+  performance.clearMarks();
+  performance.clearMeasures();
+  expect(performance.getEntries()).toEqual([]);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a debug assertion in `performance.getEntries()` and `performance.getEntriesByType()`. A fuzzer found it.

```
ASSERTION FAILED: entries.size() <= safeInitialCapacity
src/jsc/bindings/webcore/PerformanceUserTiming.cpp(280) : convertToEntrySequence
```

Repro on an unfixed debug build:

```js
performance.mark("a");
performance.mark("b");
performance.clearMarks("a");
performance.getEntries();
```

The same sequence with `measure()` and `clearMeasures("m1")` fails in the same way.

### Root cause

`PerformanceUserTiming` keeps a count of the mark entries and a count of the measure entries next to the two maps. `getMarks()` and `getMeasures()` use the count as the initial capacity of the result vector. The assertion at line 280 checks that the result fits in that capacity.

`clearMarks(name)` and `clearMeasures(name)` remove one name from the map. They then set the count to 0 (`PerformanceUserTiming.cpp:101` and `:267` before this change). The entries for the other names stay in the map. The next `getEntries()` builds a vector with more entries than the count, and the assertion fails.

A release build does not check the assertion. There, a wrong count only makes the result vector grow once more. The output is correct.

The fuzzer reported the crash as flaky. The fuzzer runs many scripts in one process, and the `performance` object is shared between them. An earlier script left the count out of sync. The reported script only called `getEntries()`.

### The fix

`clearPerformanceEntries()` now takes the count. When it removes one name, it takes the vector out of the map and subtracts its size from the count. When it clears the whole map, it sets the count to 0. This is the only change to `src/jsc/bindings/webcore/PerformanceUserTiming.cpp`.

### Tests

New test in `test/js/web/timers/performance-entries.test.ts`. It clears one name from each map, then reads the entries back with `getEntries()` and `getEntriesByType()`.

- On an unfixed debug build, the test process aborts with the assertion above.
- With this change, `bun bd test test/js/web/timers/performance-entries.test.ts` passes.
- On a release build, the test passes before and after this change. The assertion is only compiled into debug builds.

Also ran `test/js/node/perf_hooks/perf_hooks.test.ts` and the `test-performance-*` files in `test/js/node/test/parallel/` with the debug build. They pass.
