### PR TITLE
Module loader: removing a registry entry out from under the import cache no longer crashes the next import() (WebKit bump for oven-sh/WebKit#472)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+export const WEBKIT_VERSION = "autobuild-preview-pr-472-eaacac28";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -309,6 +309,182 @@ describe.concurrent("require.cache", () => {
     }, 20000);
   });
 
+  // `delete require.cache[path]` removes the module's ES module registry entry.
+  // It can run while an import() of that module is still loading: here the
+  // module's dependency is held back by an async onLoad plugin until the test
+  // opens a gate. The in-flight load must finish with the module it started to
+  // load, and must not put that module back into the loader's import cache, or
+  // the next import() of the path answers from a record whose registry entry is
+  // gone (null loadPromise, crash in JSModuleLoader::loadModule).
+  describe("delete require.cache[esm] while an import() of it is in flight", () => {
+    // Every load of entry.mjs gets its own `load` number. Only the first load
+    // imports dep.mjs, whose onLoad waits for the gate.
+    const fixture = (scenario: string) => ({
+      "entry.mjs": "",
+      "dep.mjs": "",
+      "main.mjs": `
+        const gate = Promise.withResolvers();
+        const depLoadStarted = Promise.withResolvers();
+        let loads = 0;
+        Bun.plugin({
+          name: "gate",
+          setup(build) {
+            build.onLoad({ filter: /entry\\.mjs$/ }, () => {
+              const load = ++loads;
+              return {
+                loader: "js",
+                contents: load === 1 ? 'import "./dep.mjs"; export const load = 1;' : \`export const load = \${load};\`,
+              };
+            });
+            build.onLoad({ filter: /dep\\.mjs$/ }, async () => {
+              depLoadStarted.resolve();
+              await gate.promise;
+              return { loader: "js", contents: "" };
+            });
+          },
+        });
+        const entryPath = require.resolve("./entry.mjs");
+        const result = {};
+
+        const first = import("./entry.mjs");
+        await depLoadStarted.promise;
+        delete require.cache[entryPath];
+        ${scenario}
+
+        console.log(JSON.stringify(result));
+      `,
+    });
+
+    async function run(dir: string) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "main.mjs"],
+        env: bunEnv,
+        cwd: dir,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.trim(), stderr, exitCode };
+    }
+
+    test("the next import() loads the file again", async () => {
+      using dir = tempDir(
+        "require-cache-delete-in-flight",
+        fixture(`
+          gate.resolve();
+          const firstNamespace = await first;
+          const secondNamespace = await import("./entry.mjs");
+          result.loads = [firstNamespace.load, secondNamespace.load];
+        `),
+      );
+
+      expect(await run(String(dir))).toEqual({ stdout: JSON.stringify({ loads: [1, 2] }), stderr: "", exitCode: 0 });
+    });
+
+    test("a load that finishes after the replacement load does not replace it", async () => {
+      using dir = tempDir(
+        "require-cache-delete-in-flight-replaced",
+        fixture(`
+          const secondNamespace = await import("./entry.mjs");
+          gate.resolve();
+          const firstNamespace = await first;
+          const thirdNamespace = await import("./entry.mjs");
+          result.loads = [firstNamespace.load, secondNamespace.load, thirdNamespace.load];
+          result.thirdIsSecond = thirdNamespace === secondNamespace;
+        `),
+      );
+
+      expect(await run(String(dir))).toEqual({
+        stdout: JSON.stringify({ loads: [1, 2, 2], thirdIsSecond: true }),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+
+  // The loader's import cache is keyed by the specifier import() was resolved
+  // to, and the registry by what that key resolves to once more. An onResolve
+  // plugin that redirects a.mjs -> b.mjs -> c.mjs -> d.mjs makes those differ,
+  // so `delete require.cache[d]` removes the registry entry but leaves the
+  // cache line for a.mjs behind. The next import("./a.mjs") must notice that
+  // the line no longer matches the registry and load again, instead of using
+  // the registry entry the line points at (missing: crash at address 0x38, or
+  // a different module: the stale instance).
+  describe("delete require.cache[esm] whose import() was resolved through a chain", () => {
+    const fixture = (scenario: string) => ({
+      "a.mjs": `export const name = "a";`,
+      "b.mjs": `export const name = "b";`,
+      "c.mjs": `export const name = "c";`,
+      "d.mjs": `export const name = "d";`,
+      "main.mjs": `
+        import { basename, join } from "node:path";
+        const next = { "a.mjs": "b.mjs", "b.mjs": "c.mjs", "c.mjs": "d.mjs" };
+        Bun.plugin({
+          name: "chain",
+          setup(build) {
+            build.onResolve({ filter: /\\.mjs$/ }, ({ path }) => {
+              const to = next[basename(path)];
+              return to && { path: join(import.meta.dir, to) };
+            });
+          },
+        });
+        const result = {};
+
+        const first = await import("./a.mjs");
+        result.first = first.name;
+        delete require.cache[join(import.meta.dir, "d.mjs")];
+        ${scenario}
+
+        console.log(JSON.stringify(result));
+      `,
+    });
+
+    async function run(dir: string) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "main.mjs"],
+        env: bunEnv,
+        cwd: dir,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.trim(), stderr, exitCode };
+    }
+
+    test("the next import() loads the file again", async () => {
+      using dir = tempDir(
+        "require-cache-delete-resolve-chain",
+        fixture(`
+          const second = await import("./a.mjs");
+          result.second = second.name;
+          result.secondIsFirst = second === first;
+        `),
+      );
+
+      expect(await run(String(dir))).toEqual({
+        stdout: JSON.stringify({ first: "d", second: "d", secondIsFirst: false }),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test("the next import() returns the module that replaced it", async () => {
+      using dir = tempDir(
+        "require-cache-delete-resolve-chain-replaced",
+        fixture(`
+          const replacement = await import("./d.mjs");
+          result.replacementIsFirst = replacement === first;
+          const second = await import("./a.mjs");
+          result.secondIsReplacement = second === replacement;
+        `),
+      );
+
+      expect(await run(String(dir))).toEqual({
+        stdout: JSON.stringify({ first: "d", replacementIsFirst: false, secondIsReplacement: true }),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+
   // These tests are extra slow in debug builds
   describe("files transpiled and loaded don't leak file paths", () => {
     test("via require()", async () => {

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -309,6 +309,18 @@ describe.concurrent("require.cache", () => {
     }, 20000);
   });
 
+  // Runs the main.mjs of one of the `delete require.cache[esm]` fixtures below.
+  async function runMain(dir: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "main.mjs"],
+      env: bunEnv,
+      cwd: dir,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
   // `delete require.cache[path]` removes the module's ES module registry entry.
   // It can run while an import() of that module is still loading: here the
   // module's dependency is held back by an async onLoad plugin until the test
@@ -355,17 +367,6 @@ describe.concurrent("require.cache", () => {
       `,
     });
 
-    async function run(dir: string) {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "run", "main.mjs"],
-        env: bunEnv,
-        cwd: dir,
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return { stdout: stdout.trim(), stderr, exitCode };
-    }
-
     test("the next import() loads the file again", async () => {
       using dir = tempDir(
         "require-cache-delete-in-flight",
@@ -377,7 +378,11 @@ describe.concurrent("require.cache", () => {
         `),
       );
 
-      expect(await run(String(dir))).toEqual({ stdout: JSON.stringify({ loads: [1, 2] }), stderr: "", exitCode: 0 });
+      expect(await runMain(String(dir))).toEqual({
+        stdout: JSON.stringify({ loads: [1, 2] }),
+        stderr: "",
+        exitCode: 0,
+      });
     });
 
     test("a load that finishes after the replacement load does not replace it", async () => {
@@ -393,7 +398,7 @@ describe.concurrent("require.cache", () => {
         `),
       );
 
-      expect(await run(String(dir))).toEqual({
+      expect(await runMain(String(dir))).toEqual({
         stdout: JSON.stringify({ loads: [1, 2, 2], thirdIsSecond: true }),
         stderr: "",
         exitCode: 0,
@@ -438,17 +443,6 @@ describe.concurrent("require.cache", () => {
       `,
     });
 
-    async function run(dir: string) {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "run", "main.mjs"],
-        env: bunEnv,
-        cwd: dir,
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return { stdout: stdout.trim(), stderr, exitCode };
-    }
-
     test("the next import() loads the file again", async () => {
       using dir = tempDir(
         "require-cache-delete-resolve-chain",
@@ -459,7 +453,7 @@ describe.concurrent("require.cache", () => {
         `),
       );
 
-      expect(await run(String(dir))).toEqual({
+      expect(await runMain(String(dir))).toEqual({
         stdout: JSON.stringify({ first: "d", second: "d", secondIsFirst: false }),
         stderr: "",
         exitCode: 0,
@@ -477,7 +471,7 @@ describe.concurrent("require.cache", () => {
         `),
       );
 
-      expect(await run(String(dir))).toEqual({
+      expect(await runMain(String(dir))).toEqual({
         stdout: JSON.stringify({ first: "d", replacementIsFirst: false, secondIsReplacement: true }),
         stderr: "",
         exitCode: 0,

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -8,6 +8,7 @@
 // - Write test for import {foo} from "./foo"; export {foo}
 
 import { expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { default as defaultValue, fn, iCallFn, rexported, rexportedAs, variable } from "./mock-module-fixture";
 import * as spyFixture from "./spymodule-fixture";
 
@@ -212,4 +213,56 @@ test("onResolve plugin errors surface from mock.module; an unresolvable specifie
   } finally {
     Bun.plugin.clearAll();
   }
+});
+
+// mock.module() of a file whose import() is still loading removes the file's
+// registry entry (the module is not linked yet, so there is no namespace to
+// patch). The in-flight import must still finish with the real module, and the
+// next import() must load the mock instead of answering from the removed
+// entry, which crashed in JSModuleLoader::loadModule. The load is held in
+// flight by an async onLoad plugin for the module's dependency. Runs in a
+// subprocess because the failure is a crash.
+test("mocking a file whose import() is in flight", async () => {
+  using dir = tempDir("mock-module-in-flight", {
+    "entry.mjs": `
+      import { dep } from "./dep.mjs";
+      export const value = dep;
+    `,
+    "dep.mjs": "",
+    "in-flight.test.ts": `
+      import { expect, mock, test } from "bun:test";
+
+      const gate = Promise.withResolvers<void>();
+      const depLoadStarted = Promise.withResolvers<void>();
+      Bun.plugin({
+        name: "gate",
+        setup(build) {
+          build.onLoad({ filter: /dep\\.mjs$/ }, async () => {
+            depLoadStarted.resolve();
+            await gate.promise;
+            return { loader: "js", contents: 'export const dep = "real";' };
+          });
+        },
+      });
+
+      test("mock.module while import() is in flight", async () => {
+        const first = import("./entry.mjs");
+        await depLoadStarted.promise;
+        mock.module("./entry.mjs", () => ({ value: "mocked" }));
+        gate.resolve();
+        expect((await first).value).toBe("real");
+        expect((await import("./entry.mjs")).value).toBe("mocked");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "in-flight.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout + stderr).toContain(" 1 pass");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Bumps `WEBKIT_VERSION` to pick up oven-sh/WebKit#472 and adds the tests for it.

### Problem

- `delete require.cache[path]`, `mock.module()` and plugin `module()` remove a module's ES module registry entry. If an `import()` of the module is still loading, the next `import()` of it crashes: `JSPromise::performPromiseThenWithInternalMicrotask` on a null promise in `JSModuleLoader::loadModule` (segfault at address `0x10`, under `moduleLoadTopSettled`). Sentry BUN-443N (canary builds, macOS and Linux) and BUN-4NFS (the same stack on the 1.4.0 release build, macOS arm64).
- Cause, in JavaScriptCore: `JSModuleLoader::removeEntry()` (`functionEsmRegistryDelete`, `src/jsc/bindings/ZigGlobalObject.cpp:779`; `mock.module`, `src/jsc/bindings/BunPlugin.cpp:703`) drops the entry while its load is in flight. When the load finishes, `finishLoadingImportedModule` puts the old record back into the realm's `[[LoadedModules]]` cache. The next `import()` hits the cache fast path in `hostLoadImportedModule`, which answers with the registry entry that now exists for the key: a fresh one, with a null `loadPromise()`.
- The same fast path also breaks without an in-flight load when the cache key and the registry key differ (an `onResolve` chain): `delete require.cache[]` of the registry key leaves the cache line behind, and the next `import()` crashes at address `0x38` (no entry) or returns the stale module (a different entry).

### Fix

- oven-sh/WebKit#472: a record is only cached while the registry still holds it through a loaded entry, and the fast path checks the same condition, otherwise it drops the line and loads what the registry holds. The in-flight `import()` still resolves with the module it started to load. No Bun source change: the engine change covers every `removeEntry()` caller.
- Tests in `test/cli/run/require-cache.test.ts`: an async `onLoad` plugin holds the module's dependency in flight while the test deletes the module (re-import after the removed load finishes, and with a replacement load that finishes first), and the `onResolve` chain shape (with and without a replacement). `test/js/bun/test/mock/mock-module.test.ts`: the in-flight shape with `mock.module()`, as a `bun test` subprocess.
- Verified: the five tests pass with `bun bd test` on the preview build. On the current pin, four fail (segfaults at `0x10` and `0x38`, the stale module, and a debug-only assertion). Notes below.

### Background

- The registry maps a module key to a `ModuleRegistryEntry`: the load's promises and, once fetched, the record. `removeEntry()` is a Bun addition, so upstream only asserts the invariant it breaks.
- The realm's `[[LoadedModules]]` is a cache from the specifier a top-level import was resolved to, to its record. The fast path uses it to skip the second `resolve()` on repeat imports and answers with the registry entry's load promise, so it is only valid while it agrees with the registry.
- A top-level load runs as microtasks that hold the entry they started from. After `removeEntry()` they finish against that detached entry.

<details><summary>Notes</summary>

Fail-before on the current pin (`USE_SYSTEM_BUN=1 bun test`, 1.4.0-canary): `in flight > the next import() loads the file again` and `mocking a file whose import() is in flight` crash the child with `Segmentation fault at address 0x10`; `chain > the next import() loads the file again` crashes it at `0x38`; `chain > returns the module that replaced it` gets `secondIsReplacement: false`. `in flight > a load that finishes after the replacement load does not replace it` passes on the release build (release ignores the assertion and the cache happens to hold the right record) and fails on a debug build with `ASSERTION FAILED: iter->value.m_module.get() == *resultRecord` at `JSModuleLoader.cpp:955`; the two `0x10` cases fail on a debug build with `ASSERTION FAILED: loadedEntry->record() == loaded` at `JSModuleLoader.cpp:630`. The debug results come from one debug build linked against the pinned tarball as is, and against the pinned tarball with the `JSModuleLoader.cpp` bundle rebuilt from oven-sh/WebKit#472; the pass-after was then repeated with the preview build this PR pins.

The chain shape exists because Bun resolves a top-level `import()` more than once (the import hook, `requestImportModule`, `hostLoadImportedModule`), so a hook that is not idempotent on its own output keys the cache line and the registry entry differently. That is pre-existing and unchanged here.

Not covered, pre-existing, and left for a follow-up: when the removed in-flight load fails instead, `moduleLoadTopSettled`, `moduleLoadTopRejected` and `moduleLoadStoreError` (`JSMicrotask.cpp`) store the error through `ensureRegistered(key)`, which creates a fresh entry for the key, so the next `import()` rejects with the removed load's error instead of loading again. Same window, no crash, and it needs the entry threaded through the top-level `ModuleLoadingContext`, which oven-sh/WebKit#258 is also reworking.

Also run on the new engine: `test/js/bun/test/mock/`, `test/js/node/module/`, `test/js/bun/plugin/`, `test/cli/test/isolation.test.ts`, `test/cli/hot/hot.test.ts`, 27 files of `test/js/bun/resolve/`, and `--rerun-each=3` on two files. The leak tests in `require-cache.test.ts` and `load the same empty JS file 2000 times` time out on this debug-asan build with and without the change. 3000 iterations of `delete require.cache[]` + `import()` take the same time on both engines, and repeat imports still skip the second `resolve()` (same `BUN_JSC_dumpModuleLoadingState=1` trace as before).

Also in this range: nothing. The pinned preview `autobuild-preview-pr-472-f7cb3cb4` is `f5deafe090`, the commit main pins, plus oven-sh/WebKit#472 (rebased each time main moved its pin: `0f966e81b7`, `b7f217b4a6`, `aea1f010b6`, `c148a12dd8`, `cb61607f1a`, `1cb96a7b0e`, `76882271d7`, `2da33d53e3`, `7259739917`, `0bb01ed526`, `f5deafe090`). #40674's engine commit lets embedded modules be registered without loader promises (`provideModule()` + `markLoaded()`, answered by `loadedPromise()`); `isCacheableLoadedModule()` accepts those entries (`loadPromise() || isLoaded()`), and `test/bundler/bundler_compile_splitting.test.ts` passes on this preview.

</details>

> [!NOTE]
> `WEBKIT_VERSION` points at the preview tag `autobuild-preview-pr-472-f7cb3cb4` while oven-sh/WebKit#472 is open. It has to move to the merged main sha before this lands.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/require-cache.test.ts

<!-- robobun:evidence:end -->











