### PR TITLE
gitattributes: check out every text file with LF by default

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
+# Check out every detected-text file with LF, even under core.autocrlf=true
+# (the Git for Windows installer default). Files whose exact bytes matter must
+# opt out with `-text`, like the entries below.
+* text=auto eol=lf
+
 *.css text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.js text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.jsx text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
@@ -30,6 +35,14 @@ test/js/bun/resolve/xml/xml-utf16le-bom.xml -text
 test/js/bun/resolve/xml/xml-utf16be-bom.xml -text
 test/js/bun/resolve/xml/xml-utf8-bom.xml -text
 test/js/bun/resolve/xml/xml-latin1.xml -text
+
+# Committed with CRLF. `-text` keeps their bytes exactly as committed, in both
+# directions, so `git add --renormalize` cannot rewrite them.
+packages/bun-release/.gitignore -text
+src/runtime/cli/uninstall.ps1 -text
+src/windows-app-info.rc -text
+test/js/bun/io/hello-world.txt -text
+test/js/bun/resolve/toml/toml-fixture.toml.txt -text
 
 .vscode/launch.json linguist-generated
 fixture.*.c linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -23,6 +23,8 @@
 *.mdx text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.mjs text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.mts text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.cjs text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.cts text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 
 # Patch files are line-ending-sensitive — `git apply` rejects CRLF as corrupt.
 *.patch text eol=lf

--- a/test/internal/gitattributes.test.ts
+++ b/test/internal/gitattributes.test.ts
@@ -1,0 +1,98 @@
+// Guards the repo's .gitattributes against the gap reported in
+// oven-sh/bun#39676: the old per-extension eol=lf list missed 1106 tracked
+// files (.cjs, .sh, .snap, .pem, ...), so a default Windows clone
+// (core.autocrlf=true) checked them out as CRLF and byte-exact fixtures broke.
+//
+// The tests replay the repo's .gitattributes in a scratch repo, so they do not
+// need the test checkout itself to be a git worktree.
+import { expect, test } from "bun:test";
+import { join } from "path";
+import { bunEnv, tempDir } from "harness";
+
+const repoRoot = join(import.meta.dir, "..", "..");
+const gitattributes = await Bun.file(join(repoRoot, ".gitattributes")).text();
+
+// Extensions the issue found unprotected, plus extension-less files.
+const lfFiles: Record<string, string> = {};
+for (const name of [
+  "a.cjs",
+  "a.cts",
+  "a.sh",
+  "a.snap",
+  "a.snapshot",
+  "a.pem",
+  "a.txt",
+  "a.yaml",
+  "a.gyp",
+  "a.idl",
+  ".gitignore",
+  ".env",
+  "no-extension",
+]) {
+  lfFiles[name] = "line one\nline two\n";
+}
+
+// Real repo paths that are committed with CRLF and must stay byte-exact.
+const crlfFiles: Record<string, string> = {
+  "packages/bun-release/.gitignore": "dist\r\n",
+  "src/runtime/cli/uninstall.ps1": "Write-Host 'bye'\r\n",
+  "src/windows-app-info.rc": "// resource\r\n",
+  "test/js/bun/io/hello-world.txt": "Hello World!\r\n",
+  "test/js/bun/resolve/toml/toml-fixture.toml.txt": "a = 1\r\n",
+};
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  await using proc = Bun.spawn({
+    cmd: ["git", ...args],
+    cwd,
+    env: {
+      ...bunEnv,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: join(cwd, "does-not-exist.gitconfig"),
+      GIT_AUTHOR_NAME: "test",
+      GIT_AUTHOR_EMAIL: "test@example.com",
+      GIT_COMMITTER_NAME: "test",
+      GIT_COMMITTER_EMAIL: "test@example.com",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr.includes("fatal:"), `git ${args.join(" ")} failed: ${stderr}`).toBe(false);
+  expect(exitCode).toBe(0);
+  return stdout;
+}
+
+async function makeScratchRepo(dir: string): Promise<void> {
+  await git(dir, "init", "-q", "-b", "main");
+  // autocrlf=false on add: the index gets the bytes exactly as written above.
+  await git(dir, "-c", "core.autocrlf=false", "add", "-A");
+  await git(dir, "-c", "core.autocrlf=false", "commit", "-q", "-m", "init");
+}
+
+test("every text file checks out as LF under core.autocrlf=true", async () => {
+  using dir = tempDir("gitattributes-lf", { ".gitattributes": gitattributes, ...lfFiles });
+  await makeScratchRepo(String(dir));
+  await git(String(dir), "-c", "core.autocrlf=true", "clone", "-q", ".", "clone");
+
+  const clone = join(String(dir), "clone");
+  for (const name of Object.keys(lfFiles)) {
+    const content = await Bun.file(join(clone, name)).text();
+    expect(content.includes("\r"), `${name} checked out with CRLF`).toBe(false);
+  }
+});
+
+test("files committed with CRLF keep their bytes", async () => {
+  using dir = tempDir("gitattributes-crlf", { ".gitattributes": gitattributes, ...crlfFiles });
+  await makeScratchRepo(String(dir));
+  await git(String(dir), "-c", "core.autocrlf=true", "clone", "-q", ".", "clone");
+
+  const clone = join(String(dir), "clone");
+  for (const [name, expected] of Object.entries(crlfFiles)) {
+    expect(await Bun.file(join(clone, name)).text(), name).toBe(expected);
+  }
+
+  // A renormalize must not rewrite them either.
+  await git(clone, "-c", "core.autocrlf=true", "add", "--renormalize", ".");
+  expect(await git(clone, "status", "--porcelain")).toBe("");
+});

--- a/test/internal/gitattributes.test.ts
+++ b/test/internal/gitattributes.test.ts
@@ -47,6 +47,12 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
     cwd,
     env: {
       ...bunEnv,
+      // Point HOME/XDG_CONFIG_HOME into the scratch dir too: git's default
+      // core.excludesFile ($HOME/.config/git/ignore) is not covered by
+      // GIT_CONFIG_NOSYSTEM, and a host ignore for .env or *.pem would skip
+      // those fixtures on `git add -A`.
+      HOME: cwd,
+      XDG_CONFIG_HOME: cwd,
       GIT_CONFIG_NOSYSTEM: "1",
       GIT_CONFIG_GLOBAL: join(cwd, "does-not-exist.gitconfig"),
       GIT_AUTHOR_NAME: "test",

--- a/test/internal/gitattributes.test.ts
+++ b/test/internal/gitattributes.test.ts
@@ -58,8 +58,7 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr.includes("fatal:"), `git ${args.join(" ")} failed: ${stderr}`).toBe(false);
-  expect(exitCode).toBe(0);
+  expect(exitCode, `git ${args.join(" ")} in ${cwd} exited with ${exitCode}:\n${stderr}`).toBe(0);
   return stdout;
 }
 
