### PR TITLE
s3: fail a streaming upload at VM teardown instead of leaking it

### DIFF
--- a/src/jsc/bindings/NativePromiseContext.h
+++ b/src/jsc/bindings/NativePromiseContext.h
@@ -49,6 +49,7 @@ public:
         HTMLRewriterSuspension,
         // Task-only tag on the Rust side; never stored in a context cell.
         HTMLRewriterPipeFree,
+        S3UploadStreamWrapper,
     };
 
     // `held` is visited, so the reaction keeps it alive for as long as the

--- a/src/runtime/api/NativePromiseContext.rs
+++ b/src/runtime/api/NativePromiseContext.rs
@@ -28,6 +28,7 @@ use bun_jsc::{JSGlobalObject, JSValue};
 
 use crate::api::html_rewriter;
 use crate::api::server;
+use crate::webcore::s3::client::S3UploadStreamWrapper;
 
 // Request contexts are a single generic
 // `NewRequestContext<ThisServer, SSL, DEBUG, MUX>`; alias the eight
@@ -66,10 +67,12 @@ pub enum Tag {
     /// Task-only tag (never a context cell): drops the last ref of a
     /// `RewriterPipe` on behalf of `RewriterPipe::deref_outside_caller`.
     HTMLRewriterPipeFree,
+    /// The stream pump's claim on an `S3UploadStreamWrapper` (`pump_cell`).
+    S3UploadStreamWrapper,
 }
 
 impl Tag {
-    pub const COUNT: usize = 10;
+    pub const COUNT: usize = 11;
 
     #[inline]
     const fn from_raw(n: u8) -> Tag {
@@ -84,6 +87,7 @@ impl Tag {
             7 => Tag::DebugHTTPSServerMuxRequestContext,
             8 => Tag::HTMLRewriterSuspension,
             9 => Tag::HTMLRewriterPipeFree,
+            10 => Tag::S3UploadStreamWrapper,
             _ => unreachable!(),
         }
     }
@@ -117,6 +121,9 @@ impl<ThisServer, const SSL: bool, const DBG: bool, const MUX: bool> NativePromis
 }
 impl NativePromiseContextType for html_rewriter::RewriterPipe {
     const TAG: Tag = Tag::HTMLRewriterSuspension;
+}
+impl NativePromiseContextType for S3UploadStreamWrapper {
+    const TAG: Tag = Tag::S3UploadStreamWrapper;
 }
 
 // `&JSGlobalObject` is ABI-identical to a non-null pointer. `ctx` is stored
@@ -202,6 +209,9 @@ fn clear_remembered_cell(ctx: *mut c_void, tag: Tag) {
             Tag::DebugHTTPSServerMuxRequestContext => {
                 (*ctx.cast::<DebugHTTPSServerMuxRequestContext>()).promise_cell_collected()
             }
+            Tag::S3UploadStreamWrapper => {
+                (*ctx.cast::<S3UploadStreamWrapper>()).pump_cell_collected()
+            }
             Tag::HTMLRewriterSuspension | Tag::HTMLRewriterPipeFree => {}
         }
     }
