### PR TITLE
valkey: accept a plus sign in big number replies and never throw on oversize ones

### DIFF
--- a/docs/runtime/redis.mdx
+++ b/docs/runtime/redis.mdx
@@ -342,7 +342,7 @@ The client automatically converts Redis responses to JavaScript values:
 - Simple strings are returned as JavaScript strings
 - Null bulk strings and null arrays are returned as `null`
 - Array responses are returned as JavaScript arrays
-- Big number responses (RESP3) are returned as `BigInt`. A payload that is not an integer literal is returned as a string. `getBuffer` returns the payload as a `Buffer`.
+- Big number responses (RESP3) are returned as `BigInt`. A payload that is not an integer literal, or that has too many digits for a `BigInt`, is returned as a string. `getBuffer` returns the payload as a `Buffer`.
 - Error responses throw JavaScript errors with appropriate error codes
 - Boolean responses (RESP3) are returned as JavaScript booleans
 - Map responses (RESP3) are returned as JavaScript objects

--- a/packages/bun-types/redis.d.ts
+++ b/packages/bun-types/redis.d.ts
@@ -116,7 +116,7 @@ declare module "bun" {
      * - A simple, bulk or verbatim string becomes a string. Methods that return a Buffer, such as getBuffer, keep the bytes.
      * - An integer becomes a number.
      * - A double becomes a number.
-     * - A big number becomes a bigint. When its payload is not an integer literal it becomes a string.
+     * - A big number becomes a bigint. When its payload is not an integer literal, or has too many digits for a bigint, it becomes a string.
      * - A boolean becomes a boolean.
      * - A null, a null bulk string and a null array become null.
      * - An array becomes an array.

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -666,23 +666,23 @@ impl JSValue {
     pub fn from_uint64_no_truncate(global: &JSGlobalObject, i: u64) -> JsResult<JSValue> {
         host_fn::from_js_host_call(global, || JSC__JSValue__fromUInt64NoTruncate(global, i))
     }
-    /// A BigInt from a decimal integer literal (optional `-`, then digits).
-    /// Returns `Ok(None)` when `digits` is not such a literal.
-    #[track_caller]
-    pub fn big_int_from_decimal(
-        global: &JSGlobalObject,
-        digits: &[u8],
-    ) -> JsResult<Option<JSValue>> {
-        let unsigned = digits.strip_prefix(b"-").unwrap_or(digits);
-        if unsigned.is_empty() || !unsigned.iter().all(u8::is_ascii_digit) {
-            return Ok(None);
+    /// A BigInt from a decimal integer literal (optional `+` or `-`, then
+    /// digits). Returns `None` when `literal` is not such a literal, or when
+    /// the value does not fit in a BigInt. Never throws.
+    pub fn big_int_from_decimal(global: &JSGlobalObject, literal: &[u8]) -> Option<JSValue> {
+        let (negative, digits) = match literal.split_first() {
+            Some((b'-', digits)) => (true, digits),
+            Some((b'+', digits)) => (false, digits),
+            _ => (false, literal),
+        };
+        if digits.is_empty() || !digits.iter().all(u8::is_ascii_digit) {
+            return None;
         }
-        // Only text StringToBigInt accepts gets here, so empty means it threw (too large).
-        let value = host_fn::from_js_host_call(global, || {
-            // SAFETY: `digits` is a live slice for the duration of the call.
-            unsafe { JSC__JSValue__bigIntFromLatin1(global, digits.as_ptr(), digits.len()) }
-        })?;
-        Ok(Some(value))
+        // SAFETY: `digits` is a live, non-empty slice for the duration of the call.
+        let value = unsafe {
+            JSC__JSValue__bigIntFromDecimalDigits(global, digits.as_ptr(), digits.len(), negative)
+        };
+        (!value.is_empty()).then_some(value)
     }
     /// `JSValue.fromTimevalNoTruncate` — encode a `struct timeval`
     /// as a BigInt (`sec * 1_000_000 + nsec`) without precision loss. May allocate
@@ -2002,10 +2002,11 @@ unsafe extern "C" {
     safe fn JSC__JSValue__dateInstanceFromNumber(global: &JSGlobalObject, n: f64) -> JSValue;
     safe fn JSC__JSValue__fromInt64NoTruncate(global: &JSGlobalObject, i: i64) -> JSValue;
     safe fn JSC__JSValue__fromUInt64NoTruncate(global: &JSGlobalObject, i: u64) -> JSValue;
-    fn JSC__JSValue__bigIntFromLatin1(
+    fn JSC__JSValue__bigIntFromDecimalDigits(
         global: &JSGlobalObject,
-        ptr: *const u8,
+        digits: *const u8,
         len: usize,
+        negative: bool,
     ) -> JSValue;
     safe fn JSC__JSValue__fromTimevalNoTruncate(
         global: &JSGlobalObject,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4487,11 +4487,15 @@ JSC::EncodedJSValue JSC__JSValue__fromUInt64NoTruncate(JSC::JSGlobalObject* glob
     return JSC::JSValue::encode(JSC::JSBigInt::createFrom(globalObject, val));
 }
 
-// Decimal integer literal (Latin-1) -> BigInt. Returns the empty value when
-// the text is not a valid StringToBigInt input.
-JSC::EncodedJSValue JSC__JSValue__bigIntFromLatin1(JSC::JSGlobalObject* globalObject, const uint8_t* ptr, size_t len)
+// One or more decimal digits (no sign) -> BigInt. Returns the empty value,
+// without throwing, when the value does not fit in a JSBigInt.
+[[ZIG_EXPORT(nothrow)]] JSC::EncodedJSValue JSC__JSValue__bigIntFromDecimalDigits(JSC::JSGlobalObject* globalObject, const uint8_t* digits, size_t len, bool negative)
 {
-    return JSC::JSValue::encode(JSC::JSBigInt::stringToBigInt(globalObject, WTF::StringView(std::span { reinterpret_cast<const char*>(ptr), len })));
+    ASSERT(len > 0);
+    auto sign = negative ? JSC::JSBigInt::ParseIntSign::Signed : JSC::JSBigInt::ParseIntSign::Unsigned;
+    // With no global object to throw into, parseInt reports a too-large value
+    // as the empty value.
+    return JSC::JSValue::encode(JSC::JSBigInt::parseInt(nullptr, JSC::getVM(globalObject), WTF::StringView(std::span { reinterpret_cast<const char*>(digits), len }), 10, JSC::JSBigInt::ErrorParseMode::IgnoreExceptions, sign));
 }
 
 uint64_t JSC__JSValue__toUInt64NoTruncate(JSC::EncodedJSValue val)

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -225,7 +225,7 @@ CPP_DECL void JSC__JSValue__forEachPropertyOrdered(JSC::EncodedJSValue JSValue0,
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromEntries(JSC::JSGlobalObject* arg0, ZigString* arg1, ZigString* arg2, size_t arg3, bool arg4);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromInt64NoTruncate(JSC::JSGlobalObject* arg0, int64_t arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromUInt64NoTruncate(JSC::JSGlobalObject* arg0, uint64_t arg1);
-CPP_DECL JSC::EncodedJSValue JSC__JSValue__bigIntFromLatin1(JSC::JSGlobalObject* arg0, const uint8_t* arg1, size_t arg2);
+CPP_DECL JSC::EncodedJSValue JSC__JSValue__bigIntFromDecimalDigits(JSC::JSGlobalObject* arg0, const uint8_t* digits, size_t len, bool negative);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromTimevalNoTruncate(JSC::JSGlobalObject* arg0, int64_t nsec, int64_t sec);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__bigIntSum(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1);
 CPP_DECL void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString* arg2);

--- a/src/runtime/valkey_jsc/protocol_jsc.rs
+++ b/src/runtime/valkey_jsc/protocol_jsc.rs
@@ -150,11 +150,12 @@ pub(crate) fn resp_value_to_js_with_options(
 
             Ok(js_obj)
         }
-        // BigInt when the payload is an integer literal; modules and Lua can
-        // put anything after `(`, so other text stays a string.
+        // BigInt when the payload is an integer literal that fits in one;
+        // modules and Lua can put anything after `(`, so other text stays a
+        // string.
         RESPValue::BigNumber(str) => {
             if !options.return_as_buffer
-                && let Some(big) = JSValue::big_int_from_decimal(global, str)?
+                && let Some(big) = JSValue::big_int_from_decimal(global, str)
             {
                 return Ok(big);
             }

--- a/test/js/valkey/valkey-incremental-scan.test.ts
+++ b/test/js/valkey/valkey-incremental-scan.test.ts
@@ -8,7 +8,21 @@ const bulk = (s: string) => `$${Buffer.byteLength(s)}${CRLF}${s}${CRLF}`;
 const HELLO =
   `%3${CRLF}` + bulk("server") + bulk("redis") + bulk("proto") + `:3${CRLF}` + bulk("version") + bulk("7.4.0");
 
-type PerSocket = { buf: Buffer; replied: boolean };
+type PerSocket = { buf: Buffer; replied: boolean; unsent: Buffer | null };
+
+/** Writes `reply`; whatever the socket does not take at once goes out on `drain`. */
+function writeReply(s: Socket<PerSocket>, reply: string) {
+  const bytes = Buffer.from(reply, "latin1");
+  s.data.unsent = s.data.unsent ? Buffer.concat([s.data.unsent, bytes]) : bytes;
+  flushUnsent(s);
+}
+
+function flushUnsent(s: Socket<PerSocket>) {
+  const st = s.data;
+  if (!st.unsent) return;
+  const written = Math.max(0, s.write(st.unsent));
+  st.unsent = written < st.unsent.length ? st.unsent.subarray(written) : null;
+}
 
 /**
  * Mock server: parses the client's RESP command frames
@@ -22,8 +36,9 @@ function createCommandServer(
     port: 0,
     socket: {
       open(s) {
-        s.data = { buf: Buffer.alloc(0), replied: false };
+        s.data = { buf: Buffer.alloc(0), replied: false, unsent: null };
       },
+      drain: flushUnsent,
       error() {},
       close() {},
       data(s, raw) {
@@ -90,16 +105,16 @@ function createReplyServer(
         };
         writeByte(0);
       } else {
-        s.write(reply.slice(0, splitAt));
+        writeReply(s, reply.slice(0, splitAt));
         s.flush();
         if (splitAt < reply.length) {
           // Yield twice so the first write reaches the client's `on_data`
           // before the second is sent.
-          setImmediate(() => setImmediate(() => s.write(reply.slice(splitAt))));
+          setImmediate(() => setImmediate(() => writeReply(s, reply.slice(splitAt))));
         }
       }
     } else {
-      s.write(`+OK${CRLF}`);
+      writeReply(s, `+OK${CRLF}`);
     }
   });
 }
@@ -133,8 +148,10 @@ const FRAMES: [name: string, frame: string, expected: Decoded][] = [
   ],
   ["big number above 2^53", `(9007199254740993${CRLF}`, { value: 9007199254740993n }],
   ["negative big number", `(-42${CRLF}`, { value: -42n }],
+  ["big number with an explicit plus sign", `(+42${CRLF}`, { value: 42n }],
   ["big number above 2^64", `(340282366920938463463374607431768211456${CRLF}`, { value: 2n ** 128n }],
   ["big number with a non-integer payload", `(12abc${CRLF}`, { value: "12abc" }],
+  ["big number with a sign and no digits", `(+${CRLF}`, { value: "+" }],
   [
     "simple error (-ERR)",
     `-ERR unknown command${CRLF}`,
@@ -181,6 +198,19 @@ describe.concurrent("Valkey reply decoding", () => {
       const value = await client.getBuffer("k");
       expect(value).toBeInstanceOf(Buffer);
       expect(value!.toString()).toBe("9007199254740993");
+    });
+  });
+
+  test("big number with more digits than a BigInt can hold resolves as a string", async () => {
+    // JavaScriptCore caps a BigInt at 2^20 bits, about 313,600 decimal digits.
+    // The RESP line limit is far above that.
+    const digits = Buffer.alloc(400_000, "7").toString();
+    const server = createReplyServer(`(${digits}${CRLF}`);
+    await withClient(server, async client => {
+      const value = await client.get("k");
+      expect(typeof value).toBe("string");
+      expect(value).toBe(digits);
+      expect(await client.send("PING", [])).toBe("OK");
     });
   });
 


### PR DESCRIPTION
### Problem
- A RESP3 big number reply with a plus sign, `(+42`, resolves as the string `"+42"`. The spec shape is `([+|-]<digits>`, and the `:` integer path already accepts `+`. `big_int_from_decimal` (`src/jsc/JSValue.rs:676`) stripped only `-`.
- A `(` reply with more digits than a BigInt can hold (about 313,600) rejects the command with an uncoded `RangeError: Out of memory: BigInt generated from this operation is too big`. The binding (`src/jsc/bindings/bindings.cpp:4492`) called `JSBigInt::stringToBigInt` with a global object, so the size check threw. #39544 documents the `(` arm as "integer literal becomes a BigInt, anything else stays a string, the decoder never throws". Both replies fall outside that.
- Only a module, a Lua script or a non-Redis peer can send these. The connection stays usable either way.

### Fix
- `big_int_from_decimal` strips `+` or `-`, checks the digits, and passes the digits and a sign flag to the binding. It returns `Option<JSValue>` and cannot throw.
- The binding, now `JSC__JSValue__bigIntFromDecimalDigits`, calls `JSBigInt::parseInt` with a null global object. In that mode JSC returns the empty value for a value that does not fit instead of an exception. This is the same call JSC's own bytecode generator uses for BigInt literals. The `(` arm in `protocol_jsc.rs` then takes the existing string fallback.
- The docs and the `send()` JSDoc name the oversize case.
- Verified: `test/js/valkey/valkey-incremental-scan.test.ts`. On main, `(+42` (both send modes) and the 400,000 digit reply fail, 43 other cases pass. With the fix all 46 pass. Also `test/integration/bun-types/bun-types.test.ts`.

### Background
- RESP3 is the Redis wire protocol. A reply line that starts with `(` is a big number: an integer too large for the `:` 64-bit integer type. Redis core emits it only for values above `i64::MAX`. Modules and Lua can put any text after `(`.
- `JSBigInt::parseInt` takes a "global object for OOM" argument. With a global object it throws a RangeError when the result would exceed JSC's BigInt limit of 2^20 bits. With `nullptr` it returns the empty JSValue instead. `stringToBigInt` always passes the global object.
- The test file drives the client against an in-process mock server. Every entry in `FRAMES` is sent whole and one byte per read. The mock now finishes a reply on `drain`, because a 400 KB reply does not fit in one socket write on every platform.

<details><summary>Notes</summary>

- The limit: `JSBigInt::maxLengthBits` is 1024 * 1024. `computeLength` budgets 107/32 bits per decimal digit, so a literal with more than about 313,593 significant digits fails. The RESP line cap is 512 MB, so the gap is reachable. A 300,000 digit reply still becomes a BigInt.
- `parseInt` with a null global asserts on an empty digit span in debug builds. The Rust side returns `None` for an empty span before the call (`(`, `(+` and `(-` stay strings), and the binding asserts `len > 0`.
- Extra cases probed against the debug build with `BUN_JSC_validateExceptionChecks=1`, no reports: `(+0` and `(-0` give `0n`, `(007` gives `7n`, `(+-5`, `( 5` and `(0x10` stay strings, a negative oversize literal stays a string, an oversize literal nested in an array stays a string next to a BigInt sibling, and PING works after each.
- The rest of the valkey suite needs the docker fixture and did not run locally.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-incremental-scan.test.ts
bun test v1.4.0 (4c689909e)

test/js/valkey/valkey-incremental-scan.test.ts:
(pass) Valkey reply decoding, frame sent whole > RESP3 null with trailing bytes (_junk) [89.81ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null array (*-1) [141.53ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null array nested in an array [116.55ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null bulk string ($-1) [116.05ms]
(pass) Valkey reply decoding, frame sent whole > RESP3 null (_) [115.77ms]
173 |       const outcome = await client.get("k").then(
174 |         value => ({ value }),
175 |         error => ({ error }),
176 |       );
177 |       if ("value" in expected) {
178 |         expect(outcome).toEqual({ value: expected.value });
                              ^
error: expect(received).toEqual(expected)

  {
-   "value": 42n,
+   "value": "+42",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/valkey/valkey-incremental-scan.test.ts
... (truncated)

release without fix: 27 FAILED
bun test v1.4.0-canary.1 (4c689909e)

test/js/valkey/valkey-incremental-scan.test.ts:
173 |       const outcome = await client.get("k").then(
174 |         value => ({ value }),
175 |         error => ({ error }),
176 |       );
177 |       if ("value" in expected) {
178 |         expect(outcome).toEqual({ value: expected.value });
                              ^
error: expect(received).toEqual(expected)

  {
-   "value": null,
+   "value": [],
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/valkey/valkey-incremental-scan.test.ts:178:25)
      at async withClient (/workspace/bun/test/js/valkey/valkey-incremental-scan.test.ts:127:18)
      at async <anonymous> (/workspace/bun/test/js/valkey/valkey-incremental-scan.test.ts:172:11)
173 |       const outcome = await client.get("k").then(
174 |         value => ({ value }),
175 |         error => ({ error }),
176 |       );
177 |       if ("value" in expected) {
178 |         expect(outcome).toEqual({ value: expected.value });
                              ^
error: expect(received).toEqual(expected)

  {
    "value": [
-     null,
+     [],
      "abc",
    ],
  }

- Expected  - 1
+ Rec
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey-incremental-scan.test.ts
bun test v1.4.0 (4c689909e)

test/js/valkey/valkey-incremental-scan.test.ts:
(pass) Valkey reply decoding, frame sent whole > RESP3 null with trailing bytes (_junk) [47.71ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null array (*-1) [81.82ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null array nested in an array [66.62ms]
(pass) Valkey reply decoding, frame sent whole > RESP2 null bulk string ($-1) [66.41ms]
(pass) Valkey reply decoding, frame sent whole > RESP3 null (_) [66.41ms]
(pass) Valkey reply decoding, frame sent whole > big number above 2^53 [41.26ms]
(pass) Valkey reply decoding, frame sent whole > negative big number [40.84ms]
(pass) Valkey reply decoding, frame sent whole > big number with an explicit plus sign [40.20ms]
(pass) Valkey reply decoding, frame sent whole > big number above 2^64 [40.04ms]
(pass) Valkey reply decoding, frame sent whole > big number with a non-integer payload [40.89ms]
(pass) Valkey reply decoding, frame sent whole > big nu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 717ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[2/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[3/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[4/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[5/22] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[6/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[7/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[8/22] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[9/22] cxx obj/src/jsc/bindings/BunProcess.cpp.o
[10/22] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[11/22] cxx obj/src/jsc/bindings/BunObject.cpp.o
[12/22] cxx obj/src/jsc/bindings/bindings.cpp.o
[13/22] cxx obj/codegen/ZigGeneratedClasses.cpp.o
[14/22] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[15/22] cxx obj/src/jsc/bindings/napi.cpp.o
[16/22] cxx obj/codegen/JSSink.cpp.o
[17/22] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/runtime/redis.mdx                         |  2 +-
 packages/bun-types/redis.d.ts                  |  2 +-
 src/jsc/JSValue.rs                             | 37 ++++++++++++------------
 src/jsc/bindings/bindings.cpp                  | 14 +++++----
 src/jsc/bindings/headers.h                     |  2 +-
 src/runtime/valkey_jsc/protocol_jsc.rs         |  7 +++--
 test/js/valkey/valkey-incremental-scan.test.ts | 40 ++++++++++++++++++++++----
 7 files changed, 70 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
docs/runtime/redis.mdx                              1      1      0
packages/bun-types/redis.d.ts                       1      1      0
src/jsc/JSValue.rs                                  2      2      0
src/jsc/bindings/bindings.cpp                       1      1      0
src/jsc/bindings/headers.h                          1      2      0
src/runtime/valkey_jsc/protocol_jsc.rs              1      1      0
test/js/valkey/valkey-incremental-scan.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->