### PR TITLE
paths: bounds-check path normalization and spill thread-local results to the heap

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -213,6 +213,14 @@ let joined = resolve_path::join_string_buf::<platform::Auto>(&mut buf, &[a, b]);
 let rel    = resolve_path::relative(from, to);
 ```
 
+The threadlocal-buffer functions (`join`, `join_abs_string`, `normalize_string`,
+`relative`, ...) accept input of any length. The caller-buffer functions panic
+when the result does not fit the buffer; when the input comes from the user
+(a package.json field, a command operand, an archive entry), use the
+`*_checked` variant (`join_string_buf_checked`, `join_z_buf_checked`,
+`join_abs_string_buf_checked`, `normalize_buf_checked`, `relative_buf_z_checked`,
+...) and report its `None` as `ENAMETOOLONG`.
+
 Use the path-buffer pool to avoid 64 KB stack allocations on Windows
 (`PathBuffer` is `[u8; PATH_MAX_BYTES]`, ~64 KB on Windows):
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -214,12 +214,12 @@ let rel    = resolve_path::relative(from, to);
 ```
 
 The threadlocal-buffer functions (`join`, `join_abs_string`, `normalize_string`,
-`relative`, ...) accept input of any length. The caller-buffer functions panic
-when the result does not fit the buffer; when the input comes from the user
-(a package.json field, a command operand, an archive entry), use the
-`*_checked` variant (`join_string_buf_checked`, `join_z_buf_checked`,
-`join_abs_string_buf_checked`, `normalize_buf_checked`, `relative_buf_z_checked`,
-...) and report its `None` as `ENAMETOOLONG`.
+`relative`, ...) accept input of any length. The `join*_buf`, `normalize*_buf`
+and `relative*_buf` functions panic when the result does not fit the buffer;
+when the input comes from the user (a package.json field, a command operand, an
+archive entry), use the `*_checked` variant (`join_string_buf_checked`,
+`join_z_buf_checked`, `join_abs_string_buf_checked`, `normalize_buf_checked`,
+`relative_buf_z_checked`, ...) and report its `None` as `ENAMETOOLONG`.
 
 Use the path-buffer pool to avoid 64 KB stack allocations on Windows
 (`PathBuffer` is `[u8; PATH_MAX_BYTES]`, ~64 KB on Windows):

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -806,7 +806,13 @@ impl TarballStream {
         let rest: &[OSPathChar] = tokenize_rest_after_first(&pathname[..]);
 
         let mut norm_buf = OSPathBuffer::uninit();
-        if rest.len() >= norm_buf.len() {
+        // The last unit of `norm_buf` is reserved for the NUL.
+        let capacity = norm_buf.len() - 1;
+        let Some(norm_len) = resolve_path::normalize_buf_t::<OSPathChar, platform::Auto>(
+            rest,
+            &mut norm_buf[..capacity],
+        )
+        .map(|normalized| normalized.len()) else {
             bun_core::warn!(
                 "Skipping entry with a path longer than the maximum path length: {}\n",
                 bun_core::fmt::fmt_os_path(rest, Default::default()),
@@ -814,10 +820,7 @@ impl TarballStream {
             self.phase = Phase::WantData;
             self.out_fd = None;
             return Ok(());
-        }
-        let normalized =
-            resolve_path::normalize_buf_t::<OSPathChar, platform::Auto>(rest, &mut norm_buf[..]);
-        let norm_len = normalized.len();
+        };
         norm_buf[norm_len] = 0;
         // SAFETY: norm_buf[norm_len] == 0 written above.
         let path: OSPathZMut =

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1016,12 +1016,14 @@ pub fn is_symlink_target_safe(
     written += link_target_bytes.len();
 
     let mut norm_buf = bun_paths::path_buffer_pool::get();
-    let resolved = bun_paths::resolve_path::normalize_string_generic_t::<u8, true, false>(
+    let Some(resolved) = bun_paths::resolve_path::normalize_string_generic_t::<u8, true, false>(
         &join_buf[..written],
         &mut norm_buf[..],
         b'/',
         |c| c == b'/',
-    );
+    ) else {
+        return false;
+    };
 
     !(strings::eql(resolved, b"..") || strings::has_prefix_comptime(resolved, b"../"))
 }
@@ -1304,14 +1306,19 @@ impl Archiver {
 
                     // pathname = sliceTo(remaining[..len :0], 0)
                     let pathname = slice_to_nul(remaining);
-                    if pathname.is_empty() || pathname.len() >= normalized_buf.len() {
+                    if pathname.is_empty() {
                         continue 'loop_;
                     }
-                    let normalized = bun_paths::resolve_path::normalize_buf_t::<
-                        u8,
-                        bun_paths::platform::Auto,
-                    >(pathname, &mut normalized_buf[..]);
-                    let normalized_len = normalized.len();
+                    // An entry too long to be a path cannot overwrite anything.
+                    let Some(normalized_len) =
+                        bun_paths::resolve_path::normalize_buf_t::<u8, bun_paths::platform::Auto>(
+                            pathname,
+                            &mut normalized_buf[..],
+                        )
+                        .map(|normalized| normalized.len())
+                    else {
+                        continue 'loop_;
+                    };
                     let pathname: &[u8] = &normalized_buf[..normalized_len];
                     if pathname.is_empty() || pathname == b"." {
                         continue 'loop_;
@@ -1498,7 +1505,15 @@ impl Archiver {
                     // at its original `.len()`; therefore `remaining[remaining.len()] == 0`.
                     let pathname: &[OSPathChar] = remaining;
 
-                    if pathname.len() >= normalized_buf.len() {
+                    // The last unit of `normalized_buf` is reserved for the NUL.
+                    let capacity = normalized_buf.len() - 1;
+                    let Some(normalized_len) =
+                        bun_paths::resolve_path::normalize_buf_t::<
+                            OSPathChar,
+                            bun_paths::platform::Auto,
+                        >(pathname, &mut normalized_buf[..capacity])
+                        .map(|normalized| normalized.len())
+                    else {
                         if options.log {
                             bun_core::warn!(
                                 "Skipping entry with a path longer than the maximum path length: {}\n",
@@ -1506,13 +1521,7 @@ impl Archiver {
                             );
                         }
                         continue;
-                    }
-
-                    let normalized = bun_paths::resolve_path::normalize_buf_t::<
-                        OSPathChar,
-                        bun_paths::platform::Auto,
-                    >(pathname, &mut normalized_buf[..]);
-                    let normalized_len = normalized.len();
+                    };
                     normalized_buf[normalized_len] = 0;
                     // SAFETY: we just wrote a NUL at normalized_buf[normalized_len]
                     let path: &mut [OSPathChar] = &mut normalized_buf[..normalized_len];

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -24,21 +24,16 @@ thread_local! {
     static RELATIVE_SPILL: UnsafeCell<Vec<u8>> = const { UnsafeCell::new(Vec::new()) };
 }
 
-/// Fixed output capacity of [`join_abs_string`] / [`join_abs_string_z`]; longer
-/// results spill to the heap.
+/// Fixed capacity of [`join_abs_string`]'s output; longer results spill to the heap.
 const PARSER_JOIN_INPUT_BUFFER_LEN: usize = 4096;
 
-/// Fixed output capacity of [`normalize_string`]; longer results spill to the heap.
+/// Fixed capacity of [`normalize_string`]'s output; longer results spill to the heap.
 const PARSER_BUFFER_LEN: usize = 1024;
 
-/// Heap half of a thread-local output buffer, for the functions that return a
-/// slice that is valid until their next call on this thread (`join`,
-/// `join_abs_string`, `normalize_string`, `relative`, ...). Their fixed buffer
-/// serves every result that fits it. For one that does not, `spill_out` runs
-/// `op` on a fresh heap buffer of `len` bytes and keeps that buffer in `spill`
-/// until the next spilled result of the same function. The previous spilled
-/// result is freed only after `op` returns because it may be among `op`'s
-/// inputs.
+/// Runs `op` on a heap buffer of `len` bytes that `spill` then keeps until the
+/// next result spilled through it, so the result is valid for as long as one in
+/// the fixed thread-local buffers. The previous spill is freed only after `op`
+/// returns: it may be one of `op`'s inputs.
 fn spill_out<'r>(
     spill: &'static std::thread::LocalKey<UnsafeCell<Vec<u8>>>,
     len: usize,
@@ -46,10 +41,10 @@ fn spill_out<'r>(
 ) -> &'static [u8] {
     let mut out = vec![0u8; len];
     let out_start = out.as_mut_ptr();
-    // `'r` is the lifetime of `op`'s result, which may also borrow `op`'s
-    // inputs, so the buffer is handed over detached from `out`'s own borrow.
-    // SAFETY: `out` holds `len` initialized bytes and nothing else touches it
-    // until `op` has returned; `buf` is not used after that.
+    // SAFETY: `out` holds `len` initialized bytes that nothing else touches
+    // until `op` returns, and `buf` is not used after that. (`'r` belongs to
+    // `op`'s result, which may also borrow `op`'s inputs; it is not a borrow of
+    // `out`, which is moved below.)
     let buf: &'r mut [u8] = unsafe { core::slice::from_raw_parts_mut(out_start, len) };
     let result = op(buf);
     let result_len = result.len();
@@ -58,8 +53,7 @@ fn spill_out<'r>(
         if result_start >= out_start && result_start + result_len <= out_start + len {
             (result_start - out_start, out)
         } else {
-            // `op` returned one of its inputs instead (`join_abs_string` with
-            // no parts returns the cwd); keep a copy of it.
+            // An input returned as the result (`join_abs_string` with no parts returns the cwd).
             (0, result.to_vec())
         };
     spill.with(|cell| {
@@ -73,10 +67,8 @@ fn spill_out<'r>(
     })
 }
 
-/// The `join*` / `normalize*` / `relative*` functions that take a caller
-/// buffer and return a plain slice require a buffer that holds their result.
-/// A caller that builds a path from input of unbounded length uses the
-/// `*_checked` variant instead and reports its `None` as `ENAMETOOLONG`.
+/// Callers with input of unbounded length use the `*_checked` variant and
+/// report its `None` as `ENAMETOOLONG`; the plain variants require a buffer that fits.
 #[cold]
 #[inline(never)]
 #[track_caller]
@@ -441,8 +433,7 @@ pub fn relative_to_common_path_buf() -> *mut PathBuffer {
     RELATIVE_TO_COMMON_PATH_BUF.with(lazy_path_buf)
 }
 
-/// The result of `relative_to_common_path` when it is a suffix of the
-/// normalized `to`: a copy in `buf` (`None` if it does not fit) or `to` itself.
+/// `result` is a suffix of `to`; `None` when a requested copy does not fit `buf`.
 #[inline]
 fn copy_or_borrow<'a, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
@@ -456,8 +447,7 @@ fn copy_or_borrow<'a, const ALWAYS_COPY: bool>(
     Some(out)
 }
 
-/// Find a relative path from a common path. `None` when the result does not
-/// fit `buf` (`relative_result_capacity` gives a length that always does).
+/// Find a relative path from a common path. `None` when it does not fit `buf`.
 // Loosely based on Node.js' implementation of path.relative
 // https://github.com/nodejs/node/blob/9a7cbe25de88d87429a69050a1a1971234558d97/lib/path.js#L1250-L1259
 fn relative_to_common_path<'a, const ALWAYS_COPY: bool, P: PlatformT>(
@@ -613,17 +603,14 @@ fn relative_to_common_path<'a, const ALWAYS_COPY: bool, P: PlatformT>(
     Some(&buf[..out_len])
 }
 
-/// Buffer length that holds the result of [`relative_to_common_path`] for any
-/// inputs of these lengths: it emits at most one `/..` per separator in `from`
-/// and one more, then a separator and the tail of `to`.
+/// Holds any result of `relative_to_common_path`: one `/..` per separator of
+/// `from` plus one, then a separator and the tail of `to`.
 #[inline]
 fn relative_result_capacity(normalized_from_len: usize, normalized_to_len: usize) -> usize {
     (normalized_from_len + 1) * 3 + 1 + normalized_to_len
 }
 
-/// Relative path from `from` to `to`, both already normalized, written into
-/// `buf`. `None` when it does not fit `buf`. With `ALWAYS_COPY == false` the
-/// result may borrow `to` instead of `buf`.
+/// `None` when the result does not fit `buf`. Without `ALWAYS_COPY` it may borrow `to`.
 pub fn relative_normalized_buf_checked<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
     from: &'a [u8],
@@ -644,8 +631,7 @@ pub fn relative_normalized_buf_checked<'a, P: PlatformT, const ALWAYS_COPY: bool
     relative_to_common_path::<ALWAYS_COPY, P>(common_path, from, to, buf)
 }
 
-/// [`relative_normalized_buf_checked`] for a `buf` known to be large enough
-/// (see [`relative_result_capacity`]); panics otherwise.
+/// [`relative_normalized_buf_checked`]; panics when the result does not fit `buf`.
 #[track_caller]
 pub fn relative_normalized_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
@@ -673,8 +659,6 @@ pub fn relative_normalized<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     }
 }
 
-/// [`relative_normalized`] for a result that does not fit the thread-local
-/// common-path buffer.
 #[cold]
 #[inline(never)]
 fn relative_normalized_spilled<P: PlatformT>(from: &[u8], to: &[u8]) -> &'static [u8] {
@@ -739,9 +723,7 @@ pub fn relative(from: &[u8], to: &[u8]) -> &'static [u8] {
     relative_platform::<platform::Auto, false>(from, to)
 }
 
-/// [`relative_platform_buf_checked`] for the host platform, NUL-terminated.
-/// `None` when `from`, `to` or the result with its NUL does not fit a path
-/// buffer.
+/// NUL-terminated [`relative_platform_buf_checked`] for the host platform.
 pub fn relative_buf_z_checked<'a>(buf: &'a mut [u8], from: &[u8], to: &[u8]) -> Option<&'a ZStr> {
     let capacity = buf.len().checked_sub(1)?;
     let len =
@@ -751,18 +733,15 @@ pub fn relative_buf_z_checked<'a>(buf: &'a mut [u8], from: &[u8], to: &[u8]) -> 
     Some(ZStr::from_buf(&buf[..], len))
 }
 
-/// [`relative_buf_z_checked`] for inputs known to fit a path buffer; panics
-/// otherwise.
+/// [`relative_buf_z_checked`]; panics when something does not fit.
 #[track_caller]
 pub fn relative_buf_z<'a>(buf: &'a mut [u8], from: &[u8], to: &[u8]) -> &'a ZStr {
     let buf_len = buf.len();
     relative_buf_z_checked(buf, from, to).unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-/// Normalizes one input of `relative*` into `out`, resolving a relative one
-/// against the top-level directory (it is normalized into `scratch` first, so
-/// that the join does not read the buffer it writes). `None` when it does not
-/// fit.
+/// A relative `path` is resolved against the top-level directory; `scratch`
+/// holds its normalized form so that the join does not read the buffer it writes.
 fn normalize_relative_input<'a, P: PlatformT>(
     out: &'a mut [u8],
     scratch: &mut [u8],
@@ -793,11 +772,9 @@ fn normalize_relative_input<'a, P: PlatformT>(
     Some(&out[0..path_len + 1])
 }
 
-/// Relative path from `from` to `to` (either may be relative to the top-level
-/// directory) written into `buf`, which also serves as scratch on the way.
-/// `None` when `from`, `to` or the result does not fit a path buffer. With
-/// `ALWAYS_COPY == false` the result may instead borrow a thread-local buffer
-/// that the next `relative*` call on this thread overwrites.
+/// `None` when `from`, `to` or the result does not fit a path buffer (`buf` is
+/// also the scratch space). Without `ALWAYS_COPY` the result may borrow a
+/// thread-local buffer that the next `relative*` call overwrites.
 pub fn relative_platform_buf_checked<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
     from: &[u8],
@@ -812,8 +789,7 @@ pub fn relative_platform_buf_checked<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     relative_normalized_buf_checked::<P, ALWAYS_COPY>(buf, normalized_from, normalized_to)
 }
 
-/// [`relative_platform_buf_checked`] for inputs known to fit a path buffer;
-/// panics otherwise.
+/// [`relative_platform_buf_checked`]; panics when something does not fit.
 #[track_caller]
 pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
@@ -825,8 +801,7 @@ pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
         .unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-/// Relative path from `from` to `to` for input of any length. The result is
-/// valid until the next `relative*` call on this thread.
+/// Takes input of any length; the result is valid until the next `relative*` call on this thread.
 pub fn relative_platform<P: PlatformT, const ALWAYS_COPY: bool>(
     from: &[u8],
     to: &[u8],
@@ -852,15 +827,12 @@ pub fn relative_platform<P: PlatformT, const ALWAYS_COPY: bool>(
     }
 }
 
-/// [`relative_platform`] when `from` or `to` does not fit the thread-local path
-/// buffers: the same computation in heap buffers sized for the inputs.
+/// [`relative_platform`] in heap buffers sized for `from` and `to`.
 #[cold]
 #[inline(never)]
 fn relative_platform_spilled<P: PlatformT>(from: &[u8], to: &[u8]) -> &'static [u8] {
-    // Normalizing grows a path by at most one byte (see
-    // `normalize_string_generic_tz`): that byte goes into `scratch` and, for a
-    // relative input, into the part that is then joined onto the top-level
-    // directory; an absolute input gets a leading separator slot instead.
+    // Normalizing adds at most one byte (`normalize_string_generic_tz`); an
+    // absolute input also gets its leading separator slot, a relative one is joined.
     let input_capacity = |path: &[u8]| {
         if P::P.is_absolute(path) {
             path.len() + 2
@@ -1020,10 +992,7 @@ fn windows_filesystem_root_t<T: PathChar>(path: &[T]) -> &[T] {
     &path[0..0]
 }
 
-/// Called before every write of `units` units at `buf[at..]`. Returning `false`
-/// makes the normalizer report `None` instead of writing past `buf`. `at` is a
-/// write position, so it never exceeds `buf.len()`: every advance of it
-/// follows a write this function admitted.
+/// Whether `units` more units fit at `buf[at..]`; `at` only ever advances past admitted writes.
 #[inline(always)]
 fn has_room<T>(buf: &[T], at: usize, units: usize) -> bool {
     debug_assert!(at <= buf.len());
@@ -1050,19 +1019,13 @@ pub fn normalize_string_generic_t<
     )
 }
 
-/// The normalizer every `join*` / `normalize*` / `relative*` function in this
-/// module writes through. `path_` may be of any length. Returns `None` as soon
-/// as a write would not fit `buf`, which then holds a partial result; since it
-/// works in place this includes the intermediate form of a path that later
-/// `..` segments shorten again (`normalize_string_buf_t` covers that case for
-/// the `*_checked` functions). The output is at most one unit longer than the
-/// input (on Windows: `C:` -> `C:.`, a bare `\\server\share` gains its
-/// trailing separator, `C:\..` keeps its `..`), plus `\??\` / `\??\UNC\` when
-/// `ADD_NT_PREFIX` and the NUL when `ZERO_TERMINATE`.
-///
-/// Rust cannot vary the return type on a const-generic bool without
-/// specialization, so we always return `&mut [T]` and write the NUL when
-/// `ZERO_TERMINATE`. Callers that need a `&ZStr`/`&WStr` re-wrap it.
+/// `None` as soon as a write does not fit `buf`, which then holds a partial
+/// result. Works in place, so a `..` that later shortens the path still needs
+/// the room (`normalize_string_buf_t` handles that). Output is at most input +
+/// 1 (Windows: `C:` -> `C:.`, bare UNC volume + `\`, `C:\..` keeps its `..`),
+/// + 4 or 6 for `ADD_NT_PREFIX`, + 1 for the NUL of `ZERO_TERMINATE`, which
+/// callers re-wrap as `ZStr`/`WStr` themselves (the return type cannot vary
+/// with a const generic).
 pub fn normalize_string_generic_tz<
     'a,
     T: PathChar,
@@ -1107,9 +1070,7 @@ pub fn normalize_string_generic_tz<
                 buf_i += 4;
             }
             if path_[1] != T::from_u8(b':') {
-                // UNC paths. Every write below ends at or before
-                // `buf_i + vol_len + 1` (plus the two units `UNC\` is longer
-                // than the `\\` it replaces).
+                // UNC paths: the volume, its trailing separator, and the two units `UNC\` adds.
                 if !has_room(buf, buf_i, vol_len + 1 + if ADD_NT_PREFIX { 2 } else { 0 }) {
                     return None;
                 }
@@ -1461,8 +1422,7 @@ impl Platform {
     }
 }
 
-/// Normalizes `str`, of any length, into a thread-local buffer. The result is
-/// valid until the next call on this thread.
+/// Takes input of any length; the result is valid until the next call on this thread.
 pub fn normalize_string<const ALLOW_ABOVE_ROOT: bool, P: PlatformT>(str: &[u8]) -> &'static [u8] {
     // Normalizing grows a path by at most one byte (see `normalize_string_generic_tz`).
     let capacity = str.len() + 1;
@@ -1495,7 +1455,7 @@ pub fn normalize_string_spill<'a, const ALLOW_ABOVE_ROOT: bool, P: PlatformT>(
     normalize_string_buf::<ALLOW_ABOVE_ROOT, P, false>(str, &mut spill[..])
 }
 
-/// [`normalize_buf_t`] for `u8` paths. `None` when the result does not fit `buf`.
+/// `None` when the result does not fit `buf`.
 pub fn normalize_buf_checked<'a, P: PlatformT>(
     str: &[u8],
     buf: &'a mut [u8],
@@ -1503,15 +1463,14 @@ pub fn normalize_buf_checked<'a, P: PlatformT>(
     normalize_buf_t::<u8, P>(str, buf)
 }
 
-/// [`normalize_buf_checked`] for a `buf` known to hold the result; panics otherwise.
+/// [`normalize_buf_checked`]; panics when the result does not fit `buf`.
 #[track_caller]
 pub fn normalize_buf<'a, P: PlatformT>(str: &[u8], buf: &'a mut [u8]) -> &'a mut [u8] {
     let buf_len = buf.len();
     normalize_buf_checked::<P>(str, buf).unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-/// [`normalize_buf_checked`], NUL-terminated. `None` when the result and its
-/// NUL do not fit `buf`.
+/// NUL-terminated [`normalize_buf_checked`].
 pub fn normalize_buf_z_checked<'a, P: PlatformT>(
     str: &[u8],
     buf: &'a mut [u8],
@@ -1523,15 +1482,14 @@ pub fn normalize_buf_z_checked<'a, P: PlatformT>(
     Some(unsafe { ZStr::from_raw_mut(buf.as_mut_ptr(), len) })
 }
 
-/// [`normalize_buf_z_checked`] for a `buf` known to hold the result; panics otherwise.
+/// [`normalize_buf_z_checked`]; panics when the result does not fit `buf`.
 #[track_caller]
 pub fn normalize_buf_z<'a, P: PlatformT>(str: &[u8], buf: &'a mut [u8]) -> &'a mut ZStr {
     let buf_len = buf.len();
     normalize_buf_z_checked::<P>(str, buf).unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-/// Normalizes a `u8` or `u16` path (`""` becomes `.`, a trailing separator is
-/// kept). `None` when the result does not fit `buf`.
+/// `None` when the result does not fit `buf`.
 pub fn normalize_buf_t<'a, T: PathChar, P: PlatformT>(
     str: &[T],
     buf: &'a mut [T],
