### PR TITLE
bun:sqlite: bind a single non-array parameter passed to prepare()

### DIFF
--- a/src/js/bun/sqlite.ts
+++ b/src/js/bun/sqlite.ts
@@ -523,7 +523,10 @@ class Database implements SqliteTypes.Database {
     return createChangesObject();
   }
 
-  prepare(query: string, params: any[] | undefined, flags: number = 0) {
+  prepare(query: string, params?: SqliteTypes.SQLQueryBindings | SqliteTypes.SQLQueryBindings[], flags: number = 0) {
+    if (params !== undefined && !isArray(params) && (!params || typeof params !== "object" || isTypedArray(params))) {
+      params = [params];
+    }
     return new Statement(SQL.prepare(this.#handle, query, params, flags || 0, this.#internalFlags));
   }
 

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -990,6 +990,7 @@ describe("prepare() binds a single non-array parameter", () => {
     ["number", 42, 42],
     ["zero", 0, 0],
     ["boolean", true, 1],
+    ["boolean false", false, 0],
     ["null", null, null],
   ])("%s", (_label, binding, expected) => {
     using db = new Database(":memory:");
@@ -1018,6 +1019,13 @@ describe("prepare() binds a single non-array parameter", () => {
     using db = new Database(":memory:");
 
     expect(() => db.prepare("SELECT 1 AS a", "extra")).toThrow("SQLite query expected 0 values, received 1");
+  });
+
+  it("an explicit undefined binding stays unbound", () => {
+    using db = new Database(":memory:");
+    using stmt = db.prepare("SELECT ? AS value", undefined);
+
+    expect(stmt.get()).toEqual({ value: null });
   });
 
   it("arrays and objects keep binding positionally and by name", () => {

--- a/test/js/bun/sqlite/sqlite.test.js
+++ b/test/js/bun/sqlite/sqlite.test.js
@@ -983,6 +983,55 @@ describe("does not throw missing parameter error in", () => {
   }
 });
 
+describe("prepare() binds a single non-array parameter", () => {
+  it.each([
+    ["string", "hello", "hello"],
+    ["empty string", "", ""],
+    ["number", 42, 42],
+    ["zero", 0, 0],
+    ["boolean", true, 1],
+    ["null", null, null],
+  ])("%s", (_label, binding, expected) => {
+    using db = new Database(":memory:");
+    using stmt = db.prepare("SELECT ? AS value", binding);
+
+    expect(stmt.get()).toEqual({ value: expected });
+  });
+
+  it("typed array, as one blob", () => {
+    using db = new Database(":memory:");
+    const blob = new Uint8Array([1, 2, 3]);
+    using stmt = db.prepare("SELECT ? AS value", blob);
+
+    expect(stmt.get()).toEqual({ value: blob });
+  });
+
+  it("shows the bound value in toString() with strict: true", () => {
+    using db = new Database(":memory:", { strict: true });
+    db.run("CREATE TABLE test (name TEXT)");
+    using stmt = db.prepare("INSERT INTO test (name) VALUES (?)", "test1");
+
+    expect(stmt.toString()).toBe("INSERT INTO test (name) VALUES ('test1')");
+  });
+
+  it("an extra binding is an arity error, not a silent drop", () => {
+    using db = new Database(":memory:");
+
+    expect(() => db.prepare("SELECT 1 AS a", "extra")).toThrow("SQLite query expected 0 values, received 1");
+  });
+
+  it("arrays and objects keep binding positionally and by name", () => {
+    using db = new Database(":memory:");
+    using positional = db.prepare("SELECT ? AS a, ? AS b", ["x", "y"]);
+    using named = db.prepare("SELECT $a AS a", { $a: "z" });
+    using unbound = db.prepare("SELECT 1 AS a");
+
+    expect(positional.get()).toEqual({ a: "x", b: "y" });
+    expect(named.get()).toEqual({ a: "z" });
+    expect(unbound.get()).toEqual({ a: 1 });
+  });
+});
+
 it("db.transaction()", () => {
   const db = Database.open(":memory:");
 


### PR DESCRIPTION
### What does this PR do?

Fixes #25472. `db.prepare("SELECT ? AS value", "hello").get()` returned `{ value: null }`. The binding was dropped with no error.

Every other entry point in `bun:sqlite` normalizes a single non-array binding into a one element array. `Database.run`, `Statement.run`, `.get`, `.all`, `.values`, `.raw` and `.iterate` carry the same predicate in seven places in this one file (`sqlite.ts:242`, `:254`, `:267`, `:282`, `:294`, `:307`, `:517`). `Database.prepare` was the one that passed its argument straight through:

```ts
prepare(query: string, params: any[] | undefined, flags: number = 0) {
  return new Statement(SQL.prepare(this.#handle, query, params, flags || 0, this.#internalFlags));
}
```

On the native side `jsSQLStatementPrepareStatementFunction` only rebinds when the value is an object (`JSSQLStatement.cpp:1722`), so a string, number, boolean or `null` fell past the guard and the statement was left with nothing bound. `DO_REBIND` itself throws `TypeError: Expected object or array` for a non-object, so the outer `isObject()` check is what turns the mistake into silence rather than an error.

This applies the existing predicate in `prepare` too.

The declared type already promised this behaviour. `packages/bun-types/sqlite.d.ts:249` types the parameter as `SQLQueryBindings | SQLQueryBindings[]` and returns `Statement<ReturnType, ParamsType extends any[] ? ParamsType : [ParamsType]>`, so a single binding is specified to behave as `[binding]`. No change to the types was needed, only to the runtime.

PR #25473 made the same runtime change and was closed automatically after 90 days without activity rather than on the merits. This redoes it against current main, with the parameter typed as the public `SQLQueryBindings` union rather than `any`.

Five things worth a look in review:

- **An extra binding is now an arity error rather than nothing.** `prepare("SELECT 1", "extra")` used to prepare cleanly and ignore the argument. It now throws `SQLite query expected 0 values, received 1` (`JSSQLStatement.cpp:1156`), which is what `prepare("SELECT 1", ["extra"])` has always done. Making the single value form match the array form is the premise of the issue, so I kept it, but it is the one place where a program that used to run can now throw.
- **A typed array changes behaviour beyond what the issue reports.** `new Uint8Array([1, 2, 3])` is an object, so it reached `DO_REBIND` and bound as an array-like: `prepare("SELECT ? AS value", new Uint8Array([1, 2, 3])).get()` returned `{ value: 1 }`, the first byte. It now binds as one blob, which is what `.get(blob)` and `.run(blob)` have always done. I read that as part of the same bug rather than a separate change, but it is the one case where a column that used to hold a value now holds a different one.
- `undefined` is left alone, so `db.prepare(sql)` still prepares with nothing bound. The check is `params !== undefined` first for exactly that reason.
- A plain object is left alone, so named parameters (`prepare("SELECT $a", { $a: 1 })`) are unaffected.
- `null` now binds NULL explicitly instead of binding nothing. The column reads back `null` either way, so this is not an observable change, but it is a real change in what reaches sqlite.

`Database.query` does not go through this path. It calls `[kPrepareOwned]`, which passes `undefined` for bindings and takes them later from `.get`/`.all`/`.run`, so the query cache is untouched by this PR.

### How did you verify your code works?

Debug build (`bun bd`) on Linux x64, branch based on `0a4e3b1e19`.

**1. Reproduced it first**, on the released 1.3.14:

```console
$ bun --version
1.3.14
$ bun -e 'import {Database} from "bun:sqlite"; const db = new Database(":memory:");
  console.log(db.prepare("SELECT ? AS value", "hello").get());
  console.log(db.prepare("SELECT ? AS value", new Uint8Array([1, 2, 3])).get());'
{
  value: null,
}
{
  value: 1,
}
```

The asymmetry also shows from the outside, without reading any source. The `INSERT` binds its
single value through `run()` and the `SELECT` reads it back through `.all()`, so both of those
accept the same shape of argument that `prepare()` drops:

```console
$ bun -e 'import {Database} from "bun:sqlite"; const db = new Database(":memory:");
  db.run("CREATE TABLE t (a TEXT)");
  db.run("INSERT INTO t VALUES (?)", "x");
  console.log("query().all()", db.query("SELECT * FROM t WHERE a = ?").all("x"));
  console.log("prepare()    ", db.prepare("SELECT * FROM t WHERE a = ?", "x").all());'
query().all() [
  {
    a: "x",
  }
]
prepare()     []
```

**2. The new tests fail without the fix.** Same file, released 1.3.14:

```console
$ USE_SYSTEM_BUN=1 bun test test/js/bun/sqlite/sqlite.test.js -t "binds a single non-array parameter"
(fail) prepare() binds a single non-array parameter > string
(fail) prepare() binds a single non-array parameter > empty string
(fail) prepare() binds a single non-array parameter > number
(fail) prepare() binds a single non-array parameter > zero
(fail) prepare() binds a single non-array parameter > boolean
(fail) prepare() binds a single non-array parameter > boolean false
(fail) prepare() binds a single non-array parameter > typed array, as one blob
(fail) prepare() binds a single non-array parameter > shows the bound value in toString() with strict: true
(fail) prepare() binds a single non-array parameter > an extra binding is an arity error, not a silent drop
 3 pass
 122 filtered out
 9 fail
 14 expect() calls
Ran 12 tests across 1 file. [214.00ms]
```

The `toString` one is the issue's own reproduction:

```console
Expected: "INSERT INTO test (name) VALUES ('test1')"
Received: "INSERT INTO test (name) VALUES (NULL)"
```

The three that pass there pass on purpose. They are the regression guards: `null` reads back as NULL either way, an explicit `undefined` must stay unbound, and the array/object case is the path this PR must not change.

**3. With the fix**, the whole sqlite file:

```console
$ bun bd test test/js/bun/sqlite/sqlite.test.js --timeout 120000
 134 pass
 0 fail
 1025 expect() calls
Ran 134 tests across 1 file. [60.45s]
```

The runner does not print the names of passing tests, so that total does not by
itself show the new block ran. Filtered to just it:

```console
$ bun bd test test/js/bun/sqlite/sqlite.test.js -t "binds a single non-array parameter" --timeout 120000
 12 pass
 122 filtered out
 0 fail
 14 expect() calls
Ran 12 tests across 1 file. [6.08s]
```

About the raised timeout: at the 5000 ms default this file is not reliable on a busy machine
under debug + ASAN. On a first run at load average 33 it lost four tests to the clock, `db.query()`
at 14 s, `#13082` at 38 s, `raw() does not touch the statement when a result-row push closes the
database and throws`, and `exit-time WAL checkpoint runs even with a never-finalized prepared
statement`. Every one reported `this test timed out after 5000ms`, not an assertion failure,
and each spawns a subprocess. The run in section 3 above, at load average 16, passes all 134 in 60 s. None of the four
is in the block this PR adds, and none touches `prepare`.

**4. Lints.**

```console
$ bun run lint
$ oxlint --config=oxlint.json --format=github src/js
Found 0 warnings and 0 errors.
Finished in 1.3s on 204 files with 88 rules using 8 threads.

$ bunx prettier --check src/js/bun/sqlite.ts test/js/bun/sqlite/sqlite.test.js
Checking formatting...
All matched files use Prettier code style!

$ bun bd test test/internal/source-lints/ --timeout 120000
 160 pass
 0 fail
 157 expect() calls
Ran 160 tests across 23 files. [1051.74s]
```

`tsc --noEmit` at the repo root is clean. I did not run `cargo fmt` or `clippy`, since this PR
changes no Rust.
