### PR TITLE
node:fs: free the per-VM NodeFS when a worker's VM is torn down

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -162,10 +162,6 @@ pub struct VirtualMachine {
     pub overridden_main: crate::strong::Optional,
     pub(crate) entry_point: bun_bundler::entry_points::ServerEntryPoint,
     pub origin: bun_url::URL<'static>,
-    // LAYERING: real type is `Option<Box<bun_runtime::node::fs::NodeFS>>`, but
-    // `bun_runtime` is a forward dep of this crate; stored type-erased and
-    // cast back by the `bun_runtime` consumers.
-    pub node_fs: Option<*mut c_void>,
     /// Opaque per-VM `bun_runtime` state (boxed `timer::All` +
     /// `Body::Value::HiveAllocator` + …). Set by
     /// `RuntimeHooks::init_runtime_state` in [`init`]; reclaimed by
@@ -2175,10 +2171,6 @@ pub struct RuntimeHooks {
         opts: &uws::SocketContext::BunSocketContextOptions,
         err: &mut uws::create_bun_socket_error_t,
     ) -> Option<bun_boringssl::c::OwnedSslCtx>,
-    /// Lazy `NodeFS` creation.
-    /// `NodeFS` lives in `bun_runtime`; the high tier boxes one and returns
-    /// the type-erased pointer. Stored back into `vm.node_fs`.
-    pub create_node_fs: unsafe fn(vm: *mut VirtualMachine) -> *mut c_void,
     /// `ObjectURLRegistry` lookup. Registry lives in `bun_runtime::webcore`.
     pub has_blob_url: fn(blob_id: &[u8]) -> bool,
     /// `Response::get_blob_without_call_frame` /
@@ -3946,24 +3938,6 @@ impl VirtualMachine {
         if self.reload_entry_point(main.slice()).is_err() {
             panic!("Failed to reload");
         }
-    }
-
-    /// `NodeFS` lives in `bun_runtime` (forward-dep on `bun_jsc`), so the
-    /// field is stored type-erased and the lazy boxed allocation goes through
-    /// [`RuntimeHooks::create_node_fs`]. Callers in `bun_runtime` cast the
-    /// returned pointer back to `*mut node::fs::NodeFS`.
-    #[inline]
-    pub fn node_fs(&mut self) -> *mut c_void {
-        if let Some(existing) = self.node_fs {
-            return existing;
-        }
-        let hooks = runtime_hooks().expect("runtime hooks not installed");
-        // SAFETY: hook contract — `self` is the live per-thread VM. The hook
-        // boxes a `NodeFS{ vm: self if standalone else null }` and returns
-        // the leaked pointer.
-        let new = unsafe { (hooks.create_node_fs)(self) };
-        self.node_fs = Some(new);
-        new
     }
 
     /// Returns the next debugger async-task id, or 0 when no debugger is attached.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -75,6 +75,9 @@ pub(crate) struct RuntimeState {
     /// Lazy-init by [`crate::dns_jsc::global_resolver`]; freed when this box
     /// drops in [`deinit_runtime_state`].
     pub(crate) global_dns_data: core::cell::OnceCell<Box<crate::dns_jsc::GlobalData>>,
+    /// Lazy-init by [`crate::node::node_fs_binding::Binding::for_vm`]; freed
+    /// when this box drops in [`deinit_runtime_state`].
+    pub(crate) node_fs_binding: core::cell::OnceCell<Box<crate::node::node_fs_binding::Binding>>,
     /// Synthetic `bun:main` wrapper source.
     pub(crate) entry_point: ServerEntryPoint,
     /// Backing arena for `vm.transpiler` (spec passes `bun.default_allocator`;
@@ -248,6 +251,21 @@ pub(crate) fn global_dns_data() -> &'static core::cell::OnceCell<Box<crate::dns_
     unsafe { &(*state).global_dns_data }
 }
 
+/// Per-VM lazy slot behind [`crate::node::node_fs_binding::Binding::for_vm`].
+#[inline]
+pub(crate) fn vm_node_fs_binding()
+-> &'static core::cell::OnceCell<Box<crate::node::node_fs_binding::Binding>> {
+    let state = runtime_state();
+    debug_assert!(
+        !state.is_null(),
+        "vm_node_fs_binding before init_runtime_state"
+    );
+    // SAFETY: `state` is the live per-thread `RuntimeState` box; the field
+    // address is stable for the VM's lifetime and only read (interior
+    // mutability via `OnceCell`).
+    unsafe { &(*state).node_fs_binding }
+}
+
 /// Recover the [`RuntimeState`] owned by a specific `vm` (not the calling
 /// thread's). `WTFTimer` may be entered off the VM's JS thread (the locked
 /// `All.wtf_timers` heap exists for exactly that), and the
