### PR TITLE
Reject a NaN uid or gid in Bun.spawn instead of running the child as id 0

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -53,6 +53,42 @@ fn signal_code_from_js(val: JSValue, global: &JSGlobalObject) -> JsResult<Signal
     bun_sys_jsc::signal_code_jsc::from_js(val, global)
 }
 
+/// The `uid` / `gid` option. Node semantics: an int32 passed through to the OS
+/// (negative values are cast to uid_t/gid_t, matching libuv). `null` leaves the
+/// child's id unchanged.
+fn user_or_group_id_from_js(
+    global: &JSGlobalObject,
+    value: JSValue,
+    field_name: &'static [u8],
+) -> JsResult<Option<u32>> {
+    if value == JSValue::NULL {
+        return Ok(None);
+    }
+    // `validate_integer_range` maps NaN to the default, which here is id 0
+    // (root); a NaN that came from a failed lookup must not become that.
+    if value.is_number() && value.as_number().is_nan() {
+        return Err(global.throw_range_error(
+            value.as_number(),
+            bun_fmt::OutOfRangeOptions {
+                field_name,
+                msg: b"an integer",
+                ..Default::default()
+            },
+        ));
+    }
+    let id = global.validate_integer_range::<i32>(
+        value,
+        0,
+        bun_sql_jsc::jsc::IntegerRange {
+            min: i128::from(i32::MIN),
+            max: i128::from(i32::MAX),
+            field_name,
+            ..Default::default()
+        },
+    )?;
+    Ok(Some(id as u32))
+}
+
 #[inline]
 fn subprocess_ipc_owner(ptr: *mut SubprocessT<'_>) -> Option<IPC::SendQueueOwner> {
     core::ptr::NonNull::new(ptr.cast::<SubprocessT<'static>>()).map(IPC::SendQueueOwner::Subprocess)
@@ -662,38 +698,12 @@ fn spawn_maybe_sync(
                 }
             }
 
-            // Node semantics: uid/gid are int32s passed through to the OS
-            // (negative values are cast to uid_t/gid_t, matching libuv).
             if let Some(uid_value) = args.get(global_this, "uid")? {
-                if uid_value != JSValue::NULL {
-                    let uid_int = global_this.validate_integer_range::<i32>(
-                        uid_value,
-                        0,
-                        bun_sql_jsc::jsc::IntegerRange {
-                            min: i128::from(i32::MIN),
-                            max: i128::from(i32::MAX),
-                            field_name: b"uid",
-                            ..Default::default()
-                        },
-                    )?;
-                    uid = Some(uid_int as u32);
-                }
+                uid = user_or_group_id_from_js(global_this, uid_value, b"uid")?;
             }
 
             if let Some(gid_value) = args.get(global_this, "gid")? {
-                if gid_value != JSValue::NULL {
-                    let gid_int = global_this.validate_integer_range::<i32>(
-                        gid_value,
-                        0,
-                        bun_sql_jsc::jsc::IntegerRange {
-                            min: i128::from(i32::MIN),
-                            max: i128::from(i32::MAX),
-                            field_name: b"gid",
-                            ..Default::default()
-                        },
-                    )?;
-                    gid = Some(gid_int as u32);
-                }
+                gid = user_or_group_id_from_js(global_this, gid_value, b"gid")?;
             }
 
             // Ignored where cgroups don't exist, like `windowsHide` on POSIX.

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -53,8 +53,7 @@ fn signal_code_from_js(val: JSValue, global: &JSGlobalObject) -> JsResult<Signal
     bun_sys_jsc::signal_code_jsc::from_js(val, global)
 }
 
-/// `uid` / `gid` are int32s passed through to the OS (negative values are cast
-/// to uid_t/gid_t, matching libuv).
+/// Like node, `uid` / `gid` are int32s that the OS casts to uid_t / gid_t.
 fn user_or_group_id_from_js(
     global: &JSGlobalObject,
     value: JSValue,

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -53,9 +53,8 @@ fn signal_code_from_js(val: JSValue, global: &JSGlobalObject) -> JsResult<Signal
     bun_sys_jsc::signal_code_jsc::from_js(val, global)
 }
 
