### PR TITLE
transpiler cache: continue a short write from the unwritten bytes

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -72,6 +72,8 @@ new!(pub BUN_INTERNAL_NAPI_FORCE_MUSL_CHECK: boolean, "BUN_INTERNAL_NAPI_FORCE_M
 new!(pub BUN_DEBUG_HASH_RANDOM_SEED: unsigned, "BUN_DEBUG_HASH_RANDOM_SEED", { deser: { error_handling: NotSet } });
 new!(pub BUN_DEBUG_QUIET_LOGS: boolean, "BUN_DEBUG_QUIET_LOGS", {});
 new!(pub BUN_DEBUG_TEST_TEXT_LOCKFILE: boolean, "BUN_DEBUG_TEST_TEXT_LOCKFILE", { default: false });
+// Debug-only testing hook: caps the bytes per write in `RuntimeTranspilerCache.rs` (0 or unset: no cap).
+new!(pub BUN_DEBUG_TRANSPILER_CACHE_MAX_WRITE: unsigned, "BUN_DEBUG_TRANSPILER_CACHE_MAX_WRITE", {});
 new!(pub BUN_DEV_SERVER_TEST_RUNNER: string, "BUN_DEV_SERVER_TEST_RUNNER", {});
 // Debug-only: when set, `NumberRenamer` dumps the symbol table before
 // renaming (`src/js_printer/renamer.rs`). Presence-checked, value ignored.

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -364,47 +364,57 @@ impl Entry {
             };
             let metadata_bytes: &[u8] = &metadata_buf[0..metadata_bytes_len];
 
-            let mut vecs_buf: [sys::PlatformIoVecConst; 4] = bun_core::ffi::zeroed();
-            let mut vecs_i: usize = 0;
-            vecs_buf[vecs_i] = sys::platform_iovec_const_create(metadata_bytes);
-            vecs_i += 1;
-            if !output_bytes.is_empty() {
-                vecs_buf[vecs_i] = sys::platform_iovec_const_create(output_bytes);
-                vecs_i += 1;
-            }
-            if !sourcemap.is_empty() {
-                vecs_buf[vecs_i] = sys::platform_iovec_const_create(sourcemap);
-                vecs_i += 1;
-            }
-            if !esm_record.is_empty() {
-                vecs_buf[vecs_i] = sys::platform_iovec_const_create(esm_record);
-                vecs_i += 1;
-            }
-            let vecs: &[sys::PlatformIoVecConst] = &vecs_buf[0..vecs_i];
-
-            let mut position: i64 = 0;
             let file_len = Metadata::SIZE + output_bytes.len() + sourcemap.len() + esm_record.len();
+            // The unwritten part of each section, in file order.
+            let mut pending: [&[u8]; 4] = [metadata_bytes, output_bytes, sourcemap, esm_record];
+            debug_assert_eq!(
+                file_len,
+                pending.iter().map(|section| section.len()).sum::<usize>()
+            );
 
-            #[cfg(debug_assertions)]
-            {
-                let mut total: usize = 0;
-                for v in vecs {
-                    debug_assert!(v.len > 0);
-                    // `uv_buf_t::len` is `ULONG` (u32) on Windows, `usize` on POSIX.
-                    total += v.len as usize;
-                }
-                debug_assert!(file_len == total);
-            }
+            // Debug builds let a test cap each write so that the loop below has to continue.
+            #[cfg(not(bun_debug))]
+            let max_write = usize::MAX;
+            #[cfg(bun_debug)]
+            let max_write = match env_var::BUN_DEBUG_TRANSPILER_CACHE_MAX_WRITE.get() {
+                Some(limit) if limit > 0 => usize::try_from(limit).unwrap_or(usize::MAX),
+                _ => usize::MAX,
+            };
 
             let end_position = i64::try_from(file_len).expect("int cast");
             let _ = sys::preallocate_file(tmpfile.fd.cast(), 0, end_position);
+            let mut position: i64 = 0;
             while position < end_position {
-                let written = sys::pwritev(tmpfile.fd, vecs, position)?;
+                let mut vecs_buf: [sys::PlatformIoVecConst; 4] = bun_core::ffi::zeroed();
+                let mut vecs_len: usize = 0;
+                let mut budget = max_write;
+                for section in pending {
+                    let len = section.len().min(budget);
+                    if len == 0 {
+                        continue;
+                    }
+                    vecs_buf[vecs_len] = sys::platform_iovec_const_create(&section[..len]);
+                    vecs_len += 1;
+                    budget -= len;
+                }
+
+                let written = sys::pwritev(tmpfile.fd, &vecs_buf[..vecs_len], position)?;
                 if written == 0 {
                     return Err(crate::CrateError::WriteFailed);
                 }
 
+                advance_sections(&mut pending, written);
+                let offset = position;
                 position += i64::try_from(written).expect("int cast");
+                if position < end_position {
+                    bun_core::scoped_log!(
+                        cache,
+                        "save: wrote {} bytes at offset {}, {} bytes left",
+                        written,
+                        offset,
+                        end_position - position
+                    );
+                }
             }
 
             let _ = scopeguard::ScopeGuard::into_inner(errdefer);
@@ -611,6 +621,19 @@ impl Default for RuntimeTranspilerCache {
 
 pub(crate) fn hash(bytes: &[u8]) -> u64 {
     Wyhash::hash(SEED, bytes)
+}
+
+/// Drops the first `written` bytes of the concatenation of `sections`.
+fn advance_sections(sections: &mut [&[u8]], mut written: usize) {
+    for section in sections {
+        let len = written.min(section.len());
+        *section = &section[len..];
+        written -= len;
+    }
+    debug_assert_eq!(
+        written, 0,
+        "the write reported more bytes than were pending"
+    );
 }
 
 /// Allocate `len` bytes and fill them via `pread_all` at `offset`, returning

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -1,7 +1,17 @@
 import { Subprocess } from "bun";
 import { beforeEach, describe, expect, test } from "bun:test";
-import { chmodSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, tmpdirSync } from "harness";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
+import { bunEnv, bunExe, bunRun, isDebug, tmpdirSync } from "harness";
 import { join } from "path";
 
 function dummyFile(size: number, cache_bust: string, value: string | { code: string }) {
@@ -291,6 +301,89 @@ describe("transpiler cache", () => {
       expect(await bunRun(join(temp_dir, "entry.mjs"), env)).toSpawn("file-loader");
       expect(newCacheCount()).toBe(0);
     });
+  });
+
+  // Entry::save (src/jsc/RuntimeTranspilerCache.rs) writes an entry with one
+  // gather write of four sections: header, output, sourcemap, esm record. When
+  // the OS writes less than that, save has to continue with the unwritten rest
+  // of each section. It used to send every section again from its start. No
+  // filesystem in a test produces such a short write, so debug builds read
+  // BUN_DEBUG_TRANSPILER_CACHE_MAX_WRITE, a cap on the bytes handed to each
+  // write, and log every write that save continues after. Release builds have
+  // neither, so this test only runs on debug builds (the gate and bun bd).
+  test.skipIf(!isDebug)("a save that needs several writes produces the same entry as one write", async () => {
+    // lib.mjs is the only file that is large enough to be cached (4 KiB).
+    // `bun test --isolate` also stores its esm record, so every section of
+    // the entry is non-empty; the last test of this file documents the layout.
+    const lib = [];
+    for (let i = 0; i < 300; i++) lib.push(`export const v${i} = ${i};`);
+    writeFileSync(join(temp_dir, "lib.mjs"), lib.join("\n") + "\n");
+    writeFileSync(
+      join(temp_dir, "uses-lib.test.js"),
+      `import { test, expect } from "bun:test";
+import { v1, v299 } from "./lib.mjs";
+test("lib", () => {
+  expect(v1 + v299).toBe(300);
+});`,
+    );
+
+    async function run(extraEnv: Record<string, string>) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--isolate", "./uses-lib.test.js"],
+        cwd: temp_dir,
+        env: { ...env, BUN_DEBUG_cache: "1", ...extraEnv },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout + stderr).toContain("1 pass");
+      expect(exitCode).toBe(0);
+      return (stdout + stderr).match(/\[cache\] save: wrote \d+ bytes at offset \d+, \d+ bytes left/g) ?? [];
+    }
+
+    function entry() {
+      const names = readdirSync(cache_dir);
+      expect(names).toHaveLength(1);
+      return join(cache_dir, names[0]);
+    }
+
+    expect(await run({})).toEqual([]);
+    const expected = readFileSync(entry());
+    const ESM_RECORD_BYTE_LENGTH_AT = 86;
+    expect(expected.readBigUInt64LE(ESM_RECORD_BYTE_LENGTH_AT)).toBeGreaterThan(0n);
+
+    // 100 stops the first write inside the header, so the second write
+    // finishes the header and starts the output: one continuation drops a
+    // finished section and trims a partly written one. 4093 cuts the entry at
+    // offsets unrelated to the section boundaries.
+    for (const maxWrite of [100, 4093]) {
+      removeCache();
+      const continued = await run({ BUN_DEBUG_TRANSPILER_CACHE_MAX_WRITE: String(maxWrite) });
+      const actual = readFileSync(entry());
+      expect({
+        maxWrite,
+        size: actual.length,
+        writes: continued.length + 1,
+        firstWrite: continued[0],
+        identical: actual.equals(expected),
+      }).toEqual({
+        maxWrite,
+        size: expected.length,
+        writes: Math.ceil(expected.length / maxWrite),
+        firstWrite: `[cache] save: wrote ${maxWrite} bytes at offset 0, ${expected.length - maxWrite} bytes left`,
+        identical: true,
+      });
+    }
+
+    // The next run is served from the entry written in pieces. A rejected
+    // entry is unlinked and written again, which gives it a new inode.
+    const identity = () => {
+      const { ino, mtimeNs } = statSync(entry(), { bigint: true });
+      return { ino, mtimeNs };
+    };
+    const written = identity();
+    expect(await run({})).toEqual([]);
+    expect(identity()).toEqual(written);
   });
 });
 


