### PR TITLE
napi: wait for async cleanup hooks to finish before tearing down the env

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1732,11 +1732,23 @@ impl VirtualMachine {
             || self.should_destruct_main_thread_on_exit()
     }
 
+    /// Whether an env's cleanup may turn the event loop to wait for the addon's
+    /// async cleanup hooks (`NapiEnv::drain`). Of the exits that tear the envs
+    /// down, only a requested main-thread exit under `BUN_DESTRUCT_VM_ON_EXIT`
+    /// may not: Node runs no cleanup hooks there at all, so nothing can depend
+    /// on the wait, and the exit stays immediate.
+    pub fn exit_waits_for_cleanup(&self) -> bool {
+        !self.is_main_thread() || !self.exit_handler.requested
+    }
+
     /// Drains `RareData::cleanup_hooks`, repeating while the hooks push more (an env's
     /// cleanup defers finalizers onto this list once shutdown has begun). The `Vec` is
-    /// taken out of `rare_data` before the hooks run: they re-enter the VM.
-    fn run_cleanup_hooks(&mut self) {
+    /// taken out of `rare_data` before the hooks run: they re-enter the VM. Also called
+    /// on each loop turn an env's cleanup makes while it waits for the addon's async
+    /// cleanup hooks (`napi_internal_tick_event_loop`).
+    pub fn run_cleanup_hooks(&mut self) {
         loop {
+            // The hooks re-enter the VM, so no borrow of `rare_data` is held while they run.
             let hooks = match self.rare_data.as_deref_mut() {
                 Some(rare) if !rare.cleanup_hooks.is_empty() => {
                     core::mem::take(&mut rare.cleanup_hooks)

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3372,6 +3372,14 @@ extern "C" JS_EXPORT napi_status napi_remove_async_cleanup_hook(napi_async_clean
     }
 
     napi_env env = handle->env;
+
+    if (handle->started.load(std::memory_order_acquire)) {
+        // The hook's completion, possibly from another thread: no preamble and no
+        // last-error write (Node's version touches no env state either).
+        env->asyncCleanupHookCompleted(handle);
+        return napi_ok;
+    }
+
     NAPI_PREAMBLE_NO_PENDING_CHECK(env);
 
     // Always attempt removal like Node.js (no VM terminating check)

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -21,11 +21,14 @@
 #include <wtf/ListHashSet.h>
 #include <wtf/Lock.h>
 
+#include <atomic>
 #include <optional>
 #include <unordered_set>
 #include <variant>
 
 extern "C" void napi_internal_register_cleanup_zig(napi_env env);
+extern "C" bool napi_internal_exit_waits_for_cleanup_hooks(napi_env env);
+extern "C" void napi_internal_tick_event_loop(napi_env env);
 extern "C" void napi_internal_threadsafe_function_env_teardown(void* tsfn);
 extern "C" void napi_internal_suppress_crash_on_abort_if_desired();
 extern "C" void Bun__crashHandler(const char* message, size_t message_len);
@@ -124,6 +127,9 @@ napi_status defineProperty(napi_env env, JSC::JSObject* to, const napi_property_
 // itself has already run (that call is how it signals completion).
 struct napi_async_cleanup_hook_handle__ {
     napi_env env;
+    // Set by NapiEnv::drain() before it calls the hook: from then on, removing the
+    // handle is the completion drain() waits for (Node: AsyncCleanupHookInfo::started).
+    std::atomic<bool> started { false };
 
     explicit napi_async_cleanup_hook_handle__(napi_env env)
         : env(env)
@@ -365,9 +371,11 @@ public:
         return handle.release();
     }
 
+    // napi_remove_async_cleanup_hook on a hook drain() has not called: unregister it.
     // The caller has already rejected null handles (napi_invalid_arg).
     void removeAsyncCleanupHook(napi_async_cleanup_hook_handle handle)
     {
+        ASSERT(!handle->started.load(std::memory_order_relaxed));
         for (auto iter = m_cleanupHooks.begin(), end = m_cleanupHooks.end(); iter != end; ++iter) {
             if (auto* async = std::get_if<Napi::AsyncCleanupHook>(&*iter)) {
                 if (async->handle == handle) {
@@ -377,9 +385,23 @@ public:
             }
         }
 
-        // Freed unconditionally, matching Node: for an already-drained hook
-        // this call is the addon's completion signal.
+        // Freed unconditionally, matching Node (a handle is removed at most once).
         delete handle;
+    }
+
+    // napi_remove_async_cleanup_hook on a hook drain() has called, from any thread
+    // (Node: FinishAsyncCleanupHook). The decrement lets drain() go on and, in a
+    // worker, free this env: nothing of `this` is used after it.
+    void asyncCleanupHookCompleted(napi_async_cleanup_hook_handle handle)
+    {
+        ASSERT(handle->started.load(std::memory_order_relaxed));
+        delete handle;
+        const ::BunVmHandleRef* vmHandle = Bun__VmHandle__retainRef(m_vmHandle);
+        size_t previous = m_asyncCleanupHooksInFlight.fetch_sub(1, std::memory_order_acq_rel);
+        ASSERT_UNUSED(previous, previous > 0);
+        // Gives back the keep-alive drain() took for this hook, which also wakes the loop.
+        Bun__VmHandle__refKeepAlive(vmHandle, BunLoopKind::Regular, -1);
+        Bun__VmHandle__release(vmHandle);
     }
 
     bool inGC() const
@@ -581,6 +603,8 @@ private:
     Napi::HookSet m_cleanupHooks;
     JSC::Strong<JSC::Unknown> m_pendingException;
     size_t m_cleanupHookCounter = 0;
+    // Async cleanup hooks called and not yet completed (Node: request_waiting_).
+    std::atomic<size_t> m_asyncCleanupHooksInFlight { 0 };
 
     WTF::Lock m_threadSafeFunctionsLock;
     WTF::HashSet<void*> m_threadSafeFunctions WTF_GUARDED_BY_LOCK(m_threadSafeFunctionsLock);
@@ -606,6 +630,7 @@ private:
     void drain()
     {
         std::vector<Napi::EitherCleanupHook> hooks = getHooks();
+        size_t started = 0;
 
         for (const Napi::EitherCleanupHook& hook : hooks) {
             if (auto set_iter = m_cleanupHooks.find(hook); set_iter != m_cleanupHooks.end()) {
@@ -621,14 +646,49 @@ private:
             } else {
                 auto& async = std::get<Napi::AsyncCleanupHook>(hook);
                 ASSERT(async.function != nullptr);
-                // The addon owns the handle and frees it via
-                // napi_remove_async_cleanup_hook, possibly after this returns (#37201).
+                // Counted, and keeping the loop alive (so that the wait below parks
+                // in its poll), before the call: the hook may complete inside it.
+                m_asyncCleanupHooksInFlight.fetch_add(1, std::memory_order_acq_rel);
+                // Env teardown runs on the regular loop, never inside a macro.
+                Bun__VmHandle__refKeepAlive(m_vmHandle, BunLoopKind::Regular, 1);
+                // A started handle keeps this env allocated (Node: the handle holds a
+                // reference to the env) for the completion that may still come.
+                ref();
+                started++;
+                async.handle->started.store(true, std::memory_order_release);
                 async.function(async.handle, async.data);
             }
             // Same invariant as the finalizer loop in cleanup(): a hook
             // that leaked an exception must not poison the next hook.
             clearExceptionsBetweenFinalizers();
         }
+
+        if (waitForAsyncCleanupHooks()) {
+            // The global object's reference keeps `this` alive through cleanup().
+            while (started--) {
+                deref();
+            }
+        }
+    }
+
+    // After Node's Environment::CleanupHandles(), per env: the batch has been called,
+    // now the async hooks in it get to finish. Their completions arrive through the
+    // env's event loop. Unbounded, as in Node: a hook that never completes keeps the
+    // env alive. False if it returns with hooks still in flight: an exit that does not
+    // wait for them (see the Rust side of napi_internal_exit_waits_for_cleanup_hooks).
+    bool waitForAsyncCleanupHooks()
+    {
+        if (m_asyncCleanupHooksInFlight.load(std::memory_order_acquire) == 0) {
+            return true;
+        }
+        if (!napi_internal_exit_waits_for_cleanup_hooks(this)) {
+            return false;
+        }
+        do {
+            napi_internal_tick_event_loop(this);
+        } while (m_asyncCleanupHooksInFlight.load(std::memory_order_acquire) > 0);
+        clearExceptionsBetweenFinalizers();
+        return true;
     }
 };
 

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -227,6 +227,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
             if vm.exit_handler.exit_code == 0 {
                 vm.exit_handler.exit_code = 1;
             }
+            vm.exit_handler.requested = true;
             vm.on_exit();
             vm.global_exit();
         }

--- a/src/runtime/cli/repl_command.rs
+++ b/src/runtime/cli/repl_command.rs
@@ -219,6 +219,7 @@ impl<'a, 'r> ReplRunner<'a, 'r> {
                 vm.print_error_like_object_to_console(exception);
             }
             vm.exit_handler.exit_code = 1;
+            vm.exit_handler.requested = true;
             vm.on_exit();
             vm.global_exit();
         }

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -55,10 +55,12 @@ impl Taskable for napi_async_work {
 }
 impl Taskable for ThreadSafeFunction {
     const TAG: TaskTag = task_tag::ThreadSafeFunction;
-    /// `this` is the TSFN itself, which the env's cleanup hook (`env_teardown`,
-    /// run with the exit handlers before the queue is released) already
-    /// neutralised or freed. Nothing to do, and `this` must not be dereferenced.
-    unsafe fn release_unrun(_: *mut Self) {}
+    /// `this` is the TSFN itself, which `env_teardown` (run before the queue is
+    /// released) left allocated for this task's sake. Only the task's hold to drop.
+    unsafe fn release_unrun(this: *mut Self) {
+        // SAFETY: fn contract; a queued task keeps its TSFN allocated.
+        unsafe { ThreadSafeFunction::task_taken(this) };
+    }
 }
 impl Taskable for NapiFinalizerTask {
     const TAG: TaskTag = task_tag::NapiFinalizerTask;
@@ -2361,6 +2363,32 @@ extern "C" fn napi_internal_register_cleanup_zig(env_: napi_env) {
     );
 }
 
+/// See [`VirtualMachine::exit_waits_for_cleanup`].
+#[unsafe(no_mangle)]
+extern "C" fn napi_internal_exit_waits_for_cleanup_hooks(env_: napi_env) -> bool {
+    // SAFETY: caller (`NapiEnv::drain()`, on the env's thread) guarantees env_
+    // is non-null.
+    let env = unsafe { &*env_ };
+    env.to_js().bun_vm().exit_waits_for_cleanup()
+}
+
+/// One turn of the env's event loop, for `NapiEnv::drain()` while it waits for
+/// the addon's async cleanup hooks to complete.
+#[unsafe(no_mangle)]
+extern "C" fn napi_internal_tick_event_loop(env_: napi_env) {
+    // SAFETY: caller (`NapiEnv::drain()`, on the env's thread) guarantees env_
+    // is non-null.
+    let env = unsafe { &*env_ };
+    let global = env.to_js();
+    // The poll parks (the hooks hold keep-alives) until a completion arrives:
+    // a task posted to the loop, or a keep-alive given back from another thread.
+    global.bun_vm().as_mut().auto_tick_active();
+    global.bun_vm().as_mut().tick();
+    // We are inside `on_exit()`'s walk of these, so the finalizers that shutdown
+    // queues there (`NapiFinalizerTask::schedule`) only run if each turn does it.
+    global.bun_vm().as_mut().run_cleanup_hooks();
+}
+
 #[unsafe(no_mangle)]
 extern "C" fn napi_internal_suppress_crash_on_abort_if_desired() {
     if bun_core::env_var::feature_flag::BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT
@@ -2447,7 +2475,8 @@ extern "C" fn napi_internal_enqueue_finalizer(
 
 /// Ownership: the JS thread owns this allocation while the env lives and frees
 /// it in `destroy`; from `env_teardown_done` on it belongs to the remaining
-/// `thread_count` references, and whoever drops the last one frees it.
+/// `thread_count` references and to a task still queued for it
+/// (`tasks_queued`), and whoever drops the last of those frees it.
 // TODO: generate a compile-time version of this instead of runtime checking
 pub(crate) struct ThreadSafeFunction {
     /// thread-safe functions can be "referenced" and "unreferenced". A
@@ -2504,6 +2533,11 @@ pub(crate) struct ThreadSafeFunction {
     /// so a thread that drops the last `thread_count` reference must not free
     /// it (Node's `kClosed`).
     pub(crate) env_teardown_done: AtomicBool,
+    /// Tasks queued for this object (a dispatch or the finalizer task, at most
+    /// one at a time). The loop can still turn after `env_teardown` (an env
+    /// waiting for its async cleanup hooks ticks it), so a queued task holds the
+    /// allocation like a thread reference does, until `task_taken`.
+    pub(crate) tasks_queued: AtomicU8,
 }
 
 pub(crate) enum TsfnCallback {
@@ -2591,11 +2625,16 @@ impl ThreadSafeFunction {
     /// (`dispatch_one`) and the drain goes on; the VM's termination ends it.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub(crate) fn on_dispatch(this: *mut ThreadSafeFunction) {
-        // SAFETY: `this` is a live heap allocation owned by the event loop
-        // dispatch; `env_dead` is atomic so a shared reborrow suffices.
+        // SAFETY: the task that is being dispatched kept `this` allocated.
+        if unsafe { ThreadSafeFunction::task_taken(this) } {
+            // The env is gone: nothing to dispatch, and `this` may already be freed.
+            return;
+        }
+        // SAFETY: the env has not finished tearing this down, so only this
+        // thread frees it (`destroy`, below); `env_dead` is atomic so a shared
+        // reborrow suffices.
         if unsafe { (*this).env_dead.load(Ordering::SeqCst) } {
-            // `env_teardown` already released everything and owns the free
-            // decision. The loop this task came from is being destroyed.
+            // `env_teardown` is in progress on this thread and owns the rest.
             return;
         }
         // SAFETY: as above.
@@ -2691,12 +2730,18 @@ impl ThreadSafeFunction {
                     self.callback = TsfnCallback::Js(StrongOptional::empty());
                     self.poll_ref.disable();
                     let self_ptr: *mut Self = self;
-                    let Some(loop_) = self.loop_mut() else {
+                    let Some(event_loop) = self.event_loop.as_mut() else {
                         // env torn down: `env_teardown` owns the finalize + free.
                         return;
                     };
-                    loop_.enqueue_task(Task::init(self_ptr));
+                    // SAFETY: BackRef invariant while `Some`; JS thread, outside tick().
+                    let loop_ = unsafe { event_loop.get_mut() };
+                    if loop_.is_closed_for_tasks() {
+                        return;
+                    }
                     self.has_queued_finalizer = true;
+                    let _ = self.tasks_queued.fetch_add(1, Ordering::SeqCst);
+                    loop_.enqueue_task(Task::init(self_ptr));
                 }
             }
             _ => {
@@ -2929,6 +2974,7 @@ impl ThreadSafeFunction {
                     return;
                 }
                 let ct = ConcurrentTask::create_from(self_ptr);
+                let _ = self.tasks_queued.fetch_add(1, Ordering::SeqCst);
                 if let bun_jsc::vm_handle::Posted::Refused(ct) =
                     self.handle.post(self.loop_kind, ct)
                 {
@@ -2937,6 +2983,7 @@ impl ThreadSafeFunction {
                     // teardown path. Free the task and fall back to Idle.
                     // SAFETY: refused ⇒ we own the task box.
                     unsafe { drop(bun_core::heap::take(ct.as_ptr())) };
+                    let _ = self.tasks_queued.fetch_sub(1, Ordering::SeqCst);
                     self.dispatch_state
                         .store(DispatchState::Idle as u8, Ordering::SeqCst);
                 }
@@ -2958,6 +3005,8 @@ impl ThreadSafeFunction {
         // the sole owner; reclaim the Box up front so the body works on owned
         // state and the drop at scope end frees it.
         let mut self_ = unsafe { bun_core::heap::take(this) };
+        // The finalizer task that brought us here was the only one outstanding.
+        debug_assert_eq!(self_.tasks_queued.load(Ordering::SeqCst), 0);
         self_.unref();
 
         if let Some(env) = self_.env.as_ref() {
@@ -2986,7 +3035,7 @@ impl ThreadSafeFunction {
     /// (`env_teardown`) or be safe to drop here (a creation that failed).
     ///
     /// SAFETY: `this` is a live allocation from `new`, the caller holds no
-    /// lock on it, and no other thread holds a reference.
+    /// lock on it, no other thread holds a reference, and no task is queued for it.
     unsafe fn free_orphaned(this: *mut ThreadSafeFunction) {
         // SAFETY: per this function's contract, `this` is a live allocation from `new`.
         drop(unsafe { bun_core::heap::take(this) });
@@ -3072,11 +3121,41 @@ impl ThreadSafeFunction {
         self.event_loop = None;
         drop(self.env.take());
         self.env_teardown_done.store(true, Ordering::SeqCst);
-        // Cleanup hooks are the loop's last tick: a task still queued for this
-        // TSFN will never run (and its `release_unrun` does not dereference it).
-        // With no thread_count reference left, nobody else can reach this, so
-        // free it here.
+        self.nothing_holds_it()
+    }
+
+    /// Caller holds `lock`. Once `env_teardown_done` is published, whoever makes
+    /// this true frees the allocation.
+    fn nothing_holds_it(&self) -> bool {
         self.thread_count.load(Ordering::SeqCst) <= 0
+            && self.tasks_queued.load(Ordering::SeqCst) == 0
+    }
+
+    /// A task pointing at this object came off the loop, to be run or not.
+    /// Returns true when the env is gone. The caller must not touch `this`
+    /// after that: either this call freed it (the task was the last hold), or
+    /// a thread dropping the last reference may free it at any moment now.
+    ///
+    /// SAFETY: `this` is the live allocation a task queued for it points at, and
+    /// the caller holds no lock on it.
+    unsafe fn task_taken(this: *mut ThreadSafeFunction) -> bool {
+        let (torn_down, free) = {
+            // SAFETY: live allocation per the fn contract; the guard holds the
+            // lock by raw pointer, so the borrows here end before the free below.
+            let _g = unsafe { (*this).lock.lock_guard() };
+            // SAFETY: as above.
+            let this_ref = unsafe { &*this };
+            let previous = this_ref.tasks_queued.fetch_sub(1, Ordering::SeqCst);
+            debug_assert!(previous > 0);
+            let torn_down = this_ref.env_teardown_done.load(Ordering::SeqCst);
+            (torn_down, torn_down && this_ref.nothing_holds_it())
+        };
+        if free {
+            // SAFETY: env teardown released everything it owned, and no thread
+            // reference and no task is left to reach this.
+            unsafe { ThreadSafeFunction::free_orphaned(this) };
+        }
+        torn_down
     }
 
     /// `napi_ref_threadsafe_function` — JS thread only (as in Node).
@@ -3140,10 +3219,11 @@ impl ThreadSafeFunction {
         if self.env_dead.load(Ordering::SeqCst) {
             // The event loop we were created on is gone (`env_teardown` set
             // this under the lock we hold). Never schedule onto it. Whoever
-            // drops the last reference frees us -- but only once teardown has
-            // released the JS-thread-owned resources; until then it owns us
-            // and will free us itself if we are the last to let go.
-            let orphaned = prev_remaining == 1 && self.env_teardown_done.load(Ordering::SeqCst);
+            // drops the last hold (a thread reference, or a task still queued)
+            // frees us -- but only once teardown has released the
+            // JS-thread-owned resources; until then it owns us and will free
+            // us itself if we are the last to let go.
+            let orphaned = self.env_teardown_done.load(Ordering::SeqCst) && self.nothing_holds_it();
             return (NapiStatus::ok as napi_status, orphaned);
         }
 
@@ -3180,8 +3260,7 @@ extern "C" fn napi_internal_threadsafe_function_env_teardown(tsfn: *mut c_void) 
     // `env_teardown` both remove the entry before freeing. Exclusive borrow
     // scoped to this call.
     if unsafe { (*this).env_teardown() } {
-        // SAFETY: no other thread holds a reference (thread_count == 0) and no
-        // event-loop task will run again.
+        // SAFETY: no thread holds a reference and no task is queued for it.
         unsafe { ThreadSafeFunction::free_orphaned(this) };
     }
 }
@@ -3253,6 +3332,7 @@ extern "C" fn napi_create_threadsafe_function(
         closing: AtomicU8::new(ClosingState::NotClosing as u8),
         env_dead: AtomicBool::new(false),
         env_teardown_done: AtomicBool::new(false),
+        tasks_queued: AtomicU8::new(0),
     });
 
     // Register with the env so that VM/worker teardown neutralizes this TSFN

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -176,6 +176,28 @@
             ],
         },
         {
+            "target_name": "test_async_cleanup_hook_wait",
+            "sources": ["test_async_cleanup_hook_wait.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
+            ],
+        },
+        {
+            "target_name": "test_tsfn_released_at_exit",
+            "sources": ["test_tsfn_released_at_exit.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
+            ],
+        },
+        {
             "target_name": "test_cleanup_hook_duplicates",
             "sources": ["test_cleanup_hook_duplicates.c"],
             "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -359,7 +359,6 @@ nativeTests.test_get_all_property_names_throwing_proxy_traps = () => {
       napi_key_keep_numbers,
     ),
   );
-
 };
 
 nativeTests.test_get_all_property_names_get_prototype_throws_in_descriptor_walk = () => {
@@ -1441,6 +1440,97 @@ nativeTests.test_async_cleanup_hook_remove_nonexistent = () => {
 nativeTests.test_async_cleanup_hook_tsfn_release = () => {
   const addon = require("./build/Debug/test_async_cleanup_hook_tsfn_release.node");
   addon.start();
+};
+
+const asyncCleanupHookWaitAddon = require("node:path").join(__dirname, "build/Debug/test_async_cleanup_hook_wait.node");
+
+// Resolves with the worker's exit code. A worker that posts a message is
+// terminated by us when it does.
+function runWorker(code) {
+  const { Worker } = require("node:worker_threads");
+  const worker = new Worker(code, { eval: true });
+  return new Promise((resolve, reject) => {
+    worker.on("error", reject);
+    worker.on("exit", resolve);
+    worker.on("message", () => worker.terminate());
+  });
+}
+
+// Env teardown waits for an async cleanup hook until the addon removes the
+// hook's handle, and turns the event loop meanwhile (test_async_cleanup_hook_wait.c
+// describes the `mode`s of completing the hook). `where` picks the exit that
+// tears the env down:
+//   "main": this thread's loop runs dry
+//   "worker": a Worker's loop runs dry
+//   "worker-exit": a Worker calls process.exit(); its env is still waited for
+//   "worker-terminate": the parent terminates a busy Worker; same
+//   "exit": this thread calls process.exit(); no env teardown (as in Node),
+//           except under BUN_DESTRUCT_VM_ON_EXIT, where the hooks are called
+//           but not waited for
+//   "uncaught": this thread dies of an uncaught exception; same as "exit"
+nativeTests.test_async_cleanup_hook_wait = async (_gc, mode, where) => {
+  const armInWorker = `require(${JSON.stringify(asyncCleanupHookWaitAddon)}).arm(${JSON.stringify(mode)});`;
+  switch (where) {
+    case "main":
+      require(asyncCleanupHookWaitAddon).arm(mode);
+      break;
+    case "worker":
+      console.log("worker exited with", await runWorker(armInWorker));
+      break;
+    case "worker-exit":
+      console.log("worker exited with", await runWorker(armInWorker + "process.exit(0);"));
+      break;
+    case "worker-terminate": {
+      const stayBusyAndReport = `setInterval(() => {}, 1000); require("node:worker_threads").parentPort.postMessage("armed");`;
+      console.log("worker exited with", await runWorker(armInWorker + stayBusyAndReport));
+      break;
+    }
+    case "exit":
+      require(asyncCleanupHookWaitAddon).arm(mode);
+      process.exit(0);
+      break;
+    case "uncaught":
+      // main.js turns an uncaught exception into process.exit(); this wants the real thing.
+      process.removeAllListeners("uncaughtException");
+      require(asyncCleanupHookWaitAddon).arm(mode);
+      setTimeout(() => {
+        throw new Error("uncaught, on purpose");
+      }, 0);
+      break;
+    default:
+      throw new Error(`unknown where: ${where}`);
+  }
+};
+
+// test_tsfn_released_at_exit.c: a threadsafe function's last event loop task is
+// still queued when its env is torn down. Here a second env, torn down later,
+// waits for its async cleanup hook and so dispatches that task.
+nativeTests.test_tsfn_released_at_exit_then_wait = () => {
+  require("./build/Debug/test_tsfn_released_at_exit.node").start("release");
+  require(asyncCleanupHookWaitAddon).arm("tsfn");
+};
+
+// Same, with the env's own second round of cleanup hooks dispatching the task.
+nativeTests.test_tsfn_released_at_exit_rearm = () => {
+  require("./build/Debug/test_tsfn_released_at_exit.node").start("rearm");
+};
+
+// Bun-only: the function freed once in each of the two ways a queued task ends,
+// dispatched (by the waiting env) or released unrun (by the Worker's teardown).
+nativeTests.test_tsfn_released_at_exit_in_worker = async () => {
+  const { napiThreadsafeFunctionLiveCount } = require("bun:internal-for-testing");
+  const path = require("node:path");
+  const releaseAddon = path.join(__dirname, "build/Debug/test_tsfn_released_at_exit.node");
+  const before = napiThreadsafeFunctionLiveCount();
+  const start = `require(${JSON.stringify(releaseAddon)}).start("release");`;
+  const unrun = await runWorker(start);
+  const liveAfterUnrun = napiThreadsafeFunctionLiveCount() - before;
+  const dispatched = await runWorker(start + `require(${JSON.stringify(asyncCleanupHookWaitAddon)}).arm("tsfn");`);
+  const liveAfterDispatched = napiThreadsafeFunctionLiveCount() - before;
+  // Printed after both workers are gone, so these lines cannot interleave with
+  // what the addons print from the workers.
+  console.log(`released unrun: worker exited with ${unrun}, live=${liveAfterUnrun}`);
+  console.log(`dispatched: worker exited with ${dispatched}, live=${liveAfterDispatched}`);
 };
 
 nativeTests.test_cleanup_hook_duplicates = () => {

--- a/test/napi/napi-app/test_async_cleanup_hook_wait.c
+++ b/test/napi/napi-app/test_async_cleanup_hook_wait.c
@@ -1,0 +1,240 @@
+// Env teardown has to wait for an async cleanup hook until the addon calls
+// napi_remove_async_cleanup_hook on its handle, and has to keep turning the
+// event loop meanwhile, because that is how the completion gets back to the
+// thread that runs the teardown (Node: Environment::CleanupHandles()). Only
+// then do the env's finalizers run.
+//
+// arm(mode) registers two hooks. Teardown calls hooks in reverse registration
+// order, so "late" runs first and defers its completion in the way `mode`
+// selects, and "early" runs second and completes at once. An instance data
+// finalizer then reports which hooks had completed by the time it ran. The
+// lines come out in the same order under Node and Bun:
+//
+//   late: hook
+//   early: hook
+//   early: done
+//   late: done
+//   instance data finalizer: early done=1 late done=1
+//
+// A teardown that does not wait prints the finalizer line with "late done=0"
+// right after "early: done", whatever the late completion does afterwards.
+//
+// mode "tsfn": the late hook hands its handle to a thread. The thread reports
+// back through a threadsafe function the hook created, and the function's
+// callback, on the env's thread, completes the hook.
+//
+// mode "thread": the late hook hands its handle to a thread and that thread
+// completes it directly, after a short sleep so the teardown is already waiting.
+//
+// mode "never": the late hook never completes. A teardown that waits never
+// ends (as in Node); this is for the exits that must not wait.
+#include <node_api.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+typedef HANDLE thread_t;
+#define THREAD_RETURN DWORD WINAPI
+static void thread_sleep_ms(int ms) { Sleep(ms); }
+static int thread_start(thread_t* thread, LPTHREAD_START_ROUTINE body, void* arg) {
+  *thread = CreateThread(NULL, 0, body, arg, 0, NULL);
+  return *thread != NULL;
+}
+static void thread_join(thread_t thread) {
+  WaitForSingleObject(thread, INFINITE);
+  CloseHandle(thread);
+}
+#else
+#include <pthread.h>
+#include <unistd.h>
+typedef pthread_t thread_t;
+#define THREAD_RETURN void*
+static void thread_sleep_ms(int ms) { usleep(ms * 1000); }
+static int thread_start(thread_t* thread, void* (*body)(void*), void* arg) {
+  return pthread_create(thread, NULL, body, arg) == 0;
+}
+static void thread_join(thread_t thread) { pthread_join(thread, NULL); }
+#endif
+
+static void print_line(const char* line) {
+  printf("%s\n", line);
+  fflush(stdout);
+}
+
+static int early_done = 0;
+static int late_done = 0;
+
+// The line and the flag come before the removal. In mode "thread" this runs on
+// a thread that nothing joins, and the removal is what lets the teardown go on
+// and end the process. The finalizer reads the flag after the removal has been
+// observed, which is what orders the write before the read.
+static void complete(const char* name, int* done, napi_async_cleanup_hook_handle handle) {
+  printf("%s: done\n", name);
+  fflush(stdout);
+  *done = 1;
+  napi_status status = napi_remove_async_cleanup_hook(handle);
+  if (status != napi_ok) {
+    printf("%s: napi_remove_async_cleanup_hook failed: status=%d\n", name, (int)status);
+    fflush(stdout);
+  }
+}
+
+static void early_hook(napi_async_cleanup_hook_handle handle, void* data) {
+  print_line("early: hook");
+  complete("early", &early_done, handle);
+}
+
+static void instance_data_finalizer(napi_env env, void* data, void* hint) {
+  printf("instance data finalizer: early done=%d late done=%d\n", early_done, late_done);
+  fflush(stdout);
+}
+
+struct late_state {
+  napi_env env;
+  napi_async_cleanup_hook_handle handle;
+  napi_threadsafe_function tsfn;
+  thread_t thread;
+};
+
+static struct late_state late;
+
+// A step of the late hook's completion did not go as planned. Report it and
+// complete the hook right away: the output then differs from the expected
+// lines, instead of the teardown waiting forever for a completion that is not
+// coming.
+static void late_failed(const char* what, int status) {
+  printf("late: %s failed: status=%d\n", what, status);
+  fflush(stdout);
+  complete("late", &late_done, late.handle);
+}
+
+// mode "tsfn"
+
+static THREAD_RETURN tsfn_thread(void* arg) {
+  napi_status status = napi_call_threadsafe_function(late.tsfn, NULL, napi_tsfn_blocking);
+  if (status != napi_ok) {
+    late_failed("napi_call_threadsafe_function", (int)status);
+  }
+  return 0;
+}
+
+static void release_tsfn(napi_threadsafe_function_release_mode mode) {
+  napi_status status = napi_release_threadsafe_function(late.tsfn, mode);
+  if (status != napi_ok) {
+    printf("late: napi_release_threadsafe_function failed: status=%d\n", (int)status);
+    fflush(stdout);
+  }
+}
+
+static void tsfn_callback(napi_env env, napi_value js_callback, void* context, void* data) {
+  thread_join(late.thread);
+  if (env == NULL) {
+    // The env was torn down with the call still queued, and is handing the
+    // call's data back: the call was never made.
+    late_failed("dispatch of the call", 0);
+    return;
+  }
+  complete("late", &late_done, late.handle);
+  release_tsfn(napi_tsfn_release);
+}
+
+static napi_status create_tsfn(napi_env env) {
+  // A cleanup hook runs outside of any napi callback, so it has no handle
+  // scope for the values it creates.
+  napi_handle_scope scope;
+  napi_status status = napi_open_handle_scope(env, &scope);
+  if (status != napi_ok) return status;
+  napi_value name;
+  status = napi_create_string_utf8(env, "late", NAPI_AUTO_LENGTH, &name);
+  if (status == napi_ok) {
+    status = napi_create_threadsafe_function(env, NULL, NULL, name, 0, 1, NULL, NULL, NULL, tsfn_callback, &late.tsfn);
+  }
+  napi_close_handle_scope(env, scope);
+  return status;
+}
+
+static void late_hook_tsfn(napi_async_cleanup_hook_handle handle, void* data) {
+  print_line("late: hook");
+  late.handle = handle;
+  napi_status status = create_tsfn(late.env);
+  if (status != napi_ok) {
+    late_failed("create_tsfn", (int)status);
+    return;
+  }
+  if (!thread_start(&late.thread, tsfn_thread, NULL)) {
+    release_tsfn(napi_tsfn_abort);
+    late_failed("thread_start", 0);
+  }
+}
+
+// mode "thread"
+
+static THREAD_RETURN complete_thread(void* arg) {
+  thread_sleep_ms(100);
+  complete("late", &late_done, late.handle);
+  return 0;
+}
+
+static void late_hook_thread(napi_async_cleanup_hook_handle handle, void* data) {
+  print_line("late: hook");
+  late.handle = handle;
+  // Nothing joins this thread: the process (or the worker that loaded the
+  // addon) ends as soon as the hook is complete.
+  if (!thread_start(&late.thread, complete_thread, NULL)) {
+    late_failed("thread_start", 0);
+  }
+}
+
+// mode "never"
+
+static void late_hook_never(napi_async_cleanup_hook_handle handle, void* data) {
+  print_line("late: hook");
+  // Kept, as an addon that means to complete later would keep it: the handle
+  // and the env it keeps alive are then not leaks to a leak checker.
+  late.handle = handle;
+}
+
+static napi_value arm(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  char mode[16] = {0};
+  napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+  if (argc >= 1) {
+    napi_get_value_string_utf8(env, argv[0], mode, sizeof mode, NULL);
+  }
+
+  napi_async_cleanup_hook late_hook;
+  if (strcmp(mode, "tsfn") == 0) {
+    late_hook = late_hook_tsfn;
+  } else if (strcmp(mode, "thread") == 0) {
+    late_hook = late_hook_thread;
+  } else if (strcmp(mode, "never") == 0) {
+    late_hook = late_hook_never;
+  } else {
+    napi_throw_error(env, NULL, "unknown mode");
+    return NULL;
+  }
+
+  late.env = env;
+  napi_async_cleanup_hook_handle early_handle;
+  napi_status status = napi_set_instance_data(env, &late, instance_data_finalizer, NULL);
+  if (status == napi_ok) {
+    status = napi_add_async_cleanup_hook(env, early_hook, NULL, &early_handle);
+  }
+  if (status == napi_ok) {
+    status = napi_add_async_cleanup_hook(env, late_hook, NULL, NULL);
+  }
+  printf("armed: %s status=%d\n", mode, (int)status);
+  fflush(stdout);
+  return NULL;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_value fn;
+  napi_create_function(env, "arm", NAPI_AUTO_LENGTH, arm, NULL, &fn);
+  napi_set_named_property(env, exports, "arm", fn);
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/napi/napi-app/test_cleanup_hook_mixed_order.c
+++ b/test/napi/napi-app/test_cleanup_hook_mixed_order.c
@@ -24,13 +24,15 @@ static void regular_hook2(void* arg) {
 static void async_hook1(napi_async_cleanup_hook_handle handle, void* arg) {
     async1_executed = execution_order++;
     printf("async_hook1 executed at position %d\n", async1_executed);
-    // Signal completion (this is required for async hooks)
+    // Signal completion (this is required for async hooks: teardown waits for it)
+    napi_remove_async_cleanup_hook(handle);
 }
 
 static void async_hook2(napi_async_cleanup_hook_handle handle, void* arg) {
     async2_executed = execution_order++;
     printf("async_hook2 executed at position %d\n", async2_executed);
-    // Signal completion (this is required for async hooks)
+    // Signal completion (this is required for async hooks: teardown waits for it)
+    napi_remove_async_cleanup_hook(handle);
 }
 
 napi_value test_function(napi_env env, napi_callback_info info) {

--- a/test/napi/napi-app/test_tsfn_released_at_exit.c
+++ b/test/napi/napi-app/test_tsfn_released_at_exit.c
@@ -1,0 +1,123 @@
+// A threadsafe function released from an env cleanup hook (the usual way an
+// addon tears one down) queues its last dispatch on the event loop right as
+// the env is being torn down. The env's teardown used to be the loop's last
+// turn, so the queued task could never run. Now an env that waits for its
+// async cleanup hooks turns the loop again, and that task is dispatched: the
+// threadsafe function has to stay allocated until the task has been taken off
+// the loop, and be freed after that (ASAN sees either mistake).
+//
+// start("release"): just that. Load this addon before one that waits (the
+// other env's wait dispatches the task), or in a Worker (the Worker's teardown
+// releases the task unrun); either way the function is freed exactly once.
+//
+// start("rearm"): in addition, the function's finalizer, which teardown runs,
+// registers an async cleanup hook that completes from a thread. The same env
+// then waits in a second round of hooks and dispatches its own stale task.
+#include <node_api.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#define THREAD_RETURN DWORD WINAPI
+static void thread_sleep_ms(int ms) { Sleep(ms); }
+static int thread_start(LPTHREAD_START_ROUTINE body, void* arg) {
+  HANDLE thread = CreateThread(NULL, 0, body, arg, 0, NULL);
+  if (thread == NULL) return 0;
+  CloseHandle(thread);
+  return 1;
+}
+#else
+#include <pthread.h>
+#include <unistd.h>
+#define THREAD_RETURN void*
+static void thread_sleep_ms(int ms) { usleep(ms * 1000); }
+static int thread_start(void* (*body)(void*), void* arg) {
+  pthread_t thread;
+  if (pthread_create(&thread, NULL, body, arg) != 0) return 0;
+  pthread_detach(thread);
+  return 1;
+}
+#endif
+
+static void print_line(const char* line) {
+  printf("%s\n", line);
+  fflush(stdout);
+}
+
+static napi_threadsafe_function tsfn;
+static int rearm;
+
+static THREAD_RETURN complete_thread(void* arg) {
+  thread_sleep_ms(50);
+  print_line("async hook: done");
+  napi_remove_async_cleanup_hook((napi_async_cleanup_hook_handle)arg);
+  return 0;
+}
+
+static void async_hook(napi_async_cleanup_hook_handle handle, void* data) {
+  print_line("async hook: called");
+  if (!thread_start(complete_thread, handle)) {
+    print_line("async hook: thread_start failed");
+    napi_remove_async_cleanup_hook(handle);
+  }
+}
+
+static void tsfn_finalizer(napi_env env, void* data, void* hint) {
+  if (!rearm) {
+    print_line("tsfn finalizer");
+    return;
+  }
+  napi_status status = napi_add_async_cleanup_hook(env, async_hook, NULL, NULL);
+  printf("tsfn finalizer: registered an async cleanup hook, status=%d\n", (int)status);
+  fflush(stdout);
+}
+
+static void call_js(napi_env env, napi_value js_callback, void* context, void* data) {}
+
+static void release_at_exit(void* data) {
+  napi_status status = napi_release_threadsafe_function(tsfn, napi_tsfn_release);
+  printf("released tsfn at exit: status=%d\n", (int)status);
+  fflush(stdout);
+}
+
+static napi_value start(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  char mode[16] = {0};
+  napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+  if (argc >= 1) {
+    napi_get_value_string_utf8(env, argv[0], mode, sizeof mode, NULL);
+  }
+  if (strcmp(mode, "rearm") == 0) {
+    rearm = 1;
+  } else if (strcmp(mode, "release") != 0) {
+    napi_throw_error(env, NULL, "unknown mode");
+    return NULL;
+  }
+
+  napi_value name;
+  napi_status status = napi_create_string_utf8(env, "released at exit", NAPI_AUTO_LENGTH, &name);
+  if (status == napi_ok) {
+    status = napi_create_threadsafe_function(env, NULL, NULL, name, 0, 1, NULL, tsfn_finalizer, NULL, call_js, &tsfn);
+  }
+  if (status == napi_ok) {
+    // The function must not be what keeps the process (or Worker) running.
+    status = napi_unref_threadsafe_function(env, tsfn);
+  }
+  if (status == napi_ok) {
+    status = napi_add_env_cleanup_hook(env, release_at_exit, NULL);
+  }
+  printf("started: %s status=%d\n", mode, (int)status);
+  fflush(stdout);
+  return NULL;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+  napi_value fn;
+  napi_create_function(env, "start", NAPI_AUTO_LENGTH, start, NULL, &fn);
+  napi_set_named_property(env, exports, "start", fn);
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -2094,6 +2094,176 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
     });
   });
 
+  // test_async_cleanup_hook_wait.c registers an "early" hook that completes at
+  // once and a "late" hook that completes later, once env teardown is already
+  // waiting for it, and an instance data finalizer that reports what had
+  // completed when it ran. Teardown calls the whole batch (latest registered
+  // first), turns the event loop until every handle has been removed, and only
+  // then runs the finalizers, so the lines always come out in this order. A
+  // teardown that does not wait prints the finalizer line with "late done=0"
+  // right after "early: done".
+  describe.concurrent("async cleanup hooks", () => {
+    const hookLines = [
+      "late: hook",
+      "early: hook",
+      "early: done",
+      "late: done",
+      "instance data finalizer: early done=1 late done=1",
+    ];
+
+    it("env teardown waits for a hook that completes through the event loop", async () => {
+      // The late hook's thread reports back through a threadsafe function the
+      // hook created; the function's callback completes the hook.
+      const output = await checkSameOutput("test_async_cleanup_hook_wait", ["tsfn", "main"]);
+      // Pinned so matching Node on a shared failure cannot pass. printf() via
+      // the Windows CRT emits \r\n, so split on either ending.
+      expect(output.split(/\r?\n/)).toEqual(["armed: tsfn status=0", "resolved to undefined", ...hookLines]);
+    });
+
+    it("a Worker's env teardown waits the same way", async () => {
+      const output = await checkSameOutput("test_async_cleanup_hook_wait", ["tsfn", "worker"]);
+      expect(output.split(/\r?\n/)).toEqual([
+        "armed: tsfn status=0",
+        ...hookLines,
+        "worker exited with 0",
+        "resolved to undefined",
+      ]);
+    });
+
+    it("a Worker that calls process.exit() still waits", async () => {
+      const output = await checkSameOutput("test_async_cleanup_hook_wait", ["tsfn", "worker-exit"]);
+      expect(output.split(/\r?\n/)).toEqual([
+        "armed: tsfn status=0",
+        ...hookLines,
+        "worker exited with 0",
+        "resolved to undefined",
+      ]);
+    });
+
+    it("a Worker that its parent terminates still waits", async () => {
+      // Script is forbidden in the Worker by then; the completion is native.
+      const output = await checkSameOutput("test_async_cleanup_hook_wait", ["tsfn", "worker-terminate"]);
+      expect(output.split(/\r?\n/)).toEqual([
+        "armed: tsfn status=0",
+        ...hookLines,
+        "worker exited with 1",
+        "resolved to undefined",
+      ]);
+    });
+
+    // The two below complete the hook from another thread, which Node only
+    // supports by accident (its bookkeeping is not thread safe), so Bun's
+    // output is checked on its own instead of against Node. The wait parks in
+    // the loop's poll, so these also hang unless the completion wakes it.
+    it("a completion signalled from another thread ends the wait", async () => {
+      const output = await runOn(bunExe(), "test_async_cleanup_hook_wait", ["thread", "main"]);
+      expect(output.trim().split(/\r?\n/)).toEqual(["armed: thread status=0", "resolved to undefined", ...hookLines]);
+    });
+
+    it("a completion signalled from another thread ends a Worker's wait", async () => {
+      // The Worker frees its env as soon as the wait ends, while the other
+      // thread may still be inside napi_remove_async_cleanup_hook.
+      const output = await runOn(bunExe(), "test_async_cleanup_hook_wait", ["thread", "worker"]);
+      expect(output.trim().split(/\r?\n/)).toEqual([
+        "armed: thread status=0",
+        ...hookLines,
+        "worker exited with 0",
+        "resolved to undefined",
+      ]);
+    });
+
+    // Node runs no cleanup hooks at all when the main thread exits through
+    // process.exit() or a fatal error, and neither does Bun ("env teardown on
+    // the main thread" above). BUN_DESTRUCT_VM_ON_EXIT is the exception: the
+    // VM is destroyed like a worker's, so the envs are torn down first. Even
+    // then the exit does not wait for a hook: the late hook here never
+    // completes, so a wait would never end.
+    const destruct = { BUN_DESTRUCT_VM_ON_EXIT: "1" };
+    const unwaitedLines = [
+      "late: hook",
+      "early: hook",
+      "early: done",
+      "instance data finalizer: early done=1 late done=0",
+    ];
+
+    it("process.exit() on the main thread does not wait for the hooks when it tears the envs down", async () => {
+      const output = await runOn(bunExe(), "test_async_cleanup_hook_wait", ["never", "exit"], destruct);
+      expect(output.trim().split(/\r?\n/)).toEqual(["armed: never status=0", ...unwaitedLines]);
+    });
+
+    it("an uncaught exception on the main thread does not wait for the hooks when it tears the envs down", async () => {
+      await using proc = spawn({
+        cmd: [bunExe(), join(__dirname, "napi-app/main.js"), "test_async_cleanup_hook_wait", '["never", "uncaught"]'],
+        env: { ...bunEnv, ...destruct },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout.trim().split(/\r?\n/)).toEqual([
+        "armed: never status=0",
+        "resolved to undefined",
+        ...unwaitedLines,
+      ]);
+      expect(stderr).toContain("uncaught, on purpose");
+      expect(exitCode).toBe(1);
+    });
+
+    // Turning the loop during teardown dispatches tasks that were queued for
+    // threadsafe functions whose env was torn down earlier. The function has
+    // to stay allocated for its task (ASAN catches a use after free here) and
+    // be freed once the task is gone.
+    it("dispatches the queued task of a threadsafe function an earlier env released at exit", async () => {
+      const output = await runOn(bunExe(), "test_tsfn_released_at_exit_then_wait", []);
+      expect(output.trim().split(/\r?\n/)).toEqual([
+        "started: release status=0",
+        "armed: tsfn status=0",
+        "released tsfn at exit: status=0",
+        "tsfn finalizer",
+        ...hookLines,
+      ]);
+    });
+
+    it("dispatches the queued task of the env's own threadsafe function in a second round of hooks", async () => {
+      const output = await runOn(bunExe(), "test_tsfn_released_at_exit_rearm", []);
+      expect(output.trim().split(/\r?\n/)).toEqual([
+        "started: rearm status=0",
+        "released tsfn at exit: status=0",
+        "tsfn finalizer: registered an async cleanup hook, status=0",
+        "async hook: called",
+        "async hook: done",
+      ]);
+    });
+
+    it("frees a threadsafe function whose task a Worker released unrun, or dispatched, exactly once", async () => {
+      const output = await runOn(bunExe(), "test_tsfn_released_at_exit_in_worker", []);
+      expect(output.trim().split(/\r?\n/)).toEqual([
+        "started: release status=0",
+        "released tsfn at exit: status=0",
+        "tsfn finalizer",
+        "started: release status=0",
+        "armed: tsfn status=0",
+        "released tsfn at exit: status=0",
+        "tsfn finalizer",
+        ...hookLines,
+        "released unrun: worker exited with 0, live=0",
+        "dispatched: worker exited with 0, live=0",
+        "resolved to undefined",
+      ]);
+    });
+
+    it("calls sync and async hooks from one queue in reverse registration order", async () => {
+      // Each async hook here removes its handle inside the hook itself, so the
+      // wait ends as soon as the batch has been called.
+      const output = await checkSameOutput("test_cleanup_hook_mixed_order", []);
+      expect(output.split(/\r?\n/).slice(-4)).toEqual([
+        "async_hook2 executed at position 0",
+        "regular_hook2 executed at position 1",
+        "async_hook1 executed at position 2",
+        "regular_hook1 executed at position 3",
+      ]);
+    });
+  });
+
   describe("error handling", () => {
     it("removing non-existent env cleanup hook should not crash", async () => {
       // Test that removing non-existent hooks doesn't crash the process
@@ -2108,7 +2278,10 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
     it("hook handle stays valid until the addon removes it (#37201)", async () => {
       // An async cleanup hook releases a threadsafe function whose finalizer
       // then calls napi_remove_async_cleanup_hook; the handle must not be
-      // freed when the hook returns.
+      // freed when the hook returns. That finalizer is also what completes the
+      // hook, and during shutdown finalizers are queued as VM cleanup hooks,
+      // not on the event loop: the wait for the hook has to run that queue,
+      // or this hangs.
       const output = await checkSameOutput("test_async_cleanup_hook_tsfn_release", []);
       // Pin the successful lifecycle, so matching Node on a shared failure
       // (non-zero status in both) cannot pass. printf() via the Windows CRT

--- a/test/napi/node-napi-tests/test/node-api/test_async_cleanup_hook/do.test.ts
+++ b/test/napi/node-napi-tests/test/node-api/test_async_cleanup_hook/do.test.ts
@@ -1,3 +1,4 @@
+import { isWindows } from "harness";
 import { basename, dirname, sep } from "node:path";
 import { build, run } from "../../../harness";
 
@@ -6,8 +7,9 @@ test("build", async () => {
 });
 
 for (const file of Array.from(new Bun.Glob("*.js").scanSync(import.meta.dir))) {
-  // crash inside uv_async_init
-  test.todoIf(["test.js"].includes(file))(file, () => {
+  // The hooks complete through a uv_async_t on the env's loop, which Bun only
+  // has on Windows: on POSIX, uv_async_init crashes (not implemented).
+  test.todoIf(file === "test.js" && !isWindows)(file, () => {
     run(dirname(import.meta.dir), basename(import.meta.dir) + sep + file);
   });
 }


### PR DESCRIPTION
### Problem
- Env teardown does not wait for `napi_add_async_cleanup_hook` hooks. `NapiEnv::drain()` (`src/jsc/bindings/napi.h`) calls each hook once and goes on to the finalizers. Node's `test_async_cleanup_hook` dies with `ObjectFinalizer: Assertion 'cleanup_hook_count == 6' failed`.
- Node (`Environment::CleanupHandles`) turns the event loop until the addon has removed every handle with `napi_remove_async_cleanup_hook`.

### Fix
- `drain()` counts the async hooks it calls and takes a loop keep-alive per hook. After the batch it turns the env's loop, parked in the poll, until the count is zero. Removing a started handle completes it: the count goes down and the keep-alive goes back, which wakes the poll.
- Turning the loop at teardown dispatches tasks queued for threadsafe functions that an earlier env's teardown freed (a use after free). A queued task now holds the function too (`tasks_queued`). Taking it off the loop, run or not, frees the function when it was the last hold.
- A `process.exit()` or fatal error on the main thread does not wait (`exit_waits_for_cleanup`). Since #40028 it does not tear the envs down at all, as in Node, except under `BUN_DESTRUCT_VM_ON_EXIT`, where the hooks are called and now not waited for. A worker waits however it exits, as in Node.
- Verified: `test/napi/napi.test.ts` "async cleanup hooks" (8 of 12 fail on main, 3 catch the use after free under ASAN) and Node's `test_async_cleanup_hook`, now enabled on Windows (exit 3 on main).

### Background
- An async cleanup hook is a teardown callback that may finish later. The addon owns its handle (#37204) and removes it to say the hook is done.
- Once its env is gone, a threadsafe function is freed by whoever drops the last hold on it. The holds were the addon threads' references only.
- The loop's keep-alive count is what makes its poll block. `Bun__VmHandle__refKeepAlive` adjusts it from any thread and wakes the loop.

<details><summary>Notes</summary>

- Each turn of the wait also runs the VM cleanup hook queue: shutdown puts finalizers there rather than on the loop, and a finalizer is what completes the hook in the #37201 fixture.
- Supersedes #34136. That PR conflicts with #37204 and ticks only the platform I/O loop, which runs neither event loop tasks nor the deferred finalizer queue, so the #37201 fixture would deadlock with it.
- The completion path touches no env state besides the count, so a thread the hook started can call `napi_remove_async_cleanup_hook` too. A started handle holds a reference to its env (as in Node), so an exit that does not wait leaves the env allocated for a completion that still arrives. `asyncCleanupHookCompleted` retains the VM handle before the decrement. After the decrement the waiting thread may go on and, for a Worker, free the env, so nothing of the env is touched past that point. The keep-alive release is a no-op once the VM is closed.
- `task_taken` reports a torn-down env, and `on_dispatch` then touches nothing: once the task's hold is gone, an addon thread dropping the last reference frees the function at any moment.
- `tasks_queued`: at most one task is outstanding per function (a dispatch is posted only from Idle, the finalizer task only once). `env_teardown`, `release_locked` and `task_taken` decide under the function's lock, so exactly one of them frees. On the main thread a function whose task is never dispatched stays allocated until exit, reachable from the queue. A Worker's teardown releases the queue, and `release_unrun` frees it (pinned with `napiThreadsafeFunctionLiveCount`).
- The use after free needs two addons (one releases a threadsafe function at exit, a later one waits), or one addon whose threadsafe function finalizer registers an async hook. Both are tests now.
- The wait is per env, so two addons with async hooks wait one after the other. Node fires all addons' hooks from one queue and waits once. Left as is: it only costs time when several addons have slow hooks.
- Rebased on #40028, which added `ExitHandler::requested` and the teardown skip on requested main-thread exits. This PR's copy of the flag is dropped, and the two no-wait tests now run under `BUN_DESTRUCT_VM_ON_EXIT=1`, the only configuration in which such an exit still reaches the hooks. Also rebased on #39810 (`env_teardown` no longer hands a queue back with a null env on the main thread), which changed neighbouring lines of `env_teardown`. The `tasks_queued` hold is orthogonal to it.
- Turning the loop on a natural exit can run what is still queued or unref'd. This happens only while a started hook is outstanding, the state in which Node turns its loop too. A hook that never completes hangs the exit, as in Node. Without the keep-alive the wait spun at 100% CPU whenever nothing else kept the loop active. It parks now (a 2 s wait costs 0.2 s of CPU).
- Completing a hook from a foreign thread is not compared against Node: Node's bookkeeping for it is not thread safe, and its env then leaks (no instance data finalizer runs). Those tests check Bun's output on its own.
- The fixture creates its threadsafe function inside the hook on purpose: one created earlier is torn down by its own cleanup hook in the same batch, in Node too. It prints before it removes the handle, since nothing joins its thread. An instance data finalizer reports what had completed, which makes the output of an unfixed build deterministic (checked three times against main's source).
- Ran: `test/napi/napi.test.ts` (186 pass), the other `test/napi/*.test.ts`, `node-napi-tests/test/node-api` (45 pass, 22 todo), `js-native-api` (3 timeouts that also time out with main's source in this debug build), `test/internal/source-lints`, `process.test.js` and `worker_destruction.test.ts` (same failures with main's source). The "async cleanup hooks", "#37201" and "threadsafe" blocks also pass under the ASAN lane's settings (`BUN_DESTRUCT_VM_ON_EXIT=1`, LeakSanitizer with `test/leaksan.supp`). Windows x64: the "async cleanup hooks", "#37201" and "threadsafe" blocks (29 pass) and the flipped `test_async_cleanup_hook` suite pass. The suite fails with the stock build.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/napi/node-napi-tests/test/node-api/test_async_cleanup_hook/do.test.ts, test/napi/napi.test.ts

<!-- robobun:evidence:end -->

