### PR TITLE
node:http: validate server socket setTimeout(msecs) like net.Socket

### DIFF
--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -185,14 +185,6 @@ function onDataIncomingMessage(this: any, chunk, isLast, aborted: NodeHTTPRespon
   }
 }
 
-function validateMsecs(numberlike: any, field: string) {
-  if (typeof numberlike !== "number" || numberlike < 0) {
-    throw $ERR_INVALID_ARG_TYPE(field, "number", numberlike);
-  }
-
-  return numberlike;
-}
-
 const METHODS = [
   "ACL",
   "BIND",
@@ -527,5 +519,4 @@ export {
   tlsSymbol,
   typeSymbol,
   utcDate,
-  validateMsecs,
 };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -50,7 +50,6 @@ const {
   noBodySymbol,
   kOutHeaders,
   onDataIncomingMessage,
-  validateMsecs,
 } = require("internal/http");
 const { FakeSocket } = require("internal/http/FakeSocket");
 const NumberIsNaN = Number.isNaN;
@@ -1468,6 +1467,7 @@ type NodeHTTPServerSocket = InstanceType<ReturnType<typeof getNodeHTTPServerSock
 function getNodeHTTPServerSocket() {
   if (NodeHTTPServerSocket) return NodeHTTPServerSocket;
   const { Socket: NetSocket } = require("node:net");
+  const { getTimerDuration } = require("internal/timers");
   NodeHTTPServerSocket = class Socket extends NetSocket {
     bytesRead = 0;
     connecting = false;
@@ -1900,7 +1900,8 @@ function getNodeHTTPServerSocket() {
         return this;
       }
 
-      msecs = validateMsecs(msecs, "msecs");
+      msecs = getTimerDuration(msecs, "msecs");
+      // Assigned after validation (unlike setStreamTimeout): onSocketTimeoutTimerExpired reads this.timeout.
       this.timeout = msecs;
 
       const existingTimer = this[kSocketTimeoutTimer];

--- a/test/js/node/http/node-http-server-timeouts.test.ts
+++ b/test/js/node/http/node-http-server-timeouts.test.ts
@@ -218,3 +218,121 @@ describe("node:http server timeout enforcement", () => {
     }
   });
 });
