### PR TITLE
Build: extract dep archives without symlink privilege on Windows

### DIFF
--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -258,7 +258,9 @@ export async function downloadWithRetry(
  * every other entry, then exits 1 on just those. So the happy path runs
  * unchanged, and only after a failure do we list the archive for symlink
  * entries and retry with each excluded. An archive with no symlinks failed
- * for some other reason and the original error is rethrown.
+ * for some other reason and the original error is rethrown. The same goes
+ * for a symlink name that cannot be excluded literally (see
+ * isLiterallyExcludable): declining is safer than excluding too much.
  *
  * @param stripComponents How many top-level dirs to strip. 1 for github
  *   archives. 0 for tarballs that are already flat (e.g. prebuilt WebKit
@@ -281,7 +283,7 @@ export async function extractTarGz(tarball: string, dest: string, stripComponent
   }
   if (result.status !== 0) {
     const symlinks = listSymlinkEntries(tarball);
-    if (symlinks.length === 0) {
+    if (symlinks.length === 0 || !symlinks.every(isLiterallyExcludable)) {
       throw new BuildError(`tar extraction failed (exit ${result.status}): ${result.stderr}`, { file: tarball });
     }
     console.log(
@@ -304,6 +306,18 @@ export async function extractTarGz(tarball: string, dest: string, stripComponent
 
   const entries = await readdir(dest);
   assert(entries.length > 0, `tar extracted nothing from ${tarball}`, { hint: "Tarball may be corrupt" });
+}
+
+/**
+ * `--exclude` takes a glob pattern in both bsdtar and GNU tar, and Windows'
+ * bsdtar has no literal-match mode, so a name with a metacharacter could
+ * also exclude a regular member. A control character is no safer (a newline
+ * breaks the listing pairing in listSymlinkEntries). No pinned dep archive
+ * has such names; if one ever does, the fallback declines and the original
+ * error stands.
+ */
+function isLiterallyExcludable(name: string): boolean {
+  return /^[\x20-\x7e]+$/.test(name) && !/[\\*?[\]]/.test(name);
 }
 
 /**

--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -250,6 +250,16 @@ export async function downloadWithRetry(
  * checks miss the change entirely. With -m, everything extracted is "now",
  * so any .o built BEFORE this extraction is correctly stale.
  *
+ * ## Symlink fallback
+ *
+ * Creating a symlink needs privilege on Windows (Developer Mode or an
+ * elevated shell). Some dep archives carry symlinks the build never reads —
+ * zstd ships two test fixtures under tests/cli-tests/ — and bsdtar extracts
+ * every other entry, then exits 1 on just those. So the happy path runs
+ * unchanged, and only after a failure do we list the archive for symlink
+ * entries and retry with each excluded. An archive with no symlinks failed
+ * for some other reason and the original error is rethrown.
+ *
  * @param stripComponents How many top-level dirs to strip. 1 for github
  *   archives. 0 for tarballs that are already flat (e.g. prebuilt WebKit
  *   has `bun-webkit/` that the caller wants to keep for a rename step).
@@ -270,11 +280,51 @@ export async function extractTarGz(tarball: string, dest: string, stripComponent
     });
   }
   if (result.status !== 0) {
-    throw new BuildError(`tar extraction failed (exit ${result.status}): ${result.stderr}`, { file: tarball });
+    const symlinks = listSymlinkEntries(tarball);
+    if (symlinks.length === 0) {
+      throw new BuildError(`tar extraction failed (exit ${result.status}): ${result.stderr}`, { file: tarball });
+    }
+    console.log(
+      `tar exited ${result.status}; retrying without ${symlinks.length} symlink ` +
+        `${symlinks.length === 1 ? "entry" : "entries"}: ${symlinks.join(", ")}`,
+    );
+    const retry = spawnSync(tarExe, [...args, ...symlinks.map(entry => `--exclude=${entry}`)], {
+      stdio: ["ignore", "ignore", "pipe"],
+      encoding: "utf8",
+    });
+    if (retry.status !== 0) {
+      throw new BuildError(
+        `tar extraction failed even with symlink entries excluded:\n` +
+          `  first attempt (exit ${result.status}): ${result.stderr}\n` +
+          `  retry (exit ${retry.status}): ${retry.error?.message ?? retry.stderr}`,
+        { file: tarball },
+      );
+    }
   }
 
   const entries = await readdir(dest);
   assert(entries.length > 0, `tar extracted nothing from ${tarball}`, { hint: "Tarball may be corrupt" });
+}
+
+/**
+ * Archive entries that are symlinks, in archive order. Empty when the
+ * listing itself fails (the caller then rethrows its original error).
+ *
+ * `-tv` marks a symlink with `l` in the mode column, but the entry name is
+ * awkward to parse out of the verbose line (variable date columns, a
+ * ` -> target` suffix). `-t` prints one bare name per line in the same
+ * order, so pair the two listings by index instead.
+ */
+function listSymlinkEntries(tarball: string): string[] {
+  const list = (flags: string) =>
+    spawnSync(tarExe, [flags, tarball], { stdio: ["ignore", "pipe", "ignore"], encoding: "utf8" });
+  const verbose = list("-tzvf");
+  const names = list("-tzf");
+  if (verbose.status !== 0 || names.status !== 0) return [];
+  const modes = verbose.stdout.split(/\r?\n/).filter(Boolean);
+  const entries = names.stdout.split(/\r?\n/).filter(Boolean);
+  if (modes.length !== entries.length) return [];
+  return entries.filter((_, i) => modes[i]!.startsWith("l"));
 }
 
 /**

--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -250,23 +250,35 @@ export async function downloadWithRetry(
  * checks miss the change entirely. With -m, everything extracted is "now",
  * so any .o built BEFORE this extraction is correctly stale.
  *
- * ## Symlink fallback
+ * ## Symlink fallback (opt-in)
  *
  * Creating a symlink needs privilege on Windows (Developer Mode or an
  * elevated shell). Some dep archives carry symlinks the build never reads —
  * zstd ships two test fixtures under tests/cli-tests/ — and bsdtar extracts
- * every other entry, then exits 1 on just those. So the happy path runs
- * unchanged, and only after a failure do we list the archive for symlink
- * entries and retry with each excluded. An archive with no symlinks failed
- * for some other reason and the original error is rethrown. The same goes
- * for a symlink name that cannot be excluded literally (see
- * isLiterallyExcludable): declining is safer than excluding too much.
+ * every other entry, then exits 1 on just those. With `skipUnusedSymlinks`
+ * the happy path runs unchanged, and only after a failure do we list the
+ * archive for symlink entries and retry with each excluded. An archive with
+ * no symlinks failed for some other reason and the original error is
+ * rethrown. The same goes for a symlink name that cannot be excluded
+ * literally (see isLiterallyExcludable): declining is safer than excluding
+ * too much.
  *
  * @param stripComponents How many top-level dirs to strip. 1 for github
  *   archives. 0 for tarballs that are already flat (e.g. prebuilt WebKit
  *   has `bun-webkit/` that the caller wants to keep for a rename step).
+ * @param skipUnusedSymlinks The caller asserts the build reads none of the
+ *   archive's symlink entries, so extraction may skip them instead of
+ *   failing. Only the dep-archive fetch sets this: dep builds compile
+ *   explicit source lists. Leave it off for archives whose symlinks may
+ *   matter (prebuilt WebKit, the xwin sysroot, prefetch trees), where a
+ *   quiet success with entries missing would be worse than the failure.
  */
-export async function extractTarGz(tarball: string, dest: string, stripComponents = 1): Promise<void> {
+export async function extractTarGz(
+  tarball: string,
+  dest: string,
+  stripComponents = 1,
+  { skipUnusedSymlinks = false }: { skipUnusedSymlinks?: boolean } = {},
+): Promise<void> {
   const args = ["-xzmf", tarball, "-C", dest];
   if (stripComponents > 0) args.push(`--strip-components=${stripComponents}`);
 
@@ -282,7 +294,7 @@ export async function extractTarGz(tarball: string, dest: string, stripComponent
     });
   }
   if (result.status !== 0) {
-    const symlinks = listSymlinkEntries(tarball);
+    const symlinks = skipUnusedSymlinks ? listSymlinkEntries(tarball) : [];
     if (symlinks.length === 0 || !symlinks.every(isLiterallyExcludable)) {
       throw new BuildError(`tar extraction failed (exit ${result.status}): ${result.stderr}`, { file: tarball });
     }

--- a/scripts/build/fetch-cli.ts
+++ b/scripts/build/fetch-cli.ts
@@ -262,7 +262,10 @@ async function fetchDep(
   await mkdir(dest, { recursive: true });
 
   // Github archives have a top-level directory <repo>-<commit>/. Strip it.
-  await extractTarGz(tarballPath, dest);
+  // skipUnusedSymlinks: dep builds compile explicit source lists and never
+  // read a symlink entry (zstd ships two as test fixtures), so extraction
+  // must not require symlink privilege (Windows without Developer Mode).
+  await extractTarGz(tarballPath, dest, 1, { skipUnusedSymlinks: true });
 
   // ─── Apply patches / overlays ───
   for (let i = 0; i < patches.length; i++) {

--- a/test/internal/build-extract-symlink-fallback.test.ts
+++ b/test/internal/build-extract-symlink-fallback.test.ts
@@ -142,25 +142,28 @@ test.skipIf(cannotRunFakeTar)("with symlink support, symlink entries extract nor
   expect(lines).toEqual([]);
 });
 
-test.skipIf(cannotRunFakeTar)("without symlink privilege, extraction retries with the symlink entries excluded", async () => {
-  using dir = tempDir("extract-symlink", {});
-  const tarball = makeTarball(String(dir), { symlinks: ["unzstd", "zstdcat"] });
-  const dest = join(String(dir), "out");
-  mkdirSync(dest);
+test.skipIf(cannotRunFakeTar)(
+  "without symlink privilege, extraction retries with the symlink entries excluded",
+  async () => {
+    using dir = tempDir("extract-symlink", {});
+    const tarball = makeTarball(String(dir), { symlinks: ["unzstd", "zstdcat"] });
+    const dest = join(String(dir), "out");
+    mkdirSync(dest);
 
-  const { lines } = await withFakeTar(String(dir), tarWithoutSymlinkPrivilege, () =>
-    withLogCaptured(() => extractTarGz(tarball, dest)),
-  );
+    const { lines } = await withFakeTar(String(dir), tarWithoutSymlinkPrivilege, () =>
+      withLogCaptured(() => extractTarGz(tarball, dest)),
+    );
 
-  // Everything the build reads is there; only the two fixtures are skipped.
-  expect(existsSync(join(dest, "lib", "zstd.c"))).toBe(true);
-  expect(existsSync(join(dest, "tests", "cli-tests", "bin", "zstd"))).toBe(true);
-  expect(existsSync(join(dest, "tests", "cli-tests", "bin", "unzstd"))).toBe(false);
-  expect(lines).toEqual([
-    "tar exited 1; retrying without 2 symlink entries: " +
-      "zstd-abc123/tests/cli-tests/bin/unzstd, zstd-abc123/tests/cli-tests/bin/zstdcat",
-  ]);
-});
+    // Everything the build reads is there; only the two fixtures are skipped.
+    expect(existsSync(join(dest, "lib", "zstd.c"))).toBe(true);
+    expect(existsSync(join(dest, "tests", "cli-tests", "bin", "zstd"))).toBe(true);
+    expect(existsSync(join(dest, "tests", "cli-tests", "bin", "unzstd"))).toBe(false);
+    expect(lines).toEqual([
+      "tar exited 1; retrying without 2 symlink entries: " +
+        "zstd-abc123/tests/cli-tests/bin/unzstd, zstd-abc123/tests/cli-tests/bin/zstdcat",
+    ]);
+  },
+);
 
 test.skipIf(cannotRunFakeTar)("an archive with no symlinks rethrows the original error", async () => {
   using dir = tempDir("extract-symlink", {});

--- a/test/internal/build-extract-symlink-fallback.test.ts
+++ b/test/internal/build-extract-symlink-fallback.test.ts
@@ -4,9 +4,11 @@
  * Developer Mode or elevation, bsdtar extracts every other entry of the
  * zstd dep archive and exits 1 on its two symlink test fixtures
  * (tests/cli-tests/bin/{unzstd,zstdcat} -> zstd), killing the build
- * (oven-sh/bun#39669). The fallback: after a failure, list the archive's
- * symlink entries and retry with each excluded; with none, or with a name
- * that cannot be excluded literally (--exclude is a glob), rethrow.
+ * (oven-sh/bun#39669). The fallback, opt-in via skipUnusedSymlinks (the
+ * dep-archive fetch sets it, archives whose symlinks may matter do not):
+ * after a failure, list the archive's symlink entries and retry with each
+ * excluded; with none, or with a name that cannot be excluded literally
+ * (--exclude is a glob), rethrow.
  *
  * The privilege failure can't be reproduced on a POSIX host (and on Windows
  * tarExe is an absolute System32 path), so these tests put a fake `tar` on
@@ -151,7 +153,7 @@ test.skipIf(cannotRunFakeTar)(
     mkdirSync(dest);
 
     const { lines } = await withFakeTar(String(dir), tarWithoutSymlinkPrivilege, () =>
-      withLogCaptured(() => extractTarGz(tarball, dest)),
+      withLogCaptured(() => extractTarGz(tarball, dest, 1, { skipUnusedSymlinks: true })),
     );
 
     // Everything the build reads is there; only the two fixtures are skipped.
@@ -172,7 +174,7 @@ test.skipIf(cannotRunFakeTar)("an archive with no symlinks rethrows the original
   mkdirSync(dest);
 
   const { result: err, lines } = await withFakeTar(String(dir), tarThatAlwaysFailsExtraction, () =>
-    withLogCaptured(() => rejection(extractTarGz(tarball, dest))),
+    withLogCaptured(() => rejection(extractTarGz(tarball, dest, 1, { skipUnusedSymlinks: true }))),
   );
 
   expect(err).toBeInstanceOf(BuildError);
@@ -188,7 +190,7 @@ test.skipIf(cannotRunFakeTar)("a retry that still fails reports both attempts", 
   mkdirSync(dest);
 
   const { result: err, lines } = await withFakeTar(String(dir), tarThatAlwaysFailsExtraction, () =>
-    withLogCaptured(() => rejection(extractTarGz(tarball, dest))),
+    withLogCaptured(() => rejection(extractTarGz(tarball, dest, 1, { skipUnusedSymlinks: true }))),
   );
 
   expect(err).toBeInstanceOf(BuildError);
@@ -208,11 +210,30 @@ test.skipIf(cannotRunFakeTar)("a symlink name with a glob metacharacter declines
   mkdirSync(dest);
 
   const { result: err, lines } = await withFakeTar(String(dir), tarThatAlwaysFailsExtraction, () =>
-    withLogCaptured(() => rejection(extractTarGz(tarball, dest))),
+    withLogCaptured(() => rejection(extractTarGz(tarball, dest, 1, { skipUnusedSymlinks: true }))),
   );
 
   expect(err).toBeInstanceOf(BuildError);
   expect((err as BuildError).message).toStartWith("tar extraction failed (exit 1):");
   expect((err as BuildError).message).toContain("boom: disk full");
+  expect(lines).toEqual([]);
+});
+
+test.skipIf(cannotRunFakeTar)("without the opt-in, a symlink failure is not retried", async () => {
+  using dir = tempDir("extract-symlink", {});
+  const tarball = makeTarball(String(dir), { symlinks: ["unzstd", "zstdcat"] });
+  const dest = join(String(dir), "out");
+  mkdirSync(dest);
+
+  // Archives whose symlinks may matter (prebuilt WebKit, the xwin sysroot)
+  // extract without skipUnusedSymlinks: a quiet success with entries missing
+  // would be worse than the failure.
+  const { result: err, lines } = await withFakeTar(String(dir), tarWithoutSymlinkPrivilege, () =>
+    withLogCaptured(() => rejection(extractTarGz(tarball, dest))),
+  );
+
+  expect(err).toBeInstanceOf(BuildError);
+  expect((err as BuildError).message).toStartWith("tar extraction failed (exit 1):");
+  expect((err as BuildError).message).toContain("Cannot create");
   expect(lines).toEqual([]);
 });

--- a/test/internal/build-extract-symlink-fallback.test.ts
+++ b/test/internal/build-extract-symlink-fallback.test.ts
@@ -5,7 +5,8 @@
  * zstd dep archive and exits 1 on its two symlink test fixtures
  * (tests/cli-tests/bin/{unzstd,zstdcat} -> zstd), killing the build
  * (oven-sh/bun#39669). The fallback: after a failure, list the archive's
- * symlink entries and retry with each excluded; with none, rethrow.
+ * symlink entries and retry with each excluded; with none, or with a name
+ * that cannot be excluded literally (--exclude is a glob), rethrow.
  *
  * The privilege failure can't be reproduced on a POSIX host (and on Windows
  * tarExe is an absolute System32 path), so these tests put a fake `tar` on
@@ -22,21 +23,35 @@ import { join } from "node:path";
 import { extractTarGz } from "../../scripts/build/download.ts";
 import { BuildError } from "../../scripts/build/error.ts";
 
-const realTar = Bun.which("tar")!;
+const realTar = Bun.which("tar");
+// The fixtures are sh scripts and the fake tar intercepts a PATH lookup,
+// which the absolute System32 tarExe on Windows ignores anyway.
+const cannotRunFakeTar = isWindows || realTar === null;
 
-/** A zstd-shaped .tar.gz: lib sources plus, optionally, the two symlink test fixtures. */
-function makeTarball(root: string, { withSymlinks }: { withSymlinks: boolean }): string {
+/** A zstd-shaped .tar.gz: lib sources plus symlink test fixtures named by `symlinks`. */
+function makeTarball(root: string, { symlinks, files = [] }: { symlinks: string[]; files?: string[] }): string {
   const top = join(root, "src", "zstd-abc123");
   mkdirSync(join(top, "lib"), { recursive: true });
   mkdirSync(join(top, "tests", "cli-tests", "bin"), { recursive: true });
   writeFileSync(join(top, "lib", "zstd.c"), "int zstd;\n");
   writeFileSync(join(top, "tests", "cli-tests", "bin", "zstd"), "#!/bin/sh\n");
-  if (withSymlinks) {
-    symlinkSync("zstd", join(top, "tests", "cli-tests", "bin", "unzstd"));
-    symlinkSync("zstd", join(top, "tests", "cli-tests", "bin", "zstdcat"));
+  for (const name of symlinks) {
+    symlinkSync("zstd", join(top, "tests", "cli-tests", "bin", name));
   }
+  for (const name of files) {
+    writeFileSync(join(top, "tests", "cli-tests", "bin", name), "");
+  }
+  // List the members explicitly: archiving the directory stores them in
+  // readdir order, which varies by filesystem, and the tests assert on the
+  // entry order the fallback reports.
+  const members = [
+    "zstd-abc123/lib/zstd.c",
+    "zstd-abc123/tests/cli-tests/bin/zstd",
+    ...symlinks.map(name => `zstd-abc123/tests/cli-tests/bin/${name}`),
+    ...files.map(name => `zstd-abc123/tests/cli-tests/bin/${name}`),
+  ];
   const tarball = join(root, "dep.tar.gz");
-  const result = spawnSync(realTar, ["-czf", tarball, "-C", join(root, "src"), "zstd-abc123"], { encoding: "utf8" });
+  const result = spawnSync(realTar!, ["-czf", tarball, "-C", join(root, "src"), ...members], { encoding: "utf8" });
   expect(result.status).toBe(0);
   return tarball;
 }
@@ -65,8 +80,9 @@ esac
 case "$1" in
   -t*) exec ${realTar} "$@" ;;
 esac
-# Plain extraction: extract everything, then fail the symlink entries the
-# way bsdtar does without privilege (error per entry, delayed exit 1).
+# Plain extraction: extract everything, then fail the two known symlink
+# fixtures the way bsdtar does without privilege (error per entry,
+# delayed exit 1).
 dest=.
 prev=
 for a in "$@"; do
@@ -74,7 +90,8 @@ for a in "$@"; do
   prev=$a
 done
 ${realTar} "$@"
-find "$dest" -type l | while read -r link; do
+for link in "$dest/tests/cli-tests/bin/unzstd" "$dest/tests/cli-tests/bin/zstdcat"; do
+  [ -L "$link" ] || continue
   echo "$link: Cannot create: Invalid argument" >&2
   rm -f "$link"
 done
@@ -113,9 +130,9 @@ async function withLogCaptured<T>(fn: () => Promise<T>): Promise<{ result: T; li
   }
 }
 
-test.skipIf(isWindows)("with symlink support, symlink entries extract normally", async () => {
+test.skipIf(cannotRunFakeTar)("with symlink support, symlink entries extract normally", async () => {
   using dir = tempDir("extract-symlink", {});
-  const tarball = makeTarball(String(dir), { withSymlinks: true });
+  const tarball = makeTarball(String(dir), { symlinks: ["unzstd", "zstdcat"] });
   const dest = join(String(dir), "out");
   mkdirSync(dest);
 
@@ -125,9 +142,9 @@ test.skipIf(isWindows)("with symlink support, symlink entries extract normally",
   expect(lines).toEqual([]);
 });
 
-test.skipIf(isWindows)("without symlink privilege, extraction retries with the symlink entries excluded", async () => {
+test.skipIf(cannotRunFakeTar)("without symlink privilege, extraction retries with the symlink entries excluded", async () => {
   using dir = tempDir("extract-symlink", {});
-  const tarball = makeTarball(String(dir), { withSymlinks: true });
+  const tarball = makeTarball(String(dir), { symlinks: ["unzstd", "zstdcat"] });
   const dest = join(String(dir), "out");
   mkdirSync(dest);
 
@@ -145,9 +162,9 @@ test.skipIf(isWindows)("without symlink privilege, extraction retries with the s
   ]);
 });
 
-test.skipIf(isWindows)("an archive with no symlinks rethrows the original error", async () => {
+test.skipIf(cannotRunFakeTar)("an archive with no symlinks rethrows the original error", async () => {
   using dir = tempDir("extract-symlink", {});
-  const tarball = makeTarball(String(dir), { withSymlinks: false });
+  const tarball = makeTarball(String(dir), { symlinks: [] });
   const dest = join(String(dir), "out");
   mkdirSync(dest);
 
@@ -161,9 +178,9 @@ test.skipIf(isWindows)("an archive with no symlinks rethrows the original error"
   expect(lines).toEqual([]);
 });
 
-test.skipIf(isWindows)("a retry that still fails reports both attempts", async () => {
+test.skipIf(cannotRunFakeTar)("a retry that still fails reports both attempts", async () => {
   using dir = tempDir("extract-symlink", {});
-  const tarball = makeTarball(String(dir), { withSymlinks: true });
+  const tarball = makeTarball(String(dir), { symlinks: ["unzstd", "zstdcat"] });
   const dest = join(String(dir), "out");
   mkdirSync(dest);
 
@@ -177,4 +194,22 @@ test.skipIf(isWindows)("a retry that still fails reports both attempts", async (
   expect((err as BuildError).message).toContain("retry (exit 1): boom: disk full");
   expect(lines).toHaveLength(1);
   expect(lines[0]).toStartWith("tar exited 1; retrying without 2 symlink entries:");
+});
+
+test.skipIf(cannotRunFakeTar)("a symlink name with a glob metacharacter declines the fallback", async () => {
+  using dir = tempDir("extract-symlink", {});
+  // --exclude=un*zstd would also drop the regular member unXzstd, so the
+  // fallback must rethrow the original error instead of retrying.
+  const tarball = makeTarball(String(dir), { symlinks: ["un*zstd"], files: ["unXzstd"] });
+  const dest = join(String(dir), "out");
+  mkdirSync(dest);
+
+  const { result: err, lines } = await withFakeTar(String(dir), tarThatAlwaysFailsExtraction, () =>
+    withLogCaptured(() => rejection(extractTarGz(tarball, dest))),
+  );
+
+  expect(err).toBeInstanceOf(BuildError);
+  expect((err as BuildError).message).toStartWith("tar extraction failed (exit 1):");
+  expect((err as BuildError).message).toContain("boom: disk full");
+  expect(lines).toEqual([]);
 });

--- a/test/internal/build-extract-symlink-fallback.test.ts
+++ b/test/internal/build-extract-symlink-fallback.test.ts
@@ -1,0 +1,180 @@
+/**
+ * extractTarGz() (scripts/build/download.ts) must not require symlink
+ * privilege for archive entries the build never reads. On Windows without
+ * Developer Mode or elevation, bsdtar extracts every other entry of the
+ * zstd dep archive and exits 1 on its two symlink test fixtures
+ * (tests/cli-tests/bin/{unzstd,zstdcat} -> zstd), killing the build
+ * (oven-sh/bun#39669). The fallback: after a failure, list the archive's
+ * symlink entries and retry with each excluded; with none, rethrow.
+ *
+ * The privilege failure can't be reproduced on a POSIX host (and on Windows
+ * tarExe is an absolute System32 path), so these tests put a fake `tar` on
+ * PATH that simulates bsdtar without symlink privilege: it extracts, then
+ * deletes the symlinks it created and exits 1 the way bsdtar does, but
+ * delegates listings and `--exclude` retries to the real tar.
+ */
+import { expect, spyOn, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, lstatSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { extractTarGz } from "../../scripts/build/download.ts";
+import { BuildError } from "../../scripts/build/error.ts";
+
+const realTar = Bun.which("tar")!;
+
+/** A zstd-shaped .tar.gz: lib sources plus, optionally, the two symlink test fixtures. */
+function makeTarball(root: string, { withSymlinks }: { withSymlinks: boolean }): string {
+  const top = join(root, "src", "zstd-abc123");
+  mkdirSync(join(top, "lib"), { recursive: true });
+  mkdirSync(join(top, "tests", "cli-tests", "bin"), { recursive: true });
+  writeFileSync(join(top, "lib", "zstd.c"), "int zstd;\n");
+  writeFileSync(join(top, "tests", "cli-tests", "bin", "zstd"), "#!/bin/sh\n");
+  if (withSymlinks) {
+    symlinkSync("zstd", join(top, "tests", "cli-tests", "bin", "unzstd"));
+    symlinkSync("zstd", join(top, "tests", "cli-tests", "bin", "zstdcat"));
+  }
+  const tarball = join(root, "dep.tar.gz");
+  const result = spawnSync(realTar, ["-czf", tarball, "-C", join(root, "src"), "zstd-abc123"], { encoding: "utf8" });
+  expect(result.status).toBe(0);
+  return tarball;
+}
+
+/** Install a fake `tar` script first on PATH for the duration of fn. */
+async function withFakeTar<T>(root: string, script: string, fn: () => Promise<T>): Promise<T> {
+  const bin = join(root, "fake-bin");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(join(bin, "tar"), script);
+  chmodSync(join(bin, "tar"), 0o755);
+  const oldPath = process.env.PATH;
+  process.env.PATH = `${bin}:${oldPath}`;
+  try {
+    return await fn();
+  } finally {
+    process.env.PATH = oldPath;
+  }
+}
+
+/** Simulates bsdtar on Windows without symlink privilege. */
+const tarWithoutSymlinkPrivilege = `#!/bin/sh
+# --exclude retries and listings (-t...) behave like the real tar.
+case " $* " in
+  *" --exclude="*) exec ${realTar} "$@" ;;
+esac
+case "$1" in
+  -t*) exec ${realTar} "$@" ;;
+esac
+# Plain extraction: extract everything, then fail the symlink entries the
+# way bsdtar does without privilege (error per entry, delayed exit 1).
+dest=.
+prev=
+for a in "$@"; do
+  [ "$prev" = "-C" ] && dest=$a
+  prev=$a
+done
+${realTar} "$@"
+find "$dest" -type l | while read -r link; do
+  echo "$link: Cannot create: Invalid argument" >&2
+  rm -f "$link"
+done
+echo "tar: Error exit delayed from previous errors." >&2
+exit 1
+`;
+
+/** Fails every extraction, whatever the flags. Listings still work. */
+const tarThatAlwaysFailsExtraction = `#!/bin/sh
+case "$1" in
+  -t*) exec ${realTar} "$@" ;;
+esac
+echo "boom: disk full" >&2
+exit 1
+`;
+
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  throw new Error("expected the extraction to fail");
+}
+
+/** The fallback narrates through console.log; collect the lines instead of printing them. */
+async function withLogCaptured<T>(fn: () => Promise<T>): Promise<{ result: T; lines: string[] }> {
+  const lines: string[] = [];
+  const log = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.join(" "));
+  });
+  try {
+    return { result: await fn(), lines };
+  } finally {
+    log.mockRestore();
+  }
+}
+
+test.skipIf(isWindows)("with symlink support, symlink entries extract normally", async () => {
+  using dir = tempDir("extract-symlink", {});
+  const tarball = makeTarball(String(dir), { withSymlinks: true });
+  const dest = join(String(dir), "out");
+  mkdirSync(dest);
+
+  const { lines } = await withLogCaptured(() => extractTarGz(tarball, dest));
+
+  expect(lstatSync(join(dest, "tests", "cli-tests", "bin", "unzstd")).isSymbolicLink()).toBe(true);
+  expect(lines).toEqual([]);
+});
+
+test.skipIf(isWindows)("without symlink privilege, extraction retries with the symlink entries excluded", async () => {
+  using dir = tempDir("extract-symlink", {});
+  const tarball = makeTarball(String(dir), { withSymlinks: true });
+  const dest = join(String(dir), "out");
+  mkdirSync(dest);
+
+  const { lines } = await withFakeTar(String(dir), tarWithoutSymlinkPrivilege, () =>
+    withLogCaptured(() => extractTarGz(tarball, dest)),
+  );
+
+  // Everything the build reads is there; only the two fixtures are skipped.
+  expect(existsSync(join(dest, "lib", "zstd.c"))).toBe(true);
+  expect(existsSync(join(dest, "tests", "cli-tests", "bin", "zstd"))).toBe(true);
+  expect(existsSync(join(dest, "tests", "cli-tests", "bin", "unzstd"))).toBe(false);
+  expect(lines).toEqual([
+    "tar exited 1; retrying without 2 symlink entries: " +
+      "zstd-abc123/tests/cli-tests/bin/unzstd, zstd-abc123/tests/cli-tests/bin/zstdcat",
+  ]);
+});
+
+test.skipIf(isWindows)("an archive with no symlinks rethrows the original error", async () => {
+  using dir = tempDir("extract-symlink", {});
+  const tarball = makeTarball(String(dir), { withSymlinks: false });
+  const dest = join(String(dir), "out");
+  mkdirSync(dest);
+
+  const { result: err, lines } = await withFakeTar(String(dir), tarThatAlwaysFailsExtraction, () =>
+    withLogCaptured(() => rejection(extractTarGz(tarball, dest))),
+  );
+
+  expect(err).toBeInstanceOf(BuildError);
+  expect((err as BuildError).message).toStartWith("tar extraction failed (exit 1):");
+  expect((err as BuildError).message).toContain("boom: disk full");
+  expect(lines).toEqual([]);
+});
+
+test.skipIf(isWindows)("a retry that still fails reports both attempts", async () => {
+  using dir = tempDir("extract-symlink", {});
+  const tarball = makeTarball(String(dir), { withSymlinks: true });
+  const dest = join(String(dir), "out");
+  mkdirSync(dest);
+
+  const { result: err, lines } = await withFakeTar(String(dir), tarThatAlwaysFailsExtraction, () =>
+    withLogCaptured(() => rejection(extractTarGz(tarball, dest))),
+  );
+
+  expect(err).toBeInstanceOf(BuildError);
+  expect((err as BuildError).message).toStartWith("tar extraction failed even with symlink entries excluded:");
+  expect((err as BuildError).message).toContain("first attempt (exit 1): boom: disk full");
+  expect((err as BuildError).message).toContain("retry (exit 1): boom: disk full");
+  expect(lines).toHaveLength(1);
+  expect(lines[0]).toStartWith("tar exited 1; retrying without 2 symlink entries:");
+});


### PR DESCRIPTION
### Problem

- On Windows without Developer Mode or an elevated shell, `bun bd` stops during the zstd dep fetch: `tar extraction failed (exit 1): tests/cli-tests/bin/unzstd: Can't create '\\?\C:\...\unzstd': Invalid argument`. Fixes #39669.
- The pinned zstd archive has exactly two symlink entries, both test fixtures under `tests/cli-tests/bin/`. The build never reads them: `scripts/build/deps/zstd.ts` compiles a fixed list of `lib/*.c`. bsdtar extracts everything else and exits 1 at the end, and `extractTarGz` (`scripts/build/download.ts`) throws on any nonzero exit.

### Fix

- `extractTarGz` gains an opt-in `skipUnusedSymlinks`. With it, after a failed extraction it lists the archive's symlink entries, retries with `--exclude` for each, and logs which entries it skipped.
- Only the dep-archive fetch (`scripts/build/fetch-cli.ts`) opts in: dep builds compile explicit source lists. Prebuilt WebKit, the xwin sysroot, and prefetch trees keep the strict behavior, so an archive whose symlinks matter cannot report success with entries missing.
- The fallback declines and rethrows the original error when the archive has no symlinks, or when a symlink name contains a glob metacharacter or control character. `--exclude` is a glob in both bsdtar and GNU tar, so such a name could also exclude a regular member.
- Verified: `test/internal/build-extract-symlink-fallback.test.ts` (6 tests, the fallback ones fail without the fix). On Windows Server 2019 under a basic-user token (`runas /trustlevel:0x20000`, no symlink privilege), the real pinned zstd tarball fails unfixed with the exact error above, extracts with the opt-in (all 102 `lib/` files, two fixtures skipped), and still fails strictly without it. An elevated run extracts the symlinks with no fallback.

### Background

- Creating a symlink on Windows requires a privilege that a normal shell does not hold. Developer Mode or elevation grants it. #39667 documents that requirement; this change removes it for dep archives.
- `tar -tv` marks a symlink with `l` in the mode column, but the entry name is awkward to parse out of the verbose line. `tar -t` prints one bare name per line in the same order, so the two listings are paired by index.
- The privilege failure cannot be reproduced on a POSIX host, and on Windows the tar path is absolute (System32). The tests put a fake `tar` on PATH that simulates bsdtar without symlink privilege, and delegate listings and `--exclude` retries to the real tar.

<details><summary>Notes</summary>

- Pinned archive check: `tar -tvzf zstd-f8745da6....tar.gz | grep '^l'` shows exactly `tests/cli-tests/bin/unzstd -> zstd` and `tests/cli-tests/bin/zstdcat -> zstd`. Of the dep tarballs a build downloads, zstd is the only one with symlinks.
- Windows verification detail: a driver script imported `extractTarGz` directly and ran under `runas /trustlevel:0x20000`. Unfixed output matched the issue verbatim. Fixed output with the opt-in: `tar exited 1; retrying without 2 symlink entries: ...unzstd, ...zstdcat`, then success. Without the opt-in the original error is preserved, exit 1.
- The fallback logic is not gated on `process.platform`: it only runs after a failure and only for the opted-in call site, which keeps it testable on every platform and the cross-platform diff minimal.
- Exclude patterns are the full entry names from the listing, so they match exactly in both bsdtar and GNU tar, before `--strip-components` renaming. Names that a glob could mis-match decline the fallback instead (covered by a test with a `un*zstd` symlink next to a regular `unXzstd` member).
- The test fixture tarball lists its members explicitly so the entry order does not depend on readdir order (it differed on alpine CI).
- `bunx tsc --noEmit -p scripts/build/tsconfig.json` reports no errors in the touched files (pre-existing errors in `ci.ts`, `jsonByteClass.ts`, `xmlByteClass.ts`, `rust-lto-fix-cli.ts` are untouched).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->