### PR TITLE
test(inspector): park the inspectee at a second debugger statement before it exits

### DIFF
--- a/test/cli/inspect/bun-inspector-protocol.test.ts
+++ b/test/cli/inspect/bun-inspector-protocol.test.ts
@@ -98,13 +98,19 @@ function checkObject(
 const fixtureFiles = ["entry.mjs", "dep.cjs"];
 
 test("the protocol snapshot in packages/bun-inspector-protocol matches what bun sends", async () => {
+  // reportError() counts as an unhandled error, so bun exits with code 1 as soon as the
+  // module body finishes, whatever else is scheduled. The second debugger statement keeps
+  // the inspectee parked after the session resumes it from the first one: the inspector's
+  // messages are written by the debugger thread, and a process that exits right after
+  // resuming can be gone before the Debugger.resume response and the Debugger.resumed
+  // event have been written to the socket.
   using dir = tempDir("bun-inspector-protocol", {
     "entry.mjs": `
       import "./dep.cjs";
       console.log("hello");
       reportError(new Error("reported"));
       debugger;
-      setInterval(() => {}, 60_000);
+      debugger;
     `,
     "dep.cjs": `module.exports = 1;`,
   });
@@ -230,9 +236,12 @@ test("the protocol snapshot in packages/bun-inspector-protocol matches what bun 
     await send("LifecycleReporter.getModuleGraph");
 
     const resumed = waitForEvent("Debugger.resumed");
+    const pausedAgain = waitForEvent("Debugger.paused");
     await send("Debugger.resume");
     await resumed;
+    await pausedAgain;
   } finally {
+    // Closing the last connection resumes the parked inspectee, which then exits.
     ws.close();
   }
 


### PR DESCRIPTION
### Problem
- `test/cli/inspect/bun-inspector-protocol.test.ts` is the test most often flagged as flaky in CI right now: it failed once and passed on retry in 221 of the last 400 builds, on every Linux lane, almost always in the parallel batch. The failure is `WebSocket closed (1006) (inspectee exit: 1)` or `inspectee exited (inspectee exit: 1)` with the fixture's `error: reported` in the inspectee's stderr.
- The fixture calls `reportError()`. Bun counts that as an unhandled error (`VirtualMachine::uncaught_exception`), and `is_event_loop_alive_excluding_immediates` (`src/jsc/VirtualMachine.rs:1206`) returns false once `unhandled_error_counter` is set, so the inspectee exits with code 1 as soon as the module body finishes. The `setInterval` in the fixture did not keep it alive.
- The inspector writes its messages from the debugger thread (`BunInspectorConnection::sendMessageToDebuggerThread`, `src/jsc/bindings/BunDebugger.cpp`). After `Debugger.resume` the inspectee runs to the end of the module and exits. Under load it is gone before the response to `Debugger.resume` and the `Debugger.resumed` event reach the socket. An instrumented copy of the test confirmed this: in 58 failures out of 300 runs under load, every one was waiting for one of those two messages.

### Fix
- The fixture has a second `debugger` statement. After the test resumes the first pause, the inspectee pauses again at once, so it is still alive while the debugger thread writes the resume messages. The test waits for that second `Debugger.paused` event, then closes the socket. Closing the last connection resumes the inspectee, which then exits as before.
- The `setInterval` line is gone. It had no effect, see above.
- Verified: `bun bd test test/cli/inspect/bun-inspector-protocol.test.ts`. With the release build and 12 copies of the file running in a loop: 123 failures in 480 runs before this change, 0 in 480 after. The debug build passed 30 of 30 loaded runs.

### Background
- `--inspect-wait` makes bun start the script only after a client sends `Inspector.initialized`. The test enables every domain first, so the `debugger` statements pause the script.
- A pause runs `BunInspectorConnection::runWhilePaused` on the JS thread. It returns when a client resumes the script or when every connection is closed.
- Bun does not flush queued inspector messages when the process exits. `LifecycleReporter.preventExit` sets a flag that nothing reads. This change only removes the test's dependence on that, it does not change bun.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/cli/inspect/bun-inspector-protocol.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/cli/inspect/bun-inspector-protocol.test.ts
bun test v1.4.0 (4c689909e)

test/cli/inspect/bun-inspector-protocol.test.ts:
(pass) the protocol snapshot in packages/bun-inspector-protocol matches what bun sends [965.22ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [3.28s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/cli/inspect/bun-inspector-protocol.test.ts | 11 ++++++++++-
 1 file changed, 10 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
test/cli/inspect/bun-inspector-protocol.test.ts      1      2      0
```

</details>

<!-- robobun:evidence:end -->