### PR TITLE
windows: drain microtasks and report throws left by addon uv callbacks after the libuv poll

### DIFF
--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1254,6 +1254,22 @@ impl EventLoop {
         }
     }
 
+    /// A poll of this thread's uv loop (`tick_possibly_forever`, `auto_tick`,
+    /// `auto_tick_active`) also ran whatever callbacks an addon put on that loop
+    /// through `napi_get_uv_event_loop` (`uv_queue_work`, `uv_async_t`, ...),
+    /// with no `enter()`/`exit()` around them. Each poll folds for them
+    /// afterwards, as `on_exit` does for cleanup hooks: an exception one left on
+    /// the VM is reported, else the checkpoint runs (deferred, like any fold,
+    /// while a blocking wait has an `enter()` open).
+    #[cfg(windows)]
+    pub fn fold_addon_uv_callbacks(global: &JSGlobalObject) {
+        if global.has_exception() {
+            let _ = crate::task::report_error_or_terminate(global, crate::JsError::Thrown);
+            return;
+        }
+        let _ = global.bun_vm().event_loop_mut().maybe_drain_microtasks();
+    }
+
     pub fn tick_possibly_forever(&mut self) {
         let loop_ptr = self.usockets_loop();
 
@@ -1286,6 +1302,8 @@ impl EventLoop {
             )
         };
 
+        #[cfg(windows)]
+        Self::fold_addon_uv_callbacks(self.global_ref());
         self.vm_ref().as_mut().on_after_event_loop();
         self.tick_concurrent();
         self.tick();

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1101,6 +1101,11 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     }
     #[cfg(not(unix))]
     let _ = state;
+    #[cfg(windows)]
+    {
+        // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
+        bun_jsc::event_loop::EventLoop::fold_addon_uv_callbacks(unsafe { &*(*vm).global });
+    }
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };
@@ -1223,6 +1228,11 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     }
     #[cfg(not(unix))]
     let _ = state;
+    #[cfg(windows)]
+    {
+        // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
+        bun_jsc::event_loop::EventLoop::fold_addon_uv_callbacks(unsafe { &*(*vm).global });
+    }
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };

--- a/test/napi/napi-app/async_tests.cpp
+++ b/test/napi/napi-app/async_tests.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <mutex>
 #include <thread>