### PR DESCRIPTION
### Problem
- `Entry::save` (`src/jsc/RuntimeTranspilerCache.rs`) writes a cache entry with one `pwritev` over four buffers. After a short write it called `pwritev` again with the same iovecs, so every section started again at the new offset.
- The loop stopped at the file length and the damaged entry was renamed into place. The next run rejects it and transpiles again. Unchanged since #7365 (2023), no reports. Found in #39717.

### Fix
- `save` keeps the unwritten rest of each section in `pending`, builds the iovecs of every write from it, and `advance_sections` drops the written bytes. The common case is still one `pwritev`. The `written == 0` check stays.
- Correct because `pwritev` writes the buffers in order: the written bytes are a prefix of the pending sections, and writing the rest at `position` gives one complete write.
- No test filesystem produces a retryable short write (Notes). Debug builds read `BUN_DEBUG_TRANSPILER_CACHE_MAX_WRITE`, a cap on the bytes per write, and log each continued write. Release builds contain neither. The test saves one entry in 1, 172 and 5 writes, checks the counts, that the entries are identical, and that the next run is served from the last one.
- Verified: `bun bd test test/cli/run/transpiler-cache.test.ts` (14 pass). Without the fix the new test fails: 1 write instead of 172.

### Background
- The cache keeps transpiled output on disk. `save` writes a temporary file and renames it, so a reader sees a complete entry or none.
- `pwritev(2)` writes a list of buffers (iovecs) at one offset in one system call. Like `write(2)`, it may write less than requested and returns the count.
- `cfg(bun_debug)` marks debug builds. The `-debug` version suffix (`isDebug`) and the debug logs exist under the same cfg as the hook.