@@ -70,19 +69,18 @@ async function makeScratchRepo(dir: string): Promise<void> {
   await git(dir, "-c", "core.autocrlf=false", "commit", "-q", "-m", "init");
 }
 
-test("every text file checks out as LF under core.autocrlf=true", async () => {
+test.concurrent("every text file checks out as LF under core.autocrlf=true", async () => {
   using dir = tempDir("gitattributes-lf", { ".gitattributes": gitattributes, ...lfFiles });
   await makeScratchRepo(String(dir));
   await git(String(dir), "-c", "core.autocrlf=true", "clone", "-q", ".", "clone");
 
   const clone = join(String(dir), "clone");
   for (const name of Object.keys(lfFiles)) {
-    const content = await Bun.file(join(clone, name)).text();
-    expect(content.includes("\r"), `${name} checked out with CRLF`).toBe(false);
+    expect(await Bun.file(join(clone, name)).text(), name).toBe(lfFiles[name]);
   }
 });
 
-test("files committed with CRLF keep their bytes", async () => {
+test.concurrent("files committed with CRLF keep their bytes", async () => {
   using dir = tempDir("gitattributes-crlf", { ".gitattributes": gitattributes, ...crlfFiles });
   await makeScratchRepo(String(dir));
   await git(String(dir), "-c", "core.autocrlf=true", "clone", "-q", ".", "clone");

--- a/test/internal/gitattributes.test.ts
+++ b/test/internal/gitattributes.test.ts
@@ -75,6 +75,17 @@ async function makeScratchRepo(dir: string): Promise<void> {
   await git(dir, "-c", "core.autocrlf=false", "commit", "-q", "-m", "init");
 }
 
+// `git check-attr -a` prints one "<path>: <attr>: <value>" line per attribute
+// that applies to the path. Returns the sorted "<attr>: <value>" parts.
+async function attributesOf(dir: string, name: string): Promise<string[]> {
+  const stdout = await git(dir, "check-attr", "-a", "--", name);
+  return stdout
+    .split("\n")
+    .filter(Boolean)
+    .map(line => line.slice(`${name}: `.length))
+    .sort();
+}
+
 test.concurrent("every text file checks out as LF under core.autocrlf=true", async () => {
   using dir = tempDir("gitattributes-lf", { ".gitattributes": gitattributes, ...lfFiles });
   await makeScratchRepo(String(dir));
@@ -99,4 +110,20 @@ test.concurrent("files committed with CRLF keep their bytes", async () => {
   // A renormalize must not rewrite them either.
   await git(clone, "-c", "core.autocrlf=true", "add", "--renormalize", ".");
   expect(await git(clone, "status", "--porcelain")).toBe("");
+});
+
+// The catch-all only pins eol. The per-extension lines also set the whitespace
+// policy, and .cjs/.cts must get the same one as .js/.ts.
+test.concurrent(".cjs and .cts carry the same attributes as .js and .ts", async () => {
+  using dir = tempDir("gitattributes-siblings", { ".gitattributes": gitattributes });
+  await git(String(dir), "init", "-q", "-b", "main");
+
+  for (const [sibling, reference] of [
+    ["a.cjs", "a.js"],
+    ["a.cts", "a.ts"],
+  ]) {
+    const expected = await attributesOf(String(dir), reference);
+    expect(expected, reference).toContain("eol: lf");
+    expect(await attributesOf(String(dir), sibling), sibling).toEqual(expected);
+  }
 });

--- a/test/internal/gitattributes.test.ts
+++ b/test/internal/gitattributes.test.ts
@@ -6,8 +6,8 @@
 // The tests replay the repo's .gitattributes in a scratch repo, so they do not
 // need the test checkout itself to be a git worktree.
 import { expect, test } from "bun:test";
-import { join } from "path";
 import { bunEnv, tempDir } from "harness";
+import { join } from "path";
 
 const repoRoot = join(import.meta.dir, "..", "..");
 const gitattributes = await Bun.file(join(repoRoot, ".gitattributes")).text();


### PR DESCRIPTION
### Problem

- `.gitattributes` pins `eol=lf` extension by extension. On a default Windows clone (`core.autocrlf=true`, the Git for Windows default), 1106 tracked files are LF in the index and CRLF on disk: `.cjs`, `.sh`, `.snap`, `.pem`, `.txt`, and more (#39676).
- Byte-exact fixtures then break. `test/js/node/test/fixtures/x.txt` becomes 5 bytes instead of 4, so `test-fs-read-optional-params.js` fails. The reporter counted ten such failures on Windows 11.

### Fix

- Add a catch-all as the first rule: `* text=auto eol=lf`. Every file that git detects as text checks out with LF on every platform, and new file types are covered by default. The five files that are committed with CRLF (`src/windows-app-info.rc`, `src/runtime/cli/uninstall.ps1`, two test fixtures, one `.gitignore`) get `-text`, so their bytes cannot change in either direction.
- This is the tree CI already tests. The Windows CI images set `core.autocrlf=false` and `core.eol=lf` (`scripts/bootstrap.ps1:217`), so the Windows lanes run against LF checkouts today. A default local clone now gets the same tree. No committed bytes change: checkout never converts to LF, and `git add --renormalize .` under the new rules changes none of the 19676 tracked files.
- Add `*.cjs` and `*.cts` lines with the whitespace policy of `*.js` and `*.ts`, adopted from #39849. That policy is the one part of #39849 the catch-all does not give.
- Verified: `test/internal/gitattributes.test.ts` replays the repo's `.gitattributes` in a scratch repo. All three tests fail with main's file and pass with this one. The clone repro from the issue drops from 1106 files to 0.

### Background

- `core.autocrlf=true` converts LF to CRLF on checkout for any file without a `text` or `eol` attribute. An `eol=lf` attribute overrides it.
- `text=auto` lets git decide text or binary from the content. For text it normalizes CRLF to LF on check-in only. A file already committed with CRLF stays as it is unless someone renormalizes it. The `-text` entries block that too.
- `-text` disables all conversion for a path. The repo already uses it for the byte-encoding XML fixtures.

<details><summary>Notes</summary>

- Repro without Windows: `git -c core.autocrlf=true clone <repo> d && cd d && git ls-files --eol | awk '$1=="i/lf" && $2=="w/crlf"' | wc -l`. On main (40ef811) this prints 1106. With this branch's `.gitattributes` it prints 0, and the only `w/crlf` files are the five `i/crlf` ones.
- The same count with #39849's `.gitattributes` (five more extensions, no catch-all) is 842. `.pem` (139), `.txt` (93, including the issue's `x.txt` example), `.gyp`, `.gitignore`, `.idl`, `.yaml`, extension-less files and more stay CRLF. Its `*.cjs` and `*.cts` lines are adopted here, with a co-author trailer on the commit.
- The five CRLF-in-index files, found with `git ls-files --eol | awk '$1=="i/crlf" || $1=="i/mixed"'`: `packages/bun-release/.gitignore`, `src/runtime/cli/uninstall.ps1`, `src/windows-app-info.rc`, `test/js/bun/io/hello-world.txt`, `test/js/bun/resolve/toml/toml-fixture.toml.txt`. There are no `i/mixed` files. The list is unchanged on current main.
- `git -c core.autocrlf=true add --renormalize .` with this branch's rules on top of current main content leaves `git status` empty. So the catch-all rewrites nothing that exists today, including the files already `-text` and the binary files. All 114 `.cjs`/`.cts` files are `i/lf` (one is empty), so the explicit `text` on them is a no-op as well.
- Existing clones: in an `autocrlf=true` clone of main with the 1106 CRLF files on disk, dropping in this `.gitattributes` leaves `git status` clean apart from `.gitattributes` itself. The files stay CRLF on disk until they are checked out again, as the issue describes. A re-checkout of `x.txt` gives LF.
- `.github/workflows/format.yml` sets `core.autocrlf=true` after checkout on Linux. The catch-all normalizes check-ins the same way `autocrlf=true` does, so the autofix job is unaffected. The files prettier rewrites already had explicit `text eol=lf` rules.
- `test/js/node/test/fixtures/keys/.gitattributes` sets `* -text` and then `text` for `Makefile` and `*.cnf`. Attributes combine per attribute, so those files keep `text` and take `eol=lf` from the root. They check out as LF on Windows now. The rest of that directory stays unconverted as before.
- The one-line `.bat` fixtures under `test/js/node/test/fixtures/run-script` now check out with LF on Windows. They contain no `goto` labels, so `cmd.exe` runs them the same either way. #39675 (closed by its author in favor of this PR) marked that whole subtree `-text`, which composes with this change.
- The guard test does not require the checkout to be a git worktree. It copies `.gitattributes` into a scratch repo, commits sample files with `autocrlf=false`, clones with `autocrlf=true`, and asserts the bytes. The third test compares `git check-attr -a` for `a.cjs`/`a.cts` against `a.js`/`a.ts`. It fails on the previous head of this branch and on main.
- This PR changes only `.gitattributes` and adds the test. The fail-before evidence was produced by checking out main's `.gitattributes` and running the test file: all three tests fail.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/gitattributes.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/gitattributes.test.ts
bun test v1.4.0 (6e906e468)

test/internal/gitattributes.test.ts:
(pass) .cjs and .cts carry the same attributes as .js and .ts [102.81ms]
(pass) files committed with CRLF keep their bytes [153.78ms]
(pass) every text file checks out as LF under core.autocrlf=true [244.49ms]

 3 pass
 0 fail
 38 expect() calls
Ran 3 tests across 1 file. [2.53s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.gitattributes                      |  15 +++++
 test/internal/gitattributes.test.ts | 129 ++++++++++++++++++++++++++++++++++++
 2 files changed, 144 insertions(+)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
.gitattributes                           1      1      0
test/internal/gitattributes.test.ts      2      3      0
```

</details>

**root cause** · written by the author bot

The repository's .gitattributes pinned eol=lf on a per-extension basis, so any file type missing from the list, such as .cjs, .cts, .sh, and snapshot fixtures, was checked out with CRLF line endings on Windows clones where core.autocrlf=true, causing byte-exact test comparisons and shell scripts to fail. The fix replaces the per-extension approach with a repository-wide `* text=auto eol=lf` rule so every text file checks out with LF by default, while adding explicit `-text` opt-outs for the handful of files intentionally committed with CRLF and extending the whitespace attributes to cover .…

<!-- robobun:evidence:end -->

