### PR TITLE
test(install): speed up bun-install-lifecycle-scripts.test.ts and check what the scripts do

### DIFF
--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -2322,11 +2322,22 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
 
-    // Without a node-gyp dependency, the `node-gyp` on the PATH of a lifecycle script is the script
-    // that `bun install` writes to its temp dir, and that script runs `bun x node-gyp`. bunx
-    // installs the package outside of the project, where the project's bunfig.toml does not apply,
-    // so the registry has to come from the environment. The registry's node-gyp@latest writes
-    // `build.node` into the directory it runs in.
+    // The three tests that use this check what `bun install` itself puts on the PATH of lifecycle
+    // scripts, so the scripts get exactly `path` to search on top of that. The env can also carry
+    // PATH under another spelling (`Path` on Windows), and a spawned bun keeps whichever spelling it
+    // reads last, so all of them go.
+    function envWithPath(env: Record<string, string>, path: string): Record<string, string> {
+      return {
+        ...Object.fromEntries(Object.entries(env).filter(([key]) => key.toUpperCase() !== "PATH")),
+        PATH: path,
+      };
+    }
+
+    // Without a node-gyp dependency, the `node-gyp` that a lifecycle script finds is the script that
+    // `bun install` writes to its temp dir, which runs `bun x node-gyp` with the `bun` that
+    // `bun install` put next to its `node`. bunx installs the package outside of the project, where
+    // the project's bunfig.toml does not apply, so the registry has to come from the environment.
+    // The registry's node-gyp@latest writes the directory it runs in to `build.node`.
     function envForBunx(env: Record<string, string>): Record<string, string> {
       return { ...env, BUN_CONFIG_REGISTRY: verdaccio.registryUrl() };
     }
@@ -2346,6 +2357,10 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           },
         }),
       );
+      // A PATH that is not empty, but has no node, bun or node-gyp on it: `bun install` has to add
+      // its directories to it. ("ensureTempNodeGypScript works" starts from an empty PATH.)
+      const emptyDir = join(packageDir, "empty");
+      await mkdir(emptyDir);
 
       await using proc = spawn({
         cmd: [bunExe(), "install"],
@@ -2354,16 +2369,15 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         stdout: "ignore",
         stdin: "ignore",
         stderr: "pipe",
-        env: envForBunx(testEnv),
+        env: envForBunx(envWithPath(testEnv, emptyDir)),
       });
 
       const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
       expect(splitErrLines(err)).toEqual(["No packages! Deleted empty lockfile", "", "$ node-gyp --version", ""]);
-      // if node-gyp isn't available, it would return a non-zero exit code
       expect(exitCode).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
 
-      expect(await exists(join(packageDir, "build.node"))).toBeTrue();
+      expect(await file(join(packageDir, "build.node")).text()).toBe(join(packageDir, "build.node"));
     });
 
     // if this test fails, `electron` might be removed from the default list
@@ -3667,21 +3681,14 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       });
     });
 
-    // The two tests below check what `bun install` itself puts on the PATH of lifecycle scripts, so
-    // they start from an empty PATH. NODE and npm_node_execpath have to go as well: `bun install`
-    // uses the node they point at instead of providing its own, and `bun run` (so also `bun bd`)
-    // sets both of them.
-    function envWithoutNode(env: Record<string, string>): Record<string, string> {
-      const { NODE, npm_node_execpath, ...rest } = env;
-      return { ...rest, PATH: "" };
-    }
-
     test("node -p should work in postinstall scripts", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
-      const postinstall = `node -p "require('fs').writeFileSync('postinstall.txt', 'postinstall')"`;
+      // With an empty PATH, the only `node` the script can find is the one `bun install` provides,
+      // which is `bun install`'s own binary. A real node has no `process.versions.bun`.
+      const postinstall = `node -p "require('fs').writeFileSync('postinstall.txt', process.versions.bun)"`;
       await writeFile(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", scripts: { postinstall } }));
 
       await using proc = spawn({
@@ -3690,7 +3697,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         stdout: "pipe",
         stdin: "ignore",
         stderr: "pipe",
-        env: envWithoutNode(testEnv),
+        env: envWithPath(testEnv, ""),
       });
 
       const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -3704,7 +3711,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(exitCode).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
 
-      expect(await file(join(packageDir, "postinstall.txt")).text()).toBe("postinstall");
+      expect(await file(join(packageDir, "postinstall.txt")).text()).toBe(process.versions.bun);
     });
 
     test("ensureTempNodeGypScript works", async () => {
@@ -3730,7 +3737,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         stdout: "ignore",
         stderr: "pipe",
         stdin: "ignore",
-        env: envForBunx(envWithoutNode(testEnv)),
+        env: envForBunx(envWithPath(testEnv, "")),
       });
 
       const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
