### PR TITLE
install: fail instead of hanging when a tarball download task cannot be created

### DIFF
--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1860,7 +1860,17 @@ pub fn generate_network_task_for_tarball<'a>(
         .expect("unreachable"),
     };
 
-    network_task.for_tarball(extract_tarball, scope, authorization)?;
+    if let Err(err) = network_task.for_tarball(extract_tarball, scope, authorization) {
+        // `has_created_network_task` recorded `task_id` as created, but no task
+        // exists to ever complete or fail it. Without this mark a later enqueue
+        // for the same id queues its callback behind the missing task, and the
+        // isolated installer waits for that callback forever.
+        mark_network_task_failed(this, task_id);
+        // SAFETY: `write_init` fully initialized the slot. `for_tarball` fails
+        // before it writes `unsafe_http_client`, so `put` has nothing else to drop.
+        unsafe { this.preallocated_network_tasks.put(net_ptr) };
+        return Err(err);
+    }
 
     if extract_tarball::uses_streaming_extraction() {
         // Pre-create the extract Task and streaming state here on the

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1070,6 +1070,125 @@ index 1f0e8b9f1f9a56799cdbc1a5a2f8cf9f9a3b2f1c..2f0e8b9f1f9a56799cdbc1a5a2f8cf9f
   expect(await installedIndexJs.text()).toBe('console.log("patched");\n');
 });
 