@@ -1562,7 +1520,7 @@ pub fn normalize_buf_t<'a, T: PathChar, P: PlatformT>(
     normalize_string_buf_t::<T, false, P, true>(str, buf)
 }
 
-/// Normalizes `str` into `buf`. `None` when the result does not fit `buf`.
+/// `None` when the result does not fit `buf`.
 pub fn normalize_string_buf_checked<
     'a,
     const ALLOW_ABOVE_ROOT: bool,
@@ -1575,8 +1533,7 @@ pub fn normalize_string_buf_checked<
     normalize_string_buf_t::<u8, ALLOW_ABOVE_ROOT, P, PRESERVE_TRAILING_SLASH>(str, buf)
 }
 
-/// [`normalize_string_buf_checked`] for a `buf` known to hold the result;
-/// panics otherwise.
+/// [`normalize_string_buf_checked`]; panics when the result does not fit `buf`.
 #[track_caller]
 pub fn normalize_string_buf<
     'a,
@@ -1592,10 +1549,8 @@ pub fn normalize_string_buf<
         .unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-/// The `*_checked` contract: `None` only when the *result* does not fit `buf`.
-/// The normalizer works in place and a `..` pops what it wrote before, so a
-/// path whose intermediate form is longer than `buf` but whose result is not
-/// is normalized in a scratch buffer and copied over.
+/// `None` only when the *result* does not fit `buf`: a path that `..` segments
+/// shorten below its intermediate form is normalized in a scratch buffer first.
 fn normalize_string_buf_t<
     'a,
     T: PathChar,
@@ -1734,8 +1689,7 @@ thread_local! {
         const { UnsafeCell::new([0u8; JOIN_BUF_LEN]) };
 }
 
-/// Joins and normalizes `parts`, of any length, into a thread-local buffer.
-/// The result is valid until the next `join` / `join_z` call on this thread.
+/// Takes input of any length; the result is valid until the next `join`/`join_z` on this thread.
 pub fn join<P: PlatformT>(parts: &[&[u8]]) -> &'static [u8] {
     let capacity = join_needed(parts);
     if capacity <= JOIN_BUF_LEN {
@@ -1761,11 +1715,8 @@ pub fn join_z<P: PlatformT>(parts: &[&[u8]]) -> &'static ZStr {
     ZStr::from_slice_with_nul(with_nul)
 }
 
-/// Buffer length in which [`join_z_buf`] normalizes any `parts` in place: the
-/// parts, a separator per part (the leading slot of `normalize_string_node_t`,
-/// or the unit Windows normalization can add, takes the one the first part does
-/// not need), the NUL, and one more byte so that no parts still fit `.` and
-/// its NUL.
+/// Holds any [`join_z_buf`] result in place: one separator per part covers the
+/// leading slot of `normalize_string_node_t`, + 2 covers the NUL and `.`.
 #[inline]
 fn join_needed(parts: &[&[u8]]) -> usize {
     parts.iter().map(|p| p.len() + 1).sum::<usize>() + 2
@@ -1816,8 +1767,7 @@ pub fn join_z_spill<'a, P: PlatformT>(spill: &'a mut Vec<u8>, parts: &[&[u8]]) -
     join_z_buf::<P>(&mut spill[..], parts)
 }
 
-/// Where a `join*` result lies in the buffer it was written to: off Windows
-/// `normalize_string_node_t` places a relative result at `start == 1`.
+/// Where a `join*` result lies in its buffer (see `normalize_string_node_t`).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct Placed {
     start: usize,
@@ -1830,8 +1780,7 @@ impl Placed {
     }
 }
 
-/// [`join_string_buf_checked`], NUL-terminated. `None` when the result and its
-/// NUL do not fit `buf`.
+/// NUL-terminated [`join_string_buf_checked`].
 pub fn join_z_buf_checked<'a, P: PlatformT>(
     buf: &'a mut [u8],
     parts: &[&[u8]],
@@ -1842,15 +1791,14 @@ pub fn join_z_buf_checked<'a, P: PlatformT>(
     Some(ZStr::from_slice_with_nul(&buf[placed.start..=placed.end()]))
 }
 
-/// [`join_z_buf_checked`] for a `buf` known to hold the result; panics otherwise.
+/// [`join_z_buf_checked`]; panics when the result does not fit `buf`.
 #[track_caller]
 pub fn join_z_buf<'a, P: PlatformT>(buf: &'a mut [u8], parts: &[&[u8]]) -> &'a ZStr {
     let buf_len = buf.len();
     join_z_buf_checked::<P>(buf, parts).unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-/// Joins `parts` with the platform separator and normalizes the result into
-/// `buf` (`path.join`). `None` when it does not fit `buf`.
+/// `path.join` into `buf`; `None` when the result does not fit it.
 pub fn join_string_buf_checked<'a, P: PlatformT>(
     buf: &'a mut [u8],
     parts: &[&[u8]],
@@ -1859,7 +1807,7 @@ pub fn join_string_buf_checked<'a, P: PlatformT>(
     Some(&buf[placed.start..placed.end()])
 }
 
-/// [`join_string_buf_checked`] for a `buf` known to hold the result; panics otherwise.
+/// [`join_string_buf_checked`]; panics when the result does not fit `buf`.
 #[track_caller]
 pub fn join_string_buf<'a, P: PlatformT>(buf: &'a mut [u8], parts: &[&[u8]]) -> &'a [u8] {
     let buf_len = buf.len();
@@ -1876,8 +1824,7 @@ pub fn join_string_buf_w_same_checked<'a, P: PlatformT>(
     Some(&buf[placed.start..placed.end()])
 }
 
-/// [`join_string_buf_w_same_checked`] for a `buf` known to hold the result;
-/// panics otherwise.
+/// [`join_string_buf_w_same_checked`]; panics when the result does not fit `buf`.
 #[track_caller]
 pub fn join_string_buf_w_same<'a, P: PlatformT>(buf: &'a mut [u16], parts: &[&[u16]]) -> &'a [u16] {
     let buf_len = buf.len();
@@ -1951,9 +1898,7 @@ fn join_dot<T: PathChar>(buf: &mut [T]) -> Option<Placed> {
     Some(Placed { start: 0, len: 1 })
 }
 
-/// `normalize_string_node_t` under the `*_checked` contract (see
-/// `normalize_string_buf_t`): a result that fits `buf` is produced even when
-/// the intermediate form does not, by normalizing in a scratch buffer first.
+/// `normalize_string_node_t` with the result-fits contract of `normalize_string_buf_t`.
 fn join_normalize_into<T: PathChar, P: PlatformT>(joined: &[T], buf: &mut [T]) -> Option<Placed> {
     normalize_string_node_t::<T, P>(joined, buf)
         .or_else(|| join_normalize_via_scratch::<T, P>(joined, buf))
@@ -2035,9 +1980,8 @@ fn join_abs_needed(cwd_len: usize, parts: &[&[u8]]) -> usize {
     parts.iter().map(|p| p.len() + 1).sum::<usize>() + cwd_len + 2
 }
 
-/// Buffer length that holds [`join_abs_string_buf_z`]'s result for `cwd` and
-/// `parts`: [`join_abs_needed`] covers the path (the separator the first part
-/// does not need pays for the NUL), plus the `\\?\` prefix `Platform::Nt` adds.
+/// Holds any [`join_abs_string_buf_z`] result: the first part's unused separator
+/// slot in [`join_abs_needed`] covers the NUL; `Platform::Nt` adds `\\?\`.
 #[inline]
 fn join_abs_capacity<P: PlatformT>(cwd_len: usize, parts: &[&[u8]]) -> usize {
     join_abs_needed(cwd_len, parts) + if P::P == Platform::Nt { 4 } else { 0 }
@@ -2073,8 +2017,7 @@ impl JoinScratch {
     }
 }
 
-/// [`join_abs_string_buf_checked`] for a `buf` known to hold the result (a
-/// `PathBuffer` does when the inputs are paths that fit one); panics otherwise.
+/// [`join_abs_string_buf_checked`]; panics when the result does not fit `buf`.
 #[track_caller]
 pub fn join_abs_string_buf<'a, P: PlatformT>(
     cwd: &'a [u8],
@@ -2086,10 +2029,8 @@ pub fn join_abs_string_buf<'a, P: PlatformT>(
         .unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-/// `path.resolve(cwd, ...parts)` into `buf`. Returns `None` when the
-/// *normalized* result does not fit `buf`, so `parts` may carry user input of
-/// any length: a path whose unnormalized length exceeds `buf.len()` but
-/// normalizes down still succeeds. With no `parts` the result is `cwd` itself.
+/// `path.resolve(cwd, ...parts)` into `buf`; `None` only when the *normalized*
+/// result does not fit it, so `parts` may be user input of any length.
 pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     cwd: &'a [u8],
     buf: &'a mut [u8],
@@ -2098,8 +2039,7 @@ pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     _join_abs_string_buf::<false, P>(cwd, buf, parts)
 }
 
-/// [`join_abs_string_buf_checked`], NUL-terminated. `None` when the result and
-/// its NUL do not fit `buf`. `parts` must not be empty.
+/// NUL-terminated [`join_abs_string_buf_checked`]; `parts` must not be empty.
 pub fn join_abs_string_buf_z_checked<'a, P: PlatformT>(
     cwd: &'a [u8],
     buf: &'a mut [u8],
@@ -2109,8 +2049,7 @@ pub fn join_abs_string_buf_z_checked<'a, P: PlatformT>(
     Some(ZStr::from_buf(buf, len))
 }
 
-/// [`join_abs_string_buf_z_checked`] for a `buf` known to hold the result;
-/// panics otherwise.
+/// [`join_abs_string_buf_z_checked`]; panics when the result does not fit `buf`.
 #[track_caller]
 pub fn join_abs_string_buf_z<'a, P: PlatformT>(
     cwd: &'a [u8],
@@ -2122,10 +2061,8 @@ pub fn join_abs_string_buf_z<'a, P: PlatformT>(
         .unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-// We always return `&[u8]`; when `IS_SENTINEL` a NUL is written at
-// `buf[result.len()]` (the result then always starts at `buf[0]`) and callers
-// (e.g. `join_abs_string_buf_z_checked`) re-wrap as `ZStr`. `None` when the
-// result (and its NUL) does not fit `buf`.
+// With `IS_SENTINEL` the result starts at `buf[0]` and a NUL follows it, for
+// `join_abs_string_buf_z_checked` to re-wrap; `None` when either does not fit.
 fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
     _cwd: &'a [u8],
     buf: &'a mut [u8],
@@ -2233,8 +2170,7 @@ fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
         1
     };
     // Copy leading separator into buf (order-independent with normalize,
-    // which writes into buf[leading_len..]). The last byte is reserved for the
-    // sentinel.
+    // which writes into buf[leading_len..]).
     let capacity = buf.len().checked_sub(IS_SENTINEL as usize)?;
     let out_buf = &mut buf[..capacity];
     out_buf
@@ -2354,7 +2290,6 @@ fn join_abs_string_buf_windows<'a, const IS_SENTINEL: bool>(
         out += part_without_vol.len();
     }
 
-    // The last byte is reserved for the sentinel.
     let capacity = buf.len().checked_sub(IS_SENTINEL as usize)?;
     let result_len = normalize_string_buf_checked::<false, platform::Windows, true>(
         &temp_buf[0..out],
@@ -2440,10 +2375,8 @@ fn normalize_string_windows_t<
     )
 }
 
-/// `path.normalize` for `join*`. Off Windows the result of a relative input
-/// starts at `buf[1]`, the slot an absolute one uses for its leading separator.
-/// `None` when the intermediate form does not fit `buf` (see
-/// `normalize_string_generic_tz`).
+/// `path.normalize` for `join*`. Off Windows a relative result starts at
+/// `buf[1]`, behind the slot for an absolute result's leading separator.
 fn normalize_string_node_t<T: PathChar, P: PlatformT>(str: &[T], buf: &mut [T]) -> Option<Placed> {
     if str.is_empty() {
         return join_dot(buf);

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -17,13 +17,72 @@ thread_local! {
         const { UnsafeCell::new([0u8; PARSER_JOIN_INPUT_BUFFER_LEN]) };
     static PARSER_BUFFER: UnsafeCell<[u8; PARSER_BUFFER_LEN]> =
         const { UnsafeCell::new([0u8; PARSER_BUFFER_LEN]) };
+    // Results of the wrappers above each fixed buffer that did not fit it; see `spill_out`.
+    static PARSER_JOIN_INPUT_SPILL: UnsafeCell<Vec<u8>> = const { UnsafeCell::new(Vec::new()) };
+    static PARSER_SPILL: UnsafeCell<Vec<u8>> = const { UnsafeCell::new(Vec::new()) };
+    static JOIN_SPILL: UnsafeCell<Vec<u8>> = const { UnsafeCell::new(Vec::new()) };
+    static RELATIVE_SPILL: UnsafeCell<Vec<u8>> = const { UnsafeCell::new(Vec::new()) };
 }
 
-/// Output capacity of [`join_abs_string`] / [`join_abs_string_z`].
+/// Fixed output capacity of [`join_abs_string`] / [`join_abs_string_z`]; longer
+/// results spill to the heap.
 const PARSER_JOIN_INPUT_BUFFER_LEN: usize = 4096;
 
-/// Output capacity of [`normalize_string`].
+/// Fixed output capacity of [`normalize_string`]; longer results spill to the heap.
 const PARSER_BUFFER_LEN: usize = 1024;
+
+/// Heap half of a thread-local output buffer, for the functions that return a
+/// slice that is valid until their next call on this thread (`join`,
+/// `join_abs_string`, `normalize_string`, `relative`, ...). Their fixed buffer
+/// serves every result that fits it. For one that does not, `spill_out` runs
+/// `op` on a fresh heap buffer of `len` bytes and keeps that buffer in `spill`
+/// until the next spilled result of the same function. The previous spilled
+/// result is freed only after `op` returns because it may be among `op`'s
+/// inputs.
+fn spill_out<'r>(
+    spill: &'static std::thread::LocalKey<UnsafeCell<Vec<u8>>>,
+    len: usize,
+    op: impl FnOnce(&'r mut [u8]) -> &'r [u8],
+) -> &'static [u8] {
+    let mut out = vec![0u8; len];
+    let out_start = out.as_mut_ptr();
+    // `'r` is the lifetime of `op`'s result, which may also borrow `op`'s
+    // inputs, so the buffer is handed over detached from `out`'s own borrow.
+    // SAFETY: `out` holds `len` initialized bytes and nothing else touches it
+    // until `op` has returned; `buf` is not used after that.
+    let buf: &'r mut [u8] = unsafe { core::slice::from_raw_parts_mut(out_start, len) };
+    let result = op(buf);
+    let result_len = result.len();
+    let (out_start, result_start) = (out_start as usize, result.as_ptr() as usize);
+    let (start, to_store) =
+        if result_start >= out_start && result_start + result_len <= out_start + len {
+            (result_start - out_start, out)
+        } else {
+            // `op` returned one of its inputs instead (`join_abs_string` with
+            // no parts returns the cwd); keep a copy of it.
+            (0, result.to_vec())
+        };
+    spill.with(|cell| {
+        // SAFETY: thread-local UnsafeCell, so this thread is the sole accessor,
+        // and `op` has returned, so nothing reads the buffer being replaced.
+        // The returned slice follows the same "valid until the next call"
+        // contract as the fixed buffers (see `tl_buf_mut`).
+        let stored: &'static mut Vec<u8> = unsafe { &mut *cell.get() };
+        *stored = to_store;
+        &stored[start..start + result_len]
+    })
+}
+
+/// The `join*` / `normalize*` / `relative*` functions that take a caller
+/// buffer and return a plain slice require a buffer that holds their result.
+/// A caller that builds a path from input of unbounded length uses the
+/// `*_checked` variant instead and reports its `None` as `ENAMETOOLONG`.
+#[cold]
+#[inline(never)]
+#[track_caller]
+fn path_buffer_too_small(buf_len: usize) -> ! {
+    panic!("path does not fit in a {buf_len}-unit path buffer; use the *_checked variant");
+}
 
 /// Project `&'static mut` into a thread-local `UnsafeCell<[u8; N]>` scratch
 /// buffer. One `unsafe` site for all `PARSER_BUFFER` / `PARSER_JOIN_INPUT_BUFFER`
@@ -382,7 +441,23 @@ pub fn relative_to_common_path_buf() -> *mut PathBuffer {
     RELATIVE_TO_COMMON_PATH_BUF.with(lazy_path_buf)
 }
 
-/// Find a relative path from a common path
+/// The result of `relative_to_common_path` when it is a suffix of the
+/// normalized `to`: a copy in `buf` (`None` if it does not fit) or `to` itself.
+#[inline]
+fn copy_or_borrow<'a, const ALWAYS_COPY: bool>(
+    buf: &'a mut [u8],
+    result: &'a [u8],
+) -> Option<&'a [u8]> {
+    if !ALWAYS_COPY {
+        return Some(result);
+    }
+    let out = buf.get_mut(..result.len())?;
+    out.copy_from_slice(result);
+    Some(out)
+}
+
+/// Find a relative path from a common path. `None` when the result does not
+/// fit `buf` (`relative_result_capacity` gives a length that always does).
 // Loosely based on Node.js' implementation of path.relative
 // https://github.com/nodejs/node/blob/9a7cbe25de88d87429a69050a1a1971234558d97/lib/path.js#L1250-L1259
 fn relative_to_common_path<'a, const ALWAYS_COPY: bool, P: PlatformT>(
@@ -390,7 +465,7 @@ fn relative_to_common_path<'a, const ALWAYS_COPY: bool, P: PlatformT>(
     normalized_from_: &[u8],
     normalized_to_: &'a [u8],
     buf: &'a mut [u8],
-) -> &'a [u8] {
+) -> Option<&'a [u8]> {
     let mut normalized_from = normalized_from_;
     let mut normalized_to = normalized_to_;
     let win_root_len: Option<usize> = if P::P == Platform::Windows {
@@ -401,24 +476,14 @@ fn relative_to_common_path<'a, const ALWAYS_COPY: bool, P: PlatformT>(
             if common_path_.is_empty() {
                 // the only case path.relative can return not a relative string
                 if !strings::eql_case_insensitive_ascii_check_length(from_root, to_root) {
-                    if normalized_to_.len() > to_root.len()
+                    let result = if normalized_to_.len() > to_root.len()
                         && normalized_to_[normalized_to_.len() - 1] == b'\\'
                     {
-                        if ALWAYS_COPY {
-                            let n = normalized_to_.len() - 1;
-                            buf[..n].copy_from_slice(&normalized_to_[..n]);
-                            return &buf[..n];
-                        } else {
-                            return &normalized_to_[..normalized_to_.len() - 1];
-                        }
+                        &normalized_to_[..normalized_to_.len() - 1]
                     } else {
-                        if ALWAYS_COPY {
-                            buf[..normalized_to_.len()].copy_from_slice(normalized_to_);
-                            return &buf[..normalized_to_.len()];
-                        } else {
-                            return normalized_to_;
-                        }
-                    }
+                        normalized_to_
+                    };
+                    return copy_or_borrow::<ALWAYS_COPY>(buf, result);
                 }
             }
 
@@ -455,12 +520,7 @@ fn relative_to_common_path<'a, const ALWAYS_COPY: bool, P: PlatformT>(
 
                 // We get here if `from` is the root
                 // For example: from='/'; to='/foo'
-                if ALWAYS_COPY {
-                    buf[..normalized_to.len()].copy_from_slice(normalized_to);
-                    return &buf[..normalized_to.len()];
-                } else {
-                    return normalized_to;
-                }
+                return copy_or_borrow::<ALWAYS_COPY>(buf, normalized_to);
             }
 
             if normalized_to[common_path.len() - 1] == separator {
@@ -475,14 +535,9 @@ fn relative_to_common_path<'a, const ALWAYS_COPY: bool, P: PlatformT>(
                     slice
                 };
 
-                if ALWAYS_COPY {
-                    // We get here if `from` is the exact base path for `to`.
-                    // For example: from='/foo/bar'; to='/foo/bar/baz'
-                    buf[..without_trailing_slash.len()].copy_from_slice(without_trailing_slash);
-                    return &buf[..without_trailing_slash.len()];
-                } else {
-                    return without_trailing_slash;
-                }
+                // We get here if `from` is the exact base path for `to`.
+                // For example: from='/foo/bar'; to='/foo/bar/baz'
+                return copy_or_borrow::<ALWAYS_COPY>(buf, without_trailing_slash);
             }
         }
     }
@@ -512,11 +567,12 @@ fn relative_to_common_path<'a, const ALWAYS_COPY: bool, P: PlatformT>(
                 || (normalized_from[i] == separator && i + 1 < normalized_from.len())
             {
                 if out_len == 0 {
-                    buf[0..2].copy_from_slice(b"..");
+                    buf.get_mut(0..2)?.copy_from_slice(b"..");
                     out_len = 2;
                 } else {
-                    buf[out_len] = separator;
-                    buf[out_len + 1..out_len + 3].copy_from_slice(b"..");
+                    let dotdot = buf.get_mut(out_len..out_len + 3)?;
+                    dotdot[0] = separator;
+                    dotdot[1..].copy_from_slice(b"..");
                     out_len += 3;
                 }
             }
@@ -539,14 +595,14 @@ fn relative_to_common_path<'a, const ALWAYS_COPY: bool, P: PlatformT>(
         let insert_leading_slash =
             !P::P.is_separator(tail[0]) && out_len > 0 && !P::P.is_separator(buf[out_len - 1]);
 
-        if insert_leading_slash {
-            buf[out_len] = separator;
-            out_len += 1;
-        }
-
         // Lastly, append the rest of the destination (`to`) path that comes after
         // the common path parts.
-        buf[out_len..out_len + tail.len()].copy_from_slice(tail);
+        let rest = buf.get_mut(out_len..out_len + insert_leading_slash as usize + tail.len())?;
+        if insert_leading_slash {
+            rest[0] = separator;
+            out_len += 1;
+        }
+        rest[insert_leading_slash as usize..].copy_from_slice(tail);
         out_len += tail.len();
     }
 
@@ -554,21 +610,32 @@ fn relative_to_common_path<'a, const ALWAYS_COPY: bool, P: PlatformT>(
         out_len -= 1;
     }
 
-    &buf[..out_len]
+    Some(&buf[..out_len])
 }
 
-pub fn relative_normalized_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
+/// Buffer length that holds the result of [`relative_to_common_path`] for any
+/// inputs of these lengths: it emits at most one `/..` per separator in `from`
+/// and one more, then a separator and the tail of `to`.
+#[inline]
+fn relative_result_capacity(normalized_from_len: usize, normalized_to_len: usize) -> usize {
+    (normalized_from_len + 1) * 3 + 1 + normalized_to_len
+}
+
+/// Relative path from `from` to `to`, both already normalized, written into
+/// `buf`. `None` when it does not fit `buf`. With `ALWAYS_COPY == false` the
+/// result may borrow `to` instead of `buf`.
+pub fn relative_normalized_buf_checked<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
     from: &'a [u8],
     to: &'a [u8],
-) -> &'a [u8] {
+) -> Option<&'a [u8]> {
     let equal = if P::P == Platform::Windows {
         strings::eql_case_insensitive_ascii(from, to, true)
     } else {
         from.len() == to.len() && strings::eql_long(from, to, false)
     };
     if equal {
-        return b"";
+        return Some(b"");
     }
 
     let two: [&[u8]; 2] = [from, to];