@@ -3738,7 +3745,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       expect(exitCode).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
 
-      expect(await exists(join(packageDir, "build.node"))).toBeTrue();
+      expect(await file(join(packageDir, "build.node")).text()).toBe(join(packageDir, "build.node"));
     });
 
     test("bun pm trust and untrusted on missing package", async () => {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -8,6 +8,7 @@ import {
   bunExe,
   isLinux,
   isWindows,
+  normalizeBunSnapshot,
   readdirSorted,
   runBunInstall,
 } from "harness";
@@ -739,73 +740,66 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
-      const writeScript = async (name: string) => {
-        const contents = `
-      import { writeFileSync, existsSync, rmSync } from "fs";
-      import { join } from "path";
 
-      const file = join(import.meta.dir, "${name}.txt");
-
-      if (existsSync(file)) {
-        rmSync(file);
-        writeFileSync(file, "${name} exists!");
-      } else {
-        writeFileSync(file, "${name}!");
-      }
-      `;
-        await writeFile(join(packageDir, `${name}.js`), contents);
+      const scriptNames = ["preinstall", "install", "postinstall", "preprepare", "prepare", "postprepare"];
+      // Every root script appends its own name to `<name>.txt`, so that file holds one line per run.
+      const scripts = Object.fromEntries(scriptNames.map(name => [name, `echo ${name} >> ${name}.txt`]));
+      const rootScriptFiles = (runs: number) =>
+        Object.fromEntries(scriptNames.map(name => [name, `${name}\n`.repeat(runs)]));
+      // Each script of `all-lifecycle-scripts` writes `<name>!` to `<name>.txt`, or `<name> exists!`
+      // when the file is already there. `prepare.txt` ships in the tarball: dependencies only run
+      // preinstall, install and postinstall.
+      const depDir = join(packageDir, "node_modules", "all-lifecycle-scripts");
+      const depScriptFiles = {
+        preinstall: "preinstall!",
+        install: "install!",
+        postinstall: "postinstall!",
+        preprepare: null,
+        prepare: "prepare!",
+        postprepare: null,
       };
 
-      await writeFile(
-        packageJson,
-        JSON.stringify({
-          name: "foo",
-          version: "1.0.0",
-          scripts: {
-            preinstall: `${bunExe()} preinstall.js`,
-            install: `${bunExe()} install.js`,
-            postinstall: `${bunExe()} postinstall.js`,
-            preprepare: `${bunExe()} preprepare.js`,
-            prepare: `${bunExe()} prepare.js`,
-            postprepare: `${bunExe()} postprepare.js`,
-          },
-        }),
-      );
+      async function scriptFiles(dir: string): Promise<Record<string, string | null>> {
+        return Object.fromEntries(
+          await Promise.all(
+            scriptNames.map(async name => {
+              const path = join(dir, `${name}.txt`);
+              return [name, (await exists(path)) ? await file(path).text() : null];
+            }),
+          ),
+        );
+      }
 
-      await writeScript("preinstall");
-      await writeScript("install");
-      await writeScript("postinstall");
-      await writeScript("preprepare");
-      await writeScript("prepare");
-      await writeScript("postprepare");
+      async function install() {
+        await using proc = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env: testEnv,
+        });
+        const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(err).not.toContain("not found");
+        expect(err).not.toContain("error:");
+        // Root scripts run in the foreground, and bun prints each command before it runs it.
+        expect(splitErrLines(err).filter(line => line.startsWith("$ "))).toEqual(
+          scriptNames.map(name => `$ ${scripts[name]}`),
+        );
+        expect(exitCode).toBe(0);
+        assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
+        return { out, err };
+      }
 
-      var { stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: packageDir,
-        stdout: "pipe",
-        stdin: "ignore",
-        stderr: "pipe",
-        env: testEnv,
-      });
-      var err = await stderr.text();
-      var out = await stdout.text();
-      expect(err).not.toContain("not found");
-      expect(err).not.toContain("error:");
-      expect(await exited).toBe(0);
-      assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
+      await writeFile(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", scripts }));
 
-      expect(await exists(join(packageDir, "preinstall.txt"))).toBeTrue();
-      expect(await exists(join(packageDir, "install.txt"))).toBeTrue();
-      expect(await exists(join(packageDir, "postinstall.txt"))).toBeTrue();
-      expect(await exists(join(packageDir, "preprepare.txt"))).toBeTrue();
-      expect(await exists(join(packageDir, "prepare.txt"))).toBeTrue();
-      expect(await exists(join(packageDir, "postprepare.txt"))).toBeTrue();
-      expect(await file(join(packageDir, "preinstall.txt")).text()).toBe("preinstall!");
-      expect(await file(join(packageDir, "install.txt")).text()).toBe("install!");
-      expect(await file(join(packageDir, "postinstall.txt")).text()).toBe("postinstall!");
-      expect(await file(join(packageDir, "preprepare.txt")).text()).toBe("preprepare!");
-      expect(await file(join(packageDir, "prepare.txt")).text()).toBe("prepare!");
-      expect(await file(join(packageDir, "postprepare.txt")).text()).toBe("postprepare!");
+      let { out, err } = await install();
+      expect(err).toContain("No packages! Deleted empty lockfile");
+      expect(normalizeBunSnapshot(out)).toMatchInlineSnapshot(`
+        "bun install <version> (<revision>)
+         done"
+      `);
+      expect(await scriptFiles(packageDir)).toEqual(rootScriptFiles(1));
 
       // add a dependency with all lifecycle scripts
       await writeFile(
@@ -813,14 +807,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         JSON.stringify({
           name: "foo",
           version: "1.0.0",
-          scripts: {
-            preinstall: `${bunExe()} preinstall.js`,
-            install: `${bunExe()} install.js`,
-            postinstall: `${bunExe()} postinstall.js`,
-            preprepare: `${bunExe()} preprepare.js`,
-            prepare: `${bunExe()} prepare.js`,
-            postprepare: `${bunExe()} postprepare.js`,
-          },
+          scripts,
           dependencies: {
             "all-lifecycle-scripts": "1.0.0",
           },
@@ -828,96 +815,36 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         }),
       );
 
-      ({ stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: packageDir,
-        stdout: "pipe",
-        stdin: "ignore",
-        stderr: "pipe",
-        env: testEnv,
-      }));
-
-      err = await stderr.text();
-      out = await stdout.text();
+      ({ out, err } = await install());
       expect(err).toContain("Saved lockfile");