@@ -240,15 +250,16 @@ impl Taskable for DeferredDerefTask {
 impl DeferredDerefTask {
     const TAG_MASK: usize = 0b1111;
 
+    /// From a cell's destructor (and `RewriterPipe::deref_outside_caller`).
     pub(crate) fn schedule(ctx: *mut c_void, tag: Tag) {
         // SAFETY: called from the JS thread (GC sweep → C++ destructor); the
         // thread-local VM is alive for the duration of this call.
-        let vm = VirtualMachine::get();
-        if vm.event_loop_ref().is_closed_for_tasks() {
+        if VirtualMachine::get().event_loop_ref().is_closed_for_tasks() {
             // Teardown has forbidden script and released the queue; from here on only GC destructors
             // (possibly mid-sweep in `~VM`) reach this, and theirs is the last use of `ctx` in that
             // frame. A worker's HTMLRewriter pipe would outlive it, so those refs are released now,
-            // sweep-safe; a RequestContext's deref is not sweep-safe and dies with the VM instead.
+            // sweep-safe; a RequestContext's or an S3 wrapper's release is not sweep-safe and dies
+            // with the VM instead.
             match tag {
                 // SAFETY: the destroyed context held the suspension's ref on this live pipe.
                 Tag::HTMLRewriterSuspension => unsafe {
@@ -267,7 +278,17 @@ impl DeferredDerefTask {
             }
             return;
         }
+        Self::enqueue(ctx, tag);
+    }
 
+    /// For JS-thread code that owns a ref on `ctx` but must not release it in the
+    /// current frame (a frame of `ctx`'s own may be below it): the release runs on the
+    /// next tick, or at once if teardown has closed the queue, when no such frame exists.
+    pub(crate) fn schedule_outside_caller(ctx: *mut c_void, tag: Tag) {
+        Self::enqueue(ctx, tag);
+    }
+
+    fn enqueue(ctx: *mut c_void, tag: Tag) {
         let addr = ctx as usize;
         debug_assert!(addr & Self::TAG_MASK == 0);
 
@@ -277,9 +298,10 @@ impl DeferredDerefTask {
             <DeferredDerefTask as Taskable>::TAG,
             (addr | (tag as usize)) as *mut (),
         );
-        // SAFETY: event_loop() returns the VM's owned EventLoop; we are the
-        // sole mutator on the JS thread here.
-        vm.event_loop_ref().enqueue_task(task);
+        // A closed queue releases the task on arrival (`release_unrun` above runs it).
+        // SAFETY: JS thread; event_loop() returns the VM's owned EventLoop; we are the
+        // sole mutator here.
+        VirtualMachine::get().event_loop_ref().enqueue_task(task);
     }
 
     pub(crate) fn run_from_js_thread(packed_ptr: usize) {
@@ -289,7 +311,8 @@ impl DeferredDerefTask {
         // of the type indicated by `tag`, and this task owns one ref on it,
         // released below (for the HTMLRewriter tags: the ref taken in
         // `begin_suspension`, or the last ref handed over by
-        // `deref_outside_caller`). We are on the JS thread.
+        // `deref_outside_caller`; for the S3 tag: the pump's claim from
+        // `upload_stream`). We are on the JS thread.
         unsafe {
             match tag {
                 Tag::HTTPServerRequestContext => (*ctx.cast::<HTTPServerRequestContext>()).deref(),
@@ -325,6 +348,9 @@ impl DeferredDerefTask {
                         NonNull::new_unchecked(ctx.cast::<html_rewriter::RewriterPipe>()),
                     );
                 }
+                Tag::S3UploadStreamWrapper => {
+                    S3UploadStreamWrapper::release_pump_claim(ctx.cast::<S3UploadStreamWrapper>());
+                }
             }
         }
     }
@@ -353,3 +379,4 @@ const _: () = assert!(
 );
 const _: () =
     assert!(core::mem::align_of::<html_rewriter::RewriterPipe>() > DeferredDerefTask::TAG_MASK);
+const _: () = assert!(core::mem::align_of::<S3UploadStreamWrapper>() > DeferredDerefTask::TAG_MASK);

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -129,6 +129,8 @@ pub(crate) enum ActiveHandle {
     /// An S3 request / streaming download out on the HTTP thread; same.
     S3Request(ptr::NonNull<crate::webcore::s3::simple_request::S3HttpSimpleTask>),
     S3Download(ptr::NonNull<crate::webcore::s3::download_stream::S3HttpDownloadStreamingTask>),
+    /// An S3 upload; between parts nothing of it is out on the HTTP thread.
+    S3Upload(ptr::NonNull<crate::webcore::s3::MultiPartUpload>),
     /// A `Bun.build` running on the bundle thread with this VM's plugins/env.
     Bundle(ptr::NonNull<crate::api::js_bundle_completion_task::JSBundleCompletionTask>),
     /// A `dns.Resolver` (or the VM-global one) with a live c-ares channel.
@@ -229,6 +231,21 @@ impl ActiveHandle {
     pub(crate) fn unregister(&self) {
         if let Some(handles) = active_handles() {
             handles.swap_remove(self);
+        }
+    }
+
+    /// Whether a `bun test --isolate` swap leaves this running; its completion
+    /// lands on the next file's loop.
+    fn outlives_test_isolation(&self) -> bool {
+        match *self {
+            // A live VM cannot cancel a build: hop tasks it already queued would
+            // still be dispatched against the finished pass.
+            ActiveHandle::Bundle(_) => true,
+            // SAFETY: registered ⇒ live (it unregisters in `on_response`). A field
+            // read through the raw place: the HTTP thread may be writing the task's
+            // other fields, so no `&` to the whole task is formed.
+            ActiveHandle::S3Request(t) => unsafe { (*t.as_ptr()).outlives_test_isolation },
+            _ => false,
         }
     }
 }
@@ -1713,11 +1730,19 @@ fn stop_dns_for_vm_teardown() -> SweepResult {
 /// `--isolate` swap: a microtask still pending at end-of-file (queued by
 /// `tick_immediate_tasks` or `handle_rejected_promises`) can register new
 /// handles when it runs, so drain first so they land in the registry before it
-/// empties, then stop. (VM teardown must *not* drain here — its
-/// prepareForDestruction discards the pre-exit queues.)
+/// empties, then stop. A stop can queue such microtasks too (a failed upload's
+/// `.catch`), and the swap closes every socket blind right after this, so
+/// repeat while a round stopped something. Bounded: a `.catch` that restarts
+/// its upload would otherwise never let this end. (VM teardown must *not*
+/// drain here — its prepareForDestruction discards the pre-exit queues.)
 pub(crate) fn stop_active_handles_for_test_isolation(vm: &mut VirtualMachine) {
-    let _ = vm.event_loop_mut().drain_microtasks();
-    let _ = stop_active_handles(vm, StopReason::TestIsolation);
+    const MAX_ROUNDS: usize = 8;
+    for _ in 0..MAX_ROUNDS {
+        let _ = vm.event_loop_mut().drain_microtasks();
+        if stop_active_handles(vm, StopReason::TestIsolation) == SweepResult::Idle {
+            break;
+        }
+    }
 }
 
 pub(crate) fn stop_active_handles_for_vm_teardown(vm: &mut VirtualMachine) -> SweepResult {
@@ -1760,7 +1785,9 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
             unsafe { (*all).event_loop_delay.disable() };
         }
     }
-    // Entries that stay registered across a test-isolation swap.
+    // Entries that stay registered across a test-isolation swap (including what
+    // a stop below registers: the rollback of a failed upload). Not counted as
+    // stopped, so a sweep that only meets these again reports `Idle`.
     let mut kept: Vec<ActiveHandle> = Vec::new();
     loop {
         // SAFETY: live boxed per-thread `RuntimeState`; the borrow ends before
@@ -1768,6 +1795,10 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
         let Some(kv) = (unsafe { &mut (*state).active_handles }).pop() else {
             break;
         };
+        if reason == StopReason::TestIsolation && kv.key.outlives_test_isolation() {
+            kept.push(kv.key);
+            continue;
+        }
         result = SweepResult::Stopped;
         match kv.key {
             // SAFETY: live until it unregisters in `detach`.
@@ -1809,10 +1840,11 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
             ActiveHandle::S3Download(t) => unsafe {
                 crate::webcore::s3::download_stream::S3HttpDownloadStreamingTask::stop_for_vm_teardown(t.as_ptr())
             },
-            // A live VM cannot cancel a build: hop tasks it already queued here
-            // would still be dispatched against the finished pass. The build
-            // runs on; its completion lands on the next file's global.
-            ActiveHandle::Bundle(_) if reason == StopReason::TestIsolation => kept.push(kv.key),
+            // SAFETY: live until it unregisters in `Drop`; may free itself inside,
+            // not touched after.
+            ActiveHandle::S3Upload(u) => unsafe {
+                crate::webcore::s3::MultiPartUpload::stop_for_vm_teardown(u.as_ptr())
+            },
             // SAFETY: live until it unregisters in `on_complete_anytask`.
             ActiveHandle::Bundle(c) => unsafe {
                 crate::api::js_bundle_completion_task::JSBundleCompletionTask::stop_for_vm_teardown(

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -44,6 +44,7 @@ pub use crate::webcore::s3::simple_request::S3UploadResult;
 
 use crate::webcore::s3::simple_request as s3_simple_request;
 
+use crate::api::native_promise_context;
 use crate::webcore::ByteStream;
 use crate::webcore::ReadableStream;
 use crate::webcore::readable_stream::Source as ReadableStreamPtr;
@@ -303,6 +304,7 @@ pub(crate) fn list_objects(
         body: Box::default(),
         poll_ref: bun_io::KeepAlive::init(),
         signal_store: Default::default(),
+        outlives_test_isolation: false,
     }));
     // SAFETY: just allocated, non-null
     let task = unsafe { &mut *task_ptr };
@@ -435,6 +437,8 @@ pub(crate) fn writable_stream(
             .global_this
             .expect("NetworkSink.global_this set at construction");
         let global = global.get();
+        // A failed settle (`Terminated` during teardown) must not skip `finalize`.
+        let mut settled: JsResult<()> = Ok(());
         if sink.end_promise.has_value() || sink.flush_promise.has_value() {
             // SAFETY: `bun_vm()` returns the live per-thread VM pointer.
             let event_loop = global.bun_vm().as_mut().event_loop();
@@ -444,21 +448,21 @@ pub(crate) fn writable_stream(
             match result {
                 S3UploadResult::Success => {
                     if sink.flush_promise.has_value() {
-                        sink.flush_promise
-                            .resolve(global, JSValue::js_number(0.0))?;
+                        settled = sink.flush_promise.resolve(global, JSValue::js_number(0.0));
                     }
-                    if sink.end_promise.has_value() {
-                        sink.end_promise
-                            .resolve(global, JSValue::js_number(uploaded as f64))?;
+                    if settled.is_ok() && sink.end_promise.has_value() {
+                        settled = sink
+                            .end_promise
+                            .resolve(global, JSValue::js_number(uploaded as f64));
                     }
                 }
                 S3UploadResult::Failure(err) => {
                     let js_err = s3_error_to_js(&err, global, sink.path());
                     if sink.flush_promise.has_value() {
-                        sink.flush_promise.reject(global, Ok(js_err))?;
+                        settled = sink.flush_promise.reject(global, Ok(js_err));
                     }
-                    if sink.end_promise.has_value() {
-                        sink.end_promise.reject(global, Ok(js_err))?;
+                    if settled.is_ok() && sink.end_promise.has_value() {
+                        settled = sink.end_promise.reject(global, Ok(js_err));
                     }
                     if !sink.done {
                         sink.abort();
@@ -467,7 +471,7 @@ pub(crate) fn writable_stream(
             }
         }
         sink.finalize();
-        Ok(())
+        settled
     }
 
     // Thunks adapting typed callbacks to the erased `*mut c_void` signatures stored on
@@ -539,6 +543,7 @@ pub(crate) fn writable_stream(
 
     task.poll_ref
         .with_mut(|poll_ref| poll_ref.ref_(bun_io::js_vm_ctx()));
+    task.active_handle().register();
 
     // Heap-allocate; `JSSink<NetworkSink>` is layout-
     // compatible (`{ sink: NetworkSink }`) so the cast in `to_sink()` is just a pointer reinterpret.
@@ -562,7 +567,10 @@ pub(crate) fn writable_stream(
     Ok(sink.to_js(global_this))
 }
 
+/// `align(16)`: `NativePromiseContext`'s deferred-deref task packs a 4-bit
+/// type tag into the low bits of a pointer to this.
 #[derive(bun_ptr::CellRefCounted)]
+#[repr(align(16))]
 pub struct S3UploadStreamWrapper {
     pub(crate) ref_count: core::cell::Cell<u32>,
 
@@ -577,6 +585,10 @@ pub struct S3UploadStreamWrapper {
     /// taken (no JS reader to lock it). Empty on the `assign_to_stream` path.
     pub readable_stream_ref: ReadableStreamStrong,
     pub global: GlobalRef, // JSC_BORROW
+    /// The `NativePromiseContext` holding the JS pump's +1 while the pump promise
+    /// is unsettled, or `ZERO`. Not visited: the reaction keeps the cell alive, and
+    /// the cell's destructor clears this first (`pump_cell_collected`).
+    pump_cell: Cell<JSValue>,
 }
 
 impl S3UploadStreamWrapper {
@@ -597,6 +609,66 @@ impl S3UploadStreamWrapper {
     fn sink_mut(&mut self) -> Option<&mut NetworkSink> {
         // SAFETY: sink is a live Box allocation owned by this wrapper.
         self.sink.map(|p| unsafe { &mut *p.as_ptr() })
+    }
+
+    /// Whether `resolve` now owns the pump's +1 (`upload_stream`): it takes it out of
+    /// `pump_cell` (the shims and the cell's destructor then find nothing), or a native
+    /// source is still attached, so `end_from_stream`, which clears the source before
+    /// it releases, has not. Runs before anything allocates: a collection could free
+    /// the cell.
+    fn take_pump_claim(&mut self) -> bool {
+        let cell = self.pump_cell.replace(JSValue::ZERO);
+        if !cell.is_empty() && native_promise_context::take::<Self>(cell).is_some() {
+            return true;
+        }
+        self.native_source_attached()
+    }
+
+    fn native_source_attached(&mut self) -> bool {
+        matches!(
+            self.sink_mut().map(|sink| &sink.source),
+            Some(
+                crate::webcore::streams::SourceHandle::ByteStream(_)
+                    | crate::webcore::streams::SourceHandle::FileReader(_)
+            )
+        )
+    }
+
+    /// Hands the +1 `take_pump_claim` took to `release_pump_claim`, a tick later: the
+    /// release frees the sink, and `resolve` can be running inside the sink's own
+    /// `write` or `end` (a request refused or failing to sign on the spot). A native
+    /// source is cleared now: while one is attached, `end_from_stream` and the attach
+    /// code in `upload_stream` treat the +1 as theirs.
+    fn release_pump_claim_later(&mut self) {
+        if self.native_source_attached() {
+            if let Some(sink) = self.sink_mut() {
+                sink.source.clear();
+            }
+        }
+        native_promise_context::DeferredDerefTask::schedule_outside_caller(
+            core::ptr::from_mut::<Self>(self).cast::<c_void>(),
+            native_promise_context::Tag::S3UploadStreamWrapper,
+        );
+    }
+
+    /// The cell's destructor (GC sweep; the cell's +1 keeps this alive): a plain field
+    /// write here, `release_pump_claim` a tick later.
+    pub(crate) fn pump_cell_collected(&self) {
+        bun_output::scoped_log!(S3UploadStream, "pump collected");
+        self.pump_cell.set(JSValue::ZERO);
+    }
+
+    /// Frees the sink and drops the pump's +1, for `resolve` or for the collected
+    /// cell, in a frame that belongs to neither the sink nor the pump.
+    ///
+    /// # Safety
+    /// `this` is live (the +1 being released keeps it so); JS thread.
+    pub(crate) unsafe fn release_pump_claim(this: *mut Self) {
+        bun_output::scoped_log!(S3UploadStream, "releasePumpClaim");
+        // SAFETY: fn contract; the borrow ends before the deref, which may free it.
+        unsafe { (*this).detach_sink() };
+        // SAFETY: fn contract.
+        unsafe { Self::deref(this) };
     }
 
     pub(crate) fn on_writable(task: &MultiPartUpload, self_: &mut Self, flushed: u64) {
@@ -651,7 +723,8 @@ impl S3UploadStreamWrapper {
         // SAFETY: adopts the upload's ref; released at scope exit, after the borrows below.
         let _upload_ref = unsafe { RefPtr::from_raw(std::ptr::from_mut::<Self>(self_)) };
         let global = self_.global;
-        // The native teardown (source close, pump-ref release, completion callback)
+        let owns_pump_claim = self_.take_pump_claim();
+        // The native teardown (source close, pump-ref hand-off, completion callback)
         // runs on every path; the promise slots are settled until one settle leaves an
         // exception pending, which is what this returns (nothing settles over it).
         let mut settled: JsResult<()> = Ok(());
@@ -682,23 +755,7 @@ impl S3UploadStreamWrapper {
                 let js_err = stashed
                     .unwrap_or_else(|| s3_error_to_js(err, &global, Some(self_.path.slice())));
                 js_err.ensure_still_alive();
-                let mut is_native = false;
                 if let Some(sink) = self_.sink_mut() {
-                    // Sink pump still in-flight: fire source.close() so the JSSink
-                    // controller's onClose cancels the upstream ReadableStream. The
-                    // pump promise settles after, triggering the `.then` shim which
-                    // calls `detach_sink` and releases the pump ref.
-                    //
-                    // Captured before `source.close()`: on the native fast-path
-                    // there is no pump promise, so the pump +1 must be released
-                    // inline below (mirrors `FetchTasklet::cancel_request_body_sink`).
-                    // `end_from_stream` cleared `source` when it drove this call,
-                    // so this is only true when the S3 side failed first.
-                    is_native = matches!(
-                        sink.source,
-                        crate::webcore::streams::SourceHandle::ByteStream(_)
-                            | crate::webcore::streams::SourceHandle::FileReader(_)
-                    );
                     sink.ended = true;
                     sink.done = true;
                     sink.pending.result = crate::webcore::streams::Writable::Done;
@@ -711,13 +768,6 @@ impl S3UploadStreamWrapper {
                     }
                     sink.source.close(None);
                 }
-                if is_native {
-                    self_.detach_sink();
-                    // SAFETY: `self_` is the live Box allocation; this balances the
-                    // pump +1 from `upload_stream` (rc 2→1). The scopeguard above
-                    // releases the remaining ref at scope exit.
-                    unsafe { Self::deref(std::ptr::from_mut::<Self>(self_)) };
-                }
                 if self_.end_promise.has_value() {
                     if settled.is_ok() {
                         settled = self_.end_promise.reject(&global, Ok(js_err));
@@ -725,6 +775,9 @@ impl S3UploadStreamWrapper {
                     self_.end_promise = bun_jsc::JSPromiseStrong::empty();
                 }
             }
+        }
+        if owns_pump_claim {
+            self_.release_pump_claim_later();
         }
 
         if let Some(callback) = self_.callback {
@@ -734,16 +787,27 @@ impl S3UploadStreamWrapper {
     }
 }
 
+/// The pump promise settled: the wrapper, now owing the +1 its `handle_*_stream`
+/// releases, or `None` if `resolve` or the cell's destructor took it first (the
+/// wrapper may be gone; nothing is left to do).
+fn s3_upload_stream_take_pump_claim(
+    callframe: &CallFrame,
+) -> Option<NonNull<S3UploadStreamWrapper>> {
+    let args = callframe.arguments();
+    let this = native_promise_context::take::<S3UploadStreamWrapper>(args[args.len() - 1])?;
+    // SAFETY: the claim just taken keeps the wrapper alive.
+    unsafe { this.as_ref() }.pump_cell.set(JSValue::ZERO);
+    Some(this)
+}
+
 fn s3_upload_stream_on_resolve(
     _global_this: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
-    let args = callframe.arguments();
-    let this: *mut S3UploadStreamWrapper =
-        args[args.len() - 1].as_promise_ptr::<S3UploadStreamWrapper>();
-    // SAFETY: `as_promise_ptr` recovers the ctx stashed by `upload_stream`; kept
-    // alive by the ref taken there, which `handle_resolve_stream` balances.
-    unsafe { (*this).handle_resolve_stream() };
+    if let Some(this) = s3_upload_stream_take_pump_claim(callframe) {
+        // SAFETY: alive on the claim taken above, which this releases last.
+        unsafe { (*this.as_ptr()).handle_resolve_stream() };
+    }
     Ok(JSValue::UNDEFINED)
 }
 
@@ -751,13 +815,11 @@ fn s3_upload_stream_on_reject(
     _global_this: &JSGlobalObject,
     callframe: &CallFrame,
 ) -> JsResult<JSValue> {
-    let args = callframe.arguments();
-    let this: *mut S3UploadStreamWrapper =
-        args[args.len() - 1].as_promise_ptr::<S3UploadStreamWrapper>();
-    let err = args[0];
-    // SAFETY: `as_promise_ptr` recovers the ctx stashed by `upload_stream`; kept
-    // alive by the ref taken there, which `handle_reject_stream` balances.
-    unsafe { (*this).handle_reject_stream(err) };
+    let err = callframe.argument(0);
+    if let Some(this) = s3_upload_stream_take_pump_claim(callframe) {
+        // SAFETY: as in `s3_upload_stream_on_resolve`.
+        unsafe { (*this.as_ptr()).handle_reject_stream(err) };
+    }
     Ok(JSValue::UNDEFINED)
 }
 
@@ -789,6 +851,8 @@ bun_jsc::jsc_host_abi! {
 impl Drop for S3UploadStreamWrapper {
     fn drop(&mut self) {
         bun_output::scoped_log!(S3UploadStream, "deinit {}", self.sink.is_some());
+        // A claim still in its cell would be a ref, and this is the last one going.
+        debug_assert!(self.pump_cell.get().is_empty());
         self.detach_sink();
     }
 }
@@ -949,10 +1013,13 @@ pub(crate) fn upload_stream(
 
     task.poll_ref
         .with_mut(|poll_ref| poll_ref.ref_(bun_io::js_vm_ctx()));
+    task.active_handle().register();
 
     let ctx_ptr: *mut S3UploadStreamWrapper =
         bun_core::heap::into_raw(Box::new(S3UploadStreamWrapper {
-            ref_count: Cell::new(2), // +1 for the stream pump (released by the .then shim / handle_*_stream)
+            // +1 for the stream pump: `handle_*_stream`, `end_from_stream`, `resolve`
+            // (`take_pump_claim`) or the collected `pump_cell` releases it, whichever ends it.
+            ref_count: Cell::new(2),
             sink: None,
             callback,
             callback_context,
@@ -962,6 +1029,7 @@ pub(crate) fn upload_stream(
             end_promise: bun_jsc::JSPromiseStrong::init(global_this),
             readable_stream_ref: ReadableStreamStrong::default(),
             global: global_static,
+            pump_cell: Cell::new(JSValue::ZERO),
         }));
     // SAFETY: freshly heap-allocated; exclusive access here.
     let ctx = unsafe { &mut *ctx_ptr };
@@ -1019,7 +1087,16 @@ pub(crate) fn upload_stream(
                 } else {
                     crate::webcore::streams::StreamResult::Owned(buffered)
                 };
-                match sink.write(&chunk) {
+                let wrote = sink.write(&chunk);
+                if !matches!(
+                    sink.source,
+                    crate::webcore::streams::SourceHandle::ByteStream(_)
+                ) {
+                    // The write failed the upload on the spot (its request was refused
+                    // or did not sign); `resolve` has taken the pump's +1.
+                    return Ok(end_promise_value);
+                }
+                match wrote {
                     crate::webcore::streams::Writable::Backpressure(_) => {
                         byte_stream.sink_paused.set(true);
                     }
@@ -1072,9 +1149,12 @@ pub(crate) fn upload_stream(
         if let Some(promise) = assignment_result.as_any_promise() {
             match promise.status() {
                 bun_jsc::js_promise::Status::Pending => {
-                    assignment_result.then(
+                    // The cell takes over the pump's +1 (see `pump_cell`).
+                    let cell = native_promise_context::create(global_this, ctx_ptr, JSValue::ZERO);
+                    ctx.pump_cell.set(cell);
+                    assignment_result.then_with_value(
                         global_this,
-                        ctx_ptr,
+                        cell,
                         s3_upload_stream_on_resolve_shim,
                         s3_upload_stream_on_reject_shim,
                     );

--- a/src/runtime/webcore/s3/multipart.rs
+++ b/src/runtime/webcore/s3/multipart.rs
@@ -209,6 +209,29 @@ impl MultiPartUpload {
     fn as_ctx_ptr(&self) -> *mut c_void {
         self.root_ptr().cast::<c_void>()
     }
+
+    /// Registered by `writable_stream` / `upload_stream`, removed in `Drop`.
+    pub(crate) fn active_handle(&self) -> crate::jsc_hooks::ActiveHandle {
+        crate::jsc_hooks::ActiveHandle::S3Upload(
+            self.root
+                .get()
+                .expect("MultiPartUpload root set at construction"),
+        )
+    }
+
+    /// Stop phase (teardown or the `--isolate` swap): nothing feeds this upload any
+    /// more, so fail it. A request still out drops its ref when it finds the upload
+    /// finished; the rollback this may send is refused during teardown and, under
+    /// `--isolate`, completes on the next file's loop (`outlives_test_isolation`).
+    ///
+    /// # Safety
+    /// `this` is live; JS thread. May free it.
+    pub(crate) unsafe fn stop_for_vm_teardown(this: *mut Self) {
+        // SAFETY: fn contract; the guard's ref outlives `fail`, which may release
+        // every other one.
+        let guard = unsafe { RefPtr::init_ref(this) };
+        crate::dispatch::fold(guard.fail(s3_simple_request::VM_SHUTDOWN));
+    }
 }
 
 #[repr(u8)]
@@ -377,10 +400,10 @@ impl UploadPart {
 impl Drop for MultiPartUpload {
     fn drop(&mut self) {
         scoped_log!(S3MultiPartUpload, "deinit");
+        self.active_handle().unregister();
         // queue: Box<[UploadPart]> — dropped automatically (parts' raw `data` already freed during lifecycle)
         // KeepAlive::unref takes an `EventLoopCtx` (aio cycle-break vtable),
         // not `&VirtualMachine`. Route through the global hook like simple_request does.
-        let _ = self.vm;
         self.poll_ref.with_mut(|poll_ref| {
             poll_ref.unref(bun_io::posix_event_loop::get_vm_ctx(
                 bun_io::AllocatorType::Js,
@@ -572,19 +595,22 @@ impl MultiPartUpload {
         }
         if self.state.get() != State::Finished {
             let old_state = self.state.replace(State::Finished);
-            (self.callback)(
+            // The deref must run after the callback, whatever it returned:
+            let settled = (self.callback)(
                 self,
                 S3UploadResult::Failure(err),
                 self.callback_context.get(),
-            )?;
-
+            );
             if old_state == State::MultipartCompleted {
                 // we are a multipart upload so we need to rollback
                 // will deref after rollback
-                self.rollback_multi_part_request()?;
+                let rollback = self.rollback_multi_part_request();
+                settled?;
+                rollback?;
             } else {
                 // single file upload no need to rollback
                 MultiPartUpload::deref_(self.root_ptr());
+                settled?;
             }
         }
         Ok(())
@@ -727,7 +753,8 @@ impl MultiPartUpload {
         match result {
             S3CommitResult::Failure(err) => {
                 let mut options = self_.options.get();
-                if options.retry > 0 {
+                // A stopping VM refuses every request: do not walk the retries through it.
+                if options.retry > 0 && self_.vm.script_allowed() {
                     options.retry -= 1;
                     self_.options.set(options);
                     // retry commit
@@ -772,7 +799,8 @@ impl MultiPartUpload {
         match result {
             S3UploadResult::Failure(_err) => {
                 let mut options = self_.options.get();
-                if options.retry > 0 {
+                // As in `on_commit_multi_part_request`.
+                if options.retry > 0 && self_.vm.script_allowed() {
                     options.retry -= 1;
                     self_.options.set(options);
                     // retry rollback
@@ -842,6 +870,7 @@ impl MultiPartUpload {
                 body: b"",
                 search_params: Some(search_params),
                 request_payer: self.request_payer,
+                outlives_test_isolation: true,
                 ..Default::default()
             },
             s3_simple_request::S3Callback::Upload(Self::on_rollback_multi_part_request),

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -137,6 +137,8 @@ pub struct S3HttpSimpleTask {
     /// The HTTP client's abort flag: set by the VM's stop phase so a request
     /// still queued or in flight fails promptly and comes back.
     pub(crate) signal_store: bun_http::signals::Store,
+    /// `S3SimpleRequestOptions::outlives_test_isolation`.
+    pub(crate) outlives_test_isolation: bool,
 }
 
 impl Taskable for S3HttpSimpleTask {
@@ -528,6 +530,10 @@ pub struct S3SimpleRequestOptions<'a> {
     pub(crate) acl: Option<ACL>,
     pub(crate) storage_class: Option<StorageClass>,
     pub(crate) request_payer: bool,
+    /// The `bun test --isolate` swap stops the finished file's requests, except
+    /// one that is cleanup the swap itself caused (a failed upload's rollback):
+    /// that one completes, without script, on the next file's loop.
+    pub(crate) outlives_test_isolation: bool,
 }
 
 impl<'a> Default for S3SimpleRequestOptions<'a> {
@@ -545,9 +551,16 @@ impl<'a> Default for S3SimpleRequestOptions<'a> {
             acl: None,
             storage_class: None,
             request_payer: false,
+            outlives_test_isolation: false,
         }
     }
 }
+
+/// What an S3 operation fails with when its VM stops before it is done.
+pub(crate) const VM_SHUTDOWN: S3Error<'static> = S3Error {
+    code: b"ERR_S3_VM_SHUTDOWN",
+    message: b"The JavaScript VM that owns this request is shutting down",
+};
 
 pub(crate) fn execute_simple_s3_request(
     this: &S3Credentials,
@@ -559,11 +572,7 @@ pub(crate) fn execute_simple_s3_request(
     // release; nothing new leaves a VM that is stopping.
     if !VirtualMachine::get().script_allowed() {
         drop(options.range);
-        callback.fail(
-            b"ERR_S3_VM_SHUTDOWN",
-            b"The JavaScript VM that owns this request is shutting down",
-            callback_context,
-        )?;
+        callback.fail(VM_SHUTDOWN.code, VM_SHUTDOWN.message, callback_context)?;
         return Ok(());
     }
     let result = match this.sign_request::<false>(
@@ -640,6 +649,7 @@ pub(crate) fn execute_simple_s3_request(
         body: Box::<[u8]>::from(options.body),
         poll_ref,
         signal_store: Default::default(),
+        outlives_test_isolation: options.outlives_test_isolation,
     });
     // SAFETY: `task_ptr` is a freshly heap-allocated pointer; shared reads only until
     // the scoped exclusive `http` writes below.

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, normalizeBunSnapshot, tempDir } from "harness";
 import fs from "node:fs";
 import net from "node:net";
 import { join } from "node:path";
@@ -946,6 +946,10 @@ test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next fil
 // - monitorEventLoopDelay().enable(): the per-thread monitor holds the file's
 //   histogram. It is disabled at the swap and only ever holds the histogram
 //   weakly, so an enabled monitor must not keep the file's global alive.
+// - S3 upload from a stream that never delivers enough for a part: nothing was
+//   registered for the swap to stop (the upload has no request out while it
+//   buffers), so its native wrapper kept holding the caller's promise, which
+//   pins the global. The swap now fails the upload like VM teardown does.
 //
 // Each fixture runs 8 isolated files that leak one handle apiece, forces a
 // full GC, and counts live GlobalObject cells. Pinned globals accumulate
@@ -1084,7 +1088,183 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
     );
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
   });
+
+  // The endpoint is never contacted: the upload buffers until it has a whole
+  // part, and the stream stops after one small chunk.
+  test("S3 upload from a stream left waiting for bytes", async () => {
+    using dir = tempDir(
+      "isolate-leak-s3-upload",
+      makeLeakFixture(`
+        const s3 = new Bun.S3Client({ accessKeyId: "k", secretAccessKey: "s", bucket: "b", endpoint: "http://127.0.0.1:1" });
+        s3.file("key").write(new Response(new ReadableStream({
+          pull(c) { c.enqueue(new Uint8Array(64)); return new Promise(() => {}); },
+        }))).catch(() => {});
+      `),
+    );
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+  });
 });
+
+// The swap fails a multipart S3 upload the finished file left open, whether a
+// stream or a writer() feeds it. Two things about how it does so:
+// - The AbortMultipartUpload that failing it sends must reach S3. It is a new
+//   request started by the swap's own sweep, so that sweep must let it through
+//   (retry: 0 makes the one attempt the only one). It is also the only sign, on
+//   a release build, that the swap reached the upload.
+// - Failing a stream-fed upload frees the upload's native wrapper, whatever
+//   state the stream's pump is in: file a drops its stream and collects, so by
+//   the swap the pump may be gone or still parked on its backpressure. On a
+//   debug build the wrapper's and the upload's own teardown log lines show both
+//   were freed exactly once: the wrapper at the swap (or earlier, if the
+//   collected pump gave it up first), the upload once the rollback came back
+//   (or at the exit teardown, if it had not yet).
+const ROLLBACK_FEEDERS = {
+  stream: `
+    s3.file("key").write(new Response(new ReadableStream({
+      pull(c) { c.enqueue(new Uint8Array(5 * 1024 * 1024)); return new Promise(() => {}); },
+    }))).catch(() => {});
+  `,
+  writer: `
+    s3.file("key").writer({ retry: 0 }).write(new Uint8Array(5 * 1024 * 1024));
+  `,
+};
+test.concurrent.each(Object.keys(ROLLBACK_FEEDERS) as (keyof typeof ROLLBACK_FEEDERS)[])(
+  "--isolate: a multipart S3 upload fed by a %s and left open is rolled back and freed",
+  async feeder => {
+    const testFile = (body: string) => `
+    import { test } from "bun:test";
+    const seen = async (method) => (await (await fetch(process.env.STAND_IN + "__seen")).json()).includes(method);
+    ${body}
+  `;
+    using dir = tempDir("isolate-s3-rollback", {
+      "a.test.js": testFile(`
+      const s3 = new Bun.S3Client({ accessKeyId: "k", secretAccessKey: "s", bucket: "b", endpoint: process.env.STAND_IN, retry: 0 });
+      ${ROLLBACK_FEEDERS[feeder]}
+      test("a: the upload gets its first part out, then waits for more", async () => {
+        while (!(await seen("PUT"))) await Bun.sleep(10);
+        Bun.gc(true);
+      });
+    `),
+      "b.test.js": testFile(`
+      test("b: the swap rolled a's upload back", async () => {
+        while (!(await seen("DELETE"))) await Bun.sleep(10);
+      });
+    `),
+      "host.js": `
+      const seen = [];
+      const standIn = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          if (req.url.endsWith("/__seen")) return Response.json(seen.map(r => r.split(" ")[0]));
+          await req.arrayBuffer();
+          const url = new URL(req.url);
+          seen.push(req.method + " " + url.pathname + url.search);
+          if (req.method === "POST") {
+            return new Response("<InitiateMultipartUploadResult><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>");
+          }
+          return new Response(undefined, { headers: { etag: '"part"' } });
+        },
+      });
+      const child = Bun.spawn({
+        cmd: [process.execPath, "test", "--isolate", "./a.test.js", "./b.test.js"],
+        env: { ...process.env, STAND_IN: standIn.url.href, BUN_DEBUG_S3UploadStream: "1", BUN_DEBUG_S3MultiPartUpload: "1", BUN_DESTRUCT_VM_ON_EXIT: "1" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([child.stdout.text(), child.stderr.text(), child.exited]);
+      const output = stdout + stderr;
+      standIn.stop(true);
+      console.log(JSON.stringify({
+        seen,
+        wrappers: output.match(/^\\[s3uploadstream\\] deinit /gm)?.length ?? 0,
+        uploads: output.match(/^\\[s3multipartupload\\] deinit$/gm)?.length ?? 0,
+        passed: /\\b2 pass\\b/.test(output) && !/\\b[1-9]\\d* fail\\b/.test(output),
+        exitCode,
+        output,
+      }));
+    `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "host.js"],
+      cwd: String(dir),
+      // The S3 client does not honor NO_PROXY; an inherited proxy would hijack the
+      // requests to the stand-in.
+      env: { ...bunEnv, HTTP_PROXY: undefined, HTTPS_PROXY: undefined, http_proxy: undefined, https_proxy: undefined },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const expected = {
+      seen: [
+        "POST /b/key?uploads=",
+        "PUT /b/key?partNumber=1&uploadId=upload-1&x-id=UploadPart",
+        "DELETE /b/key?uploadId=upload-1",
+      ],
+      wrappers: isDebug && feeder === "stream" ? 1 : 0,
+      uploads: isDebug ? 1 : 0,
+      passed: true,
+      exitCode: 0,
+      output: "",
+    };
+    const actual = JSON.parse(stdout);
+    // On a failure, everything the isolated run printed.
+    if (Bun.deepEquals({ ...actual, output: "" }, expected)) actual.output = "";
+    expect(actual).toEqual(expected);
+    expect(exitCode).toBe(0);
+  },
+);
+
+// Failing the upload runs the finished file's own code: the stream's cancel()
+// right there, and whatever was chained on the write() promise when the swap
+// next drains microtasks. Anything that code opens has to be stopped by the
+// same swap too. Otherwise the swap closes the new server's socket blind (as it
+// does every socket of the finished file) and leaves the server registered, and
+// the next swap stops it on top of its closed socket (use after free, seen by
+// ASAN at the b -> c boundary). Hence the third file.
+const REOPENERS = {
+  "the stream's cancel()": `
+    s3.file("key").write(new Response(new ReadableStream({
+      pull(c) { c.enqueue(new Uint8Array(64)); return new Promise(() => {}); },
+      cancel() { openServer(); },
+    }))).catch(() => {});
+  `,
+  "the write() promise's catch": `
+    s3.file("key").write(new Response(new ReadableStream({
+      pull(c) { c.enqueue(new Uint8Array(64)); return new Promise(() => {}); },
+    }))).catch(openServer);
+  `,
+};
+test.concurrent.each(Object.keys(REOPENERS) as (keyof typeof REOPENERS)[])(
+  "--isolate: a server opened by %s of the upload the swap fails is stopped by that swap",
+  async reopener => {
+    using dir = tempDir("isolate-s3-reopen", {
+      "a.test.js": `
+        import { test } from "bun:test";
+        const s3 = new Bun.S3Client({ accessKeyId: "k", secretAccessKey: "s", bucket: "b", endpoint: "http://127.0.0.1:1" });
+        const openServer = () => { globalThis.reopened = Bun.serve({ port: 0, fetch: () => new Response("") }); };
+        ${REOPENERS[reopener]}
+        test("a leaves the upload waiting for bytes", () => {});
+      `,
+      "b.test.js": `import { test } from "bun:test"; test("b", () => {});`,
+      "c.test.js": `import { test } from "bun:test"; test("c", () => {});`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "./a.test.js", "./b.test.js", "./c.test.js"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const output = stdout + stderr;
+    expect({
+      passed: /\b3 pass\b/.test(output),
+      sanitizer: output.includes("Sanitizer"),
+      exitCode,
+    }).toEqual({ passed: true, sanitizer: false, exitCode: 0 });
+  },
+);
 
 // fs.watchFile's StatWatcher is thread-safe-refcounted: the scheduler queue
 // holds a ref that is dropped on the work-pool thread. After unwatchFile +

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1714,6 +1714,16 @@ describe.skipIf(!minioCredentials)("Archive with S3", () => {
   });
 });
 
+// The S3 client does not honor NO_PROXY; an inherited proxy would hijack the
+// requests to a stand-in server.
+const noProxyEnv = {
+  ...bunEnv,
+  HTTP_PROXY: undefined,
+  HTTPS_PROXY: undefined,
+  http_proxy: undefined,
+  https_proxy: undefined,
+};
+
 describe("s3 multipart upload id validation", () => {
   it("rejects a CreateMultipartUpload response whose upload id contains non-ASCII bytes", async () => {
     // The whole scenario runs in a subprocess so a misbehaving runtime cannot take down the test runner.
@@ -1786,7 +1796,7 @@ describe("s3 multipart upload id validation", () => {
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      env: noProxyEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -1844,7 +1854,7 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      env: noProxyEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -2040,7 +2050,7 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      env: noProxyEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -2121,7 +2131,7 @@ describe("s3 upload stream body error", () => {
     `;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
+      env: noProxyEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -2131,6 +2141,127 @@ describe("s3 upload stream body error", () => {
     expect(received).toBe(totalBytes);
     expect(exitCode).toBe(0);
   });
+
+  // Once S3 fails a JS-pumped upload, its native wrapper is freed on the next
+  // turn of the loop. The pump promise's .then shim can still run after that: a
+  // direct stream's pump promise is settled by the pull promise the user
+  // returned, whenever that happens. Here it happens after the wrapper is gone,
+  // so the shim must find nothing left to do (with the wrapper handed to it
+  // directly, ASAN reports a use after free here).
+  it.concurrent("a pump that settles after S3 failed the upload and freed its wrapper touches nothing", async () => {
+    const fixture = `
+      const standIn = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          await req.arrayBuffer();
+          return new Response("<Error><Code>AccessDenied</Code><Message>no</Message></Error>", { status: 403 });
+        },
+      });
+      const client = new Bun.S3Client({ accessKeyId: "k", secretAccessKey: "s", bucket: "b", endpoint: standIn.url.href });
+      const pull = Promise.withResolvers();
+      const written = client.write("key", new Response(new ReadableStream({
+        type: "direct",
+        pull(controller) {
+          controller.write(new Uint8Array(5 * 1024 * 1024));
+          return pull.promise;
+        },
+      })));
+      console.log("write:", await written.then(() => "resolved", e => e.code));
+      // The turn on which the wrapper is freed.
+      await new Promise(resolve => setImmediate(resolve));
+      pull.resolve();
+      // The pump promise settles, and with it the shim, before the next macrotask.
+      await new Promise(resolve => setImmediate(resolve));
+      console.log("pump settled");
+      standIn.stop(true);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: noProxyEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "write: AccessDenied\npump settled\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // A request can fail before it leaves (here: nothing to sign with), which fails
+  // the upload while the call that tried to send it, the sink's own write() or
+  // end(), is still on the stack. Freeing the sink right there is a use after
+  // free on the way back out (ASAN); the upload must only reject the write.
+  // Both feeders: a JS stream whose bytes arrive once the pump is waiting for
+  // them, and a fetch body attached with a whole part already buffered, which the
+  // attach code writes into the sink itself. The body is bigger than a part so
+  // that, by the time the upstream has written it all, at least a part of it has
+  // usually arrived; if less has, the upload fails a turn later, a path the
+  // other tests cover.
+  const UNSIGNABLE_UPLOADS = {
+    "a JS stream": `
+      const chunk = Promise.withResolvers();
+      const written = client.write("key", new Response(new ReadableStream({
+        async start(c) { await chunk.promise; c.enqueue(new Uint8Array(64)); c.close(); },
+      })));
+      await new Promise(resolve => setImmediate(resolve));
+      chunk.resolve();
+    `,
+    "a fetch body": `
+      const upstreamDone = Promise.withResolvers();
+      const upstream = Bun.serve({
+        port: 0,
+        fetch: () => new Response(new ReadableStream({
+          type: "direct",
+          async pull(controller) {
+            for (let i = 0; i < 8; i++) { controller.write(new Uint8Array(1024 * 1024)); await controller.flush(); }
+            controller.close();
+            upstreamDone.resolve();
+          },
+        })),
+      });
+      const res = await fetch(upstream.url);
+      res.body; // the body now buffers into its stream's native source
+      await upstreamDone.promise;
+      const written = client.write("key", res);
+      written.catch(() => {}).then(() => upstream.stop(true));
+    `,
+  };
+  it.concurrent.each(Object.keys(UNSIGNABLE_UPLOADS) as (keyof typeof UNSIGNABLE_UPLOADS)[])(
+    "an upload from %s whose request fails before it is sent only rejects",
+    async feeder => {
+      const fixture = `
+        const client = new Bun.S3Client({ bucket: "b", endpoint: "http://127.0.0.1:1" });
+        ${UNSIGNABLE_UPLOADS[feeder]}
+        console.log("write:", await written.then(() => "resolved", e => e.code));
+        // The turn on which the upload's native side is freed.
+        await new Promise(resolve => setImmediate(resolve));
+        console.log("still here");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: {
+          ...noProxyEnv,
+          // No credentials from the environment either: signing must fail.
+          S3_ACCESS_KEY_ID: undefined,
+          S3_SECRET_ACCESS_KEY: undefined,
+          S3_SESSION_TOKEN: undefined,
+          AWS_ACCESS_KEY_ID: undefined,
+          AWS_SECRET_ACCESS_KEY: undefined,
+          AWS_SESSION_TOKEN: undefined,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "write: ERR_S3_MISSING_CREDENTIALS\nstill here\n",
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+  );
 });
 
 describe("presigned url signature", () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -2572,45 +2572,240 @@ describe("VM teardown ordering", () => {
     expect(await proc.exited).toBe(0);
   });
 
-  // An S3 upload aborted by its worker's teardown must not retry onto the
-  // closed VM: the retry would complete on the HTTP thread against a dead handle.
-  test("terminating a worker mid S3 upload does not retry onto the dead VM", async () => {
-    let first = true;
-    using server = Bun.serve({
-      port: 0,
-      fetch: () => {
-        if (first) {
-          first = false;
-          return new Promise(() => {}); // the upload terminate() interrupts
-        }
-        return new Response("no", { status: 503 }); // any retry fails fast
+  // A streaming S3 upload (a MultiPartUpload fed by s3file.write(stream) or by
+  // s3file.writer()) buffers bytes until it has a whole part, so most of the
+  // time it has no request out on the HTTP thread, and only the stop phase can
+  // end it. It has to drop everything the upload holds: the upload itself
+  // (buffered bytes, credentials), and for s3file.write(stream) the wrapper
+  // around the source stream, which also holds the stream and the sink. The
+  // "request out" rows cover the other order: the stop phase ends the upload
+  // first, and the request coming back must not free anything twice, nor, now
+  // that the upload is already finished, retry onto the VM that is going away.
+  // The "first part in flight" row ends an upload that has to roll back: during
+  // teardown the rollback is refused on the spot and not retried, and the upload
+  // still has to free itself. The "commit in flight" rows end an upload that has
+  // sent everything and only waits for its last answer, so the stop phase finds
+  // both the upload and a request of it. For a JS stream that is also the
+  // shape where the wrapper is still claimed by the stream's pump, which ends
+  // only when S3 answers: before the fix the wrapper and the upload both stayed
+  // allocated. The writer() variant passes before the fix too, and pins down
+  // that the two stops do not free anything twice. The Bun.file() row is the
+  // same claim-still-held shape for a file source (a file is pumped the same
+  // way as a JS stream). The "pump collected" row has the collector take the
+  // stream's pump first, which gives the claim up on its own (the debug build
+  // logs that too), so that the stop phase then finds nothing of it to free.
+  //
+  // Two oracles. On a debug build, each object's own teardown log line: exactly
+  // one MultiPartUpload deinit per row, and one S3UploadStreamWrapper deinit per
+  // s3file.write(stream). On the ASAN build (a release build, so no debug logs),
+  // LeakSanitizer at the host's exit, which reported the upload in the streamed
+  // rows before the fix, and ASAN itself for a double release. The writer() rows
+  // run without leak detection: the sink object behind s3file.writer() is not
+  // freed on any path, fixed or not (#34999), and the leaked upload stayed
+  // reachable to LeakSanitizer there anyway. On release builds the writer()
+  // path is checked by the rollback test in test/cli/test/isolation.test.ts.
+  describe.skipIf(!isDebug && !isASAN)("an S3 upload still open when its VM goes", () => {
+    const ROWS: {
+      name: string;
+      // Runs with `file` (an S3File against the stand-in server) and `upstream` (a URL whose
+      // response body delivers one chunk and then stays open until the host ends it).
+      start: string;
+      endUpstream?: boolean;
+      // The host waits for the stand-in to receive a request it leaves unanswered before it
+      // tears the VM down.
+      waitForRequest?: boolean;
+      // How far the stand-in lets a multipart upload get: it answers the initiate, so the
+      // upload sends its first part, or also every part, so the upload sends its commit.
+      multipart?: "part" | "commit";
+      wrappers: number;
+      // How many pumps the collector took before the VM went (debug builds log it). The
+      // other JS stream rows keep their pull promise's resolvers reachable, as a producer
+      // that could still deliver would, so their pumps stay for the stop phase to find.
+      collected?: number;
+      mainThread?: boolean;
+      leakCheck?: false;
+    }[] = [
+      {
+        name: "s3file.write(response) still waiting for bytes, worker terminated",
+        start: `const res = await fetch(upstream); file.write(res).catch(() => {});`,
+        wrappers: 1,
       },
-    });
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const { Worker } = require("worker_threads");
-         const w = new Worker(
-           'const { workerData, parentPort } = require("worker_threads");' +
-           'const s3 = new Bun.S3Client({ accessKeyId: "k", secretAccessKey: "s", bucket: "b", endpoint: workerData.url, retry: 3 });' +
-           // writer(): a MultiPartUpload, whose single-send failure path retries.
-           'const wr = s3.file("key").writer({ retry: 3 }); wr.write(Buffer.alloc(1024 * 1024)); wr.end().catch(() => {});' +
-           'parentPort.postMessage("uploading");',
-           { eval: true, workerData: { url: "${server.url.href}" } });
-         w.once("message", async () => {
-           console.log("exit", await w.terminate());
-           // Outlive any retry the HTTP thread would complete.
-           setTimeout(() => process.exit(0), 500);
-         });`,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "inherit",
-    });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-    expect(stdout).toBe("exit 1\n");
-    expect(exitCode).toBe(0);
+      {
+        name: "s3file.write(new Response(jsStream)) still waiting for bytes, worker terminated",
+        start: `globalThis.moreBytes = Promise.withResolvers();
+          file.write(new Response(new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(64)); return globalThis.moreBytes.promise; } }))).catch(() => {});`,
+        wrappers: 1,
+      },
+      // At least two collections: the first frees the Response, whose body holds a Strong on
+      // the stream, the second the stream and its pump. The turn of the loop after each runs
+      // what the collected pump's cell queued. The extra rounds change nothing once it is gone.
+      {
+        name: "s3file.write(new Response(jsStream)) whose pump was collected while waiting for bytes, worker terminated",
+        start: `file.write(new Response(new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(64)); return new Promise(() => {}); } }))).catch(() => {});
+          for (let i = 0; i < 4; i++) { Bun.gc(true); await new Promise(resolve => setImmediate(resolve)); }`,
+        wrappers: 1,
+        collected: 1,
+      },
+      {
+        name: "s3file.writer() with bytes written and no end(), worker terminated",
+        start: `const w = file.writer(); w.write(new Uint8Array(64));`,
+        wrappers: 0,
+        leakCheck: false,
+      },
+      {
+        name: "s3file.write(response) whose body ended, PUT in flight, worker terminated",
+        start: `const res = await fetch(upstream); file.write(res).catch(() => {});`,
+        endUpstream: true,
+        waitForRequest: true,
+        wrappers: 1,
+      },
+      {
+        name: "s3file.write(new Response(Bun.file().stream())) whose file was read, PUT in flight, worker terminated",
+        start: `file.write(new Response(Bun.file("payload.bin").stream())).catch(() => {});`,
+        waitForRequest: true,
+        wrappers: 1,
+      },
+      {
+        name: "s3file.writer() ended, PUT in flight, worker terminated",
+        start: `const w = file.writer(); w.write(new Uint8Array(64)); w.end().catch(() => {});`,
+        waitForRequest: true,
+        wrappers: 0,
+        leakCheck: false,
+      },
+      {
+        name: "s3file.write(new Response(jsStream)) with its first part in flight, worker terminated",
+        start: `globalThis.moreBytes = Promise.withResolvers();
+          file.write(new Response(new ReadableStream({ pull(c) { c.enqueue(new Uint8Array(5 * 1024 * 1024)); return globalThis.moreBytes.promise; } }))).catch(() => {});`,
+        multipart: "part",
+        waitForRequest: true,
+        wrappers: 1,
+      },
+      {
+        name: "s3file.write(new Response(jsStream)) with its commit in flight, worker terminated",
+        start: `file.write(new Response(new ReadableStream({ start(c) { c.enqueue(new Uint8Array(5 * 1024 * 1024)); c.close(); } }))).catch(() => {});`,
+        multipart: "commit",
+        waitForRequest: true,
+        wrappers: 1,
+      },
+      {
+        name: "s3file.writer() ended, commit in flight, worker terminated",
+        start: `const w = file.writer(); w.write(new Uint8Array(5 * 1024 * 1024)); w.end().catch(() => {});`,
+        multipart: "commit",
+        waitForRequest: true,
+        wrappers: 0,
+        leakCheck: false,
+      },
+      {
+        name: "s3file.write(response) still waiting for bytes, process.exit() on the main thread",
+        start: `const res = await fetch(upstream); file.write(res).catch(() => {});`,
+        wrappers: 1,
+        mainThread: true,
+      },
+    ];
+
+    const host = (row: (typeof ROWS)[number]) => `
+      const { Worker } = require("node:worker_threads");
+      const gotRequest = Promise.withResolvers();
+      const standIn = Bun.serve({
+        port: 0,
+        async fetch(req) {
+          // Read, so the request left unanswered holds no body buffer of its own.
+          await req.arrayBuffer();
+          if (${!!row.multipart} && new URL(req.url).searchParams.has("uploads")) {
+            return new Response("<InitiateMultipartUploadResult><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>");
+          }
+          if (${row.multipart === "commit"} && req.method === "PUT") {
+            return new Response("", { headers: { etag: '"part"' } });
+          }
+          gotRequest.resolve();
+          return new Promise(() => {});
+        },
+      });
+      let endUpstream;
+      const upstream = Bun.serve({
+        port: 0,
+        fetch: () => new Response(new ReadableStream({
+          start(c) { c.enqueue(new Uint8Array(64)); endUpstream = () => c.close(); },
+          pull() { return new Promise(() => {}); },
+        })),
+      });
+      const startUpload = \`async (s3Url, upstream) => {
+        const file = new Bun.S3Client({ accessKeyId: "k", secretAccessKey: "s", bucket: "b", endpoint: s3Url }).file("key");
+        ${row.start}
+      }\`;
+      const onStarted = async () => {
+        ${row.endUpstream ? "endUpstream();" : ""}
+        ${row.waitForRequest ? "await gotRequest.promise;" : ""}
+      };
+      if (${!!row.mainThread}) {
+        await (0, eval)(startUpload)(standIn.url.href, upstream.url.href);
+        await onStarted();
+        console.log("upload started");
+        process.exit(0);
+      }
+      const worker = new Worker(
+        'const { workerData, parentPort } = require("node:worker_threads");' +
+        '(' + startUpload + ')(workerData.s3Url, workerData.upstream).then(() => parentPort.postMessage("started"));',
+        { eval: true, workerData: { s3Url: standIn.url.href, upstream: upstream.url.href } },
+      );
+      worker.on("error", e => { console.error("worker error:", e); process.exit(1); });
+      const exited = new Promise(resolve => worker.on("exit", resolve));
+      worker.once("message", async () => { await onStarted(); worker.terminate(); });
+      console.log("worker exit code:", await exited);
+      standIn.stop(true);
+      upstream.stop(true);
+    `;
+
+    for (const row of ROWS) {
+      test.concurrent(row.name, async () => {
+        using dir = tempDir("s3-upload-teardown", { "payload.bin": Buffer.alloc(64, "x").toString() });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "-e", host(row)],
+          cwd: String(dir),
+          env: {
+            ...bunEnv,
+            // The S3 client does not honor NO_PROXY; an inherited proxy would
+            // hijack the requests to the stand-in.
+            HTTP_PROXY: undefined,
+            HTTPS_PROXY: undefined,
+            http_proxy: undefined,
+            https_proxy: undefined,
+            BUN_DEBUG_S3MultiPartUpload: "1",
+            BUN_DEBUG_S3UploadStream: "1",
+            BUN_DESTRUCT_VM_ON_EXIT: "1",
+            ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, `detect_leaks=${row.leakCheck === false ? 0 : 1}`]
+              .filter(Boolean)
+              .join(":"),
+            LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        const output = stdout + stderr;
+        const expected = {
+          started: row.mainThread ? "upload started" : "worker exit code: 1",
+          uploads: isDebug ? 1 : "release build",
+          wrappers: isDebug ? row.wrappers : "release build",
+          collected: isDebug ? (row.collected ?? 0) : "release build",
+          sanitizer: false,
+          exitCode: 0,
+          detail: "",
+        };
+        const actual = {
+          started: output.match(/^(upload started|worker exit code: \d+)$/m)?.[1],
+          uploads: isDebug ? (output.match(/^\[s3multipartupload\] deinit$/gm)?.length ?? 0) : "release build",
+          wrappers: isDebug ? (output.match(/^\[s3uploadstream\] deinit /gm)?.length ?? 0) : "release build",
+          collected: isDebug ? (output.match(/^\[s3uploadstream\] pump collected$/gm)?.length ?? 0) : "release build",
+          sanitizer: output.includes("Sanitizer"),
+          exitCode,
+          detail: "",
+        };
+        // On a failure, everything the host printed.
+        if (!Bun.deepEquals(actual, expected)) actual.detail = output;
+        expect(actual).toEqual(expected);
+      });
+    }
   });
 });
 


### PR DESCRIPTION
### Problem
- A streaming S3 upload (`s3file.write(stream)` or `s3file.writer()`) still open when its VM goes is never freed: the wrapper (`client.rs:561`), its sink and source stream, and up to a part (5 MiB or more) of buffered bytes, per terminated worker. Under `bun test --isolate` it also pins the file's global. This is the S3 half that #39639 handed off.
- Between parts nothing of it is out, and the stop phase only knows requests. With a request out it leaked too: `fail` (`multipart.rs:585`) returned through `?` on a `Terminated` settle before it released the upload's own ref, and a JS stream's pump holds a ref on the wrapper that only the pump's own completion released.

### Fix
- Every `MultiPartUpload` is an `ActiveHandle` until `Drop`, failed by the sweep like any handle. Its rollback is the one request a `--isolate` sweep must let through (`outlives_test_isolation`, kept like a `Bundle`). The `--isolate` sweep drains microtasks and sweeps again while a round stopped something (`jsc_hooks.rs:1752`), because failing an upload runs the file's code, and a server it opens after the sweep would be stopped on top of its closed socket at the next swap.
- `fail` and the `writer()` callback release on every settle outcome. Commit and rollback do not retry on a VM that refuses every request.
- The pump's ref on the wrapper lives in a `NativePromiseContext` (`pump_cell`). The settle shim that runs takes it, `resolve` takes it first when the upload is over (`take_pump_claim`), and a pump collected unsettled gives it up from the cell's destructor. Whoever takes it releases it, exactly once, with no VM-state predicate. `resolve` releases through the cell's own deferred task (`release_pump_claim_later`): it can run inside the sink's `write` or `end` when a request fails before it leaves, and freeing the sink there is a use after free on the way out. The wrapper gets the `align(16)` the other types the deferred task packs a tag into have.
- Verified: 11 rows in `worker_threads.test.ts` (10 fail on main), 5 tests in `isolation.test.ts` (3 fail on main, 2 guard the sweep order), 3 guards in `s3.test.ts`. Also those suites, `html-rewriter`, `serve-pending-promise-abort-leak`, source lints, clippy.

### Background
- `MultiPartUpload` holds one ref of its own until it finishes, one per feeder (wrapper, `NetworkSink`), one per request out.
- A JS stream is pumped into the wrapper's sink by `readStreamIntoSink`. Its promise settles only when the upload is over (it adopts the sink's end promise), and the wrapper's `.then` shims on it held the pump's ref as a raw pointer.
- `NativePromiseContext` is a GC cell that owns a native ref for a promise reaction: `take()` hands the ref to exactly one caller, and the destructor of a cell that was never taken releases it on the next tick. `Bun.serve` uses it the same way (#39743).
- The sweep (`stop_active_handles`) pops the registry until it is empty, so what a stop registers is popped too. Teardown runs it with script forbidden. `--isolate` runs it between files with script allowed, then closes every socket of the file blind.

<details><summary>Notes</summary>

**History.** Revision 1 failed each upload as the sweep popped it; under `--isolate` the rollback it sent was popped and aborted next, so S3 never got it. Revision 2 failed the uploads after the registry was drained instead, and released a JS pump's ref when the pump's controller had been collected. Review found the release unsound (a direct stream's pump promise settles from the user's pull promise after the controller is gone: use after free, reproduced) and the release moved to "script forbidden", then to JSC's execution-forbidden state when self-review found that a parent's `terminate()` clears `script_allowed()` from the parent thread. Review of that revision found two things. Failing an upload after the drain runs user code (the stream's `cancel()` at once, the write's `.catch` on the swap's own later drain) after the point where what it opens is still stopped: a server opened there had its socket closed blind and was stopped on top of it at the next swap (heap-use-after-free, reproduced with both variants, now the two "reopen" tests, which fail on that revision). And the pump-ref predicate hand-rolled what `NativePromiseContext` already does. This revision is the result: uploads are an ordinary sweep arm, the rollback survives the sweep by being marked, the isolate sweep repeats, and the pump ref is a cell claim. A further review pass of that found the last hazard: `resolve` freed the sink inline, and a request that fails before it leaves (a stopping VM refuses it, or there is nothing to sign with) fails the upload while the sink's own `write` or `end` is still on the stack (heap-use-after-free in `NetworkSink::end`, reproduced with a JS stream whose bytes arrive after the pump started waiting, and the same hazard on the native attach path). `resolve` now hands the claim to the cell's deferred task, and the native attach code bails out when its inline write failed the upload. The two "fails before it is sent" tests pin that; on main they pass (main never freed anything there). No earlier revision was on main. The predicate-based leaks the earlier revisions documented as left open (an upload already finished when the stop arrives, a pump collected before an `--isolate` swap) are closed: `resolve` reclaims the claim whenever the upload finishes, and a collected pump releases its own.

**Design choices.** The isolate sweep is bounded because each extra round only matters if a reaction to the previous round opened something, and a `.catch` that starts its upload again would otherwise keep it going forever. At the cap, what the last round's reactions open is left to the swap's own drain, the same as any reaction queued after the sweep today. Any small cap does; 8 keeps that worst case cheap. Two rounds are the norm for a file that leaked an upload (the second finds the kept rollback only and reports idle), one for a clean file. The rollback is marked on the request rather than special-cased by type because the sweep cannot otherwise tell it from the file's own requests, which it must still abort; the `Bundle` case moves into the same predicate. (An earlier revision carried the new context tag under a second task tag because the deferred task's packed field had three bits; main has since widened it to four with `#[repr(align(16))]` on the packed types, so the wrapper now simply gets the same attribute.)

**Tests.** `worker_threads.test.ts`, "an S3 upload still open when its VM goes", 11 rows: a fetch body, a JS stream and a `writer()` left waiting for bytes; a JS stream whose pump the collector took first (exactly two collections: the first frees the Response whose body holds a Strong on the stream, the second the stream and pump; the debug build logs the cell's release, the row checks exactly one); a fetch body, a `Bun.file()` stream and a `writer()` ended with their PUT out; a JS stream with its first part out (rolls back; the rollback is refused during teardown and not retried); a JS stream and a `writer()` with their commit out; and a main-thread `process.exit()` under `BUN_DESTRUCT_VM_ON_EXIT`. Oracles: on debug builds one upload deinit per row, one wrapper deinit per streamed row, and the collected-pump count; on the ASAN build LeakSanitizer (the streamed rows) and ASAN itself. The `writer()` rows run without LeakSanitizer: the sink object behind `writer()` is never freed (#34999). On main 10 rows fail (the `writer()` commit row passes there and pins the two stops not freeing twice). `isolation.test.ts`: the leak-fixture row; the rollback test for a stream-fed and a `writer()`-fed upload with `retry: 0` (the stand-in must see initiate, part and abort; the stream variant no longer pins its stream, so the pump may or may not be collected by the swap, and the wrapper count must be one either way); and the two reopen tests (three files; a's upload opens a server from `cancel()` or from `.catch`; ASAN reported the b to c swap on the previous revision; they pass on main, which stops nothing). `s3.test.ts`: a direct stream whose pull promise settles after S3 failed the upload and the wrapper is gone; the shim must find its claim taken (a raw pointer here is the revision 2 use after free). And the two uploads, from a JS stream and from a fetch body, whose request fails before it is sent (no credentials), so the upload fails inside the sink's own `end` or `write`. All three pass on main as well; they guard the contract.

**Rebases.** The branch was squashed and rebased onto main twice. First after main changed the S3 upload callback (`uploaded` byte count, `&MultiPartUpload` as its first argument): the conflicts in `fail` and the `writer()` callback kept both sides, main's values and this PR's settle-on-every-outcome. Then after main's HTTP/2 work widened `NativePromiseContext`'s packed tag field to four bits and `bun_ptr` lost `ScopedRef`: the second task tag this PR had added is gone, the S3 tag is the eleventh, the wrapper is `align(16)` like the other packed types, and `stop_for_vm_teardown` holds its guard as a `RefPtr`. A third rebase (31a2318) only dropped an import main no longer has. A fourth (e6773d9) met #40516, which made `S3UploadStreamWrapper` a `#[derive(CellRefCounted)]` type with a `RefPtr<MultiPartUpload>` field: the wrapper keeps `#[repr(align(16))]` next to the derive, `release_pump_claim` calls the derived `deref`, the `task_ref()` helper is gone (the `RefPtr` derefs), and the inline release of the native pump ref in `resolve` that main still had stays removed, since `take_pump_claim` and the deferred release cover it.

**Suites run** on the debug build: all of `worker_threads.test.ts`, `isolation.test.ts`, `test/js/bun/s3/`, the five HTMLRewriter files and `serve-pending-promise-abort-leak.test.ts` (the other `NativePromiseContext` users), `test/internal/source-lints/`, `cargo clippy -p bun_runtime -p bun_event_loop`. Pre-existing local failures, unchanged by this diff: one `s3-list-objects.test.ts` test unless run alone (#38353 notes it), and "uploads a fetch response body via the native ByteStream" in `s3.test.ts`, which now and then reports 5 of 10 MiB received (3 of 12 runs of its block right after a rebuild, then 0 of 100 with the stand-in logging every request; its fixture alone passed 200 runs); the bytes it counts flow before any code in this diff runs.

**Probes**, all on the debug ASAN build: every shape above as a standalone worker host, before and after (before: no deinit, or for the request-out shapes a `fail ERR_S3_VM_SHUTDOWN` and no deinit; after: one of each); normal operation against a stand-in that fails the initiate (native and JS source), succeeds, or fails after the source ended (unchanged); the dead-pump collection count (0 of 5 runs after one collection, 5 of 5 after two).

Seen on the way, not changed here: `FileSink` fed by a stream holds the same kind of pump ref (#39639 notes it too) and is not an `ActiveHandle`; a rollback answered with 204 is retried (#33682); `partSize` given to `S3Client` does not reach `file().writer()` (#33502); `s3file.write(readableStream)` with a bare stream uploads the string `[object ReadableStream]`.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 failed, 286 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/isolation.test.ts "test/js/bun/s3/s3.test.ts" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.1 (65362b53b)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [378.12ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [319.71ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [505.79ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [564.56ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [319.02ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [1388.64ms]
(pass) bun test --isolate > with --isolate, leaked fs.watch is closed before next file [1216.52ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket is closed before next file [1455.18ms]
(pass) bun test --isolate > with --isolate, a leaked monitorEventLoopDelay() is disabl
... (truncated)

release without fix: 4 failed, 297 skipped
bun test v1.4.1-canary.1 (31a23181d)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > with --isolate, module state is not shared between files [28.39ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [32.83ms]
(pass) bun test --isolate > with --isolate, each file gets a fresh global [37.10ms]
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [43.80ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [36.16ms]
(pass) bun test --isolate > leaked subprocesses are killed for every isolated file, not just the first [35.55ms]
(pass) --isolate: JSC options survive a bunfig.toml with an install hoist pattern [32.81ms]
(pass) bun test --isolate > module-scope subprocesses are killed for every isolated file, not just the first (--isolate) [37.65ms]
(pass) --isolate: SourceProvider cache covers node_modules .mjs and type:commonjs packages [32.25ms]
(pass) --isolate: SourceProvider cache covers CommonJS modules [34.63ms]
(pass) --isolate: delete require.cache evicts the SourceProvider cache [40.92ms]
(pass) --isolate: cached module_info handles `import
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 286 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/isolation.test.ts "test/js/bun/s3/s3.test.ts" test/js/node/worker_threads/worker_threads.test.ts
bun test v1.4.1 (65362b53b)

test/cli/test/isolation.test.ts:
(pass) bun test --isolate > with --isolate, each file gets a fresh global [489.15ms]
(pass) bun test --isolate > without --isolate, leaked global is visible to next file [603.42ms]
(pass) bun test --isolate > without --isolate, --preload still runs once (regression) [711.56ms]
(pass) bun test --isolate > with --isolate, --preload re-runs in each file's fresh global [773.55ms]
(pass) bun test --isolate > with --isolate, module state is not shared between files [394.41ms]
(pass) bun test --isolate > with --isolate, a file's process.chdir() is undone before the next file [1520.59ms]
(pass) bun test --isolate > with --isolate, leaked fs.watch is closed before next file [1264.34ms]
(pass) bun test --isolate > with --isolate, leaked outbound socket is closed before next file [1590.86ms]
(pass) bun test --isolate > with --isolate, a leaked monitorEventLoopDelay() is disabl
... (truncated)

release with fix: 297 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e6773d9f02
  features     baseline

23 deps, 131 codegen, 1172 objects in 934ms

ninja: Entering directory `/workspace/bun/build/release'
[1/145] fetch WebKit (prebuilt)
[WebKit] up to date
[2/145] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[3/145] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - Matc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/NativePromiseContext.h            |   1 +
 src/runtime/api/NativePromiseContext.rs            |  43 +++-
 src/runtime/jsc_hooks.rs                           |  50 +++-
 src/runtime/webcore/s3/client.rs                   | 180 ++++++++++----
 src/runtime/webcore/s3/multipart.rs                |  43 +++-
 src/runtime/webcore/s3/simple_request.rs           |  20 +-
 test/cli/test/isolation.test.ts                    | 182 +++++++++++++-
 test/js/bun/s3/s3.test.ts                          | 139 ++++++++++-
 test/js/node/worker_threads/worker_threads.test.ts | 273 ++++++++++++++++++---
 9 files changed, 808 insertions(+), 123 deletions(-)
```

</details>

**gate history** · 5 passed · 1 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/bindings/NativePromiseContext.h                 1      2      0
src/runtime/api/NativePromiseContext.rs                 8     20      0
src/runtime/jsc_hooks.rs                               11     17      0
src/runtime/webcore/s3/client.rs                       50     62      0
src/runtime/webcore/s3/multipart.rs                    28     24      0
src/runtime/webcore/s3/simple_request.rs                9      7      0
test/cli/test/isolation.test.ts                        13     18      0
test/js/bun/s3/s3.test.ts                               8     15      0
test/js/node/worker_threads/worker_threads.test.ts     17     38      0
```

</details>

<!-- robobun:evidence:end -->