+#include <uv.h>
 #include <vector>
 
 namespace napitests {
@@ -648,6 +649,99 @@ napi_value threadsafe_function_with_queued_items_finalized(
   return Napi::Boolean::New(info.Env(), queued_items_tsfn_finalized);
 }
 
+struct UvQueueWorkData {
+  uv_work_t req;
+  napi_env env;
+  napi_deferred deferred;
+  // Optional: called after resolving, with its status ignored.
+  napi_ref callback;
+};
+
+static void uv_queue_work_noop(uv_work_t *req) {}
+
+// libuv calls this on the JS thread itself; unlike a napi_async_work complete
+// callback, nothing in the runtime scheduled it. Written the way Node documents
+// for that situation: inside a callback scope, whose close is what runs the
+// promise's reactions in Node.
+static void uv_queue_work_resolve(uv_work_t *req, int status) {
+  UvQueueWorkData *data = reinterpret_cast<UvQueueWorkData *>(req->data);
+  napi_env env = data->env;
+  napi_ref callback = data->callback;
+  napi_deferred deferred = data->deferred;
+  delete data;
+
+  napi_handle_scope handle_scope;
+  NODE_API_CALL_CUSTOM_RETURN(env, void(),
+                              napi_open_handle_scope(env, &handle_scope));
+  napi_value resource_name;
+  NODE_API_CALL_CUSTOM_RETURN(
+      env, void(),
+      napi_create_string_utf8(env, "uv_queue_work", NAPI_AUTO_LENGTH,
+                              &resource_name));
+  napi_async_context context;
+  NODE_API_CALL_CUSTOM_RETURN(
+      env, void(), napi_async_init(env, nullptr, resource_name, &context));
+  napi_value resource;
+  NODE_API_CALL_CUSTOM_RETURN(env, void(), napi_create_object(env, &resource));
+  napi_callback_scope scope;
+  NODE_API_CALL_CUSTOM_RETURN(
+      env, void(), napi_open_callback_scope(env, resource, context, &scope));
+
+  char buf[64];
+  snprintf(buf, sizeof(buf), "after_work_cb status %d", status);
+  napi_value result;
+  NODE_API_CALL_CUSTOM_RETURN(
+      env, void(),
+      napi_create_string_utf8(env, buf, NAPI_AUTO_LENGTH, &result));
+  NODE_API_CALL_CUSTOM_RETURN(env, void(),
+                              napi_resolve_deferred(env, deferred, result));
+
+  NODE_API_CALL_CUSTOM_RETURN(env, void(),
+                              napi_close_callback_scope(env, scope));
+  NODE_API_CALL_CUSTOM_RETURN(env, void(), napi_async_destroy(env, context));
+
+  if (callback != nullptr) {
+    napi_value function;
+    NODE_API_CALL_CUSTOM_RETURN(
+        env, void(), napi_get_reference_value(env, callback, &function));
+    NODE_API_CALL_CUSTOM_RETURN(env, void(),
+                                napi_delete_reference(env, callback));
+    napi_value undefined;
+    NODE_API_CALL_CUSTOM_RETURN(env, void(),
+                                napi_get_undefined(env, &undefined));
+    // Like an addon that does not check: whatever the function throws is left
+    // where napi_call_function put it. Only ungated calls may follow.
+    napi_call_function(env, undefined, function, 0, nullptr, nullptr);
+  }
+
+  napi_close_handle_scope(env, handle_scope);
+}
+
+// Queues a uv_work_t on the loop napi_get_uv_event_loop returns and resolves
+// the returned promise from its after-work callback, which then calls the
+// function passed as the first argument, if there is one.
+static napi_value
+create_promise_with_uv_queue_work(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  uv_loop_t *loop;
+  NODE_API_CALL(env, napi_get_uv_event_loop(env, &loop));
+
+  napi_ref callback = nullptr;
+  if (info.Length() > 0 && info[0].IsFunction()) {
+    NODE_API_CALL(env, napi_create_reference(env, info[0], 1, &callback));
+  }
+
+  auto *data = new UvQueueWorkData();
+  data->env = env;
+  data->req.data = data;
+  data->callback = callback;
+  napi_value promise;
+  NODE_API_CALL(env, napi_create_promise(env, &data->deferred, &promise));
+  NODE_API_ASSERT(env, uv_queue_work(loop, &data->req, uv_queue_work_noop,
+                                     uv_queue_work_resolve) == 0);
+  return promise;
+}
+
 void register_async_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, queue_threadsafe_function_items);
   REGISTER_FUNCTION(env, exports, abort_threadsafe_function_with_queued_items);
@@ -658,6 +752,7 @@ void register_async_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, create_promise);
   REGISTER_FUNCTION(env, exports, create_promise_with_napi_cpp);
   REGISTER_FUNCTION(env, exports, create_promise_with_threadsafe_function);
+  REGISTER_FUNCTION(env, exports, create_promise_with_uv_queue_work);
   REGISTER_FUNCTION(env, exports, create_async_work_with_null_execute);
   REGISTER_FUNCTION(env, exports, create_async_work_with_null_complete);
   REGISTER_FUNCTION(env, exports, test_cancel_async_work);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -88,6 +88,41 @@ nativeTests.test_promise_with_threadsafe_function = async () => {
   return await nativeTests.create_promise_with_threadsafe_function(() => 1234);
 };
 
