### PR TITLE
Make concurrent bun test and bun install processes safe on shared files

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -105,6 +105,11 @@ new!(pub BUN_INSTALL_STREAMING_MIN_SIZE: unsigned, "BUN_INSTALL_STREAMING_MIN_SI
 // thread schedules a drain; collapses the per-chunk thread-pool futex wake
 // into roughly one per `threshold` bytes.
 new!(pub BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: unsigned, "BUN_INSTALL_STREAMING_DRAIN_THRESHOLD", { default: 256 * 1024 });
+// Set in the environment of the lifecycle scripts that a package manager process runs while it
+// holds the lock of the project at this path (`lock_project` in bun_install). A bun process that
+// such a script starts to edit the same project runs under its parent's lock instead of waiting
+// for it forever.
+new!(pub BUN_INTERNAL_INSTALL_LOCK_DIR: string, "BUN_INTERNAL_INSTALL_LOCK_DIR", {});
 new!(pub BUN_NEEDS_PROC_SELF_WORKAROUND: boolean, "BUN_NEEDS_PROC_SELF_WORKAROUND", { default: false });
 new!(pub BUN_OPTIONS: string, "BUN_OPTIONS", {});
 new!(pub BUN_POSTGRES_SOCKET_MONITOR: string, "BUN_POSTGRES_SOCKET_MONITOR", {});

--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -105,10 +105,7 @@ new!(pub BUN_INSTALL_STREAMING_MIN_SIZE: unsigned, "BUN_INSTALL_STREAMING_MIN_SI
 // thread schedules a drain; collapses the per-chunk thread-pool futex wake
 // into roughly one per `threshold` bytes.
 new!(pub BUN_INSTALL_STREAMING_DRAIN_THRESHOLD: unsigned, "BUN_INSTALL_STREAMING_DRAIN_THRESHOLD", { default: 256 * 1024 });
-// Set in the environment of the lifecycle scripts that a package manager process runs while it
-// holds the lock of the project at this path (`lock_project` in bun_install). A bun process that
-// such a script starts to edit the same project runs under its parent's lock instead of waiting
-// for it forever.
+// The project a parent bun process holds the install lock of; see `lock_project` in bun_install.
 new!(pub BUN_INTERNAL_INSTALL_LOCK_DIR: string, "BUN_INTERNAL_INSTALL_LOCK_DIR", {});
 new!(pub BUN_NEEDS_PROC_SELF_WORKAROUND: boolean, "BUN_NEEDS_PROC_SELF_WORKAROUND", { default: false });
 new!(pub BUN_OPTIONS: string, "BUN_OPTIONS", {});

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -339,8 +339,7 @@ pub struct PackageManager {
     /// Only set in `bun pm`
     pub root_package_json_name_at_time_of_init: Box<[u8]>,
 
-    /// The lock file of the project this process edits, held (see `lock_project`) until the
-    /// process exits. `None` while no lock is held.
+    /// Held from `lock_project` until the process exits.
     pub(crate) project_lock: Option<bun_sys::File>,
 
     /// The package id corresponding to the workspace the install is happening in. Could be root, or
@@ -544,9 +543,7 @@ impl Subcommand {
         !matches!(self, Self::Link)
     }
 
-    /// Subcommands that rewrite package.json, the lockfile or node_modules on every run, and so
-    /// hold the project lock (`lock_project`) from `init` on. `Pm` and `Audit` only write for
-    /// some of their arguments; those commands take the lock themselves.
+    /// `init` takes the project lock for these. `Pm` and `Audit` take it themselves when they edit.
     pub(crate) fn always_edits_project(self) -> bool {
         matches!(
             self,
@@ -1884,9 +1881,7 @@ pub fn init(
             root_buf[..p.len()].copy_from_slice(p);
             p.len()
         } else {
-            // The cwd is the project root now. Resolved by name rather than through the fd:
-            // package.json is replaced by rename (`write_file_atomically`), and once another
-            // process has done that, the fd's path names a deleted file.
+            // By name, not through the fd: another process may have renamed a new file over it.
             match bun_sys::realpath(bun_core::zstr!("package.json"), root_buf) {
                 Ok(path) => path.len(),
                 Err(_) => bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?.len(),
@@ -2277,8 +2272,7 @@ pub fn init(
 
         if subcommand.always_edits_project() && !manager.options.dry_run {
             manager.lock_project();
-            // The workspace package.json files read while looking for the root above were read
-            // before the lock. Edits start from what is on disk now that this process holds it.
+            // The workspace walk above read package.json files before the lock was held.
             manager.workspace_package_json_cache.map.clear();
         }
     }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2265,8 +2265,6 @@ pub fn init(
 
         if subcommand.always_edits_project() && !manager.options.dry_run {
             manager.lock_project();
-            // The workspace walk above read package.json files before the lock was held.
-            manager.workspace_package_json_cache.map.clear();
         }
     }
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1828,10 +1828,6 @@ pub fn init(
                                 // process-lifetime (`set_top_level_dir` requires `'static`).
                                 fs.set_top_level_dir(fs.dirname_store().append(parent)?);
                                 let _ = child_json.close();
-                                #[cfg(windows)]
-                                {
-                                    json_file.seek_to(0)?;
-                                }
                                 workspace_name_hash =
                                     Some(Semver::string::Builder::string_hash(&entry.name));
                                 break 'root_package_json_file json_file;

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -339,7 +339,9 @@ pub struct PackageManager {
     /// Only set in `bun pm`
     pub root_package_json_name_at_time_of_init: Box<[u8]>,
 
-    pub root_package_json_file: bun_sys::File,
+    /// The lock file of the project this process edits, held (see `lock_project`) until the
+    /// process exits. `None` while no lock is held.
+    pub(crate) project_lock: Option<bun_sys::File>,
 
     /// The package id corresponding to the workspace the install is happening in. Could be root, or
     /// could be any of the workspaces.
@@ -540,6 +542,24 @@ impl Subcommand {
     // TODO: make all subcommands find root and chdir
     pub(crate) fn should_chdir_to_root(self) -> bool {
         !matches!(self, Self::Link)
+    }
+
+    /// Subcommands that rewrite package.json, the lockfile or node_modules on every run, and so
+    /// hold the project lock (`lock_project`) from `init` on. `Pm` and `Audit` only write for
+    /// some of their arguments; those commands take the lock themselves.
+    pub(crate) fn always_edits_project(self) -> bool {
+        matches!(
+            self,
+            Self::Install
+                | Self::Update
+                | Self::Add
+                | Self::Remove
+                | Self::Link
+                | Self::Patch
+                | Self::PatchCommit
+                | Self::Dedupe
+                | Self::Prune
+        )
     }
 }
 
@@ -1864,7 +1884,13 @@ pub fn init(
             root_buf[..p.len()].copy_from_slice(p);
             p.len()
         } else {
-            bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?.len()
+            // The cwd is the project root now. Resolved by name rather than through the fd:
+            // package.json is replaced by rename (`write_file_atomically`), and once another
+            // process has done that, the fd's path names a deleted file.
+            match bun_sys::realpath(bun_core::zstr!("package.json"), root_buf) {
+                Ok(path) => path.len(),
+                Err(_) => bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?.len(),
+            }
         };
         root_buf[plen] = 0;
         ROOT_PACKAGE_JSON_PATH.write(ZStr::from_raw(root_buf.as_ptr(), plen));
@@ -2061,7 +2087,7 @@ pub fn init(
         // zero-bit pattern is UB; allocate the real (empty) lockfile here directly.
         // `Lockfile::default()` ≡ `Lockfile::init_empty()`.
         wr!(lockfile, Box::new(Lockfile::default()));
-        wr!(root_package_json_file, root_package_json_file);
+        wr!(project_lock, None);
         // .progress
         wr!(event_loop, AnyEventLoop::init());
         wr!(
@@ -2247,6 +2273,13 @@ pub fn init(
             if let Some(p) = config.hoist_pattern.take() {
                 manager.options.hoist_pattern = Some(p);
             }
+        }
+
+        if subcommand.always_edits_project() && !manager.options.dry_run {
+            manager.lock_project();
+            // The workspace package.json files read while looking for the root above were read
+            // before the lock. Edits start from what is on disk now that this process holds it.
+            manager.workspace_package_json_cache.map.clear();
         }
     }
 
@@ -2501,13 +2534,7 @@ fn init_with_runtime_once(
         // `Lockfile` holds `HashMap`/`Vec`/`NonNull` (zero-bit pattern is
         // UB), so allocate the real empty lockfile here directly instead of a zeroed placeholder.
         wr!(lockfile, Box::new(Lockfile::default()));
-        // `.root_package_json_file` is never read in the runtime
-        // path. Use the explicit invalid-fd sentinel rather than `mem::zeroed()` —
-        // on posix `Fd(0)` is stdin, not the invalid marker.
-        wr!(
-            root_package_json_file,
-            bun_sys::File::from_fd(Fd::invalid())
-        );
+        wr!(project_lock, None);
         // erased *mut () set by tier-6; `js_current()` resolves the per-thread JS
         // event loop via `bun_io::__bun_get_vm_ctx` (link-time, definer in bun_runtime).
         wr!(event_loop, AnyEventLoop::js_current());

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1850,6 +1850,8 @@ pub fn init(
         fs.set_top_level_dir(fs.dirname_store().append(child_cwd)?);
         break 'root_package_json_file child_json;
     };
+    // Opened to report a package.json that cannot be written to. The commands read it by path.
+    drop(root_package_json_file);
 
     let top_level_dir_z = ZBox::from_bytes(fs.top_level_dir());
     bun_sys::chdir(&top_level_dir_z)?;
@@ -1872,21 +1874,12 @@ pub fn init(
         // until now). The slice excludes the NUL — `top_level_dir` is `[]u8`.
         // PathBuffer is repr(transparent) over [u8; N], so the raw cast is sound.
         fs.set_top_level_dir(bun_core::ffi::slice(CWD_BUF.get().cast::<u8>(), tld.len()));
-        // bun_sys exposes the non-Z `get_fd_path`;
-        // append the NUL ourselves so the static `&ZStr` invariant holds.
+        // By name, not through the file opened above: another process may replace that file.
         let root_buf = &mut *ROOT_PACKAGE_JSON_PATH_BUF.get();
-        let plen = if no_project {
-            // Where the file would be; nothing reads it in this mode.
-            let p = original_package_json_path.as_bytes();
-            root_buf[..p.len()].copy_from_slice(p);
-            p.len()
-        } else {
-            // By name, not through the fd: another process may have renamed a new file over it.
-            match bun_sys::realpath(bun_core::zstr!("package.json"), root_buf) {
-                Ok(path) => path.len(),
-                Err(_) => bun_sys::get_fd_path(root_package_json_file.handle, root_buf)?.len(),
-            }
-        };
+        let tld_no_slash = strings::without_trailing_slash(tld);
+        let plen = tld_no_slash.len() + SEP_PACKAGE_JSON.len();
+        root_buf[..tld_no_slash.len()].copy_from_slice(tld_no_slash);
+        root_buf[tld_no_slash.len()..plen].copy_from_slice(SEP_PACKAGE_JSON);
         root_buf[plen] = 0;
         ROOT_PACKAGE_JSON_PATH.write(ZStr::from_raw(root_buf.as_ptr(), plen));
     }

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -79,8 +79,13 @@ pub fn lock_project(this: &mut PackageManager) {
     if this.project_lock.is_some() {
         return;
     }
-    let project_dir =
-        bun_core::strings::without_trailing_slash(FileSystem::instance().top_level_dir());
+    // Canonical: a junction or another case of the same directory must lock the same file.
+    let top_level_dir = FileSystem::instance().top_level_dir();
+    let top_level_dir_z = ZBox::from_bytes(top_level_dir);
+    let mut project_dir_buf = path::path_buffer_pool::get();
+    let project_dir = bun_core::strings::without_trailing_slash(
+        sys::realpath(top_level_dir_z.as_zstr(), &mut project_dir_buf).unwrap_or(top_level_dir),
+    );
     if env_var::BUN_INTERNAL_INSTALL_LOCK_DIR
         .get()
         .is_some_and(|held| bun_core::strings::without_trailing_slash(held) == project_dir)

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -88,7 +88,8 @@ pub fn lock_project(this: &mut PackageManager) {
     if this.project_lock.is_some() {
         return;
     }
-    let project_dir = bun_core::strings::without_trailing_slash(FileSystem::instance().top_level_dir());
+    let project_dir =
+        bun_core::strings::without_trailing_slash(FileSystem::instance().top_level_dir());
     if env_var::BUN_INTERNAL_INSTALL_LOCK_DIR
         .get()
         .is_some_and(|held| bun_core::strings::without_trailing_slash(held) == project_dir)
@@ -115,7 +116,11 @@ pub fn lock_project(this: &mut PackageManager) {
         Err(_) => false,
     };
     if !locked {
-        bun_core::scoped_log!(project_lock, "could not lock {}", bstr::BStr::new(project_dir));
+        bun_core::scoped_log!(
+            project_lock,
+            "could not lock {}",
+            bstr::BStr::new(project_dir)
+        );
         return;
     }
 

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -123,6 +123,8 @@ pub fn lock_project(this: &mut PackageManager) {
         return;
     }
 
+    // The process this one may have waited for has rewritten the package.json files read so far.
+    this.workspace_package_json_cache.map.clear();
     bun_core::handle_oom(
         this.env_mut()
             .map

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -74,8 +74,7 @@ impl PackageManager {
 
 // ───────────────────────────── project lock ───────────────────────────────────
 
-/// Holds `<cache dir>/.locks/<hash of the project root>` until the process exits, so that the
-/// processes that edit one project run one at a time. Best effort: without a lock file, no lock.
+/// Serializes the processes that edit one project; held until exit, and best effort.
 pub fn lock_project(this: &mut PackageManager) {
     if this.project_lock.is_some() {
         return;

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -65,6 +65,96 @@ impl PackageManager {
     pub(crate) fn get_temporary_directory(&mut self) -> &'static TemporaryDirectory {
         get_temporary_directory(self)
     }
+
+    #[inline]
+    pub fn lock_project(&mut self) {
+        lock_project(self)
+    }
+}
+
+// ───────────────────────────── project lock ───────────────────────────────────
+
+/// Makes the bun processes that edit one project run one at a time. Without it, `bun add` and
+/// `bun remove` started together each read package.json and bun.lock, and the one that writes
+/// last silently drops the other one's edit; two installs also undo each other's work while they
+/// place the same packages in node_modules. The lock is a file in the install cache directory,
+/// named after the project root, locked with `flock` (see `File::lock_exclusive`) and held until
+/// this process exits. Lifecycle scripts get `BUN_INTERNAL_INSTALL_LOCK_DIR` so that a bun they
+/// run in the same project does not wait for this process.
+///
+/// Best effort: when the lock file cannot be created or locked, the command runs without it,
+/// as every command did before the lock existed. Calling this again is a no-op.
+pub fn lock_project(this: &mut PackageManager) {
+    if this.project_lock.is_some() {
+        return;
+    }
+    let project_dir = bun_core::strings::without_trailing_slash(FileSystem::instance().top_level_dir());
+    if env_var::BUN_INTERNAL_INSTALL_LOCK_DIR
+        .get()
+        .is_some_and(|held| bun_core::strings::without_trailing_slash(held) == project_dir)
+    {
+        return;
+    }
+
+    let Some(lock_file) = open_project_lock_file(this, project_dir) else {
+        bun_core::scoped_log!(project_lock, "no lock for {}", bstr::BStr::new(project_dir));
+        return;
+    };
+    let locked = match lock_file.lock_exclusive(false) {
+        Ok(true) => true,
+        Ok(false) => {
+            if !this.options.log_level.is_silent() {
+                bun_core::pretty_errorln!(
+                    "<d>Waiting for another bun process to finish in {}<r>",
+                    bstr::BStr::new(project_dir)
+                );
+                Output::flush();
+            }
+            matches!(lock_file.lock_exclusive(true), Ok(true))
+        }
+        Err(_) => false,
+    };
+    if !locked {
+        bun_core::scoped_log!(project_lock, "could not lock {}", bstr::BStr::new(project_dir));
+        return;
+    }
+
+    bun_core::handle_oom(
+        this.env_mut()
+            .map
+            .put(env_var::BUN_INTERNAL_INSTALL_LOCK_DIR.key(), project_dir),
+    );
+    this.project_lock = Some(lock_file);
+}
+
+bun_core::declare_scope!(project_lock, hidden);
+
+/// `<cache dir>/.locks/<hash of the project root>`. Opened read-only: `flock` does not need write
+/// access, so a lock file created by another user of a shared cache directory works too.
+fn open_project_lock_file(this: &mut PackageManager, project_dir: &[u8]) -> Option<File> {
+    let mut locks_dir_path = fetch_cache_directory_path(this.env_mut(), Some(&this.options)).path;
+    if locks_dir_path.last() != Some(&SEP) {
+        locks_dir_path.push(SEP);
+    }
+    locks_dir_path.extend_from_slice(b".locks");
+    let locks_dir = Dir::cwd()
+        .make_open_path(&locks_dir_path, Default::default())
+        .ok()?;
+
+    let mut lock_file_name = [0u8; b"0123456789abcdef.lock".len()];
+    write!(
+        &mut lock_file_name[..],
+        "{:016x}.lock",
+        bun_wyhash::hash(project_dir)
+    )
+    .expect("the buffer is sized for this format");
+    File::openat(
+        locks_dir.fd(),
+        &lock_file_name,
+        sys::O::RDONLY | sys::O::CREAT | sys::O::CLOEXEC,
+        0o644,
+    )
+    .ok()
 }
 
 // ───────────────────────────── cache directory ────────────────────────────────
@@ -1052,14 +1142,27 @@ pub fn compute_cache_dir_and_subpath<'a>(
 // ─────────────────────────── package.json / lockfile ──────────────────────────
 
 pub(crate) fn attempt_to_create_package_json_and_open() -> Result<File, Error> {
-    let package_json_file = match Dir::cwd().create_file_z(
-        z_static(b"package.json\0"),
-        sys::CreateFlags {
-            read: true,
-            ..Default::default()
-        },
+    let open_flags = sys::O::RDWR | sys::O::CLOEXEC;
+    let opened = match File::openat(
+        Fd::cwd(),
+        b"package.json",
+        open_flags | sys::O::CREAT | sys::O::EXCL,
+        0o666,
     ) {
-        Ok(f) => f,
+        Ok(package_json_file) => {
+            package_json_file.pwrite_all(b"{\"dependencies\": {}}", 0)?;
+            return Ok(package_json_file);
+        }
+        // Another bun process created it after this one found none. That process writes the
+        // initial contents; until it does, the empty file parses as `{}`.
+        Err(err) if err.get_errno() == sys::E::EEXIST => {
+            File::openat(Fd::cwd(), b"package.json", open_flags, 0)
+        }
+        Err(err) => Err(err),
+    };
+
+    match opened {
+        Ok(package_json_file) => Ok(package_json_file),
         Err(err) => {
             bun_core::pretty_errorln!(
                 "<r><red>error:<r> {} create package.json",
@@ -1067,11 +1170,7 @@ pub(crate) fn attempt_to_create_package_json_and_open() -> Result<File, Error> {
             );
             Global::crash();
         }
-    };
-
-    package_json_file.pwrite_all(b"{\"dependencies\": {}}", 0)?;
-
-    Ok(package_json_file)
+    }
 }
 
 pub fn attempt_to_create_package_json() -> Result<(), Error> {

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -74,16 +74,8 @@ impl PackageManager {
 
 // ───────────────────────────── project lock ───────────────────────────────────
 
-/// Makes the bun processes that edit one project run one at a time. Without it, `bun add` and
-/// `bun remove` started together each read package.json and bun.lock, and the one that writes
-/// last silently drops the other one's edit; two installs also undo each other's work while they
-/// place the same packages in node_modules. The lock is a file in the install cache directory,
-/// named after the project root, locked with `sys::flock` and held until
-/// this process exits. Lifecycle scripts get `BUN_INTERNAL_INSTALL_LOCK_DIR` so that a bun they
-/// run in the same project does not wait for this process.
-///
-/// Best effort: when the lock file cannot be created or locked, the command runs without it,
-/// as every command did before the lock existed. Calling this again is a no-op.
+/// Holds `<cache dir>/.locks/<hash of the project root>` until the process exits, so that the
+/// processes that edit one project run one at a time. Best effort: without a lock file, no lock.
 pub fn lock_project(this: &mut PackageManager) {
     if this.project_lock.is_some() {
         return;
@@ -137,8 +129,7 @@ pub fn lock_project(this: &mut PackageManager) {
 
 bun_core::declare_scope!(project_lock, hidden);
 
-/// `<cache dir>/.locks/<hash of the project root>`. Opened read-only: `flock` does not need write
-/// access, so a lock file created by another user of a shared cache directory works too.
+/// Read-only: `flock` does not need more, and another user may own the file in a shared cache.
 fn open_project_lock_file(this: &mut PackageManager, project_dir: &[u8]) -> Option<File> {
     let mut locks_dir_path = fetch_cache_directory_path(this.env_mut(), Some(&this.options)).path;
     if locks_dir_path.last() != Some(&SEP) {
@@ -1161,8 +1152,7 @@ pub(crate) fn attempt_to_create_package_json_and_open() -> Result<File, Error> {
             package_json_file.pwrite_all(b"{\"dependencies\": {}}", 0)?;
             return Ok(package_json_file);
         }
-        // Another bun process created it after this one found none. That process writes the
-        // initial contents; until it does, the empty file parses as `{}`.
+        // Another process created it first and writes the contents; an empty file parses as `{}`.
         Err(err) if err.get_errno() == sys::E::EEXIST => {
             File::openat(Fd::cwd(), b"package.json", open_flags, 0)
         }

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -78,7 +78,7 @@ impl PackageManager {
 /// `bun remove` started together each read package.json and bun.lock, and the one that writes
 /// last silently drops the other one's edit; two installs also undo each other's work while they
 /// place the same packages in node_modules. The lock is a file in the install cache directory,
-/// named after the project root, locked with `flock` (see `File::lock_exclusive`) and held until
+/// named after the project root, locked with `sys::flock` and held until
 /// this process exits. Lifecycle scripts get `BUN_INTERNAL_INSTALL_LOCK_DIR` so that a bun they
 /// run in the same project does not wait for this process.
 ///
@@ -101,7 +101,7 @@ pub fn lock_project(this: &mut PackageManager) {
         bun_core::scoped_log!(project_lock, "no lock for {}", bstr::BStr::new(project_dir));
         return;
     };
-    let locked = match lock_file.lock_exclusive(false) {
+    let locked = match sys::flock(lock_file.handle, sys::FileLockMode::Exclusive, true) {
         Ok(true) => true,
         Ok(false) => {
             if !this.options.log_level.is_silent() {
@@ -111,7 +111,10 @@ pub fn lock_project(this: &mut PackageManager) {
                 );
                 Output::flush();
             }
-            matches!(lock_file.lock_exclusive(true), Ok(true))
+            matches!(
+                sys::flock(lock_file.handle, sys::FileLockMode::Exclusive, false),
+                Ok(true)
+            )
         }
         Err(_) => false,
     };

--- a/src/install/PackageManager/add_remove_with_filter.rs
+++ b/src/install/PackageManager/add_remove_with_filter.rs
@@ -11,7 +11,7 @@ use bun_install::dependency;
 use bun_install::{Lockfile, PackageID, PackageNameHash};
 use bun_paths::path_buffer_pool;
 use bun_paths::resolve_path::{self, Platform, join_abs_string_buf, platform};
-use bun_sys::{Fd, File};
+use bun_sys::File;
 
 use super::add_catalog;
 use super::install_with_manager::install_with_manager;
@@ -295,7 +295,7 @@ pub(crate) fn write_target(manager: &mut PackageManager, target: &WorkspaceTarge
     let entry = fetch_entry(manager, target);
     let mut zbuf = path_buffer_pool::get();
     let path = resolve_path::z(&target.package_json_path, &mut zbuf);
-    match File::write_file(Fd::cwd(), path, &entry.source.contents) {
+    match File::write_file_atomically(path, &entry.source.contents, 0o644) {
         Ok(()) => true,
         Err(err) => {
             Output::err_generic(

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -12,7 +12,7 @@ use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
 use bun_js_printer as js_printer;
 use bun_paths::{self, PathBuffer};
-use bun_sys::{self, Fd, File};
+use bun_sys::{self, File};
 
 use super::add_catalog;
 use super::add_remove_with_filter::WorkspaceTarget;
@@ -698,14 +698,7 @@ fn update_package_json_and_install_with_manager_with_updates(
 
         // Now that we've run the install step
         // We can save our in-memory package.json to disk
-        let workspace_package_json_file =
-            File::openat(Fd::cwd(), path, bun_sys::O::RDWR, 0).map_err(Error::from)?;
-
-        workspace_package_json_file
-            .pwrite_all(source, 0)
-            .map_err(Error::from)?;
-        let _ = bun_sys::ftruncate(workspace_package_json_file.handle, source.len() as i64);
-        let _ = workspace_package_json_file.close(); // close error is non-actionable
+        File::write_file_atomically(path, source, 0o644).map_err(Error::from)?;
 
         if subcommand == Subcommand::Remove {
             if !any_changes {

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1322,10 +1322,7 @@ impl<'a> Linker<'a> {
         Self::chmod_on_ok(self.err, abs_target);
     }
 
-    /// A destination that already links to `rel_target` counts as linked: a
-    /// repeat install must not unlink and recreate it, and concurrent installs
-    /// into one directory (`bunx` runs one `bun add` per invocation in a shared
-    /// install dir) race to create the same link.
+    /// A link that already points at `rel_target` (a repeat or a concurrent install) is kept.
     #[cfg(not(windows))]
     fn symlink_or_keep(rel_target: &ZStr, abs_dest: &ZStr) -> sys::Result<()> {
         match sys::symlink_running_executable(rel_target, abs_dest) {

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1268,7 +1268,7 @@ impl<'a> Linker<'a> {
 
         debug_assert!(strings::has_prefix(rel_target.as_bytes(), b".."));
 
-        match sys::symlink_running_executable(rel_target, abs_dest) {
+        match Self::symlink_or_keep(rel_target, abs_dest) {
             sys::Result::Err(err) => {
                 if err.get_errno() != sys::Errno::EEXIST && err.get_errno() != sys::Errno::ENOENT {
                     self.err = Some(err.into());
@@ -1291,7 +1291,7 @@ impl<'a> Linker<'a> {
                     let _ = sys::Dir::cwd().make_path(self.node_modules_path.slice());
                     self.node_modules_path.set_length(node_modules_path_save);
 
-                    match sys::symlink_running_executable(rel_target, abs_dest) {
+                    match Self::symlink_or_keep(rel_target, abs_dest) {
                         sys::Result::Err(real_error) => {
                             // It was just created, no need to delete destination and symlink again
                             self.err = Some(real_error.into());
@@ -1316,10 +1316,36 @@ impl<'a> Linker<'a> {
 
         // delete and try again
         let _ = sys::delete_tree_absolute(abs_dest.as_bytes());
-        if let Err(err) = sys::symlink_running_executable(rel_target, abs_dest) {
+        if let Err(err) = Self::symlink_or_keep(rel_target, abs_dest) {
             self.err = Some(err.into());
         }
         Self::chmod_on_ok(self.err, abs_target);
+    }
+
+    /// A destination that already links to `rel_target` counts as linked: a
+    /// repeat install must not unlink and recreate it, and concurrent installs
+    /// into one directory (`bunx` runs one `bun add` per invocation in a shared
+    /// install dir) race to create the same link.
+    #[cfg(not(windows))]
+    fn symlink_or_keep(rel_target: &ZStr, abs_dest: &ZStr) -> sys::Result<()> {
+        match sys::symlink_running_executable(rel_target, abs_dest) {
+            Err(err)
+                if err.get_errno() == sys::Errno::EEXIST
+                    && Self::already_links_to(abs_dest, rel_target) =>
+            {
+                Ok(())
+            }
+            result => result,
+        }
+    }
+
+    #[cfg(not(windows))]
+    fn already_links_to(abs_dest: &ZStr, rel_target: &ZStr) -> bool {
+        let mut existing_target_buf = path::path_buffer_pool::get();
+        match sys::readlink(abs_dest, &mut existing_target_buf) {
+            Ok(len) => strings::eql(&existing_target_buf[..len], rel_target.as_bytes()),
+            Err(_) => false,
+        }
     }
 
     #[cfg(not(windows))]

--- a/src/install/migration.rs
+++ b/src/install/migration.rs
@@ -100,7 +100,7 @@ pub fn detect_and_load_other_lockfile<'a>(
         let Ok(data) = File::read_from(dir, b"pnpm-lock.yaml") else {
             break 'pnpm;
         };
-        let migrate_result = match pnpm::migrate_pnpm_lockfile(this, manager, log, &data, dir) {
+        let migrate_result = match pnpm::migrate_pnpm_lockfile(this, manager, log, &data) {
             Ok(r) => r,
             Err(MigratePnpmLockfileError::PnpmLockfileTooOld) => {
                 report_unsupported_lockfile_version(

--- a/src/install/pnpm.rs
+++ b/src/install/pnpm.rs
@@ -477,7 +477,6 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
     manager: &mut PackageManager,
     log: &mut bun_ast::Log,
     data: &[u8],
-    dir: Fd,
 ) -> Result<LoadResult<'a>, MigratePnpmLockfileError> {
     lockfile.init_empty();
     crate::initialize_store();
@@ -1625,7 +1624,7 @@ pub(crate) fn migrate_pnpm_lockfile<'a>(
 
     lockfile.fetch_necessary_package_metadata_after_yarn_or_pnpm_migration::<false>(manager)?;
 
-    update_package_json_after_migration(manager, log, dir, &found_patches)?;
+    update_package_json_after_migration(manager, log, &found_patches)?;
 
     Ok(LoadResult::Ok(LoadResultOk {
         lockfile,
@@ -2334,7 +2333,6 @@ fn rewrite_bare_patch_keys(
 fn update_package_json_after_migration(
     manager: &mut PackageManager,
     log: &mut bun_ast::Log,
-    dir: Fd,
     patches: &StringArrayHashMap<Box<[u8]>>,
 ) -> Result<(), AllocError> {
     let mut pkg_json_path = bun_paths::AutoAbsPath::init_top_level_dir();
@@ -2747,10 +2745,10 @@ fn update_package_json_after_migration(
         );
 
         // Write the updated package.json
-        if sys::File::write_file(
-            dir,
-            bun_core::zstr!("package.json"),
+        if sys::File::write_file_atomically(
+            pkg_json_path.slice_z(),
             root_pkg_json.source.contents(),
+            0o644,
         )
         .is_ok()
             && !moved.is_empty()

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -154,6 +154,9 @@ impl AuditCommand {
         };
         let json_output = manager.options.json_output;
         if fix {
+            if !manager.options.dry_run {
+                manager.lock_project();
+            }
             return Self::audit_fix(
                 ctx,
                 manager,

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1310,17 +1310,20 @@ impl BunxCommand {
             Global::exit(1);
         }
 
-        'create_package_json: {
-            // create package.json, but only if it doesn't exist
-            let package_json = match bun_sys::File::create(
-                bunx_install_dir.fd,
-                b"package.json",
-                /* truncate */ true,
-            ) {
-                Ok(f) => f,
-                Err(_) => break 'create_package_json,
-            };
-            let _ = package_json.write_all(b"{}\n");
+        // Reset on every install so `bun add` below edits this package.json, not one further up
+        // the tree. Concurrent runs of the same package share this directory (and this file),
+        // so the file is replaced whole rather than truncated and rewritten.
+        {
+            let mut package_json_path: Vec<u8> =
+                Vec::with_capacity(bunx_cache_dir.len() + b"/package.json\0".len());
+            package_json_path.extend_from_slice(bunx_cache_dir);
+            package_json_path.push(bun_paths::SEP);
+            package_json_path.extend_from_slice(b"package.json\0");
+            let _ = bun_sys::File::write_file_atomically(
+                ZStr::from_slice_with_nul(&package_json_path),
+                b"{}\n",
+                0o644,
+            );
         }
 
         let install_args: [&[u8]; 4] = [

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1310,9 +1310,7 @@ impl BunxCommand {
             Global::exit(1);
         }
 
-        // Reset on every install so `bun add` below edits this package.json, not one further up
-        // the tree. Concurrent runs of the same package share this directory (and this file),
-        // so the file is replaced whole rather than truncated and rewritten.
+        // Gives `bun add` below a package.json here. Concurrent runs share this directory.
         {
             let mut package_json_path: Vec<u8> =
                 Vec::with_capacity(bunx_cache_dir.len() + b"/package.json\0".len());

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -314,6 +314,11 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             setup_global_dir(pm, &&mut *ctx)?;
         }
 
+        // `bun pm` subcommands that always rewrite package.json or the lockfile.
+        if strings::eql_comptime(subcommand, b"trust") || strings::eql_comptime(subcommand, b"migrate") {
+            pm.lock_project();
+        }
+
         if strings::eql_comptime(subcommand, b"scan") {
             ScanCommand::exec_with_manager(&mut *ctx, pm, &cwd)?;
             Global::exit(0);

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -315,7 +315,9 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
         }
 
         // `bun pm` subcommands that always rewrite package.json or the lockfile.
-        if strings::eql_comptime(subcommand, b"trust") || strings::eql_comptime(subcommand, b"migrate") {
+        if strings::eql_comptime(subcommand, b"trust")
+            || strings::eql_comptime(subcommand, b"migrate")
+        {
             pm.lock_project();
         }
 

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -854,7 +854,7 @@ impl PmPkgCommand {
 
         let content = writer.ctx.written_without_trailing_zero();
         let path_z = bun_core::ZBox::from_bytes(path);
-        if let Err(e) = bun_sys::File::write_file(bun_sys::Fd::cwd(), path_z.as_zstr(), content) {
+        if let Err(e) = bun_sys::File::write_file_atomically(path_z.as_zstr(), content, 0o644) {
             Output::err_generic(
                 "Failed to write package.json: {s}",
                 (bstr::BStr::new(e.name()),),

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -539,7 +539,8 @@ impl TrustCommand {
         // Read by path, not through the descriptor `init` opened before this process took the
         // project lock: a `bun add` that finished in between replaced the file.
         let package_json_contents =
-            bun_sys::File::read_from(bun_sys::Fd::cwd(), root_package_json_path).map_err(crate::Error::from)?;
+            bun_sys::File::read_from(bun_sys::Fd::cwd(), root_package_json_path)
+                .map_err(crate::Error::from)?;
         let package_json_source = bun_ast::Source::init_path_string(
             root_package_json_path.as_bytes(),
             package_json_contents.as_slice(),
@@ -664,8 +665,12 @@ impl TrustCommand {
 
         let new_package_json_contents = package_json_writer.ctx.written_without_trailing_zero();
 
-        bun_sys::File::write_file_atomically(root_package_json_path, new_package_json_contents, 0o644)
-            .map_err(crate::Error::from)?;
+        bun_sys::File::write_file_atomically(
+            root_package_json_path,
+            new_package_json_contents,
+            0o644,
+        )
+        .map_err(crate::Error::from)?;
 
         debug_assert!(total_scripts_ran > 0);
 

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -533,20 +533,15 @@ impl TrustCommand {
             }
         }
 
-        // SAFETY: `pm_raw` singleton; this scope takes over the descriptor
-        // (the original `pm.root_package_json_file` is replaced with INVALID so
-        // its eventual drop is a no-op).
-        let root_file = unsafe {
-            let fd = (*pm_raw).root_package_json_file.handle;
-            (*pm_raw).root_package_json_file.handle = bun_core::Fd::INVALID;
-            bun_sys::File::from_fd(fd)
-        };
-        let package_json_contents = root_file.read_to_end().map_err(crate::Error::from)?;
-
         // SAFETY: `ROOT_PACKAGE_JSON_PATH` is set during `PackageManager::init`
         // (single-threaded startup) and immutable thereafter.
+        let root_package_json_path = unsafe { ROOT_PACKAGE_JSON_PATH.read() };
+        // Read by path, not through the descriptor `init` opened before this process took the
+        // project lock: a `bun add` that finished in between replaced the file.
+        let package_json_contents =
+            bun_sys::File::read_from(bun_sys::Fd::cwd(), root_package_json_path).map_err(crate::Error::from)?;
         let package_json_source = bun_ast::Source::init_path_string(
-            unsafe { ROOT_PACKAGE_JSON_PATH.read() }.as_bytes(),
+            root_package_json_path.as_bytes(),
             package_json_contents.as_slice(),
         );
 
@@ -669,11 +664,8 @@ impl TrustCommand {
 
         let new_package_json_contents = package_json_writer.ctx.written_without_trailing_zero();
 
-        root_file
-            .pwrite_all(new_package_json_contents, 0)
+        bun_sys::File::write_file_atomically(root_package_json_path, new_package_json_contents, 0o644)
             .map_err(crate::Error::from)?;
-        let _ = bun_sys::ftruncate(root_file.handle, new_package_json_contents.len() as i64);
-        let _ = root_file.close();
 
         debug_assert!(total_scripts_ran > 0);
 

--- a/src/runtime/cli/pm_trusted_command.rs
+++ b/src/runtime/cli/pm_trusted_command.rs
@@ -536,8 +536,7 @@ impl TrustCommand {
         // SAFETY: `ROOT_PACKAGE_JSON_PATH` is set during `PackageManager::init`
         // (single-threaded startup) and immutable thereafter.
         let root_package_json_path = unsafe { ROOT_PACKAGE_JSON_PATH.read() };
-        // Read by path, not through the descriptor `init` opened before this process took the
-        // project lock: a `bun add` that finished in between replaced the file.
+        // By path: the file may have been replaced between `init` and the project lock.
         let package_json_contents =
             bun_sys::File::read_from(bun_sys::Fd::cwd(), root_package_json_path)
                 .map_err(crate::Error::from)?;

--- a/src/runtime/cli/pm_version_command.rs
+++ b/src/runtime/cli/pm_version_command.rs
@@ -221,10 +221,10 @@ impl PmVersionCommand {
                 Global::exit(1);
             }
 
-            if let Err(err) = bun_sys::File::write_file(
-                Fd::cwd(),
+            if let Err(err) = bun_sys::File::write_file_atomically(
                 package_json_path,
                 package_json_writer.ctx.written_without_trailing_zero(),
+                0o644,
             ) {
                 Output::err_generic("Failed to write package.json: {}", (BStr::new(err.name()),));
                 Global::exit(1);

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -225,12 +225,10 @@ impl UpdateInteractiveCommand {
             Box::from(package_json_writer.ctx.written_without_trailing_zero());
 
         // Write the updated package.json
-        // Routes through `bun_sys::File::write_file` (cwd-relative
-        // open + write + close) per src/CLAUDE.md.
         let mut path_zbuf = PathBuffer::uninit();
         let path_z = path::resolve_path::z(package_json_path, &mut path_zbuf);
         if let Err(err) =
-            bun_sys::File::write_file(bun_sys::Fd::cwd(), path_z, &new_package_json_source)
+            bun_sys::File::write_file_atomically(path_z, &new_package_json_source, 0o644)
         {
             Output::err_generic(
                 "Failed to write package.json at {s}: {s}",

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1229,9 +1229,13 @@ impl Expect {
                     crate::Error::FailedToWriteSnapshotFile => {
                         global_this.throw(format_args!("Failed write to snapshot file: {test_file_path}"))
                     }
-                    crate::Error::SyntaxError | crate::Error::ParseError => {
-                        global_this.throw(format_args!("Failed to parse snapshot file for: {test_file_path}"))
-                    }
+                    crate::Error::ParseError => match runner.snapshots.unparseable_file_path() {
+                        Some(snapshot_file_path) => global_this.throw(format_args!(
+                            "Failed to parse snapshot file: {}",
+                            bstr::BStr::new(snapshot_file_path)
+                        )),
+                        None => global_this.throw(format_args!("Failed to parse snapshot file for: {test_file_path}")),
+                    },
                     crate::Error::SnapshotCreationNotAllowedInCI => {
                         let snapshot_name = runner.snapshots.last_error_snapshot_name.take();
                         if let Some(name) = snapshot_name {

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -9,7 +9,6 @@ use crate::Error;
 use bun_core::{ZStr, strings};
 use bun_js_parser::{self as js_parser, lexer as js_lexer};
 use bun_jsc::virtual_machine::VirtualMachine;
-use bun_paths::{self, PathBuffer};
 use bun_sys::{self};
 use bun_wyhash::hash;
 
@@ -104,9 +103,24 @@ impl InlineSnapshotToWrite {
     }
 }
 
-pub struct File {
-    pub(crate) id: FileId,
-    pub(crate) file: bun_sys::File,
+/// The `.snap` file of the test file whose tests are running. Its entries live in
+/// `Snapshots::file_buf` and `Snapshots::values` until `write_snapshot_file` replaces the file.
+struct File {
+    id: FileId,
+    /// `<test dir>/__snapshots__/<test file name>.snap`, NUL-terminated.
+    path: Vec<u8>,
+    /// `file_buf` has entries the file on disk does not have. Always set under
+    /// `--update-snapshots`, which rewrites the file from the snapshots this run reaches.
+    dirty: bool,
+    /// The file on disk did not parse. Every snapshot of this test file fails and the file is
+    /// left as it is.
+    unparseable: bool,
+}
+
+impl File {
+    fn path_z(&self) -> &ZStr {
+        ZStr::from_slice_with_nul(&self.path)
+    }
 }
 
 impl Snapshots {
@@ -159,6 +173,9 @@ impl Snapshots {
                     crate::Error::SnapshotFailed
                 });
             }
+        }
+        if self.current_file().unparseable {
+            return Err(crate::Error::ParseError);
         }
 
         let (name, counter) = self.add_count(expect, hint)?;
@@ -217,16 +234,51 @@ impl Snapshots {
         .map_err(|_| crate::Error::WriteError)?;
 
         self.added += 1;
+        self.current_file_mut().dirty = true;
         self.values
             .insert(name_hash, Box::<[u8]>::from(target_value));
         Ok(None)
     }
 
-    pub(crate) fn parse_file(&mut self, file: &File) -> Result<(), Error> {
-        if self.file_buf.is_empty() {
-            return Ok(());
-        }
+    fn current_file(&self) -> &File {
+        self._current_file
+            .as_ref()
+            .expect("get_snapshot_file sets _current_file before it returns Ok")
+    }
 
+    fn current_file_mut(&mut self) -> &mut File {
+        self._current_file
+            .as_mut()
+            .expect("get_snapshot_file sets _current_file before it returns Ok")
+    }
+
+    /// The `.snap` file whose parse failure made `get_or_put` return `Error::ParseError`.
+    pub(crate) fn unparseable_file_path(&self) -> Option<&[u8]> {
+        self._current_file
+            .as_ref()
+            .filter(|file| file.unparseable)
+            .map(|file| file.path_z().as_bytes())
+    }
+
+    /// Loads the entries of `file_buf` (the `.snap` file as read from disk) into `values`.
+    /// Prints the parse errors, if any. The caller decides what happens to the file.
+    fn parse_file(&mut self, snapshot_file_path: &[u8]) -> Result<(), Error> {
+        let mut temp_log = bun_ast::Log::init();
+        let result = self.parse_file_into_values(snapshot_file_path, &mut temp_log);
+        if temp_log.errors > 0 {
+            let _ = temp_log.print(std::ptr::from_mut::<bun_core::io::Writer>(
+                bun_output::error_writer(),
+            ));
+            bun_output::flush();
+        }
+        result
+    }
+
+    fn parse_file_into_values(
+        &mut self,
+        snapshot_file_path: &[u8],
+        temp_log: &mut bun_ast::Log,
+    ) -> Result<(), Error> {
         // SAFETY: VM is thread-local singleton installed before any test runs; lives for the
         // duration of the runner. Per `VirtualMachine::get` doc, callers form a short-lived borrow.
         let vm = VirtualMachine::get().as_mut();
@@ -236,53 +288,19 @@ impl Snapshots {
         );
         // Thread a per-call arena — js_parser is bump-allocated.
         let arena = bun_alloc::Arena::new();
-        let mut temp_log = bun_ast::Log::init();
 
-        // do NOT call `Jest::runner()` here — it hands out an exclusive ref to the global TestRunner,
-        // and `self: &mut Snapshots` is a live borrow of that same TestRunner's `.snapshots`
-        // field. Retagging the whole TestRunner would invalidate `self` under Stacked Borrows.
-        // Project the disjoint `.files` sibling through the raw `RUNNER` pointer instead.
-        // SAFETY: single-threaded JS VM; RUNNER is set before any Snapshots method runs
-        // (Snapshots is a field of TestRunner). Raw-pointer place projection touches only
-        // `.files` bytes, disjoint from `&mut self`.
-        let test_file_source = unsafe {
-            let p = Jest::RUNNER.read().expect("Jest runner not set").as_ptr();
-            &(*p).files.items_source()[file.id as usize]
-        };
-        let name = test_file_source.path.name();
-        let test_filename = name.filename;
-        let dir_path = name.dir_with_trailing_slash();
-
-        let mut snapshot_file_path_buf = PathBuffer::uninit();
-        let buf = snapshot_file_path_buf.0.as_mut_slice();
-        let mut pos = 0usize;
-        buf[pos..pos + dir_path.len()].copy_from_slice(dir_path);
-        pos += dir_path.len();
-        buf[pos..pos + Self::SNAPSHOTS_DIR_NAME.len()].copy_from_slice(Self::SNAPSHOTS_DIR_NAME);
-        pos += Self::SNAPSHOTS_DIR_NAME.len();
-        buf[pos..pos + test_filename.len()].copy_from_slice(test_filename);
-        pos += test_filename.len();
-        buf[pos..pos + b".snap".len()].copy_from_slice(b".snap");
-        pos += b".snap".len();
-        buf[pos] = 0;
-        // SAFETY: buf[pos] == 0 written above
-        let snapshot_file_path = ZStr::from_buf(&buf[..], pos);
-
-        let source = bun_ast::Source::init_path_string(
-            snapshot_file_path.as_bytes(),
-            self.file_buf.as_slice(),
-        );
+        let source = bun_ast::Source::init_path_string(snapshot_file_path, self.file_buf.as_slice());
 
         let parser = js_parser::Parser::init(
             opts,
-            &mut temp_log,
+            temp_log,
             &source,
             &vm.transpiler.options.define,
             &arena,
-        )?;
+        )
+        .map_err(|_| crate::Error::ParseError)?;
 
-        let parse_result = parser.parse()?;
-        let mut ast = match parse_result {
+        let mut ast = match parser.parse().map_err(|_| crate::Error::ParseError)? {
             bun_js_parser::Result::Ast(ast) => ast,
             _ => return Err(crate::Error::ParseError),
         };
@@ -346,19 +364,29 @@ impl Snapshots {
     }
 
     pub(crate) fn write_snapshot_file(&mut self) -> Result<(), Error> {
-        if let Some(file) = self._current_file.take() {
-            file.file
-                .write_all(&self.file_buf)
-                .map_err(|_| crate::Error::FailedToWriteSnapshotFile)?;
-            let _ = file.file.close();
-            self.file_buf.clear();
-            self.file_buf.shrink_to_fit();
+        let Some(file) = self._current_file.take() else {
+            return Ok(());
+        };
+        let result = if file.dirty {
+            bun_sys::File::write_file_atomically(file.path_z(), &self.file_buf, 0o644)
+        } else {
+            Ok(())
+        };
+        self.file_buf.clear();
+        self.file_buf.shrink_to_fit();
 
-            self.values.clear();
+        self.values.clear();
 
-            self.counts.clear();
-        }
-        Ok(())
+        self.counts.clear();
+
+        result.map_err(|err| {
+            bun_output::err(
+                err,
+                "Failed to write snapshot file: {}",
+                (bstr::BStr::new(file.path_z().as_bytes()),),
+            );
+            crate::Error::FailedToWriteSnapshotFile
+        })
     }
 
     pub(crate) fn add_inline_snapshot_to_write(
@@ -417,8 +445,8 @@ impl Snapshots {
 
             // 2. load file text
             // avoid `Jest::runner()` (would alias `&mut TestRunner` over the live
-            // `&mut self` / `ils_info` borrow of `runner.snapshots`). See comment in `parse_file`.
-            // SAFETY: see `parse_file` — raw-pointer projection to disjoint `.files` field.
+            // `&mut self` / `ils_info` borrow of `runner.snapshots`). See comment in `get_snapshot_file`.
+            // SAFETY: see `get_snapshot_file` — raw-pointer projection to disjoint `.files` field.
             let test_file_source = unsafe {
                 let p = Jest::RUNNER.read().expect("Jest runner not set").as_ptr();
                 &(*p).files.items_source()[file_id as usize]
@@ -431,8 +459,10 @@ impl Snapshots {
             // SAFETY: NUL appended above
             let test_filename_z = ZStr::from_slice_with_nul(&test_filename[..]);
 
-            let fd = match bun_sys::open(test_filename_z, bun_sys::O::RDWR, 0o644) {
-                bun_sys::Result::Ok(r) => r,
+            // O_RDWR rather than O_RDONLY: a file that may not be written to is reported here
+            // instead of being replaced below.
+            let file = match bun_sys::File::open(test_filename_z, bun_sys::O::RDWR, 0o644) {
+                bun_sys::Result::Ok(file) => file,
                 bun_sys::Result::Err(e) => {
                     log.add_error_fmt(
                         &bun_ast::Source::init_empty_file(test_filename_z.as_bytes()),
@@ -445,12 +475,9 @@ impl Snapshots {
                     continue;
                 }
             };
-            let file = File {
-                id: file_id,
-                file: bun_sys::File::from_fd(fd),
-            };
 
-            let file_text: Vec<u8> = file.file.read_to_end().map_err(Error::from)?;
+            let file_text: Vec<u8> = file.read_to_end().map_err(Error::from)?;
+            drop(file);
 
             let source =
                 bun_ast::Source::init_path_string(test_filename_z.as_bytes(), file_text.as_slice());
@@ -806,19 +833,7 @@ impl Snapshots {
             }
 
             // 4. write out result_text to the file
-            if let Err(e) = file.file.seek_to(0) {
-                log.add_error_fmt(
-                    &source,
-                    bun_ast::Loc { start: 0 },
-                    format_args!(
-                        "Failed to update inline snapshot: Seek file error: {}",
-                        bstr::BStr::new(e.name()),
-                    ),
-                );
-                continue;
-            }
-
-            if let Err(e) = file.file.write_all(&result_text) {
+            if let Err(e) = bun_sys::File::write_file_atomically(test_filename_z, &result_text, 0o644) {
                 log.add_error_fmt(
                     &source,
                     bun_ast::Loc { start: 0 },
@@ -827,100 +842,97 @@ impl Snapshots {
                         bstr::BStr::new(e.name()),
                     ),
                 );
-                continue;
-            }
-            if result_text.len() < file_text.len() {
-                if bun_sys::ftruncate(file.file.handle, result_text.len() as i64).is_err() {
-                    panic!("Failed to update inline snapshot: File was left in an invalid state");
-                }
             }
         }
         Ok(success.get())
     }
 
     fn get_snapshot_file(&mut self, file_id: FileId) -> Result<bun_sys::Result<()>, Error> {
-        if self._current_file.is_none() || self._current_file.as_ref().unwrap().id != file_id {
-            self.write_snapshot_file()?;
+        if self._current_file.as_ref().is_some_and(|file| file.id == file_id) {
+            return Ok(bun_sys::Result::Ok(()));
+        }
+        self.write_snapshot_file()?;
 
-            // avoid `Jest::runner()` (aliases `&mut TestRunner` over live `&mut self`).
-            // SAFETY: see `parse_file` — raw-pointer projection to disjoint `.files` field.
-            let test_file_source = unsafe {
-                let p = Jest::RUNNER.read().expect("Jest runner not set").as_ptr();
-                &(*p).files.items_source()[file_id as usize]
-            };
-            let name = test_file_source.path.name();
-            let test_filename = name.filename;
-            let dir_path = name.dir_with_trailing_slash();
+        // do NOT call `Jest::runner()` here — it hands out an exclusive ref to the global TestRunner,
+        // and `self: &mut Snapshots` is a live borrow of that same TestRunner's `.snapshots`
+        // field. Retagging the whole TestRunner would invalidate `self` under Stacked Borrows.
+        // Project the disjoint `.files` sibling through the raw `RUNNER` pointer instead.
+        // SAFETY: single-threaded JS VM; RUNNER is set before any Snapshots method runs
+        // (Snapshots is a field of TestRunner). Raw-pointer place projection touches only
+        // `.files` bytes, disjoint from `&mut self`.
+        let test_file_source = unsafe {
+            let p = Jest::RUNNER.read().expect("Jest runner not set").as_ptr();
+            &(*p).files.items_source()[file_id as usize]
+        };
+        let name = test_file_source.path.name();
+        let test_filename = name.filename;
+        let dir_path = name.dir_with_trailing_slash();
 
-            let mut snapshot_file_path_buf = PathBuffer::uninit();
-            let buf = snapshot_file_path_buf.0.as_mut_slice();
-            let mut pos = 0usize;
-            buf[pos..pos + dir_path.len()].copy_from_slice(dir_path);
-            pos += dir_path.len();
-            buf[pos..pos + Self::SNAPSHOTS_DIR_NAME.len()]
-                .copy_from_slice(Self::SNAPSHOTS_DIR_NAME);
-            pos += Self::SNAPSHOTS_DIR_NAME.len();
+        let mut path: Vec<u8> = Vec::with_capacity(
+            dir_path.len()
+                + Self::SNAPSHOTS_DIR_NAME.len()
+                + test_filename.len()
+                + b".snap".len()
+                + 1,
+        );
+        path.extend_from_slice(dir_path);
+        path.extend_from_slice(Self::SNAPSHOTS_DIR_NAME);
 
-            let cached_dir = self.snapshot_dir_path;
-            if cached_dir.is_none() || !strings::eql_long(dir_path, cached_dir.unwrap(), true) {
-                buf[pos] = 0;
-                // SAFETY: buf[pos] == 0 written above
-                let snapshot_dir_path = ZStr::from_buf(&buf[..], pos);
-                match bun_sys::mkdir(snapshot_dir_path, 0o777) {
-                    bun_sys::Result::Ok(()) => {
+        let cached_dir = self.snapshot_dir_path;
+        if cached_dir.is_none() || !strings::eql_long(dir_path, cached_dir.unwrap(), true) {
+            path.push(0);
+            match bun_sys::mkdir(ZStr::from_slice_with_nul(&path), 0o777) {
+                bun_sys::Result::Ok(()) => {
+                    self.snapshot_dir_path = Some(dir_path);
+                }
+                bun_sys::Result::Err(err) => match err.get_errno() {
+                    bun_sys::Errno::EEXIST => {
                         self.snapshot_dir_path = Some(dir_path);
                     }
-                    bun_sys::Result::Err(err) => match err.get_errno() {
-                        bun_sys::Errno::EEXIST => {
-                            self.snapshot_dir_path = Some(dir_path);
-                        }
-                        _ => return Ok(bun_sys::Result::Err(err)),
-                    },
-                }
+                    _ => return Ok(bun_sys::Result::Err(err)),
+                },
             }
-
-            buf[pos..pos + test_filename.len()].copy_from_slice(test_filename);
-            pos += test_filename.len();
-            buf[pos..pos + b".snap".len()].copy_from_slice(b".snap");
-            pos += b".snap".len();
-            buf[pos] = 0;
-            // SAFETY: buf[pos] == 0 written above
-            let snapshot_file_path = ZStr::from_buf(&buf[..], pos);
-
-            let mut flags: i32 = bun_sys::O::CREAT | bun_sys::O::RDWR;
-            if self.update_snapshots {
-                flags |= bun_sys::O::TRUNC;
-            }
-            let fd = match bun_sys::open(snapshot_file_path, flags, 0o644) {
-                bun_sys::Result::Ok(fd) => fd,
-                bun_sys::Result::Err(err) => return Ok(bun_sys::Result::Err(err)),
-            };
-
-            let file = File {
-                id: file_id,
-                file: bun_sys::File::from_fd(fd),
-            };
-
-            if self.update_snapshots {
-                self.file_buf.extend_from_slice(Self::FILE_HEADER);
-            } else {
-                let length = file.file.get_end_pos().map_err(Error::from)?;
-                if length == 0 {
-                    self.file_buf.extend_from_slice(Self::FILE_HEADER);
-                } else {
-                    let mut tmp = vec![0u8; length];
-                    let _ = file.file.pread_all(&mut tmp, 0).map_err(Error::from)?;
-                    #[cfg(windows)]
-                    {
-                        file.file.seek_to(0).map_err(Error::from)?;
-                    }
-                    self.file_buf.extend_from_slice(&tmp);
-                }
-            }
-
-            self.parse_file(&file)?;
-            self._current_file = Some(file);
+            path.pop();
         }
+
+        path.extend_from_slice(test_filename);
+        path.extend_from_slice(b".snap");
+        path.push(0);
+
+        let mut file = File {
+            id: file_id,
+            path,
+            dirty: self.update_snapshots,
+            unparseable: false,
+        };
+
+        let existing: Vec<u8> = if self.update_snapshots {
+            Vec::new()
+        } else {
+            match bun_sys::File::open(file.path_z(), bun_sys::O::RDONLY, 0)
+                .and_then(|existing| existing.read_to_end())
+            {
+                bun_sys::Result::Ok(contents) => contents,
+                bun_sys::Result::Err(err) => match err.get_errno() {
+                    bun_sys::Errno::ENOENT => Vec::new(),
+                    _ => return Ok(bun_sys::Result::Err(err)),
+                },
+            }
+        };
+
+        if existing.is_empty() {
+            self.file_buf.extend_from_slice(Self::FILE_HEADER);
+        } else {
+            self.file_buf = existing;
+            if self.parse_file(file.path_z().as_bytes()).is_err() {
+                file.unparseable = true;
+                self.file_buf = Vec::new();
+                bun_core::note!(
+                    "Restore the snapshot file or run \"bun test --update-snapshots\" to regenerate it"
+                );
+            }
+        }
+        self._current_file = Some(file);
 
         Ok(bun_sys::Result::Ok(()))
     }

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -103,17 +103,14 @@ impl InlineSnapshotToWrite {
     }
 }
 
-/// The `.snap` file of the test file whose tests are running. Its entries live in
-/// `Snapshots::file_buf` and `Snapshots::values` until `write_snapshot_file` replaces the file.
+/// The `.snap` file of the test file that is running; `write_snapshot_file` replaces it.
 struct File {
     id: FileId,
-    /// `<test dir>/__snapshots__/<test file name>.snap`, NUL-terminated.
+    /// NUL-terminated.
     path: Vec<u8>,
-    /// `file_buf` has entries the file on disk does not have. Always set under
-    /// `--update-snapshots`, which rewrites the file from the snapshots this run reaches.
+    /// `file_buf` has entries the file does not have. Always set under `--update-snapshots`.
     dirty: bool,
-    /// The file on disk did not parse. Every snapshot of this test file fails and the file is
-    /// left as it is.
+    /// The file did not parse: its snapshots fail and it is left as it is.
     unparseable: bool,
 }
 
@@ -260,8 +257,7 @@ impl Snapshots {
             .map(|file| file.path_z().as_bytes())
     }
 
-    /// Loads the entries of `file_buf` (the `.snap` file as read from disk) into `values`.
-    /// Prints the parse errors, if any. The caller decides what happens to the file.
+    /// Loads the entries of `file_buf` into `values`, printing the parse errors if it fails.
     fn parse_file(&mut self, snapshot_file_path: &[u8]) -> Result<(), Error> {
         let mut temp_log = bun_ast::Log::init();
         let result = self.parse_file_into_values(snapshot_file_path, &mut temp_log);
@@ -459,8 +455,7 @@ impl Snapshots {
             // SAFETY: NUL appended above
             let test_filename_z = ZStr::from_slice_with_nul(&test_filename[..]);
 
-            // O_RDWR rather than O_RDONLY: a file that may not be written to is reported here
-            // instead of being replaced below.
+            // O_RDWR: a file that may not be written to is reported here, not replaced below.
             let file = match bun_sys::File::open(test_filename_z, bun_sys::O::RDWR, 0o644) {
                 bun_sys::Result::Ok(file) => file,
                 bun_sys::Result::Err(e) => {

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -456,23 +456,23 @@ impl Snapshots {
             let test_filename_z = ZStr::from_slice_with_nul(&test_filename[..]);
 
             // O_RDWR: a file that may not be written to is reported here, not replaced below.
-            let file = match bun_sys::File::open(test_filename_z, bun_sys::O::RDWR, 0o644) {
-                bun_sys::Result::Ok(file) => file,
+            let file_text: Vec<u8> = match bun_sys::File::open(test_filename_z, bun_sys::O::RDWR, 0o644)
+                .and_then(|file| file.read_to_end())
+            {
+                bun_sys::Result::Ok(file_text) => file_text,
                 bun_sys::Result::Err(e) => {
                     log.add_error_fmt(
                         &bun_ast::Source::init_empty_file(test_filename_z.as_bytes()),
                         bun_ast::Loc { start: 0 },
                         format_args!(
-                            "Failed to update inline snapshot: Failed to open file: {}",
+                            "Failed to update inline snapshot: Failed to {} file: {}",
+                            e.syscall.name(),
                             bstr::BStr::new(e.name()),
                         ),
                     );
                     continue;
                 }
             };
-
-            let file_text: Vec<u8> = file.read_to_end().map_err(Error::from)?;
-            drop(file);
 
             let source =
                 bun_ast::Source::init_path_string(test_filename_z.as_bytes(), file_text.as_slice());

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -385,6 +385,71 @@ impl File {
         let f = Self::openat(dir, path, O::WRONLY | O::CREAT | O::TRUNC, 0o664)?;
         f.write_all(data)
     }
+    /// Like [`File::write_file`], but the file at `path` (absolute, or relative to the cwd)
+    /// changes in one step: a process that reads or replaces it at the same time sees either
+    /// the previous contents or `data`, never a truncated file or a mix of two writers. `data`
+    /// goes to `.<name>.<random>.tmp` next to the file, which is then renamed over it.
+    ///
+    /// Like the in-place write this replaces, it follows a symlink at `path`, fails with the
+    /// open error (EACCES, EISDIR, ...) when the existing file cannot be written to, and keeps
+    /// the permission bits of an existing file. A new file is created with `mode`, minus the
+    /// umask. Other hard links to the old file keep the old contents.
+    pub fn write_file_atomically(path: &ZStr, data: &[u8], mode: Mode) -> Maybe<()> {
+        use std::io::Write as _;
+
+        // Resolves symlinks so that the replacement lands next to (and over) the real file.
+        // Fails when the file does not exist yet, in which case `path` itself is the target.
+        let mut realpath_buf = bun_paths::path_buffer_pool::get();
+        let mut target: Vec<u8> = match realpath(path, &mut realpath_buf) {
+            Ok(resolved) => resolved.to_vec(),
+            Err(_) => path.as_bytes().to_vec(),
+        };
+        target.push(0);
+        let target = ZStr::from_slice_with_nul(&target);
+
+        let existing_mode: Option<Mode> = match Self::open(target, O::WRONLY | O::CLOEXEC, 0) {
+            // Closed on drop. Opening for writing is what reports a file that cannot be
+            // replaced by its writer, since the rename below only needs the directory.
+            Ok(existing) => Some(existing.stat()?.st_mode as Mode & 0o7777),
+            Err(err) if err.get_errno() == E::ENOENT => None,
+            Err(err) => return Err(err),
+        };
+
+        let target_bytes = target.as_bytes();
+        let dir_len = target_bytes.len() - bun_paths::basename(target_bytes).len();
+        let mut tmp_path: Vec<u8> =
+            Vec::with_capacity(target_bytes.len() + b"..0123456789abcdef.tmp\0".len());
+        tmp_path.extend_from_slice(&target_bytes[..dir_len]);
+        tmp_path.push(b'.');
+        tmp_path.extend_from_slice(&target_bytes[dir_len..]);
+        write!(tmp_path, ".{:016x}.tmp\0", bun_core::fast_random()).expect("Vec write is infallible");
+        let tmp_path = ZStr::from_slice_with_nul(&tmp_path);
+
+        let cwd = Fd::cwd();
+        let mut tmpfile = Tmpfile::create_with_mode(cwd, tmp_path, existing_mode.unwrap_or(mode))?;
+        // Closes the descriptor on every path below. `Tmpfile` does not own it.
+        let file = File::from_fd(tmpfile.fd);
+        let result = file.write_all(data).and_then(|()| {
+            // The create applied the umask; the replaced file's exact bits are restored on a
+            // best-effort basis. A new file keeps the umask like every other new file.
+            #[cfg(unix)]
+            if let Some(existing_mode) = existing_mode {
+                let _ = fchmod(file.handle, existing_mode);
+            }
+            tmpfile.finish(target)
+        });
+        drop(file);
+        if result.is_err() {
+            let _ = unlinkat(cwd, tmp_path);
+        }
+        result
+    }
+    /// Takes the exclusive advisory lock of this file (`flock(LOCK_EX)`, `LockFileEx` on
+    /// Windows). Closing the file releases it, so a process that dies releases it too. With
+    /// `wait == false`, returns `Ok(false)` when another process holds the lock.
+    pub fn lock_exclusive(&self, wait: bool) -> Maybe<bool> {
+        flock_exclusive(self.handle, wait)
+    }
     /// Like [`File::write_file`] but takes the platform-native path type so Windows
     /// callers can pass a `&WStr` without round-tripping through UTF-8.
     pub fn write_file_os_path(

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -385,9 +385,7 @@ impl File {
         let f = Self::openat(dir, path, O::WRONLY | O::CREAT | O::TRUNC, 0o664)?;
         f.write_all(data)
     }
-    /// [`File::write_file`] through `.<name>.<random>.tmp` and a rename, so that a concurrent
-    /// reader or writer sees the old file or the new one. Follows symlinks, fails when the file
-    /// exists and cannot be opened for writing, keeps its mode; `mode` is for a new file.
+    /// [`File::write_file`] through a temporary file and a rename; an existing file keeps its mode.
     pub fn write_file_atomically(path: &ZStr, data: &[u8], mode: Mode) -> Maybe<()> {
         use std::io::Write as _;
 

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -419,31 +419,44 @@ impl File {
         let tmp_path = ZStr::from_slice_with_nul(&tmp_path);
 
         let cwd = Fd::cwd();
-        let Ok(mut tmpfile) = Tmpfile::create_with_mode(cwd, tmp_path, create_mode) else {
-            return Self::write_file_in_place(target, data, mode);
+        let mut tmpfile = match Tmpfile::create_with_mode(cwd, tmp_path, create_mode) {
+            Ok(tmpfile) => tmpfile,
+            // The directory refuses new files from this user. The file itself opened above.
+            Err(err) if matches!(err.get_errno(), E::EACCES | E::EPERM) => {
+                return Self::write_file_in_place(target, data, mode);
+            }
+            Err(err) => return Err(err),
         };
         // Closes the descriptor on every path below. `Tmpfile` does not own it.
         let file = File::from_fd(tmpfile.fd);
-        let written = file.write_all(data);
-        let renamed = written.is_ok() && {
-            #[cfg(unix)]
-            if let Some(st) = &existing {
-                // The new inode belongs to this process, and the create applied the umask.
-                let _ = fchown(file.handle, st.st_uid, st.st_gid);
-                let _ = fchmod(file.handle, st.st_mode as Mode & 0o7777);
-            }
-            tmpfile.finish(target).is_ok()
-        };
-        drop(file);
-        if renamed {
-            return Ok(());
+        if let Err(err) = file.write_all(data) {
+            // Disk full, and the like: the old file is intact, and writing in place would empty it.
+            drop(file);
+            let _ = unlinkat(cwd, tmp_path);
+            return Err(err);
         }
+        #[cfg(unix)]
+        if let Some(st) = &existing {
+            // The new inode belongs to this process, and the create applied the umask.
+            let _ = fchown(file.handle, st.st_uid, st.st_gid);
+            let _ = fchmod(file.handle, st.st_mode as Mode & 0o7777);
+        }
+        let renamed = tmpfile.finish(target);
+        drop(file);
+        let Err(err) = renamed else {
+            return Ok(());
+        };
         let _ = unlinkat(cwd, tmp_path);
-        // Writing in place truncates the old file first, so a write that failed is not retried.
-        written?;
-        Self::write_file_in_place(target, data, mode)
+        // A volume without rename over a file, a file another program holds open, a sticky dir.
+        if matches!(
+            err.get_errno(),
+            E::EACCES | E::EPERM | E::EINVAL | E::ENOTSUP | E::EBUSY | E::ETXTBSY
+        ) {
+            return Self::write_file_in_place(target, data, mode);
+        }
+        Err(err)
     }
-    /// Where the directory takes no temporary file, or no rename over the target: as before.
+    /// The write every caller did before: for a directory or a volume that refuses the mechanism.
     fn write_file_in_place(target: &ZStr, data: &[u8], mode: Mode) -> Maybe<()> {
         crate::syslog!(
             "write_file_atomically({}) writes in place",

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -445,12 +445,6 @@ impl File {
         }
         result
     }
-    /// Takes the exclusive advisory lock of this file (`flock(LOCK_EX)`, `LockFileEx` on
-    /// Windows). Closing the file releases it, so a process that dies releases it too. With
-    /// `wait == false`, returns `Ok(false)` when another process holds the lock.
-    pub fn lock_exclusive(&self, wait: bool) -> Maybe<bool> {
-        flock_exclusive(self.handle, wait)
-    }
     /// Like [`File::write_file`] but takes the platform-native path type so Windows
     /// callers can pass a `&WStr` without round-tripping through UTF-8.
     pub fn write_file_os_path(

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -422,7 +422,8 @@ impl File {
         tmp_path.extend_from_slice(&target_bytes[..dir_len]);
         tmp_path.push(b'.');
         tmp_path.extend_from_slice(&target_bytes[dir_len..]);
-        write!(tmp_path, ".{:016x}.tmp\0", bun_core::fast_random()).expect("Vec write is infallible");
+        write!(tmp_path, ".{:016x}.tmp\0", bun_core::fast_random())
+            .expect("Vec write is infallible");
         let tmp_path = ZStr::from_slice_with_nul(&tmp_path);
 
         let cwd = Fd::cwd();

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -389,7 +389,7 @@ impl File {
     pub fn write_file_atomically(path: &ZStr, data: &[u8], mode: Mode) -> Maybe<()> {
         use std::io::Write as _;
 
-        // Fails for a file that does not exist yet; then `path` itself is the target.
+        // Best effort (on Windows it opens the file to read); the open for writing below decides.
         let mut realpath_buf = bun_paths::path_buffer_pool::get();
         let mut target: Vec<u8> = match realpath(path, &mut realpath_buf) {
             Ok(resolved) => resolved.to_vec(),

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -385,20 +385,13 @@ impl File {
         let f = Self::openat(dir, path, O::WRONLY | O::CREAT | O::TRUNC, 0o664)?;
         f.write_all(data)
     }
-    /// Like [`File::write_file`], but the file at `path` (absolute, or relative to the cwd)
-    /// changes in one step: a process that reads or replaces it at the same time sees either
-    /// the previous contents or `data`, never a truncated file or a mix of two writers. `data`
-    /// goes to `.<name>.<random>.tmp` next to the file, which is then renamed over it.
-    ///
-    /// Like the in-place write this replaces, it follows a symlink at `path`, fails with the
-    /// open error (EACCES, EISDIR, ...) when the existing file cannot be written to, and keeps
-    /// the permission bits of an existing file. A new file is created with `mode`, minus the
-    /// umask. Other hard links to the old file keep the old contents.
+    /// [`File::write_file`] through `.<name>.<random>.tmp` and a rename, so that a concurrent
+    /// reader or writer sees the old file or the new one. Follows symlinks, fails when the file
+    /// exists and cannot be opened for writing, keeps its mode; `mode` is for a new file.
     pub fn write_file_atomically(path: &ZStr, data: &[u8], mode: Mode) -> Maybe<()> {
         use std::io::Write as _;
 
-        // Resolves symlinks so that the replacement lands next to (and over) the real file.
-        // Fails when the file does not exist yet, in which case `path` itself is the target.
+        // Fails for a file that does not exist yet; then `path` itself is the target.
         let mut realpath_buf = bun_paths::path_buffer_pool::get();
         let mut target: Vec<u8> = match realpath(path, &mut realpath_buf) {
             Ok(resolved) => resolved.to_vec(),
@@ -408,8 +401,7 @@ impl File {
         let target = ZStr::from_slice_with_nul(&target);
 
         let existing_mode: Option<Mode> = match Self::open(target, O::WRONLY | O::CLOEXEC, 0) {
-            // Closed on drop. Opening for writing is what reports a file that cannot be
-            // replaced by its writer, since the rename below only needs the directory.
+            // The rename below only needs the directory; this open reports an unwritable file.
             Ok(existing) => Some(existing.stat()?.st_mode as Mode & 0o7777),
             Err(err) if err.get_errno() == E::ENOENT => None,
             Err(err) => return Err(err),
@@ -431,8 +423,7 @@ impl File {
         // Closes the descriptor on every path below. `Tmpfile` does not own it.
         let file = File::from_fd(tmpfile.fd);
         let result = file.write_all(data).and_then(|()| {
-            // The create applied the umask; the replaced file's exact bits are restored on a
-            // best-effort basis. A new file keeps the umask like every other new file.
+            // The create applied the umask.
             #[cfg(unix)]
             if let Some(existing_mode) = existing_mode {
                 let _ = fchmod(file.handle, existing_mode);

--- a/src/sys/file.rs
+++ b/src/sys/file.rs
@@ -385,10 +385,8 @@ impl File {
         let f = Self::openat(dir, path, O::WRONLY | O::CREAT | O::TRUNC, 0o664)?;
         f.write_all(data)
     }
-    /// [`File::write_file`] through a temporary file and a rename; an existing file keeps its mode.
+    /// [`File::write_file`] through a temporary file and a rename. Keeps the file's mode and owner.
     pub fn write_file_atomically(path: &ZStr, data: &[u8], mode: Mode) -> Maybe<()> {
-        use std::io::Write as _;
-
         // Best effort (on Windows it opens the file to read); the open for writing below decides.
         let mut realpath_buf = bun_paths::path_buffer_pool::get();
         let mut target: Vec<u8> = match realpath(path, &mut realpath_buf) {
@@ -398,41 +396,60 @@ impl File {
         target.push(0);
         let target = ZStr::from_slice_with_nul(&target);
 
-        let existing_mode: Option<Mode> = match Self::open(target, O::WRONLY | O::CLOEXEC, 0) {
+        let existing = match Self::open(target, O::WRONLY | O::CLOEXEC, 0) {
             // The rename below only needs the directory; this open reports an unwritable file.
-            Ok(existing) => Some(existing.stat()?.st_mode as Mode & 0o7777),
+            Ok(existing) => Some(existing.stat()?),
             Err(err) if err.get_errno() == E::ENOENT => None,
             Err(err) => return Err(err),
         };
+        let create_mode = existing
+            .as_ref()
+            .map_or(mode, |st| st.st_mode as Mode & 0o7777);
 
         let target_bytes = target.as_bytes();
         let dir_len = target_bytes.len() - bun_paths::basename(target_bytes).len();
-        let mut tmp_path: Vec<u8> =
-            Vec::with_capacity(target_bytes.len() + b"..0123456789abcdef.tmp\0".len());
+        let mut tmp_name_buf = [0u8; 64];
+        let tmp_name =
+            bun_paths::fs::FileSystem::tmpname(b"tmp", &mut tmp_name_buf, bun_core::fast_random())
+                .expect("the buffer is sized for this name");
+        let mut tmp_path: Vec<u8> = Vec::with_capacity(dir_len + tmp_name.as_bytes().len() + 1);
         tmp_path.extend_from_slice(&target_bytes[..dir_len]);
-        tmp_path.push(b'.');
-        tmp_path.extend_from_slice(&target_bytes[dir_len..]);
-        write!(tmp_path, ".{:016x}.tmp\0", bun_core::fast_random())
-            .expect("Vec write is infallible");
+        tmp_path.extend_from_slice(tmp_name.as_bytes());
+        tmp_path.push(0);
         let tmp_path = ZStr::from_slice_with_nul(&tmp_path);
 
         let cwd = Fd::cwd();
-        let mut tmpfile = Tmpfile::create_with_mode(cwd, tmp_path, existing_mode.unwrap_or(mode))?;
+        let Ok(mut tmpfile) = Tmpfile::create_with_mode(cwd, tmp_path, create_mode) else {
+            return Self::write_file_in_place(target, data, mode);
+        };
         // Closes the descriptor on every path below. `Tmpfile` does not own it.
         let file = File::from_fd(tmpfile.fd);
-        let result = file.write_all(data).and_then(|()| {
-            // The create applied the umask.
+        let written = file.write_all(data);
+        let renamed = written.is_ok() && {
             #[cfg(unix)]
-            if let Some(existing_mode) = existing_mode {
-                let _ = fchmod(file.handle, existing_mode);
+            if let Some(st) = &existing {
+                // The new inode belongs to this process, and the create applied the umask.
+                let _ = fchown(file.handle, st.st_uid, st.st_gid);
+                let _ = fchmod(file.handle, st.st_mode as Mode & 0o7777);
             }
-            tmpfile.finish(target)
-        });
+            tmpfile.finish(target).is_ok()
+        };
         drop(file);
-        if result.is_err() {
-            let _ = unlinkat(cwd, tmp_path);
+        if renamed {
+            return Ok(());
         }
-        result
+        let _ = unlinkat(cwd, tmp_path);
+        // Writing in place truncates the old file first, so a write that failed is not retried.
+        written?;
+        Self::write_file_in_place(target, data, mode)
+    }
+    /// Where the directory takes no temporary file, or no rename over the target: as before.
+    fn write_file_in_place(target: &ZStr, data: &[u8], mode: Mode) -> Maybe<()> {
+        crate::syslog!(
+            "write_file_atomically({}) writes in place",
+            bstr::BStr::new(target.as_bytes())
+        );
+        Self::open(target, O::WRONLY | O::CREAT | O::TRUNC | O::CLOEXEC, mode)?.write_all(data)
     }
     /// Like [`File::write_file`] but takes the platform-native path type so Windows
     /// callers can pass a `&WStr` without round-tripping through UTF-8.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1052,8 +1052,7 @@ impl error::IntoErrnoInt for bun_windows_sys::NTSTATUS {
     }
 }
 
-/// Mode for [`flock`]: a whole-file lock that closing the fd releases. Mandatory on Windows
-/// (`LockFileEx` fails other handles' reads and writes), so lock the files nobody reads.
+/// Whole-file lock for [`flock`], released with the fd; mandatory on Windows, so lock unread files.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FileLockMode {
     Shared,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1393,6 +1393,7 @@ impl Tag {
     #[cfg(not(windows))]
     pub(crate) const setrlimit: Tag = Tag(106);
     pub const clone3: Tag = Tag(107);
+    pub const flock: Tag = Tag(108);
     // `inotify_init1`/`inotify_add_watch` fold under the generic `.watch`
     // tag; `INotifyWatcher.rs` spells it `.inotify`. Alias to `.watch`
     // so the JS-facing `err.syscall == "watch"` string stays node-compatible.
@@ -1400,7 +1401,7 @@ impl Tag {
     /// The tag name — spelling is frozen (JS-facing
     /// `err.syscall` string; node-compat code matches on it).
     pub fn name(self) -> &'static str {
-        const NAMES: [&str; 108] = [
+        const NAMES: [&str; 109] = [
             "TODO",
             "dup",
             "access",
@@ -1510,6 +1511,7 @@ impl Tag {
             "getrlimit",
             "setrlimit",
             "clone3",
+            "flock",
         ];
         NAMES.get(self.0 as usize).copied().unwrap_or("unknown")
     }
@@ -2645,6 +2647,30 @@ mod posix_impl {
     pub fn ftruncate(fd: Fd, len: i64) -> Maybe<()> {
         check!(safe_libc::ftruncate(fd.native(), len), Tag::ftruncate);
         Ok(())
+    }
+    /// `flock(LOCK_EX)`. The lock belongs to the open file description: closing `fd` (or the
+    /// process exiting) releases it. With `wait == false` the call returns `Ok(false)` instead of
+    /// blocking while another process holds the lock.
+    pub fn flock_exclusive(fd: Fd, wait: bool) -> Maybe<bool> {
+        let operation = if wait {
+            libc::LOCK_EX
+        } else {
+            libc::LOCK_EX | libc::LOCK_NB
+        };
+        loop {
+            // SAFETY: `flock` takes only by-value scalars; a bad fd is EBADF, never UB.
+            if unsafe { libc::flock(fd.native(), operation) } == 0 {
+                return Ok(true);
+            }
+            let errno = last_errno();
+            if errno == libc::EINTR {
+                continue;
+            }
+            if !wait && errno == libc::EWOULDBLOCK {
+                return Ok(false);
+            }
+            return Err(Error::from_code_int(errno, Tag::flock).with_fd(fd));
+        }
     }
     pub fn getcwd(buf: &mut [u8]) -> Maybe<usize> {
         // SAFETY: `buf` is a valid exclusive slice; `getcwd` writes at most
@@ -3903,6 +3929,30 @@ mod windows_impl {
             return Err(Error::new(errno, Tag::ftruncate).with_fd(fd));
         }
         Ok(())
+    }
+    /// The POSIX arm's `flock(LOCK_EX)`: `LockFileEx` over the first byte of the file. The
+    /// lock is released when the handle is closed, which includes the process exiting. With
+    /// `wait == false` the call returns `Ok(false)` instead of blocking while another process
+    /// holds the lock.
+    pub fn flock_exclusive(fd: Fd, wait: bool) -> Maybe<bool> {
+        let mut flags = w::LOCKFILE_EXCLUSIVE_LOCK;
+        if !wait {
+            flags |= w::LOCKFILE_FAIL_IMMEDIATELY;
+        }
+        // The zeroed offset selects byte 0. Every locker uses the same range, so the locks
+        // conflict with each other; the file's contents are irrelevant.
+        let mut overlapped: w::OVERLAPPED = bun_core::ffi::zeroed();
+        // SAFETY: FFI; `fd` is a live handle and `overlapped` outlives the call, which is
+        // synchronous for the handles bun opens (no FILE_FLAG_OVERLAPPED).
+        let rc = unsafe { w::kernel32::LockFileEx(fd.native(), flags, 0, 1, 0, &mut overlapped) };
+        if rc != 0 {
+            return Ok(true);
+        }
+        let er = w::Win32Error::get();
+        if !wait && er == w::Win32Error::LOCK_VIOLATION {
+            return Ok(false);
+        }
+        Err(Error::new(er.to_e(), Tag::flock).with_fd(fd))
     }
 
     // ── kernel32 / ntdll arms ────────────────────────────────────────────

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1052,10 +1052,8 @@ impl error::IntoErrnoInt for bun_windows_sys::NTSTATUS {
     }
 }
 
-/// Mode for [`flock`], a whole-file lock: advisory `flock(2)` on POSIX, `LockFileEx` on Windows,
-/// where it is mandatory (reads and writes through other handles fail while it is held, so lock
-/// files whose contents nobody needs are the intended use). Closing the fd releases it, so a
-/// process that dies releases it too.
+/// Mode for [`flock`]: a whole-file lock that closing the fd releases. Mandatory on Windows
+/// (`LockFileEx` fails other handles' reads and writes), so lock the files nobody reads.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FileLockMode {
     Shared,
@@ -2658,8 +2656,7 @@ mod posix_impl {
         check!(safe_libc::ftruncate(fd.native(), len), Tag::ftruncate);
         Ok(())
     }
-    /// See [`FileLockMode`]. With `nonblocking`, returns `Ok(false)` instead of waiting while
-    /// another process holds a conflicting lock.
+    /// See [`FileLockMode`]. `nonblocking` returns `Ok(false)` instead of waiting.
     pub fn flock(fd: Fd, mode: FileLockMode, nonblocking: bool) -> Maybe<bool> {
         let mut operation = match mode {
             FileLockMode::Shared => libc::LOCK_SH,
@@ -3941,9 +3938,7 @@ mod windows_impl {
         }
         Ok(())
     }
-    /// See [`FileLockMode`]: `LockFileEx` over the whole possible range of the file, the
-    /// closest thing to the POSIX arm's whole-file lock. With `nonblocking`, returns `Ok(false)`
-    /// instead of waiting while another process holds a conflicting lock.
+    /// See [`FileLockMode`]: `LockFileEx` over the whole range. `nonblocking` returns `Ok(false)`.
     pub fn flock(fd: Fd, mode: FileLockMode, nonblocking: bool) -> Maybe<bool> {
         let mut flags: w::DWORD = 0;
         if mode == FileLockMode::Exclusive {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1052,6 +1052,16 @@ impl error::IntoErrnoInt for bun_windows_sys::NTSTATUS {
     }
 }
 
+/// Mode for [`flock`], a whole-file lock: advisory `flock(2)` on POSIX, `LockFileEx` on Windows,
+/// where it is mandatory (reads and writes through other handles fail while it is held, so lock
+/// files whose contents nobody needs are the intended use). Closing the fd releases it, so a
+/// process that dies releases it too.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FileLockMode {
+    Shared,
+    Exclusive,
+}
+
 /// `Exchange` and `NoReplace` are mutually exclusive at the kernel level.
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub enum RenameMode {
@@ -2648,15 +2658,16 @@ mod posix_impl {
         check!(safe_libc::ftruncate(fd.native(), len), Tag::ftruncate);
         Ok(())
     }
-    /// `flock(LOCK_EX)`. The lock belongs to the open file description: closing `fd` (or the
-    /// process exiting) releases it. With `wait == false` the call returns `Ok(false)` instead of
-    /// blocking while another process holds the lock.
-    pub fn flock_exclusive(fd: Fd, wait: bool) -> Maybe<bool> {
-        let operation = if wait {
-            libc::LOCK_EX
-        } else {
-            libc::LOCK_EX | libc::LOCK_NB
+    /// See [`FileLockMode`]. With `nonblocking`, returns `Ok(false)` instead of waiting while
+    /// another process holds a conflicting lock.
+    pub fn flock(fd: Fd, mode: FileLockMode, nonblocking: bool) -> Maybe<bool> {
+        let mut operation = match mode {
+            FileLockMode::Shared => libc::LOCK_SH,
+            FileLockMode::Exclusive => libc::LOCK_EX,
         };
+        if nonblocking {
+            operation |= libc::LOCK_NB;
+        }
         loop {
             // SAFETY: `flock` takes only by-value scalars; a bad fd is EBADF, never UB.
             if unsafe { libc::flock(fd.native(), operation) } == 0 {
@@ -2666,7 +2677,7 @@ mod posix_impl {
             if errno == libc::EINTR {
                 continue;
             }
-            if !wait && errno == libc::EWOULDBLOCK {
+            if nonblocking && errno == libc::EWOULDBLOCK {
                 return Ok(false);
             }
             return Err(Error::from_code_int(errno, Tag::flock).with_fd(fd));
@@ -3930,26 +3941,29 @@ mod windows_impl {
         }
         Ok(())
     }
-    /// The POSIX arm's `flock(LOCK_EX)`: `LockFileEx` over the first byte of the file. The
-    /// lock is released when the handle is closed, which includes the process exiting. With
-    /// `wait == false` the call returns `Ok(false)` instead of blocking while another process
-    /// holds the lock.
-    pub fn flock_exclusive(fd: Fd, wait: bool) -> Maybe<bool> {
-        let mut flags = w::LOCKFILE_EXCLUSIVE_LOCK;
-        if !wait {
+    /// See [`FileLockMode`]: `LockFileEx` over the whole possible range of the file, the
+    /// closest thing to the POSIX arm's whole-file lock. With `nonblocking`, returns `Ok(false)`
+    /// instead of waiting while another process holds a conflicting lock.
+    pub fn flock(fd: Fd, mode: FileLockMode, nonblocking: bool) -> Maybe<bool> {
+        let mut flags: w::DWORD = 0;
+        if mode == FileLockMode::Exclusive {
+            flags |= w::LOCKFILE_EXCLUSIVE_LOCK;
+        }
+        if nonblocking {
             flags |= w::LOCKFILE_FAIL_IMMEDIATELY;
         }
-        // The zeroed offset selects byte 0. Every locker uses the same range, so the locks
-        // conflict with each other; the file's contents are irrelevant.
+        // The zeroed offset starts the range at byte 0.
         let mut overlapped: w::OVERLAPPED = bun_core::ffi::zeroed();
         // SAFETY: FFI; `fd` is a live handle and `overlapped` outlives the call, which is
         // synchronous for the handles bun opens (no FILE_FLAG_OVERLAPPED).
-        let rc = unsafe { w::kernel32::LockFileEx(fd.native(), flags, 0, 1, 0, &mut overlapped) };
+        let rc = unsafe {
+            w::kernel32::LockFileEx(fd.native(), flags, 0, u32::MAX, u32::MAX, &mut overlapped)
+        };
         if rc != 0 {
             return Ok(true);
         }
         let er = w::Win32Error::get();
-        if !wait && er == w::Win32Error::LOCK_VIOLATION {
+        if nonblocking && er == w::Win32Error::LOCK_VIOLATION {
             return Ok(false);
         }
         Err(Error::new(er.to_e(), Tag::flock).with_fd(fd))

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -78,9 +78,7 @@ pub mod kernel32 {
             dwFlags: DWORD,
         ) -> BOOL;
 
-        /// `LockFileEx` (`fileapi.h`). `lpOverlapped` carries the lock offset and must stay
-        /// valid for the duration of the call; on a synchronous handle the call blocks
-        /// (unless `LOCKFILE_FAIL_IMMEDIATELY` is set) and is complete when it returns.
+        /// `LockFileEx` (`fileapi.h`). `lpOverlapped` holds the range offset; required.
         pub fn LockFileEx(
             hFile: HANDLE,
             dwFlags: DWORD,

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -78,6 +78,18 @@ pub mod kernel32 {
             dwFlags: DWORD,
         ) -> BOOL;
 
+        /// `LockFileEx` (`fileapi.h`). `lpOverlapped` carries the lock offset and must stay
+        /// valid for the duration of the call; on a synchronous handle the call blocks
+        /// (unless `LOCKFILE_FAIL_IMMEDIATELY` is set) and is complete when it returns.
+        pub fn LockFileEx(
+            hFile: HANDLE,
+            dwFlags: DWORD,
+            dwReserved: DWORD,
+            nNumberOfBytesToLockLow: DWORD,
+            nNumberOfBytesToLockHigh: DWORD,
+            lpOverlapped: LPOVERLAPPED,
+        ) -> BOOL;
+
         // ── SRW locks / condition variables (`bun_threading` windows arm) ──
         pub fn ReleaseSRWLockExclusive(SRWLock: *mut SRWLOCK);
         pub fn SleepConditionVariableSRW(
@@ -131,6 +143,9 @@ pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: DWORD = 0x0004;
 pub const MOVEFILE_COPY_ALLOWED: DWORD = 0x2;
 pub const MOVEFILE_REPLACE_EXISTING: DWORD = 0x1;
 pub const MOVEFILE_WRITE_THROUGH: DWORD = 0x8;
+/// `LockFileEx` flags (`minwinbase.h`).
+pub const LOCKFILE_FAIL_IMMEDIATELY: DWORD = 0x1;
+pub const LOCKFILE_EXCLUSIVE_LOCK: DWORD = 0x2;
 pub use bun_windows_sys::FILETIME;
 
 pub use bun_windows_sys::DUPLICATE_SAME_ACCESS;

--- a/test/cli/install/bin-link-idempotent.test.ts
+++ b/test/cli/install/bin-link-idempotent.test.ts
@@ -1,0 +1,99 @@
+import { write } from "bun";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { lstatSync, lutimesSync, mkdirSync, readlinkSync, symlinkSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isWindows, VerdaccioRegistry } from "harness";
+import { join } from "path";
+
+// `what-bin@1.0.0` declares `bin: { "what-bin": "what-bin.js" }`. Both linkers
+// link it from the root `node_modules/.bin`, so the link target is the same.
+const EXPECTED_TARGET = "../what-bin/what-bin.js";
+
+// Any fixed time in the past: a link that `bun install` unlinks and recreates
+// comes back with the current time as its mtime, whatever inode number the
+// filesystem hands out for it.
+const STAMP = new Date("2000-01-01T00:00:00Z");
+
+const LINKERS = ["hoisted", "isolated"] as const;
+
+const STALE_BIN_ENTRIES = {
+  "a symlink to another file": (entry: string) => symlinkSync(join("..", "..", "package.json"), entry),
+  "a regular file": (entry: string) => writeFileSync(entry, "#!/bin/sh\n"),
+};
+
+// `.bin/<name>` is a symlink on POSIX. Windows writes `<name>.exe` and
+// `<name>.bunx` shims instead.
+describe.skipIf(isWindows)("node_modules/.bin links", () => {
+  const registry = new VerdaccioRegistry();
+
+  beforeAll(async () => {
+    await registry.start();
+  });
+
+  afterAll(() => {
+    registry.stop();
+  });
+
+  async function createProject(linker: (typeof LINKERS)[number]) {
+    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker } });
+    await write(packageJson, JSON.stringify({ name: "bin-link-test", dependencies: { "what-bin": "1.0.0" } }));
+    return { packageDir, binLink: join(packageDir, "node_modules", ".bin", "what-bin") };
+  }
+
+  async function install(packageDir: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function linkIdentity(link: string) {
+    const { ino, mtimeMs } = lstatSync(link);
+    return { ino, mtimeMs, target: readlinkSync(link) };
+  }
+
+  for (const linker of LINKERS) {
+    test.concurrent(`${linker}: a repeat install keeps the existing link instead of recreating it`, async () => {
+      const { packageDir, binLink } = await createProject(linker);
+
+      const first = await install(packageDir);
+      expect(first.stderr).not.toContain("error:");
+      expect(first.stdout).toContain("1 package installed");
+      expect(first.exitCode).toBe(0);
+
+      lutimesSync(binLink, STAMP, STAMP);
+      const before = linkIdentity(binLink);
+      expect(before).toEqual({ ino: expect.any(Number), mtimeMs: STAMP.getTime(), target: EXPECTED_TARGET });
+
+      const second = await install(packageDir);
+      expect(second.stderr).not.toContain("error:");
+      expect(second.stdout).toContain("(no changes)");
+      expect(second.exitCode).toBe(0);
+
+      expect(linkIdentity(binLink)).toEqual(before);
+    });
+  }
+
+  // Only a link that already points at the right target is kept. `create_symlink`
+  // is shared by both linkers, so one linker is enough for the replacement cases.
+  for (const [kind, createStaleEntry] of Object.entries(STALE_BIN_ENTRIES)) {
+    test.concurrent(`hoisted: replaces ${kind} left at the link's path`, async () => {
+      const { packageDir, binLink } = await createProject("hoisted");
+      mkdirSync(join(packageDir, "node_modules", ".bin"), { recursive: true });
+      createStaleEntry(binLink);
+
+      const { stdout, stderr, exitCode } = await install(packageDir);
+      expect(stderr).not.toContain("error:");
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+
+      expect(lstatSync(binLink).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(binLink)).toBe(EXPECTED_TARGET);
+    });
+  }
+});

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -1,8 +1,10 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { chmodSync, chownSync, mkdirSync, rmSync, statSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { join } from "path";
+
+const isRoot = !isWindows && process.getuid?.() === 0;
 
 async function runPmPkg(args: string[], cwd: string, expectSuccess = true) {
   await using proc = spawn({
@@ -200,6 +202,28 @@ describe.concurrent("bun pm pkg", () => {
       expect(error).toBe("");
       expect(code).toBe(0);
       expect((await readPkg(dir)).description).toBe("New description");
+    });
+
+    // package.json is replaced through a temporary file; the new file must look like the old one.
+    it.skipIf(isWindows)("keeps the mode of package.json", async () => {
+      using dir = makeTestDir();
+      const packageJson = join(String(dir), "package.json");
+      chmodSync(packageJson, 0o600);
+      const { code } = await runPmPkg(["set", "description=Updated"], dir);
+      expect(code).toBe(0);
+      expect({ mode: statSync(packageJson).mode & 0o777, description: (await readPkg(dir)).description }).toEqual({
+        mode: 0o600,
+        description: "Updated",
+      });
+    });
+
+    it.skipIf(!isRoot)("keeps the owner of package.json", async () => {
+      using dir = makeTestDir();
+      const packageJson = join(String(dir), "package.json");
+      chownSync(packageJson, 1, 1);
+      const { code } = await runPmPkg(["set", "description=Updated"], dir);
+      expect(code).toBe(0);
+      expect(statSync(packageJson)).toMatchObject({ uid: 1, gid: 1 });
     });
 
     it("should set multiple properties", async () => {

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -217,13 +217,31 @@ describe.concurrent("bun pm pkg", () => {
       });
     });
 
+    // Root creates files in any directory, so root cannot run this one.
+    it.skipIf(isWindows || isRoot)("writes a package.json whose directory refuses new files", async () => {
+      using dir = makeTestDir();
+      chmodSync(String(dir), 0o555);
+      try {
+        const { code } = await runPmPkg(["set", "description=Updated"], dir);
+        expect(code).toBe(0);
+        expect((await readPkg(dir)).description).toBe("Updated");
+      } finally {
+        chmodSync(String(dir), 0o755);
+      }
+    });
+
     it.skipIf(!isRoot)("keeps the owner of package.json", async () => {
       using dir = makeTestDir();
       const packageJson = join(String(dir), "package.json");
       chownSync(packageJson, 1, 1);
       const { code } = await runPmPkg(["set", "description=Updated"], dir);
       expect(code).toBe(0);
-      expect(statSync(packageJson)).toMatchObject({ uid: 1, gid: 1 });
+      const { uid, gid } = statSync(packageJson);
+      expect({ uid, gid, description: (await readPkg(dir)).description }).toEqual({
+        uid: 1,
+        gid: 1,
+        description: "Updated",
+      });
     });
 
     it("should set multiple properties", async () => {

--- a/test/cli/install/concurrent-processes.test.ts
+++ b/test/cli/install/concurrent-processes.test.ts
@@ -149,9 +149,9 @@ describe("package manager processes that share a project", () => {
       const postinstall = `${bunExe()} hold.js`;
       const { packageDir, packageJson } = await registry.createTestDir({
         files: {
-          // Holds only the process started with HOLD in its environment; `bun install` and `bun
-          // add` below run it too. The test writes "release"; the deadline only bounds the
-          // damage if it never does.
+          // Holds only the process started with HOLD in its environment; the `bun add` and the
+          // `bun install` below run it too. The test writes "release"; the deadline only bounds
+          // the damage if it never does.
           "hold.js": `
             const fs = require("fs");
             if (!process.env.HOLD) process.exit(0);
@@ -174,8 +174,9 @@ describe("package manager processes that share a project", () => {
         editedPackageJson = join(cwd, "package.json");
         await write(editedPackageJson, JSON.stringify({ name: "app", dependencies }));
       }
-      await installed(packageDir);
 
+      // Also the first install of the project. It holds in the postinstall script once it has
+      // placed the packages, and writes package.json after that.
       const removeArgs = ["remove", "a-dep"];
       await using remove = spawn({
         cmd: [bunExe(), ...removeArgs],

--- a/test/cli/install/concurrent-processes.test.ts
+++ b/test/cli/install/concurrent-processes.test.ts
@@ -75,7 +75,10 @@ describe("package manager processes that share a project", () => {
     await write(packageJson, JSON.stringify({ name: "root", workspaces: ["packages/*"] }));
     const appDir = join(packageDir, "packages", "app");
     const appPackageJson = join(appDir, "package.json");
-    await write(appPackageJson, JSON.stringify({ name: "app", dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" } }));
+    await write(
+      appPackageJson,
+      JSON.stringify({ name: "app", dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" } }),
+    );
     await installed(packageDir);
 
     await addAndRemoveTogether(appDir);
@@ -98,9 +101,9 @@ describe("package manager processes that share a project", () => {
     );
 
     const results = await Promise.all(Array.from({ length: 4 }, () => run(packageDir, "install")));
-    expect(results.map(({ stderr, exitCode }) => ({ stderr: stderr.includes("error:") ? stderr : "", exitCode }))).toEqual(
-      results.map(() => ({ stderr: "", exitCode: 0 })),
-    );
+    expect(
+      results.map(({ stderr, exitCode }) => ({ stderr: stderr.includes("error:") ? stderr : "", exitCode })),
+    ).toEqual(results.map(() => ({ stderr: "", exitCode: 0 })));
     // The first install runs the script, which writes "postinstall!". The others find the package
     // installed and leave it alone. A second run of the script writes "postinstall exists!".
     expect(await file(join(packageDir, "node_modules", "lifecycle-postinstall", "postinstall.txt")).text()).toBe(
@@ -125,7 +128,11 @@ describe("package manager processes that share a project", () => {
     // The root postinstall script runs while the install still holds the project.
     await write(
       packageJson,
-      JSON.stringify({ name: "held", dependencies: { "no-deps": "1.0.0" }, scripts: { postinstall: `${bunExe()} hold.js` } }),
+      JSON.stringify({
+        name: "held",
+        dependencies: { "no-deps": "1.0.0" },
+        scripts: { postinstall: `${bunExe()} hold.js` },
+      }),
     );
 
     await using install = spawn({

--- a/test/cli/install/concurrent-processes.test.ts
+++ b/test/cli/install/concurrent-processes.test.ts
@@ -31,13 +31,11 @@ describe("package manager processes that share a project", () => {
   ];
   const PACKAGES = [...PATCHABLE, "a-dep@1.0.1", "lifecycle-postinstall@1.0.0"];
 
-  // The first start of the registry on a fresh Windows machine took longer than the 5 second hook
-  // default (1.5 seconds once warm).
   beforeAll(async () => {
     await registry.start();
     const { packageDir } = await registry.createTestDir();
     succeeded(await run(packageDir, "add", ...PACKAGES));
-  }, 60_000);
+  });
 
   afterAll(() => {
     registry.stop();

--- a/test/cli/install/concurrent-processes.test.ts
+++ b/test/cli/install/concurrent-processes.test.ts
@@ -11,9 +11,17 @@ import { join } from "path";
 // on disk.
 describe("package manager processes that share a project", () => {
   const registry = new VerdaccioRegistry();
+  // One package cache for every process these tests start, filled before the tests run. The
+  // tests are about processes that share a project; two projects that fill one cache with the
+  // same package at the same time is a different race (the CI runner points every process at
+  // one cache), and the project lock does not serialize different projects on purpose.
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(tmpdirSync(), "cache") };
+  const PACKAGES = ["no-deps@1.0.0", "a-dep@1.0.1", "is-number@1.0.0", "left-pad@1.0.0", "lifecycle-postinstall@1.0.0"];
 
   beforeAll(async () => {
     await registry.start();
+    const { packageDir } = await registry.createTestDir();
+    succeeded(await run(packageDir, "add", ...PACKAGES));
   });
 
   afterAll(() => {
@@ -24,7 +32,7 @@ describe("package manager processes that share a project", () => {
     await using proc = spawn({
       cmd: [bunExe(), ...args],
       cwd,
-      env: bunEnv,
+      env,
       stdin: "ignore",
       stdout: "pipe",
       stderr: "pipe",
@@ -33,20 +41,24 @@ describe("package manager processes that share a project", () => {
     return { args, stdout, stderr, exitCode };
   }
 
+  // The command exited 0 without reporting an error. A failure shows the whole output.
+  function succeeded({ args, stdout, stderr, exitCode }: Awaited<ReturnType<typeof run>>) {
+    expect({ args, exitCode, output: exitCode === 0 && !stderr.includes("error:") ? "" : stdout + stderr }).toEqual({
+      args,
+      exitCode: 0,
+      output: "",
+    });
+  }
+
   async function installed(cwd: string) {
-    const { stderr, exitCode } = await run(cwd, "install");
-    expect(stderr).not.toContain("error:");
-    expect(exitCode).toBe(0);
+    succeeded(await run(cwd, "install"));
   }
 
   // `bun add` reads package.json a few milliseconds after it starts and writes it back once the
   // package is installed. `bun remove` started at the same time writes in between.
   async function addAndRemoveTogether(cwd: string) {
-    const [add, remove] = await Promise.all([run(cwd, "add", "is-number@1.0.0"), run(cwd, "remove", "a-dep")]);
-    for (const result of [add, remove]) {
-      expect(result.stderr).not.toContain("error:");
-      expect(result.exitCode).toBe(0);
-    }
+    const results = await Promise.all([run(cwd, "add", "is-number@1.0.0"), run(cwd, "remove", "a-dep")]);
+    for (const result of results) succeeded(result);
   }
 
   test.concurrent("bun add and bun remove started together both reach package.json and bun.lock", async () => {
@@ -63,9 +75,7 @@ describe("package manager processes that share a project", () => {
     }).toEqual({ "a-dep": false, "is-number": true });
 
     // bun.lock was written by whichever process ran second, from the other one's result.
-    const frozen = await run(packageDir, "install", "--frozen-lockfile");
-    expect(frozen.stderr).not.toContain("error:");
-    expect(frozen.exitCode).toBe(0);
+    succeeded(await run(packageDir, "install", "--frozen-lockfile"));
   });
 
   // The package.json of the workspace the command runs in is read while the project root is
@@ -84,9 +94,7 @@ describe("package manager processes that share a project", () => {
     await addAndRemoveTogether(appDir);
 
     expect((await file(appPackageJson).json()).dependencies).toEqual({ "no-deps": "1.0.0", "is-number": "1.0.0" });
-    const frozen = await run(packageDir, "install", "--frozen-lockfile");
-    expect(frozen.stderr).not.toContain("error:");
-    expect(frozen.exitCode).toBe(0);
+    succeeded(await run(packageDir, "install", "--frozen-lockfile"));
   });
 
   test.concurrent("installs of one project started together install and run each package once", async () => {
@@ -101,9 +109,7 @@ describe("package manager processes that share a project", () => {
     );
 
     const results = await Promise.all(Array.from({ length: 4 }, () => run(packageDir, "install")));
-    expect(
-      results.map(({ stderr, exitCode }) => ({ stderr: stderr.includes("error:") ? stderr : "", exitCode })),
-    ).toEqual(results.map(() => ({ stderr: "", exitCode: 0 })));
+    for (const result of results) succeeded(result);
     // The first install runs the script, which writes "postinstall!". The others find the package
     // installed and leave it alone. A second run of the script writes "postinstall exists!".
     expect(await file(join(packageDir, "node_modules", "lifecycle-postinstall", "postinstall.txt")).text()).toBe(
@@ -115,72 +121,98 @@ describe("package manager processes that share a project", () => {
     });
   });
 
-  test.concurrent("a second process waits for the one that holds the project", async () => {
-    const { packageDir, packageJson } = await registry.createTestDir({
-      files: {
-        "hold.js": `
-          const fs = require("fs");
-          fs.writeFileSync("postinstall-started", "");
-          while (!fs.existsSync("release")) Bun.sleepSync(5);
-        `,
-      },
-    });
-    // The root postinstall script runs while the install still holds the project.
-    await write(
-      packageJson,
-      JSON.stringify({
-        name: "held",
-        dependencies: { "no-deps": "1.0.0" },
-        scripts: { postinstall: `${bunExe()} hold.js` },
-      }),
-    );
-
-    await using install = spawn({
-      cmd: [bunExe(), "install"],
-      cwd: packageDir,
-      env: bunEnv,
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const installOutput = Promise.all([install.stdout.text(), install.stderr.text(), install.exited]);
-    while (!existsSync(join(packageDir, "postinstall-started"))) {
-      expect(install.exitCode).toBeNull();
-      await Bun.sleep(5);
-    }
-
-    await using add = spawn({
-      cmd: [bunExe(), "add", "left-pad@1.0.0"],
-      cwd: packageDir,
-      env: bunEnv,
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const addStdout = add.stdout.text();
-    // Resolves as soon as the message shows up, or with everything `bun add` wrote if it finished
-    // without it. The stream is read to its end either way.
-    const waitingMessage = new Promise<string>(async resolve => {
-      let stderr = "";
-      for await (const chunk of add.stderr) {
-        stderr += Buffer.from(chunk).toString();
-        if (stderr.includes("Waiting for another bun process to finish in ")) resolve(stderr);
+  // The same lost update, with the order forced. `bun remove` writes package.json after the root
+  // scripts ran, so a remove held in its postinstall script still has its edit in memory while
+  // the add arrives. Before the lock the add went through at once and the remove then wrote its
+  // stale copy over it. Now the add waits and starts from the remove's result.
+  for (const where of ["the project root", "a workspace package"]) {
+    test.concurrent(`a bun add that arrives while bun remove holds ${where} waits, and both edits land`, async () => {
+      const dependencies = { "no-deps": "1.0.0", "a-dep": "1.0.1" };
+      const postinstall = `${bunExe()} hold.js`;
+      const { packageDir, packageJson } = await registry.createTestDir({
+        files: {
+          // Holds only the process started with HOLD in its environment; `bun install` and `bun
+          // add` below run it too. The test writes "release"; the deadline only bounds the
+          // damage if it never does.
+          "hold.js": `
+            const fs = require("fs");
+            if (!process.env.HOLD) process.exit(0);
+            fs.writeFileSync("postinstall-started", "");
+            const deadline = Date.now() + 30_000;
+            while (!fs.existsSync("release") && Date.now() < deadline) Bun.sleepSync(5);
+          `,
+        },
+      });
+      let cwd = packageDir;
+      let editedPackageJson = packageJson;
+      if (where === "the project root") {
+        await write(packageJson, JSON.stringify({ name: "held", dependencies, scripts: { postinstall } }));
+      } else {
+        await write(
+          packageJson,
+          JSON.stringify({ name: "root", workspaces: ["packages/*"], scripts: { postinstall } }),
+        );
+        cwd = join(packageDir, "packages", "app");
+        editedPackageJson = join(cwd, "package.json");
+        await write(editedPackageJson, JSON.stringify({ name: "app", dependencies }));
       }
-      resolve(stderr);
+      await installed(packageDir);
+
+      const removeArgs = ["remove", "a-dep"];
+      await using remove = spawn({
+        cmd: [bunExe(), ...removeArgs],
+        cwd,
+        env: { ...env, HOLD: "1" },
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const removeOutput = Promise.all([remove.stdout.text(), remove.stderr.text(), remove.exited]);
+      while (!existsSync(join(packageDir, "postinstall-started"))) {
+        expect(remove.exitCode).toBeNull();
+        await Bun.sleep(5);
+      }
+
+      const addArgs = ["add", "is-number@1.0.0"];
+      await using add = spawn({
+        cmd: [bunExe(), ...addArgs],
+        cwd,
+        env,
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const addStdout = add.stdout.text();
+      // Settles when the message shows up, or when `bun add` closes its stderr without it.
+      // `addStderr` is the whole stream either way.
+      const stderrSoFar: string[] = [];
+      const sawMessage = Promise.withResolvers<void>();
+      const addStderr = (async () => {
+        for await (const chunk of add.stderr) {
+          stderrSoFar.push(Buffer.from(chunk).toString());
+          if (stderrSoFar.join("").includes("Waiting for another bun process")) sawMessage.resolve();
+        }
+        sawMessage.resolve();
+        return stderrSoFar.join("");
+      })();
+      await sawMessage.promise;
+      // Captured before the release, so a failed assertion does not leave hold.js waiting for it.
+      const whileHeld = { stderr: stderrSoFar.join(""), addExitCode: add.exitCode };
+      await write(join(packageDir, "release"), "");
+      const [removeStdout, removeStderr, removeExitCode] = await removeOutput;
+      const addResult = { args: addArgs, stdout: await addStdout, stderr: await addStderr, exitCode: await add.exited };
+
+      // Both commands exit 0 either way. What differs is what is left in package.json.
+      expect((await file(editedPackageJson).json()).dependencies).toEqual({ "no-deps": "1.0.0", "is-number": "1.0.0" });
+      expect(whileHeld).toEqual({
+        stderr: expect.stringContaining(`Waiting for another bun process to finish in ${packageDir}`),
+        addExitCode: null,
+      });
+      succeeded({ args: removeArgs, stdout: removeStdout, stderr: removeStderr, exitCode: removeExitCode });
+      succeeded(addResult);
+      succeeded(await run(packageDir, "install", "--frozen-lockfile"));
     });
-    expect(await waitingMessage).toContain(`Waiting for another bun process to finish in ${packageDir}`);
-    expect(add.exitCode).toBeNull();
-
-    await write(join(packageDir, "release"), "");
-    const [, installStderr, installExitCode] = await installOutput;
-    expect(installStderr).not.toContain("error:");
-    expect(installExitCode).toBe(0);
-
-    const addExitCode = await add.exited;
-    expect(await addStdout).toContain("installed left-pad@1.0.0");
-    expect(addExitCode).toBe(0);
-    expect((await file(packageJson).json()).dependencies).toEqual({ "no-deps": "1.0.0", "left-pad": "1.0.0" });
-  });
+  }
 
   // The install holds the project while its scripts run. The nested `bun add` runs under that
   // lock instead of waiting for it. (`--ignore-scripts` keeps the nested add from running this
@@ -196,10 +228,9 @@ describe("package manager processes that share a project", () => {
       }),
     );
 
-    const { stderr, exitCode } = await run(packageDir, "install");
-    expect(stderr).not.toContain("error:");
-    expect(stderr).not.toContain("Waiting for another bun process");
-    expect(exitCode).toBe(0);
+    const result = await run(packageDir, "install");
+    succeeded(result);
+    expect(result.stderr).not.toContain("Waiting for another bun process");
     expect((await file(packageJson).json()).dependencies).toEqual({ "no-deps": "1.0.0", "left-pad": "1.0.0" });
     expect(existsSync(join(packageDir, "node_modules", "left-pad"))).toBe(true);
   });
@@ -209,7 +240,7 @@ describe("package manager processes that share a project", () => {
   test.concurrent.skipIf(isWindows)("cold bunx runs of one package started together all run it", async () => {
     const tempDir = tmpdirSync();
     const cwd = tmpdirSync();
-    const env = {
+    const bunxEnv = {
       ...bunEnv,
       TMPDIR: tempDir,
       BUN_TMPDIR: tempDir,
@@ -223,16 +254,16 @@ describe("package manager processes that share a project", () => {
         await using proc = spawn({
           cmd: [bunExe(), "x", "what-bin@1.0.0"],
           cwd,
-          env,
+          env: bunxEnv,
           stdin: "ignore",
           stdout: "pipe",
           stderr: "pipe",
         });
         const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        return { stderr: stderr.includes("error:") ? stdout + stderr : "", exitCode };
+        return { exitCode, output: exitCode === 0 && !stderr.includes("error:") ? "" : stdout + stderr };
       }),
     );
-    expect(results).toEqual(results.map(() => ({ stderr: "", exitCode: 0 })));
+    expect(results).toEqual(results.map(() => ({ exitCode: 0, output: "" })));
     // what-bin writes this file into the directory it runs in.
     expect(await file(join(cwd, "what-bin.txt")).text()).toBe("what-bin@1.0.0");
   });

--- a/test/cli/install/concurrent-processes.test.ts
+++ b/test/cli/install/concurrent-processes.test.ts
@@ -30,11 +30,13 @@ describe("package manager processes that share a project", () => {
   ];
   const PACKAGES = [...PATCHABLE, "a-dep@1.0.1", "lifecycle-postinstall@1.0.0"];
 
+  // The first start of the registry on a fresh Windows machine took longer than the 5 second hook
+  // default (1.5 seconds once warm).
   beforeAll(async () => {
     await registry.start();
     const { packageDir } = await registry.createTestDir();
     succeeded(await run(packageDir, "add", ...PACKAGES));
-  });
+  }, 60_000);
 
   afterAll(() => {
     registry.stop();

--- a/test/cli/install/concurrent-processes.test.ts
+++ b/test/cli/install/concurrent-processes.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { appendFileSync, existsSync, readdirSync, readFileSync, realpathSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync, VerdaccioRegistry } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, VerdaccioRegistry } from "harness";
 import { join } from "path";
 
 // Two package manager processes that edit the same project at the same time. Each one reads
@@ -15,7 +15,8 @@ describe("package manager processes that share a project", () => {
   // tests are about processes that share a project; two projects that fill one cache with the
   // same package at the same time is a different race (the CI runner points every process at
   // one cache), and the project lock does not serialize different projects on purpose.
-  const cacheDir = join(tmpdirSync(), "cache");
+  const cacheRoot = tempDir("concurrent-processes-cache", {});
+  const cacheDir = join(String(cacheRoot), "cache");
   const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir };
   // Packages with an index.js to edit, and nothing to run.
   const PATCHABLE = [
@@ -40,6 +41,7 @@ describe("package manager processes that share a project", () => {
 
   afterAll(() => {
     registry.stop();
+    cacheRoot[Symbol.dispose]();
   });
 
   function run(cwd: string, ...args: string[]) {
@@ -314,14 +316,15 @@ describe("package manager processes that share a project", () => {
   // Every `bunx <pkg>@<version>` of one version shares one install directory under the temp dir.
   // Windows bunx installs are not race free (see bunx.test.ts).
   test.concurrent.skipIf(isWindows)("cold bunx runs of one package started together all run it", async () => {
-    const tempDir = tmpdirSync();
-    const cwd = tmpdirSync();
+    using dir = tempDir("bunx-race", { "tmp/.keep": "", "app/.keep": "" });
+    const temp = join(String(dir), "tmp");
+    const cwd = join(String(dir), "app");
     const bunxEnv = {
       ...bunEnv,
-      TMPDIR: tempDir,
-      BUN_TMPDIR: tempDir,
-      TEMP: tempDir,
-      BUN_INSTALL_CACHE_DIR: join(tempDir, "install-cache"),
+      TMPDIR: temp,
+      BUN_TMPDIR: temp,
+      TEMP: temp,
+      BUN_INSTALL_CACHE_DIR: join(temp, "install-cache"),
       npm_config_registry: registry.registryUrl(),
     };
 

--- a/test/cli/install/concurrent-processes.test.ts
+++ b/test/cli/install/concurrent-processes.test.ts
@@ -1,0 +1,232 @@
+import { file, spawn, write } from "bun";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { existsSync } from "fs";
+import { bunEnv, bunExe, isWindows, tmpdirSync, VerdaccioRegistry } from "harness";
+import { join } from "path";
+
+// Two package manager processes that edit the same project at the same time. Each one reads
+// package.json and bun.lock, edits them in memory and writes them back, so without the project
+// lock the one that writes last drops the other one's edit, and two installs of one project
+// place the same packages twice. These tests start the processes together and check the result
+// on disk.
+describe("package manager processes that share a project", () => {
+  const registry = new VerdaccioRegistry();
+
+  beforeAll(async () => {
+    await registry.start();
+  });
+
+  afterAll(() => {
+    registry.stop();
+  });
+
+  async function run(cwd: string, ...args: string[]) {
+    await using proc = spawn({
+      cmd: [bunExe(), ...args],
+      cwd,
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { args, stdout, stderr, exitCode };
+  }
+
+  async function installed(cwd: string) {
+    const { stderr, exitCode } = await run(cwd, "install");
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  // `bun add` reads package.json a few milliseconds after it starts and writes it back once the
+  // package is installed. `bun remove` started at the same time writes in between.
+  async function addAndRemoveTogether(cwd: string) {
+    const [add, remove] = await Promise.all([run(cwd, "add", "is-number@1.0.0"), run(cwd, "remove", "a-dep")]);
+    for (const result of [add, remove]) {
+      expect(result.stderr).not.toContain("error:");
+      expect(result.exitCode).toBe(0);
+    }
+  }
+
+  test.concurrent("bun add and bun remove started together both reach package.json and bun.lock", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir();
+    await write(packageJson, JSON.stringify({ name: "race", dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" } }));
+    await installed(packageDir);
+
+    await addAndRemoveTogether(packageDir);
+
+    expect((await file(packageJson).json()).dependencies).toEqual({ "no-deps": "1.0.0", "is-number": "1.0.0" });
+    expect({
+      "a-dep": existsSync(join(packageDir, "node_modules", "a-dep")),
+      "is-number": existsSync(join(packageDir, "node_modules", "is-number")),
+    }).toEqual({ "a-dep": false, "is-number": true });
+
+    // bun.lock was written by whichever process ran second, from the other one's result.
+    const frozen = await run(packageDir, "install", "--frozen-lockfile");
+    expect(frozen.stderr).not.toContain("error:");
+    expect(frozen.exitCode).toBe(0);
+  });
+
+  // The package.json of the workspace the command runs in is read while the project root is
+  // being located, before the lock is taken. It has to be read again once the lock is held.
+  test.concurrent("bun add and bun remove started together in a workspace package", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir();
+    await write(packageJson, JSON.stringify({ name: "root", workspaces: ["packages/*"] }));
+    const appDir = join(packageDir, "packages", "app");
+    const appPackageJson = join(appDir, "package.json");
+    await write(appPackageJson, JSON.stringify({ name: "app", dependencies: { "no-deps": "1.0.0", "a-dep": "1.0.1" } }));
+    await installed(packageDir);
+
+    await addAndRemoveTogether(appDir);
+
+    expect((await file(appPackageJson).json()).dependencies).toEqual({ "no-deps": "1.0.0", "is-number": "1.0.0" });
+    const frozen = await run(packageDir, "install", "--frozen-lockfile");
+    expect(frozen.stderr).not.toContain("error:");
+    expect(frozen.exitCode).toBe(0);
+  });
+
+  test.concurrent("installs of one project started together install and run each package once", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir();
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "many-installs",
+        dependencies: { "lifecycle-postinstall": "1.0.0", "no-deps": "1.0.0" },
+        trustedDependencies: ["lifecycle-postinstall"],
+      }),
+    );
+
+    const results = await Promise.all(Array.from({ length: 4 }, () => run(packageDir, "install")));
+    expect(results.map(({ stderr, exitCode }) => ({ stderr: stderr.includes("error:") ? stderr : "", exitCode }))).toEqual(
+      results.map(() => ({ stderr: "", exitCode: 0 })),
+    );
+    // The first install runs the script, which writes "postinstall!". The others find the package
+    // installed and leave it alone. A second run of the script writes "postinstall exists!".
+    expect(await file(join(packageDir, "node_modules", "lifecycle-postinstall", "postinstall.txt")).text()).toBe(
+      "postinstall!",
+    );
+    expect(results.filter(({ stdout }) => stdout.includes("2 packages installed"))).toHaveLength(1);
+    expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      version: "1.0.0",
+    });
+  });
+
+  test.concurrent("a second process waits for the one that holds the project", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir({
+      files: {
+        "hold.js": `
+          const fs = require("fs");
+          fs.writeFileSync("postinstall-started", "");
+          while (!fs.existsSync("release")) Bun.sleepSync(5);
+        `,
+      },
+    });
+    // The root postinstall script runs while the install still holds the project.
+    await write(
+      packageJson,
+      JSON.stringify({ name: "held", dependencies: { "no-deps": "1.0.0" }, scripts: { postinstall: `${bunExe()} hold.js` } }),
+    );
+
+    await using install = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const installOutput = Promise.all([install.stdout.text(), install.stderr.text(), install.exited]);
+    while (!existsSync(join(packageDir, "postinstall-started"))) {
+      expect(install.exitCode).toBeNull();
+      await Bun.sleep(5);
+    }
+
+    await using add = spawn({
+      cmd: [bunExe(), "add", "left-pad@1.0.0"],
+      cwd: packageDir,
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const addStdout = add.stdout.text();
+    // Resolves as soon as the message shows up, or with everything `bun add` wrote if it finished
+    // without it. The stream is read to its end either way.
+    const waitingMessage = new Promise<string>(async resolve => {
+      let stderr = "";
+      for await (const chunk of add.stderr) {
+        stderr += Buffer.from(chunk).toString();
+        if (stderr.includes("Waiting for another bun process to finish in ")) resolve(stderr);
+      }
+      resolve(stderr);
+    });
+    expect(await waitingMessage).toContain(`Waiting for another bun process to finish in ${packageDir}`);
+    expect(add.exitCode).toBeNull();
+
+    await write(join(packageDir, "release"), "");
+    const [, installStderr, installExitCode] = await installOutput;
+    expect(installStderr).not.toContain("error:");
+    expect(installExitCode).toBe(0);
+
+    const addExitCode = await add.exited;
+    expect(await addStdout).toContain("installed left-pad@1.0.0");
+    expect(addExitCode).toBe(0);
+    expect((await file(packageJson).json()).dependencies).toEqual({ "no-deps": "1.0.0", "left-pad": "1.0.0" });
+  });
+
+  // The install holds the project while its scripts run. The nested `bun add` runs under that
+  // lock instead of waiting for it. (`--ignore-scripts` keeps the nested add from running this
+  // postinstall script again.)
+  test.concurrent("a lifecycle script can run bun add in the project being installed", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir();
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "nested",
+        dependencies: { "no-deps": "1.0.0" },
+        scripts: { postinstall: `${bunExe()} add --ignore-scripts left-pad@1.0.0` },
+      }),
+    );
+
+    const { stderr, exitCode } = await run(packageDir, "install");
+    expect(stderr).not.toContain("error:");
+    expect(stderr).not.toContain("Waiting for another bun process");
+    expect(exitCode).toBe(0);
+    expect((await file(packageJson).json()).dependencies).toEqual({ "no-deps": "1.0.0", "left-pad": "1.0.0" });
+    expect(existsSync(join(packageDir, "node_modules", "left-pad"))).toBe(true);
+  });
+
+  // Every `bunx <pkg>@<version>` of one version shares one install directory under the temp dir.
+  // Windows bunx installs are not race free (see bunx.test.ts).
+  test.concurrent.skipIf(isWindows)("cold bunx runs of one package started together all run it", async () => {
+    const tempDir = tmpdirSync();
+    const cwd = tmpdirSync();
+    const env = {
+      ...bunEnv,
+      TMPDIR: tempDir,
+      BUN_TMPDIR: tempDir,
+      TEMP: tempDir,
+      BUN_INSTALL_CACHE_DIR: join(tempDir, "install-cache"),
+      npm_config_registry: registry.registryUrl(),
+    };
+
+    const results = await Promise.all(
+      Array.from({ length: 6 }, async () => {
+        await using proc = spawn({
+          cmd: [bunExe(), "x", "what-bin@1.0.0"],
+          cwd,
+          env,
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        return { stderr: stderr.includes("error:") ? stdout + stderr : "", exitCode };
+      }),
+    );
+    expect(results).toEqual(results.map(() => ({ stderr: "", exitCode: 0 })));
+    // what-bin writes this file into the directory it runs in.
+    expect(await file(join(cwd, "what-bin.txt")).text()).toBe("what-bin@1.0.0");
+  });
+});

--- a/test/cli/install/concurrent-processes.test.ts
+++ b/test/cli/install/concurrent-processes.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { existsSync } from "fs";
-import { bunEnv, bunExe, isWindows, tmpdirSync, VerdaccioRegistry } from "harness";
+import { appendFileSync, existsSync, readdirSync, readFileSync, realpathSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync, VerdaccioRegistry } from "harness";
 import { join } from "path";
 
 // Two package manager processes that edit the same project at the same time. Each one reads
@@ -15,8 +15,20 @@ describe("package manager processes that share a project", () => {
   // tests are about processes that share a project; two projects that fill one cache with the
   // same package at the same time is a different race (the CI runner points every process at
   // one cache), and the project lock does not serialize different projects on purpose.
-  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(tmpdirSync(), "cache") };
-  const PACKAGES = ["no-deps@1.0.0", "a-dep@1.0.1", "is-number@1.0.0", "left-pad@1.0.0", "lifecycle-postinstall@1.0.0"];
+  const cacheDir = join(tmpdirSync(), "cache");
+  const env = { ...bunEnv, BUN_INSTALL_CACHE_DIR: cacheDir };
+  // Packages with an index.js to edit, and nothing to run.
+  const PATCHABLE = [
+    "no-deps@1.0.0",
+    "is-number@1.0.0",
+    "left-pad@1.0.0",
+    "basic-1@1.0.0",
+    "no-deps-esm@1.0.0",
+    "no-deps-exports@1.0.0",
+    "no-deps-tags@1.0.0",
+    "no-deps-browser-field@1.0.0",
+  ];
+  const PACKAGES = [...PATCHABLE, "a-dep@1.0.1", "lifecycle-postinstall@1.0.0"];
 
   beforeAll(async () => {
     await registry.start();
@@ -28,7 +40,11 @@ describe("package manager processes that share a project", () => {
     registry.stop();
   });
 
-  async function run(cwd: string, ...args: string[]) {
+  function run(cwd: string, ...args: string[]) {
+    return runWithEnv(env, cwd, ...args);
+  }
+
+  async function runWithEnv(env: Record<string, string | undefined>, cwd: string, ...args: string[]) {
     await using proc = spawn({
       cmd: [bunExe(), ...args],
       cwd,
@@ -233,6 +249,64 @@ describe("package manager processes that share a project", () => {
     expect(result.stderr).not.toContain("Waiting for another bun process");
     expect((await file(packageJson).json()).dependencies).toEqual({ "no-deps": "1.0.0", "left-pad": "1.0.0" });
     expect(existsSync(join(packageDir, "node_modules", "left-pad"))).toBe(true);
+  });
+
+  // `bun patch <pkg>` installs, then replaces the package's hard links into the cache with copies,
+  // so that the user's edits stay out of the cache. The install pass of a sibling used to link the
+  // package from the cache again, and the `--commit` processes used to drop each other's entries.
+  test.concurrent("bun patch of eight packages started together, then eight commits", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir();
+    const names = PATCHABLE.map(spec => spec.split("@")[0]);
+    await write(
+      packageJson,
+      JSON.stringify({ name: "patched", dependencies: Object.fromEntries(PATCHABLE.map(spec => spec.split("@"))) }),
+    );
+    await installed(packageDir);
+
+    for (const result of await Promise.all(names.map(name => run(packageDir, "patch", name)))) succeeded(result);
+    for (const name of names) appendFileSync(join(packageDir, "node_modules", name, "index.js"), "\n// edited\n");
+    const editedInCache = PATCHABLE.filter(spec =>
+      readFileSync(join(cacheEntry(spec), "index.js"), "utf8").includes("// edited"),
+    );
+    const commits = names.map(name => run(packageDir, "patch", "--commit", join("node_modules", name)));
+    for (const result of await Promise.all(commits)) succeeded(result);
+
+    expect({
+      editedInCache,
+      patchedDependencies: (await file(packageJson).json()).patchedDependencies,
+      patchFiles: readdirSync(join(packageDir, "patches")).sort(),
+    }).toEqual({
+      editedInCache: [],
+      patchedDependencies: Object.fromEntries(PATCHABLE.map(spec => [spec, `patches/${spec}.patch`])),
+      patchFiles: PATCHABLE.map(spec => `${spec}.patch`).sort(),
+    });
+    succeeded(await run(packageDir, "install", "--frozen-lockfile"));
+  });
+
+  // The directory the cache keeps `name@version` in. Its name also carries the registry.
+  function cacheEntry(spec: string) {
+    const [name, version] = spec.split("@");
+    const entries = readdirSync(cacheDir).filter(entry => {
+      if (!entry.startsWith(`${name}@`)) return false;
+      return JSON.parse(readFileSync(join(cacheDir, entry, "package.json"), "utf8")).version === version;
+    });
+    expect(entries).toHaveLength(1);
+    return join(cacheDir, entries[0]);
+  }
+
+  // `bun link` in a package directory removes the entry the global directory has for the package
+  // and creates it again. Eight of them used to remove each other's entries and fail with EEXIST.
+  test.concurrent("bun link of one package started eight times registers it", async () => {
+    using dir = tempDir("link-register", {
+      "lib/package.json": JSON.stringify({ name: "linked-lib", version: "1.0.0" }),
+    });
+    const libDir = join(String(dir), "lib");
+    const globalDir = join(String(dir), "install", "global");
+    const linkEnv = { ...env, BUN_INSTALL: String(dir), BUN_INSTALL_GLOBAL_DIR: globalDir };
+
+    const results = await Promise.all(Array.from({ length: 8 }, () => runWithEnv(linkEnv, libDir, "link")));
+    for (const result of results) succeeded(result);
+    expect(realpathSync(join(globalDir, "node_modules", "linked-lib"))).toBe(realpathSync(libDir));
   });
 
   // Every `bunx <pkg>@<version>` of one version shares one install directory under the temp dir.

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -45,10 +45,10 @@ test.skipIf(isWindows)("writes the .snap file of a test file with the longest po
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, proc.stdout.text()]);
   expect(stderr).toContain("snapshots: +1 added");
-  expect(exitCode).toBe(0);
   expect(fs.existsSync(join(String(dir), "__snapshots__", name + ".snap"))).toBe(true);
+  expect(exitCode).toBe(0);
 });
 
 // The runs below share one project directory on purpose: several `bun test` processes of the

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isASAN, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 test("it will create a snapshot file and directory if they don't exist", () => {
@@ -30,17 +30,44 @@ test("it will create a snapshot file and directory if they don't exist", () => {
   expect(fs.existsSync(tempDir + "/__snapshots__/new-snapshot.test.ts.snap")).toBe(true);
 });
 
+// The name of the file the .snap file is written through must not grow with the name of the .snap
+// file, which can already be as long as the file system allows (255 bytes here).
+test.skipIf(isWindows)("writes the .snap file of a test file with the longest possible name", async () => {
+  const name = Buffer.alloc(250 - ".test.ts".length, "a").toString() + ".test.ts";
+  using dir = tempDir("snap-long-name", {
+    [name]: `import { test, expect } from "bun:test"; test("k", () => expect(1).toMatchSnapshot());`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./" + name],
+    cwd: String(dir),
+    env: { ...bunEnv, CI: "false" },
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("snapshots: +1 added");
+  expect(exitCode).toBe(0);
+  expect(fs.existsSync(join(String(dir), "__snapshots__", name + ".snap"))).toBe(true);
+});
+
 // The runs below share one project directory on purpose: several `bun test` processes of the
 // same file at the same time (a CI matrix, two terminals) must leave the files they write in
 // one piece. Each process records values of a different length, so two of them writing the same
 // file in place leave the tail of the longer one behind the shorter one.
 describe("snapshot files written by several processes", () => {
-  // `PAD` comes from the environment, so each process records values of its own length.
+  // `PAD` comes from the environment, so each process records values of its own length. The first
+  // snapshot loads the .snap file; the process creates LOADED right after that, and it exits only
+  // once WAIT_FOR exists.
   const SNAPSHOT_TEST_FILE = (count: number) => `
     import { test, expect } from "bun:test";
-    import { existsSync } from "fs";
+    import { existsSync, writeFileSync } from "fs";
     const PAD = Buffer.alloc(Number(process.env.PAD), "#").toString();
-    ${Array.from({ length: count }, (_, i) => `test("k${i}", () => expect({ i: ${i}, s: PAD }).toMatchSnapshot());`).join("\n")}
+    test("k0", () => expect({ i: 0, s: PAD }).toMatchSnapshot());
+    test("loaded", () => {
+      if (process.env.LOADED) writeFileSync(process.env.LOADED, "");
+    });
+    ${Array.from({ length: count - 1 }, (_, i) => `test("k${i + 1}", () => expect({ i: ${i + 1}, s: PAD }).toMatchSnapshot());`).join("\n")}
     test("waits", () => {
       // The test writes WAIT_FOR. The deadline only bounds the damage if it never does.
       const deadline = Date.now() + 30_000;
@@ -78,12 +105,17 @@ describe("snapshot files written by several processes", () => {
 
   test.concurrent("a .snap file has the entries of exactly one process", async () => {
     using dir = tempDir("snap-two-writers", { "a.test.ts": SNAPSHOT_TEST_FILE(COUNT) });
+    const loaded = join(String(dir), "loaded");
     const release = join(String(dir), "release");
 
-    // Both processes start with no .snap file. The one with the short values records its
-    // snapshots, then waits in its last test until the one with the long values has written
-    // the file, and writes its own, shorter, file last.
-    await using short = runTest(String(dir), { PAD: "4", WAIT_FOR: release });
+    // The process with the short values loads the missing .snap file first. Then the one with the
+    // long values runs to the end and writes the file. Then the short one writes its own, shorter,
+    // file over it.
+    await using short = runTest(String(dir), { PAD: "4", LOADED: loaded, WAIT_FOR: release });
+    while (!fs.existsSync(loaded)) {
+      expect(short.exitCode).toBeNull();
+      await Bun.sleep(5);
+    }
     const long = await finished(runTest(String(dir), { PAD: "400" }));
     fs.writeFileSync(release, "");
     expect(long.stderr).toContain(`snapshots: +${COUNT} added`);

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
 test("it will create a snapshot file and directory if they don't exist", () => {
@@ -42,7 +42,9 @@ describe("snapshot files written by several processes", () => {
     const PAD = Buffer.alloc(Number(process.env.PAD), "#").toString();
     ${Array.from({ length: count }, (_, i) => `test("k${i}", () => expect({ i: ${i}, s: PAD }).toMatchSnapshot());`).join("\n")}
     test("waits", () => {
-      if (process.env.WAIT_FOR) while (!existsSync(process.env.WAIT_FOR)) Bun.sleepSync(5);
+      // The test writes WAIT_FOR. The deadline only bounds the damage if it never does.
+      const deadline = Date.now() + 30_000;
+      if (process.env.WAIT_FOR) while (!existsSync(process.env.WAIT_FOR) && Date.now() < deadline) Bun.sleepSync(5);
     });
   `;
 
@@ -81,11 +83,11 @@ describe("snapshot files written by several processes", () => {
     // Both processes start with no .snap file. The one with the short values records its
     // snapshots, then waits in its last test until the one with the long values has written
     // the file, and writes its own, shorter, file last.
-    const short = runTest(String(dir), { PAD: "4", WAIT_FOR: release });
+    await using short = runTest(String(dir), { PAD: "4", WAIT_FOR: release });
     const long = await finished(runTest(String(dir), { PAD: "400" }));
+    fs.writeFileSync(release, "");
     expect(long.stderr).toContain(`snapshots: +${COUNT} added`);
     expect(long.exitCode).toBe(0);
-    fs.writeFileSync(release, "");
     const shortResult = await finished(short);
     expect(shortResult.stderr).toContain(`snapshots: +${COUNT} added`);
     expect(shortResult.exitCode).toBe(0);
@@ -142,9 +144,9 @@ describe("a .snap file that does not parse", () => {
     ${Array.from({ length: COUNT }, (_, i) => `test("k${i}", () => expect({ i: ${i}, s: "x".repeat(${i % 50}) }).toMatchSnapshot());`).join("\n")}
   `;
 
-  async function runTest(dir: string) {
+  async function runTest(dir: string, ...args: string[]) {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "./a.test.ts"],
+      cmd: [bunExe(), "test", ...args, "./a.test.ts"],
       cwd: dir,
       env: { ...bunEnv, CI: "false" },
       stdin: "ignore",
@@ -175,7 +177,7 @@ describe("a .snap file that does not parse", () => {
     expect(fs.readFileSync(snapPath, "utf8")).toBe(torn);
 
     // Re-reading and re-parsing the file for every test used hundreds of megabytes for 300 tests.
-    expect(result.maxRSS - intact.maxRSS).toBeLessThan(64 * 1024 * 1024);
+    expect(result.maxRSS - intact.maxRSS).toBeLessThan((isASAN ? 128 : 64) * 1024 * 1024);
   });
 
   test("--update-snapshots replaces it", async () => {
@@ -184,15 +186,7 @@ describe("a .snap file that does not parse", () => {
     fs.mkdirSync(join(String(dir), "__snapshots__"));
     fs.writeFileSync(snapPath, "exports[`torn");
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "--update-snapshots", "./a.test.ts"],
-      cwd: String(dir),
-      env: { ...bunEnv, CI: "false" },
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const { stderr, exitCode } = await runTest(String(dir), "--update-snapshots");
     expect(stderr).not.toContain("Failed to parse snapshot file");
     expect(stderr).toContain(`snapshots: +${COUNT} added`);
     expect(exitCode).toBe(0);

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -1,6 +1,7 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
+import { join } from "path";
 
 test("it will create a snapshot file and directory if they don't exist", () => {
   const tempDir = tmpdirSync();
@@ -27,4 +28,174 @@ test("it will create a snapshot file and directory if they don't exist", () => {
 
   expect(exitCode2).toBe(0);
   expect(fs.existsSync(tempDir + "/__snapshots__/new-snapshot.test.ts.snap")).toBe(true);
+});
+
+// The runs below share one project directory on purpose: several `bun test` processes of the
+// same file at the same time (a CI matrix, two terminals) must leave the files they write in
+// one piece. Each process records values of a different length, so two of them writing the same
+// file in place leave the tail of the longer one behind the shorter one.
+describe("snapshot files written by several processes", () => {
+  // `PAD` comes from the environment, so each process records values of its own length.
+  const SNAPSHOT_TEST_FILE = (count: number) => `
+    import { test, expect } from "bun:test";
+    import { existsSync } from "fs";
+    const PAD = Buffer.alloc(Number(process.env.PAD), "#").toString();
+    ${Array.from({ length: count }, (_, i) => `test("k${i}", () => expect({ i: ${i}, s: PAD }).toMatchSnapshot());`).join("\n")}
+    test("waits", () => {
+      if (process.env.WAIT_FOR) while (!existsSync(process.env.WAIT_FOR)) Bun.sleepSync(5);
+    });
+  `;
+
+  const INLINE_TEST_FILE = (count: number) => `
+    import { test, expect } from "bun:test";
+    const PAD = Buffer.alloc(Number(process.env.PAD), "#").toString();
+    ${Array.from({ length: count }, (_, i) => `test("k${i}", () => {\n  expect("${i}:" + PAD).toMatchInlineSnapshot();\n});`).join("\n")}
+  `;
+
+  function runTest(dir: string, env: Record<string, string>) {
+    return Bun.spawn({
+      cmd: [bunExe(), "test", "./a.test.ts"],
+      cwd: dir,
+      env: { ...bunEnv, CI: "false", ...env },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  }
+
+  async function finished(proc: ReturnType<typeof runTest>) {
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, maxRSS: proc.resourceUsage()!.maxRSS };
+  }
+
+  function snapshotKeys(snap: string) {
+    return snap.match(/^exports\[`[^`]*`\]/gm) ?? [];
+  }
+
+  const COUNT = 40;
+
+  test.concurrent("a .snap file has the entries of exactly one process", async () => {
+    using dir = tempDir("snap-two-writers", { "a.test.ts": SNAPSHOT_TEST_FILE(COUNT) });
+    const release = join(String(dir), "release");
+
+    // Both processes start with no .snap file. The one with the short values records its
+    // snapshots, then waits in its last test until the one with the long values has written
+    // the file, and writes its own, shorter, file last.
+    const short = runTest(String(dir), { PAD: "4", WAIT_FOR: release });
+    const long = await finished(runTest(String(dir), { PAD: "400" }));
+    expect(long.stderr).toContain(`snapshots: +${COUNT} added`);
+    expect(long.exitCode).toBe(0);
+    fs.writeFileSync(release, "");
+    const shortResult = await finished(short);
+    expect(shortResult.stderr).toContain(`snapshots: +${COUNT} added`);
+    expect(shortResult.exitCode).toBe(0);
+
+    const snap = fs.readFileSync(join(String(dir), "__snapshots__", "a.test.ts.snap"), "utf8");
+    const keys = snapshotKeys(snap);
+    expect({ keys: keys.length, unique: new Set(keys).size }).toEqual({ keys: COUNT, unique: COUNT });
+    // The file holds the values of the process that wrote last, and nothing else.
+    expect(snap).toContain(`"s": "####"`);
+    expect(snap).not.toContain("#".repeat(5));
+
+    // A third process reads it back without complaint.
+    const again = await finished(runTest(String(dir), { PAD: "4" }));
+    expect(again.stderr).not.toContain("error:");
+    expect(again.stderr).toContain(`${COUNT} snapshots, `);
+    expect(again.exitCode).toBe(0);
+  });
+
+  test.concurrent("a process that adds nothing leaves the .snap file alone", async () => {
+    using dir = tempDir("snap-unchanged", { "a.test.ts": SNAPSHOT_TEST_FILE(COUNT) });
+    const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
+    expect((await finished(runTest(String(dir), { PAD: "4" }))).exitCode).toBe(0);
+    const written = fs.statSync(snapPath);
+    const stamp = new Date("2000-01-01T00:00:00Z");
+    fs.utimesSync(snapPath, stamp, stamp);
+
+    expect((await finished(runTest(String(dir), { PAD: "4" }))).exitCode).toBe(0);
+    expect(fs.statSync(snapPath)).toMatchObject({ size: written.size, mtimeMs: stamp.getTime() });
+  });
+
+  test.concurrent("the source file of inline snapshots stays valid", async () => {
+    using dir = tempDir("inline-many-writers", { "a.test.ts": INLINE_TEST_FILE(COUNT) });
+    const results = await Promise.all(
+      Array.from({ length: 8 }, (_, i) => finished(runTest(String(dir), { PAD: String(1 + i * 20) }))),
+    );
+    expect(results.some(({ exitCode }) => exitCode === 0)).toBe(true);
+
+    // Whatever the order the processes finished in, the file is one process's complete output:
+    // it parses, every call has its value, and the values all have the same length.
+    const source = fs.readFileSync(join(String(dir), "a.test.ts"), "utf8");
+    expect(() => new Bun.Transpiler({ loader: "ts" }).transformSync(source)).not.toThrow();
+    const values = [...source.matchAll(/toMatchInlineSnapshot\(`"(\d+):(#+)"`\)/g)];
+    expect(values.map(match => match[1])).toEqual(Array.from({ length: COUNT }, (_, i) => String(i)));
+    expect(new Set(values.map(match => match[2].length)).size).toBe(1);
+    expect(source.match(/toMatchInlineSnapshot\(/g)).toHaveLength(COUNT);
+  });
+});
+
+describe("a .snap file that does not parse", () => {
+  // Enough tests that re-reading the file once per test would show up in memory.
+  const COUNT = 300;
+  const TEST_FILE = `
+    import { test, expect } from "bun:test";
+    ${Array.from({ length: COUNT }, (_, i) => `test("k${i}", () => expect({ i: ${i}, s: "x".repeat(${i % 50}) }).toMatchSnapshot());`).join("\n")}
+  `;
+
+  async function runTest(dir: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "./a.test.ts"],
+      cwd: dir,
+      env: { ...bunEnv, CI: "false" },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, maxRSS: proc.resourceUsage()!.maxRSS };
+  }
+
+  test("fails every test with the file's name, leaves the file as it is, and reads it once", async () => {
+    using dir = tempDir("snap-unparseable", { "a.test.ts": TEST_FILE });
+    const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
+    expect((await runTest(String(dir))).exitCode).toBe(0);
+    const intact = await runTest(String(dir));
+    expect(intact.exitCode).toBe(0);
+
+    // The tail a second writer leaves behind: an entry that never ends.
+    const torn = fs.readFileSync(snapPath, "utf8") + "\nexports[`torn";
+    fs.writeFileSync(snapPath, torn);
+
+    const result = await runTest(String(dir));
+    expect(result.stderr).toContain('Restore the snapshot file or run "bun test --update-snapshots"');
+    expect(result.stderr.split(`error: Failed to parse snapshot file: ${snapPath}\n`)).toHaveLength(COUNT + 1);
+    expect(result.stderr).not.toContain("Failed to snapshot value");
+    expect(result.stderr).toContain(` ${COUNT} fail`);
+    expect(result.exitCode).toBe(1);
+    expect(fs.readFileSync(snapPath, "utf8")).toBe(torn);
+
+    // Re-reading and re-parsing the file for every test used hundreds of megabytes for 300 tests.
+    expect(result.maxRSS - intact.maxRSS).toBeLessThan(64 * 1024 * 1024);
+  });
+
+  test("--update-snapshots replaces it", async () => {
+    using dir = tempDir("snap-unparseable-update", { "a.test.ts": TEST_FILE });
+    const snapPath = join(String(dir), "__snapshots__", "a.test.ts.snap");
+    fs.mkdirSync(join(String(dir), "__snapshots__"));
+    fs.writeFileSync(snapPath, "exports[`torn");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--update-snapshots", "./a.test.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, CI: "false" },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("Failed to parse snapshot file");
+    expect(stderr).toContain(`snapshots: +${COUNT} added`);
+    expect(exitCode).toBe(0);
+    expect(fs.readFileSync(snapPath, "utf8").match(/^exports\[/gm)).toHaveLength(COUNT);
+  });
 });


### PR DESCRIPTION
### Problem
- Concurrent `bun test` runs of one file write its `.snap`, and its inline snapshot source, in place. The tail of the longer write survives and the file no longer parses. Every `toMatchSnapshot()` then re-reads the broken `.snap`: 300 tests took 234 MB, and each said only `Failed to snapshot value`.
- `bun add` and `bun remove` started together both rewrite package.json and bun.lock. The last writer drops the other edit. Both exit 0.
- Concurrent installs of one project (N cold `bunx pkg@ver`, for example) fill one node_modules at once: `Failed to link x: EEXIST`, scripts run N times.

### Fix
- `File::write_file_atomically` (`src/sys/file.rs`) writes a temporary file and renames it over the target, and gives the new file the mode and owner of the old one. Where the directory takes no temporary file or no rename, it writes in place, as before. The `.snap`, inline snapshot and package.json writers use it.
- A broken `.snap` is parsed once, and its tests report `Failed to parse snapshot file: <path>`. `bin.rs` keeps a `.bin` link that already has the right target. `ROOT_PACKAGE_JSON_PATH` is built from the project root, not from an fd that a rename left behind.
- A command that edits a project takes a `flock` on `<install cache>/.locks/<hash of the root>` at the end of `init` (`PackageManager::lock_project`). A second process prints `Waiting for another bun process to finish in <dir>` and waits. Lifecycle scripts inherit the lock through `BUN_INTERNAL_INSTALL_LOCK_DIR`.
- Verified: `test/cli/install/concurrent-processes.test.ts`, `bin-link-idempotent.test.ts` and `snapshot-tests/new-snapshot.test.ts` on Linux and Windows. The notes list the other suites.

### Background
- A test run reads the `.snap` into a buffer and writes it all back at exit. Inline snapshots are spliced into the source at exit too.
- `init` locates the project root before a command reads any file it edits, so `init` takes the lock. `lock_project` drops the package.json files read on the way up once it holds the lock.
- A `flock` lock dies with its process. The lock file is outside the project and is never deleted, so no process locks an unlinked file. Windows locks are mandatory, so the file holds no data.

<details><summary>Notes</summary>

Fuzz ledger entries covered (ledger numbers, not GitHub issue numbers): torn `.snap` (16211), corrupted inline source (16212), memory on a malformed `.snap` (16213), add/remove lost update (16214), install and bunx loser diagnostics (16215), and 16573: eight concurrent `bun patch` of different packages in one project leave packages hard linked to the cache, so the user's edits land in the cache and other projects install them, and eight concurrent `bun patch --commit` keep one or two of the eight entries; also eight concurrent `bun link` registrations of one package, some of which fail with EEXIST. Patch, PatchCommit and Link were in the locked set already; `concurrent-processes.test.ts` now has both shapes. On the bun without this branch the patch test fails in 6 runs of 6 (in one run: 5 of 8 edits in the cache, 1 of 8 entries kept, 3 patch files), and the link test fails in 6 of 6 with the EEXIST error; both pass on this branch on Linux (debug, 4 runs of the file) and on Windows (debug build of 023d98c, 8 pass and the bunx skip).

Reproductions on the baked `1.4.0-canary.1` (release): `.snap` with 8 runners of 300 tests torn in 3 of 6 rounds (360 or 603 keys for 300 tests); inline source corrupted in 3 of 8 rounds; a `.snap` with one trailing `exports[\`torn` line: 300 tests 234 MB, 600 tests 1466 MB, intact 29 to 32 MB. With this branch (debug build): 0 of 6, 0 of 6, and the torn run uses 6 MB more than the intact one.

Tests that fail on the baked bun: the two held tests in `concurrent-processes.test.ts` (a `bun remove`, which is also the project's first install, held in its postinstall script, a `bun add` arriving; on the baked bun the add goes through at once and the remove then writes its copy over it, so `is-number` is missing from package.json, both in the root and in a workspace package), usually the two simultaneous add+remove tests and the four-installs test (timing), the two-writer `.snap` test, the unchanged `.snap` test (the file was rewritten), the unparseable `.snap` test (message and memory), and the repeat-install bin link test. The inline source test and the bunx test pass or fail by timing on the old code. The two-writer `.snap` test starts the long process only after the short one reports that it has loaded the `.snap` file (a marker file written by its second test); without that, a slow short process loaded the file the long one had already written and failed its comparisons (3 runs in 10 on a loaded debug machine). The mode and owner tests in `bun-pm-pkg.test.ts` and the long name test in `new-snapshot.test.ts` pass on the old code too: they pin behavior the in-place writes had. All processes in `concurrent-processes.test.ts` share one package cache that is filled before the tests run: the CI runner points every process of a test file at one cache, and two projects filling the same cache entry at the same time is a different race (#33884 fixes it on Windows); the project lock does not serialize different projects on purpose.

package.json writers converted: `write_target` (add, update, link, install pkg, audit fix, -g), `update_package_json_and_install_with_manager_with_updates` (remove, patch, patch --commit), `bun pm trust` (which now also reads package.json by path after locking), `bun pm pkg`, `bun pm version`, `bun update -i`, pnpm migration (`migrate_pnpm_lockfile` lost its unused `dir` parameter), bunx's `{}` reset of its install dir's package.json. `attempt_to_create_package_json_and_open` creates with `O_EXCL` and opens the file when another process created it first. `bun init` and `bun create` still write the files they scaffold in place.

Which commands lock: Install, Add, Remove, Update (including `-i`), Link, Patch, PatchCommit, Dedupe, Prune through `Subcommand::always_edits_project` in `init`, unless `--dry-run`; `bun audit fix`, `bun pm trust` and `bun pm migrate` lock after `init`. `lock_project` clears `workspace_package_json_cache` once it holds the lock, so every one of these commands re-reads the package.json files that the walk up in `init` read before the wait (the explicit callers missed that at first; the held workspace test exercises the path). `bun pm version` and `bun pm pkg` have read-only forms and do not lock; their writes are atomic. `bun pm version` also runs git with the process environment, so a git hook that runs `bun install` in the same project would wait for a lock its parent holds. The lock directory comes from `fetch_cache_directory_path`, so `BUN_INSTALL_CACHE_DIR`, bunfig and the default all work, also when the package cache is disabled. The lock file is opened read-only so a shared cache directory works for every user. `bun_sys::flock` takes `FileLockMode::{Shared, Exclusive}`; only `Exclusive` is used here.

`write_file_atomically` resolves the path with `realpath` first so a symlinked package.json (a global package.json kept in dotfiles, for example) is replaced at its target, and opens the existing file for writing before it writes anything, which keeps `test/cli/install/bun-add-filter.test.ts` ("an unwritable target is reported by name") passing and gives the mode and owner to copy. The owner matters for `bun add` as root in a bind mount of a user's project, which used to leave package.json owned by the user (`bun-pm-pkg.test.ts` checks the mode, and the owner when the tests run as root). The temporary file is named by `FileSystem::tmpname`, so a `.snap` file whose name is already 255 bytes long still gets written (`new-snapshot.test.ts` has that case). When the directory refuses the temporary file (EACCES, EPERM), or the rename over the target fails with EACCES, EPERM, EINVAL, ENOTSUP, EBUSY or ETXTBSY, the helper writes the target in place, which is what every one of these writers did before: this covers Windows volumes without `FileRenameInformationEx` (EINVAL, #10169, which #33029 fixes in the rename itself for the lockfile), a target that another program holds open without `FILE_SHARE_DELETE` (EBUSY or EPERM), and a writable file in a directory the user may not write to (`bun-pm-pkg.test.ts` has that case; it is skipped as root, and checked by hand as a non-root user here). Every other error, including a write into the temporary file that fails, is returned with the old file as it was: under `ulimit -f 0`, `bun pm pkg set` prints `Failed to write package.json: EFBIG`, exits 1, and leaves no temporary file. `fchown` and `fchmod` on the new file are best effort: a user who may write a file owned by someone else cannot give it back, and the edit used to work for that user. Checked as a non-root user: a read-only `.snap` that gains an entry fails with `EACCES: ... Failed to write snapshot file: <path>`, and a read-only `.snap` that gains nothing passes (it used to fail at open). Hard links to the old file keep the old contents. The helper does not fsync: the writers it replaces did not either, and the problem here is what other processes see, not what survives a power loss.

`root_package_json_file` is removed from `PackageManager`: `bun pm trust` was its only reader. `init` still opens the file during the walk up, as the check that it can be written to, and closes it right after (the Windows rewind of that file, which served the `pm trust` read, is gone too). `ROOT_PACKAGE_JSON_PATH` is built from `top_level_dir` and `package.json` (the shape #39361 uses, for its own reason) instead of `get_fd_path` of that open file, which on Linux reports `package.json (deleted)` once another process has renamed a new file over it, for example while this process waits for the lock.

Related open PRs. #39403 folds the open install PRs into one branch and touches 15 of the 20 source files changed here; of the changes folded there, #37851 carries the same `sys::flock` as this branch and #39361 builds `ROOT_PACKAGE_JSON_PATH` the same way (those hunks resolve to either side), and #38745 also removes `root_package_json_file`, so it overlaps with this branch in `init` and in `pm_trusted_command.rs`; the project lock, the atomic package.json writes and the snapshot changes exist only here. #36701 makes the same change to `bin.rs` as this branch for the main link site (this branch covers the three sites, for `EEXIST`); its `EPERM`/`EACCES` arms for a read-only `.bin` (#14736) are a two-line addition on top of either. #39701 is stacked on this branch: it converts `bun init`, sets an exit code when the `.snap` write fails, and tests writes that fail; #39666 is its companion for an empty package.json. #37851 adds a `bunx`-level lock with a completion handshake for dist-tag installs, which pass `--force` and can still reinstall under a bunx that already runs the tree; this branch serializes the children and keeps the bin links, and its `sys::flock` has the same signature as the one in #37851. #33992 adds a third `flock` wrapper for a JS API. #38974 and #36679 change the `.snap` write in `snapshot.rs` too (write back and `ftruncate`); the rename here covers their `O_TRUNC` concern, so whichever lands second keeps its per-file and bail changes only. #37384 fixes the debug-only node shim directory race that makes `node -p should work in postinstall scripts` and `ensureTempNodeGypScript works` fail in debug builds on main; those, the `npm_config_user_agent` debug version suffix in `bunx.test.ts`, the debug error return trace in `bun-link.test.ts`, and the color-dependent `error snapshots` test fail here without this branch as well.

Other suites run with the debug build, under `test/cli/install/` unless noted: `bun-add.test.ts`, `bun-remove.test.ts`, `bun-add-filter.test.ts`, `bun-update.test.ts`, `bun-link.test.ts`, `bun-lock.test.ts`, `bun-install-registry.test.ts`, `bun-workspaces.test.ts`, `bad-workspace.test.ts`, `bunx.test.ts`, `bun-pm-pkg.test.ts`, `bun-pm-version.test.ts`, `bun-add-catalog.test.ts`, `bun-install-lifecycle-scripts.test.ts`, `bun-patch.test.ts`, `bun-install-patch.test.ts`, `registry/` (248 tests), `migration/pnpm-migration.test.ts`, `isolated-install.test.ts -t "concurrent|global store"`, `test/js/bun/test/snapshot-tests/` (all files), and `test/internal/source-lints/`. `cargo check` of `bun_sys`, `bun_install` and `bun_runtime` for aarch64-apple-darwin, x86_64-pc-windows-msvc and x86_64-unknown-linux-musl; clippy clean on the touched files.
</details>