@@ -577,7 +644,20 @@ pub fn relative_normalized_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     relative_to_common_path::<ALWAYS_COPY, P>(common_path, from, to, buf)
 }
 
-// result borrows either the thread-local common-path buf ('static)
+/// [`relative_normalized_buf_checked`] for a `buf` known to be large enough
+/// (see [`relative_result_capacity`]); panics otherwise.
+#[track_caller]
+pub fn relative_normalized_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
+    buf: &'a mut [u8],
+    from: &'a [u8],
+    to: &'a [u8],
+) -> &'a [u8] {
+    let buf_len = buf.len();
+    relative_normalized_buf_checked::<P, ALWAYS_COPY>(buf, from, to)
+        .unwrap_or_else(|| path_buffer_too_small(buf_len))
+}
+
+// result borrows the thread-local common-path buf or its spill ('static)
 // or `to` (when !ALWAYS_COPY and result==to). Return lifetime is `'a` (=to's),
 // since 'static: 'a. "Valid until next call" still applies for
 // the buf-backed case.
@@ -586,10 +666,25 @@ pub fn relative_normalized<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     to: &'a [u8],
 ) -> &'a [u8] {
     // SAFETY: thread-local scratch; single live borrow per thread.
-    relative_normalized_buf::<P, ALWAYS_COPY>(
-        RELATIVE_TO_COMMON_PATH_BUF.with(lazy_path_buf),
-        from,
-        to,
+    let common_buf = RELATIVE_TO_COMMON_PATH_BUF.with(lazy_path_buf);
+    match relative_normalized_buf_checked::<P, ALWAYS_COPY>(&mut common_buf[..], from, to) {
+        Some(rel) => rel,
+        None => relative_normalized_spilled::<P>(from, to),
+    }
+}
+
+/// [`relative_normalized`] for a result that does not fit the thread-local
+/// common-path buffer.
+#[cold]
+#[inline(never)]
+fn relative_normalized_spilled<P: PlatformT>(from: &[u8], to: &[u8]) -> &'static [u8] {
+    spill_out(
+        &RELATIVE_SPILL,
+        relative_result_capacity(from.len(), to.len()),
+        |buf| {
+            relative_normalized_buf_checked::<P, true>(buf, from, to)
+                .unwrap_or_else(|| unreachable!("relative_result_capacity bounds the result"))
+        },
     )
 }
 
@@ -644,104 +739,161 @@ pub fn relative(from: &[u8], to: &[u8]) -> &'static [u8] {
     relative_platform::<platform::Auto, false>(from, to)
 }
 
-pub fn relative_buf_z<'a>(buf: &'a mut [u8], from: &[u8], to: &[u8]) -> &'a ZStr {
-    let rel = relative_platform_buf::<platform::Auto, true>(buf, from, to);
-    let len = rel.len();
-    // reshaped for borrowck — drop `rel` borrow before mutating buf
+/// [`relative_platform_buf_checked`] for the host platform, NUL-terminated.
+/// `None` when `from`, `to` or the result with its NUL does not fit a path
+/// buffer.
+pub fn relative_buf_z_checked<'a>(buf: &'a mut [u8], from: &[u8], to: &[u8]) -> Option<&'a ZStr> {
+    let capacity = buf.len().checked_sub(1)?;
+    let len =
+        relative_platform_buf_checked::<platform::Auto, true>(&mut buf[..capacity], from, to)?
+            .len();
     buf[len] = 0;
-    // SAFETY: buf[len] == 0 written above
-    ZStr::from_buf(&buf[..], len)
+    Some(ZStr::from_buf(&buf[..], len))
 }
 
+/// [`relative_buf_z_checked`] for inputs known to fit a path buffer; panics
+/// otherwise.
+#[track_caller]
+pub fn relative_buf_z<'a>(buf: &'a mut [u8], from: &[u8], to: &[u8]) -> &'a ZStr {
+    let buf_len = buf.len();
+    relative_buf_z_checked(buf, from, to).unwrap_or_else(|| path_buffer_too_small(buf_len))
+}
+
+/// Normalizes `from` and `to` into `from_buf` and `to_buf`, resolving a
+/// relative one against the top-level directory (normalizing it into `scratch`
+/// first, so that the join does not read the buffer it writes). `None` when
+/// one of them does not fit.
+fn normalize_relative_inputs<'a, P: PlatformT>(
+    from_buf: &'a mut [u8],
+    to_buf: &'a mut [u8],
+    scratch: &mut [u8],
+    from: &[u8],
+    to: &[u8],
+) -> Option<(&'a [u8], &'a [u8])> {
+    let normalized_from = normalize_relative_input::<P>(from_buf, scratch, from)?;
+    let normalized_to = normalize_relative_input::<P>(to_buf, scratch, to)?;
+    Some((normalized_from, normalized_to))
+}
+
+fn normalize_relative_input<'a, P: PlatformT>(
+    out: &'a mut [u8],
+    scratch: &mut [u8],
+    path: &[u8],
+) -> Option<&'a [u8]> {
+    if !P::P.is_absolute(path) {
+        let norm_len = normalize_string_buf_checked::<true, P, true>(path, scratch)?.len();
+        return join_abs_string_buf_checked::<P>(
+            Fs::FileSystem::instance().top_level_dir(),
+            out,
+            &[&scratch[..norm_len]],
+        );
+    }
+    if P::P == Platform::Loose && cfg!(windows) {
+        // we want to invoke the windows resolution behavior but end up with a
+        // string with forward slashes.
+        let normalized =
+            normalize_string_buf_checked::<true, platform::Windows, true>(path, out.get_mut(1..)?)?;
+        platform_to_posix_in_place::<u8>(normalized);
+        return Some(&*normalized);
+    }
+    // reshaped for borrowck — capture len, drop inner &mut, re-slice
+    let path_len = normalize_string_buf_checked::<true, P, true>(path, out.get_mut(1..)?)?.len();
+    if P::P == Platform::Windows {
+        return Some(&out[1..1 + path_len]);
+    }
+    out[0] = P::P.separator();
+    Some(&out[0..path_len + 1])
+}
+
+/// Relative path from `from` to `to` (either may be relative to the top-level
+/// directory) written into `buf`, which also serves as scratch on the way.
+/// `None` when `from`, `to` or the result does not fit a path buffer. With
+/// `ALWAYS_COPY == false` the result may instead borrow a thread-local buffer
+/// that the next `relative*` call on this thread overwrites.
+pub fn relative_platform_buf_checked<'a, P: PlatformT, const ALWAYS_COPY: bool>(
+    buf: &'a mut [u8],
+    from: &[u8],
+    to: &[u8],
+) -> Option<&'a [u8]> {
+    // RELATIVE_FROM_BUF and RELATIVE_TO_BUF are independent allocations so the
+    // two `&mut` borrows below are disjoint.
+    let relative_from_buf = RELATIVE_FROM_BUF.with(lazy_path_buf);
+    let relative_to_buf = RELATIVE_TO_BUF.with(lazy_path_buf);
+    let (normalized_from, normalized_to) = normalize_relative_inputs::<P>(
+        &mut relative_from_buf[..],
+        &mut relative_to_buf[..],
+        buf,
+        from,
+        to,
+    )?;
+    relative_normalized_buf_checked::<P, ALWAYS_COPY>(buf, normalized_from, normalized_to)
+}
+
+/// [`relative_platform_buf_checked`] for inputs known to fit a path buffer;
+/// panics otherwise.
+#[track_caller]
 pub fn relative_platform_buf<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     buf: &'a mut [u8],
     from: &[u8],
     to: &[u8],
 ) -> &'a [u8] {
-    // RELATIVE_FROM_BUF and RELATIVE_TO_BUF are independent allocations so the
-    // two `&mut` borrows below are disjoint.
-    let relative_from_buf = RELATIVE_FROM_BUF.with(lazy_path_buf);
-    let relative_to_buf = RELATIVE_TO_BUF.with(lazy_path_buf);
-
-    let normalized_from: &[u8] = if P::P.is_absolute(from) {
-        'brk: {
-            if P::P == Platform::Loose && cfg!(windows) {
-                // we want to invoke the windows resolution behavior but end up with a
-                // string with forward slashes.
-                let normalized = normalize_string_buf::<true, platform::Windows, true>(
-                    from,
-                    &mut relative_from_buf[1..],
-                );
-                platform_to_posix_in_place::<u8>(normalized);
-                break 'brk &*normalized;
-            }
-            // reshaped for borrowck — capture len, drop inner &mut, re-slice
-            let path_len =
-                normalize_string_buf::<true, P, true>(from, &mut relative_from_buf[1..]).len();
-            if P::P == Platform::Windows {
-                break 'brk &relative_from_buf[1..1 + path_len];
-            }
-            relative_from_buf[0] = P::P.separator();
-            break 'brk &relative_from_buf[0..path_len + 1];
-        }
-    } else {
-        // Avoid aliasing relative_from_buf as both input (normalize result)
-        // and output (join target): normalize into relative_to_buf scratch,
-        // then join into relative_from_buf. Safe because normalized_to is computed
-        // afterwards (overwrites relative_to_buf anyway).
-        let norm_len = normalize_string_buf::<true, P, true>(from, &mut relative_to_buf[..]).len();
-        join_abs_string_buf::<P>(
-            Fs::FileSystem::instance().top_level_dir(),
-            relative_from_buf,
-            &[&relative_to_buf[..norm_len]],
-        )
-    };
-
-    let normalized_to: &[u8] = if P::P.is_absolute(to) {
-        'brk: {
-            if P::P == Platform::Loose && cfg!(windows) {
-                let normalized = normalize_string_buf::<true, platform::Windows, true>(
-                    to,
-                    &mut relative_to_buf[1..],
-                );
-                platform_to_posix_in_place::<u8>(normalized);
-                break 'brk &*normalized;
-            }
-            // reshaped for borrowck — capture len, drop inner &mut, re-slice
-            let path_len =
-                normalize_string_buf::<true, P, true>(to, &mut relative_to_buf[1..]).len();
-            if P::P == Platform::Windows {
-                break 'brk &relative_to_buf[1..1 + path_len];
-            }
-            relative_to_buf[0] = P::P.separator();
-            break 'brk &relative_to_buf[0..path_len + 1];
-        }
-    } else {
-        // Avoid aliasing relative_to_buf as both input (normalize result)
-        // and output (join target): normalize into `buf` scratch (caller
-        // output buffer, untouched until the final relative_normalized_buf call
-        // and disjoint from both threadlocals), then join into relative_to_buf.
-        let norm_len = normalize_string_buf::<true, P, true>(to, buf).len();
-        join_abs_string_buf::<P>(
-            Fs::FileSystem::instance().top_level_dir(),
-            relative_to_buf,
-            &[&buf[..norm_len]],
-        )
-    };
-
-    relative_normalized_buf::<P, ALWAYS_COPY>(buf, normalized_from, normalized_to)
+    let buf_len = buf.len();
+    relative_platform_buf_checked::<P, ALWAYS_COPY>(buf, from, to)
+        .unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
+/// Relative path from `from` to `to` for input of any length. The result is
+/// valid until the next `relative*` call on this thread.
 pub fn relative_platform<P: PlatformT, const ALWAYS_COPY: bool>(
     from: &[u8],
     to: &[u8],
 ) -> &'static [u8] {
     // SAFETY: thread-local scratch; single live borrow per thread.
-    relative_platform_buf::<P, ALWAYS_COPY>(
-        RELATIVE_TO_COMMON_PATH_BUF.with(lazy_path_buf),
+    let common_buf = RELATIVE_TO_COMMON_PATH_BUF.with(lazy_path_buf);
+    let relative_from_buf = RELATIVE_FROM_BUF.with(lazy_path_buf);
+    let relative_to_buf = RELATIVE_TO_BUF.with(lazy_path_buf);
+    let Some((normalized_from, normalized_to)) = normalize_relative_inputs::<P>(
+        &mut relative_from_buf[..],
+        &mut relative_to_buf[..],
+        &mut common_buf[..],
         from,
         to,
-    )
+    ) else {
+        return relative_platform_spilled::<P>(from, to);
+    };
+    match relative_normalized_buf_checked::<P, ALWAYS_COPY>(
+        &mut common_buf[..],
+        normalized_from,
+        normalized_to,
+    ) {
+        Some(rel) => rel,
+        None => relative_normalized_spilled::<P>(normalized_from, normalized_to),
+    }
+}
+
+/// [`relative_platform`] when `from` or `to` does not fit the thread-local path
+/// buffers: the same computation in heap buffers sized for the inputs.
+#[cold]
+#[inline(never)]
+fn relative_platform_spilled<P: PlatformT>(from: &[u8], to: &[u8]) -> &'static [u8] {
+    // Normalizing grows a path by at most one byte (see
+    // `normalize_string_generic_tz`): that byte goes into `scratch` and, for a
+    // relative input, into the part that is then joined onto the top-level
+    // directory; an absolute input gets a leading separator slot instead.
+    let input_capacity = |path: &[u8]| {
+        if P::P.is_absolute(path) {
+            path.len() + 2
+        } else {
+            join_abs_needed(Fs::FileSystem::instance().top_level_dir().len(), &[path]) + 1
+        }
+    };
+    let mut from_buf = vec![0u8; input_capacity(from)];
+    let mut to_buf = vec![0u8; input_capacity(to)];
+    let mut scratch = vec![0u8; from.len().max(to.len()) + 1];
+    let (normalized_from, normalized_to) =
+        normalize_relative_inputs::<P>(&mut from_buf, &mut to_buf, &mut scratch, from, to)
+            .unwrap_or_else(|| unreachable!("input_capacity bounds the normalized inputs"));
+    relative_normalized_spilled::<P>(normalized_from, normalized_to)
 }
 
 pub fn relative_alloc(from: &[u8], to: &[u8]) -> Result<Box<[u8]>, bun_alloc::AllocError> {
@@ -886,6 +1038,14 @@ fn windows_filesystem_root_t<T: PathChar>(path: &[T]) -> &[T] {
     &path[0..0]
 }
 
+/// Called before every write of `units` units at `buf[at..]`. Returning `false`
+/// makes the normalizer report `None` instead of writing past `buf`.
+#[inline(always)]
+fn has_room<T>(buf: &[T], at: usize, units: usize) -> bool {
+    at <= buf.len() && units <= buf.len() - at
+}
+
+/// [`normalize_string_generic_tz`] without NUL termination or an NT prefix.
 pub fn normalize_string_generic_t<
     'a,
     T: PathChar,
@@ -896,7 +1056,7 @@ pub fn normalize_string_generic_t<
     buf: &'a mut [T],
     separator: T,
     is_separator_t: impl Fn(T) -> bool + Copy,
-) -> &'a mut [T] {
+) -> Option<&'a mut [T]> {
     normalize_string_generic_tz::<T, ALLOW_ABOVE_ROOT, PRESERVE_TRAILING_SLASH, false, false>(
         path_,
         buf,
@@ -905,10 +1065,19 @@ pub fn normalize_string_generic_t<
     )
 }
 
-// Rust cannot vary the return type on a const-generic bool without
-// specialization, so
-// we always return `&mut [T]` and write the NUL when `ZERO_TERMINATE`. Callers
-// that need `&ZStr`/`&WStr` re-wrap with `from_raw`.
+/// The normalizer every `join*` / `normalize*` / `relative*` function in this
+/// module writes through. `path_` may be of any length. Returns `None` as soon
+/// as a write would not fit `buf`, which then holds a partial result; since it
+/// works in place this includes the intermediate form of a path that later
+/// `..` segments shorten again (`normalize_string_buf_t` covers that case for
+/// the `*_checked` functions). The output is at most one unit longer than the
+/// input (on Windows: `C:` -> `C:.`, a bare `\\server\share` gains its
+/// trailing separator, `C:\..` keeps its `..`), plus `\??\` / `\??\UNC\` when
+/// `ADD_NT_PREFIX` and the NUL when `ZERO_TERMINATE`.
+///
+/// Rust cannot vary the return type on a const-generic bool without
+/// specialization, so we always return `&mut [T]` and write the NUL when
+/// `ZERO_TERMINATE`. Callers that need a `&ZStr`/`&WStr` re-wrap it.
 pub fn normalize_string_generic_tz<
     'a,
     T: PathChar,
@@ -921,7 +1090,7 @@ pub fn normalize_string_generic_tz<
     buf: &'a mut [T],
     separator: T,
     is_separator: impl Fn(T) -> bool + Copy,
-) -> &'a mut [T] {
+) -> Option<&'a mut [T]> {
     let is_windows = separator == T::from_u8(SEP_WINDOWS);
     // sep_str: single-char slice [separator], built per-call.
 
@@ -946,11 +1115,19 @@ pub fn normalize_string_generic_tz<
     if is_windows {
         if vol_len > 0 {
             if ADD_NT_PREFIX {
+                if !has_room(buf, buf_i, 4) {
+                    return None;
+                }
                 buf[buf_i..buf_i + 4].copy_from_slice(T::lit(b"\\??\\"));
                 buf_i += 4;
             }
             if path_[1] != T::from_u8(b':') {
-                // UNC paths
+                // UNC paths. Every write below ends at or before
+                // `buf_i + vol_len + 1` (plus the two units `UNC\` is longer
+                // than the `\\` it replaces).
+                if !has_room(buf, buf_i, vol_len + 1 + if ADD_NT_PREFIX { 2 } else { 0 }) {
+                    return None;
+                }
                 if ADD_NT_PREFIX {
                     // "UNC" ++ sep_str
                     buf[buf_i..buf_i + 3].copy_from_slice(T::lit(b"UNC"));
@@ -978,12 +1155,18 @@ pub fn normalize_string_generic_tz<
                 // it is just a volume name
                 if path_begin >= path_.len() {
                     if ZERO_TERMINATE {
+                        if !has_room(buf, buf_i, 1) {
+                            return None;
+                        }
                         buf[buf_i] = T::from_u8(0);
                     }
-                    return &mut buf[0..buf_i];
+                    return Some(&mut buf[0..buf_i]);
                 }
             } else {
                 // drive letter
+                if !has_room(buf, buf_i, 2) {
+                    return None;
+                }
                 buf[buf_i] = T::to_ascii_upper(path_[0]);
                 buf[buf_i + 1] = T::from_u8(b':');
                 buf_i += 2;
@@ -991,6 +1174,9 @@ pub fn normalize_string_generic_tz<
                 path_begin = 2;
             }
         } else if !path_.is_empty() && is_separator(path_[0]) {
+            if !has_room(buf, buf_i, 1) {
+                return None;
+            }
             buf[buf_i] = separator;
             buf_i += 1;
             dotdot = buf_i;
@@ -1011,6 +1197,9 @@ pub fn normalize_string_generic_tz<
         // consume leading slashes on windows
         if r < n && is_separator(path[r]) {
             r += 1;
+            if !has_room(buf, buf_i, 1) {
+                return None;
+            }
             buf[buf_i] = separator;
             buf_i += 1;
 
@@ -1046,11 +1235,17 @@ pub fn normalize_string_generic_tz<
             } else if ALLOW_ABOVE_ROOT {
                 if buf_i > buf_start {
                     // sep_str ++ ".."
+                    if !has_room(buf, buf_i, 3) {
+                        return None;
+                    }
                     buf[buf_i] = separator;
                     buf[buf_i + 1] = T::from_u8(b'.');
                     buf[buf_i + 2] = T::from_u8(b'.');
                     buf_i += 3;
                 } else {
+                    if !has_room(buf, buf_i, 2) {
+                        return None;
+                    }
                     buf[buf_i] = T::from_u8(b'.');
                     buf[buf_i + 1] = T::from_u8(b'.');
                     buf_i += 2;
@@ -1062,17 +1257,20 @@ pub fn normalize_string_generic_tz<
         }
 
         // real path element.
-        // add slash if needed
-        if buf_i != buf_start && buf_i > 0 && !is_separator(buf[buf_i - 1]) {
-            buf[buf_i] = separator;
-            buf_i += 1;
-        }
-
         let from = r;
         while r < n && !is_separator(path[r]) {
             r += 1;
         }
         let count = r - from;
+        // add slash if needed
+        let needs_separator = buf_i != buf_start && buf_i > 0 && !is_separator(buf[buf_i - 1]);
+        if !has_room(buf, buf_i, count + needs_separator as usize) {
+            return None;
+        }
+        if needs_separator {
+            buf[buf_i] = separator;
+            buf_i += 1;
+        }
         buf[buf_i..buf_i + count].copy_from_slice(&path[from..from + count]);
         buf_i += count;
     }
@@ -1080,6 +1278,9 @@ pub fn normalize_string_generic_tz<
     if PRESERVE_TRAILING_SLASH {
         // Was there a trailing slash? Let's keep it.
         if buf_i > 0 && path_[path_.len() - 1] == separator && buf[buf_i - 1] != separator {
+            if !has_room(buf, buf_i, 1) {
+                return None;
+            }
             buf[buf_i] = separator;
             buf_i += 1;
         }
@@ -1088,6 +1289,9 @@ pub fn normalize_string_generic_tz<
     if is_windows && buf_i == 2 && buf[1] == T::from_u8(b':') {
         // If the original path is just a relative path with a drive letter,
         // add .
+        if !has_room(buf, buf_i, 1) {
+            return None;
+        }
         buf[buf_i] = if !path.is_empty() && path[0] == T::from_u8(b'\\') {
             T::from_u8(b'\\')
         } else {
@@ -1097,10 +1301,13 @@ pub fn normalize_string_generic_tz<
     }
 
     if ZERO_TERMINATE {
+        if !has_room(buf, buf_i, 1) {
+            return None;
+        }
         buf[buf_i] = T::from_u8(0);
     }
 
-    &mut buf[0..buf_i]
+    Some(&mut buf[0..buf_i])
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, core::marker::ConstParamTy)]
@@ -1269,12 +1476,20 @@ impl Platform {
     }
 }
 
-/// `str` must normalize into [`PARSER_BUFFER_LEN`] bytes; for input of
-/// arbitrary length use [`normalize_string_spill`].
-pub fn normalize_string<const ALLOW_ABOVE_ROOT: bool, P: PlatformT>(str: &[u8]) -> &mut [u8] {
-    // returns slice into thread-local PARSER_BUFFER; valid until the
-    // next call on this thread.
-    PARSER_BUFFER.with(|b| normalize_string_buf::<ALLOW_ABOVE_ROOT, P, false>(str, tl_buf_mut(b)))
+/// Normalizes `str`, of any length, into a thread-local buffer. The result is
+/// valid until the next call on this thread.
+pub fn normalize_string<const ALLOW_ABOVE_ROOT: bool, P: PlatformT>(str: &[u8]) -> &'static [u8] {
+    // Normalizing grows a path by at most one byte (see `normalize_string_generic_tz`).
+    let capacity = str.len() + 1;
+    if capacity <= PARSER_BUFFER_LEN {
+        return PARSER_BUFFER
+            .with(|b| &*normalize_string_buf::<ALLOW_ABOVE_ROOT, P, false>(str, tl_buf_mut(b)));
+    }
+    spill_out(&PARSER_SPILL, capacity, |buf| {
+        normalize_string_buf_checked::<ALLOW_ABOVE_ROOT, P, false>(str, buf)
+            .map(|normalized| &*normalized)
+            .unwrap_or_else(|| unreachable!("capacity bounds the normalized path"))
+    })
 }
 
 /// [`normalize_string`] (thread-local buffer) when the result fits, otherwise
@@ -1295,22 +1510,51 @@ pub fn normalize_string_spill<'a, const ALLOW_ABOVE_ROOT: bool, P: PlatformT>(
     normalize_string_buf::<ALLOW_ABOVE_ROOT, P, false>(str, &mut spill[..])
 }
 
-pub fn normalize_buf<'a, P: PlatformT>(str: &[u8], buf: &'a mut [u8]) -> &'a mut [u8] {
+/// [`normalize_buf_t`] for `u8` paths. `None` when the result does not fit `buf`.
+pub fn normalize_buf_checked<'a, P: PlatformT>(
+    str: &[u8],
+    buf: &'a mut [u8],
+) -> Option<&'a mut [u8]> {
     normalize_buf_t::<u8, P>(str, buf)
 }
 