-      expect(err).not.toContain("not found");
-      expect(err).not.toContain("error:");
-      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-        expect.stringContaining("bun install v1."),
-        "",
-        "+ all-lifecycle-scripts@1.0.0",
-        "",
-        "1 package installed",
-      ]);
-      expect(await exited).toBe(0);
-      assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
+      expect(normalizeBunSnapshot(out)).toMatchInlineSnapshot(`
+        "bun install <version> (<revision>)
 
-      expect(await file(join(packageDir, "preinstall.txt")).text()).toBe("preinstall exists!");
-      expect(await file(join(packageDir, "install.txt")).text()).toBe("install exists!");
-      expect(await file(join(packageDir, "postinstall.txt")).text()).toBe("postinstall exists!");
-      expect(await file(join(packageDir, "preprepare.txt")).text()).toBe("preprepare exists!");
-      expect(await file(join(packageDir, "prepare.txt")).text()).toBe("prepare exists!");
-      expect(await file(join(packageDir, "postprepare.txt")).text()).toBe("postprepare exists!");
+        + all-lifecycle-scripts@1.0.0
 
-      const depDir = join(packageDir, "node_modules", "all-lifecycle-scripts");
-
-      expect(await exists(join(depDir, "preinstall.txt"))).toBeTrue();
-      expect(await exists(join(depDir, "install.txt"))).toBeTrue();
-      expect(await exists(join(depDir, "postinstall.txt"))).toBeTrue();
-      expect(await exists(join(depDir, "preprepare.txt"))).toBeFalse();
-      expect(await exists(join(depDir, "prepare.txt"))).toBeTrue();
-      expect(await exists(join(depDir, "postprepare.txt"))).toBeFalse();
-
-      expect(await file(join(depDir, "preinstall.txt")).text()).toBe("preinstall!");
-      expect(await file(join(depDir, "install.txt")).text()).toBe("install!");
-      expect(await file(join(depDir, "postinstall.txt")).text()).toBe("postinstall!");
-      expect(await file(join(depDir, "prepare.txt")).text()).toBe("prepare!");
-
-      await rm(join(packageDir, "preinstall.txt"));
-      await rm(join(packageDir, "install.txt"));
-      await rm(join(packageDir, "postinstall.txt"));
-      await rm(join(packageDir, "preprepare.txt"));
-      await rm(join(packageDir, "prepare.txt"));
-      await rm(join(packageDir, "postprepare.txt"));
-      await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-      await rm(join(packageDir, "bun.lock"));
+        1 package installed"
+      `);
+      expect(await scriptFiles(packageDir)).toEqual(rootScriptFiles(2));
+      expect(await scriptFiles(depDir)).toEqual(depScriptFiles);
 
       // all at once
