### PR TITLE
Disable the transpiler cache when its directory does not fit in a path buffer

### DIFF
--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -68,10 +68,9 @@ const CACHE_FILE_SUFFIX: &[u8] = if bun_core::env::IS_DEBUG {
 } else {
     b".pile"
 };
-/// `<input_hash as 16 hex digits><CACHE_FILE_SUFFIX>`, see `write_cache_filename`.
+/// Hex `input_hash` + suffix, as written by `write_cache_filename`.
 const CACHE_FILE_NAME_LEN: usize = size_of::<u64>() * 2 + CACHE_FILE_SUFFIX.len();
-/// Bytes `get_cache_file_path` appends after the cache directory: the
-/// separator, the file name, and the NUL.
+/// Separator + file name + NUL, appended to the directory by `get_cache_file_path`.
 const CACHE_FILE_NAME_RESERVE: usize = 1 + CACHE_FILE_NAME_LEN + 1;
 
 // When making parser changes, it gets extremely confusing.
@@ -677,10 +676,8 @@ impl RuntimeTranspilerCache {
         Ok(ZStr::from_buf(&buf[..], total))
     }
 
-    /// Writes the resolved cache directory into `buf` (NUL-terminated) and
-    /// returns its byte length. Returns 0 to mean "cache disabled", which is
-    /// also the answer when the directory (taken from the environment, so of
-    /// any length) leaves no room in a `PathBuffer` for the cache file name.
+    /// Writes the resolved cache directory into `buf` (NUL-terminated) and returns
+    /// its byte length, or 0 when the cache is disabled or the directory does not fit.
     fn really_get_cache_dir(buf: &mut PathBuffer) -> usize {
         #[cfg(bun_debug)]
         {
@@ -708,8 +705,6 @@ impl RuntimeTranspilerCache {
             &[dir, b"bun", b"@t@"]
         } else if let Some(home) = env_var::HOME.get() {
             if cfg!(target_os = "macos") {
-                // On a mac, default to ~/Library/Caches/bun/*
-                // This is different than ~/.bun/install/cache, and not configurable by the user.
                 &[home, b"Library/", b"Caches/", b"bun", b"@t@"]
             } else {
                 &[home, b".bun", b"install", b"cache", b"@t@"]
@@ -718,10 +713,7 @@ impl RuntimeTranspilerCache {
             return 0;
         };
 
-        // The inline `bun_resolver::fs::FileSystem` surface only exposes
-        // `abs_buf` (no size-checked variant), so go straight to the
-        // underlying joiner with the same `top_level_dir` + `Loose` platform
-        // that `absBufZ` used.
+        // `FileSystem::abs_buf` has no size-checked variant, so call the joiner it wraps.
         let top = FileSystem::instance().top_level_dir;
         let Some(dir) =
             path_handler::join_abs_string_buf_checked::<platform::Loose>(top, dir_buf, parts)

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -63,6 +63,17 @@ const EXPECTED_VERSION: u32 = 25;
 /// `is_stale`), so shrinking this does not weaken staleness detection.
 const MINIMUM_CACHE_SIZE: usize = 4 * 1024;
 
+const CACHE_FILE_SUFFIX: &[u8] = if bun_core::env::IS_DEBUG {
+    b".debug.pile"
+} else {
+    b".pile"
+};
+/// `<input_hash as 16 hex digits><CACHE_FILE_SUFFIX>`, see `write_cache_filename`.
+const CACHE_FILE_NAME_LEN: usize = size_of::<u64>() * 2 + CACHE_FILE_SUFFIX.len();
+/// Bytes `get_cache_file_path` appends after the cache directory: the
+/// separator, the file name, and the NUL.
+const CACHE_FILE_NAME_RESERVE: usize = 1 + CACHE_FILE_NAME_LEN + 1;
+
 // When making parser changes, it gets extremely confusing.
 #[cfg(bun_debug)]
 static BUN_DEBUG_RESTORE_FROM_CACHE: AtomicBool = AtomicBool::new(false);
@@ -641,20 +652,14 @@ impl RuntimeTranspilerCache {
         buf: &mut [u8],
         input_hash: u64,
     ) -> crate::CrateResult<usize> {
-        // Hex-encode the 8 native-endian bytes of `input_hash`.
-        let bytes = input_hash.to_ne_bytes();
-        let suffix: &[u8] = if bun_core::env::IS_DEBUG {
-            b".debug.pile"
-        } else {
-            b".pile"
-        };
-        let needed = bytes.len() * 2 + suffix.len();
-        if buf.len() < needed {
+        if buf.len() < CACHE_FILE_NAME_LEN {
             return Err(crate::CrateError::Sys(bun_errno::SystemErrno::ENOSPC));
         }
+        // Hex-encode the 8 native-endian bytes of `input_hash`.
+        let bytes = input_hash.to_ne_bytes();
         let i = bun_core::fmt::bytes_to_hex_lower(&bytes, &mut buf[..bytes.len() * 2]);
-        buf[i..i + suffix.len()].copy_from_slice(suffix);
-        Ok(needed)
+        buf[i..i + CACHE_FILE_SUFFIX.len()].copy_from_slice(CACHE_FILE_SUFFIX);
+        Ok(CACHE_FILE_NAME_LEN)
     }
 
     pub(crate) fn get_cache_file_path(
@@ -673,7 +678,9 @@ impl RuntimeTranspilerCache {
     }
 
     /// Writes the resolved cache directory into `buf` (NUL-terminated) and
-    /// returns its byte length. Returns 0 to mean "cache disabled".
+    /// returns its byte length. Returns 0 to mean "cache disabled", which is
+    /// also the answer when the directory (taken from the environment, so of
+    /// any length) leaves no room in a `PathBuffer` for the cache file name.
     fn really_get_cache_dir(buf: &mut PathBuffer) -> usize {
         #[cfg(bun_debug)]
         {
@@ -685,59 +692,45 @@ impl RuntimeTranspilerCache {
             );
         }
 
+        let dir_buf = &mut buf[..MAX_PATH_BYTES - CACHE_FILE_NAME_RESERVE];
+
         if let Some(dir) = env_var::BUN_RUNTIME_TRANSPILER_CACHE_PATH.get() {
-            if dir.is_empty() || (dir.len() == 1 && dir[0] == b'0') {
+            if dir.is_empty() || (dir.len() == 1 && dir[0] == b'0') || dir.len() > dir_buf.len() {
                 return 0;
             }
 
-            let len = dir.len().min(MAX_PATH_BYTES - 1);
-            buf[0..len].copy_from_slice(&dir[0..len]);
-            buf[len] = 0;
-            return len;
+            dir_buf[..dir.len()].copy_from_slice(dir);
+            buf[dir.len()] = 0;
+            return dir.len();
         }
 
+        let parts: &[&[u8]] = if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
+            &[dir, b"bun", b"@t@"]
+        } else if let Some(home) = env_var::HOME.get() {
+            if cfg!(target_os = "macos") {
+                // On a mac, default to ~/Library/Caches/bun/*
+                // This is different than ~/.bun/install/cache, and not configurable by the user.
+                &[home, b"Library/", b"Caches/", b"bun", b"@t@"]
+            } else {
+                &[home, b".bun", b"install", b"cache", b"@t@"]
+            }
+        } else {
+            return 0;
+        };
+
         // The inline `bun_resolver::fs::FileSystem` surface only exposes
-        // `abs_buf` (no NUL-terminating `_z` variant), so go straight to the
+        // `abs_buf` (no size-checked variant), so go straight to the
         // underlying joiner with the same `top_level_dir` + `Loose` platform
         // that `absBufZ` used.
         let top = FileSystem::instance().top_level_dir;
-
-        if let Some(dir) = env_var::XDG_CACHE_HOME.get() {
-            let parts: &[&[u8]] = &[dir, b"bun", b"@t@"];
-            return path_handler::join_abs_string_buf_z::<platform::Loose>(
-                top,
-                &mut buf[..],
-                parts,
-            )
-            .len();
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            // On a mac, default to ~/Library/Caches/bun/*
-            // This is different than ~/.bun/install/cache, and not configurable by the user.
-            if let Some(home) = env_var::HOME.get() {
-                let parts: &[&[u8]] = &[home, b"Library/", b"Caches/", b"bun", b"@t@"];
-                return path_handler::join_abs_string_buf_z::<platform::Loose>(
-                    top,
-                    &mut buf[..],
-                    parts,
-                )
-                .len();
-            }
-        }
-
-        if let Some(dir) = env_var::HOME.get() {
-            let parts: &[&[u8]] = &[dir, b".bun", b"install", b"cache", b"@t@"];
-            return path_handler::join_abs_string_buf_z::<platform::Loose>(
-                top,
-                &mut buf[..],
-                parts,
-            )
-            .len();
-        }
-
-        0
+        let Some(dir) =
+            path_handler::join_abs_string_buf_checked::<platform::Loose>(top, dir_buf, parts)
+        else {
+            return 0;
+        };
+        let len = dir.len();
+        buf[len] = 0;
+        len
     }
 
     // Only do this at most once per-thread.

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -192,7 +192,8 @@ describe("transpiler cache", () => {
     for (const result of results) {
       expect(result).toSpawn("long-cache-dir");
     }
-    // Neither the over-long location nor the one from `env` received an entry.
+    // Every variant overrode the cache location from `env`, so none of the runs
+    // exercised that one instead of its over-long value.
     expect(existsSync(cache_dir)).toBeFalse();
   });
   test("works if the cache is not user-readable", async () => {

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -168,6 +168,31 @@ describe("transpiler cache", () => {
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("no-tmpdir-cache");
     expect(newCacheCount()).toBe(1);
   });
+  test("disables the cache when the cache directory does not fit in a path buffer", async () => {
+    writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "long-cache-dir"));
+
+    // The cache directory is derived from environment variables, which can be
+    // longer than PATH_MAX (4096 on Linux, 1024 on macOS). Joining such a value
+    // into the fixed-size path buffer used to panic while loading the first
+    // file large enough for the cache. 4095 is the longest value that still
+    // fits on its own; 4200 does not fit at all.
+    const variants: Record<string, string | undefined>[] = [];
+    for (const length of [4095, 4200]) {
+      const dir = "/" + Buffer.alloc(length - 1, "h").toString();
+      variants.push(
+        { BUN_RUNTIME_TRANSPILER_CACHE_PATH: undefined, XDG_CACHE_HOME: undefined, HOME: dir },
+        { BUN_RUNTIME_TRANSPILER_CACHE_PATH: undefined, XDG_CACHE_HOME: dir },
+        { BUN_RUNTIME_TRANSPILER_CACHE_PATH: dir },
+      );
+    }
+
+    const results = await Promise.all(variants.map(vars => bunRun(join(temp_dir, "a.js"), { ...env, ...vars })));
+    for (const result of results) {
+      expect(result).toSpawn("long-cache-dir");
+    }
+    // Neither the over-long location nor the one from `env` received an entry.
+    expect(existsSync(cache_dir)).toBeFalse();
+  });
   test("works if the cache is not user-readable", async () => {
     mkdirSync(cache_dir, { recursive: true });
     writeFileSync(join(temp_dir, "a.js"), dummyFile((50 * 1024 * 1.5) | 0, "1", "b"));

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -175,12 +175,14 @@ describe("transpiler cache", () => {
     // longer than PATH_MAX (4096 on Linux, 1024 on macOS). Joining such a value
     // into the fixed-size path buffer used to panic while loading the first
     // file large enough for the cache. 4095 is the longest value that still
-    // fits on its own; 4200 does not fit at all.
+    // fits on its own; 4200 does not fit at all. (On Windows, where the buffer
+    // is 98 KB, they fit and creating the directory fails instead.) Windows
+    // reads HOME from USERPROFILE, so both are set.
     const variants: Record<string, string | undefined>[] = [];
     for (const length of [4095, 4200]) {
       const dir = "/" + Buffer.alloc(length - 1, "h").toString();
       variants.push(
-        { BUN_RUNTIME_TRANSPILER_CACHE_PATH: undefined, XDG_CACHE_HOME: undefined, HOME: dir },
+        { BUN_RUNTIME_TRANSPILER_CACHE_PATH: undefined, XDG_CACHE_HOME: undefined, HOME: dir, USERPROFILE: dir },
         { BUN_RUNTIME_TRANSPILER_CACHE_PATH: undefined, XDG_CACHE_HOME: dir },
         { BUN_RUNTIME_TRANSPILER_CACHE_PATH: dir },
       );


### PR DESCRIPTION
### Problem
- With a `HOME` or `XDG_CACHE_HOME` of about 4 KB, running any file of 4 KiB or more dies with `panic: index out of bounds: the len is 4095 but the index is 4095` (or `range end index 4099 out of range for slice of length 4095`), `Crashed while parsing <file>`. Bun 1.3 ran the file.
- `RuntimeTranspilerCache::really_get_cache_dir` (`src/jsc/RuntimeTranspilerCache.rs:705` and `:730` before this change) joins the variable into a fixed `PathBuffer` with `join_abs_string_buf_z`, which does not check the size. The panic is in `normalize_string_buf` during the cache lookup for the first file large enough to be cached.

### Fix
- Join with `join_abs_string_buf_checked` into the first `MAX_PATH_BYTES - CACHE_FILE_NAME_RESERVE` bytes of the buffer. A directory that does not fit returns 0, which the caller already treats as "cache disabled" (the state `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0` produces). An over-long `BUN_RUNTIME_TRANSPILER_CACHE_PATH` takes the same exit instead of being cut to 4095 bytes.
- The reserve is derived from the name `write_cache_filename` writes (`CACHE_FILE_SUFFIX`, `CACHE_FILE_NAME_LEN`, now used there too), so `get_cache_file_path` always has room for the separator, the name and the NUL.
- Verified: `test/cli/run/transpiler-cache.test.ts`, "disables the cache when the cache directory does not fit in a path buffer" (`HOME`, `XDG_CACHE_HOME`, explicit path, at 4095 and 4200 bytes). It panics on the current build and passes with the fix. The other 13 tests still pass.

### Background
- The runtime transpiler cache stores the transpiled output of files of at least 4 KiB as `<hash>.pile` under `$XDG_CACHE_HOME/bun/@t@`, `~/.bun/install/cache/@t@` or `BUN_RUNTIME_TRANSPILER_CACHE_PATH`. Every failure in it is meant to be silent: Bun transpiles instead.
- `PathBuffer` is a fixed `[u8; MAX_PATH_BYTES]` (4096 on Linux, 1024 on macOS). An environment variable has no such limit.
- `join_abs_string_buf_checked` is the existing size checked joiner. It returns `None` when the normalized result does not fit.

<details><summary>Notes</summary>

- Crash window on Linux before the fix: `HOME` from about 4073 bytes up (`HOME` plus `/.bun/install/cache/@t@` no longer fits). A 4061 byte `HOME` already worked: only the file name failed to fit, which `write_cache_filename` reports as `ENOSPC` and the callers swallow. The cut down `BUN_RUNTIME_TRANSPILER_CACHE_PATH` ended in that `ENOSPC` path on every lookup too, so its visible behavior (no cache) is unchanged, it is just decided in one place now. That variant of the test passes before and after, the `HOME` and `XDG_CACHE_HOME` variants are the ones that panic.
- `CACHE_FILE_NAME_RESERVE` is 29 bytes in debug builds (separator, 16 hex digits, `.debug.pile`, NUL) and 23 in release.
- The macOS branch moved from `#[cfg]` to `cfg!` so the three candidate part lists share one join call. Candidate order and the "no HOME means no cache" result (test "disables the cache instead of falling back to the shared temp directory") are unchanged.
- Touches the same function as the open #35747 (per-uid cache root) and the same suffix strings as #31803 (`.pile2`). Both are independent of this fix. Whichever lands second needs a small rebase.
- Checked by hand on the debug build: `HOME`, `XDG_CACHE_HOME` and `BUN_RUNTIME_TRANSPILER_CACHE_PATH` of 4096 bytes run an 84 KB file, and normal values still write a `.debug.pile` entry.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts
bun test v1.4.0 (4c689909e)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [847.37ms]
(pass) transpiler cache > works with empty files [738.23ms]
(pass) transpiler cache > ignores files under the minimum cache size [359.76ms]
(pass) transpiler cache > it is indeed content addressable [1103.84ms]
(pass) transpiler cache > doing 50 buns at once does not crash [2133.28ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [762.25ms]
188 |       );
189 |     }
190 | 
191 |     const results = await Promise.all(variants.map(vars => bunRun(join(temp_dir, "a.js"), { ...env, ...vars })));
192 |     for (const result of results) {
193 |       expect(result).toSpawn("long-cache-dir");
                           ^
error: expect(received).toSpawn(expectedStdout)

Expected process to exit with code 0 but got 134 (signal: SIGABRT)
stderr: ============================================================
Bun Debug v1.4.0 (4c689909e) Linux x64
Linu
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4c689909e)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [32.43ms]
(pass) transpiler cache > works with empty files [29.93ms]
(pass) transpiler cache > ignores files under the minimum cache size [16.83ms]
(pass) transpiler cache > it is indeed content addressable [51.89ms]
(pass) transpiler cache > doing 50 buns at once does not crash [116.07ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [29.35ms]
188 |       );
189 |     }
190 | 
191 |     const results = await Promise.all(variants.map(vars => bunRun(join(temp_dir, "a.js"), { ...env, ...vars })));
192 |     for (const result of results) {
193 |       expect(result).toSpawn("long-cache-dir");
                           ^
error: expect(received).toSpawn(expectedStdout)

Expected process to exit with code 0 but got 134 (signal: SIGABRT)
stderr: ============================================================
Bun Canary v1.4.0-canary.1 (4c689909e) Linux x64
Linux Kernel v6.17.0 | glibc v2.41
CPU: sse42 popcnt avx avx2 avx512
Args: "/workspace/bun/build/release/bun" "/tmp/bun.test.1TvVhb/a.js"
Features: jsc 
Builtins: 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts
bun test v1.4.0 (4c689909e)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [790.97ms]
(pass) transpiler cache > works with empty files [742.88ms]
(pass) transpiler cache > ignores files under the minimum cache size [354.73ms]
(pass) transpiler cache > it is indeed content addressable [1129.52ms]
(pass) transpiler cache > doing 50 buns at once does not crash [2335.93ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [760.04ms]
(pass) transpiler cache > disables the cache when the cache directory does not fit in a path buffer [421.46ms]
(pass) transpiler cache > works if the cache is not user-readable [1134.51ms]
(pass) transpiler cache > works if the cache is not user-writable [378.47ms]
(pass) transpiler cache > does not inline process.env [748.71ms]
(pass) transpiler cache > --feature flag invalidates cache [2164.85ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > require.extension
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 596ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/7] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[2/7] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[3/7] gen cpp.rs (cppbind)
[3/7] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_http_jsc v0.0.0 (/workspace/bun/src/http_jsc)
[1m[92m   Compiling[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
[1m[92m   Compiling[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/workspace/bun/src/sourcemap_jsc)
[1m[92m   Compiling[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
[1m[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/RuntimeTranspilerCache.rs     | 101 +++++++++++++++-------------------
 test/cli/run/transpiler-cache.test.ts |  28 ++++++++++
 2 files changed, 71 insertions(+), 58 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/jsc/RuntimeTranspilerCache.rs          7      9      0
test/cli/run/transpiler-cache.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->