### PR TITLE
bun test: kill only the timed-out test's processes, and a concurrent group's once it is done

### DIFF
--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -74,7 +74,7 @@ test("wat", async () => {
 }, 500); // test must run in <500ms
 ```
 
-In `bun:test`, a timeout throws an uncatchable exception to force the test to stop running and fail. Bun also kills any child processes spawned in the test, so they don't linger as zombie processes.
+In `bun:test`, a timeout throws an uncatchable exception to force the test to stop running and fail. Bun also kills any child processes the test (or its `beforeEach`/`afterEach` hooks) spawned that are still running, so they don't linger as zombie processes. Processes started in `beforeAll` or by earlier tests are left alone.
 
 The default timeout for each test is 5000ms (5 seconds) unless you override it with this timeout option or `jest.setTimeout()`.
 
@@ -117,7 +117,7 @@ test(
 
 ### 🧟 Zombie Process Killer
 
-When a test times out, Bun kills any still-running processes that the test spawned with `Bun.spawn`, `Bun.spawnSync`, or `node:child_process`, and logs a message to the console. This prevents zombie processes from lingering after timed-out tests.
+When a test times out, Bun kills any still-running processes that the test (or its `beforeEach`/`afterEach` hooks) spawned with `Bun.spawn`, `Bun.spawnSync`, or `node:child_process`, and logs a message to the console. This prevents zombie processes from lingering after timed-out tests. Processes spawned in `beforeAll` or by earlier tests are not affected; a `beforeAll` or `afterAll` hook that times out only has its own processes killed.
 
 ## Test Modifiers
 

--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -119,6 +119,8 @@ test(
 
 When a test times out, Bun kills any still-running processes that the test (or its `beforeEach`/`afterEach` hooks) spawned with `Bun.spawn`, `Bun.spawnSync`, or `node:child_process`, and logs a message to the console. This prevents zombie processes from lingering after timed-out tests. Processes spawned in `beforeAll` or by earlier tests are not affected; a `beforeAll` or `afterAll` hook that times out only has its own processes killed.
 
+When a `test.concurrent` test times out, Bun cannot tell its processes apart from those of the concurrent tests running alongside it. Bun waits until those tests have finished, then kills the processes that any of them spawned and that are still running.
+
 ## Test Modifiers
 
 ### test.skip

--- a/src/jsc/ProcessAutoKiller.rs
+++ b/src/jsc/ProcessAutoKiller.rs
@@ -9,9 +9,11 @@ bun_core::declare_scope!(AutoKiller, hidden);
 pub struct ProcessAutoKiller {
     /// Keys are intrusively-refcounted `*Process` (ref()'d on insert, deref()'d
     /// on remove/drop). Stored as raw ptr for identity-hash semantics.
-    pub(crate) processes: ArrayHashMap<*mut Process, ()>,
+    pub(crate) processes: ArrayHashMap<*mut Process, u32>,
     pub enabled: bool,
     pub(crate) ever_enabled: bool,
+    /// Map value of each tracked process; the test runner begins a new one per execution group.
+    scope: u32,
 }
 
 impl ProcessAutoKiller {
@@ -24,34 +26,56 @@ impl ProcessAutoKiller {
         self.enabled = false;
     }
 
-    pub fn kill(&mut self) -> Result {
-        Result {
-            processes: self.kill_processes(),
-        }
+    pub fn begin_scope(&mut self) {
+        self.scope = self.scope.wrapping_add(1);
     }
 
-    fn kill_processes(&mut self) -> u32 {
+    pub fn kill(&mut self) -> Result {
         let mut count: u32 = 0;
         while let Some(entry) = self.processes.pop() {
-            {
-                // SAFETY: every key in `processes` was ref()'d on insert and is
-                // live until the matching deref() below; popped entry is
-                // exclusively owned for this scope so `&mut Process` is unaliased.
-                let p: &mut Process = unsafe { &mut *entry.key };
-                if !p.has_exited() {
-                    bun_core::scoped_log!(AutoKiller, "process.kill {}", p.pid);
-                    count += p.kill(SignalCode::DEFAULT.0).is_ok() as u32;
-                }
-            }
-            // SAFETY: key live until this releases the ref taken on insert.
-            unsafe { Process::deref(entry.key) };
+            count += Self::kill_and_release(entry.key);
         }
-        count
+        Result { processes: count }
+    }
+
+    /// Earlier scopes stay tracked (and alive) so that [`Self::kill`] still covers them.
+    pub fn kill_scope(&mut self) -> Result {
+        let mut count: u32 = 0;
+        let mut index = self.processes.len();
+        while index > 0 {
+            index -= 1;
+            if self.processes.values()[index] != self.scope {
+                continue;
+            }
+            // Walking backwards, so the entry swapped into `index` was already visited.
+            let (process, _) = self.processes.swap_remove_at(index);
+            count += Self::kill_and_release(process);
+        }
+        Result { processes: count }
+    }
+
+    /// `process` must already be removed from `processes`; this releases its ref.
+    fn kill_and_release(process: *mut Process) -> u32 {
+        let killed = {
+            // SAFETY: every key in `processes` was ref()'d on insert and is
+            // live until the matching deref() below; the entry was removed
+            // from the map by the caller, so `&mut Process` is unaliased.
+            let p: &mut Process = unsafe { &mut *process };
+            if p.has_exited() {
+                false
+            } else {
+                bun_core::scoped_log!(AutoKiller, "process.kill {}", p.pid);
+                p.kill(SignalCode::DEFAULT.0).is_ok()
+            }
+        };
+        // SAFETY: key live until this releases the ref taken on insert.
+        unsafe { Process::deref(process) };
+        killed as u32
     }
 
     pub fn clear(&mut self) {
         for process in self.processes.keys() {
-            // SAFETY: see kill_processes — key is live until deref().
+            // SAFETY: see kill_and_release — key is live until deref().
             unsafe { Process::deref(*process) };
         }
 
@@ -69,7 +93,7 @@ impl ProcessAutoKiller {
         if self.enabled {
             // Alloc failure means we never took
             // a ref, so just bail. `put` here is fallible only on OOM.
-            if self.processes.put(process.as_ptr(), ()).is_err() {
+            if self.processes.put(process.as_ptr(), self.scope).is_err() {
                 return;
             }
             // SAFETY: caller passes a live Process; we take a ref to extend its
@@ -99,7 +123,7 @@ pub struct Result {
 impl Drop for ProcessAutoKiller {
     fn drop(&mut self) {
         for process in self.processes.keys() {
-            // SAFETY: see kill_processes — key is live until deref().
+            // SAFETY: see kill_and_release — key is live until deref().
             unsafe { Process::deref(*process) };
         }
         // `self.processes` storage freed by its own Drop.

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -307,8 +307,7 @@ impl Execution {
     /// The kill-only half of [`handle_timeout`]: reaps a timed-out test's spawned processes without touching the runner's queue, so it may run from inside `spawnSync`'s isolated loop.
     pub(crate) fn kill_dangling_processes_on_timeout(&mut self, global_this: &JSGlobalObject) {
         // if the concurrent group has one sequence and the sequence has an active entry that has timed out,
-        //   kill any dangling processes
-        // when using test.concurrent(), we can't do this because it could kill multiple tests at once.
+        //   kill the dangling processes it spawned
         if let Some(current_group) = self.active_group() {
             // reshaped for borrowck — capture range, drop &mut group, re-borrow sequences
             let (start, end) = (current_group.sequence_start, current_group.sequence_end);
@@ -319,17 +318,11 @@ impl Execution {
                     // SAFETY: arena-owned entry, alive for lifetime of BunTest
                     let entry = unsafe { entry.as_ref() };
                     let now = Timespec::now_force_real_time();
-                    if entry.timespec.order(&now) == core::cmp::Ordering::Less {
-                        // SAFETY: bun_vm() returns the live per-thread VM.
-                        let kill_count = global_this.bun_vm().as_mut().auto_killer.kill();
-                        if kill_count.processes > 0 {
-                            bun_core::pretty_errorln!(
-                                "<d>killed {} dangling process{}<r>",
-                                kill_count.processes,
-                                if kill_count.processes != 1 { "es" } else { "" },
-                            );
-                            bun_core::Output::flush();
-                        }
+                    // EPOCH: this entry has no timeout; a timer left armed by an earlier entry fired.
+                    if !entry.timespec.eql(&Timespec::EPOCH)
+                        && entry.timespec.order(&now) == core::cmp::Ordering::Less
+                    {
+                        kill_dangling_processes(end - start, global_this);
                     }
                 }
             }
@@ -568,7 +561,9 @@ impl Execution {
 
     fn on_group_started(global_this: &JSGlobalObject) {
         // SAFETY: bun_vm() returns the live per-thread VM.
-        global_this.bun_vm().as_mut().auto_killer.enable();
+        let auto_killer = &mut global_this.bun_vm().as_mut().auto_killer;
+        auto_killer.begin_scope();
+        auto_killer.enable();
     }
 
     fn on_group_completed(global_this: &JSGlobalObject) {
@@ -1044,7 +1039,12 @@ fn step_sequence_one(
             // SAFETY: re-deref after run_test_callback; sequence_ptr still valid (sequences is a
             // Box<[ExecutionSequence]>, never reallocated during execution).
             let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
-            let _ = next_item.evaluate_timeout(sequence, now);
+            if next_item.evaluate_timeout(sequence, now) {
+                // The callback overran its deadline synchronously, so handle_timeout may never have run.
+                // SAFETY: group points into buntest.execution.groups; read-only.
+                let g = unsafe { group.as_ref() };
+                kill_dangling_processes(g.sequence_end - g.sequence_start, global_this);
+            }
 
             // the result is available immediately; advance the sequence and run again.
             Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
@@ -1083,5 +1083,21 @@ fn step_sequence_one(
         }
         Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
         return Ok(None); // run again
+    }
+}
+
+/// Skipped for test.concurrent() groups: their tests share one scope, so this would hit other tests' children.
+fn kill_dangling_processes(group_sequence_count: usize, global_this: &JSGlobalObject) {
+    if group_sequence_count != 1 {
+        return;
+    }
+    let kill_count = global_this.bun_vm().as_mut().auto_killer.kill_scope();
+    if kill_count.processes > 0 {
+        bun_core::pretty_errorln!(
+            "<d>killed {} dangling process{}<r>",
+            kill_count.processes,
+            if kill_count.processes != 1 { "es" } else { "" },
+        );
+        bun_core::Output::flush();
     }
 }

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -111,6 +111,8 @@ pub struct ConcurrentGroup {
     pub(crate) remaining_incomplete_entries: usize,
     /// used by beforeAll to skip directly to afterAll if it fails
     pub(crate) failure_skip_to: usize,
+    /// A concurrent sequence timed out; `on_group_completed` kills the scope the sequences share.
+    pub(crate) kill_scope_on_completion: bool,
 }
 
 impl ConcurrentGroup {
@@ -122,6 +124,7 @@ impl ConcurrentGroup {
             remaining_incomplete_entries: sequence_end - sequence_start,
             failure_skip_to: next_index,
             next_sequence_index: 0,
+            kill_scope_on_completion: false,
         }
     }
 
@@ -132,6 +135,13 @@ impl ConcurrentGroup {
         self.sequence_end = next_sequence_end;
         self.remaining_incomplete_entries = self.sequence_end - self.sequence_start;
         true
+    }
+
+    /// A group of one sequence is killed right away instead (see [`kill_dangling_processes`]).
+    pub(crate) fn on_sequence_timed_out(&mut self) {
+        if self.sequence_end - self.sequence_start > 1 {
+            self.kill_scope_on_completion = true;
+        }
     }
 
     pub(crate) fn sequences<'a>(&self, execution: &'a Execution) -> &'a [ExecutionSequence] {
@@ -566,7 +576,11 @@ impl Execution {
         auto_killer.enable();
     }
 
-    fn on_group_completed(global_this: &JSGlobalObject) {
+    fn on_group_completed(global_this: &JSGlobalObject, group: &ConcurrentGroup) {
+        // The scope begun in on_group_started is still the current one.
+        if group.kill_scope_on_completion {
+            kill_scope_dangling_processes(global_this);
+        }
         // SAFETY: bun_vm() returns the live per-thread VM.
         let vm = global_this.bun_vm().as_mut();
         // Under --isolate the swap between files kills and clears the tracked set.
@@ -846,7 +860,7 @@ fn step_group(
         // SAFETY: re-deref after step_group_one; disjoint from this.sequences read below.
         let group = unsafe { &mut *group_ptr.as_ptr() };
         group.executing = false;
-        Execution::on_group_completed(global_this);
+        Execution::on_group_completed(global_this, group);
 
         // if there is one sequence and it failed, skip to the next group
         let (start, end, failure_skip_to) =
@@ -976,6 +990,8 @@ fn step_sequence_one(
         // SAFETY: arena-owned entry
         let active_entry = unsafe { &mut *active_entry_ptr.as_ptr() };
         if active_entry.evaluate_timeout(sequence, now) {
+            // SAFETY: group points into buntest.execution.groups; nothing else references it here.
+            unsafe { &mut *group.as_ptr() }.on_sequence_timed_out();
             Execution::advance_sequence(buntest_ptr, sequence_ptr, group);
             return Ok(None); // run again
         }
@@ -1041,8 +1057,9 @@ fn step_sequence_one(
             let sequence = unsafe { &mut *sequence_ptr.as_ptr() };
             if next_item.evaluate_timeout(sequence, now) {
                 // The callback overran its deadline synchronously, so handle_timeout may never have run.
-                // SAFETY: group points into buntest.execution.groups; read-only.
-                let g = unsafe { group.as_ref() };
+                // SAFETY: group points into buntest.execution.groups; nothing else references it here.
+                let g = unsafe { &mut *group.as_ptr() };
+                g.on_sequence_timed_out();
                 kill_dangling_processes(g.sequence_end - g.sequence_start, global_this);
             }
 
@@ -1086,11 +1103,15 @@ fn step_sequence_one(
     }
 }
 
-/// Skipped for test.concurrent() groups: their tests share one scope, so this would hit other tests' children.
+/// Skipped for test.concurrent() groups: their tests share one scope, which `on_group_completed` kills instead.
 fn kill_dangling_processes(group_sequence_count: usize, global_this: &JSGlobalObject) {
     if group_sequence_count != 1 {
         return;
     }
+    kill_scope_dangling_processes(global_this);
+}
+
+fn kill_scope_dangling_processes(global_this: &JSGlobalObject) {
     let kill_count = global_this.bun_vm().as_mut().auto_killer.kill_scope();
     if kill_count.processes > 0 {
         bun_core::pretty_errorln!(

--- a/test/cli/test/test-timeout-behavior.test.ts
+++ b/test/cli/test/test-timeout-behavior.test.ts
@@ -291,3 +291,102 @@ test.concurrent("a test without a timeout keeps its processes when an earlier te
   expect(combined).toContain(" 2 pass\n");
   expect(exitCode).toBe(0);
 });
+
+// Consecutive test.concurrent tests share one group and one auto-kill scope, so
+// the runner cannot tell which of them spawned a process. A timeout in such a
+// group kills the scope once the group is done. These two files wait for the
+// runner to kill a child, which can take a while on a slow machine, hence the
+// generous default timeout; the timeouts under test are set per test.
+const waitForKill = ["--timeout=30000"];
+
+test.concurrent("test.concurrent: the children of timed-out tests are killed once the group is done", async () => {
+  const { combined, exitCode } = await runTestFile(
+    /* ts */ `
+      import { afterAll, describe, expect, test } from "bun:test";
+
+      const children: ReturnType<typeof spawnEcho>[] = [];
+      afterAll(() => children.forEach(child => child.kill()));
+
+      describe("hanging", () => {
+        test.concurrent.each(["a", "b"])(
+          "hangs %s",
+          async () => {
+            children.push(spawnEcho());
+            await new Promise(() => {});
+          },
+          100,
+        );
+      });
+
+      // Spawns from a continuation, well before its deadline.
+      test.concurrent("hangs after returning to the event loop", async () => {
+        await new Promise(resolve => setImmediate(resolve));
+        children.push(spawnEcho());
+        await new Promise(() => {});
+      }, 500);
+
+      test("the children were killed", async () => {
+        expect(children).toHaveLength(3);
+        await Promise.all(children.map(child => child.exited));
+        expect(children.map(child => child.signalCode)).toEqual(["SIGTERM", "SIGTERM", "SIGTERM"]);
+      });
+    `,
+    waitForKill,
+  );
+
+  expect(combined.match(/killed \d+ dangling process(?:es)?/g)).toEqual(["killed 3 dangling processes"]);
+  expect(combined).toContain("(fail) hanging > hangs a");
+  expect(combined).toContain("(fail) hanging > hangs b");
+  expect(combined).toContain("(fail) hangs after returning to the event loop");
+  expect(combined).toContain("(pass) the children were killed");
+  expect(combined).toContain(" 1 pass\n");
+  expect(combined).toContain(" 3 fail\n");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent(
+  "test.concurrent: nothing is killed while a sibling of the timed-out test is still running",
+  async () => {
+    const { combined, exitCode } = await runTestFile(
+      /* ts */ `
+      import { afterAll, expect, test } from "bun:test";
+
+      const children: ReturnType<typeof spawnEcho>[] = [];
+      afterAll(() => children.forEach(child => child.kill()));
+
+      let fromTimedOut: ReturnType<typeof spawnEcho>;
+      const timedOutStarted = Promise.withResolvers<void>();
+
+      test.concurrent("times out", async () => {
+        fromTimedOut = spawnEcho();
+        children.push(fromTimedOut);
+        timedOutStarted.resolve();
+        await new Promise(() => {});
+      }, 100);
+
+      test.concurrent("sibling that keeps running", async () => {
+        children.push(spawnEcho());
+        await timedOutStarted.promise;
+        // The 100ms deadline above was armed before this timer, so the runner has
+        // handled that timeout by the time this resolves, with this test still running.
+        await Bun.sleep(200);
+        expect(await echo(fromTimedOut, "still here")).toBe("still here");
+      });
+
+      test("both children were killed once the group was done", async () => {
+        await Promise.all(children.map(child => child.exited));
+        expect(children.map(child => child.signalCode)).toEqual(["SIGTERM", "SIGTERM"]);
+      });
+    `,
+      waitForKill,
+    );
+
+    expect(combined.match(/killed \d+ dangling process(?:es)?/g)).toEqual(["killed 2 dangling processes"]);
+    expect(combined).toContain("(fail) times out");
+    expect(combined).toContain("(pass) sibling that keeps running");
+    expect(combined).toContain("(pass) both children were killed once the group was done");
+    expect(combined).toContain(" 2 pass\n");
+    expect(combined).toContain(" 1 fail\n");
+    expect(exitCode).toBe(1);
+  },
+);

--- a/test/cli/test/test-timeout-behavior.test.ts
+++ b/test/cli/test/test-timeout-behavior.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isFlaky, isLinux } from "harness";
+import { bunEnv, bunExe, isFlaky, isLinux, tempDir } from "harness";
 import path from "path";
 
 if (isFlaky && isLinux) {
@@ -33,3 +33,261 @@ if (isFlaky && isLinux) {
     expect(combined).toContain("(pass) slow test after test timeout");
   });
 }
+
+// Shared by the inline test files below. An echo child stays alive until it is
+// killed, and `echo()` only gets its message back while the child is alive: a
+// killed child never runs again, so its stdout just reports EOF.
+const echoChildHelpers = /* ts */ `
+  function spawnEcho() {
+    return Bun.spawn({
+      cmd: [process.execPath, "-e", "process.stdin.pipe(process.stdout)"],
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+  }
+
+  async function echo(child: ReturnType<typeof spawnEcho>, message: string) {
+    child.stdin.write(message);
+    await child.stdin.flush();
+    const reader = child.stdout.getReader();
+    let received = "";
+    while (received.length < message.length) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      received += Buffer.from(value).toString();
+    }
+    reader.releaseLock();
+    return received;
+  }
+`;
+
+async function runTestFile(source: string, args: string[] = []) {
+  using dir = tempDir("test-timeout-kill", { "kill.test.ts": echoChildHelpers + source });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", ...args, "./kill.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { combined: stdout + stderr, exitCode };
+}
+
+// Under --isolate the runner also tracks the module-scope child; without it only
+// the hooks and tests are tracked. Either way the timeout must not touch it.
+test.concurrent.each([[[]], [["--isolate"]]])(
+  "a test timeout only kills the processes spawned by that test (args: %p)",
+  async args => {
+    const { combined, exitCode } = await runTestFile(
+      /* ts */ `
+        import { afterAll, beforeAll, expect, test } from "bun:test";
+
+        const children: ReturnType<typeof spawnEcho>[] = [spawnEcho()];
+        afterAll(() => children.forEach(child => child.kill()));
+
+        beforeAll(() => {
+          children.push(spawnEcho());
+        });
+
+        test("spawns a child that outlives the test", () => {
+          children.push(spawnEcho());
+        });
+
+        test("times out", async () => {
+          children.push(spawnEcho());
+          await new Promise(() => {});
+        }, 100);
+
+        test("the other children are still running", async () => {
+          const [fromModuleScope, fromBeforeAll, fromEarlierTest] = children;
+          expect(
+            await Promise.all([
+              echo(fromModuleScope, "module scope"),
+              echo(fromBeforeAll, "beforeAll"),
+              echo(fromEarlierTest, "earlier test"),
+            ]),
+          ).toEqual(["module scope", "beforeAll", "earlier test"]);
+        });
+      `,
+      args,
+    );
+
+    expect(combined).toContain("killed 1 dangling process");
+    expect(combined).not.toContain("dangling processes");
+    expect(combined).toContain("(pass) spawns a child that outlives the test");
+    expect(combined).toContain("(fail) times out");
+    expect(combined).toContain("(pass) the other children are still running");
+    expect(combined).toContain(" 2 pass\n");
+    expect(combined).toContain(" 1 fail\n");
+    expect(exitCode).toBe(1);
+  },
+);
+
+test.concurrent("a test timeout kills the children of its beforeEach hooks, not of beforeAll", async () => {
+  const { combined, exitCode } = await runTestFile(/* ts */ `
+    import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+    let fromBeforeAll: ReturnType<typeof spawnEcho>;
+    let fromBeforeEach: ReturnType<typeof spawnEcho>;
+    afterAll(() => {
+      fromBeforeAll.kill();
+      fromBeforeEach.kill();
+    });
+
+    beforeAll(() => {
+      fromBeforeAll = spawnEcho();
+    });
+
+    describe("with a beforeEach", () => {
+      beforeEach(() => {
+        fromBeforeEach = spawnEcho();
+      });
+
+      test("times out", async () => {
+        await new Promise(() => {});
+      }, 100);
+    });
+
+    test("only the beforeEach child was killed", async () => {
+      await fromBeforeEach.exited;
+      expect(await echo(fromBeforeAll, "beforeAll")).toBe("beforeAll");
+    });
+  `);
+
+  expect(combined).toContain("killed 1 dangling process");
+  expect(combined).not.toContain("dangling processes");
+  expect(combined).toContain("(fail) with a beforeEach > times out");
+  expect(combined).toContain("(pass) only the beforeEach child was killed");
+  expect(combined).toContain(" 1 pass\n");
+  expect(combined).toContain(" 1 fail\n");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("a beforeAll timeout only kills the children of that hook", async () => {
+  const { combined, exitCode } = await runTestFile(/* ts */ `
+    import { afterAll, beforeAll, test } from "bun:test";
+
+    let fromFirstHook: ReturnType<typeof spawnEcho>;
+    let fromTimedOutHook: ReturnType<typeof spawnEcho>;
+
+    beforeAll(() => {
+      fromFirstHook = spawnEcho();
+    });
+
+    beforeAll(async () => {
+      fromTimedOutHook = spawnEcho();
+      await new Promise(() => {});
+    }, 100);
+
+    test("is skipped because beforeAll failed", () => {});
+
+    afterAll(async () => {
+      await fromTimedOutHook.exited;
+      console.log("first hook's child answered:", JSON.stringify(await echo(fromFirstHook, "still here")));
+      fromFirstHook.kill();
+    });
+  `);
+
+  expect(combined).toContain("killed 1 dangling process");
+  expect(combined).not.toContain("dangling processes");
+  expect(combined).toContain('first hook\'s child answered: "still here"');
+  expect(exitCode).toBe(1);
+});
+
+// on_subprocess_exit swap-removes entries, so once a child from an earlier scope
+// exits, the timed-out test's children are no longer the tail of the tracked set.
+test.concurrent("a test timeout kills all of its children after an earlier child exited", async () => {
+  const { combined, exitCode } = await runTestFile(/* ts */ `
+    import { afterAll, beforeAll, expect, test } from "bun:test";
+
+    const children: ReturnType<typeof spawnEcho>[] = [];
+    afterAll(() => children.forEach(child => child.kill()));
+
+    beforeAll(() => {
+      children.push(spawnEcho(), spawnEcho());
+    });
+
+    test("spawns a child that outlives the test", () => {
+      children.push(spawnEcho());
+    });
+
+    test("times out after the first beforeAll child exited", async () => {
+      children.push(spawnEcho(), spawnEcho());
+      children[0].kill();
+      await children[0].exited;
+      await new Promise(() => {});
+    }, 100);
+
+    test("the second beforeAll child and the earlier test's child are still running", async () => {
+      const [, secondFromBeforeAll, fromEarlierTest] = children;
+      expect(await Promise.all([echo(secondFromBeforeAll, "beforeAll"), echo(fromEarlierTest, "earlier test")])).toEqual([
+        "beforeAll",
+        "earlier test",
+      ]);
+    });
+  `);
+
+  expect(combined).toContain("killed 2 dangling processes");
+  expect(combined).toContain("(pass) the second beforeAll child and the earlier test's child are still running");
+  expect(combined).toContain(" 2 pass\n");
+  expect(combined).toContain(" 1 fail\n");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("a test that overruns its timeout without yielding still gets its children killed", async () => {
+  const { combined, exitCode } = await runTestFile(/* ts */ `
+    import { afterAll, test } from "bun:test";
+
+    let child: ReturnType<typeof spawnEcho>;
+    afterAll(() => child.kill());
+
+    test("blocks past its timeout", () => {
+      child = spawnEcho();
+      Bun.sleepSync(150);
+    }, 50);
+
+    test("its child was killed", async () => {
+      await child.exited;
+    });
+  `);
+
+  expect(combined).toContain("killed 1 dangling process");
+  expect(combined).not.toContain("dangling processes");
+  expect(combined).toContain("(fail) blocks past its timeout");
+  expect(combined).toContain("(pass) its child was killed");
+  expect(combined).toContain(" 1 pass\n");
+  expect(combined).toContain(" 1 fail\n");
+  expect(exitCode).toBe(1);
+});
+
+test.concurrent("a test without a timeout keeps its processes when an earlier test's timer fires", async () => {
+  const { combined, exitCode } = await runTestFile(/* ts */ `
+    import { expect, test } from "bun:test";
+
+    // Arms a 50ms timer for this test. The runner never disarms it, so it fires
+    // while the next test is running.
+    test("finishes immediately", () => {}, 50);
+
+    test("has no timeout and spawns a child", async () => {
+      const child = spawnEcho();
+      try {
+        // Nothing in this file can observe the stale timer firing, so wait on a
+        // timer with a later deadline instead: the runner's timer and this one
+        // are in the same heap and fire in deadline order, so the 50ms timer
+        // (armed before this test started) has fired once this resolves.
+        await Bun.sleep(100);
+        expect(await echo(child, "still here")).toBe("still here");
+      } finally {
+        child.kill();
+      }
+    }, 0);
+  `);
+
+  expect(combined).not.toContain("dangling process");
+  expect(combined).toContain("(pass) finishes immediately");
+  expect(combined).toContain("(pass) has no timeout and spawns a child");
+  expect(combined).toContain(" 2 pass\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Replaces #38774 (closed in favor of this PR). Commit 1 is its change, commit 2 adds the `test.concurrent` case.

### Problem
- A timeout kills the wrong processes. `kill_dangling_processes_on_timeout` (`src/runtime/test_runner/Execution.rs:316` on main) calls `auto_killer.kill()`, which kills every process tracked in the file: the children of `beforeAll`, of earlier tests, and of module scope under `--isolate`. It also fires on a stale timer during a test without a timeout, and not at all when a callback overruns its deadline synchronously (#38774).
- In a group of consecutive `test.concurrent` tests it kills nothing, because the tracked set cannot tell the timed-out test's processes from the siblings'. A file of only concurrent tests (the `cat` tests of #37752, 22 tests) leaves all 22 hung children running after `bun test` exits.

### Fix
- `ProcessAutoKiller` tags each process with a scope. `on_group_started` begins one per group, and a timeout calls `kill_scope()` instead of `kill()`. The kill also runs at the synchronous return in `step_sequence_one`, and only after `evaluate_timeout` failed the entry, which an entry without a timeout never is (commit 1, from #38774).
- Several concurrent sequences share one scope. `ConcurrentGroup::on_sequence_timed_out` records the timeout, and `on_group_completed` kills the scope once no sequence of the group runs any more. A group of one sequence is still killed at once (commit 2).
- Correct because a process now dies only when the test, hook, or concurrent group that spawned it timed out, and never while a test that may own it is running. A finished concurrent sibling's leftover process dies too. The docs say so.
- Verified: `test/cli/test/test-timeout-behavior.test.ts`, nine new cases (seven from #38774). Nine of its eleven fail on bun 1.4.0, all pass here. Related suites, clippy and `cargo fmt` in the notes.

### Background
- Group and sequence (`Order.rs`): a test with its `beforeEach`/`afterEach` hooks is one sequence, as is each `beforeAll`/`afterAll` hook. Consecutive `test.concurrent` tests form one group and run interleaved, also across `describe` blocks. Every other group has one sequence.
- `ProcessAutoKiller` (`src/jsc/`): the per-VM set of processes spawned while tracking is on, that is during groups, or the whole file under `--isolate`, whose swap between files still calls `kill()`.
- A timeout is detected by the timer (`handle_timeout`) and by `evaluate_timeout` in `step_sequence_one`, on the timer path and on a synchronous overrun. The concurrent flag is set at the `evaluate_timeout` sites, so a stale timer cannot set it.

<details><summary>Notes</summary>

- History: the first version of this PR gave every process a per-sequence owner, so that a concurrent test's own processes died at its timeout. Review found that it re-implemented #38774 and that the attribution (only spawns before the first I/O `await`) was not worth its size. This PR was then cut down to a delta stacked on #38774, while #38774's session closed that PR in favor of this one. This version carries #38774 unchanged as commit 1 plus the concurrent delta as commit 2. The bot reviews above refer to the earlier versions.
- #38774's tests are carried over in full, including the two cases its closing comment asked to keep: the `beforeEach` child dies with the test while the `beforeAll` child survives, and a `Bun.sleepSync` overrun gets its child killed. The second one is the only case that exercises the kill at the synchronous return: in the `spawnSync` fixture the wait loop kills first.
- Remaining gap, unchanged from main: `--bail` exits while the first failure is reported, before the group completes, so a concurrent timeout under `--bail` still leaves that group's processes behind.
- The two concurrent cases: case one has two hanging tests and one that spawns from a continuation (500ms timeout, so the spawn is long done when it fires); a sequential test after the group awaits the three exits and checks `signalCode`, and the runner must print exactly one `killed 3 dangling processes`. Case two keeps a sibling running past the timed-out test's deadline (a timer armed after that deadline fires after it), proves the hung test's child is still alive with a round trip, and the test after the group sees both children killed with one `killed 2 dangling processes` line. Both files run with `--timeout=30000` so the waits for the kill cannot flake on a slow machine; the timeouts under test are per test. On an unfixed build both fail because the exits never come.
- Debug build: the file takes about 6s (eleven cases, concurrent). Also run on this build: `isolation`, `concurrent-test-glob`, `concurrent`, `concurrent_immediate`, `bun_test`, `failure-skip`, `test-retry-repeats-basic`, `jest-hooks`, `spawnSync`, `spawnsync-isolated-event-loop`, `spawnsync-no-microtask-drain`, `spawn-signal`, `spawn-maxbuf`, `regression/issue/07261`, `node-test`; `cargo clippy` on `bun_jsc` and `bun_runtime`; `cargo fmt --check` on `bun_jsc`.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/test-timeout-behavior.test.ts

<!-- robobun:evidence:end -->