### PR TITLE
no-orphans: close a spawn gate before the exit-time descendant sweep

### DIFF
--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -384,8 +384,8 @@ extern "C" fn on_process_exit() {
 ///      and unlike SIGTERM can't be trapped or ignored.
 /// A frozen process can neither exit (so its pid can't be reused) nor fork
 /// (so its child set is stable while we recurse), which is what makes the
-/// verify step sufficient. The only forking process is `self`, and past
-/// `spawn_gate::close()` a child it still creates is killed by its spawner.
+/// verify step sufficient. The only forking process is `self`, and
+/// `spawn_gate::close()` has refused new spawns and waited for the in-flight ones.
 fn kill_descendants() {
     #[cfg(unix)]
     {

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -18,9 +18,9 @@
 //!        JS runtime actually starts; commands that never spin up an event
 //!        loop are short-lived enough not to need it.
 //!
-//!   2. On any clean exit (`Global.exit` → `Bun__onExit`), closes the spawn
-//!      gate, then walks the process tree rooted at `getpid()` and SIGKILLs
-//!      every descendant so children Bun spawned don't outlive it.
+//!   2. On any clean exit (`Global.exit` → `Bun__onExit`), walks the process
+//!      tree rooted at `getpid()` and SIGKILLs every descendant so children
+//!      Bun spawned don't outlive it.
 //!      - macOS: libproc `proc_listchildpids()`.
 //!      - Linux: `/proc/<pid>/task/*/children`.
 //!
@@ -384,8 +384,8 @@ extern "C" fn on_process_exit() {
 ///      and unlike SIGTERM can't be trapped or ignored.
 /// A frozen process can neither exit (so its pid can't be reused) nor fork
 /// (so its child set is stable while we recurse), which is what makes the
-/// verify step sufficient. `self`, the only unfrozen process, is past
-/// `spawn_gate::close()` (or still single-threaded, from `enable`).
+/// verify step sufficient. The only forking process is `self`, and we're in
+/// the exit handler, past `spawn_gate::close()`: not forking.
 fn kill_descendants() {
     #[cfg(unix)]
     {

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -384,8 +384,8 @@ extern "C" fn on_process_exit() {
 ///      and unlike SIGTERM can't be trapped or ignored.
 /// A frozen process can neither exit (so its pid can't be reused) nor fork
 /// (so its child set is stable while we recurse), which is what makes the
-/// verify step sufficient. The only forking process is `self`, and we're in
-/// the exit handler, past `spawn_gate::close()`: not forking.
+/// verify step sufficient. The only forking process is `self`, and past
+/// `spawn_gate::close()` a child it still creates is killed by its spawner.
 fn kill_descendants() {
     #[cfg(unix)]
     {

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -19,8 +19,7 @@
 //!        loop are short-lived enough not to need it.
 //!
 //!   2. On any clean exit (`Global.exit` → `Bun__onExit`), closes
-//!      `bun_spawn_sys::spawn_gate` (threads that are still running, such as
-//!      Workers, can no longer spawn), then walks the process tree rooted at
+//!      `bun_spawn_sys::spawn_gate`, then walks the process tree rooted at
 //!      `getpid()` and SIGKILLs every descendant so children Bun spawned don't
 //!      outlive it.
 //!      - macOS: libproc `proc_listchildpids()`.
@@ -363,12 +362,9 @@ pub fn on_parent_exit(_this: &mut ParentDeathWatchdog) {
 /// Registered with `Global.addExitCallback` so it runs from `Bun__onExit`
 /// (atexit on macOS, at_quick_exit on Linux, and the explicit `Global.exit`
 /// path). C calling convention because that's the exit-callback ABI.
-///
-/// Only the calling thread is exiting in an orderly way: Worker threads (and
-/// any other spawning thread) keep running until `_exit`. Close the spawn gate
-/// first so the tree walk below sees every child this process will ever have;
-/// otherwise a child created after the walk lists our children survives it.
 extern "C" fn on_process_exit() {
+    // Workers keep running until `_exit`; without this they can spawn a child
+    // after the walk has listed our children.
     #[cfg(unix)]
     bun_spawn_sys::spawn_gate::close();
     kill_sync_pgroups_and_descendants();
@@ -390,9 +386,8 @@ extern "C" fn on_process_exit() {
 ///      and unlike SIGTERM can't be trapped or ignored.
 /// A frozen process can neither exit (so its pid can't be reused) nor fork
 /// (so its child set is stable while we recurse), which is what makes the
-/// verify step sufficient. The only unfrozen process in the tree is `self`,
-/// whose child set is stable because the callers run either before any other
-/// thread exists (`enable`) or after `spawn_gate::close()` (`on_process_exit`).
+/// verify step sufficient. `self` is the only unfrozen process. It does not
+/// fork here: callers run single-threaded or after `spawn_gate::close()`.
 fn kill_descendants() {
     #[cfg(unix)]
     {

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -18,10 +18,9 @@
 //!        JS runtime actually starts; commands that never spin up an event
 //!        loop are short-lived enough not to need it.
 //!
-//!   2. On any clean exit (`Global.exit` → `Bun__onExit`), closes
-//!      `bun_spawn_sys::spawn_gate`, then walks the process tree rooted at
-//!      `getpid()` and SIGKILLs every descendant so children Bun spawned don't
-//!      outlive it.
+//!   2. On any clean exit (`Global.exit` → `Bun__onExit`), closes the spawn
+//!      gate, then walks the process tree rooted at `getpid()` and SIGKILLs
+//!      every descendant so children Bun spawned don't outlive it.
 //!      - macOS: libproc `proc_listchildpids()`.
 //!      - Linux: `/proc/<pid>/task/*/children`.
 //!
@@ -363,8 +362,7 @@ pub fn on_parent_exit(_this: &mut ParentDeathWatchdog) {
 /// (atexit on macOS, at_quick_exit on Linux, and the explicit `Global.exit`
 /// path). C calling convention because that's the exit-callback ABI.
 extern "C" fn on_process_exit() {
-    // Workers keep running until `_exit`; without this they can spawn a child
-    // after the walk has listed our children.
+    // Workers are still running: stop their spawns before the walk below.
     #[cfg(unix)]
     bun_spawn_sys::spawn_gate::close();
     kill_sync_pgroups_and_descendants();
@@ -386,8 +384,8 @@ extern "C" fn on_process_exit() {
 ///      and unlike SIGTERM can't be trapped or ignored.
 /// A frozen process can neither exit (so its pid can't be reused) nor fork
 /// (so its child set is stable while we recurse), which is what makes the
-/// verify step sufficient. `self` is the only unfrozen process. It does not
-/// fork here: callers run single-threaded or after `spawn_gate::close()`.
+/// verify step sufficient. `self`, the only unfrozen process, is past
+/// `spawn_gate::close()` (or still single-threaded, from `enable`).
 fn kill_descendants() {
     #[cfg(unix)]
     {

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -18,9 +18,11 @@
 //!        JS runtime actually starts; commands that never spin up an event
 //!        loop are short-lived enough not to need it.
 //!
-//!   2. On any clean exit (`Global.exit` → `Bun__onExit`), walks the process
-//!      tree rooted at `getpid()` and SIGKILLs every descendant so children
-//!      Bun spawned don't outlive it.
+//!   2. On any clean exit (`Global.exit` → `Bun__onExit`), closes
+//!      `bun_spawn_sys::spawn_gate` (threads that are still running, such as
+//!      Workers, can no longer spawn), then walks the process tree rooted at
+//!      `getpid()` and SIGKILLs every descendant so children Bun spawned don't
+//!      outlive it.
 //!      - macOS: libproc `proc_listchildpids()`.
 //!      - Linux: `/proc/<pid>/task/*/children`.
 //!
@@ -361,7 +363,14 @@ pub fn on_parent_exit(_this: &mut ParentDeathWatchdog) {
 /// Registered with `Global.addExitCallback` so it runs from `Bun__onExit`
 /// (atexit on macOS, at_quick_exit on Linux, and the explicit `Global.exit`
 /// path). C calling convention because that's the exit-callback ABI.
+///
+/// Only the calling thread is exiting in an orderly way: Worker threads (and
+/// any other spawning thread) keep running until `_exit`. Close the spawn gate
+/// first so the tree walk below sees every child this process will ever have;
+/// otherwise a child created after the walk lists our children survives it.
 extern "C" fn on_process_exit() {
+    #[cfg(unix)]
+    bun_spawn_sys::spawn_gate::close();
     kill_sync_pgroups_and_descendants();
 }
 
@@ -381,8 +390,9 @@ extern "C" fn on_process_exit() {
 ///      and unlike SIGTERM can't be trapped or ignored.
 /// A frozen process can neither exit (so its pid can't be reused) nor fork
 /// (so its child set is stable while we recurse), which is what makes the
-/// verify step sufficient. The only forking process is `self`, and we're in
-/// the exit handler — not forking.
+/// verify step sufficient. The only unfrozen process in the tree is `self`,
+/// whose child set is stable because the callers run either before any other
+/// thread exists (`enable`) or after `spawn_gate::close()` (`on_process_exit`).
 fn kill_descendants() {
     #[cfg(unix)]
     {

--- a/src/spawn_sys/lib.rs
+++ b/src/spawn_sys/lib.rs
@@ -182,18 +182,12 @@ pub mod pdeathsig {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Exit-time spawn gate. The no-orphans exit callback
-// (`bun_io::ParentDeathWatchdog::on_process_exit`) closes it before it lists
-// and kills our descendants. That walk lists our children once, so it is only
-// complete if no other thread of this process (a Worker's `Bun.spawn`, a
-// threadpool `git`) creates a child after the listing. Every spawn the runtime
-// can issue from such a thread goes through `posix_spawn::spawn_z`, which
-// holds an `InFlight` token from before the fork until the child exists. Once
-// the gate is closed, `spawn_z` fails with ECANCELED instead. The one spawn
-// path outside `spawn_z` is `bun_core::spawn_sync_inherit` (tier-0, so it
-// cannot see this gate). Its callers are CLI commands and the crash handler.
-// They block until the child exists, and none of them runs on a thread that
-// can race this exit callback.
+// Exit-time spawn gate, closed by the no-orphans exit callback before it
+// lists and kills our descendants, so a thread that is still running (a
+// Worker) cannot add a child after the listing. `posix_spawn::spawn_z` holds
+// an `InFlight` token across the fork and fails with ECANCELED once closed.
+// (`bun_core::spawn_sync_inherit` bypasses it: tier-0, synchronous CLI and
+// crash-handler use only.)
 // ──────────────────────────────────────────────────────────────────────────
 #[cfg(unix)]
 pub mod spawn_gate {
@@ -203,7 +197,6 @@ pub mod spawn_gate {
     static CLOSED: AtomicBool = AtomicBool::new(false);
     static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
 
-    /// A spawn that passed the gate and whose child may not exist yet.
     pub(crate) struct InFlight(());
 
     impl Drop for InFlight {
@@ -212,11 +205,8 @@ pub mod spawn_gate {
         }
     }
 
-    /// `None` once the gate is closed: the caller must not create a child.
-    ///
-    /// The count is raised before the flag is read and `close()` raises the
-    /// flag before it reads the count (all SeqCst), so a spawn either observes
-    /// the closed gate or is counted by the time `close()` waits.
+    /// `None` once closed. Count first, then read the flag (SeqCst, mirrored
+    /// by `close`), so a spawn is either refused or seen by `close`'s wait.
     pub(crate) fn enter() -> Option<InFlight> {
         IN_FLIGHT.fetch_add(1, Ordering::SeqCst);
         if CLOSED.load(Ordering::SeqCst) {
@@ -226,12 +216,8 @@ pub mod spawn_gate {
         Some(InFlight(()))
     }
 
-    /// Fail every spawn from now on, then wait for the spawns already past the
-    /// gate to return, so the children they create are visible to the caller.
-    /// Process exit only: the gate never reopens. A spawn in flight is a
-    /// thread suspended in vfork until its child execs, so the wait is
-    /// normally microseconds; the bound keeps a stuck exec from holding up
-    /// exit.
+    /// Refuse further spawns, then wait for the in-flight ones to return.
+    /// Never reopens. Bounded so a child stuck before exec cannot hold up exit.
     pub fn close() {
         CLOSED.store(true, Ordering::SeqCst);
         let deadline = Instant::now() + Duration::from_secs(1);

--- a/src/spawn_sys/lib.rs
+++ b/src/spawn_sys/lib.rs
@@ -10,6 +10,7 @@
 //!   - `PosixSpawnOptions`/`PosixStdio`/`PosixSpawnResult`/`ExtraPipe`/
 //!     `StdioKind`/`Dup2`/`Rusage`
 //!   - signal-forwarding / no-orphans `extern "C"` decls
+//!   - the no-orphans `pdeathsig` default and exit-time `spawn_gate`
 //!
 //! Dependencies are deliberately leaf-only: `libc`, `bun_sys`, `bun_core`,
 //! `bun_analytics`, and (Windows-only) `bun_libuv_sys`. There is **no**
@@ -177,6 +178,62 @@ pub mod pdeathsig {
     #[inline]
     pub fn is_arming_thread() -> bool {
         INSTALL_THREAD.get().copied() == Some(std::thread::current().id())
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Exit-time spawn gate. The no-orphans exit callback
+// (`bun_io::ParentDeathWatchdog::on_process_exit`) closes it before it lists
+// and kills our descendants. That walk lists our children once, so it is only
+// complete if no other thread of this process (a Worker's `Bun.spawn`, a
+// threadpool `git`) creates a child after the listing. Every POSIX spawn goes
+// through `posix_spawn::spawn_z`, which holds an `InFlight` token from before
+// the fork until the child exists. Once the gate is closed, `spawn_z` fails
+// with ECANCELED instead.
+// ──────────────────────────────────────────────────────────────────────────
+#[cfg(unix)]
+pub mod spawn_gate {
+    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+
+    static CLOSED: AtomicBool = AtomicBool::new(false);
+    static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+
+    /// A spawn that passed the gate and whose child may not exist yet.
+    pub(crate) struct InFlight(());
+
+    impl Drop for InFlight {
+        fn drop(&mut self) {
+            IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    /// `None` once the gate is closed: the caller must not create a child.
+    ///
+    /// The count is raised before the flag is read and `close()` raises the
+    /// flag before it reads the count (all SeqCst), so a spawn either observes
+    /// the closed gate or is counted by the time `close()` waits.
+    pub(crate) fn enter() -> Option<InFlight> {
+        IN_FLIGHT.fetch_add(1, Ordering::SeqCst);
+        if CLOSED.load(Ordering::SeqCst) {
+            IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
+            return None;
+        }
+        Some(InFlight(()))
+    }
+
+    /// Fail every spawn from now on, then wait for the spawns already past the
+    /// gate to return, so the children they create are visible to the caller.
+    /// Process exit only: the gate never reopens. A spawn in flight is a
+    /// thread suspended in vfork until its child execs, so the wait is
+    /// normally microseconds; the bound keeps a stuck exec from holding up
+    /// exit.
+    pub fn close() {
+        CLOSED.store(true, Ordering::SeqCst);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while IN_FLIGHT.load(Ordering::SeqCst) != 0 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_micros(100));
+        }
     }
 }
 

--- a/src/spawn_sys/lib.rs
+++ b/src/spawn_sys/lib.rs
@@ -181,14 +181,10 @@ pub mod pdeathsig {
     }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Exit-time spawn gate, closed by the no-orphans exit callback before it
-// lists and kills our descendants, so a thread that is still running (a
-// Worker) cannot add a child after the listing. `posix_spawn::spawn_z` holds
-// an `InFlight` token across the fork and fails with ECANCELED once closed.
-// (`bun_core::spawn_sync_inherit` bypasses it: tier-0, synchronous CLI and
-// crash-handler use only.)
-// ──────────────────────────────────────────────────────────────────────────
+/// Closed by the no-orphans exit callback before it kills our descendants, so
+/// a Worker cannot spawn one after the callback has listed them. Covers every
+/// `posix_spawn::spawn_z` caller (`bun_core::spawn_sync_inherit`, tier-0 and
+/// synchronous, is the one spawn path outside it).
 #[cfg(unix)]
 pub mod spawn_gate {
     use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -205,8 +201,7 @@ pub mod spawn_gate {
         }
     }
 
-    /// `None` once closed. Count first, then read the flag (SeqCst, mirrored
-    /// by `close`), so a spawn is either refused or seen by `close`'s wait.
+    /// Count, then read the flag. `close` does the reverse: no spawn is missed.
     pub(crate) fn enter() -> Option<InFlight> {
         IN_FLIGHT.fetch_add(1, Ordering::SeqCst);
         if CLOSED.load(Ordering::SeqCst) {
@@ -216,8 +211,7 @@ pub mod spawn_gate {
         Some(InFlight(()))
     }
 
-    /// Refuse further spawns, then wait for the in-flight ones to return.
-    /// Never reopens. Bounded so a child stuck before exec cannot hold up exit.
+    /// Refuse new spawns, wait for in-flight ones. Bounded so exit cannot hang.
     pub fn close() {
         CLOSED.store(true, Ordering::SeqCst);
         let deadline = Instant::now() + Duration::from_secs(1);

--- a/src/spawn_sys/lib.rs
+++ b/src/spawn_sys/lib.rs
@@ -181,40 +181,20 @@ pub mod pdeathsig {
     }
 }
 
-/// Closed at no-orphans exit so a Worker cannot spawn once the tree walk runs.
+/// Closed at no-orphans exit so a Worker cannot add a child the tree walk misses.
 #[cfg(unix)]
 pub mod spawn_gate {
-    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::time::{Duration, Instant};
+    use core::sync::atomic::{AtomicBool, Ordering};
 
     static CLOSED: AtomicBool = AtomicBool::new(false);
-    static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
 
-    pub(crate) struct InFlight(());
-
-    impl Drop for InFlight {
-        fn drop(&mut self) {
-            IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
-        }
-    }
-
-    /// Count, then read the flag. `close` does the reverse: no spawn is missed.
-    pub(crate) fn enter() -> Option<InFlight> {
-        IN_FLIGHT.fetch_add(1, Ordering::SeqCst);
-        if CLOSED.load(Ordering::SeqCst) {
-            IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
-            return None;
-        }
-        Some(InFlight(()))
-    }
-
-    /// Refuse new spawns, wait for in-flight ones. Bounded so exit cannot hang.
+    /// Call before the walk lists our children. Never reopens.
     pub fn close() {
         CLOSED.store(true, Ordering::SeqCst);
-        let deadline = Instant::now() + Duration::from_secs(1);
-        while IN_FLIGHT.load(Ordering::SeqCst) != 0 && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_micros(100));
-        }
+    }
+
+    pub(crate) fn is_closed() -> bool {
+        CLOSED.load(Ordering::SeqCst)
     }
 }
 

--- a/src/spawn_sys/lib.rs
+++ b/src/spawn_sys/lib.rs
@@ -181,10 +181,7 @@ pub mod pdeathsig {
     }
 }
 
-/// Closed by the no-orphans exit callback before it kills our descendants, so
-/// a Worker cannot spawn one after the callback has listed them. Covers every
-/// `posix_spawn::spawn_z` caller (`bun_core::spawn_sync_inherit`, tier-0 and
-/// synchronous, is the one spawn path outside it).
+/// Closed at no-orphans exit so a Worker cannot spawn once the tree walk runs.
 #[cfg(unix)]
 pub mod spawn_gate {
     use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/src/spawn_sys/lib.rs
+++ b/src/spawn_sys/lib.rs
@@ -186,10 +186,14 @@ pub mod pdeathsig {
 // (`bun_io::ParentDeathWatchdog::on_process_exit`) closes it before it lists
 // and kills our descendants. That walk lists our children once, so it is only
 // complete if no other thread of this process (a Worker's `Bun.spawn`, a
-// threadpool `git`) creates a child after the listing. Every POSIX spawn goes
-// through `posix_spawn::spawn_z`, which holds an `InFlight` token from before
-// the fork until the child exists. Once the gate is closed, `spawn_z` fails
-// with ECANCELED instead.
+// threadpool `git`) creates a child after the listing. Every spawn the runtime
+// can issue from such a thread goes through `posix_spawn::spawn_z`, which
+// holds an `InFlight` token from before the fork until the child exists. Once
+// the gate is closed, `spawn_z` fails with ECANCELED instead. The one spawn
+// path outside `spawn_z` is `bun_core::spawn_sync_inherit` (tier-0, so it
+// cannot see this gate). Its callers are CLI commands and the crash handler.
+// They block until the child exists, and none of them runs on a thread that
+// can race this exit callback.
 // ──────────────────────────────────────────────────────────────────────────
 #[cfg(unix)]
 pub mod spawn_gate {

--- a/src/spawn_sys/lib.rs
+++ b/src/spawn_sys/lib.rs
@@ -184,17 +184,45 @@ pub mod pdeathsig {
 /// Closed at no-orphans exit so a Worker cannot add a child the tree walk misses.
 #[cfg(unix)]
 pub mod spawn_gate {
-    use core::sync::atomic::{AtomicBool, Ordering};
+    use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
 
     static CLOSED: AtomicBool = AtomicBool::new(false);
+    static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
 
-    /// Call before the walk lists our children. Never reopens.
-    pub fn close() {
-        CLOSED.store(true, Ordering::SeqCst);
+    /// Held by `spawn_z` across the fork. A spawner sits in vfork until its
+    /// child execs, so this is what `close` has to wait for.
+    pub(crate) struct InFlight(());
+
+    impl Drop for InFlight {
+        fn drop(&mut self) {
+            IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    /// Counts before it reads the flag (`close` stores, then reads the count).
+    pub(crate) fn enter() -> Option<InFlight> {
+        IN_FLIGHT.fetch_add(1, Ordering::SeqCst);
+        if CLOSED.load(Ordering::SeqCst) {
+            IN_FLIGHT.fetch_sub(1, Ordering::SeqCst);
+            return None;
+        }
+        Some(InFlight(()))
     }
 
     pub(crate) fn is_closed() -> bool {
         CLOSED.load(Ordering::SeqCst)
+    }
+
+    /// Refuse new spawns, then wait for the ones in flight. Never reopens.
+    /// The bound keeps exit from hanging on a stalled spawner, whose child is
+    /// then killed by `spawn_z` itself.
+    pub fn close() {
+        CLOSED.store(true, Ordering::SeqCst);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while IN_FLIGHT.load(Ordering::SeqCst) != 0 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_micros(100));
+        }
     }
 }
 

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -611,6 +611,13 @@ pub mod posix_spawn {
     }
 
     #[cfg(unix)]
+    unsafe extern "C" {
+        // safe: by-value args; a bad pid is ESRCH, never UB.
+        safe fn kill(pid: pid_t, sig: c_int) -> c_int;
+    }
+
+    /// Every runtime spawn passes here (`bun_core::spawn_sync_inherit` does not).
+    #[cfg(unix)]
     pub(crate) fn spawn_z(
         path: &CStr,
         actions: Option<&Actions>,
@@ -618,13 +625,31 @@ pub mod posix_spawn {
         argv: *const *const c_char,
         envp: *const *const c_char,
     ) -> sys::Result<pid_t> {
-        // Every runtime spawn passes here, except `bun_core::spawn_sync_inherit`.
-        let Some(_in_flight) = crate::spawn_gate::enter() else {
+        if crate::spawn_gate::is_closed() {
             return sys::Result::Err(
                 sys::Error::from_code(sys::E::ECANCELED, SYSCALL_POSIX_SPAWN)
                     .with_path(path.to_bytes()),
             );
-        };
+        }
+        let result = spawn_z_inner(path, actions, attr, argv, envp);
+        // Closed during the spawn: the exit walk may have listed our children
+        // before this one existed, so it is killed here instead.
+        if let Ok(pid) = result
+            && crate::spawn_gate::is_closed()
+        {
+            let _ = kill(pid, system::SIGKILL);
+        }
+        result
+    }
+
+    #[cfg(unix)]
+    fn spawn_z_inner(
+        path: &CStr,
+        actions: Option<&Actions>,
+        attr: Option<&Attr>,
+        argv: *const *const c_char,
+        envp: *const *const c_char,
+    ) -> sys::Result<pid_t> {
         let pty_slave_fd = attr.map_or(-1, |a| a.pty_slave_fd);
         let detached = attr.is_some_and(|a| a.detached);
         let uid = attr.and_then(|a| a.uid);

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -618,8 +618,7 @@ pub mod posix_spawn {
         argv: *const *const c_char,
         envp: *const *const c_char,
     ) -> sys::Result<pid_t> {
-        // Dropped when this returns, i.e. once the child exists (or the spawn
-        // failed), which is what `spawn_gate::close()` waits for.
+        // Held until this returns, i.e. until the child exists.
         let Some(_in_flight) = crate::spawn_gate::enter() else {
             return sys::Result::Err(
                 sys::Error::from_code(sys::E::ECANCELED, SYSCALL_POSIX_SPAWN)

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -625,15 +625,15 @@ pub mod posix_spawn {
         argv: *const *const c_char,
         envp: *const *const c_char,
     ) -> sys::Result<pid_t> {
-        if crate::spawn_gate::is_closed() {
+        let Some(_in_flight) = crate::spawn_gate::enter() else {
             return sys::Result::Err(
                 sys::Error::from_code(sys::E::ECANCELED, SYSCALL_POSIX_SPAWN)
                     .with_path(path.to_bytes()),
             );
-        }
+        };
         let result = spawn_z_inner(path, actions, attr, argv, envp);
-        // Closed during the spawn: the exit walk may have listed our children
-        // before this one existed, so it is killed here instead.
+        // The gate closed meanwhile. If `close` gave up waiting for this spawn,
+        // the exit walk listed our children without this one.
         if let Ok(pid) = result
             && crate::spawn_gate::is_closed()
         {

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -618,7 +618,7 @@ pub mod posix_spawn {
         argv: *const *const c_char,
         envp: *const *const c_char,
     ) -> sys::Result<pid_t> {
-        // Held until this returns, i.e. until the child exists.
+        // Every runtime spawn passes here, except `bun_core::spawn_sync_inherit`.
         let Some(_in_flight) = crate::spawn_gate::enter() else {
             return sys::Result::Err(
                 sys::Error::from_code(sys::E::ECANCELED, SYSCALL_POSIX_SPAWN)

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -618,6 +618,14 @@ pub mod posix_spawn {
         argv: *const *const c_char,
         envp: *const *const c_char,
     ) -> sys::Result<pid_t> {
+        // Dropped when this returns, i.e. once the child exists (or the spawn
+        // failed), which is what `spawn_gate::close()` waits for.
+        let Some(_in_flight) = crate::spawn_gate::enter() else {
+            return sys::Result::Err(
+                sys::Error::from_code(sys::E::ECANCELED, SYSCALL_POSIX_SPAWN)
+                    .with_path(path.to_bytes()),
+            );
+        };
         let pty_slave_fd = attr.map_or(-1, |a| a.pty_slave_fd);
         let detached = attr.is_some_and(|a| a.detached);
         let uid = attr.and_then(|a| a.uid);

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -330,6 +330,9 @@ test.concurrent.skipIf(!isPosix)(
   "--no-orphans: clean exit reaps children spawned by Workers during the exit",
   async () => {
     using dir = tempDir("no-orphans-workers", {
+      // Pre-created so that a run in which no child got to write still fails
+      // on the assertions below rather than on reading the file.
+      pids: "",
       "exit-while-workers-spawn.js": `
         import { Worker, isMainThread, parentPort } from "node:worker_threads";
         import { appendFileSync } from "node:fs";

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -317,18 +317,22 @@ async function waitUntilAllDead(pids: number[], timeoutMs: number): Promise<numb
 // running, and spawning, until the process is gone. The exit handler lists
 // bun's children once before it kills them, so a child a Worker spawned after
 // that listing used to outlive bun. The handler now closes the spawn gate
-// first (a later spawn fails with ECANCELED, and one already in flight is
-// waited for), so every child either is listed and killed or never exists.
+// first: a later spawn fails with ECANCELED, and a spawn that was in flight
+// kills the child it created. So every child is either listed or killed by
+// its spawner.
 //
 // Each child appends its own pid to the pidfile before it execs sleep, so a
 // child that lives long enough to matter is always on the list, whether or
-// not the Worker that spawned it got to run again before exit.
+// not the Worker that spawned it got to run again before exit. A spawn
+// failure other than ECANCELED is appended too, so the test cannot pass
+// because the workers failed to spawn.
 test.concurrent.skipIf(!isPosix)(
   "--no-orphans: clean exit reaps children spawned by Workers during the exit",
   async () => {
     using dir = tempDir("no-orphans-workers", {
       "exit-while-workers-spawn.js": `
         import { Worker, isMainThread, parentPort } from "node:worker_threads";
+        import { appendFileSync } from "node:fs";
         const workerCount = 4;
         if (isMainThread) {
           let hot = 0;
@@ -346,8 +350,9 @@ test.concurrent.skipIf(!isPosix)(
                 cmd: ["/bin/sh", "-c", 'echo $$ >> "$0"; exec sleep 30', process.env.PIDFILE],
                 stdio: ["ignore", "ignore", "ignore"],
               });
-            } catch {
-              // ECANCELED once the exit handler has closed the gate.
+            } catch (e) {
+              // ECANCELED is expected once the exit handler has closed the gate.
+              if (e.code !== "ECANCELED") appendFileSync(process.env.PIDFILE, "error " + e.code + "\\n");
             }
             if (++spawned === 10) parentPort.postMessage("hot");
             setTimeout(spawnOne, 0);
@@ -365,15 +370,16 @@ test.concurrent.skipIf(!isPosix)(
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    const children = readFileSync(pidfile, "utf8").split("\n").filter(Boolean).map(Number);
+    const lines = readFileSync(pidfile, "utf8").split("\n").filter(Boolean);
+    const spawnErrors = lines.filter(line => !/^\d+$/.test(line));
+    const children = lines.filter(line => /^\d+$/.test(line)).map(Number);
     // A child killed before its echo is not on the list, so the count varies;
     // this only proves the workers were spawning.
     expect(children.length).toBeGreaterThan(0);
     const survivors = await waitUntilAllDead(children, 10000);
     reap(...survivors);
     if (exitCode !== 0) console.error(stderr);
-    expect(survivors).toEqual([]);
-    expect(exitCode).toBe(0);
+    expect({ spawnErrors, survivors, exitCode }).toEqual({ spawnErrors: [], survivors: [], exitCode: 0 });
   },
 );
 

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -302,6 +302,81 @@ describe.concurrent.each([
   });
 });
 
+/** Poll until every pid is gone or `timeoutMs` elapses; returns the pids still alive. */
+async function waitUntilAllDead(pids: number[], timeoutMs: number): Promise<number[]> {
+  const deadline = Date.now() + timeoutMs;
+  let alive = pids.filter(isAlive);
+  while (alive.length > 0 && Date.now() < deadline) {
+    await sleep(25);
+    alive = alive.filter(isAlive);
+  }
+  return alive;
+}
+
+// process.exit() on the main thread does not stop Worker threads: they keep
+// running, and spawning, until the process is gone. The exit handler lists
+// bun's children once before it kills them, so a child a Worker spawned after
+// that listing used to outlive bun. The handler now closes the spawn gate
+// first (a later spawn fails with ECANCELED, and one already in flight is
+// waited for), so every child either is listed and killed or never exists.
+//
+// Each child appends its own pid to the pidfile before it execs sleep, so a
+// child that lives long enough to matter is always on the list, whether or
+// not the Worker that spawned it got to run again before exit.
+test.concurrent.skipIf(!isPosix)(
+  "--no-orphans: clean exit reaps children spawned by Workers during the exit",
+  async () => {
+    using dir = tempDir("no-orphans-workers", {
+      "exit-while-workers-spawn.js": `
+        import { Worker, isMainThread, parentPort } from "node:worker_threads";
+        const workerCount = 4;
+        if (isMainThread) {
+          let hot = 0;
+          for (let i = 0; i < workerCount; i++) {
+            new Worker(new URL(import.meta.url)).on("message", () => {
+              // Every worker is inside its spawn loop: exit in the middle of it.
+              if (++hot === workerCount) process.exit(0);
+            });
+          }
+        } else {
+          let spawned = 0;
+          const spawnOne = () => {
+            try {
+              Bun.spawn({
+                cmd: ["/bin/sh", "-c", 'echo $$ >> "$0"; exec sleep 30', process.env.PIDFILE],
+                stdio: ["ignore", "ignore", "ignore"],
+              });
+            } catch {
+              // ECANCELED once the exit handler has closed the gate.
+            }
+            if (++spawned === 10) parentPort.postMessage("hot");
+            setTimeout(spawnOne, 0);
+          };
+          spawnOne();
+        }
+      `,
+    });
+    const pidfile = `${dir}/pids`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--no-orphans", "exit-while-workers-spawn.js"],
+      env: { ...bunEnv, PIDFILE: pidfile },
+      cwd: String(dir),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const children = readFileSync(pidfile, "utf8").split("\n").filter(Boolean).map(Number);
+    // A child killed before its echo is not on the list, so the count varies;
+    // this only proves the workers were spawning.
+    expect(children.length).toBeGreaterThan(0);
+    const survivors = await waitUntilAllDead(children, 10000);
+    reap(...survivors);
+    if (exitCode !== 0) console.error(stderr);
+    expect(survivors).toEqual([]);
+    expect(exitCode).toBe(0);
+  },
+);
+
 // `bun run --no-orphans` while the supervisor is SIGKILLed.
 // Tree: test → sh (supervisor) → `bun run` → /bin/sh (script). The script is
 // non-Bun so it never installs its own watchdog — survival of the script after

--- a/test/cli/run/no-orphans.test.ts
+++ b/test/cli/run/no-orphans.test.ts
@@ -325,24 +325,33 @@ async function waitUntilAllDead(pids: number[], timeoutMs: number): Promise<numb
 // child that lives long enough to matter is always on the list, whether or
 // not the Worker that spawned it got to run again before exit. A spawn
 // failure other than ECANCELED is appended too, so the test cannot pass
-// because the workers failed to spawn.
+// because the workers failed to spawn. The main thread exits only once the
+// file has MIN_RECORDED lines: on a release build the first spawns and the
+// exit are otherwise so close together that no child has written yet, and
+// the list would be empty.
+const MIN_RECORDED = 20;
 test.concurrent.skipIf(!isPosix)(
   "--no-orphans: clean exit reaps children spawned by Workers during the exit",
   async () => {
     using dir = tempDir("no-orphans-workers", {
-      // Pre-created so that a run in which no child got to write still fails
-      // on the assertions below rather than on reading the file.
       pids: "",
       "exit-while-workers-spawn.js": `
         import { Worker, isMainThread, parentPort } from "node:worker_threads";
-        import { appendFileSync } from "node:fs";
+        import { appendFileSync, readFileSync } from "node:fs";
         const workerCount = 4;
         if (isMainThread) {
           let hot = 0;
+          const started = performance.now();
+          const exitOnceChildrenHaveRun = () => {
+            const recorded = readFileSync(process.env.PIDFILE, "utf8").split("\\n").filter(Boolean).length;
+            // The deadline is a hang guard: the test then fails on the count.
+            if (recorded >= ${MIN_RECORDED} || performance.now() - started > 10_000) process.exit(0);
+            setTimeout(exitOnceChildrenHaveRun, 1);
+          };
           for (let i = 0; i < workerCount; i++) {
             new Worker(new URL(import.meta.url)).on("message", () => {
-              // Every worker is inside its spawn loop: exit in the middle of it.
-              if (++hot === workerCount) process.exit(0);
+              // Every worker is inside its spawn loop and stays there until exit.
+              if (++hot === workerCount) exitOnceChildrenHaveRun();
             });
           }
         } else {
@@ -376,13 +385,11 @@ test.concurrent.skipIf(!isPosix)(
     const lines = readFileSync(pidfile, "utf8").split("\n").filter(Boolean);
     const spawnErrors = lines.filter(line => !/^\d+$/.test(line));
     const children = lines.filter(line => /^\d+$/.test(line)).map(Number);
-    // A child killed before its echo is not on the list, so the count varies;
-    // this only proves the workers were spawning.
-    expect(children.length).toBeGreaterThan(0);
     const survivors = await waitUntilAllDead(children, 10000);
     reap(...survivors);
     if (exitCode !== 0) console.error(stderr);
     expect({ spawnErrors, survivors, exitCode }).toEqual({ spawnErrors: [], survivors: [], exitCode: 0 });
+    expect(children.length).toBeGreaterThanOrEqual(MIN_RECORDED);
   },
 );
 


### PR DESCRIPTION
### Problem
- With `--no-orphans`, `process.exit()` leaves children alive when a Worker is spawning at that moment. The repro in Notes left orphans in 20 of 20 runs on 1.4.0.
- Cause: `on_process_exit` (`src/io/ParentDeathWatchdog.rs`) lists the children of this process once, then kills them. Exit does not stop Worker threads, so a Worker can create a child after the listing.

### Fix
- `spawn_gate` (`src/spawn_sys/lib.rs`): a closed flag and an in-flight count. `spawn_z` (`src/spawn_sys/posix_spawn.rs`), which every runtime spawn goes through, holds a count token across the fork and fails with `ECANCELED` once the gate is closed.
- `on_process_exit` closes the gate, waits for the count to reach zero (1 s bound), then walks the tree. So a child that was being created exists when the walk lists our children. A spawner sits in vfork until its child has exec'd, which can take longer than the walk of a small tree, hence the wait.
- After the fork, `spawn_z` reads the flag again and kills its own child if the gate closed meanwhile: the backstop for a spawner that outlasts the bound. Nothing is joined, so exit cannot block. Only the no-orphans callback closes the gate.
- Verified: `test/cli/run/no-orphans.test.ts` (new test, fails with main's `src/` and on stock 1.4.0, passes 22 of 22 fixed). Also the spawn, child_process, and worker suites with the flag set, and `cargo check` for darwin, freebsd, windows.

### Background
- The walk SIGSTOPs each child, checks its parent, recurses, then kills leaves first. A stopped process cannot fork, so only this process can add children during the walk.
- The CI ASAN lane sets `BUN_FEATURE_FLAG_NO_ORPHANS=1` for every test process, so it runs this path at every exit.
- Windows is not affected: there no-orphans is a kill-on-close Job Object, which covers every thread's children.
- Linux `PR_SET_PDEATHSIG` is armed for main-thread spawns only, so a SIGKILLed bun still leaves Worker-spawned children alive. Not changed here (Notes).

<details><summary>Notes</summary>

Repro (`bun --no-orphans r.mjs; sleep .5; pgrep -c -f 'sleep 8.0424'`):

```js
import { Worker, isMainThread } from "node:worker_threads";
if (isMainThread) {
  for (let i = 0; i < 4; i++) new Worker(new URL(import.meta.url));
  setTimeout(() => process.exit(0), 100);
} else {
  setInterval(() => Bun.spawn({ cmd: ["sleep", "8.0424"], stdio: ["ignore", "ignore", "ignore"] }), 2);
}
```

Stock 1.4.0: 20 of 20 runs leave orphans, 159 `sleep` processes in total. Fixed debug build: 0 of 10 (counted with `pgrep`, so this includes children that no file recorded). On the debug build the 100 ms timer in this repro fires before the Workers start, so the test instead waits until every Worker reports that it is spawning and 20 children have recorded themselves, then exits while the Workers keep spawning. With main's `src/` that gives 21 to 63 survivors per run: the window between the listing and `_exit` is hundreds of milliseconds there. On stock 1.4.0 the test fails on survivors in 6 of 6 runs.

The test's children are `sh -c 'echo $$ >> pidfile; exec sleep 30'`, so each child records itself. In 20 measured unfixed runs every survivor was on the list. Recording the pid from the Worker instead missed about a quarter of the survivors, because the Worker did not always run again before `_exit`. The Worker also records any spawn failure other than `ECANCELED` in the same file, and the test asserts there is none. A spawn after the gate closed throws `ECANCELED: operation canceled, posix_spawn '/usr/bin/sleep'` (24 to 31 of them in one debug run).

What remains after the bound: a spawner that is stalled for more than 1 s between taking its token and returning from the fork, and that then does not run again before `_exit`, leaks its child. Both the wait and the post-fork kill have to fail for that. Neither has a deterministic test. The test exercises them only by chance (four Workers spawn in a loop while the gate closes).

Why a refused spawn fails instead of blocking: the caller releases whatever it holds. A thread parked inside the spawn path could hold a lock that a later exit callback needs, and exit would hang. The same reasoning is why the wait is bounded.

The remaining gap is pre-existing and documented in #39044: a child that exits on its own between the listing and its SIGSTOP reparents its children to init. `kill_subreaper_adoptees` and `kill_tree_rooted_at` (the `bun run` cleanup that runs while the process continues) do not close the gate on purpose: it never reopens.

Second face from the same report: `kill -9` of a `--no-orphans` bun kills main-thread children (their own `PR_SET_PDEATHSIG`) and leaves Worker-spawned children alive (3 of 3 probe runs; `pdeathsig::should_default` returns true only on the arming thread). The kernel sends the death signal when the spawning thread exits, so arming it for Worker spawns would also kill a Worker's children on `worker.terminate()`, on Linux only. That is a behavior decision and is left out of this PR.

Local failures seen while testing, identical with and without this change: the uid/gid test in this file (this container has no `CAP_KILL`, #38938 gates it), `$SHELL` unset, debug-build timeouts, and an LSan leak of the `node:fs` binding per terminated Worker (reported separately).

Revision history. e7da7c6: count plus bounded wait. e5c638c: replaced the count with the post-fork kill after review questioned the bound. That was a step back: a spawner suspended in vfork while a small tree is walked never reaches its post-fork check before `_exit`. 16389a5: both mechanisms, as described above. 0b550dc made the test wait for 20 recorded children, because on a release build the exit otherwise followed the first spawns before any child had written.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/no-orphans.test.ts

<!-- robobun:evidence:end -->