-      ({ stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: packageDir,
-        stdout: "pipe",
-        stdin: "ignore",
-        stderr: "pipe",
-        env: testEnv,
-      }));
-      expect(await exited).toBe(0);
-      assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
-
-      err = await stderr.text();
-      out = await stdout.text();
-      expect(err).toContain("Saved lockfile");
-      expect(err).not.toContain("not found");
-      expect(err).not.toContain("error:");
-      expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
-        expect.stringContaining("bun install v1."),
-        "",
-        "+ all-lifecycle-scripts@1.0.0",
-        "",
-        "1 package installed",
+      await Promise.all([
+        ...scriptNames.map(name => rm(join(packageDir, `${name}.txt`))),
+        rm(join(packageDir, "node_modules"), { recursive: true, force: true }),
+        rm(join(packageDir, "bun.lock")),
       ]);
 
-      expect(await file(join(packageDir, "preinstall.txt")).text()).toBe("preinstall!");
-      expect(await file(join(packageDir, "install.txt")).text()).toBe("install!");
-      expect(await file(join(packageDir, "postinstall.txt")).text()).toBe("postinstall!");
-      expect(await file(join(packageDir, "preprepare.txt")).text()).toBe("preprepare!");
-      expect(await file(join(packageDir, "prepare.txt")).text()).toBe("prepare!");
-      expect(await file(join(packageDir, "postprepare.txt")).text()).toBe("postprepare!");
+      ({ out, err } = await install());
+      expect(err).toContain("Saved lockfile");
+      expect(normalizeBunSnapshot(out)).toMatchInlineSnapshot(`
+        "bun install <version> (<revision>)
 
-      expect(await file(join(depDir, "preinstall.txt")).text()).toBe("preinstall!");
-      expect(await file(join(depDir, "install.txt")).text()).toBe("install!");
-      expect(await file(join(depDir, "postinstall.txt")).text()).toBe("postinstall!");
-      expect(await file(join(depDir, "prepare.txt")).text()).toBe("prepare!");
+        + all-lifecycle-scripts@1.0.0
+
+        1 package installed"
+      `);
+      expect(await scriptFiles(packageDir)).toEqual(rootScriptFiles(1));
+      expect(await scriptFiles(depDir)).toEqual(depScriptFiles);
     });
 
     test("workspace lifecycle scripts", async () => {
@@ -1754,11 +1681,12 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         env: testEnv,
       });
 
-      const err = await stderr.text();
+      let err = await stderr.text();
       expect(err).toContain("Saved lockfile");
       expect(err).not.toContain("not found");
       expect(err).not.toContain("error:");
-      const out = await stdout.text();
+      expect(splitErrLines(err).filter(line => line.startsWith("$ "))).toEqual(["$ node-gyp rebuild"]);
+      let out = await stdout.text();
       expect(out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "").split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
         "",
@@ -1773,6 +1701,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
 
       await rm(join(packageDir, "build.node"));
 
+      // The script is added again on every install, not only when the lockfile changes.
       ({ stdout, stderr, exited } = spawn({
         cmd: [bunExe(), "install"],
         cwd: packageDir,
@@ -1782,6 +1711,16 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         env: testEnv,
       }));
 
+      err = await stderr.text();
+      expect(err).not.toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      expect(splitErrLines(err).filter(line => line.startsWith("$ "))).toEqual(["$ node-gyp rebuild"]);
+      out = await stdout.text();
+      expect(normalizeBunSnapshot(out)).toMatchInlineSnapshot(`
+        "bun install <version> (<revision>)
+
+        Checked 1 install across 2 packages (no changes)"
+      `);
       expect(await exited).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
 
@@ -2091,6 +2030,23 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
 