-pub fn normalize_buf_z<'a, P: PlatformT>(str: &[u8], buf: &'a mut [u8]) -> &'a mut ZStr {
-    let norm = normalize_buf_t::<u8, P>(str, buf);
-    let len = norm.len();
-    buf[len] = 0;
-    // SAFETY: buf[len] == 0 written above
-    unsafe { ZStr::from_raw_mut(buf.as_mut_ptr(), len) }
+/// [`normalize_buf_checked`] for a `buf` known to hold the result; panics otherwise.
+#[track_caller]
+pub fn normalize_buf<'a, P: PlatformT>(str: &[u8], buf: &'a mut [u8]) -> &'a mut [u8] {
+    let buf_len = buf.len();
+    normalize_buf_checked::<P>(str, buf).unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-pub fn normalize_buf_t<'a, T: PathChar, P: PlatformT>(str: &[T], buf: &'a mut [T]) -> &'a mut [T] {
+/// [`normalize_buf_checked`], NUL-terminated. `None` when the result and its
+/// NUL do not fit `buf`.
+pub fn normalize_buf_z_checked<'a, P: PlatformT>(
+    str: &[u8],
+    buf: &'a mut [u8],
+) -> Option<&'a mut ZStr> {
+    let capacity = buf.len().checked_sub(1)?;
+    let len = normalize_buf_t::<u8, P>(str, &mut buf[..capacity])?.len();
+    buf[len] = 0;
+    // SAFETY: buf[len] == 0 written above
+    Some(unsafe { ZStr::from_raw_mut(buf.as_mut_ptr(), len) })
+}
+
+/// [`normalize_buf_z_checked`] for a `buf` known to hold the result; panics otherwise.
+#[track_caller]
+pub fn normalize_buf_z<'a, P: PlatformT>(str: &[u8], buf: &'a mut [u8]) -> &'a mut ZStr {
+    let buf_len = buf.len();
+    normalize_buf_z_checked::<P>(str, buf).unwrap_or_else(|| path_buffer_too_small(buf_len))
+}
+
+/// Normalizes a `u8` or `u16` path (`""` becomes `.`, a trailing separator is
+/// kept). `None` when the result does not fit `buf`.
+pub fn normalize_buf_t<'a, T: PathChar, P: PlatformT>(
+    str: &[T],
+    buf: &'a mut [T],
+) -> Option<&'a mut [T]> {
     if str.is_empty() {
-        buf[0] = T::from_u8(b'.');
-        return &mut buf[0..1];
+        let dot = buf.get_mut(0..1)?;
+        dot[0] = T::from_u8(b'.');
+        return Some(dot);
     }
 
     let is_absolute = P::P.is_absolute_t::<T>(str);
@@ -1333,6 +1577,22 @@ pub fn normalize_buf_t<'a, T: PathChar, P: PlatformT>(str: &[T], buf: &'a mut [T
     normalize_string_buf_t::<T, false, P, true>(str, buf)
 }
 
+/// Normalizes `str` into `buf`. `None` when the result does not fit `buf`.
+pub fn normalize_string_buf_checked<
+    'a,
+    const ALLOW_ABOVE_ROOT: bool,
+    P: PlatformT,
+    const PRESERVE_TRAILING_SLASH: bool,
+>(
+    str: &[u8],
+    buf: &'a mut [u8],
+) -> Option<&'a mut [u8]> {
+    normalize_string_buf_t::<u8, ALLOW_ABOVE_ROOT, P, PRESERVE_TRAILING_SLASH>(str, buf)
+}
+
+/// [`normalize_string_buf_checked`] for a `buf` known to hold the result;
+/// panics otherwise.
+#[track_caller]
 pub fn normalize_string_buf<
     'a,
     const ALLOW_ABOVE_ROOT: bool,
@@ -1342,9 +1602,15 @@ pub fn normalize_string_buf<
     str: &[u8],
     buf: &'a mut [u8],
 ) -> &'a mut [u8] {
-    normalize_string_buf_t::<u8, ALLOW_ABOVE_ROOT, P, PRESERVE_TRAILING_SLASH>(str, buf)
+    let buf_len = buf.len();
+    normalize_string_buf_checked::<ALLOW_ABOVE_ROOT, P, PRESERVE_TRAILING_SLASH>(str, buf)
+        .unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
+/// The `*_checked` contract: `None` only when the *result* does not fit `buf`.
+/// The normalizer works in place and a `..` pops what it wrote before, so a
+/// path whose intermediate form is longer than `buf` but whose result is not
+/// is normalized in a scratch buffer and copied over.
 fn normalize_string_buf_t<
     'a,
     T: PathChar,
@@ -1354,7 +1620,36 @@ fn normalize_string_buf_t<
 >(
     str: &[T],
     buf: &'a mut [T],
-) -> &'a mut [T] {
+) -> Option<&'a mut [T]> {
+    if let Some(len) =
+        normalize_string_buf_in_place_t::<T, ALLOW_ABOVE_ROOT, P, PRESERVE_TRAILING_SLASH>(str, buf)
+            .map(|normalized| normalized.len())
+    {
+        return Some(&mut buf[..len]);
+    }
+    // Normalizing grows a path by at most one unit (see `normalize_string_generic_tz`).
+    let mut scratch = vec![T::from_u8(0); str.len() + 1];
+    let normalized =
+        normalize_string_buf_in_place_t::<T, ALLOW_ABOVE_ROOT, P, PRESERVE_TRAILING_SLASH>(
+            str,
+            &mut scratch,
+        )
+        .unwrap_or_else(|| unreachable!("the scratch buffer is sized for the input"));
+    let out = buf.get_mut(..normalized.len())?;
+    out.copy_from_slice(normalized);
+    Some(out)
+}
+
+fn normalize_string_buf_in_place_t<
+    'a,
+    T: PathChar,
+    const ALLOW_ABOVE_ROOT: bool,
+    P: PlatformT,
+    const PRESERVE_TRAILING_SLASH: bool,
+>(
+    str: &[T],
+    buf: &'a mut [T],
+) -> Option<&'a mut [T]> {
     match P::P {
         Platform::Nt => unreachable!("not implemented"),
         Platform::Windows => {
@@ -1378,10 +1673,19 @@ pub fn join_abs<'a, P: PlatformT>(cwd: &'a [u8], part: &[u8]) -> &'a [u8] {
 /// This is the equivalent of path.resolve
 ///
 /// Returned path is stored in a temporary buffer. It must be copied if it needs to be stored.
+/// `cwd` and `parts` may be of any length.
 // result borrows the thread-local buffer ('static) OR returns `cwd`
 // directly when `parts.is_empty()`. Return tied to `cwd`'s lifetime ('static: 'a).
 pub fn join_abs_string<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'a [u8] {
-    PARSER_JOIN_INPUT_BUFFER.with(|b| join_abs_string_buf::<P>(cwd, tl_buf_mut(b), parts))
+    let capacity = join_abs_capacity::<P>(cwd.len(), parts);
+    if capacity <= PARSER_JOIN_INPUT_BUFFER_LEN {
+        return PARSER_JOIN_INPUT_BUFFER
+            .with(|b| join_abs_string_buf::<P>(cwd, tl_buf_mut(b), parts));
+    }
+    spill_out(&PARSER_JOIN_INPUT_SPILL, capacity, |buf| {
+        join_abs_string_buf_checked::<P>(cwd, buf, parts)
+            .unwrap_or_else(|| unreachable!("join_abs_capacity bounds the joined path"))
+    })
 }
 
 /// [`join_abs_string`] (thread-local buffer) when the result fits, otherwise
@@ -1407,10 +1711,22 @@ pub fn join_abs_string_spill<'a, P: PlatformT>(
 /// This is the equivalent of path.resolve
 ///
 /// Returned path is stored in a temporary buffer. It must be copied if it needs to be stored.
+/// `cwd` and `parts` may be of any length.
 pub fn join_abs_string_z<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'a ZStr {
-    PARSER_JOIN_INPUT_BUFFER.with(|b| join_abs_string_buf_z::<P>(cwd, tl_buf_mut(b), parts))
+    let capacity = join_abs_capacity::<P>(cwd.len(), parts);
+    if capacity <= PARSER_JOIN_INPUT_BUFFER_LEN {
+        return PARSER_JOIN_INPUT_BUFFER
+            .with(|b| join_abs_string_buf_z::<P>(cwd, tl_buf_mut(b), parts));
+    }
+    let with_nul = spill_out(&PARSER_JOIN_INPUT_SPILL, capacity, |buf| {
+        join_abs_string_buf_z_checked::<P>(cwd, buf, parts)
+            .unwrap_or_else(|| unreachable!("join_abs_capacity bounds the joined path"))
+            .as_bytes_with_nul()
+    });
+    ZStr::from_slice_with_nul(with_nul)
 }
 
+/// Fixed output capacity of [`join`] / [`join_z`]; longer results spill to the heap.
 const JOIN_BUF_LEN: usize = 4096;
 
 thread_local! {
@@ -1418,17 +1734,41 @@ thread_local! {
         const { UnsafeCell::new([0u8; JOIN_BUF_LEN]) };
 }
 
+/// Joins and normalizes `parts`, of any length, into a thread-local buffer.
+/// The result is valid until the next `join` / `join_z` call on this thread.
 pub fn join<P: PlatformT>(parts: &[&[u8]]) -> &'static [u8] {
-    JOIN_BUF.with(|b| join_string_buf::<P>(tl_buf_mut(b), parts))
+    let capacity = join_needed(parts);
+    if capacity <= JOIN_BUF_LEN {
+        return JOIN_BUF.with(|b| join_string_buf::<P>(tl_buf_mut(b), parts));
+    }
+    spill_out(&JOIN_SPILL, capacity, |buf| {
+        join_string_buf_checked::<P>(buf, parts)
+            .unwrap_or_else(|| unreachable!("join_needed bounds the joined path"))
+    })
 }
 
+/// [`join`], NUL-terminated.
 pub fn join_z<P: PlatformT>(parts: &[&[u8]]) -> &'static ZStr {
-    JOIN_BUF.with(|b| join_z_buf::<P>(tl_buf_mut(b), parts))
+    let capacity = join_needed(parts);
+    if capacity <= JOIN_BUF_LEN {
+        return JOIN_BUF.with(|b| join_z_buf::<P>(tl_buf_mut(b), parts));
+    }
+    let with_nul = spill_out(&JOIN_SPILL, capacity, |buf| {
+        join_z_buf_checked::<P>(buf, parts)
+            .unwrap_or_else(|| unreachable!("join_needed bounds the joined path"))
+            .as_bytes_with_nul()
+    });
+    ZStr::from_slice_with_nul(with_nul)
 }
 
+/// Buffer length in which [`join_z_buf`] normalizes any `parts` in place: the
+/// parts, a separator per part (the leading slot of `normalize_string_node_t`,
+/// or the unit Windows normalization can add, takes the one the first part does
+/// not need), the NUL, and one more byte so that no parts still fit `.` and
+/// its NUL.
 #[inline]
 fn join_needed(parts: &[&[u8]]) -> usize {
-    parts.iter().map(|p| p.len() + 1).sum::<usize>() + 1
+    parts.iter().map(|p| p.len() + 1).sum::<usize>() + 2
 }
 
 /// [`join_z_buf`] into `buf` when the result fits, otherwise into `spill`
@@ -1476,31 +1816,59 @@ pub fn join_z_spill<'a, P: PlatformT>(spill: &'a mut Vec<u8>, parts: &[&[u8]]) -
     join_z_buf::<P>(&mut spill[..], parts)
 }
 
-pub fn join_z_buf<'a, P: PlatformT>(buf: &'a mut [u8], parts: &[&[u8]]) -> &'a ZStr {
-    // reshaped for borrowck — capture buf base ptr before sub-borrow
-    let buf_base = buf.as_mut_ptr();
-    let buf_len = buf.len();
-    let (start_offset, len) = {
-        let joined = join_string_buf::<P>(&mut buf[..buf_len - 1], parts);
-        (
-            (joined.as_ptr() as usize) - (buf_base as usize),
-            joined.len(),
-        )
-    };
-    debug_assert!(start_offset + len < buf_len);
-    buf[start_offset + len] = 0;
-    // SAFETY: NUL written at buf[start_offset + len]; slice is within buf
-    unsafe { ZStr::from_raw(buf_base.add(start_offset), len) }
+/// [`join_string_buf_checked`], NUL-terminated. `None` when the result and its
+/// NUL do not fit `buf`.
+pub fn join_z_buf_checked<'a, P: PlatformT>(
+    buf: &'a mut [u8],
+    parts: &[&[u8]],
+) -> Option<&'a ZStr> {
+    let capacity = buf.len().checked_sub(1)?;
+    let (start, len) = join_string_buf_t::<u8, P>(&mut buf[..capacity], parts)?;
+    buf[start + len] = 0;
+    Some(ZStr::from_slice_with_nul(&buf[start..=start + len]))
 }
 
+/// [`join_z_buf_checked`] for a `buf` known to hold the result; panics otherwise.
+#[track_caller]
+pub fn join_z_buf<'a, P: PlatformT>(buf: &'a mut [u8], parts: &[&[u8]]) -> &'a ZStr {
+    let buf_len = buf.len();
+    join_z_buf_checked::<P>(buf, parts).unwrap_or_else(|| path_buffer_too_small(buf_len))
+}
+
+/// Joins `parts` with the platform separator and normalizes the result into
+/// `buf` (`path.join`). `None` when it does not fit `buf`.
+pub fn join_string_buf_checked<'a, P: PlatformT>(
+    buf: &'a mut [u8],
+    parts: &[&[u8]],
+) -> Option<&'a [u8]> {
+    let (start, len) = join_string_buf_t::<u8, P>(buf, parts)?;
+    Some(&buf[start..start + len])
+}
+
+/// [`join_string_buf_checked`] for a `buf` known to hold the result; panics otherwise.
+#[track_caller]
 pub fn join_string_buf<'a, P: PlatformT>(buf: &'a mut [u8], parts: &[&[u8]]) -> &'a [u8] {
-    join_string_buf_t::<u8, P>(buf, parts)
+    let buf_len = buf.len();
+    join_string_buf_checked::<P>(buf, parts).unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
 /// `joinStringBufW` overload for u16 parts (no transcode): the
-/// `T == u16 && Elem == u16` case.
+/// `T == u16 && Elem == u16` case. `None` when the result does not fit `buf`.
+pub fn join_string_buf_w_same_checked<'a, P: PlatformT>(
+    buf: &'a mut [u16],
+    parts: &[&[u16]],
+) -> Option<&'a [u16]> {
+    let (start, len) = join_string_buf_t_same::<u16, P>(buf, parts)?;
+    Some(&buf[start..start + len])
+}
+
+/// [`join_string_buf_w_same_checked`] for a `buf` known to hold the result;
+/// panics otherwise.
+#[track_caller]
 pub fn join_string_buf_w_same<'a, P: PlatformT>(buf: &'a mut [u16], parts: &[&[u16]]) -> &'a [u16] {
-    join_string_buf_t_same::<u16, P>(buf, parts)
+    let buf_len = buf.len();
+    join_string_buf_w_same_checked::<P>(buf, parts)
+        .unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
 const JOIN_TEMP_LEN: usize = 4096;
@@ -1521,11 +1889,12 @@ fn join_temp_buf<'a, T>(
 
 /// Same-width `joinStringBufT`: parts already match `T`, so no UTF-8→16 transcode.
 /// split out of `join_string_buf_t` because Rust can't monomorphize on the
-/// parts' element types — callers pick the overload.
-fn join_string_buf_t_same<'a, T: PathChar, P: PlatformT>(
-    buf: &'a mut [T],
+/// parts' element types — callers pick the overload. Returns where in `buf`
+/// the result starts and its length (see `normalize_string_node_t`).
+fn join_string_buf_t_same<T: PathChar, P: PlatformT>(
+    buf: &mut [T],
     parts: &[&[T]],
-) -> &'a [T] {
+) -> Option<(usize, usize)> {
     let mut written: usize = 0;
     let mut stack_temp_buf = [const { MaybeUninit::<T>::uninit() }; JOIN_TEMP_LEN];
     let mut heap_temp_buf: Vec<T> = Vec::new();
@@ -1555,33 +1924,51 @@ fn join_string_buf_t_same<'a, T: PathChar, P: PlatformT>(
     }
 
     if written == 0 {
-        buf[0] = T::from_u8(b'.');
-        return &buf[0..1];
+        return join_dot(buf);
     }
 
     // SAFETY: the loop above wrote every unit of `temp_buf[..written]`.
     let joined = unsafe { temp_buf[..written].assume_init_ref() };
-    normalize_string_node_t::<T, P>(joined, buf)
+    join_normalize_into::<T, P>(joined, buf)
 }
 
+/// The result of joining nothing but empty parts.
+fn join_dot<T: PathChar>(buf: &mut [T]) -> Option<(usize, usize)> {
+    *buf.get_mut(0)? = T::from_u8(b'.');
+    Some((0, 1))
+}
+
+/// `normalize_string_node_t` under the `*_checked` contract (see
+/// `normalize_string_buf_t`): a result that fits `buf` is produced even when
+/// the intermediate form does not, by normalizing in a scratch buffer first.
+fn join_normalize_into<T: PathChar, P: PlatformT>(
+    joined: &[T],
+    buf: &mut [T],
+) -> Option<(usize, usize)> {
+    if let Some(placed) = normalize_string_node_t::<T, P>(joined, buf) {
+        return Some(placed);
+    }
+    // Room for the leading slot or the one unit Windows normalization can add.
+    let mut scratch = vec![T::from_u8(0); joined.len() + 2];
+    let (start, len) = normalize_string_node_t::<T, P>(joined, &mut scratch)
+        .unwrap_or_else(|| unreachable!("the scratch buffer is sized for the input"));
+    buf.get_mut(..len)?
+        .copy_from_slice(&scratch[start..start + len]);
+    Some((0, len))
+}
+
+/// [`join_z_buf`] under its older name.
+#[track_caller]
 pub fn join_string_buf_z<'a, P: PlatformT>(buf: &'a mut [u8], parts: &[&[u8]]) -> &'a ZStr {
-    // reshaped for borrowck — capture buf base ptr before sub-borrow
-    let buf_base = buf.as_mut_ptr();
-    let buf_len = buf.len();
-    let (start_offset, len) = {
-        let joined = join_string_buf_t::<u8, P>(&mut buf[..buf_len - 1], parts);
-        (
-            (joined.as_ptr() as usize) - (buf_base as usize),
-            joined.len(),
-        )
-    };
-    debug_assert!(start_offset + len < buf_len);
-    buf[start_offset + len] = 0;
-    // SAFETY: NUL written at buf[start_offset + len]; slice is within buf
-    unsafe { ZStr::from_raw(buf_base.add(start_offset), len) }
+    join_z_buf::<P>(buf, parts)
 }
 
-fn join_string_buf_t<'a, T: PathChar, P: PlatformT>(buf: &'a mut [T], parts: &[&[u8]]) -> &'a [T] {
+/// Returns where in `buf` the result starts and its length (see
+/// `normalize_string_node_t`).
+fn join_string_buf_t<T: PathChar, P: PlatformT>(
+    buf: &mut [T],
+    parts: &[&[u8]],
+) -> Option<(usize, usize)> {
     // Takes `&[&[u8]]` — every in-tree caller passes u8
     // parts — and transcodes to u16 below when `T == u16`.
     let mut written: usize = 0;
@@ -1617,13 +2004,12 @@ fn join_string_buf_t<'a, T: PathChar, P: PlatformT>(buf: &'a mut [T], parts: &[&
     }
 
     if written == 0 {
-        buf[0] = T::from_u8(b'.');
-        return &buf[0..1];
+        return join_dot(buf);
     }
 
     // SAFETY: the loop above wrote every unit of `temp_buf[..written]`.
     let joined = unsafe { temp_buf[..written].assume_init_ref() };
-    normalize_string_node_t::<T, P>(joined, buf)
+    join_normalize_into::<T, P>(joined, buf)
 }
 
 /// Buffer length that holds `_join_abs_string_buf`'s concatenation of `cwd` and
@@ -1632,6 +2018,14 @@ fn join_string_buf_t<'a, T: PathChar, P: PlatformT>(buf: &'a mut [T], parts: &[&
 #[inline]
 fn join_abs_needed(cwd_len: usize, parts: &[&[u8]]) -> usize {
     parts.iter().map(|p| p.len() + 1).sum::<usize>() + cwd_len + 2
+}
+
+/// Buffer length that holds [`join_abs_string_buf_z`]'s result for `cwd` and
+/// `parts`: [`join_abs_needed`] covers the path (the separator the first part
+/// does not need pays for the NUL), plus the `\\?\` prefix `Platform::Nt` adds.
+#[inline]
+fn join_abs_capacity<P: PlatformT>(cwd_len: usize, parts: &[&[u8]]) -> usize {
+    join_abs_needed(cwd_len, parts) + if P::P == Platform::Nt { 4 } else { 0 }
 }
 
 /// Scratch buffer for `_join_abs_string_buf`'s unnormalized concatenation.
@@ -1664,74 +2058,78 @@ impl JoinScratch {
     }
 }
 
+/// [`join_abs_string_buf_checked`] for a `buf` known to hold the result (a
+/// `PathBuffer` does when the inputs are paths that fit one); panics otherwise.
+#[track_caller]
 pub fn join_abs_string_buf<'a, P: PlatformT>(
     cwd: &'a [u8],
     buf: &'a mut [u8],
     parts: &[&[u8]],
 ) -> &'a [u8] {
-    _join_abs_string_buf::<false, P>(cwd, buf, parts)
+    let buf_len = buf.len();
+    join_abs_string_buf_checked::<P>(cwd, buf, parts)
+        .unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-/// Like `join_abs_string_buf`, but returns null when the *normalized* result is
-/// too large for `buf`. Use this when `parts` may contain user-controlled
-/// input of arbitrary length. `..` segments are handled correctly: a path
-/// whose unnormalized length exceeds `buf.len` but normalizes down will still
-/// succeed.
+/// `path.resolve(cwd, ...parts)` into `buf`. Returns `None` when the
+/// *normalized* result does not fit `buf`, so `parts` may carry user input of
+/// any length: a path whose unnormalized length exceeds `buf.len()` but
+/// normalizes down still succeeds. With no `parts` the result is `cwd` itself.
 pub fn join_abs_string_buf_checked<'a, P: PlatformT>(
     cwd: &'a [u8],
     buf: &'a mut [u8],
     parts: &[&[u8]],
 ) -> Option<&'a [u8]> {