@@ -381,6 +399,7 @@ unsafe fn init_runtime_state(
         },
         ssl_ctx_cache: Default::default(),
         global_dns_data: core::cell::OnceCell::new(),
+        node_fs_binding: core::cell::OnceCell::new(),
         entry_point: ServerEntryPoint::default(),
         // `borrowing_default()` wraps `mi_heap_main()` so `Transpiler`-level
         // allocations use the same heap as the global allocator and skip the
@@ -1313,29 +1332,6 @@ unsafe fn timer_remove(
     unsafe { &mut (*state).timer }.remove(t);
 }
 
-/// `Node.fs.NodeFS{ .vm = … }` lazy creation.
-/// The low tier stores the result in `vm.node_fs: Option<*mut c_void>`.
-///
-/// # Safety
-/// `vm` is the live per-thread VM. The returned box is reclaimed (if at all)
-/// only by VM teardown.
-unsafe fn create_node_fs(vm: *mut VirtualMachine) -> *mut c_void {
-    use crate::node::fs::NodeFS;
-    // `.vm` is set only when standalone-module-graph is active
-    // (it gates the embedded-file `Bun.file()` lookups inside `node:fs`).
-    // SAFETY: per fn contract.
-    let vm_field = if unsafe { &*vm }.standalone_module_graph.is_some() {
-        core::ptr::NonNull::new(vm)
-    } else {
-        None
-    };
-    bun_core::heap::into_raw(Box::new(NodeFS {
-        sync_error_buf: bun_paths::PathBuffer::uninit(),
-        vm: vm_field,
-    }))
-    .cast::<c_void>()
-}
-
 /// `WebCore.ObjectURLRegistry.singleton().has(specifier["blob:".len..])`.
 fn has_blob_url(blob_id: &[u8]) -> bool {
     crate::webcore::object_url_registry::ObjectURLRegistry::singleton().has(blob_id)
@@ -1516,7 +1512,6 @@ static __BUN_RUNTIME_HOOKS: RuntimeHooks = RuntimeHooks {
     timer_remove,
     default_client_ssl_ctx,
     ssl_ctx_cache_get_or_create,
-    create_node_fs,
     has_blob_url,
     body_mixin_get_blob,
     process_exit,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9363,15 +9363,15 @@ pub(crate) unsafe extern "C" fn Bun__mkdirp(
 ) -> bool {
     // SAFETY: caller passes a NUL-terminated C string
     let path_bytes = unsafe { bun_core::ffi::cstr(path) }.to_bytes();
-    // SAFETY: `bun_vm()` returns the live VM; `node_fs()` returns its cached
-    // `*NodeFS` (type-erased to `*mut c_void` in `bun_jsc` to break the dep cycle).
-    let node_fs: &mut NodeFS =
-        unsafe { &mut *global_this.bun_vm().as_mut().node_fs().cast::<NodeFS>() };
-    node_fs
-        .mkdir_recursive(&args::Mkdir {
-            path: PathLike::borrowed(path_bytes),
-            recursive: true,
-            ..Default::default()
+    // R-2: blocking syscalls, no JS re-entry; the `&mut NodeFS` is scoped to the call.
+    Binding::for_vm(global_this)
+        .node_fs
+        .with_mut(|node_fs| {
+            node_fs.mkdir_recursive(&args::Mkdir {
+                path: PathLike::borrowed(path_bytes),
+                recursive: true,
+                ..Default::default()
+            })
         })
         .is_ok()
 }

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -122,24 +122,22 @@ impl Binding {
     // `pub const js = jsc.Codegen.JSNodeJSFS;` + `toJS`/`fromJS`/`fromJSDirect`
     // → provided by `#[bun_jsc::JsClass]` derive.
 
-    // `pub const new = bun.TrivialNew(@This());`
-    pub(crate) fn new(init: Self) -> Box<Self> {
-        Box::new(init)
+    fn init(vm: *mut VirtualMachine) -> Box<Self> {
+        let binding = Box::new(Self::default());
+        binding.node_fs.with_mut(|nfs| nfs.vm = NonNull::new(vm));
+        binding
     }
 
+    /// The instance for native callers outside `node:fs` (`Blob.stat()`,
+    /// `File::unlink()`, `Bun__mkdirp`): one path buffer per VM, neither on the
+    /// stack nor allocated per call. `RuntimeState` owns it and frees it on VM
+    /// teardown; it never gets a JS wrapper.
+    pub(crate) fn for_vm(global: &JSGlobalObject) -> &Self {
+        crate::jsc_hooks::vm_node_fs_binding().get_or_init(|| Self::init(global.bun_vm_ptr()))
+    }
+
+    /// Only [`create_binding`]'s boxes get a wrapper, and the wrapper owns them.
     pub fn finalize(self: Box<Self>) {
-        if self.node_fs.get().vm.is_some() {
-            // `node_fs.vm` is always the per-thread VM when set; route the
-            // read through the safe singleton accessor.
-            let vm_node_fs = VirtualMachine::get().node_fs;
-            // `JsCell` is `repr(transparent)` over `UnsafeCell<NodeFS>`, so
-            // `as_ptr()` yields the same address the VM stored at init time.
-            if vm_node_fs == Some(self.node_fs.as_ptr().cast()) {
-                // VM-owned singleton — keep alive.
-                let _ = bun_core::heap::release(self);
-                return;
-            }
-        }
         drop(self);
     }
 
@@ -326,16 +324,7 @@ impl Binding {
 }
 
 pub(crate) fn create_binding(global: &JSGlobalObject) -> JSValue {
-    let module = Binding::new(Binding::default());
-
-    let vm = global.bun_vm_ptr();
-    // R-2: init-time write before the JS wrapper exists; `with_mut` here is
-    // trivially un-aliased (sole owner of the fresh `Box`).
-    module.node_fs.with_mut(|nfs| nfs.vm = NonNull::new(vm));
-
-    // `module` was `Box::new`-allocated; ownership transfers to the GC
-    // wrapper, which calls `Binding::finalize` to reclaim it.
-    Binding::to_js_boxed(module, global)
+    Binding::to_js_boxed(Binding::init(global.bun_vm_ptr()), global)
 }
 
 /// Test-only (`bun:internal-for-testing`): run `(path, options)` through the

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2177,14 +2177,11 @@ impl BlobExt for Blob {
                     .expect("infallible: store present")
                     .data
                     .as_file();
+                let binding = crate::node::fs::Binding::for_vm(global_this);
                 match &file.pathlike {
                     PathOrFileDescriptor::Path(path_like) => {
                         // SAFETY: bun_vm() returns the live VM for this global.
                         let vm = global_this.bun_vm().as_mut();
-                        // SAFETY: lazily-initialised per-VM NodeFS binding; never null after init.
-                        let binding = unsafe {
-                            &*vm.node_fs().cast::<crate::node::node_fs_binding::Binding>()
-                        };
                         Ok(crate::node::fs::async_::Stat::create(
                             global_this,
                             binding,
@@ -2195,10 +2192,6 @@ impl BlobExt for Blob {
                     PathOrFileDescriptor::Fd(fd) => {
                         // SAFETY: bun_vm() returns the live VM for this global.
                         let vm = global_this.bun_vm().as_mut();
-                        // SAFETY: lazily-initialised per-VM NodeFS binding; never null after init.
-                        let binding = unsafe {
-                            &*vm.node_fs().cast::<crate::node::node_fs_binding::Binding>()
-                        };
                         Ok(crate::node::fs::async_::Fstat::create(
                             global_this,
                             binding,
@@ -4305,10 +4298,6 @@ fn write_file_with_empty_source_to_destination(
     match &destination_store.data {
         store::Data::File(file) => {
             // TODO: make this async
-            // `VirtualMachine::node_fs()` currently returns `*mut c_void`; the
-            // typed `&mut NodeFS` accessor isn't wired yet, so use a fresh
-            // `NodeFS` (it carries no per-call state for
-            // `truncate`/`mkdir_recursive`).
             let mut node_fs = node::fs::NodeFS::default();
             let mut result = node_fs.truncate(
                 &node::fs::args::Truncate {

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -222,13 +222,11 @@ impl FileExt for File {
     fn unlink(&self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         match &self.pathlike {
             PathOrFileDescriptor::Path(path_like) => {
-                // The `*Binding` arg is unused in `AsyncFSTask::create`.
-                let binding = node_fs::Binding::default();
                 // SAFETY: `bun_vm()` returns the live per-global VM pointer; the
                 // task is created on the JS thread that owns it.
                 Ok(node_fs::async_::Unlink::create(
                     global_this,
-                    &binding,
+                    node_fs::Binding::for_vm(global_this),
                     node_fs::args::Unlink::owned(path_like.slice().to_vec()),
                     global_this.bun_vm().as_mut(),
                 ))

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1518,8 +1518,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
     if body.needs_to_read_file() {
         'prepare_body: {
             // A local `PathBuffer` serves as NUL-termination scratch for
-            // `path.slice_z()` (the `vm.node_fs()` accessor is gated behind a
-            // jsc↔runtime cycle).
+            // `path.slice_z()`.
             let mut open_path_buf = PathBuffer::uninit();
             let opened_fd_res: bun_sys::Result<bun_sys::Fd> = {
                 let store = body.store().expect("needs_to_read_file implies store");
@@ -1617,9 +1616,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             // TODO: make this async + lazy
             let blob_offset = body.any_blob().blob().offset.get();
             let blob_size = body.any_blob().blob().size.get();
-            // The `vm.node_fs()` accessor is a jsc↔runtime cycle. `read_file`
-            // with an `Fd` path only touches `self.sync_error_buf` for
-            // path-variant inputs, so a fresh `NodeFS` is sufficient here.
             let mut node_fs = node::fs::NodeFS::default();
             // `ReadFile` has `Drop`; can't use FRU `..Default::default()`.
             let mut rf_args = node::fs::args::ReadFile::default();

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -164,6 +164,55 @@ test.skipIf(!isASAN)(
       ],
       env: {
         ...bunEnv,
+        // The CI runner sets this for every test; set it here too so the
+        // main thread's own per-VM state is not reported when run directly.
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+  },
+  timeout,
+);
+
+// Regression: the per-VM NodeFS that Bun.file().stat() (and bun:jsc's
+// startSamplingProfiler) use hung off the VirtualMachine as a raw box no
+// teardown path freed, so every Worker that called it leaked 4104 bytes on
+// exit, terminated or not. It now belongs to the VM's runtime state, which
+// teardown drops. stat() runs from a timer so that the allocation's stack holds
+// no module-evaluation frame, which leaksan.supp would suppress (how this
+// stayed hidden in scripts that stat() at top level).
+test.skipIf(!isASAN)(
+  "a worker's Bun.file().stat() does not leak the per-VM NodeFS when it exits or is terminated",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { Worker } = require("worker_threads");
+        const stat = "setTimeout(() => Bun.file(process.execPath).stat().then(() => ";
+        const exits = stat + "process.exit(0)), 0);";
+        const signals = stat + "require('worker_threads').parentPort.postMessage(0)), 0);";
+        let done = 0;
+        const finish = () => { if (++done === 4) console.log("ok"); };
+        for (let i = 0; i < 2; i++) {
+          new Worker(exits, { eval: true }).on("exit", code => code === 0 && finish());
+          const w = new Worker(signals, { eval: true });
+          w.on("message", () => w.terminate().then(finish));
+        }
+      `,
+      ],
+      env: {
+        ...bunEnv,
+        // The CI runner sets this for every test; set it here too so the
+        // main thread's own per-VM state is not reported when run directly.
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
         ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
         LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
       },


### PR DESCRIPTION
### Problem
- A Worker that calls `Bun.file().stat()` leaks the per-VM `NodeFS` (4104 bytes) when it exits or is terminated. LSan: `Direct leak of 4104 byte(s)` from `jsc_hooks::create_node_fs` via `VirtualMachine::node_fs` (`src/jsc/VirtualMachine.rs:3906`). `bun:jsc`'s `startSamplingProfiler(dir)` uses the same instance.
- `VirtualMachine.node_fs` (`VirtualMachine.rs:168`) held it as a type-erased pointer. `VirtualMachine::destroy` frees every other owned field, but not this one.

### Fix
- The instance stays on the heap, as designed: it holds the path buffer off the stack without an allocation per call. It now lives in `RuntimeState` (`src/runtime/jsc_hooks.rs`) as a lazily created `Box<Binding>`, like `global_dns_data`. `destroy()` drops that state, and the instance with it. The `VirtualMachine` field, its accessor and the `create_node_fs` hook are gone.
- Freeing it there is safe. Its users hold it only for the duration of a call (`mkdir_recursive`, and the path scratch while a task is created), and `destroy()` runs after the wait for off-thread work.
- Callers reach it through `Binding::for_vm`. `Blob.rs` no longer casts a bare `NodeFS` to a `Binding`, `File::unlink` no longer builds a path-buffer sized `Binding` on the stack, and `Binding::finalize` loses its branch for a VM-owned instance, which never gets a JS wrapper.
- Verified: `test/js/web/workers/worker-terminate-lifetime.test.ts` (new test, fails on main with the stack above, 26/26 here). Also the node:fs, Bun.file and blob-write suites, the sibling worker leak tests, clippy, a Windows `cargo check`.

### Background
- `node:fs` has its own `Binding` from `create_binding`, owned by its JS wrapper. `Binding` wraps a `NodeFS`, whose `sync_error_buf` is the path buffer (about 96 KB on Windows) the sync operations work in. Native callers outside the module need one too, and that is the per-VM instance.
- `RuntimeState` is the per-VM state owned by `bun_runtime`. `bun_jsc` holds it as an opaque pointer and frees it in `destroy()`, the last step of VM teardown. Workers run that on exit, the main thread only under `BUN_DESTRUCT_VM_ON_EXIT`.
- LSan does not scan the JSC heap, and `test/leaksan.supp` hides the resulting reports by module evaluation frames. The new test calls `stat()` from a timer, so its stack has none, and sets `BUN_DESTRUCT_VM_ON_EXIT=1` as CI's runner does.

<details><summary>Notes</summary>

- Rebased onto main (0e395c2459) as one commit. The conflicts were in code main also changed: the `RuntimeHooks` table next to the removed `create_node_fs` entry, `Bun__mkdirp`'s path construction (`PathLike::borrowed`), and `File::unlink`'s arguments (`args::Unlink::owned`). Each keeps main's new code and this PR's use of the per-VM binding.
- History: the first push had this shape. The self-review argued that nothing reads the instance, and two pushes deleted it and put a `NodeFS` on the stack in `Bun__mkdirp`. That misses the point of the instance (Jarred's review: https://github.com/oven-sh/bun/pull/39684#pullrequestreview-4979258824), so the final shape is the first one. The async constructors keep their `Binding` parameter: the Windows `UVFSRequest::create` uses its buffer for `open` and `statfs`.
- This started from a report that the `dns.lookup` test in the same file fails when the file is run directly. That is a different allocation: the module's own binding on the main thread (`create_binding`), which is not a leak. The main thread does not destroy its VM, and the Rust allocator frames push the `Bun::generateModule` suppression past `malloc_context_size=30`. CI passes it because the runner sets `BUN_DESTRUCT_VM_ON_EXIT=1`. #35159 fixes the report at the source. This PR adds that variable to the `dns.lookup` test, in the same words as #37513, so the file passes when run directly. The new test is the one that proves this fix.
- Failure modes of the new test: a worker that throws or whose `stat()` rejects exits non-zero and prints the error, so the child prints no `ok` and stderr is not empty. Nothing keeps the child alive once the workers are gone.
- Probes with the fix and `test/leaksan.supp` disabled: 4 workers (2 terminated, 2 `process.exit`) that each run `stat()` and `unlink()` report zero leaks. On main the same probe with the suppressions enabled reports one `create_node_fs` allocation per worker.
- `create_node_fs` set `NodeFS.vm` only for standalone executables. `Binding::init` sets it always, as `create_binding` does. Only the sync `readFile` path reads the field, and none of these callers use that path.
- The other `NodeFS::default()` locals (`fetch.rs`, three in `Blob.rs`, and more) are unchanged. They could use `Binding::for_vm` too, which is a separate change.
- `startSamplingProfiler(dir)` crashes after `Bun__mkdirp` returns, on the main thread too (#32212). The directory is still created.
- Other suites run: `test/js/node/fs/fs.test.ts`, `fs-oom.test.ts`, `test/js/bun/util/bun-file.test.ts`, `test/js/web/fetch/blob-write.test.ts`, `worker-shutdown-post-leak.test.ts`, `shell-worker-terminate-leak.test.ts`. `cargo clippy -p bun_jsc -p bun_runtime` and `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` are clean.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/workers/worker-terminate-lifetime.test.ts

<!-- robobun:evidence:end -->



