### PR TITLE
Bun.serve: release the request body slot once the body is complete

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -149,7 +149,8 @@ pub struct RequestContext<
 
     pub(crate) request_body_readable_stream_ref: JsCell<readable_stream::Strong>,
     /// Owning `+1` handle into the per-VM `Body::Value` hive pool. Shared with
-    /// `Request.body` (each holds its own `+1`). `Drop` releases the count.
+    /// `Request.body` (each holds its own `+1`). Released by the last chunk in
+    /// `on_buffered_body_chunk`, or in `deinit` if the body never completes.
     pub(crate) request_body: JsCell<Option<body::BodyHiveHandle>>,
     pub(crate) request_body_buf: JsCell<Vec<u8>>,
     pub(crate) request_body_content_len: Cell<usize>,
@@ -4125,6 +4126,12 @@ where
 
                     let _ = Body::Value::resolve(&mut old, body, global_this, None); // TODO: properly propagate exception upwards
                 }
+                // The slot is the JS `Request`'s alone now, as in the streaming
+                // arm: a context parked on a promise must not pin the bytes, and
+                // `end_request_streaming` must not reject a `Locked` value that
+                // `request.body` creates over them. This may free the slot, so
+                // `body` is dead past this point.
+                this.request_body_take_unref();
                 return;
             }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3190,8 +3190,8 @@ where
 
         // Pooled body slot, ref_count = 1.
         let body_hive = crate::webcore::body::hive_alloc(BodyValue::Null);
-        // The ctx and Request each own a +1 on the
-        // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
+        // The ctx and Request each own a +1 on the same slot: see the
+        // `RequestContext::request_body` doc and `Request::finalize`.
         ctx.set_request_body(Some(body_hive.clone()));
 
         let signal = AbortSignal::new(&server.global());
@@ -3460,8 +3460,8 @@ where
 
         // Pooled body slot, ref_count = 1.
         let body_hive = crate::webcore::body::hive_alloc(BodyValue::Null);
-        // The ctx and Request each own a +1 on the
-        // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
+        // The ctx and Request each own a +1 on the same slot: see the
+        // `RequestContext::request_body` doc and `Request::finalize`.
         ctx.request_body.set(Some(body_hive.clone()));
 
         let signal = AbortSignal::new(&this.global());

--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -1,6 +1,6 @@
 import type { Subprocess } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir } from "harness";
 import { join } from "path";
 
 const payload = Buffer.alloc(512 * 1024, "1").toString("utf-8"); // decent size payload to test memory leak
@@ -248,3 +248,300 @@ it("aborting direct-stream responses parked in pull() does not leak the native s
   // 20 extra aborted requests leaked ~176 bytes each before the fix.
   expect(large - small).toBeLessThan(1000);
 }, 30_000);