+
+// server.setTimeout (applied per connection), req.setTimeout, res.setTimeout
+// and req.socket.setTimeout all end up in the server socket's setTimeout,
+// which has to check msecs the way net.Socket#setTimeout does.
+describe("node:http server socket setTimeout(msecs) checks", () => {
+  const TIMEOUT_MAX = 2 ** 31 - 1;
+
+  function thrownBy(fn: () => unknown) {
+    try {
+      fn();
+      return "did not throw";
+    } catch (err: any) {
+      return { name: err.constructor.name, code: err.code, message: err.message };
+    }
+  }
+
+  function outOfRange(received: string) {
+    return {
+      name: "RangeError",
+      code: "ERR_OUT_OF_RANGE",
+      message: `The value of "msecs" is out of range. It must be a non-negative finite number. Received ${received}`,
+    };
+  }
+
+  function invalidDurations(setTimeout: (msecs: any) => unknown) {
+    return {
+      negative: thrownBy(() => setTimeout(-1)),
+      nan: thrownBy(() => setTimeout(NaN)),
+      infinity: thrownBy(() => setTimeout(Infinity)),
+      string: thrownBy(() => setTimeout("foo")),
+    };
+  }
+
+  const expectedInvalidDurations = {
+    negative: outOfRange("-1"),
+    nan: outOfRange("NaN"),
+    infinity: outOfRange("Infinity"),
+    string: {
+      name: "TypeError",
+      code: "ERR_INVALID_ARG_TYPE",
+      message: `The "msecs" argument must be of type number. Received type string ('foo')`,
+    },
+  };
+
+  test("socket, req and res setTimeout reject invalid msecs like net.Socket#setTimeout", async () => {
+    let observed: unknown;
+    const server = http.createServer((req, res) => {
+      const socket = req.socket;
+      observed = {
+        socket: invalidDurations(msecs => socket.setTimeout(msecs)),
+        req: invalidDurations(msecs => req.setTimeout(msecs)),
+        res: invalidDurations(msecs => res.setTimeout(msecs)),
+        msecsIsCheckedBeforeCallback: thrownBy(() => socket.setTimeout(-1, "not a function" as any)),
+        timeoutAfterRejectedCalls: socket.timeout,
+        validCallReturnsSocket: socket.setTimeout(1000) === socket,
+        timeoutAfterValidCall: socket.timeout,
+      };
+      res.end("ok");
+    });
+    const port = await listen(server);
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/`);
+      expect(await response.text()).toBe("ok");
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
+    expect(observed).toEqual({
+      socket: expectedInvalidDurations,
+      req: expectedInvalidDurations,
+      res: expectedInvalidDurations,
+      msecsIsCheckedBeforeCallback: outOfRange("-1"),
+      timeoutAfterRejectedCalls: 0,
+      validCallReturnsSocket: true,
+      timeoutAfterValidCall: 1000,
+    });
+  });
+
+  // Node truncates a duration above 2**31 - 1 ms to that maximum and warns.
+  // Passing the raw value on to setTimeout() would instead arm a 1 ms timer
+  // (with a different warning), which destroys the connection at once.
+  test.each([
+    ["server.setTimeout()", (server: http.Server) => server.setTimeout(TIMEOUT_MAX + 1), undefined],
+    ["req.setTimeout()", undefined, (req: http.IncomingMessage) => req.setTimeout(TIMEOUT_MAX + 1)],
+    [
+      "res.setTimeout()",
+      undefined,
+      (_req: http.IncomingMessage, res: http.ServerResponse) => res.setTimeout(TIMEOUT_MAX + 1),
+    ],
+    ["req.socket.setTimeout()", undefined, (req: http.IncomingMessage) => req.socket.setTimeout(TIMEOUT_MAX + 1)],
+  ])("%s truncates a duration above 2**31 - 1 ms like net.Socket#setTimeout", async (_name, configure, arm) => {
+    const warnings: { name: string; message: string }[] = [];
+    const onWarning = (warning: Error) => warnings.push({ name: warning.name, message: warning.message });
+    process.on("warning", onWarning);
+    const server = http.createServer((req, res) => {
+      arm?.(req, res);
+      res.end("ok");
+    });
+    configure?.(server);
+    const port = await listen(server);
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/`);
+      expect(await response.text()).toBe("ok");
+    } finally {
+      server.closeAllConnections();
+      server.close();
+      process.removeListener("warning", onWarning);
+    }
+    // The warning is emitted while the request is handled, so it has been
+    // delivered by the time the response has arrived.
+    expect(warnings).toEqual([
+      {
+        name: "TimeoutOverflowWarning",
+        message: `${TIMEOUT_MAX + 1} does not fit into a 32-bit signed integer.\nTimer duration was truncated to ${TIMEOUT_MAX}.`,
+      },
+    ]);
+  });
+});