-    debug_assert!(!matches!(P::P, Platform::Nt));
-    // Fast path: size check only — don't allocate a JoinScratch here since the
-    // inner join_abs_string_buf already has its own (avoids doubling stack usage).
-    let total = join_abs_needed(cwd.len(), parts);
-    if total < buf.len() {
-        return Some(join_abs_string_buf::<P>(cwd, buf, parts));
-    }
-
-    // Slow path: allocate a large scratch for the result. The inner
-    // join_abs_string_buf will heap-allocate its own temp buffer for the concat
-    // since `total > MAX_PATH_BYTES * 2 > sfa inline size` is likely here.
-    let mut scratch = vec![0u8; total];
-    let joined = join_abs_string_buf::<P>(cwd, &mut scratch, parts);
-    if joined.len() > buf.len() {
-        return None;
-    }
-    let len = joined.len();
-    buf[..len].copy_from_slice(joined);
-    Some(&buf[..len])
+    _join_abs_string_buf::<false, P>(cwd, buf, parts)
 }
 
+/// [`join_abs_string_buf_checked`], NUL-terminated. `None` when the result and
+/// its NUL do not fit `buf`. `parts` must not be empty.
+pub fn join_abs_string_buf_z_checked<'a, P: PlatformT>(
+    cwd: &'a [u8],
+    buf: &'a mut [u8],
+    parts: &[&[u8]],
+) -> Option<&'a ZStr> {
+    let len = _join_abs_string_buf::<true, P>(cwd, buf, parts)?.len();
+    Some(ZStr::from_buf(buf, len))
+}
+
+/// [`join_abs_string_buf_z_checked`] for a `buf` known to hold the result;
+/// panics otherwise.
+#[track_caller]
 pub fn join_abs_string_buf_z<'a, P: PlatformT>(
     cwd: &'a [u8],
     buf: &'a mut [u8],
     parts: &[&[u8]],
 ) -> &'a ZStr {
-    let r = _join_abs_string_buf::<true, P>(cwd, buf, parts);
-    // SAFETY: IS_SENTINEL=true wrote NUL at r.len()
-    unsafe { ZStr::from_raw(r.as_ptr(), r.len()) }
+    let buf_len = buf.len();
+    join_abs_string_buf_z_checked::<P>(cwd, buf, parts)
+        .unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-// We always return `&[u8]`; when `IS_SENTINEL` a NUL is written
-// at `result.len()` and callers (e.g. `join_abs_string_buf_z`) re-wrap as `ZStr`.
+// We always return `&[u8]`; when `IS_SENTINEL` a NUL is written at
+// `buf[result.len()]` (the result then always starts at `buf[0]`) and callers
+// (e.g. `join_abs_string_buf_z_checked`) re-wrap as `ZStr`. `None` when the
+// result (and its NUL) does not fit `buf`.
 fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
     _cwd: &'a [u8],
     buf: &'a mut [u8],
     _parts: &[&[u8]],
-) -> &'a [u8] {
+) -> Option<&'a [u8]> {
     if P::P == Platform::Windows || (cfg!(windows) && P::P == Platform::Loose) {
         return join_abs_string_buf_windows::<IS_SENTINEL>(_cwd, buf, _parts);
     }
 
     if P::P == Platform::Nt {
-        let end_path = join_abs_string_buf_windows::<IS_SENTINEL>(_cwd, &mut buf[4..], _parts);
-        let end_len = end_path.len();
-        buf[0..4].copy_from_slice(b"\\\\?\\");
-        if IS_SENTINEL {
-            buf[end_len + 4] = 0;
-        }
-        return &buf[0..end_len + 4];
+        const NT_PREFIX: &[u8] = b"\\\\?\\";
+        let end_len = join_abs_string_buf_windows::<IS_SENTINEL>(
+            _cwd,
+            buf.get_mut(NT_PREFIX.len()..)?,
+            _parts,
+        )?
+        .len();
+        buf[..NT_PREFIX.len()].copy_from_slice(NT_PREFIX);
+        return buf.get(..NT_PREFIX.len() + end_len);
     }
 
     let mut parts: &[&[u8]] = _parts;
@@ -1739,7 +2137,7 @@ fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
         if IS_SENTINEL {
             unreachable!();
         }
-        return _cwd;
+        return Some(_cwd);
     }
 
     if matches!(P::P, Platform::Loose | Platform::Posix)
@@ -1750,11 +2148,12 @@ fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
         // A bare `b"/"` literal is NOT NUL-terminated and not in `buf`, breaking callers
         // that assume buf-backing (`ZStr::from_raw`, trailing-slash check).
         // Write into `buf` so the result is always buf-backed and sentinel-safe.
-        buf[0] = b'/';
+        let root = buf.get_mut(..1 + IS_SENTINEL as usize)?;
+        root[0] = b'/';
         if IS_SENTINEL {
-            buf[1] = 0;
+            root[1] = 0;
         }
-        return &buf[0..1];
+        return Some(&root[..1]);
     }
 
     let mut cwd = if cfg!(windows) && _cwd.len() >= 3 && _cwd[1] == b':' {
@@ -1819,33 +2218,40 @@ fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
         1
     };
     // Copy leading separator into buf (order-independent with normalize,
-    // which writes into buf[leading_len..]).
-    buf[..leading_len].copy_from_slice(&leading_buf[..leading_len]);
+    // which writes into buf[leading_len..]). The last byte is reserved for the
+    // sentinel.
+    let capacity = buf.len().checked_sub(IS_SENTINEL as usize)?;
+    let out_buf = &mut buf[..capacity];
+    out_buf
+        .get_mut(..leading_len)?
+        .copy_from_slice(&leading_buf[..leading_len]);
 
-    let result = normalize_string_buf::<false, P, true>(
+    let result_len = normalize_string_buf_checked::<false, P, true>(
         &temp_buf[leading_len..out],
-        &mut buf[leading_len..],
-    );
-    let result_len = result.len();
+        &mut out_buf[leading_len..],
+    )?
+    .len();
+    let len = leading_len + result_len;
 
     if IS_SENTINEL {
-        buf[result_len + leading_len] = 0;
+        buf[len] = 0;
     }
-    &buf[0..result_len + leading_len]
+    Some(&buf[..len])
 }
 
+/// See `_join_abs_string_buf` for the return contract.
 fn join_abs_string_buf_windows<'a, const IS_SENTINEL: bool>(
     cwd: &'a [u8],
     buf: &'a mut [u8],
     parts: &[&[u8]],
-) -> &'a [u8] {
+) -> Option<&'a [u8]> {
     debug_assert!(crate::is_absolute_windows(cwd));
 
     if parts.is_empty() {
         if IS_SENTINEL {
             unreachable!();
         }
-        return cwd;
+        return Some(cwd);
     }
 
     // path.resolve is a bit different on Windows, as there are multiple possible filesystem roots.
@@ -1933,13 +2339,18 @@ fn join_abs_string_buf_windows<'a, const IS_SENTINEL: bool>(
         out += part_without_vol.len();
     }
 
-    let result = normalize_string_buf::<false, platform::Windows, true>(&temp_buf[0..out], buf);
-    let result_len = result.len();
+    // The last byte is reserved for the sentinel.
+    let capacity = buf.len().checked_sub(IS_SENTINEL as usize)?;
+    let result_len = normalize_string_buf_checked::<false, platform::Windows, true>(
+        &temp_buf[0..out],
+        &mut buf[..capacity],
+    )?
+    .len();
 
     if IS_SENTINEL {
         buf[result_len] = 0;
     }
-    &buf[0..result_len]
+    Some(&buf[..result_len])
 }
 
 // Separator predicates live in T0 `bun_core::path_sep`; re-export the full set
@@ -1988,7 +2399,7 @@ fn normalize_string_loose_buf_t<
 >(
     str: &[T],
     buf: &'a mut [T],
-) -> &'a mut [T] {
+) -> Option<&'a mut [T]> {
     normalize_string_generic_t::<T, ALLOW_ABOVE_ROOT, PRESERVE_TRAILING_SLASH>(
         str,
         buf,
@@ -2005,7 +2416,7 @@ fn normalize_string_windows_t<
 >(
     str: &[T],
     buf: &'a mut [T],
-) -> &'a mut [T] {
+) -> Option<&'a mut [T]> {
     normalize_string_generic_t::<T, ALLOW_ABOVE_ROOT, PRESERVE_TRAILING_SLASH>(
         str,
         buf,
@@ -2014,13 +2425,16 @@ fn normalize_string_windows_t<
     )
 }
 
-fn normalize_string_node_t<'a, T: PathChar, P: PlatformT>(
+/// `path.normalize` for `join*`. Returns where in `buf` the result starts and
+/// its length: off Windows the result of a relative input starts at `buf[1]`,
+/// the slot an absolute one uses for its leading separator. `None` when the
+/// intermediate form does not fit `buf` (see `normalize_string_generic_tz`).
+fn normalize_string_node_t<T: PathChar, P: PlatformT>(
     str: &[T],
-    buf: &'a mut [T],
-) -> &'a mut [T] {
+    buf: &mut [T],
+) -> Option<(usize, usize)> {
     if str.is_empty() {
-        buf[0] = T::from_u8(b'.');
-        return &mut buf[0..1];
+        return join_dot(buf);
     }
 
     let is_absolute = P::P.is_absolute_t::<T>(str);
@@ -2034,58 +2448,44 @@ fn normalize_string_node_t<'a, T: PathChar, P: PlatformT>(
     let separator_t = T::from_u8(P::P.separator());
     let is_sep_fn = |c: T| P::P.is_separator_t::<T>(c);
 
+    let out = buf.get_mut(buf_off..)?;
     let out_len = if !is_absolute {
-        normalize_string_generic_t::<T, true, false>(
-            str,
-            &mut buf[buf_off..],
-            separator_t,
-            is_sep_fn,
-        )
-        .len()
+        normalize_string_generic_t::<T, true, false>(str, out, separator_t, is_sep_fn)?.len()
     } else {
-        normalize_string_generic_t::<T, false, false>(
-            str,
-            &mut buf[buf_off..],
-            separator_t,
-            is_sep_fn,
-        )
-        .len()
+        normalize_string_generic_t::<T, false, false>(str, out, separator_t, is_sep_fn)?.len()
     };
     let mut out_len = out_len;
 
     if out_len == 0 {
         if is_absolute {
-            buf[0] = separator_t;
-            return &mut buf[0..1];
+            *buf.get_mut(0)? = separator_t;
+            return Some((0, 1));
         }
 
         if trailing_separator {
             let sep = P::P.trailing_separator();
-            buf[0] = T::from_u8(sep[0]);
-            buf[1] = T::from_u8(sep[1]);
-            return &mut buf[0..2];
+            let dot_slash = buf.get_mut(0..2)?;
+            dot_slash[0] = T::from_u8(sep[0]);
+            dot_slash[1] = T::from_u8(sep[1]);
+            return Some((0, 2));
         }
 
-        buf[0] = T::from_u8(b'.');
-        return &mut buf[0..1];
+        return join_dot(buf);
     }
 
     if trailing_separator {
         if !P::P.is_separator_t::<T>(buf[buf_off + out_len - 1]) {
-            buf[buf_off + out_len] = separator_t;
+            *buf.get_mut(buf_off + out_len)? = separator_t;
             out_len += 1;
         }
     }
 
-    if is_absolute {
-        if P::P == Platform::Windows {
-            return &mut buf[buf_off..buf_off + out_len];
-        }
+    if is_absolute && P::P != Platform::Windows {
         buf[0] = separator_t;
-        return &mut buf[0..out_len + 1];
+        return Some((0, out_len + 1));
     }
 
-    &mut buf[buf_off..buf_off + out_len]
+    Some((buf_off, out_len))
 }
 
 /// **NOT** plain basename (see
@@ -2529,6 +2929,46 @@ mod tests {
             .unwrap_or(text_len)
     }
 
+    /// Returns `haystack_len` when `needle` does not occur, like the kernel.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_last_index_of_char(
+        haystack: *const u8,
+        haystack_len: usize,
+        needle: u8,
+    ) -> usize {
+        // SAFETY: test stub; callers pass a valid (ptr, len) pair.
+        let haystack = unsafe { core::slice::from_raw_parts(haystack, haystack_len) };
+        haystack
+            .iter()
+            .rposition(|&b| b == needle)
+            .unwrap_or(haystack_len)
+    }
+
+    /// Returns `usize::MAX` when `needle` does not occur, like the kernel.
+    #[unsafe(no_mangle)]
+    unsafe extern "C" fn highway_memrmem16(
+        haystack: *const u16,
+        haystack_len: usize,
+        needle: *const u16,
+        needle_len: usize,
+    ) -> usize {
+        // SAFETY: test stub; callers pass valid (ptr, len) pairs.
+        let (haystack, needle) = unsafe {
+            (
+                core::slice::from_raw_parts(haystack, haystack_len),
+                core::slice::from_raw_parts(needle, needle_len),
+            )
+        };
+        haystack_len
+            .checked_sub(needle_len)
+            .and_then(|last| {
+                (0..=last)
+                    .rev()
+                    .find(|&i| haystack[i..i + needle_len] == *needle)
+            })
+            .unwrap_or(usize::MAX)
+    }
+
     #[test]
     fn normalize_string_spill_leaves_spill_untouched_when_the_input_fits() {
         let mut spill = Vec::new();
@@ -2703,6 +3143,536 @@ mod tests {
         assert_eq!(
             join_string_buf_w_same::<platform::Windows>(&mut out, &[&long, &rest]),
             &expected[..]
+        );
+    }
+
+    /// `f` into a buffer one byte shorter than `expected` fails, and into one
+    /// exactly as long succeeds with `expected`, no matter where inside the
+    /// buffer the result is placed.
+    #[track_caller]
+    fn assert_fits_exactly(expected: &[u8], f: impl Fn(&mut [u8]) -> Option<Vec<u8>>) {
+        let mut short = vec![0xAAu8; expected.len() - 1];
+        assert_eq!(f(&mut short), None, "must not fit {} bytes", short.len());
+        let mut exact = vec![0xAAu8; expected.len()];
+        assert_eq!(f(&mut exact).as_deref(), Some(expected));
+        assert_eq!(f(&mut []), None);
+    }
+
+    fn normalize_posix<'a>(path: &[u8], buf: &'a mut [u8]) -> Option<&'a mut [u8]> {
+        normalize_string_generic_t::<u8, true, false>(path, buf, b'/', |c| c == b'/')
+    }
+
+    fn normalize_windows<'a, const ALLOW_ABOVE_ROOT: bool>(
+        path: &[u8],
+        buf: &'a mut [u8],
+    ) -> Option<&'a mut [u8]> {
+        normalize_string_generic_t::<u8, ALLOW_ABOVE_ROOT, true>(path, buf, b'\\', is_sep_any)
+    }
+
+    #[test]
+    fn normalizer_reports_instead_of_writing_past_the_buffer() {
+        let long = vec![b'a'; 100];
+        assert_fits_exactly(&long, |buf| normalize_posix(&long, buf).map(|s| s.to_vec()));
+        assert_fits_exactly(b"a/b/c", |buf| {
+            normalize_posix(b"a//./b/x/../c", buf).map(|s| s.to_vec())
+        });
+        assert_fits_exactly(b"../..", |buf| {
+            normalize_posix(b"a/../../..", buf).map(|s| s.to_vec())
+        });
+
+        // The primitive works in place, so it needs room for the intermediate
+        // form (`dir`) of a path that collapses; the `*_checked` functions
+        // built on it only need room for the result.
+        assert_eq!(normalize_posix(b"dir/../x", &mut [0u8; 1]), None);
+        assert_eq!(
+            normalize_posix(b"dir/../x", &mut [0u8; 3]).as_deref(),
+            Some(&b"x"[..])
+        );
+        let mut collapsing = b"dir/../".repeat(1000);
+        collapsing.extend_from_slice(b"x");
+        let mut one = [0u8; 1];
+        assert_eq!(
+            normalize_buf_checked::<platform::Posix>(&collapsing, &mut one).as_deref(),
+            Some(&b"x"[..])
+        );
+        assert_eq!(
+            normalize_string_buf_checked::<true, platform::Loose, false>(&collapsing, &mut one)
+                .as_deref(),
+            Some(&b"x"[..])
+        );
+        assert_eq!(
+            normalize_buf_checked::<platform::Posix>(b"dir/../xy", &mut one),
+            None
+        );
+    }
+
+    #[test]
+    fn normalizer_checks_the_units_windows_adds_to_its_input() {
+        let windows = |path: &'static [u8], expected: &[u8]| {
+            assert_fits_exactly(expected, |buf| {
+                normalize_windows::<false>(path, buf).map(|s| s.to_vec())
+            });
+        };
+        windows(b"c:", b"C:.");
+        windows(b"c:\\x\\", b"C:\\x\\");
+        windows(b"\\\\server\\share", b"\\\\server\\share\\");
+        windows(b"\\\\server/share\\x", b"\\\\server\\share\\x");
+        windows(b"\\x\\..\\y", b"\\y");
+        assert_fits_exactly(b"C:\\\\..", |buf| {
+            normalize_windows::<true>(b"C:\\..", buf).map(|s| s.to_vec())
+        });
+    }
+
+    #[test]
+    fn normalizer_checks_the_nt_prefix_and_the_nul() {
+        fn nt<const ADD_NT_PREFIX: bool>(path: &str, buf: &mut [u16]) -> Option<Vec<u16>> {
+            let path: Vec<u16> = path.encode_utf16().collect();
+            let len = normalize_string_generic_tz::<u16, false, false, true, ADD_NT_PREFIX>(
+                &path,
+                buf,
+                b'\\' as u16,
+                is_sep_any_t::<u16>,
+            )?
+            .len();
+            assert_eq!(buf[len], 0);
+            Some(buf[..=len].to_vec())
+        }
+        let check = |expected_with_nul: &str, f: &dyn Fn(&mut [u16]) -> Option<Vec<u16>>| {
+            let expected: Vec<u16> = expected_with_nul.encode_utf16().collect();
+            let mut short = vec![0xAAAAu16; expected.len() - 1];
+            assert_eq!(f(&mut short), None, "{expected_with_nul:?} must not fit");
+            let mut exact = vec![0xAAAAu16; expected.len()];
+            assert_eq!(f(&mut exact), Some(expected));
+            assert_eq!(f(&mut []), None);
+        };
+        check("\\??\\C:\\x\0", &|buf| nt::<true>("C:/./x", buf));
+        check("\\??\\C:\\\0", &|buf| nt::<true>("C:\\", buf));
+        check("\\??\\UNC\\s\\sh\\\0", &|buf| nt::<true>("\\\\s\\sh", buf));
+        check("\\??\\UNC\\s\\sh\\x\0", &|buf| nt::<true>("//s/sh/x", buf));
+        check("\\\\s\\sh\\\0", &|buf| nt::<false>("\\\\s\\sh", buf));
+        check("C:\\x\\y\0", &|buf| nt::<false>("C:/x//./y", buf));
+        check("x\0", &|buf| nt::<false>("x", buf));
+        // The primitive works in place: the intermediate form `C:\x\y` needs
+        // six units even though the result is shorter.
+        assert_eq!(nt::<false>("C:\\x\\y\\..", &mut [0u16; 5]), None);
+        let expected: Vec<u16> = "C:\\x\0".encode_utf16().collect();
+        assert_eq!(nt::<false>("C:\\x\\y\\..", &mut [0u16; 6]), Some(expected));
+    }
+
+    #[test]
+    fn checked_buffer_variants_fit_exactly() {
+        assert_fits_exactly(b"a/b", |buf| {
+            normalize_buf_checked::<platform::Posix>(b"a/./b", buf).map(|s| s.to_vec())
+        });
+        assert_fits_exactly(b".", |buf| {
+            normalize_buf_checked::<platform::Posix>(b"", buf).map(|s| s.to_vec())
+        });
+        assert_fits_exactly(b"a/b/\0", |buf| {
+            normalize_buf_z_checked::<platform::Posix>(b"a//b/", buf)
+                .map(|s| s.as_bytes_with_nul().to_vec())
+        });
+        assert_fits_exactly(b"/work/b", |buf| {
+            join_abs_string_buf_checked::<platform::Posix>(b"/work", buf, &[b"a/../b"])
+                .map(|s| s.to_vec())
+        });
+        assert_fits_exactly(b"/work/b\0", |buf| {
+            join_abs_string_buf_z_checked::<platform::Posix>(b"/work", buf, &[b"a", b"../b"])
+                .map(|s| s.as_bytes_with_nul().to_vec())
+        });
+        assert_fits_exactly(b"/\0", |buf| {
+            join_abs_string_buf_z_checked::<platform::Posix>(b"/work", buf, &[b"/"])
+                .map(|s| s.as_bytes_with_nul().to_vec())
+        });
+        assert_fits_exactly(b"C:\\work\\b\0", |buf| {
+            join_abs_string_buf_z_checked::<platform::Windows>(b"C:\\work", buf, &[b"a/../b"])
+                .map(|s| s.as_bytes_with_nul().to_vec())
+        });
+        assert_fits_exactly(b"\\\\?\\C:\\work\\b\0", |buf| {
+            join_abs_string_buf_z_checked::<platform::Nt>(b"C:\\work", buf, &[b"b"])
+                .map(|s| s.as_bytes_with_nul().to_vec())
+        });
+        assert_fits_exactly(b"C:\\b", |buf| {
+            join_string_buf_checked::<platform::Windows>(buf, &[b"C:\\", b"a\\..\\b"])
+                .map(|s| s.to_vec())
+        });
+        assert_fits_exactly(b"foo\\baz", |buf| {
+            let mut wide = vec![0u16; buf.len()];
+            let foo: Vec<u16> = "foo".encode_utf16().collect();
+            let rest: Vec<u16> = "bar\\..\\baz".encode_utf16().collect();
+            let out =
+                join_string_buf_w_same_checked::<platform::Windows>(&mut wide, &[&foo, &rest])?;
+            Some(out.iter().map(|&c| c as u8).collect())
+        });
+
+        // A collapsing part that is longer than the buffer still joins.
+        let mut part = b"sub/../".repeat(100);
+        part.extend_from_slice(b"x");
+        let mut buf = [0u8; 8];
+        assert_eq!(
+            join_abs_string_buf_checked::<platform::Posix>(b"/work", &mut buf, &[&part]),
+            Some(&b"/work/x"[..])
+        );
+        assert_eq!(
+            join_abs_string_buf_checked::<platform::Posix>(b"/work", &mut buf, &[b"toolong1"]),
+            None
+        );
+    }
+
+    #[test]
+    fn join_checked_variants_only_need_room_for_the_result() {
+        // Off Windows `normalize_string_node_t` places a relative result at
+        // `buf[1..]`; a buffer with room for the result alone still works.
+        let mut buf = [0u8; 8];
+        assert_eq!(
+            join_string_buf_t::<u8, platform::Posix>(&mut buf, &[b"a", b"b"]),
+            Some((1, 3))
+        );
+        assert_eq!(
+            join_string_buf_t::<u8, platform::Posix>(&mut buf, &[b"/a", b"b"]),
+            Some((0, 4))
+        );
+        assert_eq!(
+            join_string_buf_t::<u8, platform::Windows>(&mut buf, &[b"a", b"b"]),
+            Some((0, 3))
+        );
+        assert_eq!(
+            join_string_buf_t::<u8, platform::Posix>(&mut buf[..3], &[b"a", b"b"]),
+            Some((0, 3))
+        );
+        assert_fits_exactly(b"a/b", |buf| {
+            join_string_buf_checked::<platform::Posix>(buf, &[b"a", b"b"]).map(|s| s.to_vec())
+        });
+        assert_fits_exactly(b"a/b\0", |buf| {
+            join_z_buf_checked::<platform::Posix>(buf, &[b"a", b"b"])
+                .map(|z| z.as_bytes_with_nul().to_vec())
+        });
+        assert_fits_exactly(b"/", |buf| {
+            join_string_buf_checked::<platform::Posix>(buf, &[b"/"]).map(|s| s.to_vec())
+        });
+
+        // The same goes for a result that only fits once `..` has collapsed
+        // the path.
+        let mut two = [0u8; 2];
+        assert_eq!(
+            join_string_buf_checked::<platform::Posix>(&mut two[..1], &[b"dir", b"../x"]),
+            Some(&b"x"[..])
+        );
+        assert_eq!(
+            join_z_buf_checked::<platform::Posix>(&mut two, &[b"dir", b"../x"])
+                .map(|z| z.as_bytes_with_nul().to_vec())
+                .as_deref(),
+            Some(&b"x\0"[..])
+        );
+        assert_eq!(
+            join_string_buf_checked::<platform::Posix>(&mut two, &[b"dir", b"../xyz"]),
+            None
+        );
+    }
+
+    #[test]
+    fn join_needed_holds_for_the_results_that_grow() {
+        fn check<P: PlatformT>(parts: &[&[u8]], expected: &[u8]) {
+            let mut buf = vec![0u8; join_needed(parts)];
+            assert_eq!(
+                join_z_buf_checked::<P>(&mut buf, parts)
+                    .map(|z| z.as_bytes().to_vec())
+                    .as_deref(),
+                Some(expected)
+            );
+        }
+        check::<platform::Windows>(&[b"C:"], b"C:.");
+        check::<platform::Windows>(&[b"\\\\s\\sh"], b"\\\\s\\sh\\");
+        check::<platform::Windows>(&[b"..", b".."], b"..\\..");
+        check::<platform::Posix>(&[b"a", b"b/"], b"a/b/");
+        check::<platform::Posix>(&[b"a/"], b"a/");
+        check::<platform::Posix>(&[b"./"], b"./");
+        check::<platform::Posix>(&[b"/"], b"/");
+        check::<platform::Posix>(&[b"", b""], b".");
+        check::<platform::Posix>(&[], b".");
+    }
+
+    #[test]
+    fn join_abs_needed_holds_for_the_results_that_grow() {
+        fn check<P: PlatformT>(cwd: &[u8], parts: &[&[u8]], expected: &[u8]) {
+            let mut buf = vec![0u8; join_abs_capacity::<P>(cwd.len(), parts)];
+            assert_eq!(
+                join_abs_string_buf_z_checked::<P>(cwd, &mut buf, parts)
+                    .map(|z| z.as_bytes().to_vec())
+                    .as_deref(),
+                Some(expected)
+            );
+        }
+        check::<platform::Posix>(b"/x", &[b"y"], b"/x/y");
+        check::<platform::Posix>(b"/", &[b"y"], b"/y");
+        check::<platform::Posix>(b"/", &[b"a", b"/b", b"c"], b"/b/c");
+        check::<platform::Posix>(b"/x", &[b"", b"y/"], b"/x/y/");
+        check::<platform::Loose>(b"/w", &[b"a\\b"], b"/w/a/b");
+        // The root comes from one part and the directory from another.
+        check::<platform::Windows>(
+            b"C:\\",
+            &[b"/one", b"D:two", b"three"],
+            b"D:\\one\\two\\three",
+        );
+        check::<platform::Windows>(b"\\\\s\\sh", &[b"x"], b"\\\\s\\sh\\x");
+        check::<platform::Nt>(b"C:\\w", &[b"x"], b"\\\\?\\C:\\w\\x");
+    }
+
+    fn relative_into(buf: &mut [u8], from: &[u8], to: &[u8]) -> Option<Vec<u8>> {
+        relative_normalized_buf_checked::<platform::Posix, true>(buf, from, to).map(|r| r.to_vec())
+    }
+
+    #[test]
+    fn relative_checked_variants_fit_exactly() {
+        assert_fits_exactly(b"../../c/d", |buf| relative_into(buf, b"/x/a/b", b"/x/c/d"));
+        assert_fits_exactly(b"../..", |buf| relative_into(buf, b"/x/a/b", b"/x"));
+        assert_fits_exactly(b"b/c", |buf| relative_into(buf, b"/x/a", b"/x/a/b/c"));
+        assert_fits_exactly(b"a/b", |buf| relative_into(buf, b"/", b"/a/b"));
+        assert_eq!(relative_into(&mut [], b"/same", b"/same"), Some(Vec::new()));
+
+        assert_fits_exactly(b"../d", |buf| {
+            relative_platform_buf_checked::<platform::Posix, true>(buf, b"/x/a/", b"/x//d")
+                .map(|r| r.to_vec())
+        });
+        if cfg!(unix) {
+            assert_fits_exactly(b"../b/c\0", |buf| {
+                relative_buf_z_checked(buf, b"/x/a", b"/x/b/./c")
+                    .map(|z| z.as_bytes_with_nul().to_vec())
+            });
+        }
+    }
+
+    // Windows paths are compared case-insensitively through libc, which Miri
+    // has no shim for.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn relative_checked_variants_fit_exactly_on_windows() {
+        fn relative_windows<const ALWAYS_COPY: bool>(
+            buf: &mut [u8],
+            from: &[u8],
+            to: &[u8],
+        ) -> Option<Vec<u8>> {
+            relative_normalized_buf_checked::<platform::Windows, ALWAYS_COPY>(buf, from, to)
+                .map(|r| r.to_vec())
+        }
+        assert_fits_exactly(b"..\\..\\y", |buf| {
+            relative_windows::<true>(buf, b"C:\\x\\a\\b", b"C:\\x\\y")
+        });
+        assert_fits_exactly(b"D:\\y", |buf| {
+            relative_windows::<true>(buf, b"C:\\x", b"D:\\y\\")
+        });
+
+        // From a root the result is a suffix of `to`: copied when asked to,
+        // otherwise borrowed from `to` without touching the buffer.
+        assert_fits_exactly(b"x\\y", |buf| {
+            relative_windows::<true>(buf, b"C:\\", b"C:\\x\\y")
+        });
+        assert_eq!(
+            relative_windows::<false>(&mut [], b"C:\\", b"C:\\x\\y").as_deref(),
+            Some(&b"x\\y"[..])
+        );
+    }
+
+    #[test]
+    fn relative_result_capacity_bounds_every_input_shape() {
+        let inputs: &[&[u8]] = &[
+            b"/",
+            b"/a",
+            b"/a/",
+            b"/a/b/c",
+            b"/ab/cd",
+            b"/x/y/z/w",
+            b"a",
+            b"a/b",
+            b"///",
+            b"/////",
+            b"//a//b//",
+            b"/a/../..",
+            b"..",
+            b"../..",
+            b"",
+            b"/\xff/\xfe",
+        ];
+        let mut big = vec![0u8; 4096];
+        for from in inputs {
+            for to in inputs {
+                let expected = relative_into(&mut big, from, to).unwrap();
+                assert!(
+                    expected.len() <= relative_result_capacity(from.len(), to.len()),
+                    "relative({from:?}, {to:?}) = {expected:?}"
+                );
+                let mut exact = vec![0u8; relative_result_capacity(from.len(), to.len())];
+                assert_eq!(
+                    relative_into(&mut exact, from, to).as_deref(),
+                    Some(&expected[..])
+                );
+            }
+        }
+    }
+
+    /// The results the spilling wrappers return must match a direct
+    /// computation into a buffer that is large enough.
+    fn reference_join_abs(cwd: &[u8], parts: &[&[u8]]) -> Vec<u8> {
+        let mut buf = vec![0u8; join_abs_needed(cwd.len(), parts)];
+        join_abs_string_buf::<platform::Posix>(cwd, &mut buf, parts).to_vec()
+    }
+
+    #[test]
+    fn normalize_string_spills_results_longer_than_its_fixed_buffer() {
+        let mut input = b"./".to_vec();
+        input.resize(PARSER_BUFFER_LEN * 2, b'b');
+        input.extend_from_slice(b"/./x");
+        let mut expected = vec![b'b'; PARSER_BUFFER_LEN * 2 - 2];
+        expected.extend_from_slice(b"/x");
+        assert_eq!(
+            normalize_string::<true, platform::Posix>(&input),
+            &expected[..]
+        );
+
+        // Exactly one byte too long for the fixed buffer, and a result that
+        // grows by one byte on Windows.
+        let mut unc = b"\\\\".to_vec();
+        unc.resize(PARSER_BUFFER_LEN, b's');
+        let mut expected = unc.clone();
+        expected.push(b'\\');
+        assert_eq!(
+            normalize_string::<true, platform::Windows>(&unc),
+            &expected[..]
+        );
+
+        // Back to the fixed buffer afterwards.
+        assert_eq!(normalize_string::<true, platform::Posix>(b"a/./b"), b"a/b");
+    }
+
+    #[test]
+    fn join_spills_results_longer_than_its_fixed_buffer() {
+        let long = vec![b'a'; JOIN_BUF_LEN];
+        let mut expected = long.clone();
+        expected.extend_from_slice(b"/y");
+        assert_eq!(join::<platform::Posix>(&[&long, b"x/../y"]), &expected[..]);
+        expected.push(0);
+        assert_eq!(
+            join_z::<platform::Posix>(&[&long, b"x/../y"]).as_bytes_with_nul(),
+            &expected[..]
+        );
+
+        // An absolute result is placed at `buf[0]`, a relative one at `buf[1]`.
+        let mut abs = b"/".to_vec();
+        abs.extend_from_slice(&long);
+        assert_eq!(join::<platform::Posix>(&[&abs]), &abs[..]);
+        assert_eq!(join::<platform::Posix>(&[&long]), &long[..]);
+        assert_eq!(join::<platform::Posix>(&[b"a", b"b"]), b"a/b");
+    }
+
+    #[test]
+    fn join_accepts_its_previous_spilled_result_as_input() {
+        let long = vec![b'a'; JOIN_BUF_LEN];
+        let previous = join::<platform::Posix>(&[&long]);
+        let mut expected = long.clone();
+        expected.extend_from_slice(b"/b");
+        assert_eq!(join::<platform::Posix>(&[previous, b"b"]), &expected[..]);
+    }
+
+    #[test]
+    fn join_abs_string_spills_results_longer_than_its_fixed_buffer() {
+        let name = vec![b'n'; PARSER_JOIN_INPUT_BUFFER_LEN];
+        let parts: &[&[u8]] = &[&name, b"..", &name, b"x"];
+        let expected = reference_join_abs(b"/work", parts);
+        assert!(expected.len() > PARSER_JOIN_INPUT_BUFFER_LEN);
+        assert_eq!(
+            join_abs_string::<platform::Posix>(b"/work", parts),
+            &expected[..]
+        );
+        let z = join_abs_string_z::<platform::Posix>(b"/work", parts);
+        assert_eq!(z.as_bytes(), &expected[..]);
+        assert_eq!(z.as_bytes_with_nul()[expected.len()], 0);
+
+        let mut cwd = b"/".to_vec();
+        cwd.resize(PARSER_JOIN_INPUT_BUFFER_LEN * 2, b'c');
+        assert_eq!(
+            join_abs_string::<platform::Posix>(&cwd, &[b"./x", b".."]),
+            &cwd[..]
+        );
+        // With no parts the cwd itself is the result; it is not in any buffer.
+        assert_eq!(join_abs_string::<platform::Posix>(&cwd, &[]), &cwd[..]);
+        assert_eq!(
+            join_abs_string::<platform::Posix>(b"/work", &[b"y"]),
+            b"/work/y"
+        );
+    }
+
+    // Path-buffer-sized inputs take most of a minute under Miri; `spill_out`,
+    // the only unsafe code on this path, is covered by the join tests above.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn relative_spills_inputs_and_results_longer_than_a_path_buffer() {
+        Fs::FileSystem::init(b"/work");
+        let mut big = vec![0u8; MAX_PATH_BYTES * 8];
+
+        let mut from = b"/".to_vec();
+        from.resize(MAX_PATH_BYTES, b'f');
+        let mut to = b"/".to_vec();
+        to.resize(MAX_PATH_BYTES * 2, b't');
+        let expected = relative_into(&mut big, &from, &to).unwrap();
+        assert_eq!(
+            relative_platform::<platform::Posix, false>(&from, &to),
+            &expected[..]
+        );
+        let expected = relative_into(&mut big, &to, &from).unwrap();
+        assert_eq!(expected.len(), from.len() + 2);
+        assert_eq!(
+            relative_platform::<platform::Posix, true>(&to, &from),
+            &expected[..]
+        );
+        // A second spill replaces the first.
+        assert_eq!(
+            relative_platform::<platform::Posix, true>(&to, &from),
+            &expected[..]
+        );
+        assert_eq!(
+            relative_platform_buf_checked::<platform::Posix, true>(&mut big, &from, &to),
+            None
+        );
+
+        // Relative inputs resolve against the top-level dir before spilling.
+        let mut rel = Vec::new();
+        while rel.len() < MAX_PATH_BYTES {
+            rel.extend_from_slice(b"deep/");
+        }
+        assert_eq!(
+            relative_platform::<platform::Posix, true>(b"/work", &rel),
+            &rel[..rel.len() - 1]
+        );
+        let mut resolved = b"/work/".to_vec();
+        resolved.extend_from_slice(&rel);
+        let expected = relative_into(&mut big, &resolved, b"/work/x").unwrap();
+        assert_eq!(
+            relative_platform::<platform::Posix, false>(&rel, b"/work/x"),
+            &expected[..]
+        );
+
+        // Inputs that fit a path buffer but whose result does not.
+        let deep = b"/a".repeat(MAX_PATH_BYTES / 2 - 8);
+        let expected = relative_into(&mut big, &deep, b"/b").unwrap();
+        assert!(expected.len() > MAX_PATH_BYTES);
+        assert_eq!(
+            relative_platform::<platform::Posix, false>(&deep, b"/b"),
+            &expected[..]
+        );
+        assert_eq!(
+            relative_normalized::<platform::Posix, false>(&deep, b"/b"),
+            &expected[..]
+        );
+        if cfg!(unix) {
+            assert_eq!(
+                relative_alloc(&deep, b"/b").unwrap().as_ref(),
+                &expected[..]
+            );
+        }
+
+        // Back to the thread-local buffers afterwards.
+        assert_eq!(
+            relative_platform::<platform::Posix, false>(b"/x/a", b"/x/b"),
+            b"../b"
         );
     }
 }

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -759,22 +759,10 @@ pub fn relative_buf_z<'a>(buf: &'a mut [u8], from: &[u8], to: &[u8]) -> &'a ZStr
     relative_buf_z_checked(buf, from, to).unwrap_or_else(|| path_buffer_too_small(buf_len))
 }
 
