### PR TITLE
docs: document the Developer Mode requirement for Windows builds

### DIFF
--- a/docs/project/building-windows.mdx
+++ b/docs/project/building-windows.mdx
@@ -17,7 +17,7 @@ Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted
 
 ### Enable Developer Mode
 
-Some of the source archives the build downloads contain symbolic links. Windows allows only administrators to create symbolic links until you turn on Developer Mode. Without Developer Mode, the build fails while extracting those archives:
+Some of the source archives the build downloads contain symbolic links. A standard Windows account cannot create symbolic links until you turn on Developer Mode. Without Developer Mode, the build fails while extracting those archives:
 
 ```
 [zstd] error: tar extraction failed (exit 1): tests/cli-tests/bin/unzstd: Can't create '\\?\C:\...\vendor\zstd\tests\cli-tests\bin\unzstd': Invalid argument

--- a/docs/project/building-windows.mdx
+++ b/docs/project/building-windows.mdx
@@ -15,6 +15,21 @@ By default, running unverified scripts is blocked.
 Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy Unrestricted
 ```
 
+### Enable Developer Mode
+
+Some of the source archives the build downloads contain symbolic links. Windows allows only administrators to create symbolic links until you turn on Developer Mode. Without Developer Mode, the build fails while extracting those archives:
+
+```
+[zstd] error: tar extraction failed (exit 1): tests/cli-tests/bin/unzstd: Can't create '\\?\C:\...\vendor\zstd\tests\cli-tests\bin\unzstd': Invalid argument
+ninja: build stopped: subcommand failed.
+```
+
+Search the Start menu for "Developer settings" and turn on Developer Mode. To confirm it is on, check that this prints `1`:
+
+```ps1
+(Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock").AllowDevelopmentWithoutDevLicense
+```
+
 ### System Dependencies
 
 Bun v1.1 or later. The build uses Bun to run its own code generators.


### PR DESCRIPTION
### What

Adds an "Enable Developer Mode" step to the Windows build prerequisites.

### Why

Windows allows only administrators to create symbolic links until Developer Mode is on. The zstd source archive contains two symlinks — `tests/cli-tests/bin/unzstd` and `tests/cli-tests/bin/zstdcat`, both pointing at `zstd` — so `bun bd` fails while extracting it on a machine with Developer Mode off and no elevation:

```
[zstd] error: tar extraction failed (exit 1): tests/cli-tests/bin/unzstd: Can't create '\?\C:\...\vendor\zstd\tests\cli-tests\bin\unzstd': Invalid argument
ninja: build stopped: subcommand failed.
```

bsdtar extracts every other entry successfully and only returns exit 1, so the build stops on two files that the zstd build never reads — `scripts/build/deps/zstd.ts` compiles `lib/*.c` only.

`docs/project/building-windows.mdx` does not mention this requirement today, and neither do the build scripts. A contributor who follows the page exactly on a fresh Windows machine hits the error above with nothing pointing at the cause.

### How I hit it

Fresh Windows 11 setup following the page as written. Turning on Developer Mode was the only change needed; the build then completed and produced a working `bun-debug.exe` (`1.4.0-debug+4c689909e`).

### Verification

- Ran the published verification command as written; it prints `1` with Developer Mode on.
- Confirmed the failure mode directly: with Developer Mode off, `New-Item -ItemType SymbolicLink` fails with "Administrator privilege required for this operation", and `tar -tvzf` on the cached zstd tarball lists exactly those two `l`-type entries. Of the nine dependency tarballs the build downloaded, zstd is the only one containing symlinks.
- `prettier --check` passes on the changed file.

### Scope

Docs only. The build could also stop depending on symlink creation for entries it never uses — I left that out of this PR since it changes shared extraction behavior in `scripts/build/download.ts` and deserves its own discussion. Tracked in #39669.