--- a/test/js/node/http/node-http-server-timeouts.test.ts
+++ b/test/js/node/http/node-http-server-timeouts.test.ts
@@ -222,7 +222,7 @@ describe("node:http server timeout enforcement", () => {
 // server.setTimeout (applied per connection), req.setTimeout, res.setTimeout
 // and req.socket.setTimeout all end up in the server socket's setTimeout,
 // which has to check msecs the way net.Socket#setTimeout does.
-describe("node:http server socket setTimeout(msecs) checks", () => {
+describe.concurrent("node:http server socket setTimeout(msecs) checks", () => {
   const TIMEOUT_MAX = 2 ** 31 - 1;
 
   function thrownBy(fn: () => unknown) {
@@ -298,41 +298,47 @@ describe("node:http server socket setTimeout(msecs) checks", () => {
 
   // Node truncates a duration above 2**31 - 1 ms to that maximum and warns.
   // Passing the raw value on to setTimeout() would instead arm a 1 ms timer
-  // (with a different warning), which destroys the connection at once.
-  test.each([
-    ["server.setTimeout()", (server: http.Server) => server.setTimeout(TIMEOUT_MAX + 1), undefined],
-    ["req.setTimeout()", undefined, (req: http.IncomingMessage) => req.setTimeout(TIMEOUT_MAX + 1)],
-    [
-      "res.setTimeout()",
-      undefined,
-      (_req: http.IncomingMessage, res: http.ServerResponse) => res.setTimeout(TIMEOUT_MAX + 1),
-    ],
-    ["req.socket.setTimeout()", undefined, (req: http.IncomingMessage) => req.socket.setTimeout(TIMEOUT_MAX + 1)],
-  ])("%s truncates a duration above 2**31 - 1 ms like net.Socket#setTimeout", async (_name, configure, arm) => {
-    const warnings: { name: string; message: string }[] = [];
-    const onWarning = (warning: Error) => warnings.push({ name: warning.name, message: warning.message });
-    process.on("warning", onWarning);
-    const server = http.createServer((req, res) => {
-      arm?.(req, res);
-      res.end("ok");
-    });
-    configure?.(server);
-    const port = await listen(server);
-    try {
-      const response = await fetch(`http://127.0.0.1:${port}/`);
-      expect(await response.text()).toBe("ok");
-    } finally {
-      server.closeAllConnections();
-      server.close();
-      process.removeListener("warning", onWarning);
-    }
-    // The warning is emitted while the request is handled, so it has been
-    // delivered by the time the response has arrived.
-    expect(warnings).toEqual([
-      {
-        name: "TimeoutOverflowWarning",
-        message: `${TIMEOUT_MAX + 1} does not fit into a 32-bit signed integer.\nTimer duration was truncated to ${TIMEOUT_MAX}.`,
-      },
-    ]);
-  });
+  // (with a different warning), which destroys the connection at once. Both
+  // warnings start with the duration, so each case gets its own duration to
+  // pick its warning out of the process-wide 'warning' event.
+  type Configure = (msecs: number, server: http.Server) => unknown;
+  type Arm = (msecs: number, req: http.IncomingMessage, res: http.ServerResponse) => unknown;
+  const oversizedDurations: [string, number, Configure | undefined, Arm | undefined][] = [
+    ["server.setTimeout()", TIMEOUT_MAX + 1, (msecs, server) => server.setTimeout(msecs), undefined],
+    ["req.setTimeout()", TIMEOUT_MAX + 2, undefined, (msecs, req) => req.setTimeout(msecs)],
+    ["res.setTimeout()", TIMEOUT_MAX + 3, undefined, (msecs, _req, res) => res.setTimeout(msecs)],
+    ["req.socket.setTimeout()", TIMEOUT_MAX + 4, undefined, (msecs, req) => req.socket.setTimeout(msecs)],
+  ];
+  test.each(oversizedDurations)(
+    "%s truncates a duration above 2**31 - 1 ms like net.Socket#setTimeout",
+    async (_name, msecs, configure, arm) => {
+      const warnings: { name: string; message: string }[] = [];
+      const onWarning = (warning: Error) => {
+        if (warning.message.startsWith(`${msecs} `)) warnings.push({ name: warning.name, message: warning.message });
+      };
+      process.on("warning", onWarning);
+      const server = http.createServer((req, res) => {
+        arm?.(msecs, req, res);
+        res.end("ok");
+      });
+      configure?.(msecs, server);
+      const port = await listen(server);
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/`);
+        expect(await response.text()).toBe("ok");
+      } finally {
+        server.closeAllConnections();
+        server.close();
+        process.removeListener("warning", onWarning);
+      }
+      // The warning is emitted while the request is handled, so it has been
+      // delivered by the time the response has arrived.
+      expect(warnings).toEqual([
+        {
+          name: "TimeoutOverflowWarning",
+          message: `${msecs} does not fit into a 32-bit signed integer.\nTimer duration was truncated to ${TIMEOUT_MAX}.`,
+        },
+      ]);
+    },
+  );
 });


### PR DESCRIPTION
### Problem
- In a `node:http` server, `socket.setTimeout`, `req.setTimeout`, `res.setTimeout` and `server.setTimeout` do not check `msecs` like Node. `setTimeout(-1)` throws `ERR_INVALID_ARG_TYPE`, Node throws `ERR_OUT_OF_RANGE`. `NaN` and `Infinity`, which Node rejects, are accepted and arm a 1 ms timer.
- A duration above `2**31 - 1` ms (about 24.8 days) also arms a 1 ms timer, so `res.setTimeout(30 days)` destroys the connection at once. Node truncates it to `2**31 - 1` and warns.
- Cause: `NodeHTTPServerSocket.setTimeout` (`src/js/node/_http_server.ts:1903` on main) checks `msecs` with `validateMsecs` (`src/js/internal/http.ts:188`). All four spellings end up in this method.

### Fix
- `NodeHTTPServerSocket.setTimeout` now calls `getTimerDuration(msecs, "msecs")`. That line is the fix. The require sits in `getNodeHTTPServerSocket()`, next to the `node:net` require (#39628 builds this class on the first connection), so module init does not change. `validateMsecs` has no other caller, so this PR deletes it.
- Correct because a server socket is a `net.Socket` in Node, and `getTimerDuration` is the check that `net.Socket#setTimeout` runs. Bun's `net`, `_http_client` and `http2` already use it. All four spellings now throw the same errors as Node 26.3.0 (Notes).
- Deliberate difference: `socket.timeout` is still assigned after the check. Node assigns it first. `onSocketTimeoutTimerExpired` reads `socket.timeout`, so a rejected value must not reach it.
- Verified: `test/js/node/http/node-http-server-timeouts.test.ts` (5 new cases, all fail on main). Also 19 ported Node timeout tests and `node-http.test.ts`.

### Background
- `getTimerDuration` (`src/js/internal/timers.ts`) is the port of Node's helper. A non-number throws `ERR_INVALID_ARG_TYPE`. A negative or non-finite number throws `ERR_OUT_OF_RANGE`. A larger value is truncated to `2**31 - 1` with a `TimeoutOverflowWarning`.
- `NodeHTTPServerSocket` is the `net.Socket` subclass behind `req.socket`. Its `setTimeout` owns the per-connection inactivity timer. `server.setTimeout` is applied through it on each connection, `req.setTimeout` and `res.setTimeout` delegate to it.
- `setTimeout()` itself turns a duration that does not fit in a signed 32-bit integer into 1 ms.

<details><summary>Notes</summary>

Found while closing #33732. That PR implemented `socket.setTimeout` for server sockets, and #32488 landed a different implementation first. The one case of its test that still failed on main was this validation.

Probe results. Node 26.3.0 and Bun with this fix agree on every line. The right column is Bun on main.

```
socket.setTimeout(-1)           ERR_OUT_OF_RANGE (RangeError)   main: ERR_INVALID_ARG_TYPE (TypeError), message 'The "msecs" argument must be of type number. Received type number (-1)'
socket.setTimeout(NaN)          ERR_OUT_OF_RANGE                main: accepted, 1 ms timer, TimeoutNaNWarning
socket.setTimeout(Infinity)     ERR_OUT_OF_RANGE                main: accepted, 1 ms timer
socket.setTimeout("foo")        ERR_INVALID_ARG_TYPE            main: same
socket.setTimeout(-1, "nope")   ERR_OUT_OF_RANGE                main: ERR_INVALID_ARG_TYPE
req.setTimeout(-1)              ERR_OUT_OF_RANGE                main: ERR_INVALID_ARG_TYPE
res.setTimeout(-1)              ERR_OUT_OF_RANGE                main: ERR_INVALID_ARG_TYPE
socket.setTimeout(2**31)        warning "truncated to 2147483647"   main: warning "set to 1", fires at once
server.timeout = Infinity       uncaughtException ERR_OUT_OF_RANGE on connect, same as Node
```

`res.setTimeout(30 * 24 * 3600 * 1000)` on main fired after 401 ms in a debug build and destroyed a stalled connection. With the fix it does not fire, like Node.

Error messages: Bun's `net.Socket#setTimeout` already produces the same name, code and message as Node for all of these inputs (a diff of the two outputs is empty), so the new test asserts the full message.

`socket.timeout` readback is the only difference left. After a rejected call Node reports the rejected value (`-1`, `"foo"`), Bun reports the previous value. After `setTimeout(2**31)` Node reports `2147483648`, Bun reports the effective `2147483647`. `onSocketTimeoutTimerExpired` uses `socket.timeout` for its `=== 0` check and for the keep-alive budget, so the stored value has to be the armed one.

Internal callers of the changed method: the connection-time `server.timeout` path only runs for a truthy value, and the keep-alive path passes a sum that it has already checked to be finite and non-negative. The only inputs whose outcome changes are the ones Node also rejects or truncates. `server.timeout = -1` already threw on connect before this change, only the code changes.

The truncation test asserts the warning text. The native `setTimeout()` overflow warning on main has the same name but says `Timeout duration was set to 1.`, so the test fails on main for each of the four spellings without a wait. Each spelling uses its own duration (`2**31 + 0..3`) and keeps only the warnings that start with it, so the block runs as `describe.concurrent` and also passes under a forced `bun test --concurrent` of the whole file.

Suites run with the fix (debug build): `node-http-server-timeouts.test.ts` (11 pass), `node-http-res-settimeout-unref.test.ts`, `client-timeout-error.test.ts`, `node-http-connect.test.ts`, `node-http.test.ts` (144 pass), and these ported Node tests (19 pass): test-http-set-timeout-server, test-http-set-timeout, test-http-timeout, test-http-timeout-overflow, test-http-outgoing-settimeout, test-http-server-consumed-timeout, test-http-server-keep-alive-timeout, test-http-keep-alive-timeout, test-http-keep-alive-timeout-custom, test-http-keep-alive-timeout-buffer, test-http-keep-alive-timeout-race-condition, test-http-server-timeouts-validation, test-http-server-close-destroy-timeout, test-http-server-headers-timeout-keepalive, test-http-server-request-timeout-keepalive, test-http-server-keepalive-end, test-http-server-keep-alive-defaults, test-net-socket-timeout, test-net-settimeout.

Two failures in this container are not related. `node-http.test.ts > request via http proxy` fails with `ECONNREFUSED` on the unmodified system Bun as well (localhost resolution in the container). `node-http-connect.test.ts > tests should run on bun` hits its 5 s budget because the child run takes 5.3 s in a debug build. The child file passes 7 of 7 on its own and does not call `setTimeout`.

Rebase notes. First rebase: #39732 trimmed the export list of `internal/http.ts` next to the `validateMsecs` entry this PR removes, so the resolved list just drops that entry. Second rebase: #39628 moved the class into `getNodeHTTPServerSocket()` and re-indented it, and git placed this PR's two lines into `_destroy` by mistake. The resolution keeps `_destroy` as on main, applies the two lines in `setTimeout`, and moves the `internal/timers` require from module scope into the factory next to the `node:net` require. After each rebase, the test file passed 11 of 11 with the fix, the 5 new cases still failed on the unmodified build, and a few of the ported timeout tests were rerun as a smoke check (7 after the second rebase).
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-timeouts.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-server-timeouts.test.ts:
(pass) node:http server timeout enforcement > headersTimeout closes a connection that never completes its request headers [800.31ms]
(pass) node:http server timeout enforcement > requestTimeout closes a connection that stalls mid-body [433.60ms]
(pass) node:http server timeout enforcement > server.setTimeout() fires the 'timeout' event for an inactive connection [320.38ms]
(pass) node:http server timeout enforcement > keepAliveTimeout closes an idle keep-alive connection after the response [1355.41ms]
(pass) node:http server timeout enforcement > headersTimeout answers 408 when there is no 'clientError' listener [331.32ms]
(pass) node:http server timeout enforcement > requestTimeout does not fire while a slow handler streams a response [586.15ms]
(node:44710) TimeoutNaNWarning: NaN is not a number.
Timeout duration was set to 1.
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
... (truncated)

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/node/http/node-http-server-timeouts.test.ts:
(pass) node:http server timeout enforcement > headersTimeout closes a connection that never completes its request headers [256.84ms]
(pass) node:http server timeout enforcement > requestTimeout closes a connection that stalls mid-body [354.07ms]
(pass) node:http server timeout enforcement > server.setTimeout() fires the 'timeout' event for an inactive connection [205.25ms]
(pass) node:http server timeout enforcement > keepAliveTimeout closes an idle keep-alive connection after the response [1206.16ms]
(pass) node:http server timeout enforcement > headersTimeout answers 408 when there is no 'clientError' listener [254.49ms]
(pass) node:http server timeout enforcement > requestTimeout does not fire while a slow handler streams a response [406.98ms]
(node:44736) TimeoutNaNWarning: NaN is not a number.
Timeout duration was set to 1.
(Use `bun --trace-warnings ...` to show where the warning was created)
(node:44736) TimeoutOverflowWarning: Infinity does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
(node:44736) TimeoutOverflowWarning: Infinity does not fit in
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-timeouts.test.ts
bun test v1.4.1 (4448a2e21)

test/js/node/http/node-http-server-timeouts.test.ts:
(pass) node:http server timeout enforcement > headersTimeout closes a connection that never completes its request headers [864.11ms]
(pass) node:http server timeout enforcement > requestTimeout closes a connection that stalls mid-body [483.48ms]
(pass) node:http server timeout enforcement > server.setTimeout() fires the 'timeout' event for an inactive connection [315.49ms]
(pass) node:http server timeout enforcement > keepAliveTimeout closes an idle keep-alive connection after the response [1330.34ms]
(pass) node:http server timeout enforcement > headersTimeout answers 408 when there is no 'clientError' listener [344.93ms]
(pass) node:http server timeout enforcement > requestTimeout does not fire while a slow handler streams a response [590.93ms]
(node:53456) TimeoutOverflowWarning: 2147483648 does not fit into a 32-bit signed integer.
Timer duration was truncated to 2147483647.
(Use `bun-debug --trace-w
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 836ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/22] gen JS modules (bundle-modules)
Preprocess modules (10766ms)
Bundle modules (46ms)
Postprocesss modules (56ms)
Bundle Functions (868ms)
Generate Code (19ms)

[11.78s] Bundled "src/js" for production
  2621 kb
  198 internal modules
  13 native modules
  91 internal functions across 16 files
[2/6] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/http.ts                            |   9 --
 src/js/node/_http_server.ts                        |   5 +-
 .../js/node/http/node-http-server-timeouts.test.ts | 124 +++++++++++++++++++++
 3 files changed, 127 insertions(+), 11 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/js/internal/http.ts                                  2      3      0
src/js/node/_http_server.ts                             11      7      0
test/js/node/http/node-http-server-timeouts.test.ts      3      3      0
```

</details>

<!-- robobun:evidence:end -->