-/// Normalizes `from` and `to` into `from_buf` and `to_buf`, resolving a
-/// relative one against the top-level directory (normalizing it into `scratch`
-/// first, so that the join does not read the buffer it writes). `None` when
-/// one of them does not fit.
-fn normalize_relative_inputs<'a, P: PlatformT>(
-    from_buf: &'a mut [u8],
-    to_buf: &'a mut [u8],
-    scratch: &mut [u8],
-    from: &[u8],
-    to: &[u8],
-) -> Option<(&'a [u8], &'a [u8])> {
-    let normalized_from = normalize_relative_input::<P>(from_buf, scratch, from)?;
-    let normalized_to = normalize_relative_input::<P>(to_buf, scratch, to)?;
-    Some((normalized_from, normalized_to))
-}
-
+/// Normalizes one input of `relative*` into `out`, resolving a relative one
+/// against the top-level directory (it is normalized into `scratch` first, so
+/// that the join does not read the buffer it writes). `None` when it does not
+/// fit.
 fn normalize_relative_input<'a, P: PlatformT>(
     out: &'a mut [u8],
     scratch: &mut [u8],
@@ -819,13 +807,8 @@ pub fn relative_platform_buf_checked<'a, P: PlatformT, const ALWAYS_COPY: bool>(
     // two `&mut` borrows below are disjoint.
     let relative_from_buf = RELATIVE_FROM_BUF.with(lazy_path_buf);
     let relative_to_buf = RELATIVE_TO_BUF.with(lazy_path_buf);
-    let (normalized_from, normalized_to) = normalize_relative_inputs::<P>(
-        &mut relative_from_buf[..],
-        &mut relative_to_buf[..],
-        buf,
-        from,
-        to,
-    )?;
+    let normalized_from = normalize_relative_input::<P>(&mut relative_from_buf[..], buf, from)?;
+    let normalized_to = normalize_relative_input::<P>(&mut relative_to_buf[..], buf, to)?;
     relative_normalized_buf_checked::<P, ALWAYS_COPY>(buf, normalized_from, normalized_to)
 }
 
@@ -852,13 +835,11 @@ pub fn relative_platform<P: PlatformT, const ALWAYS_COPY: bool>(
     let common_buf = RELATIVE_TO_COMMON_PATH_BUF.with(lazy_path_buf);
     let relative_from_buf = RELATIVE_FROM_BUF.with(lazy_path_buf);
     let relative_to_buf = RELATIVE_TO_BUF.with(lazy_path_buf);
-    let Some((normalized_from, normalized_to)) = normalize_relative_inputs::<P>(
-        &mut relative_from_buf[..],
-        &mut relative_to_buf[..],
-        &mut common_buf[..],
-        from,
-        to,
-    ) else {
+    let normalized = (
+        normalize_relative_input::<P>(&mut relative_from_buf[..], &mut common_buf[..], from),
+        normalize_relative_input::<P>(&mut relative_to_buf[..], &mut common_buf[..], to),
+    );
+    let (Some(normalized_from), Some(normalized_to)) = normalized else {
         return relative_platform_spilled::<P>(from, to);
     };
     match relative_normalized_buf_checked::<P, ALWAYS_COPY>(
@@ -890,9 +871,10 @@ fn relative_platform_spilled<P: PlatformT>(from: &[u8], to: &[u8]) -> &'static [
     let mut from_buf = vec![0u8; input_capacity(from)];
     let mut to_buf = vec![0u8; input_capacity(to)];
     let mut scratch = vec![0u8; from.len().max(to.len()) + 1];
-    let (normalized_from, normalized_to) =
-        normalize_relative_inputs::<P>(&mut from_buf, &mut to_buf, &mut scratch, from, to)
-            .unwrap_or_else(|| unreachable!("input_capacity bounds the normalized inputs"));
+    let normalized_from = normalize_relative_input::<P>(&mut from_buf, &mut scratch, from)
+        .unwrap_or_else(|| unreachable!("input_capacity bounds the normalized input"));
+    let normalized_to = normalize_relative_input::<P>(&mut to_buf, &mut scratch, to)
+        .unwrap_or_else(|| unreachable!("input_capacity bounds the normalized input"));
     relative_normalized_spilled::<P>(normalized_from, normalized_to)
 }
 
@@ -1039,10 +1021,13 @@ fn windows_filesystem_root_t<T: PathChar>(path: &[T]) -> &[T] {
 }
 
 /// Called before every write of `units` units at `buf[at..]`. Returning `false`
-/// makes the normalizer report `None` instead of writing past `buf`.
+/// makes the normalizer report `None` instead of writing past `buf`. `at` is a
+/// write position, so it never exceeds `buf.len()`: every advance of it
+/// follows a write this function admitted.
 #[inline(always)]
 fn has_room<T>(buf: &[T], at: usize, units: usize) -> bool {
-    at <= buf.len() && units <= buf.len() - at
+    debug_assert!(at <= buf.len());
+    units <= buf.len() - at
 }
 
 /// [`normalize_string_generic_tz`] without NUL termination or an NT prefix.
@@ -1627,6 +1612,21 @@ fn normalize_string_buf_t<
     {
         return Some(&mut buf[..len]);
     }
+    normalize_string_buf_via_scratch_t::<T, ALLOW_ABOVE_ROOT, P, PRESERVE_TRAILING_SLASH>(str, buf)
+}
+
+#[cold]
+#[inline(never)]
+fn normalize_string_buf_via_scratch_t<
+    'a,
+    T: PathChar,
+    const ALLOW_ABOVE_ROOT: bool,
+    P: PlatformT,
+    const PRESERVE_TRAILING_SLASH: bool,
+>(
+    str: &[T],
+    buf: &'a mut [T],
+) -> Option<&'a mut [T]> {
     // Normalizing grows a path by at most one unit (see `normalize_string_generic_tz`).
     let mut scratch = vec![T::from_u8(0); str.len() + 1];
     let normalized =
@@ -1816,6 +1816,20 @@ pub fn join_z_spill<'a, P: PlatformT>(spill: &'a mut Vec<u8>, parts: &[&[u8]]) -
     join_z_buf::<P>(&mut spill[..], parts)
 }
 
+/// Where a `join*` result lies in the buffer it was written to: off Windows
+/// `normalize_string_node_t` places a relative result at `start == 1`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Placed {
+    start: usize,
+    len: usize,
+}
+
+impl Placed {
+    fn end(self) -> usize {
+        self.start + self.len
+    }
+}
+
 /// [`join_string_buf_checked`], NUL-terminated. `None` when the result and its
 /// NUL do not fit `buf`.
 pub fn join_z_buf_checked<'a, P: PlatformT>(
@@ -1823,9 +1837,9 @@ pub fn join_z_buf_checked<'a, P: PlatformT>(
     parts: &[&[u8]],
 ) -> Option<&'a ZStr> {
     let capacity = buf.len().checked_sub(1)?;
-    let (start, len) = join_string_buf_t::<u8, P>(&mut buf[..capacity], parts)?;
-    buf[start + len] = 0;
-    Some(ZStr::from_slice_with_nul(&buf[start..=start + len]))
+    let placed = join_string_buf_t::<u8, P>(&mut buf[..capacity], parts)?;
+    buf[placed.end()] = 0;
+    Some(ZStr::from_slice_with_nul(&buf[placed.start..=placed.end()]))
 }
 
 /// [`join_z_buf_checked`] for a `buf` known to hold the result; panics otherwise.
@@ -1841,8 +1855,8 @@ pub fn join_string_buf_checked<'a, P: PlatformT>(
     buf: &'a mut [u8],
     parts: &[&[u8]],
 ) -> Option<&'a [u8]> {
-    let (start, len) = join_string_buf_t::<u8, P>(buf, parts)?;
-    Some(&buf[start..start + len])
+    let placed = join_string_buf_t::<u8, P>(buf, parts)?;
+    Some(&buf[placed.start..placed.end()])
 }
 
 /// [`join_string_buf_checked`] for a `buf` known to hold the result; panics otherwise.
@@ -1858,8 +1872,8 @@ pub fn join_string_buf_w_same_checked<'a, P: PlatformT>(
     buf: &'a mut [u16],
     parts: &[&[u16]],
 ) -> Option<&'a [u16]> {
-    let (start, len) = join_string_buf_t_same::<u16, P>(buf, parts)?;
-    Some(&buf[start..start + len])
+    let placed = join_string_buf_t_same::<u16, P>(buf, parts)?;
+    Some(&buf[placed.start..placed.end()])
 }
 
 /// [`join_string_buf_w_same_checked`] for a `buf` known to hold the result;