+    // Lifecycle scripts run inside the installed package, so a script that writes `fileName`
+    // leaves it in `node_modules/<package>/`. Packages whose script did not write it map to null.
+    async function scriptOutputs(
+      packageDir: string,
+      packages: string[],
+      fileName: string,
+    ): Promise<Record<string, string | null>> {
+      return Object.fromEntries(
+        await Promise.all(
+          packages.map(async pkg => {
+            const path = join(packageDir, "node_modules", pkg, fileName);
+            return [pkg, (await exists(path)) ? await file(path).text() : null];
+          }),
+        ),
+      );
+    }
+
     async function createPackagesWithScripts(
       packageDir: string,
       packageJson: string,
@@ -2139,11 +2095,22 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
-      const scripts = {
-        "preinstall": `${bunExe()} -e 'Bun.sleepSync(500)'`,
-      };
-
-      const dependenciesList = await createPackagesWithScripts(packageDir, packageJson, 4, scripts);
+      // Each script runs in its own package directory under node_modules. It keeps a marker file in
+      // node_modules while it runs, and halfway through it records how many other scripts have a
+      // marker there. Scripts that start together have all written their markers by then, so a
+      // script that runs alongside more than one other script records it.
+      const preinstall = [
+        "const marker = '../running-' + process.pid",
+        "await Bun.write(marker, '')",
+        "Bun.sleepSync(250)",
+        "const others = [...new Bun.Glob('running-*').scanSync('..')].length - 1",
+        "Bun.sleepSync(250)",
+        "await Bun.file(marker).delete()",
+        "await Bun.write('preinstall.txt', String(others))",
+      ].join("; ");
+      const dependenciesList = await createPackagesWithScripts(packageDir, packageJson, 4, {
+        preinstall: `${bunExe()} -e "${preinstall}"`,
+      });
 
       var { stdout, stderr, exited } = spawn({
         cmd: [bunExe(), "install", "--concurrent-scripts=2"],
@@ -2169,6 +2136,11 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       ]);
       expect(exitCode).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
+
+      // Every script ran, and none of them ran alongside more than one other script.
+      expect(await scriptOutputs(packageDir, dependenciesList, "preinstall.txt")).toEqual(
+        Object.fromEntries(dependenciesList.map(dep => [dep, expect.stringMatching(/^[01]$/)])),
+      );
     });
 
     test("stress test", async () => {
@@ -2176,11 +2148,13 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
+      // The script is quick: `echo` is a shell builtin, so none of the 500 scripts starts a process
+      // of its own (500 `bun` processes made this the slowest test in the file under ASAN). Default
+      // number for max concurrent scripts.
       const dependenciesList = await createPackagesWithScripts(packageDir, packageJson, 500, {
-        "postinstall": `${bunExe()} --version`,
+        "postinstall": "echo postinstall > postinstall.txt",
       });
 
-      // the script is quick, default number for max concurrent scripts
       var { stdout, stderr, exited } = spawn({
         cmd: [bunExe(), "install"],
         cwd: packageDir,
@@ -2206,6 +2180,10 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
 
       expect(exitCode).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
+
+      expect(await scriptOutputs(packageDir, dependenciesList, "postinstall.txt")).toEqual(
+        Object.fromEntries(dependenciesList.map(dep => [dep, "postinstall\n"])),
+      );
     });
 
     test("it should install and use correct binary version", async () => {
@@ -2344,6 +2322,15 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
 
+    // Without a node-gyp dependency, the `node-gyp` on the PATH of a lifecycle script is the script
+    // that `bun install` writes to its temp dir, and that script runs `bun x node-gyp`. bunx
+    // installs the package outside of the project, where the project's bunfig.toml does not apply,
+    // so the registry has to come from the environment. The registry's node-gyp@latest writes
+    // `build.node` into the directory it runs in.
+    function envForBunx(env: Record<string, string>): Record<string, string> {
+      return { ...env, BUN_CONFIG_REGISTRY: verdaccio.registryUrl() };
+    }
+
     test("node-gyp should always be available for lifecycle scripts", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;
@@ -2360,24 +2347,23 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         }),
       );
 
-      const { stdout, stderr, exited } = spawn({
+      await using proc = spawn({
         cmd: [bunExe(), "install"],
         cwd: packageDir,
-        stdout: "pipe",
+        // On Windows the shim is a .cmd file, and cmd.exe echoes its lines to stdout.
+        stdout: "ignore",
         stdin: "ignore",
         stderr: "pipe",
-        env: testEnv,
+        env: envForBunx(testEnv),
       });
 
-      const err = await stderr.text();
-      expect(err).not.toContain("Saved lockfile");
-      expect(err).not.toContain("not found");
-      expect(err).not.toContain("error:");
-      const out = await stdout.text();
-
+      const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(splitErrLines(err)).toEqual(["No packages! Deleted empty lockfile", "", "$ node-gyp --version", ""]);
       // if node-gyp isn't available, it would return a non-zero exit code
-      expect(await exited).toBe(0);
+      expect(exitCode).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
+
+      expect(await exists(join(packageDir, "build.node"))).toBeTrue();
     });
 
     // if this test fails, `electron` might be removed from the default list
@@ -2403,7 +2389,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         stdout: "pipe",
         stdin: "ignore",
         stderr: "pipe",
-        env,
+        env: testEnv,
       });
 
       const err = await stderr.text();