+// A tarball that cannot even be requested (here: a URL that is not http) hung
+// `bun install` forever with the isolated linker. Creating the download task
+// fails after the task id is recorded as created, so every later request for
+// the same tarball parked its store entry behind a task that does not exist.
+describe("tarball whose download task cannot be created", () => {
+  test("second store entry of the package: fails instead of hanging", async () => {
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+    // `peer-deps@1.0.0` has a peer on `no-deps`. Two workspaces with different
+    // `no-deps` versions give it two store entries sharing one tarball.
+    await write(packageJson, JSON.stringify({ name: "invalid-tarball-url", workspaces: ["packages/*"] }));
+    for (const version of ["1.0.0", "1.0.1"]) {
+      await write(
+        join(packageDir, "packages", `pkg-${version}`, "package.json"),
+        JSON.stringify({
+          name: `pkg-${version}`,
+          version: "1.0.0",
+          dependencies: { "peer-deps": "1.0.0", "no-deps": version },
+        }),
+      );
+    }
+
+    async function install(cacheDir: string) {
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        // CI exports BUN_INSTALL_CACHE_DIR; pin it so the second install really
+        // has to download `peer-deps` again.
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    const first = await install(join(packageDir, ".bun-cache-1"));
+    expect(first.stderr).not.toContain("error:");
+    expect(first.exitCode).toBe(0);
+    expect(
+      (await readdirSorted(join(packageDir, "node_modules", ".bun"))).filter(entry => entry.startsWith("peer-deps@")),
+    ).toHaveLength(2);
+
+    const lockfile = join(packageDir, "bun.lock");
+    const lockfileBefore = await file(lockfile).text();
+    const lockfileAfter = lockfileBefore.replace(
+      /("peer-deps@1\.0\.0", )"[^"]*"/,
+      '$1"ftp://localhost/peer-deps/-/peer-deps-1.0.0.tgz"',
+    );
+    expect(lockfileAfter).not.toBe(lockfileBefore);
+    await write(lockfile, lockfileAfter);
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+    // Empty cache: the install phase requests the tarball for both entries.
+    const second = await install(join(packageDir, ".bun-cache-2"));
+    expect(second.stderr).toContain("failed to enqueue package for download: peer-deps@1.0.0");
+    expect(second.stdout).not.toContain("packages installed");
+    expect(second.exitCode).toBe(1);
+  });
+
+  test("package resolved from the manifest cache: fails instead of hanging", async () => {
+    // The first install fetches the manifest, caches it, and fails when it
+    // requests the tarball while resolving. The second install resolves from
+    // the cached manifest. That request fails again, and this time the
+    // install phase asks for the same tarball once more.
+    using server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (new URL(req.url).pathname !== "/bad-tarball-url") return new Response("Not found", { status: 404 });
+        return Response.json(
+          {
+            name: "bad-tarball-url",
+            "dist-tags": { latest: "1.0.0" },
+            versions: {
+              "1.0.0": {
+                name: "bad-tarball-url",
+                version: "1.0.0",
+                dist: { tarball: "ftp://localhost/bad-tarball-url/-/bad-tarball-url-1.0.0.tgz" },
+              },
+            },
+          },
+          { headers: { "Cache-Control": "public, max-age=300" } },
+        );
+      },
+    });
+
+    using packageDir = tempDir("manifest-cache-bad-tarball-", {
+      "package.json": JSON.stringify({
+        name: "manifest-cache-bad-tarball",
+        dependencies: { "bad-tarball-url": "1.0.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "http://localhost:${server.port}/"\nlinker = "isolated"\n`,
+    });
+
+    async function install() {
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(packageDir),
+        // One cache for both installs, separate from the other tests' caches.
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(String(packageDir), ".bun-cache") },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout, stderr, exitCode };
+    }
+
+    const expectedError = 'Expected tarball URL to start with https:// or http://, got "ftp://localhost/';
+    const first = await install();
+    expect(first.stderr).toContain(expectedError);
+    expect(first.exitCode).toBe(1);
+
+    const second = await install();
+    expect(second.stderr).toContain(expectedError);
+    expect(second.stdout).not.toContain("packages installed");
+    expect(second.exitCode).toBe(1);
+  });
+});
+
 for (const backend of ["clonefile", "hardlink", "copyfile"]) {
   test(`isolated install with backend: ${backend}`, async () => {
     const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });


### PR DESCRIPTION
### Problem
- `bun install` with the isolated linker hangs forever when a tarball download task cannot be created, for example a tarball URL that is not http. Two cases reach it: the second store entry of the package (peer variants), and any retry of the install once the manifest is in the manifest cache, because the resolve phase already failed the same way.
- The cause is in `generate_network_task_for_tarball` (`src/install/PackageManager/runTasks.rs`). It records the task id in `network_dedupe_map` before `for_tarball` can fail. A later enqueue for the same id then sees a created task and queues its callback behind it. No task exists, so the callback never runs and the store entry's pending-task slot is never released.
- The vended `NetworkTask` slot was also leaked on that path.

### Fix
- On the `for_tarball` error path, mark the task id failed and return the slot to the pool. Later enqueues get `AlreadyFailed`, which every caller (isolated, hoisted, runtime auto-install) already handles by releasing its own bookkeeping, and the install exits 1 with the existing error.
- This is the function that creates the dedupe record, so all six callers are covered, including the resolve-phase prefetch that causes the manifest cache case.
- Verified: two new tests in `test/cli/install/isolated-install.test.ts`. Both hang on the released bun (the test times out) and pass in under a second with the fix. Also the install suites listed in Notes.

### Background
- The install phase reserves one pending-task slot per store entry and waits until all slots are released. An entry that needs a download releases its slot when the download's callbacks run.
- `task_queue` maps a task id to the callbacks waiting for it. `network_dedupe_map` records which task ids already have a task, so one tarball is downloaded once. `failed` on that record (#34103) makes later enqueues fail fast with `AlreadyFailed`.
- The hoisted linker does not reserve slots, so it already exited 1 in both cases. Only the isolated linker hung.

<details><summary>Notes</summary>

**Repro of the manifest cache case** (the realistic one: any failed install caches the manifest, and the retry hangs). Registry manifest with `dist.tarball: "ftp://..."`, isolated linker. Run 1: `error: Expected tarball URL to start with https:// or http://` and exit 1 (the error propagates out of the resolve phase). Run 2 within the manifest max-age: the dependency resolves synchronously from the cache, the prefetch fails and is only logged, the install phase enqueues the tarball, `has_created_network_task` says it exists, and the process never exits. With the fix run 2 prints the same error and exits 1. The hoisted linker exits 1 in run 2 before and after.

**Repro of the peer variant case.** Two workspaces depend on `peer-deps@1.0.0` with different `no-deps` versions. Install, replace the tarball URL of `peer-deps` in `bun.lock` with `ftp://...`, remove `node_modules`, install with an empty cache. Released bun prints `InvalidURL: failed to enqueue package for download: peer-deps@1.0.0` once and never exits.

**Why here and not in the callers.** An earlier version of this change removed the queued callback in `enqueue_package_for_download` and `enqueue_tarball_for_download`. That fixes the peer variant case only. The manifest cache case fails in the resolve-phase prefetch (`PackageManagerEnqueue.rs`, `get_or_put_resolved_package`), which never touches `task_queue`, so the install phase still parked the entry. Marking the record where it is created covers both. The callbacks that the two enqueue functions queued before the failure stay in `task_queue`. Nothing reads them: both functions check `network_task_has_failed` before they look at the queue.

**Slot return.** All error returns in `for_tarball` happen before it initializes `unsafe_http_client`, so `put` (which drops the rest of the `NetworkTask`) is the whole cleanup.

**Suites run** with the debug build: `isolated-install` (84), `bun-install-tarball-integrity`, `bun-install-retry`, `bun-add`, `bun-install-patch`, `bun-install-git-deps`, `bun-install` (the same 14 failures as on main in this sandbox: they need the public internet or an IPv6 localhost). `cargo fmt` is clean.

Split out of #39640, which keeps the unrelated isolated installer drain.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->