+
+// The request context and the JS Request each hold a ref on the pooled slot that
+// stores a buffered request body. The context used to drop its ref in deinit only.
+// A promise that never settles (the handler's, or a response stream's pull())
+// defers deinit until GC collects the promise, and VM teardown never runs it, so
+// a complete body stored in the slot outlived the per-VM body pool. The context
+// now drops its ref as soon as the body is complete, so only the Request keeps
+// the bytes alive. The children below exit with such a request parked.
+// BUN_DESTRUCT_VM_ON_EXIT frees the pool at exit, so LeakSanitizer reports the
+// bytes if a parked context still pins them.
+describe.concurrent("buffered request body of a request parked on a promise that never settles", () => {
+  const leakCheckedEnv = {
+    ...bunEnv,
+    BUN_DESTRUCT_VM_ON_EXIT: "1",
+    ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+    LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+  };
+  // A small POST body travels in the same packet as the headers, so the server
+  // stores it in the same read that invoked fetch(), before it returns to the
+  // event loop and can observe the abort or the termination below.
+  const body = JSON.stringify("0123456789abcdef");
+
+  async function expectCleanExit(options: { cmd: string[]; cwd?: string }) {
+    await using proc = Bun.spawn({
+      ...options,
+      env: leakCheckedEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  }
+
+  // LSan symbolizes through llvm-symbolizer on failure, which is slow against the
+  // debug binary, and the Worker cell spends a few seconds in LSan's exit scan.
+  const timeout = 30_000;
+
+  it.skipIf(!isASAN || isWindows)(
+    "is freed when the client aborts before the handler settles",
+    async () => {
+      await expectCleanExit({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const gotRequest = Promise.withResolvers();
+            const server = Bun.serve({
+              port: 0,
+              fetch() {
+                gotRequest.resolve();
+                return new Promise(() => {});
+              },
+            });
+            const ac = new AbortController();
+            const fetched = fetch(server.url, { method: "POST", body: ${body}, signal: ac.signal }).catch(() => {});
+            await gotRequest.promise;
+            ac.abort();
+            await fetched;
+            server.stop(true);
+          `,
+        ],
+      });
+    },
+    timeout,
+  );
+
+  // The handler settles here. The abort reaches the context while it owns a
+  // response stream, which is a different branch of the abort path than above.
+  it.skipIf(!isASAN || isWindows)(
+    "is freed when the client aborts a direct stream response parked in pull()",
+    async () => {
+      await expectCleanExit({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const firstChunkSent = Promise.withResolvers();
+            const server = Bun.serve({
+              port: 0,
+              idleTimeout: 0,
+              fetch() {
+                return new Response(
+                  new ReadableStream({
+                    type: "direct",
+                    async pull(controller) {
+                      controller.write("part1");
+                      await controller.flush();
+                      firstChunkSent.resolve();
+                      await new Promise(() => {});
+                    },
+                  }),
+                  { headers: { "Content-Length": "100000" } },
+                );
+              },
+            });
+            const ac = new AbortController();
+            const fetched = fetch(server.url, { method: "POST", body: ${body}, signal: ac.signal }).catch(() => {});
+            await firstChunkSent.promise;
+            ac.abort();
+            await fetched;
+            server.stop(true);
+          `,
+        ],
+      });
+    },
+    timeout,
+  );
+
+  it.skipIf(!isASAN || isWindows)(
+    "is freed when the Worker that serves it is terminated",
+    async () => {
+      using dir = tempDir("serve-body-worker-teardown", {
+        "worker.ts": `
+          const server = Bun.serve({
+            port: 0,
+            fetch() {
+              // Report from the next task: by then the server has subscribed to
+              // the returned promise and stored the body. Reporting synchronously
+              // can get the worker terminated before it subscribes, and such a
+              // request is torn down on the spot instead of staying parked.
+              setImmediate(() => postMessage("request"));
+              return new Promise(() => {});
+            },
+          });
+          postMessage(String(server.url));
+        `,
+        "main.ts": `
+          const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+          const message = () => new Promise(resolve => worker.addEventListener("message", e => resolve(e.data), { once: true }));
+          const url = await message();
+          const requested = message();
+          const ac = new AbortController();
+          const fetched = fetch(url, { method: "POST", body: ${body}, signal: ac.signal }).catch(() => {});
+          await requested;
+          await worker.terminate();
+          ac.abort();
+          await fetched;
+        `,
+      });
+      await expectCleanExit({ cmd: [bunExe(), "main.ts"], cwd: String(dir) });
+    },
+    timeout,
+  );
+
+  // In the cells above the Request is alive when the context drops its ref, so
+  // the slot survives the drop. The two cells below collect the Request first, so
+  // the context's drop at the last chunk is the one that frees the slot. The
+  // first one leaks before this change. The second passes before it as well and
+  // pins the order of that drop against the read it resolves from the slot: ASAN
+  // reports the read if the drop ever moves ahead of it. The upload is sent by
+  // hand so that the request can be held at 16 of 4096 body bytes while the
+  // Request is collected.
+  function collectedRequestScript({ inHandler, afterCollected }: { inHandler: string; afterCollected: string }) {
+    return `
+      const handlerRan = Promise.withResolvers();
+      const requestCollected = Promise.withResolvers();
+      const registry = new FinalizationRegistry(() => requestCollected.resolve());
+      const aborted = Promise.withResolvers();
+      let text;
+      // Kept reachable: the collections below must not collect the handler's
+      // promise too, which would unpark the context and let it deinit on abort.
+      let parked;
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        idleTimeout: 0,
+        fetch(req) {
+          registry.register(req, "request");
+          req.signal.addEventListener("abort", () => aborted.resolve());
+          ${inHandler}
+          req = undefined;
+          handlerRan.resolve();
+          return (parked = new Promise(() => {}));
+        },
+      });
+      const body = Buffer.alloc(4096, "x");
+      // A socket failure rejects the wait in progress instead of parking the
+      // script. One after the last wait no longer matters.
+      const socketFailed = Promise.withResolvers();
+      socketFailed.promise.catch(() => {});
+      const until = promise => Promise.race([promise, socketFailed.promise]);
+      const write = (bytes) => {
+        const written = socket.write(bytes);
+        if (written !== bytes.length) throw new Error("wrote " + written + " of " + bytes.length + " bytes");
+        socket.flush();
+      };
+      const socket = await Bun.connect({
+        hostname: server.hostname,
+        port: server.port,
+        socket: { data() {}, error(_socket, error) { socketFailed.reject(error); } },
+      });
+      write(Buffer.from("POST / HTTP/1.1\\r\\nHost: localhost\\r\\nContent-Length: " + body.length + "\\r\\n\\r\\n"));
+      write(body.subarray(0, 16));
+      await until(handlerRan.promise);
+      let collected = false;
+      requestCollected.promise.then(() => (collected = true));
+      for (let i = 0; i < 200 && !collected; i++) {
+        Bun.gc(true);
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      if (!collected) console.log("the Request was not collected");
+      ${afterCollected}
+      server.stop(true);
+    `;
+  }
+
+  it.skipIf(!isASAN || isWindows)(
+    "is freed by the last chunk when the Request was collected before it arrived",
+    async () => {
+      await expectCleanExit({
+        cmd: [
+          bunExe(),
+          "-e",
+          collectedRequestScript({
+            inHandler: "",
+            // The server stores the rest of the body, then sees the FIN behind it.
+            afterCollected: `
+              write(body.subarray(16));
+              socket.end();
+              await until(aborted.promise);
+            `,
+          }),
+        ],
+      });
+    },
+    timeout,
+  );
+
+  // on_buffered_body_chunk must resolve the pending read from the slot before
+  // it drops the slot.
+  it.skipIf(!isASAN || isWindows)(
+    "resolves a pending read from the last chunk when the Request was collected",
+    async () => {
+      await expectCleanExit({
+        cmd: [
+          bunExe(),
+          "-e",
+          collectedRequestScript({
+            inHandler: "text = req.text();",
+            afterCollected: `
+              write(body.subarray(16));
+              const received = await until(text);
+              if (received !== body.toString()) console.log("text() resolved with " + received.length + " bytes");
+            `,
+          }),
+        ],
+      });
+    },
+    timeout,
+  );
+});
+
+// Once the whole body has been stored, the context has no further use for the
+// slot, and anything the handler does with the body from then on is between the
+// Request and its consumer. While the context still held its ref, finishing the
+// response made it error a Locked value that request.body or request.text() had
+// created over the complete bytes, as if the body had been cut off.
+describe.concurrent("fully buffered request body after the response has been sent", () => {
+  const body = "0123456789abcdef";
+
+  // The body arrives in the same packet as the headers and is stored before the
+  // server returns to the event loop, so one task hop is enough for it to be
+  // complete without consuming it.
+  const bodyStored = () => new Promise<void>(resolve => setImmediate(resolve));
+
+  it("request.body taken before responding still yields the body", async () => {
+    const captured = Promise.withResolvers<ReadableStream<Uint8Array>>();
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        await bodyStored();
+        captured.resolve(req.body!);
+        return new Response("ack");
+      },
+    });
+    const res = await fetch(server.url, { method: "POST", body });
+    expect(await res.text()).toBe("ack");
+    expect(await new Response(await captured.promise).text()).toBe(body);
+  });
+
+  it("request.text() after responding resolves with the body", async () => {
+    const captured = Promise.withResolvers<Request>();
+    using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        await bodyStored();
+        // The getter is what moves the stored bytes behind a stream.
+        expect(req.body).not.toBeNull();
+        captured.resolve(req);
+        return new Response("ack");
+      },
+    });
+    const res = await fetch(server.url, { method: "POST", body });
+    expect(await res.text()).toBe("ack");
+    expect(await (await captured.promise).text()).toBe(body);
+  });
+});


