### PR TITLE
Atomic writes: convert bun init and test a write that fails

### DIFF
--- a/src/runtime/cli/init_command.rs
+++ b/src/runtime/cli/init_command.rs
@@ -438,8 +438,6 @@ impl InitCommand {
                     .list
                     .resize(usize::try_from(size).expect("int cast"), 0);
 
-                #[cfg(windows)]
-                let prev_file_pos = pkg.get_pos()?;
                 if pkg
                     .pread_all(package_json_contents.list.as_mut_slice(), 0)
                     .is_err()
@@ -447,8 +445,6 @@ impl InitCommand {
                     package_json_file = None;
                     break 'read_package_json;
                 }
-                #[cfg(windows)]
-                pkg.seek_to(prev_file_pos)?;
             }
         }
 
@@ -787,17 +783,9 @@ impl InitCommand {
             template.write_to_package_json(&mut fields, &bump)?;
         }
 
+        // The handle was only needed to read the file. Close it before the file is replaced.
+        let mut had_package_json_file = package_json_file.take().is_some();
         'write_package_json: {
-            let (fd, created_close): (Fd, Option<bun_sys::CloseOnDrop>) = match package_json_file
-                .as_ref()
-            {
-                Some(f) => (f.handle(), None),
-                None => {
-                    let fd = bun_sys::File::create(Fd::cwd(), b"package.json", true)?.into_raw();
-                    (fd, Some(bun_sys::CloseOnDrop::new(fd)))
-                }
-            };
-            let _close = created_close;
             let mut buffer_writer = js_printer::BufferWriter::init();
             buffer_writer.append_newline = true;
             let mut package_json_writer = js_printer::BufferPrinter::init(buffer_writer);
@@ -820,26 +808,20 @@ impl InitCommand {
                     "package.json failed to write due to error {}",
                     err.name(),
                 );
-                package_json_file = None;
+                had_package_json_file = false;
                 break 'write_package_json;
             }
             let written = package_json_writer.ctx.get_written();
-            if let Err(err) = bun_sys::File::borrow(&fd).write_all(written) {
+            if let Err(err) = bun_sys::File::write_file_atomically(
+                ZStr::from_static(b"package.json\0"),
+                written,
+                0o666,
+            ) {
                 bun_core::pretty_errorln!(
                     "package.json failed to write due to error {}",
                     bstr::BStr::new(err.name()),
                 );
-                package_json_file = None;
-                break 'write_package_json;
-            }
-            if let Err(err) =
-                bun_sys::ftruncate(fd, i64::try_from(written.len()).expect("int cast"))
-            {
-                bun_core::pretty_errorln!(
-                    "package.json failed to write due to error {}",
-                    bstr::BStr::new(err.name()),
-                );
-                package_json_file = None;
+                had_package_json_file = false;
                 break 'write_package_json;
             }
         }
@@ -855,7 +837,7 @@ impl InitCommand {
                     Template::create_agent_rule();
                 }
 
-                if package_json_file.is_some() && !did_load_package_json {
+                if had_package_json_file && !did_load_package_json {
                     bun_core::prettyln!(" + <r><d>package.json<r>");
                     Output::flush();
                 }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2721,14 +2721,17 @@ impl TestCommand {
             }
         }
 
-        let write_snapshots_success = jest::Jest::runner()
+        let wrote_inline_snapshots = jest::Jest::runner()
             .unwrap()
             .snapshots
             .write_inline_snapshots()?;
-        jest::Jest::runner()
+        // `write_snapshot_file` reports its own failure, and the old file is still there.
+        let wrote_snapshot_file = jest::Jest::runner()
             .unwrap()
             .snapshots
-            .write_snapshot_file()?;
+            .write_snapshot_file()
+            .is_ok();
+        let write_snapshots_success = wrote_inline_snapshots && wrote_snapshot_file;
         if reporter.summary().pass > 20
             && !Output::is_ai_agent()
             && !reporter.reporters.dots