@@ -1889,12 +1903,11 @@ fn join_temp_buf<'a, T>(
 
 /// Same-width `joinStringBufT`: parts already match `T`, so no UTF-8→16 transcode.
 /// split out of `join_string_buf_t` because Rust can't monomorphize on the
-/// parts' element types — callers pick the overload. Returns where in `buf`
-/// the result starts and its length (see `normalize_string_node_t`).
+/// parts' element types — callers pick the overload.
 fn join_string_buf_t_same<T: PathChar, P: PlatformT>(
     buf: &mut [T],
     parts: &[&[T]],
-) -> Option<(usize, usize)> {
+) -> Option<Placed> {
     let mut written: usize = 0;
     let mut stack_temp_buf = [const { MaybeUninit::<T>::uninit() }; JOIN_TEMP_LEN];
     let mut heap_temp_buf: Vec<T> = Vec::new();
@@ -1933,28 +1946,35 @@ fn join_string_buf_t_same<T: PathChar, P: PlatformT>(
 }
 
 /// The result of joining nothing but empty parts.
-fn join_dot<T: PathChar>(buf: &mut [T]) -> Option<(usize, usize)> {
+fn join_dot<T: PathChar>(buf: &mut [T]) -> Option<Placed> {
     *buf.get_mut(0)? = T::from_u8(b'.');
-    Some((0, 1))
+    Some(Placed { start: 0, len: 1 })
 }
 
 /// `normalize_string_node_t` under the `*_checked` contract (see
 /// `normalize_string_buf_t`): a result that fits `buf` is produced even when
 /// the intermediate form does not, by normalizing in a scratch buffer first.
-fn join_normalize_into<T: PathChar, P: PlatformT>(
+fn join_normalize_into<T: PathChar, P: PlatformT>(joined: &[T], buf: &mut [T]) -> Option<Placed> {
+    normalize_string_node_t::<T, P>(joined, buf)
+        .or_else(|| join_normalize_via_scratch::<T, P>(joined, buf))
+}
+
+#[cold]
+#[inline(never)]
+fn join_normalize_via_scratch<T: PathChar, P: PlatformT>(
     joined: &[T],
     buf: &mut [T],
-) -> Option<(usize, usize)> {
-    if let Some(placed) = normalize_string_node_t::<T, P>(joined, buf) {
-        return Some(placed);
-    }
+) -> Option<Placed> {
     // Room for the leading slot or the one unit Windows normalization can add.
     let mut scratch = vec![T::from_u8(0); joined.len() + 2];
-    let (start, len) = normalize_string_node_t::<T, P>(joined, &mut scratch)
+    let in_scratch = normalize_string_node_t::<T, P>(joined, &mut scratch)
         .unwrap_or_else(|| unreachable!("the scratch buffer is sized for the input"));
-    buf.get_mut(..len)?
-        .copy_from_slice(&scratch[start..start + len]);
-    Some((0, len))
+    let out = buf.get_mut(..in_scratch.len)?;
+    out.copy_from_slice(&scratch[in_scratch.start..in_scratch.end()]);
+    Some(Placed {
+        start: 0,
+        len: out.len(),
+    })
 }
 
 /// [`join_z_buf`] under its older name.
@@ -1963,12 +1983,7 @@ pub fn join_string_buf_z<'a, P: PlatformT>(buf: &'a mut [u8], parts: &[&[u8]]) -
     join_z_buf::<P>(buf, parts)
 }
 
-/// Returns where in `buf` the result starts and its length (see
-/// `normalize_string_node_t`).
-fn join_string_buf_t<T: PathChar, P: PlatformT>(
-    buf: &mut [T],
-    parts: &[&[u8]],
-) -> Option<(usize, usize)> {
+fn join_string_buf_t<T: PathChar, P: PlatformT>(buf: &mut [T], parts: &[&[u8]]) -> Option<Placed> {
     // Takes `&[&[u8]]` — every in-tree caller passes u8
     // parts — and transcodes to u16 below when `T == u16`.
     let mut written: usize = 0;
@@ -2425,14 +2440,11 @@ fn normalize_string_windows_t<
     )
 }
 
-/// `path.normalize` for `join*`. Returns where in `buf` the result starts and
-/// its length: off Windows the result of a relative input starts at `buf[1]`,
-/// the slot an absolute one uses for its leading separator. `None` when the
-/// intermediate form does not fit `buf` (see `normalize_string_generic_tz`).
-fn normalize_string_node_t<T: PathChar, P: PlatformT>(
-    str: &[T],
-    buf: &mut [T],
-) -> Option<(usize, usize)> {
+/// `path.normalize` for `join*`. Off Windows the result of a relative input
+/// starts at `buf[1]`, the slot an absolute one uses for its leading separator.
+/// `None` when the intermediate form does not fit `buf` (see
+/// `normalize_string_generic_tz`).
+fn normalize_string_node_t<T: PathChar, P: PlatformT>(str: &[T], buf: &mut [T]) -> Option<Placed> {
     if str.is_empty() {
         return join_dot(buf);
     }
@@ -2459,7 +2471,7 @@ fn normalize_string_node_t<T: PathChar, P: PlatformT>(
     if out_len == 0 {
         if is_absolute {
             *buf.get_mut(0)? = separator_t;
-            return Some((0, 1));
+            return Some(Placed { start: 0, len: 1 });
         }
 
         if trailing_separator {
@@ -2467,7 +2479,7 @@ fn normalize_string_node_t<T: PathChar, P: PlatformT>(
             let dot_slash = buf.get_mut(0..2)?;
             dot_slash[0] = T::from_u8(sep[0]);
             dot_slash[1] = T::from_u8(sep[1]);
-            return Some((0, 2));
+            return Some(Placed { start: 0, len: 2 });
         }
 
         return join_dot(buf);
@@ -2482,10 +2494,16 @@ fn normalize_string_node_t<T: PathChar, P: PlatformT>(
 
     if is_absolute && P::P != Platform::Windows {
         buf[0] = separator_t;
-        return Some((0, out_len + 1));
+        return Some(Placed {
+            start: 0,
+            len: out_len + 1,
+        });
     }
 
-    Some((buf_off, out_len))
+    Some(Placed {
+        start: buf_off,
+        len: out_len,
+    })
 }
 
 /// **NOT** plain basename (see
@@ -3323,21 +3341,22 @@ mod tests {
         // Off Windows `normalize_string_node_t` places a relative result at
         // `buf[1..]`; a buffer with room for the result alone still works.
         let mut buf = [0u8; 8];
+        let placed = |start: usize, len: usize| Some(Placed { start, len });
         assert_eq!(
             join_string_buf_t::<u8, platform::Posix>(&mut buf, &[b"a", b"b"]),
-            Some((1, 3))
+            placed(1, 3)
         );
         assert_eq!(
             join_string_buf_t::<u8, platform::Posix>(&mut buf, &[b"/a", b"b"]),
-            Some((0, 4))
+            placed(0, 4)
         );
         assert_eq!(
             join_string_buf_t::<u8, platform::Windows>(&mut buf, &[b"a", b"b"]),
-            Some((0, 3))
+            placed(0, 3)
         );
         assert_eq!(
             join_string_buf_t::<u8, platform::Posix>(&mut buf[..3], &[b"a", b"b"]),
-            Some((0, 3))
+            placed(0, 3)
         );
         assert_fits_exactly(b"a/b", |buf| {
             join_string_buf_checked::<platform::Posix>(buf, &[b"a", b"b"]).map(|s| s.to_vec())

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1628,7 +1628,7 @@ pub fn join_abs<'a, P: PlatformT>(cwd: &'a [u8], part: &[u8]) -> &'a [u8] {
 /// This is the equivalent of path.resolve
 ///
 /// Returned path is stored in a temporary buffer. It must be copied if it needs to be stored.
-/// `cwd` and `parts` may be of any length.
+/// `cwd` and each part may be of any length.
 // result borrows the thread-local buffer ('static) OR returns `cwd`
 // directly when `parts.is_empty()`. Return tied to `cwd`'s lifetime ('static: 'a).
 pub fn join_abs_string<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'a [u8] {
@@ -1666,7 +1666,8 @@ pub fn join_abs_string_spill<'a, P: PlatformT>(
 /// This is the equivalent of path.resolve
 ///
 /// Returned path is stored in a temporary buffer. It must be copied if it needs to be stored.
-/// `cwd` and `parts` may be of any length.
+/// `cwd` and each part may be of any length. `parts` must not be empty: the
+/// result would be `cwd` itself, which has no NUL.
 pub fn join_abs_string_z<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'a ZStr {
     let capacity = join_abs_capacity::<P>(cwd.len(), parts);
     if capacity <= PARSER_JOIN_INPUT_BUFFER_LEN {

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -1339,12 +1339,12 @@ fn extract_to_disk_filtered(
         let raw_pathname = raw_pathname_z.as_bytes();
 
         let mut normalized_buf = bun_paths::PathBuffer::uninit();
-        if raw_pathname.len() >= normalized_buf.len() {
-            continue;
-        }
-        let pathname_z: &bun_core::ZStr = bun_paths::resolve_path::normalize_buf_z::<
+        let Some(pathname_z) = bun_paths::resolve_path::normalize_buf_z_checked::<
             bun_paths::platform::Posix,
-        >(raw_pathname, &mut normalized_buf[..]);
+        >(raw_pathname, &mut normalized_buf[..]) else {
+            continue;
+        };
+        let pathname_z: &bun_core::ZStr = pathname_z;
         let pathname = pathname_z.as_bytes();
 
         // Validate path safety (reject absolute paths, path traversal)

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -579,6 +579,16 @@ impl ShellCpTask {
             .is_some_and(|&c| resolve_path::Platform::AUTO.is_separator(c))
     }
 
+    /// `ENAMETOOLONG` naming `parts` (the target path that did not fit a path buffer).
+    #[cold]
+    fn target_too_long(parts: &[&[u8]]) -> ShellErr {
+        let path = parts.join(&resolve_path::Platform::AUTO.separator());
+        ShellErr::new_sys(
+            &bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, bun_sys::Tag::copyfile)
+                .with_path(&path),
+        )
+    }
+
     fn is_dir(path: &bun_core::ZStr) -> bun_sys::Maybe<bool> {
         #[cfg(windows)]
         {
@@ -618,13 +628,15 @@ impl ShellCpTask {
         } else {
             resolve_path::join_z::<platform::Auto>(&[&self.cwd_path, &self.src])
         };
-        let mut tgt: &bun_core::ZStr = if Platform::AUTO.is_absolute(&self.tgt) {
-            resolve_path::join_z_buf::<platform::Auto>(buf2.as_mut_slice(), &[&self.tgt])
+        let tgt_parts: &[&[u8]] = if Platform::AUTO.is_absolute(&self.tgt) {
+            &[&self.tgt]
         } else {
-            resolve_path::join_z_buf::<platform::Auto>(
-                buf2.as_mut_slice(),
-                &[&self.cwd_path, &self.tgt],
-            )
+            &[&self.cwd_path, &self.tgt]
+        };
+        let Some(mut tgt) =
+            resolve_path::join_z_buf_checked::<platform::Auto>(buf2.as_mut_slice(), tgt_parts)
+        else {
+            return Some(Self::target_too_long(tgt_parts));
         };
 
         // Cases:
@@ -678,10 +690,13 @@ impl ShellCpTask {
             // 2nd synopsis: -R source_files... -> target.
             if tgt_exists {
                 let basename = resolve_path::basename(src.as_bytes());
-                tgt = resolve_path::join_z_buf::<platform::Auto>(
+                tgt = match resolve_path::join_z_buf_checked::<platform::Auto>(
                     buf3.as_mut_slice(),
                     &[tgt.as_bytes(), basename],
-                );
+                ) {
+                    Some(tgt) => tgt,
+                    None => return Some(Self::target_too_long(&[tgt.as_bytes(), basename])),
+                };
             } else if self.operands == 2 {
                 // source_dir -> new_target_dir.
             } else {
@@ -709,10 +724,13 @@ impl ShellCpTask {
                 ));
             }
             let basename = resolve_path::basename(src.as_bytes());
-            tgt = resolve_path::join_z_buf::<platform::Auto>(
+            tgt = match resolve_path::join_z_buf_checked::<platform::Auto>(
                 buf3.as_mut_slice(),
                 &[tgt.as_bytes(), basename],
-            );
+            ) {
+                Some(tgt) => tgt,
+                None => return Some(Self::target_too_long(&[tgt.as_bytes(), basename])),
+            };
             _copying_many = true;
         }
 

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -633,17 +633,17 @@ impl ShellMvBatchedTask {
         buf: &mut PathBuffer,
     ) -> Result<(), bun_sys::Error> {
         let base = resolve_path::basename(src.as_bytes());
-        let len =
-            resolve_path::normalize_buf::<bun_paths::platform::Auto>(base, &mut buf[..]).len();
-        if len + 1 >= bun_paths::MAX_PATH_BYTES {
-            return Err(bun_sys::Error::from_code(
+        let result = match resolve_path::normalize_buf_z_checked::<bun_paths::platform::Auto>(
+            base,
+            &mut buf[..],
+        ) {
+            Some(path_in_dir) => Self::do_rename(cwd, src, target_fd, path_in_dir),
+            None => Err(bun_sys::Error::from_code(
                 bun_sys::E::ENAMETOOLONG,
                 bun_sys::Tag::rename,
-            ));
-        }
-        buf[len] = 0;
-        let path_in_dir = ZStr::from_buf(buf.as_slice(), len);
-        Self::do_rename(cwd, src, target_fd, path_in_dir).map_err(|e| {
+            )),
+        };
+        result.map_err(|e| {
             // Surface `target/basename(src)` as the failing path.
             let joined = resolve_path::join_z::<bun_paths::platform::Auto>(&[target, base]);
             e.with_path(joined.as_bytes())

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2254,13 +2254,18 @@ pub(crate) fn shell_dup(fd: Fd) -> bun_sys::Result<Fd> {
 /// Windows-only: rewrite shell paths so POSIX-absolute `/foo` resolves onto
 /// `dirfd`'s drive root, `/dev/null` maps to `NUL`, and relative paths are
 /// joined against `dirfd`'s real path. Returns a NUL-terminated slice that
-/// either borrows `buf` or is `to` itself.
+/// either borrows `buf` or is `to` itself. `to` is a command operand of any
+/// length; one whose rewritten path does not fit `buf` fails with the
+/// `ENAMETOOLONG` that `syscall` would report for it.
 #[cfg(windows)]
 fn shell_get_path<'a>(
     dirfd: Fd,
     to: &'a bun_core::ZStr,
     buf: &'a mut bun_paths::PathBuffer,
+    syscall: bun_sys::Tag,
 ) -> bun_sys::Result<&'a bun_core::ZStr> {
+    let name_too_long =
+        || bun_sys::Error::from_code(bun_sys::E::ENAMETOOLONG, syscall).with_path(to.as_bytes());
     if to.as_bytes() == b"/dev/null" {
         return Ok(crate::shell::shell_body::WINDOWS_DEV_NULL);
     }
@@ -2271,9 +2276,12 @@ fn shell_get_path<'a>(
         };
         // `dirpath` already
         // occupies `buf[0..]` and the root is its prefix, so no copy is
-        // needed. Splice `to[1..]` after the root.
+        // needed. Splice `to[1..]` after the root, leaving room for the NUL.
         let to_tail = &to.as_bytes()[1..];
         let end = source_root_len + to_tail.len();
+        if end >= buf.len() {
+            return Err(name_too_long());
+        }
         buf[source_root_len..end].copy_from_slice(to_tail);
         buf[end] = 0;
         return Ok(bun_core::ZStr::from_buf(buf.as_slice(), end));
@@ -2288,9 +2296,11 @@ fn shell_get_path<'a>(
     let dirpath = bun_sys::get_fd_path(dirfd, buf)
         .map_err(|e| e.with_fd(dirfd))?
         .to_vec();
-    Ok(bun_paths::resolve_path::join_z_buf::<
-        bun_paths::platform::Auto,
-    >(&mut buf[..], &[&dirpath, to.as_bytes()]))
+    bun_paths::resolve_path::join_z_buf_checked::<bun_paths::platform::Auto>(
+        &mut buf[..],
+        &[&dirpath, to.as_bytes()],
+    )
+    .ok_or_else(name_too_long)
 }
 
 /// Windows: rewrite the path via `shell_get_path` then `bun_sys::stat`, tagging
@@ -2301,7 +2311,7 @@ pub(crate) fn shell_statat(dir: Fd, path_: &bun_core::ZStr) -> bun_sys::Result<b
     #[cfg(windows)]
     {
         let mut buf = bun_paths::path_buffer_pool::get();
-        let p = shell_get_path(dir, path_, &mut buf)?;
+        let p = shell_get_path(dir, path_, &mut buf, bun_sys::Tag::fstatat)?;
         return bun_sys::stat(p).map_err(|e| e.with_path(path_.as_bytes()));
     }
     #[cfg(not(windows))]
@@ -2341,7 +2351,7 @@ pub(crate) fn shell_openat(
         if flags & bun_sys::O::DIRECTORY != 0 {
             if bun_paths::Platform::Posix.is_absolute(path.as_bytes()) {
                 let mut buf = bun_paths::path_buffer_pool::get();
-                let p = shell_get_path(dir, path, &mut buf)?;
+                let p = shell_get_path(dir, path, &mut buf, bun_sys::Tag::open)?;
                 return bun_sys::open_dir_at_windows_a(
                     dir,
                     p.as_bytes(),
@@ -2370,7 +2380,7 @@ pub(crate) fn shell_openat(
             .make_lib_uv_owned_for_syscall(bun_sys::Tag::open, bun_sys::ErrorCase::CloseOnFail);
         }
         let mut buf = bun_paths::path_buffer_pool::get();
-        let p = shell_get_path(dir, path, &mut buf)?;
+        let p = shell_get_path(dir, path, &mut buf, bun_sys::Tag::open)?;
         // No `makeLibUVOwnedForSyscall` here: `bun_sys::open` on Windows
         // routes through `sys_uv` and already yields a uv-owned fd.
         return bun_sys::open(p, flags, perm);

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2325,7 +2325,7 @@ pub(crate) fn shell_lstatat(dir: Fd, path_: &bun_core::ZStr) -> bun_sys::Result<
     #[cfg(windows)]
     {
         let mut buf = bun_paths::path_buffer_pool::get();
-        let p = shell_get_path(dir, path_, &mut buf)?;
+        let p = shell_get_path(dir, path_, &mut buf, bun_sys::Tag::lstat)?;
         return bun_sys::lstat(p).map_err(|e| e.with_path(path_.as_bytes()));
     }
     #[cfg(not(windows))]

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6408,47 +6408,36 @@ pub fn normalize_path_windows_opts<'a>(
         }
         if opts.add_nt_prefix {
             // Absolute → add `\??\` (idempotent if already present), normalize
-            // separators/`.`/`..` and NUL-terminate.
-            // `nt_prefix_headroom = 8`: reject when `path.len >
-            // buf.len - nt_prefix_headroom`.
-            // `normalizeStringGenericTZ` performs no bounds checking of its
-            // own, so reserve room for `\??\` + trailing-`\` growth + NUL
-            // before calling it. NOTE: `to_nt_path16` is NOT a substitute here
-            // — it only normalizes slashes and leaves `.`/`..` segments in
-            // place, which `NtCreateFile` rejects (e.g. `\??\C:\dir\.` →
-            // OBJECT_NAME_NOT_FOUND).
-            if path.len() > buf.len().saturating_sub(8) {
-                return Err(too_long());
-            }
-            let norm = bun_paths::resolve_path::normalize_string_generic_tz::<
+            // separators/`.`/`..` and NUL-terminate. NOTE: `to_nt_path16` is
+            // NOT a substitute here — it only normalizes slashes and leaves
+            // `.`/`..` segments in place, which `NtCreateFile` rejects (e.g.
+            // `\??\C:\dir\.` → OBJECT_NAME_NOT_FOUND).
+            let len = bun_paths::resolve_path::normalize_string_generic_tz::<
                 u16,
                 /*ALLOW_ABOVE_ROOT*/ false,
                 /*PRESERVE_TRAILING_SLASH*/ false,
                 /*ZERO_TERMINATE*/ true,
                 /*ADD_NT_PREFIX*/ true,
-            >(path, buf, b'\\' as u16, bun_paths::is_sep_any_t::<u16>);
-            let len = norm.len();
-            // SAFETY: ZERO_TERMINATE wrote NUL at buf[len].
-            return Ok(unsafe { WStr::from_raw(norm.as_ptr(), len) });
+            >(path, buf, b'\\' as u16, bun_paths::is_sep_any_t::<u16>)
+            .ok_or_else(too_long)?
+            .len();
+            // ZERO_TERMINATE wrote the NUL at buf[len].
+            return Ok(WStr::from_buf(&buf[..], len));
         }
         // `add_nt_prefix = false` — produce a Win32 path
         // (no `\??\` object prefix) for callers that feed kernel32 APIs
-        // (CreateDirectoryW / CopyFileW). With .add_nt_prefix = false the
-        // normalizer can still grow the input by one u16 (trailing `\` after a
-        // bare UNC volume name) plus the NUL terminator.
-        if path.len() > buf.len().saturating_sub(2) {
-            return Err(too_long());
-        }
-        let norm = bun_paths::resolve_path::normalize_string_generic_tz::<
+        // (CreateDirectoryW / CopyFileW).
+        let len = bun_paths::resolve_path::normalize_string_generic_tz::<
             u16,
             /*ALLOW_ABOVE_ROOT*/ false,
             /*PRESERVE_TRAILING_SLASH*/ false,
             /*ZERO_TERMINATE*/ true,
             /*ADD_NT_PREFIX*/ false,
-        >(path, buf, b'\\' as u16, bun_paths::is_sep_any_t::<u16>);
-        let len = norm.len();
-        // SAFETY: ZERO_TERMINATE wrote NUL at buf[len].
-        return Ok(unsafe { WStr::from_raw(norm.as_ptr(), len) });
+        >(path, buf, b'\\' as u16, bun_paths::is_sep_any_t::<u16>)
+        .ok_or_else(too_long)?
+        .len();
+        // ZERO_TERMINATE wrote the NUL at buf[len].
+        return Ok(WStr::from_buf(&buf[..], len));
     }
 
     // Strip a leading drive letter (`C:`) on the relative part; the bypass
@@ -6607,6 +6596,7 @@ pub fn normalize_path_windows_opts<'a>(
         b'\\' as u16,
         bun_paths::is_sep_any_t::<u16>,
     )
+    .ok_or_else(too_long)?
     .len();
     // A lone-separator suffix means `rel` collapsed to nothing: drop it for a
     // directory-path prefix, keep it for a bare device name where it selects

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -806,6 +806,8 @@ describe("Bun.Archive", () => {
       // its end (`panic: index out of bounds: the len is 32767 but the index is
       // 32767`); it has to be skipped like any other name that does not fit.
       // Elsewhere it is a single 32766-byte component and is skipped as well.
+      // The extraction with a glob is a separate implementation (it also
+      // rejects the drive letter outright) and has to apply the same limit.
       const collapsing = Buffer.alloc(50_000, "d/../").toString() + "payload.txt";
       const growing = "C:\\" + Buffer.alloc(32763, "..\\").toString();
       expect(growing).toHaveLength(32766);
@@ -818,9 +820,14 @@ describe("Bun.Archive", () => {
         ]),
         "extract.ts": `
           const fs = require("node:fs");
-          fs.mkdirSync("out");
-          const count = await new Bun.Archive(new Uint8Array(fs.readFileSync("input.tar"))).extract("out");
-          console.log(JSON.stringify({ count, files: fs.readdirSync("out").sort() }));
+          const archive = new Bun.Archive(new Uint8Array(fs.readFileSync("input.tar")));
+          const results = {};
+          for (const [out, options] of [["out", undefined], ["out-glob", { glob: "**" }]]) {
+            fs.mkdirSync(out);
+            const count = await archive.extract(out, options);
+            results[out] = { count, files: fs.readdirSync(out).sort() };
+          }
+          console.log(JSON.stringify(results));
         `,
       });
 
@@ -835,7 +842,8 @@ describe("Bun.Archive", () => {
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       expect(stderr).toBe("");
-      expect(JSON.parse(stdout)).toEqual({ count: 2, files: ["ok.txt", "payload.txt"] });
+      const extracted = { count: 2, files: ["ok.txt", "payload.txt"] };
+      expect(JSON.parse(stdout)).toEqual({ "out": extracted, "out-glob": extracted });
       expect(exitCode).toBe(0);
     });
 

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -819,7 +819,7 @@ describe("Bun.Archive", () => {
           { name: "ok.txt", data: "ok" },
         ]),
         "extract.ts": `
-          const fs = require("node:fs");
+          import fs from "node:fs";
           const archive = new Bun.Archive(new Uint8Array(fs.readFileSync("input.tar")));
           const results = {};
           for (const [out, options] of [["out", undefined], ["out-glob", { glob: "**" }]]) {

--- a/test/js/bun/archive.test.ts
+++ b/test/js/bun/archive.test.ts
@@ -796,6 +796,49 @@ describe("Bun.Archive", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("applies the path limit to the normalized path of an entry", async () => {
+      // The limit is on the path an entry is extracted to, not on the name as
+      // written in the archive: `d/../` repeated 10000 times collapses to
+      // `payload.txt`. The second name is the other way around. On Windows it
+      // is one code unit short of the path buffer and normalizes to one unit
+      // more (`C:\..\..\` keeps its `..` segments and its trailing separator),
+      // which used to fill the buffer exactly and put the NUL terminator past
+      // its end (`panic: index out of bounds: the len is 32767 but the index is
+      // 32767`); it has to be skipped like any other name that does not fit.
+      // Elsewhere it is a single 32766-byte component and is skipped as well.
+      const collapsing = Buffer.alloc(50_000, "d/../").toString() + "payload.txt";
+      const growing = "C:\\" + Buffer.alloc(32763, "..\\").toString();
+      expect(growing).toHaveLength(32766);
+
+      using dir = tempDir("archive-normalized-path-limit", {
+        "input.tar": buildPaxTarball([
+          { name: collapsing, data: "collapsed" },
+          { name: growing, data: "grown" },
+          { name: "ok.txt", data: "ok" },
+        ]),
+        "extract.ts": `
+          const fs = require("node:fs");
+          fs.mkdirSync("out");
+          const count = await new Bun.Archive(new Uint8Array(fs.readFileSync("input.tar"))).extract("out");
+          console.log(JSON.stringify({ count, files: fs.readdirSync("out").sort() }));
+        `,
+      });
+
+      // In a child process: the failure mode on Windows was a process abort.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "extract.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toBe("");
+      expect(JSON.parse(stdout)).toEqual({ count: 2, files: ["ok.txt", "payload.txt"] });
+      expect(exitCode).toBe(0);
+    });
+
     test("normalizes paths with redundant separators", async () => {
       const archive = new Bun.Archive({
         "dir//subdir///file.txt": "content",

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -573,6 +573,62 @@ describe.concurrent("browser map with a key longer than 1024 bytes", () => {
   });
 });
 
+// Every "sideEffects" entry is joined onto the package directory when its
+// package.json is parsed. The join wrote into a fixed 4 KB threadlocal buffer
+// without a bounds check, so an entry longer than that aborted the process
+// (`panic: range end index 100072 out of range for slice of length 4095`) as
+// soon as the package was resolved. Longer than a path buffer on every
+// platform, including Windows (32767 UTF-16 code units).
+describe.concurrent("sideEffects entries longer than the path buffers", () => {
+  const longName = Buffer.alloc(100_000, "e").toString();
+  const sideEffects = [`./${longName}.js`, `./${longName}/*.js`, "./effect.js"];
+
+  it("does not crash resolving the package at runtime", async () => {
+    using dir = tempDir("resolver-side-effects-long-entry-runtime", {
+      "node_modules/dep/package.json": JSON.stringify({ name: "dep", main: "index.js", sideEffects }),
+      "node_modules/dep/index.js": "module.exports = 1;",
+      "index.js": `console.log(require("dep"));`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("1\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // On Windows no sideEffects entry matches anything yet (#30320).
+  it.skipIf(isWindows)("still applies the other entries when bundling", async () => {
+    using dir = tempDir("resolver-side-effects-long-entry-build", {
+      "node_modules/dep/package.json": JSON.stringify({ name: "dep", sideEffects }),
+      "node_modules/dep/effect.js": `console.log("effect kept");`,
+      "node_modules/dep/pure.js": `console.log("pure dropped");`,
+      "entry.js": `import "dep/effect.js"; import "dep/pure.js";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "entry.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("effect kept");
+    expect(stdout).not.toContain("pure dropped");
+    expect(exitCode).toBe(0);
+  });
+});
+
 // ESModule.Package.parse scanned the entire specifier for an `@` to split off a
 // version. For wildcard `exports` maps the matched substring can contain `@`
 // (e.g. `ember-source/@ember/renderer/...`, `pkg/@scope/sub`) — those `@`s

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3314,6 +3314,7 @@ test.if(isWindows)("operands longer than the path buffer fail with ENAMETOOLONG"
           relative: await run($\`cat \${long}\`),
           rooted: await run($\`cat \${"/" + long}\`),
           stat: await run($\`[[ -f \${long} ]]\`),
+          lstat: await run($\`ls \${long}\`),
           redirect: await run($\`echo hi > \${long}\`),
           collapsing: await run($\`cat \${collapsing}\`),
         }),
@@ -3335,6 +3336,7 @@ test.if(isWindows)("operands longer than the path buffer fail with ENAMETOOLONG"
     relative: { exitCode: 1, stdout: "", stderr: "cat: <long>: File name too long\n" },
     rooted: { exitCode: 1, stdout: "", stderr: "cat: /<long>: File name too long\n" },
     stat: { exitCode: 1, stdout: "", stderr: "" },
+    lstat: { exitCode: 1, stdout: "", stderr: "ls: <long>: File name too long\n" },
     redirect: { exitCode: 1, stdout: "", stderr: "bun: File name too long: <long>" },
     collapsing: { exitCode: 0, stdout: "content\n", stderr: "" },
   });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3286,3 +3286,57 @@ test.skipIf(isWindows)("external command resolution uses the PATH from the shell
     expect(exitCode).toBe(0);
   }
 });
+
+// On Windows the shell rewrites every file operand against the cwd it tracks
+// before opening or stat-ing it (a relative name is joined onto the cwd, a
+// `/name` is put on the cwd's drive). The rewrite goes through one path
+// buffer, and an operand that did not fit it took the process down
+// (`panic: range end index 100064 out of range for slice of length 98301`).
+// POSIX hands operands to the *at() syscalls as-is, so there is nothing to
+// rewrite there. Runs in a child process so that a regression fails the test
+// instead of the test runner.
+test.if(isWindows)("operands longer than the path buffer fail with ENAMETOOLONG", async () => {
+  using dir = tempDir("shell-long-operand", {
+    "in.txt": "content\n",
+    "fixture.ts": `
+      import { $ } from "bun";
+      $.nothrow().cwd(process.cwd());
+      const long = Buffer.alloc(100_000, "a").toString();
+      // Longer than the buffer as written, but normalizes to a name inside the cwd.
+      const collapsing = Buffer.alloc(100_000, "a/../").toString() + "in.txt";
+      const run = async (promise) => {
+        const { exitCode, stdout, stderr } = await promise.quiet();
+        const show = (buf) => buf.toString().replaceAll(long, "<long>");
+        return { exitCode, stdout: show(stdout), stderr: show(stderr) };
+      };
+      console.log(
+        JSON.stringify({
+          relative: await run($\`cat \${long}\`),
+          rooted: await run($\`cat \${"/" + long}\`),
+          stat: await run($\`[[ -f \${long} ]]\`),
+          redirect: await run($\`echo hi > \${long}\`),
+          collapsing: await run($\`cat \${collapsing}\`),
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [BUN, "fixture.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    relative: { exitCode: 1, stdout: "", stderr: "cat: <long>: File name too long\n" },
+    rooted: { exitCode: 1, stdout: "", stderr: "cat: /<long>: File name too long\n" },
+    stat: { exitCode: 1, stdout: "", stderr: "" },
+    redirect: { exitCode: 1, stdout: "", stderr: "bun: File name too long: <long>" },
+    collapsing: { exitCode: 0, stdout: "content\n", stderr: "" },
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, tempDir, tempDirWithFiles } from "harness";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -171,6 +171,56 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
   });
+});
+
+// cp resolves its operands against the cwd into path buffers. An operand that
+// did not fit took the process down (`panic: range end index 5012 out of range
+// for slice of length 4094`), so the fixture runs in a child. The flag turns the
+// builtin on where it is off by default (POSIX).
+test("operands longer than the path buffer fail with ENAMETOOLONG", async () => {
+  using dir = tempDir("cp-long-operand", {
+    "in.txt": "content\n",
+    "fixture.ts": `
+      import { $ } from "bun";
+      $.nothrow();
+      const long = Buffer.alloc(100_000, "a").toString();
+      const run = async (promise) => {
+        const { exitCode, stdout, stderr } = await promise.quiet();
+        return { exitCode, stdout: stdout.toString(), stderr: stderr.toString().replaceAll(long, "<long>") };
+      };
+      console.log(
+        JSON.stringify({
+          target: await run($\`cp in.txt \${long}\`),
+          source: await run($\`cp \${long} out.txt\`),
+        }),
+      );
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.ts"],
+    env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    target: {
+      exitCode: 1,
+      stdout: "",
+      stderr: expect.stringMatching(/^cp: File name too long: .+[\\/]<long>\n$/),
+    },
+    // The source goes to the OS first; Windows reports every failed stat as a missing file.
+    source: {
+      exitCode: 1,
+      stdout: "",
+      stderr: expect.stringMatching(/^cp: (File name too long|No such file or directory): .+[\\/]<long>\n$/),
+    },
+  });
+  expect(exitCode).toBe(0);
 });
 
 function expectSortedOutput(expected: string) {

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isPosix } from "harness";
+import { bunEnv, bunExe, isFreeBSD, isMacOS, isPosix, tempDir } from "harness";
 import {
   accessSync,
   chmodSync,
@@ -233,5 +233,37 @@ describe("mv", async () => {
         rmSync(dst, { recursive: true, force: true });
       }
     });
+  });
+
+  // `mv src dir` builds `basename(src)` in a path buffer before the rename. A
+  // name longer than the buffer took the process down (`panic: range end index
+  // 5000 out of range for slice of length 4096`), so the fixture runs in a child.
+  test("source name longer than the path buffer fails with ENAMETOOLONG", async () => {
+    using dir = tempDir("mv-long-name", {
+      "d": {},
+      "fixture.ts": `
+        import { $ } from "bun";
+        const long = Buffer.alloc(100_000, "a").toString();
+        const { exitCode, stdout, stderr } = await $\`mv \${long} d\`.nothrow().quiet();
+        console.log(JSON.stringify({ exitCode, stdout: stdout.toString(), stderr: stderr.toString().replaceAll(long, "<long>") }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      exitCode: isMacOS || isFreeBSD ? 63 : 36, // the rename's errno, ENAMETOOLONG
+      stdout: "",
+      stderr: `mv: ${join("d", "<long>")}: File name too long\n`,
+    });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- A path longer than a path function's buffer aborts the process: `panic: range end index 100072 out of range for slice of length 4095` (a 100 KB `sideEffects` entry). Nine Sentry signatures, listed in the notes.
- All write through `normalize_string_generic_tz` (`src/paths/resolve_path.rs:912` on main), which never reads `buf.len()`. Callers get patched one at a time (#37526, #38368, #38379) and new callers regress.

### Fix
- The normalizer checks every write and returns `None` when the output does not fit.
- Each caller-buffer function gets a `*_checked` variant. The old name wraps it and panics with a message that names the caller.
- The thread-local functions keep an oversized result on the heap until their next one, so every caller accepts any length. The raw normalizer's callers (`bun_sys`, tar extraction, the shell) skip the entry or report `ENAMETOOLONG`.
- Verified: `cargo test -p bun_paths` (15 new tests, also under Miri). New tests in `test/js/bun/resolve/resolve.test.ts`, `archive.test.ts` and three shell files fail on the released build (Linux, Windows).

### Background
- `resolve_path.rs` fills either a caller's `PathBuffer` (the longest path the OS accepts) or a 1 KB or 4 KB thread-local buffer, valid until the next call.
- Both run `normalize_string_generic_tz` in place. Its output is at most one unit longer than its input, so a buffer sized from the input holds it.
- A path with `..` segments needs room for its intermediate form. `normalize_string_buf_t` uses a scratch buffer for that case.
- `spill_out` frees the previous heap result after the new one exists: it can be an input of the new call.

<details><summary>Notes</summary>

- Sentry: BUN-4ABX, BUN-4ABH, BUN-4ABY, BUN-4ABZ, BUN-4AC8, BUN-4AB4, BUN-4BKJ, BUN-4BKQ, BUN-4B2C.
- The other signatures: `index out of bounds: the len is 32767 but the index is 32767` (a tar entry on Windows, `extract_to_dir`), `range end index 98302 out of range for slice of length 98301` (`relative` on a 98302-byte `file:` path, Windows), `range end index 100064 out of range for slice of length 98301` (a shell operand, Windows), `range end index 1106 out of range for slice of length 1024` (`normalize_string` in `run_command.rs`, Windows), `range end index 100002 out of range for slice of length 98219` and `index out of bounds: the len is 98302 but the index is 98302` (`folder_resolver.rs`).
- The nine Sentry events are the Windows runs of the per-caller fix PRs. Five of them are the sink. BUN-4BKQ's top frame `write_u8_part` is an inlined-frame attribution. The length in its message is the caller's `PathBuffer`. BUN-4ABX, 4AC8 and 4ABY are `normalize_package_json_path`'s own unchecked concatenation in `folder_resolver.rs`, which #38359 rewrites (it is part of #39403), so this PR leaves install alone except for the `normalize_buf_t` call in `TarballStream.rs`. With this PR a 4096-byte `file:` dependency on Linux gets past `parse_dependency`'s `relative` and still stops in `folder_resolver.rs`. BUN-4AB4 is fixed by the thread-local change with no caller change.
- On POSIX, `relative` had one byte of slack by accident (the normalizer drops the leading `/` and the caller puts it back), which is why BUN-4ABZ only fired on Windows. The unit tests cover the overflow directly.
- Open PRs whose crash this PR covers with no change at their caller, or with the same change (each one patches one caller, or resizes one buffer in `resolve_path.rs`): #36340 (thread-local buffer sizes), #37529 (sideEffects, the entry now also keeps working instead of being dropped), #37528 (`normalize_string` in run_command), #38205 (shell operands in `shell_get_path`), #37527 (shell `mv`), #38162 (shell `cp`). The shell hunks here are those three fixes written on top of the checked variants.
- Open PRs that shrink to their caller-side part once this lands (their `relative*` / `join_abs*` thread-local callers are covered, their caller-buffer sites still need the caller to report the error, and can use the checked variants instead of the helpers they add to `resolve_path.rs`): #38392 (`resolver_jsc.rs`), #38696 and #37502 (`relative_platform_buf` in `Chunk.rs` and `generateChunksInParallel.rs`), #38784 (`bun pm pack` and `bun publish` entries), #37457 (`get_source_code` in `Mapping.rs`), #35860 (the bundler's error report). Until then those sites panic with the message that names them instead of a slice index.
- #38365 rewrites `shell_get_path` to take the cwd string and to be infallible, so as written it keeps the unchecked splice and `join_z_buf` for an operand that does not fit. Whichever of the two lands second keeps the fallible shape from this PR (checked join, `ENAMETOOLONG`) on the cwd-string signature. Its `move_in_dir` hunk in `mv.rs` overlaps textually with the one here (a call gains a parameter).
- The existing `*_spill` helpers (`join_spill`, `join_z_spill`, `join_abs_string_spill`, `normalize_string_spill`, `join_z_buf_spill`, callers in 9 files) keep working unchanged. Now that the thread-local functions take any length, the `Vec` variants only matter for a caller that holds a long result across another call. Folding their callers back onto the plain names is a follow-up that has to look at each caller, so it is not in this PR.
- `resolve_path::z` (a plain copy into a `PathBuffer`, 33 callers) is unchanged. It has its own contract (debug panic, empty string in release) and no normalizer behind it. The CLAUDE.md paragraph names the `join*_buf` / `normalize*_buf` / `relative*_buf` families only.
- Public signature changes: `normalize_string` returns `&'static [u8]` instead of `&mut [u8]` (no caller wrote through it). `normalize_buf_t`, `normalize_string_generic_t` and `normalize_string_generic_tz` return `Option`. Every other public name keeps its signature (the private helpers under them return `Option` too). The `unsafe` this PR adds is `spill_out` (`resolve_path.rs:37`), covered under Miri by the spill tests.
- `join_needed` gains one byte so that the `.` result of no parts also fits with its NUL. `normalize_string` and `join_abs_string` now send an input whose size bound exceeds the fixed buffer to the heap even when its result would have fit. That only affects inputs of more than 1 KB / 4 KB.
- The fast paths do not allocate: the fixed buffer, or the bound-sized heap buffer, always holds the intermediate form, so the scratch fallbacks (kept out of line) only run when a caller buffer is too small. Release build of `bun_paths`, minimum of 10 interleaved runs of 5M calls each, main against this branch: `join_abs_string_buf` 116.7 against 118.8 ns (`..` segments) and 83.9 against 86.7 ns (`./name`), `normalize_string_buf` 58.9 against 60.7 ns (POSIX rules) and 53.0 against 52.7 ns (Windows rules). The per-segment work is one length comparison that replaces the slice-indexing check it makes redundant. Differences of a few ns are within the layout noise of this benchmark (single instantiations swing more in both directions). `test/js/bun/resolve/load-same-js-file-a-lot.test.ts` (2000 imports, debug + ASAN) takes the same time as a build of main within noise. Its 5 s test fails on main in this build too.
- `relative_result_capacity` holds for any input shape, including non-normalized ones (`relative_result_capacity_bounds_every_input_shape` checks a grid). `relative_spills_inputs_and_results_longer_than_a_path_buffer` is ignored under Miri only because path-buffer-sized inputs take about 40 s there. The unsafe code on that path is `spill_out`, which the join tests cover under Miri (`join_accepts_its_previous_spilled_result_as_input`).
- The three tar extractors (`bun install`, `Bun.Archive#extract` with and without a glob) now extract an entry whose name is too long as written but normalizes to a path that fits (`d/../` repeated). Short names with `..` already extracted that way (the `archive-path-dots` test). The limit now applies to the path that is created, which is the one the OS checks. `Bun.Archive` does not log skipped entries and `bun install` does, as before. The first revision missed the glob variant (a review finding).
- Shell (`test/js/bun/shell/bunshell.test.ts`, `shell/commands/mv.test.ts`, `shell/commands/cp.test.ts`): the Windows operand rewrite in `shell_get_path` is the Sentry signature. `mv src dir` normalized `basename(src)` into a `PathBuffer` before its length check, on every platform (`panic: range end index 5000 out of range for slice of length 4096` on Linux). `cp` joined its target into a `PathBuffer` with no check. The builtin is on by default on Windows and behind `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS` elsewhere. Its source goes through the thread-local `join_z`, which the heap fallback covers. Both print `File name too long` with the operand, like their other errors, and `mv` exits with the errno. `cd` and `rm` already size or check their buffers. The remaining caller-buffer sites take bounded input or the project's own files (the `bin` field in `bun pm pack` and `bun publish`, the `bun create` arguments). On absurd input they now panic with the message that names the caller instead of a slice index.
- `join_abs_string_buf_checked` documents that `None` means the result does not fit. The scratch fallback in `normalize_string_buf_t` keeps that true for a path that `..` segments shorten below its intermediate form. The fallback is out of line and does not run on the fast paths (see the timing note).
- Rebased onto main (238 commits). The one textual conflict was a dead Zig comment that #40610 removed from `join_abs_string_buf_windows`. #40091 added `shell_lstatat`, a new `shell_get_path` caller for `ls`, which panics on a long operand on the current canary (`range end index 100021 out of range for slice of length 98301`). It now passes its syscall tag and reports `ls: <name>: File name too long`, covered by the Windows shell test. #39828's `MAX_PATH_BYTES` guard in `ZigStackFrame::relative_source_url` becomes unnecessary once `relative` takes any length. Removing it changes the expected output of two reporter tests, so that is a follow-up.
- Other long-path panics seen while fuzzing have their own open PRs: #38391 (`Bun.build` entry point), #39307 (`FileSystemRouter` dir, which now panics with the new message). `sideEffects` entries never match on Windows (#30320), so the bundling test is skipped there. The runtime test is the crash case on every platform.
- Unit tests added: `normalizer_reports_instead_of_writing_past_the_buffer`, `normalizer_checks_the_units_windows_adds_to_its_input`, `normalizer_checks_the_nt_prefix_and_the_nul`, `checked_buffer_variants_fit_exactly`, `join_checked_variants_only_need_room_for_the_result`, `join_needed_holds_for_the_results_that_grow`, `join_abs_needed_holds_for_the_results_that_grow`, `relative_checked_variants_fit_exactly` and `_on_windows`, `relative_result_capacity_bounds_every_input_shape`, `normalize_string_spills_results_longer_than_its_fixed_buffer`, `join_spills_results_longer_than_its_fixed_buffer`, `join_accepts_its_previous_spilled_result_as_input`, `join_abs_string_spills_results_longer_than_its_fixed_buffer`, `relative_spills_inputs_and_results_longer_than_a_path_buffer`. Two highway stubs were added to the test module because `relative` reaches `last_index_of_char`.
- Suites run on Linux (debug): `test/js/bun/resolve`, `archive.test.ts`, `shell/bunshell.test.ts`, `shell/commands`, `bundler_splitting`, `bundler_naming`, `esbuild/dce`, `install/bun-install-streaming-extract`, `bun-link`, `bun-workspaces`, `test/js/node/path`. The failures seen are unrelated and reproduce without this change: the root-user `ls` permission tests, the 5 s import-loop test, `bun-link`'s stdout comparison against the debug-only install trace, and one RSS test that passes when run alone. On Windows (debug): `archive`, `resolve`, `bunshell`, `shell/commands/mv` and `cp`, `node/fs/fs.test.ts`, `bun-install-streaming-extract`. The `tilde_expansion` and `readSync large files` failures there reproduce with the released build on the same machine.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/commands/mv.test.ts, test/js/bun/shell/commands/cp.test.ts, test/js/bun/shell/bunshell.test.ts, test/js/bun/resolve/resolve.test.ts, test/js/bun/archive.test.ts

<!-- robobun:evidence:end -->
