### PR TITLE
test: make the #39621 reset fixture report its fd layout and bind its dead port

### DIFF
--- a/test/js/bun/http/proxy-stress-helpers.ts
+++ b/test/js/bun/http/proxy-stress-helpers.ts
@@ -546,7 +546,7 @@ function buildResponse(opts: AdversarialOriginOptions, reqBody: Buffer): Buffer 
   const framing = opts.framing ?? "content-length";
   const encoded = encodeBody(rawBody, encoding);
 
-  let head = `HTTP/1.1 ${status} ${status === 200 ? "OK" : STATUS_TEXT[status] ?? "Status"}\r\n`;
+  let head = `HTTP/1.1 ${status} ${status === 200 ? "OK" : (STATUS_TEXT[status] ?? "Status")}\r\n`;
   for (const [k, v] of Object.entries(opts.headers ?? {})) head += `${k}: ${v}\r\n`;
   if (encoding !== "identity") head += `Content-Encoding: ${encoding}\r\n`;
 
@@ -717,6 +717,11 @@ export interface DeadPort {
  * `listen(0)`, and not listening, so `connect()` to it is refused. Do not
  * simplify to bind-then-close: that frees the port into exactly the pool
  * `listen(0)` draws from, and a sibling `test.concurrent` will take it.
+ *
+ * `localAddress` makes the holder bind() its port itself. A port that connect()
+ * bound automatically can be handed out again as the automatic local port of a
+ * later connect() to it, which then connects to itself instead of being refused
+ * (about once in 13k connects on Linux). A port that bind() handed out is not.
  */
 export async function deadPort(): Promise<DeadPort> {
   let accepted: net.Socket | undefined;
@@ -726,7 +731,11 @@ export async function deadPort(): Promise<DeadPort> {
   });
   sink.listen(0, "127.0.0.1");
   await once(sink, "listening");
-  const holder = net.connect({ host: "127.0.0.1", port: (sink.address() as net.AddressInfo).port });
+  const holder = net.connect({
+    host: "127.0.0.1",
+    port: (sink.address() as net.AddressInfo).port,
+    localAddress: "127.0.0.1",
+  });
   holder.on("error", () => {});
   await once(holder, "connect");
   const port = (holder.address() as net.AddressInfo).port;

--- a/test/js/bun/http/proxy-stress-helpers.ts
+++ b/test/js/bun/http/proxy-stress-helpers.ts
@@ -717,11 +717,6 @@ export interface DeadPort {
  * `listen(0)`, and not listening, so `connect()` to it is refused. Do not
  * simplify to bind-then-close: that frees the port into exactly the pool
  * `listen(0)` draws from, and a sibling `test.concurrent` will take it.
- *
- * `localAddress` makes the holder bind() its port itself. A port that connect()
- * bound automatically can be handed out again as the automatic local port of a
- * later connect() to it, which then connects to itself instead of being refused
- * (about once in 13k connects on Linux). A port that bind() handed out is not.
  */
 export async function deadPort(): Promise<DeadPort> {
   let accepted: net.Socket | undefined;
@@ -731,11 +726,7 @@ export async function deadPort(): Promise<DeadPort> {
   });
   sink.listen(0, "127.0.0.1");
   await once(sink, "listening");
-  const holder = net.connect({
-    host: "127.0.0.1",
-    port: (sink.address() as net.AddressInfo).port,
-    localAddress: "127.0.0.1",
-  });
+  const holder = net.connect({ host: "127.0.0.1", port: (sink.address() as net.AddressInfo).port });
   holder.on("error", () => {});
   await once(holder, "connect");
   const port = (holder.address() as net.AddressInfo).port;

--- a/test/js/bun/http/proxy-stress-helpers.ts
+++ b/test/js/bun/http/proxy-stress-helpers.ts
@@ -546,7 +546,7 @@ function buildResponse(opts: AdversarialOriginOptions, reqBody: Buffer): Buffer 
   const framing = opts.framing ?? "content-length";
   const encoded = encodeBody(rawBody, encoding);
 
-  let head = `HTTP/1.1 ${status} ${status === 200 ? "OK" : (STATUS_TEXT[status] ?? "Status")}\r\n`;
+  let head = `HTTP/1.1 ${status} ${status === 200 ? "OK" : STATUS_TEXT[status] ?? "Status"}\r\n`;
   for (const [k, v] of Object.entries(opts.headers ?? {})) head += `${k}: ${v}\r\n`;
   if (encoding !== "identity") head += `Content-Encoding: ${encoding}\r\n`;
 

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -4286,29 +4286,54 @@ describe.concurrent("close() error after the peer resets the connection", () => 
 // socket's error, and its refused connect reported ECONNRESET.
 //
 // The fd arrangement in the fixture is what makes the stale read land on the new socket
-// on POSIX, where a new socket gets the lowest free number. The outcome it checks, a
-// refused connect reports ECONNREFUSED, holds on every platform, so it is not skipped
-// anywhere: on Windows the fixture is only that check.
+// on POSIX, where a new socket gets the lowest free number. The fixture reports whether
+// the arrangement held, so a change in how many fds the runtime opens fails this test
+// instead of leaving it passing without reaching the stale read. The outcome itself, a
+// refused connect reports ECONNREFUSED, holds on every platform, so the test is not
+// skipped anywhere: on Windows, where socket handles are not fd numbers, the fixture
+// reports only the outcome.
 describe.concurrent("a socket closed by data() while its peer's reset is being dispatched", () => {
   it("does not consume the connect error of a socket opened from close()", async () => {
     const source = `
-      import { closeSync, openSync } from "node:fs";
+      import { closeSync, fstatSync, openSync } from "node:fs";
 
-      // A port nothing listens on. The established connection keeps it bound, so no
-      // listener can take it while the test runs.
+      const checkFds = process.platform !== "win32";
+      function isOpen(fd) {
+        try {
+          fstatSync(fd);
+          return true;
+        } catch {
+          return false;
+        }
+      }
+
+      // A port nothing listens on. The holder binds its port itself (localAddress): a
+      // port that bind() handed out is not handed out again by a later connect() that
+      // binds automatically, so the connect below cannot be connected to itself. The
+      // port of a holder that connect() bound was, about once in 13k connects on Linux.
       const sink = Bun.listen({ hostname: "127.0.0.1", port: 0, socket: { data() {} } });
-      const holder = await Bun.connect({ hostname: "127.0.0.1", port: sink.port, socket: { data() {} } });
+      const holder = await Bun.connect({
+        hostname: "127.0.0.1",
+        port: sink.port,
+        localAddress: "127.0.0.1",
+        socket: { data() {} },
+      });
       const refusedPort = holder.localPort;
 
+      let acceptedFd = -1;
+      const report = {};
       const outcome = Promise.withResolvers();
       const server = Bun.listen({
         hostname: "127.0.0.1",
         port: 0,
         socket: {
           data(socket) {
+            acceptedFd = socket.fd;
             socket.terminate();
           },
           close() {
+            // Runs inside terminate(), after the accepted socket's fd was closed.
+            if (checkFds) report.acceptedFdFreeInClose = !isOpen(acceptedFd);
             Bun.connect({
               hostname: "127.0.0.1",
               port: refusedPort,
@@ -4318,6 +4343,10 @@ describe.concurrent("a socket closed by data() while its peer's reset is being d
                 connectError: (_socket, error) => outcome.resolve(error.code),
               },
             }).catch(() => {});
+            // Bun.connect() to an IP literal creates its socket before it returns. With
+            // the arrangement below that socket got the accepted socket's number: the
+            // number a stale SO_ERROR read for the accepted socket would hit.
+            if (checkFds) report.acceptedFdReusedByConnect = isOpen(acceptedFd);
           },
         },
       });
@@ -4335,7 +4364,8 @@ describe.concurrent("a socket closed by data() while its peer's reset is being d
       peer.write("x");
       peer.terminate();
 
-      console.log(await outcome.promise);
+      report.outcome = await outcome.promise;
+      console.log(JSON.stringify(report));
       holder.terminate();
       sink.stop(true);
       server.stop(true);
@@ -4350,7 +4380,10 @@ describe.concurrent("a socket closed by data() while its peer's reset is being d
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr }).toEqual({ stdout: "ECONNREFUSED\n", stderr: "" });
+    const expectedReport = isWindows
+      ? { outcome: "ECONNREFUSED" }
+      : { acceptedFdFreeInClose: true, acceptedFdReusedByConnect: true, outcome: "ECONNREFUSED" };
+    expect({ stdout, stderr }).toEqual({ stdout: JSON.stringify(expectedReport) + "\n", stderr: "" });
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem

- Test-only follow-up to #39621, from its self-review. Its fixture only reaches the stale `SO_ERROR` read it was written for when the connect it opens from `close()` gets the accepted socket's fd number. Nothing checked that. If the runtime starts to open one more fd on that path, the test keeps passing without covering the bug (checked: holding one extra fd at the right moment makes the fixture print `ECONNREFUSED` with and without the #39621 guard).
- The fixture's dead port was the local port of a `connect()` that bound its port automatically. On Linux such a port can be handed out again as the automatic local port of the connect that is meant to be refused, which then connects to itself and the fixture sees `open`. Measured with the fixture's construction: 9 self-connects in 120000 connects, so about 1 in 13k runs. This is the defect #35400 describes for `deadPort()` in `proxy-stress-helpers.ts`. That helper is left to #35400; an earlier revision of this PR changed it too, and d80854a0cf took that back.

### Fix

- The fixture reports its precondition next to the outcome: the accepted socket's fd number is closed when `close()` runs, and open again right after `Bun.connect()` returns (`fstatSync`). The test compares the whole JSON line. On Windows, where socket handles are not fd numbers, the fixture reports only the outcome, and the comment above the describe says so.
- The holder connects with `localAddress: "127.0.0.1"`, so it binds its port itself. A port that `bind()` handed out is not handed out again by a later automatic bind: 0 self-connects in 120000 with this change. This is the same property #35400 uses (it returns a `bind(0)` port). The fixture runs in a child process and cannot import the helper, so it keeps this one line.
- Verified: with the #39621 guard removed from `loop.c` the test prints `{"acceptedFdFreeInClose":true,"acceptedFdReusedByConnect":true,"outcome":"ECONNRESET"}` and fails on the outcome. With main it passes, 10 of 10 runs.
- This PR changes no runtime code, so there is nothing for it to fail against on main. The fail case it guards is the removed guard above.

### Background

- Dead port: a port nothing listens on, held so that no other test can listen on it. The fixture holds it as the local port of an established connection. Connecting to it is refused because nothing listens there.
- Automatic local ports: a `connect()` without a local binding gets a port from the kernel, and a later `connect()` may reuse such a port as long as the four-tuple differs. A connect to its own port with the same tuple is a TCP self-connect, which succeeds. Ports that `bind()` handed out are skipped by that allocator (#35400 has the kernel details).
- The fixture's fd arrangement: POSIX gives a new socket the lowest free fd number. The fixture reserves a number before the peer connects and frees it before the accept, so the accepted socket gets a lower number than the peer, and the connect opened from `close()` takes the accepted socket's number.

<details><summary>Notes</summary>

Other places build refused ports by hand as well (`closedPort()` in `test/js/sql/wire-frames.ts`, `deadRegistryHref()` in `test/cli/install/bun-audit.test.ts`, bind-then-close in a few tests). A shared helper in `test/harness.ts` would be the place to carry the rule once #35400 has landed. Not done here.

Measurements, release binary on Linux 6.17 (`ip_local_port_range` 32768 to 60999): holder bound by `connect()`: 7 and 2 self-connects in two runs of 60000 (`Bun.connect` holder), 2 in 60000 (`net.connect` holder, the `deadPort()` construction). Holder bound with `localAddress`: 0 in 60000, 0 in 60000, 0 in 60000. The `connect()`-bound ports seen were all even and the `bind()`-bound ones all odd, which is how the two allocators stay apart.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->