### PR TITLE
docs, bun-types: put the @__PURE__ and __proto__ prose examples in code spans

### DIFF
--- a/docs/snippets/cli/run.mdx
+++ b/docs/snippets/cli/run.mdx
@@ -239,7 +239,7 @@ bun run <file or script>
 </ParamField>
 
 <ParamField path="--ignore-dce-annotations" type="boolean">
-  Ignore tree-shaking annotations such as <code>@__PURE__</code>
+  Ignore tree-shaking annotations such as `@__PURE__`
 </ParamField>
 
 ### Networking &amp; Security

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2770,7 +2770,7 @@ declare module "bun" {
      * Enable REPL mode transforms:
      * - Wraps top-level inputs that appear to be object literals (inputs starting with '{' without trailing ';') in parentheses
      * - Hoists all declarations as var for REPL persistence across vm.runInContext calls
-     * - Wraps last expression in { __proto__: null, value: expr } for result capture
+     * - Wraps last expression in `{ __proto__: null, value: expr }` for result capture
      * - Wraps code in sync/async IIFE to avoid parentheses around object literals
      *
      * @default false
@@ -3034,14 +3034,14 @@ declare module "bun" {
         };
 
     /**
-     * Ignore dead code elimination/tree-shaking annotations such as @__PURE__ and package.json
+     * Ignore dead code elimination/tree-shaking annotations such as `@__PURE__` and package.json
      * "sideEffects" fields. This should only be used as a temporary workaround for incorrect
      * annotations in libraries.
      */
     ignoreDCEAnnotations?: boolean;
 
     /**
-     * Force emitting @__PURE__ annotations even if minify.whitespace is true.
+     * Force emitting `@__PURE__` annotations even if minify.whitespace is true.
      */
     emitDCEAnnotations?: boolean;
 

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -326,6 +326,32 @@ describe("@types/bun integration test", () => {
     expect((await claude.text()).length).toBeGreaterThan(0);
   });
 
+  // JSDoc text is rendered as markdown (editor hovers, the reference on bun.com), so a bare
+  // `__proto__` in prose shows up as a bold "proto", and TypeScript reads the bare "@"-prefixed
+  // pure annotation as a JSDoc tag, which cuts the hover text off in front of it. A code span
+  // avoids both. (The annotation is not spelled out here: in a comment in front of test() it
+  // makes the transpiler drop the call.) Only bun's own .d.ts files are checked:
+  // vendor/expect-type writes "__Note__:" for bold on purpose.
+  test("JSDoc prose wraps __dunder__ names in code spans", async () => {
+    const offenders: string[] = [];
+
+    for await (const file of new Bun.Glob("*.d.ts").scan({ cwd: BUN_TYPES_PACKAGE_ROOT })) {
+      const source = await Bun.file(join(BUN_TYPES_PACKAGE_ROOT, file)).text();
+
+      for (const comment of source.matchAll(/\/\*\*[\s\S]*?\*\//g)) {
+        // Blank out fenced examples and inline code spans without moving the offsets of the rest.
+        const prose = comment[0].replace(/```[\s\S]*?```|`[^`\n]*`/g, code => code.replace(/\S/g, " "));
+
+        for (const dunder of prose.matchAll(/(?<!\w)__\w+__(?!\w)/g)) {
+          const line = source.slice(0, comment.index + dunder.index).split("\n").length;
+          offenders.push(`${file}:${line}: ${dunder[0]}`);
+        }
+      }
+    }
+
+    expect(offenders.sort()).toEqual([]);
+  });
+
   describe("basic type checks", () => {
     typeTest("checks without lib.dom.d.ts", {
       emptyInterfaces: expectedEmptyInterfacesWhenNoDOM,


### PR DESCRIPTION
### Problem

- Four prose lines contain `__PURE__` or `__proto__` outside a code span, so markdown renders the word in bold: `<code>@<strong>PURE</strong></code>` on https://bun.com/docs/runtime, `@<strong>PURE</strong>` twice on https://bun.com/reference/bun/BuildConfig, `{ <strong>proto</strong>: null` on https://bun.com/reference/bun/TranspilerOptions.
- The sources are `docs/snippets/cli/run.mdx:242` (a raw `<code>` element) and `packages/bun-types/bun.d.ts:2773`, `:3037`, `:3044` (JSDoc prose).
- TypeScript also reads a bare `@__PURE__` in JSDoc as a tag: the `ignoreDCEAnnotations` hover ends at "such as", the `emitDCEAnnotations` hover is "Force emitting" (Notes).

### Fix

- Put each example in a code span. Markdown emits it verbatim and TypeScript reads no tag inside it, so the hover text is whole.
- The same pages already render this form (`build.mdx:159`, `bun.d.ts:3003`).
- These four lines are the whole class. Every other `__x__` in both trees is in a code span, a fence, or type code (Notes).
- A new case in `test/integration/bun-types/bun-types.test.ts` scans the JSDoc of bun's own `.d.ts` files for a `__x__` outside a code span or fence. Without the `bun.d.ts` change it reports the three lines.
- Verified: `bun bd test test/integration/bun-types/bun-types.test.ts`, `prettier --check` on the three files.

### Background

- `docs/runtime/index.mdx` imports `docs/snippets/cli/run.mdx`, where each flag description is a markdown `<ParamField>` body. Markdown parses the children of a raw `<code>` element, not of a code span.
- Since #38729, bun.com renders `docs/**` and the `bun-types` reference itself, without the old `--` to dash pass, so #38397 is closed in favor of this PR.
- `@__PURE__` marks a call a bundler can drop. `ignoreDCEAnnotations` ignores it, `emitDCEAnnotations` keeps writing it.

<details><summary>Notes</summary>

The first version of this PR changed only the `run.mdx` line. A self-review found the same token live on the reference pages, so the three `bun.d.ts` lines are folded in. The test came last. Its first draft vanished: the comment above it spelled out the pure annotation, and a comment with that annotation in front of an unused `test(...)` call makes bun's transpiler drop the call. The comment now describes the annotation without spelling it out.

Fail-before output of the new case, with `bun.d.ts` at main:

```
+   "bun.d.ts:2773: __proto__",
+   "bun.d.ts:3037: __PURE__",
+   "bun.d.ts:3044: __PURE__",
```

Live check of the 10 pages that import `docs/snippets/cli/*.mdx` (bundler, bundler/executables, runtime, test, pm/cli/add, link, outdated, patch, remove, update): no code span contains a dash, a curly quote or an ellipsis, `<code>--flag</code>` spans are common, `process.env.${name}` and `{ retry: N }` render literally, and the runtime `@__PURE__` entry was the only code span with nested emphasis.

Other `__x__` hits that are fine as they are: `bun.d.ts:1326` (already a code span), `bun.d.ts:9603` (inside a ts fence), `ffi.d.ts:346` (type code). In `docs/`, `bundler/index.mdx:1720` and `:1726` are inside the fence that opens at `:1645`, and `bundler/minifier.mdx:666` is inside a fence.

TypeScript 6.0.2 quick info on `bun.d.ts`, before: `ignoreDCEAnnotations` documentation is "Ignore dead code elimination/tree-shaking annotations such as" plus a tag named `__PURE__`. `emitDCEAnnotations` documentation is "Force emitting" plus the same tag. After: each documentation string is the full sentence and there is no tag.

The open #32790 rewrites the `bun.d.ts:2773` bullet as part of a feature change. It already conflicts with main, so the one token changed here adds no new conflict.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.0 (4c689909e)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [2.73ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.07ms]
347 |           offenders.push(`${file}:${line}: ${dunder[0]}`);
348 |         }
349 |       }
350 |     }
351 | 
352 |     expect(offenders.sort()).toEqual([]);
                                   ^
error: expect(received).toEqual(expected)

- []
+ [
+   "bun.d.ts:2773: __proto__",
+   "bun.d.ts:3037: __PURE__",
+   "bun.d.ts:3044: __PURE__",
+ ]

- Expected  - 1
+ Received  + 5

      at <anonymous> (/workspace/bun/test/integration/bun-types/bun-types.test.ts:352:30)
(fail) @types/bun integration test > JSDoc prose wraps __dunder__ names in code spans [4979.60ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4c689909e)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [0.08ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [0.51ms]
347 |           offenders.push(`${file}:${line}: ${dunder[0]}`);
348 |         }
349 |       }
350 |     }
351 | 
352 |     expect(offenders.sort()).toEqual([]);
                                   ^
error: expect(received).toEqual(expected)

- []
+ [
+   "bun.d.ts:2773: __proto__",
+   "bun.d.ts:3037: __PURE__",
+   "bun.d.ts:3044: __PURE__",
+ ]

- Expected  - 1
+ Received  + 5

      at <anonymous> (/workspace/bun/test/integration/bun-types/bun-types.test.ts:352:30)
(fail) @types/bun integration test > JSDoc prose wraps __dunder__ names in code spans [15.04ms]
(pass) @types/bun integration test > basic type checks > checks without lib.dom.d.ts [2979.69ms]
(pass) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts [563.48ms]
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [78.09ms]
(pass) @types/bun integration te
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 12 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/integration/bun-types/bun-types.test.ts
bun test v1.4.0 (4c689909e)

test/integration/bun-types/bun-types.test.ts:
(pass) @types/bun integration test > building and packing bun-types leaves packages/bun-types untouched [2.43ms]
(pass) @types/bun integration test > packed bun-types includes CLAUDE.md [6.03ms]
(pass) @types/bun integration test > JSDoc prose wraps __dunder__ names in code spans [4895.14ms]
(skip) @types/bun integration test > basic type checks > checks without lib.dom.d.ts
(skip) @types/bun integration test > tsgo (TypeScript 7 native preview) > checks without lib.dom.d.ts
(pass) @types/bun integration test > Bun.mmap > MMapOptions accepts offset and size [1039.13ms]
(skip) @types/bun integration test > Test Globals > checks without lib.dom.d.ts and test-globals references
(skip) @types/bun integration test > Test Globals > test-globals FAILS when the test-globals.d.ts is not referenced
(skip) @types/bun integration test > bun:bundle feature() > Registry augmentation restricts feature() to known flags
(skip) @types/
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 607ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/snippets/cli/run.mdx                    |  2 +-
 packages/bun-types/bun.d.ts                  |  6 +++---
 test/integration/bun-types/bun-types.test.ts | 26 ++++++++++++++++++++++++++
 3 files changed, 30 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
docs/snippets/cli/run.mdx                         1      1      0
packages/bun-types/bun.d.ts                       2      3      0
test/integration/bun-types/bun-types.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->