### PR TITLE
bundler: give each module its own __dirname and __filename binding

### DIFF
--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1136,10 +1136,7 @@ impl<'a> Parser<'a> {
         //    var __filename = "foo/bar/baz.js"
         //
         if p.options.bundle || !p.options.features.commonjs_at_runtime {
-            // Each bundled module declares its own `var __dirname`, so the refs become
-            // renamable once visiting (which needs them unbound for `define`) is done.
-            // Unused refs too: an unbound symbol reserves its name for the whole chunk.
-            // Direct eval pins names, so such a module keeps the unbound refs.
+            // Every bundled module declares these below, so after visiting they can be renamed.
             if p.options.bundle && !p.module_scope().contains_direct_eval {
                 for ref_ in [p.dirname_ref, p.filename_ref] {
                     p.symbols.as_mut_slice()[ref_.inner_index() as usize].kind =

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1136,14 +1136,6 @@ impl<'a> Parser<'a> {
         //    var __filename = "foo/bar/baz.js"
         //
         if p.options.bundle || !p.options.features.commonjs_at_runtime {
-            // Every bundled module declares these below, so after visiting they can be renamed.
-            if p.options.bundle && !p.module_scope().contains_direct_eval {
-                for ref_ in [p.dirname_ref, p.filename_ref] {
-                    p.symbols.as_mut_slice()[ref_.inner_index() as usize].kind =
-                        js_ast::symbol::Kind::Hoisted;
-                }
-            }
-
             if uses_dirname || uses_filename {
                 let count = (uses_dirname as usize) + (uses_filename as usize);
                 let mut declared_symbols =
@@ -1218,6 +1210,19 @@ impl<'a> Parser<'a> {
                 });
                 uses_dirname = false;
                 uses_filename = false;
+            }
+
+            // Renamable per module, unused refs too: an unbound name stays reserved chunk-wide.
+            if p.options.bundle && !p.module_scope().contains_direct_eval {
+                for (ref_, needs_binding) in [
+                    (p.dirname_ref, uses_dirname),
+                    (p.filename_ref, uses_filename),
+                ] {
+                    if !needs_binding {
+                        p.symbols.as_mut_slice()[ref_.inner_index() as usize].kind =
+                            js_ast::symbol::Kind::Hoisted;
+                    }
+                }
             }
         }
 

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1136,15 +1136,10 @@ impl<'a> Parser<'a> {
         //    var __filename = "foo/bar/baz.js"
         //
         if p.options.bundle || !p.options.features.commonjs_at_runtime {
-            // The refs are unbound during the visit pass so `define` and friends treat
-            // them as globals, and the renamer never renames an unbound symbol. In a
-            // bundle every module declares its own `var __dirname`, and unwrapped
-            // modules share the chunk's top-level scope, so the declarations have to be
-            // ordinary `var` bindings for the renamer to give each module its own name.
-            // This also applies to modules that do not use them: an unbound symbol
-            // reserves its name in the whole chunk even when nothing references it.
-            // A module with a direct `eval()` keeps the fixed names so that
-            // `eval("__dirname")` still resolves.
+            // Each bundled module declares its own `var __dirname`, so the refs become
+            // renamable once visiting (which needs them unbound for `define`) is done.
+            // Unused refs too: an unbound symbol reserves its name for the whole chunk.
+            // Direct eval pins names, so such a module keeps the unbound refs.
             if p.options.bundle && !p.module_scope().contains_direct_eval {
                 for ref_ in [p.dirname_ref, p.filename_ref] {
                     p.symbols.as_mut_slice()[ref_.inner_index() as usize].kind =

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1214,14 +1214,9 @@ impl<'a> Parser<'a> {
 
             // Renamable per module, unused refs too: an unbound name stays reserved chunk-wide.
             if p.options.bundle && !p.module_scope().contains_direct_eval {
-                for (ref_, needs_binding) in [
-                    (p.dirname_ref, uses_dirname),
-                    (p.filename_ref, uses_filename),
-                ] {
-                    if !needs_binding {
-                        p.symbols.as_mut_slice()[ref_.inner_index() as usize].kind =
-                            js_ast::symbol::Kind::Hoisted;
-                    }
+                for ref_ in [p.dirname_ref, p.filename_ref] {
+                    p.symbols.as_mut_slice()[ref_.inner_index() as usize].kind =
+                        js_ast::symbol::Kind::Hoisted;
                 }
             }
         }

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1136,6 +1136,22 @@ impl<'a> Parser<'a> {
         //    var __filename = "foo/bar/baz.js"
         //
         if p.options.bundle || !p.options.features.commonjs_at_runtime {
+            // The refs are unbound during the visit pass so `define` and friends treat
+            // them as globals, and the renamer never renames an unbound symbol. In a
+            // bundle every module declares its own `var __dirname`, and unwrapped
+            // modules share the chunk's top-level scope, so the declarations have to be
+            // ordinary `var` bindings for the renamer to give each module its own name.
+            // This also applies to modules that do not use them: an unbound symbol
+            // reserves its name in the whole chunk even when nothing references it.
+            // A module with a direct `eval()` keeps the fixed names so that
+            // `eval("__dirname")` still resolves.
+            if p.options.bundle && !p.module_scope().contains_direct_eval {
+                for ref_ in [p.dirname_ref, p.filename_ref] {
+                    p.symbols.as_mut_slice()[ref_.inner_index() as usize].kind =
+                        js_ast::symbol::Kind::Hoisted;
+                }
+            }
+
             if uses_dirname || uses_filename {
                 let count = (uses_dirname as usize) + (uses_filename as usize);
                 let mut declared_symbols =

--- a/src/js_printer/renamer.rs
+++ b/src/js_printer/renamer.rs
@@ -1058,7 +1058,14 @@ pub fn compute_initial_reserved_names(
 
     const EXTRAS: [&[u8]; 2] = [b"Promise", b"Require"];
 
-    const CJS_NAMES: [&[u8]; 2] = [b"exports", b"module"];
+    // The wrapper's parameters: a top-level class with one of these names is a syntax error.
+    const CJS_NAMES: [&[u8]; 5] = [
+        b"exports",
+        b"require",
+        b"module",
+        b"__filename",
+        b"__dirname",
+    ];
 
     let cjs_names_len: u32 = if output_format == Format::Cjs {
         CJS_NAMES.len() as u32

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3245,12 +3245,14 @@ describe("bundler", () => {
         import * as a from "./a/a";
         import * as b from "./b/b";
         import c from "./c/c.cjs";
+        import { d } from "./d/d";
         ${dirnameEntryPrelude}
         console.log(JSON.stringify({
           entry: [rel(__dirname), rel(__filename)],
           a: [rel(a.dir()), rel(a.file())],
           b: [rel(b.dir()), rel(b.file())],
           c: [rel(c.dir()), rel(c.file())],
+          d: d(),
         }));
       `,
       "/a/a.ts": dirnameModule,
@@ -3258,6 +3260,15 @@ describe("bundler", () => {
       "/c/c.cjs": /* js */ `
         module.exports = { dir: () => __dirname, file: () => __filename };
       `,
+      "/d/d.ts": /* ts */ `
+        export function d() { return "d"; }
+      `,
+    },
+    onAfterBundle(api) {
+      // A module that does not use the names (d.ts) must not reserve them: the first
+      // module that uses them keeps the plain names.
+      api.expectFile("/out.js").toContain('var __dirname = "');
+      api.expectFile("/out.js").toContain('__filename = "');
     },
     run: {
       stdout: JSON.stringify({
@@ -3265,6 +3276,7 @@ describe("bundler", () => {
         a: ["/a", "/a/a.ts"],
         b: ["/b", "/b/b.ts"],
         c: ["/c", "/c/c.cjs"],
+        d: "d",
       }),
     },
   });

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3321,28 +3321,38 @@ describe("bundler", () => {
       }),
     },
   });
+  // In CommonJS output the names are reserved, so the injected declarations do not shadow
+  // the __dirname parameter of the wrapper. A module that only reaches the name through
+  // eval() therefore sees the directory of the output file (out/).
   itBundled("edgecase/DirnameFilenamePerModuleCJSFormat", {
     files: {
       "/entry.ts": /* ts */ `
         import * as a from "./a/a";
         import * as b from "./b/b";
+        import { viaEval } from "./e/e";
         ${dirnameEntryPrelude}
         console.log(JSON.stringify({
           entry: [rel(__dirname), rel(__filename)],
           a: [rel(a.dir()), rel(a.file())],
           b: [rel(b.dir()), rel(b.file())],
+          wrapper: rel(viaEval()),
         }));
       `,
       "/a/a.ts": dirnameModule,
       "/b/b.ts": dirnameModule,
+      "/e/e.ts": /* ts */ `
+        export function viaEval() { return eval("__dirname"); }
+      `,
     },
     target: "bun",
     format: "cjs",
+    outdir: "/out",
     run: {
       stdout: JSON.stringify({
         entry: ["", "/entry.ts"],
         a: ["/a", "/a/a.ts"],
         b: ["/b", "/b/b.ts"],
+        wrapper: "/out",
       }),
     },
   });

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3269,6 +3269,9 @@ describe("bundler", () => {
       // module that uses them keeps the plain names.
       api.expectFile("/out.js").toContain('var __dirname = "');
       api.expectFile("/out.js").toContain('__filename = "');
+      // The CJS module keeps its own declaration inside its closure. Only the suffix
+      // of the name depends on the other modules of the chunk.
+      api.expectFile("/out.js").toMatch(/var __dirname\d* = "[^"]*c", __filename\d* = "[^"]*c\.cjs";/);
     },
     run: {
       stdout: JSON.stringify({
@@ -3277,6 +3280,44 @@ describe("bundler", () => {
         b: ["/b", "/b/b.ts"],
         c: ["/c", "/c/c.cjs"],
         d: "d",
+      }),
+    },
+  });
+  // require() of an ES module wraps it in an __esm() closure and the linker hoists the
+  // injected declarations out of that closure, so they also need their own names there.
+  // On main, even a read at the top level of such a module saw the wrong value.
+  itBundled("edgecase/DirnameFilenamePerModuleEsmWrapper", {
+    files: {
+      "/entry.ts": /* ts */ `
+        const a = require("./a/a");
+        const b = require("./b/b");
+        ${dirnameEntryPrelude}
+        console.log(JSON.stringify({
+          entry: [rel(__dirname), rel(__filename)],
+          a: [rel(a.topDir), rel(a.topFile), rel(a.dir()), rel(a.file())],
+          b: [rel(b.topDir), rel(b.topFile), rel(b.dir()), rel(b.file())],
+        }));
+      `,
+      "/a/a.ts": /* ts */ `
+        export const topDir = __dirname;
+        export const topFile = __filename;
+        ${dirnameModule}
+      `,
+      "/b/b.ts": /* ts */ `
+        export const topDir = __dirname;
+        export const topFile = __filename;
+        ${dirnameModule}
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("__esm(");
+    },
+    run: {
+      stdout: JSON.stringify({
+        entry: ["", "/entry.ts"],
+        a: ["/a", "/a/a.ts", "/a", "/a/a.ts"],
+        b: ["/b", "/b/b.ts", "/b", "/b/b.ts"],
       }),
     },
   });
@@ -3302,6 +3343,36 @@ describe("bundler", () => {
         entry: ["", "/entry.ts"],
         a: ["/a", "/a/a.ts"],
         b: ["/b", "/b/b.ts"],
+      }),
+    },
+  });
+  // CommonJS output runs inside a function whose parameters are named exports, require,
+  // module, __filename and __dirname. A top-level class with one of these names has to be
+  // renamed, or the output is a syntax error. On main the bundler's own unbound symbols
+  // reserved the names by accident, so this guards the explicit reservation.
+  itBundled("edgecase/DirnameFilenameUserClassCJSFormat", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import { __dirname as Dir, __filename as File } from "./names/names";
+        import * as a from "./a/a";
+        ${dirnameEntryPrelude}
+        console.log(JSON.stringify({
+          classes: [Dir.tag, File.tag],
+          a: [rel(a.dir()), rel(a.file())],
+        }));
+      `,
+      "/names/names.ts": /* ts */ `
+        export class __dirname { static tag = "dir class"; }
+        export class __filename { static tag = "file class"; }
+      `,
+      "/a/a.ts": dirnameModule,
+    },
+    target: "bun",
+    format: "cjs",
+    run: {
+      stdout: JSON.stringify({
+        classes: ["dir class", "file class"],
+        a: ["/a", "/a/a.ts"],
       }),
     },
   });

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3223,6 +3223,249 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("var arguments = 1;");
     },
   });
+
+  // The bundler inlines `var __dirname = "..."` / `var __filename = "..."` into every
+  // module that uses them. Modules that are not wrapped in a closure share the chunk's
+  // top-level scope, so each module needs its own binding or the last module printed
+  // overwrites the value for all of them. The modules below read the values inside
+  // functions that the entry point calls after every module has been evaluated, which
+  // is when the collision is observable. The entry point prints every path relative to
+  // its own directory so the expected output is the same on every platform.
+  const dirnameModule = /* ts */ `
+    export function dir() { return __dirname; }
+    export function file() { return __filename; }
+  `;
+  const dirnameEntryPrelude = /* ts */ `
+    const base = __dirname;
+    const rel = (p: string) => p.slice(base.length).replaceAll("\\\\", "/");
+  `;
+  itBundled("edgecase/DirnameFilenamePerModule", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import * as a from "./a/a";
+        import * as b from "./b/b";
+        import c from "./c/c.cjs";
+        ${dirnameEntryPrelude}
+        console.log(JSON.stringify({
+          entry: [rel(__dirname), rel(__filename)],
+          a: [rel(a.dir()), rel(a.file())],
+          b: [rel(b.dir()), rel(b.file())],
+          c: [rel(c.dir()), rel(c.file())],
+        }));
+      `,
+      "/a/a.ts": dirnameModule,
+      "/b/b.ts": dirnameModule,
+      "/c/c.cjs": /* js */ `
+        module.exports = { dir: () => __dirname, file: () => __filename };
+      `,
+    },
+    run: {
+      stdout: JSON.stringify({
+        entry: ["", "/entry.ts"],
+        a: ["/a", "/a/a.ts"],
+        b: ["/b", "/b/b.ts"],
+        c: ["/c", "/c/c.cjs"],
+      }),
+    },
+  });
+  itBundled("edgecase/DirnameFilenamePerModuleCJSFormat", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import * as a from "./a/a";
+        import * as b from "./b/b";
+        ${dirnameEntryPrelude}
+        console.log(JSON.stringify({
+          entry: [rel(__dirname), rel(__filename)],
+          a: [rel(a.dir()), rel(a.file())],
+          b: [rel(b.dir()), rel(b.file())],
+        }));
+      `,
+      "/a/a.ts": dirnameModule,
+      "/b/b.ts": dirnameModule,
+    },
+    target: "bun",
+    format: "cjs",
+    run: {
+      stdout: JSON.stringify({
+        entry: ["", "/entry.ts"],
+        a: ["/a", "/a/a.ts"],
+        b: ["/b", "/b/b.ts"],
+      }),
+    },
+  });
+  itBundled("edgecase/DirnameFilenamePerModuleMinifyIdentifiers", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import * as a from "./a/a";
+        import * as b from "./b/b";
+        ${dirnameEntryPrelude}
+        console.log(JSON.stringify({
+          entry: [rel(__dirname), rel(__filename)],
+          a: [rel(a.dir()), rel(a.file())],
+          b: [rel(b.dir()), rel(b.file())],
+        }));
+      `,
+      "/a/a.ts": dirnameModule,
+      "/b/b.ts": dirnameModule,
+    },
+    target: "bun",
+    minifyIdentifiers: true,
+    run: {
+      stdout: JSON.stringify({
+        entry: ["", "/entry.ts"],
+        a: ["/a", "/a/a.ts"],
+        b: ["/b", "/b/b.ts"],
+      }),
+    },
+  });
+  // A module with a direct eval() keeps the literal names `__dirname` / `__filename`
+  // so that the eval'd code can still see them. The other modules are renamed around it.
+  itBundled("edgecase/DirnameFilenamePerModuleDirectEval", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import * as a from "./a/a";
+        import * as e from "./e/e";
+        import f from "./f/f.cjs";
+        ${dirnameEntryPrelude}
+        console.log(JSON.stringify({
+          entry: [rel(__dirname), rel(__filename)],
+          a: [rel(a.dir()), rel(a.file())],
+          e: [rel(e.dir()), rel(e.file())],
+          eEval: [rel(e.evalDir()), rel(e.evalFile())],
+          f: [rel(f.dir()), rel(f.file())],
+          fEval: [rel(f.evalDir()), rel(f.evalFile())],
+        }));
+      `,
+      "/a/a.ts": dirnameModule,
+      "/e/e.ts": /* ts */ `
+        ${dirnameModule}
+        export function evalDir() { return eval("__dirname"); }
+        export function evalFile() { return eval("__filename"); }
+      `,
+      "/f/f.cjs": /* js */ `
+        exports.dir = () => __dirname;
+        exports.file = () => __filename;
+        exports.evalDir = () => eval("__dirname");
+        exports.evalFile = () => eval("__filename");
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: JSON.stringify({
+        entry: ["", "/entry.ts"],
+        a: ["/a", "/a/a.ts"],
+        e: ["/e", "/e/e.ts"],
+        eEval: ["/e", "/e/e.ts"],
+        f: ["/f", "/f/f.cjs"],
+        fEval: ["/f", "/f/f.cjs"],
+      }),
+    },
+  });
+  // A module that declares its own `__dirname` must not be confused with the ones the
+  // bundler injects into the other modules of the same chunk.
+  itBundled("edgecase/DirnameFilenamePerModuleUserDeclared", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import * as a from "./a/a";
+        import * as u from "./u/u";
+        ${dirnameEntryPrelude}
+        console.log(JSON.stringify({
+          entry: [rel(__dirname), rel(__filename)],
+          a: [rel(a.dir()), rel(a.file())],
+          u: [u.dir(), u.file()],
+        }));
+      `,
+      "/a/a.ts": dirnameModule,
+      "/u/u.ts": /* ts */ `
+        const __dirname = "user-dir";
+        const __filename = "user-file";
+        export function dir() { return __dirname; }
+        export function file() { return __filename; }
+      `,
+    },
+    target: "bun",
+    run: {
+      stdout: JSON.stringify({
+        entry: ["", "/entry.ts"],
+        a: ["/a", "/a/a.ts"],
+        u: ["user-dir", "user-file"],
+      }),
+    },
+  });
+  itBundled("edgecase/DirnameFilenamePerModuleSplitting", {
+    files: {
+      "/entry1.ts": /* ts */ `
+        import * as a from "./a/a";
+        import * as shared from "./shared/shared";
+        ${dirnameEntryPrelude}
+        console.log(JSON.stringify({
+          entry: [rel(__dirname), rel(__filename)],
+          a: [rel(a.dir()), rel(a.file())],
+          shared: [rel(shared.dir()), rel(shared.file())],
+        }));
+      `,
+      "/entry2.ts": /* ts */ `
+        import * as b from "./b/b";
+        import * as shared from "./shared/shared";
+        ${dirnameEntryPrelude}
+        console.log(JSON.stringify({
+          entry: [rel(__dirname), rel(__filename)],
+          b: [rel(b.dir()), rel(b.file())],
+          shared: [rel(shared.dir()), rel(shared.file())],
+        }));
+      `,
+      "/a/a.ts": dirnameModule,
+      "/b/b.ts": dirnameModule,
+      "/shared/shared.ts": dirnameModule,
+    },
+    entryPoints: ["/entry1.ts", "/entry2.ts"],
+    outdir: "/out",
+    splitting: true,
+    target: "bun",
+    run: [
+      {
+        file: "/out/entry1.js",
+        stdout: JSON.stringify({
+          entry: ["", "/entry1.ts"],
+          a: ["/a", "/a/a.ts"],
+          shared: ["/shared", "/shared/shared.ts"],
+        }),
+      },
+      {
+        file: "/out/entry2.js",
+        stdout: JSON.stringify({
+          entry: ["", "/entry2.ts"],
+          b: ["/b", "/b/b.ts"],
+          shared: ["/shared", "/shared/shared.ts"],
+        }),
+      },
+    ],
+  });
+  // `define` replaces the identifiers during the visit pass, so nothing is injected.
+  itBundled("edgecase/DirnameFilenameDefine", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import * as a from "./a/a";
+        console.log(JSON.stringify({ entry: [__dirname, __filename], a: [a.dir(), a.file()] }));
+      `,
+      "/a/a.ts": dirnameModule,
+    },
+    target: "bun",
+    define: {
+      __dirname: '"/defined"',
+      __filename: '"/defined/entry.js"',
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__dirname");
+      api.expectFile("/out.js").not.toContain("__filename");
+    },
+    run: {
+      stdout: JSON.stringify({
+        entry: ["/defined", "/defined/entry.js"],
+        a: ["/defined", "/defined/entry.js"],
+      }),
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -3374,12 +3374,14 @@ describe("bundler", () => {
     },
   });
   // A module that declares its own `__dirname` must not be confused with the ones the
-  // bundler injects into the other modules of the same chunk.
+  // bundler injects into the other modules of the same chunk. The bundler's unused
+  // symbol for that module must not reserve the name either: u.ts comes first in the
+  // chunk, so its own declarations keep the plain names.
   itBundled("edgecase/DirnameFilenamePerModuleUserDeclared", {
     files: {
       "/entry.ts": /* ts */ `
-        import * as a from "./a/a";
         import * as u from "./u/u";
+        import * as a from "./a/a";
         ${dirnameEntryPrelude}
         console.log(JSON.stringify({
           entry: [rel(__dirname), rel(__filename)],
@@ -3396,11 +3398,57 @@ describe("bundler", () => {
       `,
     },
     target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain('var __dirname = "user-dir"');
+      api.expectFile("/out.js").toContain('var __filename = "user-file"');
+    },
     run: {
       stdout: JSON.stringify({
         entry: ["", "/entry.ts"],
         a: ["/a", "/a/a.ts"],
         u: ["user-dir", "user-file"],
+      }),
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/15996: the same for a module that exports its
+  // own `__dirname` and `__filename`. Nothing else in the bundle uses the names, so they
+  // must not be renamed.
+  itBundled("edgecase/DirnameFilenameUserExported", {
+    files: {
+      "/entry.ts": /* ts */ `
+        export const __filename = "user-file";
+        export const __dirname = "user-dir";
+        console.log(__dirname, __filename);
+      `,
+    },
+    target: "bun",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__dirname2");
+      api.expectFile("/out.js").not.toContain("__filename2");
+    },
+    run: { stdout: "user-dir user-file" },
+  });
+  itBundled("edgecase/DirnameFilenamePerModuleCompile", {
+    compile: true,
+    files: {
+      "/entry.ts": /* ts */ `
+        import * as a from "./a/a";
+        import * as b from "./b/b";
+        ${dirnameEntryPrelude}
+        console.log(JSON.stringify({
+          entry: [rel(__dirname), rel(__filename)],
+          a: [rel(a.dir()), rel(a.file())],
+          b: [rel(b.dir()), rel(b.file())],
+        }));
+      `,
+      "/a/a.ts": dirnameModule,
+      "/b/b.ts": dirnameModule,
+    },
+    run: {
+      stdout: JSON.stringify({
+        entry: ["", "/entry.ts"],
+        a: ["/a", "/a/a.ts"],
+        b: ["/b", "/b/b.ts"],
       }),
     },
   });


### PR DESCRIPTION
### Problem
- A bundle injects `var __dirname = "<source dir>"` into each module that uses it (same for `__filename`). Unwrapped modules share one scope, so every declaration prints as `__dirname` and the last one, the entry point, wins (#17188).
- Cause: `src/js_parser/p.rs:2743` declares both refs `Kind::Unbound`, and the renamer never renames an unbound symbol (`src/js_printer/renamer.rs:540`).

### Fix
- When bundling, `parse_entry.rs` changes both refs to `Kind::Hoisted` after it has injected the declarations, so the renamer numbers them per module. Unbound only matters during the visit pass (`define`, `visit_expr.rs:261`), which is over. A module with a direct `eval()` keeps them unbound, so `eval("__dirname")` still resolves.
- The unbound refs also reserved the names in every chunk, which hid that a top-level `class __dirname {}` collides with the cjs wrapper parameter. `compute_initial_reserved_names` now reserves all five parameter names for cjs output.
- The values do not change. The review of #17222 said: "This collision is intentional and important for making things like `.node` addons bundle successfully ... we need to add an option". Addons are CJS, and a CJS-wrapped module already had its own value on main (only the spelling of its declaration can change). Unwrapped modules only ever got the entry point's directory. `--define __dirname=...` still gives one uniform value. @Jarred-Sumner, please confirm that no option is needed.
- Verified: `test/bundler/bundler_edgecase.test.ts`, 11 new tests, 10 fail on main. Other suites in the notes.

### Background
- `Kind::Unbound`: a symbol that the file does not declare. `Kind::Hoisted`: a `var` binding.
- `rename_symbols_in_chunk` names a chunk's top-level symbols in one scope. Unbound names are reserved chunk-wide, used or not. A hoisted symbol gets its name, or the name plus a number.
- cjs output is the body of a function whose parameters are `exports, require, module, __filename, __dirname`. A `var` may repeat a parameter name, a class may not.

Fixes #17188

<details><summary>Notes</summary>

Output of the repro from #17188 (`sub/b.ts` exports a function that returns `__dirname`, `index.ts` imports it) with this change:

```js
// sub/b.ts
var __dirname = "/tmp/p/sub";
function subDir() {
  return __dirname;
}

// index.ts
var __dirname2 = "/tmp/p";
console.log("index:", __dirname2);
console.log("sub:", subDir());
```

With `--minify-identifiers` the two declarations become `var r = ...` and `var n = ...`. With `require()` of an ES module, or `import()` without splitting, the module goes into an `__esm` closure and the linker hoists the declaration out of it, so on main even a top-level `export const dir = __dirname` in such a module got the wrong value (`DirnameFilenamePerModuleEsmWrapper`). In `--format=internal_bake_dev` output each module is already in its own closure, so the rename there is cosmetic. `--compile` uses the same linker path (`DirnameFilenamePerModuleCompile`).

CJS-wrapped modules: the declaration inside a `__commonJS` closure keeps its value. Its name is still `__dirname` unless an unwrapped module earlier in the chunk took that name, then it is `__dirname2` and so on, and under `--minify-identifiers` it is minified like the other locals. `DirnameFilenamePerModule` pins the closure shape with a regex.

cjs output: with the five names reserved, the injected declarations print as `__dirname2`, `__dirname3`, ... and no longer shadow the wrapper's own `__dirname`. The values are unchanged. One visible consequence: a module that only reaches `__dirname` through `eval()` now sees the wrapper's value (the directory of the bundle) instead of the build-time path of whichever module was printed last. `DirnameFilenamePerModuleCJSFormat` pins this with an output directory that differs from the source directory. `require` was already reserved through the unbound `require` symbol of every module. It is in the list so that the list is the parameter list. The pre-existing `"Require"` entry in `EXTRAS` is left alone.

Output that changes for a single module: only a module that declares its own top-level `__dirname` or `__filename` in esm output. On main the bundler's unused unbound symbol reserved the name and the user's binding printed as `__dirname2` (the rename part of #15996). Now it keeps its name. `DirnameFilenameUserExported` pins the single-module shape and `DirnameFilenamePerModuleUserDeclared` pins it next to injected declarations. A module that does not declare its own prints what it printed before, because the first hoisted symbol gets the plain name (`DirnameFilenamePerModule` has a module that does not use the names and checks this). The const to var part of #15996 is unrelated and stays open.

Direct eval: bun does not pin module-scope names for direct eval today (the module scope pop is commented out in `parse_entry.rs`, #35955 adds it for CommonJS files), so keeping these two symbols unbound is a per-symbol stand-in for that rule. Probe: with the `contains_direct_eval` exclusion removed, `DirnameFilenamePerModuleDirectEval` fails, because `eval("__dirname")` in the ESM module and in the CJS module both returned the directory of module `a`, which took the plain name. With the exclusion the eval module keeps `__dirname` and the other modules get `__dirname2` and `__dirname3`. Two eval modules in one unwrapped chunk still collide with each other, as on main.

Why the kind change is unconditional: in this block bundling declares every used ref, so each ref is either declared here or unused. A per-ref guard on the use flags was tried (9a6e8f0) and removed again (375e544), because both flags are always false at that point. A later change that makes a bundled ref refer to an outer binding instead (a wrapper parameter, as #29066 and #35470 explore) has to leave that ref unbound. #17222 fixed the same bug in the Zig parser with hashed names and was closed today in favor of this PR. #29066, #35651 and #35955 change the same block or the same symbols for other bugs and need a rebase over this.

`declare_common_js_symbol` (`p.rs:4321`) creates both refs in every file before the visit pass. Visit-pass uses of the unbound kind that stay intact: `define` substitution (`visit_expr.rs:261`), the "is not declared in this file" export check (`visit_stmt.rs:197`), and the side-effect analysis of a bare reference. The linker reads the kind in two places. `compute_reserved_names_for_scope` is the one this change is about. `computeCrossChunkDependencies.rs:207` now sees a declared symbol, but it is declared and used in the same file, so no cross-chunk import is created (`DirnameFilenamePerModuleSplitting`).

Whether to inline a build-time path at all (#4216, #29066, #35470) is a separate question that this change does not touch. `DirnameFilenameDefine` pins that `--define` still replaces every reference with one value.

Unchanged paths: the kind change is gated on `options.bundle`. The runtime CommonJS wrapper parameters (`WrapMode::BunCommonjs` in `p.rs`), the runtime `var __dirname = import.meta.dir` injection and `bun build --no-bundle` (with and without `--minify-identifiers --format=cjs`) produce byte-identical output before and after. The non-bundle printer also calls `compute_initial_reserved_names`, but there the refs are still unbound and so were already reserved.

Most tests read the values inside functions that the entry point calls after every module has run, which is where unwrapped modules show the collision. The `__esm` test also reads them at the top level.

Suites run with the debug build: `bundler_edgecase`, `bundler_cjs`, `bundler_cjs2esm`, `bundler_bun`, `bundler_minify`, `bundler_splitting`, `bundler_regressions`, `bundler_banner`, `bundler_footer`, the bytecode and cjs tests of `bundler_compile`, `esbuild/default`, `bun-build-api`, the `__dirname` test in `cli.test.ts`, `bake/dev/esm`, `test/js/node/module/node-module-module.test.js`. All pass.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->