### PR TITLE
shell(ls): report an operand whose parent is a file instead of listing it

### DIFF
--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -9,7 +9,7 @@ use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable, ShellTask,
-    shell_openat,
+    shell_openat, shell_statat,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -459,14 +459,19 @@ impl ShellLsTask {
         let fd = match shell_openat(this.cwd, this.path.as_zstr(), O::RDONLY | O::DIRECTORY, 0) {
             Err(e) => {
                 match e.get_errno() {
-                    E::ENOENT => {
-                        this.err = Some(this.error_with_path(&e));
-                    }
-                    E::ENOTDIR => {
-                        // Clone the path to dodge the &mut/& borrow overlap.
-                        let p = ZBox::from_bytes(this.path.as_bytes());
-                        this.add_entry(p.as_bytes(), this.cwd);
-                    }
+                    // ENOTDIR is also what the open reports when a parent
+                    // component of the path is a file (`ls file/x`). Only an
+                    // operand that exists is listed as a file.
+                    E::ENOTDIR => match shell_statat(this.cwd, this.path.as_zstr()) {
+                        Ok(_) => {
+                            // Clone the path to dodge the &mut/& borrow overlap.
+                            let p = ZBox::from_bytes(this.path.as_bytes());
+                            this.add_entry(p.as_bytes(), this.cwd);
+                        }
+                        Err(stat_err) => {
+                            this.err = Some(this.error_with_path(&stat_err));
+                        }
+                    },
                     _ => {
                         this.err = Some(this.error_with_path(&e));
                     }

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2227,7 +2227,7 @@ fn shell_get_path<'a>(
 /// Windows: rewrite the path via `shell_get_path` then `bun_sys::stat`, tagging
 /// the error with the *original* `path_` (not the rewritten one). POSIX: plain
 /// `bun_sys::fstatat(dir, path_)`.
-// consumed by states/CondExpr (`[[ -e/-f/-d ... ]]`)
+// consumed by states/CondExpr (`[[ -e/-f/-d ... ]]`) and the `ls` builtin
 pub(crate) fn shell_statat(dir: Fd, path_: &bun_core::ZStr) -> bun_sys::Result<bun_sys::Stat> {
     #[cfg(windows)]
     {

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -287,6 +287,34 @@ describe.concurrent("bunshell ls", () => {
         .run();
     });
 
+    // The O_DIRECTORY open also fails with ENOTDIR when a parent component of
+    // the operand is a file. Windows can report that case as ENOENT instead.
+    const notADirectory = (s: string) =>
+      isPosix
+        ? expect(s).toBe("ls: file/x: Not a directory\n")
+        : expect(s).toMatch(/^ls: file\/x: (Not a directory|No such file or directory)\n$/);
+
+    test("operand whose parent is a regular file", async () => {
+      await TestBuilder.command`ls file/x`.file("file", "").exitCode(1).stderr(notADirectory).run();
+    });
+
+    test("operand whose parent is a regular file with -l", async () => {
+      await TestBuilder.command`ls -l file/x`.file("file", "").exitCode(1).stderr(notADirectory).run();
+    });
+
+    test("operand whose parent is a regular file with -d", async () => {
+      await TestBuilder.command`ls -d file/x`.file("file", "").exitCode(1).stderr(notADirectory).run();
+    });
+
+    test("file operand next to an operand whose parent is a regular file", async () => {
+      await TestBuilder.command`ls file file/x`
+        .file("file", "")
+        .exitCode(1)
+        .stdout("file\n")
+        .stderr(notADirectory)
+        .run();
+    });
+
     test("invalid flag", async () => {
       await TestBuilder.command`ls -z`
         .exitCode(1)


### PR DESCRIPTION
### Problem
- Bun Shell `ls` on a path whose parent is a regular file prints the path and exits 0: `ls /etc/hostname/x` writes `/etc/hostname/x` to stdout. coreutils prints `cannot access '/etc/hostname/x': Not a directory` and fails.
- Cause: `ShellLsTask::run_from_thread_pool` (`src/runtime/shell/builtin/ls.rs:459`) opens each operand with `O_DIRECTORY` and takes ENOTDIR to mean "the operand is a file". The kernel also reports ENOTDIR when a parent component is a file.

### Fix
- The ENOTDIR arm now stats the operand with `shell_statat`. If the stat succeeds, the operand is a file and is printed as before. If it fails, `ls` reports `ls: file/x: Not a directory` and exits 1, the same way its ENOENT path does.
- `shell_statat` is the helper `[[ -e ]]` uses. It applies the same Windows path rewrite as the `shell_openat` call above it.
- The ENOENT arm had the same body as the `_` arm and is folded into it.
- Verified: four new cases in `test/js/bun/shell/commands/ls.test.ts` (`ls file/x`, `-l`, `-d`, `ls file file/x`). All four fail on the release build. The rest of `ls.test.ts` and `bunshell.test.ts` pass.

### Background
- The `ls` builtin runs one `ShellLsTask` per operand on the thread pool. A task either lists a directory or appends a file operand to its output. A task that sets `err` makes the builtin print `ls: <path>: <strerror>` and exit 1.
- `openat(..., O_DIRECTORY)` fails with ENOTDIR when the last component is not a directory and also when an earlier one is not. A second syscall tells them apart.

<details><summary>Notes</summary>

- Release build (1.4 canary) before the change:

  ```
  ls /etc/hostname/x   exit 0  stdout "/etc/hostname/x\n"  stderr ""
  ls -l file/x         exit 0  stdout "?????????? ? ? ? ?            ? file/x\n"
  ```

- Debug build after the change:

  ```
  ls /etc/hostname/x   exit 1  stderr "ls: /etc/hostname/x: Not a directory\n"
  ls /etc/hostname     exit 0  stdout "/etc/hostname\n"
  ls f                 exit 0  stdout "f\n"
  ls link-to-file      exit 0  stdout "link-to-file\n"
  ls link-to-file/x    exit 1  stderr "ls: link-to-file/x: Not a directory\n"
  ls -l f/x            exit 1  stderr "ls: f/x: Not a directory\n"
  ls nope/x            exit 1  stderr "ls: nope/x: No such file or directory\n"
  ls f lnk f/x         exit 1  stdout "f\nlnk\n"  stderr "ls: f/x: Not a directory\n"
  ```

- `shell_statat` follows symlinks. A symlink whose target path runs through a file (`ln -s f/x bad`) is therefore reported as `Not a directory`. This matches the existing `broken symlink file` test in `ls.test.ts`, which expects a dangling link to be an error rather than printed as coreutils does.
- The stat error, not the open error, is what gets reported. Both are ENOTDIR for `file/x`. If the file disappears between the two calls, the stat error (ENOENT) describes the current state.
- On Windows the `file\x` open can already fail with ENOENT (`STATUS_OBJECT_PATH_NOT_FOUND`), which was an error before this change too. The new tests accept either message there and pin `Not a directory` on POSIX.
- The exit code stays 1. The builtin uses 1 for every error, coreutils uses 2 for this one. Not changed here.
- `ls.test.ts` has two chmod-based `permission denied` tests that fail in any environment that runs as root, with or without this change. #39232 covers them.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/ls.test.ts

<!-- robobun:evidence:end -->