### PR TITLE
Keep an unparseable LANG / LC_ALL / LC_MESSAGES from crashing ICU

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -282,11 +282,15 @@ extern "C" void Bun__REPRL__registerFuzzilliFunctions(Zig::GlobalObject*);
 extern "C" long Bun__crashHandlerFromJSCFrame(void*, void*, void*, void*);
 #endif
 
+// bun_icu_default_locale.cpp
+extern "C" void Bun__ensureICUDefaultLocale();
+
 extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(const char* ptr, size_t length), bool evalMode, bool oneShotStartup, bool shortLivedGlobals)
 {
     static std::once_flag jsc_init_flag;
     // NOLINTBEGIN
     std::call_once(jsc_init_flag, [evalMode, oneShotStartup, shortLivedGlobals, envp, envc, onCrash]() {
+        Bun__ensureICUDefaultLocale();
         JSC::Config::enableRestrictedOptions();
         // JSC options come from BUN_JSC_* (applied in the callback below), not JSC_*.
         JSC::Config::disableEnvironmentOptions();

--- a/src/jsc/bindings/bun_icu_default_locale.cpp
+++ b/src/jsc/bindings/bun_icu_default_locale.cpp
@@ -1,0 +1,57 @@
+// ICU initializes its default locale lazily, on POSIX from LC_ALL, LC_MESSAGES
+// or LANG (Bun never calls setlocale(), so libc's locale is "C" and ICU reads
+// the variables directly). When that value does not canonicalize, for example
+// LANG=abcdefghijkl (a language subtag of 12+ bytes) or LANG=/usr/lib/locale/en_US,
+// the lazy init fails without setting anything and icu::Locale::getDefault()
+// returns a null reference. The first ucal_open / ucol_open (Date#toString,
+// localeCompare, any Intl constructor) then crashes inside ICU.
+//
+// Run the same canonicalization up front and, only when it fails, set the
+// default to the locale Bun reports anyway. A value ICU accepts is left for
+// ICU to read itself, so its behavior is unchanged.
+
+#include "root.h"
+
+#if !OS(WINDOWS)
+
+#include <cstdlib>
+#include <initializer_list>
+#include <unicode/utypes.h>
+
+// Apple's SDK has no <unicode/uloc.h>; utypes.h supplies U_CAPI + renaming.
+U_CAPI int32_t U_EXPORT2 uloc_canonicalize(const char* localeID, char* name, int32_t nameCapacity, UErrorCode* err);
+U_CAPI void U_EXPORT2 uloc_setDefault(const char* localeID, UErrorCode* status);
+
+extern "C" void Bun__ensureICUDefaultLocale()
+{
+    const char* localeID = nullptr;
+    for (const char* name : { "LC_ALL", "LC_MESSAGES", "LANG" }) {
+        localeID = getenv(name);
+        if (localeID)
+            break;
+    }
+    if (!localeID)
+        return;
+
+    // Only the status matters. A valid id that does not fit (U_BUFFER_OVERFLOW_ERROR)
+    // is pinned too, which is harmless.
+    char canonical[256];
+    UErrorCode status = U_ZERO_ERROR;
+    uloc_canonicalize(localeID, canonical, sizeof(canonical), &status);
+    if (U_SUCCESS(status))
+        return;
+
+    status = U_ZERO_ERROR;
+    uloc_setDefault("en_US", &status);
+    RELEASE_ASSERT(U_SUCCESS(status));
+}
+
+#else
+
+// ICU derives its default from the user locale of the system here, not from
+// environment variables.
+extern "C" void Bun__ensureICUDefaultLocale()
+{
+}
+
+#endif

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -188,6 +188,46 @@ describe("Intl.Collator", () => {
   });
 });
 
+// ICU reads its own default locale from LC_ALL, then LC_MESSAGES, then LANG the
+// first time a calendar or collator is opened. A value it cannot parse (a
+// language subtag of 12 or more bytes, or a path) used to leave that default
+// unset, and the first Date#toString / localeCompare / Intl constructor then
+// crashed inside ICU. Bun's own default locale does not come from these
+// variables, so every value, parseable or not, must give the en-US output.
+describe.concurrent("locale variables in the environment", () => {
+  const script = `console.log(JSON.stringify([
+    new Date(0).toString(),
+    "a".localeCompare("b"),
+    (1234.5).toLocaleString(),
+    new Intl.DateTimeFormat().resolvedOptions().locale,
+  ]))`;
+
+  test.each([
+    // eleven bytes is the longest language subtag ICU accepts
+    { LANG: "abcdefghijkl" },
+    { LANG: "/usr/lib/locale/en_US" },
+    { LC_MESSAGES: "abcdefghijkl" },
+    { LC_ALL: "abcdefghijkl", LANG: "en_US.UTF-8" },
+    { LC_ALL: "de_DE.UTF-8" },
+  ])("%o", async vars => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, LANG: undefined, LC_ALL: undefined, LC_MESSAGES: undefined, ...vars },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual([
+      "Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)",
+      -1,
+      "1,234.5",
+      "en-US",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Segmenter — brkitr/* raw (incl. cjdict)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Problem
- `LANG=abcdefghijkl bun -e 'new Date().toString()'` dies with `panic(main thread): Segmentation fault at address 0x8`. Any value ICU cannot parse does it (a language subtag of 12+ bytes, or a path), also via `LC_ALL` and `LC_MESSAGES`, on the first `Date#toString`, `localeCompare` or `Intl` call.
- ICU derives its default locale lazily. When the value fails canonicalization, ICU stores nothing and `icu::Locale::getDefault()` returns a null reference. ASAN trace: `ucal_open` -> `Calendar::makeInstance` -> `Locale::Payload::copy` reads address 8.
- Bun never reads this value (JSC takes its default locale from WTF, which says `en-US`), so only the crash was visible.

### Fix
- New `src/jsc/bindings/bun_icu_default_locale.cpp`, called first in `JSCInitialize`. It reads the variable ICU will read (`LC_ALL`, then `LC_MESSAGES`, then `LANG`) and runs `uloc_canonicalize` on it. Only if that fails, it calls `uloc_setDefault("en_US")`.
- Correct because `uloc_canonicalize` is the step that fails inside ICU, and a stored default skips the lazy path. A value ICU accepts is left to ICU, so nothing changes for it. `en_US` is the locale Bun reports anyway.
- Empty on Windows, where ICU reads the system locale. The `uloc_*` functions are forward declared as in #35600 (the macOS SDK has no `uloc.h`).
- Verified: `test/js/web/intl/intl.test.ts`, block "locale variables in the environment". Four unparseable values crash the current build and pass with the fix. The rest of the file still passes.

### Background
- ICU has one default locale per process. Calendars and collators read it through `Locale::getDefault()` for resource fallback, even when JSC passes an explicit locale.
- JSC's own default locale comes from `WTF::userPreferredLanguages()`, which reads `setlocale(LC_CTYPE, nullptr)`. Bun never calls `setlocale`, so that is `"C"`, which WTF maps to `en-US`.
- `JSCInitialize` is the one time init every VM creating path runs before JS can reach ICU.

<details><summary>Notes</summary>

- The test also runs a valid `LC_ALL=de_DE.UTF-8`, which prints the same before and after. `bun install` and other paths that never start JSC do not run the check.
- Precedence matches ICU's `uprv_getPOSIXIDForCategory`: `LC_ALL`, `LC_MESSAGES`, `LANG`. A set but empty variable counts as set, as in ICU. ICU does not use `LC_CTYPE` for the locale id, which is why a long `LC_CTYPE` never crashed.
- Checked by hand on the debug build: `LANG=abcdefghijkl`, `LANG=/usr/lib/locale/en_US`, `LC_ALL=aaaaaaaaaaaa`, `LC_MESSAGES=aaaaaaaaaaaa`, `LANG=aaaaaaaaaaaa LC_ALL=C`, `LC_ALL=` (empty), `LANG=C.UTF-8`, `LANG=de_DE.UTF-8` and the 11 byte `LANG=abcdefghijk` all run and print the en-US output.
- The 12 byte threshold is `ULOC_LANG_CAPACITY`. Bun 1.3 (ICU 75) crashed at address 0x28, the current build (ICU 78) at 0x8: same cause, different `Locale` layout. Node 26 crashes on the same input at startup.
- Relation to #35600 (default locale follows the environment): that PR wires JSC's `defaultLanguage` hook to `uloc_getDefault()`, which is exactly the call that returns the null reference. This guard leaves valid values to ICU, so #35600 works on top of it unchanged and becomes crash safe. Whether to follow the environment is a separate decision. This PR changes nothing for any value ICU accepts.
- The forward declarations follow `<unicode/utypes.h>`, which supplies `U_CAPI` and the symbol renaming used by the bundled ICU on Linux and Windows. On macOS Bun links the system `libicucore`, whose SDK ships `utypes.h` but not `uloc.h`. #35600 built on all darwin lanes with this pattern.
- `uloc_canonicalize` gets a 256 byte buffer. A valid id longer than that reports an overflow and is pinned to `en_US` too, which is harmless.
- Also ran `test/js/node/test/parallel/test-intl.js`, `test-datetime-change-notify.js` and `test-icu-env.js` (skipped in Bun, as before).
</details>