### PR DESCRIPTION
### Problem
- A request parked on a promise that never settles (the handler's, or a stream's `pull()`) leaks its buffered body. LSan: `16 byte(s) leaked in 1 allocation(s)` from `RequestContext::on_buffered_body_chunk` (`RequestContext.rs:4115`), after a client abort or at VM teardown.
- The context released its ref on the body slot only in `deinit` (`RequestContext.rs:889`). The promise pins the context, so `deinit` waits for GC, and at VM teardown it never runs (`NativePromiseContext.rs:204`). #39739 tracks the rest of what such a context keeps.
- The late release also let `end_request_streaming` reject a `Locked` value that `request.body` had created over a complete body. Read after the response, it gave `""` or `The connection was closed`.

### Fix
- `on_buffered_body_chunk` releases the context's ref right after it stores and resolves the last chunk, as its streaming arm already does (`RequestContext.rs:4042`). A body that never completes is still released in `deinit`.
- Correct because the context needs the ref only while bytes can still arrive. After the last chunk nothing in the context reads the slot (notes), and the `Request` holds its own ref, so the bytes live exactly as long as the `Request`.
- Verified: seven new cells in `test/js/bun/http/serve-body-leak.test.ts`. Four LSan cells (abort, parked `pull()`, terminated Worker, `Request` collected before the last chunk) and two body reads fail on main. One ASAN cell pins that the read is resolved before the slot is dropped.

