### PR TITLE
process: disable process-wide mutators in every worker kind

### DIFF
--- a/docs/runtime/workers.mdx
+++ b/docs/runtime/workers.mdx
@@ -210,6 +210,10 @@ Calling `worker.terminate()` makes the worker exit as soon as possible.
 
 A worker can terminate itself with `process.exit()`. This does not terminate the main process. Like in Node.js, `process.on('beforeExit', callback)` and `process.on('exit', callback)` are emitted on the worker thread, not on the main thread. Bun passes the exit code to the `"close"` event.
 
+### Process-wide state
+
+All workers share one operating system process with the main thread. A worker cannot change state that belongs to the whole process. In a worker, `process.chdir()`, `process.abort()`, `process.umask(mask)`, and the `process.setuid()` family throw `ERR_WORKER_UNSUPPORTED_OPERATION`. `process.umask()` without an argument still returns the current mask. Assigning `process.title` in a worker changes the title for that worker only. This matches Node.js `worker_threads` and applies to workers made with `Worker` and with `node:worker_threads`.
+
 ### `"close"`
 
 Bun emits the `"close"` event when a worker has been marked as terminated. The worker itself can take some time to fully exit. The `CloseEvent` contains the exit code passed to `process.exit()`, or 0 if it closed for another reason.

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -707,9 +707,10 @@ function fakeParentPort() {
   return fake;
 }
 
-// In a node:worker_threads worker, several process operations are unsupported.
-// Gate on _isNodeWorker so a raw `new globalThis.Worker` that transitively loads
-// this module does NOT have process.abort/chdir/setuid replaced.
+// Node-specific additions to a worker's process object. The process-wide operations
+// (abort, chdir, umask(mask), set*id, title) are handled natively for every worker
+// kind when the process object is created (BunProcess.cpp). Gate on _isNodeWorker so
+// a raw `new globalThis.Worker` that transitively loads this module is left alone.
 if (!isMainThread && _isNodeWorker) {
   applyWorkerProcessOverrides();
 }
