### PR TITLE
node:fs: recursive rm keeps walking when a concurrent deleter wins the race

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9596,24 +9596,9 @@ fn dt_err(errno: E) -> crate::Error {
 
 #[inline]
 fn dt_open_dir(parent: &sys::Dir, name: &[u8]) -> Result<sys::Dir, E> {
-    let mut path_buf = PathBuffer::uninit();
-    let len = name.len().min(path_buf.len() - 1);
-    path_buf[..len].copy_from_slice(&name[..len]);
-    path_buf[len] = 0;
-    // SAFETY: NUL written at [len].
-    let z = ZStr::from_buf(&path_buf[..], len);
-    // Windows: a delete-pending directory reports ENOENT, like any other
+    // On Windows a delete-pending directory reports ENOENT, like any other
     // vanished entry (see `openat_dir_for_delete_tree`).
-    #[cfg(windows)]
-    let result = sys::openat_dir_for_delete_tree(parent.fd, z.as_bytes());
-    #[cfg(not(windows))]
-    let result = Syscall::openat(
-        parent.fd,
-        z,
-        sys::O::DIRECTORY | sys::O::RDONLY | sys::O::NOFOLLOW,
-        0,
-    );
-    match result {
+    match sys::openat_dir_for_delete_tree(parent.fd, name) {
         Ok(fd) => Ok(sys::Dir::from_fd(fd)),
         Err(e) => Err(e.get_errno()),
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9602,12 +9602,19 @@ fn dt_open_dir(parent: &sys::Dir, name: &[u8]) -> Result<sys::Dir, E> {
     path_buf[len] = 0;
     // SAFETY: NUL written at [len].
     let z = ZStr::from_buf(&path_buf[..], len);
-    match Syscall::openat(
+    // On Windows a concurrent deleter leaves the directory in the
+    // delete-pending state; `openat_dir_for_delete_tree` reports that as
+    // ENOENT so the walk treats it like any other vanished entry.
+    #[cfg(windows)]
+    let result = sys::openat_dir_for_delete_tree(parent.fd, z.as_bytes());
+    #[cfg(not(windows))]
+    let result = Syscall::openat(
         parent.fd,
         z,
         sys::O::DIRECTORY | sys::O::RDONLY | sys::O::NOFOLLOW,
         0,
-    ) {
+    );
+    match result {
         Ok(fd) => Ok(sys::Dir::from_fd(fd)),
         Err(e) => Err(e.get_errno()),
     }
@@ -9749,6 +9756,12 @@ pub(crate) fn zig_delete_tree(
                                 treat_as_dir = false;
                                 continue 'handle_entry;
                             }
+                            Err(E::ENOENT) => {
+                                // A concurrent deleter removed this entry
+                                // between readdir and open. Skip it, same as
+                                // the min-stack walk below.
+                                break 'handle_entry;
+                            }
                             #[cfg(target_os = "macos")]
                             Err(e @ (E::EACCES | E::EPERM)) => {
                                 // Same as the pop-delete site below: node's rimraf
@@ -9786,6 +9799,8 @@ pub(crate) fn zig_delete_tree(
                     let top_fd = stack[top_idx].iter.iter.dir;
                     match dt_delete_file(sys::Dir::borrow(&top_fd), &entry_name) {
                         Ok(()) => break 'handle_entry,
+                        // A concurrent deleter already unlinked this entry.
+                        Err(E::ENOENT) => break 'handle_entry,
                         Err(E::EISDIR) => {
                             treat_as_dir = true;
                             continue 'handle_entry;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9602,9 +9602,8 @@ fn dt_open_dir(parent: &sys::Dir, name: &[u8]) -> Result<sys::Dir, E> {
     path_buf[len] = 0;
     // SAFETY: NUL written at [len].
     let z = ZStr::from_buf(&path_buf[..], len);
-    // On Windows a concurrent deleter leaves the directory in the
-    // delete-pending state; `openat_dir_for_delete_tree` reports that as
-    // ENOENT so the walk treats it like any other vanished entry.
+    // Windows: a delete-pending directory reports ENOENT, like any other
+    // vanished entry (see `openat_dir_for_delete_tree`).
     #[cfg(windows)]
     let result = sys::openat_dir_for_delete_tree(parent.fd, z.as_bytes());
     #[cfg(not(windows))]
@@ -9756,12 +9755,9 @@ pub(crate) fn zig_delete_tree(
                                 treat_as_dir = false;
                                 continue 'handle_entry;
                             }
-                            Err(E::ENOENT) => {
-                                // A concurrent deleter removed this entry
-                                // between readdir and open. Skip it, same as
-                                // the min-stack walk below.
-                                break 'handle_entry;
-                            }
+                            // The entry vanished between readdir and open: a
+                            // concurrent deleter won. Skip it.
+                            Err(E::ENOENT) => break 'handle_entry,
                             #[cfg(target_os = "macos")]
                             Err(e @ (E::EACCES | E::EPERM)) => {
                                 // Same as the pop-delete site below: node's rimraf
@@ -9794,10 +9790,8 @@ pub(crate) fn zig_delete_tree(
                             entry.kind,
                         ) {
                             Ok(()) => break 'handle_entry,
-                            // A concurrent deleter removed this entry; skip it
-                            // like the in-stack arms above. Only the top-level
-                            // caller needs FileNotFound to propagate, and that
-                            // call is not this site.
+                            // The entry vanished: skip it. FileNotFound only
+                            // matters to the top-level caller, not mid-tree.
                             Err(crate::Error::FileNotFound) => break 'handle_entry,
                             Err(e) => return Err(e),
                         }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9788,12 +9788,19 @@ pub(crate) fn zig_delete_tree(
                         }
                     } else {
                         let top_fd = stack[top_idx].iter.iter.dir;
-                        zig_delete_tree_min_stack_size_with_kind_hint(
+                        match zig_delete_tree_min_stack_size_with_kind_hint(
                             sys::Dir::borrow(&top_fd),
                             &entry_name,
                             entry.kind,
-                        )?;
-                        break 'handle_entry;
+                        ) {
+                            Ok(()) => break 'handle_entry,
+                            // A concurrent deleter removed this entry; skip it
+                            // like the in-stack arms above. Only the top-level
+                            // caller needs FileNotFound to propagate, and that
+                            // call is not this site.
+                            Err(crate::Error::FileNotFound) => break 'handle_entry,
+                            Err(e) => return Err(e),
+                        }
                     }
                 } else {
                     let top_fd = stack[top_idx].iter.iter.dir;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9714,6 +9714,10 @@ pub(crate) fn zig_delete_tree(
             let entry = match stack[top_idx].iter.next() {
                 Ok(Some(e)) => e,
                 Ok(None) => break,
+                // A concurrent deleter removed the directory we iterate:
+                // getdents on a dead dir reports ENOENT. Nothing is left to
+                // enumerate, and the rmdir below tolerates ENOENT.
+                Err(err) if err.get_errno() == E::ENOENT => break,
                 Err(err) => return Err(dt_err(err.get_errno())),
             };
             // `entry.name` borrows the iterator's internal buffer and
@@ -9987,6 +9991,8 @@ fn zig_delete_tree_min_stack_size_with_kind_hint(
                 let entry = match dir_it.next() {
                     Ok(Some(e)) => e,
                     Ok(None) => break 'dir_it,
+                    // Same as the in-stack walk: the dir vanished mid-iteration.
+                    Err(err) if err.get_errno() == E::ENOENT => break 'dir_it,
                     Err(err) => break 'scan_dir Err(dt_err(err.get_errno())),
                 };
                 let entry_name: Vec<u8> = entry.name.slice().to_vec();

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9648,10 +9648,12 @@ fn dt_delete_file(parent: &sys::Dir, name: &[u8]) -> Result<(), E> {
             if matches!(errno, E::EPERM | E::EACCES) {
                 // No-follow stat — don't follow symlinks, to match unlinkat.
                 // `z` (a `&ZStr`, `Copy`) is still valid — `unlinkat` only borrowed it.
-                if let Ok(st) = Syscall::lstatat(parent.fd, z) {
-                    if sys::S::ISDIR(st.st_mode as u32) {
-                        return Err(E::EISDIR);
-                    }
+                match Syscall::lstatat(parent.fd, z) {
+                    Ok(st) if sys::S::ISDIR(st.st_mode as u32) => return Err(E::EISDIR),
+                    // The entry vanished between unlinkat and lstat: a
+                    // concurrent deleter won, so the real answer is ENOENT.
+                    Err(e) if e.get_errno() == E::ENOENT => return Err(E::ENOENT),
+                    _ => {}
                 }
             }
             Err(errno)

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -143,12 +143,21 @@ impl Dir {
                 let mut treat_as_dir = matches!(entry.kind, EntryKind::Directory);
                 'handle_entry: loop {
                     if treat_as_dir {
-                        let new_dir = match openat_a(
+                        // Windows: a delete-pending child reports ENOENT, so a
+                        // concurrent deleter does not abort the walk.
+                        #[cfg(windows)]
+                        let opened = crate::openat_dir_for_delete_tree(
+                            top.iter.dir(),
+                            entry.name.slice_u8(),
+                        );
+                        #[cfg(not(windows))]
+                        let opened = openat_a(
                             top.iter.dir(),
                             entry.name.slice_u8(),
                             O::DIRECTORY | O::RDONLY | O::CLOEXEC | O::NOFOLLOW,
                             0,
-                        ) {
+                        );
+                        let new_dir = match opened {
                             Ok(fd) => fd,
                             Err(e) => match e.get_errno() {
                                 E::ENOTDIR => {
@@ -260,12 +269,18 @@ impl Dir {
                     },
                 }
             } else {
-                return match openat_a(
+                // Windows: a delete-pending dir reports ENOENT (see the
+                // child-open site in `delete_tree`).
+                #[cfg(windows)]
+                let opened = crate::openat_dir_for_delete_tree(self.fd, sub_path);
+                #[cfg(not(windows))]
+                let opened = openat_a(
                     self.fd,
                     sub_path,
                     O::DIRECTORY | O::RDONLY | O::CLOEXEC | O::NOFOLLOW,
                     0,
-                ) {
+                );
+                return match opened {
                     Ok(fd) => Ok(Some(fd)),
                     Err(e) => match e.get_errno() {
                         E::ENOENT => Ok(None),

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -143,21 +143,10 @@ impl Dir {
                 let mut treat_as_dir = matches!(entry.kind, EntryKind::Directory);
                 'handle_entry: loop {
                     if treat_as_dir {
-                        // Windows: a delete-pending child reports ENOENT, so a
-                        // concurrent deleter does not abort the walk.
-                        #[cfg(windows)]
-                        let opened = crate::openat_dir_for_delete_tree(
+                        let new_dir = match crate::openat_dir_for_delete_tree(
                             top.iter.dir(),
                             entry.name.slice_u8(),
-                        );
-                        #[cfg(not(windows))]
-                        let opened = openat_a(
-                            top.iter.dir(),
-                            entry.name.slice_u8(),
-                            O::DIRECTORY | O::RDONLY | O::CLOEXEC | O::NOFOLLOW,
-                            0,
-                        );
-                        let new_dir = match opened {
+                        ) {
                             Ok(fd) => fd,
                             Err(e) => match e.get_errno() {
                                 E::ENOTDIR => {
@@ -217,16 +206,7 @@ impl Dir {
             if need_to_retry {
                 // Since we closed the handle that the previous iterator used, we
                 // need to re-open the dir and re-create the iterator.
-                #[cfg(windows)]
-                let reopened = crate::openat_dir_for_delete_tree(parent_dir, &name);
-                #[cfg(not(windows))]
-                let reopened = openat_a(
-                    parent_dir,
-                    &name,
-                    O::DIRECTORY | O::RDONLY | O::CLOEXEC | O::NOFOLLOW,
-                    0,
-                );
-                let new_dir = match reopened {
+                let new_dir = match crate::openat_dir_for_delete_tree(parent_dir, &name) {
                     Ok(fd) => fd,
                     Err(e) => match e.get_errno() {
                         E::ENOTDIR => {
@@ -273,18 +253,7 @@ impl Dir {
                     },
                 }
             } else {
-                // Windows: a delete-pending dir reports ENOENT (see the
-                // child-open site in `delete_tree`).
-                #[cfg(windows)]
-                let opened = crate::openat_dir_for_delete_tree(self.fd, sub_path);
-                #[cfg(not(windows))]
-                let opened = openat_a(
-                    self.fd,
-                    sub_path,
-                    O::DIRECTORY | O::RDONLY | O::CLOEXEC | O::NOFOLLOW,
-                    0,
-                );
-                return match opened {
+                return match crate::openat_dir_for_delete_tree(self.fd, sub_path) {
                     Ok(fd) => Ok(Some(fd)),
                     Err(e) => match e.get_errno() {
                         E::ENOENT => Ok(None),

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -217,12 +217,16 @@ impl Dir {
             if need_to_retry {
                 // Since we closed the handle that the previous iterator used, we
                 // need to re-open the dir and re-create the iterator.
-                let new_dir = match openat_a(
+                #[cfg(windows)]
+                let reopened = crate::openat_dir_for_delete_tree(parent_dir, &name);
+                #[cfg(not(windows))]
+                let reopened = openat_a(
                     parent_dir,
                     &name,
                     O::DIRECTORY | O::RDONLY | O::CLOEXEC | O::NOFOLLOW,
                     0,
-                ) {
+                );
+                let new_dir = match reopened {
                     Ok(fd) => fd,
                     Err(e) => match e.get_errno() {
                         E::ENOTDIR => {

--- a/src/sys/dir.rs
+++ b/src/sys/dir.rs
@@ -139,7 +139,16 @@ impl Dir {
         });
 
         'process_stack: while let Some(top) = stack.last_mut() {
-            while let Some(entry) = top.iter.next()? {
+            loop {
+                let entry = match top.iter.next() {
+                    Ok(Some(e)) => e,
+                    Ok(None) => break,
+                    // A concurrent deleter removed the directory we iterate:
+                    // getdents on a dead dir reports ENOENT. The rmdir below
+                    // tolerates ENOENT.
+                    Err(e) if e.get_errno() == E::ENOENT => break,
+                    Err(e) => return Err(e),
+                };
                 let mut treat_as_dir = matches!(entry.kind, EntryKind::Directory);
                 'handle_entry: loop {
                     if treat_as_dir {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6237,6 +6237,10 @@ pub struct WindowsOpenDirOptions {
     pub iterable: bool,
     pub no_follow: bool,
     pub can_rename_or_delete: bool,
+    /// Report `STATUS_DELETE_PENDING`/`STATUS_FILE_DELETED` as ENOENT instead
+    /// of the EPERM the Win32 conversion produces. A directory in that state
+    /// can never be opened again, so for a deleter it is already gone.
+    pub delete_pending_is_enoent: bool,
     pub op: WindowsOpenDirOp,
 }
 #[cfg(windows)]
@@ -6773,6 +6777,12 @@ pub(crate) fn open_dir_at_windows_nt_path(
             0,
         )
     };
+    if options.delete_pending_is_enoent
+        && (rc == bun_windows_sys::ntstatus::DELETE_PENDING
+            || rc == bun_windows_sys::ntstatus::FILE_DELETED)
+    {
+        return Err(Error::from_code(E::ENOENT, Tag::open));
+    }
     match windows::Win32Error::from_nt_status(rc) {
         windows::Win32Error::SUCCESS => Ok(Fd::from_system(fd)),
         code => Err(Error::from_code(code.to_e(), Tag::open)),
@@ -7018,6 +7028,30 @@ pub fn openat_windows(dir: Fd, path: &[u16], flags: i32, perm: Mode) -> Maybe<Fd
     let norm = normalize_path_windows(dir, path, &mut wbuf.0[..])?;
     openat_windows_impl(dir, norm, flags, perm)
 }
+/// Iterable directory open for the recursive delete-tree walk
+/// (`O_DIRECTORY | O_RDONLY | O_NOFOLLOW` semantics). Differs from a plain
+/// `openat` in one way: a directory whose deletion another party already
+/// started reports ENOENT (see `WindowsOpenDirOptions::delete_pending_is_enoent`),
+/// so the walk treats it like an entry that vanished between readdir and open.
+#[cfg(windows)]
+pub fn openat_dir_for_delete_tree(dir: impl AsFd, path: &[u8]) -> Maybe<Fd> {
+    let dir = dir.as_fd();
+    let mut wbuf = bun_paths::w_path_buffer_pool::get();
+    let wide = convert_path_u8_to_u16(&mut wbuf.0[..], path)?;
+    let mut buf2 = bun_paths::w_path_buffer_pool::get();
+    let norm = normalize_path_windows(dir, wide, &mut buf2.0[..])?;
+    open_dir_at_windows_nt_path(
+        dir,
+        norm,
+        WindowsOpenDirOptions {
+            iterable: true,
+            no_follow: true,
+            delete_pending_is_enoent: true,
+            ..Default::default()
+        },
+    )
+}
+
 /// `openatWindowsA` — UTF-8 input.
 #[cfg(windows)]
 #[inline(never)]

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7028,21 +7028,32 @@ pub fn openat_windows(dir: Fd, path: &[u16], flags: i32, perm: Mode) -> Maybe<Fd
     openat_windows_impl(dir, norm, flags, perm)
 }
 /// Iterable directory open for the recursive delete-tree walks
-/// (`O_DIRECTORY | O_RDONLY | O_NOFOLLOW` semantics), with
-/// `delete_pending_is_enoent` set: a dir whose deletion already started
+/// (`O_DIRECTORY | O_RDONLY | O_NOFOLLOW` semantics). On Windows
+/// `delete_pending_is_enoent` is set: a dir whose deletion already started
 /// reports ENOENT, like an entry that vanished between readdir and open.
-#[cfg(windows)]
 pub fn openat_dir_for_delete_tree(dir: impl AsFd, path: &[u8]) -> Maybe<Fd> {
-    open_dir_at_windows_a(
-        dir,
-        path,
-        WindowsOpenDirOptions {
-            iterable: true,
-            no_follow: true,
-            delete_pending_is_enoent: true,
-            ..Default::default()
-        },
-    )
+    #[cfg(windows)]
+    {
+        open_dir_at_windows_a(
+            dir,
+            path,
+            WindowsOpenDirOptions {
+                iterable: true,
+                no_follow: true,
+                delete_pending_is_enoent: true,
+                ..Default::default()
+            },
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        openat_a(
+            dir,
+            path,
+            O::DIRECTORY | O::RDONLY | O::CLOEXEC | O::NOFOLLOW,
+            0,
+        )
+    }
 }
 
 /// `openatWindowsA` — UTF-8 input.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7027,20 +7027,15 @@ pub fn openat_windows(dir: Fd, path: &[u16], flags: i32, perm: Mode) -> Maybe<Fd
     let norm = normalize_path_windows(dir, path, &mut wbuf.0[..])?;
     openat_windows_impl(dir, norm, flags, perm)
 }
-/// Iterable directory open for the recursive delete-tree walk
+/// Iterable directory open for the recursive delete-tree walks
 /// (`O_DIRECTORY | O_RDONLY | O_NOFOLLOW` semantics), with
 /// `delete_pending_is_enoent` set: a dir whose deletion already started
 /// reports ENOENT, like an entry that vanished between readdir and open.
 #[cfg(windows)]
 pub fn openat_dir_for_delete_tree(dir: impl AsFd, path: &[u8]) -> Maybe<Fd> {
-    let dir = dir.as_fd();
-    let mut wbuf = bun_paths::w_path_buffer_pool::get();
-    let wide = convert_path_u8_to_u16(&mut wbuf.0[..], path)?;
-    let mut buf2 = bun_paths::w_path_buffer_pool::get();
-    let norm = normalize_path_windows(dir, wide, &mut buf2.0[..])?;
-    open_dir_at_windows_nt_path(
+    open_dir_at_windows_a(
         dir,
-        norm,
+        path,
         WindowsOpenDirOptions {
             iterable: true,
             no_follow: true,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6237,9 +6237,8 @@ pub struct WindowsOpenDirOptions {
     pub iterable: bool,
     pub no_follow: bool,
     pub can_rename_or_delete: bool,
-    /// Report `STATUS_DELETE_PENDING`/`STATUS_FILE_DELETED` as ENOENT instead
-    /// of the EPERM the Win32 conversion produces. A directory in that state
-    /// can never be opened again, so for a deleter it is already gone.
+    /// Report `STATUS_DELETE_PENDING`/`STATUS_FILE_DELETED` as ENOENT: a
+    /// directory in that state can never be opened again.
     pub delete_pending_is_enoent: bool,
     pub op: WindowsOpenDirOp,
 }
@@ -7029,10 +7028,9 @@ pub fn openat_windows(dir: Fd, path: &[u16], flags: i32, perm: Mode) -> Maybe<Fd
     openat_windows_impl(dir, norm, flags, perm)
 }
 /// Iterable directory open for the recursive delete-tree walk
-/// (`O_DIRECTORY | O_RDONLY | O_NOFOLLOW` semantics). Differs from a plain
-/// `openat` in one way: a directory whose deletion another party already
-/// started reports ENOENT (see `WindowsOpenDirOptions::delete_pending_is_enoent`),
-/// so the walk treats it like an entry that vanished between readdir and open.
+/// (`O_DIRECTORY | O_RDONLY | O_NOFOLLOW` semantics), with
+/// `delete_pending_is_enoent` set: a dir whose deletion already started
+/// reports ENOENT, like an entry that vanished between readdir and open.
 #[cfg(windows)]
 pub fn openat_dir_for_delete_tree(dir: impl AsFd, path: &[u8]) -> Maybe<Fd> {
     let dir = dir.as_fd();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5875,22 +5875,26 @@ const outcome = async fn => {
 // against a concurrent deleter must keep walking instead of bailing out. The
 // bail-out left the rest of the tree behind (and on Windows surfaced
 // EFAULT/EPERM). A real concurrent deleter is not deterministic, so LD_PRELOAD
-// a shim that plays one: for marked names it really removes the entry, then
-// reports ENOENT, which is exactly what the loser of the race observes.
+// a shim that plays one through `unlinkat` (the one libc symbol on the walk's
+// path; dir opens go through raw syscalls on Linux and cannot be interposed):
+// - a marked file is really unlinked, then reported as ENOENT: the loser of
+//   an unlink race.
+// - a marked dir is really removed, then reported as ENOTEMPTY: rmdir raced a
+//   deleter that was still emptying the dir, and the re-open that follows
+//   finds it gone. The marked dir sits 16 levels deep so the walk reaches it
+//   through the min-stack hand-off, the site that used to abort the walk.
 // glibc-only, same as the statfs shim above.
 it.skipIf(!isGlibc || !cc)("fs.rm recursive keeps walking when a concurrent deleter wins (#39708)", () => {
+  const deepChain = Array.from({ length: 15 }, (_, i) => `d${i}`).join("/");
   using dir = tempDir("rm-race-shim", {
     "shim.c": `
 #define _GNU_SOURCE
 #include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <stdarg.h>
 #include <string.h>
-#include <sys/types.h>
 
 static int (*next_unlinkat)(int, const char *, int);
-static int (*next_openat)(int, const char *, int, ...);
 
 int unlinkat(int dirfd, const char *path, int flags) {
   if (!next_unlinkat) next_unlinkat = dlsym(RTLD_NEXT, "unlinkat");
@@ -5902,27 +5906,21 @@ int unlinkat(int dirfd, const char *path, int flags) {
     errno = ENOENT;
     return -1;
   }
-  return next_unlinkat(dirfd, path, flags);
-}
-
-int openat(int dirfd, const char *path, int flags, ...) {
-  if (!next_openat) next_openat = dlsym(RTLD_NEXT, "openat");
-  if (!next_unlinkat) next_unlinkat = dlsym(RTLD_NEXT, "unlinkat");
-  if ((flags & O_DIRECTORY) && strstr(path, "bun-race-doomed-dir")) {
-    next_unlinkat(dirfd, path, AT_REMOVEDIR);
-    errno = ENOENT;
+  if ((flags & AT_REMOVEDIR) && strstr(path, "bun-race-doomed-ne-dir")) {
+    // rmdir raced a deleter that was still emptying the dir: the call
+    // reports ENOTEMPTY, and by the time the caller re-opens the dir to
+    // retry, the deleter has finished and the dir is gone.
+    if (next_unlinkat(dirfd, path, flags) == 0) {
+      errno = ENOTEMPTY;
+      return -1;
+    }
     return -1;
   }
-  va_list ap;
-  va_start(ap, flags);
-  mode_t mode = va_arg(ap, mode_t);
-  va_end(ap);
-  return next_openat(dirfd, path, flags, mode);
+  return next_unlinkat(dirfd, path, flags);
 }
 `,
     "bun-shim-probe-keep.txt": "probe",
     "root/bun-race-doomed-file.txt": "doomed",
-    "root/bun-race-doomed-dir/.gitkeep": "", // emptied below; shim rmdir needs it empty
     "root/keep-a.txt": "x",
     "root/keep-sub/nested.txt": "x",
     "child.js": `
@@ -5943,8 +5941,9 @@ if (fs.existsSync("root")) {
 `,
   });
 
-  // The doomed dir must be empty so the shim's rmdir of it succeeds.
-  fs.unlinkSync(path.join(String(dir), "root/bun-race-doomed-dir/.gitkeep"));
+  // 15 nested dirs fill the walk's 16-slot stack (root is slot 1), so the
+  // marked dir at the bottom is handed to the min-stack fallback.
+  fs.mkdirSync(path.join(String(dir), "root", deepChain, "bun-race-doomed-ne-dir"), { recursive: true });
 
   const soPath = path.join(String(dir), "shim.so");
   const compile = Bun.spawnSync({

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5947,7 +5947,7 @@ if (fs.existsSync("root")) {
 
   const soPath = path.join(String(dir), "shim.so");
   const compile = Bun.spawnSync({
-    cmd: [cc!, "-shared", "-fPIC", "-o", soPath, path.join(String(dir), "shim.c")],
+    cmd: [cc!, "-shared", "-fPIC", "-o", soPath, path.join(String(dir), "shim.c"), "-ldl"],
     env: bunEnv,
   });
   if (compile.exitCode !== 0) {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5960,7 +5960,7 @@ long syscall(long nr, ...) {
     "root/keep-a.txt": "x",
     "root/keep-sub/nested.txt": "x",
     "child.js": `
-const fs = require("node:fs");
+import fs from "node:fs";
 // Probe: the shim swallows unlinkat for this name. If rmSync reports success
 // but the file is still there, the shim interposed the symbol the recursive
 // walk uses. If not, fail loudly instead of passing vacuously.

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5875,14 +5875,18 @@ const outcome = async fn => {
 // against a concurrent deleter must keep walking instead of bailing out. The
 // bail-out left the rest of the tree behind (and on Windows surfaced
 // EFAULT/EPERM). A real concurrent deleter is not deterministic, so LD_PRELOAD
-// a shim that plays one through `unlinkat` (the one libc symbol on the walk's
-// path; dir opens go through raw syscalls on Linux and cannot be interposed):
+// a shim that plays one through `unlinkat` and `syscall` (the libc symbols on
+// the walk's path; dir opens go through raw syscalls on Linux and cannot be
+// interposed):
 // - a marked file is really unlinked, then reported as ENOENT: the loser of
 //   an unlink race.
 // - a marked dir is really removed, then reported as ENOTEMPTY: rmdir raced a
 //   deleter that was still emptying the dir, and the re-open that follows
 //   finds it gone. The marked dir sits 16 levels deep so the walk reaches it
 //   through the min-stack hand-off, the site that used to abort the walk.
+// - a second marked dir is really removed from inside getdents64, so the
+//   kernel itself reports ENOENT for the directory the walk is iterating
+//   (same mechanism as the readdir shim above).
 // glibc-only, same as the statfs shim above.
 it.skipIf(!isGlibc || !cc)("fs.rm recursive keeps walking when a concurrent deleter wins (#39708)", () => {
   const deepChain = Array.from({ length: 15 }, (_, i) => `d${i}`).join("/");
@@ -5892,9 +5896,15 @@ it.skipIf(!isGlibc || !cc)("fs.rm recursive keeps walking when a concurrent dele
 #include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
 #include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
 
 static int (*next_unlinkat)(int, const char *, int);
+static long (*next_syscall)(long, ...);
 
 int unlinkat(int dirfd, const char *path, int flags) {
   if (!next_unlinkat) next_unlinkat = dlsym(RTLD_NEXT, "unlinkat");
@@ -5917,6 +5927,32 @@ int unlinkat(int dirfd, const char *path, int flags) {
     return -1;
   }
   return next_unlinkat(dirfd, path, flags);
+}
+
+long syscall(long nr, ...) {
+  va_list ap;
+  va_start(ap, nr);
+  long a1 = va_arg(ap, long), a2 = va_arg(ap, long), a3 = va_arg(ap, long);
+  long a4 = va_arg(ap, long), a5 = va_arg(ap, long), a6 = va_arg(ap, long);
+  va_end(ap);
+  if (!next_syscall) next_syscall = dlsym(RTLD_NEXT, "syscall");
+  if (nr == SYS_getdents64) {
+    int fd = (int)a1;
+    char link[64], target[PATH_MAX];
+    snprintf(link, sizeof link, "/proc/self/fd/%d", fd);
+    ssize_t n = readlink(link, target, sizeof target - 1);
+    if (n > 0) {
+      target[n] = 0;
+      const char *base = strrchr(target, '/');
+      base = base ? base + 1 : target;
+      if (strcmp(base, "bun-race-doomed-iter-dir") == 0) {
+        // The concurrent deleter rmdirs the dir mid-iteration; the real
+        // getdents64 on the dead dir then reports ENOENT.
+        rmdir(target);
+      }
+    }
+  }
+  return next_syscall(nr, a1, a2, a3, a4, a5, a6);
 }
 `,
     "bun-shim-probe-keep.txt": "probe",
@@ -5944,6 +5980,8 @@ if (fs.existsSync("root")) {
   // 15 nested dirs fill the walk's 16-slot stack (root is slot 1), so the
   // marked dir at the bottom is handed to the min-stack fallback.
   fs.mkdirSync(path.join(String(dir), "root", deepChain, "bun-race-doomed-ne-dir"), { recursive: true });
+  // Empty dir whose getdents64 the shim turns into the dead-dir ENOENT.
+  fs.mkdirSync(path.join(String(dir), "root", "bun-race-doomed-iter-dir"));
 
   const soPath = path.join(String(dir), "shim.so");
   const compile = Bun.spawnSync({

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5945,7 +5945,10 @@ long syscall(long nr, ...) {
       target[n] = 0;
       const char *base = strrchr(target, '/');
       base = base ? base + 1 : target;
-      if (strcmp(base, "bun-race-doomed-iter-dir") == 0) {
+      // "probe-getdents" doubles as the interposition probe for this hook:
+      // child.js checks that reading it really removed it.
+      if (strcmp(base, "bun-race-doomed-iter-dir") == 0 ||
+          strcmp(base, "bun-shim-probe-getdents-dir") == 0) {
         // The concurrent deleter rmdirs the dir mid-iteration; the real
         // getdents64 on the dead dir then reports ENOENT.
         rmdir(target);
@@ -5969,6 +5972,15 @@ if (!fs.existsSync("bun-shim-probe-keep.txt")) {
   console.error("shim did not interpose unlinkat");
   process.exit(3);
 }
+// Probe for the getdents64 hook: reading this dir makes the shim remove it.
+// The read itself reports the dead-dir ENOENT, which is not the point here.
+try {
+  fs.readdirSync("bun-shim-probe-getdents-dir");
+} catch {}
+if (fs.existsSync("bun-shim-probe-getdents-dir")) {
+  console.error("shim did not interpose syscall(getdents64)");
+  process.exit(3);
+}
 fs.rmSync("root", { recursive: true, force: true });
 if (fs.existsSync("root")) {
   console.error("leftover tree: " + JSON.stringify(fs.readdirSync("root", { recursive: true })));
@@ -5982,6 +5994,7 @@ if (fs.existsSync("root")) {
   fs.mkdirSync(path.join(String(dir), "root", deepChain, "bun-race-doomed-ne-dir"), { recursive: true });
   // Empty dir whose getdents64 the shim turns into the dead-dir ENOENT.
   fs.mkdirSync(path.join(String(dir), "root", "bun-race-doomed-iter-dir"));
+  fs.mkdirSync(path.join(String(dir), "bun-shim-probe-getdents-dir"));
 
   const soPath = path.join(String(dir), "shim.so");
   const compile = Bun.spawnSync({

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5871,6 +5871,120 @@ const outcome = async fn => {
   expect(exitCode).toBe(0);
 });
 
+// oven-sh/bun#39708, oven-sh/bun#36984: a recursive `rm` that loses a race
+// against a concurrent deleter must keep walking instead of bailing out. The
+// bail-out left the rest of the tree behind (and on Windows surfaced
+// EFAULT/EPERM). A real concurrent deleter is not deterministic, so LD_PRELOAD
+// a shim that plays one: for marked names it really removes the entry, then
+// reports ENOENT, which is exactly what the loser of the race observes.
+// glibc-only, same as the statfs shim above.
+it.skipIf(!isGlibc || !cc)("fs.rm recursive keeps walking when a concurrent deleter wins (#39708)", () => {
+  using dir = tempDir("rm-race-shim", {
+    "shim.c": `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <string.h>
+#include <sys/types.h>
+
+static int (*next_unlinkat)(int, const char *, int);
+static int (*next_openat)(int, const char *, int, ...);
+
+int unlinkat(int dirfd, const char *path, int flags) {
+  if (!next_unlinkat) next_unlinkat = dlsym(RTLD_NEXT, "unlinkat");
+  // Interposition probe: report success without deleting anything.
+  if (strstr(path, "bun-shim-probe-keep")) return 0;
+  if (strstr(path, "bun-race-doomed-file")) {
+    // The concurrent deleter wins: the entry is really gone, we get ENOENT.
+    next_unlinkat(dirfd, path, flags);
+    errno = ENOENT;
+    return -1;
+  }
+  return next_unlinkat(dirfd, path, flags);
+}
+
+int openat(int dirfd, const char *path, int flags, ...) {
+  if (!next_openat) next_openat = dlsym(RTLD_NEXT, "openat");
+  if (!next_unlinkat) next_unlinkat = dlsym(RTLD_NEXT, "unlinkat");
+  if ((flags & O_DIRECTORY) && strstr(path, "bun-race-doomed-dir")) {
+    next_unlinkat(dirfd, path, AT_REMOVEDIR);
+    errno = ENOENT;
+    return -1;
+  }
+  va_list ap;
+  va_start(ap, flags);
+  mode_t mode = va_arg(ap, mode_t);
+  va_end(ap);
+  return next_openat(dirfd, path, flags, mode);
+}
+`,
+    "bun-shim-probe-keep.txt": "probe",
+    "root/bun-race-doomed-file.txt": "doomed",
+    "root/bun-race-doomed-dir/.gitkeep": "", // emptied below; shim rmdir needs it empty
+    "root/keep-a.txt": "x",
+    "root/keep-sub/nested.txt": "x",
+    "child.js": `
+const fs = require("node:fs");
+// Probe: the shim swallows unlinkat for this name. If rmSync reports success
+// but the file is still there, the shim interposed the symbol the recursive
+// walk uses. If not, fail loudly instead of passing vacuously.
+fs.rmSync("bun-shim-probe-keep.txt", { recursive: true });
+if (!fs.existsSync("bun-shim-probe-keep.txt")) {
+  console.error("shim did not interpose unlinkat");
+  process.exit(3);
+}
+fs.rmSync("root", { recursive: true, force: true });
+if (fs.existsSync("root")) {
+  console.error("leftover tree: " + JSON.stringify(fs.readdirSync("root", { recursive: true })));
+  process.exit(4);
+}
+`,
+  });
+
+  // The doomed dir must be empty so the shim's rmdir of it succeeds.
+  fs.unlinkSync(path.join(String(dir), "root/bun-race-doomed-dir/.gitkeep"));
+
+  const soPath = path.join(String(dir), "shim.so");
+  const compile = Bun.spawnSync({
+    cmd: [cc!, "-shared", "-fPIC", "-o", soPath, path.join(String(dir), "shim.c")],
+    env: bunEnv,
+  });
+  if (compile.exitCode !== 0) {
+    throw new Error(`Failed to build rm race shim:\n${compile.stderr.toString()}`);
+  }
+
+  const existing = bunEnv.LD_PRELOAD;
+  const proc = Bun.spawnSync({
+    cmd: [bunExe(), "child.js"],
+    env: { ...bunEnv, LD_PRELOAD: existing ? `${soPath}:${existing}` : soPath },
+    cwd: String(dir),
+  });
+  expect(proc.stderr.toString()).toBe("");
+  expect(proc.exitCode).toBe(0);
+});
+
+// The same race without a shim: concurrent rm calls on one tree. Every call
+// must resolve (force: true) and the tree must be gone. On Windows the loser
+// used to reject with EPERM (EFAULT/EACCES before the port) when it opened a
+// directory whose deletion the winner had already started.
+it("concurrent recursive force rm of the same tree all resolve (#39708)", async () => {
+  using dir = tempDir("rm-concurrent", {});
+  for (let round = 0; round < 40; round++) {
+    const target = path.join(String(dir), `victim-${round}`);
+    fs.mkdirSync(path.join(target, "sub"), { recursive: true });
+    fs.writeFileSync(path.join(target, "a.txt"), "x");
+    fs.writeFileSync(path.join(target, "sub", "b.txt"), "x");
+    const results = await Promise.allSettled(
+      Array.from({ length: 8 }, () => fs.promises.rm(target, { recursive: true, force: true })),
+    );
+    const rejected = results.filter(r => r.status === "rejected").map(r => String((r as PromiseRejectedResult).reason));
+    expect(rejected).toEqual([]);
+    expect(fs.existsSync(target)).toBe(false);
+  }
+});
+
 it("fs.Stat constructor", () => {
   expect(new Stats()).toMatchObject({
     "atimeMs": undefined,


### PR DESCRIPTION
### Problem

- Recursive `fs.rm` and `fs.rmSync` with `force: true` reject when they race another deleter of the same tree. On Windows 1.3.14 the error is `EFAULT: bad address in system call argument, rm <path>`, on current main EPERM. 8 concurrent `rm(dir, { recursive: true, force: true })` over 1000 rounds on Windows: about 2% of the 8000 calls reject. Node: 0.
- Cause: the delete-tree walk (`zig_delete_tree`, `src/runtime/node/node_fs.rs`) stops on the first error from a child entry. When another deleter wins, the child dir open reports `STATUS_DELETE_PENDING`. The Win32 conversion turns that into EPERM (on 1.3.14 it fell through the old errno table to EFAULT). A child that is fully gone (ENOENT) also stopped the walk. `force: true` swallowed that, so the call resolved while the rest of the tree was still on disk.

### Fix

- The walks open directories through the new `sys::openat_dir_for_delete_tree` (`src/sys/lib.rs`). On Windows it reports `STATUS_DELETE_PENDING` and `STATUS_FILE_DELETED` as ENOENT. `DeleteFileBun` already treats those statuses as success on the unlink side. `sys::Dir::delete_tree` (bun install, bunx, tarball extraction) uses the same open.
- On macOS, `dt_delete_file` disambiguates the BSD `unlinkat` EPERM with an lstat. When that lstat reports ENOENT, the entry is gone and the walk now sees ENOENT instead of the stale EPERM. This is the race from #36984 (same approach as #37155, credited in the commit).
- The walk now skips a child that is gone by the time it is opened or unlinked (ENOENT), the same way the min-stack variant of the walk already does, and finishes deleting the rest of the tree. ENOENT from the dir iterator itself counts as the end of that directory: getdents on a dir that was removed mid-iteration reports ENOENT.
- Correct because a delete-pending directory can never be opened again: for a deleter it is equal to an entry that vanished between readdir and open.
- Verified: `test/js/node/fs/fs.test.ts` (the new shim test fails on main). The Windows race repro rejects 0 of 17600 calls after the fix, about 300 before. Also full `fs.test.ts` on Linux and Windows, `rm-windows-ntstatus.test.ts`, and the node parallel fs-rm tests.

### Background

- `zig_delete_tree` is the port of Zig's `std.fs.deleteTree`: readdir each directory, unlink files, recurse into subdirectories through a 16-slot stack, rmdir on pop. The sibling min-stack variant (used past depth 16) already tolerated ENOENT on child entries.
- An NTFS delete is two steps: open a handle with DELETE access, then set the delete disposition. With POSIX semantics the name unlinks at once. Openers that race those steps get `STATUS_DELETE_PENDING`.
- Windows has two errno translations. The NT-status table maps DELETE_PENDING to EBUSY. The dir-open path first converts the NT status to a Win32 error (`RtlNtStatusToDosError` gives ERROR_ACCESS_DENIED), which maps to EPERM.

Fixes #39708

<details><summary>Notes</summary>

- Reproduction: the script from #36984 (8 concurrent `rm` of one dir, 1000 rounds). Windows x64, bun 1.3.14 release: 558 EACCES + 1 EFAULT. Current main (debug): 96 to 172 EPERM per run. After the fix: 0 rejections in 17600 calls. A backtrace probe in `dt_err` showed every rejection came from the child/initial dir open, and an NT-status probe showed `STATUS_DELETE_PENDING` (0xC0000056) on every EPERM.
- The reporter's case is a single `rmSync` on a loaded CI runner. An external handle holder (AV scanner, indexer) creates the same transient statuses that a second `rm` does.
- The test simulates the race deterministically with an LD_PRELOAD shim: for marked names it really removes the entry, then reports ENOENT, which is what the loser of the race observes. It includes an interposition probe so it fails loudly instead of passing vacuously if the shim stops interposing. The unshimmed concurrency test covers the real race on the Windows lanes.
- On Linux the in-process race never rejected (0 of several thousand calls) because `force: true` masked the mid-walk ENOENT bail. The observable defect there was the leftover tree.
- Related open PRs: #37155 found the macOS lstat race first, and the `dt_delete_file` hunk here takes the same approach (credited in the commit). #35749 removes the `_ => EFAULT` fallthrough tables. #38550 covers the non-recursive `rm` branch.
- The shell `rm` builtin keeps its current behavior. Its dir open goes through `shell_openat`, which other builtins share, so the same-class fix there is left for a follow-up.
- The `need_to_retry` rmdir loop keeps its unbounded structure. That matches the min-stack variant and the Zig original.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->
