### PR TITLE
install: reject bun.lockb packages whose resolution tag no writer produces

### DIFF
--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -3322,30 +3322,12 @@ pub mod serializer {
             if end_pos as u64 <= end_at {
                 let src = &stream.buffer[stream.pos..stream.pos + bytes.len()];
                 if matches!(field, PackageField::Resolution) {
-                    // Validate the tag of every element on the raw stream bytes
-                    // before they are copied into the typed column. `ResolutionType`
-                    // is `#[repr(C)] { tag: Tag, _padding: [u8; 7], value: ... }`,
-                    // so the tag is the first byte of each element. The accepted
-                    // tags are the ones a writer produces, the same set the bun.lock
-                    // writer persists. `Uninitialized` is the in-memory default of a
-                    // package that is not resolved yet and `SingleFileModule` is a
-                    // placeholder without a producer. A loaded package with either
-                    // tag keeps its dependents resolved while nothing can install it.
+                    // `ResolutionType` is `#[repr(C)]` with the tag as its first
+                    // byte, so validate it before the bytes reach the typed column.
                     let stride = mem::size_of::<ResolutionType<SemverIntType>>();
                     debug_assert!(stride != 0 && src.len().is_multiple_of(stride));
                     for raw in src.chunks_exact(stride) {
-                        if !matches!(
-                            ResolutionTag(raw[0]),
-                            ResolutionTag::Root
-                                | ResolutionTag::Npm
-                                | ResolutionTag::Folder
-                                | ResolutionTag::LocalTarball
-                                | ResolutionTag::Github
-                                | ResolutionTag::Git
-                                | ResolutionTag::Symlink
-                                | ResolutionTag::Workspace
-                                | ResolutionTag::RemoteTarball
-                        ) {
+                        if !ResolutionTag(raw[0]).belongs_in_lockfile() {
                             return Err(crate::Error::LockfileValidationFailedInvalidResolutionTag);
                         }
                     }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -3253,9 +3253,6 @@ pub mod serializer {
                     resolutions: old.resolutions,
                     scripts: old.scripts,
                     resolution: match old.resolution.tag {
-                        ResolutionTag::Uninitialized => {
-                            Resolution::init(TaggedValue::Uninitialized)
-                        }
                         ResolutionTag::Root => Resolution::init(TaggedValue::Root),
                         ResolutionTag::Npm => {
                             Resolution::init(TaggedValue::Npm(old.resolution.npm().migrate()))
@@ -3284,7 +3281,10 @@ pub mod serializer {
                         ResolutionTag::SingleFileModule => Resolution::init(
                             TaggedValue::SingleFileModule(*old.resolution.single_file_module()),
                         ),
-                        _ => Resolution::init(TaggedValue::Uninitialized),
+                        // `load_fields` already rejected every other tag byte.
+                        _ => {
+                            return Err(crate::Error::LockfileValidationFailedInvalidResolutionTag);
+                        }
                     },
                 };
 
@@ -3325,20 +3325,19 @@ pub mod serializer {
             if end_pos as u64 <= end_at {
                 let src = &stream.buffer[stream.pos..stream.pos + bytes.len()];
                 if matches!(field, PackageField::Resolution) {
-                    // Validate the tag discriminant on the *raw stream bytes*
-                    // before they are copied into the typed column. `ResolutionTag`
-                    // is a `#[repr(u8)]` enum with non-contiguous discriminants
-                    // (0,1,2,4,8,16,32,64,72,80,100); copying an out-of-range byte
-                    // into `ResolutionType.tag` and then reading it would be
-                    // immediate UB, and a `matches!` over all 11 typed variants is
-                    // provably exhaustive and would be optimized away. Check the
-                    // raw u8 here. Layout: `ResolutionType` is `#[repr(C)]
-                    // { tag: Tag, _padding: [u8; 7], value: ... }`, so the
-                    // discriminant is the first byte of each element.
+                    // Validate the tag of every element on the raw stream bytes
+                    // before they are copied into the typed column. `ResolutionType`
+                    // is `#[repr(C)] { tag: Tag, _padding: [u8; 7], value: ... }`,
+                    // so the tag is the first byte of each element. The accepted
+                    // values are the `ResolutionTag` constants except
+                    // `Uninitialized` (0): a package is appended only once it is
+                    // resolved, so no saved package carries that tag. Loading one
+                    // would keep its dependents bound to a package nothing can
+                    // install, and `Resolution::eql` has no arm for it.
                     let stride = mem::size_of::<ResolutionType<SemverIntType>>();
                     debug_assert!(stride != 0 && src.len().is_multiple_of(stride));
                     for raw in src.chunks_exact(stride) {
-                        if !matches!(raw[0], 0 | 1 | 2 | 4 | 8 | 16 | 32 | 64 | 72 | 80 | 100) {
+                        if !matches!(raw[0], 1 | 2 | 4 | 8 | 16 | 32 | 64 | 72 | 80 | 100) {
                             return Err(crate::Error::LockfileValidationFailedInvalidResolutionTag);
                         }
                     }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -3322,12 +3322,11 @@ pub mod serializer {
             if end_pos as u64 <= end_at {
                 let src = &stream.buffer[stream.pos..stream.pos + bytes.len()];
                 if matches!(field, PackageField::Resolution) {
-                    // `ResolutionType` is `#[repr(C)]` with the tag as its first
-                    // byte, so validate it before the bytes reach the typed column.
                     let stride = mem::size_of::<ResolutionType<SemverIntType>>();
+                    let tag_at = mem::offset_of!(ResolutionType<SemverIntType>, tag);
                     debug_assert!(stride != 0 && src.len().is_multiple_of(stride));
                     for raw in src.chunks_exact(stride) {
-                        if !ResolutionTag(raw[0]).belongs_in_lockfile() {
+                        if !ResolutionTag(raw[tag_at]).belongs_in_lockfile() {
                             return Err(crate::Error::LockfileValidationFailedInvalidResolutionTag);
                         }
                     }

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -3278,9 +3278,6 @@ pub mod serializer {
                         ResolutionTag::RemoteTarball => Resolution::init(
                             TaggedValue::RemoteTarball(*old.resolution.remote_tarball()),
                         ),
-                        ResolutionTag::SingleFileModule => Resolution::init(
-                            TaggedValue::SingleFileModule(*old.resolution.single_file_module()),
-                        ),
                         // `load_fields` already rejected every other tag byte.
                         _ => {
                             return Err(crate::Error::LockfileValidationFailedInvalidResolutionTag);
@@ -3329,15 +3326,26 @@ pub mod serializer {
                     // before they are copied into the typed column. `ResolutionType`
                     // is `#[repr(C)] { tag: Tag, _padding: [u8; 7], value: ... }`,
                     // so the tag is the first byte of each element. The accepted
-                    // values are the `ResolutionTag` constants except
-                    // `Uninitialized` (0): a package is appended only once it is
-                    // resolved, so no saved package carries that tag. Loading one
-                    // would keep its dependents bound to a package nothing can
-                    // install, and `Resolution::eql` has no arm for it.
+                    // tags are the ones a writer produces, the same set the bun.lock
+                    // writer persists. `Uninitialized` is the in-memory default of a
+                    // package that is not resolved yet and `SingleFileModule` is a
+                    // placeholder without a producer. A loaded package with either
+                    // tag keeps its dependents resolved while nothing can install it.
                     let stride = mem::size_of::<ResolutionType<SemverIntType>>();
                     debug_assert!(stride != 0 && src.len().is_multiple_of(stride));
                     for raw in src.chunks_exact(stride) {
-                        if !matches!(raw[0], 1 | 2 | 4 | 8 | 16 | 32 | 64 | 72 | 80 | 100) {
+                        if !matches!(
+                            ResolutionTag(raw[0]),
+                            ResolutionTag::Root
+                                | ResolutionTag::Npm
+                                | ResolutionTag::Folder
+                                | ResolutionTag::LocalTarball
+                                | ResolutionTag::Github
+                                | ResolutionTag::Git
+                                | ResolutionTag::Symlink
+                                | ResolutionTag::Workspace
+                                | ResolutionTag::RemoteTarball
+                        ) {
                             return Err(crate::Error::LockfileValidationFailedInvalidResolutionTag);
                         }
                     }

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -694,20 +694,8 @@ impl Stringifier {
                     }
 
                     let res = &pkg_resolutions[pkg_id as usize];
-                    match res.tag {
-                        ResolutionTag::Root
-                        | ResolutionTag::Npm
-                        | ResolutionTag::Folder
-                        | ResolutionTag::LocalTarball
-                        | ResolutionTag::Github
-                        | ResolutionTag::Git
-                        | ResolutionTag::Symlink
-                        | ResolutionTag::Workspace
-                        | ResolutionTag::RemoteTarball => {}
-                        ResolutionTag::Uninitialized => continue,
-                        // should not be possible, just being safe
-                        ResolutionTag::SingleFileModule => continue,
-                        _ => continue,
+                    if !res.tag.belongs_in_lockfile() {
+                        continue;
                     }
 
                     if first {

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -1014,9 +1014,8 @@ impl Tag {
         self == Tag::Git || self == Tag::Github
     }
 
-    /// The tags a package can have in a saved lockfile. A package is appended
-    /// only once it is resolved, so `Uninitialized` never reaches a writer, and
-    /// `SingleFileModule` has no producer. Nothing can install either one.
+    /// Tags a saved package can have. `Uninitialized` is the state before a
+    /// package is appended and `SingleFileModule` has no producer.
     pub(crate) fn belongs_in_lockfile(self) -> bool {
         matches!(
             self,

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -1014,6 +1014,24 @@ impl Tag {
         self == Tag::Git || self == Tag::Github
     }
 
+    /// The tags a package can have in a saved lockfile. A package is appended
+    /// only once it is resolved, so `Uninitialized` never reaches a writer, and
+    /// `SingleFileModule` has no producer. Nothing can install either one.
+    pub(crate) fn belongs_in_lockfile(self) -> bool {
+        matches!(
+            self,
+            Tag::Root
+                | Tag::Npm
+                | Tag::Folder
+                | Tag::LocalTarball
+                | Tag::Github
+                | Tag::Git
+                | Tag::Symlink
+                | Tag::Workspace
+                | Tag::RemoteTarball
+        )
+    }
+
     pub(crate) fn can_enqueue_install_task(self) -> bool {
         self == Tag::Npm
             || self == Tag::LocalTarball

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, expect, it } from "bun:test";
 import { copyFile, exists, open, rm, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, isWindows, runBunInstall, VerdaccioRegistry } from "harness";
+import { bunExe, bunEnv as env, isWindows, runBunInstall, tempDir, VerdaccioRegistry } from "harness";
 import { join } from "path";
 
 const registry = new VerdaccioRegistry();
@@ -349,6 +349,134 @@ it("rejects a binary lockfile whose package scripts flag byte is out of range", 
   expect(code).toBe(0);
   expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBe(true);
 });
+
+// The `resolution` column follows the name (8) and name_hash (8) columns. Each
+// entry is a 72-byte (64 in format v2) `Resolution` whose first byte is the tag:
+// 1 = root, 2 = npm, 72 = workspace, ... and 0 = uninitialized, which a saved
+// package never has.
+function packageResolutionTagOffsets(lockb: Buffer): number[] {
+  const fmt = lockb.readUInt32LE(42);
+  const N = Number(lockb.readBigUInt64LE(86));
+  const begin = Number(lockb.readBigUInt64LE(110));
+  const resolutionSize = fmt === 2 ? 64 : 72;
+  const resolutionStart = begin + N * (8 + 8);
+  const offsets: number[] = [];
+  for (let i = 0; i < N; i++) {
+    offsets.push(resolutionStart + i * resolutionSize);
+  }
+  return offsets;
+}
+
+it("rejects a binary lockfile in which a package has an uninitialized resolution", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "lockb-uninitialized-resolution",
+      version: "1.0.0",
+      dependencies: {
+        "no-deps": "1.0.0",
+        "a-dep": "1.0.1",
+      },
+    }),
+  );
+
+  await runBunInstall(env, packageDir);
+  const lockbPath = join(packageDir, "bun.lockb");
+  expect(await exists(lockbPath)).toBe(true);
+
+  const lockb = Buffer.from(await file(lockbPath).arrayBuffer());
+  const offsets = packageResolutionTagOffsets(lockb);
+  expect(offsets.map(offset => lockb[offset])).toEqual([1, 2, 2]);
+  // One of the root's dependencies still resolves to package 1, but the
+  // package no longer says where it comes from.
+  lockb[offsets[1]] = 0;
+  await write(lockbPath, lockb);
+
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "bun.lockb"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).toContain("invalid resolution tag");
+    expect(out).not.toContain('version ""');
+    expect(code).toBe(1);
+  }
+
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "install", "--no-progress"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+  // The lockfile is rejected and the install resolves every dependency again
+  // instead of silently skipping the one bound to the unresolved package.
+  expect(err).toContain("invalid resolution tag");
+  expect(err).toContain("Ignoring lockfile");
+  expect(out).toContain("no-deps@1.0.0");
+  expect(out).toContain("a-dep@1.0.1");
+  expect(out).toContain("2 packages installed");
+  expect(code).toBe(0);
+  expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBe(true);
+  expect(await exists(join(packageDir, "node_modules", "a-dep"))).toBe(true);
+
+  // The unresolved package is not written back out.
+  const saved = Buffer.from(await file(lockbPath).arrayBuffer());
+  expect(packageResolutionTagOffsets(saved).map(offset => saved[offset])).toEqual([1, 2, 2]);
+});
+
+it("rejects a format v2 binary lockfile in which a package has an uninitialized resolution", async () => {
+  // `bun bun.lockb` only prints the lockfile, so this exercises the v2
+  // migration path of the loader without a registry.
+  using dir = tempDir("lockb-v2-uninitialized-resolution", {});
+  const lockbPath = join(String(dir), "bun.lockb");
+  const lockb = Buffer.from(await file(join(__dirname, "fixtures", "bun.lockb.v2")).arrayBuffer());
+  expect(lockb.readUInt32LE(42)).toBe(2);
+  const offsets = packageResolutionTagOffsets(lockb);
+  expect(offsets.map(offset => lockb[offset])).toEqual([1, 2, 2, 2, 2, 2, 2]);
+
+  await write(lockbPath, lockb);
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "bun.lockb"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).toBe("");
+    expect(out).toContain("# yarn lockfile v1");
+    expect(code).toBe(0);
+  }
+
+  lockb[offsets[1]] = 0;
+  await write(lockbPath, lockb);
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "bun.lockb"],
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+    expect(err).toContain("invalid resolution tag");
+    expect(out).toBe("");
+    expect(code).toBe(1);
+  }
+});
+
 it("rejects a binary lockfile whose git resolved tag contains path separators", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
 

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -352,8 +352,7 @@ it("rejects a binary lockfile whose package scripts flag byte is out of range", 
 
 // The `resolution` column follows the name (8) and name_hash (8) columns. Each
 // entry is a 72-byte (64 in format v2) `Resolution` whose first byte is the tag:
-// 1 = root, 2 = npm, 72 = workspace, ... and 0 = uninitialized, which a saved
-// package never has.
+// 1 = root, 2 = npm, 72 = workspace, ...
 function packageResolutionTagOffsets(lockb: Buffer): number[] {
   const fmt = lockb.readUInt32LE(42);
   const N = Number(lockb.readBigUInt64LE(86));
@@ -367,115 +366,130 @@ function packageResolutionTagOffsets(lockb: Buffer): number[] {
   return offsets;
 }
 
-it("rejects a binary lockfile in which a package has an uninitialized resolution", async () => {
-  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
+// Nothing in bun writes a package with one of these tags: 0 (uninitialized) is
+// the in-memory state of a package that is not resolved yet, and 100 (single
+// file module) is a placeholder. Nothing installs such a package either, so a
+// lockfile that contains one has to be rejected.
+const resolutionTagsWithoutAWriter = [
+  { tag: 0, name: "uninitialized" },
+  { tag: 100, name: "single file module" },
+];
 
-  await write(
-    packageJson,
-    JSON.stringify({
-      name: "lockb-uninitialized-resolution",
-      version: "1.0.0",
-      dependencies: {
-        "no-deps": "1.0.0",
-        "a-dep": "1.0.1",
-      },
-    }),
-  );
+it.each(resolutionTagsWithoutAWriter)(
+  "rejects a binary lockfile in which a package has the $name resolution tag",
+  async ({ tag }) => {
+    const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
 
-  await runBunInstall(env, packageDir);
-  const lockbPath = join(packageDir, "bun.lockb");
-  expect(await exists(lockbPath)).toBe(true);
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "lockb-resolution-without-a-writer",
+        version: "1.0.0",
+        dependencies: {
+          "no-deps": "1.0.0",
+          "a-dep": "1.0.1",
+        },
+      }),
+    );
 
-  const lockb = Buffer.from(await file(lockbPath).arrayBuffer());
-  const offsets = packageResolutionTagOffsets(lockb);
-  expect(offsets.map(offset => lockb[offset])).toEqual([1, 2, 2]);
-  // One of the root's dependencies still resolves to package 1, but the
-  // package no longer says where it comes from.
-  lockb[offsets[1]] = 0;
-  await write(lockbPath, lockb);
+    await runBunInstall(env, packageDir);
+    const lockbPath = join(packageDir, "bun.lockb");
+    expect(await exists(lockbPath)).toBe(true);
 
-  {
+    const lockb = Buffer.from(await file(lockbPath).arrayBuffer());
+    const offsets = packageResolutionTagOffsets(lockb);
+    expect(offsets.map(offset => lockb[offset])).toEqual([1, 2, 2]);
+    // One of the root's dependencies still resolves to package 1, but the
+    // package no longer says where it comes from.
+    lockb[offsets[1]] = tag;
+    await write(lockbPath, lockb);
+
+    {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "bun.lockb"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).toContain("invalid resolution tag");
+      expect(out).toBe("");
+      expect(code).toBe(1);
+    }
+
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+
     const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "bun.lockb"],
+      cmd: [bunExe(), "install", "--no-progress"],
       cwd: packageDir,
       stdout: "pipe",
       stderr: "pipe",
       env,
     });
     const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+
+    // The lockfile is rejected and the install resolves every dependency again
+    // instead of silently skipping the one bound to the broken package.
     expect(err).toContain("invalid resolution tag");
-    expect(out).not.toContain('version ""');
-    expect(code).toBe(1);
-  }
-
-  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
-
-  const { stdout, stderr, exited } = spawn({
-    cmd: [bunExe(), "install", "--no-progress"],
-    cwd: packageDir,
-    stdout: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
-
-  // The lockfile is rejected and the install resolves every dependency again
-  // instead of silently skipping the one bound to the unresolved package.
-  expect(err).toContain("invalid resolution tag");
-  expect(err).toContain("Ignoring lockfile");
-  expect(out).toContain("no-deps@1.0.0");
-  expect(out).toContain("a-dep@1.0.1");
-  expect(out).toContain("2 packages installed");
-  expect(code).toBe(0);
-  expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBe(true);
-  expect(await exists(join(packageDir, "node_modules", "a-dep"))).toBe(true);
-
-  // The unresolved package is not written back out.
-  const saved = Buffer.from(await file(lockbPath).arrayBuffer());
-  expect(packageResolutionTagOffsets(saved).map(offset => saved[offset])).toEqual([1, 2, 2]);
-});
-
-it("rejects a format v2 binary lockfile in which a package has an uninitialized resolution", async () => {
-  // `bun bun.lockb` only prints the lockfile, so this exercises the v2
-  // migration path of the loader without a registry.
-  using dir = tempDir("lockb-v2-uninitialized-resolution", {});
-  const lockbPath = join(String(dir), "bun.lockb");
-  const lockb = Buffer.from(await file(join(__dirname, "fixtures", "bun.lockb.v2")).arrayBuffer());
-  expect(lockb.readUInt32LE(42)).toBe(2);
-  const offsets = packageResolutionTagOffsets(lockb);
-  expect(offsets.map(offset => lockb[offset])).toEqual([1, 2, 2, 2, 2, 2, 2]);
-
-  await write(lockbPath, lockb);
-  {
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "bun.lockb"],
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-      env,
-    });
-    const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
-    expect(err).toBe("");
-    expect(out).toContain("# yarn lockfile v1");
+    expect(err).toContain("Ignoring lockfile");
+    expect(out).toContain("no-deps@1.0.0");
+    expect(out).toContain("a-dep@1.0.1");
+    expect(out).toContain("2 packages installed");
     expect(code).toBe(0);
-  }
+    expect(await exists(join(packageDir, "node_modules", "no-deps"))).toBe(true);
+    expect(await exists(join(packageDir, "node_modules", "a-dep"))).toBe(true);
 
-  lockb[offsets[1]] = 0;
-  await write(lockbPath, lockb);
-  {
-    const { stdout, stderr, exited } = spawn({
-      cmd: [bunExe(), "bun.lockb"],
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-      env,
-    });
-    const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
-    expect(err).toContain("invalid resolution tag");
-    expect(out).toBe("");
-    expect(code).toBe(1);
-  }
-});
+    // The broken package is not written back out.
+    const saved = Buffer.from(await file(lockbPath).arrayBuffer());
+    expect(packageResolutionTagOffsets(saved).map(offset => saved[offset])).toEqual([1, 2, 2]);
+  },
+);
+
+it.each(resolutionTagsWithoutAWriter)(
+  "rejects a format v2 binary lockfile in which a package has the $name resolution tag",
+  async ({ tag }) => {
+    // `bun bun.lockb` only prints the lockfile, so this exercises the v2
+    // migration path of the loader without a registry.
+    using dir = tempDir("lockb-v2-resolution-without-a-writer", {});
+    const lockbPath = join(String(dir), "bun.lockb");
+    const lockb = Buffer.from(await file(join(__dirname, "fixtures", "bun.lockb.v2")).arrayBuffer());
+    expect(lockb.readUInt32LE(42)).toBe(2);
+    const offsets = packageResolutionTagOffsets(lockb);
+    expect(offsets.map(offset => lockb[offset])).toEqual([1, 2, 2, 2, 2, 2, 2]);
+
+    await write(lockbPath, lockb);
+    {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "bun.lockb"],
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).toBe("");
+      expect(out).toContain("# yarn lockfile v1");
+      expect(code).toBe(0);
+    }
+
+    lockb[offsets[1]] = tag;
+    await write(lockbPath, lockb);
+    {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "bun.lockb"],
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+      expect(err).toContain("invalid resolution tag");
+      expect(out).toBe("");
+      expect(code).toBe(1);
+    }
+  },
+);
 
 it("rejects a binary lockfile whose git resolved tag contains path separators", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });


### PR DESCRIPTION
### Problem
- A `bun.lockb` package whose resolution tag byte is 0 (`Uninitialized`) or 100 (`SingleFileModule`) loads. `bun install` prints `Saved lockfile`, exits 0, installs nothing for it, and writes it back out. A debug build panics instead: `unreachable!()` in `ResolutionType::eql` (`src/install/resolution.rs:525`). Install fuzzer ledger entry 16544.
- Cause: the tag check in `load_fields` (`src/install/lockfile/Package.rs`) accepted every tag constant. Dependencies on such a package keep a valid package id, so `verify_resolutions` counts them as resolved. No installer has a path for either tag.

### Fix
- `Tag::belongs_in_lockfile` lists the nine tags a writer produces. The bun.lockb loader rejects every other byte with `invalid resolution tag`, as it did for unknown bytes: `bun install` prints `Ignoring lockfile` and resolves again, `bun bun.lockb` exits 1. The bun.lock writer, which skipped the same two tags with its own list, uses the helper too.
- Correct because a package is appended only once it is resolved, and `SingleFileModule` is a placeholder with no producer. The one way to get such a file today is the yarn.lock migration bug that the open #39001 fixes, with `saveTextLockfile = false`. That file misses a dependency on every install. Now the next install resolves it again from package.json.
- Verified: `test/cli/install/bun-lockb.test.ts`, four new cases (both tags, format v3 through the registry and format v2 through the checked in fixture). All four fail without the src change.

### Background
- `bun.lockb` stores packages as columns. Each `resolution` entry is a tag byte plus a union that says where the package comes from (npm, folder, git, workspace, ...). Tag 0 is the state of a package that is not resolved yet.
- `load_fields` copies each column from the file and checks the enum bytes first, because the rest of the loader matches on them.
- On a load error `bun install` warns `Ignoring lockfile` and resolves from package.json. `--frozen-lockfile` fails with `lockfile had changes`.

<details><summary>Notes</summary>

Debug build panic path for tag 0: `ResolutionType::eql` <- `Lockfile::get_package_id` <- the `debug_assert!` in `Lockfile::append_package_with_id` <- `Package::clone` <- `Lockfile::clean_with_logger`. The release build skips the assertion and carries the package through. Tag 100 has an `eql` arm and reaches the `_` arm of `PackageInstaller::install_package_with_name_and_resolution` instead, which panics in debug builds and counts the package as installed in release builds. `isolated_install` treats the two tags as one class as well.

The format v2 migration arms for the two tags return the same error as the loader. History of this PR: the first version rejected tag 0 only. The self-review found that tag 100 reproduces the report one byte away. The comment that explained the loader's list was then flagged as too long, so the list moved next to the tag constants, the writer shares it, and the loader reads the tag offset with `offset_of!` like the `Meta`, `Bin` and `Scripts` checks next to it.

Before this change `bun install --frozen-lockfile` already refused the mutated file (`lockfile had changes`). It accepted the file that the plain install saved afterwards, so the broken state was sticky. The new tests check that the saved file has no such tag left.

Suites run with the debug build: `bun-lockb`, `bun-lock`, `bun-install`, `migrate-bun-lockb-v2`, `bun-workspaces`, `bun-link`, `bun-add`, `bun-update`, `bun-remove`, `catalogs`, `migration/migrate`, and the `port-era-markers`, `pre-port-identifiers` and `byte-search` source lints. `bun-install.test.ts`: 224 pass, 14 fail. The failures are the bitbucket, gitlab and external tarball URL tests plus `--registry CLI flag`. All of them fail the same way on the released build in this environment (no network). `bun-link.test.ts` has one failure, `should link dependency without crashing`. It expects exact stdout and gets the debug only `debug_trace` of an install failure. Both are unrelated to this change.

The fuzz report had a second part: a `bun.lock` whose `"packages"` key names one package (`xbin`) while the tuple id names another (`p13@1.1.0`) installs `p13` at `node_modules/xbin` with exit 0. This PR does not change that, on purpose:

- The key is the install path and the tuple is the package that lives there. They differ in every lockfile with an `npm:` alias (`"my-alias": ["no-deps@1.0.0", ...]`, checked with the released build) and with overrides. A check on the key name rejects those lockfiles.
- A check of the dependency's real name against the package name is not sound either. `enqueue_dependency_with_main_and_success_fn` redirects a plain dependency to a same named `npm:` alias declared elsewhere in the tree (`known_npm_aliases`). When the alias is removed later, the redirected edge survives `clean_with_logger`. So bun itself writes a lockfile in which a plain `foo` edge points at a package named `bar`, with no alias or override left to explain it. `--frozen-lockfile` would then fail on a lockfile bun wrote.
- The version is not checked today either: a `bun.lock` that pins `no-deps@2.0.0` under a package.json that says `1.0.0` installs 2.0.0 under `--frozen-lockfile` (checked with the released build). Locked edges are trusted as a whole. Validating them against package.json is a feature in the area of #33632, not a loader bug.

The report's third point, never exit 0 with a root dependency bound to a package that cannot be installed, has two producers: this loader, fixed here, and the yarn.lock migration, fixed by the open #39001. A release mode check at the `append_package*` entry points would also cover a future producer. It is left out here because both known producers are covered.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-lockb.test.ts

<!-- robobun:evidence:end -->