### PR TITLE
Let ICU derive its default locale itself after pinning en_US

### DIFF
--- a/src/jsc/bindings/bun_icu_default_locale.cpp
+++ b/src/jsc/bindings/bun_icu_default_locale.cpp
@@ -1,57 +1,25 @@
-// ICU initializes its default locale lazily, on POSIX from LC_ALL, LC_MESSAGES
-// or LANG (Bun never calls setlocale(), so libc's locale is "C" and ICU reads
-// the variables directly). When that value does not canonicalize, for example
-// LANG=abcdefghijkl (a language subtag of 12+ bytes) or LANG=/usr/lib/locale/en_US,
-// the lazy init fails without setting anything and icu::Locale::getDefault()
-// returns a null reference. The first ucal_open / ucol_open (Date#toString,
-// localeCompare, any Intl constructor) then crashes inside ICU.
+// ICU derives its default locale lazily (on POSIX from LC_ALL / LC_MESSAGES /
+// LANG). When that value does not parse, for example LANG=abcdefghijkl or a
+// modifier too long to become a variant, the derivation leaves the default
+// unset and icu::Locale::getDefault() returns a null reference, so the first
+// ucal_open / ucol_open (Date#toString, localeCompare, any Intl constructor)
+// crashes inside ICU.
 //
-// Run the same canonicalization up front and, only when it fails, set the
-// default to the locale Bun reports anyway. A value ICU accepts is left for
-// ICU to read itself, so its behavior is unchanged.
+// Set the default to en_US, the locale Bun reports anyway, then let ICU derive
+// it from the environment as it would have done lazily. A failed derivation
+// keeps the previous default, so the environment is only ever parsed by ICU's
+// own code and a value it accepts behaves exactly as before.
 
 #include "root.h"
 
-#if !OS(WINDOWS)
-
-#include <cstdlib>
-#include <initializer_list>
 #include <unicode/utypes.h>
 
 // Apple's SDK has no <unicode/uloc.h>; utypes.h supplies U_CAPI + renaming.
-U_CAPI int32_t U_EXPORT2 uloc_canonicalize(const char* localeID, char* name, int32_t nameCapacity, UErrorCode* err);
 U_CAPI void U_EXPORT2 uloc_setDefault(const char* localeID, UErrorCode* status);
 
 extern "C" void Bun__ensureICUDefaultLocale()
 {
-    const char* localeID = nullptr;
-    for (const char* name : { "LC_ALL", "LC_MESSAGES", "LANG" }) {
-        localeID = getenv(name);
-        if (localeID)
-            break;
-    }
-    if (!localeID)
-        return;
-
-    // Only the status matters. A valid id that does not fit (U_BUFFER_OVERFLOW_ERROR)
-    // is pinned too, which is harmless.
-    char canonical[256];
     UErrorCode status = U_ZERO_ERROR;
-    uloc_canonicalize(localeID, canonical, sizeof(canonical), &status);
-    if (U_SUCCESS(status))
-        return;
-
-    status = U_ZERO_ERROR;
     uloc_setDefault("en_US", &status);
-    RELEASE_ASSERT(U_SUCCESS(status));
+    uloc_setDefault(nullptr, &status);
 }
-
-#else
-
-// ICU derives its default from the user locale of the system here, not from
-// environment variables.
-extern "C" void Bun__ensureICUDefaultLocale()
-{
-}
-
-#endif

--- a/test/js/web/intl/intl.test.ts
+++ b/test/js/web/intl/intl.test.ts
@@ -10,7 +10,7 @@
 // links the unmodified libicudata.a.
 
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isMacOS, libcPathForDlopen } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, isWindows, libcPathForDlopen } from "harness";
 
 // Snapshots are CLDR-version-specific. Only check them where Bun bundles the
 // ICU they were generated against; macOS uses Apple's libicucore, so snapshot
@@ -189,12 +189,13 @@ describe("Intl.Collator", () => {
 });
 
 // ICU reads its own default locale from LC_ALL, then LC_MESSAGES, then LANG the