@@ -3681,45 +3667,44 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       });
     });
 
+    // The two tests below check what `bun install` itself puts on the PATH of lifecycle scripts, so
+    // they start from an empty PATH. NODE and npm_node_execpath have to go as well: `bun install`
+    // uses the node they point at instead of providing its own, and `bun run` (so also `bun bd`)
+    // sets both of them.
+    function envWithoutNode(env: Record<string, string>): Record<string, string> {
+      const { NODE, npm_node_execpath, ...rest } = env;
+      return { ...rest, PATH: "" };
+    }
+
     test("node -p should work in postinstall scripts", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;
       const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
-      await writeFile(
-        packageJson,
-        JSON.stringify({
-          name: "foo",
-          version: "1.0.0",
-          scripts: {
-            postinstall: `node -p "require('fs').writeFileSync('postinstall.txt', 'postinstall')"`,
-          },
-        }),
-      );
+      const postinstall = `node -p "require('fs').writeFileSync('postinstall.txt', 'postinstall')"`;
+      await writeFile(packageJson, JSON.stringify({ name: "foo", version: "1.0.0", scripts: { postinstall } }));
 
-      const originalPath = env.PATH;
-      env.PATH = "";
-
-      let { stderr, exited } = spawn({
+      await using proc = spawn({
         cmd: [bunExe(), "install"],
         cwd: packageDir,
         stdout: "pipe",
         stdin: "ignore",
         stderr: "pipe",
-        env: testEnv,
+        env: envWithoutNode(testEnv),
       });
 
-      env.PATH = originalPath;
-
-      let err = await stderr.text();
-      expect(err).toContain("No packages! Deleted empty lockfile");
-      expect(err).not.toContain("not found");
-      expect(err).not.toContain("error:");
-      expect(err).not.toContain("warn:");
-      expect(await exited).toBe(0);
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(splitErrLines(err)).toEqual(["No packages! Deleted empty lockfile", "", `$ ${postinstall}`, ""]);
+      // `node -p` prints what `writeFileSync` returned.
+      expect(normalizeBunSnapshot(out)).toMatchInlineSnapshot(`
+        "bun install <version> (<revision>)
+        undefined
+         done"
+      `);
+      expect(exitCode).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
 
-      expect(await exists(join(packageDir, "postinstall.txt"))).toBeTrue();
+      expect(await file(join(packageDir, "postinstall.txt")).text()).toBe("postinstall");
     });
 
     test("ensureTempNodeGypScript works", async () => {
@@ -3738,27 +3723,22 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         }),
       );
 
