### PR TITLE
bundler: pass the real import.meta to cjs output for the bun target

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -201,6 +201,11 @@ pub struct Super;
 #[derive(Clone, Copy, Default)]
 pub struct ImportMeta;
 
+impl ImportMeta {
+    /// Sixth parameter of the CommonJS wrapper. JSCommonJSModule.cpp passes `import.meta` for it.
+    pub const CJS_WRAPPER_ARG: &'static [u8] = b"$Bun_import_meta";
+}
+
 #[derive(Clone, Copy, Default)]
 pub struct ImportMetaMain {
     /// If true, print `!import.meta.main` (or `require.main != module`).

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -2313,6 +2313,12 @@ impl<'a> LinkerContext<'a> {
         Ok(true)
     }
 
+    /// The one place that decides whether a chunk gets the `@bun-cjs` function wrapper.
+    pub(crate) fn chunk_has_bun_cjs_wrapper(&self, chunk: &Chunk) -> bool {
+        self.options.output_format == Format::Cjs
+            && self.graph.ast.items_target()[chunk.entry_point.source_index() as usize].is_bun()
+    }
+
     pub(crate) fn print_code_for_file_in_chunk_js(
         &mut self,
         r: renamer::Renamer,
@@ -2324,6 +2330,7 @@ impl<'a> LinkerContext<'a> {
         to_esm_ref: Ref,
         to_commonjs_ref: Ref,
         runtime_require_ref: Option<Ref>,
+        inside_bun_cjs_wrapper: bool,
         source_index: Index,
         source: &Source,
         module_info: Option<&mut crate::analyze_transpiled_module::ModuleInfo>,
@@ -2403,6 +2410,7 @@ impl<'a> LinkerContext<'a> {
                 Format::Cjs => None, // use unbounded global
                 _ => runtime_require_ref,
             },
+            inside_bun_cjs_wrapper,
             require_or_import_meta_for_source_callback:
                 js_printer::RequireOrImportMetaCallback::init(self),
             line_offset_tables: Some(line_offset_table),

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2639,6 +2639,10 @@ pub mod parse_worker {
             opts.lower_import_meta_main_for_node_js = true;
         }
 
+        // For bun, cjs output gets import.meta from the `@bun-cjs` wrapper instead.
+        opts.inline_import_meta_paths = topts.framework.is_some()
+            || (output_format == options::Format::Cjs && !target.is_bun());
+
         opts.tree_shaking = if task.source_index.is_runtime() {
             true
         } else {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7766,10 +7766,9 @@ pub mod bv2_impl {
         fn default() -> Self {
             CompileResult::Javascript {
                 source_index: 0,
-                result: bun_js_printer::PrintResult::Result(bun_js_printer::PrintResultSuccess {
-                    code: Box::new([]),
-                    source_map: None,
-                }),
+                result: bun_js_printer::PrintResult::Result(
+                    bun_js_printer::PrintResultSuccess::default(),
+                ),
                 module_info: None,
             }
         }

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -31,6 +31,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     to_common_js_ref: Ref,
     to_esm_ref: Ref,
     runtime_require_ref: Option<Ref>,
+    inside_bun_cjs_wrapper: bool,
     stmts: &mut StmtList,
     arena: &Bump,
     temp_arena: &Bump,
@@ -226,6 +227,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 Ref::NONE,
                 Ref::NONE,
                 None,
+                false,
                 part_range.source_index,
                 source,
                 module_info,
@@ -967,10 +969,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     let out_stmts: &mut [Stmt] = out_stmts.slice_mut();
 
     if out_stmts.is_empty() {
-        return PrintResult::Result(PrintResultSuccess {
-            code: Box::new([]),
-            source_map: None,
-        });
+        return PrintResult::Result(PrintResultSuccess::default());
     }
 
     // `get_source` returns `&'static Source` (parse_graph SoA is append-only and
@@ -987,6 +986,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         to_esm_ref,
         to_common_js_ref,
         runtime_require_ref,
+        inside_bun_cjs_wrapper,
         part_range.source_index,
         source,
         module_info,

--- a/src/bundler/linker_context/generateCompileResultForJSChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForJSChunk.rs
@@ -121,6 +121,7 @@ fn generate_compile_result_for_js_chunk_impl(
                 .follow(runtime_members.get(b"__require".as_slice()).unwrap().ref_),
         )
     };
+    let inside_bun_cjs_wrapper = c.chunk_has_bun_cjs_wrapper(chunk);
 
     // `worker.arena` (= `BackRef` to `worker.heap`) is a disjoint field from
     // `worker.temporary_arena` / `worker.stmt_list` borrowed `&mut` above, so
@@ -149,6 +150,7 @@ fn generate_compile_result_for_js_chunk_impl(
         to_common_js_ref,
         to_esm_ref,
         runtime_require_ref,
+        inside_bun_cjs_wrapper,
         stmt_list,
         worker_alloc,
         &**arena,

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -99,6 +99,18 @@ fn module_preload_registration(
     Ok(code)
 }
 
+fn chunk_uses_import_meta_arg(chunk: &Chunk) -> bool {
+    chunk.compile_results_for_chunk.iter().any(|result| {
+        matches!(
+            result,
+            CompileResult::Javascript {
+                result: PrintResult::Result(printed),
+                ..
+            } if printed.uses_import_meta_arg
+        )
+    })
+}
+
 /// This runs after we've already populated the compile results
 pub(crate) fn post_process_js_chunk(
     ctx: GenerateChunkCtx,
@@ -361,10 +373,7 @@ pub(crate) fn post_process_js_chunk(
 
         break 'brk CompileResult::Javascript {
             source_index: Index::INVALID.value(),
-            result: PrintResult::Result(js_printer::PrintResultSuccess {
-                code: Box::default(),
-                source_map: None,
-            }),
+            result: PrintResult::Result(js_printer::PrintResultSuccess::default()),
             module_info: None,
         };
     };
@@ -441,20 +450,27 @@ pub(crate) fn post_process_js_chunk(
 
     // Add @bun comments and CJS wrapper start for each chunk when targeting Bun.
     let is_bun = c.graph.ast.items_target()[chunk.entry_point.source_index() as usize].is_bun();
-    if is_bun {
-        if c.options.generate_bytecode_cache && output_format == options::OutputFormat::Cjs {
-            const INPUT: &[u8] =
-                b"// @bun @bytecode @bun-cjs\n(function(exports, require, module, __filename, __dirname) {";
-            j.push_static(INPUT);
-            line_offset.advance(INPUT);
-        } else if c.options.generate_bytecode_cache {
+    let has_bun_cjs_wrapper = c.chunk_has_bun_cjs_wrapper(chunk);
+    if has_bun_cjs_wrapper {
+        let mut push = |bytes: &'static [u8]| {
+            j.push_static(bytes);
+            line_offset.advance(bytes);
+        };
+        push(if c.options.generate_bytecode_cache {
+            b"// @bun @bytecode @bun-cjs\n"
+        } else {
+            b"// @bun @bun-cjs\n"
+        });
+        push(b"(function(exports, require, module, __filename, __dirname");
+        if chunk_uses_import_meta_arg(chunk) {
+            push(b", ");
+            push(E::ImportMeta::CJS_WRAPPER_ARG);
+        }
+        push(b") {");
+    } else if is_bun {
+        if c.options.generate_bytecode_cache {
             j.push_static(b"// @bun @bytecode\n");
             line_offset.advance(b"// @bun @bytecode\n");
-        } else if output_format == options::OutputFormat::Cjs {
-            const INPUT: &[u8] =
-                b"// @bun @bun-cjs\n(function(exports, require, module, __filename, __dirname) {";
-            j.push_static(INPUT);
-            line_offset.advance(INPUT);
         } else {
             j.push_static(b"// @bun\n");
             line_offset.advance(b"// @bun\n");
@@ -749,7 +765,7 @@ pub(crate) fn post_process_js_chunk(
             }
         }
         options::OutputFormat::Cjs => {
-            if is_bun {
+            if has_bun_cjs_wrapper {
                 j.push_static(b"})\n");
                 line_offset.advance(b"})\n");
             }
@@ -1260,10 +1276,7 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
     if stmts.is_empty() {
         return CompileResult::Javascript {
             source_index,
-            result: PrintResult::Result(js_printer::PrintResultSuccess {
-                code: Box::default(),
-                source_map: None,
-            }),
+            result: PrintResult::Result(js_printer::PrintResultSuccess::default()),
             module_info: None,
         };
     }

--- a/src/bundler/linker_context/renameSymbolsInChunk.rs
+++ b/src/bundler/linker_context/renameSymbolsInChunk.rs
@@ -59,6 +59,7 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
     // borrow does not assert immutability over the heap cells written below.
     // SAFETY: see fn safety doc — `c` is live for the call.
     let c: &LinkerContext<'_> = unsafe { &*c };
+    let has_bun_cjs_wrapper = c.chunk_has_bun_cjs_wrapper(chunk);
 
     // ── raw SoA column pointers (root provenance) ────────────────────────
     // `split_raw()` derives `*mut [T]` directly from the buffer base with no
@@ -144,6 +145,10 @@ pub(crate) unsafe fn rename_symbols_in_chunk(
     };
 
     let mut reserved_names = renamer::compute_initial_reserved_names(c.options.output_format)?;
+    if has_bun_cjs_wrapper {
+        // The printer refers to this wrapper parameter by name.
+        reserved_names.put(bun_ast::E::ImportMeta::CJS_WRAPPER_ARG, 1)?;
+    }
     for &source_index in files_in_order {
         renamer::compute_reserved_names_for_scope(
             &all_module_scopes[source_index as usize],

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1598,6 +1598,7 @@ impl<'a> Transpiler<'a> {
                     transform_only: self.options.transform_only,
                     import_meta_main_value: None,
                     lower_import_meta_main_for_node_js: false,
+                    inline_import_meta_paths: false,
                     framework: None,
                     repl_mode: self.options.repl_mode,
                     lower_toml_datetimes: false,

--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -3,7 +3,7 @@ use bun_collections::VecExt;
 use bun_core::feature_flags as FeatureFlags;
 
 use crate::p::P;
-use crate::parser::{self as js_parser, IdentifierOpts, RelocateVars, RelocateVarsMode};
+use crate::parser::{IdentifierOpts, RelocateVars, RelocateVarsMode};
 use bun_ast::ast_result::CommonJSNamedExport;
 use bun_ast::{self as js_ast, Binding, E, Expr, Flags, G, LocRef, S};
 
@@ -599,11 +599,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         });
                     }
 
-                    // Inline import.meta properties for Bake
-                    if p.options.framework.is_some()
-                        || (p.options.bundle
-                            && p.options.output_format == js_parser::options::Format::Cjs)
-                    {
+                    if p.options.inline_import_meta_paths {
                         if name == b"dir" || name == b"dirname" {
                             // Inline import.meta.dir
                             return Some(

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -9144,7 +9144,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             };
             if self.has_import_meta {
                 self.import_meta_ref =
-                    self.new_symbol(js_ast::symbol::Kind::Other, b"$Bun_import_meta");
+                    self.new_symbol(js_ast::symbol::Kind::Other, E::ImportMeta::CJS_WRAPPER_ARG);
                 args[5] = Arg {
                     binding: self.b(
                         B::Identifier {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -96,6 +96,9 @@ pub struct Options<'a> {
     pub import_meta_main_value: Option<bool>,
     pub lower_import_meta_main_for_node_js: bool,
 
+    /// Inline the source file's paths for `import.meta.dir`, `.dirname`, `.file`, `.path`, `.url`.
+    pub inline_import_meta_paths: bool,
+
     /// When using react fast refresh or server components, the framework is
     /// able to customize what import sources are used.
     pub framework: Option<&'a options::Framework>, // TYPE_ONLY: was bun_runtime::bake::Framework
@@ -142,6 +145,7 @@ impl<'a> Default for Options<'a> {
             transform_only: false,
             import_meta_main_value: None,
             lower_import_meta_main_for_node_js: false,
+            inline_import_meta_paths: false,
             framework: None,
             repl_mode: false,
             lower_toml_datetimes: false,
@@ -228,6 +232,7 @@ impl<'a> Options<'a> {
             transform_only: self.transform_only,
             import_meta_main_value: self.import_meta_main_value,
             lower_import_meta_main_for_node_js: self.lower_import_meta_main_for_node_js,
+            inline_import_meta_paths: self.inline_import_meta_paths,
             framework: self.framework,
             repl_mode: self.repl_mode,
             lower_toml_datetimes: self.lower_toml_datetimes,
@@ -301,6 +306,7 @@ impl<'a> Options<'a> {
             transform_only: false,
             import_meta_main_value: None,
             lower_import_meta_main_for_node_js: false,
+            inline_import_meta_paths: false,
             framework: None,
             repl_mode: false,
             lower_toml_datetimes: loader == options::Loader::Toml,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1326,6 +1326,8 @@ pub struct Options<'a> {
     pub module_preload_ref: Ref,
     pub require_ref: Option<Ref>,
     pub import_meta_ref: Ref,
+    /// Print `import.meta` as `E::ImportMeta::CJS_WRAPPER_ARG`, a parameter of the `@bun-cjs` wrapper.
+    pub inside_bun_cjs_wrapper: bool,
     pub hmr_ref: Ref,
     pub indent: Indentation,
     // allocator dropped — global mimalloc (this is an AST crate but Options.allocator is the global default)
@@ -1408,6 +1410,7 @@ impl<'a> Default for Options<'a> {
             module_preload_ref: Ref::NONE,
             require_ref: None,
             import_meta_ref: Ref::NONE,
+            inside_bun_cjs_wrapper: false,
             hmr_ref: Ref::NONE,
             indent: Indentation::default(),
             source_map_handler: None,
@@ -1553,9 +1556,12 @@ pub enum PrintResult {
     Err(crate::Error),
 }
 
+#[derive(Default)]
 pub struct PrintResultSuccess {
     pub code: Box<[u8]>,
     pub source_map: Option<SourceMap::Chunk>,
+    /// `code` refers to `E::ImportMeta::CJS_WRAPPER_ARG` (see `Options::inside_bun_cjs_wrapper`).
+    pub uses_import_meta_arg: bool,
 }
 
 // do not make this a packed struct
@@ -1677,6 +1683,7 @@ pub(crate) mod __gated_printer {
         pub(crate) stack_overflowed: bool,
 
         pub(crate) was_lazy_export: bool,
+        pub(crate) uses_import_meta_arg: bool,
         // Always carried; gated at call sites with MAY_HAVE_MODULE_INFO.
         pub(crate) module_info: Option<&'a mut analyze_transpiled_module::ModuleInfo>,
 
@@ -3290,23 +3297,22 @@ pub(crate) mod __gated_printer {
                         debug_assert!(self.options.hmr_ref.is_valid());
                         self.print_symbol(self.options.hmr_ref);
                         self.print(b".importMeta");
-                    } else if !self.options.import_meta_ref.is_valid() {
-                        // Most of the time, leave it in there
-                        if let Some(mi) = self.module_info() {
-                            mi.flags.contains_import_meta = true;
-                        }
-                        self.print(b"import.meta");
-                    } else {
-                        // Note: The bundler will not hit this code path. The bundler will replace
-                        // the ImportMeta AST node with a regular Identifier AST node.
-                        //
-                        // This is currently only used in Bun's runtime for CommonJS modules
-                        // referencing import.meta
+                    } else if self.options.import_meta_ref.is_valid() {
+                        // The runtime's CommonJS wrapper (`WrapMode::BunCommonjs`).
                         //
                         // TODO: This assertion trips when using `import.meta` with `--format=cjs`
                         debug_assert!(self.options.module_type == bundle_opts::Format::Cjs);
 
                         self.print_symbol(self.options.import_meta_ref);
+                    } else if self.options.inside_bun_cjs_wrapper {
+                        self.print(E::ImportMeta::CJS_WRAPPER_ARG);
+                        self.uses_import_meta_arg = true;
+                    } else {
+                        // Most of the time, leave it in there
+                        if let Some(mi) = self.module_info() {
+                            mi.flags.contains_import_meta = true;
+                        }
+                        self.print(b"import.meta");
                     }
                 }
                 ExprData::EImportMetaMain(data) => {
@@ -7026,6 +7032,7 @@ pub(crate) mod __gated_printer {
                 stack_check: bun_core::StackCheck::init(),
                 stack_overflowed: false,
                 was_lazy_export: false,
+                uses_import_meta_arg: false,
                 module_info: None,
             }
         }
@@ -8230,6 +8237,7 @@ pub(crate) fn print_with_writer_and_platform<
     PrintResult::Result(PrintResultSuccess {
         code: buffer.take_slice().into(),
         source_map,
+        uses_import_meta_arg: printer.uses_import_meta_arg,
     })
 }
 

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import { describe, expect } from "bun:test";
+import { readdirSync } from "node:fs";
 import { itBundled } from "./expectBundled";
 
 const nestedFunctions = /* js */ `
@@ -176,6 +177,163 @@ error: Hello World`,
     },
     run: { stdout: "" },
   });
+
+  // cjs output for bun (which --bytecode implies) gets the output file's import.meta
+  // as the sixth argument of the @bun-cjs wrapper, like esm output gets it natively.
+  // It used to inline the source file's paths from the build machine instead.
+  const importMetaFiles = {
+    "/entry.ts": /* js */ `
+      import { basename, dirname } from "node:path";
+      import { pathOfDep } from "./lib/dep.cjs";
+      var $Bun_import_meta = "user variable";
+      function shadowed() {
+        let $Bun_import_meta = "shadowed";
+        return import.meta.file;
+      }
+      console.log(
+        import.meta.path === Bun.main,
+        import.meta.dir === dirname(Bun.main),
+        import.meta.file === basename(Bun.main),
+        import.meta.url === Bun.pathToFileURL(Bun.main).href,
+        import.meta.filename === Bun.main,
+        import.meta.dirname === dirname(Bun.main),
+        import.meta.main,
+        typeof import.meta,
+        import.meta.env.IMPORT_META_PROBE,
+        typeof import.meta.resolve,
+        shadowed() === basename(Bun.main),
+        $Bun_import_meta,
+        pathOfDep() === Bun.main,
+      );
+    `,
+    "/lib/dep.cjs": /* js */ `
+      exports.pathOfDep = () => import.meta.path;
+    `,
+  };
+  const importMetaStdout = "true true true true true true true object from-env function true user variable true";
+  const importMetaEnv = { IMPORT_META_PROBE: "from-env" };
+  const expectBytecodeCacheHit = {
+    env: { ...importMetaEnv, BUN_JSC_verboseDiskCache: "1" },
+    validate({ stderr }: { stderr: string }) {
+      expect(stderr).toContain("[Disk Cache] Cache hit for sourceCode");
+    },
+  };
+  const bunCjsWrapper = (pragma: string, arg: string) =>
+    `// @bun ${pragma}@bun-cjs\n(function(exports, require, module, __filename, __dirname${arg}) {`;
+  for (const variant of ["", "+minify", "+bytecode"] as const) {
+    const bytecode = variant === "+bytecode";
+    const minify = variant === "+minify";
+    itBundled(`bun/ImportMetaFormatCjs${variant}`, {
+      target: "bun",
+      format: "cjs",
+      minifySyntax: minify,
+      minifyWhitespace: minify,
+      minifyIdentifiers: minify,
+      bytecode,
+      // --bytecode writes a second file, which the CLI only allows with --outdir.
+      ...(bytecode ? { outdir: "/out" } : {}),
+      files: importMetaFiles,
+      onAfterBundle(api) {
+        const out = api.readFile(bytecode ? "/out/entry.js" : "/out.js");
+        expect(out).toStartWith(bunCjsWrapper(bytecode ? "@bytecode " : "", ", $Bun_import_meta"));
+        expect(out).not.toContain("import.meta");
+        // The build directory must not end up in the output.
+        expect(out).not.toContain(api.root);
+      },
+      run: { stdout: importMetaStdout, env: importMetaEnv, ...(bytecode ? expectBytecodeCacheHit : {}) },
+    });
+  }
+  itBundled("bun/ImportMetaFormatCjsUnused", {
+    target: "bun",
+    format: "cjs",
+    files: {
+      "/entry.ts": /* js */ `
+        import { value } from "./dep.cjs";
+        console.log(value);
+      `,
+      "/dep.cjs": /* js */ `
+        exports.value = "no import.meta here";
+      `,
+    },
+    onAfterBundle(api) {
+      // The runtime helpers linked into this chunk use import.meta in their
+      // source, but cjs output never keeps that part, so the wrapper does not
+      // take the argument.
+      expect(api.readFile("/out.js")).toStartWith(bunCjsWrapper("", ""));
+    },
+    run: { stdout: "no import.meta here" },
+  });
+  // The sqlite loader builds its module out of `import.meta.require(...)` itself.
+  itBundled("bun/ImportMetaFormatCjsEmbeddedSqlite", {
+    target: "bun",
+    format: "cjs",
+    outfile: "",
+    outdir: "/out",
+    files: {
+      "/entry.ts": /* js */ `
+        import db from './db.sqlite' with {type: "sqlite", embed: "true"};
+        console.log(db.query("select message from messages LIMIT 1").get().message);
+      `,
+      "/db.sqlite": (() => {
+        const db = new Database(":memory:");
+        db.exec("create table messages (message text)");
+        db.exec("insert into messages values ('Hello from cjs!')");
+        return db.serialize();
+      })(),
+    },
+    run: { stdout: "Hello from cjs!" },
+  });
+  // The browser chunk of an HTML import is loaded as a module script, so it
+  // keeps `import.meta`. Only the server chunk is wrapped.
+  itBundled("bun/ImportMetaFormatCjsHtmlImport", {
+    target: "bun",
+    format: "cjs",
+    outdir: "/out",
+    entryPoints: ["/server.ts"],
+    files: {
+      "/server.ts": /* js */ `
+        import html from "./index.html";
+        console.log(typeof html, import.meta.path === Bun.main);
+      `,
+      "/index.html": `<!DOCTYPE html><html><head><script type="module" src="./client.ts"></script></head><body></body></html>`,
+      "/client.ts": /* js */ `
+        console.log(typeof import.meta.env, import.meta);
+      `,
+    },
+    onAfterBundle(api) {
+      expect(api.readFile("/out/server.js")).toStartWith(bunCjsWrapper("", ", $Bun_import_meta"));
+      const browserChunk = readdirSync(api.outdir).find(name => name !== "server.js" && name.endsWith(".js"))!;
+      const browser = api.readFile("/out/" + browserChunk);
+      expect(browser).toContain("typeof import.meta.env, import.meta");
+      expect(browser).not.toContain("$Bun_import_meta");
+    },
+    run: { stdout: "object true" },
+  });
+  // `bun build --compile --bytecode` is the documented production command.
+  // https://github.com/oven-sh/bun/issues/21097
+  itBundled("bun/ImportMetaCompileBytecode", {
+    compile: true,
+    bytecode: true,
+    files: {
+      "/entry.ts": /* js */ `
+        import { basename, dirname } from "node:path";
+        const slashes = (s) => s.replaceAll("\\\\", "/");
+        console.log(
+          slashes(import.meta.path) === slashes(Bun.main),
+          slashes(import.meta.dir) === slashes(dirname(Bun.main)),
+          import.meta.file === basename(Bun.main),
+          import.meta.url === Bun.pathToFileURL(Bun.main).href,
+          import.meta.env.IMPORT_META_PROBE,
+          slashes(import.meta.dir),
+        );
+      `,
+    },
+    run: {
+      stdout: /^true true true true from-env (\/\$bunfs|[A-Z]:\/~BUN)\/root$/,
+      ...expectBytecodeCacheHit,
+    },
+  });
+
   if (Bun.version.startsWith("1.4") || Bun.version.startsWith("1.3") || Bun.version.startsWith("1.2")) {
     for (const backend of ["api", "cli"] as const) {
       itBundled("bun/ExportsConditionsDevelopment" + backend.toUpperCase(), {


### PR DESCRIPTION
### Problem
- `bun build --compile --bytecode` bakes the build machine's source paths into `import.meta.path`, `.dir`, `.file` and `.url`. Without `--bytecode` the same build reports `/$bunfs/root/<name>`. `--format=cjs` alone does the same. `--asset` lookups under `import.meta.dir` break, and every shipped binary contains the build tree.
- Cause: `src/js_parser/fold.rs:513` inlines those properties as the source paths for all cjs output (#23803, for the `import.meta is only valid inside modules` SyntaxError of #14954). Every other use of `import.meta` still throws that SyntaxError in cjs output, which is #21097.

### Fix
- Bun's CommonJS wrapper already passes the module's real `import.meta` as a sixth argument when the wrapper declares one (`JSCommonJSModule.cpp:228`). `LinkerContext::chunk_has_bun_cjs_wrapper` decides once per chunk whether the chunk gets the `@bun-cjs` wrapper. The header and footer, the chunk renamer (which reserves the name `$Bun_import_meta` there) and a printer option for every file in the chunk use that answer.
- Inside such a chunk the printer prints `import.meta` as `$Bun_import_meta` and reports that on its result. The header declares the argument when any part range reported it. Chunks without the wrapper, such as the browser chunk of an HTML import, print `import.meta` as before.
- The parser inlines the source paths only for Bake and for cjs output of files whose target is not bun (`inline_import_meta_paths`, set in `ParseTask`).
- Correct because the runtime builds the object the way the ESM loader does (`ZigGlobalObject.cpp:3923`), so cjs output gets the ESM values for every property. Output that does not use `import.meta` is unchanged.
- Verified: `test/bundler/bundler_bun.test.ts`, 7 new tests, 6 fail on the released build. Other suites are listed in the notes.

### Background
- cjs output for bun is a `(function(exports, require, module, __filename, __dirname) {...})` script that the runtime calls, and that `--bytecode` compiles. `import.meta` is a syntax error in a script. A bun build with an HTML import also emits browser chunks, which are plain module scripts without the wrapper.
- `$Bun_import_meta` is the name the runtime transpiler already uses for this argument when it wraps a CommonJS file that uses `import.meta`. Both sites read `E::ImportMeta::CJS_WRAPPER_ARG`.
- Reserved names are names the renamer gives to no symbol in a chunk. `exports` and `module` are reserved in cjs output the same way, which is what lets the printer emit `require.main == module` by name.
- `PrintResultSuccess` is what the printer returns per part range. #37677 derives the ESM bytecode module record from what the printer emitted instead of from the AST. The new `uses_import_meta_arg` flag on it follows that pattern.

Fixes #21097

<details><summary>Notes</summary>

Repro on main, and the binary built from this branch:

```
$ cat ident.ts
console.log(JSON.stringify({ path: import.meta.path, dir: import.meta.dir, url: import.meta.url, main: import.meta.main, bunMain: Bun.main }));
$ bun build --compile --bytecode ./ident.ts --outfile ./bc && ./bc
# main:  {"path":"/tmp/proj/ident.ts","dir":"/tmp/proj","url":"file:///tmp/proj/ident.ts","main":true,"bunMain":"/$bunfs/root/bc"}
# fixed: {"path":"/$bunfs/root/bc","dir":"/$bunfs/root","url":"file:///$bunfs/root/bc","main":true,"bunMain":"/$bunfs/root/bc"}
$ strings ./bc | grep -c /tmp/proj
# main: 4, fixed: 0. A file that also uses __dirname keeps the hits of the __dirname inlining, see below.
```

The sixth argument hook dates from #3104 (2023), so it predates `@bun-cjs` output (#14232). Bundles built this way load on every Bun that can load `@bun-cjs` output. #19250's closing note lists these inlined `import.meta` values as the remaining build paths in a `--bytecode` binary.

Output of a plain `bun build --target=bun --format=cjs` for a file that uses `import.meta`, plus a `.cjs` dependency that uses it too:

```js
// @bun @bun-cjs
(function(exports, require, module, __filename, __dirname, $Bun_import_meta) {
// lib/dep.cjs
var require_dep = __commonJS(function(exports2) {
  exports2.pathOfDep = () => $Bun_import_meta.path;
});
// entry.ts
var $Bun_import_meta2 = "user variable";
console.log($Bun_import_meta.path === Bun.main);
})
```

A user variable with the reserved name is renamed, in nested scopes too. `--minify` output keeps the argument because the header is printed by the linker. Non-compile `--target=bun --format=cjs` bundles change as well: `import.meta.dir` is now the output directory at run time, which is what esm output of the same build already reported. cjs output for node and browser, esm output, iife output and Bake are unchanged. The embedded sqlite module, which the loader builds as `import.meta.require(...)` without the parser, now works in cjs output too, because the argument is declared from what the printer emitted, not from a parser flag.

Revision history. The first revision keyed the printer on the build's target and declared the argument from the per-file `HAS_IMPORT_META` flag. Review of that revision found two things. The sqlite module has no such flag, so it was patched with one (commit 767beef, now removed). And a bun build with an HTML import prints browser chunks with the same printer options, so `import.meta.env` in a client file became a bare `$Bun_import_meta` reference in a chunk that has no wrapper (main ships `import.meta` there). Reproduced with this branch's debug build before the rework. The current revision keys everything on `chunk_has_bun_cjs_wrapper` and is covered by `bun/ImportMetaFormatCjsHtmlImport`, which checks that the browser chunk still contains `import.meta` and that only the server chunk is wrapped. A `--target=node --format=cjs` build whose entry has a `#!/usr/bin/env bun` hashbang gets the wrapper today, because the entry's own target is bun. The entry file now uses the argument (its target is bun, so nothing is inlined) and the other files keep the inlined paths. Checked: such a bundle runs, and `import.meta.env` in it used to be a SyntaxError.

Related open PRs, and how this composes with them:

- #38173 makes the sqlite module print `require(...)` in cjs output. No shared lines any more. Its tests pin `require(`, the test here only runs the bundle, so both pass in either order.
- #33859 narrows when a chunk counts as bun for the pragma and the wrapper. That decision now has one home, `chunk_has_bun_cjs_wrapper`, so its narrowing goes there, and the header block has a small textual conflict either way.
- #38200 lowers `import.meta` to an empty per-file object for cjs and iife output of other targets. Whichever lands second excludes the files this PR leaves alone (cjs output for bun), where the wrapper supplies the real object. Its `inline_import_meta` gate and `inline_import_meta_paths` here are the same predicate.
- #29066 makes `__dirname` / `__filename` use the virtual path in `--compile` output (the CJS sibling in the fuzz ledger). It also rewrites `import.meta.dir/.dirname/.path/.filename` to those identifiers for `--compile` cjs output and leaves `.url` and `.file` inlined. With this PR that fold.rs hunk is not needed. Its `__dirname` change and Windows separator fix are independent.

Found while testing and handed off separately: two bundled modules that both use `__dirname` collide (the last declaration wins), and `new Worker(new URL("./w.ts", import.meta.url))` from the executables docs fails in every standalone executable with `ModuleNotFound /$bunfs/root/w.ts` (the `.ts` to `.js` remap only applies to relative specifiers). A `--bytecode` build of that docs example only appeared to work before because it loaded the worker from the source tree on the build machine.

Test placement: `compile/HelloWorldWithProcessVersionsBun` in `bundler_compile.test.ts` fails on every debug build independent of this change, so the new compile case lives in `bundler_bun.test.ts`, which is green on a debug build. The compile case also reads `import.meta.env`, which is the #21097 program. Three `bake/dev/production` tests timed out locally at the 5 s default and pass with a longer timeout. They do not involve `import.meta`.

Suites run with the debug build after the rework: `bundler_bun` (17 tests), `bundler_banner`, `bundler_cjs`, `html-import-manifest`, `bundler_html_server`, `bundler_edgecase`, `bun-build-api`, `esbuild/default -t "ImportMeta|import.meta"`, `bundler_compile -t "Bytecode|ImportMeta|pathToFileURLWorks|sqlite|html"`, `bake/dev/import-meta-inline`, `js/bun/resolve/import-meta`. `cargo clippy` and `cargo fmt` are clean for the four touched crates.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 1 · 14 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_bun.test.ts
bun test v1.4.3 (e0a2b82fd)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/bytecode-depth-cli [1122.23ms]
(pass) bundler > bun/bytecode-depth-api [487.06ms]
(pass) bundler > bun/import-bun-format-cjs [446.69ms]
(pass) bundler > bun/embedded-sqlite-file [411.87ms]
(pass) bundler > bun/sqlite-file [388.10ms]
(pass) bundler > bun/TargetBunNoSourcemapMessage [448.36ms]
(pass) bundler > bun/TargetBunSourcemapInline [454.11ms]
(pass) bundler > bun/unicode comment [340.15ms]
233 |       // --bytecode writes a second file, which the CLI only allows with --outdir.
234 |       ...(bytecode ? { outdir: "/out" } : {}),
235 |       files: importMetaFiles,
236 |       onAfterBundle(api) {
237 |         const out = api.readFile(bytecode ? "/out/entry.js" : "/out.js");
238 |         expect(out).toStartWith(bunCjsWrapper(bytecode ? "@bytecode " : "", ", $Bun_import_meta"));
                          ^
error: expect(received).toStartWith(expected)

Expected to start with: "// @bun @bun-cjs\n(function(exports, req
... (truncated)

release without fix: all passed
bun test v1.4.3-canary.1 (954f4cde7)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/bytecode-depth-cli [22.42ms]
(pass) bundler > bun/bytecode-depth-api [9.64ms]
(pass) bundler > bun/import-bun-format-cjs [7.16ms]
(pass) bundler > bun/embedded-sqlite-file [8.42ms]
(pass) bundler > bun/sqlite-file [6.86ms]
(pass) bundler > bun/TargetBunNoSourcemapMessage [8.13ms]
(pass) bundler > bun/TargetBunSourcemapInline [7.88ms]
(pass) bundler > bun/unicode comment [6.11ms]
(pass) bundler > bun/ImportMetaFormatCjs [8.01ms]
(pass) bundler > bun/ImportMetaFormatCjs+minify [7.42ms]
(pass) bundler > bun/ImportMetaFormatCjs+bytecode [10.47ms]
(pass) bundler > bun/ImportMetaFormatCjsUnused [7.23ms]
(pass) bundler > bun/ImportMetaFormatCjsEmbeddedSqlite [7.49ms]
(pass) bundler > bun/ImportMetaFormatCjsHtmlImport [6.44ms]
(pass) bundler > bun/ImportMetaCompileBytecode [148.66ms]
(pass) bundler > bun/ExportsConditionsDevelopmentAPI [8.41ms]
(pass) bundler > bun/ExportsConditionsDevelopmentInProductionAPI [7.06ms]
(pass) bundler > bun/ExportsConditionsDevelopmentCLI [8.33ms]
(pass) bundler > bun/ExportsConditionsDevelopmentInProductionCLI [8.02ms]

 19 pass
 0 fail
 44 expect() c
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/bundler_bun.test.ts
bun test v1.4.3 (e0a2b82fd)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/bytecode-depth-cli [990.43ms]
(pass) bundler > bun/bytecode-depth-api [456.81ms]
(pass) bundler > bun/import-bun-format-cjs [439.49ms]
(pass) bundler > bun/embedded-sqlite-file [418.60ms]
(pass) bundler > bun/sqlite-file [406.53ms]
(pass) bundler > bun/TargetBunNoSourcemapMessage [559.97ms]
(pass) bundler > bun/TargetBunSourcemapInline [456.70ms]
(pass) bundler > bun/unicode comment [345.19ms]
(pass) bundler > bun/ImportMetaFormatCjs [650.53ms]
(pass) bundler > bun/ImportMetaFormatCjs+minify [562.79ms]
(pass) bundler > bun/ImportMetaFormatCjs+bytecode [783.74ms]
(pass) bundler > bun/ImportMetaFormatCjsUnused [434.43ms]
(pass) bundler > bun/ImportMetaFormatCjsEmbeddedSqlite [596.85ms]
(pass) bundler > bun/ImportMetaFormatCjsHtmlImport [378.73ms]
(pass) bundler > bun/ImportMetaCompileBytecode [3453.59ms]
(pass) bundler > bun/ExportsConditionsDevelopmentAPI [353.04ms]
(pass) bundler > bun/ExportsConditionsDevelopmentInProduc
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 616ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compiling[0m bun_output v0.0.0 (/workspace/bun/src/output)
[1m[92m   Compiling[0m bun_clap v0.0.0 (/workspace/bun/src/clap)
[1m[92m   Compiling[0m bu
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/e.rs                                       |   5 +
 src/bundler/LinkerContext.rs                       |   8 ++
 src/bundler/ParseTask.rs                           |   4 +
 src/bundler/bundle_v2.rs                           |   7 +-
 .../linker_context/generateCodeForFileInChunkJS.rs |   8 +-
 .../generateCompileResultForJSChunk.rs             |   2 +
 src/bundler/linker_context/postProcessJSChunk.rs   |  55 ++++---
 src/bundler/linker_context/renameSymbolsInChunk.rs |   5 +
 src/bundler/transpiler.rs                          |   1 +
 src/js_parser/fold.rs                              |   8 +-
 src/js_parser/p.rs                                 |   2 +-
 src/js_parser/parse/parse_entry.rs                 |   6 +
 src/js_printer/lib.rs                              |  32 +++--
 test/bundler/bundler_bun.test.ts                   | 158 +++++++++++++++++++++
 14 files changed, 253 insertions(+), 48 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/ast/e.rs                                                  3      4     21
src/bundler/LinkerContext.rs                                  4      3     21
src/bundler/ParseTask.rs                                     10      7     21
src/bundler/bundle_v2.rs                                      2      1     21
…/bundler/linker_context/generateCodeForFileInChunkJS.rs      3      4     21
…ndler/linker_context/generateCompileResultForJSChunk.rs      1      2     21
src/bundler/linker_context/postProcessJSChunk.rs             11     10     21
src/bundler/linker_context/renameSymbolsInChunk.rs            3      2     21
src/bundler/transpiler.rs                                     2      1     21
src/js_parser/fold.rs                                         2      2     21
src/js_parser/p.rs                                            7      1     21
src/js_parser/parse/parse_entry.rs                            6      6     21
src/js_printer/lib.rs                                        11     10     21
test/bundler/bundler_bun.test.ts                              5     11     21
```

</details>

**root cause** · written by the author bot

When the bundler lowers a Bun target to CommonJS (which `--bytecode` implies), the parser inlines `import.meta.url`, `import.meta.path`, `import.meta.dir`, and `import.meta.file` as string constants taken from the build machine's source path, so the standalone executable reports the build directory instead of the virtual `/$bunfs/root/<name>` location that the non-CJS compile uses. The fix makes `inline_import_meta_paths` an explicit opt-in that stays off for Bun CommonJS compile output and instead threads a wrapper argument through the linker and printer, so the Bun CJS module wrapper rece…

<!-- robobun:evidence:end -->