--- a/test/cli/init/init.test.ts
+++ b/test/cli/init/init.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test } from "bun:test";
 import fs, { readdirSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles, withFileSizeLimit } from "harness";
 import path from "path";
 
 // Whether `bun init` emits CLAUDE.md depends on a `claude` binary being on
@@ -134,6 +134,33 @@ const initEnv = { ...bunEnv, BUN_AGENT_RULE_DISABLED: "1" };
     expect(await exited).not.toBe(0);
     expect(readdirSync(temp).sort()).toEqual(["mydir"]);
     expect(await Bun.file(path.join(temp, "mydir")).text()).toBe("don't delete me!!!");
+  });
+
+  // The existing package.json already has every dependency `-y` would add, so
+  // this run does not install anything. It only rewrites package.json, and the
+  // file size limit makes that write fail after the first block.
+  test.skipIf(isWindows)("bun init keeps the old package.json when the write fails", async () => {
+    const original =
+      JSON.stringify({
+        name: "keep-me",
+        devDependencies: { "@types/bun": "latest" },
+        peerDependencies: { typescript: "^7" },
+        description: Buffer.alloc(3000, "x").toString(),
+      }) + "\n";
+    await using temp = tempDir("bun-init-write-fails", { "package.json": original });
+
+    await using proc = Bun.spawn({
+      cmd: withFileSizeLimit(1, [bunExe(), "init", "-y"]),
+      cwd: temp,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: initEnv,
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("package.json failed to write due to error EFBIG");
+    // bun init reports the failed write and still creates the other files.
+    expect(exitCode).toBe(0);
+    expect(await Bun.file(path.join(temp, "package.json")).text()).toBe(original);
+    expect(readdirSync(temp).filter(name => name.endsWith(".tmp"))).toEqual([]);
   });
 
   test("bun init utf-8", async () => {

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { chmodSync, chownSync, mkdirSync, rmSync, statSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { chmodSync, chownSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, isWindows, tempDir, withFileSizeLimit } from "harness";
 import { join } from "path";
 
 const isRoot = !isWindows && process.getuid?.() === 0;
@@ -475,6 +475,23 @@ describe.concurrent("bun pm pkg", () => {
       const { error, code } = await runPmPkg(["set", "emptyString="], dir, false);
       expect(error).toContain("Empty value");
       expect(code).toBe(1);
+    });
+
+    it.skipIf(isWindows)("should keep the old package.json when the write fails", async () => {
+      const original = createTestPackageJson();
+      using dir = tempDir("pm-pkg-write-fails", { "package.json": original });
+      await using proc = spawn({
+        cmd: withFileSizeLimit(0, [bunExe(), "pm", "pkg", "set", "name=renamed"]),
+        cwd: dir,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("Failed to write package.json: EFBIG");
+      expect(exitCode).toBe(1);
+      expect(await Bun.file(join(dir, "package.json")).text()).toBe(original);
+      expect(readdirSync(dir)).toEqual(["package.json"]);
     });
   });
 

--- a/test/cli/install/bun-pm-version.test.ts
+++ b/test/cli/install/bun-pm-version.test.ts
@@ -1,6 +1,7 @@
 import { spawn } from "bun";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles, withFileSizeLimit } from "harness";
+import { readdirSync } from "node:fs";
 import { join } from "node:path";
 
 describe.concurrent("bun pm version", () => {
@@ -316,6 +317,21 @@ describe.concurrent("bun pm version", () => {
       );
       expect(error).toContain("Failed to parse package.json");
       expect(code).toBe(1);
+    });
+
+    it.skipIf(isWindows)("keeps the old package.json when the write fails", async () => {
+      const original = JSON.stringify({ name: "test-package", version: "1.0.0" }, null, 2) + "\n";
+      await using testDir = tempDir(`version-${i++}`, { "package.json": original });
+
+      const { error, code } = await runCommand(
+        withFileSizeLimit(0, [bunExe(), "pm", "version", "patch", "--no-git-tag-version"]),
+        testDir,
+        false,
+      );
+      expect(error).toContain("Failed to write package.json: EFBIG");
+      expect(code).toBe(1);
+      expect(await Bun.file(join(testDir, "package.json")).text()).toBe(original);
+      expect(readdirSync(testDir)).toEqual(["package.json"]);
     });
   });
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -530,6 +530,19 @@ export async function bunRun(
   };
 }
 
+/**
+ * Wrap `cmd` so that it runs with `RLIMIT_FSIZE` set to `blocks` ulimit blocks.
+ * A block is 512 bytes in dash and busybox and 1024 bytes in bash, so size the
+ * files in the test for either. With `0` no regular file can receive a single
+ * byte and every write to one fails with `EFBIG`. Bun ignores `SIGXFSZ`, so the
+ * command sees the error instead of being killed. POSIX only.
+ *
+ * Use it to check what a command leaves behind when a write fails.
+ */
+export function withFileSizeLimit(blocks: number, cmd: string[]): string[] {
+  return ["/bin/sh", "-c", `ulimit -f ${blocks} && exec "$@"`, "--", ...cmd];
+}
+
 export function bunTest(file: string, env?: Record<string, string>) {
   var path = require("path");
   const result = Bun.spawnSync([bunExe(), "test", path.basename(file)], {

--- a/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/new-snapshot.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isASAN, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, tempDir, tmpdirSync, withFileSizeLimit } from "harness";
 import { join } from "path";
 
 test("it will create a snapshot file and directory if they don't exist", () => {
@@ -223,5 +223,81 @@ describe("a .snap file that does not parse", () => {
     expect(stderr).toContain(`snapshots: +${COUNT} added`);
     expect(exitCode).toBe(0);
     expect(fs.readFileSync(snapPath, "utf8").match(/^exports\[/gm)).toHaveLength(COUNT);
+  });
+});
+
+// A run that does not get as far as writing the file, or whose write fails, leaves the file
+// from before the run. Until the rename at the end, nothing touches it.
+describe.concurrent("a run that cannot write its snapshots leaves the old files", () => {
+  const OLD_SNAP =
+    '// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n\nexports[`a 1`] = `"old a"`;\n\nexports[`b 1`] = `"old b"`;\n';
+  const TEST_FILE = `
+    import { test, expect } from "bun:test";
+    test("a", () => expect("new a").toMatchSnapshot());
+    test("b", () => expect("old b").toMatchSnapshot());
+  `;
+
+  async function runTest(dir: string, args: string[], fileSizeLimitBlocks?: number) {
+    const cmd = [bunExe(), "test", ...args, "./a.test.ts"];
+    await using proc = Bun.spawn({
+      cmd: fileSizeLimitBlocks === undefined ? cmd : withFileSizeLimit(fileSizeLimitBlocks, cmd),
+      cwd: dir,
+      env: { ...bunEnv, CI: "false" },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("--update-snapshots: the process exits during a test", async () => {
+    using dir = tempDir("snap-exit-early", {
+      "a.test.ts": `
+        import { test, expect } from "bun:test";
+        test("a", () => {
+          expect("new a").toMatchSnapshot();
+          process.exit(0);
+        });
+      `,
+      "__snapshots__/a.test.ts.snap": OLD_SNAP,
+    });
+    expect((await runTest(String(dir), ["--update-snapshots"])).exitCode).toBe(0);
+    expect(fs.readFileSync(join(String(dir), "__snapshots__", "a.test.ts.snap"), "utf8")).toBe(OLD_SNAP);
+  });
+
+  // `withFileSizeLimit(0, ...)`: every write to a regular file fails with EFBIG.
+  test.skipIf(isWindows)("--update-snapshots: the .snap file cannot be written", async () => {
+    using dir = tempDir("snap-write-fails", {
+      "a.test.ts": TEST_FILE,
+      "__snapshots__/a.test.ts.snap": OLD_SNAP,
+    });
+    const { stderr, exitCode } = await runTest(String(dir), ["--update-snapshots"], 0);
+    expect(stderr).toContain("Failed to write snapshot file: ");
+    expect(stderr).not.toContain("returned error");
+    expect(exitCode).toBe(1);
+    expect(fs.readFileSync(join(String(dir), "__snapshots__", "a.test.ts.snap"), "utf8")).toBe(OLD_SNAP);
+    expect(fs.readdirSync(join(String(dir), "__snapshots__"))).toEqual(["a.test.ts.snap"]);
+  });
+
+  // The source is longer than the one block the limit allows, so on Linux the write stops after
+  // the first block instead of failing as a whole. Written in place, that would leave the start of
+  // the new text in front of the rest of the old one.
+  test.skipIf(isWindows)("the source of an inline snapshot cannot be written", async () => {
+    const source =
+      `
+      import { test, expect } from "bun:test";
+      test("a", () => {
+        expect("new a").toMatchInlineSnapshot();
+      });
+      // ` +
+      Buffer.alloc(3000, "x").toString() +
+      "\n";
+    using dir = tempDir("inline-snap-write-fails", { "a.test.ts": source });
+    const { stderr, exitCode } = await runTest(String(dir), [], 1);
+    expect(stderr).toContain("Failed to update inline snapshot: Write file error: EFBIG");
+    expect(exitCode).toBe(1);
+    expect(fs.readFileSync(join(String(dir), "a.test.ts"), "utf8")).toBe(source);
+    expect(fs.readdirSync(String(dir))).toEqual(["a.test.ts"]);
   });
 });


### PR DESCRIPTION
Stacked on #39689, which adds `File::write_file_atomically` and converts the package.json and snapshot writers. This PR holds what that branch leaves out: one more writer, and tests in which the write itself fails.

### Problem
- `bun init` on a project with a `package.json` writes the new text over the old bytes and truncates afterwards (`init_command.rs`, `'write_package_json`). A write that stops early leaves the start of the new file in front of the rest of the old one: `package.json failed to write due to error EFBIG`, file changed.
- #39689 tests writers that succeed. Nothing tests a write that fails, which is what the atomic write is for.

### Fix
- `bun init` writes `package.json` with `write_file_atomically`, after it closes the handle it read the file with. The Windows-only save and restore of that handle's position around the read is deleted: it only served the write through the same handle.
- A failed `.snap` write at the end of a serial `bun test` run sets the exit code, like a failed inline snapshot write. It used to leave `main` as an internal error. The `--parallel` worker (`test/parallel/runner.rs`, `worker_flush_aggregates`) still drops both results and exits 0. That needs a worker to coordinator message and is left out here on purpose. It is reported separately.
- Verified: `withFileSizeLimit(blocks, cmd)` in `test/harness.ts` runs a command under `ulimit -f`. New tests in `bun-pm-pkg`, `bun-pm-version`, `init` and `new-snapshot.test.ts` check that the old file is intact and no `.tmp` file is left, after `EFBIG` and after a `process.exit()` under `--update-snapshots`. All fail on 1.4 canary. On #39689 alone the `init` test and the exit code assertion fail.

### Background
- Bun ignores `SIGXFSZ`, so a write past `RLIMIT_FSIZE` returns `EFBIG`. A limit of 0 fails every write at once, which exposes a truncate-then-write writer. A limit of one block makes Linux cut the write short, which exposes a write-then-truncate writer. The tests only check that the file is intact, so they also pass on macOS, where the whole write fails.
- `write_file_atomically` in #39689 returns the write error without trying the in-place fallback, so these tests hold with its fallback in place.
- `bun create` still writes in place. It rewrites the package.json it has just copied.

<details><summary>Notes</summary>

The first version of this PR also made `write_file_atomically` keep the owner of the old file. #39689 took that change (35bb9d3), together with a fix for its two-writer test, so this PR was rebuilt on top of it as one commit without the `file.rs` part. The review notes on the earlier commits (drained pipes, one-line comments, the deleted Windows seek pair, the `--parallel` exclusion) are all folded into the current commit.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/test/snapshot-tests/new-snapshot.test.ts, test/cli/install/bun-pm-version.test.ts, test/cli/install/bun-pm-pkg.test.ts, test/cli/init/init.test.ts

<!-- robobun:evidence:end -->