@@ -720,42 +721,24 @@ function applyWorkerProcessOverrides() {
   try {
     Object.defineProperty(proc, "debugPort", { value: 9229, writable: true, configurable: true, enumerable: true });
   } catch {}
-  // process.umask(setMask) is unsupported in workers; the getter still works.
-  const realUmask = proc.umask;
-  function umask(mask?: unknown) {
-    if (mask === undefined) return realUmask.$call(proc);
-    throw $ERR_WORKER_UNSUPPORTED_OPERATION("Setting process.umask() is not supported in workers");
-  }
-  proc.umask = umask;
-  // Disabled, throwing stubs (each carries `.disabled === true`, like node).
-  const disabled = ["abort", "chdir"];
-  if (process.platform !== "win32") {
-    disabled.push("setuid", "seteuid", "setgid", "setegid", "setgroups", "initgroups");
-  }
   // node only disables send/disconnect/channel/connected in workers that inherited an
   // IPC channel (NODE_CHANNEL_FD); otherwise they stay absent so `if (process.send)` works.
-  const hasIpc = !!process.env.NODE_CHANNEL_FD;
-  if (hasIpc) {
-    disabled.push("send", "disconnect");
-  }
-  for (const name of disabled) {
+  if (!process.env.NODE_CHANNEL_FD) return;
+  for (const name of ["send", "disconnect"]) {
     const stub: any = function () {
       throw $ERR_WORKER_UNSUPPORTED_OPERATION(`process.${name}() is not supported in workers`);
     };
     stub.disabled = true;
     Object.defineProperty(proc, name, { configurable: true, writable: true, enumerable: true, value: stub });
   }
-  // IPC accessors throw on access only in a worker that inherited an IPC channel.
-  if (hasIpc) {
-    for (const name of ["channel", "connected"]) {
-      Object.defineProperty(proc, name, {
-        configurable: true,
-        enumerable: false,
-        get() {
-          throw $ERR_WORKER_UNSUPPORTED_OPERATION(`process.${name} is not supported in workers`);
-        },
-      });
-    }
+  for (const name of ["channel", "connected"]) {
+    Object.defineProperty(proc, name, {
+      configurable: true,
+      enumerable: false,
+      get() {
+        throw $ERR_WORKER_UNSUPPORTED_OPERATION(`process.${name} is not supported in workers`);
+      },
+    });
   }
 }
 

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -707,10 +707,7 @@ function fakeParentPort() {
   return fake;
 }
 
-// Node-specific additions to a worker's process object. The process-wide operations
-// (abort, chdir, umask(mask), set*id, title) are handled natively for every worker
-// kind when the process object is created (BunProcess.cpp). Gate on _isNodeWorker so
-// a raw `new globalThis.Worker` that transitively loads this module is left alone.
+// Node-only process additions; the process-wide stubs are native (BunProcess.cpp).
 if (!isMainThread && _isNodeWorker) {
   applyWorkerProcessOverrides();
 }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -792,6 +792,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUmask, (JSGlobalObject * globalObject, 
 
     auto& vm = JSC::getVM(globalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
+    if (WebCore::clientData(vm)->isWorkerVM()) {
+        return throwError(globalObject, throwScope, ErrorCode::ERR_WORKER_UNSUPPORTED_OPERATION, "Setting process.umask() is not supported in workers"_s);
+    }
     auto value = callFrame->argument(0);
 
     mode_t newUmask;
@@ -3692,6 +3695,7 @@ void Process::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_uncaughtExceptionCaptureCallback);
     visitor.append(thisObject->m_nextTickFunction);
     visitor.append(thisObject->m_cachedCwd);
+    visitor.append(thisObject->m_workerTitle);
     visitor.append(thisObject->m_argv);
     visitor.append(thisObject->m_execArgv);
     visitor.append(thisObject->m_onWarning);
@@ -4560,6 +4564,9 @@ JSC_DEFINE_CUSTOM_GETTER(processTitle, (JSC::JSGlobalObject * globalObject, JSC:
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
+    if (auto* process = dynamicDowncast<Process>(JSValue::decode(thisValue)); process && process->workerTitle()) {
+        return JSValue::encode(process->workerTitle());
+    }
 #if !OS(WINDOWS)
     auto* result = jsString(globalObject->vm(), Bun__Process__getTitle(globalObject).transferToWTFString());
     RETURN_IF_EXCEPTION(scope, {});
@@ -4595,6 +4602,14 @@ JSC_DEFINE_CUSTOM_SETTER(setProcessTitle, (JSC::JSGlobalObject * globalObject, J
     JSC::JSString* jsString = dynamicDowncast<JSC::JSString>(JSValue::decode(value));
     if (!thisObject || !jsString) {
         return false;
+    }
+    if (WebCore::clientData(vm)->isWorkerVM()) {
+        auto* process = dynamicDowncast<Process>(thisObject);
+        if (!process) {
+            return false;
+        }
+        process->setWorkerTitle(vm, jsString);
+        return true;
     }
     WTF::String wtfStr = jsString->value(globalObject);
     RETURN_IF_EXCEPTION(scope, false);
@@ -4962,6 +4977,40 @@ const JSC::ClassInfo Process::s_info
     = { "Process"_s, &Base::s_info, &processObjectTable, nullptr,
           CREATE_METHOD_TABLE(Process) };
 
+JSC_DEFINE_HOST_FUNCTION(Process_functionUnsupportedInWorker, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto name = uncheckedDowncast<JSFunction>(callFrame->jsCallee())->name(vm);
+    return throwError(globalObject, scope, ErrorCode::ERR_WORKER_UNSUPPORTED_OPERATION, makeString("process."_s, name, "() is not supported in workers"_s));
+}
+
+// These act on the whole process, so Node replaces them with throwing stubs on
+// every worker thread (lib/internal/process/worker_thread_only.js). Both the
+// Web Worker and the node:worker_threads constructors create a worker VM.
+static void installWorkerProcessStubs(JSC::VM& vm, Process* process)
+{
+    static constexpr ASCIILiteral unsupportedInWorker[] = {
+        "abort"_s,
+        "chdir"_s,
+#if !OS(WINDOWS)
+        "setuid"_s,
+        "seteuid"_s,
+        "setgid"_s,
+        "setegid"_s,
+        "setgroups"_s,
+        "initgroups"_s,
+#endif
+    };
+    auto* globalObject = process->globalObject();
+    auto disabled = Identifier::fromString(vm, "disabled"_s);
+    for (auto name : unsupportedInWorker) {
+        auto* stub = JSFunction::create(vm, globalObject, 0, name, Process_functionUnsupportedInWorker, ImplementationVisibility::Public);
+        stub->putDirect(vm, disabled, jsBoolean(true), 0);
+        process->putDirect(vm, Identifier::fromString(vm, name), stub, 0);
+    }
+}
+
 void Process::finishCreation(JSC::VM& vm)
 {
     Base::finishCreation(vm);
@@ -4995,8 +5044,13 @@ void Process::finishCreation(JSC::VM& vm)
     putDirect(vm, vm.propertyNames->toStringTagSymbol, jsString(vm, String("process"_s)), 0);
     putDirect(vm, Identifier::fromString(vm, "_exiting"_s), jsBoolean(false), 0);
 
+    auto* clientData = WebCore::clientData(vm);
+    if (clientData->isWorkerVM()) {
+        installWorkerProcessStubs(vm, this);
+    }
+
     // No-op stubs Node only has on the main thread; a worker_threads Worker's process lacks them.
-    if (!WebCore::clientData(vm)->isNodeWorkerVM()) {
+    if (!clientData->isNodeWorkerVM()) {
         putDirectNativeFunction(vm, globalObject(), Identifier::fromString(vm, "_debugEnd"_s), 0, Process_stubEmptyFunction, ImplementationVisibility::Public, NoIntrinsic, 0);
         putDirectNativeFunction(vm, globalObject(), Identifier::fromString(vm, "_debugProcess"_s), 0, Process_stubEmptyFunction, ImplementationVisibility::Public, NoIntrinsic, 0);
         putDirectNativeFunction(vm, globalObject(), Identifier::fromString(vm, "_startProfilerIdleNotifier"_s), 0, Process_stubEmptyFunction, ImplementationVisibility::Public, NoIntrinsic, 0);

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -782,9 +782,13 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(Process_functionDlopen, __attribute__((
     return JSValue::encode(resultValue);
 }
 
+// A read is umask(0) then umask(old); a worker's read must not interleave with the main thread's set.
+static WTF::Lock umaskLock;
+
 JSC_DEFINE_HOST_FUNCTION(Process_functionUmask, (JSGlobalObject * globalObject, CallFrame* callFrame))
 {
     if (callFrame->argumentCount() == 0 || callFrame->argument(0).isUndefined()) {
+        Locker locker { umaskLock };
         mode_t currentMask = umask(0);
         umask(currentMask);
         return JSValue::encode(jsNumber(currentMask));
@@ -810,6 +814,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUmask, (JSGlobalObject * globalObject, 
         newUmask = value.toUInt32(globalObject);
     }
 
+    Locker locker { umaskLock };
     return JSC::JSValue::encode(JSC::jsNumber(umask(newUmask)));
 }
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4985,9 +4985,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionUnsupportedInWorker, (JSGlobalObject * 
     return throwError(globalObject, scope, ErrorCode::ERR_WORKER_UNSUPPORTED_OPERATION, makeString("process."_s, name, "() is not supported in workers"_s));
 }
 
-// These act on the whole process, so Node replaces them with throwing stubs on
-// every worker thread (lib/internal/process/worker_thread_only.js). Both the
-// Web Worker and the node:worker_threads constructors create a worker VM.
+// Node's list from lib/internal/process/worker_thread_only.js; each acts on the whole process.
 static void installWorkerProcessStubs(JSC::VM& vm, Process* process)
 {
     static constexpr ASCIILiteral unsupportedInWorker[] = {

--- a/src/jsc/bindings/BunProcess.h
+++ b/src/jsc/bindings/BunProcess.h
@@ -30,6 +30,8 @@ class Process : public WebCore::JSEventEmitter {
     WriteBarrier<JSObject> m_nextTickFunction;
     // https://github.com/nodejs/node/blob/2eff28fb7a93d3f672f80b582f664a7c701569fb/lib/internal/bootstrap/switches/does_own_process_state.js#L113-L116
     WriteBarrier<JSString> m_cachedCwd;
+    // A worker's `process.title = x` is thread-local, as in Node. The OS title belongs to the main thread.
+    WriteBarrier<JSString> m_workerTitle;
     WriteBarrier<Unknown> m_argv;
     WriteBarrier<Unknown> m_execArgv;
     // The JS warning printer (ProcessObjectInternals createOnWarning), built on the first warning.
@@ -88,6 +90,9 @@ public:
     JSString* cachedCwd() { return m_cachedCwd.get(); }
     void setCachedCwd(JSC::VM& vm, JSString* cwd) { m_cachedCwd.set(vm, this, cwd); }
     void clearCachedCwd() { m_cachedCwd.clear(); }
+
+    JSString* workerTitle() { return m_workerTitle.get(); }
+    void setWorkerTitle(JSC::VM& vm, JSString* title) { m_workerTitle.set(vm, this, title); }
 
     JSValue getArgv(JSGlobalObject* globalObject);
     void setArgv(JSGlobalObject* globalObject, JSValue argv);

--- a/test/js/node/worker_threads/worker-process-state.test.ts
+++ b/test/js/node/worker_threads/worker-process-state.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// process.abort/chdir/umask(mask)/set*id act on the whole process and
+// process.title is per thread, as in Node. The same rules must apply to a
+// worker made with the global Worker and one made with worker_threads.Worker.
+// Spawned: a worker that does get through would change this process's cwd.
+
+const posixOnly = ["setuid", "seteuid", "setgid", "setegid", "setgroups", "initgroups"];
+const stubbed = ["abort", "chdir", ...(isWindows ? [] : posixOnly)];
+
+const fixture = /* js */ `
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const kind = process.argv[2];
+  if (Bun.isMainThread) {
+    process.title = "main-title";
+    const umaskBefore = process.umask();
+    const cwdBefore = process.cwd();
+    const onResult = worker => {
+      // A relative write follows the kernel cwd. process.cwd() would keep
+      // returning the cached cwdBefore even after a worker moved the process.
+      fs.writeFileSync("probe.txt", "x");
+      const main = {
+        relativeWriteLandedInCwd: fs.existsSync(path.join(cwdBefore, "probe.txt")),
+        umaskChanged: process.umask() !== umaskBefore,
+        title: process.title,
+      };
+      console.log(JSON.stringify({ worker, main }));
+    };
+    if (kind === "web") {
+      const w = new Worker(import.meta.url, { argv: [kind] });
+      w.onmessage = e => { onResult(e.data); w.terminate(); };
+      w.onerror = e => { console.error(e.message); process.exit(1); };
+    } else {
+      const { Worker } = require("node:worker_threads");
+      const w = new Worker(new URL(import.meta.url), { argv: [kind] });
+      w.on("message", r => { onResult(r); w.terminate(); });
+      w.on("error", e => { console.error(e); process.exit(1); });
+    }
+  } else {
+    const probe = fn => {
+      try {
+        return { returned: fn() };
+      } catch (e) {
+        return { name: e.name, code: e.code, message: e.message };
+      }
+    };
+    const stub = name => {
+      if (process[name].disabled !== true) return { disabled: process[name].disabled };
+      return { disabled: true, ...probe(() => process[name]()) };
+    };
+    const result = {
+      stubs: Object.fromEntries(${JSON.stringify(stubbed)}.map(name => [name, stub(name)])),
+      chdirWithArgument: probe(() => process.chdir("elsewhere")),
+      umaskSet: probe(() => process.umask(0o077)),
+      umaskGet: typeof process.umask(),
+      titleBefore: process.title,
+    };
+    process.title = "worker-title";
+    result.titleAfter = process.title;
+    if (kind === "web") postMessage(result);
+    else require("node:worker_threads").parentPort.postMessage(result);
+  }
+`;
+
+const unsupported = (name: string) => ({
+  disabled: true,
+  name: "TypeError",
+  code: "ERR_WORKER_UNSUPPORTED_OPERATION",
+  message: `process.${name}() is not supported in workers`,
+});
+
+describe.each(["web", "node"])("%s Worker cannot change process-wide state", kind => {
+  test.concurrent("process mutators throw and the main thread is untouched", async () => {
+    using dir = tempDir("worker-process-state", { "main.mjs": fixture, "elsewhere/.keep": "" });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs", kind],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      worker: {
+        stubs: Object.fromEntries(stubbed.map(name => [name, unsupported(name)])),
+        chdirWithArgument: {
+          name: "TypeError",
+          code: "ERR_WORKER_UNSUPPORTED_OPERATION",
+          message: "process.chdir() is not supported in workers",
+        },
+        umaskSet: {
+          name: "TypeError",
+          code: "ERR_WORKER_UNSUPPORTED_OPERATION",
+          message: "Setting process.umask() is not supported in workers",
+        },
+        umaskGet: "number",
+        titleBefore: "main-title",
+        titleAfter: "worker-title",
+      },
+      main: {
+        relativeWriteLandedInCwd: true,
+        umaskChanged: false,
+        title: "main-title",
+      },
+    });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- Inside a worker made with the global `Worker`, `process.chdir()`, `process.umask(mask)`, `process.setuid()` and the rest of the set*id family return normally and act on the whole process. The main thread's relative `fs` calls then use the new directory while its cached `process.cwd()` still reports the old one. The same calls in a `node:worker_threads` worker already throw `ERR_WORKER_UNSUPPORTED_OPERATION`.
- `process.title = x` inside a worker of either kind renames the whole process. Node keeps the title per thread in workers.
- Cause: the stubs live in JS at the end of `src/js/node/worker_threads.ts`, gated on the node worker flag. A Web Worker never runs that code. Nothing handled the title.

### Fix
- `Process::finishCreation` (`src/jsc/bindings/BunProcess.cpp`) installs the `abort`, `chdir` and set*id stubs when `clientData(vm)->isWorkerVM()` is set. Each stub throws `process.<name>() is not supported in workers` and carries `.disabled === true`, as in Node. `Process_functionUmask` throws on the set path in a worker VM. The getter still works, and a `WTF::Lock` now covers both the read (`umask(0)` then `umask(old)`) and the set, so a worker's read cannot restore an old mask over a main thread set. Node holds `per_process::umask_mutex` for the same reason.
- The `process.title` setter stores into a new per-Process `m_workerTitle` in a worker VM. The getter returns it once set. The main thread path is unchanged.
- `worker_threads.ts` keeps only the node-specific parts (`debugPort`, the IPC stubs). The duplicate stubs are deleted.
- Correct because `isWorkerVM` is set at VM creation for both Worker constructors and nothing else, so the process object is born with the stubs. This follows the `process.execve` guard in the same file. Node's list is in `lib/internal/process/worker_thread_only.js`.
- Verified: `test/js/node/worker_threads/worker-process-state.test.ts` (both constructors, fails on the released build: the web case leaks cwd, umask and title, the node case leaks the title). Also `test-worker-unsupported-things.js`, `test-process-umask.js`, `worker_threads.test.ts`, `worker.test.ts`, `process.test.js`.

### Background
- Every worker runs in its own JSC VM on its own thread, but all threads share one process. cwd, umask, credentials and the title are process state.
- `JSVMClientData::isWorkerVM()` is a per-VM flag set from the `WorkerMessagingProxy` pointer when the VM is created. The main VM and the debugger VM have no proxy.
- The `process` object has a static property table. An own property put in `finishCreation` shadows the table entry. JSC skips shadowed entries when it reifies the table.

Supersedes #33842, which predates the JS stubs and conflicts with main.

<details><summary>Notes</summary>

- Repro from the report: a Web Worker runs `process.chdir("/tmp"); process.umask(0)`. The main thread then prints `process.cwd()` as the launch directory while `/proc/self/cwd` is `/tmp`, `process.umask()` is `0`, and a relative `writeFileSync` lands in `/tmp`.
- `process.abort()` is in the list for the same reason as in Node: it takes down the whole process. `process.exit()` in a worker already only stops the worker.
- Windows gets `abort` and `chdir` only. The set*id functions do not exist there, as in the static table.
- A worker's `process.chdir` stays a plain writable property, so user code can still replace it. `Object.keys(process)` lists each name once (checked: no duplicates from the shadowed static entries).
- The fixture ran clean under `BUN_JSC_validateExceptionChecks=1`.
- `worker.test.ts` and `process.test.js` had failures in this container that also happen without the change: worker start takes over a second in the debug ASAN build here, and `process.env.USER` is unset. They pass in isolation.
- A main-thread `process.chdir()` still does not refresh a worker's cached `process.cwd()`. #35501 covers that.
- The Web Worker default `env` snapshot (a separate report in the same family) is a different code path in `JSWorker.cpp` and gets its own PR.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/worker_threads/worker-process-state.test.ts

<!-- robobun:evidence:end -->