-/// The `uid` / `gid` option. Node semantics: an int32 passed through to the OS
-/// (negative values are cast to uid_t/gid_t, matching libuv). `null` leaves the
-/// child's id unchanged.
+/// `uid` / `gid` are int32s passed through to the OS (negative values are cast
+/// to uid_t/gid_t, matching libuv).
 fn user_or_group_id_from_js(
     global: &JSGlobalObject,
     value: JSValue,
@@ -64,8 +63,7 @@ fn user_or_group_id_from_js(
     if value == JSValue::NULL {
         return Ok(None);
     }
-    // `validate_integer_range` maps NaN to the default, which here is id 0
-    // (root); a NaN that came from a failed lookup must not become that.
+    // `validate_integer_range` maps NaN to the default, and the default id 0 is root.
     if value.is_number() && value.as_number().is_nan() {
         return Err(global.throw_range_error(
             value.as_number(),

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1673,6 +1673,22 @@ describe("option combinations", () => {
 describe("uid/gid", () => {
   const isRoot = process.getuid?.() === 0;
 
+  // NaN used to be coerced to 0, so a uid from a failed lookup ran the child as root.
+  it("rejects a NaN uid/gid before spawning", () => {
+    expect(() => spawn({ cmd: [bunExe(), "--version"], env: bunEnv, uid: NaN })).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: 'The value of "uid" is out of range. It must be an integer. Received NaN',
+      }),
+    );
+    expect(() => spawn({ cmd: [bunExe(), "--version"], env: bunEnv, gid: NaN })).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: 'The value of "gid" is out of range. It must be an integer. Received NaN',
+      }),
+    );
+  });
+
   it.if(isPosix && isRoot)("applies uid and gid to the child", async () => {
     await using proc = spawn({ cmd: ["id", "-u"], uid: 65534, gid: 65534, stdout: "pipe" });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);

--- a/test/js/bun/spawn/spawnSync.test.ts
+++ b/test/js/bun/spawn/spawnSync.test.ts
@@ -163,6 +163,27 @@ describe("uid/gid", () => {
     expect(() => Bun.spawnSync({ cmd: [bunExe()], env: bunEnv, gid: 1.5 })).toThrow();
   });
 
+  // NaN used to be coerced to 0, so a uid from a failed lookup ran the child as root.
+  it("rejects a NaN uid/gid before spawning", () => {
+    expect(() => Bun.spawnSync({ cmd: [bunExe(), "--version"], env: bunEnv, uid: NaN })).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: 'The value of "uid" is out of range. It must be an integer. Received NaN',
+      }),
+    );
+    expect(() => Bun.spawnSync({ cmd: [bunExe(), "--version"], env: bunEnv, gid: NaN })).toThrow(
+      expect.objectContaining({
+        code: "ERR_OUT_OF_RANGE",
+        message: 'The value of "gid" is out of range. It must be an integer. Received NaN',
+      }),
+    );
+  });
+
+  it("accepts a null uid/gid", () => {
+    const result = Bun.spawnSync({ cmd: [bunExe(), "--version"], env: bunEnv, uid: null as any, gid: null as any });
+    expect(result.exitCode).toBe(0);
+  });
+
   it.if(isPosix && isRoot)("applies uid/gid and drops supplementary groups", () => {
     const result = Bun.spawnSync({ cmd: ["id"], uid: 65534, gid: 65534 });
     const out = result.stdout.toString();

--- a/test/js/bun/spawn/spawnSync.test.ts
+++ b/test/js/bun/spawn/spawnSync.test.ts
@@ -180,7 +180,13 @@ describe("uid/gid", () => {
   });
 
   it("accepts a null uid/gid", () => {
-    const result = Bun.spawnSync({ cmd: [bunExe(), "--version"], env: bunEnv, uid: null as any, gid: null as any });
+    const result = Bun.spawnSync({
+      cmd: [bunExe(), "-e", "console.log('ok')"],
+      env: bunEnv,
+      uid: null as any,
+      gid: null as any,
+    });
+    expect(result.stdout.toString()).toBe("ok\n");
     expect(result.exitCode).toBe(0);
   });
 


### PR DESCRIPTION
### Problem
- `Bun.spawn(cmd, { uid: NaN })` and `Bun.spawnSync` spawn the child. The child calls `setgroups(0, NULL)`, `setgid(0)` and `setuid(0)` before exec. So a `uid` from a failed user lookup runs the child as root. `child_process.spawn` throws for the same input.
- `uid` and `gid` go through `validate_integer_range` (`src/runtime/api/bun/js_bun_spawn_bindings.rs:690`). It returns the caller's default for NaN (`src/jsc/JSGlobalObject.rs:1307`), and the default here is 0. Every other bad shape already throws.

### Fix
- A NaN `uid` or `gid` now throws `ERR_OUT_OF_RANGE` before the spawn: `The value of "uid" is out of range. It must be an integer. Received NaN`. The `timeout` and `cgroup` options in the same parser already do this.
- The two option blocks share one helper, `user_or_group_id_from_js`. `null`, valid ids, and the other errors do not change.
- The shared helper is not changed. 18 other callers rely on its NaN behavior. This parser is the only caller whose default is a credential.
- Verified: `test/js/bun/spawn/spawnSync.test.ts` and `test/js/bun/spawn/spawn.test.ts` (new `uid/gid` tests, both fail on bun 1.4.0). Both files pass in full. So does the `uid/gid` block of the `child_process` tests.

### Background
- `Bun.spawn` and `Bun.spawnSync` share one option parser, `spawn_maybe_sync`. It stores `uid` and `gid` as `Option<u32>`. `Some(id)` makes the child call `setgid` and `setuid` (`src/spawn_sys/posix_spawn.rs:660`). `None` leaves the ids alone.
- `validate_integer_range` is the port of node's integer validators. It throws for a non-number, a fraction, and an out-of-range value. It maps NaN to the caller's default.
- `node:child_process` validates `uid` and `gid` in JavaScript (`src/js/node/child_process.ts`), so NaN never reaches this path from there.

<details><summary>Notes</summary>

Behavior matrix on this branch. Only the NaN rows changed from bun 1.4.0:

```
child_process uid:NaN        ERR_INVALID_ARG_TYPE (unchanged, JS validator)
Bun.spawnSync uid:NaN        ERR_OUT_OF_RANGE   (was: exit 0, child ran as uid 0)
Bun.spawnSync gid:NaN        ERR_OUT_OF_RANGE   (was: exit 0, child ran as gid 0)
Bun.spawn     uid:NaN        ERR_OUT_OF_RANGE   (was: spawned)
Bun.spawnSync uid:Infinity   ERR_OUT_OF_RANGE   (unchanged)
Bun.spawnSync uid:1.5        ERR_INVALID_ARG_TYPE (unchanged)
Bun.spawnSync uid:"0"        ERR_INVALID_ARG_TYPE (unchanged)
Bun.spawnSync uid:2**32      ERR_OUT_OF_RANGE   (unchanged)
Bun.spawnSync uid:undefined  spawns, ids unchanged (unchanged; `get` maps undefined to absent)
Bun.spawnSync uid:null       spawns, ids unchanged (unchanged)
```

The executable lookup runs before the option parser, so the tests use `bunExe()` as the command. A missing command would throw `ENOENT` first.

On Windows the parser also runs. Before this change `uid: NaN` there failed later with `ENOTSUP`. Now it throws `ERR_OUT_OF_RANGE` like the other platforms, so the new tests are not platform gated.

Not a regression: bun 1.3.14 behaves the same as 1.4.0 here.

`get_optional_int` (`src/jsc/JSValue.rs:1568`) has the same NaN to default behavior for 7 callers in valkey and csrf. None of those defaults is a credential. Whether the shared helpers should reject NaN in general is a separate decision and is not part of this change.

Two unrelated failures in `test/js/node/child_process/child_process.test.ts` in this environment: "should allow us to spawn in the default shell" ($SHELL is not exported here, fails the same way on 1.4.0), and "extra stdio pipes are not double-closed on GC" (about 5.1 s of work against a 5 s timeout on a debug build, passes on a release build). Reported separately.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawnSync.test.ts, test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->