### PR TITLE
compile: stop .env autoload from reading the cwd and every ancestor directory

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -784,12 +784,9 @@ impl<'a> Transpiler<'a> {
                 };
 
                 if !self.resolver.opts.load_tsconfig_json {
-                    // The `read_dir_info(cwd)` walk below reads the cwd and
-                    // every ancestor directory in full. Without tsconfig.json
-                    // loading (standalone executables, unless built with
-                    // `--compile-autoload-tsconfig`) nothing else at startup
-                    // needs those listings, and the walk would only serve as
-                    // an existence check for the default .env files.
+                    // Standalone executables (tsconfig.json loading off) have no
+                    // other use for the cwd listing, which `read_dir_info` builds
+                    // by reading every ancestor directory in full.
                     env.load(
                         &dot_env::OpenEachDefaultFile,
                         &env_files,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -770,38 +770,6 @@ impl<'a> Transpiler<'a> {
                     self.resolver.opts.set_production(true);
                 }
 
-                // Load the project root for .env file discovery. If the cwd
-                // (or a parent) is unreadable, readDirInfo may return null;
-                // bail out of .env file loading in that case, but process
-                // env vars were already loaded above.
-                let top_level_dir = self.fs().top_level_dir;
-                let dir_info = match self.resolver.read_dir_info(top_level_dir) {
-                    Ok(Some(d)) => d,
-                    _ => return Ok(()),
-                };
-
-                if let Some(tsconfig) = dir_info.tsconfig_json() {
-                    merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
-                }
-
-                // Copy the listing's basenames out under `entries_mutex`,
-                // refreshing it at our generation in the same critical
-                // section: concurrent resolvers rewrite the `DirEntry` map in
-                // place under that lock, and `dot_env::Loader::load` does
-                // file I/O between probes.
-                let dir = {
-                    let _entries_lock = bun_resolver::fs::FileSystem::instance()
-                        .fs
-                        .entries_mutex
-                        .lock_guard();
-                    match dir_info.get_entries_ref_locked(self.resolver.generation) {
-                        Some(entries) => dot_env::DirEntryKeys(
-                            entries.data.iter().map(|(k, _)| Box::from(&**k)).collect(),
-                        ),
-                        None => return Ok(()),
-                    }
-                };
-
                 // `Env.files: Box<[Box<[u8]>]>` but `Loader::load`
                 // wants `&[&[u8]]`. Re-borrow into a small Vec; the explicit
                 // `--env-file` list is bounded (CLI args), not hot-path.
@@ -814,7 +782,55 @@ impl<'a> Transpiler<'a> {
                 } else {
                     dot_env::DotEnvFileSuffix::Development
                 };
-                env.load(&dir, &env_files, suffix, skip_default_env)?;
+
+                if !self.resolver.opts.load_tsconfig_json {
+                    // The `read_dir_info(cwd)` walk below reads the cwd and
+                    // every ancestor directory in full. Without tsconfig.json
+                    // loading (standalone executables, unless built with
+                    // `--compile-autoload-tsconfig`) nothing else at startup
+                    // needs those listings, and the walk would only serve as
+                    // an existence check for the default .env files.
+                    env.load(
+                        &dot_env::OpenEachDefaultFile,
+                        &env_files,
+                        suffix,
+                        skip_default_env,
+                    )?;
+                } else {
+                    // Load the project root for .env file discovery. If the cwd
+                    // (or a parent) is unreadable, readDirInfo may return null;
+                    // bail out of .env file loading in that case, but process
+                    // env vars were already loaded above.
+                    let top_level_dir = self.fs().top_level_dir;
+                    let dir_info = match self.resolver.read_dir_info(top_level_dir) {
+                        Ok(Some(d)) => d,
+                        _ => return Ok(()),
+                    };
+
+                    if let Some(tsconfig) = dir_info.tsconfig_json() {
+                        merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
+                    }
+
+                    // Copy the listing's basenames out under `entries_mutex`,
+                    // refreshing it at our generation in the same critical
+                    // section: concurrent resolvers rewrite the `DirEntry` map in
+                    // place under that lock, and `dot_env::Loader::load` does
+                    // file I/O between probes.
+                    let dir = {
+                        let _entries_lock = bun_resolver::fs::FileSystem::instance()
+                            .fs
+                            .entries_mutex
+                            .lock_guard();
+                        match dir_info.get_entries_ref_locked(self.resolver.generation) {
+                            Some(entries) => dot_env::DirEntryKeys(
+                                entries.data.iter().map(|(k, _)| Box::from(&**k)).collect(),
+                            ),
+                            None => return Ok(()),
+                        }
+                    };
+
+                    env.load(&dir, &env_files, suffix, skip_default_env)?;
+                }
             }
             DotEnvBehavior::disable => {
                 env.load_process()?;

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -53,9 +53,10 @@ impl DefaultEnvFile {
 /// Directory-entry probe used by `Loader::load`. `bun_dotenv` sits below
 /// `bun_resolver` in the crate graph, so the directory listing is taken
 /// generically; the only operation `load_default_files` performs is a lookup
-/// of a known-at-compile-time filename. Callers snapshot the resolver's
-/// listing into a [`DirEntryKeys`] (the live `DirEntry` map may be rewritten
-/// in place by a concurrent resolver, so `load` must not probe it directly).
+/// of a known-at-compile-time filename. Callers that already hold the cwd
+/// listing snapshot it into a [`DirEntryKeys`] (the live `DirEntry` map may be
+/// rewritten in place by a concurrent resolver, so `load` must not probe it
+/// directly). Callers without a listing pass [`OpenEachDefaultFile`].
 pub trait DirEntryProbe {
     /// The argument MUST already be ASCII-lowercase.
     fn has_comptime_query(&self, query_lower: &'static [u8]) -> bool;
@@ -68,6 +69,18 @@ pub struct DirEntryKeys(pub Vec<Box<[u8]>>);
 impl DirEntryProbe for DirEntryKeys {
     fn has_comptime_query(&self, query_lower: &'static [u8]) -> bool {
         self.0.iter().any(|k| **k == *query_lower)
+    }
+}
+
+/// Probe for callers without a listing of the cwd: `Loader::load` then
+/// `openat`s each default file (at most four) and `load_env_file` treats
+/// `ENOENT` as absent. Building a listing instead means reading the cwd and
+/// every ancestor directory in full.
+pub struct OpenEachDefaultFile;
+
+impl DirEntryProbe for OpenEachDefaultFile {
+    fn has_comptime_query(&self, _query_lower: &'static [u8]) -> bool {
+        true
     }
 }
 
@@ -746,7 +759,6 @@ impl Loader {
     ) -> crate::Result<()> {
         if dir.has_comptime_query(env_file.name()) {
             self.load_env_file::<false>(dir_handle, env_file, value_buffer)?;
-            analytics::Features::dotenv_inc();
         }
         Ok(())
     }
@@ -803,12 +815,9 @@ impl Loader {
             Err(err) => {
                 use bun_sys::E;
                 match err.get_errno() {
+                    // Not recorded: `print_loaded` lists `default_files_loaded`.
                     // A unix socket: ENXIO on Linux, EOPNOTSUPP on macOS and FreeBSD.
-                    E::EISDIR | E::ENOENT | E::ENXIO | E::EOPNOTSUPP => {
-                        // prevent retrying
-                        self.default_files_loaded.insert(env_file);
-                        return Ok(());
-                    }
+                    E::EISDIR | E::ENOENT | E::ENXIO | E::EOPNOTSUPP => return Ok(()),
                     E::EBUSY | E::EACCES => {
                         if !self.quiet {
                             bun_core::pretty_errorln!(
@@ -843,6 +852,7 @@ impl Loader {
         }
 
         self.default_files_loaded.insert(env_file);
+        analytics::Features::dotenv_inc();
         Ok(())
     }
 

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -72,10 +72,8 @@ impl DirEntryProbe for DirEntryKeys {
     }
 }
 
-/// Probe for callers without a listing of the cwd: `Loader::load` then
-/// `openat`s each default file (at most four) and `load_env_file` treats
-/// `ENOENT` as absent. Building a listing instead means reading the cwd and
-/// every ancestor directory in full.
+/// Probe for callers without a cwd listing: `Loader::load` opens every default
+/// file and `load_env_file` treats `ENOENT` as absent.
 pub struct OpenEachDefaultFile;
 
 impl DirEntryProbe for OpenEachDefaultFile {

--- a/src/dotenv/lib.rs
+++ b/src/dotenv/lib.rs
@@ -7,8 +7,8 @@ pub use error::{Error, Result};
 
 pub use env_loader::{
     DirEntryKeys, DirEntryProbe, DotEnvBehavior, DotEnvFileSuffix, HAS_NO_CLEAR_SCREEN_CLI_FLAG,
-    HashTable, HashTableValue, INSTANCE, Loader, Map, NullDelimitedEnvMap, S3Credentials,
-    StdEnvMapWrapper, instance, set_instance,
+    HashTable, HashTableValue, INSTANCE, Loader, Map, NullDelimitedEnvMap, OpenEachDefaultFile,
+    S3Credentials, StdEnvMapWrapper, instance, set_instance,
 };
 
 /// `dotenv::map::{HashTable, Entry}` namespace expected by `install_jsc::ini_jsc` et al.

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -115,7 +115,7 @@ describe("bundler", () => {
         build.stderr.text(),
         build.exited,
       ]);
-      expect(buildStderr).not.toContain("error:");
+      expect(buildStderr).toBe("");
       expect(buildExitCode).toBe(0);
 
       await using proc = Bun.spawn({

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -1,4 +1,6 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
+import path from "node:path";
 import { itBundled } from "./expectBundled";
 
 // Not describe.concurrent: the backend:"cli" cases each spawn a full
@@ -60,6 +62,77 @@ describe("bundler", () => {
       setCwd: true,
     },
   });
+
+  // .env autoload must open the default files in the cwd directly. It used to
+  // go through the resolver's directory cache, which reads the cwd and every
+  // ancestor directory in full, so startup scaled with the size of unrelated
+  // directories. The resolver logs each listing it reads under the `Fs` debug
+  // scope, which is compiled out of release builds.
+  (isDebug ? itBundled : itBundled.skip)("compile/AutoloadDotenvDoesNotReadDirectories", {
+    compile: true,
+    files: {
+      "/entry.ts": /* js */ `
+        console.log(process.env.TEST_VAR || "not found");
+      `,
+    },
+    runtimeFiles: {
+      "/.env": `TEST_VAR=from_dotenv`,
+    },
+    run: {
+      setCwd: true,
+      env: {
+        BUN_DEBUG_Fs: "1",
+      },
+      validate({ stdout }) {
+        expect(stdout).toContain("from_dotenv");
+        expect(stdout).not.toContain("readdir(");
+      },
+    },
+  });
+
+  // The resolver's directory walk gives up once a path has more than 256
+  // uncached components. .env autoload no longer depends on that walk, so the
+  // files still load from such a cwd. Windows limits a process cwd to 260
+  // characters, which is too short for this path.
+  test.skipIf(isWindows)(
+    "compile/AutoloadDotenvFromDeepCwd",
+    async () => {
+      const deep = Array(300).fill("d").join("/");
+      using dir = tempDir("compile-autoload-dotenv-deep", {
+        "entry.ts": `console.log(process.env.TEST_VAR || "not found");`,
+        [`${deep}/.env`]: "TEST_VAR=from_dotenv",
+      });
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", "./entry.ts", "--outfile", "app"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, buildStderr, buildExitCode] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      expect(buildStderr).not.toContain("error:");
+      expect(buildExitCode).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [path.join(String(dir), "app")],
+        env: bunEnv,
+        cwd: path.join(String(dir), deep),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout).toBe("from_dotenv\n");
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    },
+    // Same budget itBundled gives its compile cases: the link step dominates.
+    30_000,
+  );
 
   // Test that process environment variables take precedence over .env files
   itBundled("compile/AutoloadDotenvWithExistingEnv", {

--- a/test/bundler/bundler_compile_autoload.test.ts
+++ b/test/bundler/bundler_compile_autoload.test.ts
@@ -94,45 +94,36 @@ describe("bundler", () => {
   // uncached components. .env autoload no longer depends on that walk, so the
   // files still load from such a cwd. Windows limits a process cwd to 260
   // characters, which is too short for this path.
-  test.skipIf(isWindows)(
-    "compile/AutoloadDotenvFromDeepCwd",
-    async () => {
-      const deep = Array(300).fill("d").join("/");
-      using dir = tempDir("compile-autoload-dotenv-deep", {
-        "entry.ts": `console.log(process.env.TEST_VAR || "not found");`,
-        [`${deep}/.env`]: "TEST_VAR=from_dotenv",
-      });
+  test.skipIf(isWindows)("compile/AutoloadDotenvFromDeepCwd", async () => {
+    const deep = Array(300).fill("d").join("/");
+    using dir = tempDir("compile-autoload-dotenv-deep", {
+      "entry.ts": `console.log(process.env.TEST_VAR || "not found");`,
+      [`${deep}/.env`]: "TEST_VAR=from_dotenv",
+    });
 
-      await using build = Bun.spawn({
-        cmd: [bunExe(), "build", "--compile", "./entry.ts", "--outfile", "app"],
-        env: bunEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [, buildStderr, buildExitCode] = await Promise.all([
-        build.stdout.text(),
-        build.stderr.text(),
-        build.exited,
-      ]);
-      expect(buildStderr).toBe("");
-      expect(buildExitCode).toBe(0);
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "--compile", "./entry.ts", "--outfile", "app"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExitCode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildStderr).toBe("");
+    expect(buildExitCode).toBe(0);
 
-      await using proc = Bun.spawn({
-        cmd: [path.join(String(dir), "app")],
-        env: bunEnv,
-        cwd: path.join(String(dir), deep),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stdout).toBe("from_dotenv\n");
-      expect(stderr).toBe("");
-      expect(exitCode).toBe(0);
-    },
-    // Same budget itBundled gives its compile cases: the link step dominates.
-    30_000,
-  );
+    await using proc = Bun.spawn({
+      cmd: [path.join(String(dir), "app")],
+      env: bunEnv,
+      cwd: path.join(String(dir), deep),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("from_dotenv\n");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 
   // Test that process environment variables take precedence over .env files
   itBundled("compile/AutoloadDotenvWithExistingEnv", {


### PR DESCRIPTION
### Problem
- A compiled executable reads the cwd and every ancestor directory in full at startup to find its default `.env` files. A 200,000 entry ancestor adds about 90 ms and 37 MB to `console.log("hello")` (1.4.0 and main).
- Cause: `run_env_loader` (`src/bundler/transpiler.rs:760`) calls `resolver.read_dir_info(cwd)`, which runs `readdir` from `/` down to the cwd. The listing is then used only as an existence check for four file names.
- The walk also gives up past 256 path components (`src/resolver/resolver.rs:4337`), which silently dropped `.env` there.

### Fix
- When `resolver.opts.load_tsconfig_json` is off, `run_env_loader` skips the walk and passes the new `OpenEachDefaultFile` probe to `Loader::load`, which then does at most four `openat` calls in the cwd. Only standalone executables turn this option off. `bun run` and `--compile-autoload-tsconfig` keep the walk: they need the cwd `tsconfig.json` from it.
- `load_env_file` no longer records a file that does not exist, and the `dotenv` analytics counter moves to where a file is read. Otherwise the direct probe would report four loaded files on every start.
- Correct because `load_env_file` already opened the files relative to the process cwd. The listing only decided whether to call it.
- Verified: `test/bundler/bundler_compile_autoload.test.ts` (2 new cases, both fail before the fix). Also the `.env` suites under `test/cli` and `bundler_compile.test.ts`.

### Background
- `run_env_loader` runs once per VM at startup. It loads the process environment, then the default `.env` files for the current `NODE_ENV`.
- `read_dir_info` is the resolver's directory cache. A miss reads the directory and every uncached ancestor, because module resolution later looks up the tree. A compiled program resolves from its embedded graph and normally never needs this.
- `DirEntryProbe` is how `bun_dotenv`, which sits below the resolver, asks whether a default file exists. `DirEntryKeys` answers from a listing. `OpenEachDefaultFile` answers yes, so the open call decides.
- `BUN_DEBUG_Fs=1` makes debug builds log each `readdir`. The first new test uses it (skipped on release builds). The second uses the 256 component limit (skipped on Windows, 260 character cwd limit).

<details><summary>Notes</summary>

Measurements on this machine with bun 1.4.0, `console.log(process.env.TEST_VAR || "not found")` compiled, cwd two levels below a directory with 200,000 files: 94 to 97 ms and 63 MB max RSS, against 5 to 6 ms and 26 MB from a small directory. `--no-compile-autoload-dotenv` removes every directory read. The report this fixes measured 2.4 s and 480 MB with a 2.6 M entry ancestor.

Debug build before the fix, `BUN_DEBUG_Fs=1`, cwd `/tmp/repro/P/sub/app`:

```
[fs] readdir(8[/], /) = 26
[fs] readdir(9[/tmp], /tmp/) = 6
[fs] readdir(10[/tmp/repro], /tmp/repro/) = 4
[fs] readdir(11[/tmp/repro/P], /tmp/repro/P/) = 1
[fs] readdir(12[/tmp/repro/P/sub], /tmp/repro/P/sub/) = 1
[fs] readdir(13[/tmp/repro/P/sub/app], /tmp/repro/P/sub/app/) = 1
from_dotenv
```

After the fix the same run prints only `from_dotenv`.

`load_tsconfig_json` defaults to true everywhere. Only `apply_standalone_runtime_flags` (`src/bun.js.rs`) sets it to false, for the main thread and for the workers of a compiled program, so workers take the direct path too (at most four `openat` calls per worker start). `bun test` and `bun build` therefore keep the walk as well. For `bun run` the walk in `run_env_loader` is a cache hit: `configure_linker()` already read the cwd for the entry point.

Behavior equivalence: the listing keys are lowercased basenames on every platform, so a name the listing matched but `openat` did not find was never loaded before either. On Windows a missing file maps to `ENOENT` through `ERROR_FILE_NOT_FOUND` (`src/errno/windows_errno.rs`). Precedence checked by hand with the fixed build: `.env.development.local` > `.env.local` > `.env.development` > `.env`, and the `.env.production` set with `NODE_ENV=production`. `compile/AutoloadTsconfigPathsEnabled` and the other tsconfig and package.json cases in the file pass unchanged.

Permissions, checked as an unprivileged user with a compiled debug build: a cwd that is searchable but not readable (mode 111) used to lose its `.env` silently and now loads it. A cwd that is not searchable fails every `openat` with `EACCES` and prints nothing, because the loader is quiet at the default log level. An unreadable `.env` file behaves as before.

Other callers of `Loader::load` (`bun install`, `bun pm`) build a `DirEntryKeys` from a listing they read anyway and are unchanged. A second `load()` on the same `Loader` can now retry a missing default file with one more `openat`. A file that was opened is still recorded and skipped.

Rebased onto #40711, which touched the same `openat` error arm in `load_env_file`. The merged arm keeps its `ENXIO` and `EOPNOTSUPP` (unix socket) cases and, like `ENOENT`, does not record them. Its `fstat` check and `O_NONBLOCK` also cover the direct probe: a compiled program with a directory or a FIFO named `.env` in the cwd prints nothing and does not hang (checked with a debug build). The resolver listing used to drop FIFOs before they were opened, so this is the same result by a different route.

Suites run: `bundler_compile_autoload.test.ts`, `cli/run/env.test.ts`, `cli/run/no-envfile.test.ts`, `bundler_compile.test.ts`, `cli/install/bun-lockb.test.ts`, the `.env` cases of `cli/install/bun-pm.test.ts`, and the byte-search, port-era, pre-port and dead-code source lints. `compile/HelloWorldWithProcessVersionsBun` in `bundler_compile.test.ts` fails on every debug build for an unrelated reason (it compares against a version string without the `-debug` suffix). Reported separately.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_compile_autoload.test.ts

<!-- robobun:evidence:end -->
