### PR TITLE
docs: add a Docker guide for Next.js on the Bun runtime

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -379,6 +379,7 @@
               "/guides/ecosystem/neon-drizzle",
               "/guides/ecosystem/neon-serverless-postgres",
               "/guides/ecosystem/nextjs",
+              "/guides/ecosystem/nextjs-docker",
               "/guides/ecosystem/nuxt",
               "/guides/ecosystem/pm2",
               "/guides/ecosystem/prisma",

--- a/docs/guides/ecosystem/docker.mdx
+++ b/docs/guides/ecosystem/docker.mdx
@@ -146,4 +146,4 @@ CONTAINER ID        IMAGE               COMMAND                  CREATED        
 
 ---
 
-See the [Docker documentation](https://docs.docker.com/) for more advanced usage.
+See the [Docker documentation](https://docs.docker.com/) for more advanced usage. To containerize a Next.js app, see [Next.js with Docker](/guides/ecosystem/nextjs-docker).

--- a/docs/guides/ecosystem/nextjs-docker.mdx
+++ b/docs/guides/ecosystem/nextjs-docker.mdx
@@ -1,0 +1,131 @@
+---
+title: Containerize a Next.js app with Bun and Docker
+sidebarTitle: Next.js with Docker
+mode: center
+---
+
+This guide builds a Docker image for a [Next.js](https://nextjs.org/) app. In the image, Bun installs the dependencies, Bun runs `next build`, and the Bun runtime serves the app. The image does not contain Node.js.
+
+The image uses the `standalone` output of Next.js. With this output, `next build` writes a `server.js` file to `.next/standalone`, together with a copy of the `node_modules` files that the server imports. In a new `create-next-app` project, `.next/standalone` is about 57 MB. The full `node_modules` directory is about 465 MB.
+
+<Note>
+  This guide assumes that you have [Docker](https://docs.docker.com/get-started/get-docker/) installed and that your
+  project has a `bun.lock` file. To create a Next.js project with Bun, see [Next.js with Bun](/guides/ecosystem/nextjs).
+  If the project has no `bun.lock` yet, run `bun install` once to create it.
+</Note>
+
+---
+
+<Steps>
+  <Step title="Enable the standalone output">
+    Set `output` to `"standalone"` in `next.config.ts`.
+
+    ```ts next.config.ts icon="/icons/typescript.svg"
+    import type { NextConfig } from "next";
+
+    const nextConfig: NextConfig = {
+      output: "standalone", // [!code ++]
+    };
+
+    export default nextConfig;
+    ```
+
+    `next build` writes the resolved config into `.next/standalone/server.js`, so the final image does not need `next.config.ts`. Start the app with `server.js`, not with `next start`. With this output, `next start` prints the warning `"next start" does not work with "output: standalone" configuration`.
+
+  </Step>
+  <Step title="Create a Dockerfile">
+    Create a `Dockerfile` in the root of your project.
+
+    ```docker Dockerfile icon="docker"
+    # Every stage uses this image, so native dependencies such as sharp
+    # are installed for the libc of the final image.
+    # See all tags at https://hub.docker.com/r/oven/bun/tags
+    FROM oven/bun:1 AS base
+    WORKDIR /app
+
+    # Install all dependencies. `next build` needs the devDependencies,
+    # for example typescript.
+    FROM base AS deps
+    COPY package.json bun.lock ./
+    RUN bun install --frozen-lockfile
+
+    # Build the app. `--bun` runs the Next.js CLI with Bun.
+    FROM base AS build
+    COPY --from=deps /app/node_modules ./node_modules
+    COPY . .
+    RUN bun --bun next build
+
+    # Copy the standalone output into a clean image. `next build` leaves
+    # `.next/static` and `public` out of the standalone output, so copy
+    # them next to server.js. At run time the server writes its caches
+    # (for example optimized images) to `.next`, so the `bun` user has to
+    # own these files.
+    FROM base AS release
+    COPY --from=build --chown=bun:bun /app/.next/standalone ./
+    COPY --from=build --chown=bun:bun /app/.next/static ./.next/static
+    COPY --from=build --chown=bun:bun /app/public ./public
+
+    # server.js listens on the address in HOSTNAME. Docker sets HOSTNAME
+    # to the container ID, so set it to all interfaces here.
+    ENV HOSTNAME=0.0.0.0
+    USER bun
+    EXPOSE 3000
+    CMD ["bun", "server.js"]
+    ```
+
+    The `oven/bun` image does not contain Node.js. The `node` command on its `PATH` is a link to `bun`, so a `build` script that runs `next build` also runs on Bun inside this image. If your `build` script runs more steps than `next build`, replace the build line with `RUN bun run build`. See [`--bun`](/runtime#--bun) for how Bun runs a CLI that asks for `node`.
+
+    `server.js` listens on the port in `PORT`. The default is `3000`.
+
+  </Step>
+  <Step title="Create a .dockerignore file">
+    Create a `.dockerignore` file next to the `Dockerfile`. Docker leaves the listed files out of the build context.
+
+    ```txt .dockerignore icon="docker"
+    node_modules
+    .next
+    .git
+    .env
+    .env*.local
+    ```
+
+    A `node_modules` directory from your machine can contain native binaries for a different operating system or libc. The `deps` stage installs the dependencies inside the image instead. The `build` stage writes a new `.next` directory. `.env` and the `.env*.local` files hold settings for your machine.
+
+  </Step>
+  <Step title="Build and run the image">
+    Build the image. Then start a container and publish port 3000.
+
+    ```sh terminal icon="terminal"
+    docker build -t my-next-app .
+    docker run -p 3000:3000 my-next-app
+    ```
+
+    Open [`http://localhost:3000`](http://localhost:3000) in your browser. In a route handler or a server component, `process.versions.bun` contains the version of Bun that serves the request.
+
+  </Step>
+</Steps>
+
+---
+
+## Environment variables
+
+Next.js reads environment variables at two different times.
+
+- Server code reads `process.env.MY_VAR` when it handles a request. Pass these variables to the container, for example with `docker run -e DATABASE_URL=... my-next-app`.
+- `next build` replaces every `process.env.NEXT_PUBLIC_*` expression with its value at build time. The container environment does not change these values. Pass them to the `build` stage as build arguments:
+
+```docker Dockerfile icon="docker"
+FROM base AS build
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+```
+
+```sh terminal icon="terminal"
+docker build --build-arg NEXT_PUBLIC_API_URL=https://api.example.com -t my-next-app .
+```
+
+`next build` reads `.env.production` from the build context and copies it into `.next/standalone`, so this file ends up in the image. Keep secrets out of it and pass them to the container instead.
+
+---
+
+See [Docker with Bun](/guides/ecosystem/docker) for more on `docker build` and `docker run`. See the Next.js documentation on [`output`](https://nextjs.org/docs/app/api-reference/config/next-config-js/output) for the layout of the standalone output in a monorepo.

--- a/docs/guides/ecosystem/nextjs.mdx
+++ b/docs/guides/ecosystem/nextjs.mdx
@@ -69,6 +69,9 @@ mode: center
   <Card title="Render" href="/guides/deployment/render" icon="/icons/ecosystem/render.svg">
     Deploy on Render
   </Card>
+  <Card title="Docker" href="/guides/ecosystem/nextjs-docker" icon="container">
+    Build a Docker image that serves the app with Bun
+  </Card>
 </Columns>
 
 ---

--- a/docs/snippets/guides.jsx
+++ b/docs/snippets/guides.jsx
@@ -153,6 +153,10 @@ export const GuidesList = () => {
           { title: "Build an HTTP server using Elysia and Bun", href: "/guides/ecosystem/elysia" },
           { title: "Containerize a Bun application with Docker", href: "/guides/ecosystem/docker" },
           {
+            title: "Containerize a Next.js app with Bun and Docker",
+            href: "/guides/ecosystem/nextjs-docker",
+          },
+          {
             title: "Build an HTTP server using Express and Bun",
             href: "/guides/ecosystem/express",
           },


### PR DESCRIPTION
Closes #39691

### Problem
- #39691 asks for a reference Dockerfile that builds a Next.js app and serves it with Bun. No docs page covers this.
- Friction points from the report: the standalone output, native modules such as sharp, and the entry point (`server.js` against `next start`).

### Fix
- Adds `docs/guides/ecosystem/nextjs-docker.mdx`. Every stage uses `oven/bun:1`: `bun install --frozen-lockfile`, `bun --bun next build`, then a release stage that copies `.next/standalone`, `.next/static` and `public` with `--chown=bun:bun`, sets `HOSTNAME=0.0.0.0`, and runs `bun server.js` as the `bun` user.
- A short section covers run time variables, inlined `NEXT_PUBLIC_*` variables, and which `.env` files end up in the image.
- Registers the page in `docs.json` and `guides.jsx`. Links to it from the Next.js and Docker guides.
- Verified: each Dockerfile line ran as a shell command against a fresh `create-next-app` project (Next.js 16.3.1, Bun 1.4.0). Probes against the server passed. Docker cannot run in this environment, so `docker build` itself did not run.

### Background
- `output: "standalone"` makes `next build` write `.next/standalone/` with `server.js` and only the `node_modules` files the server imports. It leaves out `.next/static` and `public`. The resolved config is inlined into `server.js`.
- `server.js` listens on `process.env.HOSTNAME || "0.0.0.0"`. Docker sets `HOSTNAME` to the container ID, so the Dockerfile sets it to `0.0.0.0`. Vercel's `with-docker` example does the same.
- The `oven/bun` images contain no Node.js. A `node` symlink to `bun` is on their `PATH` (`dockerhub/*/Dockerfile`), so a plain `next build` script also runs on Bun there. The guide uses `bun --bun next build` to make this explicit.

<details><summary>Notes</summary>

Verification, all on linux x64 with Bun 1.4.0 and Next.js 16.3.1 from a fresh `create-next-app` (the Google font import was removed because this environment has no access to fonts.googleapis.com). A script extracted the Dockerfile and `.dockerignore` from the mdx and ran the stages as separate directories:

- deps stage: `bun install --frozen-lockfile` from `package.json` + `bun.lock` alone installs 31 packages, including `sharp` and `@img/*`.
- A `--production` install makes `next build` fail with "It looks like you're trying to use TypeScript but do not have the required package(s) installed", which is the reason the deps stage installs devDependencies.
- `bun --bun next build` with a `console.log(process.versions.bun)` in `next.config.ts` prints the Bun version. `bun run build` with a plain `next build` script prints the Node version when a real `node` is on `PATH`, and the Bun version when only a `node -> bun` symlink is on `PATH` (the image layout).
- `.next/standalone` is 57 MB, `node_modules` is 465 MB. The standalone `node_modules` contains `sharp` and `@img/*`.
- Release stage: the copied tree, chowned to uid 1000, run as uid 1000 with an empty environment plus `PATH` (bun only, no node), `HOSTNAME=0.0.0.0`, `PORT`, `GREETING`, and a different `NEXT_PUBLIC_GREETING` than at build time. `bun server.js` logs `Network: http://0.0.0.0:<port>`. Probes: `/` 200, a `/_next/static/chunks/*.js` 200, `/test.png` from `public` 200, `/_next/image?url=%2Ftest.png&w=64&q=75` 200 `image/png` (sharp), and a dynamic route handler returns `{"bun":"1.4.0","greeting":"from-container-env","publicGreeting":"inlined-at-build"}`. The server created `.next/cache/images/` in the process.
- The same run with the tree owned by root logs `EACCES: permission denied, mkdir '.../.next/cache'` on the image request. This is the reason for `--chown=bun:bun`.
- `next start` with `output: "standalone"` prints `"next start" does not work with "output: standalone" configuration`. The guide quotes this warning. It still answered requests in this version, so the guide does not claim otherwise.
- `next build` with `.env`, `.env.local`, `.env.production`, `.env.production.local` and `.env.development` present loads the first four and copies `.env` and `.env.production` into `.next/standalone`. With the guide's `.dockerignore`, only `.env.production` reaches the build context and the image. The env section describes this.
- The server chunk contains `greeting:process.env.GREETING??null,publicGreeting:"..."`, which shows the `NEXT_PUBLIC_*` inlining the env section describes.
- Docker cannot run here (no namespaces, and the registry is not reachable), so `docker build` and `docker run` were not executed. The `COPY --chown`, `USER bun`, and `CMD` lines follow the existing Docker guide in these docs and Vercel's `examples/with-docker/Dockerfile.bun`, which uses the same `oven/bun:1` image, `--chown=bun:bun`, `USER bun`, and `CMD ["bun", "server.js"]`.
- The `bun` user and the `node` fallback symlink come from `dockerhub/debian/Dockerfile`, `dockerhub/debian-slim/Dockerfile`, and `dockerhub/alpine/Dockerfile` in this repo.
- Links: the internal links resolve to files in `docs/`, the `/runtime#--bun` anchor exists on the live page, `container` is a lucide icon name, and the nextjs.org URL follows the path the Next.js docs use for sibling pages in `next-config-js/`.
- The mdx compiles with `@mdx-js/mdx` and passes prettier. `docs/snippets/guides.jsx` still parses.
- The original report was filed on `bun-templates/bun-nextjs-todo`. That template's README points at these deployment guides, so the template can link to this page. This PR does not change the template repository.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · docs-only change; test-proof not applicable

<!-- robobun:evidence:end -->