-// first time a calendar or collator is opened. A value it cannot parse (a
-// language subtag of 12 or more bytes, or a path) used to leave that default
-// unset, and the first Date#toString / localeCompare / Intl constructor then
-// crashed inside ICU. Bun's own default locale does not come from these
-// variables, so every value, parseable or not, must give the en-US output.
-describe.concurrent("locale variables in the environment", () => {
+// first time a calendar or collator is opened. A value it cannot parse used to
+// leave that default unset, and the first Date#toString / localeCompare / Intl
+// constructor then crashed inside ICU. Bun's own default locale does not come
+// from these variables, so every value, parseable or not, must give the en-US
+// output. On Windows neither holds: ICU reads the system locale and JSC reports
+// the UI language of the machine.
+describe.skipIf(isWindows).concurrent("locale variables in the environment", () => {
   const script = `console.log(JSON.stringify([
     new Date(0).toString(),
     "a".localeCompare("b"),
@@ -206,8 +207,14 @@ describe.concurrent("locale variables in the environment", () => {
     // eleven bytes is the longest language subtag ICU accepts
     { LANG: "abcdefghijkl" },
     { LANG: "/usr/lib/locale/en_US" },
+    // ICU turns the modifier into a variant before it parses the value, and a
+    // variant of 180 or more bytes is rejected. The value itself canonicalizes.
+    { LANG: "en_US@k=" + Buffer.alloc(200, "a").toString() },
     { LC_MESSAGES: "abcdefghijkl" },
     { LC_ALL: "abcdefghijkl", LANG: "en_US.UTF-8" },
+    // a parseable or empty variable in front of an unparseable one wins
+    { LC_ALL: "C", LANG: "abcdefghijkl" },
+    { LC_ALL: "", LANG: "abcdefghijkl" },
     { LC_ALL: "de_DE.UTF-8" },
   ])("%o", async vars => {
     await using proc = Bun.spawn({


### PR DESCRIPTION
### Problem
- Follow-up to #39704. `LANG='en_US@k='$(printf 'a%.0s' {1..200}) bun -e 'new Date().toString()'` still dies with `Segmentation fault at address 0x8` on main (`a443fa91aa`): the same null `icu::Locale::getDefault()`.
- #39704 canonicalizes the raw variable and pins only when that fails. ICU first rewrites the value (`uprv_getDefaultLocaleID` strips the codeset and turns `@modifier` into a variant) and canonicalizes that. The raw value above passes, the rewritten one fails (a variant of 180+ bytes), so the guard declines and ICU still ends up without a default.

### Fix
- `bun_icu_default_locale.cpp` now calls `uloc_setDefault("en_US")` and then `uloc_setDefault(nullptr)`. The second call is ICU's own derivation from the environment, the one that used to run lazily.
- Correct because `locale_set_default_internal` leaves the stored default untouched on every failure path (ICU 78 `locid.cpp:190`). A value ICU rejects keeps `en_US`, a value it accepts is stored exactly as the lazy path stored it. Nothing is parsed on our side, so nothing can disagree with ICU again. The Windows stub goes away, the two calls work there too.
- The test block is skipped on Windows: JSC reports the UI language of the machine there (`LanguageWin.cpp`), so the en-US assertions are not deterministic, and ICU does not read these variables on Windows (review comment on #39704).
- Verified: `test/js/web/intl/intl.test.ts`. The new `en_US@k=...` case fails on main and passes with the fix, the other 7 pass on both. The whole file (41 tests, 20 snapshots) and node's `test-intl.js` still pass.

### Background
- ICU stores one default locale per process and fills it on first use. `Locale::getDefault()` dereferences the result of that fill, which is null when the derivation fails. Anything stored beforehand makes it return early.
- `uloc_setDefault(NULL)` is documented as "try to get the system's default locale" (`@stable ICU 2.0`) and goes through the same function as the lazy fill.
- JS cannot see this value today (JSC's default locale is `en-US` via WTF on Linux and macOS). It only steers ICU's internal resource fallback, so keeping ICU's own result for valid values preserves behavior.

<details><summary>Notes</summary>

- Probe against the ICU 78.3 static libraries Bun links, running exactly these two calls and then `ucal_open`: `LANG=de_DE.UTF-8` -> default `de_DE`, `LANG=en_US@calendar=japanese` -> `en_US_CALENDAR=JAPANESE`, `LANG=C` and unset -> `en_US_POSIX`, `LANG=` (empty) -> root, `LANG=abcdefghijkl` and the 200 byte modifier -> `en_US`. The first four are what the lazy path produced before, the last two used to crash.
- Hand runs on the debug build, all print the en-US output: both modifier forms (`en_US@k=...`, `de_DE.UTF-8@k=...`), `abcdefghijkl`, the path, `LC_ALL` / `LC_MESSAGES` garbage, `LC_ALL=` empty, `C.UTF-8`, `de_DE.UTF-8`, `en_US@euro`, the 11 byte `abcdefghijk`.
- `uloc_setDefault` only checks the status on entry and never sets it (ICU 78 `uloc.cpp:2341`), so one status variable serves both calls and a failed derivation is silent, as intended.
- The two precedence cases (`LC_ALL=C` or `LC_ALL=` in front of a bad `LANG`) pass before and after. They pin down that a valid or empty higher variable wins, which is ICU's rule.
- The opposite mismatch of #39704 (pinning a value such as `de_DE@x=` that ICU accepts) disappears as well. It was harmless.
- Relation to #35600 unchanged: `uloc_getDefault()` now always returns a real locale, so wiring JSC's `defaultLanguage` to it would be safe. Whether to do that is still a separate decision.
</details>
