### PR TITLE
gitattributes: keep Node's test fixtures byte-for-byte on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,6 +31,12 @@ test/js/bun/resolve/xml/xml-utf16be-bom.xml -text
 test/js/bun/resolve/xml/xml-utf8-bom.xml -text
 test/js/bun/resolve/xml/xml-latin1.xml -text
 
+# Node's test fixtures are read as exact bytes: certificates, console
+# snapshots, and files whose byte length a test asserts. Git converts them to
+# CRLF on checkout under `core.autocrlf=true`, which the Git for Windows
+# installer sets by default, and those assertions then fail.
+test/js/node/test/fixtures/** -text
+
 .vscode/launch.json linguist-generated
 fixture.*.c linguist-generated
 *-fixture* linguist-generated


### PR DESCRIPTION
### Root cause

The Git for Windows installer sets `core.autocrlf=true` at the **system** level, so it is what a contributor gets by default:

```
$ git config --system --get core.autocrlf
true
```

`.gitattributes` pins `eol=lf` per extension (`*.js`, `*.ts`, `*.md`, …), but Node's fixture tree is mostly extensions that list does not cover. With autocrlf on, 308 files under `test/js/node/test/fixtures/` are LF in the index and CRLF in the working tree:

```
$ git ls-files --eol test/js/node/test/fixtures | awk '$1=="i/lf" && $2=="w/crlf"' | wc -l
308
```

By extension: 57 `.pem`, 53 `.cjs`, 45 `.snapshot`, 36 `.txt`, 27 `.cnf`, 17 extensionless, 10 `.node`, and a tail of `.reg`, `.env`, `.bat`, `.py`.

Tests read these as exact bytes, so the byte counts move. `fixtures/x.txt` is `xyz\n` in the index and `xyz\r\n` on disk, which is what `test-fs-read-optional-params.js` reports:

```
AssertionError: Not passing in any object (as params)
     actual: 5,
   expected: 4,
```

### The fix

One line, matching the `-text` pattern already used in this file for the byte-encoding-sensitive XML loader fixtures.

### Verification

With `core.autocrlf=true` set and the fixture tree re-checked-out from a clean state, these ten files fail before the change and pass after it:

```
test-fs-read.js                            test-fs-read-stream-resume.js
test-fs-read-optional-params.js            test-fs-write-stream-encoding.js
test-fs-readSync-optional-params.js        test-stream-flatMap.js
test-fs-read-promises-optional-params.js   test-stream-preprocess.js
test-fs-read-stream.js                     test-fs-read-stream-inherit.js
```

Before: 0/10 pass. After: 10/10 pass. Run against a debug build of `main` on Windows 11 x64, each file executed directly per `test/js/node/test/parallel/CLAUDE.md`.

I found these while running a 1310-file slice of `test/js/node/test/parallel` (http, http2, https, stream, fs) against a debug build: 1285 passed, and ten of the failures were this and nothing else.

### Scope

`fixtures/keys/` is untouched. It has its own `.gitattributes` marking `Makefile` and `*.cnf` as `text` on purpose, and a nested file takes precedence over this rule, so those 22 files keep the line endings upstream Node chose for them.

The same gap exists elsewhere in the repo — 1106 files are `i/lf w/crlf` under this config, including `.sh` (44), `.snap`/`.snapshot` (107), and `.cjs`/`.cts` (113, sitting right next to the `*.js`/`*.mjs`/`*.ts`/`*.mts` entries that are covered). I kept this PR to the fixtures I could demonstrate breaking tests rather than guessing at a repo-wide `text=auto eol=lf`; tracked in #39676 with the full data.
