### PR TITLE
test(child_process): keep the extra stdio GC test under the timeout on debug builds

### DIFF
--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -943,16 +943,22 @@ it.skipIf(isWindows)("extra stdio pipes are not double-closed on GC", async () =
       `
         const { spawn } = require("node:child_process");
         async function once() {
-          const child = spawn(process.execPath, ["-e", ""], {
+          // The child only has to exit. Under bun bd, process.execPath is a
+          // debug build that takes 100+ ms to start on every iteration.
+          const child = spawn("true", {
             stdio: ["ignore", "ignore", "ignore", "pipe", "pipe", "pipe"],
           });
           const sockets = child.stdio.slice(3);
           if (sockets.length !== 3) throw new Error("expected 3 extra sockets");
+          const closed = Promise.all(sockets.map(s => new Promise(r => s.once("close", r))));
           await new Promise(r => child.on("exit", r));
           for (const s of sockets) s.destroy();
-          await new Promise(r => setTimeout(r, 10));
+          // A socket emits 'close' after its handle has closed the fd. From
+          // here on, a close of these fds by the Subprocess finalizer is a
+          // double close.
+          await closed;
         }
-        for (let i = 0; i < 20; i++) {
+        for (let i = 0; i < 5; i++) {
           await once();
           Bun.gc(true);
           await new Promise(r => setTimeout(r, 0));


### PR DESCRIPTION
### Problem
- On a debug build, `child_process.test.ts` fails: `(fail) extra stdio pipes are not double-closed on GC [5005.63ms]`, `this test timed out after 5000ms`.
- The test's script spawns `process.execPath` 20 times. A debug build takes 120 to 250 ms to start. Plus 40 full GCs, that is about 4.7 s.

### Fix
- Spawn `true` instead of `process.execPath`. The child only has to exit: the bug is about who closes the parent end of each pipe.
- Wait for the sockets' `'close'` events instead of a 10 ms timer. usockets closes the fd before `net.Socket` emits `'close'`, so a later close by the finalizer is a double close.
- Run 5 iterations instead of 20. With both ownership guards removed from `src` (Notes), the new script aborts at the first `Bun.gc(true)` of iteration 0 in 10 of 10 runs.
- Verified: `test/js/node/child_process/child_process.test.ts`. The GC test takes about 2.05 s on debug (8 of 8 reruns) and 42 ms on release. With the guards removed it fails: `exitCode: 134`, `panic: assertion failed: err.is_none()`.

### Background
- `node:child_process` wraps each extra `"pipe"` in a `net.Socket`. usockets closes the fd when that socket closes.
- `Subprocess::finalize_streams` (`src/runtime/api/bun/subprocess.rs`) runs when the GC collects the wrapper. It closes each slot still marked `ExtraPipe::OwnedFd`. Two guards mark the slot `UnownedFd` first: `"socket-fd"` (#32520) and the `.stdio` getter (#33828).
- On assertion builds (`bun bd`, the release-asan CI lane), `Fd::close` (`src/sys/fd.rs:73`) asserts that `close(2)` succeeded. A double close is EBADF, so the script aborts (exit code 134).

<details><summary>Notes</summary>

The release binary (1.4.0) passes the current test in about 330 ms. The behavior under test is fine. Only the time budget is too small for a debug build.

Timing on the debug build (16 vCPU, idle). The script alone, without the test runner:

| script | wall time |
| --- | --- |
| current test (bun child, 20 iterations) | 4.69 s, 4.71 s |
| `true` child, 5 iterations | 1.62 s, 1.71 s, 1.64 s |
| `true` child, 10 iterations | 2.04 s, 2.03 s, 2.08 s |
| `true` child, 20 iterations | 2.87 s, 2.94 s, 2.82 s |

Per iteration with the bun child: 125 to 250 ms for spawn and exit, 40 to 100 ms for the two GCs. The test runner's own start of the script adds the rest of the 5 s.

Every variant pays a fixed cost of about 1.3 s: process start of the debug binary is about 250 ms, `require("node:child_process")` about 290 ms, and the first `require("node:net")` about 355 ms. That is most of the 2.05 s the test takes now.

`bun -v` costs the same as `bun -e ""` on the debug build (about 120 ms each). The cost is the start of the binary, not the JS it runs, so a cheaper bun flag does not help. The old child did not run any JS either: on main, `bun -e ""` prints the help text and exits. So the switch to `true` removes no coverage of bun as the child.

`cmd: ["true"]` is what the POSIX spawn tests use for a child that exits at once (for example `test/js/bun/spawn/spawn-stdin-pipe-fd-leak.test.ts`). This test skips Windows.

To confirm the new test still detects the bug, I built a scratch binary with both guards disabled behind an environment variable: the `"pipe"` to `"socket-fd"` loop in `src/js/node/child_process.ts`, and the `OwnedFd` to `UnownedFd` downgrade in `Subprocess::get_stdio`. With that binary:

- the current script aborts in iteration 0 in 5 of 5 runs,
- the new script aborts in iteration 0 at the first `Bun.gc(true)` in 10 of 10 runs,
- the new test fails with `exitCode: 134` and `panic: assertion failed: err.is_none()` in `Subprocess::finalize_streams`.

The scratch change is not part of this PR. The extra iterations only cover a GC pass that does not collect the wrapper on one try.

Why the `'close'` wait is correct: `Socket.prototype._destroy` calls `closeSocketHandle`, which calls `handle.close()` and then emits `'close'` from a `setImmediate`. `handle.close()` runs `us_socket_close`, which calls `bsd_close_socket` before it dispatches the close callback (`packages/bun-usockets/src/socket.c`). The listeners are attached right after `spawn()`, so a socket that closes before `destroy()` is not missed either. In 60 traced closes, none did.

`spawn() > should allow us to spawn in the default shell` also fails in my container, with the release binary too. `$SHELL` is not exported there. It is not related to this change.

#38587 touches the same test. It gives the test a 30 s timeout because its change makes `bun -e ""` boot the runtime. With this PR the test does not spawn bun, so that hunk is not needed after a rebase.

A self-review of the diff (edge cases, coverage, alternatives such as keeping `process.execPath` with fewer iterations, or adding an fd-recycling check) raised no concern that needs a change.

Suites run: `test/js/node/child_process/child_process.test.ts` on the debug build (65 pass, 2 skip, plus the `$SHELL` failure above) and with `USE_SYSTEM_BUN=1` (same result).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->