### PR TITLE
net: deliver the reply to the final write before end() over Windows named pipes

### DIFF
--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -2217,6 +2217,7 @@ unsafe impl bun_core::ffi::Zeroable for uv_buf_t {}
 unsafe impl bun_core::ffi::Zeroable for uv_req_t {}
 unsafe impl bun_core::ffi::Zeroable for uv_write_t {}
 unsafe impl bun_core::ffi::Zeroable for uv_connect_t {}
+unsafe impl bun_core::ffi::Zeroable for uv_shutdown_t {}
 unsafe impl bun_core::ffi::Zeroable for Handle {}
 unsafe impl bun_core::ffi::Zeroable for Timer {}
 unsafe impl bun_core::ffi::Zeroable for Pipe {}
@@ -2669,6 +2670,11 @@ unsafe extern "C" {
         read_cb: uv_read_cb,
     ) -> ReturnCode;
     pub fn uv_read_stop(stream: *mut uv_stream_t) -> ReturnCode;
+    pub fn uv_shutdown(
+        req: *mut uv_shutdown_t,
+        handle: *mut uv_stream_t,
+        cb: uv_shutdown_cb,
+    ) -> ReturnCode;
     pub fn uv_write(
         req: *mut uv_write_t,
         handle: *mut uv_stream_t,

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -96,7 +96,7 @@ bun_event_loop::impl_timer_owner!(WindowsNamedPipe; from_timer_ptr => event_loop
 bitflags::bitflags! {
     #[repr(transparent)]
     #[derive(Clone, Copy, Default)]
-    pub struct Flags: u8 {
+    pub struct Flags: u16 {
         const DISCONNECTED = 1 << 0;
         const IS_CLOSED    = 1 << 1;
         const IS_CLIENT    = 1 << 2;
@@ -108,7 +108,12 @@ bitflags::bitflags! {
         const PIPE_ADOPTED = 1 << 4;
         const WRAPPER_BUSY = 1 << 5;
         const WRITER_BUSY  = 1 << 6;
-        // _: u2 padding
+        /// `shutdown()` was called on a plain (non-TLS) pipe: the write side
+        /// ends once outgoing data drains, but the read side stays open so
+        /// the peer's remaining data still arrives (half-close).
+        const SHUTDOWN_REQUESTED = 1 << 7;
+        /// The `uv_shutdown` request was handed to libuv.
+        const SHUTDOWN_SENT = 1 << 8;
     }
 }
 
@@ -254,14 +259,17 @@ impl WindowsNamedPipe {
             WriteStatus::Drained => {
                 // unref after sending all data
                 #[cfg(windows)]
-                self.writer.with_mut(|w| {
-                    if let Some(source) = w.source.as_mut() {
-                        // `Source` is an enum;
-                        // `unref()` matches the active variant (always `Pipe` here
-                        // via `start_with_pipe`).
-                        source.unref();
-                    }
-                });
+                {
+                    self.writer.with_mut(|w| {
+                        if let Some(source) = w.source.as_mut() {
+                            // `Source` is an enum;
+                            // `unref()` matches the active variant (always `Pipe` here
+                            // via `start_with_pipe`).
+                            source.unref();
+                        }
+                    });
+                    self.send_shutdown_if_drained();
+                }
             }
             WriteStatus::EndOfFile => {
                 // we send FIN so we close after this
@@ -614,6 +622,9 @@ impl WindowsNamedPipe {
             }
         }
         self.flush();
+        // An `end()` that raced the connect: nothing was queued, so no
+        // on_write(Drained) will fire to submit the deferred shutdown.
+        self.send_shutdown_if_drained();
         self.deref();
     }
 
@@ -947,13 +958,70 @@ impl WindowsNamedPipe {
             let _ = w.shutdown(false);
         });
         if handled.is_none() {
-            // Plain (non-TLS) named pipe: half-close the write side so the peer
-            // observes EOF. Without this, Socket.prototype.end() over a Windows
-            // named pipe (endNT → shutdown()) never signals the peer, and an
-            // allowHalfOpen peer waiting on 'end' hangs. `writer.end()` is
-            // idempotent and mirrors `close`'s unconditional writer teardown.
+            // Plain (non-TLS) named pipe: half-close the write side with
+            // uv_shutdown once outgoing data drains. libuv keeps a readable
+            // pipe open after shutdown (it force-closes only after its EOF
+            // timer sees the reads go idle), so the peer's response to the
+            // bytes we just flushed still arrives. `writer.end()` here would
+            // close the whole handle and drop that inbound data.
+            #[cfg(windows)]
+            {
+                let flags = self.flags.get();
+                if flags.contains(Flags::SHUTDOWN_REQUESTED) || flags.is_closed() {
+                    return;
+                }
+                self.update_flags(|f| f.insert(Flags::SHUTDOWN_REQUESTED));
+                self.send_shutdown_if_drained();
+            }
+            #[cfg(not(windows))]
             self.with_writer(|w| w.end());
         }
+    }
+
+    /// Submit the deferred `uv_shutdown` once every queued byte reached libuv.
+    /// Called from [`shutdown`], from `on_write` when the writer drains, and
+    /// from `on_connect` for an `end()` that raced the connect.
+    #[cfg(windows)]
+    fn send_shutdown_if_drained(&self) {
+        let flags = self.flags.get();
+        if !flags.contains(Flags::SHUTDOWN_REQUESTED)
+            || flags.contains(Flags::SHUTDOWN_SENT)
+            || flags.is_closed()
+            || flags.disconnected()
+        {
+            return;
+        }
+        if self.writer.get().has_pending_data() {
+            // on_write(Drained) retries once the queue empties.
+            return;
+        }
+        let Some(stream) = self.writer.with_mut(|w| w.get_stream()) else {
+            self.with_writer(|w| w.end());
+            return;
+        };
+        self.update_flags(|f| f.insert(Flags::SHUTDOWN_SENT));
+        let req = bun_core::heap::into_raw(Box::new(bun_core::ffi::zeroed::<uv::uv_shutdown_t>()));
+        // SAFETY: `stream` is the live pipe stream owned by `self.writer.source`;
+        // `req` is freed exactly once in `uv_on_shutdown` (libuv invokes the
+        // callback exactly once, with ECANCELED if the handle closes first).
+        let rc = unsafe { uv::uv_shutdown(req, stream, Some(Self::uv_on_shutdown)) };
+        if rc.int() < 0 {
+            // SAFETY: libuv did not take ownership of `req` on error.
+            unsafe { bun_core::heap::destroy(req) };
+            // No graceful half-close; fall back to the full teardown so the
+            // peer still observes EOF.
+            self.with_writer(|w| w.end());
+        }
+    }
+
+    /// `uv_shutdown_cb`: only reclaims the request. It must not touch the
+    /// owning `WindowsNamedPipe`; on a cancelled shutdown the close path that
+    /// cancelled it may already be tearing that object down.
+    #[cfg(windows)]
+    extern "C" fn uv_on_shutdown(req: *mut uv::uv_shutdown_t, _status: core::ffi::c_int) {
+        // SAFETY: `req` is the Box leaked in `send_shutdown_if_drained`; libuv
+        // calls this exactly once.
+        unsafe { bun_core::heap::destroy(req) };
     }
 
     #[bun_uws::uws_callback(export = "WindowsNamedPipe__shutdown_read")]
@@ -976,7 +1044,10 @@ impl WindowsNamedPipe {
             return wrapper.is_shutdown();
         }
 
-        self.flags.get().disconnected() || self.writer.get().is_done
+        let flags = self.flags.get();
+        flags.disconnected()
+            || flags.contains(Flags::SHUTDOWN_REQUESTED)
+            || self.writer.get().is_done
     }
 
     #[bun_uws::uws_callback(export = "WindowsNamedPipe__is_closed", no_catch)]

--- a/test/js/node/net/node-net-allowHalfOpen.test.js
+++ b/test/js/node/net/node-net-allowHalfOpen.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunRun, isWindows, nodeExe, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, bunRun, isWindows, nodeExe, tempDir, tempDirWithFiles } from "harness";
 import net from "node:net";
 import { join } from "node:path";
 
