### PR TITLE
node:http: clear the socket inactivity timer in _destroy

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1734,11 +1734,9 @@ function getNodeHTTPServerSocket() {
     }
 
     _destroy(err, callback) {
-      // Like Node.js's net.Socket._destroy (clearTimeout(s[kTimeout])): a
-      // destroyed socket must not emit 'timeout'. #onClose also clears the
-      // timer, but the native close is delivered asynchronously; an expired
-      // timer already queued would fire in between and re-enter the server's
-      // 'timeout' path on a destroyed socket.
+      // Like Node.js's net.Socket._destroy: a destroyed socket must not emit
+      // 'timeout'. #onClose clears the timer too, but the native close is
+      // asynchronous; an already-expired timer would fire in that gap.
       const timer = this[kSocketTimeoutTimer];
       if (timer) {
         clearTimeout(timer);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1734,9 +1734,7 @@ function getNodeHTTPServerSocket() {
     }
 
     _destroy(err, callback) {
-      // Like Node.js's net.Socket._destroy: a destroyed socket must not emit
-      // 'timeout'. #onClose clears the timer too, but the native close is
-      // asynchronous; an already-expired timer would fire in that gap.
+      // Match net.Socket._destroy: #onClose clears this too, but the native close is async and an already-due timer would fire first.
       const timer = this[kSocketTimeoutTimer];
       if (timer) {
         clearTimeout(timer);

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1734,6 +1734,16 @@ function getNodeHTTPServerSocket() {
     }
 
     _destroy(err, callback) {
+      // Like Node.js's net.Socket._destroy (clearTimeout(s[kTimeout])): a
+      // destroyed socket must not emit 'timeout'. #onClose also clears the
+      // timer, but the native close is delivered asynchronously; an expired
+      // timer already queued would fire in between and re-enter the server's
+      // 'timeout' path on a destroyed socket.
+      const timer = this[kSocketTimeoutTimer];
+      if (timer) {
+        clearTimeout(timer);
+        this[kSocketTimeoutTimer] = undefined;
+      }
       const handle = this[kHandle];
       if (!handle) {
         if ($isCallable(callback)) callback(err);

--- a/test/js/node/http/node-http-server-timeouts.test.ts
+++ b/test/js/node/http/node-http-server-timeouts.test.ts
@@ -179,6 +179,42 @@ describe("node:http server timeout enforcement", () => {
     }
   });
 
+  test("server.setTimeout callback does not fire after the socket is destroyed (#39681)", async () => {
+    const { promise: done, resolve: onDone } = Promise.withResolvers<void>();
+    const server = http.createServer((req, res) => {
+      res.end();
+      // Hold the event loop until the socket's 50ms inactivity timer has
+      // expired, so the destroy below races a 'timeout' that is already due.
+      const deadline = Date.now() + 150;
+      while (Date.now() < deadline) {}
+      req.socket.destroy();
+      // This fresh timer is queued behind the expired inactivity timer, so
+      // by the time it runs, a stale 'timeout' (the bug) has already fired.
+      setTimeout(onDone, 100);
+    });
+    // Keep the 50ms timer in the slot across the response finish; a keep-alive
+    // timeout would replace it with a longer one.
+    server.keepAliveTimeout = 0;
+    const timeoutCalls: boolean[] = [];
+    server.setTimeout(50, (socket: net.Socket) => {
+      timeoutCalls.push(socket.destroyed);
+    });
+    const port = await listen(server);
+    try {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.on("error", () => {});
+      socket.resume();
+      socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: a\r\n\r\n"));
+      await done;
+      // Node clears the inactivity timer in Socket._destroy, so the callback
+      // never runs for a socket destroyed before the expired timer fired.
+      expect(timeoutCalls).toEqual([]);
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
+  });
+
   test("requestTimeout does not fire while a slow handler streams a response", async () => {
     // The request (a body-less GET) is complete as soon as its head is
     // parsed, so requestTimeout must stop ticking even though the handler


### PR DESCRIPTION
### Problem
- `server.setTimeout(msecs, cb)` fires `cb` a second time, on a destroyed socket, when the callback or the request handler destroys the socket. The vendored `test/js/node/test/parallel/test-http-set-timeout-server.js` fails with "Mismatched <anonymous> function calls. Expected exactly 1, actual 2." on Windows debug builds (fastTimeout case).
- The cause is `NodeHTTPServerSocket._destroy` (src/js/node/_http_server.ts). It does not clear `kSocketTimeoutTimer`. `#onClose` clears it, but the native close arrives asynchronously. An inactivity timer that expired before `destroy()` is already queued, fires in that window, and emits 'timeout' on the destroyed socket.

### Fix
- Clear the timer at the top of `_destroy`, like `net.Socket._destroy` does with `clearTimeout(s[kTimeout])` (net.ts:2196, mirroring Node).
- Correct because Node never emits 'timeout' after destroy. Node reports 0 calls on the new test scenario, unfixed bun reports 1.
- Verified: new test in `test/js/node/http/node-http-server-timeouts.test.ts` fails on unfixed bun and passes with the fix on linux and Windows. On Windows the vendored test now exits 0 (3/3, was exit 1 3/3) and the issue repro prints 1 (3/3, was 2).

### Background
- `server.setTimeout` arms one unref'd JS inactivity timer per connection. Socket activity refreshes it. When it fires, the socket emits 'timeout', which reaches the server 'timeout' listeners and the user callback.
- `socket.destroy()` closes the native handle. The close callback that clears the timer runs on a later loop iteration. The stale fire lands in that gap. Windows (libuv) delivers the close more slowly, so the issue reproduced there, but the gap exists on every platform: the new test hits it deterministically on linux.
- The "0 calls on 1.3.14" half of the issue is an older timeout bug that is already fixed on main: with a wait longer than the issue's 800ms, current builds report 1 call.

<details><summary>Notes</summary>

Reproduction mechanics: the double call needs three steps on one socket.

1. The inactivity timer fires once (the first, legitimate callback call). On the `server.timeout` path the fired timer stays in `kSocketTimeoutTimer` so `_unrefTimer()` can refresh it.
2. Activity (a new request dispatch) refreshes the timer, and it expires again while JS still holds the event loop (for example inside the request handler).
3. The handler destroys the socket. The expired timer is already queued, `_destroy` did not cancel it, and the native close that would clear it has not been delivered yet. The queued timer runs `onSocketTimeoutTimerExpired` -> `socket._onTimeout()` -> 'timeout' on the destroyed socket.

On Windows debug builds the dispatch of the first request takes longer than the 1ms timeout, so step 1 happens before the handler and the whole sequence fits in the issue's 800ms window. On linux the first fire lands on the keep-alive path instead, which drops the timer reference before emitting, so the issue's script reports 1 there.

The new test removes the race: the timer is armed at dispatch, the handler busy-waits past its expiry, then destroys the socket. A second timer queued after the destroy orders the assertion behind any stale fire. Node prints 0 calls for this scenario, unfixed bun prints 1 with `socket.destroyed === true`.

Suites run on the fixed debug build (linux): `test/js/node/http/node-http-server-timeouts.test.ts`, vendored `test-http-set-timeout-server.js`, `test-https-set-timeout-server.js`, `test-http-set-timeout.js`, `test-http-outgoing-settimeout.js`, `test-http-client-set-timeout.js`, `test-http-client-set-timeout-after-end.js`. On Windows: the new test file (7 pass), the vendored server test (3/3 exit 0), and the issue repro (3/3 prints 1).
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-timeouts.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-server-timeouts.test.ts:
(pass) node:http server timeout enforcement > headersTimeout closes a connection that never completes its request headers [703.46ms]
(pass) node:http server timeout enforcement > requestTimeout closes a connection that stalls mid-body [407.07ms]
(pass) node:http server timeout enforcement > server.setTimeout() fires the 'timeout' event for an inactive connection [281.46ms]
(pass) node:http server timeout enforcement > keepAliveTimeout closes an idle keep-alive connection after the response [1319.49ms]
(pass) node:http server timeout enforcement > headersTimeout answers 408 when there is no 'clientError' listener [317.23ms]
206 |       socket.resume();
207 |       socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: a\r\n\r\n"));
208 |       await done;
209 |       // Node clears the inactivity timer in Socket._destroy, so the callback
210 |       // never runs for a socket destroyed before th
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/node/http/node-http-server-timeouts.test.ts:
(pass) node:http server timeout enforcement > headersTimeout closes a connection that never completes its request headers [257.44ms]
(pass) node:http server timeout enforcement > requestTimeout closes a connection that stalls mid-body [354.45ms]
(pass) node:http server timeout enforcement > server.setTimeout() fires the 'timeout' event for an inactive connection [204.31ms]
(pass) node:http server timeout enforcement > keepAliveTimeout closes an idle keep-alive connection after the response [1205.16ms]
(pass) node:http server timeout enforcement > headersTimeout answers 408 when there is no 'clientError' listener [253.65ms]
206 |       socket.resume();
207 |       socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: a\r\n\r\n"));
208 |       await done;
209 |       // Node clears the inactivity timer in Socket._destroy, so the callback
210 |       // never runs for a socket destroyed before the expired timer fired.
211 |       expect(timeoutCalls).toEqual([]);
                                 ^
error: expect(received).toEqual(expected)

- []
+ [
+   true,
+ ]

- Exp
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-timeouts.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-server-timeouts.test.ts:
(pass) node:http server timeout enforcement > headersTimeout closes a connection that never completes its request headers [716.96ms]
(pass) node:http server timeout enforcement > requestTimeout closes a connection that stalls mid-body [413.49ms]
(pass) node:http server timeout enforcement > server.setTimeout() fires the 'timeout' event for an inactive connection [285.39ms]
(pass) node:http server timeout enforcement > keepAliveTimeout closes an idle keep-alive connection after the response [1327.06ms]
(pass) node:http server timeout enforcement > headersTimeout answers 408 when there is no 'clientError' listener [319.07ms]
(pass) node:http server timeout enforcement > server.setTimeout callback does not fire after the socket is destroyed (#39681) [314.10ms]
(pass) node:http server timeout enforcement > requestTimeout does not fire while a slow handler streams a response [540.87ms]

 7 pass
 0 fail
 10 ex
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b9072c96d9
  features     baseline

23 deps, 129 codegen, 1172 objects in 765ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [20.00ms]
[2/1244] gen bindgenv2
[3/1244] fetch tinycc
[tinycc] up to date
[4/1243] fetch zlib
[zlib] up to date
[5/1243] gen .bind.ts → GeneratedBindings.cpp
[6/1243] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/1243] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [1.00ms]
[8/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1216] gen ErrorCode+*.h
[10/1216] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1216] gen ba
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts                        |  6 ++++
 .../js/node/http/node-http-server-timeouts.test.ts | 36 ++++++++++++++++++++++
 2 files changed, 42 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/js/node/_http_server.ts                              8      5      0
test/js/node/http/node-http-server-timeouts.test.ts      1      1      0
```

</details>

**root cause** · written by the author bot

The root cause was that NodeHTTPServerSocket's inactivity timer was only cleared in the #onClose handler, which runs asynchronously after the native close is delivered, so a timer that had already expired when the socket was destroyed could still fire in that gap and emit a second 'timeout' event on the destroyed socket. The fix clears the timer synchronously in _destroy, mirroring what Node.js does in net.Socket._destroy, so no 'timeout' can be emitted once the socket is destroyed.

<!-- robobun:evidence:end -->