### Background
- A buffered body lives in a refcounted slot of the per-VM `body_value_pool`. The `RequestContext` and the JS `Request` hold one ref each. VM teardown frees the pool without dropping occupied slots (`jsc_hooks.rs:95`).
- A pending promise holds a ref on the context through a `NativePromiseContext` cell. Only GC of the cell releases it. VM teardown does not deref the context: unsafe during the sweep.
- `request.body` on a complete body replaces the stored bytes with a `Locked` value over a stream of them. `end_request_streaming`, run by every end path, rejects a `Locked` value in a slot the context still holds.

<details><summary>Notes</summary>

- Repro from the report, run with `BUN_DESTRUCT_VM_ON_EXIT=1 ASAN_OPTIONS=detect_leaks=1 LSAN_OPTIONS=suppressions=test/leaksan.supp`: leaks every run on the unfixed debug build, clean with this change. The LSan cells fail on main at `RequestContext.rs:4115`. The `Request` wrapper is destroyed at teardown and drops its ref, so with this change the slot count reaches zero and the bytes are freed.
- Readers of the slot after the last chunk: `is_dead_request` only tests for `Locked` and tolerates `None`. `end_request_streaming` and `deinit` tolerate `None`. `on_start_buffering` is reachable only through the `Locked` value created at prepare time, which `resolve` consumes here. `Body::Value::resolve` hands the bytes to its consumer synchronously, so the release right after it is safe. The context is pinned for the callback, so the release is safe when it is the slot's last ref too. The two collected-`Request` cells exercise that case.
- Earlier revisions also released the slot of an incomplete body from `end_request_streaming`. Review showed that no test can observe that: such a slot holds no allocation of its own, and a slot past the inline pool stays reachable through the parked context, so LSan does not report it either. It is the same class as the other resources a parked context keeps, so it is left to #39739, and this PR is reduced to the one release that the failing cells need.
- The Worker cell reports from `setImmediate` inside the handler. When it reported synchronously, `terminate()` sometimes reached the worker before `on_response` subscribed to the promise. `drain_microtasks` then returns `Stopped`, the context keeps a single ref, and `on_abort` frees it on the spot, so that request never reached the leaking state. The body read cells use the same hop to let a small body be stored without consuming it: it arrives in the same packet as the headers. The collected-`Request` cells send the upload by hand and keep the handler promise reachable, so that `Bun.gc` collects the `Request` (a `FinalizationRegistry` proves it) but not the promise.
- Related open PRs: #39743 is the fix for #39739 (tear a parked context down at abort). It and this change are independent: this one frees the bytes of a complete body as soon as it is complete, whatever happens to the context later, and fixes the body read after the response, which #39743 does not touch. #37513 keeps a request pool with parked contexts alive at Worker teardown and names this body leak as separate work. #33524 keeps delivering a late body after the response. None of them overlaps with this change.
- Suites run on this build: `serve-body-leak.test.ts` (whole file), `test/js/web/fetch/body*.test.ts` (6 files), `serve-pending-promise-abort-leak`, `bun-serve-body-json-async`, `serve-async-stream-client-abort`, `serve-request-extra-memory`, `http-server-chunking`, `bun-serve-static-stress-access-body`, `serve.test.ts`, `bun-server.test.ts`, `proxy.test.ts`, `proxy.test.js`. The last four have a few `localhost` and proxy env failures in this container that also occur with the released binary.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/serve-body-leak.test.ts

<!-- robobun:evidence:end -->