@@ -113,6 +113,72 @@ test("allowHalfOpen: false should work on client-side", async () => {
       .map(s => s.trim())
       .filter(s => s),
   ).toEqual(["Hello, World", "Received FIN"]);
+});
+
+// Regression test for #39723: over a Windows named pipe, client.end() closed the whole
+// pipe handle instead of half-closing the write side, so the server's reply to the
+// final write never reached the client (test-net-pingpong, 1000 !== 1001).
+// Runs the same ping-pong over a unix socket elsewhere.
+test("allowHalfOpen: reply to the final write before end() is still delivered (pipe transport)", async () => {
+  using dir = tempDir("net-pipe-pingpong", {
+    "pingpong-fixture.js": `
+      const net = require("net");
+      const path = require("path");
+      const N = 3;
+      const PIPE =
+        process.platform === "win32"
+          ? "\\\\\\\\.\\\\pipe\\\\bun-halfopen-pingpong-" + process.pid
+          : path.join(__dirname, "pingpong.sock");
+      let count = 0;
+      let sentFinalPing = false;
+      const server = net.createServer({ allowHalfOpen: true }, socket => {
+        socket.setEncoding("utf8");
+        socket.on("data", data => {
+          if (data !== "PING") {
+            console.error("server got " + JSON.stringify(data));
+            process.exit(1);
+          }
+          socket.write("PONG");
+        });
+        socket.on("end", () => socket.end());
+        socket.on("close", () => server.close());
+      });
+      server.listen(PIPE, () => {
+        const client = net.createConnection(PIPE);
+        client.setEncoding("utf8");
+        client.on("connect", () => client.write("PING"));
+        client.on("data", data => {
+          if (data !== "PONG") {
+            console.error("client got " + JSON.stringify(data));
+            process.exit(1);
+          }
+          count++;
+          if (sentFinalPing) return;
+          if (count < N) {
+            client.write("PING");
+          } else {
+            sentFinalPing = true;
+            client.write("PING");
+            client.end();
+          }
+        });
+        client.on("close", () => {
+          console.log("count = " + count + " expected " + (N + 1));
+          process.exit(count === N + 1 ? 0 : 1);
+        });
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "pingpong-fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("count = 4 expected 4\n");
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 // A paused allowHalfOpen socket whose AF_UNIX peer writes a tail and closes (EPOLLHUP while paused) must keep


### PR DESCRIPTION
### Problem

- `socket.end()` over a Windows named pipe drops the reply to the final write. The pipe variant of `test/js/node/test/parallel/test-net-pingpong.js` fails with `1000 !== 1001` (issue #39723). The TCP and IPv6 variants pass.
- The cause is `WindowsNamedPipe::shutdown` (`src/runtime/socket/WindowsNamedPipe.rs:945`). It calls `writer.end()`, and `WindowsStreamingWriter::end` closes the whole uv handle once the write queue drains. That also closes the read side, so the peer's response never arrives.

### Fix

- `shutdown()` on a plain (non-TLS) pipe now records a pending half-close and submits `uv_shutdown` once the streaming writer drains. The drain hook lives in `on_write(Drained)`, with a second hook in `on_connect` for an `end()` that raced the connect.
- libuv keeps a readable pipe open after `uv_shutdown`. It force-closes only after its EOF timer sees the reads go idle. So the final inbound data is delivered before `'close'`. Node on Windows behaves the same way through the same libuv path.
- `is_shutdown()` now also reports the pending half-close, so the socket layer does not run `end()` twice.
- Verified: the new test in `test/js/node/net/node-net-allowHalfOpen.test.js` fails on the current canary on Windows and passes with this change. `test-net-pingpong.js` passes 3/3 on Windows. Also ran `node-net.test.ts`, `node-net-server.test.ts`, and `test/js/bun/net/socket.test.ts` on Windows, and the full `node-net-allowHalfOpen.test.js` file on Linux.

### Background

- Windows named pipes have no transport-level half-close. The peer observes EOF only when the other end's handle closes.
- libuv emulates half-close for pipes: `uv_shutdown` flushes pending writes, and a handle that is still readable stays open. An internal EOF timer force-closes the pipe after reads stay idle for 50 ms, which is when the peer finally sees EOF.
- `WindowsNamedPipe` adapts libuv pipes to the uSockets socket interface for `node:net` and `node:tls` pipe paths. Its writes go through a `WindowsStreamingWriter` that owns the uv handle, and `end()` on that writer closes the handle. The TLS path is unchanged: it routes shutdown through the SSL wrapper.

<details><summary>Notes</summary>

- The bug reproduces only on Windows. On Linux and macOS, unix sockets go through uSockets, not this file, and the same ping-pong passes there. The fail-before proof is therefore Windows-only: with stock bun 1.3.14 and canary on Windows, the minimal repro prints `count = 1 expected 2` at N=1. With this change it prints `count = 2 expected 2`, and N=1000 prints `count = 1001 expected 1001`.
- The `uv_shutdown` request is a heap `uv_shutdown_t` freed in its callback. The callback does not touch the owning `WindowsNamedPipe`: on a cancelled shutdown the close path that cancelled it may already be tearing that object down.
- If `uv_shutdown` fails synchronously, the code falls back to the old full teardown (`writer.end()`), so the peer still observes EOF.
- `Flags` widened from `u8` to `u16` for the two new bits. It is Rust-only bookkeeping, not shared over FFI.
- Also ran on Windows: `test-net-pipe-connect-errors.js`, `test-http-client-pipe-end.js`, `test-net-allow-half-open.js`, all pass.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/net/node-net-allowHalfOpen.test.js

<!-- robobun:evidence:end -->