+nativeTests.test_promise_with_uv_queue_work = () => {
+  // The uv_work_t is the only thing keeping the loop alive. Once its after-work
+  // callback has resolved the promise, main.js's reaction ("resolved to ...")
+  // belongs to that loop turn, so it must print before the idle loop's beforeExit.
+  process.on("beforeExit", () => console.log("beforeExit"));
+  return nativeTests.create_promise_with_uv_queue_work();
+};
+
+// Bun-only: the after-work callback calls a function that throws and returns
+// without checking, so the throw is left on the engine (node keeps it in the
+// addon's env until the next module callback, which never comes here). The turn
+// that ran the callback reports it as uncaught and still runs the reaction to
+// the promise the callback resolved just before.
+nativeTests.test_promise_with_uv_queue_work_callback_throws = () => {
+  // main.js's handler exits the process; this test wants to see what follows.
+  process.removeAllListeners("uncaughtException");
+  process.on("uncaughtException", err => console.log("uncaughtException", err.message));
+  process.on("beforeExit", () => console.log("beforeExit"));
+  return nativeTests.create_promise_with_uv_queue_work(() => {
+    throw new Error("thrown from after_work_cb");
+  });
+};
+
+// A worker's loop is the other one that is polled and then asked whether it is
+// still alive. uv-queue-work-entry.mjs awaits the addon's promise at top level;
+// in "reject" mode its reaction throws instead, which has to reach the parent as
+// the worker's 'error' event.
+nativeTests.test_promise_with_uv_queue_work_in_worker = async (_, mode = "resolve") => {
+  const { Worker } = require("node:worker_threads");
+  const path = require("node:path");
+  const worker = new Worker(path.join(__dirname, "uv-queue-work-entry.mjs"), { workerData: mode });
+  worker.on("error", err => console.log("worker error:", err.message));
+  console.log("worker exited with", await new Promise(resolve => worker.on("exit", resolve)));
+};
+
 nativeTests.test_threadsafe_function_abort_then_last_release = async (_, queued = 0) => {
   // create (thread_count=1), acquire (=2), optionally queue items, abort (=1, closing)
   nativeTests.test_napi_threadsafe_function_abort_then_last_release(queued);

--- a/test/napi/napi-app/uv-queue-work-entry.mjs
+++ b/test/napi/napi-app/uv-queue-work-entry.mjs
@@ -1,0 +1,33 @@
+// Awaits the addon's uv_queue_work promise at top level, as the entry of a
+// worker (test_promise_with_uv_queue_work_in_worker in module.js, mode in
+// workerData) or of the main thread (mode in argv). Either way the after-work
+// callback runs inside the wait for this module, not in the ordinary run loop,
+// and a worker still awaiting when its loop goes idle exits with code 13.
+//
+// Modes: "resolve" logs the value; "reject" throws from the reaction instead;
+// "callback-throws" has the callback call a throwing function and logs what
+// the process reports, then the value.
+import { createRequire } from "node:module";
+import { isMainThread, workerData } from "node:worker_threads";
+
+const nativeTests = createRequire(import.meta.url)("./build/Debug/napitests.node");
+const mode = isMainThread ? process.argv[2] : workerData;
+if (!["resolve", "reject", "callback-throws"].includes(mode)) {
+  throw new Error(`unknown mode ${JSON.stringify(mode)}`);
+}
+
+let callback;
+if (mode === "callback-throws") {
+  process.on("uncaughtException", err => console.log("uncaughtException", err.message));
+  callback = () => {
+    throw new Error("thrown from after_work_cb");
+  };
+}
+
+let promise = nativeTests.create_promise_with_uv_queue_work(callback);
+if (mode === "reject") {
+  promise = promise.then(() => {
+    throw new Error("thrown in the reaction");
+  });
+}
+console.log(await promise);

--- a/test/napi/napi-app/uv-queue-work-hot-entry.mjs
+++ b/test/napi/napi-app/uv-queue-work-hot-entry.mjs
@@ -1,0 +1,22 @@
+// Run with --hot. Queues the addon's work, then fails at top level: with an
+// error counted, the loop is never alive again, so the after-work callback
+// runs inside the park --hot falls back to (tick_possibly_forever) instead of
+// an ordinary turn. The callback installs the listener (the top-level error
+// has to stay unhandled to get there) and then throws; that throw has to be
+// reported from the park, and the reaction still has to run, or the process
+// never reaches exit(0).
+import { createRequire } from "node:module";
+
+const nativeTests = createRequire(import.meta.url)("./build/Debug/napitests.node");
+
+nativeTests
+  .create_promise_with_uv_queue_work(() => {
+    process.on("uncaughtException", err => console.log("uncaughtException", err.message));
+    throw new Error("thrown from after_work_cb");
+  })
+  .then(value => {
+    console.log(value);
+    process.exit(0);
+  });
+
+throw new Error("entry failed");

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -629,6 +629,77 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     });
   });
 
