### PR TITLE
process: NUL-terminate the PSI trigger that arms memoryPressure on Linux

### DIFF
--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -66,6 +66,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "ini.rs": "ini/ini.rs",
   "install_binding.rs": "install_jsc/install_binding.rs",
   "jest.rs": "runtime/test_runner/jest.rs",
+  "memory_pressure.rs": "runtime/node/memory_pressure.rs",
   "mysql.rs": "sql_jsc/mysql.rs",
   "napi_body.rs": "runtime/napi/napi_body.rs",
   "node_assert_binding.rs": "runtime/node/node_assert_binding.rs",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -673,6 +673,19 @@ export const isMemoryPressureWatcherInstalled: () => boolean = $newCppFunction(
   0,
 );
 
+// True when the installed watcher registered a real OS source (a PSI trigger
+// on Linux). The watcher installs silently without one when the kernel
+// refuses the trigger, so isMemoryPressureWatcherInstalled() cannot tell.
+export const memoryPressureWatcherHasOsBackend: () => boolean = $newRustFunction(
+  "memory_pressure.rs",
+  "jsWatcherHasOsBackend",
+  0,
+);
+
+// The exact bytes Bun writes to /proc/pressure/memory to arm its trigger.
+// null where there is no PSI backend (everything except Linux).
+export const memoryPressurePsiTrigger: () => Buffer | null = $newRustFunction("memory_pressure.rs", "jsPsiTrigger", 0);
+
 export const getEventLoopStats: () => {
   activeTasks: number;
   tasks: number;

--- a/src/runtime/node/memory_pressure.rs
+++ b/src/runtime/node/memory_pressure.rs
@@ -26,9 +26,11 @@
 //! are wired. The watcher does not keep the event loop alive.
 
 use bun_event_loop::ConcurrentTask::{Task, task_tag};
-use bun_jsc::JSGlobalObject;
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use bun_jsc::ArrayBuffer;
 #[cfg(not(windows))]
 use bun_jsc::virtual_machine::VirtualMachine;
+use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 #[cfg(not(windows))]
 use core::ptr::NonNull;
 
@@ -142,15 +144,21 @@ mod posix {
         None
     }
 
+    /// 150 ms of "some"-stall in any 2 s window. 2 s is the minimum
+    /// window for unprivileged PSI triggers (kernel 6.6+).
+    ///
+    /// The trailing NUL is part of the write: `psi_write()` in
+    /// `kernel/sched/psi.c` replaces the last byte it receives with NUL
+    /// before it parses the buffer. Without it the kernel sees
+    /// `some 150000 200000` and rejects the 200 ms window with `EINVAL`.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub(super) const PSI_TRIGGER: &[u8] = b"some 150000 2000000\0";
+
     /// Open a PSI memory file and write a trigger. Tries the system-wide
     /// `/proc/pressure/memory` first, then the current cgroup's file.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     fn open_psi_fd() -> Option<Fd> {
         use bun_sys::O;
-
-        /// 150 ms of "some"-stall in any 2 s window. 2 s is the minimum
-        /// window for unprivileged PSI triggers (kernel 6.6+).
-        const TRIGGER: &[u8] = b"some 150000 2000000";
 
         let mut cgroup_buf = [0u8; 320];
         let paths = [
@@ -161,7 +169,7 @@ mod posix {
             let Ok(fd) = bun_sys::open(path, O::RDWR | O::NONBLOCK | O::CLOEXEC, 0) else {
                 continue;
             };
-            if bun_sys::write(fd, TRIGGER).is_ok() {
+            if bun_sys::write(fd, PSI_TRIGGER).is_ok() {
                 return Some(fd);
             }
             let _ = bun_sys::close(fd);
@@ -213,6 +221,19 @@ mod posix {
             poll: register_os_watch(global),
         });
         *slot(global.bun_vm().as_mut()) = NonNull::new(bun_core::heap::into_raw(watcher).cast());
+    }
+
+    /// Whether the installed watcher holds a live OS source. `install` still
+    /// fills the slot when no backend could be registered, so `isInstalled`
+    /// alone cannot tell the two apart.
+    pub(super) fn has_os_backend(global: &JSGlobalObject) -> bool {
+        let Some(raw) = *slot(global.bun_vm().as_mut()) else {
+            return false;
+        };
+        // SAFETY: slot is populated only by `install` with a `Box<MemoryPressureWatcher>`,
+        // and nothing else borrows it while this JS host call runs.
+        let watcher = unsafe { raw.cast::<MemoryPressureWatcher>().as_ref() };
+        watcher.poll.is_some()
     }
 
     pub(super) fn uninstall(global: &JSGlobalObject) {
@@ -425,6 +446,40 @@ pub(crate) extern "C" fn Bun__MemoryPressure__isInstalled(global: &JSGlobalObjec
         .rare_data()
         .memory_pressure_watcher_slot()
         .is_some()
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// bun:internal-for-testing hooks
+// ────────────────────────────────────────────────────────────────────────────
+
+/// `memoryPressurePsiTrigger()`: the bytes `open_psi_fd` writes, as a
+/// `Buffer`. `null` where there is no PSI backend.
+#[bun_jsc::host_fn]
+pub(crate) fn js_psi_trigger(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        ArrayBuffer::create_buffer(global, posix::PSI_TRIGGER)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        let _ = global;
+        Ok(JSValue::NULL)
+    }
+}
+
+/// `memoryPressureWatcherHasOsBackend()`: whether the watcher installed by
+/// the current listeners registered an OS source. On Windows `install` either
+/// starts the thread or leaves the slot empty, so this equals `isInstalled`.
+#[bun_jsc::host_fn]
+pub(crate) fn js_watcher_has_os_backend(
+    global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    #[cfg(not(windows))]
+    let armed = posix::has_os_backend(global);
+    #[cfg(windows)]
+    let armed = Bun__MemoryPressure__isInstalled(global);
+    Ok(JSValue::js_boolean(armed))
 }
 
 #[cfg(not(windows))]

--- a/test/js/node/process/process-memory-pressure.test.ts
+++ b/test/js/node/process/process-memory-pressure.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isLinux } from "harness";
+import { closeSync, constants, openSync, readFileSync, writeSync } from "node:fs";
 
 // process.on("memoryPressure") is a Bun extension. These tests drive the
 // emit path synthetically via bun:internal-for-testing since real OS memory
 // pressure cannot be induced reliably (and PSI trigger creation requires
 // CAP_SYS_RESOURCE on Linux kernels before 6.6, which CI containers lack).
+// The one test that arms a real PSI trigger first checks that this process
+// is allowed to create one, and is skipped otherwise.
 
 async function run(src: string) {
   await using proc = Bun.spawn({
@@ -15,6 +18,42 @@ async function run(src: string) {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };
+}
+
+function canArmPsiTriggerAt(path: string): boolean {
+  let fd: number;
+  try {
+    fd = openSync(path, constants.O_RDWR | constants.O_NONBLOCK);
+  } catch {
+    return false;
+  }
+  try {
+    // The trigger format from Documentation/accounting/psi.rst. The kernel
+    // sample writes strlen + 1 bytes, so the NUL is part of the write.
+    writeSync(fd, Buffer.from("some 150000 2000000\0"));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+// The same two files, in the same order, that Bun tries when a listener is
+// added: the system-wide PSI file, then this process's own cgroup v2 file.
+function canArmPsiTrigger(): boolean {
+  if (!isLinux) return false;
+  if (canArmPsiTriggerAt("/proc/pressure/memory")) return true;
+  let cgroup: string;
+  try {
+    cgroup = readFileSync("/proc/self/cgroup", "utf8");
+  } catch {
+    return false;
+  }
+  const entry = cgroup.split("\n").find(line => line.startsWith("0::"));
+  if (entry === undefined) return false;
+  const rest = entry.slice("0::".length).replace(/^\//, "");
+  return canArmPsiTriggerAt(`/sys/fs/cgroup/${rest}${rest ? "/" : ""}memory.pressure`);
 }
 
 describe.concurrent("process.on('memoryPressure')", () => {
@@ -91,6 +130,44 @@ describe.concurrent("process.on('memoryPressure')", () => {
       process.stdout.write("done");
     `);
     expect(stdout).toBe("done");
+    expect(exitCode).toBe(0);
+  });
+
+  // psi_write() in kernel/sched/psi.c overwrites the last byte of the write
+  // with NUL before it parses the trigger. A write without its own NUL loses
+  // the last digit of the window, and the kernel rejects the trigger.
+  test.skipIf(!isLinux)("the PSI trigger write ends in NUL", async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      const { memoryPressurePsiTrigger } = require("bun:internal-for-testing");
+      process.stdout.write(memoryPressurePsiTrigger());
+    `);
+    expect(stderr.trim()).toBe("");
+    expect(stdout).toMatch(/^(some|full) \d+ \d+\0$/);
+    // The other two rules psi_trigger_create() applies to an unprivileged
+    // writer: the threshold fits in the window, and the window is N * 2 s.
+    const [, thresholdUs, windowUs] = stdout.slice(0, -1).split(" ").map(Number);
+    expect({
+      thresholdFitsWindow: thresholdUs <= windowUs,
+      windowRemainderUs: windowUs % 2_000_000,
+    }).toEqual({ thresholdFitsWindow: true, windowRemainderUs: 0 });
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!canArmPsiTrigger())("first listener arms a PSI trigger on Linux", async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      const { memoryPressureWatcherHasOsBackend } = require("bun:internal-for-testing");
+      const h = () => {};
+      const before = memoryPressureWatcherHasOsBackend();
+      process.on("memoryPressure", h);
+      const armed = memoryPressureWatcherHasOsBackend();
+      process.off("memoryPressure", h);
+      const after = memoryPressureWatcherHasOsBackend();
+      process.stdout.write(JSON.stringify({ before, armed, after }));
+    `);
+    expect({ stdout, stderr: stderr.trim() }).toEqual({
+      stdout: JSON.stringify({ before: false, armed: true, after: false }),
+      stderr: "",
+    });
     expect(exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### Problem
- `process.on("memoryPressure")` never fires on Linux.
- `open_psi_fd` (`src/runtime/node/memory_pressure.rs:153`) writes `some 150000 2000000` with no terminator. `psi_write()` in `kernel/sched/psi.c` replaces the last byte of a write with NUL before it parses. It sees a 200 ms window and returns `EINVAL`, so the watcher installs with no OS source.

### Fix
- Write the trigger with a trailing NUL. The kernel's own sample writes `strlen + 1` bytes.
- Add two `bun:internal-for-testing` hooks through `$newRustFunction`. `memoryPressurePsiTrigger()` returns the bytes Bun writes. `memoryPressureWatcherHasOsBackend()` tells whether the watcher holds a live poll.
- Two tests in `test/js/node/process/process-memory-pressure.test.ts`. The first checks the bytes on every Linux machine. The second arms a real trigger. It is skipped where the test process cannot create one itself (most CI containers).
- Verified: the file passes, and the first test fails with only the NUL removed. Also `cargo check` for Windows, macOS and FreeBSD, clippy, and `test/internal/source-lints`.

### Background
- PSI (pressure stall information) is the Linux pressure source Bun uses. A write of `some <threshold_us> <window_us>` to `/proc/pressure/memory` arms a trigger on that fd.
- Bun tries that file first, then the cgroup's `memory.pressure`. kernfs terminates the cgroup write itself, so that fallback worked either way. Most hosts only offer the `/proc` file.
- Since kernel 6.4 an unprivileged writer may arm a trigger, but only with a window that is a multiple of 2 s. The truncated window fails that rule.
- Same byte as #34018 (from a fork, so CI did not run on it). Its author is credited in the commit.

<details><summary>Notes</summary>

Kernel source for the claim (v6.6, `kernel/sched/psi.c`, `psi_write`):

```c
buf_size = min(nbytes, sizeof(buf));
if (copy_from_user(buf, user_buf, buf_size))
    return -EFAULT;
buf[buf_size - 1] = '\0';
```

`psi_trigger_create` then rejects `window_us % 2000000 != 0` for a writer without `CAP_SYS_RESOURCE`. A writer with that capability gets a 200 ms window on the RT polling aggregator instead, which needs a 75% stall to fire rather than 7.5%.

The cgroup path (`kernel/cgroup/cgroup.c`, `pressure_write`) receives a kernfs buffer that already has a NUL after the data, so it worked with and without this change.

The first test also checks the two other rules `psi_trigger_create` applies to an unprivileged writer: the threshold fits in the window, and the window is a multiple of 2 s. The second test checks `hasOsBackend` before a listener is added (false), with one (true), and after it is removed (false). Its skip guard opens and writes the same two files, in the same order, that `open_psi_fd` uses.

This container denies `O_RDWR` on `/proc/pressure/memory` (`EACCES`, AppArmor) and mounts the cgroup fs read-only, so the second test is skipped here. Fail-before output with only the NUL removed from `PSI_TRIGGER`:

```
(fail) process.on('memoryPressure') > the PSI trigger write ends in NUL
```

#36525 was an earlier copy of the same fix. It was closed in favor of #34018, and its branch no longer merges. #31021 (opt-in shrink on pressure) still carries the unterminated string and needs this byte too.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/process/process-memory-pressure.test.ts

<!-- robobun:evidence:end -->
