### PR TITLE
Bun.serve: require a boolean for reusePort and ipv6Only

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1311,15 +1311,15 @@ impl ServerConfig {
             }
         }
 
-        if let Some(dev) = arg.get(global, "reusePort")? {
-            args.reuse_port = dev.to_boolean();
+        if let Some(reuse_port) = arg.get_boolean_strict(global, "reusePort")? {
+            args.reuse_port = reuse_port;
         }
         if global.has_exception() {
             return Err(JsError::Thrown);
         }
 
-        if let Some(dev) = arg.get(global, "ipv6Only")? {
-            args.ipv6_only = dev.to_boolean();
+        if let Some(ipv6_only) = arg.get_boolean_strict(global, "ipv6Only")? {
+            args.ipv6_only = ipv6_only;
         }
         if global.has_exception() {
             return Err(JsError::Thrown);

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -461,6 +461,107 @@ describe("Bun.serve hostname and port validation", () => {
   });
 });
 
+describe("Bun.serve reusePort and ipv6Only must be booleans", () => {
+  // Every one of these is truthy or falsy under ToBoolean. Coercing them
+  // silently turned `reusePort: "false"` (an env var) into SO_REUSEPORT.
+  const nonBooleans: { value: unknown; name: string }[] = [
+    { value: "false", name: '"false"' },
+    { value: "0", name: '"0"' },
+    { value: "true", name: '"true"' },
+    { value: "", name: '""' },
+    { value: 0, name: "0" },
+    { value: 1, name: "1" },
+    { value: -1, name: "-1" },
+    { value: NaN, name: "NaN" },
+    { value: null, name: "null" },
+    { value: {}, name: "{}" },
+    { value: [], name: "[]" },
+    { value: new Boolean(false), name: "new Boolean(false)" },
+    { value: () => false, name: "() => false" },
+    { value: Symbol("reuse"), name: "Symbol()" },
+  ];
+
+  function serveWith(option: "reusePort" | "ipv6Only", value: unknown) {
+    return serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      [option]: value as boolean,
+      fetch() {
+        return new Response("ok");
+      },
+    });
+  }
+
+  for (const option of ["reusePort", "ipv6Only"] as const) {
+    describe(option, () => {
+      for (const { value, name } of nonBooleans) {
+        test(`${name} throws ERR_INVALID_ARG_TYPE`, () => {
+          expect(() => {
+            using server = serveWith(option, value);
+          }).toThrow(
+            expect.objectContaining({
+              code: "ERR_INVALID_ARG_TYPE",
+              message: expect.stringContaining(`"${option}"`),
+            }),
+          );
+        });
+      }
+
+      for (const value of [true, false, undefined]) {
+        test(`${value} is accepted`, () => {
+          using server = serveWith(option, value);
+          expect(server.port).toBeGreaterThan(0);
+          server.stop(true);
+        });
+      }
+
+      test(`server.reload() rejects a non-boolean ${option}`, () => {
+        using server = serveWith(option, false);
+        expect(() =>
+          server.reload({
+            [option]: "false" as unknown as boolean,
+            fetch() {
+              return new Response("reloaded");
+            },
+          }),
+        ).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+        server.stop(true);
+      });
+    });
+  }
+
+  test("reusePort: false keeps a second server off the port", () => {
+    using first = serveWith("reusePort", false);
+    expect(() => {
+      using second = serve({
+        port: first.port,
+        hostname: "127.0.0.1",
+        reusePort: false,
+        fetch() {
+          return new Response("second");
+        },
+      });
+    }).toThrow(expect.objectContaining({ code: "EADDRINUSE" }));
+    first.stop(true);
+  });
+
+  // reusePort is a no-op on Windows: SO_REUSEPORT does not exist there.
+  test.skipIf(isWindows)("reusePort: true lets a second server share the port", () => {
+    using first = serveWith("reusePort", true);
+    using second = serve({
+      port: first.port,
+      hostname: "127.0.0.1",
+      reusePort: true,
+      fetch() {
+        return new Response("second");
+      },
+    });
+    expect(second.port).toBe(first.port);
+    second.stop(true);
+    first.stop(true);
+  });
+});
+
 describe("Bun.serve hostname coercion", () => {
   // Windows can't bind to hostname "0" (POSIX resolves it to 0.0.0.0).
   test.skipIf(isWindows)("number hostnames coerce to string", () => {


### PR DESCRIPTION
### Problem
- `Bun.serve()` reads `reusePort` and `ipv6Only` with ToBoolean (`src/runtime/server/ServerConfig.rs:1314` and `:1321`). `"false"`, `"0"`, `{}`, `[]` and `-1` all turn the option on.
- `reusePort: "false"` (for example a value from an env var) sets `SO_REUSEPORT`. A second instance of the app then binds the same port and takes about half of the connections instead of failing with `EADDRINUSE`.
- `Bun.listen()`, `net.Server` and `development.hmr` already throw `ERR_INVALID_ARG_TYPE` for these values.

### Fix
- Read both options with `JSValue::get_boolean_strict`. `undefined` keeps the default. A boolean sets the option. Any other value, `null` included, throws `TypeError [ERR_INVALID_ARG_TYPE]: The "reusePort" property must be of type boolean, got string`.
- This is the reader the `development` object uses a few lines above, so the error text and the `null` handling match `development.hmr` and `Bun.listen()`.
- `server.reload()` uses the same parser, so it rejects the same values.
- Verified: `test/js/bun/http/bun-serve-args.test.ts` (30 of 38 new cases fail on bun 1.4.0, all pass here). Also `serve-listen.test.ts` and the node reuseport and cluster tests.

### Background
- `SO_REUSEPORT` is a socket option. When every listener on an address sets it, several sockets can bind the same port and share the connections. Without it the second `bind()` fails with `EADDRINUSE`. Windows has no such option, so the new dual-bind test skips Windows.
- `IPV6_V6ONLY` (`ipv6Only`) controls whether a `::` listener also accepts IPv4 connections.
- `ServerConfig::from_js` parses the `Bun.serve()` options object for both `Bun.serve()` and `server.reload()`. `Bun.listen()` uses a generated parser (`SocketConfig.bindv2.ts`) whose `b.bool` fields are strict.

<details><summary>Notes</summary>

Observed on stock bun 1.4.0 with two `Bun.serve()` calls on the same `127.0.0.1` port:

| `reusePort` value | second bind |
| --- | --- |
| `"false"`, `"0"`, `"no"`, `{}`, `[]`, `-1`, `1.5`, `Symbol()`, `new Boolean(false)`, `() => false`, `true` | succeeds (`SO_REUSEPORT` on) |
| `false`, `null`, `0`, `""`, `NaN` | `EADDRINUSE` |

`ipv6Only: "false"` and `ipv6Only: {}` on a `::` listener made `127.0.0.1` unreachable, the same as `ipv6Only: true`.

Oracles on the same binary: `Bun.listen({ reusePort: "false" })` throws `ERR_INVALID_ARG_TYPE SocketOptions.reusePort must be a boolean`, and so does `reusePort: null`. `Bun.serve({ development: { hmr: "false" } })` throws `The "hmr" property must be of type boolean, got string`, and so does `hmr: null`. The new reader gives `reusePort` and `ipv6Only` the same behavior, so `null` is now rejected where it used to mean `false`.

`packages/bun-types/serve.d.ts` already types both options as `boolean`.

Callers inside Bun: `node:http` (`src/js/node/_http_server.ts`) passes a literal boolean to `Bun.serve()`. `node:net` goes through `Bun.listen()`. `src/js/internal/html.ts` and `debugger.ts` pass neither option. The `reusePort` default that `development: false` implies (`ServerConfig.rs:841`) is unchanged.

Suites run with the debug build: `bun-serve-args.test.ts`, `serve-listen.test.ts`, `test-net-reuseport.js`, `test-cluster-net-reuseport.js`, `test-child-process-net-reuseport.js`, `test-cluster-listening-port.js`, `test/js/node/cluster/test-docs-http-server.ts`.

Out of scope: the `development` option itself still coerces a non-object value with ToBoolean. #35140 covers it. `http1` and `http3` also use ToBoolean. They select a protocol and do not relax a security setting, so this change leaves them alone.

The two `global.has_exception()` checks after the reads are redundant with `?`. They stay because every other read in `from_js` has one.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/http/bun-serve-args.test.ts

<!-- robobun:evidence:end -->