<details><summary>Notes</summary>

Land #39717 first. Both change the same part of `save`. The test reads one header field (esm record length at offset 86), which #39717 does not move.

Why a hook. A short write that a retry can finish needs a filesystem that produces one (FUSE, network filesystems) or a single write above 2 GiB (`MAX_RW_COUNT` on Linux). `RLIMIT_FSIZE` and `ENOSPC` also produce a short write, but the retry fails too, so the old and the new loop both unlink the temporary file. On Windows `uv_fs_write` returns a short count when a later buffer fails, and the retry fails the same way. The hook follows the testing hooks already in `env_var.rs` (`BUN_DEBUG_FORCE_NIX_HOST`, `BUN_DEBUG_TEST_TEXT_LOCKFILE`, and `BUN_DEBUG_ENABLE_RESTORE_FROM_TRANSPILER_CACHE` in this same file). It is an env var because the save happens in the spawned `bun test --isolate` process. It is debug-only so that release builds get the loop fix and nothing else (plain `cargo clippy` compiles that arm, `bun bd` the other).

Alternative. Commit adb700afce (an earlier head of this PR) replaced the loop with one `File::pwrite_all` per section, as `NodeCompileCache.rs` does. That is 26 lines shorter, but leaves nothing a test can observe and drops the `written == 0` check. If that shape is preferred without a test, say so and I will switch back.

What the test covers. With a cap of 100 the first write stops inside the header, and the second write hands the kernel the last 2 header bytes plus 98 bytes of output, so one `advance_sections` call drops a finished section and trims a partly written one. With 4093 the cuts fall inside every section. The write counts come from the log line, so a cap that stops engaging fails the test. The final run checks inode and mtime: a rejected entry is unlinked and written again. The counts 172 and 5 are for the current 17140 byte entry; the test derives them from the entry size.

