### PR TITLE
shell: ? and [...] written in the template keep their glob meaning

### DIFF
--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -139,6 +139,7 @@ pub mod test {
         Dollar,
         Asterisk,
         DoubleAsterisk,
+        GlobText(&'a [u8]),
         Eq,
         Semicolon,
         Newline,
@@ -183,6 +184,9 @@ pub mod test {
                 Token::Dollar => TestToken::Dollar,
                 Token::Asterisk => TestToken::Asterisk,
                 Token::DoubleAsterisk => TestToken::DoubleAsterisk,
+                Token::GlobText(txt) => {
+                    TestToken::GlobText(&buf[txt.start as usize..txt.end as usize])
+                }
                 Token::Eq => TestToken::Eq,
                 Token::Semicolon => TestToken::Semicolon,
                 Token::Newline => TestToken::Newline,
@@ -226,6 +230,11 @@ pub mod test {
                 T::Dollar => unit!("Dollar"),
                 T::Asterisk => unit!("Asterisk"),
                 T::DoubleAsterisk => unit!("DoubleAsterisk"),
+                T::GlobText(s) => {
+                    w.write_str("{\"GlobText\":")?;
+                    encode_json_string(w, s)?;
+                    w.write_char('}')
+                }
                 T::Eq => unit!("Eq"),
                 T::Semicolon => unit!("Semicolon"),
                 T::Newline => unit!("Newline"),
@@ -640,7 +649,7 @@ impl<'a> ShellSrcBuilder<'a> {
             // marker recognized regardless of quote context (e.g. inside single quotes).
             if needs_escape_bunstr(bunstr)
                 || is_if_clause_keyword_bunstr(bunstr)
-                || self.outbuf_ends_with_var_ref()
+                || self.position_needs_ref()
             {
                 self.append_js_str_ref(bunstr)?;
                 return Ok(true);
@@ -670,7 +679,7 @@ impl<'a> ShellSrcBuilder<'a> {
         if ALLOW_ESCAPE {
             if needs_escape_utf8_ascii_latin1(utf8)
                 || IfClauseTok::from_text(utf8).is_some()
-                || self.outbuf_ends_with_var_ref()
+                || self.position_needs_ref()
             {
                 let bunstr = OwnedString::new(BunString::clone_utf8(utf8));
                 self.append_js_str_ref(bunstr.get())?;
@@ -680,6 +689,29 @@ impl<'a> ShellSrcBuilder<'a> {
 
         self.append_utf8_impl(utf8)?;
         Ok(true)
+    }
+
+    /// A value with nothing to escape is spliced into the source as is, which
+    /// is only safe where plain text cannot become syntax: not right after a
+    /// `$`, and not inside a `[...]` the template opened, where `!` or `a-z`
+    /// would shape the class (see `SimpleAtom::GlobText`). The marker that
+    /// `append_js_str_ref` emits instead keeps the lexer from forming either.
+    fn position_needs_ref(&self) -> bool {
+        self.outbuf_ends_with_var_ref() || self.outbuf_ends_inside_bracket()
+    }
+
+    fn outbuf_ends_inside_bracket(&self) -> bool {
+        let word_start =
+            strings::last_index_of_any(&self.outbuf[..], b" \t\r\n;|&()<>").map_or(0, |i| i + 1);
+        let word = &self.outbuf[word_start..];
+        match (
+            strings::last_index_of_char(word, b'['),
+            strings::last_index_of_char(word, b']'),
+        ) {
+            (Some(open), Some(close)) => close < open,
+            (Some(_), None) => true,
+            (None, _) => false,
+        }
     }
 
     fn outbuf_ends_with_var_ref(&self) -> bool {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -30,8 +30,8 @@ pub struct Expansion {
     /// via `push_current_out`.
     pub(crate) current_out: Vec<u8>,
     /// Byte offsets in `current_out` written by literal metacharacter atoms
-    /// (`Asterisk`/`DoubleAsterisk`/`BraceBegin`/`Comma`/`BraceEnd`). Only
-    /// these positions may act as pattern syntax in `do_brace_expand` or
+    /// (`Asterisk`/`DoubleAsterisk`/`GlobText`/`BraceBegin`/`Comma`/`BraceEnd`).
+    /// Only these positions may act as pattern syntax in `do_brace_expand` or
     /// `transition_to_glob_state`; metacharacter bytes from any other source
     /// (JS interpolation, quoted text, `$var`, command substitution) are data
     /// and must not change the expansion structure or broaden the glob.
@@ -278,8 +278,9 @@ impl Expansion {
         // metacharacters. Bytes from Text/Var/cmd-subst expansion — notably JS
         // `${...}` interpolations — are data: backslash-escape them so the
         // brace lexer cannot be steered into emitting extra argv words.
-        // (`meta_offsets` also records literal `*`/`**` positions for the glob
-        // path; those are inert here since `*` is not in the escape set.)
+        // (`meta_offsets` also records literal `*`/`**`/GlobText positions for
+        // the glob path; those are inert here since neither `*` nor anything the
+        // lexer admits into a class is in the escape set.)
         let mut escaped: Vec<u8> = Vec::with_capacity(me.current_out.len());
         let mut next_meta = 0usize;
         for (i, &b) in me.current_out.iter().enumerate() {
@@ -499,6 +500,11 @@ impl Expansion {
                 meta_offsets.push(out.len() as u32);
                 meta_offsets.push(out.len() as u32 + 1);
                 out.extend_from_slice(b"**");
+            }
+            ast::SimpleAtom::GlobText(txt) => {
+                let start = out.len() as u32;
+                meta_offsets.extend(start..start + txt.len() as u32);
+                out.extend_from_slice(txt);
             }
             ast::SimpleAtom::BraceBegin => {
                 meta_offsets.push(out.len() as u32);

--- a/src/shell_parser/json_fmt.rs
+++ b/src/shell_parser/json_fmt.rs
@@ -271,6 +271,10 @@ fn write_simple_atom(w: &mut impl Write, s: &SimpleAtom<'_>) -> fmt::Result {
         SimpleAtom::QuotedEmpty => w.write_str("{\"quoted_empty\":{}")?,
         SimpleAtom::Asterisk => w.write_str("{\"asterisk\":{}")?,
         SimpleAtom::DoubleAsterisk => w.write_str("{\"double_asterisk\":{}")?,
+        SimpleAtom::GlobText(t) => {
+            w.write_str("{\"glob_text\":")?;
+            encode_json_string(w, t)?;
+        }
         SimpleAtom::BraceBegin => w.write_str("{\"brace_begin\":{}")?,
         SimpleAtom::BraceEnd => w.write_str("{\"brace_end\":{}")?,
         SimpleAtom::Comma => w.write_str("{\"comma\":{}")?,

--- a/src/shell_parser/parse.rs
+++ b/src/shell_parser/parse.rs
@@ -679,6 +679,13 @@ pub mod ast {
         QuotedEmpty,
         Asterisk,
         DoubleAsterisk,
+        /// A `?` or a whole `[...]` class written unquoted in the shell source.
+        /// Unlike `*` it does not make the word glob on its own (`curl url?a=b`
+        /// stays literal), but once a literal `*` makes the word glob it is
+        /// pattern syntax (`*.[jt]s`, `a?*`). The same bytes from quotes, escapes,
+        /// `$var`, command substitution or a JS interpolation, and a class that
+        /// contains any of those, are [`SimpleAtom::Text`] and match themselves.
+        GlobText(&'arena [u8]),
         BraceBegin,
         BraceEnd,
         Comma,
@@ -1530,6 +1537,14 @@ impl<'bump> Parser<'bump> {
                             break;
                         }
                     }
+                    Token::GlobText(txtrng) => {
+                        let _ = self.expect(TokenTag::GlobText);
+                        atoms.push(ast::SimpleAtom::GlobText(self.text(txtrng)));
+                        if next_delimits {
+                            let _ = self.r#match(TokenTag::Delimit);
+                            break;
+                        }
+                    }
                     Token::BraceBegin => {
                         has_brace_open = true;
                         let _ = self.expect(TokenTag::BraceBegin);
@@ -1971,6 +1986,7 @@ pub enum TokenTag {
     Dollar,
     Asterisk,
     DoubleAsterisk,
+    GlobText,
     Eq,
     Semicolon,
     Newline,
@@ -2013,6 +2029,8 @@ pub enum Token {
     /// `*`
     Asterisk,
     DoubleAsterisk,
+    /// `?` or a `[...]` class, see [`ast::SimpleAtom::GlobText`]
+    GlobText(TextRange),
 
     /// =
     Eq,
@@ -2086,6 +2104,7 @@ impl Token {
             Token::Dollar => b"`$`",
             Token::Asterisk => b"`*`",
             Token::DoubleAsterisk => b"`**`",
+            Token::GlobText(r) => &strpool[r.start as usize..r.end as usize],
             Token::Eq => b"`=`",
             Token::Semicolon => b"`;`",
             Token::Newline => b"`\\n`",
@@ -2444,6 +2463,7 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                             }
                             if let Some(p) = self.peek() {
                                 if p.escaped || p.char != u32::from(b'[') {
+                                    fell_through = self.eat_bracket_class()?;
                                     break 'escaped;
                                 }
                                 let state = self.make_snapshot();
@@ -2529,6 +2549,19 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                                 self.backtrack(&state);
                             }
                             break 'escaped;
+                        }
+                        c if c == u32::from(b'?') => {
+                            const _: () = assert!(SPECIAL_CHARS_TABLE.is_set(b'?' as usize));
+                            if self.chars.state == CharState::Single
+                                || self.chars.state == CharState::Double
+                            {
+                                break 'escaped;
+                            }
+                            self.break_word(AddDelimiter::No)?;
+                            let start = self.j;
+                            self.append_char_to_str_pool(c)?;
+                            self.push_glob_text(start);
+                            fell_through = true;
                         }
                         c if c == u32::from(b'#') => {
                             const _: () = assert!(SPECIAL_CHARS_TABLE.is_set(b'#' as usize));
@@ -2964,6 +2997,68 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                     .is_some_and(|p| !p.escaped && p.char == u32::from(b'\'')))
     }
 
+    /// Called after an unquoted `[`. Lexes the rest of the `[...]` class into
+    /// one [`Token::GlobText`] and returns true if every byte of the class is
+    /// plain source text: no quote, escape, `$`, interpolation, `*`, nested `[`
+    /// or word break before the `]`. Otherwise nothing is consumed and the `[`
+    /// stays ordinary text, as does a `]` on its own.
+    fn eat_bracket_class(&mut self) -> Result<bool, LexerError> {
+        let snapshot = self.make_snapshot();
+        let mut body_len: usize = 0;
+        loop {
+            let Some(input) = self.eat() else {
+                self.backtrack(&snapshot);
+                return Ok(false);
+            };
+            if input.escaped {
+                self.backtrack(&snapshot);
+                return Ok(false);
+            }
+            if input.char == u32::from(b']') {
+                if body_len == 0 {
+                    self.backtrack(&snapshot);
+                    return Ok(false);
+                }
+                break;
+            }
+            if !Self::is_bracket_class_char(input.char) {
+                self.backtrack(&snapshot);
+                return Ok(false);
+            }
+            body_len += 1;
+        }
+
+        self.backtrack(&snapshot);
+        self.break_word(AddDelimiter::No)?;
+        let start = self.j;
+        self.append_char_to_str_pool(u32::from(b'['))?;
+        for _ in 0..=body_len {
+            let input = self.eat().expect("validated by the loop above");
+            self.append_char_to_str_pool(input.char)?;
+        }
+        self.push_glob_text(start);
+        Ok(true)
+    }
+
+    /// Bytes the lexer would otherwise treat as plain text, plus the few special
+    /// ones that are meaningful or harmless inside a class (`[0-9]`, `[?]`).
+    fn is_bracket_class_char(char: u32) -> bool {
+        match u8::try_from(char) {
+            Ok(byte) => {
+                !SPECIAL_CHARS_TABLE.is_set(byte as usize)
+                    || matches!(byte, b'0'..=b'9' | b'?' | b'=' | b'~' | b'#')
+            }
+            Err(_) => true,
+        }
+    }
+
+    /// Turns the bytes appended since `start` into a [`Token::GlobText`].
+    fn push_glob_text(&mut self, start: u32) {
+        self.tokens
+            .push(Token::GlobText(TextRange { start, end: self.j }));
+        self.word_start = self.j;
+    }
+
     fn break_word(&mut self, add_delimiter: AddDelimiter) -> Result<(), LexerError> {
         let start: u32 = self.word_start;
         let end: u32 = self.j;
@@ -2989,7 +3084,8 @@ impl<'bump, const ENCODING: StringEncoding> Lexer<'bump, ENCODING> {
                 | TokenTag::Comma
                 | TokenTag::BraceEnd
                 | TokenTag::CmdSubstEnd
-                | TokenTag::Asterisk => true,
+                | TokenTag::Asterisk
+                | TokenTag::GlobText => true,
 
                 TokenTag::Pipe
                 | TokenTag::DoublePipe

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -847,10 +847,103 @@ booga"
       })
       .runAsTest("Should work with a different cwd");
 
+    describe("metacharacters written in the template keep their glob meaning", () => {
+      // Only a literal `*` makes a word glob, but once it does, `?` and `[...]`
+      // written in the template are pattern syntax as in bash. The quoted,
+      // escaped, and interpolated (next block) forms of the same bytes match
+      // themselves only.
+      TestBuilder.command`ls [ab]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("banana", "")
+        .file("cherry", "")
+        .stdout(out => expect(sortedShellOutput(out)).toEqual(["apple", "banana"]))
+        .runAsTest("[...] class");
+
+      TestBuilder.command`ls *.[jt]s`
+        .ensureTempDir()
+        .file("x.js", "")
+        .file("y.ts", "")
+        .file("z.md", "")
+        .stdout(out => expect(sortedShellOutput(out)).toEqual(["x.js", "y.ts"]))
+        .runAsTest("[...] class after the *");
+
+      TestBuilder.command`ls [a-b]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("banana", "")
+        .file("cherry", "")
+        .stdout(out => expect(sortedShellOutput(out)).toEqual(["apple", "banana"]))
+        .runAsTest("[...] range");
+
+      TestBuilder.command`ls [!a]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("banana", "")
+        .stdout("banana\n")
+        .runAsTest("negated [!...] class");
+
+      TestBuilder.command`ls a?*`
+        .ensureTempDir()
+        .file("a", "")
+        .file("ax.txt", "")
+        .stdout("ax.txt\n")
+        .runAsTest("? wildcard");
+
+      TestBuilder.command`ls "[ab]"*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("[ab]c", "")
+        .stdout("[ab]c\n")
+        .runAsTest("quoted [...] is literal");
+
+      TestBuilder.command`ls \[ab\]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("[ab]c", "")
+        .stdout("[ab]c\n")
+        .runAsTest("escaped [...] is literal");
+
+      TestBuilder.command`ls [\!a]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("banana", "")
+        .file("[!a]c", "")
+        .stdout("[!a]c\n")
+        .runAsTest("an escape inside the class makes the whole class literal");
+
+      // The brace variants are expanded by the glob walker as well, so the
+      // class has to survive brace expansion of the same word.
+      TestBuilder.command`echo {x,y}*.[jt]s`
+        .ensureTempDir()
+        .file("x1.js", "")
+        .file("y2.ts", "")
+        .file("x3.md", "")
+        .file("z4.js", "")
+        .stdout(out => {
+          expect(out).toContain("x1.js");
+          expect(out).toContain("y2.ts");
+          expect(out).not.toContain("x3.md");
+          expect(out).not.toContain("z4.js");
+        })
+        .runAsTest("[...] class combined with brace expansion");
+
+      TestBuilder.command`echo [ab] hi?`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("hi1", "")
+        .stdout("[ab] hi?\n")
+        .runAsTest("without a * the word does not glob");
+
+      TestBuilder.command`FOO=a?[b]c; echo $FOO x?y [z] w]`
+        .stdout("a?[b]c x?y [z] w]\n")
+        .runAsTest("words that do not glob are assembled unchanged");
+    });
+
     describe("interpolated values cannot inject glob syntax", () => {
-      // Only `*`/`**` written literally in the template act as glob syntax.
-      // Metacharacters arriving via `${...}` interpolation are data and must
-      // match only files containing them literally.
+      // Only `*`/`**`, `?` and `[...]` written literally in the template act as
+      // glob syntax. Metacharacters arriving via `${...}` interpolation are
+      // data and must match only files containing them literally.
       TestBuilder.command`echo ${"**/"}*`
         .ensureTempDir()
         .file("f.txt", "f")
@@ -892,6 +985,56 @@ booga"
           expect(out).not.toContain("ac.txt");
         })
         .runAsTest("injected [...] is literal");
+
+      // A class the template opens is only a class when all of it comes from
+      // the template. Anything injected into it turns the whole `[...]` into
+      // text, so an injected `!`, range or `]` cannot negate, widen or cut it.
+      // (`!` and `a-z` need no escaping on their own, so this is the case the
+      // builder has to catch by position.)
+      TestBuilder.command`ls [${"!"}a]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("banana", "")
+        .file("[!a]c", "")
+        .stdout("[!a]c\n")
+        .runAsTest("injected ! inside a template class does not negate it");
+
+      TestBuilder.command`ls [${"a-z"}]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("[a-z]c", "")
+        .stdout("[a-z]c\n")
+        .runAsTest("injected range inside a template class is literal");
+
+      TestBuilder.command`ls [${"]"}]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("[]]c", "")
+        .stdout("[]]c\n")
+        .runAsTest("injected ] inside a template class is literal");
+
+      TestBuilder.command`ls [${["!", "a"]}]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("[!", "")
+        .file("a]c", "")
+        .stdout(out => expect(sortedShellOutput(out)).toEqual(["[!", "a]c"]))
+        .runAsTest("injected array inside a template class is literal");
+
+      TestBuilder.command`X='!'; ls [$X]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("[!]c", "")
+        .stdout("[!]c\n")
+        .runAsTest("variable inside a template class makes it literal");
+
+      TestBuilder.command`ls ["!"a]*`
+        .ensureTempDir()
+        .file("apple", "")
+        .file("banana", "")
+        .file("[!a]c", "")
+        .stdout("[!a]c\n")
+        .runAsTest("quoted text inside a template class makes it literal");
 
       TestBuilder.command`echo ${"foo"}*`
         .ensureTempDir()

--- a/test/js/bun/shell/lex.test.ts
+++ b/test/js/bun/shell/lex.test.ts
@@ -224,6 +224,84 @@ describe("lex shell", () => {
     expect(result).toEqual(expected);
   });
 
+  test("glob text", () => {
+    // A `?` or a whole `[...]` written in the template is a token of its own,
+    // so expansion can tell it apart from the same bytes arriving quoted,
+    // escaped, or interpolated, which stay plain text.
+    const expected = [
+      { "Text": "echo" },
+      { "Delimit": {} },
+      { "Asterisk": {} },
+      { "Text": "." },
+      { "GlobText": "[jt]" },
+      { "Text": "s" },
+      { "Delimit": {} },
+      { "Text": "x" },
+      { "GlobText": "[!0-9]" },
+      { "Asterisk": {} },
+      { "Delimit": {} },
+      { "Text": "a" },
+      { "GlobText": "?" },
+      { "Delimit": {} },
+      { "DoubleQuotedText": "[x]?" },
+      { "Delimit": {} },
+      { "Text": "[y]?" },
+      { "Delimit": {} },
+      { "Text": "[z]?" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ];
+    const result = JSON.parse(lex`echo *.[jt]s x[!0-9]* a? "[x]?" \[y\]\? ${"[z]?"}`);
+    expect(result).toEqual(expected);
+  });
+
+  test("a class is text when any of it is not template text", () => {
+    // Interpolated, quoted, escaped or expanded bytes inside the brackets, and
+    // brackets that do not close within the word, all stay plain text. The
+    // interpolated `!` has no character to escape, so the builder has to route it
+    // through a string ref because of the open `[` in front of it.
+    const expected = [
+      { "Text": "[" },
+      { "Text": "!a]" },
+      { "Delimit": {} },
+      { "Text": "[" },
+      { "DoubleQuotedText": "!" },
+      { "Text": "a]" },
+      { "Delimit": {} },
+      { "Text": "[!a]" },
+      { "Delimit": {} },
+      { "Text": "[" },
+      { "Var": "X" },
+      { "Text": "]" },
+      { "Delimit": {} },
+      { "Text": "[a" },
+      { "Delimit": {} },
+      { "Text": "b]" },
+      { "Delimit": {} },
+      { "Text": "[" },
+      { "Asterisk": {} },
+      { "Text": "]" },
+      { "Delimit": {} },
+      { "Eof": {} },
+    ];
+    const result = JSON.parse(lex`[${"!"}a] ["!"a] [\!a] [$X] [a b] [*]`);
+    expect(result).toEqual(expected);
+  });
+
+  test("glob text does not interfere with [[ ]]", () => {
+    const expected = [
+      { "DoubleBracketOpen": {} },
+      { "Text": "-f" },
+      { "Delimit": {} },
+      { "Text": "a]" },
+      { "Delimit": {} },
+      { "DoubleBracketClose": {} },
+      { "Eof": {} },
+    ];
+    const result = JSON.parse(lex`[[ -f a] ]]`);
+    expect(result).toEqual(expected);
+  });
+
   test("op_and", () => {
     const expected = [
       { "Text": "echo" },


### PR DESCRIPTION
### Problem
- In Bun Shell, `echo [a-z]*`, `ls *.[jt]s` and `echo a?*` fail with `bun: no matches found: [a-z]*` on the 1.4 canary. Bun 1.3 expanded them. Only the shell's expansion is affected, `Bun.Glob` matches these patterns.
- Regression from #31220. `neutralize_glob_metachars` (`src/runtime/shell/states/Expansion.rs`) escapes every glob byte whose offset is not in `meta_offsets`, and the lexer only produced metacharacter atoms for `*` and `**`. A `?` or `[...]` typed in the template was escaped like interpolated data.

### Fix
- The lexer emits `Token::GlobText` for an unquoted `?` and for a `[...]` whose every byte is template text (`eat_bracket_class`, `src/shell_parser/parse.rs`). Expansion records its bytes in `meta_offsets` like `*`. A class containing a quote, escape, `$`, interpolation, `*` or nested `[`, or not closed inside the word, stays `Text` and is neutralized as on main.
- `GlobText` does not set `glob_hint`. As in 1.3 only a literal `*` makes a word glob, so `curl http://x/a?b=1` and `echo [ok]` stay literal.
- A value with nothing to escape (`!`, `a-z`) is spliced into the source verbatim, so `[${x}]*` would still read as a template class. `ShellSrcBuilder` now sends such a value through a string ref when the word before it has an open `[` (`position_needs_ref`, next to the existing check for a value after `$`). The lexer sees the ref marker and the class stays text.
- Verified: `test/js/bun/shell/bunshell.test.ts`. 6 template cases fail on the canary. 6 new injection cases (injected `!`, range, `]`, array, `$var`, quotes inside a template class) fail if either the class rule or the builder check is removed. `lex.test.ts` pins the tokens. All of `test/js/bun/shell/` was run.

### Background
- Expansion builds a word into `current_out` and pushes the offset of every byte written by a metacharacter atom to `meta_offsets`. Every other glob byte is wrapped in a one character class before the glob walker runs. The lexer decides what is syntax, the atoms carry the decision.
- A template class has to be one token: its body (`!`, `^`, `-`, members) is plain text to the lexer, so separate `[` and `]` tokens would let data between them act as class syntax.
- `ShellSrcBuilder` turns the template into shell source. A value with special characters becomes a `\x08__bunstr_N` ref that the lexer expands as data. Other values are copied verbatim, which is safe only where plain text cannot become syntax.

<details><summary>Notes</summary>

- Behavior table (files `apple`, `banana`, `x.js`, `y.ts`, `a]x`): 1.3.13 and this branch expand `?ppl*`, `[ab]*`, `*.[jt]s`, `x[0-9]*`, `[^a-z]*`, `file[0-9]*.txt` and print `?pple`, `x.[jt]s`, `[a-z]`, `hi?` literally. `[[:upper:]]*` is "no matches found" on 1.3, main and here (the matcher has no POSIX classes, the nested `[` keeps it text). Differences to 1.3: `\[a\]*` and `[\!a]*` are literal here (1.3 handed the escaped bytes to the matcher), and `*"*"` keeps the 1.4 behavior (quoted `*` is literal).
- Bytes admitted into a class: everything the lexer treats as plain text, plus digits, `?`, `=`, `~` and `#`. Nothing in the brace escape set (`{ } , \`) can get in, so `do_brace_expand` is unaffected. `[*]` stays text plus a `*` token, as on main.
- `outbuf_ends_inside_bracket` is conservative: a `[` the lexer would reject anyway (quoted, escaped) also sends the value through a ref. That changes how the value travels, not the argument.
- `?` was already in `SPECIAL_CHARS`, so the ASCII fast path already stopped on it and an interpolated `?`, `[` or `]` was already ref'd. No table change.
- The first version of this PR emitted a token per bracket. The self review found the injected `!` / range problem described above, hence the whole class token plus the builder check.
- `bunshell.test.ts`: 441 pass. The full directory had 13 failures that are environmental in this container (tests that need a non-root user, a 512 pid cgroup limit, 100 s leak tests under ASAN). They fail the same way without this change.
- Handed off separately: `echo ** zzz` lexes as one word (`DoubleAsterisk` missing from the `break_word` list, since 1.3.13).
- Related open PRs: #33423 rewrites brace + glob composition in `Expansion.rs` and must keep `GlobText` offsets (the brace + class test here checks that). #36462 and #36463 document `?` and `[...]` as always literal, which this PR changes for words that contain a `*`.
</details>
