### PR TITLE
fix(bun_core): feature_flags.rs shadowed the real feature_flag module with a stub

### DIFF
--- a/src/bun_core/feature_flags.rs
+++ b/src/bun_core/feature_flags.rs
@@ -2,7 +2,12 @@
 //! instead.
 
 use crate::env;
-use crate::feature_flag;
+// `crate::feature_flag` (lib.rs) is a stub module for flags "not yet wired"
+// into the real env_var-backed accessors -- every `.get()` there is a
+// hardcoded `false`. BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE and
+// BUN_FEATURE_FLAG_NO_LIBDEFLATE are both already properly declared in
+// env_var.rs's `feature_flag` module, so this import needs to be that one.
+use crate::env_var::feature_flag;
 
 /// Store and reuse file descriptors during module resolution
 /// This was a ~5% performance improvement
@@ -120,14 +125,20 @@ pub fn is_libdeflate_enabled() -> bool {
         return false;
     }
 
-    !feature_flag::BUN_FEATURE_FLAG_NO_LIBDEFLATE.get()
+    // env_var's Accessor::get() returns Option<bool>, not bool -- always Some
+    // in practice given this flag's `{default: false}`.
+    !feature_flag::BUN_FEATURE_FLAG_NO_LIBDEFLATE.get().unwrap_or(false)
 }
 
 /// Enable the "app" option in Bun.serve. This option will likely be removed
 /// in favor of HTML loaders and configuring framework options in bunfig.toml
 pub fn bake() -> bool {
     // In canary or if an environment variable is specified.
-    env::IS_CANARY || env::IS_DEBUG || feature_flag::BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE.get()
+    env::IS_CANARY
+        || env::IS_DEBUG
+        || feature_flag::BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE
+            .get()
+            .unwrap_or(false)
 }
 
 /// Additional debugging features for bake.DevServer, such as the incremental visualizer.


### PR DESCRIPTION
## Summary

`src/bun_core/feature_flags.rs` imports `crate::feature_flag`, which resolves to a placeholder stub module in `lib.rs`:

```rust
/// `bun.feature_flag.*` runtime env-var getters. The canonical typed
/// accessors live in `env_var::feature_flag`; this stub provides the
/// `.get()` accessor surface for flags not yet wired there.
pub mod feature_flag {
    macro_rules! flag { ($($name:ident),* $(,)?) => { $(
        #[allow(non_camel_case_types)] pub struct $name;
        impl $name { #[inline] pub fn get(&self) -> bool { false } }
    )* } }
    flag!(
        BUN_FEATURE_FLAG_NO_LIBDEFLATE,
        BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE
    );
}
```

Every `.get()` in this stub is hardcoded `false`. But both `BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE` and `BUN_FEATURE_FLAG_NO_LIBDEFLATE` are already properly declared with real, env-var-backed accessors in `env_var.rs`'s own `feature_flag` module (`new_feature_flag!(pub BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE, ...)`), which `feature_flags.rs` never actually imports.

Net effect: neither flag's environment-variable override has ever worked, on any platform, regardless of what the variable is set to.
- `bake()` (gates the `app` option of `Bun.serve()`) only ever returns `true` via `IS_CANARY`/`IS_DEBUG` — setting `BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE=1` on a release build does nothing.
- `is_libdeflate_enabled()`'s disable switch (`BUN_FEATURE_FLAG_NO_LIBDEFLATE`) is similarly a no-op.

## How I found this

Debugging why `Bun.serve({app: {framework}, routes: {...}})` on a release build silently drops the framework's file-system router and the internal `/_bun/hmr` WebSocket route (explicit `routes` entries still respond fine; "Started development server" still logs) — even with `BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE=1` set. Traced it down to `bake()` unconditionally returning `false`. Added instrumented `eprintln!`s along the chain and confirmed via a CI build that `std::env::var()` and the underlying `getenv_z()` both correctly saw the variable's value, but the flag's own accessor didn't — because that accessor was the stub, not the real one.

## Fix

- `use crate::feature_flag;` → `use crate::env_var::feature_flag;`
- `env_var`'s real `Accessor::get()` returns `Option<bool>` rather than the stub's bare `bool`, so both call sites need `.unwrap_or(false)` — safe, since both flags declare `{default: false}` and `.get()` is always `Some` in practice.

## Test plan

- [x] Reproduced on a from-source release build: `BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE=1 bun build --app ./src/index.tsx --outdir ./dist` printed the canary-only error message unconditionally before the fix.
- [x] After the fix, an instrumented build confirms `bake()` correctly returns `true` when the env var is set, and the full `Bun.serve({app, routes})` chain (`ServerConfig` → `DevServer::init` → `DevServer::set_routes`) is actually exercised, reaching real downstream errors (missing `react-refresh`/`react-server-dom-bun` deps in the test fixture) instead of being silently skipped.
- [x] Full build passes (surfaced and fixed the `Option<bool>` type mismatch this same way).