What the old loop produced. The first N bytes of the entry, then the whole entry again at offset N. With N at or past the header, the output hash check rejects it on the next run. Below that, the header is torn and the metadata checks reject it. On a filesystem that short-writes regularly, every save of a large file was wasted and the file was transpiled on every run.

Also run with `bun bd test`: `test/cli/test/isolation.test.ts`, `test/regression/issue/30887.test.ts`, `test/regression/issue/28159.test.ts` (31 pass), `test/internal/source-lints` (160 pass), `cargo clippy -p bun_jsc -p bun_core`, `cargo fmt`, prettier.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts
bun test v1.4.0 (4199361ed)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [651.95ms]
(pass) transpiler cache > works with empty files [592.17ms]
(pass) transpiler cache > ignores files under the minimum cache size [270.64ms]
(pass) transpiler cache > it is indeed content addressable [866.16ms]
(pass) transpiler cache > doing 50 buns at once does not crash [1788.94ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [580.30ms]
(pass) transpiler cache > works if the cache is not user-readable [873.88ms]
(pass) transpiler cache > works if the cache is not user-writable [293.05ms]
(pass) transpiler cache > does not inline process.env [617.09ms]
(pass) transpiler cache > --feature flag invalidates cache [1702.77ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > require.extensions is still consulted [569.11ms]
(pass) transpiler cache > a cached entry point does not change how later modules 
... (truncated)

release without fix: 1 skipped
bun test v1.4.0-canary.1 (0a4e3b1e1)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [13.75ms]
(pass) transpiler cache > works with empty files [11.16ms]
(pass) transpiler cache > ignores files under the minimum cache size [5.81ms]
(pass) transpiler cache > it is indeed content addressable [16.69ms]
(pass) transpiler cache > doing 50 buns at once does not crash [48.59ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [11.70ms]
(pass) transpiler cache > works if the cache is not user-readable [16.35ms]
(pass) transpiler cache > works if the cache is not user-writable [5.87ms]
(pass) transpiler cache > does not inline process.env [11.59ms]
(pass) transpiler cache > --feature flag invalidates cache [31.79ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > require.extensions is still consulted [12.27ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > unknown extensions still use the file loader [11.29ms]
(skip) transpiler cache > a save that needs several writes produces the same entry as one write
(pass) rejects cach
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/run/transpiler-cache.test.ts
bun test v1.4.0 (4199361ed)

test/cli/run/transpiler-cache.test.ts:
(pass) transpiler cache > works [627.16ms]
(pass) transpiler cache > works with empty files [578.18ms]
(pass) transpiler cache > ignores files under the minimum cache size [271.18ms]
(pass) transpiler cache > it is indeed content addressable [873.48ms]
(pass) transpiler cache > doing 50 buns at once does not crash [1723.48ms]
(pass) transpiler cache > disables the cache instead of falling back to the shared temp directory [589.22ms]
(pass) transpiler cache > works if the cache is not user-readable [868.56ms]
(pass) transpiler cache > works if the cache is not user-writable [304.08ms]
(pass) transpiler cache > does not inline process.env [644.99ms]
(pass) transpiler cache > --feature flag invalidates cache [1704.63ms]
(pass) transpiler cache > a cached entry point does not change how later modules load > require.extensions is still consulted [570.08ms]
(pass) transpiler cache > a cached entry point does not change how later modules 
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     04df944832
  features     baseline

23 deps, 120 codegen, 1172 objects in 636ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1235] install /workspace/bun
bun install v1.4.0-canary.1 (0a4e3b1e1)

Checked 26 installs across 63 packages (no changes) [13.00ms]
[2/1235] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (0a4e3b1e1)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1235] gen ErrorCode+*.h
[4/1235] gen bindgenv2
[5/1235] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1208] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (0a4e3b1e1)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[7/1208] fetch tinycc
[tinycc] up to date
[8/1207] gen .bind.ts → GeneratedBindings.cpp
[9/1207] fetch zlib
[zlib] up to date
[10/1207] subst deps/zlib/zlib.h
[11/1207] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs               |  2 +
 src/jsc/RuntimeTranspilerCache.rs     | 83 +++++++++++++++++++-----------
 test/cli/run/transpiler-cache.test.ts | 97 ++++++++++++++++++++++++++++++++++-
 3 files changed, 150 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/bun_core/env_var.rs                    2      3      0
src/jsc/RuntimeTranspilerCache.rs         11     13      0
test/cli/run/transpiler-cache.test.ts      4     10      0
```

</details>

<!-- robobun:evidence:end -->