+  // Only Windows hands out a libuv loop; on POSIX uv_queue_work is a stub.
+  // libuv invokes the after-work callback directly, so the loop turn that ran it
+  // has to run the reactions it queued and report what it left thrown. That turn
+  // is the ordinary run loop's (main.js attaches the reaction itself) or a wait's
+  // (the entry module awaits the promise: a worker's spin, or the wait for the
+  // main thread's entry). Before the fix the reactions stayed queued (main.js
+  // printed "beforeExit" first, a worker exited 13) and an unchecked throw was
+  // found by whatever entered JS next.
+  describe.skipIf(!isWindows)("napi_get_uv_event_loop", () => {
+    it("runs the reactions to a promise resolved from uv_queue_work's after-work callback", async () => {
+      const output = await checkSameOutput("test_promise_with_uv_queue_work", []);
+      expect(output).toBe("resolved to after_work_cb status 0\nbeforeExit");
+    });
+
+    // Worker startup dominates the next two, as for the terminate() test above:
+    // under a debug build they run close to the default timeout once the rest
+    // of this file is loading the machine.
+    it("settles a worker's top-level await on such a promise", async () => {
+      const output = await checkSameOutput("test_promise_with_uv_queue_work_in_worker", ["resolve"]);
+      expect(output).toBe("after_work_cb status 0\nworker exited with 0\nresolved to undefined");
+    }, 30_000);
+
+    it("delivers a reaction's throw in a worker as its 'error' event", async () => {
+      const output = await checkSameOutput("test_promise_with_uv_queue_work_in_worker", ["reject"]);
+      expect(output).toBe("worker error: thrown in the reaction\nworker exited with 1\nresolved to undefined");
+    }, 30_000);
+
+    // Bun-only: node keeps the unchecked throw in the addon's env and never
+    // reports it in these two shapes (see module.js). Before the fix the first
+    // exited with the throw still pending, the second never finished the wait.
+    it.each([
+      [
+        "in the run loop",
+        ["main.js", "test_promise_with_uv_queue_work_callback_throws", "[]"],
+        "uncaughtException thrown from after_work_cb\nresolved to after_work_cb status 0\nbeforeExit\n",
+      ],
+      [
+        "in the wait for the entry module",
+        ["uv-queue-work-entry.mjs", "callback-throws"],
+        "uncaughtException thrown from after_work_cb\nafter_work_cb status 0\n",
+      ],
+    ])("reports a throw the after-work callback did not check %s", async (_, [entry, ...args], expected) => {
+      await using proc = spawn({
+        cmd: [bunExe(), join(__dirname, "napi-app", entry), ...args],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe(expected);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+
+    // The third poll: the park --hot sits in once the loop is dead (see the
+    // fixture). Before the fix the throw stayed pending through the park and the
+    // tick after it failed on it, so exit(0) was never reached.
+    it("reports a throw the after-work callback did not check in the --hot park", async () => {
+      await using proc = spawn({
+        cmd: [bunExe(), "--hot", join(__dirname, "napi-app/uv-queue-work-hot-entry.mjs")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("uncaughtException thrown from after_work_cb\nafter_work_cb status 0\n");
+      expect(stderr).toContain("entry failed");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("napi_threadsafe_function", () => {
     it("passes NULL js_callback to call_js when created without a func", async () => {
       const output = await checkSameOutput("test_tsfn_null_js_callback_driver", []);

--- a/test/napi/node-napi-tests/test/node-api/test_callback_scope/do.test.ts
+++ b/test/napi/node-napi-tests/test/node-api/test_callback_scope/do.test.ts
@@ -7,12 +7,13 @@ test("build", async () => {
 });
 
 for (const file of Array.from(new Bun.Glob("*.js").scanSync(import.meta.dir))) {
-  // crash inside uv_queue_work
-  // https://github.com/oven-sh/bun/issues/12827 is the latter
-  test.todoIf(["test-resolve-async.js", "test-async-hooks.js"].includes(file) || (file === "test.js" && isWindows))(
-    file,
-    () => {
-      run(dirname(import.meta.dir), basename(import.meta.dir) + sep + file);
-    },
-  );
+  test.todoIf(
+    // uv_queue_work is a not-implemented stub on POSIX; only Windows runs a real libuv loop.
+    (file === "test-resolve-async.js" && !isWindows) ||
+      file === "test-async-hooks.js" ||
+      // https://github.com/oven-sh/bun/issues/12827
+      (file === "test.js" && isWindows),
+  )(file, () => {
+    run(dirname(import.meta.dir), basename(import.meta.dir) + sep + file);
+  });
 }


### PR DESCRIPTION
### Problem
- Windows only. An addon queues a `uv_work_t` on the loop from `napi_get_uv_event_loop` and resolves a promise in the after-work callback: the callback runs, the reactions never do. Node's `test_callback_scope/test-resolve-async.js` fails with `Mismatched noop function calls. Expected exactly 1, actual 0.` A worker awaiting such a promise at top level exits 13.
- On Windows that loop is the one Bun polls. `uv_run` (`auto_tick_active`, `src/runtime/jsc_hooks.rs:1215`, `auto_tick`, `:1083`, and the `--hot` park `tick_possibly_forever`, `src/jsc/event_loop.rs:1238`) calls the addon callback directly, with no `enter()`/`exit()` around its napi calls into JS, so nothing drains after it, and a throw the callback did not check stays on the VM. The request is done, so `is_event_loop_alive()` (`src/jsc/VirtualMachine.rs:1216`) is false and the process exits. With the throw still pending, the next JS entry meets it: the `beforeExit` emit, the tick after the park (a panic in debug builds), or, under the wait for an entry module, no drain ever succeeds again and the process hangs.

### Fix
- `EventLoop::fold_addon_uv_callbacks` (`event_loop.rs:1204`), called on Windows after each of the three polls: an exception on the VM goes to `report_error_or_terminate`, which reports it as uncaught and then drains, otherwise `maybe_drain_microtasks()`. This is the fold `on_exit` already applies to cleanup hooks (`VirtualMachine.rs:1718`). Both helpers handle the depth themselves: under a blocking wait the drain defers to the wait's next `tick()`.
- A poll runs after every callback of its turn, so folding there covers every kind of handle or request an addon can put on the loop. On POSIX each callback does this at its own `exit()`, and #39652 folds the same way after each addon callback it adds there.
- Matches Node for the reactions: its callback scope runs the checkpoint before the exit decision. For a JS throw the callback ignored, Node keeps it latched in the env and never reports it in these shapes. Bun reports it, as it does for the callbacks it dispatches itself, and a throw raised with `napi_throw_*` stays latched as in Node. Implementing `napi_open_callback_scope` and `napi_make_callback` as `enter()`/`exit()` would be a separate, complementary change: it would not cover addons that use neither.
- Verified on windows-x64: the six `napi_get_uv_event_loop` tests in `test/napi/napi.test.ts` (run loop, worker resolve and reject, unchecked throw in the run loop, under the entry-module wait, and in the `--hot` park) and `test-resolve-async.js`, enabled on Windows in `test_callback_scope/do.test.ts`. Each fails on main, and the park test also fails on the two-site version of this branch (notes).

### Background
- `EventLoop::enter()`/`exit()` (`src/jsc/event_loop.rs:283`) bracket each native entry into JS. The outermost `exit()` runs the microtask checkpoint, and the dispatcher that invoked the callback folds what it threw with `report_error_or_terminate` (`src/jsc/Task.rs:37`). Nothing else runs microtasks or reports such throws, and JSC refuses to drain while an exception is pending.
- The polls: `auto_tick` and `auto_tick_active` are the poll step of the run loops and blocking waits (`Run::start`, a worker's spin, `on_before_exit`, `wait_for_promise`, `bun test`). `tick_possibly_forever` is where `--hot`/`--watch` park once the loop is dead. On Windows all three run `uv_run(UV_RUN_ONCE)` on the thread's libuv loop (`packages/bun-usockets/src/eventing/libuv.c:417`).
- `napi_get_uv_event_loop` (`src/runtime/napi/napi_body.rs:2289`) returns that loop on Windows, so libuv calls addon code with no Bun frame on the stack. Bun's `napi_open_callback_scope` and its close are no-ops (`napi_body.rs:1362`).
- `is_event_loop_alive()` reads `uv_loop_alive()`, which counts the request, so the loop does live until the callback has run. Only the fold after it was missing.

<details><summary>Notes</summary>

**Probe.** A minimal addon (`uv_queue_work` on the napi loop, `after_work_cb` prints and resolves a deferred, JS attaches `.then` and logs `beforeExit` / `exit`), run with `1.4.0-canary.1+32e87032b` on Windows x64:

```
[addon] uv_queue_work -> 0 alive_after=1
[addon] after_work_cb status=0
[addon] napi_resolve_deferred -> 0
[js] beforeExit, resolved = false
[js] exit, resolved = false code = 0
```

With this branch `[js] then callback ran` is printed before `beforeExit`, exit code 0.

**Fail-before on windows-x64** (same canary, tests from this branch; the left column is what node prints and what the tests assert):

```
test_promise_with_uv_queue_work
  resolved to after_work_cb status 0 / beforeExit        bun: beforeExit / resolved to ...
test_promise_with_uv_queue_work_in_worker ["resolve"]
  after_work_cb status 0 / worker exited with 0          bun: worker exited with 13
test_promise_with_uv_queue_work_in_worker ["reject"]
  worker error: thrown in the reaction / exited with 1   bun: worker exited with 13
test_promise_with_uv_queue_work_callback_throws (bun-only, run loop)
  expected: uncaughtException ... / resolved to ... / beforeExit
  canary:   uncaughtException ... / resolved to ...       (beforeExit listener lost: the
            exception surfaces inside the beforeExit emit and is charged to that listener)
uv-queue-work-entry.mjs callback-throws (bun-only, entry-module wait)
  expected: uncaughtException ... / after_work_cb status 0, exit 0
  canary:   hangs with no output (killed after 20 s): the pending throw makes every
            drain a no-op, so the wait for the entry module never ends
uv-queue-work-hot-entry.mjs under --hot (bun-only, the park)
  expected: uncaughtException ... / after_work_cb status 0, exit 0
  two-site branch (debug): no stdout, `panic: a task returned Ok with a JS exception
            pending` from the tick after the park; main: same class of failure
test_callback_scope/do.test.ts: (fail) test-resolve-async.js
```

In the first case the reaction does run late: `Process__dispatchOnBeforeExit` drains the nextTick queue when one exists, and that drain also runs microtasks. The upstream test and the probe never create that queue, so there the reaction is lost. The test asserts node's order, so it still fails on main once #32866 lands, and passes only with the drain in the poll step.

**Intermediate state** (this branch's first commit, drain only, debug build): the three reaction tests pass and the throws test fails with empty stdout and exit code 3. `drainMicrotasks` is a no-op over a pending exception, and the `beforeExit` emit then dies on JSC's `assertNoException` in `Interpreter::executeCallImpl`. That is what the exception half of the fold is for. The entry-module variant pins the `auto_tick` site: every caller of `auto_tick` follows it with a `tick()`, so there the drain half is redundant and only the exception half is observable. The same holds for the park: `tick_possibly_forever` ticks right after its poll, so its fixture has the entry fail first (an error counted keeps `is_event_loop_alive()` false, so the callback can only run in the park) and asserts that the throw is reported from there and that `exit(0)` is still reached.

**Node's behavior for the unchecked throw** (Linux, real libuv, node v26.3.0 running the same fixture): prints `resolved to after_work_cb status 0` and `beforeExit`, exit 0, no uncaught exception. The throw stays in the env's latched exception and nothing rethrows it. The test is bun-only for that reason.

**Out of scope.** A throw the callback raises with `napi_throw_*` is latched in that addon's env, not on the VM. `NapiEnv::surface_exception` reads it for callbacks Bun dispatches itself (`napi_body.rs:175`), but this fold has no env to read, and a latched throw does not block the VM: it is thrown at the addon's next entry from JS, as in Node. Sweeping every env after each poll was considered and not done.

**Nested waits.** `auto_tick` also runs under blocking waits that hold an `enter()` (`expect().toThrow` on an async function, `Bun.build` with an async plugin). There `maybe_drain_microtasks` is a no-op and the wait's next `tick()` drains, and `report_error_or_terminate` reports as it does for any task folded beneath such a wait. The first version of this PR documented "no `enter()` open" as a precondition of the helper; it was not one, and the helper is now a safe fn.

**Pass-after on windows-x64** (`bun bd` of this branch): napi.test.ts block of six: pass, plus a `--hot` run of a probe script that parks for several seconds with the fold running on every wakeup. test_callback_scope: 2 pass, 2 todo (`test-async-hooks.js`, and `test.js` on Windows, both pre-existing). worker_threads.test.ts 137 pass. spawn.test.ts 125 pass. exit-code.test.ts 5 pass. microtask, setImmediate, setTimeout, setInterval suites pass. process.test.js 158 pass, 1 fail: `process.env reads are never stale after a write` times out at 5 s; its first loop alone (100k `process.env` writes) takes 4 s of synchronous time under the debug build, before the loop polls at all, so unrelated. The fold also acts as a check that none of Bun's own paths leaves an exception pending at the poll site: these suites would now report it.

**Full napi.test.ts on the same box, later in the day:** 2 to 4 unrelated conversion and GC tests time out at the 5 s limit under the file's concurrency (total 65 s instead of 57 s earlier); an A/B against the build of the previous head shows the same timeouts and the same total, so that is the machine, not the change. The earlier full runs (napi.test.ts 178 and 179 pass, worker_threads 137, spawn 125, timers, exit-code, process.test.js apart from the env-JIT timeout explained above) were on the same fold with the helper in `jsc_hooks.rs`; the move into `bun_jsc` does not change the two sites they exercise.

**Linux:** the napi-app fixture compiles (clang), napi.test.ts passes with the six new tests skipped, test_callback_scope unchanged (todo on POSIX), `test/internal/source-lints` 160 pass.

**Cost:** one `has_exception()` and one `drainMicrotasks` per loop turn on Windows, the same calls every callback exit already makes.

**Gate.** The code is `#[cfg(windows)]` and the tests are gated to Windows, so on Linux they pass with and without the change. The proof is the Windows runs above and the Windows CI lanes.

**Rebase.** Rebased onto main at b7b4ddda1b and squashed to one commit. The only conflict was in `test/napi/napi-app/async_tests.cpp`, where #39810 added its fixtures at the same spot as the `uv_queue_work` one; both blocks are kept. On a freshly provisioned windows-x64 machine the rebased tree passes the six tests, `test_callback_scope`, and `worker_threads.test.ts` (137). In the full `napi.test.ts` run on that machine the two worker tests took 5.0 s and 5.9 s under the file's own load, so they now carry the 30 s timeout the file already gives its other worker test. The failures left in that full run (`napi_wrap` lifetime, the printf-losing pending-exception test, 5 s timeouts on conversion tests and on one of #39810's new worker tests) are the same pre-existing load and GC classes as before.

**Related PRs.**
- #39652 implements `uv_queue_work` on POSIX and edits the same `todoIf` in `test_callback_scope/do.test.ts` (it marks `test-resolve-async.js` todo on Windows, this PR marks it todo on POSIX). Whichever lands second drops the remaining condition.
- #38378 merges `auto_tick` and `auto_tick_active` into one `poll()`. The two `jsc_hooks.rs` call sites here become one there, at the same spot after the poll (the `tick_possibly_forever` one stays). Whichever lands second makes that adjustment.
- #32866 drains after `beforeExit` listeners. Separate gap in the same exit path, left to that PR. It would also make the upstream test pass, but only by running the reactions at exit time instead of in the turn that resolved the promise.
- #37981 covers unhandled rejections left by the turn that lets the loop go idle. A rejection among the reactions drained here lands in that same cell (main thread: reported by `Run::start` before `on_exit`), exactly as a rejection in a timer callback does today on POSIX.
- `test_uv_loop/test.js` (a `uv_check_t` on the napi loop that calls JS directly, no promise) already passes on Windows with and without this change. Its todo reason is the POSIX stub, so it is left alone here.
- #23192 is about handles on `uv_default_loop()`, libuv's static loop, which Bun does not run. Different cause, not addressed here.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts test/napi/node-napi-tests/test/node-api/test_callback_scope/do.test.ts

<!-- robobun:evidence:end -->
