### PR TITLE
Bump WebKit (oven-sh/WebKit#475 preview): a property lookup stops at a lazy property whose builder threw

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,12 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+// Preview of oven-sh/WebKit#475 (on top of ceb9f90f, the previous pin here): a property
+// lookup stops at a static-table lazy property whose builder threw, instead of walking on
+// to the prototype and, on the megamorphic slow paths, recording the property as missing,
+// and reifyAllStaticProperties checks each builder's exception scope. Swap in the merged
+// sha once that PR lands.
+export const WEBKIT_VERSION = "autobuild-preview-pr-475-94c5a2d5";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/util/BunObject.test.ts
+++ b/test/js/bun/util/BunObject.test.ts
@@ -39,17 +39,14 @@ test("a lazy property whose builtin fails to load throws from the read", async (
   // The shell builtin ($) and the sql module body (sql, SQL, postgres) call Symbol(), so
   // breaking it makes each builder throw. The read must throw that error (debug builds used to
   // report the still-pending exception from inside the sql builders and abort) and the slot
-  // must stay unreified so a later read runs the builder again.
-  //
-  // process.env is read first because the shell builtin reads it before calling Symbol(), and
-  // building it on Windows reifies another property of the Bun object; doing that in the middle
-  // of the throwing read trips a separate structure assertion in debug builds.
+  // must stay unreified so a later read runs the builder again. On Windows the shell builtin also
+  // builds process.env before it calls Symbol(), which reifies Bun.inspect, so there the throwing
+  // read of $ transitions the Bun object mid-lookup as well: the case the next test sets up by hand.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),
       "-e",
-      `process.env;
-       globalThis.Symbol = NaN;
+      `globalThis.Symbol = NaN;
        const results = {};
        for (const name of ["$", "sql", "SQL", "postgres"]) {
          results[name] = [];
@@ -70,6 +67,140 @@ test("a lazy property whose builtin fails to load throws from the read", async (
       sql: ["TypeError", "TypeError"],
       SQL: ["TypeError", "TypeError"],
       postgres: ["TypeError", "TypeError"],
+    }),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test.concurrent("a lazy property builder that reifies another property of Bun and then throws", async () => {
+  // The sql module body reads Error.prototype (class ... extends Error). The proxy makes that read
+  // reify Bun.semver, which transitions the Bun object while the Bun.sql lookup is still running,
+  // and then throw. Debug builds used to abort in the lookup's prototype step, which still held
+  // the structure from before the transition (ASSERT in Structure::storedPrototype); the lookup now
+  // ends as soon as the builder has thrown. "phase" 1 proves the trap ran: if the sql module stops
+  // reading Error.prototype while it is evaluated, this test needs a new trigger.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const RealError = Error;
+       let phase = 0;
+       globalThis.Error = new Proxy(function () {}, {
+         get(target, key, receiver) {
+           if (key === "prototype" && phase === 0) {
+             phase = 1;
+             Bun.semver;
+             throw "boom";
+           }
+           return Reflect.get(target, key, receiver);
+         },
+       });
+       let thrown;
+       try { Bun.sql; thrown = "no throw"; } catch (e) { thrown = e; }
+       globalThis.Error = RealError;
+       console.log(JSON.stringify([thrown, phase, typeof Bun.sql]));`,
+    ],
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify(["boom", 1, "function"]),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// A read of an unreified lazy property whose builder throws has to end the lookup at the Bun
+// object. It used to go on to Bun's prototype with the exception still pending. The Proxy put
+// behind Bun here has its own getOwnPropertySlot, and running it with a pending exception is what
+// BUN_JSC_validateExceptionChecks=1 aborts on in debug builds. Both prototype walk loops are
+// covered: a plain receiver uses JSObject::getPropertySlot, and a receiver that overrides
+// getOwnPropertySlot (a function) sends the rest of the walk through
+// JSObject::getNonIndexPropertySlot. The second read, which lets the builder succeed, used to
+// abort the same way through the function: that loop did not check after running a builder at all.
+test.concurrent.each([
+  ["Bun itself", "Bun"],
+  ["a function that inherits from Bun", "Object.setPrototypeOf(function () {}, Bun)"],
+])("a lazy property builder that throws ends the lookup when the receiver is %s", async (_, receiver) => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `Object.setPrototypeOf(Bun, new Proxy(Object.prototype, {}));
+       const receiver = ${receiver};
+       const RealSymbol = Symbol;
+       globalThis.Symbol = NaN;
+       let thrown;
+       try { receiver.sql; thrown = "no throw"; } catch (e) { thrown = e.constructor.name; }
+       globalThis.Symbol = RealSymbol;
+       console.log(JSON.stringify([thrown, typeof receiver.sql]));`,
+    ],
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify(["TypeError", "function"]),
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test.concurrent("a lazy property builder that throws is not recorded as a missing property", async () => {
+  // Each access site is trained on many object shapes first, so that it is megamorphic by the
+  // time it sees Bun and the access takes the megamorphic slow path. That path used to walk past
+  // the builder that threw and record "not present" for Bun's structure. A builder that throws
+  // stores nothing, so Bun kept that structure and every later access from a megamorphic site got
+  // undefined (false for `in`) instead of running the builder again. So the second access of each
+  // site has to throw like the first one. Symbol stays broken throughout because the three sql
+  // properties share one module, which would stop throwing once any of them loaded it. Each site
+  // has its own property because the record is per property name.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const byValKey = "postgres";
+       const inByValKey = "$";
+       const sites = {
+         get_by_id: o => typeof o.sql,
+         get_by_val: o => typeof o[byValKey],
+         in_by_id: o => "SQL" in o,
+         in_by_val: o => inByValKey in o,
+       };
+       const shapes = [];
+       for (let i = 0; i < 32; i++) {
+         const o = { sql: 0, postgres: 0, SQL: 0, $: 0 };
+         o["shape" + i] = i;
+         shapes.push(o);
+       }
+       for (let i = 0; i < 200; i++) {
+         for (const o of shapes) for (const name in sites) sites[name](o);
+       }
+       const access = site => { try { return site(Bun); } catch (e) { return e.constructor.name; } };
+       const RealSymbol = Symbol;
+       globalThis.Symbol = NaN;
+       const results = {};
+       for (const name in sites) results[name] = [access(sites[name]), access(sites[name])];
+       globalThis.Symbol = RealSymbol;
+       results.afterwards = typeof Bun.sql;
+       console.log(JSON.stringify(results));`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({
+      get_by_id: ["TypeError", "TypeError"],
+      get_by_val: ["TypeError", "TypeError"],
+      in_by_id: ["TypeError", "TypeError"],
+      in_by_val: ["TypeError", "TypeError"],
+      afterwards: "function",
     }),
     stderr: "",
     exitCode: 0,

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -4,7 +4,6 @@
 test/bake/dev/production.test.ts
 test/integration/vite-build/vite-build.test.ts
 test/js/bun/test/parallel/test-integration-rspack.ts
-test/js/bun/util/BunObject.test.ts
 test/js/bun/util/fuzzy-wuzzy.test.ts
 test/js/node/module/node-module-module.test.js
 test/js/node/test/parallel/test-vm-module-referrer-realm.mjs


### PR DESCRIPTION
### Problem
- After one read of `Bun.sql` whose builder throws, every megamorphic access site returns `undefined` for `Bun.sql` (`false` for `in`) and never runs the builder again (release Bun 1.4.0). On debug builds the same read aborts: under `BUN_JSC_validateExceptionChecks=1` with a Proxy prototype behind `Bun` (`unchecked as of this scope: getNonIndexPropertySlot @ JSObjectInlines.h:286`), or in `Structure::storedPrototype` when the builder transitions `Bun` first (#37001).
- Cause: `setUpStaticFunctionSlot` (WebKit `Lookup.cpp:73`) reports the throw as a miss and every lookup loop walks on. The megamorphic paths in `JITOperations.cpp` then record the miss for Bun's structure, which the throw did not change.
- `reifyAllStaticProperties` also runs the builders of `{...Bun}` without checking between them, which keeps this test file in `test/no-validate-exceptions.txt`.

### Fix
- oven-sh/WebKit#475, pinned as its preview. Each lookup loop checks for an exception after the own-property step on a static-table object and stops. `reifyAllStaticProperties` checks after each builder. Land that PR first, then set `WEBKIT_VERSION` to the merged sha.
- Correct because only a static table can make that step run a builder, so other objects are unchanged, and it is the check the loops already make after an overridden `getOwnPropertySlot`. Nothing runs after the throw, so nothing records the miss or reads the stale structure.
- Tests: four new tests in `test/js/bun/util/BunObject.test.ts`, the `process.env` workaround above them removed, the file un-quarantined. On the current pin the four fail with the symptoms above and the file aborts under the validator. Also ran `bun/util`, `bun/jsc`, `globals` under the validator.
- Supersedes the engine half of #37001 (oven-sh/WebKit#390) and carries its test.

### Background
- `Bun` properties are static-table entries with a builder. The first read runs it and stores the result. In this fork a builder can throw. It then stores nothing, and the next read runs it again.
- The own-property step returns only hit or miss. Six loops call it and walk to the prototype on a miss. Spread and `Object.assign` reify every entry in one loop instead.
- The megamorphic cache is a VM-wide table keyed by structure and property name. A recorded miss is valid only while the property cannot appear without a structure change.
- The validator is a debug mode: a caller must check every scope that ran. The ASAN lane runs tests with it, except the quarantined files.

<details><summary>Notes</summary>

Megamorphic repro on release Bun 1.4.0 (`read` trained on 8 or more shapes; with 4 shapes or `BUN_JSC_useJIT=0` the retry works):

```js
const RealSymbol = Symbol;
globalThis.Symbol = NaN;
function read(o) { return o.sql; }
// ... call read() with 8+ differently shaped objects a few thousand times ...
try { read(Bun); } catch {}          // TypeError from the builder
globalThis.Symbol = RealSymbol;
read(Bun);                           // undefined; a fresh `Bun.sql` is a function
```

The six loops: `JSObject::getPropertySlot`, `JSObject::getNonIndexPropertySlot`, and the get_by_id, get_by_val, in_by_id, in_by_val megamorphic helpers (the `with_this` forms share them). The parent-class-table loop in `getOwnStaticPropertySlot` gets the same stop. The `in` helpers record into a separate has-cache, so `in` sites are poisoned independently of get sites.

Relation to #37001 / oven-sh/WebKit#390: that change reloads the structure before the prototype step. With oven-sh/WebKit#475 a throwing builder returns before that step, so the assertion it fixes is unreachable and its test (the Error proxy test here, reworded) passes on #475 alone. Both PRs pin a different preview on the same line, so whichever lands second has to re-pin anyway. Suggested order: land oven-sh/WebKit#475 (with or after #390), re-pin here, close #37001. #39436 and #38821 name #37001 as their engine prerequisite; this landing is the one they need.

Validator findings while testing (both in the WebKit PR): a builder that succeeds through `getNonIndexPropertySlot` was reported as unchecked by that loop's own scope, so the check there is made on a hit as well. `reifyAllStaticProperties` (spread, `Object.assign`, `Object.entries`, `delete`) runs builders back to back, so `({...Bun})` aborted with `defaultBunSQLObject` unchecked as of `defaultBunSQLObject`; it now uses a `TopExceptionScope` and checks after each builder. That is what un-quarantines this file. Of the other quarantined files, `resolve/import-meta.test.js` and `resolve/resolve.test.ts` already pass under the validator on the current pin, and `node/module/*.test.js` abort on unchecked scopes in `NodeModuleModule.cpp`; both are unrelated to this change and left alone.

Not done: the self-review also suggested skipping the store in `reifyStaticProperty` when a builder returns a value with an exception already pending. A builder that throws returns empty and stores nothing today, which is the case these tests rely on. The other case is a builder run with an exception already pending, which is a caller bug, and skipping the store there would make it run again later. Left as is.

Test notes: `Symbol` stays broken for both accesses of each megamorphic site because the three sql properties share one module, so once any read loads it the other builders stop throwing. Each site has its own property (`sql`, `postgres`, `SQL`, `$`) because the record is per name. On Windows the `$` builder reifies `Bun.inspect` before it throws, so there that site is the transition-then-throw case through the megamorphic path. The removed `process.env` pre-read worked around the same assertion on Windows; the assertion is in the prototype step that is no longer reached.

Fail-before was taken on a debug ASAN build of this branch with `WEBKIT_VERSION` set to `0f966e81` (main's pin): receiver `Bun` aborts at `getNonIndexPropertySlot @ JSObjectInlines.h:286`, the function receiver at `ProxyObject::getOwnPropertySlotCommon`, the transition test at `StructureInlinesLight.h(56) storedPrototype`, the megamorphic test prints `["TypeError","undefined"]` twice and `["TypeError",false]` twice, and the whole file under `BUN_JSC_validateExceptionChecks=1` aborts in `hasNonReifiedStatic`. Pass-after: 8 of 8 plain and under the validator against the published preview tarball on Linux x64 debug ASAN (and before that against a locally built JSC from the branch), and 8 of 8 plain and under the validator on a Windows x64 debug build. The same Windows build with the pin set to `0f966e81` fails 5 tests, including the test whose `process.env` pre-read is removed here (its child aborts on the structure assertion), so the Windows quirk that pre-read worked around is real on the old pin and gone with the new one. With either pin, `fuzzy-wuzzy.test.ts` aborts on a debug build (`_http_outgoing` `$assert`, or, with a Redis server reachable, `debug_assert!(self.is_subscriber())` in `js_valkey.rs:1320` when `new Bun.RedisClient().punsubscribe()` gets its reply), and the large DOMJIT variants and the `process.env.USER` check fail in this container. The DOMJIT timings are the same with either pin (7.0 s against 7.1 s for 200k `new TextEncoder().encode()` calls on the same host). When `bun/util` runs as one batch in one process, `exotic-global-mutable-prototype.test.ts` fails after `BunObject.test.ts` because the first test in that file sets `globalThis.a` (unchanged by this PR); the same happens with the stock pin, and CI runs each file in its own process.

Rebases: main moved its pin thirteen times while this was open, to `b7f217b4` (#39829, oven-sh/WebKit#477), `aea1f010` (#35343, oven-sh/WebKit#330), `c148a12d` (#40201, oven-sh/WebKit#494), `cb61607f` (#40276, the `8c4fd56347` upstream merge), `1cb96a7b` (#40417, oven-sh/WebKit#513), `76882271` (#40507), `2da33d53` (#40570, oven-sh/WebKit#519), `72597399` (#40270, oven-sh/WebKit#521), `0bb01ed5` (#40643), `f5deafe0` (#40674), `1817c3c3` (#40681, the `6b879687ee` upstream merge), `c4ddc0cf` (#40677, oven-sh/WebKit#527) and `ceb9f90f` (#40767, oven-sh/WebKit#530 and #531). oven-sh/WebKit#475 was rebased onto each (current head `94c5a2d5`, the same four-file diff, applied without changes each time; the `6b879687ee` merge touched `JITOperations.cpp` only in `operationPolymorphicCall`, none of the lookup loops). Two of those heads (`17a4e95f`, build 106127, and `b3532b38`, build 106406) passed every CI job and this PR pins the matching preview on top of main, squashed to one commit. The only conflict each time was the `WEBKIT_VERSION` line, plus #40065's rework of `test/no-validate-exceptions.txt`, which still lists `BunObject.test.ts` for the builder reason this change removes. Re-verified against each new preview on Linux x64 debug ASAN: this file 8 of 8 plain and under the validator, the related files above (178 tests), #39829's `ffi-ptr-non-view-cell-arg` stress fixture and `node/buffer.test.js` (678 pass) for the new bases.

Landing detail: the preview release is deleted when oven-sh/WebKit#475 closes, so the pin must be swapped to the merged sha (and the comment above it removed) before this merges.

</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 14 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/util/BunObject.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/util/BunObject.test.ts
bun test v1.4.1 (65362b53b)

test/js/bun/util/BunObject.test.ts:
(pass) hasNonReifiedStatic [254.08ms]
(pass) require('bun') [5.30ms]
Module {
  $: [Function: BunShell2],
  Archive: [class Archive],
  ArrayBufferSink: [class ArrayBufferSink],
  CSRF: {
    generate: [Function: generate],
    verify: [Function: verify],
  },
  Cookie: [class Cookie],
  CookieMap: [class CookieMap],
  CryptoHasher: [class CryptoHasher],
  FFI: {
    viewSource: [Function: viewSource],
    dlopen: [Function: dlopen],
    callback: [Function: callback],
    linkSymbols: [Function: linkSymbols],
    toBuffer: [Function: toBuffer],
    toArrayBuffer: [Function: toArrayBuffer],
    closeCallback: [Function: closeCallback],
    cfunction: [Function: cfunction],
    CString: [class CString],
    ptr: [Function: ptr],
    read: {
      u8: [Function: u8],
      u16: [Function: u16],
      u32: [Function: u32],
      ptr: [Function: ptr],
      i8: [Function: i8],
      i16: [Function: i16],
      i32: [Function: i32],
      i64: [Function: i64],
      u64: [Function: u64],
      intptr: [Function: intptr],
      f32: [Function: f32],
      f64: [Function: f64],
    },
  },
  FileSystemRouter: [class FileSystemRouter],
  Glob: [class Glob],
  Image: [class Image],
  JSON5: {
    parse: [Function: parse],
    stringify: [Function: stringify],
  },
  JSONC: {
    parse: [Function: parse],
  },
  JSONL: JSONL {
    parse: [Function: parse],
    parseChunk: [Function: parseChunk],
  },
  MD4: [class MD4],
  MD5: [class MD5],
  RedisClient: [class RedisClient],
  S3Client: [class S3Client],
  SHA1: [class SHA1],
  SHA224: [class SHA224],
  SHA256: [class SHA256],
  SHA384: [class SHA384],
  SHA512: [class SHA512],
  SHA512_256: [class SHA512_256],
  SQL: [Function: SQL2],
  TOML: {
    parse: [Function: parse],
    stringify: [Function: stringify],
  },
  Terminal: [class Te
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts       |   7 +-
 test/js/bun/util/BunObject.test.ts | 145 +++++++++++++++++++++++++++++++++++--
 test/no-validate-exceptions.txt    |   1 -
 3 files changed, 144 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 14 passed · 0 rejected · iteration 14

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
scripts/build/deps/webkit.ts            9     12      0
test/js/bun/util/BunObject.test.ts      4      5      0
test/no-validate-exceptions.txt         2      2      0
```

</details>

<!-- robobun:evidence:end -->