-      const originalPath = env.PATH;
-      env.PATH = "";
-
-      let { stderr, exited } = spawn({
+      await using proc = spawn({
         cmd: [bunExe(), "install"],
         cwd: packageDir,
-        stdout: "pipe",
+        // On Windows the shim is a .cmd file, and cmd.exe echoes its lines to stdout.
+        stdout: "ignore",
         stderr: "pipe",
         stdin: "ignore",
-        env,
+        env: envForBunx(envWithoutNode(testEnv)),
       });
 
-      env.PATH = originalPath;
-
-      let err = await stderr.text();
-      expect(err).toContain("No packages! Deleted empty lockfile");
-      expect(err).not.toContain("not found");
-      expect(err).not.toContain("error:");
-      expect(err).not.toContain("warn:");
-      expect(await exited).toBe(0);
+      const [err, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(splitErrLines(err)).toEqual(["No packages! Deleted empty lockfile", "", "$ node-gyp --version", ""]);
+      expect(exitCode).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
+
+      expect(await exists(join(packageDir, "build.node"))).toBeTrue();
     });
 
     test("bun pm trust and untrusted on missing package", async () => {

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -114,6 +114,16 @@ for (let key in bunEnv) {
     delete bunEnv[key];
     delete process.env[key];
   }
+
+  // `bun run <script>` exports these to the script, so a test run started through a
+  // package.json script (`bun bd test`) inherits them while CI, which starts `bun test`
+  // directly, does not. Spawned buns honor them: NODE/npm_node_execpath decide whether
+  // the node shim gets created, and most npm_* values (npm_config_user_agent,
+  // npm_package_name, ...) are only set when absent.
+  if (key === "NODE" || key.startsWith("npm_")) {
+    delete ciEnv[key];
+    delete bunEnv[key];
+  }
 }
 
 delete bunEnv.BUN_INSPECT_CONNECT_TO;


### PR DESCRIPTION
### Problem
- `bun-install-lifecycle-scripts.test.ts` takes 40s on x64-asan, 7s on the default lane. ASAN builds run 5 tests at a time, so total work sets the wall time.
- "stress test" starts the ASAN `bun` binary 500 times and "root package with all lifecycle scripts" 18 times: 35% of the work. Linux runs both twice.
- Neither test checked that a script ran. Six other tests had weak or wrong assertions (list in Notes).

### Fix
- The scripts are shell builtins now: `echo postinstall > postinstall.txt`, `echo preinstall >> preinstall.txt`. The tests check all 500 marker files, and one line per run per root script after each install.
- "reach max concurrent scripts" records how many scripts ran at once. Each must see at most one other. With the limit raised to 4, every script sees 3.
- The three PATH tests set the scripts' PATH themselves (empty, or one empty directory), send `bun x` to the local registry and check what ran: the `build.node` of the registry's node-gyp, or the `process.versions.bun` of the `node`. `bunEnv` in `test/harness.ts` now drops `NODE` and `npm_*`, which `bun run` exports (same hunk as #37384). Before, two of these tests failed under `bun bd test`.
- Verified: on the x64-asan lane of this PR's CI run the file takes 22.2s (40s before). `bun bd test`, alternated on one machine: Linux debug+ASAN 39.7s and 39.4s before, 25.1s and 24.4s after, CPU time 4m56s to 1m31s. Windows debug 22.5s to 18.3s.

### Background
- Bun prints `$ <script>` to stderr before each root script. New assertions read these lines for the order of the root scripts.
- Scripts run through `sh -c` on POSIX and through bun's shell on Windows. `echo` and `>>` work the same in both.
- The `node-gyp` shim runs `bun x node-gyp`, which installs outside the project, so only `BUN_CONFIG_REGISTRY` reaches it.
- `bun install` uses the node named by `NODE` before it searches PATH (`get_node_path`, `src/dotenv/env_loader.rs`). It then adds no `node` or `bun` of its own.

<details><summary>Notes</summary>

Assertion changes, per test:

- "root package with all lifecycle scripts": exact contents of the six root files after each install (one line per run, so a script that runs twice in one install, or not at all, fails), the exact ordered list of the six `$` lines on all three installs, inline snapshots of stdout, and the dependency's six files as one object. The `all-lifecycle-scripts` dependency still runs its `bun` scripts, so that path stays covered.
- "stress test": all 500 `postinstall.txt` files with exact contents. The comment in the test already said the script only has to be quick.
- "reach max concurrent scripts": every package's `preinstall.txt` exists and holds `0` or `1`. Each script writes a marker, sleeps 250ms, counts the other markers, sleeps 250ms more and removes its marker. Scripts that start together have all written their markers by the time any of them counts. With `--concurrent-scripts=4` instead of 2 every script recorded `3` in 6 of 6 runs. The script uses `Bun.write`, `Bun.Glob` and `Bun.file().delete()` because `require("fs")` adds about 0.5s per script on a debug build. The total sleep is still 500ms, so the test costs the same as before.
- "node -p should work in postinstall scripts": exact stderr lines, stdout snapshot (the `undefined` that `node -p` prints), and the script writes `process.versions.bun`, which only bun's own `node` has, so the file has to hold the version of the binary under test. Both variants now run with an empty PATH. Before, the test set `env.PATH = ""` after `testEnv` had been copied from `env`, so the waiter thread variant ran with a full PATH.
- "ensureTempNodeGypScript works" (empty PATH) and "node-gyp should always be available for lifecycle scripts" (a PATH with one empty directory on it, so `bun install` takes the branch that appends to an existing PATH): exact stderr lines, and `build.node` has to hold the package directory, which is what the registry's node-gyp writes. The first one also spawns with `testEnv` now (it used `env`, so the waiter thread flag was never set). Both used to download the real node-gyp from registry.npmjs.org through `bun x`, and the second one used to search the host PATH, so a node-gyp installed on the machine (test/package.json has one) or the `bun` on the PATH took the place of the ones `bun install` provides. With a stub node-gyp first on the PATH, the new tests pass and the first version of this PR failed. Both ignore stdout: on Windows the shim is a `.cmd` file and cmd.exe echoes its lines to stdout (seen on the Windows run).
- `envWithPath` removes every spelling of PATH before it sets `PATH`. On Windows the env carries `Path`, a spawned bun reads both, and the last one it reads wins, so `{ ...env, PATH: "" }` does not reliably empty the PATH there. On Windows all three tests pass with the PATH really empty, so the `node.exe` and `bun.exe` links that `bun install` creates there are what these tests run.
- "automatic node-gyp scripts work in package root": both installs check for the `$ node-gyp rebuild` line, and the second install checks stderr and stdout instead of only the exit code.
- "default trusted dependencies should work": spawns with `testEnv` instead of `env`.

Timing details:

- The per-test numbers come from a temporary wrapper around `setupTest()` that recorded how long each test held a slot. Before: 233s of slot time in total, 5 slots busy for the whole run (the ASAN default from `src/options_types/context.rs`, so the file's own 12-slot semaphore never binds on that lane), "root package" 30s + 21s, "stress test" 19s + 12s. After: 95s in total.
- The slowest tests now are the two "stdout/stderr is inherited" cases (about 4s each on a debug build, three `bun -e` scripts each) and "auto node-gyp script does not drop the package's own postinstall" (three `require("fs")` scripts). Both are much cheaper on release builds, so they are left alone.
- Full numbers. Linux debug+ASAN, 16 vCPUs on a shared host: before 39.7s and 39.4s (119 pass, 3 fail), after 25.1s and 24.4s (122 pass). CPU time (user+sys) 2m05s+2m51s before, 1m03s+0m28s after. An earlier pair under more load measured 54.6s before and 25.4s after. Windows x64 debug: before 22.5s and 22.8s (2 fail), after 18.3s and 19.8s (64 pass, 1 todo). On Windows the stress test still takes about 14s because every script is a `bun exec` process there. This PR does not change that.
- CI, build 101254 of this PR, time of this file per lane: x64-asan 22.2s (39.9s in `test/expected-durations.json`), windows 2019 x64 11.8s (15.1s), windows 11 aarch64 14.0s (14s), alpine x64 8.3s (8.7s), debian x64 9.9s (7.5s), debian and ubuntu aarch64 8.6s and 9.7s. Build 101434 (second commit): x64-asan 21.7s, windows 2019 x64 12.7s, windows 11 aarch64 15.2s, alpine x64 5.9s, debian x64 8.3s. The runner puts a changed file at the front of its shard, while the shard's services still start, so these numbers are higher than the same file measures on main. On the release lanes the work that is left is mostly the installs themselves and the sleeps the tests depend on.
- The failures of the old file under `bun bd test` were "node -p should work in postinstall scripts" and "ensureTempNodeGypScript works" on both platforms: `bun run` (so also `bun bd`) exports `NODE` and `npm_node_execpath`, so `bun install` took the `get_node_path` branch and the scripts found neither `node` nor `bun`.
- The second commit is the result of a self-review of the first one. It moved the `NODE` strip from a helper in this file into `test/harness.ts`, where the other `bunEnv` strips are, and made the three PATH tests independent of the host PATH as described above.
- The harness hunk applies to every test file, so for the record: CI starts `bun test` directly and never has these variables, so it changes nothing in CI. Locally it makes `bun bd test` match CI. The hunk is byte for byte the one in #37384, so the two merge in either order. It also makes `should set "npm_config_user_agent" to bun` in `bunx.test.ts` pass under `bun bd test` (it saw the outer bun's value before). `test/regression/issue/26207.test.ts` clears the same two variables for itself. That stays as it is, it does no harm.
- #37384 edits the same two PATH tests for another reason (the debug-only wipe of the shim dir). The conflict is limited to those lines.
- After the second commit: Linux debug+ASAN 122 pass (28.3s, the machine was busier), Windows x64 debug three full runs of 17.9s to 18.0s, 64 pass and 1 todo each. One earlier Windows run hung in the first `bun install` of "add trusted, delete, then add again > withRm" until the 5 minute timeout, a test this PR does not touch, with nothing written to its directory yet. Five runs of that test alone and the three full runs after it were clean.
- Not changed: `setDefaultTimeout`, the waiter thread loop, the 1s sleeps in the fixtures that the "wait for dependency scripts" and "does not use 100% cpu" tests measure against, the git dependency test (#39115 makes it local), and the `testEnv` line that every test in the block repeats (folding `forceWaiterThread` into `setupTest()` touches all 55 tests, so it is a change of its own). `tsc` over `test/` reports nothing for these files, before and after.
</details>
