### PR TITLE
Module loader: a removed module whose in-flight load fails no longer poisons later imports of it (WebKit bump for oven-sh/WebKit#474)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "autobuild-preview-pr-472-eaacac28";
+export const WEBKIT_VERSION = "autobuild-preview-pr-474-56b8426b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/cli/run/require-cache.test.ts
+++ b/test/cli/run/require-cache.test.ts
@@ -329,9 +329,16 @@ describe.concurrent("require.cache", () => {
   // the next import() of the path answers from a record whose registry entry is
   // gone (null loadPromise, crash in JSModuleLoader::loadModule).
   describe("delete require.cache[esm] while an import() of it is in flight", () => {
-    // Every load of entry.mjs gets its own `load` number. Only the first load
-    // imports dep.mjs, whose onLoad waits for the gate.
-    const fixture = (scenario: string) => ({
+    // Every load of entry.mjs gets its own `load` number. Only the first load,
+    // `firstLoad`, imports dep.mjs, whose onLoad waits for the gate and then runs
+    // `depLoad`. The defaults make the first load succeed.
+    const fixture = (
+      scenario: string,
+      {
+        firstLoad = `import "./dep.mjs"; export const load = 1;`,
+        depLoad = `return { loader: "js", contents: "" };`,
+      } = {},
+    ) => ({
       "entry.mjs": "",
       "dep.mjs": "",
       "main.mjs": `
@@ -345,13 +352,13 @@ describe.concurrent("require.cache", () => {
               const load = ++loads;
               return {
                 loader: "js",
-                contents: load === 1 ? 'import "./dep.mjs"; export const load = 1;' : \`export const load = \${load};\`,
+                contents: load === 1 ? ${JSON.stringify(firstLoad)} : \`export const load = \${load};\`,
               };
             });
             build.onLoad({ filter: /dep\\.mjs$/ }, async () => {
               depLoadStarted.resolve();
               await gate.promise;
-              return { loader: "js", contents: "" };
+              ${depLoad}
             });
           },
         });
@@ -402,6 +409,192 @@ describe.concurrent("require.cache", () => {
         stdout: JSON.stringify({ loads: [1, 2, 2], thirdIsSecond: true }),
         stderr: "",
         exitCode: 0,
+      });
+    });
+
+    // When the removed load fails instead, its error belongs to the removed
+    // entry: not to the path (the next import() has to load the file again),
+    // and not to a replacement load that registered the path in the meantime
+    // (the replacement has to stay importable). `onLoadCalls` counts the loads
+    // of entry.mjs the plugin served.
+    describe("and the removed load then fails", () => {
+      const settledAs = `namespace => ({ load: namespace.load }), error => error.message`;
+
+      test("the module throws while it evaluates: the next import() loads the file again", async () => {
+        using dir = tempDir(
+          "require-cache-delete-in-flight-throws",
+          fixture(
+            `
+              gate.resolve();
+              result.first = await first.then(${settledAs});
+              result.second = await import("./entry.mjs").then(${settledAs});
+              result.onLoadCalls = loads;
+            `,
+            { firstLoad: `import "./dep.mjs"; throw new Error("load 1 threw");` },
+          ),
+        );
+
+        expect(await runMain(String(dir))).toEqual({
+          stdout: JSON.stringify({ first: "load 1 threw", second: { load: 2 }, onLoadCalls: 2 }),
+          stderr: "",
+          exitCode: 0,
+        });
+      });
+
+      test("a dependency of the module fails to load: the next import() loads the file again", async () => {
+        using dir = tempDir(
+          "require-cache-delete-in-flight-dependency-fails",
+          fixture(
+            `
+              gate.resolve();
+              result.first = await first.then(${settledAs});
+              result.second = await import("./entry.mjs").then(${settledAs});
+              result.onLoadCalls = loads;
+            `,
+            { depLoad: `throw new Error("dep.mjs of load 1 failed");` },
+          ),
+        );
+
+        expect(await runMain(String(dir))).toEqual({
+          stdout: JSON.stringify({ first: "dep.mjs of load 1 failed", second: { load: 2 }, onLoadCalls: 2 }),
+          stderr: "",
+          exitCode: 0,
+        });
+      });
+
+      test("a replacement load finished first: the replacement stays importable", async () => {
+        using dir = tempDir(
+          "require-cache-delete-in-flight-throws-after-replacement",
+          fixture(
+            `
+              const second = await import("./entry.mjs");
+              result.second = second.load;
+              gate.resolve();
+              result.first = await first.then(${settledAs});
+              result.third = await import("./entry.mjs").then(
+                namespace => ({ load: namespace.load, isSecond: namespace === second }),
+                error => error.message,
+              );
+              result.onLoadCalls = loads;
+            `,
+            { firstLoad: `import "./dep.mjs"; throw new Error("load 1 threw");` },
+          ),
+        );
+
+        expect(await runMain(String(dir))).toEqual({
+          stdout: JSON.stringify({
+            second: 2,
+            first: "load 1 threw",
+            third: { load: 2, isSecond: true },
+            onLoadCalls: 2,
+          }),
+          stderr: "",
+          exitCode: 0,
+        });
+      });
+
+      // Here the load that fails is the fetch of entry.mjs itself. parent.mjs
+      // imports entry.mjs, which registers entry.mjs while its onLoad waits for
+      // the gate, and an import() of entry.mjs issued now joins that pending
+      // fetch. A rejected fetch must leave nothing behind under the path.
+      test("the fetch of the module is rejected: the next import() loads the file again", async () => {
+        using dir = tempDir("require-cache-delete-in-flight-fetch-rejected", {
+          "entry.mjs": "",
+          "parent.mjs": `import "./entry.mjs";`,
+          "main.mjs": `
+            const gate = Promise.withResolvers();
+            const entryLoadStarted = Promise.withResolvers();
+            let loads = 0;
+            Bun.plugin({
+              name: "gate",
+              setup(build) {
+                build.onLoad({ filter: /entry\\.mjs$/ }, async () => {
+                  const load = ++loads;
+                  if (load === 1) {
+                    entryLoadStarted.resolve();
+                    await gate.promise;
+                    throw new Error("load 1 failed to load");
+                  }
+                  return { loader: "js", contents: \`export const load = \${load};\` };
+                });
+              },
+            });
+            const entryPath = require.resolve("./entry.mjs");
+            const result = {};
+
+            const parent = import("./parent.mjs");
+            await entryLoadStarted.promise;
+            const first = import("./entry.mjs");
+            delete require.cache[entryPath];
+            gate.resolve();
+            result.parent = await parent.then(() => "fulfilled", error => error.message);
+            result.first = await first.then(${settledAs});
+            result.second = await import("./entry.mjs").then(${settledAs});
+            result.onLoadCalls = loads;
+
+            console.log(JSON.stringify(result));
+          `,
+        });
+
+        expect(await runMain(String(dir))).toEqual({
+          stdout: JSON.stringify({
+            parent: "load 1 failed to load",
+            first: "load 1 failed to load",
+            second: { load: 2 },
+            onLoadCalls: 2,
+          }),
+          stderr: "",
+          exitCode: 0,
+        });
+      });
+
+      // The same through require(): require() of a module with top-level await
+      // throws, but the module keeps evaluating in the background. Deleting it
+      // and importing it again loads the file a second time. When the first run
+      // then rejects, the second run, which succeeded, must stay importable.
+      // (Without the fix the first run's rejection is stored under the path: the
+      // replacement import() never settles when the rejection is stored first,
+      // and a later import() rejects with the first run's error otherwise.)
+      test("require() of a top-level await module that rejects later: the replacement stays importable", async () => {
+        using dir = tempDir("require-cache-delete-in-flight-require-tla", {
+          "tla.mjs": `
+            const run = (globalThis.runs = (globalThis.runs ?? 0) + 1);
+            await globalThis.gate.promise;
+            if (run === 1) throw new Error("run 1 threw");
+            export { run };
+          `,
+          "main.mjs": `
+            globalThis.gate = Promise.withResolvers();
+            const result = {};
+
+            try {
+              require("./tla.mjs");
+            } catch (error) {
+              result.require = error.message.includes("async module");
+            }
+            delete require.cache[require.resolve("./tla.mjs")];
+            const replacementPromise = import("./tla.mjs");
+            globalThis.gate.resolve();
+            const replacement = await replacementPromise;
+            result.replacement = replacement.run;
+            // Both runs continue from the gate in microtasks only. One turn of the
+            // event loop is enough for run 1 to reject and be recorded by the loader.
+            await new Promise(resolve => setImmediate(resolve));
+            result.next = await import("./tla.mjs").then(
+              namespace => ({ run: namespace.run, isReplacement: namespace === replacement }),
+              error => error.message,
+            );
+            result.runs = globalThis.runs;
+
+            console.log(JSON.stringify(result));
+          `,
+        });
+
+        expect(await runMain(String(dir))).toEqual({
+          stdout: JSON.stringify({ require: true, replacement: 2, next: { run: 2, isReplacement: true }, runs: 2 }),
+          stderr: "",
+          exitCode: 0,
+        });
       });
     });
   });

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -197,6 +197,22 @@ plugin({
   },
 });
 
+// Rejects the first load of each path and serves every later one. The test
+// reads back how often it was called for its path.
+const rejectsOnceCalls = new Map<string, number>();
+plugin({
+  name: "rejects once per path",
+  setup(builder) {
+    builder.onResolve({ filter: /.*/, namespace: "rejects-once" }, ({ path }) => ({ path, namespace: "rejects-once" }));
+    builder.onLoad({ filter: /.*/, namespace: "rejects-once" }, async ({ path }) => {
+      const calls = (rejectsOnceCalls.get(path) ?? 0) + 1;
+      rejectsOnceCalls.set(path, calls);
+      if (calls === 1) throw new Error("not ready yet");
+      return { contents: `export default ${calls};`, loader: "js" };
+    });
+  },
+});
+
 // This is to test that it works when imported from a separate file
 import { tempDir } from "harness";
 import { render as svelteRender } from "svelte/server";
@@ -506,6 +522,26 @@ describe("errors", () => {
       await import("rejected-promise2:hi");
       throw -1;
     }).toThrow("Rejected Promise");
+  });
+
+  // A module whose onLoad rejected is not kept as failed: the next import() of
+  // it calls onLoad again, so a failure that was transient stays transient.
+  it("an onLoad that rejected is called again by the next import()", async () => {
+    // A path of its own, so that a re-run of this test starts from an unloaded module.
+    const path = `module-${rejectsOnceCalls.size}`;
+    const first = await import(`rejects-once:${path}`).then(
+      () => "fulfilled",
+      error => error.message,
+    );
+    const second = await import(`rejects-once:${path}`).then(
+      namespace => namespace.default,
+      error => error.message,
+    );
+    expect({ first, second, calls: rejectsOnceCalls.get(path) }).toEqual({
+      first: "not ready yet",
+      second: 2,
+      calls: 2,
+    });
   });
 
   it("can work with http urls", async () => {

--- a/test/js/bun/resolve/build-error.test.ts
+++ b/test/js/bun/resolve/build-error.test.ts
@@ -316,3 +316,71 @@ test("BuildMessage finalize frees with the same allocator it was created with", 
     Bun.gc(true);
   }
 });
+
+// A file that failed to load is not kept as failed: the next load of it reads
+// the file again, so a file that is fixed in the meantime loads.
+describe.concurrent("a file whose build failed loads once it is fixed", () => {
+  async function runMain(files: Record<string, string>) {
+    using dir = tempDir("build-error-refetch", files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr, exitCode };
+  }
+
+  const settledAs = `namespace => ({ x: namespace.x }), error => error.name`;
+
+  test("by import() and by require()", async () => {
+    const result = await runMain({
+      "bad.ts": `export const x = ;`,
+      "main.mjs": `
+        const result = {};
+        result.broken = await import("./bad.ts").then(${settledAs});
+        try {
+          result.brokenRequire = { x: require("./bad.ts").x };
+        } catch (error) {
+          result.brokenRequire = error.name;
+        }
+        await Bun.write("./bad.ts", "export const x = 1;");
+        result.fixed = await import("./bad.ts").then(${settledAs});
+        result.fixedRequire = { x: require("./bad.ts").x };
+        console.log(JSON.stringify(result));
+      `,
+    });
+
+    expect(result).toEqual({
+      stdout: JSON.stringify({
+        broken: "BuildMessage",
+        brokenRequire: "BuildMessage",
+        fixed: { x: 1 },
+        fixedRequire: { x: 1 },
+      }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("after a module that imports it failed to load", async () => {
+    const result = await runMain({
+      "bad.ts": `export const x = ;`,
+      "importer.ts": `import { x } from "./bad.ts"; export const y = x;`,
+      "main.mjs": `
+        const result = {};
+        result.importer = await import("./importer.ts").then(() => "fulfilled", error => error.name);
+        await Bun.write("./bad.ts", "export const x = 1;");
+        result.fixed = await import("./bad.ts").then(${settledAs});
+        console.log(JSON.stringify(result));
+      `,
+    });
+
+    expect(result).toEqual({
+      stdout: JSON.stringify({ importer: "BuildMessage", fixed: { x: 1 } }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
Stacked on #39674: its branch is the base, the same way oven-sh/WebKit#474 is stacked on oven-sh/WebKit#472. The diff is the pin moving from the #472 preview to the #474 preview, plus the tests. GitHub retargets this to `main` when #39674 lands.

### Problem

- `delete require.cache[path]`, `mock.module()` and plugin `module()` remove a module's registry entry, possibly while a load of it is in flight. If that load then failed, the loader stored the error under the path again: the next `import()` or `require()` rejected with the removed load's error and never loaded the file again. If a replacement load had registered the path first, the error landed in the replacement and a module that had loaded fine became unimportable, or the replacement `import()` never settled. #39674 covers the crash flavor of the same window.
- Cause, in JavaScriptCore: `moduleLoadTopSettled`, `moduleLoadTopRejected` and `moduleLoadStoreError` (`JSMicrotask.cpp`) stored the error through `ensureRegistered(key)`, which creates a fresh entry once `removeEntry()` (`src/jsc/bindings/ZigGlobalObject.cpp:792`, `BunPlugin.cpp:706`) has dropped the one the load started from. `JSModuleLoader::loadModule()` answers every later load of the key from that entry's error.

### Fix

- Two engine changes. Upstream [319474@main](https://commits.webkit.org/319474@main) (on `main` since the 8c4fd56347 upgrade, #40276) no longer registers a rejected fetch and only stores an error into an entry that exists, so the key is no longer registered again. oven-sh/WebKit#474 adds the fork residual: a top-level load records the entry it loaded and stores its failure into that entry, so a removed load cannot store into a replacement's entry. No Bun source change.
- Correct because the error is the outcome of loading that one entry. While the entry is registered nothing changes. Once removed, the error stays with the detached entry, the path starts from nothing, and a replacement keeps its own state.
- The upstream change is also visible without a removal: a file whose load failed (a syntax error, a plugin `onLoad` that rejected) is loaded again by the next `import()` or `require()`, so a file fixed in the meantime loads. Before, every later load replayed the first error for the life of the process. `main` ships that already but has no test for it; the tests here pin it.
- Verified: eight new tests. Five removal shapes in `test/cli/run/require-cache.test.ts`, three reload shapes in `test/js/bun/resolve/build-error.test.ts` and `test/js/bun/plugin/plugins.test.ts`. On this PR's base (the #472 preview, which has the upstream change) seven pass and `a replacement load finished first` fails; all eight pass on the #474 preview. All eight failed on the pin before the upgrade. #39674's tests pass on the new pin too. Notes below.

### Background

- The registry maps a module key to a `ModuleRegistryEntry`: the load's promises, its record, and one error. `removeEntry()` is a Bun addition to the engine. Upstream never removes entries, so for upstream "the entry for this key" and "the entry this load started from" are the same thing.
- A top-level load runs as engine microtasks that carry a `ModuleLoadingContext`. The per-dependency loads always held their entry in it. The top-level ones held only the key and looked the entry up again when the load failed.

<details><summary>Notes</summary>

Fail-before: on the pin before the upgrade (the first #472 preview, and Bun 1.4.0 with the repro scripts) the four dynamic removal shapes print the removed load's error for the second import with `onLoadCalls: 1`, the `require()` shape hangs on the replacement `import()` until the test times out, the two `build-error` tests get `BuildMessage` for the fixed file, and the plugin test gets the first error back without a second `onLoad` call. On the current base (`bun bd --webkit-version=autobuild-preview-pr-472-cfccea9d`), which carries upstream 319474@main, only `a replacement load finished first` fails: `getRegisteredMayBeNull()` finds the replacement's entry and the removed load's error lands there. That is the shape oven-sh/WebKit#474 fixes. The engine-side split was first measured by recompiling the three affected unified-source bundles into the first #472 preview library, with and without the upstream change; the pass-after has been repeated on every published #474 preview since.

Suites run on the new pin: `test/js/bun/resolve/`, `test/js/bun/plugin/`, `test/js/bun/test/mock/`, `test/js/node/module/`, `test/cli/run/`, `test/cli/test/`, and the test of #33149. The failures left on this debug-asan container also fail on the unmodified engine: the seven `require.cache` leak tests (#39473 has the numbers), `load the same empty JS file 2000 times` (its sibling takes 13.6 s on both engines), `--parallel lazily scales workers based on file duration`, `should resolve self-imports by name` (a 5 s timeout around six debug-build spawns), the FUSE tests and the `NO_ORPHANS` uid/gid test. `plugins.test.ts` does not survive `--rerun-each` on the base either (its `recursion` plugin overflows on re-registration), so the new test there was checked by a normal run; it uses a path of its own per run regardless.

Open PRs this touches. #33419 works around the cached plugin failure on the Bun side; the upstream policy now on `main` does what its `import()` cases ask for (the new `plugins.test.ts` test is that shape). #39204 (oven-sh/WebKit#451) is about which error object a later load of a failed file gets: for a later top-level `import()` or `require()` the answer is now a fresh load, while the per-dependency replay it also covers is unchanged. #33149 adds a test for oven-sh/WebKit#262; it passes here, but its comment describes a mechanism that is gone (nothing is registered for the rejected fetch any more, so the static importer fetches again). #38072 and #38645 are about `require()` of a module that is evicted during, or threw during, its own evaluation; they are different bugs and are not affected.

If oven-sh/WebKit#472 and #474 merge together, the reverse packaging works too: this PR moves to the merged sha and #39674 becomes tests only.

</details>

> [!NOTE]
> `WEBKIT_VERSION` points at the preview tag `autobuild-preview-pr-474-56b8426b` while oven-sh/WebKit#474 is open. It has to move to the merged main sha before this lands, after #39674's pin does the same.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 9 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/require-cache.test.ts

<!-- robobun:evidence:end -->